### PR TITLE
test(plugin-runtime): cover resolve, claude-plugin adapter, parsers, validate, digest, merge, pipeline-fallback — wire into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,6 +499,7 @@ jobs:
           pnpm --filter @open-design/platform test
           pnpm --filter @open-design/sidecar test
           pnpm --filter @open-design/sidecar-proto test
+          pnpm --filter @open-design/plugin-runtime test
           if [ "${{ needs.scopes.outputs.tools_dev_tests_required }}" = "true" ]; then
             pnpm --filter @open-design/tools-dev test
           fi

--- a/packages/plugin-runtime/tests/claude-plugin-adapter.test.ts
+++ b/packages/plugin-runtime/tests/claude-plugin-adapter.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { adaptClaudePlugin } from '../src/adapters/claude-plugin';
+
+describe('adaptClaudePlugin', () => {
+  it('synthesizes a fallback manifest when the json is unparseable', () => {
+    const result = adaptClaudePlugin('not json', { folderId: 'broken-plugin' });
+    expect(result.manifest.name).toBe('broken-plugin');
+    expect(result.manifest.version).toBe('0.0.0');
+    expect(result.manifest.compat?.claudePlugins?.[0]?.path).toBe('./.claude-plugin/plugin.json');
+    expect(result.warnings.some((w) => w.includes('Failed to parse'))).toBe(true);
+  });
+
+  it('synthesizes a fallback when the JSON is not a plain object', () => {
+    const result = adaptClaudePlugin('[1,2,3]', { folderId: 'array-plugin' });
+    expect(result.manifest.name).toBe('array-plugin');
+    expect(result.warnings).toContain('.claude-plugin/plugin.json must be a JSON object');
+  });
+
+  it('passes through a valid minimal plugin.json', () => {
+    const result = adaptClaudePlugin(
+      JSON.stringify({ name: 'okay', version: '2.3.4', description: 'hi' }),
+      { folderId: 'irrelevant' },
+    );
+    expect(result.manifest.name).toBe('okay');
+    expect(result.manifest.version).toBe('2.3.4');
+    expect(result.manifest.description).toBe('hi');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("defaults version to '0.0.0' when the source omits it", () => {
+    const result = adaptClaudePlugin(JSON.stringify({ name: 'no-version' }), {
+      folderId: 'no-version',
+    });
+    expect(result.manifest.version).toBe('0.0.0');
+  });
+
+  it('sanitizes names with characters outside the OD plugin id pattern', () => {
+    const result = adaptClaudePlugin(
+      JSON.stringify({ name: 'My Plugin!', version: '1.0.0' }),
+      { folderId: 'fallback' },
+    );
+    expect(result.manifest.name).toBe('my-plugin-');
+    expect(
+      result.warnings.some((w) => w.includes("sanitized to 'my-plugin-'")),
+    ).toBe(true);
+  });
+
+  it('falls back to folderId when the sanitized name is empty', () => {
+    const result = adaptClaudePlugin(
+      JSON.stringify({ name: '...', version: '1.0.0' }),
+      { folderId: 'used-as-fallback' },
+    );
+    expect(result.manifest.name).toBe('used-as-fallback');
+  });
+
+  it('warns when the plugin declares commands that v1 apply ignores', () => {
+    const result = adaptClaudePlugin(
+      JSON.stringify({ name: 'with-cmds', version: '1.0.0', commands: [{}, {}, {}] }),
+      { folderId: 'with-cmds' },
+    );
+    expect(result.warnings.some((w) => w.includes('declares 3 command(s)'))).toBe(true);
+  });
+
+  it('honors a custom compatPath when supplied', () => {
+    const result = adaptClaudePlugin(
+      JSON.stringify({ name: 'p', version: '1.0.0' }),
+      { folderId: 'p', compatPath: './nested/.claude-plugin/plugin.json' },
+    );
+    expect(result.manifest.compat?.claudePlugins?.[0]?.path).toBe(
+      './nested/.claude-plugin/plugin.json',
+    );
+  });
+});

--- a/packages/plugin-runtime/tests/digest.test.ts
+++ b/packages/plugin-runtime/tests/digest.test.ts
@@ -73,4 +73,27 @@ describe('manifestSourceDigest', () => {
     });
     expect(a).not.toBe(b);
   });
