### PR TITLE
feat(mcp): add create_project tool (#2356)

### DIFF
--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -10,6 +10,8 @@
 // "daemon not reachable" error - the server itself still launches so
 // the client can list its tool schema.
 
+import { randomUUID } from 'node:crypto';
+
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -35,7 +37,7 @@ interface ProjectPayload { project?: ProjectSummary; id?: string; name?: string;
 interface ActiveContext { active?: boolean; projectId?: string; projectName?: string | null; fileName?: string | null; ageMs?: number | null }
 type ResolvedProject = { id: string; name: string; source: 'uuid' | 'id' | 'exact' | 'slug' | 'substring' };
 interface ProjectListCache { baseUrl: string; t: number; list: ProjectSummary[] }
-interface McpArgs extends JsonObject { project?: unknown; entry?: unknown; include?: unknown; maxBytes?: unknown; path?: unknown; offset?: unknown; limit?: unknown; since?: unknown; query?: unknown; pattern?: unknown; max?: unknown; name?: unknown; content?: unknown; encoding?: unknown; artifactManifest?: unknown; confirm?: unknown }
+interface McpArgs extends JsonObject { project?: unknown; entry?: unknown; include?: unknown; maxBytes?: unknown; path?: unknown; offset?: unknown; limit?: unknown; since?: unknown; query?: unknown; pattern?: unknown; max?: unknown; name?: unknown; content?: unknown; encoding?: unknown; artifactManifest?: unknown; confirm?: unknown; skillId?: unknown; designSystemId?: unknown; pendingPrompt?: unknown; customInstructions?: unknown }
 interface ProjectFileBundleEntry { name: string; mime: string; size: number | null; content: string | null; binary: boolean }
 interface BundleInput { project: ProjectPayload | ProjectSummary; entry: string; files: ProjectFileBundleEntry[]; truncated: boolean; active: ActiveContext | null; resolved?: ResolvedProject | null }
 interface ErrorWithCode { message?: string; code?: string; cause?: { code?: string } }
@@ -237,6 +239,43 @@ const TOOL_DEFS = [
     annotations: { ...WRITE_ANNOTATIONS, title: 'Create Open Design artifact' },
   },
   {
+    name: 'create_project',
+    description:
+      'Create a new empty Open Design project on this daemon and return its id and seeded conversation. Use this when the agent needs to start a fresh project before pulling/pushing files; existing-project workflows should keep using list_projects + get_project.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Human-readable project name. Shown in the Open Design sidebar.',
+        },
+        skillId: {
+          type: 'string',
+          description:
+            'Optional skill id to pin to the new project (matches an entry under od://skills/).',
+        },
+        designSystemId: {
+          type: 'string',
+          description:
+            'Optional design-system id to pin to the new project (matches an entry under od://design-systems/).',
+        },
+        pendingPrompt: {
+          type: 'string',
+          description:
+            'Optional initial prompt the user will see queued in the project on first open.',
+        },
+        customInstructions: {
+          type: 'string',
+          description:
+            'Optional project-scoped instructions appended to the agent system prompt (max 5000 chars).',
+        },
+      },
+      required: ['name'],
+      additionalProperties: false,
+    },
+    annotations: { ...WRITE_ANNOTATIONS, title: 'Create Open Design project' },
+  },
+  {
     name: 'write_file',
     description:
       'Write (or overwrite) a project file. Unlike create_artifact this does not require an ArtifactManifest and tolerates existing targets, so it is the right tool for iterating on a file the agent (or the user) already created. Project optional; defaults to the active project.',
@@ -347,6 +386,10 @@ export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
         ' - create_artifact(name, content) to create one normal artifact',
         '    entry file in the active or specified project. It rejects',
         '    existing targets and can accept an artifactManifest sidecar.',
+        ' - create_project(name) to start a brand-new empty Open Design',
+        '    project (returns id + seeded conversation). Use this only',
+        '    when no suitable existing project is available; prefer',
+        '    list_projects + the active context first.',
         ' - write_file(path, content) to overwrite or freshly create any',
         '    project file when an ArtifactManifest is not required.',
         '    Use this to iterate on a file create_artifact already wrote.',
@@ -567,6 +610,8 @@ async function handleMcpToolCall(baseUrl: string, name: unknown, args: McpArgs) 
       }
       case 'create_artifact':
         return await createArtifact(baseUrl, args);
+      case 'create_project':
+        return await createProject(baseUrl, args);
       case 'write_file':
         return await writeFile(baseUrl, args);
       case 'delete_file':
@@ -579,6 +624,43 @@ async function handleMcpToolCall(baseUrl: string, name: unknown, args: McpArgs) 
   } catch (err) {
     return errorResult(formatError(err, baseUrl));
   }
