### PR TITLE
fix(web): coalesce chokidar rewrite bursts before refreshing files

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -35,6 +35,7 @@ import {
   writeProjectTextFile,
 } from '../providers/registry';
 import { useProjectFileEvents, type ProjectEvent } from '../providers/project-events';
+import { useCoalescedCallback } from '../hooks/useCoalescedCallback';
 import {
   composeSystemPrompt,
   type AudioVoiceOption,
@@ -992,13 +993,28 @@ export function ProjectView({
   // bump filesRefresh so the file list refetches with new mtimes — which
   // propagates through to FileViewer iframes via PR #384's ?v=${mtime}
   // cache-bust, triggering an automatic preview reload without a click.
+  //
+  // Coalesce the refresh: agent rewrites surface to chokidar as an
+  // `unlink` + `add` (+ later `change`) burst within a single tick (#2195).
+  // Refreshing the file list on the intermediate `unlink` makes the open
+  // tab's active file vanish for one frame before the `add` restores it,
+  // and FileWorkspace's "tab no longer on disk" path then drops the user
+  // out of their preview. A short trailing wait absorbs the burst; the
+  // maxWait cap stops a sustained edit storm from starving the UI.
+  const refreshFilesAndDesignMd = useCallback(() => {
+    setFilesRefresh((n) => n + 1);
+    // Round 7 (mrcfps): file mutations are the dominant staleness signal
+    // post-finalize — bump the refresh key so DESIGN.md staleness
+    // recomputes against the new mtimes.
+    setDesignMdRefreshKey((n) => n + 1);
+  }, []);
+  const coalescedFileChangedRefresh = useCoalescedCallback(
+    refreshFilesAndDesignMd,
+    { wait: 80, maxWait: 250 },
+  );
   const handleProjectEvent = useCallback((evt: ProjectEvent) => {
     if (evt.type === 'file-changed') {
-      setFilesRefresh((n) => n + 1);
-      // Round 7 (mrcfps): file mutations are the dominant staleness
-      // signal post-finalize — bump the refresh key so DESIGN.md
-      // staleness recomputes against the new mtimes.
-      setDesignMdRefreshKey((n) => n + 1);
+      coalescedFileChangedRefresh();
       return;
     }
     if (evt.type === 'conversation-created') {
@@ -1046,7 +1062,7 @@ export function ProjectView({
     // Live artifact events come from chat-turn-emitted artifacts; they
     // also imply the conversation transcript changed.
     setDesignMdRefreshKey((n) => n + 1);
-  }, [onProjectsRefresh, refreshLiveArtifacts, project.id]);
+  }, [onProjectsRefresh, refreshLiveArtifacts, project.id, coalescedFileChangedRefresh]);
   useProjectFileEvents(project.id, daemonLive, handleProjectEvent);
 
   // When the URL points at a specific file, fire an open request so the

--- a/apps/web/src/hooks/useCoalescedCallback.ts
+++ b/apps/web/src/hooks/useCoalescedCallback.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+export interface CoalesceOptions {
+  /**
+   * Quiet window (ms) the trigger waits for before firing the callback.
+   * Each new trigger inside the window resets this timer.
+   */
+  wait: number;
+  /**
+   * Hard upper bound (ms) on how long a sustained burst can keep deferring
+   * the callback. If `maxWait` elapses since the first trigger of the
+   * current burst, the next call flushes immediately. Omit to disable the
+   * cap (only useful for short, well-bounded bursts).
+   */
+  maxWait?: number;
+}
+
+interface InternalState {
+  timer: ReturnType<typeof setTimeout> | null;
+  firstSeenAt: number | null;
+}
+
+/**
+ * Returns a stable trigger function that coalesces rapid bursts of calls
+ * into a single trailing invocation of `callback`. Used to absorb chokidar
+ * write-then-rename signatures (e.g. `unlink` + `add` within a single
+ * tick during an agent rewrite) before they propagate to the UI as a
+ * "file disappeared" frame. See #2195.
+ *
+ * Semantics:
+ *   - First trigger arms a timer for `wait` ms.
+ *   - Subsequent triggers inside the quiet window reset the timer.
+ *   - When the timer fires, the latest `callback` runs once.
+ *   - If `maxWait` is set and the current burst has been deferred for
+ *     `>= maxWait`, the next trigger flushes immediately instead of
+ *     resetting again — sustained edit storms don't starve the UI.
+ *   - The hook's identity is stable across renders; only `wait` /
+ *     `maxWait` changes regenerate the trigger.
+ *   - The pending timer is cleared on unmount, so a late event after the
+ *     component leaves the tree cannot call into a stale `callback`.
+ */
+export function useCoalescedCallback(
+  callback: () => void,
+  options: CoalesceOptions,
+): () => void {
+  const stateRef = useRef<InternalState>({ timer: null, firstSeenAt: null });
+  const callbackRef = useRef(callback);
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+  useEffect(() => {
+    return () => {
+      const s = stateRef.current;
+      if (s.timer !== null) {
+        clearTimeout(s.timer);
+        s.timer = null;
+        s.firstSeenAt = null;
+      }
+    };
+  }, []);
+  const { wait, maxWait } = options;
+  return useCallback(() => {
+    const s = stateRef.current;
+    const flush = () => {
+      if (s.timer !== null) clearTimeout(s.timer);
+      s.timer = null;
+      s.firstSeenAt = null;
+      callbackRef.current();
+    };
+    const now = Date.now();
+    if (
+      s.firstSeenAt !== null &&
+      maxWait !== undefined &&
+      now - s.firstSeenAt >= maxWait
+    ) {
+      flush();
+      return;
+    }
+    if (s.firstSeenAt === null) s.firstSeenAt = now;
+    if (s.timer !== null) clearTimeout(s.timer);
+    s.timer = setTimeout(flush, wait);
+  }, [wait, maxWait]);
+}

--- a/apps/web/tests/hooks/useCoalescedCallback.test.tsx
+++ b/apps/web/tests/hooks/useCoalescedCallback.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useCoalescedCallback } from '../../src/hooks/useCoalescedCallback';
+
+describe('useCoalescedCallback (#2195)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces a chokidar unlink+add burst into a single callback', () => {
+    const cb = vi.fn();
+    const { result } = renderHook(() => useCoalescedCallback(cb, { wait: 80 }));
+    // Simulate the agent's atomic rewrite: unlink at T+0, add at T+12,
+    // change at T+25. The whole burst lands inside the 80ms quiet window
+    // and the UI must NOT see a transient "file gone" refresh.
+    act(() => { result.current(); });
+    act(() => { vi.advanceTimersByTime(12); result.current(); });
+    act(() => { vi.advanceTimersByTime(13); result.current(); });
+    expect(cb).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(80); });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the callback once after a single isolated trigger', () => {
+    const cb = vi.fn();
+    const { result } = renderHook(() => useCoalescedCallback(cb, { wait: 80 }));
+    act(() => { result.current(); });
+    expect(cb).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(80); });
+    expect(cb).toHaveBeenCalledTimes(1);
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires again for a second burst after the first one settled', () => {
+    const cb = vi.fn();
+    const { result } = renderHook(() => useCoalescedCallback(cb, { wait: 80 }));
+    act(() => { result.current(); });
+    act(() => { vi.advanceTimersByTime(80); });
+    expect(cb).toHaveBeenCalledTimes(1);
+    act(() => { result.current(); });
+    act(() => { vi.advanceTimersByTime(80); });
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it('flushes synchronously once maxWait has elapsed during a sustained burst', () => {
+    const cb = vi.fn();
+    const { result } = renderHook(() =>
+      useCoalescedCallback(cb, { wait: 80, maxWait: 200 }),
+    );
+    // Continuously trigger every 50ms. The wait window keeps resetting,
+    // but the maxWait cap must force a flush around T=200ms regardless.
+    act(() => { result.current(); }); // T=0
+    act(() => { vi.advanceTimersByTime(50); result.current(); }); // T=50
+    act(() => { vi.advanceTimersByTime(50); result.current(); }); // T=100
+    act(() => { vi.advanceTimersByTime(50); result.current(); }); // T=150
+    expect(cb).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(50); result.current(); }); // T=200 -> flush
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the latest callback when it changes between triggers', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    let active = first;
+    const { rerender, result } = renderHook(() =>
+      useCoalescedCallback(active, { wait: 80 }),
+    );
+    act(() => { result.current(); });
+    active = second;
+    rerender();
+    act(() => { vi.advanceTimersByTime(80); });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels any pending timer when the component unmounts', () => {
+    const cb = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useCoalescedCallback(cb, { wait: 80 }),
+    );
+    act(() => { result.current(); });
+    unmount();
+    act(() => { vi.advanceTimersByTime(500); });
+    expect(cb).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #2195

