### PR TITLE
fix(web): preserve daemon run reattach across project switch

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1752,6 +1752,7 @@ export function ProjectView({
         runStatus: config.mode === 'daemon' ? 'running' : undefined,
         startedAt,
       };
+      let latestAssistantMsg: ChatMessage = assistantMsg;
       const updateConversationLatestRun = (
         status: NonNullable<ChatMessage['runStatus']>,
         endedAt?: number,
@@ -1846,7 +1847,12 @@ export function ProjectView({
 
       const updateAssistant = (updater: (prev: ChatMessage) => ChatMessage) => {
         setMessages((curr) =>
-          curr.map((m) => (m.id === assistantId ? updater(m) : m)),
+          curr.map((m) => {
+            if (m.id !== assistantId) return m;
+            const updated = updater(m);
+            latestAssistantMsg = updated;
+            return updated;
+          }),
         );
       };
       let persistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -2100,7 +2106,16 @@ export function ProjectView({
           model: choice?.model ?? null,
           reasoning: choice?.reasoning ?? null,
           onRunCreated: (runId) => {
-            updateMessageById(assistantId, (prev) => ({ ...prev, runId, runStatus: 'queued' }), true);
+            const pinnedAssistant = {
+              ...latestAssistantMsg,
+              runId,
+              runStatus: 'queued' as const,
+            };
+            latestAssistantMsg = pinnedAssistant;
+            // The view may already be on a different project/conversation;
+            // pin the daemon run to the original row so returning can reattach.
+            void saveMessage(project.id, runConversationId, pinnedAssistant);
+            updateMessageById(assistantId, (prev) => ({ ...prev, runId, runStatus: 'queued' }));
           },
           onRunStatus: (runStatus) => {
             const endedAt = isTerminalRunStatus(runStatus) ? Date.now() : undefined;

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -268,6 +268,163 @@ describe('ProjectView daemon cleanup', () => {
     expect(reattachDaemonRun).not.toHaveBeenCalled();
   });
 
+  it('persists a delayed daemon run id after switching projects so returning can reattach', async () => {
+    const projectOne = { id: 'project-1', name: 'Project One', skillId: null, designSystemId: null };
+    const projectTwo = { id: 'project-2', name: 'Project Two', skillId: null, designSystemId: null };
+    const messagesByConversation = new Map<string, ChatMessage[]>([
+      ['conv-1', []],
+      ['conv-2', []],
+    ]);
+
+    listConversations.mockImplementation(async (projectId: string) => [
+      projectId === 'project-1'
+        ? { id: 'conv-1', title: 'Conversation 1' }
+        : { id: 'conv-2', title: 'Conversation 2' },
+    ]);
+    listMessages.mockImplementation(async (_projectId: string, conversationId: string) =>
+      messagesByConversation.get(conversationId) ?? [],
+    );
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-delayed',
+      status: 'running',
+      createdAt: 1,
+      updatedAt: 1,
+      exitCode: null,
+      signal: null,
+    });
+    saveMessage.mockImplementation(async (_projectId: string, conversationId: string, message: ChatMessage) => {
+      const existing = messagesByConversation.get(conversationId) ?? [];
+      const next = existing.filter((item) => item.id !== message.id);
+      next.push(message);
+      messagesByConversation.set(conversationId, next);
+      return message;
+    });
+    reattachDaemonRun.mockImplementation(async () => new Promise<void>(() => {}));
+
+    let capturedRunCreated: ((runId: string) => void) | null = null;
+    let capturedStreamSignal: AbortSignal | null = null;
+    let capturedCancelSignal: AbortSignal | null = null;
+    let capturedAssistantMessageId: string | null = null;
+    streamViaDaemon.mockImplementation(async (options: {
+      assistantMessageId?: string;
+      signal: AbortSignal;
+      cancelSignal?: AbortSignal;
+      onRunCreated?: (runId: string) => void;
+    }) => {
+      capturedRunCreated = options.onRunCreated ?? null;
+      capturedStreamSignal = options.signal;
+      capturedCancelSignal = options.cancelSignal ?? null;
+      capturedAssistantMessageId = options.assistantMessageId ?? null;
+      return new Promise<void>(() => {});
+    });
+
+    const view = render(
+      <ProjectView
+        project={projectOne as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={() => {}}
+      />,
+    );
+
+    const sendProps = await waitForReadyChatPaneProps();
+    await sendProps.onSend!('keep running', [], []);
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    expect(capturedRunCreated).not.toBeNull();
+
+    view.rerender(
+      <ProjectView
+        project={projectTwo as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect((capturedStreamSignal as AbortSignal | null)?.aborted).toBe(true));
+    expect((capturedCancelSignal as AbortSignal | null)?.aborted).toBe(false);
+
+    capturedRunCreated!('run-delayed');
+
+    await waitFor(() => {
+      const persistedAssistant = saveMessage.mock.calls.find(
+        (call) =>
+          call[0] === 'project-1' &&
+          call[1] === 'conv-1' &&
+          call[2]?.id === capturedAssistantMessageId &&
+          call[2]?.role === 'assistant' &&
+          call[2]?.runId === 'run-delayed' &&
+          call[2]?.runStatus === 'queued',
+      );
+      expect(persistedAssistant).toBeTruthy();
+    });
+
+    view.rerender(
+      <ProjectView
+        project={projectOne as never}
+        routeFileName={null}
+        config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+        agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        daemonLive
+        onModeChange={() => {}}
+        onAgentChange={() => {}}
+        onAgentModelChange={() => {}}
+        onRefreshAgents={() => {}}
+        onOpenSettings={() => {}}
+        onBack={() => {}}
+        onClearPendingPrompt={() => {}}
+        onTouchProject={() => {}}
+        onProjectChange={() => {}}
+        onProjectsRefresh={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(reattachDaemonRun).toHaveBeenCalledWith(
+        expect.objectContaining({ runId: 'run-delayed' }),
+      );
+    });
+  });
+
   // Regression: when a project is created via PluginLoopHome with the
   // auto-send sessionStorage flag set, ProjectView used to seed
   // ChatComposer.initialDraft with project.pendingPrompt. The composer


### PR DESCRIPTION
Closes #2214

## Summary
- Persist the daemon `runId` back to the original assistant message even if the user has already switched to another project before `/api/runs` returns.
- Keep the browser-side stream abort separate from explicit cancellation, so project switching only detaches the local listener and the accepted run remains reattachable.
- Add a ProjectView regression that sends a daemon message, switches projects before `onRunCreated`, then returns and reattaches to the still-running run.

## Verification
- `pnpm exec vitest run -c vitest.config.ts tests/components/ProjectView.run-cleanup.test.tsx tests/components/ProjectView.run-isolation.test.tsx`
- `pnpm --filter @open-design/web typecheck`

Note: local environment is Node v26.0.0, so pnpm prints the repo's expected Node `~24` engine warning before the commands run.