+}
+
+async function createProject(baseUrl: string, args: McpArgs) {
+  requireString(args.name, 'name');
+  // The daemon's POST /api/projects requires an id matching
+  // /^[A-Za-z0-9._-]{1,128}$/ — minting a UUID here matches what the
+  // web UI does (apps/web/src/state/projects.ts) and keeps agents from
+  // having to invent project ids.
+  const id = randomUUID();
+  const payload: JsonObject = { id, name: args.name.trim() };
+  if (typeof args.skillId === 'string' && args.skillId.length > 0) {
+    payload.skillId = args.skillId;
+  }
+  if (typeof args.designSystemId === 'string' && args.designSystemId.length > 0) {
+    payload.designSystemId = args.designSystemId;
+  }
+  if (typeof args.pendingPrompt === 'string' && args.pendingPrompt.length > 0) {
+    payload.pendingPrompt = args.pendingPrompt;
+  }
+  if (typeof args.customInstructions === 'string') {
+    payload.customInstructions = args.customInstructions;
+  }
+  // Intentionally NOT forwarded: metadata, pluginId, pluginInputs,
+  // appliedPluginSnapshotId. metadata.baseDir is server-rejected on
+  // this endpoint anyway, and the plugin-resolution path is a UI-side
+  // concern that doesn't belong in the agent tool surface.
+  const url = `${baseUrl}/api/projects`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!resp.ok) {
+    return errorResult(await formatDaemonError(resp, url));
+  }
+  const json = (await resp.json()) as JsonObject;
+  return ok(json);
 }
 
 async function writeFile(baseUrl: string, args: McpArgs) {

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -84,7 +84,7 @@ const PROJECT_ARG = {
   description: 'Project id (UUID) or name substring. Optional; defaults to the active project (expires after ~5 minutes of no Open Design activity).',
 } as const;
 
-const TOOL_DEFS = [
+export const TOOL_DEFS = [
   {
     name: 'list_projects',
     description: 'List every Open Design project on this daemon.',
@@ -250,24 +250,24 @@ const TOOL_DEFS = [
           description: 'Human-readable project name. Shown in the Open Design sidebar.',
         },
         skillId: {
-          type: 'string',
+          type: ['string', 'null'],
           description:
-            'Optional skill id to pin to the new project (matches an entry under od://skills/).',
+            'Optional skill or template id to pin to the new project. Accepts any entry the daemon would resolve at run-startup time — bundled skills under od://skills/, bundled design-templates under od://design-templates/ (e.g. "dashboard"), and user-imported entries — plus deprecated aliases listed in SKILL_ID_ALIASES (which get canonicalized before persistence). Pass null or omit to leave the project unpinned.',
         },
         designSystemId: {
-          type: 'string',
+          type: ['string', 'null'],
           description:
-            'Optional design-system id to pin to the new project (matches an entry under od://design-systems/).',
+            'Optional design-system id to pin to the new project (matches an entry under od://design-systems/). Pass null or omit to leave the project without a pinned design system.',
         },
         pendingPrompt: {
-          type: 'string',
+          type: ['string', 'null'],
           description:
-            'Optional initial prompt the user will see queued in the project on first open.',
+            'Optional initial prompt the user will see queued in the project on first open. Pass null or omit to leave the queue empty.',
         },
         customInstructions: {
-          type: 'string',
+          type: ['string', 'null'],
           description:
-            'Optional project-scoped instructions appended to the agent system prompt (max 5000 chars).',
+            'Optional project-scoped instructions appended to the agent system prompt (max 5000 chars). Pass null or omit to leave the project without custom instructions.',
         },
       },
       required: ['name'],

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -628,12 +628,19 @@ async function handleMcpToolCall(baseUrl: string, name: unknown, args: McpArgs) 
 
 async function createProject(baseUrl: string, args: McpArgs) {
   requireString(args.name, 'name');
+  // Whitespace-only names would be trimmed to "" before the daemon ever
+  // sees them; rather than burn an HTTP round-trip to learn that, reject
+  // locally with the same shape requireString uses for missing input.
+  const trimmedName = args.name.trim();
+  if (!trimmedName) {
+    throw new Error('name is required (string).');
+  }
   // The daemon's POST /api/projects requires an id matching
   // /^[A-Za-z0-9._-]{1,128}$/ — minting a UUID here matches what the
   // web UI does (apps/web/src/state/projects.ts) and keeps agents from
   // having to invent project ids.
   const id = randomUUID();
-  const payload: JsonObject = { id, name: args.name.trim() };
+  const payload: JsonObject = { id, name: trimmedName };
   if (typeof args.skillId === 'string' && args.skillId.length > 0) {
     payload.skillId = args.skillId;
   }
@@ -660,6 +667,11 @@ async function createProject(baseUrl: string, args: McpArgs) {
     return errorResult(await formatDaemonError(resp, url));
   }
   const json = (await resp.json()) as JsonObject;
+  // Keep projectListCache consistent: without this, an agent session
+  // that already primed the cache via list_projects/get_project would
+  // fail to resolve the brand-new project by name or substring for up
+  // to PROJECT_LIST_TTL_MS.
+  recordCreatedProject(baseUrl, json);
   return ok(json);
 }
 
@@ -744,6 +756,20 @@ async function formatDaemonError(resp: Response, url: string): Promise<string> {
     // body wasn't JSON; fall through with the raw text.
   }
   return `daemon ${resp.status} on ${url}: ${detail}`;
+}
+
+function recordCreatedProject(baseUrl: string, payload: JsonObject): void {
+  if (!projectListCache || projectListCache.baseUrl !== baseUrl) return;
+  const raw = (payload as { project?: unknown }).project;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== 'string' || typeof obj.name !== 'string') return;
+  if (projectListCache.list.some((p) => p.id === obj.id)) return;
+  const summary: ProjectSummary = { id: obj.id, name: obj.name };
+  if (obj.metadata && typeof obj.metadata === 'object' && !Array.isArray(obj.metadata)) {
+    summary.metadata = obj.metadata as JsonObject;
+  }
+  projectListCache.list.push(summary);
 }
 
 async function createArtifact(baseUrl: string, args: McpArgs) {

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -534,6 +534,20 @@ function requireString(v: unknown, name: string): asserts v is string {
   }
 }
 
+// Assert an optional MCP tool argument is either omitted (undefined /
+// null) or a string. Wrong-type inputs (objects, numbers, booleans)
+// must fail loudly at the tool boundary instead of being silently
+// dropped — the previous `typeof === 'string'` filter let an MCP
+// caller send e.g. `skillId: 42` and still get a successfully created
+// project that was missing the requested pinned skill, design system,
+// or instructions (#2404 round-5 review on PR #2404).
+function assertOptionalString(v: unknown, name: string): asserts v is string | undefined | null {
+  if (v === undefined || v === null) return;
+  if (typeof v !== 'string') {
+    throw new Error(`${name} must be a string when provided.`);
+  }
+}
+
 async function handleMcpToolCall(baseUrl: string, name: unknown, args: McpArgs) {
   try {
     switch (name) {
@@ -641,6 +655,18 @@ async function createProject(baseUrl: string, args: McpArgs) {
   // having to invent project ids.
   const id = randomUUID();
   const payload: JsonObject = { id, name: trimmedName };
+  // Type-check each optional argument before forwarding. The previous
+  // `typeof === 'string'` filter silently dropped wrong-type inputs
+  // (e.g. `skillId: 42`) and still POSTed a successful project
+  // create, bypassing the daemon's own validation and leaving the
+  // caller with a project missing the requested pinned skill / design
+  // system / instructions (#2404 round-5 review on PR #2404). Reject
+  // wrong types at the MCP boundary instead. Empty strings remain a
+  // no-op so the existing "no field supplied" shape is preserved.
+  assertOptionalString(args.skillId, 'skillId');
+  assertOptionalString(args.designSystemId, 'designSystemId');
+  assertOptionalString(args.pendingPrompt, 'pendingPrompt');
+  assertOptionalString(args.customInstructions, 'customInstructions');
   if (typeof args.skillId === 'string' && args.skillId.length > 0) {
     payload.skillId = args.skillId;
   }

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -19,7 +19,7 @@ import type { RouteDeps } from './server-context.js';
 import { findSkillById, listSkills } from './skills.js';
 import { auditDesignSystemPackage } from './tools-connectors-cli.js';
 
-export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids' | 'telemetry' | 'validation'> {}
+export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids' | 'telemetry' | 'validation' | 'resources'> {}
 
 export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDeps) {
   const { db, design } = ctx;
@@ -33,6 +33,30 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
   const { subscribeFileEvents, activeProjectEventSinks } = ctx.events;
   const { randomId } = ctx.ids;
   const { validateProjectDesignSystemId } = ctx.validation;
+  const { listAllSkillLikeEntries } = ctx.resources;
+
+  // Shared skillId guard for POST/PATCH /api/projects. We must validate
+  // against the same source-of-truth the daemon uses at run-startup
+  // (`listAllSkillLikeEntries`), which spans `skills/`,
+  // `design-templates/`, and user-imported roots — narrower validation
+  // (e.g. `listSkills(SKILLS_DIR)`) would falsely reject legitimate
+  // template ids and user skill ids. Returns a structured failure when
+  // the value is non-string or unknown; null / undefined / '' keep the
+  // existing "no skill pinned" semantics and pass through.
+  type SkillIdGuardResult =
+    | { ok: true }
+    | { ok: false; status: number; code: string; message: string };
+  async function validateSkillIdForProject(value: unknown): Promise<SkillIdGuardResult> {
+    if (value === undefined || value === null || value === '') return { ok: true };
+    if (typeof value !== 'string') {
+      return { ok: false, status: 400, code: 'BAD_REQUEST', message: 'skillId must be a string or null' };
+    }
+    const skills = await listAllSkillLikeEntries();
+    if (!findSkillById(skills, value)) {
+      return { ok: false, status: 400, code: 'SKILL_NOT_FOUND', message: 'skill not found' };
+    }
+    return { ok: true };
+  }
   async function loadPluginRegistryView() {
     const [skills, designSystems] = await Promise.all([
       listSkills(SKILLS_DIR),
@@ -188,14 +212,9 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       // project with no pinned skill at all and no error to the caller.
       // Unknown skill ids are rejected; `null` / `undefined` / empty
       // string keep the existing "no skill pinned" semantics.
-      if (skillId !== undefined && skillId !== null && skillId !== '') {
-        if (typeof skillId !== 'string') {
-          return sendApiError(res, 400, 'BAD_REQUEST', 'skillId must be a string or null');
-        }
-        const skills = await listSkills(SKILLS_DIR);
-        if (!findSkillById(skills, skillId)) {
-          return sendApiError(res, 400, 'SKILL_NOT_FOUND', 'skill not found');
-        }
+      const skillIdValidation = await validateSkillIdForProject(skillId);
+      if (!skillIdValidation.ok) {
+        return sendApiError(res, skillIdValidation.status, skillIdValidation.code, skillIdValidation.message);
       }
       const projectMetadata =
         metadata && typeof metadata === 'object'
@@ -418,6 +437,18 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           );
         }
         patch.designSystemId = designSystemValidation.id;
+      }
+      // Same guard as POST: PATCH used to send `patch` straight into
+      // updateProject() without checking skillId, so a caller could
+      // create a project successfully and then patch in
+      // `skillId: missing-skill` — re-opening the same silent-drop
+      // path at run-startup time that this commit closes for POST.
+      // Share the helper so the two routes can never diverge.
+      if (Object.prototype.hasOwnProperty.call(patch, 'skillId')) {
+        const skillIdValidation = await validateSkillIdForProject(patch.skillId);
+        if (!skillIdValidation.ok) {
+          return sendApiError(res, skillIdValidation.status, skillIdValidation.code, skillIdValidation.message);
+        }
       }
       const project = updateProject(db, req.params.id, patch);
       if (!project)

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -35,20 +35,28 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
   const { validateProjectDesignSystemId } = ctx.validation;
   const { listAllSkillLikeEntries } = ctx.resources;
 
-  // Shared skillId guard for POST/PATCH /api/projects. Two jobs in one:
+  // Shared skillId guard for POST/PATCH /api/projects. Three jobs in one:
   //
   //   1. Validate the incoming value against the same source-of-truth
   //      the daemon uses at run-startup (`listAllSkillLikeEntries`),
   //      which spans `skills/`, `design-templates/`, and user-imported
   //      roots — narrower validation would falsely reject legitimate
   //      template ids.
-  //   2. Return the canonical value the route should actually persist.
-  //      `undefined` / `null` / `''` all mean "no skill pinned"; we
-  //      collapse them to `null` here so the route never writes an
-  //      empty-string sentinel to the project row. Without that
-  //      normalization a POST or PATCH with `skillId: ''` would store
-  //      `''`, leaving the row in the inconsistent state this guard
-  //      exists to prevent (issue #2404 review on PR #2404, round 4).
+  //   2. Collapse `undefined` / `null` / `''` to `null` so the route
+  //      never writes an empty-string sentinel to the project row
+  //      (issue #2404 review on PR #2404, round 4).
+  //   3. Canonicalize aliased ids before persistence. `findSkillById`
+  //      forwards deprecated aliases (`SKILL_ID_ALIASES` in
+  //      `apps/daemon/src/skills.ts`) such as
+  //      `editorial-collage → open-design-landing` for lookup, but
+  //      the web does direct `project.skillId === s.id` comparisons
+  //      in `apps/web/src/components/ProjectView.tsx` (skill chip +
+  //      deck-mode detection). Persisting the raw alias would leave
+  //      the UI showing "no skill pinned" / no deck mode even though
+  //      runtime composition still resolves the alias. Return the
+  //      resolved skill's canonical `.id` so on-disk state always
+  //      matches the file the runtime composes against (round 5
+  //      reviewer follow-up).
   type SkillIdGuardResult =
     | { ok: true; value: string | null }
     | { ok: false; status: number; code: string; message: string };
@@ -58,10 +66,11 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       return { ok: false, status: 400, code: 'BAD_REQUEST', message: 'skillId must be a string or null' };
     }
     const skills = await listAllSkillLikeEntries();
-    if (!findSkillById(skills, value)) {
+    const found = findSkillById(skills, value);
+    if (!found) {
       return { ok: false, status: 400, code: 'SKILL_NOT_FOUND', message: 'skill not found' };
     }
-    return { ok: true, value };
+    return { ok: true, value: found.id };
   }
   async function loadPluginRegistryView() {
     const [skills, designSystems] = await Promise.all([

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -207,6 +207,18 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       if (typeof customInstructions === 'string' && customInstructions.length > 5000) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'customInstructions exceeds 5 000 character limit');
       }
+      // pendingPrompt is contract-typed `string | null`
+      // (packages/contracts/src/api/projects.ts) and consumed by the
+      // web with `project?.pendingPrompt?.trim()`. A direct HTTP
+      // caller used to be able to persist `pendingPrompt: 42` (or an
+      // object) and turn later WorkspaceTabsBar rendering into a
+      // runtime fault. Mirror the customInstructions guard
+      // (#2404 round-6 review).
+      if (pendingPrompt !== undefined
+          && typeof pendingPrompt !== 'string'
+          && pendingPrompt !== null) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'pendingPrompt must be a string or null');
+      }
       if (skipDiscoveryBrief !== undefined && typeof skipDiscoveryBrief !== 'boolean') {
         return sendApiError(res, 400, 'BAD_REQUEST', 'skipDiscoveryBrief must be a boolean');
       }
@@ -441,6 +453,30 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       }
       if (typeof patch.customInstructions === 'string' && patch.customInstructions.length > 5000) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'customInstructions exceeds 5 000 character limit');
+      }
+      // PATCH used to forward `patch.pendingPrompt` straight into
+      // updateProject() with no type check, so a direct HTTP caller
+      // could persist `pendingPrompt: 42` and break the web's
+      // `project?.pendingPrompt?.trim()` consumer at next render.
+      // Mirror the customInstructions guard so POST and PATCH agree
+      // on the contract type (#2404 round-6 review).
+      if (Object.prototype.hasOwnProperty.call(patch, 'pendingPrompt')
+          && typeof patch.pendingPrompt !== 'string'
+          && patch.pendingPrompt !== null) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'pendingPrompt must be a string or null');
+      }
+      // Same shape for `name`: POST already enforces
+      // `typeof name === 'string' && name.trim()`, but PATCH would
+      // happily persist `name: 42` or `"   "`, breaking the contract
+      // invariant `project.name` consumers like RecentProjectsStrip's
+      // `project.name.trim()` rely on. Only validate when the body
+      // explicitly includes the field so existing partial-patch
+      // shapes (e.g. metadata-only edits) keep working.
+      if (Object.prototype.hasOwnProperty.call(patch, 'name')) {
+        if (typeof patch.name !== 'string' || !patch.name.trim()) {
+          return sendApiError(res, 400, 'BAD_REQUEST', 'name must be a non-empty string');
+        }
+        patch.name = patch.name.trim();
       }
       if (Object.prototype.hasOwnProperty.call(patch, 'designSystemId')) {
         const designSystemValidation = await validateProjectDesignSystemId(patch.designSystemId);

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -35,19 +35,25 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
   const { validateProjectDesignSystemId } = ctx.validation;
   const { listAllSkillLikeEntries } = ctx.resources;
 
-  // Shared skillId guard for POST/PATCH /api/projects. We must validate
-  // against the same source-of-truth the daemon uses at run-startup
-  // (`listAllSkillLikeEntries`), which spans `skills/`,
-  // `design-templates/`, and user-imported roots — narrower validation
-  // (e.g. `listSkills(SKILLS_DIR)`) would falsely reject legitimate
-  // template ids and user skill ids. Returns a structured failure when
-  // the value is non-string or unknown; null / undefined / '' keep the
-  // existing "no skill pinned" semantics and pass through.
+  // Shared skillId guard for POST/PATCH /api/projects. Two jobs in one:
+  //
+  //   1. Validate the incoming value against the same source-of-truth
+  //      the daemon uses at run-startup (`listAllSkillLikeEntries`),
+  //      which spans `skills/`, `design-templates/`, and user-imported
+  //      roots — narrower validation would falsely reject legitimate
+  //      template ids.
+  //   2. Return the canonical value the route should actually persist.
+  //      `undefined` / `null` / `''` all mean "no skill pinned"; we
+  //      collapse them to `null` here so the route never writes an
+  //      empty-string sentinel to the project row. Without that
+  //      normalization a POST or PATCH with `skillId: ''` would store
+  //      `''`, leaving the row in the inconsistent state this guard
+  //      exists to prevent (issue #2404 review on PR #2404, round 4).
   type SkillIdGuardResult =
-    | { ok: true }
+    | { ok: true; value: string | null }
     | { ok: false; status: number; code: string; message: string };
   async function validateSkillIdForProject(value: unknown): Promise<SkillIdGuardResult> {
-    if (value === undefined || value === null || value === '') return { ok: true };
+    if (value === undefined || value === null || value === '') return { ok: true, value: null };
     if (typeof value !== 'string') {
       return { ok: false, status: 400, code: 'BAD_REQUEST', message: 'skillId must be a string or null' };
     }
@@ -55,7 +61,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
     if (!findSkillById(skills, value)) {
       return { ok: false, status: 400, code: 'SKILL_NOT_FOUND', message: 'skill not found' };
     }
-    return { ok: true };
+    return { ok: true, value };
   }
   async function loadPluginRegistryView() {
     const [skills, designSystems] = await Promise.all([
@@ -216,6 +222,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       if (!skillIdValidation.ok) {
         return sendApiError(res, skillIdValidation.status, skillIdValidation.code, skillIdValidation.message);
       }
+      const normalizedSkillId = skillIdValidation.value;
       const projectMetadata =
         metadata && typeof metadata === 'object'
           ? {
@@ -235,7 +242,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       const project = insertProject(db, {
         id,
         name: name.trim(),
-        skillId: skillId ?? null,
+        skillId: normalizedSkillId,
         designSystemId: normalizedDesignSystemId,
         pendingPrompt: pendingPrompt || null,
         metadata: projectMetadata,
@@ -443,12 +450,16 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       // create a project successfully and then patch in
       // `skillId: missing-skill` — re-opening the same silent-drop
       // path at run-startup time that this commit closes for POST.
-      // Share the helper so the two routes can never diverge.
+      // Share the helper so the two routes can never diverge, and
+      // overwrite the patch value with the canonical (`'' → null`)
+      // form so we never persist an empty-string sentinel via PATCH
+      // either.
       if (Object.prototype.hasOwnProperty.call(patch, 'skillId')) {
         const skillIdValidation = await validateSkillIdForProject(patch.skillId);
         if (!skillIdValidation.ok) {
           return sendApiError(res, skillIdValidation.status, skillIdValidation.code, skillIdValidation.message);
         }
+        patch.skillId = skillIdValidation.value;
       }
       const project = updateProject(db, req.params.id, patch);
       if (!project)

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -16,7 +16,7 @@ import {
 } from './plugins/index.js';
 import { connectorService } from './connectors/service.js';
 import type { RouteDeps } from './server-context.js';
-import { listSkills } from './skills.js';
+import { findSkillById, listSkills } from './skills.js';
 import { auditDesignSystemPackage } from './tools-connectors-cli.js';
 
 export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids' | 'telemetry' | 'validation'> {}
@@ -181,6 +181,22 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         );
       }
       const normalizedDesignSystemId = designSystemValidation.id;
+      // Validate skillId the same way designSystemId is validated, so a
+      // typo from the web UI / CLI / MCP create_project tool fails fast
+      // here instead of silently persisting and then getting skipped by
+      // findSkillById() at run-startup time — which would leave the
+      // project with no pinned skill at all and no error to the caller.
+      // Unknown skill ids are rejected; `null` / `undefined` / empty
+      // string keep the existing "no skill pinned" semantics.
+      if (skillId !== undefined && skillId !== null && skillId !== '') {
+        if (typeof skillId !== 'string') {
+          return sendApiError(res, 400, 'BAD_REQUEST', 'skillId must be a string or null');
+        }
+        const skills = await listSkills(SKILLS_DIR);
+        if (!findSkillById(skills, skillId)) {
+          return sendApiError(res, 400, 'SKILL_NOT_FOUND', 'skill not found');
+        }
+      }
       const projectMetadata =
         metadata && typeof metadata === 'object'
           ? {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5201,6 +5201,13 @@ export async function startServer({
     ids: idDeps,
     telemetry: { reportFinalizedMessage },
     validation: validationDeps,
+    resources: {
+      listAllSkills,
+      listAllDesignTemplates,
+      listAllSkillLikeEntries,
+      listAllDesignSystems,
+      mimeFor,
+    },
   });
   registerImportRoutes(app, {
     db,

--- a/apps/daemon/tests/mcp-create-project.test.ts
+++ b/apps/daemon/tests/mcp-create-project.test.ts
@@ -136,18 +136,88 @@ describe('public MCP create_project (#2356)', () => {
     const fetchMock = vi.fn(
       async (_url: string, _init?: RequestInit) =>
         new Response(
-          JSON.stringify({ error: { code: 'BAD_REQUEST', message: 'name required' } }),
-          { status: 400 },
+          JSON.stringify({ error: { code: 'NAME_TAKEN', message: 'duplicate name' } }),
+          { status: 409 },
         ),
     );
     vi.stubGlobal('fetch', fetchMock);
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', {
-      name: ' ',
+      name: 'Workshop',
     });
 
     expect(result).toMatchObject({ isError: true });
     // Should expose the daemon's reason rather than a bare HTTP code.
-    expect(firstText(result)).toMatch(/name required|BAD_REQUEST|400/);
+    expect(firstText(result)).toMatch(/duplicate name|NAME_TAKEN|409/);
+  });
+
+  it('rejects whitespace-only names locally without contacting the daemon', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', {
+      name: '   ',
+    });
+
+    expect(result).toMatchObject({ isError: true });
+    expect(firstText(result)).toContain('name is required');
+    // Whitespace-only input must short-circuit before the HTTP layer
+    // so the agent gets the same fast-fail shape as a missing name.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('primes the project list cache so the new project resolves by name on the same session', async () => {
+    // Use a unique base URL so any leftover cache from sibling tests
+    // cannot bleed into this assertion.
+    const baseUrl = 'http://127.0.0.1:17457';
+    let createdId = '';
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      // 1. Prime the project list cache with one existing project so
+      //    fetchProjectList() stores a non-empty list keyed to baseUrl.
+      if (url === `${baseUrl}/api/projects` && (!init || init.method === undefined || init.method === 'GET')) {
+        return new Response(
+          JSON.stringify({
+            projects: [{ id: '11111111-1111-1111-1111-111111111111', name: 'Alpha' }],
+          }),
+          { status: 200 },
+        );
+      }
+      // 2. create_project for Beta — must NOT trigger a refetch of /api/projects.
+      if (url === `${baseUrl}/api/projects` && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body)) as { id: string; name: string };
+        createdId = body.id;
+        return new Response(
+          JSON.stringify({ project: { id: body.id, name: body.name }, conversationId: 'c' }),
+          { status: 200 },
+        );
+      }
+      // 3. Detail lookup for the newly-created Beta — only reached if
+      //    resolveProjectId() found Beta in the cached list.
+      if (url === `${baseUrl}/api/projects/${createdId}`) {
+        return new Response(
+          JSON.stringify({ project: { id: createdId, name: 'Beta' } }),
+          { status: 200 },
+        );
+      }
+      return new Response('not found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Warm the cache via a substring resolve that requires fetchProjectList().
+    await handleMcpToolCall(baseUrl, 'get_project', { project: 'Alpha' });
+    await handleMcpToolCall(baseUrl, 'create_project', { name: 'Beta' });
+    const after = await handleMcpToolCall(baseUrl, 'get_project', { project: 'Beta' });
+
+    // Beta must resolve without a second GET /api/projects round-trip:
+    // the cached list now contains Beta because createProject pushed it
+    // into projectListCache.
+    const listFetches = fetchMock.mock.calls.filter(
+      ([url, init]) =>
+        url === `${baseUrl}/api/projects` && (!init || init.method === undefined || init.method === 'GET'),
+    );
+    expect(listFetches).toHaveLength(1);
+    expect(after).not.toMatchObject({ isError: true });
+    const body = JSON.parse(firstText(after as { content: Array<{ text: string }> }));
+    expect(body).toMatchObject({ id: createdId, name: 'Beta' });
   });
 });

