### PR TITLE
feat(analytics): unify page_name + onboarding/design-system page_views

### DIFF
--- a/apps/web/src/analytics/onboarding-session.ts
+++ b/apps/web/src/analytics/onboarding-session.ts
@@ -1,0 +1,60 @@
+// Onboarding session id helper. The v2 doc requires every
+// `page_view / page_name=onboarding` emission to carry the same
+// `onboarding_session_id` so dashboards can stitch the 4-step funnel
+// (connect → about_you → design_system → generation).
+//
+// Because the "generation" step renders in `DesignSystemDetailView`
+// AFTER `OnboardingView` navigates away, the session id must outlive
+// the React tree that owns it. We keep it in `sessionStorage` so a
+// reload of the same tab keeps the same id; closing the tab drops it.
+// `clear()` is called when the user finishes (or skips) onboarding,
+// so a later `/design-systems/:id` visit unrelated to onboarding does
+// NOT inherit the previous session's id.
+
+import { randomUUID } from '../utils/uuid';
+
+const STORAGE_KEY = 'od:onboarding-session-id';
+
+function readSessionStorage(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.sessionStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionStorage(value: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    // Ignore — quota errors / disabled storage just mean we get a
+    // session id that doesn't persist across reload.
+  }
+}
+
+function clearSessionStorage(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore.
+  }
+}
+
+export function getOrCreateOnboardingSessionId(): string {
+  const existing = readSessionStorage();
+  if (existing) return existing;
+  const next = randomUUID();
+  writeSessionStorage(next);
+  return next;
+}
+
+export function peekOnboardingSessionId(): string | null {
+  return readSessionStorage();
+}
+
+export function clearOnboardingSessionId(): void {
+  clearSessionStorage();
+}

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -58,6 +58,16 @@ import { decideAutoOpenAfterWrite } from './auto-open-file';
 import { ChatPane } from './ChatPane';
 import { FileWorkspace } from './FileWorkspace';
 import { Icon, type IconName } from './Icon';
