### PR TITLE
fix: sort automations by creation time, newest first

### DIFF
--- a/apps/web/src/components/TasksView.tsx
+++ b/apps/web/src/components/TasksView.tsx
@@ -488,8 +488,14 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
     return map;
   }, [projects]);
 
-  const activeCount = routines.filter((routine) => routine.enabled).length;
-  const pausedCount = routines.length - activeCount;
+  // Sort routines by creation time, newest first
+  const sortedRoutines = useMemo(
+    () => [...routines].sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0)),
+    [routines],
+  );
+
+  const activeCount = sortedRoutines.filter((routine) => routine.enabled).length;
+  const pausedCount = sortedRoutines.length - activeCount;
   const sourceIngestionTemplates = useMemo(
     () =>
       automationCatalog.filter((template) =>
@@ -697,7 +703,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
           <h2 className="automations-section__label">Your automations</h2>
           {loading ? <span className="automations-section__meta">Loading</span> : null}
         </div>
-        {!loading && routines.length === 0 ? (
+        {!loading && sortedRoutines.length === 0 ? (
           <button
             type="button"
             className="automation-empty"
@@ -712,9 +718,9 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
             </span>
           </button>
         ) : null}
-        {routines.length > 0 ? (
+        {sortedRoutines.length > 0 ? (
           <ul className="automations-saved__list">
-            {routines.map((r) => {
+            {sortedRoutines.map((r) => {
               const isBusy = busyId === r.id;
               const targetLabel =
                 r.target.mode === 'reuse'


### PR DESCRIPTION
## Summary

Fixes #2387

Sorts the automations list by creation time in descending order, so newly created automations appear at the top of the list.

## Changes

- Added `useMemo` to sort routines by `createdAt` timestamp in descending order
- Replaced all references to `routines` with `sortedRoutines` in the render logic
- Newly created automations now appear at the top of the list for immediate discoverability

## Before

After creating a new automation, it appeared at the bottom of the list, making it hard to find and requiring the user to scroll down.

## After

Newly created automations appear at the top of the list, making them immediately visible and easy to access for verification, editing, or running.

## Testing

- [x] Verified automations are sorted newest first
- [x] Confirmed new automations appear at the top after creation
- [x] Tested with multiple automations
- [x] Verified empty state still works correctly

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update