### PR TITLE
fix: increase chat header horizontal padding for better spacing

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1632,7 +1632,7 @@ a.avatar-item:visited {
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 8px 12px;
+  padding: 8px 16px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-panel);
   position: sticky;


### PR DESCRIPTION
## Summary

Fixes #2180 

Increases the horizontal padding of the chat panel header from 12px to 16px to give the "Conversation" button more breathing room from the panel edge.

## Changes

- Changed  padding from  to 
- Improves visual balance and polish in the chat panel header

## Testing

- [x] Visual inspection of chat panel header spacing
- [x] Verified "Conversation" button has adequate spacing from edge

## Screenshots

Before: 12px horizontal padding (too cramped)
After: 16px horizontal padding (better visual balance)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update