### PR TITLE
fix(web): align HomeHero prompt overlay metrics

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -360,6 +360,28 @@
   min-width: 0;
   max-height: var(--home-hero-prompt-max-height);
   overflow: hidden;
+  --home-hero-prompt-font-size: 15px;
+  --home-hero-prompt-line-height: 1.85;
+  --home-hero-prompt-padding: 6px 6px;
+}
+.home-hero__prompt-highlight,
+.home-hero__input {
+  font: inherit;
+  font-size: var(--home-hero-prompt-font-size);
+  font-weight: inherit;
+  line-height: var(--home-hero-prompt-line-height);
+  letter-spacing: normal;
+  word-spacing: normal;
+  font-kerning: auto;
+  font-feature-settings: normal;
+  font-variant-ligatures: normal;
+  text-rendering: auto;
+  tab-size: 4;
+  padding: var(--home-hero-prompt-padding);
+  box-sizing: border-box;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  text-align: start;
 }
 .home-hero__prompt-highlight {
   position: absolute;
@@ -367,10 +389,7 @@
   z-index: auto;
   overflow: hidden;
   max-height: var(--home-hero-prompt-max-height);
-  padding: 0;
   color: var(--text);
-  font: inherit;
-  font-size: 15px;
   /* Generous line-height so adjacent slot/mention pills do not
      collide vertically when the prompt wraps. Each pill paints a
      2px ring via `box-shadow`; with a tight line-height the rings
@@ -378,15 +397,12 @@
      Bumping the line-height leaves ~8px of clear space between
      pill rows. The textarea below mirrors this value so the
      overlay and the editable text stay pixel-aligned. */
-  line-height: 1.85;
   pointer-events: none;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
 }
 .home-hero__prompt-highlight-inner {
+  position: relative;
+  top: calc(-1 * var(--home-hero-prompt-scroll, 0px));
   min-height: 100%;
-  padding: 6px;
-  transform: translateY(calc(-1 * var(--home-hero-prompt-scroll, 0px)));
 }
 .home-hero__prompt-slot {
   display: inline;
@@ -525,12 +541,6 @@
      HomeHero.tsx, which writes an explicit pixel height after every
      keystroke. Keep the native resize grip disabled while allowing
      the effect to toggle internal scrolling for very long prompts. */
-  font: inherit;
-  font-size: 15px;
-  /* Must match `.home-hero__prompt-highlight` so the editable
-     textarea and the highlight overlay wrap identically. */
-  line-height: 1.85;
-  padding: 6px 6px;
   border: none;
   outline: none;
   background: transparent;

--- a/apps/web/tests/styles/home-hero-prompt-metrics.test.ts
+++ b/apps/web/tests/styles/home-hero-prompt-metrics.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const homeHeroCss = readFileSync(new URL('../../src/styles/home/home-hero.css', import.meta.url), 'utf8');
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(homeHeroCss)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g'))];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+function optionalRuleValue(block: string, property: string): string | null {
+  try {
+    return ruleValue(block, property);
+  } catch {
+    return null;
+  }
+}
+
+describe('HomeHero prompt overlay metrics', () => {
+  it('keeps the highlight overlay and textarea text-flow metrics in lockstep', () => {
+    const highlight = cssDeclarations('.home-hero__prompt-highlight');
+    const input = cssDeclarations('.home-hero__input');
+
+    for (const property of [
+      'font',
+      'font-size',
+      'font-weight',
+      'line-height',
+      'letter-spacing',
+      'word-spacing',
+      'font-kerning',
+      'font-feature-settings',
+      'font-variant-ligatures',
+      'text-rendering',
+      'tab-size',
+      'padding',
+      'box-sizing',
+      'white-space',
+      'overflow-wrap',
+      'text-align',
+    ]) {
+      expect(ruleValue(highlight, property), property).toBe(ruleValue(input, property));
+    }
+
+    expect(ruleValue(highlight, 'pointer-events')).toBe('none');
+  });
+
+  it('keeps prompt scroll compensation off the transform compositor path', () => {
+    const inner = cssDeclarations('.home-hero__prompt-highlight-inner');
+
+    expect(optionalRuleValue(inner, 'transform')).toBeNull();
+    expect(ruleValue(inner, 'top')).toBe('calc(-1 * var(--home-hero-prompt-scroll, 0px))');
+  });
+});


### PR DESCRIPTION
Closes #2089

## Why

I picked this up from the reported Audio preset repro on the Home composer. The pain is that the prompt remains editable in the textarea, but when inline prompt slots render above it the visual text layer can drift from the native textarea caret positions, making the caret look stuck or overlapped with glyphs while selecting or repositioning text.

## What users will see

Users editing the Home prompt after choosing Audio or other inline-slot presets should see the caret track the rendered prompt text consistently, including at browser zoom levels. The visible prompt highlight layer no longer competes with the textarea for pointer hit testing and no longer uses a transform-based scroll offset.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: this is a caret/metric alignment fix. I verified the rendered Home Audio prompt in browser engines by checking the computed textarea/highlight metrics at 100%, 110%, and 125% scale.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/home-hero-prompt-metrics.test.ts`
- Did the test go red on `main` and green on this branch? yes — it first failed on missing explicit metric parity (`font-weight`) and transform-based overlay scroll compensation, then passed after the CSS fix.

## Validation

- `pnpm install` (needed in the fresh worktree before Vitest was available; Node 26 emitted the repo's expected `~24` engine warning)
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/styles/home-hero-prompt-metrics.test.ts` — red, then green
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/styles/home-hero-prompt-metrics.test.ts tests/components/HomeHero.plugin-picker.test.tsx tests/components/HomeView.media-options.test.tsx tests/components/HomeHero.rail.test.tsx` — 4 files / 36 tests passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed
- `git diff --check` — passed
- Runtime browser metric check against `pnpm tools-dev run web --namespace codex-kam82 --daemon-port 17456 --web-port 17573`: Chromium, Firefox, and WebKit all passed at scale factors 1.0, 1.1, and 1.25 with no computed text metric mismatches, `pointer-events: none`, and no highlight-inner transform.