+import { useAnalytics } from '../analytics/provider';
+import { trackPageView } from '../analytics/events';
+import {
+  clearOnboardingSessionId,
+  peekOnboardingSessionId,
+} from '../analytics/onboarding-session';
+import type {
+  TrackingDesignSystemStatus,
+  TrackingDesignSystemsEntryFrom,
+} from '@open-design/contracts/analytics';
 
 interface CreationProps {
   onBack: () => void;
@@ -204,6 +214,24 @@ export function DesignSystemCreationFlow({
   const githubConnectorRefreshId = useRef(0);
   const githubConnectorRequestInFlight = useRef(false);
   const embedded = chrome === 'embedded';
+
+  // DS create page_view (v2 doc). Only fires for the standalone
+  // /design-systems/create route — the embedded variant lives inside
+  // OnboardingView, which owns the `area=design_system` step page_view.
+  const analytics = useAnalytics();
+  const creationPageViewFiredRef = useRef(false);
+  useEffect(() => {
+    if (embedded) return;
+    if (creationPageViewFiredRef.current) return;
+    creationPageViewFiredRef.current = true;
+    const onboardingSessionId = peekOnboardingSessionId();
+    trackPageView(analytics.track, {
+      page_name: 'design_systems',
+      area: 'design_system_create',
+      view_type: 'page',
+      entry_from: onboardingSessionId ? 'onboarding' : 'design_systems_page',
+    });
+  }, [analytics.track, embedded]);
 
   const refreshGithubConnector = useCallback(async () => {
     if (!composioConfigured) {
@@ -858,6 +886,62 @@ export function DesignSystemDetailView({
   const recentRevisions = revisions.slice(0, 5);
   const generationActive =
     activeJob?.status === 'queued' || activeJob?.status === 'running';
+
+  // Multi-surface DS page_view (v2 doc). One emission per
+  // (system, generationActive) transition: while generation is
+  // running we surface `area=design_system_generation`; once it
+  // settles we surface `area=design_system_preview`. The fourth
+  // onboarding step (`area=generation_progress`) piggy-backs on the
+  // generation emission when an onboarding session id is present.
+  const analytics = useAnalytics();
+  const designSystemStatus: TrackingDesignSystemStatus = generationActive
+    ? 'generating'
+    : (system?.status as TrackingDesignSystemStatus | undefined) ?? 'unknown';
+  useEffect(() => {
+    if (!system) return;
+    const onboardingSessionId = peekOnboardingSessionId();
+    const entryFrom: TrackingDesignSystemsEntryFrom = onboardingSessionId
+      ? 'onboarding'
+      : 'unknown';
+    if (generationActive) {
+      trackPageView(analytics.track, {
+        page_name: 'design_system_project',
+        area: 'design_system_generation',
+        view_type: 'page',
+        entry_from: entryFrom,
+        design_system_id: system.id,
+        // Origin is the DS's provenance-style source. We don't yet
+        // have a precise mapping from `system.source` / provenance
+        // metadata to the v2 enum, so we report `unknown` rather
+        // than mis-tag — dashboards still see the funnel via
+        // `entry_from`. A follow-up can derive this honestly.
+        design_system_source: 'unknown',
+        design_system_status: 'generating',
+      });
+      if (onboardingSessionId) {
+        trackPageView(analytics.track, {
+          page_name: 'onboarding',
+          area: 'generation_progress',
+          step_index: 'progress',
+          step_name: 'generation',
+          onboarding_session_id: onboardingSessionId,
+        });
+        // Generation is the last onboarding step; clear so a later
+        // DS visit unrelated to onboarding doesn't re-attribute.
+        clearOnboardingSessionId();
+      }
+    } else {
+      trackPageView(analytics.track, {
+        page_name: 'design_system_project',
+        area: 'design_system_preview',
+        view_type: 'page',
+        entry_from: entryFrom,
+        design_system_id: system.id,
+        design_system_source: 'unknown',
+        design_system_status: designSystemStatus,
+      });
+    }
+  }, [analytics.track, system?.id, generationActive, designSystemStatus, system]);
   const introChatMessages = useMemo(
     () => buildDesignSystemChatMessages({
       system,

--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -88,8 +88,19 @@ export function DesignSystemsTab({
   useEffect(() => {
     if (designSystemsPageViewFiredRef.current) return;
     designSystemsPageViewFiredRef.current = true;
-    trackPageView(analytics.track, { page_name: 'design_systems' });
-  }, [analytics.track]);
+    // v2 doc: the DS list page also carries `area` / `view_type` /
+    // `entry_from` so it can stitch the cross-surface DS funnel.
+    // `entry_from` is `unknown` here because the tab is reached
+    // through the home nav rail; a router-aware entry mapper can
+    // refine this later.
+    trackPageView(analytics.track, {
+      page_name: 'design_systems',
+      area: 'design_system_list',
+      view_type: 'page',
+      entry_from: 'unknown',
+      available_design_system_count: systems.length,
+    });
+  }, [analytics.track, systems.length]);
   const searchTrackedRef = useRef(false);
   const categoryTrackedRef = useRef(false);
   const [filter, setFilter] = useState('');

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -23,7 +23,17 @@ import { useAnalytics } from '../analytics/provider';
 import {
   trackHomeNavClick,
   trackHomeToolbarClick,
+  trackPageView,
 } from '../analytics/events';
+import {
+  clearOnboardingSessionId,
+  getOrCreateOnboardingSessionId,
+} from '../analytics/onboarding-session';
+import type {
+  TrackingOnboardingArea,
+  TrackingOnboardingStepIndex,
+  TrackingOnboardingStepName,
+} from '@open-design/contracts/analytics';
 import { LOCALE_LABEL, LOCALES, useI18n, useT, type Locale } from '../i18n';
 import { navigate, useRoute } from '../router';
 import type {
@@ -1042,6 +1052,7 @@ function OnboardingView({
   onFinish: () => void;
 }) {
   const t = useT();
+  const analytics = useAnalytics();
   const [step, setStep] = useState(0);
   const [runtime, setRuntime] = useState<'local' | 'byok' | null>(null);
   const [designSource, setDesignSource] = useState<'github' | 'upload' | 'prompt' | null>(null);
@@ -1120,6 +1131,50 @@ function OnboardingView({
       agentRevealTimersRef.current = [];
     };
   }, []);
+
+  // Onboarding 4-step funnel (v2 doc). Fires one `page_view` per step
+  // exposure. The fourth step (`generation`) lives in
+  // `DesignSystemDetailView` because the user navigates out of this
+  // component once the design system project opens; that emission
+  // reads the same `onboarding_session_id` from sessionStorage.
+  // `clearOnboardingSessionId` runs on `onFinish` / unmount so a
+  // later DS visit unrelated to onboarding doesn't inherit the id.
+  const onboardingSessionIdRef = useRef<string>('');
+  if (!onboardingSessionIdRef.current) {
+    onboardingSessionIdRef.current = getOrCreateOnboardingSessionId();
+  }
+  useEffect(() => {
+    return () => {
+      clearOnboardingSessionId();
+    };
+  }, []);
+  useEffect(() => {
+    const onboardingSessionId = onboardingSessionIdRef.current;
+    if (!onboardingSessionId) return;
+    let area: TrackingOnboardingArea;
+    let stepIndex: TrackingOnboardingStepIndex;
+    let stepName: TrackingOnboardingStepName;
+    if (step === 0) {
+      area = 'runtime';
+      stepIndex = '1';
+      stepName = 'connect';
+    } else if (step === 1) {
+      area = 'about_you';
+      stepIndex = '2';
+      stepName = 'about_you';
+    } else {
+      area = 'design_system';
+      stepIndex = '3';
+      stepName = 'design_system';
+    }
+    trackPageView(analytics.track, {
+      page_name: 'onboarding',
+      area,
+      step_index: stepIndex,
+      step_name: stepName,
+      onboarding_session_id: onboardingSessionId,
+    });
+  }, [analytics.track, step]);
 
   const steps = [
     t('settings.onboardingStepConnect'),

--- a/apps/web/src/components/IntegrationsView.tsx
+++ b/apps/web/src/components/IntegrationsView.tsx
@@ -137,7 +137,7 @@ export function IntegrationsView({
             }
             onConnectorAuthResult={({ connectorId, action, result, errorCode }) =>
               trackSettingsConnectorAuthResult(analytics.track, {
-                page: 'settings',
+                page_name: 'settings',
                 area: 'connectors',
                 connector_id: connectorId,
                 action,

--- a/apps/web/src/components/PrivacySection.tsx
+++ b/apps/web/src/components/PrivacySection.tsx
@@ -84,7 +84,7 @@ export function PrivacySection({ cfg, setCfg }: Props): JSX.Element {
               checked={telemetry.metrics === true}
               onChange={(v) => {
                 trackSettingsPrivacyClick(analytics.track, {
-                  page: 'settings',
+                  page_name: 'settings',
                   area: 'privacy',
                   element: 'anonymous_metrics',
                   anonymous_metrics_status: v ? 'on' : 'off',
@@ -98,7 +98,7 @@ export function PrivacySection({ cfg, setCfg }: Props): JSX.Element {
               checked={telemetry.content === true}
               onChange={(v) => {
                 trackSettingsPrivacyClick(analytics.track, {
-                  page: 'settings',
+                  page_name: 'settings',
                   area: 'privacy',
                   element: 'conversation_and_tool_content',
                   conversation_and_tool_content_status: v ? 'on' : 'off',
@@ -112,7 +112,7 @@ export function PrivacySection({ cfg, setCfg }: Props): JSX.Element {
               checked={telemetry.artifactManifest === true}
               onChange={(v) => {
                 trackSettingsPrivacyClick(analytics.track, {
-                  page: 'settings',
+                  page_name: 'settings',
                   area: 'privacy',
                   element: 'project_artifacts_manifest',
                   project_artifacts_manifest_status: v ? 'on' : 'off',
@@ -142,7 +142,7 @@ export function PrivacySection({ cfg, setCfg }: Props): JSX.Element {
               className="ghost"
               onClick={() => {
                 trackSettingsPrivacyClick(analytics.track, {
-                  page: 'settings',
+                  page_name: 'settings',
                   area: 'privacy',
                   element: 'delete_my_data',
                 });

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -933,7 +933,7 @@ export function SettingsDialog({
     // tagged onto every view now lives in the configure-state global
     // properties (registered once and inherited by every event).
     trackSettingsView(analytics.track, {
-      page: 'settings',
+      page_name: 'settings',
       area: settingsSectionToTracking(activeSection),
     });
   }, [activeSection, analytics.track]);
@@ -1031,7 +1031,7 @@ export function SettingsDialog({
       const modeAfter = executionModeToTracking(mode);
       if (modeBefore !== modeAfter) {
         trackSettingsExecutionModeTabClick(analytics.track, {
-          page: 'settings',
+          page_name: 'settings',
           area: 'configure_execution_mode',
           element: 'execution_mode_tab',
           action: 'switch_execution_mode',
@@ -1124,7 +1124,7 @@ export function SettingsDialog({
       }
       setAgentTestState({ status: 'done', result });
       trackSettingsCliTestResult(analytics.track, {
-        page: 'settings',
+        page_name: 'settings',
         area: 'configure_execution_mode',
         cli_provider_id: cliProviderId,
         result: result.ok ? 'success' : 'failed',
@@ -1148,7 +1148,7 @@ export function SettingsDialog({
         },
       });
       trackSettingsCliTestResult(analytics.track, {
-        page: 'settings',
+        page_name: 'settings',
         area: 'configure_execution_mode',
         cli_provider_id: cliProviderId,
         result: 'failed',
@@ -1179,7 +1179,7 @@ export function SettingsDialog({
       const byokProviderId = byokProtocolToTracking(apiProtocol);
       if (byokProviderId) {
         trackSettingsByokTestResult(analytics.track, {
-          page: 'settings',
+          page_name: 'settings',
           area: 'execution_model',
           provider_id: byokProviderId,
           result: 'not_ready',
@@ -1221,7 +1221,7 @@ export function SettingsDialog({
       const byokProviderId = byokProtocolToTracking(apiProtocol);
       if (byokProviderId) {
         trackSettingsByokTestResult(analytics.track, {
-          page: 'settings',
+          page_name: 'settings',
           area: 'execution_model',
           provider_id: byokProviderId,
           result: result.ok ? 'success' : 'failed',
@@ -1248,7 +1248,7 @@ export function SettingsDialog({
       const byokProviderId = byokProtocolToTracking(apiProtocol);
       if (byokProviderId) {
         trackSettingsByokTestResult(analytics.track, {
-          page: 'settings',
+          page_name: 'settings',
           area: 'execution_model',
           provider_id: byokProviderId,
           result: 'failed',
@@ -1840,7 +1840,7 @@ export function SettingsDialog({
             const byokProviderId = byokProtocolToTracking(apiProtocol);
             if (byokProviderId) {
               trackSettingsByokFieldClick(analytics.track, {
-                page: 'settings',
+                page_name: 'settings',
                 area: 'configure_execution_mode_byok',
                 element: 'base_url',
                 provider_id: byokProviderId,
@@ -2257,7 +2257,7 @@ export function SettingsDialog({
                         const byokProviderId = byokProtocolToTracking(tab.id);
                         if (byokProviderId) {
                           trackSettingsByokProviderOptionClick(analytics.track, {
-                            page: 'settings',
+                            page_name: 'settings',
                             area: 'configure_execution_mode_byok',
                             element: 'byok_provider_option',
                             action: 'select_byok_provider',
@@ -2362,7 +2362,7 @@ export function SettingsDialog({
                                 className="agent-card-select"
                                 onClick={() => {
                                   trackSettingsLocalCliClick(analytics.track, {
-                                    page: 'settings',
+                                    page_name: 'settings',
                                     area: 'configure_execution_mode_local_cli',
                                     element: 'cli_provider',
                                     cli_provider_id: agentIdToTracking(a.id),
@@ -2993,7 +2993,7 @@ export function SettingsDialog({
                       const byokProviderId = byokProtocolToTracking(apiProtocol);
                       if (byokProviderId) {
                         trackSettingsByokFieldClick(analytics.track, {
-                          page: 'settings',
+                          page_name: 'settings',
                           area: 'configure_execution_mode_byok',
                           element: 'api_key',
                           provider_id: byokProviderId,
@@ -3097,7 +3097,7 @@ export function SettingsDialog({
                     const byokProviderId = byokProtocolToTracking(apiProtocol);
                     if (byokProviderId) {
                       trackSettingsByokFieldClick(analytics.track, {
-                        page: 'settings',
+                        page_name: 'settings',
                         area: 'configure_execution_mode_byok',
                         element: 'model',
                         provider_id: byokProviderId,
@@ -3246,7 +3246,7 @@ export function SettingsDialog({
               onPersistComposioKey={onPersistComposioKey}
               onConnectorAuthResult={({ connectorId, action, result, errorCode }) =>
                 trackSettingsConnectorAuthResult(analytics.track, {
-                  page: 'settings',
+                  page_name: 'settings',
                   area: 'connectors',
                   connector_id: connectorId,
                   action,
@@ -3297,7 +3297,7 @@ export function SettingsDialog({
                       // that was picked, regardless of whether it differs
                       // from the current one (user clicked = signal).
                       trackSettingsLanguageClick(analytics.track, {
-                        page: 'settings',
+                        page_name: 'settings',
                         area: 'language',
                         element: code,
                       });
@@ -5720,7 +5720,7 @@ function AppearanceSection({
               // use `accent_color` with the swatch hex below.
               if (value === 'system' || value === 'light' || value === 'dark') {
                 trackSettingsAppearanceClick(analytics.track, {
-                  page: 'settings',
+                  page_name: 'settings',
                   area: 'appearance',
                   element: value,
                 });
@@ -5749,7 +5749,7 @@ function AppearanceSection({
                 role="radio"
                 onClick={() => {
                   trackSettingsAppearanceClick(analytics.track, {
-                    page: 'settings',
+                    page_name: 'settings',
                     area: 'appearance',
                     element: 'accent_color',
                     color,
@@ -5910,7 +5910,7 @@ function NotificationsSection({
     // emits the post-click state on `completion_sound_status` so a single
     // event captures intent + outcome.
     trackSettingsNotificationsClick(analytics.track, {
-      page: 'settings',
+      page_name: 'settings',
       area: 'notifications',
       element: 'completion_sound',
       completion_sound_status: next ? 'on' : 'off',
@@ -5925,7 +5925,7 @@ function NotificationsSection({
   const toggleDesktop = async () => {
     if (notif.desktopEnabled) {
       trackSettingsNotificationsClick(analytics.track, {
-        page: 'settings',
+        page_name: 'settings',
         area: 'notifications',
         element: 'desktop_notification',
         desktop_notification_status: 'off',
@@ -5937,7 +5937,7 @@ function NotificationsSection({
     setPermission(result);
     if (result === 'granted') {
       trackSettingsNotificationsClick(analytics.track, {
-        page: 'settings',
+        page_name: 'settings',
         area: 'notifications',
         element: 'desktop_notification',
         desktop_notification_status: 'on',
@@ -5945,7 +5945,7 @@ function NotificationsSection({
       updateNotif({ desktopEnabled: true });
     } else {
       trackSettingsNotificationsClick(analytics.track, {
-        page: 'settings',
+        page_name: 'settings',
         area: 'notifications',
         element: 'desktop_notification',
         desktop_notification_status: 'off',
@@ -6000,7 +6000,7 @@ function NotificationsSection({
                     onClick={() => {
                       const trackingSoundId = soundIdToTracking(sound.id);
                       trackSettingsNotificationsClick(analytics.track, {
-                        page: 'settings',
+                        page_name: 'settings',
                         area: 'notifications',
                         element: 'success_sound',
                         ...(trackingSoundId ? { sound_id: trackingSoundId } : {}),
@@ -6027,7 +6027,7 @@ function NotificationsSection({
                     onClick={() => {
                       const trackingSoundId = soundIdToTracking(sound.id);
                       trackSettingsNotificationsClick(analytics.track, {
-                        page: 'settings',
+                        page_name: 'settings',
                         area: 'notifications',
                         element: 'failure_sound',
                         ...(trackingSoundId ? { sound_id: trackingSoundId } : {}),
@@ -6075,7 +6075,7 @@ function NotificationsSection({
           <>
             <button type="button" className="ghost" onClick={() => {
               trackSettingsNotificationsClick(analytics.track, {
-                page: 'settings',
+                page_name: 'settings',
                 area: 'notifications',
                 element: 'send_test',
               });

--- a/apps/web/src/components/pet/PetSettings.tsx
+++ b/apps/web/src/components/pet/PetSettings.tsx
@@ -560,7 +560,7 @@ export function PetSettings({ cfg, setCfg }: Props) {
               className={activeTab === 'builtIn' ? 'active' : ''}
               onClick={() => {
                 trackSettingsPetsClick(analytics.track, {
-                  page: 'settings',
+                  page_name: 'settings',
                   area: 'pets',
                   element: 'built_in',
                 });
@@ -576,7 +576,7 @@ export function PetSettings({ cfg, setCfg }: Props) {
               className={activeTab === 'custom' ? 'active' : ''}
               onClick={() => {
                 trackSettingsPetsClick(analytics.track, {
-                  page: 'settings',
+                  page_name: 'settings',
                   area: 'pets',
                   element: 'custom',
                 });
@@ -592,7 +592,7 @@ export function PetSettings({ cfg, setCfg }: Props) {
               className={activeTab === 'community' ? 'active' : ''}
               onClick={() => {
                 trackSettingsPetsClick(analytics.track, {
-                  page: 'settings',
+                  page_name: 'settings',
                   area: 'pets',
                   element: 'community',
                 });
@@ -608,7 +608,7 @@ export function PetSettings({ cfg, setCfg }: Props) {
               className={`seg-btn small${pet.enabled ? ' active' : ''}`}
               onClick={() => {
                 trackSettingsPetsClick(analytics.track, {
-                  page: 'settings',
+                  page_name: 'settings',
                   area: 'pets',
                   element: 'tuck_away',
                 });
@@ -673,7 +673,7 @@ export function PetSettings({ cfg, setCfg }: Props) {
             className={`seg-btn small${pet.adopted && pet.petId === CUSTOM_PET_ID ? ' active' : ''}`}
             onClick={() => {
               trackSettingsPetsClick(analytics.track, {
-                page: 'settings',
+                page_name: 'settings',
                 area: 'pets',
                 element: 'adopt',
                 pet_id: CUSTOM_PET_ID,

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -45,14 +45,23 @@ export type TrackingPageName =
   | 'automations'
   | 'plugins'
   | 'design_systems'
+  // `design_system_project` is the per-DS surface (preview / generation
+  // dialog inside a specific design system). Distinct from the
+  // `design_systems` list page.
+  | 'design_system_project'
   | 'integrations'
   | 'chat_panel'
   | 'file_manager'
-  | 'artifact';
+  | 'artifact'
+  | 'onboarding'
+  // `studio` is the in-project workspace that hosts the chat composer and
+  // the design system picker. Reported when a DS picker / module renders
+  // inside a project.
+  | 'studio'
+  | 'settings';
 
-// Settings events use `page=settings` (mirrors the CSV). Kept distinct from
-// `TrackingPageName` so the discriminator stays unambiguous between the
-// product surfaces and the settings dialog.
+// Alias kept for backwards-compatibility inside the contracts file; v2 wire
+// format uses the field name `page_name` for settings events too.
 export type TrackingSettingsPage = 'settings';
 
 // ---- Shared enums --------------------------------------------------------
@@ -177,22 +186,142 @@ export type TrackingFileSizeBucket =
 
 // ---- page_view ------------------------------------------------------------
 
-export interface PageViewProps {
-  page_name: TrackingPageName;
-  // `source` is supplied only by the chat_panel page_view (CSV row 41), where
-  // it records which surface launched the studio. The other page_view
-  // emissions leave it undefined.
-  source?:
-    | 'new_project'
-    | 'chat_composer'
-    | 'recent_project'
-    | 'projects_list'
-    | 'template'
-    | 'automation'
-    | 'deeplink'
-    | 'reload'
-    | 'unknown';
+// `source` is supplied only by the chat_panel page_view (CSV row 41), where
+// it records which surface launched the studio.
+export type TrackingChatPanelPageViewSource =
+  | 'new_project'
+  | 'chat_composer'
+  | 'recent_project'
+  | 'projects_list'
+  | 'template'
+  | 'automation'
+  | 'deeplink'
+  | 'reload'
+  | 'unknown';
+
+// --- Onboarding page_view (welcome flow) ---
+//
+// CSV row "Onboarding / page_view". Fires once per step exposure inside the
+// 4-step welcome flow: Connect → About you → Design system → Generation
+// progress. Each step's `step_index` / `step_name` must match the enum
+// pairs below. `onboarding_session_id` is generated once per session so
+// dashboards can stitch the funnel across the 4 events.
+export type TrackingOnboardingArea =
+  | 'runtime'
+  | 'about_you'
+  | 'design_system'
+  | 'generation_progress';
+
+// Mixed string enum: numeric steps render as the strings `'1' | '2' | '3'`
+// and the generation phase as `'progress'`. Mirrors the v2 doc literally.
+export type TrackingOnboardingStepIndex = '1' | '2' | '3' | 'progress';
+
+export type TrackingOnboardingStepName =
+  | 'connect'
+  | 'about_you'
+  | 'design_system'
+  | 'generation';
+
+export interface OnboardingPageViewProps {
+  page_name: 'onboarding';
+  area: TrackingOnboardingArea;
+  step_index: TrackingOnboardingStepIndex;
+  step_name: TrackingOnboardingStepName;
+  onboarding_session_id: string;
 }
+
+// --- Design systems page_view (multi-surface) ---
+//
+// Single shape covering the dedicated DS list / create / preview pages plus
+// the DS picker / generation-dialog exposures rendered inside home and
+// studio. `page_name` discriminates the host page; `area` + `view_type`
+// discriminate the specific surface; the rest carry the DS context needed
+// to stitch funnels (DS list → picker → project → run).
+export type TrackingDesignSystemsArea =
+  | 'design_system_list'
+  | 'design_system_create'
+  | 'design_system_generation'
+  | 'design_system_preview'
+  | 'design_system_picker'
+  | 'composer';
+
+export type TrackingDesignSystemsViewType =
+  | 'page'
+  | 'panel'
+  | 'dialog'
+  | 'popover'
+  | 'module';
+
+export type TrackingDesignSystemsEntryFrom =
+  | 'onboarding'
+  | 'design_systems_page'
+  | 'home_card'
+  | 'composer_picker'
+  | 'project_settings'
+  | 'unknown';
+
+// Origin of the design system itself. NOT the same field as
+// `TrackingDesignSystemSource` on run_created/run_finished, which records
+// *how the run picked* its DS. v2 doc reuses the field name
+// `design_system_source` for both contexts; the value sets are disjoint.
+export type TrackingDesignSystemOrigin =
+  | 'onboarding'
+  | 'manual_create'
+  | 'github_repo'
+  | 'local_code'
+  | 'fig'
+  | 'assets'
+  | 'official_preset'
+  | 'enterprise'
+  | 'template'
+  | 'mixed'
+  | 'unknown';
+
+export type TrackingDesignSystemStatus =
+  | 'draft'
+  | 'generating'
+  | 'ready'
+  | 'published'
+  | 'default'
+  | 'failed'
+  | 'archived'
+  | 'unknown';
+
+export interface DesignSystemsPageViewProps {
+  page_name: 'design_systems' | 'design_system_project' | 'home' | 'studio';
+  area: TrackingDesignSystemsArea;
+  view_type: TrackingDesignSystemsViewType;
+  entry_from: TrackingDesignSystemsEntryFrom;
+  design_system_id?: string;
+  // Re-uses the field name from the v2 doc; values are the
+  // `TrackingDesignSystemOrigin` set, NOT the run-time
+  // `TrackingDesignSystemSource` set.
+  design_system_source?: TrackingDesignSystemOrigin;
+  design_system_status?: TrackingDesignSystemStatus;
+  project_id?: string;
+  available_design_system_count?: number;
+}
+
+// --- Generic page_view (existing surfaces) ---
+//
+// Covers all page-level page_views that don't carry surface-specific
+// fields. `chat_panel` is the only one that uses the optional `source`.
+export interface GenericPageViewProps {
+  page_name: Exclude<
+    TrackingPageName,
+    'onboarding' | 'design_system_project' | 'studio'
+  >;
+  source?: TrackingChatPanelPageViewSource;
+}
+
+// Discriminated union by `page_name`. `home` and `design_systems` belong
+// to BOTH `GenericPageViewProps` (page-level visit) and
+// `DesignSystemsPageViewProps` (DS module / picker exposure on those
+// pages); call sites that pass `area` get narrowed to the DS shape.
+export type PageViewProps =
+  | GenericPageViewProps
+  | OnboardingPageViewProps
+  | DesignSystemsPageViewProps;
 
 // ---- ui_click ------------------------------------------------------------
 //
@@ -701,13 +830,13 @@ export type TrackingSettingsArea =
   | 'about';
 
 export interface SettingsSidebarClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'settings_sidebar';
   element: TrackingSettingsArea;
 }
 
 export interface SettingsExecutionModeTabClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'configure_execution_mode';
   element: 'execution_mode_tab';
   action: 'switch_execution_mode';
@@ -716,7 +845,7 @@ export interface SettingsExecutionModeTabClickProps {
 }
 
 export interface SettingsLocalCliClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'configure_execution_mode_local_cli';
   element: 'test' | 'rescan' | 'cli_provider' | 'install' | 'docs';
   cli_provider_id?: TrackingCliProviderId;
@@ -724,7 +853,7 @@ export interface SettingsLocalCliClickProps {
 }
 
 export interface SettingsByokProviderOptionClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'configure_execution_mode_byok';
   element: 'byok_provider_option';
   action: 'select_byok_provider';
@@ -733,7 +862,7 @@ export interface SettingsByokProviderOptionClickProps {
 }
 
 export interface SettingsByokFieldClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'configure_execution_mode_byok';
   element:
     | 'fetch_models'
@@ -749,7 +878,7 @@ export interface SettingsByokFieldClickProps {
 }
 
 export interface SettingsMediaProvidersClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'media_providers';
   element: 'reload' | 'key_input' | 'url_input' | 'clear';
   providers_id?: string;
@@ -757,7 +886,7 @@ export interface SettingsMediaProvidersClickProps {
 }
 
 export interface SettingsConnectorsClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'connectors';
   element:
     | 'api_key_input'
@@ -770,21 +899,21 @@ export interface SettingsConnectorsClickProps {
 }
 
 export interface SettingsLanguageClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'language';
   // Locale id, e.g. `english`, `bahasa_indonesia`, `zh_cn`.
   element: string;
 }
 
 export interface SettingsAppearanceClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'appearance';
   element: 'system' | 'light' | 'dark' | 'accent_color';
   color?: string;
 }
 
 export interface SettingsNotificationsClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'notifications';
   element:
     | 'completion_sound'
@@ -799,7 +928,7 @@ export interface SettingsNotificationsClickProps {
 }
 
 export interface SettingsPetsClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'pets';
   element:
     | 'tuck_away'
@@ -812,7 +941,7 @@ export interface SettingsPetsClickProps {
 }
 
 export interface SettingsPrivacyClickProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'privacy';
   element:
     | 'anonymous_metrics'
@@ -1048,12 +1177,12 @@ export interface FeedbackSubmitResultProps {
 
 // SETTINGS view + result events (page=settings)
 export interface SettingsViewProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: TrackingSettingsArea;
 }
 
 export interface SettingsCliTestResultProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'configure_execution_mode';
   cli_provider_id: TrackingCliProviderId;
   result: TrackingTestResult;
@@ -1062,7 +1191,7 @@ export interface SettingsCliTestResultProps {
 }
 
 export interface SettingsByokTestResultProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   // CSV row 67 names this area `execution_model`; keep that spelling so the
   // wire format matches the doc.
   area: 'execution_model';
@@ -1073,7 +1202,7 @@ export interface SettingsByokTestResultProps {
 }
 
 export interface SettingsConnectorAuthResultProps {
-  page: TrackingSettingsPage;
+  page_name: TrackingSettingsPage;
   area: 'connectors';
   connector_id: string;
   action: 'connect' | 'disconnect' | 'refresh';


### PR DESCRIPTION
## Why

Use case: the analytics 2.0 schema doc had row 12 (the settings row) carrying its discriminator as `page` while every other row uses `page_name`. Product just renamed it to `page_name` in the doc; this PR mirrors the rename in code so the wire field name matches one-for-one across every event surface. While there, the doc also defines two new `page_view` surfaces — Onboarding (4-step funnel) and Design Systems (multi-surface) — that the code hadn't started instrumenting yet.

Pain addressed: dashboard authors hitting "what's the discriminator called this time?" because settings events ship `page=settings` while product events ship `page_name=home`. Splitting the field name across event families forces every PostHog filter / breakdown to remember the exception. Unifying on `page_name` ends that.

## What users will see

No user-visible UI change. Internally:

- Every event the web app emits now uses `page_name` as the page discriminator (settings included).
- A new `page_view` fires once per step exposure in the onboarding flow (Connect / About you / Design system / Generation progress). Each carries a shared `onboarding_session_id` so dashboards can stitch the funnel even though the fourth step renders in `DesignSystemDetailView` after onboarding navigates away.
- A new `page_view` fires on the dedicated design-system pages (`/design-systems` list, `/design-systems/create`, `/design-systems/:id` preview + generation), carrying `area` / `view_type` / `entry_from` so the cross-surface DS funnel is visible.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-*` flag, or new `OD_*` env var
- [x] **API / contract** — `packages/contracts/src/analytics/events.ts`: rename `page` → `page_name` on 12 `Settings*ClickProps` / `Settings*ResultProps` / `SettingsViewProps`; `'settings'` merged into `TrackingPageName`; new `OnboardingPageViewProps` + `DesignSystemsPageViewProps`; `PageViewProps` is now a discriminated union.
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — pure analytics wire-format change. The onboarding screen and design-system pages render identically; only the events they emit are new.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm guard` ✅
- `pnpm --filter @open-design/contracts build` ✅
- `pnpm --filter @open-design/web typecheck` ✅
- `pnpm --filter @open-design/daemon typecheck` ✅
- `pnpm --filter @open-design/web test` ✅ 192 files / 1778 tests
- `pnpm --filter @open-design/daemon test` ✅ 246 files / 2942 tests

## Notes for reviewers

A few intentional scope limits, flagged here so they don't show up as missing review items:

1. **Non-page DS exposures (`view_type=module|popover|panel`) are deferred.** The v2 doc treats the home-card DS picker, composer DS picker, and DS picker dialog as `page_view` emissions. Firing `page_view` on those would double-count against the host page's own `page_view`, which is why surface_view exists. I've flagged this with product and intend to land them in a follow-up after we decide between (a) keeping them as page_view and accepting double counting, or (b) re-shaping them as `surface_view`.

2. **`design_system_source` on the DS page_view reports `'unknown'` for now.** The v2 enum (`onboarding|manual_create|github_repo|local_code|fig|assets|official_preset|enterprise|template|mixed|unknown`) needs a deterministic mapping from `DesignSystemDetail.source` / `.provenance`. Rather than guess and mistag, we report `'unknown'` until that mapper exists. Follow-up.

3. **Field name `design_system_source` is intentionally reused.** It already exists on `run_created` / `run_finished` carrying the run-time `TrackingDesignSystemSource` enum (`default|user_selected|template_inherited|project_saved|not_applicable|unknown`). The DS page_view uses the same field name (per doc) but a disjoint value set, so a new `TrackingDesignSystemOrigin` type carries it. The two types never appear on the same payload, so dashboards can split by event name to disambiguate. (I also raised this with product as a "consider renaming the page_view one to `design_system_origin`" item; if/when the doc changes, this becomes a rename.)