### PR TITLE
fix: display plugin import errors inside modal instead of behind it

### DIFF
--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -571,6 +571,7 @@ export function PluginsView({
       ) : null}
       {importOpen ? (
         <PluginImportModal
+          notice={notice}
           onClose={() => setImportOpen(false)}
           onInstallSource={(source) => finishImport(() => installPluginSource(source))}
           onUploadZip={(file) => finishImport(() => uploadPluginZip(file))}
@@ -1456,11 +1457,13 @@ function SourcesPanel({
 type ImportKind = 'github' | 'zip' | 'folder';
 
 function PluginImportModal({
+  notice,
   onClose,
   onInstallSource,
   onUploadZip,
   onUploadFolder,
 }: {
+  notice: PluginInstallOutcome | { ok: boolean; message: string } | null;
   onClose: () => void;
   onInstallSource: (source: string) => Promise<PluginInstallOutcome>;
   onUploadZip: (file: File) => Promise<PluginInstallOutcome>;
@@ -1600,6 +1603,8 @@ function PluginImportModal({
           ) : null}
 
         </div>
+
+        {notice ? <Notice outcome={notice} /> : null}
 
         <footer className="plugins-import-modal__foot">
           <p>


### PR DESCRIPTION
## Summary

Fixes #2207

Moves plugin import error messages from the background page into the import modal so they are visible when import fails.

## Changes

- Added `notice` prop to `PluginImportModal` component
- Render `Notice` component inside modal before footer
- Error messages now appear in the correct visual layer above the modal backdrop

## Before

When plugin import failed, the error message appeared on the underlying page behind the modal, making it obscured and easy to miss.

## After

Import errors are now displayed inside the modal, directly visible to the user at the moment they need the feedback.

## Testing

- [x] Verified error messages appear inside modal
- [x] Confirmed proper z-index layering
- [x] Tested with different import failure scenarios

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update