### PR TITLE
fix(prompts): remove 10-item cap from discovery TodoWrite plan

### DIFF
--- a/apps/daemon/src/prompts/discovery.ts
+++ b/apps/daemon/src/prompts/discovery.ts
@@ -189,7 +189,7 @@ Emit \`<artifact>\` **only when this turn wrote a new canonical HTML file**. If 
 
 ## RULE 3 — TodoWrite the plan, then live updates
 
-Once the design-system / inferred direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of short imperative items covering the work, in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply.
+Once the design-system / inferred direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of short imperative items covering the work, in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply. (No numeric cap — the TodoWrite schema is unbounded and complex briefs legitimately need more than ten steps.)
 
 The standard plan template (adapt the middle steps to the brief):
 

--- a/apps/daemon/src/prompts/discovery.ts
+++ b/apps/daemon/src/prompts/discovery.ts
@@ -189,7 +189,7 @@ Emit \`<artifact>\` **only when this turn wrote a new canonical HTML file**. If 
 
 ## RULE 3 — TodoWrite the plan, then live updates
 
-Once the design-system / inferred direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of 5–10 short imperative items in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply.
+Once the design-system / inferred direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of short imperative items covering the work, in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply.
 
 The standard plan template (adapt the middle steps to the brief):
 

--- a/apps/daemon/tests/prompts/discovery-todo-cap.test.ts
+++ b/apps/daemon/tests/prompts/discovery-todo-cap.test.ts
@@ -23,6 +23,13 @@ describe('discovery.ts RULE 3 — TodoWrite plan item count', () => {
     expect(DISCOVERY_AND_PHILOSOPHY).not.toMatch(/5 to 10\s+(?:short\s+)?items/i);
   });
 
+  it('does not re-introduce a numeric cap via "at most / maximum / no more than" phrasing', () => {
+    // Guard against semantically equivalent upper-bound re-introduction.
+    expect(DISCOVERY_AND_PHILOSOPHY).not.toMatch(
+      /(?:at most|maximum|no more than)\s+1[0-9]\s+(?:todo|plan|step|item)/i,
+    );
+  });
+
   it('still instructs the agent to write at least a few items', () => {
     // The intent — plan with TodoWrite before building — must survive the fix.
     expect(DISCOVERY_AND_PHILOSOPHY).toContain('TodoWrite');

--- a/apps/daemon/tests/prompts/discovery-todo-cap.test.ts
+++ b/apps/daemon/tests/prompts/discovery-todo-cap.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { DISCOVERY_AND_PHILOSOPHY } from '../../src/prompts/discovery.js';
+
+// The system prompt historically told the model to write "a plan of 5–10 short
+// imperative items". That upper bound caused the agent to cap every plan at
+// exactly ten steps and then stop or skip additional items — even when the task
+// genuinely needed more. There is no maxItems constraint in the upstream
+// TodoWrite JSON schema (the array is unbounded), so the cap is entirely
+// prompt-driven and can be removed here.
+//
+// This test locks the absence of the cap so a future prompt edit cannot
+// accidentally re-introduce the "5–10" or "5 to 10" wording.
+
+describe('discovery.ts RULE 3 — TodoWrite plan item count', () => {
+  it('does not cap the plan at 10 items via "5–10" wording', () => {
+    // The old wording was "a plan of 5–10 short imperative items".
+    // After the fix the sentence must not mention an upper bound of 10.
+    expect(DISCOVERY_AND_PHILOSOPHY).not.toMatch(/5[–\-]10\s+short\s+imperative/);
+  });
+
+  it('does not cap the plan at 10 items via "5 to 10" wording', () => {
+    expect(DISCOVERY_AND_PHILOSOPHY).not.toMatch(/5 to 10\s+(?:short\s+)?items/i);
+  });
+
+  it('still instructs the agent to write at least a few items', () => {
+    // The intent — plan with TodoWrite before building — must survive the fix.
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('TodoWrite');
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('RULE 3');
+  });
+});

--- a/packages/contracts/src/prompts/discovery.ts
+++ b/packages/contracts/src/prompts/discovery.ts
@@ -161,7 +161,7 @@ Skip directly to RULE 3. Do **not** emit any second direction-picking form and d
 
 ## RULE 3 — TodoWrite the plan, then live updates
 
-Once the design-system / inferred direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of 5–10 short imperative items in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply.
+Once the design-system / inferred direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of short imperative items covering the work, in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply. (No numeric cap — the TodoWrite schema is unbounded and complex briefs legitimately need more than ten steps.)
 
 The standard plan template (adapt the middle steps to the brief):
 

--- a/packages/contracts/tests/system-prompt.test.ts
+++ b/packages/contracts/tests/system-prompt.test.ts
@@ -1,6 +1,37 @@
 import { describe, expect, it } from 'vitest';
 
 import { composeSystemPrompt } from '../src/prompts/system.js';
+import { DISCOVERY_AND_PHILOSOPHY } from '../src/prompts/discovery.js';
+
+// Guard: the contracts copy of DISCOVERY_AND_PHILOSOPHY must have the same
+// cap removal as apps/daemon/src/prompts/discovery.ts. The web app imports
+// composeSystemPrompt from @open-design/contracts, so only testing the daemon
+// copy leaves the web-originated chat path unguarded.
+describe('DISCOVERY_AND_PHILOSOPHY (contracts copy) — TodoWrite plan item count', () => {
+  it('does not cap the plan at 10 items via "5–10" wording', () => {
+    expect(DISCOVERY_AND_PHILOSOPHY).not.toMatch(/5[–\-]10\s+short\s+imperative/);
+  });
+
+  it('does not cap the plan at 10 items via "5 to 10" wording', () => {
+    expect(DISCOVERY_AND_PHILOSOPHY).not.toMatch(/5 to 10\s+(?:short\s+)?items/i);
+  });
+
+  it('does not re-introduce a numeric cap via "at most / maximum / no more than" phrasing', () => {
+    expect(DISCOVERY_AND_PHILOSOPHY).not.toMatch(
+      /(?:at most|maximum|no more than)\s+1[0-9]\s+(?:todo|plan|step|item)/i,
+    );
+  });
+
+  it('still instructs the agent to write a TodoWrite plan', () => {
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('TodoWrite');
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('RULE 3');
+  });
+
+  it('also absent from the composed system prompt', () => {
+    const prompt = composeSystemPrompt({});
+    expect(prompt).not.toMatch(/5[–\-]10\s+short\s+imperative/);
+  });
+});
 
 describe('composeSystemPrompt', () => {
   it('treats an active design system as the visual direction', () => {


### PR DESCRIPTION
## Why

I noticed agents capping their plan at exactly 10 items even on complex
briefs that genuinely needed more — and silently skipping the rest after
hitting the limit. Tracing it back: RULE 3 of `DISCOVERY_AND_PHILOSOPHY`
in `apps/daemon/src/prompts/discovery.ts` explicitly told the model
"a plan of 5–10 short imperative items". That upper bound was the cap.

TodoWrite's schema is unbounded; the limit was entirely prompt copy. The
same wording also lived in `packages/contracts/src/prompts/discovery.ts`
(consumed by `apps/web` for BYOK API mode), so the daemon-only fix would
have left the cap active for half the user base.

## What users will see

Plans for complex tasks can now legitimately exceed 10 steps when the
brief warrants it. RULE 3's intent — TodoWrite as the first tool call,
live progress updates, planning before building — is preserved. No UI
change. No new keys, no settings, no behavior change on simpler briefs
that already fit in 10 items.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

(`packages/contracts` is touched, but only a string constant inside; no
DTO, no SSE event, no exported shape change.)

## Screenshots

N/A (server-side prompt change, no UI).

## Bug fix verification

- Red specs:
  - `apps/daemon/tests/prompts/discovery-todo-cap.test.ts`
  - `packages/contracts/tests/system-prompt.test.ts`
- Red on `main` and green on this branch: yes — the prior wording
  matched the `5[–\-]10\s+short\s+imperative` assertion the new tests
  forbid. Confirmed by grepping the main snapshot at the commit before
  this branch's first commit.
- The 4th assertion in each test forbids semantically equivalent
  re-introductions (`at most N items`, `maximum N`, `no more than N`)
  so a future prompt rewrite cannot accidentally bring the cap back.

## Validation

- `pnpm guard` (clean)
- `pnpm typecheck` (clean)
- `pnpm --filter @open-design/daemon test` — 2870 tests pass
- `pnpm --filter @open-design/contracts test` — 90 tests pass

## Adjacent issues (out of scope)

`apps/web/src/components/DesignSystemFlow.tsx:1801` silently caps the DS
workspace compact todo widget at 6 items via `todos.slice(0, 6)`. Now
that plans can legitimately exceed that count, the widget needs a
`+N more` overflow indicator. Filed as a follow-up; not in scope here.
