### PR TITLE
test(platform,sidecar-proto): cover proc-tree, stamp readers, ipc-path validation

### DIFF
--- a/packages/platform/tests/process-tree.test.ts
+++ b/packages/platform/tests/process-tree.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { collectProcessTreePids, type ProcessSnapshot } from "../src/index.js";
+
+function snapshot(pid: number, ppid: number, command = `pid-${pid}`): ProcessSnapshot {
+  return { command, pid, ppid };
+}
+
+describe("collectProcessTreePids", () => {
+  it("returns an empty array when no roots are supplied", () => {
+    expect(collectProcessTreePids([snapshot(100, 1), snapshot(101, 100)], [])).toEqual([]);
+    expect(collectProcessTreePids([], [null, undefined])).toEqual([]);
+  });
+
+  it("returns a single root with no descendants", () => {
+    expect(collectProcessTreePids([snapshot(101, 1)], [100])).toEqual([100]);
+  });
+
+  it("walks two levels of descendants and sorts pids descending", () => {
+    const processes = [
+      snapshot(100, 1),
+      snapshot(200, 100),
+      snapshot(201, 100),
+      snapshot(300, 200),
+    ];
+    expect(collectProcessTreePids(processes, [100])).toEqual([300, 201, 200, 100]);
+  });
+
+  it("returns the root even when no matching ppid exists in the process list", () => {
+    expect(collectProcessTreePids([snapshot(500, 1)], [100])).toEqual([100]);
+  });
+
+  it("dedupes repeated root pids", () => {
+    expect(collectProcessTreePids([snapshot(200, 100)], [100, 100])).toEqual([200, 100]);
+  });
+
+  it("terminates on parent-child cycles instead of looping forever", () => {
+    const processes = [snapshot(100, 200), snapshot(200, 100)];
+    expect(collectProcessTreePids(processes, [100])).toEqual([200, 100]);
+  });
+});

--- a/packages/platform/tests/stamp-read.test.ts
+++ b/packages/platform/tests/stamp-read.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  readFlagValue,
+  readProcessStamp,
+  readProcessStampFromCommand,
+  type ProcessStampContract,
+} from "../src/index.js";
+
+type FakeStamp = {
+  app: "api" | "ui";
+  namespace: string;
+};
+
+const fakeContract: ProcessStampContract<FakeStamp> = {
+  stampFields: ["app", "namespace"],
+  stampFlags: { app: "--fake-app", namespace: "--fake-namespace" },
+  normalizeStamp(input) {
+    const value = input as Partial<FakeStamp>;
+    if (value.app !== "api" && value.app !== "ui") throw new Error("invalid app");
+    if (typeof value.namespace !== "string" || value.namespace.length === 0) throw new Error("invalid namespace");
+    return { app: value.app, namespace: value.namespace };
+  },
+  normalizeStampCriteria(input = {}) {
+    const value = input as Partial<FakeStamp>;
+    return {
+      ...(value.app == null ? {} : { app: value.app }),
+      ...(value.namespace == null ? {} : { namespace: value.namespace }),
+    };
+  },
+};
+
+describe("readFlagValue", () => {
+  it("returns the inline value when the flag is written as --flag=value", () => {
+    expect(readFlagValue(["--name=ui", "--other"], "--name")).toBe("ui");
+  });
+
+  it("returns the next argv element when the flag is written as --flag value", () => {
+    expect(readFlagValue(["--name", "ui", "--other"], "--name")).toBe("ui");
+  });
+
+  it("returns null when the flag is absent", () => {
+    expect(readFlagValue(["--other", "x"], "--name")).toBeNull();
+    expect(readFlagValue([], "--name")).toBeNull();
+  });
+
+  it("returns null when the trailing flag has no value", () => {
+    expect(readFlagValue(["--name"], "--name")).toBeNull();
+  });
+
+  it("does not match a flag that shares only a prefix", () => {
+    expect(readFlagValue(["--namespace=ns"], "--name")).toBeNull();
+  });
+});
+
+describe("readProcessStamp", () => {
+  it("returns the normalized stamp when every flag resolves", () => {
+    const args = ["--fake-app=ui", "--fake-namespace=alpha"];
+    expect(readProcessStamp(args, fakeContract)).toEqual({ app: "ui", namespace: "alpha" });
+  });
+
+  it("returns null when normalizeStamp throws on missing or invalid values", () => {
+    expect(readProcessStamp(["--fake-app=ui"], fakeContract)).toBeNull();
+    expect(readProcessStamp(["--fake-app=bogus", "--fake-namespace=alpha"], fakeContract)).toBeNull();
+    expect(readProcessStamp([], fakeContract)).toBeNull();
+  });
+});
+
+describe("readProcessStampFromCommand", () => {
+  it("splits the command on whitespace before reading flag values", () => {
+    const command = "node ui.js --fake-app=ui --fake-namespace=alpha";
+    expect(readProcessStampFromCommand(command, fakeContract)).toEqual({ app: "ui", namespace: "alpha" });
+  });
+
+  it("returns null when the command line lacks the contract's flags", () => {
+    expect(readProcessStampFromCommand("node ui.js --unrelated=value", fakeContract)).toBeNull();
+  });
+});

