### PR TITLE
test(diagnostics): cover manifest + log-source collectors, wire into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,6 +495,7 @@ jobs:
       - name: Workspace unit tests
         run: |
           pnpm --filter @open-design/contracts test
+          pnpm --filter @open-design/diagnostics test
           pnpm --filter @open-design/host test
           pnpm --filter @open-design/platform test
           pnpm --filter @open-design/sidecar test

--- a/packages/diagnostics/tests/manifest.test.ts
+++ b/packages/diagnostics/tests/manifest.test.ts
@@ -1,0 +1,101 @@
+import { arch, platform, release } from "node:os";
+
+import { describe, expect, it } from "vitest";
+
+import { buildMachineInfo, buildManifest, diagnosticsFileName } from "../src/manifest.js";
+import type { CollectedFile } from "../src/sources.js";
+
+describe("buildManifest", () => {
+  it("returns a manifest with no files and no warnings for a minimal context", () => {
+    const manifest = buildManifest(
+      {
+        app: { name: "open-design" },
+        source: "test",
+      },
+      [],
+    );
+    expect(manifest.app.name).toBe("open-design");
+    expect(manifest.source).toBe("test");
+    expect(manifest.files).toEqual([]);
+    expect(manifest.warnings).toEqual([]);
+    expect(typeof manifest.exportedAt).toBe("string");
+    expect(() => new Date(manifest.exportedAt).toISOString()).not.toThrow();
+  });
+
+  it("copies a single file entry into the manifest", () => {
+    const file: CollectedFile = {
+      name: "logs/daemon.log",
+      absolutePath: "/tmp/daemon.log",
+      content: "ok",
+      bytes: 2,
+    };
+    const manifest = buildManifest(
+      {
+        app: { name: "open-design", version: "1.0.0", packaged: true },
+        source: "daemon-http",
+        namespace: "default",
+        endpoint: "http://127.0.0.1:17456",
+        daemonReachable: true,
+      },
+      [file],
+    );
+    expect(manifest.files).toEqual([
+      { name: "logs/daemon.log", absolutePath: "/tmp/daemon.log", bytes: 2, error: undefined },
+    ]);
+    expect(manifest.endpoint).toBe("http://127.0.0.1:17456");
+    expect(manifest.daemonReachable).toBe(true);
+    expect(manifest.warnings).toEqual([]);
+  });
+
+  it("merges context warnings and per-file errors into the warnings array", () => {
+    const files: CollectedFile[] = [
+      { name: "logs/a.log", absolutePath: "/tmp/a.log", content: "x", bytes: 1 },
+      { name: "logs/b.log", absolutePath: "/tmp/b.log", content: null, bytes: 0, error: "ENOENT" },
+    ];
+    const manifest = buildManifest(
+      {
+        app: { name: "open-design" },
+        source: "desktop-ipc",
+        warnings: ["file logs unavailable in this launch"],
+      },
+      files,
+    );
+    expect(manifest.warnings).toEqual([
+      "file logs unavailable in this launch",
+      "logs/b.log: ENOENT",
+    ]);
+  });
+});
+
+describe("buildMachineInfo", () => {
+  it("returns a structurally-correct snapshot of the host", () => {
+    const info = buildMachineInfo("alice");
+    expect(info.platform).toBe(platform());
+    expect(info.arch).toBe(arch());
+    expect(info.release).toBe(release());
+    expect(typeof info.hostname).toBe("string");
+    expect(typeof info.totalMemoryBytes).toBe("number");
+    expect(info.nodeVersion).toBe(process.version);
+    expect(info.pid).toBe(process.pid);
+    expect(info.username).toBe("alice");
+  });
+
+  it("accepts an undefined username", () => {
+    const info = buildMachineInfo(undefined);
+    expect(info.username).toBeUndefined();
+  });
+});
+
+describe("diagnosticsFileName", () => {
+  it("formats an explicit Date into a zip filename", () => {
+    const fixed = new Date("2025-01-02T03:04:05.678Z");
+    expect(diagnosticsFileName("open-design-diagnostics", fixed)).toBe(
+      "open-design-diagnostics-2025-01-02T03-04-05Z.zip",
+    );
+  });
+
+  it("falls back to the current date when no Date is provided", () => {
+    const name = diagnosticsFileName("prefix");
+    expect(name).toMatch(/^prefix-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z\.zip$/);
+  });
+});