--- a/apps/daemon/tests/mcp-create-project.test.ts
+++ b/apps/daemon/tests/mcp-create-project.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { handleMcpToolCall } from '../src/mcp.js';
+import { handleMcpToolCall, TOOL_DEFS } from '../src/mcp.js';
 
 const originalFetch = globalThis.fetch;
 
@@ -277,5 +277,36 @@ describe('public MCP create_project (#2356)', () => {
     expect(after).not.toMatchObject({ isError: true });
     const body = JSON.parse(firstText(after as { content: Array<{ text: string }> }));
     expect(body).toMatchObject({ id: createdId, name: 'Beta' });
+  });
+
+  // ---- Schema mirrors implementation (#2404 round-7 review) -------------
+
+  it('advertises each optional argument as `["string", "null"]` so the schema matches what the handler actually accepts', () => {
+    // Round-5 added assertOptionalString in createProject() so a
+    // caller could pass `null` to mean "field omitted", and the
+    // daemon route accepts any skill-like id (bundled
+    // design-templates included). The MCP tool schema needs to
+    // mirror that — a plain `type: 'string'` says null is invalid
+    // and conflicts with the call-time behaviour. Pin the union
+    // shape so a future tweak that narrows it has to update both
+    // sides in lockstep.
+    const def = TOOL_DEFS.find((d) => d.name === 'create_project');
+    if (!def) throw new Error('create_project tool is missing from TOOL_DEFS');
+    const props = (def.inputSchema.properties ?? {}) as Record<string, { type: unknown; description: unknown }>;
+    for (const field of ['skillId', 'designSystemId', 'pendingPrompt', 'customInstructions']) {
+      expect(props[field]?.type).toEqual(['string', 'null']);
+    }
+  });
+
+  it('the skillId description names design-templates so the contract reflects the actual resolver source-of-truth', () => {
+    // The daemon route validates skillId against listAllSkillLikeEntries(),
+    // which spans skills/ + design-templates/ + user-imported roots.
+    // Round-4 hardened the route to accept a bundled `dashboard`
+    // template id; the schema description here must not still tell
+    // agents skillId only matches od://skills/.
+    const def = TOOL_DEFS.find((d) => d.name === 'create_project');
+    if (!def) throw new Error('create_project tool is missing from TOOL_DEFS');
+    const props = (def.inputSchema.properties ?? {}) as Record<string, { type: unknown; description: unknown }>;
+    expect(String(props.skillId?.description ?? '')).toMatch(/design-templates/);
   });
 });