--- a/packages/sidecar-proto/tests/ipc-path.test.ts
+++ b/packages/sidecar-proto/tests/ipc-path.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { isWindowsNamedPipePath, normalizeIpcPath } from "../src/index.js";
+
+describe("normalizeIpcPath", () => {
+  it("returns absolute POSIX paths unchanged", () => {
+    expect(normalizeIpcPath("/tmp/open-design/ipc/ns/web.sock")).toBe("/tmp/open-design/ipc/ns/web.sock");
+  });
+
+  it("returns Windows named-pipe paths unchanged without absolute-path checking", () => {
+    expect(normalizeIpcPath("\\\\.\\pipe\\open-design-ns-web")).toBe("\\\\.\\pipe\\open-design-ns-web");
+  });
+
+  it("returns drive-letter absolute Windows paths unchanged", () => {
+    expect(normalizeIpcPath("C:\\Users\\ipc\\web.sock")).toBe("C:\\Users\\ipc\\web.sock");
+  });
+
+  it("throws when the ipc path is not a string", () => {
+    expect(() => normalizeIpcPath(42)).toThrow(/must be a string/);
+    expect(() => normalizeIpcPath(null)).toThrow(/must be a string/);
+    expect(() => normalizeIpcPath(undefined)).toThrow(/must be a string/);
+  });
+
+  it("throws on the empty string", () => {
+    expect(() => normalizeIpcPath("")).toThrow(/must not be empty/);
+  });
+
+  it("throws when the path has leading or trailing whitespace", () => {
+    expect(() => normalizeIpcPath(" /tmp/open-design/ipc/ns/web.sock")).toThrow(/whitespace/);
+    expect(() => normalizeIpcPath("/tmp/open-design/ipc/ns/web.sock\n")).toThrow(/whitespace/);
+  });
+
+  it("throws when the path contains a null byte", () => {
+    expect(() => normalizeIpcPath("/tmp/open-design/ipc/ns/web.sock\0extra")).toThrow(/null bytes/);
+  });
+
+  it("throws when a POSIX path is not absolute", () => {
+    expect(() => normalizeIpcPath("relative/path.sock")).toThrow(/must be absolute/);
+    expect(() => normalizeIpcPath("./web.sock")).toThrow(/must be absolute/);
+  });
+});
+
+describe("isWindowsNamedPipePath", () => {
+  it("returns true for paths starting with \\\\.\\pipe\\", () => {
+    expect(isWindowsNamedPipePath("\\\\.\\pipe\\open-design-ns-web")).toBe(true);
+    expect(isWindowsNamedPipePath("\\\\.\\pipe\\")).toBe(true);
+  });
+
+  it("returns false for POSIX, drive-letter, or non-string inputs", () => {
+    expect(isWindowsNamedPipePath("/tmp/open-design/ipc/ns/web.sock")).toBe(false);
+    expect(isWindowsNamedPipePath("C:\\Users\\ipc\\web.sock")).toBe(false);
+    expect(isWindowsNamedPipePath("\\\\.\\Pipe\\open-design")).toBe(false);
+    expect(isWindowsNamedPipePath(null)).toBe(false);
+    expect(isWindowsNamedPipePath(undefined)).toBe(false);
+    expect(isWindowsNamedPipePath(123)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for previously untested runtime helpers across two related packages:
- `packages/platform`: `collectProcessTreePids` BFS traversal (empty/single-root/multi-level/unreachable-root/dedup) and `readFlagValue` / `readProcessStamp` / `readProcessStampFromCommand` parsing branches.
- `packages/sidecar-proto`: `normalizeIpcPath` validation branches (non-string, empty, whitespace, null-byte, Windows named-pipe pass-through, non-absolute POSIX) and `isWindowsNamedPipePath` detection.

Tests-only — no source changes.

## Validation
- `pnpm --filter @open-design/platform test` — green locally.
- `pnpm --filter @open-design/sidecar-proto test` — green locally.