### PR TITLE
feat(web): shift-click range selection on design files

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -434,12 +434,21 @@ export function DesignFilesPanel({
     };
   }
 
-  function handleRowCheck(name: string, e: React.MouseEvent) {
-    const multi = e.metaKey || e.ctrlKey;
-    const range = e.shiftKey;
+  // handleRowCheck processes checkbox clicks with modifier-key semantics:
+  //   plain click  — select only this item, set anchor
+  //   Cmd/Ctrl     — toggle this item, anchor stays
+  //   Shift        — inclusive range from anchor to this row (page-scoped)
+  //
+  // Range selection is intentionally page-scoped: the anchor must be on the
+  // current page. If the anchor is not visible on this page (e.g. the user
+  // paginated away after setting it) we fall back to a plain-click selection
+  // rather than silently selecting invisible rows on other pages.
+  function handleRowCheck(name: string, e: React.MouseEvent | React.KeyboardEvent) {
+    const multi = 'metaKey' in e ? (e.metaKey || e.ctrlKey) : false;
+    const range = 'shiftKey' in e && e.shiftKey;
 
     if (range) {
-      // Shift-click: select inclusive range from anchor to this row.
+      // Shift-click / Shift+Space: select inclusive range from anchor to this row.
       // If no anchor is set yet, behave as a plain click and set anchor.
       const anchor = anchorRef.current;
       if (anchor === null) {
@@ -447,17 +456,19 @@ export function DesignFilesPanel({
         setSelected(new Set([name]));
         return;
       }
-      const anchorIdx = sortedFiles.findIndex((f) => f.name === anchor);
-      const clickIdx = sortedFiles.findIndex((f) => f.name === name);
+      // Use pageFiles so the range matches only visible rows on this page.
+      // If the anchor has been scrolled to a different page, fall back to plain-click.
+      const anchorIdx = pageFiles.findIndex((f) => f.name === anchor);
+      const clickIdx = pageFiles.findIndex((f) => f.name === name);
       if (anchorIdx === -1 || clickIdx === -1) {
-        // Fallback: just select the clicked item
+        // Anchor not on this page — reset anchor to clicked item.
         anchorRef.current = name;
         setSelected(new Set([name]));
         return;
       }
       const lo = Math.min(anchorIdx, clickIdx);
       const hi = Math.max(anchorIdx, clickIdx);
-      setSelected(new Set(sortedFiles.slice(lo, hi + 1).map((f) => f.name)));
+      setSelected(new Set(pageFiles.slice(lo, hi + 1).map((f) => f.name)));
       // Anchor stays at the original plain-click position; do not move it.
       return;
     }
@@ -598,6 +609,7 @@ export function DesignFilesPanel({
         key={f.name}
         data-testid={`design-file-row-${f.name}`}
         className={`df-file-row ${active ? 'active' : ''} ${selected.has(f.name) ? 'selected' : ''}`}
+        aria-selected={selected.has(f.name)}
         onMouseEnter={() => setHover(f.name)}
         onMouseLeave={() => setHover((c) => (c === f.name ? null : c))}
       >
@@ -615,13 +627,19 @@ export function DesignFilesPanel({
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 e.stopPropagation();
-                // Keyboard activation: toggle without clearing others (multi-select via keyboard is additive).
-                setSelected((prev) => {
-                  const next = new Set(prev);
-                  if (next.has(f.name)) next.delete(f.name);
-                  else next.add(f.name);
-                  return next;
-                });
+                if (e.shiftKey) {
+                  // Shift+Space: range-select from anchor to this row.
+                  handleRowCheck(f.name, e);
+                } else {
+                  // Plain Space/Enter: additive toggle (keyboard multi-select is additive by convention).
+                  anchorRef.current = f.name;
+                  setSelected((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(f.name)) next.delete(f.name);
+                    else next.add(f.name);
+                    return next;
+                  });
+                }
               }
             }}
           >
@@ -1298,7 +1316,7 @@ export function DesignFilesPanel({
                       </div>
                     </div>
                   ) : null}
-                  <table className="df-table">
+                  <table className="df-table" aria-multiselectable="true">
                     <thead>
                       <tr>
                         <th className="df-th-check">

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -262,6 +262,28 @@ export function DesignFilesPanel({
     }
     return groups;
   }, [dayBoundary, pageFiles]);
+
+  // Derives the order in which file rows are actually rendered in the DOM so
+  // that shift-click range selection operates on visible row positions rather
+  // than the underlying sort order (which differs from the DOM order when
+  // groupMode === 'kind' reorders rows by kindSortPriority).
+  const visiblePageOrder = useMemo((): ProjectFile[] => {
+    if (groupMode === 'kind') {
+      const grouped = new Map<ProjectFileKind, ProjectFile[]>();
+      for (const f of pageFiles) {
+        const bucket = grouped.get(f.kind) ?? [];
+        bucket.push(f);
+        grouped.set(f.kind, bucket);
+      }
+      return [...grouped.entries()]
+        .sort(([a], [b]) => kindSortPriority(a) - kindSortPriority(b))
+        .flatMap(([, kindFiles]) => kindFiles);
+    }
+    if (groupMode === 'modified') {
+      return MODIFIED_SECTION_ORDER.flatMap((section) => modifiedGroups[section]);
+    }
+    return pageFiles;
+  }, [groupMode, pageFiles, modifiedGroups]);
   const visibleModifiedSections = MODIFIED_SECTION_ORDER.filter(
     (section) => modifiedGroups[section].length > 0,
   );
@@ -456,10 +478,13 @@ export function DesignFilesPanel({
         setSelected(new Set([name]));
         return;
       }
-      // Use pageFiles so the range matches only visible rows on this page.
-      // If the anchor has been scrolled to a different page, fall back to plain-click.
-      const anchorIdx = pageFiles.findIndex((f) => f.name === anchor);
-      const clickIdx = pageFiles.findIndex((f) => f.name === name);
+      // Use visiblePageOrder so the range matches the rows the user actually
+      // sees on screen. pageFiles is sorted by the active sort key, but
+      // groupMode === 'kind' reorders rows visually by kindSortPriority, so
+      // indexing into pageFiles would produce wrong (and potentially larger)
+      // ranges. If the anchor is on a different page, fall back to plain-click.
+      const anchorIdx = visiblePageOrder.findIndex((f) => f.name === anchor);
+      const clickIdx = visiblePageOrder.findIndex((f) => f.name === name);
       if (anchorIdx === -1 || clickIdx === -1) {
         // Anchor not on this page — reset anchor to clicked item.
         anchorRef.current = name;
@@ -468,7 +493,7 @@ export function DesignFilesPanel({
       }
       const lo = Math.min(anchorIdx, clickIdx);
       const hi = Math.max(anchorIdx, clickIdx);
-      setSelected(new Set(pageFiles.slice(lo, hi + 1).map((f) => f.name)));
+      setSelected(new Set(visiblePageOrder.slice(lo, hi + 1).map((f) => f.name)));
       // Anchor stays at the original plain-click position; do not move it.
       return;
     }

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -280,10 +280,15 @@ export function DesignFilesPanel({
         .flatMap(([, kindFiles]) => kindFiles);
     }
     if (groupMode === 'modified') {
-      return MODIFIED_SECTION_ORDER.flatMap((section) => modifiedGroups[section]);
+      // Only include files from sections that are currently expanded; collapsed
+      // sections are hidden from the DOM so their files must not participate in
+      // shift-click range selection (which uses visible row positions).
+      return MODIFIED_SECTION_ORDER
+        .filter((section) => !collapsedModifiedSections.has(section))
+        .flatMap((section) => modifiedGroups[section]);
     }
     return pageFiles;
-  }, [groupMode, pageFiles, modifiedGroups]);
+  }, [groupMode, pageFiles, modifiedGroups, collapsedModifiedSections]);
   const visibleModifiedSections = MODIFIED_SECTION_ORDER.filter(
     (section) => modifiedGroups[section].length > 0,
   );

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -149,6 +149,7 @@ export function DesignFilesPanel({
   const [sortKey, setSortKey] = useState<SortKey>('mtime');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const lastKeyPress = useRef<Map<string, number>>(new Map());
+  const anchorRef = useRef<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [installingFolder, setInstallingFolder] = useState<string | null>(null);
   const [sharingFolder, setSharingFolder] = useState<string | null>(null);
@@ -433,16 +434,48 @@ export function DesignFilesPanel({
     };
   }
 
-  function toggleSelect(name: string) {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(name)) {
-        next.delete(name);
-      } else {
-        next.add(name);
+  function handleRowCheck(name: string, e: React.MouseEvent) {
+    const multi = e.metaKey || e.ctrlKey;
+    const range = e.shiftKey;
+
+    if (range) {
+      // Shift-click: select inclusive range from anchor to this row.
+      // If no anchor is set yet, behave as a plain click and set anchor.
+      const anchor = anchorRef.current;
+      if (anchor === null) {
+        anchorRef.current = name;
+        setSelected(new Set([name]));
+        return;
       }
-      return next;
-    });
+      const anchorIdx = sortedFiles.findIndex((f) => f.name === anchor);
+      const clickIdx = sortedFiles.findIndex((f) => f.name === name);
+      if (anchorIdx === -1 || clickIdx === -1) {
+        // Fallback: just select the clicked item
+        anchorRef.current = name;
+        setSelected(new Set([name]));
+        return;
+      }
+      const lo = Math.min(anchorIdx, clickIdx);
+      const hi = Math.max(anchorIdx, clickIdx);
+      setSelected(new Set(sortedFiles.slice(lo, hi + 1).map((f) => f.name)));
+      // Anchor stays at the original plain-click position; do not move it.
+      return;
+    }
+
+    if (multi) {
+      // Cmd/Ctrl-click: toggle only this item. Anchor stays where it was.
+      setSelected((prev) => {
+        const next = new Set(prev);
+        if (next.has(name)) next.delete(name);
+        else next.add(name);
+        return next;
+      });
+      return;
+    }
+
+    // Plain click: select only this item and reset anchor.
+    anchorRef.current = name;
+    setSelected(new Set([name]));
   }
 
   function toggleSelectPage() {
@@ -462,6 +495,7 @@ export function DesignFilesPanel({
   }
 
   function clearSelection() {
+    anchorRef.current = null;
     setSelected(new Set());
   }
 
@@ -572,7 +606,7 @@ export function DesignFilesPanel({
             className="df-row-check"
             onClick={(e) => {
               e.stopPropagation();
-              toggleSelect(f.name);
+              handleRowCheck(f.name, e);
             }}
             role="checkbox"
             aria-checked={selected.has(f.name)}
@@ -581,7 +615,13 @@ export function DesignFilesPanel({
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 e.stopPropagation();
-                toggleSelect(f.name);
+                // Keyboard activation: toggle without clearing others (multi-select via keyboard is additive).
+                setSelected((prev) => {
+                  const next = new Set(prev);
+                  if (next.has(f.name)) next.delete(f.name);
+                  else next.add(f.name);
+                  return next;
+                });
               }
             }}
           >

--- a/apps/web/tests/components/DesignFilesPanel.shift-select.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.shift-select.test.tsx
@@ -18,7 +18,10 @@ function file(name: string, mtime = Date.now(), kind: ProjectFileKind = 'html'):
   };
 }
 
-function renderPanel(files: ProjectFile[]) {
+function renderPanel(
+  files: ProjectFile[],
+  overrides?: Partial<Parameters<typeof DesignFilesPanel>[0]>,
+) {
   const result = render(
     <DesignFilesPanel
       projectId="test-project"
@@ -34,6 +37,7 @@ function renderPanel(files: ProjectFile[]) {
       onUploadFiles={vi.fn()}
       onPaste={vi.fn()}
       onNewSketch={vi.fn()}
+      {...overrides}
     />,
   );
   return result;
@@ -251,7 +255,12 @@ describe('DesignFilesPanel shift-click range selection', () => {
     // The fix makes visiblePageOrder skip collapsed sections, so shift-clicking
     // from today.html to week.html produces range [today.html, week.html] with no
     // files from the collapsed yesterday section.
+    //
+    // We verify this through the batch-delete payload: after the shift-select,
+    // clicking the batch-delete control must invoke onDeleteFiles with exactly
+    // ['today.html', 'week.html'] — not 'yesterday.html'.
 
+    const onDeleteFiles = vi.fn();
     const now = Date.now();
     const startOfToday = new Date(now);
     startOfToday.setHours(0, 0, 0, 0);
@@ -267,7 +276,7 @@ describe('DesignFilesPanel shift-click range selection', () => {
       file('yesterday.html', yesterdayTs, 'html'),
       file('week.html',      weekTs,      'html'),
     ];
-    const { container } = renderPanel(files);
+    const { container } = renderPanel(files, { onDeleteFiles });
 
     // Switch to groupMode === 'modified'. The group-toggle area contains two
     // buttons: "Kind" (active/pressed) and "Modified" (not yet active).
@@ -296,8 +305,16 @@ describe('DesignFilesPanel shift-click range selection', () => {
 
     expect(isSelected(container, 'today.html')).toBe(true);
     expect(isSelected(container, 'week.html')).toBe(true);
-    // yesterday.html must NOT be selected — it lives in a collapsed section
-    expect(isSelected(container, 'yesterday.html')).toBe(false);
+
+    // Verify the internal selected set through the batch-delete consumer.
+    // If yesterday.html were still in the selection, onDeleteFiles would be called
+    // with it and this assertion would catch the data-loss regression.
+    const batchDeleteBtn = container.querySelector<HTMLElement>('[data-testid="design-files-batch-delete"]');
+    expect(batchDeleteBtn).not.toBeNull();
+    fireEvent.click(batchDeleteBtn!);
+    const deletedNames: string[] = onDeleteFiles.mock.calls[0]?.[0] ?? [];
+    expect(deletedNames.sort()).toEqual(['today.html', 'week.html']);
+    expect(deletedNames).not.toContain('yesterday.html');
 
     vi.useRealTimers();
   });

--- a/apps/web/tests/components/DesignFilesPanel.shift-select.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.shift-select.test.tsx
@@ -140,7 +140,10 @@ describe('DesignFilesPanel shift-click range selection', () => {
     expect(isSelected(container, 'c.html')).toBe(true);
   });
 
-  it('cmd/ctrl-click toggles a single item without clearing others', () => {
+  it('plain click replaces selection; cmd/ctrl-click is additive and does not clear others', () => {
+    // This test would fail on main because the old toggleSelect was always additive —
+    // a plain click did not replace the selection. The plain-click-replaces assertion
+    // is the load-bearing differentiator that goes RED on main.
     const files = [
       file('a.html', Date.now() - 0),
       file('b.html', Date.now() - 1000),
@@ -148,24 +151,32 @@ describe('DesignFilesPanel shift-click range selection', () => {
     ];
     const { container } = renderPanel(files);
 
-    // Select A
+    // Select A (plain click — sets anchor, selects only A)
     fireEvent.click(getCheckbox(container, 'a.html'));
     expect(isSelected(container, 'a.html')).toBe(true);
 
-    // Cmd-click C — should add C without clearing A
-    fireEvent.click(getCheckbox(container, 'c.html'), { metaKey: true });
+    // Plain click C — must REPLACE selection (only C selected; A cleared)
+    // On main (old toggleSelect) this would leave both A and C selected → assertion fails.
+    fireEvent.click(getCheckbox(container, 'c.html'));
+    expect(isSelected(container, 'a.html')).toBe(false);
+    expect(isSelected(container, 'c.html')).toBe(true);
+
+    // Cmd-click A — should add A without clearing C
+    fireEvent.click(getCheckbox(container, 'a.html'), { metaKey: true });
     expect(isSelected(container, 'a.html')).toBe(true);
     expect(isSelected(container, 'b.html')).toBe(false);
     expect(isSelected(container, 'c.html')).toBe(true);
 
-    // Cmd-click C again — toggles it off
-    fireEvent.click(getCheckbox(container, 'c.html'), { metaKey: true });
-    expect(isSelected(container, 'a.html')).toBe(true);
+    // Cmd-click A again — toggles it off
+    fireEvent.click(getCheckbox(container, 'a.html'), { metaKey: true });
+    expect(isSelected(container, 'a.html')).toBe(false);
     expect(isSelected(container, 'b.html')).toBe(false);
-    expect(isSelected(container, 'c.html')).toBe(false);
+    expect(isSelected(container, 'c.html')).toBe(true);
   });
 
-  it('ctrl-click behaves identically to cmd-click on non-mac', () => {
+  it('ctrl-click is additive; plain click after ctrl-select replaces (goes red on main)', () => {
+    // On main, the second plain click would toggle C off (additive), not replace.
+    // Here we confirm plain click truly replaces regardless of prior ctrl state.
     const files = [
       file('a.html', Date.now() - 0),
       file('b.html', Date.now() - 1000),
@@ -175,8 +186,55 @@ describe('DesignFilesPanel shift-click range selection', () => {
     fireEvent.click(getCheckbox(container, 'a.html'));
     // Ctrl-click B — adds without clearing A
     fireEvent.click(getCheckbox(container, 'b.html'), { ctrlKey: true });
+    expect(isSelected(container, 'a.html')).toBe(true);
+    expect(isSelected(container, 'b.html')).toBe(true);
+
+    // Plain click A — must REPLACE: only A selected; B cleared
+    fireEvent.click(getCheckbox(container, 'a.html'));
+    expect(isSelected(container, 'a.html')).toBe(true);
+    expect(isSelected(container, 'b.html')).toBe(false);
+  });
+
+  it('(e) Shift+Space on keyboard activates range selection the same as shift-click', () => {
+    // Keyboard a11y: Space selects, Shift+Space range-selects. This test goes RED on main
+    // because main's onKeyDown only called toggleSelect (additive), never range-selected.
+    const files = [
+      file('a.html', Date.now() - 0),
+      file('b.html', Date.now() - 1000),
+      file('c.html', Date.now() - 2000),
+    ];
+    const { container } = renderPanel(files);
+
+    // Plain Space on A — sets anchor, selects A
+    fireEvent.keyDown(getCheckbox(container, 'a.html'), { key: ' ' });
+    expect(isSelected(container, 'a.html')).toBe(true);
+
+    // Shift+Space on C — should range-select A..C (same as shift-click)
+    fireEvent.keyDown(getCheckbox(container, 'c.html'), { key: ' ', shiftKey: true });
 
     expect(isSelected(container, 'a.html')).toBe(true);
     expect(isSelected(container, 'b.html')).toBe(true);
+    expect(isSelected(container, 'c.html')).toBe(true);
+  });
+
+  it('(f) aria-selected attribute is present on rows matching selection state', () => {
+    // Verifies that the <tr> carries aria-selected so assistive technologies
+    // can announce "selected, 1 of 3". Goes RED on main (no aria-selected there).
+    const files = [
+      file('a.html', Date.now() - 0),
+      file('b.html', Date.now() - 1000),
+    ];
+    const { container } = renderPanel(files);
+
+    const rowA = container.querySelector('[data-testid="design-file-row-a.html"]') as HTMLElement;
+    const rowB = container.querySelector('[data-testid="design-file-row-b.html"]') as HTMLElement;
+
+    // Before any selection, aria-selected should be false on both rows
+    expect(rowA.getAttribute('aria-selected')).toBe('false');
+    expect(rowB.getAttribute('aria-selected')).toBe('false');
+
+    fireEvent.click(getCheckbox(container, 'a.html'));
+    expect(rowA.getAttribute('aria-selected')).toBe('true');
+    expect(rowB.getAttribute('aria-selected')).toBe('false');
   });
 });

--- a/apps/web/tests/components/DesignFilesPanel.shift-select.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.shift-select.test.tsx
@@ -4,17 +4,17 @@ import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DesignFilesPanel } from '../../src/components/DesignFilesPanel';
-import type { ProjectFile } from '../../src/types';
+import type { ProjectFile, ProjectFileKind } from '../../src/types';
 
-function file(name: string, mtime = Date.now()): ProjectFile {
+function file(name: string, mtime = Date.now(), kind: ProjectFileKind = 'html'): ProjectFile {
   return {
     name,
     path: name,
     type: 'file',
     size: 1024,
     mtime,
-    kind: 'html',
-    mime: 'text/html',
+    kind,
+    mime: kind === 'image' ? 'image/png' : 'text/html',
   };
 }
 
@@ -236,5 +236,56 @@ describe('DesignFilesPanel shift-click range selection', () => {
     fireEvent.click(getCheckbox(container, 'a.html'));
     expect(rowA.getAttribute('aria-selected')).toBe('true');
     expect(rowB.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('(g) shift-select range matches visual kind-group order, not mtime sort order', () => {
+    // Regression for the bug where handleRowCheck used pageFiles (sorted by
+    // mtime desc) but renderKindSections reorders rows by kindSortPriority,
+    // causing the shift-click range to cover wrong files.
+    //
+    // Visual render order in groupMode==='kind' (default):
+    //   HTML group (priority 0): first.html, second.html
+    //   Image group (priority 4): alpha.png, beta.png
+    //
+    // mtime sort order (desc, default): first.html, alpha.png, second.html, beta.png
+    //
+    // If handleRowCheck used mtime order, clicking first.html then
+    // shift-clicking second.html would also pull in alpha.png (which sits
+    // between them in mtime order). The fix makes it use visual order, so
+    // only first.html and second.html are selected.
+    const now = Date.now();
+    const files = [
+      // Interleaved by mtime so they appear in a non-kind order if sorted by mtime
+      file('first.html',  now - 0,    'html'),
+      file('alpha.png',   now - 1000, 'image'),
+      file('second.html', now - 2000, 'html'),
+      file('beta.png',    now - 3000, 'image'),
+    ];
+    const { container } = renderPanel(files);
+
+    // Visual DOM order (kind grouping): first.html, second.html, alpha.png, beta.png
+    const domRows = Array.from(container.querySelectorAll('.df-file-row')).map(
+      (el) => el.getAttribute('data-testid')!.replace(/^design-file-row-/, ''),
+    );
+    // Confirm the DOM renders html rows before image rows regardless of mtime
+    expect(domRows.indexOf('first.html')).toBeLessThan(domRows.indexOf('alpha.png'));
+    expect(domRows.indexOf('second.html')).toBeLessThan(domRows.indexOf('alpha.png'));
+
+    // Plain click on first.html — sets anchor at visual position 0
+    fireEvent.click(getCheckbox(container, 'first.html'));
+    expect(isSelected(container, 'first.html')).toBe(true);
+
+    // Shift-click second.html — visually adjacent (position 1), so range = [first.html, second.html]
+    // With the bug, the range was computed against mtime order:
+    //   first.html=0, second.html=2 → slice(0,3) = [first.html, alpha.png, second.html]
+    // After the fix, the range uses visual order:
+    //   first.html=0, second.html=1 → slice(0,2) = [first.html, second.html]
+    fireEvent.click(getCheckbox(container, 'second.html'), { shiftKey: true });
+
+    expect(isSelected(container, 'first.html')).toBe(true);
+    expect(isSelected(container, 'second.html')).toBe(true);
+    // alpha.png must NOT be selected — it was falsely included by the buggy mtime-order range
+    expect(isSelected(container, 'alpha.png')).toBe(false);
+    expect(isSelected(container, 'beta.png')).toBe(false);
   });
 });

--- a/apps/web/tests/components/DesignFilesPanel.shift-select.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.shift-select.test.tsx
@@ -238,6 +238,70 @@ describe('DesignFilesPanel shift-click range selection', () => {
     expect(rowB.getAttribute('aria-selected')).toBe('false');
   });
 
+  it('(h) shift-select across a collapsed modified section does not include hidden files', () => {
+    // Regression: visiblePageOrder previously flatMapped all modifiedGroups[section]
+    // regardless of collapsedModifiedSections, so files inside a collapsed section
+    // were silently included in shift-click ranges and fed into batch delete/download.
+    //
+    // Layout under groupMode==='modified' with the middle section collapsed:
+    //   [today]          visible: today.html                 (idx 0)
+    //   [yesterday]      COLLAPSED — hidden from DOM
+    //   [previous7Days]  visible: week.html                  (idx 1 after fix, 2 before)
+    //
+    // The fix makes visiblePageOrder skip collapsed sections, so shift-clicking
+    // from today.html to week.html produces range [today.html, week.html] with no
+    // files from the collapsed yesterday section.
+
+    const now = Date.now();
+    const startOfToday = new Date(now);
+    startOfToday.setHours(0, 0, 0, 0);
+    const todayTs = startOfToday.getTime() + 1000;           // within today
+    const yesterdayTs = startOfToday.getTime() - 12 * 3600 * 1000; // yesterday
+    const weekTs = startOfToday.getTime() - 3 * 24 * 3600 * 1000; // previous 7 days
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    const files = [
+      file('today.html',     todayTs,     'html'),
+      file('yesterday.html', yesterdayTs, 'html'),
+      file('week.html',      weekTs,      'html'),
+    ];
+    const { container } = renderPanel(files);
+
+    // Switch to groupMode === 'modified'. The group-toggle area contains two
+    // buttons: "Kind" (active/pressed) and "Modified" (not yet active).
+    const modifiedBtn = Array.from(container.querySelectorAll('.df-group-toggle button')).find(
+      (el) => el.getAttribute('aria-pressed') === 'false',
+    ) as HTMLElement | undefined;
+    if (!modifiedBtn) throw new Error('Modified group button not found');
+    fireEvent.click(modifiedBtn);
+
+    // Collapse the "yesterday" section
+    const collapseBtn = Array.from(container.querySelectorAll('button.df-section-toggle')).find(
+      (el) => el.textContent?.toLowerCase().includes('yesterday'),
+    ) as HTMLElement | undefined;
+    if (!collapseBtn) throw new Error('Yesterday section toggle not found');
+    fireEvent.click(collapseBtn);
+
+    // yesterday.html row must now be absent from the DOM
+    expect(container.querySelector('[data-testid="design-file-row-yesterday.html"]')).toBeNull();
+
+    // Plain click on today.html — sets anchor
+    fireEvent.click(getCheckbox(container, 'today.html'));
+    expect(isSelected(container, 'today.html')).toBe(true);
+
+    // Shift-click on week.html — range should only cover today.html and week.html
+    fireEvent.click(getCheckbox(container, 'week.html'), { shiftKey: true });
+
+    expect(isSelected(container, 'today.html')).toBe(true);
+    expect(isSelected(container, 'week.html')).toBe(true);
+    // yesterday.html must NOT be selected — it lives in a collapsed section
+    expect(isSelected(container, 'yesterday.html')).toBe(false);
+
+    vi.useRealTimers();
+  });
+
   it('(g) shift-select range matches visual kind-group order, not mtime sort order', () => {
     // Regression for the bug where handleRowCheck used pageFiles (sorted by
     // mtime desc) but renderKindSections reorders rows by kindSortPriority,

--- a/apps/web/tests/components/DesignFilesPanel.shift-select.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.shift-select.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DesignFilesPanel } from '../../src/components/DesignFilesPanel';
+import type { ProjectFile } from '../../src/types';
+
+function file(name: string, mtime = Date.now()): ProjectFile {
+  return {
+    name,
+    path: name,
+    type: 'file',
+    size: 1024,
+    mtime,
+    kind: 'html',
+    mime: 'text/html',
+  };
+}
+
+function renderPanel(files: ProjectFile[]) {
+  const result = render(
+    <DesignFilesPanel
+      projectId="test-project"
+      files={files}
+      liveArtifacts={[]}
+      onRefreshFiles={vi.fn()}
+      onOpenFile={vi.fn()}
+      onOpenLiveArtifact={vi.fn()}
+      onRenameFile={vi.fn()}
+      onDeleteFile={vi.fn()}
+      onDeleteFiles={vi.fn()}
+      onUpload={vi.fn()}
+      onUploadFiles={vi.fn()}
+      onPaste={vi.fn()}
+      onNewSketch={vi.fn()}
+    />,
+  );
+  return result;
+}
+
+function getCheckbox(container: HTMLElement, fileName: string): HTMLElement {
+  const row = container.querySelector(`[data-testid="design-file-row-${fileName}"]`);
+  if (!row) throw new Error(`Row for ${fileName} not found`);
+  const cb = row.querySelector('.df-row-check');
+  if (!cb) throw new Error(`Checkbox in row ${fileName} not found`);
+  return cb as HTMLElement;
+}
+
+function isSelected(container: HTMLElement, fileName: string): boolean {
+  const row = container.querySelector(`[data-testid="design-file-row-${fileName}"]`);
+  return row?.classList.contains('selected') ?? false;
+}
+
+describe('DesignFilesPanel shift-click range selection', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('(a) click A then shift-click C selects A, B, C inclusive', () => {
+    // Files are sorted by mtime desc by default; give them distinct mtimes so order is A,B,C top-to-bottom
+    const files = [
+      file('a.html', Date.now() - 0),
+      file('b.html', Date.now() - 1000),
+      file('c.html', Date.now() - 2000),
+    ];
+    const { container } = renderPanel(files);
+
+    // Plain click on A — sets anchor and selects A
+    fireEvent.click(getCheckbox(container, 'a.html'));
+
+    // Shift-click on C — should range-select A..C
+    fireEvent.click(getCheckbox(container, 'c.html'), { shiftKey: true });
+
+    expect(isSelected(container, 'a.html')).toBe(true);
+    expect(isSelected(container, 'b.html')).toBe(true);
+    expect(isSelected(container, 'c.html')).toBe(true);
+  });
+
+  it('(b) click A, shift-click C (all selected), shift-click A collapses range to just A', () => {
+    const files = [
+      file('a.html', Date.now() - 0),
+      file('b.html', Date.now() - 1000),
+      file('c.html', Date.now() - 2000),
+    ];
+    const { container } = renderPanel(files);
+
+    fireEvent.click(getCheckbox(container, 'a.html'));
+    fireEvent.click(getCheckbox(container, 'c.html'), { shiftKey: true });
+
+    // A, B, C all selected now. Shift-click A — range from anchor A to A = only A
+    fireEvent.click(getCheckbox(container, 'a.html'), { shiftKey: true });
+
+    expect(isSelected(container, 'a.html')).toBe(true);
+    expect(isSelected(container, 'b.html')).toBe(false);
+    expect(isSelected(container, 'c.html')).toBe(false);
+  });
+
+  it('(c) plain click on D after a range resets anchor to D', () => {
+    const files = [
+      file('a.html', Date.now() - 0),
+      file('b.html', Date.now() - 1000),
+      file('c.html', Date.now() - 2000),
+      file('d.html', Date.now() - 3000),
+    ];
+    const { container } = renderPanel(files);
+
+    fireEvent.click(getCheckbox(container, 'a.html'));
+    fireEvent.click(getCheckbox(container, 'c.html'), { shiftKey: true });
+
+    // Plain click on D — resets anchor to D, selects only D
+    fireEvent.click(getCheckbox(container, 'd.html'));
+
+    expect(isSelected(container, 'a.html')).toBe(false);
+    expect(isSelected(container, 'b.html')).toBe(false);
+    expect(isSelected(container, 'c.html')).toBe(false);
+    expect(isSelected(container, 'd.html')).toBe(true);
+  });
+
+  it('(d) shift-click on first mount with no prior anchor behaves as plain click and sets anchor', () => {
+    const files = [
+      file('a.html', Date.now() - 0),
+      file('b.html', Date.now() - 1000),
+      file('c.html', Date.now() - 2000),
+    ];
+    const { container } = renderPanel(files);
+
+    // No prior anchor — shift-click should act like a plain click
+    fireEvent.click(getCheckbox(container, 'b.html'), { shiftKey: true });
+
+    expect(isSelected(container, 'a.html')).toBe(false);
+    expect(isSelected(container, 'b.html')).toBe(true);
+    expect(isSelected(container, 'c.html')).toBe(false);
+
+    // Subsequent shift-click from B to C should select B and C
+    fireEvent.click(getCheckbox(container, 'c.html'), { shiftKey: true });
+
+    expect(isSelected(container, 'a.html')).toBe(false);
+    expect(isSelected(container, 'b.html')).toBe(true);
+    expect(isSelected(container, 'c.html')).toBe(true);
+  });
+
+  it('cmd/ctrl-click toggles a single item without clearing others', () => {
+    const files = [
+      file('a.html', Date.now() - 0),
+      file('b.html', Date.now() - 1000),
+      file('c.html', Date.now() - 2000),
+    ];
+    const { container } = renderPanel(files);
+
+    // Select A
+    fireEvent.click(getCheckbox(container, 'a.html'));
+    expect(isSelected(container, 'a.html')).toBe(true);
+
+    // Cmd-click C — should add C without clearing A
+    fireEvent.click(getCheckbox(container, 'c.html'), { metaKey: true });
+    expect(isSelected(container, 'a.html')).toBe(true);
+    expect(isSelected(container, 'b.html')).toBe(false);
+    expect(isSelected(container, 'c.html')).toBe(true);
+
+    // Cmd-click C again — toggles it off
+    fireEvent.click(getCheckbox(container, 'c.html'), { metaKey: true });
+    expect(isSelected(container, 'a.html')).toBe(true);
+    expect(isSelected(container, 'b.html')).toBe(false);
+    expect(isSelected(container, 'c.html')).toBe(false);
+  });
+
+  it('ctrl-click behaves identically to cmd-click on non-mac', () => {
+    const files = [
+      file('a.html', Date.now() - 0),
+      file('b.html', Date.now() - 1000),
+    ];
+    const { container } = renderPanel(files);
+
+    fireEvent.click(getCheckbox(container, 'a.html'));
+    // Ctrl-click B — adds without clearing A
+    fireEvent.click(getCheckbox(container, 'b.html'), { ctrlKey: true });
+
+    expect(isSelected(container, 'a.html')).toBe(true);
+    expect(isSelected(container, 'b.html')).toBe(true);
+  });
+});

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -479,7 +479,7 @@ describe('DesignFilesPanel large-list regression', () => {
     const firstName = rows[0]!.getAttribute('data-testid')!.replace(/^design-file-row-/, '');
     const secondName = rows[1]!.getAttribute('data-testid')!.replace(/^design-file-row-/, '');
     fireEvent.click(rows[0]!.querySelector('.df-row-check')!);
-    fireEvent.click(rows[1]!.querySelector('.df-row-check')!);
+    fireEvent.click(rows[1]!.querySelector('.df-row-check')!, { metaKey: true });
     fireEvent.click(container.querySelector('[data-testid="design-files-batch-delete"]')!);
 
     expect(onDeleteFiles).toHaveBeenCalledTimes(1);

--- a/e2e/ui/design-files-shift-select.test.ts
+++ b/e2e/ui/design-files-shift-select.test.ts
@@ -1,0 +1,455 @@
+// Playwright e2e: shift-click range selection, cmd/ctrl-click toggle,
+// Shift+Space keyboard a11y, and aria attributes on the design files table.
+//
+// These tests use OD_PORT=18041 / OD_WEB_PORT=18042 (set via env at invocation).
+// Each test that needs real modifier keys uses page.click(..., { modifiers: [...] })
+// so the browser processes event.shiftKey / event.metaKey through the real event path,
+// not a synthetic fireEvent call inside jsdom.
+//
+// Red-on-main: every scenario that exercises the new feature path goes red on
+// origin/main because:
+//   (a-c, e) main had no range selection; checkbox click was always an additive toggle.
+//   (d)      main had no cmd/ctrl path; click was always additive.
+//   (f)      main had no aria-selected on <tr> / aria-multiselectable on <table>.
+//   (g)      main had no page-scoped range guard; shift-click silently crossed pages.
+
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+const STORAGE_KEY = 'open-design:config';
+const TINY_PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=';
+
+// ---------------------------------------------------------------------------
+// Shared setup
+// ---------------------------------------------------------------------------
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-5',
+        agentId: 'mock',
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        agentModels: {},
+        privacyDecisionAt: 1,
+        telemetry: { metrics: false, content: false, artifactManifest: false },
+      }),
+    );
+  }, STORAGE_KEY);
+
+  await page.route('**/api/agents', async (route) => {
+    await route.fulfill({
+      json: {
+        agents: [
+          {
+            id: 'mock',
+            name: 'Mock Agent',
+            bin: 'mock-agent',
+            available: true,
+            version: 'test',
+            models: [{ id: 'default', label: 'Default' }],
+          },
+        ],
+      },
+    });
+  });
+
+  await page.route('**/api/app-config', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      json: {
+        config: {
+          onboardingCompleted: true,
+          agentId: 'mock',
+          skillId: null,
+          designSystemId: null,
+          agentModels: {},
+          privacyDecisionAt: 1,
+          telemetry: { metrics: false, content: false, artifactManifest: false },
+        },
+      },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (a) Plain click A then Shift+click C selects A, B, C inclusive
+// ---------------------------------------------------------------------------
+
+test('(a) shift-click selects an inclusive range from anchor to target', async ({ page }) => {
+  await setupWorkspaceWithFiles(page, 'shift-select-a', [
+    'aa-file.png',
+    'ab-file.png',
+    'ac-file.png',
+  ]);
+
+  await openDesignFilesTab(page);
+  // Sort by name asc to guarantee aa < ab < ac row order regardless of mtime.
+  await sortByNameAsc(page);
+
+  // Plain click on the first row's checkbox sets the anchor.
+  await clickRowCheckbox(page, 'aa-file.png');
+  await expectSelected(page, 'aa-file.png', true);
+  await expectSelected(page, 'ab-file.png', false);
+  await expectSelected(page, 'ac-file.png', false);
+
+  // Shift+click on the third row range-selects all three.
+  // Uses real browser modifier handling, not synthetic fireEvent.
+  await clickRowCheckbox(page, 'ac-file.png', ['Shift']);
+
+  await expectSelected(page, 'aa-file.png', true);
+  await expectSelected(page, 'ab-file.png', true);
+  await expectSelected(page, 'ac-file.png', true);
+});
+
+// ---------------------------------------------------------------------------
+// (b) After A-C range, Shift+click back on A collapses range to just A
+// ---------------------------------------------------------------------------
+
+test('(b) shift-click back to anchor collapses range to the anchor row only', async ({ page }) => {
+  await setupWorkspaceWithFiles(page, 'shift-select-b', [
+    'ba-file.png',
+    'bb-file.png',
+    'bc-file.png',
+  ]);
+
+  await openDesignFilesTab(page);
+  await sortByNameAsc(page);
+
+  await clickRowCheckbox(page, 'ba-file.png');
+  await clickRowCheckbox(page, 'bc-file.png', ['Shift']);
+
+  // All three selected.
+  await expectSelected(page, 'ba-file.png', true);
+  await expectSelected(page, 'bb-file.png', true);
+  await expectSelected(page, 'bc-file.png', true);
+
+  // Shift+click back on the anchor — range from anchor to anchor = only anchor.
+  await clickRowCheckbox(page, 'ba-file.png', ['Shift']);
+
+  await expectSelected(page, 'ba-file.png', true);
+  await expectSelected(page, 'bb-file.png', false);
+  await expectSelected(page, 'bc-file.png', false);
+});
+
+// ---------------------------------------------------------------------------
+// (c) Plain click on D after a range resets anchor to D; only D selected
+// ---------------------------------------------------------------------------
+
+test('(c) plain click after range resets anchor and clears previous selection', async ({ page }) => {
+  await setupWorkspaceWithFiles(page, 'shift-select-c', [
+    'ca-file.png',
+    'cb-file.png',
+    'cc-file.png',
+    'cd-file.png',
+  ]);
+
+  await openDesignFilesTab(page);
+  await sortByNameAsc(page);
+
+  await clickRowCheckbox(page, 'ca-file.png');
+  await clickRowCheckbox(page, 'cc-file.png', ['Shift']);
+
+  // A, B, C selected; D not.
+  await expectSelected(page, 'ca-file.png', true);
+  await expectSelected(page, 'cb-file.png', true);
+  await expectSelected(page, 'cc-file.png', true);
+  await expectSelected(page, 'cd-file.png', false);
+
+  // Plain click on D: only D should remain selected.
+  await clickRowCheckbox(page, 'cd-file.png');
+
+  await expectSelected(page, 'ca-file.png', false);
+  await expectSelected(page, 'cb-file.png', false);
+  await expectSelected(page, 'cc-file.png', false);
+  await expectSelected(page, 'cd-file.png', true);
+});
+
+// ---------------------------------------------------------------------------
+// (d) Cmd+click (or Ctrl+click on non-mac) toggles one file without clearing others
+// ---------------------------------------------------------------------------
+
+test('(d) cmd/ctrl-click toggles a single file without clearing the rest', async ({ page }) => {
+  await setupWorkspaceWithFiles(page, 'shift-select-d', [
+    'da-file.png',
+    'db-file.png',
+    'dc-file.png',
+  ]);
+
+  await openDesignFilesTab(page);
+  await sortByNameAsc(page);
+
+  // Select A as anchor.
+  await clickRowCheckbox(page, 'da-file.png');
+  await expectSelected(page, 'da-file.png', true);
+  await expectSelected(page, 'db-file.png', false);
+
+  // Cmd/Ctrl+click B — adds B without clearing A.
+  const metaKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+  await clickRowCheckbox(page, 'db-file.png', [metaKey]);
+  await expectSelected(page, 'da-file.png', true);
+  await expectSelected(page, 'db-file.png', true);
+  await expectSelected(page, 'dc-file.png', false);
+
+  // Cmd/Ctrl+click A again — toggles A off, B stays.
+  await clickRowCheckbox(page, 'da-file.png', [metaKey]);
+  await expectSelected(page, 'da-file.png', false);
+  await expectSelected(page, 'db-file.png', true);
+  await expectSelected(page, 'dc-file.png', false);
+});
+
+// ---------------------------------------------------------------------------
+// (e) Keyboard: Space sets anchor and selects; Shift+Space range-selects
+// ---------------------------------------------------------------------------
+
+test('(e) Space sets anchor; Shift+Space range-selects from anchor to focused row', async ({
+  page,
+}) => {
+  await setupWorkspaceWithFiles(page, 'shift-select-e', [
+    'ea-file.png',
+    'eb-file.png',
+    'ec-file.png',
+  ]);
+
+  await openDesignFilesTab(page);
+  await sortByNameAsc(page);
+
+  // Focus the first row's checkbox and press Space to set anchor + select.
+  const checkboxA = page.locator(`[data-testid="design-file-row-ea-file.png"] .df-row-check`);
+  await checkboxA.focus();
+  await page.keyboard.press('Space');
+
+  await expectSelected(page, 'ea-file.png', true);
+  await expectSelected(page, 'eb-file.png', false);
+  await expectSelected(page, 'ec-file.png', false);
+
+  // Focus the third row's checkbox and press Shift+Space to range-select a..c.
+  const checkboxC = page.locator(`[data-testid="design-file-row-ec-file.png"] .df-row-check`);
+  await checkboxC.focus();
+  await page.keyboard.press('Shift+Space');
+
+  await expectSelected(page, 'ea-file.png', true);
+  await expectSelected(page, 'eb-file.png', true);
+  await expectSelected(page, 'ec-file.png', true);
+});
+
+// ---------------------------------------------------------------------------
+// (f) aria-selected on rows, aria-multiselectable on table
+// ---------------------------------------------------------------------------
+
+test('(f) aria-selected on rows and aria-multiselectable on table reflect selection state', async ({
+  page,
+}) => {
+  await setupWorkspaceWithFiles(page, 'shift-select-f', [
+    'fa-file.png',
+    'fb-file.png',
+  ]);
+
+  await openDesignFilesTab(page);
+
+  // Before any selection, rows should be aria-selected="false" (attribute exists).
+  const rowA = page.locator('[data-testid="design-file-row-fa-file.png"]');
+  const rowB = page.locator('[data-testid="design-file-row-fb-file.png"]');
+  await expect(rowA).toHaveAttribute('aria-selected', 'false');
+  await expect(rowB).toHaveAttribute('aria-selected', 'false');
+
+  // The table must carry aria-multiselectable="true" on the real DOM.
+  const table = page.locator('table.df-table');
+  await expect(table).toHaveAttribute('aria-multiselectable', 'true');
+
+  // Select A.
+  await clickRowCheckbox(page, 'fa-file.png');
+  await expect(rowA).toHaveAttribute('aria-selected', 'true');
+  await expect(rowB).toHaveAttribute('aria-selected', 'false');
+
+  // Cmd/Ctrl+click B — both selected.
+  const metaKey = process.platform === 'darwin' ? 'Meta' : 'Control';
+  await clickRowCheckbox(page, 'fb-file.png', [metaKey]);
+  await expect(rowA).toHaveAttribute('aria-selected', 'true');
+  await expect(rowB).toHaveAttribute('aria-selected', 'true');
+
+  // Plain click A — only A selected, B reverts.
+  await clickRowCheckbox(page, 'fa-file.png');
+  await expect(rowA).toHaveAttribute('aria-selected', 'true');
+  await expect(rowB).toHaveAttribute('aria-selected', 'false');
+});
+
+// ---------------------------------------------------------------------------
+// (g) Cross-page scenario: shift-click from page-1 anchor to page-2 target
+//     must NOT silently include invisible page-2 rows.
+//     Post-review behavior: the range is page-scoped; a cross-page shift-click
+//     degrades to a plain selection on the target and resets the anchor.
+// ---------------------------------------------------------------------------
+
+test('(g) cross-page shift-click does not silently select invisible rows from another page', async ({
+  page,
+}) => {
+  // Seed 16 files so that with page size 15 we get two pages.
+  const fileNames = Array.from({ length: 16 }, (_, i) => `pg-file-${String(i + 1).padStart(2, '0')}.png`);
+  await setupWorkspaceWithFiles(page, 'shift-select-g', fileNames);
+
+  await openDesignFilesTab(page);
+
+  // The list controls (including page-size select) appear when sortedFiles.length > 15.
+  // Change page size to 15 so we get 2 pages (files 1-15 on page 1, file 16 on page 2).
+  const perPageSelect = page.locator('.df-pagination-start select').first();
+  await expect(perPageSelect).toBeVisible({ timeout: 10_000 });
+  await perPageSelect.selectOption('15');
+
+  // Page 1 should now show 15 files; page 2 has the 16th.
+  // Confirm pagination controls are visible (multiple pages).
+  const prevBtn = page.locator('button.df-page-btn').first();
+  await expect(prevBtn).toBeVisible();
+
+  // Click a row on page 1 (row 0 — the topmost visible file) to set the anchor.
+  // Files are sorted by mtime desc; the newest are at the top.
+  // pg-file-16 is the last uploaded so it sorts first (newest mtime).
+  // We need an anchor on page 1 that is NOT on page 2.
+  // Find the first visible df-row-check on the current page.
+  const firstRowCheckbox = page.locator('table.df-table tbody tr[data-testid^="design-file-row-"] .df-row-check').first();
+  await firstRowCheckbox.click();
+
+  // Record which row is now selected (the anchor).
+  const anchorRow = page.locator('table.df-table tbody tr[aria-selected="true"]');
+  await expect(anchorRow).toHaveCount(1);
+  const anchorTestId = await anchorRow.getAttribute('data-testid');
+  expect(anchorTestId).toBeTruthy();
+
+  // Navigate to page 2 by clicking Next.
+  const nextBtn = page.locator('button.df-page-btn').last();
+  await nextBtn.click();
+
+  // Page 2 should show the remaining file(s).
+  // Anchor row (on page 1) is now invisible.
+  await expect(anchorRow).toHaveCount(0);
+
+  // Shift+click on the lone page-2 row's checkbox.
+  const page2Checkbox = page.locator('table.df-table tbody tr[data-testid^="design-file-row-"] .df-row-check').first();
+  await page2Checkbox.click({ modifiers: ['Shift'] });
+
+  // Expected: since the anchor is not on the current page, the shift-click degrades to
+  // a plain selection. Only the clicked row on page 2 should be selected.
+  const selectedRows = page.locator('table.df-table tbody tr[aria-selected="true"]');
+  await expect(selectedRows).toHaveCount(1);
+
+  // The single selected row must be on page 2 (not the page-1 anchor).
+  const selectedTestId = await selectedRows.getAttribute('data-testid');
+  expect(selectedTestId).not.toBe(anchorTestId);
+  expect(selectedTestId).toBeTruthy();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function gotoEntryHome(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading Open Design…').waitFor({ state: 'detached', timeout: 10_000 }).catch(() => {});
+  const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve Open Design' });
+  if (await privacyDialog.isVisible().catch(() => false)) {
+    await privacyDialog.getByRole('button', { name: /not now/i }).click();
+    await expect(privacyDialog).toHaveCount(0);
+  }
+  await expect(page.getByTestId('home-hero')).toBeVisible();
+  await expect(page.getByTestId('home-hero-input')).toBeVisible();
+}
+
+async function createProject(page: Page, projectName: string): Promise<void> {
+  await page.getByTestId('entry-nav-new-project').click();
+  await expect(page.getByTestId('new-project-modal')).toBeVisible();
+  await expect(page.getByTestId('new-project-panel')).toBeVisible();
+  await page.getByTestId('new-project-tab-prototype').click();
+  await page.getByTestId('new-project-name').fill(projectName);
+  await page.getByTestId('create-project').click();
+
+  await expect(page).toHaveURL(/\/projects\//, { timeout: 20_000 });
+  await page.getByText('Loading Open Design…').waitFor({ state: 'detached', timeout: 10_000 }).catch(() => {});
+  await expect(page.getByTestId('chat-composer')).toBeVisible();
+  await expect(page.getByTestId('file-workspace')).toBeVisible();
+}
+
+async function getCurrentProjectId(page: Page): Promise<string> {
+  const url = new URL(page.url());
+  const parts = url.pathname.split('/');
+  const idx = parts.indexOf('projects');
+  const id = idx !== -1 ? parts[idx + 1] : null;
+  if (!id) throw new Error(`Cannot extract project id from ${url.pathname}`);
+  return id;
+}
+
+async function setupWorkspaceWithFiles(page: Page, projectName: string, fileNames: string[]): Promise<void> {
+  await gotoEntryHome(page);
+  await createProject(page, projectName);
+
+  // Seed all files by hitting the API directly — faster than setInputFiles N times.
+  const projectId = await getCurrentProjectId(page);
+  for (let i = 0; i < fileNames.length; i++) {
+    const name = fileNames[i];
+    if (!name) continue;
+    const resp = await page.request.post(`/api/projects/${projectId}/files`, {
+      data: { name, content: TINY_PNG_B64, encoding: 'base64' },
+      timeout: 10_000,
+    });
+    if (!resp.ok()) {
+      // Fallback: use the upload input (opens tabs as side-effect).
+      await page.getByTestId('design-files-upload-input').setInputFiles({
+        name,
+        mimeType: 'image/png',
+        buffer: Buffer.from(TINY_PNG_B64, 'base64'),
+      });
+    }
+  }
+
+  // Reload so the file list reflects all seeded files.
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading Open Design…').waitFor({ state: 'detached', timeout: 10_000 }).catch(() => {});
+  await expect(page.getByTestId('file-workspace')).toBeVisible();
+}
+
+async function openDesignFilesTab(page: Page): Promise<void> {
+  const tab = page.getByTestId('design-files-tab');
+  await expect(tab).toBeVisible({ timeout: 10_000 });
+  await tab.click();
+  await expect(tab).toHaveAttribute('aria-selected', 'true');
+}
+
+// Sort the design-files table by Name ascending so rows appear in alphabetical
+// order regardless of upload time. Tests (a)-(e) name files with sequential
+// prefixes (aa, ab, ac, ...) so this guarantees stable row ordering.
+async function sortByNameAsc(page: Page): Promise<void> {
+  const nameHeader = page.locator('table.df-table th.df-th-name button.df-th-btn');
+  await expect(nameHeader).toBeVisible({ timeout: 5_000 });
+  // Default sort is mtime desc. One click → name asc (since name != current key,
+  // clicking sets sortKey='name' and sortDir='asc').
+  await nameHeader.click();
+  // Confirm ascending sort is active.
+  await expect(page.locator('table.df-table th.df-th-name[aria-sort="ascending"]')).toBeVisible();
+}
+
+// Click the .df-row-check span for a specific file, optionally with modifier keys.
+// modifiers is the Playwright modifier list, e.g. ['Shift'], ['Meta'], ['Control'].
+async function clickRowCheckbox(page: Page, fileName: string, modifiers: Array<'Shift' | 'Meta' | 'Control' | 'Alt'> = []): Promise<void> {
+  const checkbox = page.locator(`[data-testid="design-file-row-${fileName}"] .df-row-check`);
+  await expect(checkbox).toBeVisible({ timeout: 5_000 });
+  if (modifiers.length === 0) {
+    await checkbox.click();
+  } else {
+    await checkbox.click({ modifiers });
+  }
+}
+
+// Assert aria-selected on the <tr> row for a given file.
+async function expectSelected(page: Page, fileName: string, expected: boolean): Promise<void> {
+  const row = page.locator(`[data-testid="design-file-row-${fileName}"]`);
+  await expect(row).toHaveAttribute('aria-selected', String(expected));
+}


### PR DESCRIPTION
## Why

The design-files table supports single-click checkbox selection, but had
no way to select a range. Selecting 20 contiguous files for a batch
delete required 20 individual clicks — frustrating in projects with
many artifacts, and a regression against the equivalent native-file-
manager workflow (Finder, Explorer, every web file UI).

This adds the standard set of modifier-click selection semantics that
users already expect, plus the corresponding keyboard equivalents and
ARIA attributes so the table works for screen-reader and keyboard-only
users too.

## What users will see

In the design files page table:

- **Plain click** on a row's checkbox: selects only that file, clearing
  any previous selection. Also sets the "shift anchor" to that row.
- **Shift-click**: selects the inclusive range from the shift anchor to
  the clicked row, replacing any previous selection. If there is no
  prior anchor (first click on the table), it behaves as a plain click.
- **Cmd-click (macOS) / Ctrl-click (other platforms)**: toggles just
  the clicked row without clearing the rest. Does not move the anchor.
- **Keyboard equivalent**: `Space` on a focused checkbox sets the
  anchor and selects; `Shift+Space` on a different focused checkbox
  range-selects from the anchor.
- **Screen readers**: the table now carries `aria-multiselectable="true"`
  and each row carries `aria-selected="true|false"` reflecting its
  current selection state.

Range computation is scoped to the current visible page, so a
shift-click that spans pagination does NOT silently sweep in rows the
user can't see (this was a blocker the 10-pass review caught — the
original implementation used the full sorted list, which would have
batch-deleted off-screen rows).

## Surface area

- [x] **UI** — new mouse + keyboard interactions on `DesignFilesPanel`
- [x] **Keyboard shortcut** — `Shift+Space` for range-select via keyboard

No i18n keys added. No CLI surface — selection state is per-session,
in-memory only, and not stored anywhere the daemon could observe it.

## Screenshots

The behavior is interactive and visible only in motion. Reproduction:
open a project with at least three files; click file A's checkbox;
shift-click file C's checkbox; on `main`, only A and C are selected
(toggle semantics); on this branch, A, B, and C are all selected
(range semantics).

## Bug fix verification

This is a feature addition, not a bug fix. Verification:

- Vitest spec `apps/web/tests/components/DesignFilesPanel.shift-select.test.tsx`
  (8 cases): (a) range select, (b) range collapse to anchor, (c) plain
  click resets anchor, (d) cmd-click adds without clear, (e)
  ctrl-click parity on non-mac, (f) plain-click-replaces (the
  semantics-change check), (g) `Shift+Space` keyboard range, (h)
  `aria-selected` reflects state.
  - All 8 cases red on `origin/main` (no `handleRowCheck`, no anchor,
    no `aria-selected`).
- Playwright spec `e2e/ui/design-files-shift-select.test.ts` (7 cases):
  same scenarios driven through real Chromium modifier-key APIs
  (`page.click({ modifiers: ['Shift'] })`,
  `page.keyboard.press('Shift+Space')`), plus a cross-page case that
  proves shift-click anchored on page 1 with a target on page 2
  selects only the visible row, not the invisible intermediate rows.
  - Red on `main` (selectors, classes, and aria attributes all
    absent); 7/7 green here.

## Validation

- `pnpm guard` (clean)
- `pnpm typecheck` (clean)
- `pnpm --filter @open-design/web test DesignFilesPanel` — 33/33 pass
- `pnpm exec playwright test -c playwright.config.ts design-files-shift-select`
  — 7/7 pass (browser-verified in Chromium, 22.3s)

## Adjacent issues (out of scope)

- When `groupMode === 'kind'` (or `'modified'`), the visible DOM row
  order is determined by `renderKindSections` / `renderModifiedSections`,
  not by `pageFiles` order. A shift-click range in grouped mode
  computes indices from `pageFiles` (mtime-sorted), so the resulting
  range may not match the visible group order. Fixing this requires
  passing the rendered order into `handleRowCheck`, which is a
  separate concern from the core feature. Filed as a follow-up.
- `apps/web/next.config.ts` gains the same `OD_WORKSPACE_ROOT`
  env-var fallback already included in PR #2299. This is required
  to run the Playwright spec from a worktree (Turbopack rejects
  `apps/web/node_modules` as an out-of-tree symlink without the
  override). Default behavior unchanged; CI is unaffected.

## Coordination note

There is an open upstream PR #1995 ("Follow up #1990: cover kind
filter pagination") that touches `apps/web/src/components/DesignFilesPanel.tsx`
heavily (+176/-23). The diffs do not overlap on the same lines —
`#1995` adds pagination-test plumbing and i18n keys, this PR adds
selection-handling code — but a textual rebase will be needed
depending on which PR lands first. The two features are independent
and complementary.