--- a/apps/daemon/tests/mcp-create-project.test.ts
+++ b/apps/daemon/tests/mcp-create-project.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { handleMcpToolCall } from '../src/mcp.js';
+
+const originalFetch = globalThis.fetch;
+
+function firstText(result: { content: Array<{ text: string }> }): string {
+  const item = result.content[0];
+  if (!item) throw new Error('expected MCP text content');
+  return item.text;
+}
+
+// Coding agents driving Open Design through MCP can inspect existing
+// projects but cannot create one (issue #2356). The `create_project`
+// tool fixes that gap so the very first turn of an agent-driven session
+// no longer requires the user to click "New project" in the desktop UI.
+describe('public MCP create_project (#2356)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('posts a minimal project with an auto-generated UUID id', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      // Daemon CreateProjectResponse: { project, conversationId }.
+      const requestBody = JSON.parse(String(init?.body));
+      return new Response(
+        JSON.stringify({
+          project: { id: requestBody.id, name: requestBody.name },
+          conversationId: 'conv-1',
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', {
+      name: 'Agent-built deck',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0]!;
+    expect(calledUrl).toBe('http://127.0.0.1:17456/api/projects');
+    expect(calledInit?.method).toBe('POST');
+    expect(calledInit?.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    const sent = JSON.parse(String(calledInit?.body));
+    expect(sent.name).toBe('Agent-built deck');
+    // The MCP layer is responsible for minting a stable id so callers
+    // never have to invent one; the daemon route requires it.
+    expect(typeof sent.id).toBe('string');
+    expect(sent.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+
+    const body = JSON.parse(firstText(result));
+    expect(body).toMatchObject({
+      project: { id: sent.id, name: 'Agent-built deck' },
+      conversationId: 'conv-1',
+    });
+  });
+
+  it('forwards optional skillId, designSystemId, pendingPrompt and customInstructions', async () => {
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            project: { id: 'ignored', name: 'Workshop' },
+            conversationId: 'conv-2',
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', {
+      name: 'Workshop',
+      skillId: 'html-ppt-builder',
+      designSystemId: 'xhs-white-editorial',
+      pendingPrompt: 'Build a 6-page deck about Q3 OKRs.',
+      customInstructions: 'Prefer minimal copy.',
+    });
+
+    const sent = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(sent).toMatchObject({
+      name: 'Workshop',
+      skillId: 'html-ppt-builder',
+      designSystemId: 'xhs-white-editorial',
+      pendingPrompt: 'Build a 6-page deck about Q3 OKRs.',
+      customInstructions: 'Prefer minimal copy.',
+    });
+  });
+
+  it('rejects missing name before posting', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', {});
+
+    expect(result).toMatchObject({ isError: true });
+    expect(firstText(result)).toContain('name is required');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not forward client-controlled metadata or privileged plugin fields', async () => {
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            project: { id: 'pid', name: 'Sandboxed' },
+            conversationId: 'conv-3',
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', {
+      name: 'Sandboxed',
+      // These shouldn't be exposed through the agent tool surface —
+      // baseDir is daemon-rejected, plugin selection is a UI-side
+      // concern, and arbitrary metadata invites schema drift.
+      metadata: { baseDir: '/etc' },
+      pluginId: 'plugin-x',
+      pluginInputs: { foo: 'bar' },
+      appliedPluginSnapshotId: 'snap-1',
+    } as unknown as Record<string, unknown>);
+
+    const sent = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(sent).not.toHaveProperty('metadata');
+    expect(sent).not.toHaveProperty('pluginId');
+    expect(sent).not.toHaveProperty('pluginInputs');
+    expect(sent).not.toHaveProperty('appliedPluginSnapshotId');
+  });
+
+  it('surfaces a friendly error when the daemon rejects the request', async () => {
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({ error: { code: 'BAD_REQUEST', message: 'name required' } }),
+          { status: 400 },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', {
+      name: ' ',
+    });
+
+    expect(result).toMatchObject({ isError: true });
+    // Should expose the daemon's reason rather than a bare HTTP code.
+    expect(firstText(result)).toMatch(/name required|BAD_REQUEST|400/);
+  });
+});