+
+  it('returns the same digest for two identical invocations', () => {
+    const input = {
+      manifest: baseManifest,
+      inputs: { topic: 'design' },
+      resolvedContextRefs: [{ kind: 'skill', ref: 'sample-plugin' }],
+    };
+    expect(manifestSourceDigest(input)).toBe(manifestSourceDigest(input));
+  });
+
+  it('changes when a resolved context ref changes', () => {
+    const a = manifestSourceDigest({
+      manifest: baseManifest,
+      inputs: {},
+      resolvedContextRefs: [{ kind: 'craft', ref: 'typography' }],
+    });
+    const b = manifestSourceDigest({
+      manifest: baseManifest,
+      inputs: {},
+      resolvedContextRefs: [{ kind: 'craft', ref: 'motion' }],
+    });
+    expect(a).not.toBe(b);
+  });
 });

--- a/packages/plugin-runtime/tests/frontmatter.test.ts
+++ b/packages/plugin-runtime/tests/frontmatter.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { parseFrontmatter } from '../src/parsers/frontmatter';
+
+describe('parseFrontmatter inline arrays', () => {
+  it('parses an inline array of scalars', () => {
+    const { data } = parseFrontmatter('---\ntags: [a, b, c]\n---\n');
+    expect(data['tags']).toEqual(['a', 'b', 'c']);
+  });
+
+  it('coerces typed values inside inline arrays', () => {
+    const { data } = parseFrontmatter('---\nmixed: [1, true, "kept"]\n---\n');
+    expect(data['mixed']).toEqual([1, true, 'kept']);
+  });
+
+  it('parses an empty inline array', () => {
+    const { data } = parseFrontmatter('---\nempty: []\n---\n');
+    expect(data['empty']).toEqual([]);
+  });
+});
+
+describe('parseFrontmatter dash-prefixed arrays', () => {
+  it('parses a dash-array of scalars under a key', () => {
+    const src = '---\ntags:\n  - first\n  - second\n---\n';
+    const { data } = parseFrontmatter(src);
+    expect(data['tags']).toEqual(['first', 'second']);
+  });
+
+  it('parses a dash-array of single-line objects', () => {
+    const src = '---\ninputs:\n  - name: tone\n  - name: audience\n---\n';
+    const { data } = parseFrontmatter(src);
+    expect(data['inputs']).toEqual([{ name: 'tone' }, { name: 'audience' }]);
+  });
+});
+
+describe('parseFrontmatter delimiter handling', () => {
+  it('strips a UTF-8 BOM before the opening delimiter', () => {
+    const src = '﻿---\nname: foo\n---\nbody';
+    const { data, body } = parseFrontmatter(src);
+    expect(data['name']).toBe('foo');
+    expect(body).toBe('body');
+  });
+
+  it('handles CRLF line endings between delimiters', () => {
+    const src = '---\r\nname: foo\r\ndescription: hi\r\n---\r\nbody';
+    const { data, body } = parseFrontmatter(src);
+    expect(data['name']).toBe('foo');
+    expect(data['description']).toBe('hi');
+    expect(body).toBe('body');
+  });
+});
+
+describe('parseFrontmatter coerce primitives', () => {
+  it('coerces booleans, null, and numbers', () => {
+    const src = '---\nyes: true\nno: false\nnone: null\ntilde: ~\nint: 42\nfloat: -1.5\n---\n';
+    const { data } = parseFrontmatter(src);
+    expect(data['yes']).toBe(true);
+    expect(data['no']).toBe(false);
+    expect(data['none']).toBeNull();
+    expect(data['tilde']).toBeNull();
+    expect(data['int']).toBe(42);
+    expect(data['float']).toBe(-1.5);
+  });
+
+  it('preserves quoted strings without re-coercion', () => {
+    const src = '---\nstr1: "true"\nstr2: \'42\'\n---\n';
+    const { data } = parseFrontmatter(src);
+    expect(data['str1']).toBe('true');
+    expect(data['str2']).toBe('42');
+  });
+});
+
+describe('parseFrontmatter nested objects', () => {
+  it('parses a nested scalar block', () => {
+    const src = '---\nod:\n  mode: prototype\n  platform: desktop\n---\n';
+    const { data } = parseFrontmatter(src);
+    expect(data['od']).toEqual({ mode: 'prototype', platform: 'desktop' });
+  });
+});

