### PR TITLE
test(contracts,agui-adapter): cover error helpers, schema parse, ctx.now fallback

### DIFF
--- a/packages/agui-adapter/tests/encode.test.ts
+++ b/packages/agui-adapter/tests/encode.test.ts
@@ -179,4 +179,46 @@ describe('encodeOdEventForAgui', () => {
     );
     expect(out).toBeNull();
   });
+
+  it('falls back to Date.now() when ctx.now is not supplied', () => {
+    const before = Date.now();
+    const out = encodeOdEventForAgui(
+      { kind: 'message_chunk', text: 'hi' },
+      { runId: RUN_ID },
+    );
+    const after = Date.now();
+    expect(out).not.toBeNull();
+    expect(out!.ts).toBeGreaterThanOrEqual(before);
+    expect(out!.ts).toBeLessThanOrEqual(after);
+  });
+
+  it('substitutes defaults for tool_call when toolName/args/callId are absent', () => {
+    const out = encodeOdEventForAgui(
+      { kind: 'tool_call' },
+      { runId: RUN_ID, now: NOW },
+    );
+    expect(out).toMatchObject({
+      kind: 'tool_call',
+      runId: RUN_ID,
+      ts: NOW,
+      toolName: 'unknown',
+      args: null,
+    });
+    const record = out as unknown as Record<string, unknown>;
+    expect(record.callId).toBeUndefined();
+    expect(record.status).toBeUndefined();
+    expect(record.result).toBeUndefined();
+  });
+
+  it('keeps the value key on state_update when the value is explicitly null', () => {
+    const out = encodeOdEventForAgui(
+      { kind: 'state_update', path: 'genui.x', value: null },
+      { runId: RUN_ID, now: NOW },
+    );
+    expect(out).not.toBeNull();
+    const record = out as unknown as Record<string, unknown>;
+    expect('value' in record).toBe(true);
+    expect(record.value).toBeNull();
+    expect(record.path).toBe('genui.x');
+  });
 });

