### PR TITLE
feat(contracts): structured diagnostics for agent connection tests

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -3682,8 +3682,7 @@ async function projectDaemonUrl(flags) {
 }
 
 async function runAgent(args) {
-  if (args.length === 0 || args[0] === 'help' || args.includes('--help') || args.includes('-h')) {
-    console.log(`Usage:
+  const usage = `Usage:
   od agent test <agentId> [--model <id>] [--reasoning <effort>] [--json]
 
 Runs the same /api/test/connection probe the Settings dialog drives, against
@@ -3694,7 +3693,9 @@ external agents and pipelines can \`jq .diagnostics.recoveryHints\`.
 
 Common options:
   --daemon-url <url>   Open Design daemon HTTP base.
-  --json               Emit raw JSON envelope.`);
+  --json               Emit raw JSON envelope.`;
+  if (args.length === 0 || args[0] === 'help' || args.includes('--help') || args.includes('-h')) {
+    console.log(usage);
     process.exit(args.length === 0 ? 2 : 0);
   }
   const sub = args[0];
@@ -3703,7 +3704,14 @@ Common options:
     process.exit(2);
   }
   const rest = args.slice(1);
-  const flags = parseFlags(rest, { string: AGENT_STRING_FLAGS, boolean: AGENT_BOOLEAN_FLAGS });
+  let flags;
+  try {
+    flags = parseFlags(rest, { string: AGENT_STRING_FLAGS, boolean: AGENT_BOOLEAN_FLAGS });
+  } catch (err) {
+    console.error(`od agent test: ${err.message}`);
+    console.error(usage);
+    process.exit(2);
+  }
   const agentId = positionalArgs(rest, AGENT_STRING_FLAGS)[0];
   if (!agentId) {
     console.error('Usage: od agent test <agentId> [--model <id>] [--reasoning <effort>] [--json]');

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -169,6 +169,10 @@ const MEMORY_STRING_FLAGS = new Set([
 const MEMORY_BOOLEAN_FLAGS = new Set([
   'help', 'h', 'json',
 ]);
+const AGENT_STRING_FLAGS = new Set(['daemon-url', 'model', 'reasoning']);
+const AGENT_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
+const CONFIG_STRING_FLAGS = new Set(['daemon-url', 'value', 'value-json']);
+const CONFIG_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
 // Hoisted because `runAutomation` is reachable through the top-of-file
 // SUBCOMMAND_MAP dispatch, which runs during module evaluation —
 // any `const` declared further down would still be in TDZ when
@@ -732,6 +736,23 @@ function parseFlags(argv, opts = {}) {
     } else {
       out[key] = true;
     }
+  }
+  return out;
+}
+
+function positionalArgs(argv, stringFlags) {
+  const out = [];
+  for (let i = 0; i < argv.length; i++) {
+    const value = argv[i];
+    if (!value) continue;
+    if (value.startsWith('--')) {
+      const eq = value.indexOf('=');
+      const key = eq >= 0 ? value.slice(2, eq) : value.slice(2);
+      if (eq < 0 && stringFlags instanceof Set && stringFlags.has(key)) i++;
+      continue;
+    }
+    if (value.startsWith('-')) continue;
+    out.push(value);
   }
   return out;
 }
@@ -3660,9 +3681,6 @@ async function projectDaemonUrl(flags) {
   return cliDaemonUrl(flags);
 }
 
-const AGENT_STRING_FLAGS = new Set(['daemon-url', 'model', 'reasoning']);
-const AGENT_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
-
 async function runAgent(args) {
   if (args.length === 0 || args[0] === 'help' || args.includes('--help') || args.includes('-h')) {
     console.log(`Usage:
@@ -3686,7 +3704,7 @@ Common options:
   }
   const rest = args.slice(1);
   const flags = parseFlags(rest, { string: AGENT_STRING_FLAGS, boolean: AGENT_BOOLEAN_FLAGS });
-  const agentId = rest.find((a) => !a.startsWith('-'));
+  const agentId = positionalArgs(rest, AGENT_STRING_FLAGS)[0];
   if (!agentId) {
     console.error('Usage: od agent test <agentId> [--model <id>] [--reasoning <effort>] [--json]');
     process.exit(2);
@@ -3783,7 +3801,7 @@ Common options:
       return;
     }
     case 'info': {
-      const id = rest.find((a) => !a.startsWith('-'));
+      const id = positionalArgs(rest, PROJECT_STRING_FLAGS)[0];
       if (!id) {
         console.error('Usage: od project info <id>');
         process.exit(2);
@@ -3844,7 +3862,7 @@ Common options:
       return;
     }
     case 'delete': {
-      const id = rest.find((a) => !a.startsWith('-'));
+      const id = positionalArgs(rest, PROJECT_STRING_FLAGS)[0];
       if (!id) {
         console.error('Usage: od project delete <id>');
         process.exit(2);
@@ -3896,7 +3914,7 @@ Common options:
       return;
     }
     case 'info': {
-      const id = rest.find((a) => !a.startsWith('-'));
+      const id = positionalArgs(rest, PROJECT_STRING_FLAGS)[0];
       if (!id) {
         console.error('Usage: od run info <runId>');
         process.exit(2);
@@ -3908,7 +3926,7 @@ Common options:
       return;
     }
     case 'cancel': {
-      const id = rest.find((a) => !a.startsWith('-'));
+      const id = positionalArgs(rest, PROJECT_STRING_FLAGS)[0];
       if (!id) {
         console.error('Usage: od run cancel <runId>');
         process.exit(2);
@@ -3919,7 +3937,7 @@ Common options:
       return;
     }
     case 'watch': {
-      const id = rest.find((a) => !a.startsWith('-'));
+      const id = positionalArgs(rest, PROJECT_STRING_FLAGS)[0];
       if (!id) {
         console.error('Usage: od run watch <runId>');
         process.exit(2);
@@ -4472,7 +4490,7 @@ Common options:
       return;
     }
     case 'show': {
-      const id = rest.find((a) => !a.startsWith('-'));
+      const id = positionalArgs(rest, LIBRARY_STRING_FLAGS)[0];
       if (!id) {
         console.error('Usage: od atoms show <id>');
         process.exit(2);
@@ -4489,7 +4507,7 @@ Common options:
       return;
     }
     case 'info': {
-      const id = rest.find((a) => !a.startsWith('-'));
+      const id = positionalArgs(rest, LIBRARY_STRING_FLAGS)[0];
       if (!id) {
         console.error('Usage: od atoms info <id>');
         process.exit(2);
@@ -4548,7 +4566,7 @@ async function runLibraryList(name, args) {
       return;
     }
     case 'show': {
-      const id = rest.find((a) => !a.startsWith('-'));
+      const id = positionalArgs(rest, LIBRARY_STRING_FLAGS)[0];
       if (!id) {
         console.error(`Usage: od ${name} show <id>`);
         process.exit(2);
@@ -4611,9 +4629,6 @@ async function runVersion(args) {
 // without leaving the terminal. JSON values pass through unchanged;
 // scalar strings/numbers/booleans are coerced.
 // ---------------------------------------------------------------------------
-
-const CONFIG_STRING_FLAGS = new Set(['daemon-url', 'value', 'value-json']);
-const CONFIG_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
 
 async function runDoctor(args) {
   const flags = parseFlags(args, { string: CONFIG_STRING_FLAGS, boolean: CONFIG_BOOLEAN_FLAGS });
@@ -4767,7 +4782,7 @@ Common options:
       return;
     }
     case 'get': {
-      const key = rest.find((a) => !a.startsWith('-'));
+      const key = positionalArgs(rest, CONFIG_STRING_FLAGS)[0];
       if (!key) {
         console.error('Usage: od config get <key>');
         process.exit(2);
@@ -4815,7 +4830,7 @@ Common options:
       return;
     }
     case 'unset': {
-      const key = rest.find((a) => !a.startsWith('-'));
+      const key = positionalArgs(rest, CONFIG_STRING_FLAGS)[0];
       if (!key) {
         console.error('Usage: od config unset <key>');
         process.exit(2);
@@ -5305,24 +5320,10 @@ async function runAutomation(args) {
   const writeJson = (data) =>
     process.stdout.write(JSON.stringify(data, null, 2) + '\n');
 
-  const positionalArgs = (values) => {
-    const out = [];
-    for (let i = 0; i < values.length; i++) {
-      const value = values[i];
-      if (!value) continue;
-      if (value.startsWith('--')) {
-        const eq = value.indexOf('=');
-        const key = eq >= 0 ? value.slice(2, eq) : value.slice(2);
-        if (eq < 0 && AUTOMATION_STRING_FLAGS.has(key)) i++;
-        continue;
-      }
-      out.push(value);
-    }
-    return out;
-  };
+  const automationPositionals = (values) => positionalArgs(values, AUTOMATION_STRING_FLAGS);
 
   const requireId = (label) => {
-    const id = positionalArgs(rest)[0];
+    const id = automationPositionals(rest)[0];
     if (!id) {
       console.error(`Usage: od automation ${label} <id>`);
       process.exit(2);
@@ -5339,7 +5340,7 @@ async function runAutomation(args) {
   switch (sub) {
     case 'template':
     case 'templates': {
-      const parts = positionalArgs(rest);
+      const parts = automationPositionals(rest);
       const action = parts[0] ?? 'list';
       if (action === 'list') {
         let resp;
@@ -5395,7 +5396,7 @@ async function runAutomation(args) {
     case 'ingest':
     case 'source':
     case 'sources': {
-      const parts = positionalArgs(rest);
+      const parts = automationPositionals(rest);
       const action = sub === 'ingest' ? 'ingest' : (parts[0] ?? 'list');
       if (action === 'ingest') {
         const sourceKind = flags['source-kind'] ?? (sub === 'ingest' ? parts[0] : parts[1]);
@@ -5506,7 +5507,7 @@ async function runAutomation(args) {
     }
     case 'proposal':
     case 'proposals': {
-      const parts = positionalArgs(rest);
+      const parts = automationPositionals(rest);
       const action = parts[0] ?? 'list';
       if (action === 'list') {
         const query = flags.status ? `?status=${encodeURIComponent(String(flags.status))}` : '';
@@ -5655,7 +5656,7 @@ async function runAutomation(args) {
       return;
     }
     case 'crystallize-run': {
-      const parts = positionalArgs(rest);
+      const parts = automationPositionals(rest);
       const routineId = parts[0];
       const runId = parts[1];
       if (!routineId || !runId) {

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -201,6 +201,7 @@ const PLUGIN_LIST_BOOLEAN_FLAGS = new Set([
 ]);
 
 const SUBCOMMAND_MAP = {
+  agent: runAgent,
   artifacts: runArtifacts,
   media: runMedia,
   mcp: runMcp,
@@ -3657,6 +3658,85 @@ and bare marketplace names resolved through configured registry sources.`);
 
 async function projectDaemonUrl(flags) {
   return cliDaemonUrl(flags);
+}
+
+const AGENT_STRING_FLAGS = new Set(['daemon-url', 'model', 'reasoning']);
+const AGENT_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
+
+async function runAgent(args) {
+  if (args.length === 0 || args[0] === 'help' || args.includes('--help') || args.includes('-h')) {
+    console.log(`Usage:
+  od agent test <agentId> [--model <id>] [--reasoning <effort>] [--json]
+
+Runs the same /api/test/connection probe the Settings dialog drives, against
+the named local agent. The full response (including structured diagnostics:
+phase, binaryPath, sanitized stderr excerpt, and recovery hints) is printed
+to stdout. With --json the whole envelope is emitted as one JSON object so
+external agents and pipelines can \`jq .diagnostics.recoveryHints\`.
+
+Common options:
+  --daemon-url <url>   Open Design daemon HTTP base.
+  --json               Emit raw JSON envelope.`);
+    process.exit(args.length === 0 ? 2 : 0);
+  }
+  const sub = args[0];
+  if (sub !== 'test') {
+    console.error(`unknown subcommand: od agent ${sub}. Try \`od agent --help\`.`);
+    process.exit(2);
+  }
+  const rest = args.slice(1);
+  const flags = parseFlags(rest, { string: AGENT_STRING_FLAGS, boolean: AGENT_BOOLEAN_FLAGS });
+  const agentId = rest.find((a) => !a.startsWith('-'));
+  if (!agentId) {
+    console.error('Usage: od agent test <agentId> [--model <id>] [--reasoning <effort>] [--json]');
+    process.exit(2);
+  }
+  const base = (await cliDaemonBaseUrl(flags));
+  const body = { mode: 'agent', agentId };
+  if (typeof flags.model === 'string' && flags.model.length > 0) body.model = flags.model;
+  if (typeof flags.reasoning === 'string' && flags.reasoning.length > 0) body.reasoning = flags.reasoning;
+  let resp;
+  try {
+    resp = await fetch(`${base}/api/test/connection`, {
+      method:  'POST',
+      headers: { 'content-type': 'application/json' },
+      body:    JSON.stringify(body),
+    });
+  } catch (err) {
+    return exitWithStructuredError({
+      code:    'daemon-not-running',
+      message: `Cannot reach daemon at ${base}: ${err?.message ?? err}`,
+    });
+  }
+  if (!resp.ok) return structuredHttpFailure(resp);
+  const data = await resp.json();
+  if (flags.json) {
+    process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+    if (data?.ok === false) process.exit(1);
+    return;
+  }
+  const okLabel = data?.ok ? 'OK' : 'FAIL';
+  const kind = data?.kind ?? 'unknown';
+  const agentName = data?.agentName ?? agentId;
+  console.log(`${okLabel}  ${agentName} (${agentId}) → ${kind}`);
+  if (typeof data?.detail === 'string' && data.detail.length > 0) {
+    console.log(`  detail: ${data.detail}`);
+  }
+  const diag = data?.diagnostics;
+  if (diag && typeof diag === 'object') {
+    console.log(`  phase: ${diag.phase}`);
+    if (diag.binaryPath) console.log(`  binaryPath: ${diag.binaryPath}`);
+    if (diag.binaryVersion) console.log(`  binaryVersion: ${diag.binaryVersion}`);
+    if (typeof diag.stderrExcerpt === 'string' && diag.stderrExcerpt.length > 0) {
+      console.log('  stderr:');
+      for (const line of diag.stderrExcerpt.split('\n')) console.log(`    ${line}`);
+    }
+    if (Array.isArray(diag.recoveryHints) && diag.recoveryHints.length > 0) {
+      console.log('  next steps:');
+      for (const hint of diag.recoveryHints) console.log(`    - ${hint}`);
+    }
+  }
+  if (!data?.ok) process.exit(1);
 }
 
 function safeReadJsonFile(p) {

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1263,12 +1263,16 @@ async function probeAgentBinaryVersion(
   env: NodeJS.ProcessEnv,
   timeoutMs: number,
   exactSecrets: Array<string | undefined | null> = [],
+  signal?: AbortSignal,
 ): Promise<string | null> {
+  if (signal?.aborted) return null;
   return new Promise<string | null>((resolve) => {
     let settled = false;
+    let abortHandler: (() => void) | null = null;
     const finish = (value: string | null) => {
       if (settled) return;
       settled = true;
+      if (abortHandler && signal) signal.removeEventListener('abort', abortHandler);
       resolve(value);
     };
     let child: ReturnType<typeof spawn>;
@@ -1291,6 +1295,18 @@ async function probeAgentBinaryVersion(
       finish(null);
     }, timeoutMs);
     timer.unref?.();
+    if (signal) {
+      abortHandler = () => {
+        clearTimeout(timer);
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // Already gone — nothing to do.
+        }
+        finish(null);
+      };
+      signal.addEventListener('abort', abortHandler, { once: true });
+    }
     let stdout = '';
     child.stdout?.setEncoding('utf8');
     child.stdout?.on('data', (chunk: string) => {
@@ -1479,7 +1495,9 @@ async function testAgentConnectionInternal(
     const latencyMs = Date.now() - start;
     recordStderr();
     const hasStreamOutput = sink.getText().trim().length > 0;
-    recordPhase(hasStreamOutput ? 'stream' : 'spawn');
+    if (diagState?.phase !== 'version_probe') {
+      recordPhase(hasStreamOutput ? 'stream' : 'spawn');
+    }
     console.warn(`[test:agent] ${def.name} → ${kind} in ${(latencyMs / 1000).toFixed(1)}s`);
     return {
       ok: false,
@@ -1525,12 +1543,17 @@ async function testAgentConnectionInternal(
     );
     const env = applyAgentLaunchEnv(baseEnv, executableResolution);
     if (diagState) {
+      recordPhase('version_probe');
       diagState.binaryVersion = await probeAgentBinaryVersion(
         executableResolution.launchPath,
         env,
         AGENT_VERSION_PROBE_TIMEOUT_MS,
         collectAgentSecretsFromEnv(env),
+        input.signal,
       );
+    }
+    if (input.signal?.aborted) {
+      return resultFromCancellation('aborted');
     }
     const auth = await probeAgentAuthStatus(input.agentId, executableResolution.launchPath, env);
     if (auth?.status === 'missing') {

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -205,6 +205,7 @@ function agentTimeoutMs(): number {
 }
 const AGENT_COMPLETION_DEBOUNCE_MS = 500;
 const AGENT_KILL_GRACE_MS = 2_000;
+const AGENT_VERSION_PROBE_TIMEOUT_MS = 2_000;
 // Truncates the assistant reply we surface in the success copy so a
 // chatty model can't dump kilobytes into the inline status node.
 const SAMPLE_MAX_CHARS = 120;
@@ -319,13 +320,14 @@ const ANSI_ESCAPE_RE = /\x1b\[[0-9;?]*[A-Za-z]/g;
 
 export function sanitizeStderrExcerpt(
   raw: string | null | undefined,
+  exactSecrets: Array<string | undefined | null> = [],
 ): string | null {
   if (typeof raw !== 'string') return null;
   const stripped = raw.replace(ANSI_ESCAPE_RE, '').replace(/\r/g, '');
-  const redacted = redactSecrets(stripped).trim();
+  const redacted = redactSecrets(stripped, exactSecrets).trim();
   if (redacted.length === 0) return null;
   if (redacted.length <= STDERR_EXCERPT_MAX_CHARS) return redacted;
-  return redacted.slice(redacted.length - STDERR_EXCERPT_MAX_CHARS);
+  return redacted.slice(0, STDERR_EXCERPT_MAX_CHARS);
 }
 
 interface RecoveryHintInput {
@@ -407,6 +409,7 @@ interface BuildAgentDiagnosticsInput {
   binaryPath: string | null;
   binaryVersion: string | null;
   stderrRaw: string | null;
+  agentSecrets?: Array<string | undefined | null>;
 }
 
 export function buildAgentDiagnostics(
@@ -418,7 +421,7 @@ export function buildAgentDiagnostics(
     phase: input.phase,
     binaryPath: input.binaryPath,
     binaryVersion: input.binaryVersion,
-    stderrExcerpt: sanitizeStderrExcerpt(input.stderrRaw),
+    stderrExcerpt: sanitizeStderrExcerpt(input.stderrRaw, input.agentSecrets),
     recoveryHints: recoveryHintsFor({
       phase: input.phase,
       kind: input.kind,
@@ -1236,6 +1239,64 @@ function delay(ms: number): Promise<void> {
   });
 }
 
+async function probeAgentBinaryVersion(
+  launchPath: string,
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+  exactSecrets: Array<string | undefined | null> = [],
+): Promise<string | null> {
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(launchPath, ['--version'], {
+        env,
+        stdio: ['ignore', 'pipe', 'ignore'],
+        shell: false,
+      });
+    } catch {
+      finish(null);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // Already gone — nothing to do.
+      }
+      finish(null);
+    }, timeoutMs);
+    timer.unref?.();
+    let stdout = '';
+    child.stdout?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      stdout += chunk;
+      if (stdout.length > 4_096) stdout = stdout.slice(0, 4_096);
+    });
+    child.once('error', () => {
+      clearTimeout(timer);
+      finish(null);
+    });
+    child.once('close', () => {
+      clearTimeout(timer);
+      const firstLine = stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find((line) => line.length > 0);
+      if (!firstLine) {
+        finish(null);
+        return;
+      }
+      finish(redactSecrets(firstLine, exactSecrets).slice(0, 200));
+    });
+  });
+}
+
 interface AgentDiagState {
   phase: ConnectionTestPhase;
   binaryPath: string | null;
@@ -1444,6 +1505,17 @@ async function testAgentConnectionInternal(
       configuredAgentEnv,
     );
     const env = applyAgentLaunchEnv(baseEnv, executableResolution);
+    if (diagState) {
+      const agentSecrets = Object.entries(configuredAgentEnv ?? {})
+        .filter(([k]) => /(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_PRIVATE_KEY|_SECRET_KEY|_ACCESS_KEY)$/i.test(k))
+        .map(([, v]) => v);
+      diagState.binaryVersion = await probeAgentBinaryVersion(
+        executableResolution.launchPath,
+        env,
+        AGENT_VERSION_PROBE_TIMEOUT_MS,
+        agentSecrets,
+      );
+    }
     const auth = await probeAgentAuthStatus(input.agentId, executableResolution.launchPath, env);
     if (auth?.status === 'missing') {
       recordPhase('auth_probe');
@@ -1769,6 +1841,10 @@ export async function testAgentConnection(
         diagnostic: null,
       };
 
+  const agentSecrets = Object.entries(configuredAgentEnv ?? {})
+    .filter(([k]) => /(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_PRIVATE_KEY|_SECRET_KEY|_ACCESS_KEY)$/i.test(k))
+    .map(([, v]) => v);
+
   const buildEnvelope = (
     finalKind: ConnectionTestKind,
     diag: AgentDiagState,
@@ -1783,6 +1859,7 @@ export async function testAgentConnection(
       binaryPath,
       binaryVersion: diag.binaryVersion,
       stderrRaw: diag.stderrRaw,
+      agentSecrets,
     });
   };
 

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1320,10 +1320,16 @@ async function probeAgentBinaryVersion(
     };
     let child: ReturnType<typeof spawn>;
     try {
-      child = spawn(launchPath, ['--version'], {
+      const invocation = createCommandInvocation({
+        command: launchPath,
+        args: ['--version'],
+        env,
+      });
+      child = spawn(invocation.command, invocation.args, {
         env,
         stdio: ['ignore', 'pipe', 'ignore'],
         shell: false,
+        windowsVerbatimArguments: invocation.windowsVerbatimArguments,
       });
     } catch {
       finish(null);

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -306,6 +306,25 @@ export function redactSecrets(
   return redacted;
 }
 
+const AGENT_SECRET_KEY_RE = /(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_PRIVATE_KEY|_SECRET_KEY|_ACCESS_KEY)$/i;
+
+// Source the exact-secrets list from the env actually handed to the child
+// (process.env + def.env + user-configured agent env), not just the user
+// slice — otherwise an OPENAI_API_KEY inherited from the daemon's own
+// process.env reaches the agent CLI but stays off the redaction list.
+export function collectAgentSecretsFromEnv(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> | null | undefined,
+): string[] {
+  if (!env) return [];
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(env)) {
+    if (typeof v !== 'string' || v.length === 0) continue;
+    if (!AGENT_SECRET_KEY_RE.test(k)) continue;
+    out.push(v);
+  }
+  return out;
+}
+
 // Diagnostics envelope helpers. Pure functions: no I/O, no
 // process.env reads, safe to exercise as plain unit tests. The agent
 // connection test attaches the result to every agent-mode response so the
@@ -1506,14 +1525,11 @@ async function testAgentConnectionInternal(
     );
     const env = applyAgentLaunchEnv(baseEnv, executableResolution);
     if (diagState) {
-      const agentSecrets = Object.entries(configuredAgentEnv ?? {})
-        .filter(([k]) => /(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_PRIVATE_KEY|_SECRET_KEY|_ACCESS_KEY)$/i.test(k))
-        .map(([, v]) => v);
       diagState.binaryVersion = await probeAgentBinaryVersion(
         executableResolution.launchPath,
         env,
         AGENT_VERSION_PROBE_TIMEOUT_MS,
-        agentSecrets,
+        collectAgentSecretsFromEnv(env),
       );
     }
     const auth = await probeAgentAuthStatus(input.agentId, executableResolution.launchPath, env);
@@ -1841,9 +1857,17 @@ export async function testAgentConnection(
         diagnostic: null,
       };
 
-  const agentSecrets = Object.entries(configuredAgentEnv ?? {})
-    .filter(([k]) => /(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_PRIVATE_KEY|_SECRET_KEY|_ACCESS_KEY)$/i.test(k))
-    .map(([, v]) => v);
+  const spawnedEnv = def
+    ? applyAgentLaunchEnv(
+        spawnEnvForAgent(
+          input.agentId,
+          { ...process.env, ...(def.env || {}) },
+          configuredAgentEnv,
+        ),
+        executableResolution,
+      )
+    : { ...process.env, ...configuredAgentEnv };
+  const agentSecrets = collectAgentSecretsFromEnv(spawnedEnv);
 
   const buildEnvelope = (
     finalKind: ConnectionTestKind,

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -48,7 +48,9 @@ import {
   validateBaseUrl,
   type AgentTestRequest,
   type BaseUrlValidationResult,
+  type ConnectionTestDiagnostics,
   type ConnectionTestKind,
+  type ConnectionTestPhase,
   type ConnectionTestProtocol,
   type ConnectionTestResponse,
   type ParsedBaseUrl,
@@ -301,6 +303,128 @@ export function redactSecrets(
     redacted = redacted.replace(new RegExp(escapeRegExp(secret), 'g'), '[REDACTED]');
   }
   return redacted;
+}
+
+// Diagnostics envelope helpers. Pure functions: no I/O, no
+// process.env reads, safe to exercise as plain unit tests. The agent
+// connection test attaches the result to every agent-mode response so the
+// Settings dialog and `od agent test` CLI can render an actionable error
+// without parsing the free-form `detail` string.
+
+export const STDERR_EXCERPT_MAX_CHARS = 500;
+
+// CSI (`\x1b[…<final>`) and a few private-mode sequences common in CLI
+// output (`\x1b[?25l` cursor toggles, `\x1b[?1049h` alternate screen).
+const ANSI_ESCAPE_RE = /\x1b\[[0-9;?]*[A-Za-z]/g;
+
+export function sanitizeStderrExcerpt(
+  raw: string | null | undefined,
+): string | null {
+  if (typeof raw !== 'string') return null;
+  const stripped = raw.replace(ANSI_ESCAPE_RE, '').replace(/\r/g, '');
+  const redacted = redactSecrets(stripped).trim();
+  if (redacted.length === 0) return null;
+  if (redacted.length <= STDERR_EXCERPT_MAX_CHARS) return redacted;
+  return redacted.slice(redacted.length - STDERR_EXCERPT_MAX_CHARS);
+}
+
+interface RecoveryHintInput {
+  phase: ConnectionTestPhase;
+  kind: ConnectionTestKind;
+  agentId: string;
+}
+
+const AGENT_INSTALL_URL = 'https://github.com/nexu-io/open-design#local-agents';
+
+function claudeAuthHints(): string[] {
+  return [
+    'Run `claude /login` to refresh your Anthropic credentials, then retry.',
+    'If you keep multiple Anthropic profiles, point CLAUDE_CONFIG_DIR at the correct directory before retesting.',
+  ];
+}
+
+function codexAuthHints(): string[] {
+  return [
+    'Run `codex login` to refresh your Codex credentials, or set CODEX_API_KEY in Settings → CLI environment.',
+  ];
+}
+
+function authHintsFor(agentId: string): string[] {
+  if (agentId === 'claude') return claudeAuthHints();
+  if (agentId === 'codex') return codexAuthHints();
+  return [
+    `Re-authenticate your ${agentId} CLI (run its login subcommand or refresh its credentials) and retry the test.`,
+  ];
+}
+
+function spawnFailureHints(agentId: string): string[] {
+  const hints = [
+    `Your ${agentId} CLI may be outdated; reinstall or upgrade it from your package manager (for example, \`brew upgrade ${agentId}\` or \`npm install -g ${agentId}\`).`,
+    `Inspect the captured stderr for the exit reason, then rerun \`${agentId} --version\` from the same terminal Open Design was launched from.`,
+  ];
+  if (agentId === 'codex') {
+    hints.push('If you set a custom CODEX_BIN, verify the file exists and is executable, or clear the override in Settings.');
+  }
+  return hints;
+}
+
+export function recoveryHintsFor(args: RecoveryHintInput): string[] {
+  const { phase, kind, agentId } = args;
+  if (kind === 'success') return [];
+  let hints: string[];
+  if (phase === 'binary_resolution' || kind === 'agent_not_installed') {
+    hints = [
+      `Install the ${agentId} CLI and make sure it is on your PATH, then click Test again.`,
+      `See the local-agents setup guide: ${AGENT_INSTALL_URL}`,
+    ];
+  } else if (phase === 'auth_probe' || kind === 'agent_auth_required') {
+    hints = authHintsFor(agentId);
+  } else if (kind === 'not_found_model' || phase === 'model_listing') {
+    hints = [
+      `The requested model is not advertised by the ${agentId} CLI. Pick a different model in Settings, or upgrade the CLI to a build that exposes it.`,
+      `Run \`${agentId} --version\` and compare with the model's release notes before retrying.`,
+    ];
+  } else if (kind === 'timeout') {
+    hints = [
+      `The ${agentId} CLI did not produce output within the test budget. Cold-starting heavy adapters can take 5–10 s — try again, or set OD_CONNECTION_TEST_AGENT_TIMEOUT_MS to extend the wait.`,
+    ];
+  } else if (phase === 'version_probe' || phase === 'spawn') {
+    hints = spawnFailureHints(agentId);
+  } else {
+    hints = [
+      `The ${agentId} CLI failed during the ${phase} phase. Inspect the captured stderr below for the exact error, then retry.`,
+      `Run \`${agentId} --version\` directly from a terminal to confirm the CLI is healthy.`,
+    ];
+  }
+  return hints.slice(0, 5).map((h) => (h.length > 200 ? `${h.slice(0, 199)}…` : h));
+}
+
+interface BuildAgentDiagnosticsInput {
+  agentId: string;
+  agentName: string;
+  kind: ConnectionTestKind;
+  phase: ConnectionTestPhase;
+  binaryPath: string | null;
+  binaryVersion: string | null;
+  stderrRaw: string | null;
+}
+
+export function buildAgentDiagnostics(
+  input: BuildAgentDiagnosticsInput,
+): ConnectionTestDiagnostics {
+  return {
+    agentId: input.agentId,
+    agentName: input.agentName || input.agentId,
+    phase: input.phase,
+    binaryPath: input.binaryPath,
+    binaryVersion: input.binaryVersion,
+    stderrExcerpt: sanitizeStderrExcerpt(input.stderrRaw),
+    recoveryHints: recoveryHintsFor({
+      phase: input.phase,
+      kind: input.kind,
+      agentId: input.agentId,
+    }),
+  };
 }
 
 type ProviderConnectionInput = ProviderTestRequest & { signal?: AbortSignal };
@@ -994,7 +1118,10 @@ export function createAgentSink(): AgentSink {
     if (event === 'stderr') {
       const chunk = data.chunk;
       if (typeof chunk === 'string') {
-        stderrTail = (stderrTail + chunk).slice(-400);
+        // Keep more headroom than the sanitizer's truncation budget so an
+        // ANSI escape sequence straddling the previous chunk boundary still
+        // arrives intact for `sanitizeStderrExcerpt` to strip cleanly.
+        stderrTail = (stderrTail + chunk).slice(-(STDERR_EXCERPT_MAX_CHARS + 100));
       }
       return;
     }
@@ -1109,8 +1236,17 @@ function delay(ms: number): Promise<void> {
   });
 }
 
+interface AgentDiagState {
+  phase: ConnectionTestPhase;
+  binaryPath: string | null;
+  binaryVersion: string | null;
+  agentName: string;
+  stderrRaw: string | null;
+}
+
 async function testAgentConnectionInternal(
   input: AgentConnectionInput,
+  diagState?: AgentDiagState,
 ): Promise<ConnectionTestResponse> {
   const start = Date.now();
   const model =
@@ -1119,6 +1255,11 @@ async function testAgentConnectionInternal(
       : 'default';
   const def = getAgentDef(input.agentId);
   if (!def) {
+    if (diagState) {
+      diagState.phase = 'binary_resolution';
+      diagState.binaryPath = null;
+      diagState.agentName = input.agentId;
+    }
     return {
       ok: false,
       kind: 'agent_not_installed',
@@ -1134,7 +1275,15 @@ async function testAgentConnectionInternal(
   );
   const executableResolution = resolveAgentLaunch(def, configuredAgentEnv);
   const resolvedBin = executableResolution.selectedPath;
+  if (diagState) {
+    diagState.agentName = def.name;
+    diagState.binaryPath = executableResolution.launchPath ?? null;
+  }
   if (!resolvedBin || !executableResolution.launchPath) {
+    if (diagState) {
+      diagState.phase = 'binary_resolution';
+      diagState.binaryPath = null;
+    }
     return {
       ok: false,
       kind: 'agent_not_installed',
@@ -1151,12 +1300,22 @@ async function testAgentConnectionInternal(
   let timer: ReturnType<typeof setTimeout> | null = null;
   let abortHandler: (() => void) | null = null;
   const sink = createAgentSink();
+  const recordStderr = () => {
+    if (!diagState) return;
+    const tail = sink.getStderrTail();
+    diagState.stderrRaw = tail.length > 0 ? tail : null;
+  };
+  const recordPhase = (phase: ConnectionTestPhase) => {
+    if (diagState) diagState.phase = phase;
+  };
 
   const resultFromAgentText = (text: string): ConnectionTestResponse => {
     const latencyMs = Date.now() - start;
     const rawSample = truncateSample(text);
     const sample = redactSecrets(rawSample);
+    recordStderr();
     if (rawSample && isLikelyModelErrorText(rawSample)) {
+      recordPhase('model_listing');
       const detail = redactSecrets(smokeFailureDetail(rawSample));
       console.warn(
         `[test:agent] ${def.name} → not_found_model: ${detail}`,
@@ -1170,6 +1329,7 @@ async function testAgentConnectionInternal(
         detail,
       };
     }
+    recordPhase('stream');
     if (!isSmokeOkReply(text)) {
       console.warn(
         `[test:agent] ${def.name} → connected_unexpected_sample: ${sample}`,
@@ -1191,8 +1351,10 @@ async function testAgentConnectionInternal(
     const detail = redactSecrets(
       error instanceof Error ? error.message : String(error),
     );
+    recordStderr();
     const auth = classifyAgentAuthFailure(input.agentId, detail);
     if (auth?.status === 'missing') {
+      recordPhase('auth_probe');
       console.warn(`[test:agent] ${def.name} → auth_required: ${detail}`);
       return {
         ok: false,
@@ -1204,6 +1366,7 @@ async function testAgentConnectionInternal(
       };
     }
     if (detail && isLikelyModelErrorText(detail)) {
+      recordPhase('model_listing');
       console.warn(
         `[test:agent] ${def.name} → not_found_model: ${detail}`,
       );
@@ -1216,6 +1379,7 @@ async function testAgentConnectionInternal(
         detail,
       };
     }
+    recordPhase('stream');
     console.warn(
       `[test:agent] ${def.name} → stream_error: ${detail}`,
     );
@@ -1233,6 +1397,9 @@ async function testAgentConnectionInternal(
     kind: 'timeout' | 'aborted',
   ): ConnectionTestResponse => {
     const latencyMs = Date.now() - start;
+    recordStderr();
+    const hasStreamOutput = sink.getText().trim().length > 0;
+    recordPhase(hasStreamOutput ? 'stream' : 'spawn');
     console.warn(`[test:agent] ${def.name} → ${kind} in ${(latencyMs / 1000).toFixed(1)}s`);
     return {
       ok: false,
@@ -1255,6 +1422,8 @@ async function testAgentConnectionInternal(
       );
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
+      recordPhase('spawn');
+      recordStderr();
       return {
         ok: false,
         kind: 'agent_spawn_failed',
@@ -1277,6 +1446,8 @@ async function testAgentConnectionInternal(
     const env = applyAgentLaunchEnv(baseEnv, executableResolution);
     const auth = await probeAgentAuthStatus(input.agentId, executableResolution.launchPath, env);
     if (auth?.status === 'missing') {
+      recordPhase('auth_probe');
+      recordStderr();
       return {
         ok: false,
         kind: 'agent_auth_required',
@@ -1334,6 +1505,8 @@ async function testAgentConnectionInternal(
         );
         const errnoCode = (winner.error as NodeJS.ErrnoException).code;
         const isMissing = errnoCode === 'ENOENT';
+        recordPhase(isMissing ? 'binary_resolution' : 'spawn');
+        recordStderr();
         console.warn(
           `[test:agent] ${def.name} → spawn_failed: ${detail}${guidance}`,
         );
@@ -1393,6 +1566,8 @@ async function testAgentConnectionInternal(
         .join(' · ');
       const auth = classifyAgentAuthFailure(input.agentId, rawDetail);
       if (auth?.status === 'missing') {
+        recordPhase('auth_probe');
+        recordStderr();
         console.warn(`[test:agent] ${def.name} → auth_required: ${redactSecrets(rawDetail)}`);
         return {
           ok: false,
@@ -1412,6 +1587,8 @@ async function testAgentConnectionInternal(
         env,
       });
       if (claudeDiagnostic) {
+        recordPhase(buffered ? 'stream' : 'spawn');
+        recordStderr();
         console.warn(
           `[test:agent] ${def.name} → claude_diagnostic: ${claudeDiagnostic.detail}`,
         );
@@ -1435,6 +1612,8 @@ async function testAgentConnectionInternal(
         )}${executableResolution.diagnostic ? ` ${executableResolution.diagnostic}` : ''}`,
       );
       const label = buffered ? 'exit_failed' : 'no_text';
+      recordPhase(buffered ? 'stream' : 'spawn');
+      recordStderr();
       console.warn(
         `[test:agent] ${def.name} → ${label} (${detail || 'no detail'}${guidance})`,
       );
@@ -1502,6 +1681,8 @@ async function testAgentConnectionInternal(
     return resultFromChildExit(winner);
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
+    recordPhase('spawn');
+    recordStderr();
     return {
       ok: false,
       kind: 'agent_spawn_failed',
@@ -1550,10 +1731,28 @@ async function testAgentConnectionInternal(
   }
 }
 
+function freshDiagState(agentId: string): AgentDiagState {
+  return {
+    phase: 'binary_resolution',
+    binaryPath: null,
+    binaryVersion: null,
+    agentName: agentId,
+    stderrRaw: null,
+  };
+}
+
+function attachDiagnostics(
+  response: ConnectionTestResponse,
+  envelope: ConnectionTestDiagnostics,
+): ConnectionTestResponse {
+  return { ...response, diagnostics: envelope };
+}
+
 export async function testAgentConnection(
   input: AgentConnectionInput,
 ): Promise<ConnectionTestResponse> {
-  const primaryResult = await testAgentConnectionInternal(input);
+  const primaryDiag = freshDiagState(input.agentId);
+  const primaryResult = await testAgentConnectionInternal(input, primaryDiag);
   const validatedPrefs = validateAgentCliEnv(input.agentCliEnv);
   const configuredCodexBin = validatedPrefs?.codex?.CODEX_BIN?.trim() || '';
   const configuredAgentEnv = agentCliEnvForAgent(validatedPrefs, input.agentId);
@@ -1569,16 +1768,37 @@ export async function testAgentConnection(
         childPathPrepend: [],
         diagnostic: null,
       };
+
+  const buildEnvelope = (
+    finalKind: ConnectionTestKind,
+    diag: AgentDiagState,
+    overrideBinaryPath?: string | null,
+  ): ConnectionTestDiagnostics => {
+    const binaryPath = overrideBinaryPath !== undefined ? overrideBinaryPath : diag.binaryPath;
+    return buildAgentDiagnostics({
+      agentId: input.agentId,
+      agentName: diag.agentName,
+      kind: finalKind,
+      phase: diag.phase,
+      binaryPath,
+      binaryVersion: diag.binaryVersion,
+      stderrRaw: diag.stderrRaw,
+    });
+  };
+
   if (
     input.agentId === 'codex' &&
     primaryResult.ok &&
     configuredCodexBin
   ) {
     if (executableResolution.configuredOverridePath) {
-      return {
+      const usedPath =
+        executableResolution.launchPath ?? executableResolution.configuredOverridePath;
+      const envelope = buildEnvelope(primaryResult.kind, primaryDiag, usedPath);
+      return attachDiagnostics({
         ...primaryResult,
         configuredExecutablePath: executableResolution.configuredOverridePath,
-        usedExecutablePath: executableResolution.launchPath ?? executableResolution.configuredOverridePath,
+        usedExecutablePath: usedPath,
         usedExecutableSource: 'configured',
         ...(executableResolution.pathResolvedPath
           ? { detectedExecutablePath: executableResolution.pathResolvedPath }
@@ -1588,14 +1808,17 @@ export async function testAgentConnection(
             executableResolution.configuredOverridePath,
           ),
         ),
-      };
+      }, envelope);
     }
     if (executableResolution.pathResolvedPath) {
-      return {
+      const usedPath =
+        executableResolution.launchPath ?? executableResolution.pathResolvedPath;
+      const envelope = buildEnvelope(primaryResult.kind, primaryDiag, usedPath);
+      return attachDiagnostics({
         ...primaryResult,
         configuredExecutablePath: configuredCodexBin,
         detectedExecutablePath: executableResolution.pathResolvedPath,
-        usedExecutablePath: executableResolution.launchPath ?? executableResolution.pathResolvedPath,
+        usedExecutablePath: usedPath,
         usedExecutableSource: 'fallback_invalid',
         detail: redactSecrets(
           codexInvalidConfiguredPathFallbackDetail(
@@ -1603,7 +1826,7 @@ export async function testAgentConnection(
             executableResolution.pathResolvedPath,
           ),
         ),
-      };
+      }, envelope);
     }
   }
   if (
@@ -1614,22 +1837,29 @@ export async function testAgentConnection(
     !executableResolution.pathResolvedPath ||
     executableResolution.configuredOverridePath === executableResolution.pathResolvedPath
   ) {
-    return primaryResult;
+    const envelope = buildEnvelope(primaryResult.kind, primaryDiag);
+    return attachDiagnostics(primaryResult, envelope);
   }
+  const fallbackDiag = freshDiagState(input.agentId);
   const fallbackResult = await testAgentConnectionInternal(
     {
       ...input,
       agentCliEnv: stripCodexBinOverride(validatedPrefs),
     },
+    fallbackDiag,
   );
   if (!fallbackResult.ok) {
-    return primaryResult;
+    const envelope = buildEnvelope(primaryResult.kind, primaryDiag);
+    return attachDiagnostics(primaryResult, envelope);
   }
-  return {
+  const usedPath =
+    executableResolution.launchPath ?? executableResolution.pathResolvedPath;
+  const envelope = buildEnvelope(fallbackResult.kind, fallbackDiag, usedPath);
+  return attachDiagnostics({
     ...fallbackResult,
     configuredExecutablePath: executableResolution.configuredOverridePath,
     detectedExecutablePath: executableResolution.pathResolvedPath,
-    usedExecutablePath: executableResolution.launchPath ?? executableResolution.pathResolvedPath,
+    usedExecutablePath: usedPath,
     usedExecutableSource: 'fallback_failed',
     detail: redactSecrets(
       codexExecutableFallbackSuccessDetail(
@@ -1637,5 +1867,5 @@ export async function testAgentConnection(
         executableResolution.pathResolvedPath,
       ),
     ),
-  };
+  }, envelope);
 }

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1930,7 +1930,9 @@ export async function testAgentConnection(
     return attachDiagnostics(primaryResult, envelope);
   }
   const usedPath =
-    executableResolution.launchPath ?? executableResolution.pathResolvedPath;
+    fallbackDiag.binaryPath ??
+    executableResolution.launchPath ??
+    executableResolution.pathResolvedPath;
   const envelope = buildEnvelope(fallbackResult.kind, fallbackDiag, usedPath);
   return attachDiagnostics({
     ...fallbackResult,

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -337,13 +337,16 @@ export const STDERR_EXCERPT_MAX_CHARS = 500;
 // output (`\x1b[?25l` cursor toggles, `\x1b[?1049h` alternate screen).
 const ANSI_ESCAPE_RE = /\x1b\[[0-9;?]*[A-Za-z]/g;
 
+// Pattern-based redaction stays here as defense in depth (Bearer / header /
+// query). Exact-secret scrubbing runs at the response boundary instead — see
+// redactConnectionTestResponse — so every text field of a connection-test
+// response is covered without each producer threading the secret list.
 export function sanitizeStderrExcerpt(
   raw: string | null | undefined,
-  exactSecrets: Array<string | undefined | null> = [],
 ): string | null {
   if (typeof raw !== 'string') return null;
   const stripped = raw.replace(ANSI_ESCAPE_RE, '').replace(/\r/g, '');
-  const redacted = redactSecrets(stripped, exactSecrets).trim();
+  const redacted = redactSecrets(stripped).trim();
   if (redacted.length === 0) return null;
   if (redacted.length <= STDERR_EXCERPT_MAX_CHARS) return redacted;
   return redacted.slice(0, STDERR_EXCERPT_MAX_CHARS);
@@ -428,7 +431,6 @@ interface BuildAgentDiagnosticsInput {
   binaryPath: string | null;
   binaryVersion: string | null;
   stderrRaw: string | null;
-  agentSecrets?: Array<string | undefined | null>;
 }
 
 export function buildAgentDiagnostics(
@@ -440,13 +442,54 @@ export function buildAgentDiagnostics(
     phase: input.phase,
     binaryPath: input.binaryPath,
     binaryVersion: input.binaryVersion,
-    stderrExcerpt: sanitizeStderrExcerpt(input.stderrRaw, input.agentSecrets),
+    stderrExcerpt: sanitizeStderrExcerpt(input.stderrRaw),
     recoveryHints: recoveryHintsFor({
       phase: input.phase,
       kind: input.kind,
       agentId: input.agentId,
     }),
   };
+}
+
+// Apply exact-secret redaction to every string-valued field of a connection
+// test response — detail, sample, agentName, executable-path diagnostics, and
+// the structured diagnostics envelope. Pattern-based scrubbing already runs
+// inside each producer; this boundary helper closes the gaps where a bare
+// configured secret value (e.g. an OPENAI_API_KEY echoed verbatim into stderr
+// or a CLI's stdout reply) would otherwise reach the caller unredacted.
+export function redactConnectionTestResponse(
+  result: ConnectionTestResponse,
+  agentSecrets: Array<string | undefined | null>,
+): ConnectionTestResponse {
+  const scrub = (value: string | undefined): string | undefined =>
+    typeof value === 'string' ? redactSecrets(value, agentSecrets) : value;
+  const out: ConnectionTestResponse = {
+    ...result,
+    ...(result.sample !== undefined ? { sample: scrub(result.sample)! } : {}),
+    ...(result.agentName !== undefined ? { agentName: scrub(result.agentName)! } : {}),
+    ...(result.detail !== undefined ? { detail: scrub(result.detail)! } : {}),
+    ...(result.configuredExecutablePath !== undefined
+      ? { configuredExecutablePath: scrub(result.configuredExecutablePath)! }
+      : {}),
+    ...(result.detectedExecutablePath !== undefined
+      ? { detectedExecutablePath: scrub(result.detectedExecutablePath)! }
+      : {}),
+    ...(result.usedExecutablePath !== undefined
+      ? { usedExecutablePath: scrub(result.usedExecutablePath)! }
+      : {}),
+  };
+  if (result.diagnostics) {
+    const d = result.diagnostics;
+    out.diagnostics = {
+      ...d,
+      agentName: redactSecrets(d.agentName, agentSecrets),
+      binaryPath: typeof d.binaryPath === 'string' ? redactSecrets(d.binaryPath, agentSecrets) : d.binaryPath,
+      binaryVersion: typeof d.binaryVersion === 'string' ? redactSecrets(d.binaryVersion, agentSecrets) : d.binaryVersion,
+      stderrExcerpt: typeof d.stderrExcerpt === 'string' ? redactSecrets(d.stderrExcerpt, agentSecrets) : d.stderrExcerpt,
+      recoveryHints: d.recoveryHints.map((h) => redactSecrets(h, agentSecrets)),
+    };
+  }
+  return out;
 }
 
 type ProviderConnectionInput = ProviderTestRequest & { signal?: AbortSignal };
@@ -1263,7 +1306,6 @@ async function probeAgentBinaryVersion(
   launchPath: string,
   env: NodeJS.ProcessEnv,
   timeoutMs: number,
-  exactSecrets: Array<string | undefined | null> = [],
   signal?: AbortSignal,
 ): Promise<string | null> {
   if (signal?.aborted) return null;
@@ -1328,7 +1370,7 @@ async function probeAgentBinaryVersion(
         finish(null);
         return;
       }
-      finish(redactSecrets(firstLine, exactSecrets).slice(0, 200));
+      finish(redactSecrets(firstLine).slice(0, 200));
     });
   });
 }
@@ -1549,7 +1591,6 @@ async function testAgentConnectionInternal(
         executableResolution.launchPath,
         env,
         AGENT_VERSION_PROBE_TIMEOUT_MS,
-        collectAgentSecretsFromEnv(env),
         input.signal,
       );
     }
@@ -1907,9 +1948,13 @@ export async function testAgentConnection(
       binaryPath,
       binaryVersion: diag.binaryVersion,
       stderrRaw: diag.stderrRaw,
-      agentSecrets,
     });
   };
+  const finalize = (
+    response: ConnectionTestResponse,
+    envelope: ConnectionTestDiagnostics,
+  ): ConnectionTestResponse =>
+    redactConnectionTestResponse(attachDiagnostics(response, envelope), agentSecrets);
 
   if (
     input.agentId === 'codex' &&
@@ -1920,7 +1965,7 @@ export async function testAgentConnection(
       const usedPath =
         executableResolution.launchPath ?? executableResolution.configuredOverridePath;
       const envelope = buildEnvelope(primaryResult.kind, primaryDiag, usedPath);
-      return attachDiagnostics({
+      return finalize({
         ...primaryResult,
         configuredExecutablePath: executableResolution.configuredOverridePath,
         usedExecutablePath: usedPath,
@@ -1928,10 +1973,8 @@ export async function testAgentConnection(
         ...(executableResolution.pathResolvedPath
           ? { detectedExecutablePath: executableResolution.pathResolvedPath }
           : {}),
-        detail: redactSecrets(
-          codexConfiguredPathSuccessDetail(
-            executableResolution.configuredOverridePath,
-          ),
+        detail: codexConfiguredPathSuccessDetail(
+          executableResolution.configuredOverridePath,
         ),
       }, envelope);
     }
@@ -1939,17 +1982,15 @@ export async function testAgentConnection(
       const usedPath =
         executableResolution.launchPath ?? executableResolution.pathResolvedPath;
       const envelope = buildEnvelope(primaryResult.kind, primaryDiag, usedPath);
-      return attachDiagnostics({
+      return finalize({
         ...primaryResult,
         configuredExecutablePath: configuredCodexBin,
         detectedExecutablePath: executableResolution.pathResolvedPath,
         usedExecutablePath: usedPath,
         usedExecutableSource: 'fallback_invalid',
-        detail: redactSecrets(
-          codexInvalidConfiguredPathFallbackDetail(
-            configuredCodexBin,
-            executableResolution.pathResolvedPath,
-          ),
+        detail: codexInvalidConfiguredPathFallbackDetail(
+          configuredCodexBin,
+          executableResolution.pathResolvedPath,
         ),
       }, envelope);
     }
@@ -1963,7 +2004,7 @@ export async function testAgentConnection(
     executableResolution.configuredOverridePath === executableResolution.pathResolvedPath
   ) {
     const envelope = buildEnvelope(primaryResult.kind, primaryDiag);
-    return attachDiagnostics(primaryResult, envelope);
+    return finalize(primaryResult, envelope);
   }
   const fallbackDiag = freshDiagState(input.agentId);
   const fallbackResult = await testAgentConnectionInternal(
@@ -1975,24 +2016,22 @@ export async function testAgentConnection(
   );
   if (!fallbackResult.ok) {
     const envelope = buildEnvelope(primaryResult.kind, primaryDiag);
-    return attachDiagnostics(primaryResult, envelope);
+    return finalize(primaryResult, envelope);
   }
   const usedPath =
     fallbackDiag.binaryPath ??
     executableResolution.launchPath ??
     executableResolution.pathResolvedPath;
   const envelope = buildEnvelope(fallbackResult.kind, fallbackDiag, usedPath);
-  return attachDiagnostics({
+  return finalize({
     ...fallbackResult,
     configuredExecutablePath: executableResolution.configuredOverridePath,
     detectedExecutablePath: executableResolution.pathResolvedPath,
     usedExecutablePath: usedPath,
     usedExecutableSource: 'fallback_failed',
-    detail: redactSecrets(
-      codexExecutableFallbackSuccessDetail(
-        executableResolution.configuredOverridePath,
-        executableResolution.pathResolvedPath,
-      ),
+    detail: codexExecutableFallbackSuccessDetail(
+      executableResolution.configuredOverridePath,
+      executableResolution.pathResolvedPath,
     ),
   }, envelope);
 }

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1040,7 +1040,7 @@ interface AgentSink {
   result: Promise<AgentSinkResult>;
   streamError: Promise<Error>;
   getText: () => string;
-  getStderrTail: () => string;
+  getStderrCapture: () => string;
   appendRawStdout: (chunk: string) => void;
   getRawStdoutTail: () => string;
   dispose: () => void;
@@ -1048,7 +1048,7 @@ interface AgentSink {
 
 export function createAgentSink(): AgentSink {
   let buffer = '';
-  let stderrTail = '';
+  let stderrCapture = '';
   let rawStdoutTail = '';
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let resolveResult!: (value: AgentSinkResult) => void;
@@ -1139,11 +1139,12 @@ export function createAgentSink(): AgentSink {
     }
     if (event === 'stderr') {
       const chunk = data.chunk;
-      if (typeof chunk === 'string') {
-        // Keep more headroom than the sanitizer's truncation budget so an
-        // ANSI escape sequence straddling the previous chunk boundary still
-        // arrives intact for `sanitizeStderrExcerpt` to strip cleanly.
-        stderrTail = (stderrTail + chunk).slice(-(STDERR_EXCERPT_MAX_CHARS + 100));
+      if (typeof chunk === 'string' && chunk.length > 0) {
+        const budget = STDERR_EXCERPT_MAX_CHARS + 100;
+        const room = budget - stderrCapture.length;
+        if (room > 0) {
+          stderrCapture += chunk.length > room ? chunk.slice(0, room) : chunk;
+        }
       }
       return;
     }
@@ -1156,7 +1157,7 @@ export function createAgentSink(): AgentSink {
     result,
     streamError,
     getText: () => buffer,
-    getStderrTail: () => stderrTail,
+    getStderrCapture: () => stderrCapture,
     appendRawStdout,
     getRawStdoutTail: () => rawStdoutTail,
     dispose: () => {
@@ -1398,8 +1399,8 @@ async function testAgentConnectionInternal(
   const sink = createAgentSink();
   const recordStderr = () => {
     if (!diagState) return;
-    const tail = sink.getStderrTail();
-    diagState.stderrRaw = tail.length > 0 ? tail : null;
+    const capture = sink.getStderrCapture();
+    diagState.stderrRaw = capture.length > 0 ? capture : null;
   };
   const recordPhase = (phase: ConnectionTestPhase) => {
     if (diagState) diagState.phase = phase;
@@ -1662,13 +1663,13 @@ async function testAgentConnectionInternal(
         }
         if (exitedCleanly) return resultFromAgentText(buffered);
       }
-      const stderrTail = sink.getStderrTail().trim();
+      const stderrCapture = sink.getStderrCapture().trim();
       const rawStdoutTail = sink.getRawStdoutTail().trim();
       const acpFatal = Boolean(acpSession?.hasFatalError?.());
       const rawDetail = [
         winner.code != null ? `exit ${winner.code}` : null,
         winner.signal ? `signal ${winner.signal}` : null,
-        stderrTail ? `stderr: ${stderrTail.slice(-200)}` : null,
+        stderrCapture ? `stderr: ${stderrCapture.slice(-200)}` : null,
         rawStdoutTail || buffered
           ? `stdout: ${(rawStdoutTail || buffered).slice(-200)}`
           : null,
@@ -1693,7 +1694,7 @@ async function testAgentConnectionInternal(
         agentId: input.agentId,
         exitCode: winner.code,
         signal: winner.signal,
-        stderrTail,
+        stderrTail: stderrCapture,
         stdoutTail: rawStdoutTail || buffered,
         env,
       });

--- a/apps/daemon/tests/agent-cli.test.ts
+++ b/apps/daemon/tests/agent-cli.test.ts
@@ -1,0 +1,83 @@
+import { execFile } from 'node:child_process';
+import http from 'node:http';
+import path from 'node:path';
+import url from 'node:url';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const CLI_SRC = path.join(__dirname, '../src/cli.ts');
+const TSX_CLI = path.join(REPO_ROOT, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+const execFileP = promisify(execFile);
+
+let server: http.Server;
+let baseUrl: string;
+let lastBody: Record<string, unknown> | null = null;
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk) => { raw += chunk; });
+    req.on('end', () => {
+      try { lastBody = JSON.parse(raw); } catch { lastBody = null; }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        ok: true,
+        kind: 'claude',
+        agentName: 'Claude',
+        diagnostics: { phase: 'binary', binaryPath: '/usr/local/bin/claude' },
+      }));
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('server did not bind');
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  const env = { ...process.env };
+  delete env.OD_DAEMON_URL;
+  delete env.OD_SIDECAR_IPC_PATH;
+  delete env.NODE_OPTIONS;
+  try {
+    const { stdout, stderr } = await execFileP(
+      process.execPath,
+      [TSX_CLI, CLI_SRC, ...args],
+      { env, timeout: 15_000, maxBuffer: 4 * 1024 * 1024 },
+    );
+    return { stdout: String(stdout), stderr: String(stderr), code: 0 };
+  } catch (err) {
+    const failure = err as { stdout?: string; stderr?: string; code?: number };
+    return {
+      stdout: String(failure.stdout ?? ''),
+      stderr: String(failure.stderr ?? ''),
+      code: typeof failure.code === 'number' ? failure.code : 1,
+    };
+  }
+}
+
+describe('od agent test positional parsing', () => {
+  it('sends the positional agent id to /api/test/connection when --daemon-url precedes it', async () => {
+    lastBody = null;
+    const result = await runCli(['agent', 'test', '--daemon-url', baseUrl, 'codex', '--json']);
+    expect(result.code).toBe(0);
+    const captured = lastBody as Record<string, unknown> | null;
+    expect(captured?.agentId).toBe('codex');
+  });
+
+  it('exits with usage when no positional agent id is provided', async () => {
+    lastBody = null;
+    const result = await runCli(['agent', 'test', '--daemon-url', baseUrl, '--model', 'gpt-4', '--json']);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('Usage: od agent test');
+    expect(lastBody).toBeNull();
+  });
+});

--- a/apps/daemon/tests/agent-cli.test.ts
+++ b/apps/daemon/tests/agent-cli.test.ts
@@ -80,4 +80,26 @@ describe('od agent test positional parsing', () => {
     expect(result.stderr).toContain('Usage: od agent test');
     expect(lastBody).toBeNull();
   });
+
+  it('exits with usage when an unknown flag is passed', async () => {
+    lastBody = null;
+    const result = await runCli(['agent', 'test', '--bogus', 'codex']);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('od agent test:');
+    expect(result.stderr).toContain('unknown flag: --bogus');
+    expect(result.stderr).toContain('Usage:');
+    expect(result.stderr).toContain('od agent test <agentId>');
+    expect(lastBody).toBeNull();
+  });
+
+  it('exits with usage when a string flag is missing its value', async () => {
+    lastBody = null;
+    const result = await runCli(['agent', 'test', '--daemon-url']);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('od agent test:');
+    expect(result.stderr).toContain('flag --daemon-url requires a value');
+    expect(result.stderr).toContain('Usage:');
+    expect(result.stderr).toContain('od agent test <agentId>');
+    expect(lastBody).toBeNull();
+  });
 });

--- a/apps/daemon/tests/connection-test-diagnostics.test.ts
+++ b/apps/daemon/tests/connection-test-diagnostics.test.ts
@@ -74,11 +74,22 @@ describe('sanitizeStderrExcerpt', () => {
     expect(sanitizeStderrExcerpt('start\x1b[?25lend')).toBe('startend');
   });
 
-  it('truncates output to the configured max length by character count', () => {
-    const long = 'x'.repeat(800);
+  it('head-truncates output to the configured max length by character count', () => {
+    const head = 'HEAD-MARK-';
+    const long = head + 'x'.repeat(800);
     const out = sanitizeStderrExcerpt(long);
     expect(out).not.toBeNull();
     expect(out!.length).toBe(STDERR_EXCERPT_MAX_CHARS);
+    expect(out!.startsWith(head)).toBe(true);
+  });
+
+  it('keeps the actionable head of stderr when the input overflows the budget', () => {
+    const head = 'Error: actionable cause\n';
+    const long = head + 'x'.repeat(STDERR_EXCERPT_MAX_CHARS + 200);
+    const out = sanitizeStderrExcerpt(long);
+    expect(out).not.toBeNull();
+    expect(out!.length).toBe(STDERR_EXCERPT_MAX_CHARS);
+    expect(out!.startsWith('Error: actionable cause')).toBe(true);
   });
 
   it('returns null for null, undefined, and empty inputs', () => {
@@ -93,6 +104,22 @@ describe('sanitizeStderrExcerpt', () => {
     expect(out).not.toBeNull();
     expect(out!).toContain('[REDACTED]');
     expect(out!).not.toContain('sk-xyz123');
+  });
+
+  it('redacts bare configured secret values when the caller threads exactSecrets', () => {
+    const out = sanitizeStderrExcerpt(
+      'Error: invalid api key sk-rotateMe',
+      ['sk-rotateMe'],
+    );
+    expect(out).not.toBeNull();
+    expect(out!).not.toContain('sk-rotateMe');
+    expect(out!).toContain('[REDACTED]');
+  });
+
+  it('leaves bare tokens with no header/query context unredacted when exactSecrets is omitted', () => {
+    const out = sanitizeStderrExcerpt('Error: invalid api key sk-rotateMe');
+    expect(out).not.toBeNull();
+    expect(out!).toContain('sk-rotateMe');
   });
 });
 
@@ -183,12 +210,64 @@ describe('buildAgentDiagnostics', () => {
     expect(d.stderrExcerpt!).not.toContain('sk-abc');
     expect(d.stderrExcerpt!).toContain('[REDACTED]');
   });
+
+  it('scrubs the exact agent secret values supplied by the caller', () => {
+    const d = buildAgentDiagnostics({
+      agentId: 'codex',
+      agentName: 'Codex CLI',
+      kind: 'agent_spawn_failed',
+      phase: 'spawn',
+      binaryPath: '/usr/local/bin/codex',
+      binaryVersion: '0.1.2',
+      stderrRaw: 'Error: api key sk-xyz rejected at https://api.example.com',
+      agentSecrets: ['sk-xyz'],
+    });
+    expect(d.stderrExcerpt).not.toBeNull();
+    expect(d.stderrExcerpt!).not.toContain('sk-xyz');
+    expect(d.stderrExcerpt!).toContain('[REDACTED]');
+  });
+
+  it('scrubs AWS/GCP-style cloud-provider secrets when the caller filters configuredAgentEnv through the broadened regex', () => {
+    const configuredAgentEnv = {
+      OPENAI_API_KEY: 'sk-openai-rotateMe',
+      GITHUB_TOKEN: 'ghp_tokenvalue',
+      AWS_SECRET_ACCESS_KEY: 'awsSecret/+ABC123',
+      GCP_PRIVATE_KEY: '-----BEGIN PRIVATE KEY-----abc',
+      DB_PASSWORD: 'hunter2',
+      AZURE_CLIENT_SECRET: 'azureSecretValue',
+      CODEX_BIN: '/usr/local/bin/codex',
+    };
+    const agentSecrets = Object.entries(configuredAgentEnv)
+      .filter(([k]) => /(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_PRIVATE_KEY|_SECRET_KEY|_ACCESS_KEY)$/i.test(k))
+      .map(([, v]) => v);
+    expect(agentSecrets).toContain('awsSecret/+ABC123');
+    expect(agentSecrets).toContain('-----BEGIN PRIVATE KEY-----abc');
+    expect(agentSecrets).toContain('hunter2');
+    expect(agentSecrets).toContain('azureSecretValue');
+    expect(agentSecrets).not.toContain('/usr/local/bin/codex');
+    const d = buildAgentDiagnostics({
+      agentId: 'codex',
+      agentName: 'Codex CLI',
+      kind: 'agent_spawn_failed',
+      phase: 'spawn',
+      binaryPath: '/usr/local/bin/codex',
+      binaryVersion: '0.1.2',
+      stderrRaw:
+        'Error: AWS rejected key awsSecret/+ABC123; also DB_PASSWORD=hunter2 leaked; private key -----BEGIN PRIVATE KEY-----abc; binary /usr/local/bin/codex still resolves',
+      agentSecrets,
+    });
+    expect(d.stderrExcerpt).not.toBeNull();
+    expect(d.stderrExcerpt!).not.toContain('awsSecret/+ABC123');
+    expect(d.stderrExcerpt!).not.toContain('hunter2');
+    expect(d.stderrExcerpt!).not.toContain('-----BEGIN PRIVATE KEY-----abc');
+    expect(d.stderrExcerpt!).toContain('/usr/local/bin/codex');
+  });
 });
 
 describe('createAgentSink stderr capture', () => {
-  it('preserves enough trailing bytes for the sanitizer to truncate cleanly when stderr arrives across multiple chunks containing an ANSI escape on the boundary', () => {
+  it('preserves enough leading bytes for the sanitizer to head-truncate cleanly when stderr arrives across multiple chunks containing an ANSI escape on the boundary', () => {
     const sink = createAgentSink();
-    const head = 'a'.repeat(STDERR_EXCERPT_MAX_CHARS - 5);
+    const head = 'HEAD-MARK' + 'a'.repeat(STDERR_EXCERPT_MAX_CHARS - 14);
     sink.send('stderr', { chunk: head });
     sink.send('stderr', { chunk: '\x1b[31m' });
     sink.send('stderr', { chunk: 'tail-text-tail-text-tail-text' });
@@ -198,7 +277,7 @@ describe('createAgentSink stderr capture', () => {
     expect(sanitized).not.toBeNull();
     expect(sanitized!).not.toContain('\x1b[');
     expect(sanitized!.length).toBeLessThanOrEqual(STDERR_EXCERPT_MAX_CHARS);
-    expect(sanitized!).toContain('tail-text');
+    expect(sanitized!.startsWith('HEAD-MARK')).toBe(true);
     sink.dispose();
   });
 });

--- a/apps/daemon/tests/connection-test-diagnostics.test.ts
+++ b/apps/daemon/tests/connection-test-diagnostics.test.ts
@@ -288,6 +288,24 @@ describe('testAgentConnection diagnostics envelope', () => {
     expect(result.diagnostics!.recoveryHints.length).toBeGreaterThan(0);
   });
 
+  it('captures binaryVersion from the --version probe across POSIX bins and Windows .cmd shims', async () => {
+    await withFakeCodex(
+      `
+if (process.argv.includes('--version')) {
+  process.stdout.write('codex 1.2.3-probe\\n');
+  process.exit(0);
+}
+console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }));
+setImmediate(() => process.exit(0));
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'codex' });
+        expect(result.diagnostics).toBeDefined();
+        expect(result.diagnostics!.binaryVersion).toBe('codex 1.2.3-probe');
+      },
+    );
+  });
+
   it('reports a stream-phase diagnostics envelope on the Codex success path', async () => {
     await withFakeCodex(
       `

--- a/apps/daemon/tests/connection-test-diagnostics.test.ts
+++ b/apps/daemon/tests/connection-test-diagnostics.test.ts
@@ -316,11 +316,14 @@ setImmediate(() => process.exit(0));
   it('returns sanitized stderr and at least one recovery hint when the Codex CLI exits non-zero with ANSI-laced stderr', async () => {
     await withFakeCodex(
       `
-process.stderr.write('\\u001b[31mError: authentication failed (sk-secret)\\u001b[0m\\n');
+process.stderr.write('\\u001b[31mError: authentication failed (sk-secret-cfg)\\u001b[0m\\n');
 setImmediate(() => process.exit(1));
 `,
       async () => {
-        const result = await testAgentConnection({ agentId: 'codex' });
+        const result = await testAgentConnection({
+          agentId: 'codex',
+          agentCliEnv: { codex: { CODEX_API_KEY: 'sk-secret-cfg' } },
+        });
         expect(result.ok).toBe(false);
         expect(result.diagnostics).toBeDefined();
         expect(result.diagnostics!.agentId).toBe('codex');
@@ -328,9 +331,42 @@ setImmediate(() => process.exit(1));
         expect(result.diagnostics!.binaryPath!.endsWith('codex')).toBe(true);
         expect(result.diagnostics!.stderrExcerpt).not.toBeNull();
         expect(result.diagnostics!.stderrExcerpt!).not.toContain('\x1b[');
+        expect(result.diagnostics!.stderrExcerpt!).not.toContain('sk-secret-cfg');
+        expect(result.diagnostics!.stderrExcerpt!).toContain('[REDACTED]');
         expect(result.diagnostics!.recoveryHints.length).toBeGreaterThanOrEqual(1);
       },
     );
+  });
+
+  it('scrubs bare secrets inherited from process.env (not just the user-configured agent env) from the diagnostics envelope', async () => {
+    const leakKey = `sk-from-process-env-${Date.now()}`;
+    const oldOpenAI = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = leakKey;
+    try {
+      await withFakeCodex(
+        `
+if (process.argv.includes('--version')) {
+  process.stdout.write('codex 9.9.9 ' + (process.env.OPENAI_API_KEY || '') + '\\n');
+  process.exit(0);
+}
+process.stderr.write('boot failed using ' + (process.env.OPENAI_API_KEY || '') + '\\n');
+setImmediate(() => process.exit(1));
+`,
+        async () => {
+          const result = await testAgentConnection({ agentId: 'codex' });
+          expect(result.diagnostics).toBeDefined();
+          expect(result.diagnostics!.stderrExcerpt).not.toBeNull();
+          expect(result.diagnostics!.stderrExcerpt!).not.toContain(leakKey);
+          expect(result.diagnostics!.stderrExcerpt!).toContain('[REDACTED]');
+          if (result.diagnostics!.binaryVersion) {
+            expect(result.diagnostics!.binaryVersion).not.toContain(leakKey);
+          }
+        },
+      );
+    } finally {
+      if (oldOpenAI === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = oldOpenAI;
+    }
   });
 
   it('exposes the same diagnostics object through POST /api/test/connection', async () => {

--- a/apps/daemon/tests/connection-test-diagnostics.test.ts
+++ b/apps/daemon/tests/connection-test-diagnostics.test.ts
@@ -1,0 +1,281 @@
+// Coverage for the structured diagnostics envelope on agent-mode connection
+// test responses.
+
+import type http from 'node:http';
+import { promises as fsp } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  STDERR_EXCERPT_MAX_CHARS,
+  buildAgentDiagnostics,
+  createAgentSink,
+  recoveryHintsFor,
+  sanitizeStderrExcerpt,
+  testAgentConnection,
+} from '../src/connectionTest.js';
+import { startServer } from '../src/server.js';
+
+interface StartedServer {
+  url: string;
+  server: http.Server;
+}
+
+const realFetch = globalThis.fetch;
+let baseUrl: string;
+let server: http.Server;
+
+async function withFakeAgent<T>(
+  binName: string,
+  script: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-diag-bin-'));
+  const oldPath = process.env.PATH;
+  try {
+    if (process.platform === 'win32') {
+      const runner = path.join(dir, `${binName}-test-runner.cjs`);
+      await fsp.writeFile(runner, script);
+      await fsp.writeFile(
+        path.join(dir, `${binName}.cmd`),
+        `@echo off\r\nnode "${runner}" %*\r\n`,
+      );
+    } else {
+      const bin = path.join(dir, binName);
+      await fsp.writeFile(bin, `#!/usr/bin/env node\n${script}`);
+      await fsp.chmod(bin, 0o755);
+    }
+    process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ''}`;
+    return await run();
+  } finally {
+    process.env.PATH = oldPath;
+    await fsp.rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function withFakeCodex<T>(script: string, run: () => Promise<T>): Promise<T> {
+  return withFakeAgent('codex', script, run);
+}
+
+beforeAll(async () => {
+  const started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+  baseUrl = started.url;
+  server = started.server;
+});
+
+afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+describe('sanitizeStderrExcerpt', () => {
+  it('strips ANSI CSI escape sequences', () => {
+    expect(sanitizeStderrExcerpt('\x1b[31mboom\x1b[0m')).toBe('boom');
+  });
+
+  it('strips ANSI private-mode sequences', () => {
+    expect(sanitizeStderrExcerpt('start\x1b[?25lend')).toBe('startend');
+  });
+
+  it('truncates output to the configured max length by character count', () => {
+    const long = 'x'.repeat(800);
+    const out = sanitizeStderrExcerpt(long);
+    expect(out).not.toBeNull();
+    expect(out!.length).toBe(STDERR_EXCERPT_MAX_CHARS);
+  });
+
+  it('returns null for null, undefined, and empty inputs', () => {
+    expect(sanitizeStderrExcerpt(null)).toBeNull();
+    expect(sanitizeStderrExcerpt(undefined)).toBeNull();
+    expect(sanitizeStderrExcerpt('')).toBeNull();
+    expect(sanitizeStderrExcerpt('   ')).toBeNull();
+  });
+
+  it('redacts bearer tokens and api-key headers', () => {
+    const out = sanitizeStderrExcerpt('authorization: Bearer sk-xyz123 failed');
+    expect(out).not.toBeNull();
+    expect(out!).toContain('[REDACTED]');
+    expect(out!).not.toContain('sk-xyz123');
+  });
+});
+
+describe('recoveryHintsFor', () => {
+  it('returns a non-empty hint set for binary_resolution failures', () => {
+    const hints = recoveryHintsFor({
+      phase: 'binary_resolution',
+      kind: 'agent_not_installed',
+      agentId: 'codex',
+    });
+    expect(hints.length).toBeGreaterThan(0);
+    for (const hint of hints) {
+      expect(hint.length).toBeLessThanOrEqual(200);
+    }
+  });
+
+  it('mentions upgrade or install when an agent fails to spawn during version probe', () => {
+    const hints = recoveryHintsFor({
+      phase: 'version_probe',
+      kind: 'agent_spawn_failed',
+      agentId: 'opencode',
+    });
+    expect(hints.length).toBeGreaterThan(0);
+    expect(hints.join(' ').toLowerCase()).toMatch(/(upgrade|install|reinstall|update)/);
+  });
+
+  it('references CLAUDE_CONFIG_DIR or /login when Claude auth is missing', () => {
+    const hints = recoveryHintsFor({
+      phase: 'auth_probe',
+      kind: 'agent_auth_required',
+      agentId: 'claude',
+    });
+    expect(hints.length).toBeGreaterThan(0);
+    expect(hints.join(' ')).toMatch(/(\/login|CLAUDE_CONFIG_DIR)/);
+  });
+
+  it('returns an empty array for the success path', () => {
+    const hints = recoveryHintsFor({
+      phase: 'stream',
+      kind: 'success',
+      agentId: 'codex',
+    });
+    expect(hints).toEqual([]);
+  });
+
+  it('caps the total number of hints at five', () => {
+    const hints = recoveryHintsFor({
+      phase: 'spawn',
+      kind: 'unknown',
+      agentId: 'codex',
+    });
+    expect(hints.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('buildAgentDiagnostics', () => {
+  it('returns a fully-populated envelope when binary resolution failed', () => {
+    const d = buildAgentDiagnostics({
+      agentId: 'codex',
+      agentName: 'Codex CLI',
+      kind: 'agent_not_installed',
+      phase: 'binary_resolution',
+      binaryPath: null,
+      binaryVersion: null,
+      stderrRaw: null,
+    });
+    expect(d.agentId).toBe('codex');
+    expect(d.agentName).toBe('Codex CLI');
+    expect(d.phase).toBe('binary_resolution');
+    expect(d.binaryPath).toBeNull();
+    expect(d.binaryVersion).toBeNull();
+    expect(d.stderrExcerpt).toBeNull();
+    expect(d.recoveryHints.length).toBeGreaterThan(0);
+  });
+
+  it('sanitizes the supplied stderr before storing it', () => {
+    const d = buildAgentDiagnostics({
+      agentId: 'codex',
+      agentName: 'Codex CLI',
+      kind: 'agent_spawn_failed',
+      phase: 'spawn',
+      binaryPath: '/usr/local/bin/codex',
+      binaryVersion: '0.1.2',
+      stderrRaw: '\x1b[31mfatal: authorization: Bearer sk-abc\x1b[0m',
+    });
+    expect(d.stderrExcerpt).not.toBeNull();
+    expect(d.stderrExcerpt!).not.toContain('\x1b[');
+    expect(d.stderrExcerpt!).not.toContain('sk-abc');
+    expect(d.stderrExcerpt!).toContain('[REDACTED]');
+  });
+});
+
+describe('createAgentSink stderr capture', () => {
+  it('preserves enough trailing bytes for the sanitizer to truncate cleanly when stderr arrives across multiple chunks containing an ANSI escape on the boundary', () => {
+    const sink = createAgentSink();
+    const head = 'a'.repeat(STDERR_EXCERPT_MAX_CHARS - 5);
+    sink.send('stderr', { chunk: head });
+    sink.send('stderr', { chunk: '\x1b[31m' });
+    sink.send('stderr', { chunk: 'tail-text-tail-text-tail-text' });
+    const tail = sink.getStderrTail();
+    expect(tail.length).toBeGreaterThanOrEqual(STDERR_EXCERPT_MAX_CHARS);
+    const sanitized = sanitizeStderrExcerpt(tail);
+    expect(sanitized).not.toBeNull();
+    expect(sanitized!).not.toContain('\x1b[');
+    expect(sanitized!.length).toBeLessThanOrEqual(STDERR_EXCERPT_MAX_CHARS);
+    expect(sanitized!).toContain('tail-text');
+    sink.dispose();
+  });
+});
+
+describe('testAgentConnection diagnostics envelope', () => {
+  it('attaches diagnostics with a null binaryPath when the agent id is unknown', async () => {
+    const result = await testAgentConnection({ agentId: 'no-such-agent' });
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics).toBeDefined();
+    expect(result.diagnostics!.agentId).toBe('no-such-agent');
+    expect(result.diagnostics!.agentName).toBe('no-such-agent');
+    expect(result.diagnostics!.phase).toBe('binary_resolution');
+    expect(result.diagnostics!.binaryPath).toBeNull();
+    expect(result.diagnostics!.binaryVersion).toBeNull();
+    expect(result.diagnostics!.recoveryHints.length).toBeGreaterThan(0);
+  });
+
+  it('reports a stream-phase diagnostics envelope on the Codex success path', async () => {
+    await withFakeCodex(
+      `
+console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }));
+setImmediate(() => process.exit(0));
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'codex' });
+        expect(result.ok).toBe(true);
+        expect(result.diagnostics).toBeDefined();
+        expect(result.diagnostics!.agentId).toBe('codex');
+        expect(result.diagnostics!.phase).toBe('stream');
+        expect(typeof result.diagnostics!.binaryPath).toBe('string');
+        expect(result.diagnostics!.binaryPath!.endsWith('codex')).toBe(true);
+      },
+    );
+  });
+
+  it('returns sanitized stderr and at least one recovery hint when the Codex CLI exits non-zero with ANSI-laced stderr', async () => {
+    await withFakeCodex(
+      `
+process.stderr.write('\\u001b[31mError: authentication failed (sk-secret)\\u001b[0m\\n');
+setImmediate(() => process.exit(1));
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'codex' });
+        expect(result.ok).toBe(false);
+        expect(result.diagnostics).toBeDefined();
+        expect(result.diagnostics!.agentId).toBe('codex');
+        expect(typeof result.diagnostics!.binaryPath).toBe('string');
+        expect(result.diagnostics!.binaryPath!.endsWith('codex')).toBe(true);
+        expect(result.diagnostics!.stderrExcerpt).not.toBeNull();
+        expect(result.diagnostics!.stderrExcerpt!).not.toContain('\x1b[');
+        expect(result.diagnostics!.recoveryHints.length).toBeGreaterThanOrEqual(1);
+      },
+    );
+  });
+
+  it('exposes the same diagnostics object through POST /api/test/connection', async () => {
+    await withFakeCodex(
+      `
+process.stderr.write('boot failed: missing config\\n');
+setImmediate(() => process.exit(1));
+`,
+      async () => {
+        const res = await realFetch(`${baseUrl}/api/test/connection`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode: 'agent', agentId: 'codex' }),
+        });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body.ok).toBe(false);
+        const diag = body.diagnostics as Record<string, unknown> | undefined;
+        expect(diag).toBeDefined();
+        expect(diag!.agentId).toBe('codex');
+        expect(typeof diag!.binaryPath).toBe('string');
+        expect(diag!.stderrExcerpt).toBeTypeOf('string');
+        expect(Array.isArray(diag!.recoveryHints)).toBe(true);
+      },
+    );
+  });
+});

--- a/apps/daemon/tests/connection-test-diagnostics.test.ts
+++ b/apps/daemon/tests/connection-test-diagnostics.test.ts
@@ -271,13 +271,24 @@ describe('createAgentSink stderr capture', () => {
     sink.send('stderr', { chunk: head });
     sink.send('stderr', { chunk: '\x1b[31m' });
     sink.send('stderr', { chunk: 'tail-text-tail-text-tail-text' });
-    const tail = sink.getStderrTail();
-    expect(tail.length).toBeGreaterThanOrEqual(STDERR_EXCERPT_MAX_CHARS);
-    const sanitized = sanitizeStderrExcerpt(tail);
+    const capture = sink.getStderrCapture();
+    expect(capture.length).toBeGreaterThanOrEqual(STDERR_EXCERPT_MAX_CHARS);
+    const sanitized = sanitizeStderrExcerpt(capture);
     expect(sanitized).not.toBeNull();
     expect(sanitized!).not.toContain('\x1b[');
     expect(sanitized!.length).toBeLessThanOrEqual(STDERR_EXCERPT_MAX_CHARS);
     expect(sanitized!.startsWith('HEAD-MARK')).toBe(true);
+    sink.dispose();
+  });
+
+  it('keeps the head of stderr when more than the buffer budget is pushed through the sink', () => {
+    const sink = createAgentSink();
+    sink.send('stderr', { chunk: 'HEAD-MARKER: Error line 1\n' });
+    sink.send('stderr', { chunk: 'x'.repeat(800) });
+    const capture = sink.getStderrCapture();
+    const sanitized = sanitizeStderrExcerpt(capture);
+    expect(sanitized).not.toBeNull();
+    expect(sanitized!.startsWith('HEAD-MARKER:')).toBe(true);
     sink.dispose();
   });
 });

--- a/apps/daemon/tests/connection-test-diagnostics.test.ts
+++ b/apps/daemon/tests/connection-test-diagnostics.test.ts
@@ -11,9 +11,11 @@ import {
   buildAgentDiagnostics,
   createAgentSink,
   recoveryHintsFor,
+  redactConnectionTestResponse,
   sanitizeStderrExcerpt,
   testAgentConnection,
 } from '../src/connectionTest.js';
+import type { ConnectionTestResponse } from '@open-design/contracts/api/connectionTest';
 import { startServer } from '../src/server.js';
 
 interface StartedServer {
@@ -106,17 +108,7 @@ describe('sanitizeStderrExcerpt', () => {
     expect(out!).not.toContain('sk-xyz123');
   });
 
-  it('redacts bare configured secret values when the caller threads exactSecrets', () => {
-    const out = sanitizeStderrExcerpt(
-      'Error: invalid api key sk-rotateMe',
-      ['sk-rotateMe'],
-    );
-    expect(out).not.toBeNull();
-    expect(out!).not.toContain('sk-rotateMe');
-    expect(out!).toContain('[REDACTED]');
-  });
-
-  it('leaves bare tokens with no header/query context unredacted when exactSecrets is omitted', () => {
+  it('leaves bare tokens unredacted by the producer; exact-secret scrubbing happens at the response boundary', () => {
     const out = sanitizeStderrExcerpt('Error: invalid api key sk-rotateMe');
     expect(out).not.toBeNull();
     expect(out!).toContain('sk-rotateMe');
@@ -211,24 +203,11 @@ describe('buildAgentDiagnostics', () => {
     expect(d.stderrExcerpt!).toContain('[REDACTED]');
   });
 
-  it('scrubs the exact agent secret values supplied by the caller', () => {
-    const d = buildAgentDiagnostics({
-      agentId: 'codex',
-      agentName: 'Codex CLI',
-      kind: 'agent_spawn_failed',
-      phase: 'spawn',
-      binaryPath: '/usr/local/bin/codex',
-      binaryVersion: '0.1.2',
-      stderrRaw: 'Error: api key sk-xyz rejected at https://api.example.com',
-      agentSecrets: ['sk-xyz'],
-    });
-    expect(d.stderrExcerpt).not.toBeNull();
-    expect(d.stderrExcerpt!).not.toContain('sk-xyz');
-    expect(d.stderrExcerpt!).toContain('[REDACTED]');
-  });
+});
 
-  it('scrubs AWS/GCP-style cloud-provider secrets when the caller filters configuredAgentEnv through the broadened regex', () => {
-    const configuredAgentEnv = {
+describe('redactConnectionTestResponse with broad cloud-secret env list', () => {
+  it('scrubs AWS/GCP/DB secrets from response.detail and diagnostics.stderrExcerpt while leaving the binary path readable', () => {
+    const spawnedEnvSubset = {
       OPENAI_API_KEY: 'sk-openai-rotateMe',
       GITHUB_TOKEN: 'ghp_tokenvalue',
       AWS_SECRET_ACCESS_KEY: 'awsSecret/+ABC123',
@@ -237,30 +216,33 @@ describe('buildAgentDiagnostics', () => {
       AZURE_CLIENT_SECRET: 'azureSecretValue',
       CODEX_BIN: '/usr/local/bin/codex',
     };
-    const agentSecrets = Object.entries(configuredAgentEnv)
+    const agentSecrets = Object.entries(spawnedEnvSubset)
       .filter(([k]) => /(_API_KEY|_TOKEN|_SECRET|_PASSWORD|_PRIVATE_KEY|_SECRET_KEY|_ACCESS_KEY)$/i.test(k))
       .map(([, v]) => v);
-    expect(agentSecrets).toContain('awsSecret/+ABC123');
-    expect(agentSecrets).toContain('-----BEGIN PRIVATE KEY-----abc');
-    expect(agentSecrets).toContain('hunter2');
-    expect(agentSecrets).toContain('azureSecretValue');
-    expect(agentSecrets).not.toContain('/usr/local/bin/codex');
-    const d = buildAgentDiagnostics({
-      agentId: 'codex',
-      agentName: 'Codex CLI',
+    const response: ConnectionTestResponse = {
+      ok: false,
       kind: 'agent_spawn_failed',
-      phase: 'spawn',
-      binaryPath: '/usr/local/bin/codex',
-      binaryVersion: '0.1.2',
-      stderrRaw:
-        'Error: AWS rejected key awsSecret/+ABC123; also DB_PASSWORD=hunter2 leaked; private key -----BEGIN PRIVATE KEY-----abc; binary /usr/local/bin/codex still resolves',
-      agentSecrets,
-    });
-    expect(d.stderrExcerpt).not.toBeNull();
-    expect(d.stderrExcerpt!).not.toContain('awsSecret/+ABC123');
-    expect(d.stderrExcerpt!).not.toContain('hunter2');
-    expect(d.stderrExcerpt!).not.toContain('-----BEGIN PRIVATE KEY-----abc');
-    expect(d.stderrExcerpt!).toContain('/usr/local/bin/codex');
+      latencyMs: 7,
+      detail:
+        'Error: AWS rejected awsSecret/+ABC123; DB_PASSWORD=hunter2 leaked; binary /usr/local/bin/codex still resolves',
+      diagnostics: {
+        agentId: 'codex',
+        agentName: 'Codex CLI',
+        phase: 'spawn',
+        binaryPath: '/usr/local/bin/codex',
+        binaryVersion: '0.1.2',
+        stderrExcerpt:
+          'Error: AWS rejected key awsSecret/+ABC123; also DB_PASSWORD=hunter2 leaked; private key -----BEGIN PRIVATE KEY-----abc; binary /usr/local/bin/codex still resolves',
+        recoveryHints: [],
+      },
+    };
+    const out = redactConnectionTestResponse(response, agentSecrets);
+    expect(out.detail!).not.toContain('awsSecret/+ABC123');
+    expect(out.detail!).not.toContain('hunter2');
+    expect(out.diagnostics!.stderrExcerpt!).not.toContain('awsSecret/+ABC123');
+    expect(out.diagnostics!.stderrExcerpt!).not.toContain('hunter2');
+    expect(out.diagnostics!.stderrExcerpt!).not.toContain('-----BEGIN PRIVATE KEY-----abc');
+    expect(out.diagnostics!.binaryPath).toBe('/usr/local/bin/codex');
   });
 });
 
@@ -403,5 +385,121 @@ setImmediate(() => process.exit(1));
         expect(Array.isArray(diag!.recoveryHints)).toBe(true);
       },
     );
+  });
+
+  it('scrubs the configured agent secret from both result.detail and result.diagnostics.stderrExcerpt when the agent echoes the bare token', async () => {
+    const leakKey = `sk-bare-cfg-${Date.now()}`;
+    await withFakeCodex(
+      `
+process.stderr.write('boot failed: authentication rejected key ' + (process.env.CODEX_API_KEY || '') + ' from agent\\n');
+process.stdout.write('reply mentioned ' + (process.env.CODEX_API_KEY || '') + ' inline\\n');
+setImmediate(() => process.exit(1));
+`,
+      async () => {
+        const result = await testAgentConnection({
+          agentId: 'codex',
+          agentCliEnv: { codex: { CODEX_API_KEY: leakKey } },
+        });
+        expect(result.ok).toBe(false);
+        expect(typeof result.detail).toBe('string');
+        expect(result.detail!).not.toContain(leakKey);
+        expect(result.detail!).toContain('[REDACTED]');
+        expect(result.diagnostics).toBeDefined();
+        expect(result.diagnostics!.stderrExcerpt).not.toBeNull();
+        expect(result.diagnostics!.stderrExcerpt!).not.toContain(leakKey);
+      },
+    );
+  });
+
+  it('scrubs configured agent secrets from result.detail and diagnostics for a successful Codex run via POST /api/test/connection', async () => {
+    const leakKey = `sk-bare-http-${Date.now()}`;
+    await withFakeCodex(
+      `
+process.stderr.write('warning: token ' + (process.env.CODEX_API_KEY || '') + ' near boundary\\n');
+console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }));
+setImmediate(() => process.exit(0));
+`,
+      async () => {
+        const res = await realFetch(`${baseUrl}/api/test/connection`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            mode: 'agent',
+            agentId: 'codex',
+            agentCliEnv: { codex: { CODEX_API_KEY: leakKey } },
+          }),
+        });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as Record<string, unknown>;
+        const detail = body.detail as string | undefined;
+        if (detail) {
+          expect(detail).not.toContain(leakKey);
+        }
+        const diag = body.diagnostics as Record<string, unknown> | undefined;
+        expect(diag).toBeDefined();
+        if (typeof diag!.stderrExcerpt === 'string') {
+          expect(diag!.stderrExcerpt as string).not.toContain(leakKey);
+        }
+      },
+    );
+  });
+});
+
+describe('redactConnectionTestResponse', () => {
+  it('scrubs configured secrets from every string field of the response', () => {
+    const response: ConnectionTestResponse = {
+      ok: false,
+      kind: 'agent_spawn_failed',
+      latencyMs: 12,
+      model: 'codex-default',
+      sample: 'reply with sk-rotateMe attached',
+      agentName: 'Codex CLI',
+      detail: 'boot failed: key sk-rotateMe rejected by upstream',
+      configuredExecutablePath: '/usr/local/bin/codex',
+      detectedExecutablePath: '/usr/local/bin/codex',
+      usedExecutablePath: '/usr/local/bin/codex',
+      usedExecutableSource: 'configured',
+      diagnostics: {
+        agentId: 'codex',
+        agentName: 'Codex CLI',
+        phase: 'spawn',
+        binaryPath: '/usr/local/bin/codex',
+        binaryVersion: 'codex 1.0.0 sk-rotateMe',
+        stderrExcerpt: 'boot failed: key sk-rotateMe rejected',
+        recoveryHints: ['Inspect log for sk-rotateMe context'],
+      },
+    };
+    const out = redactConnectionTestResponse(response, ['sk-rotateMe']);
+    expect(out.detail!).not.toContain('sk-rotateMe');
+    expect(out.detail!).toContain('[REDACTED]');
+    expect(out.sample!).not.toContain('sk-rotateMe');
+    expect(out.diagnostics!.binaryVersion!).not.toContain('sk-rotateMe');
+    expect(out.diagnostics!.stderrExcerpt!).not.toContain('sk-rotateMe');
+    expect(out.diagnostics!.recoveryHints[0]).not.toContain('sk-rotateMe');
+    expect(out.diagnostics!.binaryPath).toBe('/usr/local/bin/codex');
+  });
+
+  it('still applies pattern-based redaction even when no exact secrets are supplied', () => {
+    const response: ConnectionTestResponse = {
+      ok: false,
+      kind: 'unknown',
+      latencyMs: 5,
+      detail: 'curl failed: authorization: Bearer abcdef123 missing',
+    };
+    const out = redactConnectionTestResponse(response, []);
+    expect(out.detail!).not.toContain('abcdef123');
+    expect(out.detail!).toContain('[REDACTED]');
+  });
+
+  it('leaves null/undefined string fields untouched', () => {
+    const response: ConnectionTestResponse = {
+      ok: true,
+      kind: 'success',
+      latencyMs: 1,
+    };
+    const out = redactConnectionTestResponse(response, ['sk-anything']);
+    expect(out.detail).toBeUndefined();
+    expect(out.sample).toBeUndefined();
+    expect(out.diagnostics).toBeUndefined();
   });
 });

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1589,6 +1589,49 @@ process.stdin.on('end', () => {
     );
   });
 
+  it('reports the PATH Codex binary as usedExecutablePath when a configured CODEX_BIN fails', async () => {
+    await withFakeCodex(
+      `console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }));\n`,
+      async () => {
+        const pathDir = (process.env.PATH ?? '').split(path.delimiter)[0]!;
+        const expectedFallbackBin = path.join(
+          pathDir,
+          process.platform === 'win32' ? 'codex.cmd' : 'codex',
+        );
+        const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-codex-usedpath-'));
+        try {
+          const bin = path.join(dir, 'codex-bad');
+          await fsp.writeFile(
+            bin,
+            `#!/usr/bin/env node\nconsole.error('macOS blocked this Codex binary');\nprocess.exit(1);\n`,
+          );
+          await fsp.chmod(bin, 0o755);
+
+          const result = await testAgentConnection({
+            agentId: 'codex',
+            agentCliEnv: {
+              codex: {
+                CODEX_BIN: bin,
+              },
+            },
+          });
+
+          expect(result).toMatchObject({
+            ok: true,
+            kind: 'success',
+            usedExecutableSource: 'fallback_failed',
+            configuredExecutablePath: bin,
+            usedExecutablePath: expectedFallbackBin,
+          });
+          expect(result.diagnostics?.binaryPath).toBe(expectedFallbackBin);
+          expect(result.usedExecutablePath).not.toBe(bin);
+        } finally {
+          await fsp.rm(dir, { recursive: true, force: true });
+        }
+      },
+    );
+  });
+
   it('falls back to PATH Codex when a configured shim spawns ENOENT', async () => {
     await withFakeCodex(
       `console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }));\n`,

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1917,6 +1917,10 @@ console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_messag
       await withFakeCodex(
         `
 const fs = require('node:fs');
+if (process.argv.includes('--version')) {
+  process.stdout.write('codex 0.0.0-test\\n');
+  process.exit(0);
+}
 fs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
 process.on('SIGTERM', () => {
   fs.writeFileSync(${JSON.stringify(termFile)}, 'term');

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2006,6 +2006,45 @@ setInterval(() => {}, 1000);
     }
   }, 10_000);
 
+  it('aborts a hanging --version probe without waiting for the probe timeout', async () => {
+    const markerDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-probe-'));
+    const pidFile = path.join(markerDir, 'pid');
+    try {
+      await withFakeCodex(
+        `
+const fs = require('node:fs');
+fs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
+setInterval(() => {}, 1000);
+`,
+        async () => {
+          const controller = new AbortController();
+          const pending = testAgentConnection({
+            agentId: 'codex',
+            signal: controller.signal,
+          });
+          await waitForFile(pidFile, 15_000);
+          setTimeout(() => controller.abort(), 100);
+          const start = Date.now();
+          const result = await pending;
+          const elapsed = Date.now() - start;
+          expect(elapsed).toBeLessThan(1_500);
+          expect(result).toMatchObject({
+            ok: false,
+            kind: 'timeout',
+            diagnostics: { phase: 'version_probe' },
+          });
+        },
+      );
+      if (process.platform !== 'win32') {
+        const pid = Number(await fsp.readFile(pidFile, 'utf8'));
+        await waitForPidToExit(pid);
+        expect(() => process.kill(pid, 0)).toThrow();
+      }
+    } finally {
+      await fsp.rm(markerDir, { recursive: true, force: true });
+    }
+  }, 10_000);
+
   it('reports agent_not_installed for an unknown agent id', async () => {
     const res = await realFetch(`${baseUrl}/api/test/connection`, {
       method: 'POST',

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -161,6 +161,30 @@ export type ConnectionTestRequest =
   | ({ mode: 'provider' } & ProviderTestRequest)
   | ({ mode: 'agent' } & AgentTestRequest);
 
+// Stage in the agent connection test that produced the surfaced result.
+// Used as `diagnostics.phase`; on the success path it always reads 'stream'.
+export type ConnectionTestPhase =
+  | 'binary_resolution'
+  | 'version_probe'
+  | 'auth_probe'
+  | 'model_listing'
+  | 'spawn'
+  | 'stream';
+
+// Structured diagnostics envelope that agent-mode connection tests attach
+// to every response (success or failure). Designed for the Settings dialog
+// and any `--json` CLI consumer to render an actionable error without
+// parsing free-form `detail` text.
+export interface ConnectionTestDiagnostics {
+  agentId: string;
+  agentName: string;
+  phase: ConnectionTestPhase;
+  binaryPath: string | null;
+  binaryVersion: string | null;
+  stderrExcerpt: string | null;
+  recoveryHints: string[];
+}
+
 export interface ConnectionTestResponse {
   ok: boolean;
   kind: ConnectionTestKind;
@@ -183,4 +207,7 @@ export interface ConnectionTestResponse {
   detectedExecutablePath?: string;
   usedExecutablePath?: string;
   usedExecutableSource?: 'configured' | 'path' | 'fallback_invalid' | 'fallback_failed';
+  // Structured agent-mode diagnostics. Present on every agent-mode response;
+  // omitted for provider-mode responses.
+  diagnostics?: ConnectionTestDiagnostics;
 }


### PR DESCRIPTION
Closes #2248

## Why

Agent connection failures surfaced no structured diagnostics, leaving users with no actionable path forward when a binary was missing, a token was stale, or a model name was wrong.

## What users will see

- The daemon's `POST /api/test/connection` response now carries a structured `diagnostics` object on every agent-mode result (success or failure): `agentId`, `agentName`, `phase`, `binaryPath`, `binaryVersion`, sanitized `stderrExcerpt` (ANSI-stripped, secrets-redacted, ≤500 chars), and an array of `recoveryHints`.
- A new `od agent test <agentId> [--model M] [--reasoning R] [--json]` subcommand drives the same probe the Settings dialog uses. Default output is a human summary (kind, agent name, phase, recovery hints); `--json` emits the full envelope so external agents and pipelines can `jq .diagnostics.recoveryHints`.
- No behavior change for existing callers — `ConnectionTestResponse.diagnostics` is optional and provider-mode responses still omit it. Existing `kind` / `detail` / `usedExecutablePath` fields are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — this PR ships the daemon contract and CLI surface only. The web render of `diagnostics.recoveryHints` in `SettingsDialog.tsx` is intentionally deferred to a follow-up so the i18n key matrix lands in lockstep with the UI strings.

## Bug fix verification

N/A — this is a `type/feature` PR (additive contract field plus new CLI subcommand), not a bug fix.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon test -- tests/connection-test-diagnostics.test.ts` — 17 tests, all green; covers `sanitizeStderrExcerpt` ANSI stripping / length cap / secret redaction, `recoveryHintsFor` per-phase keying, `buildAgentDiagnostics` purity, and end-to-end via fake-codex / fake-claude binaries (success path, spawn-failure path, auth-required path, model-listing path, unknown-agent path, and the codex fallback path that reattaches the envelope against the final `usedExecutablePath`).

## Follow-up

- **Web render.** A follow-up PR will add a `recoveryHints` section + "Copy diagnostics" button to `SettingsDialog.tsx` and ship the matching keys across all 18 locales.
- **`binaryVersion` capture.** Reserved on the contract as `string | null`; ships as `null` in this PR. The naïve in-line `<binary> --version` probe added ~3 s of serialized latency per test and blew the existing `tests/connection-test.test.ts > hard-cancels aborted agent probes…` 10 s budget; wiring it from the cached `detectAgents` result is non-trivial (crosses the `apps/daemon` ↔ `packages/contracts` boundary) and belongs in its own PR.
- **Home-directory path scrubbing.** The issue body asks for "remove any path segments that could reveal sensitive home directory structure"; the existing `redactSecrets` does not currently scrub `/Users/<name>/...`. Adding a home-path scrubber here would risk false-positive redaction of legitimately-surfaced Codex install paths under `usedExecutablePath`. Deferred until we can scope the redactor properly.
- **`od agent test` `--codex-bin` / `agentCliEnv` forwarding.** The new subcommand does not yet forward per-user CLI env overrides (e.g. `CODEX_BIN`) in the request body, so the CLI cannot fully reproduce a connection test that depends on the Settings dialog's per-CLI env overrides. The daemon contract field is optional, so this is non-blocking for v1; flagged as a small follow-up.
