### PR TITLE
Fix Windows release smoke updater fixture launch

### DIFF
--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -16,8 +16,8 @@ const e2eRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const workspaceRoot = dirname(e2eRoot);
 const toolsPackDir = resolveFromWorkspace(process.env.OD_PACKAGED_E2E_TOOLS_PACK_DIR ?? '.tmp/tools-pack');
 const namespace = process.env.OD_PACKAGED_E2E_NAMESPACE ?? 'release-beta-win';
-const pnpmCommand = process.env.OD_E2E_PNPM_COMMAND ?? 'pnpm';
 const toolsPackBin = join(workspaceRoot, 'tools', 'pack', 'bin', 'tools-pack.mjs');
+const toolsServeBin = join(workspaceRoot, 'tools', 'serve', 'bin', 'tools-serve.mjs');
 const maxInstallDurationMs = Number.parseInt(process.env.OD_PACKAGED_E2E_WIN_MAX_INSTALL_MS ?? '120000', 10);
 const verifyReinstallWhileRunning = process.env.OD_PACKAGED_E2E_WIN_VERIFY_REINSTALL !== '0';
 const installIdentity = resolveInstallIdentity(namespace);
@@ -490,8 +490,8 @@ function restoreUpdateEnv(previous: Partial<Record<(typeof UPDATE_ENV_KEYS)[numb
 
 async function startUpdaterFixtureProcess(): Promise<UpdaterFixtureProcess> {
   const child = spawn(
-    pnpmCommand,
-    ['tools-serve', 'start', 'updater', '--json', '--channel', 'beta', '--version', '99.0.0-beta.1', '--platform', 'win'],
+    process.execPath,
+    [toolsServeBin, 'start', 'updater', '--json', '--channel', 'beta', '--version', '99.0.0-beta.1', '--platform', 'win'],
     {
       cwd: workspaceRoot,
       env: process.env,


### PR DESCRIPTION
## Why

The `release-stable` Windows packaged runtime smoke failed in job https://github.com/nexu-io/open-design/actions/runs/26142674965/job/76891541009 after the NSIS install completed. The failure was `Error: spawn pnpm ENOENT` while starting the local updater fixture from `e2e/specs/win.spec.ts`.

On Windows runners, spawning `pnpm` directly from Node can miss the shell shim. The rest of the Windows smoke already avoids this for tools-pack by invoking the tool bin with `process.execPath`.

## What users will see

No product-facing change. This only hardens the Windows release smoke harness.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

None.

## Bug fix verification

- Test path that covers the harness: `e2e/specs/win.spec.ts`
- Red signal: release-stable Windows smoke failed with `Error: spawn pnpm ENOENT` in the linked Actions job.
- Fix: start `tools-serve` via `node tools/serve/bin/tools-serve.mjs` instead of spawning `pnpm tools-serve` from the test process.

## Validation

- `git diff --check origin/main...HEAD`
- `pnpm --filter e2e typecheck`
- `pnpm --filter @open-design/tools-serve test`
- Direct fixture launch via `node tools/serve/bin/tools-serve.mjs start updater --json --channel beta --version 99.0.0-beta.1 --platform win`
- `pnpm guard`