--- a/packages/contracts/tests/context-schema.test.ts
+++ b/packages/contracts/tests/context-schema.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ContextItemSchema,
+  ResolvedContextSchema,
+} from '../src/plugins/context.js';
+
+describe('ContextItemSchema', () => {
+  it('parses each discriminated kind with its required fields', () => {
+    expect(ContextItemSchema.parse({ kind: 'skill', id: 's1', label: 'Skill' })).toEqual({
+      kind: 'skill',
+      id: 's1',
+      label: 'Skill',
+    });
+    expect(
+      ContextItemSchema.parse({
+        kind: 'design-system',
+        id: 'ds1',
+        label: 'DS',
+        primary: true,
+      }),
+    ).toMatchObject({ kind: 'design-system', primary: true });
+    expect(
+      ContextItemSchema.parse({
+        kind: 'asset',
+        path: '/p/a.png',
+        label: 'asset',
+        mime: 'image/png',
+      }),
+    ).toMatchObject({ kind: 'asset', path: '/p/a.png', mime: 'image/png' });
+    expect(
+      ContextItemSchema.parse({ kind: 'mcp', name: 'figma', label: 'Figma' }),
+    ).toMatchObject({ kind: 'mcp', name: 'figma' });
+  });
+
+  it('rejects an unknown discriminator', () => {
+    const result = ContextItemSchema.safeParse({ kind: 'mystery', id: 'x', label: 'y' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an asset item missing its path', () => {
+    const result = ContextItemSchema.safeParse({ kind: 'asset', label: 'no-path' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a skill item missing its label', () => {
+    const result = ContextItemSchema.safeParse({ kind: 'skill', id: 's1' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ResolvedContextSchema', () => {
+  it('accepts the minimal { items: [] } shape', () => {
+    expect(ResolvedContextSchema.parse({ items: [] })).toEqual({ items: [] });
+  });
+
+  it('round-trips items, promptFragments, and atoms', () => {
+    const value = {
+      items: [
+        { kind: 'skill', id: 's1', label: 'Skill 1' },
+        { kind: 'atom', id: 'todo-write', label: 'TodoWrite' },
+      ],
+      promptFragments: { 's1': 'Use skill 1 first.' },
+      atoms: ['todo-write', 'direction-picker'],
+    };
+    expect(ResolvedContextSchema.parse(value)).toEqual(value);
+  });
+
+  it('rejects a missing items array', () => {
+    const result = ResolvedContextSchema.safeParse({ atoms: ['x'] });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects atoms that are not strings', () => {
+    const result = ResolvedContextSchema.safeParse({ items: [], atoms: [42] });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/tests/directions.test.ts
+++ b/packages/contracts/tests/directions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DESIGN_DIRECTIONS,
+  findDirectionByLabel,
+} from '../src/prompts/directions.js';
+
+describe('findDirectionByLabel', () => {
+  it('matches by exact label', () => {
+    const monocle = findDirectionByLabel('Editorial — Monocle / FT magazine');
+    expect(monocle?.id).toBe('editorial-monocle');
+  });
+
+  it('matches by kebab-case id', () => {
+    const found = findDirectionByLabel('editorial-monocle');
+    expect(found?.id).toBe('editorial-monocle');
+  });
+
+  it('trims leading/trailing whitespace before matching', () => {
+    expect(findDirectionByLabel('  editorial-monocle  ')?.id).toBe('editorial-monocle');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(findDirectionByLabel('not a real direction')).toBeUndefined();
+    expect(findDirectionByLabel('')).toBeUndefined();
+  });
+
+  it('finds every direction by both id and label', () => {
+    for (const d of DESIGN_DIRECTIONS) {
+      expect(findDirectionByLabel(d.id)?.id).toBe(d.id);
+      expect(findDirectionByLabel(d.label)?.id).toBe(d.id);
+    }
+  });
+});

--- a/packages/contracts/tests/errors.test.ts
+++ b/packages/contracts/tests/errors.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  API_ERROR_CODES,
+  createApiError,
+  createApiErrorResponse,
+  type ApiError,
+} from '../src/errors.js';
+
+describe('createApiError', () => {
+  it('returns the minimal shape when only code and message are supplied', () => {
+    const err = createApiError('NOT_FOUND', 'project missing');
+    expect(err).toEqual({ code: 'NOT_FOUND', message: 'project missing' });
+  });
+
+  it('carries optional fields (details, retryable, requestId, taskId) through', () => {
+    const err = createApiError('RATE_LIMITED', 'slow down', {
+      details: { retryAfterMs: 1500 },
+      retryable: true,
+      requestId: 'req-1',
+      taskId: 'task-9',
+    });
+    expect(err).toEqual({
+      code: 'RATE_LIMITED',
+      message: 'slow down',
+      details: { retryAfterMs: 1500 },
+      retryable: true,
+      requestId: 'req-1',
+      taskId: 'task-9',
+    });
+  });
+
+  it('does not leak omitted optional fields onto the returned object', () => {
+    const err = createApiError('UNAUTHORIZED', 'no token');
+    expect(Object.keys(err).sort()).toEqual(['code', 'message']);
+  });
+
+  it('accepts every ApiErrorCode the contract exports', () => {
+    for (const code of API_ERROR_CODES) {
+      const err = createApiError(code, 'x');
+      expect(err.code).toBe(code);
+    }
+  });
+});
+
+describe('createApiErrorResponse', () => {
+  it('wraps an ApiError in the `{ error }` envelope', () => {
+    const err: ApiError = { code: 'BAD_REQUEST', message: 'bad' };
+    expect(createApiErrorResponse(err)).toEqual({ error: err });
+  });
+
+  it('round-trips through createApiError', () => {
+    const resp = createApiErrorResponse(
+      createApiError('VALIDATION_FAILED', 'invalid input', {
+        details: { kind: 'validation', issues: [{ path: 'name', message: 'required' }] },
+      }),
+    );
+    expect(resp.error.code).toBe('VALIDATION_FAILED');
+    expect(resp.error.details).toEqual({
+      kind: 'validation',
+      issues: [{ path: 'name', message: 'required' }],
+    });
+  });
+});

--- a/packages/contracts/tests/plugin-block.test.ts
+++ b/packages/contracts/tests/plugin-block.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { renderPluginBlock } from '../src/prompts/plugin-block.js';
+import type { AppliedPluginSnapshot } from '../src/plugins/apply.js';
+
+function makeSnapshot(overrides: Partial<AppliedPluginSnapshot> = {}): AppliedPluginSnapshot {
+  return {
+    snapshotId: 'snap-1',
+    pluginId: 'demo-plugin',
+    pluginVersion: '1.0.0',
+    manifestSourceDigest: 'sha256:0',
+    inputs: {},
+    resolvedContext: { items: [] },
+    capabilitiesGranted: [],
+    capabilitiesRequired: [],
+    assetsStaged: [],
+    taskKind: 'new-generation',
+    appliedAt: 0,
+    connectorsRequired: [],
+    connectorsResolved: [],
+    mcpServers: [],
+    status: 'fresh',
+    ...overrides,
+  } as AppliedPluginSnapshot;
+}
+
+describe('renderPluginBlock', () => {
+  it('uses pluginTitle when present, falls back to pluginId otherwise', () => {
+    const withTitle = renderPluginBlock(makeSnapshot({ pluginTitle: 'Pitch Deck' }));
+    expect(withTitle).toContain('**Pitch Deck** (`demo-plugin@1.0.0`)');
+
+    const noTitle = renderPluginBlock(makeSnapshot());
+    expect(noTitle).toContain('**demo-plugin** (`demo-plugin@1.0.0`)');
+  });
+
+  it('omits Plugin inputs section when no inputs supplied', () => {
+    const out = renderPluginBlock(makeSnapshot());
+    expect(out).not.toContain('## Plugin inputs');
+  });
+
+  it('renders inputs in sorted-key order, formatting empty strings as (empty)', () => {
+    const out = renderPluginBlock(
+      makeSnapshot({
+        inputs: { topic: 'pricing', empty: '', count: 3, flag: true },
+      }),
+    );
+    expect(out).toContain('## Plugin inputs');
+    expect(out).toContain('- **count**: 3');
+    expect(out).toContain('- **empty**: (empty)');
+    expect(out).toContain('- **flag**: true');
+    expect(out).toContain('- **topic**: pricing');
+
+    const indices = ['count', 'empty', 'flag', 'topic'].map((k) =>
+      out.indexOf(`- **${k}**`),
+    );
+    for (let i = 1; i < indices.length; i += 1) {
+      expect(indices[i]!).toBeGreaterThan(indices[i - 1]!);
+    }
+  });
+
+  it('omits Plugin atoms section when resolvedContext.atoms is empty or absent', () => {
+    expect(renderPluginBlock(makeSnapshot())).not.toContain('## Plugin atoms');
+    expect(
+      renderPluginBlock(
+        makeSnapshot({ resolvedContext: { items: [], atoms: [] } }),
+      ),
+    ).not.toContain('## Plugin atoms');
+  });
+
+  it('renders one bullet per atom id when atoms are present', () => {
+    const out = renderPluginBlock(
+      makeSnapshot({
+        resolvedContext: { items: [], atoms: ['todo-write', 'direction-picker'] },
+      }),
+    );
+    expect(out).toContain('## Plugin atoms');
+    expect(out).toContain('- `todo-write`');
+    expect(out).toContain('- `direction-picker`');
+  });
+
+  it('trims plugin description and example query', () => {
+    const out = renderPluginBlock(
+      makeSnapshot({
+        pluginDescription: '  Walks a designer through a pitch deck.  \n',
+        query: '   write me a deck about fluorine   ',
+      }),
+    );
+    expect(out).toContain('Walks a designer through a pitch deck.');
+    expect(out).not.toContain('  Walks');
+    expect(out).toContain('_write me a deck about fluorine_');
+  });
+});


### PR DESCRIPTION
## Why

While reading through `packages/contracts` and `packages/agui-adapter` I noticed a few small but load-bearing pieces of runtime logic that had no direct unit coverage: the `createApiError` / `createApiErrorResponse` factories, the `renderPluginBlock` slot renderer (which feeds the `## Active plugin` system-prompt block), `findDirectionByLabel`, the `ContextItemSchema` / `ResolvedContextSchema` Zod schemas, and three encoder edges in `encodeOdEventForAgui` (the `ctx.now` fallback, tool_call optional-field passthrough, and the `state_update` explicit-null pass-through). These are all small surfaces, but they show up on hot paths (error envelope, prompt assembly, AG-UI relay), so the regression cost from an accidental refactor is disproportionate to their size. This PR fills those gaps without touching any source.

## What users will see

Nothing — tests-only.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — tests-only.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm --filter @open-design/contracts test` — 17 files, 115 tests pass (baseline was 13 files / 90 tests)
- `pnpm --filter @open-design/contracts typecheck` — clean
- `pnpm --filter @open-design/agui-adapter test` — 12 tests pass (baseline 9)
- `pnpm --filter @open-design/agui-adapter typecheck` — clean