### PR TITLE
chore(deps): upgrade posthog-node 4 -> 5 in daemon

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -47,7 +47,7 @@
     "express": "4.22.1",
     "jszip": "3.10.1",
     "multer": "2.1.1",
-    "posthog-node": "4.18.0",
+    "posthog-node": "5.34.6",
     "prom-client": "15.1.3",
     "tar": "7.5.15",
     "undici": "7.25.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       posthog-node:
-        specifier: 4.18.0
-        version: 4.18.0
+        specifier: 5.34.6
+        version: 5.34.6
       prom-client:
         specifier: 15.1.3
         version: 15.1.3
@@ -2108,9 +2108,6 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
-
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -2761,15 +2758,6 @@ packages:
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
     engines: {node: '>=8'}
-
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
 
   fontace@0.4.1:
     resolution: {integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==}
@@ -3771,9 +3759,14 @@ packages:
   posthog-js@1.374.2:
     resolution: {integrity: sha512-6z1xGlVocd3NmSZlJNFfpedLIHLcejuuQPxvrpHDvtyVI9tN1NPqbM7T7coXw2It6gdZ/nAgDuZkNxfIut+Spw==}
 
-  posthog-node@4.18.0:
-    resolution: {integrity: sha512-XROs1h+DNatgKh/AlIlCtDxWzwrKdYDb2mOs58n4yN8BkGN9ewqeQwG5ApS4/IzwCb7HPttUkOVulkYatd2PIw==}
-    engines: {node: '>=15.0.0'}
+  posthog-node@5.34.6:
+    resolution: {integrity: sha512-oDjagFRkmCbWJBxG1FVU3kOGC6dxNpR849q8ARrZSBK3zWz4zJox6V5EjrATKM9RXKvAmbCSFoxYaOYTzp3phA==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
 
   postject@1.0.0-alpha.6:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
@@ -3834,10 +3827,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -6367,14 +6356,6 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  axios@1.16.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
@@ -7173,8 +7154,6 @@ snapshots:
       - supports-color
 
   flattie@1.1.1: {}
-
-  follow-redirects@1.16.0: {}
 
   fontace@0.4.1:
     dependencies:
@@ -8365,11 +8344,9 @@ snapshots:
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.2.0
 
-  posthog-node@4.18.0:
+  posthog-node@5.34.6:
     dependencies:
-      axios: 1.16.0
-    transitivePeerDependencies:
-      - debug
+      '@posthog/core': 1.29.5
 
   postject@1.0.0-alpha.6:
     dependencies:
@@ -8446,8 +8423,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
     dependencies:


### PR DESCRIPTION
## Why

posthog-node 4.18.0 is a major version behind the current 5.x line. v5 restructures the library around a shared `@posthog/core` package and drops `axios` in favor of native `fetch` — reducing the transitive closure by three packages (`axios`, `follow-redirects`, `proxy-from-env`). `follow-redirects` in particular has a history of CVEs; removing it entirely is a net security improvement.

Note: open PR #2285 (`feat/analytics-2.0`) is a PostHog event schema change, not an SDK version change — no conflict.

## What users will see

No user-visible change. Analytics continue to emit exactly as before.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

N/A — this is a dependency upgrade, not a bug fix.

## Validation

- `pnpm install` — lockfile updated; posthog-node 5.34.6 resolved with @posthog/core 1.29.5
- `pnpm --filter @open-design/daemon typecheck` — passed (exit 0)
- `pnpm --filter @open-design/daemon test` — 240 test files passed, 2867 tests passed, 1 skipped, 4 todo
- `pnpm guard` — passed
- `pnpm typecheck` — passed (exit 0, all workspace packages)
- protobufjs resolved version after upgrade: **7.5.7** (pre-existing; posthog-node v5 does not pull in `@opentelemetry`, so no change to protobufjs from this bump)

## Breaking changes addressed

posthog-node v5 replaces the `axios`-based HTTP transport with `@posthog/core` (native `fetch`). The public API surface used by `apps/daemon/src/analytics.ts` is stable across the major boundary:
- `PostHog` constructor: unchanged (`new PostHog(key, { host, flushAt, flushInterval })`)
- `client.capture({ distinctId, event, properties })`: unchanged
- `client.on('error', cb)`: unchanged
- `client.shutdown()`: still async at runtime via `@posthog/core` base class (`PostHogCoreStateless.shutdown()` returns `Promise<void>`); the `IPostHog` interface in posthog-node types it as `void` but TypeScript compiles cleanly since the concrete implementation satisfies the stricter type from the base class

No call-site changes were required in `apps/daemon/src/analytics.ts`.