## Why

Repro from the packaged 0.8.0 macOS build: open the Web Prototype flow, open the generated \`index.html\` preview while the agent is still writing, watch the active file vanish for a frame and the preview fall back to an empty state. The reporter narrowed the agent event sequence to:

\`\`\`text
file_change index.html kind=delete
file_change index.html kind=add
file_change index.html kind=update
\`\`\`

Tracing it in source: chokidar surfaces an atomic temp-file rewrite as \`unlink\` then \`add\` (and a later \`change\`) inside a single tick. \`apps/web/src/components/ProjectView.tsx\` bumps \`filesRefresh\` on every \`file-changed\` event, so the open tab's \`activeFile\` resolver in \`FileWorkspace\` returns \`null\` between the \`unlink\` and the \`add\`, and the preview drops out for one frame.

The reporter's suggested directions were "debounce/coalesce \`file-changed\` refreshes in \`ProjectView\`" or "preserve the active file briefly when it disappears during a run". I went with the first — it's surgical to one event handler and doesn't change FileWorkspace's "tab is gone" semantics for the legitimate-delete case.

Hit this while continuing the P1 preview/v0.8.0 sweep.

## What users will see

Running an agent rewrite while a generated file is open no longer flashes the preview to empty between the chokidar \`unlink\` and \`add\` events. Single, isolated file changes still refresh as before (80ms trailing latency is below the typical agent step cadence), and a long edit storm still flushes through the 250ms maxWait cap so the file list never stays stale.

## Surface area

- [x] **None** — bug fix scoped to ProjectView's chokidar-event refresh path. New \`useCoalescedCallback\` hook in \`apps/web/src/hooks/\` for the timing contract, plus its unit tests. No UI surface, CLI, API, contract DTO, or i18n key added.

## Bug fix verification

- Test path that reproduces the bug: \`apps/web/tests/hooks/useCoalescedCallback.test.tsx\`
- Did the test go red on \`main\` and green on this branch? **Yes** — verified by temporarily removing the hook source and stashing the ProjectView edit. Vitest then fails to resolve \`../../src/hooks/useCoalescedCallback\`. With the fix restored, all 6 cases pass (the chokidar unlink+add burst case, isolated single trigger, maxWait flush under sustained burst, latest-callback semantics across re-renders, unmount cleanup, and a second burst after the first settled).

Coalesce is exercised against the real chokidar burst timing the issue documents (unlink at T+0, add at T+12, change at T+25, all inside the 80ms quiet window). The ProjectView integration is reviewable as a 22-line diff that swaps the direct setters for the coalesced trigger.

## Validation

- \`pnpm guard\` ✅
- \`pnpm --filter @open-design/web typecheck\` ✅
- \`pnpm --filter @open-design/web test tests/hooks/useCoalescedCallback.test.tsx\` ✅ (6/6)
- \`pnpm --filter @open-design/web test tests/runtime\` ✅ (13 files, 154 tests; no regressions)