### PR TITLE
fix: allow preview toolbar controls to wrap on narrow viewports

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10534,11 +10534,11 @@ button.connector-action.is-loading {
   font-size: 12.5px;
   color: var(--text-muted);
   gap: 8px;
-  height: 44px;
+  min-height: 44px;
   flex-shrink: 0;
 }
 .viewer-toolbar-left { display: inline-flex; align-items: center; gap: 8px; }
-.viewer-toolbar-actions { display: inline-flex; gap: 2px; align-items: center; }
+.viewer-toolbar-actions { display: inline-flex; gap: 2px; align-items: center; flex-wrap: wrap; }
 .viewer-toolbar .icon-only,
 .viewer-toolbar-actions .icon-only {
   width: 28px;


### PR DESCRIPTION
This is an independent contribution and is not part of any competition, organized event, or sponsored program.

## Summary

When the left chat panel is widened, the workspace panel shrinks and the preview toolbar action buttons can overflow their container, causing controls on the right side to be clipped and inaccessible.

## Root Cause

The `.viewer-toolbar` had a fixed `height: 44px` and `.viewer-toolbar-actions` used `display: inline-flex` without `flex-wrap`. When the available horizontal space decreased, the non-wrapping inline-flex container caused child controls to overflow the fixed-height container, visually clipping them.

## Fix

Two-line CSS change in `apps/web/src/index.css`:

1. Changed `.viewer-toolbar` from `height: 44px` to `min-height: 44px` — allows the bar to grow vertically when controls wrap
2. Added `flex-wrap: wrap` to `.viewer-toolbar-actions` — allows toolbar controls to wrap onto a new line instead of overflowing

This preserves the existing appearance at normal widths while allowing the toolbar to adapt when the workspace panel is narrowed.

## Testing

- Existing toolbar layout is unchanged at standard viewport widths (>900px workspace)
- At narrow workspace widths (<500px), toolbar controls wrap cleanly instead of clipping
- The `flex-shrink: 0` on `.viewer-toolbar` is preserved, so it never collapses

Closes #2166