### PR TITLE
Fix OpenCode 1.3 connection args

### DIFF
--- a/apps/daemon/src/runtimes/defs/opencode.ts
+++ b/apps/daemon/src/runtimes/defs/opencode.ts
@@ -31,10 +31,9 @@ export const opencodeAgentDef = {
         'run',
         '--format',
         'json',
-        '--dangerously-skip-permissions',
       ];
       if (options.model && options.model !== 'default') {
-        args.push('--model', options.model);
+        args.push('-m', options.model);
       }
       return args;
     },

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1658,6 +1658,69 @@ setTimeout(() => process.exit(0), 50);
     );
   });
 
+  it('launches OpenCode connection tests with 1.3-compatible JSON stdin args', async () => {
+    const markerDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-opencode-argv-'));
+    const argvFile = path.join(markerDir, 'argv.json');
+    const stdinFile = path.join(markerDir, 'stdin.txt');
+    try {
+      await withFakeOpenCode(
+        `
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args[0] === 'models') {
+  console.log('github-copilot/gpt-4o');
+  process.exit(0);
+}
+fs.writeFileSync(${JSON.stringify(argvFile)}, JSON.stringify(args));
+let stdin = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { stdin += chunk; });
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(stdinFile)}, stdin);
+  if (args.includes('--dangerously-skip-permissions') || args.includes('--model')) {
+    console.error('incompatible opencode args');
+    process.exit(1);
+    return;
+  }
+  console.log(JSON.stringify({ type: 'text', part: { text: 'ok' } }));
+});
+`,
+        async () => {
+          const res = await realFetch(`${baseUrl}/api/test/connection`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              mode: 'agent',
+              agentId: 'opencode',
+              model: 'github-copilot/gpt-4o',
+            }),
+          });
+          expect(res.status).toBe(200);
+          await expect(res.json()).resolves.toMatchObject({
+            ok: true,
+            kind: 'success',
+            agentName: 'OpenCode',
+            model: 'github-copilot/gpt-4o',
+            sample: 'ok',
+          });
+
+          await expect(fsp.readFile(argvFile, 'utf8')).resolves.toBe(
+            JSON.stringify([
+              'run',
+              '--format',
+              'json',
+              '-m',
+              'github-copilot/gpt-4o',
+            ]),
+          );
+          await expect(fsp.readFile(stdinFile, 'utf8')).resolves.toBe('Reply with only: ok');
+        },
+      );
+    } finally {
+      await fsp.rm(markerDir, { recursive: true, force: true });
+    }
+  });
+
   it('reports Cursor Agent status auth failures before running the smoke prompt', async () => {
     await withFakeCursorAgent(
       `

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -35,7 +35,6 @@ test('opencode args deliver prompts via stdin without passing a literal dash pro
     'run',
     '--format',
     'json',
-    '--dangerously-skip-permissions',
   ]);
 
   const withModel = opencode.buildArgs(
@@ -48,10 +47,11 @@ test('opencode args deliver prompts via stdin without passing a literal dash pro
     'run',
     '--format',
     'json',
-    '--dangerously-skip-permissions',
-    '--model',
+    '-m',
     'anthropic/claude-sonnet-4-5',
   ]);
+  assert.equal(withModel.includes('--dangerously-skip-permissions'), false);
+  assert.equal(withModel.includes('--model'), false);
 });
 
 // Copilot reads the prompt from stdin when `-p` is omitted entirely


### PR DESCRIPTION
Closes #2120

## Why

OpenCode 1.3.13 rejects Open Design's current Settings test command because the adapter always adds `--dangerously-skip-permissions`, even for `Default (CLI config)`. The same version also accepts selected models via `-m <provider/model>`, while Open Design was sending `--model <provider/model>`.

This PR fixes the Local CLI OpenCode smoke-test launch shape so Windows users with OpenCode 1.3.13 can use Settings -> Execution and Model -> Local CLI -> OpenCode -> Test with both default and selected models.

## What users will see

OpenCode's Test button should no longer fail immediately with `Failed to launch OpenCode: exit 1` when the installed OpenCode CLI is 1.3.13-compatible. Selected OpenCode models continue to work, but are now launched through the CLI's supported `-m` flag.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/connection-test.test.ts` -> `launches OpenCode connection tests with 1.3-compatible JSON stdin args`
- Did the test go red on `main` and green on this branch? yes. It failed before the adapter change with `agent_spawn_failed` because the fake OpenCode rejected `--dangerously-skip-permissions` / `--model`, then passed after the adapter emitted `opencode run --format json -m github-copilot/gpt-4o` and kept the prompt on stdin.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/agent-args.test.ts tests/connection-test.test.ts` (113 passed)
- `corepack pnpm --filter @open-design/daemon build`
- `corepack pnpm guard`
- `corepack pnpm --filter @open-design/contracts build`
- `corepack pnpm --filter @open-design/registry-protocol build`
- `corepack pnpm --filter @open-design/daemon exec tsc -p tsconfig.json --noEmit`
- `corepack pnpm --filter @open-design/daemon exec tsc -p tsconfig.tests.json --noEmit`

Note: this shell is on Node v26.0.0 while the repo targets Node ~24, so commands emit engine warnings. The root `corepack pnpm typecheck` and package `typecheck` scripts are also blocked here because their nested bare `pnpm` invocation resolves to pnpm 10.28.2 instead of the required pnpm >=10.33.2 <11; the equivalent build and tsc steps above were run directly through Corepack.
