### PR TITLE
fix: prevent long CLI paths from overflowing status card

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1851,6 +1851,9 @@ a.avatar-item:visited {
   font-size: 11.5px;
   line-height: 1.35;
   color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .msg.user .user-copy-btn {


### PR DESCRIPTION
## Summary

Fixes #2206

Prevents long Local CLI startup paths from overflowing the chat status card boundary by adding proper text truncation.

## Changes

- Added `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap` to `.user-status-card__copy span`
- Long filesystem paths now truncate with ellipsis (...) instead of breaking the card layout

## Before

Long paths extended beyond the card boundary, making the UI look broken.

## After

Long paths are truncated with ellipsis and stay within the card boundary.

## Testing

- [x] Visual inspection with long CLI paths
- [x] Verified ellipsis appears for paths exceeding card width
- [x] Confirmed card layout remains intact

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update