--- a/packages/plugin-runtime/tests/merge-and-pipeline.test.ts
+++ b/packages/plugin-runtime/tests/merge-and-pipeline.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import type { PluginManifest } from '@open-design/contracts';
 import { mergeManifests } from '../src/merge';
-import { resolveAppliedPipeline, type ScenarioRegistryEntry } from '../src/pipeline-fallback';
+import { resolveAppliedPipeline } from '../src/pipeline-fallback';
+import type { ScenarioRegistryEntry } from '../src/resolve';
 
 describe('mergeManifests compat dedup and emptiness', () => {
   it('dedupes identical compat paths across layers', () => {

--- a/packages/plugin-runtime/tests/merge-and-pipeline.test.ts
+++ b/packages/plugin-runtime/tests/merge-and-pipeline.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { PluginManifest } from '@open-design/contracts';
+import { mergeManifests } from '../src/merge';
+import { resolveAppliedPipeline, type ScenarioRegistryEntry } from '../src/pipeline-fallback';
+
+describe('mergeManifests compat dedup and emptiness', () => {
+  it('dedupes identical compat paths across layers', () => {
+    const sidecar: PluginManifest = {
+      name: 'p',
+      version: '1.0.0',
+      compat: { agentSkills: [{ path: './SKILL.md' }] },
+    };
+    const adapter: PluginManifest = {
+      name: 'p',
+      version: '0.0.0',
+      compat: { agentSkills: [{ path: './SKILL.md' }, { path: './OTHER.md' }] },
+    };
+    const merged = mergeManifests({ sidecar, adapters: [adapter] });
+    expect(merged.compat?.agentSkills?.map((r) => r.path)).toEqual(['./SKILL.md', './OTHER.md']);
+  });
+
+  it('returns merged.compat undefined when no layer declares compat entries', () => {
+    const sidecar: PluginManifest = { name: 'p', version: '1.0.0' };
+    const adapter: PluginManifest = { name: 'p', version: '0.0.0' };
+    const merged = mergeManifests({ sidecar, adapters: [adapter] });
+    expect(merged.compat).toBeUndefined();
+  });
+
+  it('throws when no input layer is supplied', () => {
+    expect(() => mergeManifests({})).toThrow(/at least one input layer/);
+  });
+
+  it('returns the adapter wholesale when no sidecar is supplied', () => {
+    const adapter: PluginManifest = {
+      name: 'only-adapter',
+      version: '1.0.0',
+      description: 'd',
+    };
+    const merged = mergeManifests({ adapters: [adapter] });
+    expect(merged.name).toBe('only-adapter');
+    expect(merged.description).toBe('d');
+  });
+});
+
+describe('resolveAppliedPipeline edges', () => {
+  const scenarios: ScenarioRegistryEntry[] = [
+    {
+      id: 'od-new-generation',
+      taskKind: 'new-generation',
+      pipeline: { stages: [{ id: 'discovery', atoms: ['discovery-question-form'] }] },
+    },
+  ];
+
+  it('ignores a scenario entry whose pipeline has no stages', () => {
+    const broken: ScenarioRegistryEntry[] = [
+      {
+        id: 'broken',
+        taskKind: 'new-generation',
+        pipeline: { stages: [] },
+      },
+      ...scenarios,
+    ];
+    const manifest: PluginManifest = {
+      name: 'p',
+      version: '1.0.0',
+      od: { taskKind: 'new-generation' },
+    };
+    const out = resolveAppliedPipeline({ manifest, scenarios: broken });
+    expect(out.source).toBe('scenario');
+    expect(out.scenarioId).toBe('od-new-generation');
+  });
+
+  it('returns the first matching scenario when several share a taskKind', () => {
+    const competing: ScenarioRegistryEntry[] = [
+      {
+        id: 'first',
+        taskKind: 'new-generation',
+        pipeline: { stages: [{ id: 's', atoms: ['a'] }] },
+      },
+      {
+        id: 'second',
+        taskKind: 'new-generation',
+        pipeline: { stages: [{ id: 's', atoms: ['a'] }] },
+      },
+    ];
+    const manifest: PluginManifest = {
+      name: 'p',
+      version: '1.0.0',
+      od: { taskKind: 'new-generation' },
+    };
+    const out = resolveAppliedPipeline({ manifest, scenarios: competing });
+    expect(out.scenarioId).toBe('first');
+  });
+});

--- a/packages/plugin-runtime/tests/resolve.test.ts
+++ b/packages/plugin-runtime/tests/resolve.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import type { PluginManifest } from '@open-design/contracts';
+import { resolveContext, type RegistryView } from '../src/resolve';
+
+const emptyRegistry: RegistryView = {
+  skills: [],
+  designSystems: [],
+  craft: [],
+  atoms: [],
+};
+
+const fullRegistry: RegistryView = {
+  skills: [
+    { id: 'blog-post', title: 'Blog Post' },
+    { id: 'pitch-deck', title: 'Pitch Deck' },
+  ],
+  designSystems: [{ id: 'linear-clone', title: 'Linear Clone' }],
+  craft: [{ id: 'typography', title: 'Typography' }],
+  atoms: [{ id: 'todo-write', label: 'Todo Write' }],
+};
+
+const baseManifest = (od: PluginManifest['od']): PluginManifest => ({
+  name: 'sample',
+  version: '1.0.0',
+  ...(od ? { od } : {}),
+});
+
+describe('resolveContext', () => {
+  it('returns empty items and refs for a manifest with no od.context', () => {
+    const out = resolveContext(baseManifest(undefined), { registry: emptyRegistry });
+    expect(out.context.items).toEqual([]);
+    expect(out.digestRefs).toEqual([]);
+    expect(out.warnings).toEqual([]);
+  });
+
+  it('resolves skills that exist in the registry', () => {
+    const manifest = baseManifest({
+      context: { skills: [{ ref: 'blog-post' }] },
+    });
+    const out = resolveContext(manifest, { registry: fullRegistry });
+    expect(out.context.items).toEqual([
+      { kind: 'skill', id: 'blog-post', label: 'Blog Post' },
+    ]);
+    expect(out.digestRefs).toEqual([{ kind: 'skill', ref: 'blog-post' }]);
+  });
+
+  it('strips a leading ./ from skill refs before lookup', () => {
+    const manifest = baseManifest({
+      context: { skills: [{ ref: './blog-post' }] },
+    });
+    const out = resolveContext(manifest, { registry: fullRegistry });
+    expect(out.context.items[0]?.id).toBe('blog-post');
+    expect(out.warnings).toEqual([]);
+  });
+
+  it('resolves a design-system by explicit ref', () => {
+    const manifest = baseManifest({
+      context: { designSystem: { ref: 'linear-clone' } },
+    });
+    const out = resolveContext(manifest, { registry: fullRegistry });
+    expect(out.context.items[0]).toMatchObject({
+      kind: 'design-system',
+      id: 'linear-clone',
+      primary: true,
+    });
+  });
+
+  it('falls back to the active project design-system when ref is blank', () => {
+    const manifest = baseManifest({
+      context: { designSystem: { ref: '' } },
+    });
+    const out = resolveContext(manifest, {
+      registry: { ...fullRegistry, activeProjectDesignSystem: { id: 'acme-ds', title: 'Acme' } },
+    });
+    expect(out.context.items[0]).toMatchObject({ kind: 'design-system', id: 'acme-ds' });
+  });
+
+  it('resolves craft slugs against the registry', () => {
+    const manifest = baseManifest({
+      context: { craft: ['typography'] },
+    });
+    const out = resolveContext(manifest, { registry: fullRegistry });
+    expect(out.context.items[0]).toMatchObject({ kind: 'craft', id: 'typography' });
+    expect(out.digestRefs).toContainEqual({ kind: 'craft', ref: 'typography' });
+  });
+
+  it('emits warnings for unknown registry refs when warnOnMissing is set', () => {
+    const manifest = baseManifest({
+      context: {
+        skills: [{ ref: 'missing-skill' }],
+        designSystem: { ref: 'missing-ds' },
+        craft: ['missing-craft'],
+      },
+    });
+    const out = resolveContext(manifest, { registry: fullRegistry, warnOnMissing: true });
+    expect(out.warnings).toEqual([
+      "Unknown skill ref: 'missing-skill'",
+      "Unknown design-system ref: 'missing-ds'",
+      "Unknown craft slug: 'missing-craft'",
+    ]);
+    expect(out.context.items).toEqual([]);
+  });
+
+  it('silently drops unknown refs when warnOnMissing is false', () => {
+    const manifest = baseManifest({
+      context: { skills: [{ ref: 'missing-skill' }] },
+    });
+    const out = resolveContext(manifest, { registry: fullRegistry });
+    expect(out.warnings).toEqual([]);
+    expect(out.context.items).toEqual([]);
+  });
+
+  it('records pipeline-atom refs so distinct pipelines produce distinct digests', () => {
+    const manifest = baseManifest({
+      pipeline: { stages: [{ id: 's1', atoms: ['todo-write'] }] },
+    });
+    const out = resolveContext(manifest, { registry: fullRegistry });
+    expect(out.digestRefs).toEqual([{ kind: 'pipeline-atom', ref: 's1:todo-write' }]);
+  });
+});

--- a/packages/plugin-runtime/tests/resolve.test.ts
+++ b/packages/plugin-runtime/tests/resolve.test.ts
@@ -49,7 +49,7 @@ describe('resolveContext', () => {
       context: { skills: [{ ref: './blog-post' }] },
     });
     const out = resolveContext(manifest, { registry: fullRegistry });
-    expect(out.context.items[0]?.id).toBe('blog-post');
+    expect(out.context.items[0]).toMatchObject({ kind: 'skill', id: 'blog-post' });
     expect(out.warnings).toEqual([]);
   });
 

--- a/packages/plugin-runtime/tests/validate.test.ts
+++ b/packages/plugin-runtime/tests/validate.test.ts
@@ -44,4 +44,70 @@ describe('validateManifest', () => {
     });
     expect(result.ok).toBe(false);
   });