--- a/packages/diagnostics/tests/sources.test.ts
+++ b/packages/diagnostics/tests/sources.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { collectLogSource, collectLogSources, findMacOSCrashReports } from "../src/sources.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "diagnostics-sources-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("collectLogSource", () => {
+  it("reads a text file and runs redaction over its content", async () => {
+    const filePath = join(tempDir, "daemon.log");
+    await writeFile(filePath, "GET /api?token=abc123 ok\n", "utf8");
+
+    const result = await collectLogSource({
+      name: "logs/daemon.log",
+      absolutePath: filePath,
+      kind: "text",
+    });
+    expect(result.content).toContain("token=[REDACTED]");
+    expect(result.content).not.toContain("abc123");
+    expect(result.bytes).toBeGreaterThan(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("redacts JSON content via pretty-printed JSON path when kind is json", async () => {
+    const filePath = join(tempDir, "state.json");
+    await writeFile(filePath, JSON.stringify({ token: "secret", body: "ok" }), "utf8");
+
+    const result = await collectLogSource({
+      name: "logs/state.json",
+      absolutePath: filePath,
+      kind: "json",
+    });
+    expect(result.content).toContain("[REDACTED]");
+    expect(result.content).toContain("\n");
+  });
+
+  it("returns the trailing window when tailBytes is smaller than the file", async () => {
+    const filePath = join(tempDir, "long.log");
+    await writeFile(filePath, "head-content\nmiddle\ntail-content", "utf8");
+
+    const result = await collectLogSource({
+      name: "logs/long.log",
+      absolutePath: filePath,
+      kind: "text",
+      tailBytes: 12,
+    });
+    expect(result.content).toBe("tail-content");
+    expect(result.bytes).toBe(12);
+  });
+
+  it("returns an error marker when the file does not exist", async () => {
+    const result = await collectLogSource({
+      name: "logs/missing.log",
+      absolutePath: join(tempDir, "no-such-file.log"),
+      kind: "text",
+    });
+    expect(result.content).toBeNull();
+    expect(result.bytes).toBe(0);
+    expect(result.error).toBeTruthy();
+  });
+});
+
+describe("collectLogSources", () => {
+  it("aggregates multiple sources, preserving order", async () => {
+    const aPath = join(tempDir, "a.log");
+    const bPath = join(tempDir, "b.log");
+    await writeFile(aPath, "alpha\n", "utf8");
+    await writeFile(bPath, "beta\n", "utf8");
+
+    const results = await collectLogSources([
+      { name: "logs/a.log", absolutePath: aPath, kind: "text" },
+      { name: "logs/b.log", absolutePath: bPath, kind: "text" },
+      { name: "logs/missing.log", absolutePath: join(tempDir, "nope.log"), kind: "text" },
+    ]);
+    expect(results).toHaveLength(3);
+    expect(results[0]?.name).toBe("logs/a.log");
+    expect(results[0]?.content).toBe("alpha\n");
+    expect(results[1]?.name).toBe("logs/b.log");
+    expect(results[1]?.content).toBe("beta\n");
+    expect(results[2]?.error).toBeTruthy();
+  });
+});
+
+describe("findMacOSCrashReports", () => {
+  it("returns an empty list on non-darwin platforms", async () => {
+    if (process.platform === "darwin") return;
+    const reports = await findMacOSCrashReports({
+      matchSubstrings: ["open-design"],
+      searchDirs: [tempDir],
+    });
+    expect(reports).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for `packages/diagnostics` and wires the package into `core_tests` in CI so the new suite runs on every PR.

- `manifest.ts`: covers `buildManifest`, `buildMachineInfo`, `diagnosticsFileName` (Date.now() fallback included).
- `sources.ts`: covers `collectLogSource` (happy path + missing file), `collectLogSources` aggregation, and `findMacOSCrashReports` non-darwin guard.

Tests-only + CI wiring; no product source changes.

## What users will see
Nothing — internal test coverage + CI wiring only.

## Surface area
- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — tests + a one-line CI wiring add (run the package's suite in `core_tests`); no product surface.

## Validation
- `pnpm --filter @open-design/diagnostics test` — green locally.
