### PR TITLE
Fix srcdoc transport activation race

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -158,6 +158,8 @@ type DeployResultCard = {
   message?: string;
 };
 const MAX_BRIDGE_COORDINATE = 1_000_000;
+const SRC_DOC_TRANSPORT_RETRY_DELAYS_MS = [75, 200, 500];
+const SRC_DOC_TRANSPORT_FALLBACK_MS = 1200;
 const PREVIEW_VIEWPORT_PRESETS: PreviewViewportPreset[] = [
   {
     id: 'desktop',
@@ -3488,6 +3490,7 @@ function HtmlViewer({
   const modeMenuRef = useRef<HTMLDivElement | null>(null);
   const [zoomMenuOpen, setZoomMenuOpen] = useState(false);
   const zoomMenuRef = useRef<HTMLDivElement | null>(null);
+  const paletteTweaksAnchorRef = useRef<HTMLDivElement | null>(null);
   const [presentMenuOpen, setPresentMenuOpen] = useState(false);
   const [shareMenuOpen, setShareMenuOpen] = useState(false);
   // Template save UX. We surface a transient "Saved" pill in the share
@@ -3538,7 +3541,21 @@ function HtmlViewer({
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
-  const activatedSrcDocTransportHtmlRef = useRef<string | null>(null);
+  const srcDocTransportActivationRef = useRef<{
+    token: number;
+    ackedId: string | null;
+    ackedWindow: Window | null;
+    attempts: number;
+    retryTimer: number | null;
+    fallbackTimer: number | null;
+  }>({
+    token: 0,
+    ackedId: null,
+    ackedWindow: null,
+    attempts: 0,
+    retryTimer: null,
+    fallbackTimer: null,
+  });
   const isActivePreviewIframeSource = useCallback((source: MessageEventSource | null) => {
     return !!source && source === iframeRef.current?.contentWindow;
   }, []);
@@ -3999,23 +4016,90 @@ function HtmlViewer({
   const [hasLazySrcDocTransport, setHasLazySrcDocTransport] = useState(useUrlLoadPreview);
   const [srcDocTransportResetKey, setSrcDocTransportResetKey] = useState(0);
   const wasUrlLoadPreviewRef = useRef(useUrlLoadPreview);
+  const clearSrcDocTransportTimers = useCallback(() => {
+    const state = srcDocTransportActivationRef.current;
+    if (state.retryTimer !== null) {
+      window.clearTimeout(state.retryTimer);
+      state.retryTimer = null;
+    }
+    if (state.fallbackTimer !== null) {
+      window.clearTimeout(state.fallbackTimer);
+      state.fallbackTimer = null;
+    }
+  }, []);
   useEffect(() => {
     if (useUrlLoadPreview) setHasLazySrcDocTransport(true);
   }, [useUrlLoadPreview]);
   const useLazySrcDocTransport = useUrlLoadPreview || hasLazySrcDocTransport;
   const srcDocTransportContent = useLazySrcDocTransport ? lazySrcDocTransport : srcDoc;
   const urlTransportSrc = useUrlLoadPreview ? activePreviewSrcUrl : 'about:blank';
+  const resetSrcDocTransportFallback = useCallback(() => {
+    if (palettePopoverOpen) setPalettePopoverOpen(false);
+    setPreviewPalette(null);
+    if (selectedPalette !== null) setSelectedPalette(null);
+  }, [palettePopoverOpen, selectedPalette]);
   const activateSrcDocTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
     const win = target?.contentWindow;
     if (!win || !srcDoc || useUrlLoadPreview || !useLazySrcDocTransport) return false;
-    if (activatedSrcDocTransportHtmlRef.current === srcDoc) return false;
-    win.postMessage({ type: 'od:srcdoc-transport-activate', html: srcDoc }, '*');
-    activatedSrcDocTransportHtmlRef.current = srcDoc;
+    const state = srcDocTransportActivationRef.current;
+    const id = `${state.token}:${srcDoc.length}`;
+    if (state.ackedId === id && state.ackedWindow === win) return false;
+    win.postMessage({ type: 'od:srcdoc-transport-activate', id, html: srcDoc }, '*');
     return true;
   }, [srcDoc, useLazySrcDocTransport, useUrlLoadPreview]);
+  const scheduleSrcDocTransportActivation = useCallback((
+    target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current,
+    options: { reset?: boolean } = {},
+  ) => {
+    const win = target?.contentWindow;
+    if (!win || !srcDoc || useUrlLoadPreview || !useLazySrcDocTransport) return;
+    const state = srcDocTransportActivationRef.current;
+    if (options.reset) {
+      clearSrcDocTransportTimers();
+      state.token += 1;
+      state.ackedId = null;
+      state.ackedWindow = null;
+      state.attempts = 0;
+    }
+    const token = state.token;
+    const runAttempt = () => {
+      const current = srcDocTransportActivationRef.current;
+      if (current.token !== token || useUrlLoadPreview) return;
+      const currentWin = target?.contentWindow;
+      if (!currentWin) return;
+      const id = `${token}:${srcDoc.length}`;
+      if (current.ackedId === id && current.ackedWindow === currentWin) return;
+      activateSrcDocTransport(target);
+      const delay = SRC_DOC_TRANSPORT_RETRY_DELAYS_MS[current.attempts] ?? null;
+      current.attempts += 1;
+      if (delay !== null) {
+        if (current.retryTimer !== null) window.clearTimeout(current.retryTimer);
+        current.retryTimer = window.setTimeout(runAttempt, delay);
+      }
+    };
+    runAttempt();
+    if (state.fallbackTimer !== null) window.clearTimeout(state.fallbackTimer);
+    state.fallbackTimer = window.setTimeout(() => {
+      const current = srcDocTransportActivationRef.current;
+      const id = `${token}:${srcDoc.length}`;
+      if (current.token !== token || current.ackedId === id || useUrlLoadPreview) return;
+      resetSrcDocTransportFallback();
+    }, SRC_DOC_TRANSPORT_FALLBACK_MS);
+  }, [
+    activateSrcDocTransport,
+    clearSrcDocTransportTimers,
+    resetSrcDocTransportFallback,
+    srcDoc,
+    useLazySrcDocTransport,
+    useUrlLoadPreview,
+  ]);
   useEffect(() => {
     if (useUrlLoadPreview) {
-      activatedSrcDocTransportHtmlRef.current = null;
+      clearSrcDocTransportTimers();
+      const state = srcDocTransportActivationRef.current;
+      state.ackedId = null;
+      state.ackedWindow = null;
+      state.attempts = 0;
       if (!wasUrlLoadPreviewRef.current) {
         setSrcDocTransportResetKey((key) => key + 1);
       }
@@ -4023,8 +4107,9 @@ function HtmlViewer({
       return;
     }
     wasUrlLoadPreviewRef.current = false;
-    activateSrcDocTransport();
-  }, [activateSrcDocTransport, useUrlLoadPreview]);
+    scheduleSrcDocTransportActivation(srcDocPreviewIframeRef.current, { reset: true });
+  }, [clearSrcDocTransportTimers, scheduleSrcDocTransportActivation, useUrlLoadPreview]);
+  useEffect(() => () => clearSrcDocTransportTimers(), [clearSrcDocTransportTimers]);
   useEffect(() => {
     restorePreviewScrollPosition();
   }, [boardMode, manualEditMode, srcDoc, restorePreviewScrollPosition]);
@@ -4109,15 +4194,46 @@ function HtmlViewer({
         }, '*');
       }
     }
+    function onSrcDocTransportMessage(ev: MessageEvent) {
+      if (!isOurPreviewIframeSource(ev.source)) return;
+      const data = ev.data as { type?: string; id?: string | null } | null;
+      if (!data || !data.type) return;
+      if (data.type === 'od:srcdoc-transport-ready') {
+        if (ev.source === srcDocPreviewIframeRef.current?.contentWindow) {
+          scheduleSrcDocTransportActivation(srcDocPreviewIframeRef.current, { reset: false });
+        }
+        return;
+      }
+      if (data.type !== 'od:srcdoc-transport-activated') return;
+      const state = srcDocTransportActivationRef.current;
+      if (ev.source !== srcDocPreviewIframeRef.current?.contentWindow) return;
+      state.ackedId = typeof data.id === 'string' ? data.id : null;
+      state.ackedWindow = ev.source as Window;
+      state.attempts = 0;
+      clearSrcDocTransportTimers();
+      const frame = srcDocPreviewIframeRef.current;
+      replayInspectOverridesToIframe(frame);
+      syncBridgeModes(frame);
+      if (!useUrlLoadPreview) restorePreviewScrollPosition();
+    }
     window.addEventListener('message', onMessage);
     window.addEventListener('message', onRestoreRequest);
     window.addEventListener('message', onDcViewportMessage);
+    window.addEventListener('message', onSrcDocTransportMessage);
     return () => {
       window.removeEventListener('message', onMessage);
       window.removeEventListener('message', onRestoreRequest);
       window.removeEventListener('message', onDcViewportMessage);
+      window.removeEventListener('message', onSrcDocTransportMessage);
     };
-  }, [isActivePreviewIframeSource, isOurPreviewIframeSource]);
+  }, [
+    clearSrcDocTransportTimers,
+    isActivePreviewIframeSource,
+    isOurPreviewIframeSource,
+    restorePreviewScrollPosition,
+    scheduleSrcDocTransportActivation,
+    useUrlLoadPreview,
+  ]);
 
   useEffect(() => {
     if (!effectiveDeck) {
@@ -5506,7 +5622,7 @@ function HtmlViewer({
         <div className="viewer-toolbar-actions">
           {showPreviewToolbarControls ? (
             <>
-              <div className="palette-tweaks-anchor">
+              <div className="palette-tweaks-anchor" ref={paletteTweaksAnchorRef}>
                 <button
                   type="button"
                   className={`viewer-action${selectedPalette || palettePopoverOpen ? ' active' : ''}`}
@@ -5536,6 +5652,7 @@ function HtmlViewer({
                 <PaletteTweaks
                   open={palettePopoverOpen}
                   selected={selectedPalette}
+                  ignoreOutsideRef={paletteTweaksAnchorRef}
                   onChange={setSelectedPalette}
                   onPreview={setPreviewPalette}
                   onClose={() => setPalettePopoverOpen(false)}

--- a/apps/web/src/components/PaletteTweaks.tsx
+++ b/apps/web/src/components/PaletteTweaks.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import { Icon } from './Icon';
 
 export type PaletteId =
@@ -21,12 +21,13 @@ const PALETTES: Swatch[] = [
 type Props = {
   open: boolean;
   selected: PaletteId | null;
+  ignoreOutsideRef?: RefObject<HTMLElement | null>;
   onChange: (id: PaletteId | null) => void;
   onPreview: (id: PaletteId | null) => void;
   onClose: () => void;
 };
 
-export function PaletteTweaks({ open, selected, onChange, onPreview, onClose }: Props) {
+export function PaletteTweaks({ open, selected, ignoreOutsideRef, onChange, onPreview, onClose }: Props) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [hovered, setHovered] = useState<PaletteId | 'original' | null>(null);
 
@@ -34,7 +35,9 @@ export function PaletteTweaks({ open, selected, onChange, onPreview, onClose }: 
     if (!open) return;
     function onDoc(ev: MouseEvent) {
       if (!rootRef.current) return;
-      if (rootRef.current.contains(ev.target as Node)) return;
+      const target = ev.target as Node;
+      if (rootRef.current.contains(target)) return;
+      if (ignoreOutsideRef?.current?.contains(target)) return;
       onClose();
     }
     function onKey(ev: KeyboardEvent) {
@@ -46,7 +49,7 @@ export function PaletteTweaks({ open, selected, onChange, onPreview, onClose }: 
       document.removeEventListener('mousedown', onDoc);
       document.removeEventListener('keydown', onKey);
     };
-  }, [open, onClose]);
+  }, [ignoreOutsideRef, open, onClose]);
 
   useEffect(() => {
     if (!open) {

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -82,13 +82,19 @@ export function buildLazySrcdocTransport(): string {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script data-od-lazy-srcdoc-transport>(function(){
+      function post(type, id){
+        try { window.parent.postMessage({ type: type, id: id || null }, '*'); } catch (_) {}
+      }
       window.addEventListener('message', function(ev){
         var data = ev && ev.data;
         if (!data || data.type !== 'od:srcdoc-transport-activate' || typeof data.html !== 'string') return;
+        var id = data.id;
         document.open();
         document.write(data.html);
         document.close();
+        post('od:srcdoc-transport-activated', id);
       });
+      post('od:srcdoc-transport-ready');
     })();</script>
   </head>
   <body></body>
@@ -97,13 +103,19 @@ export function buildLazySrcdocTransport(): string {
 
 function injectSrcdocTransportActivationBridge(doc: string): string {
   const script = `<script data-od-srcdoc-transport-activation>(function(){
+  function post(type, id){
+    try { window.parent.postMessage({ type: type, id: id || null }, '*'); } catch (_) {}
+  }
   window.addEventListener('message', function(ev){
     var data = ev && ev.data;
     if (!data || data.type !== 'od:srcdoc-transport-activate' || typeof data.html !== 'string') return;
+    var id = data.id;
     document.open();
     document.write(data.html);
     document.close();
+    post('od:srcdoc-transport-activated', id);
   });
+  post('od:srcdoc-transport-ready');
 })();</script>`;
   return injectBeforeBodyEnd(doc, script);
 }

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1299,6 +1299,57 @@ describe('FileViewer tweaks toolbar', () => {
     expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc).toBe(initialSrcDoc);
   });
 
+  it('resends the full srcDoc payload when the lazy transport reports ready after a lost activation', async () => {
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).getAttribute('data-od-render-mode')).toBe('url-load');
+    const inactiveSrcDocFrame = screen.getByTestId('artifact-preview-frame-srcdoc') as HTMLIFrameElement;
+    const postMessageSpy = vi.spyOn(inactiveSrcDocFrame.contentWindow!, 'postMessage');
+
+    fireEvent.click(screen.getByTestId('palette-tweaks-toggle'));
+
+    const activeFrame = await waitFor(() => {
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(frame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+      return frame;
+    });
+
+    // Simulate the existing race: the parent tried to activate before the
+    // shell listener existed, so the iframe never received that first payload.
+    postMessageSpy.mockClear();
+    window.dispatchEvent(new MessageEvent('message', {
+      source: activeFrame.contentWindow,
+      data: { type: 'od:srcdoc-transport-ready' },
+    }));
+
+    await waitFor(() => {
+      const activations = srcDocActivationMessages(postMessageSpy.mock.calls);
+      expect(activations.at(-1)?.html).toContain('<main data-od-id="hero">Hero</main>');
+      expect(activations.at(-1)?.html).toContain('data-od-palette-bridge');
+    });
+  });
+
+  it('closes the Tweaks palette from its toggle without the outside-click handler reopening it', async () => {
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    const toggle = screen.getByTestId('palette-tweaks-toggle');
+    fireEvent.click(toggle);
+    expect(screen.getByRole('dialog', { name: 'Tweaks' })).toBeTruthy();
+
+    fireEvent.mouseDown(toggle);
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Tweaks' })).toBeNull());
+  });
+
   it('disables Draw direct send while a task is running but keeps queue available', () => {
     render(
       <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { JSDOM } from 'jsdom';
-import { buildSrcdoc } from '../../src/runtime/srcdoc';
+import { buildLazySrcdocTransport, buildSrcdoc } from '../../src/runtime/srcdoc';
 
 const deckHtml = `<!doctype html>
 <html>
@@ -13,6 +13,17 @@ const deckHtml = `<!doctype html>
 </html>`;
 
 describe('buildSrcdoc', () => {
+  it('announces lazy transport readiness and activation acknowledgements', () => {
+    const shell = buildLazySrcdocTransport();
+    const activated = buildSrcdoc('<main>Hero</main>');
+
+    expect(shell).toContain('od:srcdoc-transport-ready');
+    expect(shell).toContain('od:srcdoc-transport-activated');
+    expect(shell).toContain('data.id');
+    expect(activated).toContain('od:srcdoc-transport-ready');
+    expect(activated).toContain('od:srcdoc-transport-activated');
+  });
+
   it('injects an initial slide index for deck previews', () => {
     const doc = buildSrcdoc(deckHtml, { deck: true, initialSlideIndex: 2 });
 


### PR DESCRIPTION
## Summary

- add ready/activated acknowledgements to the lazy srcDoc transport so FileViewer can resend payloads that race listener setup
- retry srcDoc transport activation with a bounded fallback that drops Tweaks-only srcDoc mode instead of leaving a blank shell
- treat the Tweaks toggle as part of the popover interaction region so closing it cannot be reopened by the outside-click handler

Closes #2253

## Superseded by #2320

PR #2320 has now merged into `main` and is the better landed approach for #2253.

Comparison:
- #2319 kept an explicit activation scheduler with retry/fallback timers. PerishCode found that `resetSrcDocTransportFallback` made `scheduleSrcDocTransportActivation` unstable across Tweaks popover toggles, which could rewrite the whole iframe.
- #2320 removes that scheduler/fallback path and gates activation on a stable shell-ready latch plus `canActivateSrcDocTransport()`, with `activatedHtml` dedupe. That avoids the callback-instability problem entirely.
- #2320 also removes the full-content `od:srcdoc-transport-ready` re-emit, so activated content no longer forces a redundant second `document.write` before the activation ack path.

I verified current `upstream/main` contains merge `ba6497b3` from #2320, so this PR should not be force-pushed further.

## Verification

- `pnpm --filter @open-design/web typecheck`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx tests/runtime/srcdoc.test.ts tests/runtime/srcdoc-palette-css-vars.test.ts`
- Supersession check on 2026-05-20: `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/runtime/srcdoc-transport.test.ts tests/runtime/srcdoc.test.ts tests/runtime/srcdoc-palette-css-vars.test.ts` (3 files, 35 tests passed)
- Supersession check on 2026-05-20: `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx` (1 file, 87 tests passed)

Note: verified in automated jsdom regression coverage. I could not attach a live browser screenshot of the specific hosted repro project from this local workspace.