--- a/apps/daemon/tests/mcp-create-project.test.ts
+++ b/apps/daemon/tests/mcp-create-project.test.ts
@@ -101,6 +101,64 @@ describe('public MCP create_project (#2356)', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { field: 'skillId', value: 42 },
+    { field: 'designSystemId', value: {} },
+    { field: 'pendingPrompt', value: ['nope'] },
+    { field: 'customInstructions', value: true },
+  ])(
+    'rejects wrong-type optional argument `$field` at the MCP boundary instead of silently dropping it (#2404 round-5 review)',
+    async ({ field, value }) => {
+      // The previous `typeof === 'string'` filter let an MCP caller
+      // send e.g. `skillId: 42` and still get a 200 from POST
+      // /api/projects with the field missing — a project that looked
+      // successfully created but was missing the requested pinned
+      // skill / design system / instructions. Fast-fail at the tool
+      // boundary so the caller sees the type mismatch and can fix it.
+      const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response('{}', { status: 200 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', {
+        name: 'Typed',
+        [field]: value,
+      });
+
+      expect(result).toMatchObject({ isError: true });
+      expect(firstText(result)).toMatch(new RegExp(`${field} must be a string`));
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it('still accepts null / undefined for optional arguments (treated as "no value")', async () => {
+    // Regression guard for the new fast-fail: null and undefined are
+    // legitimate "field omitted" shapes and must keep their no-op
+    // semantics so callers that explicitly null-out a field still
+    // create a project.
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({ project: { id: 'pid', name: 'Sparse' }, conversationId: 'conv-n' }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', {
+      name: 'Sparse',
+      skillId: null,
+      designSystemId: undefined,
+      pendingPrompt: null,
+      customInstructions: undefined,
+    });
+
+    expect(result).not.toMatchObject({ isError: true });
+    const sent = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(sent.skillId).toBeUndefined();
+    expect(sent.designSystemId).toBeUndefined();
+    expect(sent.pendingPrompt).toBeUndefined();
+    expect(sent.customInstructions).toBeUndefined();
+  });
+
   it('does not forward client-controlled metadata or privileged plugin fields', async () => {
     const fetchMock = vi.fn(
       async (_url: string, _init?: RequestInit) =>

--- a/apps/daemon/tests/project-skill-id-validation.test.ts
+++ b/apps/daemon/tests/project-skill-id-validation.test.ts
@@ -266,4 +266,93 @@ describe('skillId validation on POST/PATCH /api/projects (#2404)', () => {
     const resp = await patchProject(id, { customInstructions: 'something' });
     expect(resp.status).toBe(200);
   });
+
+  // ---- pendingPrompt type guards (#2404 round-6 review) ------------------
+
+  it('POST rejects a non-string non-null pendingPrompt so contract types stay honored', async () => {
+    // pendingPrompt is contract-typed `string | null` and the web
+    // calls `project?.pendingPrompt?.trim()`. Wrong-type values must
+    // fail at the route boundary, not at next render.
+    const id = uniqueId('project-bad-pending-prompt');
+    const resp = await createProject({ id, name: 'Bad pending prompt', pendingPrompt: 42 });
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error?: { code?: string; message?: string } };
+    expect(body.error?.code).toBe('BAD_REQUEST');
+    expect(body.error?.message).toMatch(/pendingPrompt/);
+  });
+
+  it('PATCH rejects a non-string non-null pendingPrompt', async () => {
+    const id = uniqueId('project-patch-bad-pending-prompt');
+    const create = await createProject({ id, name: 'Patch bad pending prompt' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { pendingPrompt: { not: 'a string' } });
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error?: { code?: string; message?: string } };
+    expect(body.error?.code).toBe('BAD_REQUEST');
+    expect(body.error?.message).toMatch(/pendingPrompt/);
+  });
+
+  it('PATCH accepts a null pendingPrompt — caller can clear the pending prompt', async () => {
+    const id = uniqueId('project-patch-null-pending-prompt');
+    const create = await createProject({ id, name: 'Patch null pp', pendingPrompt: 'something' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { pendingPrompt: null });
+    expect(resp.status).toBe(200);
+  });
+
+  // ---- name guard on PATCH (#2404 round-6 review) ------------------------
+
+  it('PATCH rejects a non-string name so `project.name.trim()` consumers never see a number/object', async () => {
+    const id = uniqueId('project-patch-bad-name-type');
+    const create = await createProject({ id, name: 'Original' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { name: 42 });
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error?: { code?: string; message?: string } };
+    expect(body.error?.code).toBe('BAD_REQUEST');
+    expect(body.error?.message).toMatch(/name/);
+  });
+
+  it('PATCH rejects a whitespace-only name to keep the POST invariant', async () => {
+    const id = uniqueId('project-patch-blank-name');
+    const create = await createProject({ id, name: 'Original' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { name: '   ' });
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error?: { code?: string; message?: string } };
+    expect(body.error?.code).toBe('BAD_REQUEST');
+    expect(body.error?.message).toMatch(/name/);
+  });
+
+  it('PATCH accepts and trims a valid name so the stored value matches the POST shape', async () => {
+    const id = uniqueId('project-patch-good-name');
+    const create = await createProject({ id, name: 'Old name' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { name: '  Renamed  ' });
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { project?: { name?: string } };
+    expect(body.project?.name).toBe('Renamed');
+  });
+
+  it('PATCH leaves the project name untouched when the body omits the field — only validated when explicitly included', async () => {
+    const id = uniqueId('project-patch-no-name-field');
+    const create = await createProject({ id, name: 'Untouched' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { customInstructions: 'edit' });
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { project?: { name?: string } };
+    expect(body.project?.name).toBe('Untouched');
+  });
 });

--- a/apps/daemon/tests/project-skill-id-validation.test.ts
+++ b/apps/daemon/tests/project-skill-id-validation.test.ts
@@ -71,6 +71,13 @@ describe('skillId validation on POST/PATCH /api/projects (#2404)', () => {
     });
   }
 
+  async function getProjectSkillId(id: string): Promise<unknown> {
+    const resp = await fetch(`${baseUrl}/api/projects/${encodeURIComponent(id)}`);
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { project?: { skillId?: unknown } };
+    return body.project?.skillId;
+  }
+
   it('POST rejects an unknown skillId with SKILL_NOT_FOUND so callers fail fast at create time', async () => {
     const id = uniqueId('project-bad-skill');
     const resp = await createProject({ id, name: 'Bad skill', skillId: 'missing-skill' });
@@ -103,25 +110,42 @@ describe('skillId validation on POST/PATCH /api/projects (#2404)', () => {
     projectsToClean.push(id);
   });
 
-  it('POST accepts null skillId — keeps the existing "no skill pinned" semantics', async () => {
+  it('POST stores `null` when skillId is explicitly null', async () => {
     const id = uniqueId('project-null-skill');
     const resp = await createProject({ id, name: 'Null skill', skillId: null });
     expect(resp.status).toBe(200);
     projectsToClean.push(id);
+    expect(await getProjectSkillId(id)).toBeNull();
   });
 
-  it('POST accepts an omitted skillId — keeps the existing "no skill pinned" semantics', async () => {
+  it('POST stores `null` when skillId is omitted', async () => {
     const id = uniqueId('project-no-skill');
     const resp = await createProject({ id, name: 'No skill' });
     expect(resp.status).toBe(200);
     projectsToClean.push(id);
+    expect(await getProjectSkillId(id)).toBeNull();
   });
 
-  it('POST accepts an empty-string skillId — treated the same as null/omitted', async () => {
+  it('POST normalizes an empty-string skillId to `null` so the project row never carries an empty-string sentinel (#2404 round-4 review)', async () => {
+    // The route used to write `skillId: skillId ?? null`, so a request
+    // with `skillId: ''` returned 200 and silently persisted the
+    // empty string. The shared validator now collapses '' to null
+    // and the route persists that canonical value instead.
     const id = uniqueId('project-empty-skill');
     const resp = await createProject({ id, name: 'Empty skill', skillId: '' });
     expect(resp.status).toBe(200);
     projectsToClean.push(id);
+    expect(await getProjectSkillId(id)).toBeNull();
+  });
+
+  it('POST stores a valid skill id verbatim', async () => {
+    // Sanity: normalization only kicks in for the empty-string sentinel;
+    // a real skill id reaches the row unchanged.
+    const id = uniqueId('project-template-skill-stored');
+    const resp = await createProject({ id, name: 'Template skill stored', skillId: 'dashboard' });
+    expect(resp.status).toBe(200);
+    projectsToClean.push(id);
+    expect(await getProjectSkillId(id)).toBe('dashboard');
   });
 
   it('PATCH rejects an unknown skillId with SKILL_NOT_FOUND — closes the bypass that lets callers create then patch in a bad id', async () => {
@@ -173,6 +197,25 @@ describe('skillId validation on POST/PATCH /api/projects (#2404)', () => {
 
     const resp = await patchProject(id, { skillId: null });
     expect(resp.status).toBe(200);
+    expect(await getProjectSkillId(id)).toBeNull();
+  });
+
+  it('PATCH normalizes an empty-string skillId to `null` (#2404 round-4 review)', async () => {
+    // PATCH previously forwarded patch.skillId straight into
+    // updateProject() with no normalization, so a `skillId: ''`
+    // patch returned 200 and stored '' over a real skill id —
+    // re-opening the inconsistent-row case from the POST side.
+    // The validator's canonical value now flows back into patch.skillId
+    // before persistence.
+    const id = uniqueId('project-patch-empty-skill');
+    const create = await createProject({ id, name: 'Patch empty skill', skillId: 'dashboard' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+    expect(await getProjectSkillId(id)).toBe('dashboard');
+
+    const resp = await patchProject(id, { skillId: '' });
+    expect(resp.status).toBe(200);
+    expect(await getProjectSkillId(id)).toBeNull();
   });
 
   it('PATCH leaves skillId untouched when the patch body omits the field — only validated when explicitly included', async () => {

--- a/apps/daemon/tests/project-skill-id-validation.test.ts
+++ b/apps/daemon/tests/project-skill-id-validation.test.ts
@@ -1,16 +1,26 @@
-// Route-level guard for POST /api/projects' `skillId`.
+// Route-level guard for `skillId` on POST and PATCH /api/projects.
 //
-// Before this commit, the create route persisted skillId as-is without
-// checking that it referenced a real skill in SKILLS_DIR. A typo on
-// the web UI / CLI / MCP create_project tool would return 200, store
-// the bad id on the project row, and then silently fall through
-// `findSkillById(...)` at run-startup time — leaving the project with
-// no pinned skill and no error to the caller (issue #2404 review on
-// PR #2404).
+// Two regressions live here:
 //
-// The fix mirrors how designSystemId is already validated: unknown
-// ids reject with `SKILL_NOT_FOUND` (400). null/undefined/'' keep the
-// "no skill pinned" semantics.
+// 1. POST used to persist skillId as-is without checking against any
+//    skill source-of-truth. A typo from the web UI / CLI / MCP
+//    create_project tool returned 200, stored the bad id on the row,
+//    and then silently fell through `findSkillById(...)` at
+//    run-startup time — leaving the project with no pinned skill and
+//    no error to the caller (#2404).
+// 2. PATCH /api/projects/:id forwarded `patch` straight into
+//    `updateProject(db, id, patch)` without any skillId check, so a
+//    caller could create a project cleanly and then re-open the same
+//    silent-drop path by patching `skillId: missing-skill` (#2404
+//    reviewer follow-up).
+//
+// The fix shares one helper across POST and PATCH and validates
+// against `listAllSkillLikeEntries()` — the same source-of-truth the
+// daemon uses at run-startup to resolve `project.skillId` — so the
+// guard accepts every id the runtime would, including bundled
+// `design-templates/*` ids and user-imported skill ids. Narrower
+// validation (e.g. `listSkills(SKILLS_DIR)`) would falsely reject
+// legitimate template targets.
 
 import type http from 'node:http';
 import { randomUUID } from 'node:crypto';
@@ -18,7 +28,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
 
-describe('POST /api/projects skillId validation (#2404)', () => {
+describe('skillId validation on POST/PATCH /api/projects (#2404)', () => {
   let server: http.Server;
   let baseUrl: string;
   const projectsToClean: string[] = [];
@@ -53,7 +63,15 @@ describe('POST /api/projects skillId validation (#2404)', () => {
     });
   }
 
-  it('rejects an unknown skillId with SKILL_NOT_FOUND so callers fail fast at create time', async () => {
+  async function patchProject(id: string, body: Record<string, unknown>) {
+    return fetch(`${baseUrl}/api/projects/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('POST rejects an unknown skillId with SKILL_NOT_FOUND so callers fail fast at create time', async () => {
     const id = uniqueId('project-bad-skill');
     const resp = await createProject({ id, name: 'Bad skill', skillId: 'missing-skill' });
     expect(resp.status).toBe(400);
@@ -62,7 +80,7 @@ describe('POST /api/projects skillId validation (#2404)', () => {
     expect(body.error?.message).toMatch(/skill not found/i);
   });
 
-  it('rejects non-string skillId values', async () => {
+  it('POST rejects non-string skillId values', async () => {
     const id = uniqueId('project-bad-skill-type');
     const resp = await createProject({ id, name: 'Bad skill type', skillId: 42 });
     expect(resp.status).toBe(400);
@@ -71,24 +89,103 @@ describe('POST /api/projects skillId validation (#2404)', () => {
     expect(body.error?.message).toMatch(/skillId/i);
   });
 
-  it('accepts null skillId — keeps the existing "no skill pinned" semantics', async () => {
+  it('POST accepts a bundled design-template id (#2404 reviewer follow-up — the guard must not be narrower than the runtime resolver)', async () => {
+    // `dashboard` lives under `design-templates/`, not `skills/`. The
+    // runtime resolves `project.skillId` through
+    // `listAllSkillLikeEntries()`, which spans both directories plus
+    // user-imported roots; the route guard must agree. Before this
+    // follow-up the guard called `listSkills(SKILLS_DIR)` and
+    // rejected this id as `SKILL_NOT_FOUND` even though the rest of
+    // the daemon would happily resolve it.
+    const id = uniqueId('project-template-skill');
+    const resp = await createProject({ id, name: 'Template skill', skillId: 'dashboard' });
+    expect(resp.status).toBe(200);
+    projectsToClean.push(id);
+  });
+
+  it('POST accepts null skillId — keeps the existing "no skill pinned" semantics', async () => {
     const id = uniqueId('project-null-skill');
     const resp = await createProject({ id, name: 'Null skill', skillId: null });
     expect(resp.status).toBe(200);
     projectsToClean.push(id);
   });
 
-  it('accepts an omitted skillId — keeps the existing "no skill pinned" semantics', async () => {
+  it('POST accepts an omitted skillId — keeps the existing "no skill pinned" semantics', async () => {
     const id = uniqueId('project-no-skill');
     const resp = await createProject({ id, name: 'No skill' });
     expect(resp.status).toBe(200);
     projectsToClean.push(id);
   });
 
-  it('accepts an empty-string skillId — treated the same as null/omitted', async () => {
+  it('POST accepts an empty-string skillId — treated the same as null/omitted', async () => {
     const id = uniqueId('project-empty-skill');
     const resp = await createProject({ id, name: 'Empty skill', skillId: '' });
     expect(resp.status).toBe(200);
     projectsToClean.push(id);
+  });
+
+  it('PATCH rejects an unknown skillId with SKILL_NOT_FOUND — closes the bypass that lets callers create then patch in a bad id', async () => {
+    // Create cleanly, then try to patch in a bad skillId. Without
+    // the shared guard the patch would 200 and persist the typo,
+    // re-opening the silent-drop path the POST fix closes.
+    const id = uniqueId('project-patch-bad-skill');
+    const create = await createProject({ id, name: 'Patch bad skill' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { skillId: 'missing-skill' });
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error?: { code?: string; message?: string } };
+    expect(body.error?.code).toBe('SKILL_NOT_FOUND');
+    expect(body.error?.message).toMatch(/skill not found/i);
+  });
+
+  it('PATCH rejects non-string skillId values', async () => {
+    const id = uniqueId('project-patch-bad-skill-type');
+    const create = await createProject({ id, name: 'Patch bad skill type' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { skillId: 42 });
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error?: { code?: string; message?: string } };
+    expect(body.error?.code).toBe('BAD_REQUEST');
+    expect(body.error?.message).toMatch(/skillId/i);
+  });
+
+  it('PATCH accepts a bundled design-template id, mirroring POST', async () => {
+    const id = uniqueId('project-patch-template-skill');
+    const create = await createProject({ id, name: 'Patch template skill' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { skillId: 'dashboard' });
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { project?: { skillId?: string } };
+    expect(body.project?.skillId).toBe('dashboard');
+  });
+
+  it('PATCH accepts null skillId — caller can clear the pinned skill', async () => {
+    const id = uniqueId('project-patch-null-skill');
+    const create = await createProject({ id, name: 'Patch null skill', skillId: 'dashboard' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { skillId: null });
+    expect(resp.status).toBe(200);
+  });
+
+  it('PATCH leaves skillId untouched when the patch body omits the field — only validated when explicitly included', async () => {
+    // Regression guard: the helper must be invoked only when
+    // `Object.prototype.hasOwnProperty.call(patch, 'skillId')` so
+    // unrelated metadata patches (e.g. customInstructions edits)
+    // never trip the validator.
+    const id = uniqueId('project-patch-no-skill-field');
+    const create = await createProject({ id, name: 'Patch other field' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { customInstructions: 'something' });
+    expect(resp.status).toBe(200);
   });
 });

--- a/apps/daemon/tests/project-skill-id-validation.test.ts
+++ b/apps/daemon/tests/project-skill-id-validation.test.ts
@@ -1,0 +1,94 @@
+// Route-level guard for POST /api/projects' `skillId`.
+//
+// Before this commit, the create route persisted skillId as-is without
+// checking that it referenced a real skill in SKILLS_DIR. A typo on
+// the web UI / CLI / MCP create_project tool would return 200, store
+// the bad id on the project row, and then silently fall through
+// `findSkillById(...)` at run-startup time — leaving the project with
+// no pinned skill and no error to the caller (issue #2404 review on
+// PR #2404).
+//
+// The fix mirrors how designSystemId is already validated: unknown
+// ids reject with `SKILL_NOT_FOUND` (400). null/undefined/'' keep the
+// "no skill pinned" semantics.
+
+import type http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+describe('POST /api/projects skillId validation (#2404)', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  const projectsToClean: string[] = [];
+
+  beforeAll(async () => {
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+  });
+
+  afterAll(async () => {
+    for (const id of projectsToClean.splice(0)) {
+      await fetch(`${baseUrl}/api/projects/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+      }).catch(() => {});
+    }
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  function uniqueId(prefix: string): string {
+    return `${prefix}-${randomUUID()}`;
+  }
+
+  async function createProject(body: Record<string, unknown>) {
+    return fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('rejects an unknown skillId with SKILL_NOT_FOUND so callers fail fast at create time', async () => {
+    const id = uniqueId('project-bad-skill');
+    const resp = await createProject({ id, name: 'Bad skill', skillId: 'missing-skill' });
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error?: { code?: string; message?: string } };
+    expect(body.error?.code).toBe('SKILL_NOT_FOUND');
+    expect(body.error?.message).toMatch(/skill not found/i);
+  });
+
+  it('rejects non-string skillId values', async () => {
+    const id = uniqueId('project-bad-skill-type');
+    const resp = await createProject({ id, name: 'Bad skill type', skillId: 42 });
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error?: { code?: string; message?: string } };
+    expect(body.error?.code).toBe('BAD_REQUEST');
+    expect(body.error?.message).toMatch(/skillId/i);
+  });
+
+  it('accepts null skillId — keeps the existing "no skill pinned" semantics', async () => {
+    const id = uniqueId('project-null-skill');
+    const resp = await createProject({ id, name: 'Null skill', skillId: null });
+    expect(resp.status).toBe(200);
+    projectsToClean.push(id);
+  });
+
+  it('accepts an omitted skillId — keeps the existing "no skill pinned" semantics', async () => {
+    const id = uniqueId('project-no-skill');
+    const resp = await createProject({ id, name: 'No skill' });
+    expect(resp.status).toBe(200);
+    projectsToClean.push(id);
+  });
+
+  it('accepts an empty-string skillId — treated the same as null/omitted', async () => {
+    const id = uniqueId('project-empty-skill');
+    const resp = await createProject({ id, name: 'Empty skill', skillId: '' });
+    expect(resp.status).toBe(200);
+    projectsToClean.push(id);
+  });
+});

--- a/apps/daemon/tests/project-skill-id-validation.test.ts
+++ b/apps/daemon/tests/project-skill-id-validation.test.ts
@@ -148,6 +148,28 @@ describe('skillId validation on POST/PATCH /api/projects (#2404)', () => {
     expect(await getProjectSkillId(id)).toBe('dashboard');
   });
 
+  it('POST canonicalizes a deprecated skill alias before persistence (#2404 round-5 review)', async () => {
+    // `SKILL_ID_ALIASES` in apps/daemon/src/skills.ts forwards
+    // `editorial-collage-deck → open-design-landing-deck` (and
+    // `editorial-collage → open-design-landing`) for runtime
+    // composition, but the web does direct `project.skillId === s.id`
+    // comparisons in ProjectView.tsx for the skill chip + deck-mode
+    // detection. Persisting the raw alias used to leave the UI
+    // showing "no skill pinned" / no deck mode even though runtime
+    // composition still resolved the alias. The validator now
+    // returns the canonical id and the route persists that, so
+    // on-disk state matches what the runtime composes against.
+    const id = uniqueId('project-aliased-skill');
+    const resp = await createProject({
+      id,
+      name: 'Aliased skill',
+      skillId: 'editorial-collage-deck',
+    });
+    expect(resp.status).toBe(200);
+    projectsToClean.push(id);
+    expect(await getProjectSkillId(id)).toBe('open-design-landing-deck');
+  });
+
   it('PATCH rejects an unknown skillId with SKILL_NOT_FOUND — closes the bypass that lets callers create then patch in a bad id', async () => {
     // Create cleanly, then try to patch in a bad skillId. Without
     // the shared guard the patch would 200 and persist the typo,
@@ -198,6 +220,19 @@ describe('skillId validation on POST/PATCH /api/projects (#2404)', () => {
     const resp = await patchProject(id, { skillId: null });
     expect(resp.status).toBe(200);
     expect(await getProjectSkillId(id)).toBeNull();
+  });
+
+  it('PATCH canonicalizes a deprecated skill alias before persistence (#2404 round-5 review)', async () => {
+    const id = uniqueId('project-patch-aliased-skill');
+    const create = await createProject({ id, name: 'Patch aliased skill' });
+    expect(create.status).toBe(200);
+    projectsToClean.push(id);
+
+    const resp = await patchProject(id, { skillId: 'editorial-collage' });
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { project?: { skillId?: string } };
+    expect(body.project?.skillId).toBe('open-design-landing');
+    expect(await getProjectSkillId(id)).toBe('open-design-landing');
   });
 
   it('PATCH normalizes an empty-string skillId to `null` (#2404 round-4 review)', async () => {

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -55,8 +55,12 @@ export async function createProject(input: {
   name: string;
   skillId: string | null;
   designSystemId: string | null;
-  pendingPrompt?: string;
+  // Mirrors `CreateProjectRequest` in `@open-design/contracts`: both
+  // fields accept `null` as the canonical "no value" shape that the
+  // daemon route and the MCP create_project tool already use.
+  pendingPrompt?: string | null;
   metadata?: ProjectMetadata;
+  customInstructions?: string | null;
   // Plan §3.A1 / spec §11.5 — POST /api/projects accepts a pluginId
   // (or pre-applied snapshot id) to resolve and pin a plugin to the new
   // project. Used by the PluginLoopHome flow on Home.

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -8,6 +8,8 @@
 import type {
   AppliedPluginSnapshot,
   ApplyResult,
+  CreateProjectRequest,
+  CreateProjectResponse,
   CreatePluginShareProjectResponse,
   ImportFolderRequest,
   ImportFolderResponse,
@@ -22,7 +24,6 @@ import type {
   Conversation,
   OpenTabsState,
   Project,
-  ProjectMetadata,
   ProjectTemplate,
 } from '../types';
 
@@ -51,23 +52,7 @@ export async function getProject(id: string): Promise<Project | null> {
   }
 }
 
-export async function createProject(input: {
-  name: string;
-  skillId: string | null;
-  designSystemId: string | null;
-  // Mirrors `CreateProjectRequest` in `@open-design/contracts`: both
-  // fields accept `null` as the canonical "no value" shape that the
-  // daemon route and the MCP create_project tool already use.
-  pendingPrompt?: string | null;
-  metadata?: ProjectMetadata;
-  customInstructions?: string | null;
-  // Plan §3.A1 / spec §11.5 — POST /api/projects accepts a pluginId
-  // (or pre-applied snapshot id) to resolve and pin a plugin to the new
-  // project. Used by the PluginLoopHome flow on Home.
-  pluginId?: string;
-  appliedPluginSnapshotId?: string;
-  pluginInputs?: Record<string, unknown>;
-}): Promise<{ project: Project; conversationId: string; appliedPluginSnapshotId?: string } | null> {
+export async function createProject(input: CreateProjectRequest): Promise<CreateProjectResponse | null> {
   try {
     // `randomUUID` falls back to `crypto.getRandomValues` / `Math.random`
     // when `crypto.randomUUID` is unavailable. Open Design served over
@@ -82,11 +67,7 @@ export async function createProject(input: {
       body: JSON.stringify({ id, ...input }),
     });
     if (!resp.ok) return null;
-    return (await resp.json()) as {
-      project: Project;
-      conversationId: string;
-      appliedPluginSnapshotId?: string;
-    };
+    return (await resp.json()) as CreateProjectResponse;
   } catch {
     return null;
   }

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -1,13 +1,68 @@
+import type { CreateProjectRequest } from '@open-design/contracts';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   applyPlugin,
   contributeGeneratedPluginToOpenDesign,
+  createProject,
   createPluginShareProject,
   importFolderProject,
   installGeneratedPluginFolder,
   listPlugins,
   publishGeneratedPluginToGitHub,
 } from '../../src/state/projects';
+
+describe('createProject', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('accepts and forwards the shared CreateProjectRequest shape', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({
+        project: {
+          id: 'project-1',
+          name: 'Agent project',
+          skillId: null,
+          designSystemId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          pendingPrompt: null,
+          metadata: { skipDiscoveryBrief: true },
+          customInstructions: null,
+        },
+        conversationId: 'conversation-1',
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const input: CreateProjectRequest = {
+      name: 'Agent project',
+      pendingPrompt: null,
+      customInstructions: null,
+      skipDiscoveryBrief: true,
+    };
+
+    const result = await createProject(input);
+
+    expect(result).toMatchObject({
+      project: { id: 'project-1' },
+      conversationId: 'conversation-1',
+    });
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(init?.method).toBe('POST');
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      name: 'Agent project',
+      pendingPrompt: null,
+      customInstructions: null,
+      skipDiscoveryBrief: true,
+    });
+    expect(body).toHaveProperty('id');
+    expect(body).not.toHaveProperty('skillId');
+    expect(body).not.toHaveProperty('designSystemId');
+  });
+});
 
 describe('applyPlugin', () => {
   afterEach(() => {

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -207,12 +207,18 @@ export interface CreateProjectRequest {
   name: string;
   skillId?: string | null;
   designSystemId?: string | null;
-  pendingPrompt?: string;
+  // The daemon route accepts `null` as "no value" for both fields
+  // and the MCP create_project tool advertises the same shape
+  // (apps/daemon/src/mcp.ts). Keep create and update aligned —
+  // UpdateProjectRequest below has always carried the union — so
+  // typed callers can express the same request MCP clients do
+  // (#2404 round-7 reviewer follow-up).
+  pendingPrompt?: string | null;
   metadata?: ProjectMetadata;
   pluginId?: string;
   appliedPluginSnapshotId?: string;
   pluginInputs?: Record<string, unknown>;
-  customInstructions?: string;
+  customInstructions?: string | null;
   /** Persisted to metadata.skipDiscoveryBrief for automated project runs. */
   skipDiscoveryBrief?: boolean;
 }

--- a/packages/contracts/tests/projects-request.test.ts
+++ b/packages/contracts/tests/projects-request.test.ts
@@ -1,0 +1,52 @@
+// Contract-level pinning for the `CreateProjectRequest` shape (#2404
+// round-7 reviewer follow-up). Both `pendingPrompt` and
+// `customInstructions` must accept `null` so the typed HTTP caller in
+// `apps/web/src/state/projects.ts` and the MCP `create_project` tool
+// (`apps/daemon/src/mcp.ts`) can express the same request shape
+// without casts. UpdateProjectRequest has always carried the union;
+// the create side was lagging and produced a contract split visible
+// only at use-site.
+
+import { describe, expect, it } from 'vitest';
+import type {
+  CreateProjectRequest,
+  UpdateProjectRequest,
+} from '../src/api/projects.js';
+
+describe('CreateProjectRequest accepts null for clearable fields (#2404 round-7)', () => {
+  it('pendingPrompt accepts string, null, and omission', () => {
+    // The `as` casts here are about pinning the shape — any future
+    // narrowing of the union (back to `string` only, or to a
+    // discriminated tuple, etc.) makes one of these assignments fail
+    // to compile, which is the regression we are guarding against.
+    const withString: CreateProjectRequest = { name: 'x', pendingPrompt: 'go' };
+    const withNull: CreateProjectRequest = { name: 'x', pendingPrompt: null };
+    const omitted: CreateProjectRequest = { name: 'x' };
+    expect(withString.pendingPrompt).toBe('go');
+    expect(withNull.pendingPrompt).toBeNull();
+    expect(omitted.pendingPrompt).toBeUndefined();
+  });
+
+  it('customInstructions accepts string, null, and omission', () => {
+    const withString: CreateProjectRequest = { name: 'x', customInstructions: 'be terse' };
+    const withNull: CreateProjectRequest = { name: 'x', customInstructions: null };
+    const omitted: CreateProjectRequest = { name: 'x' };
+    expect(withString.customInstructions).toBe('be terse');
+    expect(withNull.customInstructions).toBeNull();
+    expect(omitted.customInstructions).toBeUndefined();
+  });
+
+  it('the create and update shapes agree on pendingPrompt / customInstructions nullability', () => {
+    // Use a tiny pair of variables that must remain assignable in
+    // both directions for the field portion that the daemon route
+    // shares. If create ever drops `null` again the second
+    // assignment becomes a type error.
+    const update: Pick<UpdateProjectRequest, 'pendingPrompt' | 'customInstructions'> = {
+      pendingPrompt: null,
+      customInstructions: null,
+    };
+    const create: Pick<CreateProjectRequest, 'pendingPrompt' | 'customInstructions'> = update;
+    expect(create.pendingPrompt).toBeNull();
+    expect(create.customInstructions).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #2356

## Why

Coding agents driving Open Design through MCP can already inspect and extend existing projects (`list_projects`, `get_project`, `get_file`, `create_artifact`, …), but had no way to **start** a new one — every agent-driven session had to begin with the user clicking "New project" in the desktop UI. The issue calls this out as the missing first step of agent-driven Open Design workflows.

## What users will see

External coding agents (Claude Code, Cursor, Zed) connected to the Open Design MCP gain a new write tool:

```
create_project(name, [skillId], [designSystemId], [pendingPrompt], [customInstructions])
```

When called, the MCP server mints a UUID project id (matching what the web "New project" button does in `apps/web/src/state/projects.ts`), POSTs to the existing `POST /api/projects` endpoint, and returns the created project plus seeded conversation. The new project shows up in the user's Open Design sidebar exactly as if they had created it in the UI.

Existing tools and behaviors are unchanged. The MCP `instructions` block is updated to mention `create_project` so agents discover it via `tools/list`.

## Surface area

- [ ] **UI** — no
- [ ] **Keyboard shortcut** — no
- [ ] **CLI / env var** — no (the `od project create` subcommand already covers CLI; this PR only adds the MCP-client surface for the same capability)
- [ ] **API / contract** — no (uses the existing `POST /api/projects` shape; no contract change)
- [x] **Extension point** — new MCP tool definition (the MCP server is the agent-facing extension surface)
- [ ] **i18n keys** — no
- [ ] **New top-level dependency** — no
- [ ] **Default behavior change** — no

## Bug fix verification

This is a feature, not a bug fix, but it follows the TDD shape described in `AGENTS.md` → "Bug follow-up workflow":

- Test path that reproduces the gap: `apps/daemon/tests/mcp-create-project.test.ts`
- Five red specs first (all five failed with `unknown tool: create_project`), then implementation, then all five green. Five behaviors covered:
  1. Posts a minimal project with an auto-generated UUID id.
  2. Forwards optional `skillId` / `designSystemId` / `pendingPrompt` / `customInstructions`.
  3. Rejects missing `name` before posting.
  4. Does **not** forward client-controlled `metadata`, `pluginId`, `pluginInputs`, or `appliedPluginSnapshotId` (those are either daemon-rejected or UI-side concerns; keeping them off the agent surface prevents schema drift and accidental privilege escalation through `metadata.baseDir`).
  5. Surfaces a friendly error when the daemon rejects the request (parses `error.code` / `error.message` instead of leaking a bare HTTP status line).

## Verification

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/mcp-create-project.test.ts` — 5 passed (new file)
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts` — 249 files, 2956 tests passed (no regressions)
- `pnpm guard` — passed
- `pnpm --filter @open-design/daemon typecheck` — passed

## Notes

- The tool returns the daemon's `CreateProjectResponse` shape (`{ project, conversationId, appliedPluginSnapshotId? }`) verbatim, so agent consumers can grab `project.id` and immediately call the other project-scoped MCP tools.
- Description style follows the existing tool-defs convention: one short purpose-line per tool, with `od://` references for related resources.