+
+  it('accepts repeat=true together with an until expression', () => {
+    const result = validateManifest({
+      name: 'x',
+      version: '1.0.0',
+      od: {
+        pipeline: {
+          stages: [{ id: 'loop', atoms: ['critique-theater'], repeat: true, until: 'done' }],
+        },
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('does not flag until without repeat', () => {
+    const result = validateManifest({
+      name: 'x',
+      version: '1.0.0',
+      od: { pipeline: { stages: [{ id: 's1', atoms: ['a'], until: 'never' }] } },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('skips the connector cross-check when no connectors are declared', () => {
+    const result = validateManifest({
+      name: 'x',
+      version: '1.0.0',
+      od: {
+        genui: {
+          surfaces: [
+            {
+              id: 's1',
+              kind: 'oauth-prompt',
+              persist: 'project',
+              oauth: { route: 'connector', connectorId: 'any-id' },
+            },
+          ],
+        },
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects an oauth surface that points at an undeclared mcp server', () => {
+    const result = validateManifest({
+      name: 'x',
+      version: '1.0.0',
+      od: {
+        context: { mcp: [{ name: 'declared-server' }] },
+        genui: {
+          surfaces: [
+            {
+              id: 's1',
+              kind: 'oauth-prompt',
+              persist: 'project',
+              oauth: { route: 'mcp', mcpServerId: 'other-server' },
+            },
+          ],
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/other-server/);
+  });
 });


### PR DESCRIPTION
## Summary
Adds unit tests for `packages/plugin-runtime` and wires the package into `core_tests` so the suite runs on every PR. The package was not covered by any CI job prior to this change.

Modules covered:
- `resolveContext` — minimal manifest, registry-backed skills/design-system/craft, unknown-ref warnings.
- `adaptClaudePlugin` — invalid JSON / non-object JSON fallback, name sanitization, missing version default, excessive-command warning.
- Frontmatter parser — inline-array, dash-array, BOM stripping, CRLF, `coerce()` for booleans and numerics.
- `validate` — repeat-without-until / until-without-repeat / empty-connectors / MCP-route capability warnings.
- `manifestSourceDigest` — key-order-independent canonical hash.
- `mergeManifests` + `resolveAppliedPipeline` — conflict resolution, compat dedup, scenario fallback rules.

Tests-only + CI wiring; no product source changes.

## What users will see
Nothing — internal test coverage + CI wiring only.

## Surface area
- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — tests + a one-line CI wiring add (run the package's suite in `core_tests`); no product surface.

## Validation
- `pnpm --filter @open-design/plugin-runtime test` — green locally (70 tests passing, +39 new).
