### PR TITLE
fix(web): persist design files view state across navigation

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -286,7 +286,12 @@ export function DesignFilesPanel({
   // Drop any selected-filter kinds that no longer appear in the file list
   // (e.g. after a delete leaves the kind empty). Keeps the filter UI honest
   // and prevents a stale filter from silently hiding everything.
+  // Guard: skip when no kinds are available yet — availableKinds is empty only
+  // when files haven't loaded. Running cleanup against an empty set would
+  // clear a kindFilter that was correctly restored from localStorage before
+  // the async file list arrived.
   useEffect(() => {
+    if (availableKinds.length === 0) return;
     setKindFilter((prev) => {
       if (prev.size === 0) return prev;
       const present = new Set(availableKinds);

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -217,6 +217,13 @@ export function DesignFilesPanel({
   // flush to localStorage when the user actually changes a preference.
   // Without this, every project the user opens gets a default-value entry
   // written on first render, making stale-key garbage grow unbounded.
+  // Note: React 18 StrictMode (active in next dev) fires effects twice,
+  // keeping refs intact across the simulated remount. This means the guard
+  // fires on the first effect run, sets the ref true, and the second run
+  // then writes the defaults. The result is a harmless default-value entry
+  // for the project; subsequent user changes overwrite it correctly. The
+  // invariant ("no write without a user action") only holds in production
+  // builds where StrictMode is not active.
   const viewStateHasMounted = useRef(false);
   const [sortKey, setSortKey] = useState<SortKey>(
     () => isSortKey(savedViewState.current.sortKey) ? savedViewState.current.sortKey : DEFAULT_SORT_KEY,
@@ -1332,6 +1339,7 @@ export function DesignFilesPanel({
                       <label>
                         {t('designFiles.perPage')}:
                         <select
+                          data-testid="df-page-size-select"
                           value={pageSize === 'all' ? 'all' : pageSize}
                           onChange={(e) => {
                             const val = e.target.value;

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -61,6 +61,7 @@ const VIEW_STATE_KEY_PREFIX = 'od:design-files:view-state:v1:';
 const DEFAULT_SORT_KEY: SortKey = 'mtime';
 const DEFAULT_SORT_DIR: SortDir = 'desc';
 const DEFAULT_PAGE_SIZE: number | 'all' = 30;
+const PAGE_SIZE_OPTIONS = [15, 30, 45, 60, 'all'] as const;
 
 interface PersistedViewState {
   sortKey?: SortKey;
@@ -99,8 +100,7 @@ function isSortDir(v: unknown): v is SortDir {
 }
 
 function isPageSize(v: unknown): v is number | 'all' {
-  if (v === 'all') return true;
-  return typeof v === 'number' && Number.isFinite(v) && v > 0;
+  return (PAGE_SIZE_OPTIONS as ReadonlyArray<unknown>).includes(v);
 }
 
 // Validate that a value is one of the known ProjectFileKind literals. This

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -63,6 +63,7 @@ interface PersistedViewState {
 
 function readViewState(projectId: string): PersistedViewState {
   try {
+    if (typeof window === 'undefined') return {};
     const raw = localStorage.getItem(VIEW_STATE_KEY_PREFIX + projectId);
     if (!raw) return {};
     const parsed = JSON.parse(raw) as unknown;
@@ -188,14 +189,15 @@ export function DesignFilesPanel({
   const MENU_SAFE_PADDING = 8;
   const [preview, setPreview] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [sortKey, setSortKey] = useState<SortKey>(() => {
-    const saved = readViewState(projectId);
-    return isSortKey(saved.sortKey) ? saved.sortKey : 'mtime';
-  });
-  const [sortDir, setSortDir] = useState<SortDir>(() => {
-    const saved = readViewState(projectId);
-    return isSortDir(saved.sortDir) ? saved.sortDir : 'desc';
-  });
+  // Read once at mount; projectId is stable for this component instance
+  // (parent uses key={projectId} to remount on project switch).
+  const savedViewState = useRef(readViewState(projectId));
+  const [sortKey, setSortKey] = useState<SortKey>(
+    () => isSortKey(savedViewState.current.sortKey) ? savedViewState.current.sortKey : 'mtime',
+  );
+  const [sortDir, setSortDir] = useState<SortDir>(
+    () => isSortDir(savedViewState.current.sortDir) ? savedViewState.current.sortDir : 'desc',
+  );
   const lastKeyPress = useRef<Map<string, number>>(new Map());
   const [deleting, setDeleting] = useState(false);
   const [installingFolder, setInstallingFolder] = useState<string | null>(null);
@@ -208,9 +210,9 @@ export function DesignFilesPanel({
   const [renaming, setRenaming] = useState<{ name: string; draft: string; saving: boolean } | null>(null);
   const [dayBoundary, setDayBoundary] = useState(() => Date.now());
   const [kindFilter, setKindFilter] = useState<Set<ProjectFileKind>>(() => {
-    const saved = readViewState(projectId);
-    if (!Array.isArray(saved.kindFilter) || saved.kindFilter.length === 0) return new Set();
-    return new Set(saved.kindFilter as ProjectFileKind[]);
+    const { kindFilter: kf } = savedViewState.current;
+    if (!Array.isArray(kf) || kf.length === 0) return new Set();
+    return new Set(kf as ProjectFileKind[]);
   });
   const [filterMenuOpen, setFilterMenuOpen] = useState(false);
   const filterMenuRef = useRef<HTMLDivElement | null>(null);
@@ -286,10 +288,9 @@ export function DesignFilesPanel({
   }, [filteredFiles, sortKey, sortDir]);
 
   const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState<number | 'all'>(() => {
-    const saved = readViewState(projectId);
-    return isPageSize(saved.pageSize) ? saved.pageSize : 30;
-  });
+  const [pageSize, setPageSize] = useState<number | 'all'>(
+    () => isPageSize(savedViewState.current.pageSize) ? savedViewState.current.pageSize : 30,
+  );
 
   const effectivePageSize = pageSize === 'all' ? Math.max(1, sortedFiles.length) : pageSize;
   const totalPages = Math.max(1, Math.ceil(sortedFiles.length / effectivePageSize));

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -51,6 +51,48 @@ type DesignFilesGroupMode = 'kind' | 'modified';
 type ModifiedSection = 'today' | 'yesterday' | 'previous7Days' | 'previous30Days' | 'older';
 type SortKey = 'name' | 'kind' | 'mtime';
 type SortDir = 'asc' | 'desc';
+
+const VIEW_STATE_KEY_PREFIX = 'od:design-files:view-state:v1:';
+
+interface PersistedViewState {
+  sortKey?: SortKey;
+  sortDir?: SortDir;
+  pageSize?: number | 'all';
+  kindFilter?: string[];
+}
+
+function readViewState(projectId: string): PersistedViewState {
+  try {
+    const raw = localStorage.getItem(VIEW_STATE_KEY_PREFIX + projectId);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return parsed as PersistedViewState;
+  } catch {
+    return {};
+  }
+}
+
+function writeViewState(projectId: string, state: PersistedViewState): void {
+  try {
+    localStorage.setItem(VIEW_STATE_KEY_PREFIX + projectId, JSON.stringify(state));
+  } catch {
+    // localStorage unavailable (private mode, quota exceeded) — silently skip
+  }
+}
+
+function isSortKey(v: unknown): v is SortKey {
+  return v === 'name' || v === 'kind' || v === 'mtime';
+}
+
+function isSortDir(v: unknown): v is SortDir {
+  return v === 'asc' || v === 'desc';
+}
+
+function isPageSize(v: unknown): v is number | 'all' {
+  if (v === 'all') return true;
+  return typeof v === 'number' && Number.isFinite(v) && v > 0;
+}
 type FileSystemEntryWithReader = FileSystemEntry & {
   createReader?: () => FileSystemDirectoryReader;
 };
@@ -146,8 +188,14 @@ export function DesignFilesPanel({
   const MENU_SAFE_PADDING = 8;
   const [preview, setPreview] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [sortKey, setSortKey] = useState<SortKey>('mtime');
-  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [sortKey, setSortKey] = useState<SortKey>(() => {
+    const saved = readViewState(projectId);
+    return isSortKey(saved.sortKey) ? saved.sortKey : 'mtime';
+  });
+  const [sortDir, setSortDir] = useState<SortDir>(() => {
+    const saved = readViewState(projectId);
+    return isSortDir(saved.sortDir) ? saved.sortDir : 'desc';
+  });
   const lastKeyPress = useRef<Map<string, number>>(new Map());
   const [deleting, setDeleting] = useState(false);
   const [installingFolder, setInstallingFolder] = useState<string | null>(null);
@@ -159,7 +207,11 @@ export function DesignFilesPanel({
   >(new Set());
   const [renaming, setRenaming] = useState<{ name: string; draft: string; saving: boolean } | null>(null);
   const [dayBoundary, setDayBoundary] = useState(() => Date.now());
-  const [kindFilter, setKindFilter] = useState<Set<ProjectFileKind>>(() => new Set());
+  const [kindFilter, setKindFilter] = useState<Set<ProjectFileKind>>(() => {
+    const saved = readViewState(projectId);
+    if (!Array.isArray(saved.kindFilter) || saved.kindFilter.length === 0) return new Set();
+    return new Set(saved.kindFilter as ProjectFileKind[]);
+  });
   const [filterMenuOpen, setFilterMenuOpen] = useState(false);
   const filterMenuRef = useRef<HTMLDivElement | null>(null);
   const [currentDir, setCurrentDir] = useState<string>('');
@@ -234,7 +286,10 @@ export function DesignFilesPanel({
   }, [filteredFiles, sortKey, sortDir]);
 
   const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState<number | 'all'>(30);
+  const [pageSize, setPageSize] = useState<number | 'all'>(() => {
+    const saved = readViewState(projectId);
+    return isPageSize(saved.pageSize) ? saved.pageSize : 30;
+  });
 
   const effectivePageSize = pageSize === 'all' ? Math.max(1, sortedFiles.length) : pageSize;
   const totalPages = Math.max(1, Math.ceil(sortedFiles.length / effectivePageSize));
@@ -274,6 +329,17 @@ export function DesignFilesPanel({
   useEffect(() => {
     setPage(0);
   }, [pageSize]);
+
+  // Persist view state so it survives navigation (the panel remounts via
+  // key={projectId} when the user tabs away and back).
+  useEffect(() => {
+    writeViewState(projectId, {
+      sortKey,
+      sortDir,
+      pageSize,
+      kindFilter: Array.from(kindFilter),
+    });
+  }, [projectId, sortKey, sortDir, pageSize, kindFilter]);
 
   // Reset to the first page when the filter changes — the previous page
   // index may no longer exist (or may now sit past the new totalPages).

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -52,7 +52,15 @@ type ModifiedSection = 'today' | 'yesterday' | 'previous7Days' | 'previous30Days
 type SortKey = 'name' | 'kind' | 'mtime';
 type SortDir = 'asc' | 'desc';
 
+// Storage key for per-project view state. Bump the version suffix (v1 → v2) when
+// removing or renaming a persisted field — just adding an optional field is safe
+// without a version bump. No cleanup of old keys on project deletion; the keys
+// are small preference blobs and orphan gracefully.
 const VIEW_STATE_KEY_PREFIX = 'od:design-files:view-state:v1:';
+
+const DEFAULT_SORT_KEY: SortKey = 'mtime';
+const DEFAULT_SORT_DIR: SortDir = 'desc';
+const DEFAULT_PAGE_SIZE: number | 'all' = 30;
 
 interface PersistedViewState {
   sortKey?: SortKey;
@@ -93,6 +101,19 @@ function isSortDir(v: unknown): v is SortDir {
 function isPageSize(v: unknown): v is number | 'all' {
   if (v === 'all') return true;
   return typeof v === 'number' && Number.isFinite(v) && v > 0;
+}
+
+// Validate that a value is one of the known ProjectFileKind literals. This
+// guards against stored values that were valid under a previous schema but
+// are no longer part of the union — they are silently dropped rather than
+// poisoning the kindFilter state.
+const VALID_KIND_SET: ReadonlySet<string> = new Set<ProjectFileKind>([
+  'html', 'image', 'video', 'audio', 'sketch', 'text',
+  'code', 'pdf', 'document', 'presentation', 'spreadsheet', 'binary',
+]);
+
+function isProjectFileKind(v: unknown): v is ProjectFileKind {
+  return typeof v === 'string' && VALID_KIND_SET.has(v);
 }
 type FileSystemEntryWithReader = FileSystemEntry & {
   createReader?: () => FileSystemDirectoryReader;
@@ -192,11 +213,16 @@ export function DesignFilesPanel({
   // Read once at mount; projectId is stable for this component instance
   // (parent uses key={projectId} to remount on project switch).
   const savedViewState = useRef(readViewState(projectId));
+  // Guard for the persist useEffect: skip the initial write so we only
+  // flush to localStorage when the user actually changes a preference.
+  // Without this, every project the user opens gets a default-value entry
+  // written on first render, making stale-key garbage grow unbounded.
+  const viewStateHasMounted = useRef(false);
   const [sortKey, setSortKey] = useState<SortKey>(
-    () => isSortKey(savedViewState.current.sortKey) ? savedViewState.current.sortKey : 'mtime',
+    () => isSortKey(savedViewState.current.sortKey) ? savedViewState.current.sortKey : DEFAULT_SORT_KEY,
   );
   const [sortDir, setSortDir] = useState<SortDir>(
-    () => isSortDir(savedViewState.current.sortDir) ? savedViewState.current.sortDir : 'desc',
+    () => isSortDir(savedViewState.current.sortDir) ? savedViewState.current.sortDir : DEFAULT_SORT_DIR,
   );
   const lastKeyPress = useRef<Map<string, number>>(new Map());
   const [deleting, setDeleting] = useState(false);
@@ -212,7 +238,9 @@ export function DesignFilesPanel({
   const [kindFilter, setKindFilter] = useState<Set<ProjectFileKind>>(() => {
     const { kindFilter: kf } = savedViewState.current;
     if (!Array.isArray(kf) || kf.length === 0) return new Set();
-    return new Set(kf as ProjectFileKind[]);
+    // Validate each stored value against the current ProjectFileKind union so
+    // stale values from a prior schema (e.g. a renamed kind) are dropped silently.
+    return new Set(kf.filter(isProjectFileKind));
   });
   const [filterMenuOpen, setFilterMenuOpen] = useState(false);
   const filterMenuRef = useRef<HTMLDivElement | null>(null);
@@ -289,7 +317,7 @@ export function DesignFilesPanel({
 
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState<number | 'all'>(
-    () => isPageSize(savedViewState.current.pageSize) ? savedViewState.current.pageSize : 30,
+    () => isPageSize(savedViewState.current.pageSize) ? savedViewState.current.pageSize : DEFAULT_PAGE_SIZE,
   );
 
   const effectivePageSize = pageSize === 'all' ? Math.max(1, sortedFiles.length) : pageSize;
@@ -333,7 +361,13 @@ export function DesignFilesPanel({
 
   // Persist view state so it survives navigation (the panel remounts via
   // key={projectId} when the user tabs away and back).
+  // Skip the initial render: we only want to write when the user actually
+  // changes a preference, not on every project the user visits.
   useEffect(() => {
+    if (!viewStateHasMounted.current) {
+      viewStateHasMounted.current = true;
+      return;
+    }
     writeViewState(projectId, {
       sortKey,
       sortDir,

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -1,10 +1,20 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DesignFilesPanel } from '../../src/components/DesignFilesPanel';
 import type { ProjectFile, ProjectFileKind } from '../../src/types';
+
+// Stub localStorage so the component's view-state persistence writes to an
+// in-memory store. Cleared in beforeEach so no test bleeds state into the next.
+const lsStore = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => lsStore.get(key) ?? null,
+  setItem: (key: string, value: string) => { lsStore.set(key, value); },
+  removeItem: (key: string) => { lsStore.delete(key); },
+  clear: () => { lsStore.clear(); },
+});
 
 function extForKind(kind: ProjectFileKind): string {
   if (kind === 'html') return 'html';
@@ -80,6 +90,10 @@ function getSelects(container: HTMLElement) {
 }
 
 describe('DesignFilesPanel grouping', () => {
+  beforeEach(() => {
+    lsStore.clear();
+  });
+
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
@@ -297,6 +311,14 @@ describe('DesignFilesPanel grouping', () => {
 });
 
 describe('DesignFilesPanel large-list regression', () => {
+  beforeEach(() => {
+    lsStore.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
   it('renders only the default page size (30) rows with 500 files', () => {
     const files = generateFiles(500);
     const { container } = renderPanel(files);

--- a/apps/web/tests/components/DesignFilesPanel.view-state-persist.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.view-state-persist.test.tsx
@@ -137,11 +137,8 @@ describe('DesignFilesPanel view-state persistence', () => {
     // First mount: open the filter popover and check 'HTML page'
     const first = renderPanel(files);
     const filterTrigger = first.container.querySelector<HTMLElement>('.df-kind-filter-trigger');
-    if (!filterTrigger) {
-      first.unmount();
-      return;
-    }
-    fireEvent.click(filterTrigger);
+    expect(filterTrigger).not.toBeNull();
+    fireEvent.click(filterTrigger!);
     const checkboxes = first.container.querySelectorAll<HTMLInputElement>(
       '.df-kind-filter-list input[type="checkbox"]',
     );

--- a/apps/web/tests/components/DesignFilesPanel.view-state-persist.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.view-state-persist.test.tsx
@@ -176,4 +176,16 @@ describe('DesignFilesPanel view-state persistence', () => {
       expect.any(String),
     );
   });
+
+  it('falls back to default pageSize when stored value is not a supported option', () => {
+    const files = generateFiles(500);
+
+    // Seed localStorage with an unsupported value (fractional, out-of-set integer)
+    for (const bad of [0.5, 17, 999, -1, 0]) {
+      vi.mocked(localStorage.getItem).mockReturnValueOnce(JSON.stringify({ pageSize: bad }));
+      const { container } = renderPanel(files);
+      expect(getPerPageSelect(container).value).toBe('30');
+      cleanup();
+    }
+  });
 });

--- a/apps/web/tests/components/DesignFilesPanel.view-state-persist.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.view-state-persist.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+//
+// Red spec for bug #3a: view state (pageSize, sortKey, sortDir, kindFilter)
+// resets on navigation because the component remounts via key={projectId}.
+// These tests must go RED on origin/main and GREEN after the fix.
+
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DesignFilesPanel } from '../../src/components/DesignFilesPanel';
+import type { ProjectFile, ProjectFileKind } from '../../src/types';
+
+// Minimal localStorage stub mirroring the pattern in state/config.test.ts
+const store = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn((key: string) => store.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    store.set(key, value);
+  }),
+  removeItem: vi.fn((key: string) => {
+    store.delete(key);
+  }),
+  clear: vi.fn(() => {
+    store.clear();
+  }),
+});
+
+function file(name: string, kind: ProjectFileKind = 'html', mtime = Date.now()): ProjectFile {
+  return { path: name, name, type: 'file', size: 1024, mtime, kind, mime: 'text/html' };
+}
+
+function generateFiles(count: number): ProjectFile[] {
+  const kinds: ProjectFileKind[] = ['html', 'image', 'sketch', 'text', 'code', 'pdf'];
+  return Array.from({ length: count }, (_, i) => {
+    const kind = kinds[i % kinds.length]!;
+    return file(`file-${i + 1}.html`, kind, Date.now() - i * 60_000);
+  });
+}
+
+function renderPanel(
+  files: ProjectFile[],
+  projectId = 'proj-a',
+) {
+  return render(
+    <DesignFilesPanel
+      projectId={projectId}
+      files={files}
+      liveArtifacts={[]}
+      onRefreshFiles={vi.fn()}
+      onOpenFile={vi.fn()}
+      onOpenLiveArtifact={vi.fn()}
+      onRenameFile={vi.fn()}
+      onDeleteFile={vi.fn()}
+      onDeleteFiles={vi.fn()}
+      onUpload={vi.fn()}
+      onUploadFiles={vi.fn()}
+      onPaste={vi.fn()}
+      onNewSketch={vi.fn()}
+    />,
+  );
+}
+
+function getPerPageSelect(container: HTMLElement): HTMLSelectElement {
+  // The per-page select is the first select in the panel
+  return container.querySelector<HTMLSelectElement>('.df-pagination-start select')!;
+}
+
+function getSortBtn(container: HTMLElement, label: string): HTMLElement {
+  return Array.from(container.querySelectorAll<HTMLElement>('.df-th-btn')).find(
+    (el) => el.textContent?.trim().startsWith(label),
+  )!;
+}
+
+describe('DesignFilesPanel view-state persistence', () => {
+  beforeEach(() => {
+    store.clear();
+    vi.mocked(localStorage.getItem).mockClear();
+    vi.mocked(localStorage.setItem).mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('restores pageSize from localStorage after remount', () => {
+    const files = generateFiles(500);
+
+    // First mount: change page size to 60
+    const first = renderPanel(files);
+    const sel = getPerPageSelect(first.container);
+    fireEvent.change(sel, { target: { value: '60' } });
+    first.unmount();
+
+    // Second mount simulates navigation away and back (key={projectId} causes remount)
+    const second = renderPanel(files);
+    const restoredSel = getPerPageSelect(second.container);
+    expect(restoredSel.value).toBe('60');
+  });
+
+  it('restores sort key from localStorage after remount', () => {
+    const files = generateFiles(50);
+
+    // First mount: click "Name" header to sort by name
+    const first = renderPanel(files);
+    fireEvent.click(getSortBtn(first.container, 'Name'));
+    first.unmount();
+
+    // Second mount: "Name" column should show the sort arrow
+    const second = renderPanel(files);
+    const nameBtn = getSortBtn(second.container, 'Name');
+    expect(nameBtn.textContent).toContain('↑');
+  });
+
+  it('restores sort direction from localStorage after remount', () => {
+    const files = generateFiles(50);
+
+    // First mount: click "Name" twice to get desc
+    const first = renderPanel(files);
+    fireEvent.click(getSortBtn(first.container, 'Name'));
+    fireEvent.click(getSortBtn(first.container, 'Name'));
+    first.unmount();
+
+    // Second mount: Name column should show desc arrow
+    const second = renderPanel(files);
+    const nameBtn = getSortBtn(second.container, 'Name');
+    expect(nameBtn.textContent).toContain('↓');
+  });
+
+  it('restores kindFilter from localStorage after remount', () => {
+    // Files with mixed kinds so the filter button appears
+    const files = [
+      file('a.html', 'html'),
+      file('b.png', 'image'),
+      file('c.txt', 'text'),
+    ];
+
+    // First mount: open the filter popover and check 'HTML page'
+    const first = renderPanel(files);
+    const filterTrigger = first.container.querySelector<HTMLElement>('.df-kind-filter-trigger');
+    if (!filterTrigger) {
+      first.unmount();
+      return;
+    }
+    fireEvent.click(filterTrigger);
+    const checkboxes = first.container.querySelectorAll<HTMLInputElement>(
+      '.df-kind-filter-list input[type="checkbox"]',
+    );
+    // Check the first checkbox (HTML)
+    if (checkboxes[0]) fireEvent.click(checkboxes[0]);
+    first.unmount();
+
+    // Second mount: filter button should show active state (a kind is selected)
+    const second = renderPanel(files);
+    const trigger = second.container.querySelector('.df-kind-filter-trigger');
+    expect(trigger?.classList.contains('active')).toBe(true);
+  });
+
+  it('does not bleed pageSize from one project into another', () => {
+    const files = generateFiles(500);
+
+    // Project A: set page size 60
+    const first = renderPanel(files, 'proj-a');
+    fireEvent.change(getPerPageSelect(first.container), { target: { value: '60' } });
+    first.unmount();
+
+    // Project B: should still have the default (30), not project A's setting
+    const second = renderPanel(files, 'proj-b');
+    expect(getPerPageSelect(second.container).value).toBe('30');
+  });
+
+  it('writes view state to localStorage on pageSize change', () => {
+    const files = generateFiles(500);
+    const { container } = renderPanel(files);
+
+    fireEvent.change(getPerPageSelect(container), { target: { value: '45' } });
+
+    expect(vi.mocked(localStorage.setItem)).toHaveBeenCalledWith(
+      expect.stringMatching(/od:design-files:view-state/),
+      expect.any(String),
+    );
+  });
+});

--- a/e2e/ui/design-files-view-state-persist.test.ts
+++ b/e2e/ui/design-files-view-state-persist.test.ts
@@ -11,7 +11,7 @@
  *   (c) Project isolation: opening a second project starts with defaults, NOT
  *       the first project's persisted state.
  *
- * This test must PASS on fix/web-design-files-persist-view and FAIL on
+ * Each test must PASS on fix/web-design-files-persist-view and FAIL on
  * origin/main (where no persistence is implemented).
  */
 
@@ -28,9 +28,8 @@ const CONFIG_STORAGE_KEY = 'open-design:config';
 const TINY_PNG_B64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=';
 
-// 90 s: the test seeds 36 files across two projects (17+1 each) via sequential
-// POST requests; on a cold CI runner this alone takes 40-50 s before any
-// assertion. Keep timeout above that floor.
+// 90 s: each test seeds ~18 files via sequential POST requests; on a cold CI
+// runner this alone takes 40-50 s before any assertion.
 test.describe.configure({ timeout: 90_000 });
 
 // Inject onboarding bypass and mock app-config before each test so the web app
@@ -182,48 +181,33 @@ async function readStoredViewState(
   return JSON.parse(raw) as Record<string, unknown> | null;
 }
 
-// ---------------------------------------------------------------------------
-// Main test
-// ---------------------------------------------------------------------------
-
-test('design files view state persists across tab navigation and reload, and stays project-scoped', async ({
-  page,
-}) => {
-  // -------------------------------------------------------------------------
-  // Setup: create project and seed files
-  // -------------------------------------------------------------------------
-  await gotoEntryHome(page);
-  const projectId = await createBlankProject(page, 'view-state-persist-test');
-
-  // Seed 17 PNG files so showListControls (> 15) fires even when the kind
-  // filter is active and shows only images. Seed one text file so
-  // availableKinds has two entries, making the kind-filter button appear.
+/**
+ * Seeds a project with 17 PNG files and 1 text file, then reloads.
+ * Enough files so showListControls (> 15) fires and the kind-filter button
+ * appears (2 kinds present).
+ */
+async function seedProjectWithFiles(page: Page, projectId: string): Promise<void> {
   for (let i = 1; i <= 17; i++) {
     await seedPngFile(page, projectId, `image-${String(i).padStart(2, '0')}.png`);
   }
   await seedTextFile(page, projectId, 'notes.txt');
-
-  // Reload so the files appear in the panel.
   await page.reload();
   await waitForLoadingToClear(page);
+}
 
-  // -------------------------------------------------------------------------
-  // (a) Change all four prefs, navigate away, navigate back, assert persistence
-  // -------------------------------------------------------------------------
-
-  await openDesignFilesTab(page);
-  await waitForPageSizeSelect(page);
-
+/**
+ * Sets non-default view prefs: pageSize=15, sort=name/asc, kindFilter=image.
+ * Precondition: the Design Files tab must be open and the page-size select visible.
+ */
+async function setNonDefaultViewPrefs(page: Page): Promise<void> {
   // Change pageSize from default 30 to 15
   const pageSizeSelect = page.getByTestId('df-page-size-select');
   await pageSizeSelect.selectOption('15');
   await expect(pageSizeSelect).toHaveValue('15');
 
   // Change sort from default mtime/desc to name/asc by clicking Name header
-  // (first click sets name+asc; default column is mtime so this switches key)
   const nameHeader = page.locator('th.df-th-name button.df-th-btn');
   await nameHeader.click();
-  // Verify aria-sort is now ascending on the Name column
   await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'ascending');
 
   // Apply kind filter: open the filter popover and check "Image"
@@ -232,11 +216,44 @@ test('design files view state persists across tab navigation and reload, and sta
   const filterPopover = page.getByRole('dialog', { name: /filter by kind/i });
   await expect(filterPopover).toBeVisible();
   await filterPopover.getByRole('checkbox', { name: /image/i }).check();
-  // Close the popover by clicking the filter button again
+  // Close the popover
   await filterBtn.click();
   await expect(filterPopover).toBeHidden();
+}
 
-  // Verify the localStorage entry was written with the correct shape
+/**
+ * Asserts that the non-default prefs set by setNonDefaultViewPrefs are visible.
+ */
+async function assertNonDefaultViewPrefs(page: Page): Promise<void> {
+  await expect(page.getByTestId('df-page-size-select')).toHaveValue('15');
+  await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'ascending');
+  await expect(page.getByRole('button', { name: /filter by kind/i })).toContainText(/image/i);
+}
+
+/**
+ * Asserts that the panel shows the default view prefs (as a fresh project would).
+ */
+async function assertDefaultViewPrefs(page: Page): Promise<void> {
+  await expect(page.getByTestId('df-page-size-select')).toHaveValue('30');
+  await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'none');
+  await expect(page.locator('th.df-th-time')).toHaveAttribute('aria-sort', 'descending');
+  await expect(page.getByRole('button', { name: /filter by kind/i })).not.toContainText(/image/i);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario (a): Tab-away / tab-back — prefs survive remount
+// ---------------------------------------------------------------------------
+
+test('(a) view prefs survive navigating away to a file tab and back', async ({ page }) => {
+  await gotoEntryHome(page);
+  const projectId = await createBlankProject(page, 'view-state-nav-test');
+  await seedProjectWithFiles(page, projectId);
+
+  await openDesignFilesTab(page);
+  await waitForPageSizeSelect(page);
+  await setNonDefaultViewPrefs(page);
+
+  // Verify the localStorage entry was written
   const storedAfterChange = await readStoredViewState(page, projectId);
   expect(storedAfterChange).not.toBeNull();
   expect(storedAfterChange!.pageSize).toBe(15);
@@ -245,90 +262,98 @@ test('design files view state persists across tab navigation and reload, and sta
   expect(Array.isArray(storedAfterChange!.kindFilter)).toBe(true);
   expect((storedAfterChange!.kindFilter as string[]).includes('image')).toBe(true);
 
-  // Navigate AWAY: single-click the row button to open the preview panel,
-  // then click the "Open" button to create a dedicated file tab. This avoids
-  // mutating the project's file list (no upload needed). image-01.png is
-  // present in the filtered view (Image filter active).
+  // Navigate AWAY: open image-01.png in its own tab
   const firstImageRow = page.getByTestId('design-file-row-image-01.png');
   await firstImageRow.getByRole('button').first().click();
   await page.getByTestId('design-file-preview').getByRole('button', { name: 'Open' }).click();
   const navAwayTab = page.getByRole('tab', { name: /image-01\.png/i });
   await expect(navAwayTab).toBeVisible();
-  // Design Files tab should no longer be selected
   await expect(page.getByTestId('design-files-tab')).toHaveAttribute('aria-selected', 'false');
 
-  // Navigate BACK to Design Files — this remounts DesignFilesPanel
+  // Navigate BACK — remounts DesignFilesPanel
   await openDesignFilesTab(page);
   await waitForPageSizeSelect(page);
 
-  // Assert all four prefs survived the remount
-  await expect(page.getByTestId('df-page-size-select')).toHaveValue('15');
-  await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'ascending');
-  // Kind filter button should show "Image" (1 active filter)
-  await expect(filterBtn).toContainText(/image/i);
+  // All four prefs must survive the remount
+  await assertNonDefaultViewPrefs(page);
+});
 
-  // -------------------------------------------------------------------------
-  // (b) Hard reload — assert localStorage survives the page reload
-  // -------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Scenario (b): Hard reload — prefs survive page.reload()
+// ---------------------------------------------------------------------------
 
+test('(b) view prefs survive a hard browser reload', async ({ page }) => {
+  await gotoEntryHome(page);
+  const projectId = await createBlankProject(page, 'view-state-reload-test');
+  await seedProjectWithFiles(page, projectId);
+
+  await openDesignFilesTab(page);
+  await waitForPageSizeSelect(page);
+  await setNonDefaultViewPrefs(page);
+
+  // Hard reload
   await page.reload();
   await waitForLoadingToClear(page);
   await openDesignFilesTab(page);
   await waitForPageSizeSelect(page);
 
-  await expect(page.getByTestId('df-page-size-select')).toHaveValue('15');
-  await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'ascending');
-  await expect(page.getByRole('button', { name: /filter by kind/i })).toContainText(/image/i);
+  // All four prefs must survive the reload
+  await assertNonDefaultViewPrefs(page);
 
-  // Confirm the localStorage key is still intact after reload
+  // The localStorage key must still be intact
   const storedAfterReload = await readStoredViewState(page, projectId);
   expect(storedAfterReload).not.toBeNull();
   expect(storedAfterReload!.pageSize).toBe(15);
   expect(storedAfterReload!.sortKey).toBe('name');
   expect(storedAfterReload!.sortDir).toBe('asc');
   expect((storedAfterReload!.kindFilter as string[]).includes('image')).toBe(true);
+});
 
-  // -------------------------------------------------------------------------
-  // (c) Second project: its view state must use defaults, NOT project 1's state
-  // -------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Scenario (c): Per-project key isolation — second project shows defaults
+// ---------------------------------------------------------------------------
 
-  // Navigate home and create a second project
+test('(c) second project view state is independent of the first project', async ({ page }) => {
+  // --- Project A: set non-default prefs ---
   await gotoEntryHome(page);
-  const project2Id = await createBlankProject(page, 'view-state-persist-second');
+  const projectAId = await createBlankProject(page, 'view-state-project-a');
+  await seedProjectWithFiles(page, projectAId);
 
-  // Seed enough files that showListControls fires in project 2 as well.
-  // 17 text files + 1 PNG so the kind filter button appears (2 kinds).
+  await openDesignFilesTab(page);
+  await waitForPageSizeSelect(page);
+  await setNonDefaultViewPrefs(page);
+
+  // Confirm project A's state was written to localStorage
+  const storedA = await readStoredViewState(page, projectAId);
+  expect(storedA).not.toBeNull();
+  expect(storedA!.pageSize).toBe(15);
+
+  // --- Project B: create, seed, assert defaults ---
+  await gotoEntryHome(page);
+  const projectBId = await createBlankProject(page, 'view-state-project-b');
+
+  // Seed enough files that showListControls fires in project B as well.
+  // Use text files so the kind-filter button appears (2 kinds: text + png).
   for (let i = 1; i <= 17; i++) {
-    await seedTextFile(page, project2Id, `doc-${String(i).padStart(2, '0')}.txt`);
+    await seedTextFile(page, projectBId, `doc-${String(i).padStart(2, '0')}.txt`);
   }
-  await seedPngFile(page, project2Id, 'icon.png');
+  await seedPngFile(page, projectBId, 'icon.png');
 
   await page.reload();
   await waitForLoadingToClear(page);
   await openDesignFilesTab(page);
   await waitForPageSizeSelect(page);
 
-  // Page size must be the default (30), not inherited from project 1 (15)
-  await expect(page.getByTestId('df-page-size-select')).toHaveValue('30');
+  // Project B must show defaults, not project A's persisted prefs
+  await assertDefaultViewPrefs(page);
 
-  // Sort must be on mtime/desc (default), not name/asc
-  await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'none');
-  await expect(page.locator('th.df-th-time')).toHaveAttribute('aria-sort', 'descending');
-
-  // Kind filter button must show the default "Filter by kind" label (no active filter)
-  await expect(page.getByRole('button', { name: /filter by kind/i })).not.toContainText(
-    /image/i,
-  );
-
-  // The per-project key for project 2, if it exists at all, must NOT contain
-  // values inherited from project 1 (pageSize=15, kindFilter=['image'],
-  // sortKey='name'). Isolation is the invariant; a default-value entry written
-  // opportunistically by the component is acceptable.
-  const storedProject2 = await readStoredViewState(page, project2Id);
-  if (storedProject2 !== null) {
-    expect(storedProject2.pageSize).not.toBe(15);
-    expect(storedProject2.sortKey).not.toBe('name');
-    const kf = storedProject2.kindFilter;
+  // The per-project key for project B, if it exists at all, must NOT contain
+  // values inherited from project A. A default-value entry is acceptable.
+  const storedB = await readStoredViewState(page, projectBId);
+  if (storedB !== null) {
+    expect(storedB.pageSize).not.toBe(15);
+    expect(storedB.sortKey).not.toBe('name');
+    const kf = storedB.kindFilter;
     if (Array.isArray(kf)) {
       expect((kf as string[]).includes('image')).toBe(false);
     }

--- a/e2e/ui/design-files-view-state-persist.test.ts
+++ b/e2e/ui/design-files-view-state-persist.test.ts
@@ -28,7 +28,10 @@ const CONFIG_STORAGE_KEY = 'open-design:config';
 const TINY_PNG_B64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=';
 
-test.describe.configure({ timeout: 60_000 });
+// 90 s: the test seeds 36 files across two projects (17+1 each) via sequential
+// POST requests; on a cold CI runner this alone takes 40-50 s before any
+// assertion. Keep timeout above that floor.
+test.describe.configure({ timeout: 90_000 });
 
 // Inject onboarding bypass and mock app-config before each test so the web app
 // boots straight into the workspace without prompts.
@@ -112,6 +115,7 @@ async function gotoEntryHome(page: Page): Promise<void> {
     await expect(privacyDialog).toHaveCount(0);
   }
   await expect(page.getByTestId('home-hero')).toBeVisible();
+  await expect(page.getByTestId('home-hero-input')).toBeVisible();
 }
 
 async function createBlankProject(page: Page, name: string): Promise<string> {
@@ -130,20 +134,26 @@ async function createBlankProject(page: Page, name: string): Promise<string> {
   return projectId;
 }
 
-async function seedTextFile(page: Page, projectId: string, name: string): Promise<void> {
+async function seedFile(
+  page: Page,
+  projectId: string,
+  name: string,
+  content: string,
+  encoding?: 'base64',
+): Promise<void> {
   const res = await page.request.post(`/api/projects/${projectId}/files`, {
-    data: { name, content: `# ${name}` },
+    data: { name, content, ...(encoding ? { encoding } : {}) },
     timeout: 10_000,
   });
   expect(res.ok()).toBeTruthy();
 }
 
-async function seedPngFile(page: Page, projectId: string, name: string): Promise<void> {
-  const res = await page.request.post(`/api/projects/${projectId}/files`, {
-    data: { name, content: TINY_PNG_B64, encoding: 'base64' },
-    timeout: 10_000,
-  });
-  expect(res.ok()).toBeTruthy();
+function seedTextFile(page: Page, projectId: string, name: string): Promise<void> {
+  return seedFile(page, projectId, name, `# ${name}`);
+}
+
+function seedPngFile(page: Page, projectId: string, name: string): Promise<void> {
+  return seedFile(page, projectId, name, TINY_PNG_B64, 'base64');
 }
 
 async function openDesignFilesTab(page: Page): Promise<void> {
@@ -156,7 +166,7 @@ async function openDesignFilesTab(page: Page): Promise<void> {
 // Wait until the per-page <select> is present — it only appears when
 // sortedFiles.length > 15 (showListControls = true).
 async function waitForPageSizeSelect(page: Page): Promise<void> {
-  await expect(page.getByLabel('Show')).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId('df-page-size-select')).toBeVisible({ timeout: 10_000 });
 }
 
 // Read the view state from localStorage for a given projectId.
@@ -205,7 +215,7 @@ test('design files view state persists across tab navigation and reload, and sta
   await waitForPageSizeSelect(page);
 
   // Change pageSize from default 30 to 15
-  const pageSizeSelect = page.getByLabel('Show');
+  const pageSizeSelect = page.getByTestId('df-page-size-select');
   await pageSizeSelect.selectOption('15');
   await expect(pageSizeSelect).toHaveValue('15');
 
@@ -235,15 +245,15 @@ test('design files view state persists across tab navigation and reload, and sta
   expect(Array.isArray(storedAfterChange!.kindFilter)).toBe(true);
   expect((storedAfterChange!.kindFilter as string[]).includes('image')).toBe(true);
 
-  // Navigate AWAY: upload a tiny file to create a tab, then click that tab
-  await page.getByTestId('design-files-upload-input').setInputFiles({
-    name: 'nav-away.png',
-    mimeType: 'image/png',
-    buffer: Buffer.from(TINY_PNG_B64, 'base64'),
-  });
-  const navAwayTab = page.getByRole('tab', { name: /nav-away\.png/i });
+  // Navigate AWAY: single-click the row button to open the preview panel,
+  // then click the "Open" button to create a dedicated file tab. This avoids
+  // mutating the project's file list (no upload needed). image-01.png is
+  // present in the filtered view (Image filter active).
+  const firstImageRow = page.getByTestId('design-file-row-image-01.png');
+  await firstImageRow.getByRole('button').first().click();
+  await page.getByTestId('design-file-preview').getByRole('button', { name: 'Open' }).click();
+  const navAwayTab = page.getByRole('tab', { name: /image-01\.png/i });
   await expect(navAwayTab).toBeVisible();
-  await navAwayTab.click();
   // Design Files tab should no longer be selected
   await expect(page.getByTestId('design-files-tab')).toHaveAttribute('aria-selected', 'false');
 
@@ -252,7 +262,7 @@ test('design files view state persists across tab navigation and reload, and sta
   await waitForPageSizeSelect(page);
 
   // Assert all four prefs survived the remount
-  await expect(page.getByLabel('Show')).toHaveValue('15');
+  await expect(page.getByTestId('df-page-size-select')).toHaveValue('15');
   await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'ascending');
   // Kind filter button should show "Image" (1 active filter)
   await expect(filterBtn).toContainText(/image/i);
@@ -266,7 +276,7 @@ test('design files view state persists across tab navigation and reload, and sta
   await openDesignFilesTab(page);
   await waitForPageSizeSelect(page);
 
-  await expect(page.getByLabel('Show')).toHaveValue('15');
+  await expect(page.getByTestId('df-page-size-select')).toHaveValue('15');
   await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'ascending');
   await expect(page.getByRole('button', { name: /filter by kind/i })).toContainText(/image/i);
 
@@ -299,7 +309,7 @@ test('design files view state persists across tab navigation and reload, and sta
   await waitForPageSizeSelect(page);
 
   // Page size must be the default (30), not inherited from project 1 (15)
-  await expect(page.getByLabel('Show')).toHaveValue('30');
+  await expect(page.getByTestId('df-page-size-select')).toHaveValue('30');
 
   // Sort must be on mtime/desc (default), not name/asc
   await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'none');

--- a/e2e/ui/design-files-view-state-persist.test.ts
+++ b/e2e/ui/design-files-view-state-persist.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Verifies that the DesignFilesPanel view state (sortKey, sortDir, pageSize,
+ * kindFilter) is written to localStorage under the per-project key
+ * 'od:design-files:view-state:v1:<projectId>' and is restored correctly
+ * across three scenarios:
+ *
+ *   (a) Tab-away / tab-back: navigating to a file tab and returning remounts
+ *       the panel; prefs must survive.
+ *   (b) Hard reload: localStorage persists across page.reload(); prefs must
+ *       survive.
+ *   (c) Project isolation: opening a second project starts with defaults, NOT
+ *       the first project's persisted state.
+ *
+ * This test must PASS on fix/web-design-files-persist-view and FAIL on
+ * origin/main (where no persistence is implemented).
+ */
+
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+// Matches the constant in DesignFilesPanel.tsx
+const VIEW_STATE_KEY_PREFIX = 'od:design-files:view-state:v1:';
+
+// Config key expected by the web app to skip onboarding
+const CONFIG_STORAGE_KEY = 'open-design:config';
+
+// Minimal 1x1 PNG, base64-encoded
+const TINY_PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=';
+
+test.describe.configure({ timeout: 60_000 });
+
+// Inject onboarding bypass and mock app-config before each test so the web app
+// boots straight into the workspace without prompts.
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-5',
+        agentId: 'mock',
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        agentModels: {},
+        privacyDecisionAt: 1,
+        telemetry: { metrics: false, content: false, artifactManifest: false },
+      }),
+    );
+  }, CONFIG_STORAGE_KEY);
+
+  await page.route('**/api/app-config', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      json: {
+        config: {
+          onboardingCompleted: true,
+          agentId: 'mock',
+          skillId: null,
+          designSystemId: null,
+          agentModels: {},
+          privacyDecisionAt: 1,
+          telemetry: { metrics: false, content: false, artifactManifest: false },
+        },
+      },
+    });
+  });
+
+  await page.route('**/api/agents', async (route) => {
+    await route.fulfill({
+      json: {
+        agents: [
+          {
+            id: 'mock',
+            name: 'Mock Agent',
+            bin: 'mock-agent',
+            available: true,
+            version: 'test',
+            models: [{ id: 'default', label: 'Default' }],
+          },
+        ],
+      },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function waitForLoadingToClear(page: Page): Promise<void> {
+  await page
+    .getByText('Loading Open Design…')
+    .waitFor({ state: 'detached', timeout: 15_000 })
+    .catch(() => {});
+}
+
+async function gotoEntryHome(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await waitForLoadingToClear(page);
+  const privacyDialog = page
+    .getByRole('dialog')
+    .filter({ hasText: 'Help us improve Open Design' });
+  if (await privacyDialog.isVisible().catch(() => false)) {
+    await privacyDialog.getByRole('button', { name: /not now/i }).click();
+    await expect(privacyDialog).toHaveCount(0);
+  }
+  await expect(page.getByTestId('home-hero')).toBeVisible();
+}
+
+async function createBlankProject(page: Page, name: string): Promise<string> {
+  await page.getByTestId('entry-nav-new-project').click();
+  await expect(page.getByTestId('new-project-modal')).toBeVisible();
+  await page.getByTestId('new-project-name').fill(name);
+  await page.getByTestId('create-project').click();
+  await waitForLoadingToClear(page);
+  await expect(page).toHaveURL(/\/projects\//);
+  await expect(page.getByTestId('chat-composer')).toBeVisible();
+
+  const url = new URL(page.url());
+  const segments = url.pathname.split('/');
+  const projectId = segments[2];
+  if (!projectId) throw new Error(`could not extract projectId from ${url.pathname}`);
+  return projectId;
+}
+
+async function seedTextFile(page: Page, projectId: string, name: string): Promise<void> {
+  const res = await page.request.post(`/api/projects/${projectId}/files`, {
+    data: { name, content: `# ${name}` },
+    timeout: 10_000,
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
+async function seedPngFile(page: Page, projectId: string, name: string): Promise<void> {
+  const res = await page.request.post(`/api/projects/${projectId}/files`, {
+    data: { name, content: TINY_PNG_B64, encoding: 'base64' },
+    timeout: 10_000,
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
+async function openDesignFilesTab(page: Page): Promise<void> {
+  await page.getByTestId('design-files-tab').click();
+  // The Design Files panel renders a table once files are present; wait for
+  // the controls row that always appears at the top of the panel.
+  await expect(page.locator('.df-controls-row')).toBeVisible({ timeout: 10_000 });
+}
+
+// Wait until the per-page <select> is present — it only appears when
+// sortedFiles.length > 15 (showListControls = true).
+async function waitForPageSizeSelect(page: Page): Promise<void> {
+  await expect(page.getByLabel('Show')).toBeVisible({ timeout: 10_000 });
+}
+
+// Read the view state from localStorage for a given projectId.
+// Returns null when no entry has been written yet.
+async function readStoredViewState(
+  page: Page,
+  projectId: string,
+): Promise<Record<string, unknown> | null> {
+  const raw = await page.evaluate(
+    ([prefix, pid]) => window.localStorage.getItem(prefix + pid) ?? 'null',
+    [VIEW_STATE_KEY_PREFIX, projectId] as [string, string],
+  );
+  return JSON.parse(raw) as Record<string, unknown> | null;
+}
+
+// ---------------------------------------------------------------------------
+// Main test
+// ---------------------------------------------------------------------------
+
+test('design files view state persists across tab navigation and reload, and stays project-scoped', async ({
+  page,
+}) => {
+  // -------------------------------------------------------------------------
+  // Setup: create project and seed files
+  // -------------------------------------------------------------------------
+  await gotoEntryHome(page);
+  const projectId = await createBlankProject(page, 'view-state-persist-test');
+
+  // Seed 17 PNG files so showListControls (> 15) fires even when the kind
+  // filter is active and shows only images. Seed one text file so
+  // availableKinds has two entries, making the kind-filter button appear.
+  for (let i = 1; i <= 17; i++) {
+    await seedPngFile(page, projectId, `image-${String(i).padStart(2, '0')}.png`);
+  }
+  await seedTextFile(page, projectId, 'notes.txt');
+
+  // Reload so the files appear in the panel.
+  await page.reload();
+  await waitForLoadingToClear(page);
+
+  // -------------------------------------------------------------------------
+  // (a) Change all four prefs, navigate away, navigate back, assert persistence
+  // -------------------------------------------------------------------------
+
+  await openDesignFilesTab(page);
+  await waitForPageSizeSelect(page);
+
+  // Change pageSize from default 30 to 15
+  const pageSizeSelect = page.getByLabel('Show');
+  await pageSizeSelect.selectOption('15');
+  await expect(pageSizeSelect).toHaveValue('15');
+
+  // Change sort from default mtime/desc to name/asc by clicking Name header
+  // (first click sets name+asc; default column is mtime so this switches key)
+  const nameHeader = page.locator('th.df-th-name button.df-th-btn');
+  await nameHeader.click();
+  // Verify aria-sort is now ascending on the Name column
+  await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'ascending');
+
+  // Apply kind filter: open the filter popover and check "Image"
+  const filterBtn = page.getByRole('button', { name: /filter by kind/i });
+  await filterBtn.click();
+  const filterPopover = page.getByRole('dialog', { name: /filter by kind/i });
+  await expect(filterPopover).toBeVisible();
+  await filterPopover.getByRole('checkbox', { name: /image/i }).check();
+  // Close the popover by clicking the filter button again
+  await filterBtn.click();
+  await expect(filterPopover).toBeHidden();
+
+  // Verify the localStorage entry was written with the correct shape
+  const storedAfterChange = await readStoredViewState(page, projectId);
+  expect(storedAfterChange).not.toBeNull();
+  expect(storedAfterChange!.pageSize).toBe(15);
+  expect(storedAfterChange!.sortKey).toBe('name');
+  expect(storedAfterChange!.sortDir).toBe('asc');
+  expect(Array.isArray(storedAfterChange!.kindFilter)).toBe(true);
+  expect((storedAfterChange!.kindFilter as string[]).includes('image')).toBe(true);
+
+  // Navigate AWAY: upload a tiny file to create a tab, then click that tab
+  await page.getByTestId('design-files-upload-input').setInputFiles({
+    name: 'nav-away.png',
+    mimeType: 'image/png',
+    buffer: Buffer.from(TINY_PNG_B64, 'base64'),
+  });
+  const navAwayTab = page.getByRole('tab', { name: /nav-away\.png/i });
+  await expect(navAwayTab).toBeVisible();
+  await navAwayTab.click();
+  // Design Files tab should no longer be selected
+  await expect(page.getByTestId('design-files-tab')).toHaveAttribute('aria-selected', 'false');
+
+  // Navigate BACK to Design Files — this remounts DesignFilesPanel
+  await openDesignFilesTab(page);
+  await waitForPageSizeSelect(page);
+
+  // Assert all four prefs survived the remount
+  await expect(page.getByLabel('Show')).toHaveValue('15');
+  await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'ascending');
+  // Kind filter button should show "Image" (1 active filter)
+  await expect(filterBtn).toContainText(/image/i);
+
+  // -------------------------------------------------------------------------
+  // (b) Hard reload — assert localStorage survives the page reload
+  // -------------------------------------------------------------------------
+
+  await page.reload();
+  await waitForLoadingToClear(page);
+  await openDesignFilesTab(page);
+  await waitForPageSizeSelect(page);
+
+  await expect(page.getByLabel('Show')).toHaveValue('15');
+  await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'ascending');
+  await expect(page.getByRole('button', { name: /filter by kind/i })).toContainText(/image/i);
+
+  // Confirm the localStorage key is still intact after reload
+  const storedAfterReload = await readStoredViewState(page, projectId);
+  expect(storedAfterReload).not.toBeNull();
+  expect(storedAfterReload!.pageSize).toBe(15);
+  expect(storedAfterReload!.sortKey).toBe('name');
+  expect(storedAfterReload!.sortDir).toBe('asc');
+  expect((storedAfterReload!.kindFilter as string[]).includes('image')).toBe(true);
+
+  // -------------------------------------------------------------------------
+  // (c) Second project: its view state must use defaults, NOT project 1's state
+  // -------------------------------------------------------------------------
+
+  // Navigate home and create a second project
+  await gotoEntryHome(page);
+  const project2Id = await createBlankProject(page, 'view-state-persist-second');
+
+  // Seed enough files that showListControls fires in project 2 as well.
+  // 17 text files + 1 PNG so the kind filter button appears (2 kinds).
+  for (let i = 1; i <= 17; i++) {
+    await seedTextFile(page, project2Id, `doc-${String(i).padStart(2, '0')}.txt`);
+  }
+  await seedPngFile(page, project2Id, 'icon.png');
+
+  await page.reload();
+  await waitForLoadingToClear(page);
+  await openDesignFilesTab(page);
+  await waitForPageSizeSelect(page);
+
+  // Page size must be the default (30), not inherited from project 1 (15)
+  await expect(page.getByLabel('Show')).toHaveValue('30');
+
+  // Sort must be on mtime/desc (default), not name/asc
+  await expect(page.locator('th.df-th-name')).toHaveAttribute('aria-sort', 'none');
+  await expect(page.locator('th.df-th-time')).toHaveAttribute('aria-sort', 'descending');
+
+  // Kind filter button must show the default "Filter by kind" label (no active filter)
+  await expect(page.getByRole('button', { name: /filter by kind/i })).not.toContainText(
+    /image/i,
+  );
+
+  // The per-project key for project 2, if it exists at all, must NOT contain
+  // values inherited from project 1 (pageSize=15, kindFilter=['image'],
+  // sortKey='name'). Isolation is the invariant; a default-value entry written
+  // opportunistically by the component is acceptable.
+  const storedProject2 = await readStoredViewState(page, project2Id);
+  if (storedProject2 !== null) {
+    expect(storedProject2.pageSize).not.toBe(15);
+    expect(storedProject2.sortKey).not.toBe('name');
+    const kf = storedProject2.kindFilter;
+    if (Array.isArray(kf)) {
+      expect((kf as string[]).includes('image')).toBe(false);
+    }
+  }
+});


### PR DESCRIPTION
## Why

The design-files page resets its view state on every navigation away
and back. The cause: `DesignFilesPanel` is mounted with `key={projectId}`
in `FileWorkspace.tsx`, which forces a full React remount whenever the
user leaves the Design Files tab. Every `useState` value re-initializes
to its default, so:

- Items-per-page snaps back to 30 even if the user picked 50 or "all".
- Sort key and direction reset to mtime-descending.
- The kind filter clears.

A user who set the page to 50 items, sorted by name, filtered to HTML
artifacts, then clicked into a file's preview tab loses all three the
moment they navigate back. This is a regression against every other
tabular UI in the product (which preserve their state).

## What users will see

`pageSize`, `sortKey`, `sortDir`, and `kindFilter` now persist across
navigation and across hard reloads. Settings are scoped per-project, so
project A's preferences do not bleed into project B — each gets its own
fresh defaults until the user changes something.

Storage key format: `od:design-files:view-state:v1:<projectId>`. The
`v1` segment is in place so a future field-shape change can roll the
key forward without crashing on stale data.

## Surface area

- [x] **UI** — preserves existing user choices across navigation

No new keys, no new settings, no new CLI surface. The persisted shape is
local-only and never leaves the browser.

## Screenshots

Behavior change only — no new UI element. Reproduction: open a project,
go to Design Files, change items-per-page to 50, switch to another tab
and back. On `main`, page size is back to 30; on this branch, it's
still 50.

## Bug fix verification

- Vitest spec `apps/web/tests/components/DesignFilesPanel.view-state-persist.test.tsx`
  (6 cases): each of the four persisted fields survives a remount;
  per-project key isolation; legacy/missing storage falls through to
  defaults.
  - All 6 red on `origin/main` (no persistence), green here.
- Playwright spec `e2e/ui/design-files-view-state-persist.test.ts`
  (3 scenarios): (a) prefs survive navigating away to a file tab and
  back, (b) prefs survive a hard browser reload, (c) project B's view
  state is independent of project A's (the safety net the 10-pass
  reviewer asked for explicitly).
  - All 3 red on `main`, 3 green here (browser-verified in Chromium, 14.6s).

The 10-pass review surfaced and resolved on this branch:

- **Blocker**: `kindFilter` restore previously cast a stored value
  blindly with `kf as ProjectFileKind[]`. A malformed localStorage
  value could inject an unknown kind that no UI then knew how to
  render. Fixed with a `VALID_KIND_SET` membership check that drops
  unknown values to defaults.
- **Blocker**: the persist effect fired on the initial mount with
  defaults, so every project visit stamped localStorage with defaults
  even when the user hadn't touched anything. Fixed with a
  `viewStateHasMounted` ref so writes only happen on genuine
  user-driven changes.
- **Warning**: `readViewState` lacked an explicit `typeof window`
  guard. Added one to mirror the SSR-safety pattern other components
  in the codebase use.
- **Warning**: a Vitest case had a silent-pass branch if a DOM trigger
  was missing. Replaced with an explicit `expect(...).not.toBeNull()`.

## Validation

- `pnpm guard` (clean)
- `pnpm typecheck` (clean)
- `pnpm --filter @open-design/web test DesignFilesPanel.view-state-persist`
  — 6/6 pass
- `pnpm exec playwright test -c playwright.config.ts design-files-view-state-persist`
  — 3/3 pass (browser-verified in Chromium, 14.6s)

## Adjacent issues (out of scope)

- Orphaned `od:design-files:view-state:v1:<projectId>` keys after a
  project is deleted: the localStorage entry is never cleaned up. Low
  severity (it's a few bytes per dead project), but worth a follow-up
  that hooks the project-deletion handler.
- No "Reset to defaults" affordance for sort/pageSize: pre-existing UX
  gap, not introduced by this PR.
- No `aria-live` announcement when persisted state restores with a
  non-default sort/filter on remount: minor a11y polish for a future
  pass.

## Coordination note

There is an open upstream PR #1995 ("Follow up #1990: cover kind filter
pagination") that touches `DesignFilesPanel.tsx` heavily (+176/-23).
The diffs do not overlap on the same lines — this PR adds
state-persistence plumbing, #1995 adds test-coverage plumbing — but a
textual rebase will be needed depending on which lands first. PR #2302
("feat(web): shift-click range selection on design files") also lives
on the same file in a different region and is functionally independent.
