### PR TITLE
fix: resolve shared frame screen paths from embedding artifact

### DIFF
--- a/apps/daemon/tests/frame-runtime.test.ts
+++ b/apps/daemon/tests/frame-runtime.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+);
+
+const frameFiles = [
+  'iphone-15-pro.html',
+  'android-pixel.html',
+  'ipad-pro.html',
+  'macbook.html',
+  'browser-chrome.html',
+] as const;
+
+function frameScriptFor(frameFile: string): string {
+  const html = readFileSync(
+    path.join(repoRoot, 'assets', 'frames', frameFile),
+    'utf8',
+  );
+  const script = html.match(/<script>\s*([\s\S]*?)\s*<\/script>/);
+  if (!script?.[1]) {
+    throw new Error(`Missing runtime script in ${frameFile}`);
+  }
+  return script[1];
+}
+
+function resolveFrameScreenSrc({
+  frameFile,
+  screen,
+  referrer = 'http://preview.local/api/projects/project-1/raw/index.html',
+}: {
+  frameFile: string;
+  screen: string;
+  referrer?: string;
+}): string {
+  const frameUrl = new URL(`http://preview.local/frames/${frameFile}`);
+  frameUrl.searchParams.set('screen', screen);
+
+  let iframeSrc = 'about:blank';
+  const iframe = {};
+  Object.defineProperty(iframe, 'src', {
+    get() {
+      return iframeSrc;
+    },
+    set(value: string) {
+      iframeSrc = new URL(value, frameUrl.href).toString();
+    },
+  });
+
+  const urlText = { textContent: '' };
+  const context = {
+    URL,
+    URLSearchParams,
+    location: {
+      href: frameUrl.href,
+      search: frameUrl.search,
+    },
+    document: {
+      referrer,
+      getElementById(id: string) {
+        if (id === 'screen') return iframe;
+        if (id === 'url-text') return urlText;
+        return null;
+      },
+    },
+  };
+
+  vm.runInNewContext(frameScriptFor(frameFile), context, {
+    filename: `assets/frames/${frameFile}`,
+  });
+
+  return iframeSrc;
+}
+
+describe('shared frame runtime', () => {
+  it.each(frameFiles)(
+    'resolves project-relative screen paths against the embedding artifact for %s',
+    (frameFile) => {
+      expect(resolveFrameScreenSrc({
+        frameFile,
+        screen: 'screens/tablet-edition.html',
+      })).toBe('http://preview.local/api/projects/project-1/raw/screens/tablet-edition.html');
+    },
+  );
+
+  it.each(frameFiles)(
+    'keeps root-relative screen paths rooted at the preview origin for %s',
+    (frameFile) => {
+      expect(resolveFrameScreenSrc({
+        frameFile,
+        screen: '/api/projects/project-1/raw/screens/tablet-edition.html',
+      })).toBe('http://preview.local/api/projects/project-1/raw/screens/tablet-edition.html');
+    },
+  );
+
+  it.each(frameFiles)(
+    'keeps absolute screen URLs unchanged for %s',
+    (frameFile) => {
+      expect(resolveFrameScreenSrc({
+        frameFile,
+        screen: 'https://cdn.example.test/screens/tablet-edition.html',
+      })).toBe('https://cdn.example.test/screens/tablet-edition.html');
+    },
+  );
+});


### PR DESCRIPTION
Closes #2234

## Why

Generated multi-file HTML artifacts are encouraged to embed shared device frames like `/frames/ipad-pro.html?screen=screens/foo.html`. When those shared frame pages assign the `screen` query parameter directly to their inner iframe, browsers resolve project-relative paths against `/frames/`, producing `/frames/screens/foo.html` instead of the artifact's raw project route.

This fixes the preview/runtime bug for artifacts that follow the documented multi-screen frame contract.

## What users will see

Multi-file artifacts that use the shared device/browser frames can now pass project-relative `screen=` paths, and the inner screen loads from the artifact's folder instead of 404ing under `/frames/`. Absolute URLs and root-relative paths continue to behave as before.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A. This is a frame runtime path-resolution fix with no visual UI change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/frame-runtime.test.ts`
- Did the test go red on `main` and green on this branch? yes. The project-relative cases failed on current `upstream/main` with `/frames/screens/tablet-edition.html`, then passed on this branch.
- Manual browser/runtime check: served a tiny artifact at `/api/projects/project-1/raw/index.html` embedding `/frames/ipad-pro.html?screen=screens/tablet-edition.html`; Chromium loaded the inner frame at `/api/projects/project-1/raw/screens/tablet-edition.html`.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/frame-runtime.test.ts --reporter verbose` from `apps/daemon` — 15/15 passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed
- `git diff --check` — passed

Note: local validation emitted the repo's engine warning because this machine has Node `v26.0.0` while `package.json` declares `~24`.
