### PR TITLE
fix(daemon): block pitch deck placeholder artifacts

### DIFF
--- a/apps/daemon/src/artifact-publication-guard.ts
+++ b/apps/daemon/src/artifact-publication-guard.ts
@@ -1,0 +1,59 @@
+import { Buffer } from 'node:buffer';
+
+export const ARTIFACT_PUBLICATION_BLOCKED_CODE = 'ARTIFACT_PUBLICATION_BLOCKED' as const;
+
+export const PUBLICATION_GUARDED_ARTIFACT_KINDS: ReadonlySet<string> = new Set(['html', 'deck']);
+
+export const UNRESOLVED_ARTIFACT_PLACEHOLDERS = [
+  'Name to confirm',
+  '$X.XM',
+  'Replace this panel with',
+  'Replace role placeholders',
+  'Your form answer only said',
+] as const;
+
+export class ArtifactPublicationBlockedError extends Error {
+  readonly code = ARTIFACT_PUBLICATION_BLOCKED_CODE;
+  readonly placeholders: string[];
+
+  constructor(placeholders: string[]) {
+    super(buildArtifactPublicationBlockedMessage(placeholders));
+    this.name = 'ArtifactPublicationBlockedError';
+    this.placeholders = [...placeholders];
+  }
+}
+
+export function isPublicationGuardedArtifactKind(kind: unknown): boolean {
+  return typeof kind === 'string' && PUBLICATION_GUARDED_ARTIFACT_KINDS.has(kind);
+}
+
+export function findUnresolvedArtifactPlaceholders(value: unknown): string[] {
+  const text = stringifyArtifactContent(value);
+  if (!text) return [];
+  return UNRESOLVED_ARTIFACT_PLACEHOLDERS.filter((placeholder) =>
+    text.includes(placeholder),
+  );
+}
+
+export function shouldBlockArtifactPublication(value: unknown): boolean {
+  return findUnresolvedArtifactPlaceholders(value).length > 0;
+}
+
+export function buildArtifactPublicationBlockedMessage(placeholders: readonly string[]): string {
+  const list = placeholders.length > 0 ? placeholders.join(', ') : 'unknown placeholders';
+  return `Artifact still contains unresolved pitch-deck placeholders: ${list}. Provide the required pitch facts before publishing.`;
+}
+
+export function assertArtifactPublicationAllowed(value: unknown): void {
+  const placeholders = findUnresolvedArtifactPlaceholders(value);
+  if (placeholders.length > 0) {
+    throw new ArtifactPublicationBlockedError(placeholders);
+  }
+}
+
+function stringifyArtifactContent(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (Buffer.isBuffer(value)) return value.toString('utf8');
+  if (value instanceof Uint8Array) return Buffer.from(value).toString('utf8');
+  return '';
+}

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -4,6 +4,7 @@ import {
   type PluginManifest,
 } from '@open-design/contracts';
 import { createProjectArtifactFile } from './artifact-create.js';
+import { ArtifactPublicationBlockedError } from './artifact-publication-guard.js';
 import { ArtifactRegressionError } from './artifact-stub-guard.js';
 import { listDesignSystems } from './design-systems.js';
 import {
@@ -1112,6 +1113,11 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
               priorSize: err.priorSize,
               priorName: err.priorName,
             },
