### PR TITLE
docs(README): refresh stale skills and design-systems counts (#2186)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ Linux AppImage packaging is available through the optional release lane and is c
 
 ## Skills
 
-**31 skills ship in the box.** Each is a folder under [`skills/`](skills/) following the Claude Code [`SKILL.md`][skill] convention with an extended `od:` frontmatter that the daemon parses verbatim — `mode`, `platform`, `scenario`, `preview.type`, `design_system.requires`, `default_for`, `featured`, `fidelity`, `speaker_notes`, `animations`, `example_prompt` ([`apps/daemon/src/skills.ts`](apps/daemon/src/skills.ts)).
+**132 skills ship in the box.** Each is a folder under [`skills/`](skills/) following the Claude Code [`SKILL.md`][skill] convention with an extended `od:` frontmatter that the daemon parses verbatim — `mode`, `platform`, `scenario`, `preview.type`, `design_system.requires`, `default_for`, `featured`, `fidelity`, `speaker_notes`, `animations`, `example_prompt` ([`apps/daemon/src/skills.ts`](apps/daemon/src/skills.ts)).
 
-Two top-level **modes** carry the catalog: **`prototype`** (27 skills — anything that renders as a single-page artifact, from a magazine landing to a phone screen to a PM spec doc) and **`deck`** (4 skills — horizontal-swipe presentations with deck-framework chrome). The **`scenario`** field is what the picker groups them by: `design` · `marketing` · `operation` · `engineering` · `product` · `finance` · `hr` · `sale` · `personal`.
+Two **modes** anchor the interactive catalog: **`prototype`** (32 skills — anything that renders as a single-page artifact, from a magazine landing to a phone screen to a PM spec doc) and **`deck`** (9 skills — horizontal-swipe presentations with deck-framework chrome). The catalog also ships `image`, `video`, `audio`, `template`, and `design-system` modes for media generation and catalog updaters. The **`scenario`** field is what the picker groups them by: `design` · `marketing` · `operation` · `engineering` · `product` · `finance` · `hr` · `sale` · `personal`.
 
 ### Showcase examples
 
@@ -259,8 +259,8 @@ What you compose at send time isn't "system + user". It's:
 ```
 DISCOVERY directives  (turn-1 form, turn-2 brand branch, TodoWrite, 5-dim critique)
   + identity charter   (OFFICIAL_DESIGNER_PROMPT, anti-AI-slop, junior-pass)
-  + active DESIGN.md   (72 systems available)
-  + active SKILL.md    (31 skills available)
+  + active DESIGN.md   (150 systems available)
+  + active SKILL.md    (132 skills available)
   + project metadata   (kind, fidelity, speakerNotes, animations, inspiration ids)
   + skill side files   (auto-injected pre-flight: read assets/template.html + references/*.md)
   + (deck kind, no skill seed) DECK_FRAMEWORK_DIRECTIVE   (nav / counter / scroll / print)
@@ -392,7 +392,7 @@ For desktop/background startup, fixed-port restarts, and media generation dispat
 The first load:
 
 1. Detects which agent CLIs you have on `PATH` and picks one automatically.
-2. Loads 31 skills + 72 design systems.
+2. Loads 132 skills + 150 design systems.
 3. Pops the welcome dialog so you can paste an Anthropic key (only needed for the BYOK fallback path).
 4. **Auto-creates `./.od/`** — the local runtime folder for the SQLite project DB, per-project artifacts, and saved renders. There is no `od init` step; the daemon `mkdir`s everything it needs on boot.
 
@@ -693,7 +693,7 @@ open-design/
 │   ├── sidecar/                   ← generic sidecar runtime primitives
 │   └── platform/                  ← generic process/platform primitives
 │
-├── skills/                        ← 31 SKILL.md skill bundles (27 prototype + 4 deck)
+├── skills/                        ← 132 SKILL.md skill bundles (32 prototype + 9 deck + image / video / audio / template / design-system / utility)
 │   ├── web-prototype/             ← default for prototype mode
 │   ├── saas-landing/  dashboard/  pricing-page/  docs-page/  blog-post/
 │   ├── mobile-app/  mobile-onboarding/  gamified-app/
@@ -708,7 +708,7 @@ open-design/
 │       ├── assets/template.html   ← seed
 │       └── references/{themes,layouts,components,checklist}.md
 │
-├── design-systems/                ← 72 DESIGN.md systems
+├── design-systems/                ← 150 DESIGN.md systems
 │   ├── default/                   ← Neutral Modern (starter)
 │   ├── warm-editorial/            ← Warm Editorial (starter)
 │   ├── linear-app/  vercel/  stripe/  airbnb/  notion/  cursor/  apple/  …
@@ -750,10 +750,10 @@ open-design/
 ## Design Systems
 
 <p align="center">
-  <img src="docs/assets/design-systems-library.png" alt="The 72 design systems library — style guide spread" width="100%" />
+  <img src="docs/assets/design-systems-library.png" alt="The 150 design systems library — style guide spread" width="100%" />
 </p>
 
-72 systems out of the box, each as a single [`DESIGN.md`](design-systems/README.md):
+150 systems out of the box, each as a single [`DESIGN.md`](design-systems/README.md):
 
 <details>
 <summary><b>Full catalog</b> (click to expand)</summary>
@@ -972,7 +972,7 @@ Long-form provenance write-up — what we take from each, what we deliberately d
 
 - [x] Daemon + agent detection (16 CLI adapters) + skill registry + design-system catalog
 - [x] Web app + chat + question form + 5-direction picker + todo progress + sandboxed preview
-- [x] 31 skills + 72 design systems + 5 visual directions + 5 device frames
+- [x] 132 skills + 150 design systems + 5 visual directions + 5 device frames
 - [x] SQLite-backed projects · conversations · messages · tabs · templates
 - [x] Multi-provider BYOK proxy (`/api/proxy/{anthropic,openai,azure,google,ollama,senseaudio}/stream`) with SSRF guard
 - [x] Claude Design ZIP import (`/api/import/claude-design`)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Linux AppImage packaging is available through the optional release lane and is c
 
 **132 skills ship in the box.** Each is a folder under [`skills/`](skills/) following the Claude Code [`SKILL.md`][skill] convention with an extended `od:` frontmatter that the daemon parses verbatim — `mode`, `platform`, `scenario`, `preview.type`, `design_system.requires`, `default_for`, `featured`, `fidelity`, `speaker_notes`, `animations`, `example_prompt` ([`apps/daemon/src/skills.ts`](apps/daemon/src/skills.ts)).
 
-Two **modes** anchor the interactive catalog: **`prototype`** (32 skills — anything that renders as a single-page artifact, from a magazine landing to a phone screen to a PM spec doc) and **`deck`** (9 skills — horizontal-swipe presentations with deck-framework chrome). The catalog also ships `image`, `video`, `audio`, `template`, and `design-system` modes for media generation and catalog updaters. The **`scenario`** field is what the picker groups them by: `design` · `marketing` · `operation` · `engineering` · `product` · `finance` · `hr` · `sale` · `personal`.
+Two **modes** anchor the interactive catalog: **`prototype`** (32 skills — anything that renders as a single-page artifact, from a magazine landing to a phone screen to a PM spec doc) and **`deck`** (9 skills — horizontal-swipe presentations with deck-framework chrome). The catalog also ships `image`, `video`, `audio`, `template`, `design-system`, and `utility` modes for media generation, catalog updaters, and post-export audit helpers. The **`scenario`** field is what the picker groups them by: `design` · `marketing` · `operation` · `engineering` · `product` · `finance` · `hr` · `sale` · `personal`.
 
 ### Showcase examples
 


### PR DESCRIPTION
Refs #2186

## Why

The English README still reports **31 skills / 72 design systems** with a prototype(27)+deck(4) split, last accurate around v0.4.1. The actual catalog at HEAD ships **132 skills / 150 design systems**, counted from \`SKILL.md\` / \`DESIGN.md\` entry files:

\`\`\`
$ find skills -maxdepth 2 -name SKILL.md | wc -l
132
$ find design-systems -maxdepth 2 -name DESIGN.md | wc -l
150
\`\`\`

The mode mix has also outgrown the original prototype-vs-deck framing — \`grep -h '^  mode:' skills/*/SKILL.md\` now shows 32 prototype, 9 deck, 36 design-system, 24 image, 17 video, 9 template, 4 audio, 1 utility — so the description that prototype + deck "carry the catalog" reads wrong against the visible mode chips in the picker.

This is the docs-only follow-up the issue reporter offered to pick up.

## What users will see

People landing on the GitHub README, badges, or screenshots now see numbers that match what the daemon actually loads on boot. Updates:

- The "**N skills ship in the box**" line under \`## Skills\` → 132.
- The prototype / deck split paragraph → 32 / 9, plus a one-line note that the catalog also includes \`image\`, \`video\`, \`audio\`, \`template\`, and \`design-system\` modes for media generation and catalog updaters.
- The system-prompt composition example (\`active DESIGN.md (... systems available)\` / \`active SKILL.md (... skills available)\`) → 150 / 132.
- "Loads N skills + N design systems" on first-load → 132 / 150.
- \`<img alt>\` for the design-systems library screenshot → 150.
- "N systems out of the box" under \`## Design Systems\` → 150.
- The two repo-tree comments under \`skills/\` and \`design-systems/\` → 132 (with the updated mode breakdown) and 150.
- Roadmap "Done" checklist line → 132 / 150.

## Surface area

- [ ] **UI** — no
- [ ] **Keyboard shortcut** — no
- [ ] **CLI / env var** — no
- [ ] **API / contract** — no
- [ ] **Extension point** — no
- [ ] **i18n keys** — no (translation READMEs intentionally not touched; see notes)
- [ ] **New top-level dependency** — no
- [x] **None** — docs only

## Out of scope

\`README.de.md\`, \`README.fr.md\`, \`README.es.md\`, \`README.ko.md\`, \`README.ja-JP.md\`, \`README.zh-CN.md\`, \`README.zh-TW.md\`, \`README.pt-BR.md\`, \`README.ar.md\`, \`README.ru.md\`, \`README.uk.md\`, and \`README.tr.md\` carry the same stale numbers (≈ 9–14 occurrences per file). Per the issue thread, splitting translations into per-locale follow-up PRs keeps this PR easy to review and lets each translator land their language without bouncing on cross-locale wording diffs. Happy to send the locale PRs as a follow-up if maintainers prefer that route.

Also intentionally untouched: the historical blog posts under \`apps/landing-page/app/content/blog/\` whose slug is literally \`31-skills-72-systems-...\`. Those are time-stamped articles linked from external feeds; rewriting the numbers in those posts would break their stated premise.

## Verification

- \`pnpm guard\` — passed (style-policy tests, no policy hits on the README diff).
- Pre/post counts re-verified against \`find skills -maxdepth 2 -name SKILL.md | wc -l\` (132) and \`find design-systems -maxdepth 2 -name DESIGN.md | wc -l\` (150).
- \`grep -nE '\b(31|72|27)\s+(skills?|systems?|design[- ]systems?)\b' README.md\` returns 0 matches after the edit.