### PR TITLE
fix: improve plugin detail modal layout balance

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -15008,6 +15008,7 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   position: relative;
   display: flex;
   align-items: stretch;
+  gap: 0;
 }
 .ds-modal-stage-iframe {
   flex: 1;
@@ -15033,13 +15034,14 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   background: white;
 }
 .ds-modal-stage.has-sidebar .ds-modal-stage-iframe {
-  flex: 1 1 60%;
+  flex: 1 1 65%;
+  min-width: 400px;
 }
 .ds-modal-sidebar {
   position: relative;
-  flex: 1 1 40%;
-  min-width: 320px;
-  max-width: 560px;
+  flex: 0 1 35%;
+  min-width: 300px;
+  max-width: 480px;
   border-left: 1px solid var(--border);
   background: var(--bg-panel);
   overflow: auto;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -15387,7 +15387,10 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   .ds-modal-header { gap: 10px; padding: 12px 14px; }
   .ds-modal-actions { justify-content: flex-start; }
   .ds-modal-stage { flex-direction: column; }
-  .ds-modal-stage.has-sidebar .ds-modal-stage-iframe { flex: 1 1 50%; }
+  .ds-modal-stage.has-sidebar .ds-modal-stage-iframe { 
+    flex: 1 1 50%; 
+    min-width: 0;
+  }
   .ds-modal-sidebar {
     border-left: none;
     border-top: 1px solid var(--border);


### PR DESCRIPTION
## Summary

Fixes #1770

Improves the visual balance of the plugin detail modal by adjusting the preview/sidebar split ratio and constraints.

## Changes

- **Preview/sidebar split**: Changed from 60/40 to 65/35 for better visual balance
- **Preview area**: Added  to prevent over-compression
- **Sidebar constraints**: 
  - Reduced  from 320px to 300px
  - Reduced  from 560px to 480px
  - Changed  from `1 1 40%` to `0 1 35%` to prioritize preview space
- **Stage container**: Added explicit `gap: 0` for cleaner split

## Before

The modal felt visually unbalanced with an awkward vertical divider between the preview and info panel. The 60/40 split with high min-width constraints caused cramping.

## After

- More natural 65/35 split gives preview content more breathing room
- Sidebar is more compact but still readable (300-480px range)
- Cleaner visual hierarchy with preview as the primary focus
- Less jarring split between sections

## Testing

- [x] Verified layout balance at various viewport widths
- [x] Confirmed sidebar remains readable at min-width
- [x] Tested with different plugin types (HTML preview, design systems, media)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update