+          });
+        }
+        if (err instanceof ArtifactPublicationBlockedError) {
+          return sendApiError(res, 422, 'ARTIFACT_PUBLICATION_BLOCKED', err.message, {
+            details: { placeholders: err.placeholders },
           });
         }
         if (err?.code === 'EEXIST') {

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -21,6 +21,10 @@ import {
   evaluateArtifactStubGuard,
   readArtifactStubGuardConfigFromEnv,
 } from './artifact-stub-guard.js';
+import {
+  assertArtifactPublicationAllowed,
+  isPublicationGuardedArtifactKind,
+} from './artifact-publication-guard.js';
 
 const FORBIDDEN_SEGMENT = /^$|^\.\.?$/;
 const RESERVED_PROJECT_FILE_SEGMENTS = new Set(['.live-artifacts']);
@@ -640,6 +644,9 @@ export async function writeProjectFile(
     const validated = validateArtifactManifestInput(artifactManifest, safeName);
     if (validated.ok && validated.value) {
       validatedManifest = validated.value;
+      if (isPublicationGuardedArtifactKind(validatedManifest.kind)) {
+        assertArtifactPublicationAllowed(body);
+      }
       const identifier = typeof validatedManifest.metadata?.identifier === 'string'
         ? validatedManifest.metadata.identifier
         : '';

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -290,6 +290,12 @@ import {
   writeProjectFile,
 } from './projects.js';
 import { validateArtifactManifestInput } from './artifact-manifest.js';
+import {
+  ARTIFACT_PUBLICATION_BLOCKED_CODE,
+  buildArtifactPublicationBlockedMessage,
+  findUnresolvedArtifactPlaceholders,
+  isPublicationGuardedArtifactKind,
+} from './artifact-publication-guard.js';
 import { readCurrentAppVersionInfo } from './app-version.js';
 import {
   appendMessageStatusEvent,
@@ -1839,6 +1845,60 @@ async function ensureGhReady() {
 }
 
 const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
+
+async function findProjectPublicationPlaceholders(projectId, metadata, preRunFileKeys = null) {
+  if (typeof projectId !== 'string' || projectId.length === 0) return [];
+  let files;
+  try {
+    files = await listFiles(PROJECTS_DIR, projectId, { metadata });
+  } catch {
+    return [];
+  }
+  const seen = new Set();
+  const placeholders = [];
+  for (const file of files) {
+    if (
+      preRunFileKeys instanceof Set &&
+      preRunFileKeys.has(`${file?.name}:${file?.mtime}:${file?.size}`)
+    ) {
+      continue;
+    }
+    if (
+      file?.kind !== 'html' &&
+      !isPublicationGuardedArtifactKind(file?.artifactKind)
+    ) {
+      continue;
+    }
+    let body;
+    try {
+      const entry = await readProjectFile(PROJECTS_DIR, projectId, file.name, metadata);
+      body = entry.buffer;
+    } catch {
+      continue;
+    }
+    for (const placeholder of findUnresolvedArtifactPlaceholders(body)) {
+      if (seen.has(placeholder)) continue;
+      seen.add(placeholder);
+      placeholders.push(placeholder);
+    }
+  }
+  return placeholders;
+}
+
+async function findRunPublicationPlaceholders({ projectId, metadata, assistantOutput, preRunFileKeys }) {
+  const seen = new Set();
+  const placeholders = [];
+  const add = (matches) => {
+    for (const placeholder of matches) {
+      if (seen.has(placeholder)) continue;
+      seen.add(placeholder);
+      placeholders.push(placeholder);
+    }
+  };
+  add(findUnresolvedArtifactPlaceholders(assistantOutput));
+  add(await findProjectPublicationPlaceholders(projectId, metadata, preRunFileKeys));
+  return placeholders;
+}
 
 function reconcileAssistantMessageOnRunEnd(db, runs, run) {
   if (!run.assistantMessageId) return;
@@ -9015,6 +9075,9 @@ export async function startServer({
           .map((f) => `- ${f.name}`)
           .join('\n')}`
       : '\nThis folder is empty. Choose a clear, descriptive filename for whatever you create.';
+    const preRunFileKeys = new Set(
+      existingProjectFiles.map((file) => `${file.name}:${file.mtime}:${file.size}`),
+    );
     const projectRecord =
       typeof projectId === 'string' && projectId
         ? getProject(db, projectId)
@@ -9845,6 +9908,15 @@ export async function startServer({
     // plain streams (most other CLIs) we forward raw chunks unchanged so
     // the browser can append them to the assistant's text buffer.
     let agentStreamError = null;
+    let assistantPublicationBuffer = '';
+    const ASSISTANT_PUBLICATION_BUFFER_CAP = 256 * 1024;
+    const appendAssistantPublicationText = (value) => {
+      if (typeof value !== 'string' || value.length === 0) return;
+      assistantPublicationBuffer += value;
+      if (assistantPublicationBuffer.length > ASSISTANT_PUBLICATION_BUFFER_CAP) {
+        assistantPublicationBuffer = assistantPublicationBuffer.slice(-ASSISTANT_PUBLICATION_BUFFER_CAP);
+      }
+    };
     // Tracks whether any stream the run is using actually emitted user-
     // visible content. Only the streams routed through `sendAgentEvent`
     // contribute to this flag; ACP sessions and plain stdout streams are
@@ -9897,6 +9969,9 @@ export async function startServer({
       noteAgentActivity();
       if (ev?.type && SUBSTANTIVE_AGENT_EVENT_TYPES.has(ev.type)) {
         agentProducedOutput = true;
+      }
+      if (ev?.type === 'text_delta' && typeof ev.delta === 'string') {
+        appendAssistantPublicationText(ev.delta);
       }
       send('agent', ev);
     };
@@ -10041,6 +10116,7 @@ export async function startServer({
     } else {
       child.stdout.on('data', (chunk) => {
         noteAgentActivity();
+        appendAssistantPublicationText(String(chunk));
         send('stdout', { chunk });
       });
     }
@@ -10060,7 +10136,7 @@ export async function startServer({
       send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err.message));
       design.runs.finish(run, 'failed', 1, null);
     });
-    child.on('close', (code, signal) => {
+    child.on('close', async (code, signal) => {
       clearInactivityWatchdog();
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
@@ -10132,6 +10208,22 @@ export async function startServer({
         : code === 0 || acpForcedShutdown
           ? 'succeeded'
           : 'failed';
+      if (status === 'succeeded') {
+        const placeholders = await findRunPublicationPlaceholders({
+          projectId,
+          metadata: projectRecord?.metadata,
+          preRunFileKeys,
+          assistantOutput: assistantPublicationBuffer,
+        });
+        if (placeholders.length > 0) {
+          send('error', createSseErrorPayload(
+            ARTIFACT_PUBLICATION_BLOCKED_CODE,
+            buildArtifactPublicationBlockedMessage(placeholders),
+            { retryable: false, details: { placeholders } },
+          ));
+          return design.runs.finish(run, 'failed', code, signal);
+        }
+      }
       if (status === 'failed') {
         const diagnostic = diagnoseClaudeCliFailure({
           agentId: def.id,

--- a/apps/daemon/tests/artifact-publication-guard.test.ts
+++ b/apps/daemon/tests/artifact-publication-guard.test.ts
@@ -1,0 +1,82 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  ArtifactPublicationBlockedError,
+  findUnresolvedArtifactPlaceholders,
+  shouldBlockArtifactPublication,
+} from '../src/artifact-publication-guard.js';
+import { listFiles, writeProjectFile } from '../src/projects.js';
+
+const deckManifest = {
+  kind: 'deck',
+  renderer: 'deck-html',
+  title: 'Pitch deck',
+  exports: ['html', 'pdf'],
+  metadata: { identifier: 'pitch-deck' },
+};
+
+describe('artifact publication guard', () => {
+  it('detects unresolved pitch-deck placeholders from generated HTML', () => {
+    const html = `
+      <!doctype html>
+      <html>
+        <body>
+          <section>Name to confirm</section>
+          <section>$X.XM</section>
+          <section>Replace this panel with actual pipeline once known.</section>
+          <section>Replace role placeholders with leadership names.</section>
+          <section>Your form answer only said "seed deck".</section>
+        </body>
+      </html>
+    `;
+
+    expect(findUnresolvedArtifactPlaceholders(html)).toEqual([
+      'Name to confirm',
+      '$X.XM',
+      'Replace this panel with',
+      'Replace role placeholders',
+      'Your form answer only said',
+    ]);
+    expect(shouldBlockArtifactPublication(html)).toBe(true);
+  });
+
+  it('allows real pitch-deck content with concrete ask and traction data', () => {
+    const html = `
+      <!doctype html>
+      <html>
+        <body>
+          <section>Acme AI turns support transcripts into shipped product fixes.</section>
+          <section>$4.5M seed round</section>
+          <section>42% MoM revenue growth, 18 enterprise pilots, 91% retention.</section>
+          <section>Use of funds: engineering, GTM, compliance, and customer success.</section>
+        </body>
+      </html>
+    `;
+
+    expect(findUnresolvedArtifactPlaceholders(html)).toEqual([]);
+    expect(shouldBlockArtifactPublication(html)).toBe(false);
+  });
+
+  it('rejects published HTML artifacts that still contain pitch-deck placeholders', async () => {
+    const projectsRoot = await mkdtemp(path.join(tmpdir(), 'od-publication-guard-'));
+    try {
+      await expect(
+        writeProjectFile(
+          projectsRoot,
+          'project-1',
+          'pitch-deck.html',
+          Buffer.from('<html><body><section>Name to confirm</section><section>$X.XM</section></body></html>'),
+          { artifactManifest: deckManifest } as unknown as Parameters<typeof writeProjectFile>[4],
+        ),
+      ).rejects.toBeInstanceOf(ArtifactPublicationBlockedError);
+
+      const files = await listFiles(projectsRoot, 'project-1');
+      expect(files.map((file) => file.name)).not.toContain('pitch-deck.html');
+      expect(files.map((file) => file.name)).not.toContain('pitch-deck.html.artifact.json');
+    } finally {
+      await rm(projectsRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -178,6 +178,48 @@ process.exit(0);
     );
   });
 
+  it('marks successful runs failed when emitted HTML still contains pitch-deck placeholders', async () => {
+    await withFakeAgent(
+      'opencode',
+      `
+console.log(JSON.stringify({ type: 'step_start' }));
+console.log(JSON.stringify({
+  type: 'text',
+  part: {
+    text: '<!doctype html><html><body><section>Name to confirm</section><section>$X.XM</section></body></html>'
+  }
+}));
+process.exit(0);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            message: 'build a pitch deck',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'ARTIFACT_PUBLICATION_BLOCKED');
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('event: error');
+        expect(eventsBody).toContain('ARTIFACT_PUBLICATION_BLOCKED');
+        expect(eventsBody).toContain('Name to confirm');
+        expect(eventsBody).toContain('$X.XM');
+        expect(statusBody.status).toBe('failed');
+      },
+    );
+  });
+
   it('classifies Cursor Agent authentication stderr as a typed run error', async () => {
     await withFakeAgent(
       'cursor-agent',

--- a/apps/daemon/tests/pitch-deck-manifest-required-inputs.test.ts
+++ b/apps/daemon/tests/pitch-deck-manifest-required-inputs.test.ts
@@ -1,0 +1,47 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parseManifest } from '@open-design/plugin-runtime';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const manifestPath = path.join(
+  repoRoot,
+  'plugins/_official/examples/html-ppt-pitch-deck/open-design.json',
+);
+
+describe('html-ppt-pitch-deck manifest inputs', () => {
+  it('declares the financing facts the example prompt says must be confirmed first', async () => {
+    const parsed = parseManifest(await readFile(manifestPath, 'utf8'));
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    const inputs = parsed.manifest.od?.inputs ?? [];
+    const requiredNames = inputs
+      .filter((input) => input.required === true)
+      .map((input) => input.name);
+
+    expect(requiredNames).toEqual(
+      expect.arrayContaining([
+        'one_line_pitch',
+        'key_traction_numbers',
+        'ask_and_use_of_funds',
+      ]),
+    );
+
+    for (const name of [
+      'one_line_pitch',
+      'key_traction_numbers',
+      'ask_and_use_of_funds',
+    ]) {
+      const input = inputs.find((candidate) => candidate.name === name);
+      expect(input).toMatchObject({
+        type: 'text',
+        required: true,
+      });
+      expect(input?.label).toEqual(expect.any(String));
+      expect(input?.label?.trim()).not.toBe('');
+    }
+  });
+});

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -23,6 +23,9 @@ export const API_ERROR_CODES = [
   // a bare filename string, an empty fallback page) instead of the full
   // document. Configurable via OD_ARTIFACT_STUB_GUARD (reject|warn|off).
   'ARTIFACT_REGRESSION',
+  // The daemon found unresolved standard placeholders in a generated HTML/deck
+  // artifact, so the result cannot be published or marked as succeeded.
+  'ARTIFACT_PUBLICATION_BLOCKED',
   'UPSTREAM_UNAVAILABLE',
   'RATE_LIMITED',
   // PR #974 round-4: desktop-paired daemon received an import request

--- a/plugins/_official/examples/html-ppt-pitch-deck/open-design.json
+++ b/plugins/_official/examples/html-ppt-pitch-deck/open-design.json
@@ -54,6 +54,29 @@
         }
       ]
     },
+    "inputs": [
+      {
+        "name": "one_line_pitch",
+        "label": "Name + one-line pitch",
+        "type": "text",
+        "required": true,
+        "placeholder": "Company name and one sentence explaining what it does"
+      },
+      {
+        "name": "key_traction_numbers",
+        "label": "Key traction numbers",
+        "type": "text",
+        "required": true,
+        "placeholder": "Revenue, growth, users, pilots, retention, pipeline, or other investor proof"
+      },
+      {
+        "name": "ask_and_use_of_funds",
+        "label": "Ask + use of funds",
+        "type": "text",
+        "required": true,
+        "placeholder": "Round size and how the capital will be used"
+      }
+    ],
     "context": {
       "skills": [
         {


### PR DESCRIPTION
Closes #2215

## Why

The official `Html Ppt Pitch Deck` example could start without the financing facts its prompt said to confirm first, so the existing required-input gate had no manifest fields to enforce. When generation still produced the template's unresolved placeholders, the daemon could finish the run as `succeeded` and allow the placeholder HTML/deck artifact to publish.

This fixes the preview 0.8.0 failure mode by making the pitch facts part of the plugin contract and by adding a daemon-side publication invariant for the known pitch-deck placeholders.

## What users will see

Starting the official pitch-deck example now requires the company/pitch, traction, and ask/use-of-funds inputs. If a generated HTML/deck artifact still contains the standard unresolved pitch-deck placeholders, the daemon rejects artifact publication with `ARTIFACT_PUBLICATION_BLOCKED` and a would-be successful run is marked failed instead of succeeded.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/daemon/tests/pitch-deck-manifest-required-inputs.test.ts`
  - `apps/daemon/tests/artifact-publication-guard.test.ts`
  - `apps/daemon/tests/chat-route.test.ts` (`marks successful runs failed when emitted HTML still contains pitch-deck placeholders`)
- Did the test go red on `main` and green on this branch? yes. The manifest test failed with no required inputs, the guard test failed before `artifact-publication-guard` existed, and the run-boundary test showed the placeholder HTML run ending `succeeded` before the guard.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/pitch-deck-manifest-required-inputs.test.ts tests/artifact-publication-guard.test.ts tests/chat-route.test.ts` from `apps/daemon` — 3 files, 30 tests passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm --filter @open-design/plugin-runtime typecheck` — passed
- `pnpm guard` — passed
- `git diff --check` — passed

Note: this runner is on Node `v26.0.0`, so pnpm prints the expected engine warning because the repo targets Node `~24`; the commands above completed successfully.
