### PR TITLE
fix(web): gate srcDoc transport activation on shell ready

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -59,7 +59,7 @@ import {
   requestPreviewSnapshot,
 } from '../runtime/exports';
 import { buildReactComponentSrcdoc } from '../runtime/react-component';
-import { buildLazySrcdocTransport, buildSrcdoc } from '../runtime/srcdoc';
+import { buildLazySrcdocTransport, buildSrcdoc, canActivateSrcDocTransport } from '../runtime/srcdoc';
 import {
   hasUrlModeBridge,
   htmlNeedsSandboxShim,
@@ -3998,21 +3998,49 @@ function HtmlViewer({
   const lazySrcDocTransport = useMemo(() => buildLazySrcdocTransport(), []);
   const [hasLazySrcDocTransport, setHasLazySrcDocTransport] = useState(useUrlLoadPreview);
   const [srcDocTransportResetKey, setSrcDocTransportResetKey] = useState(0);
+  const [srcDocShellReady, setSrcDocShellReady] = useState(false);
   const wasUrlLoadPreviewRef = useRef(useUrlLoadPreview);
   useEffect(() => {
     if (useUrlLoadPreview) setHasLazySrcDocTransport(true);
   }, [useUrlLoadPreview]);
+  // Reset the shell-ready latch whenever the srcDoc iframe re-mounts. The
+  // next shell will post `od:srcdoc-transport-ready` (or fire onLoad) and
+  // flip this back to true. See #2253.
+  useEffect(() => {
+    setSrcDocShellReady(false);
+  }, [srcDocTransportResetKey]);
+  // Listen for the shell's ready handshake. Gating activation on this is
+  // what fixes the #2253 race: opening Tweaks right after a key-driven
+  // re-mount used to post `activate` before the shell's listener was
+  // installed, dropping the message and stranding the iframe on the empty
+  // 536-byte body.
+  useEffect(() => {
+    function onMessage(ev: MessageEvent) {
+      if (ev.source !== srcDocPreviewIframeRef.current?.contentWindow) return;
+      const data = ev.data as { type?: string } | null;
+      if (data?.type !== 'od:srcdoc-transport-ready') return;
+      setSrcDocShellReady(true);
+    }
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, []);
   const useLazySrcDocTransport = useUrlLoadPreview || hasLazySrcDocTransport;
   const srcDocTransportContent = useLazySrcDocTransport ? lazySrcDocTransport : srcDoc;
   const urlTransportSrc = useUrlLoadPreview ? activePreviewSrcUrl : 'about:blank';
   const activateSrcDocTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
+    if (!canActivateSrcDocTransport({
+      srcDoc,
+      useUrlLoadPreview,
+      useLazySrcDocTransport,
+      shellReady: srcDocShellReady,
+      activatedHtml: activatedSrcDocTransportHtmlRef.current,
+    })) return false;
     const win = target?.contentWindow;
-    if (!win || !srcDoc || useUrlLoadPreview || !useLazySrcDocTransport) return false;
-    if (activatedSrcDocTransportHtmlRef.current === srcDoc) return false;
+    if (!win) return false;
     win.postMessage({ type: 'od:srcdoc-transport-activate', html: srcDoc }, '*');
     activatedSrcDocTransportHtmlRef.current = srcDoc;
     return true;
-  }, [srcDoc, useLazySrcDocTransport, useUrlLoadPreview]);
+  }, [srcDoc, useLazySrcDocTransport, useUrlLoadPreview, srcDocShellReady]);
   useEffect(() => {
     if (useUrlLoadPreview) {
       activatedSrcDocTransportHtmlRef.current = null;
@@ -6022,6 +6050,11 @@ function HtmlViewer({
                       onLoad={() => {
                         const frame = srcDocPreviewIframeRef.current;
                         if (!useUrlLoadPreview) iframeRef.current = frame;
+                        // Belt-and-suspenders for the ready handshake: if the
+                        // postMessage racing the parent's listener registration
+                        // ever loses, the load event still tells us the shell
+                        // script ran to completion.
+                        if (useLazySrcDocTransport) setSrcDocShellReady(true);
                         activateSrcDocTransport(frame);
                         dcViewportRestoreAtRef.current = Date.now();
                         frame?.contentWindow?.postMessage({

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -75,6 +75,19 @@ export function buildSrcdoc(
   return injectSrcdocTransportActivationBridge(injectSnapshotBridge(withEdit));
 }
 
+/**
+ * Build the lazy transport shell.
+ *
+ * The shell does two things:
+ *   1. Register a listener for `od:srcdoc-transport-activate` that replaces
+ *      its own document with the real artifact HTML.
+ *   2. Post `od:srcdoc-transport-ready` to the parent as soon as the listener
+ *      is installed. This `ready` signal is the only reliable way for the
+ *      host to know the listener is live; without it, the host risks posting
+ *      `activate` before the iframe's script has executed (e.g. right after a
+ *      key-driven re-mount), in which case the message is dropped and the
+ *      iframe stays stuck on the empty shell. See #2253.
+ */
 export function buildLazySrcdocTransport(): string {
   return `<!doctype html>
 <html>
@@ -89,10 +102,48 @@ export function buildLazySrcdocTransport(): string {
         document.write(data.html);
         document.close();
       });
+      try {
+        if (window.parent && window.parent !== window) {
+          window.parent.postMessage({ type: 'od:srcdoc-transport-ready' }, '*');
+        }
+      } catch (_) { /* sandboxed parent — host falls back to onLoad */ }
     })();</script>
   </head>
   <body></body>
 </html>`;
+}
+
+export interface SrcDocActivationInputs {
+  /** The real artifact HTML the host wants to inject into the shell. */
+  srcDoc: string;
+  /** Host is currently showing the URL-loaded iframe (srcDoc iframe is hidden). */
+  useUrlLoadPreview: boolean;
+  /** Host's render pipeline is routing through the lazy transport shell. */
+  useLazySrcDocTransport: boolean;
+  /** The shell document has loaded AND posted `od:srcdoc-transport-ready`. */
+  shellReady: boolean;
+  /** Which artifact HTML has already been pushed into this shell (dedupe). */
+  activatedHtml: string | null;
+}
+
+/**
+ * Pure decision for whether the host should now post
+ * `od:srcdoc-transport-activate` to the shell iframe.
+ *
+ * Gating on `shellReady` is the fix for #2253: without it, an activation
+ * triggered by `useUrlLoadPreview` flipping to false (e.g. opening the
+ * Tweaks palette) can fire while the iframe's shell script has not yet
+ * registered its message listener. The message is dropped, the shell stays
+ * on its empty 536-byte body, and the dedupe check then suppresses the
+ * follow-up activation from the iframe's onLoad path.
+ */
+export function canActivateSrcDocTransport(state: SrcDocActivationInputs): boolean {
+  if (!state.srcDoc) return false;
+  if (state.useUrlLoadPreview) return false;
+  if (!state.useLazySrcDocTransport) return false;
+  if (!state.shellReady) return false;
+  if (state.activatedHtml === state.srcDoc) return false;
+  return true;
 }
 
 function injectSrcdocTransportActivationBridge(doc: string): string {

--- a/apps/web/tests/runtime/srcdoc-transport.test.ts
+++ b/apps/web/tests/runtime/srcdoc-transport.test.ts
@@ -1,0 +1,199 @@
+import vm from 'node:vm';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildLazySrcdocTransport,
+  canActivateSrcDocTransport,
+  type SrcDocActivationInputs,
+} from '../../src/runtime/srcdoc';
+
+function extractShellScript(shellHtml: string): string {
+  const match = shellHtml.match(
+    /<script\s+data-od-lazy-srcdoc-transport>([\s\S]*?)<\/script>/,
+  );
+  if (!match || match[1] == null) {
+    throw new Error('lazy transport shell script not found');
+  }
+  return match[1];
+}
+
+interface RunShellResult {
+  parentMessages: unknown[];
+  triggerActivate: (html: string) => void;
+}
+
+function runShellInSandbox(shellHtml: string): RunShellResult {
+  const script = extractShellScript(shellHtml);
+  const parentMessages: unknown[] = [];
+  const messageListeners: Array<(ev: { data: unknown }) => void> = [];
+  const parentMock = {
+    postMessage: (data: unknown) => {
+      parentMessages.push(data);
+    },
+  };
+  const documentMock = {
+    open: vi.fn(),
+    write: vi.fn(),
+    close: vi.fn(),
+  };
+  const win = {
+    parent: parentMock,
+    addEventListener(_type: string, listener: (ev: { data: unknown }) => void) {
+      messageListeners.push(listener);
+    },
+  };
+  const sandbox: Record<string, unknown> = {
+    document: documentMock,
+    window: win,
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(script, sandbox);
+  return {
+    parentMessages,
+    triggerActivate: (html: string) => {
+      for (const listener of messageListeners) {
+        listener({ data: { type: 'od:srcdoc-transport-activate', html } });
+      }
+    },
+  };
+}
+
+describe('buildLazySrcdocTransport (#2253)', () => {
+  it('posts od:srcdoc-transport-ready to parent on load', () => {
+    const shell = buildLazySrcdocTransport();
+    const { parentMessages } = runShellInSandbox(shell);
+    expect(parentMessages).toContainEqual({ type: 'od:srcdoc-transport-ready' });
+  });
+
+  it('skips the ready post when window.parent equals window (top-level load)', () => {
+    // When the lazy shell is somehow opened top-level (no parent), the ready
+    // message must not throw and must not fan out to itself.
+    const script = extractShellScript(buildLazySrcdocTransport());
+    const calls: unknown[] = [];
+    const win: Record<string, unknown> = {
+      addEventListener: () => {},
+      postMessage: (data: unknown) => calls.push(data),
+    };
+    win.parent = win;
+    const sandbox: Record<string, unknown> = {
+      document: { open: () => {}, write: () => {}, close: () => {} },
+      window: win,
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(script, sandbox);
+    expect(calls).toEqual([]);
+  });
+
+  it('still replaces document content when parent posts activate', () => {
+    const shell = buildLazySrcdocTransport();
+    const result = runShellInSandbox(shell);
+    result.triggerActivate('<html><body>activated</body></html>');
+    // The shell handler calls document.open/write/close in order.
+    // We assert behavior via the document mock the sandbox exposed.
+    // (Re-running with our own probe to inspect document mock.)
+    const script = extractShellScript(shell);
+    const writes: string[] = [];
+    const win: Record<string, unknown> = {
+      addEventListener(_t: string, listener: (ev: { data: unknown }) => void) {
+        (win as { __listener: typeof listener }).__listener = listener;
+      },
+    };
+    win.parent = { postMessage: () => {} };
+    const sandbox: Record<string, unknown> = {
+      document: {
+        open: () => {},
+        write: (chunk: string) => writes.push(chunk),
+        close: () => {},
+      },
+      window: win,
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(script, sandbox);
+    const listener = (win as { __listener: (ev: { data: unknown }) => void }).__listener;
+    listener({ data: { type: 'od:srcdoc-transport-activate', html: '<p>hi</p>' } });
+    expect(writes).toEqual(['<p>hi</p>']);
+  });
+
+  it('ignores activate messages with missing or non-string html', () => {
+    const shell = buildLazySrcdocTransport();
+    const script = extractShellScript(shell);
+    const writes: string[] = [];
+    const win: Record<string, unknown> = {
+      addEventListener(_t: string, listener: (ev: { data: unknown }) => void) {
+        (win as { __listener: typeof listener }).__listener = listener;
+      },
+    };
+    win.parent = { postMessage: () => {} };
+    const sandbox: Record<string, unknown> = {
+      document: {
+        open: () => {},
+        write: (chunk: string) => writes.push(chunk),
+        close: () => {},
+      },
+      window: win,
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(script, sandbox);
+    const listener = (win as { __listener: (ev: { data: unknown }) => void }).__listener;
+    listener({ data: { type: 'od:srcdoc-transport-activate' } });
+    listener({ data: { type: 'od:srcdoc-transport-activate', html: 123 } });
+    listener({ data: null });
+    listener({ data: { type: 'unrelated' } });
+    expect(writes).toEqual([]);
+  });
+});
+
+const BASE_STATE: SrcDocActivationInputs = {
+  srcDoc: '<html>real</html>',
+  useUrlLoadPreview: false,
+  useLazySrcDocTransport: true,
+  shellReady: true,
+  activatedHtml: null,
+};
+
+describe('canActivateSrcDocTransport (#2253)', () => {
+  it('returns true when shell is ready and we are in srcDoc mode', () => {
+    expect(canActivateSrcDocTransport(BASE_STATE)).toBe(true);
+  });
+
+  it('returns false when shell is not yet ready (the #2253 race)', () => {
+    expect(
+      canActivateSrcDocTransport({ ...BASE_STATE, shellReady: false }),
+    ).toBe(false);
+  });
+
+  it('returns false when host is still URL-loading the preview', () => {
+    expect(
+      canActivateSrcDocTransport({ ...BASE_STATE, useUrlLoadPreview: true }),
+    ).toBe(false);
+  });
+
+  it('returns false when the lazy transport is bypassed', () => {
+    expect(
+      canActivateSrcDocTransport({ ...BASE_STATE, useLazySrcDocTransport: false }),
+    ).toBe(false);
+  });
+
+  it('returns false when srcDoc is empty (no real artifact yet)', () => {
+    expect(canActivateSrcDocTransport({ ...BASE_STATE, srcDoc: '' })).toBe(false);
+  });
+
+  it('returns false when the same html was already activated (dedupe)', () => {
+    expect(
+      canActivateSrcDocTransport({
+        ...BASE_STATE,
+        activatedHtml: BASE_STATE.srcDoc,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when activatedHtml differs from current srcDoc', () => {
+    expect(
+      canActivateSrcDocTransport({
+        ...BASE_STATE,
+        activatedHtml: '<html>previous</html>',
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #2253

## Why

The reporter hit a blank HTML preview after opening or toggling Tweaks on a generated prototype. The artifact file itself is valid; the FileViewer just stranded the iframe on the lazy transport shell (the 536-byte empty body) and never wrote the real HTML in. The repro is exactly the sequence the issue documents — Tweaks open, Tweaks close, Tweaks open — i.e. anything that crosses the URL-load → srcDoc boundary after the iframe re-mounts.

Tracing the FileViewer state path showed a hand-rolled race: closing Tweaks bumps \`srcDocTransportResetKey\`, which re-mounts the srcDoc iframe with a fresh lazy shell. Re-opening Tweaks immediately fires the \`useUrlLoadPreview\`-driven \`activateSrcDocTransport()\` while the new shell is still parsing its inline script — so the \`postMessage\` lands in a window that has not yet called \`addEventListener('message', …)\`. The activation is silently dropped, but \`activatedSrcDocTransportHtmlRef.current\` is marked to the current srcDoc anyway, so the follow-up call from the iframe's \`onLoad\` short-circuits via the dedupe and never recovers.

Hit this while sweeping P1 preview/v0.8.0 issues — it's reproducible by every project that follows the documented Tweaks flow once the iframe has been re-mounted at least once.

## What users will see

Toggling Tweaks on an HTML prototype no longer blanks the preview. Opening Tweaks now waits for the lazy transport shell to acknowledge readiness before injecting the real artifact HTML, so the iframe stays correct across any URL-load ↔ srcDoc transition (single click, rapid double-toggle, or palette-state churn). Behavior outside the Tweaks/palette path is unchanged.

## Surface area

- [x] **None** — bug fix scoped to the FileViewer ↔ lazy transport contract: \`apps/web/src/runtime/srcdoc.ts\` (shell now posts \`od:srcdoc-transport-ready\`; new \`canActivateSrcDocTransport()\` helper) and \`apps/web/src/components/FileViewer.tsx\` (new \`srcDocShellReady\` state + ready listener + onLoad fallback). No UI surface, CLI, API, contract DTO, or i18n key added.

## Bug fix verification

- Test path that reproduces the bug: \`apps/web/tests/runtime/srcdoc-transport.test.ts\`
- Did the test go red on \`main\` and green on this branch? **Yes** — verified by stashing only the \`srcdoc.ts\` source change (test file kept): 8/11 tests fail (\`canActivateSrcDocTransport is not a function\` plus the ready-handshake assertion). After restoring the source: 11/11 pass.

The spec evaluates the shell's inline IIFE in a Node \`vm\` with a mocked \`window\`/\`window.parent\`/\`document\`, so it can directly observe both the new ready signal and the activate-handler behavior without standing up a browser or daemon. The gating helper is also exercised across every relevant gating combination (shellReady, useUrlLoadPreview, useLazySrcDocTransport, srcDoc emptiness, dedupe).

## Validation

- \`pnpm guard\` ✅
- \`pnpm --filter @open-design/web typecheck\` ✅ (clean after building workspace pre-reqs; \`apps/desktop\` & co. still report pre-existing \`Cannot find module '@open-design/host'\` when those package dists are missing — unrelated to this PR)
- \`pnpm --filter @open-design/web test tests/runtime\` ✅ (14 files, 165 tests; no regressions in the adjacent srcDoc-bridge / deck / palette suites)