### PR TITLE
fix(desktop): keep the macOS Dock icon when the desktop-pet window opens

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -685,7 +685,23 @@ function createDesktopPetWindow(preloadPath: string): BrowserWindow {
     },
   });
   petWindow.setAlwaysOnTop(true, "floating");
-  petWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  // `skipTransformProcessType: true` is load-bearing, not an
+  // optimization. By default Electron's macOS `setVisibleOnAllWorkspaces`
+  // transforms the whole *process* type between `UIElementApplication`
+  // and `ForegroundApplication` to apply the all-Spaces behavior — the
+  // Electron docs note this "will hide the window and dock for a short
+  // time". That round-trip races during the launch burst (the pet
+  // window is created alongside the main window) and on Electron 41 /
+  // macOS 26 the process can stay stuck as an accessory app: no Dock
+  // icon, no menu bar, even though the windows render fine (issue
+  // #2394). The desktop pet is a cosmetic companion window; it must
+  // never decide the app's Dock identity — the main window does.
+  // Skipping the transform keeps the app a regular Dock app; the pet
+  // still floats on every Space via its `alwaysOnTop` floating level.
+  petWindow.setVisibleOnAllWorkspaces(true, {
+    visibleOnFullScreen: true,
+    skipTransformProcessType: true,
+  });
   petWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (isHttpUrl(url)) void shell.openExternal(url);
     return { action: "deny" };

--- a/apps/desktop/tests/main/desktop-pet-dock-policy.test.ts
+++ b/apps/desktop/tests/main/desktop-pet-dock-policy.test.ts
@@ -1,0 +1,68 @@
+// Issue #2394 — the packaged macOS app launched without a Dock icon
+// (and without a menu bar): the icon flickered once during launch and
+// then vanished, while the window itself rendered and worked fine.
+//
+// Root cause: the desktop-pet companion window calls
+// `setVisibleOnAllWorkspaces` so it floats across every Space.
+// Electron's macOS implementation, by default, transforms the whole
+// *process* type between `UIElementApplication` and
+// `ForegroundApplication` while applying that call (the Electron docs
+// note it "will hide the window and dock for a short time"). On
+// Electron 41 / macOS 26 that round-trip races during the launch burst
+// — the pet window is created alongside the main window — and the
+// process can stay stuck as an accessory app: no Dock icon, no menu
+// bar. Passing `skipTransformProcessType: true` bypasses the transform,
+// keeping the app a regular Dock app; the pet still floats on every
+// Space via its `alwaysOnTop` floating level.
+//
+// `createDesktopPetWindow` builds a real Electron `BrowserWindow`, so
+// this is a source-structure guard rather than a runtime test: the
+// symptom (a missing Dock icon) is only observable on a live macOS
+// session, which no cheaper test layer can see. It mirrors the
+// `*-host-boundary` source guards already in this directory.
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const desktopRoot = join(here, "../..");
+
+function source(relativePath: string): string {
+  return readFileSync(join(desktopRoot, relativePath), "utf8");
+}
+
+function createDesktopPetWindowBody(): string {
+  const runtime = source("src/main/runtime.ts");
+  const start = runtime.indexOf("function createDesktopPetWindow");
+  expect(start, "createDesktopPetWindow not found in runtime.ts").toBeGreaterThanOrEqual(0);
+  const end = runtime.indexOf("\nfunction ", start + "function ".length);
+  expect(end, "end of createDesktopPetWindow not found").toBeGreaterThan(start);
+  return runtime.slice(start, end);
+}
+
+// Returns the `petWindow.setVisibleOnAllWorkspaces(...)` call statement
+// only — anchored on the `petWindow.` receiver and `(` so prose in the
+// surrounding docblock that merely names the API is not matched.
+function petWindowSetVisibleOnAllWorkspacesCall(): string {
+  const body = createDesktopPetWindowBody();
+  const callStart = body.indexOf("petWindow.setVisibleOnAllWorkspaces(");
+  expect(callStart, "pet window must call setVisibleOnAllWorkspaces").toBeGreaterThanOrEqual(0);
+  const callEnd = body.indexOf(";", callStart);
+  expect(callEnd, "setVisibleOnAllWorkspaces call must be terminated").toBeGreaterThan(callStart);
+  return body.slice(callStart, callEnd + 1);
+}
+
+describe("desktop-pet window must not demote the app's macOS Dock policy (issue #2394)", () => {
+  it("floats the pet window across all Spaces", () => {
+    const call = petWindowSetVisibleOnAllWorkspacesCall();
+    expect(call).toContain("visibleOnFullScreen: true");
+  });
+
+  it("skips the UIElementApplication <-> ForegroundApplication process transform", () => {
+    const call = petWindowSetVisibleOnAllWorkspacesCall();
+    expect(call).toContain("skipTransformProcessType: true");
+  });
+});


### PR DESCRIPTION
Fixes #2394

## Why

While verifying the latest stable/nightly packaged macOS build I hit #2394 directly: the app launched, its Dock icon flickered once, then vanished — and the system menu bar went with it. The window itself rendered and worked fine, which is exactly what made it hard to pin down.

A packaged desktop app with no Dock icon and no menu bar is effectively unmanageable: users can't quit it from the Dock, lose the macOS app menu, and have no obvious way back to the window. It regressed on every packaged/desktop macOS launch (channel-independent), so it blocks the v0.8.0 line.

## What users will see

On macOS, the packaged Open Design app keeps its Dock icon for the whole session (and its menu in the system menu bar), instead of the icon flashing once at launch and disappearing a few seconds later. No setting, no opt-in — the icon just stays, as it always should have.

## Surface area

- [x] **Default behavior change** — restores the macOS Dock icon and menu bar on every packaged/desktop launch; they previously vanished shortly after startup.

This is a regression fix in existing desktop window-management code — it adds no new page/dialog/panel/menu item/setting/CLI/API, so no other box applies.

## Screenshots

A screenshot of "an icon that isn't there" is not informative. The precise, objective signal is the process activation policy reported by `lsappinfo`: `type="Foreground"` = regular Dock app (icon shown), `type="UIElement"` = accessory app (no Dock icon, no menu bar). Before/after `lsappinfo` output is in Bug fix verification below.

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/desktop-pet-dock-policy.test.ts`
- Did the test go red on the base and green on this branch? **yes** — red on the unfixed `runtime.ts` (`expected '…setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });' to contain 'skipTransformProcessType: true'`), green after the one-line option change.
- Why a source-structure guard, not a runtime test: the symptom (a missing Dock icon) is only observable on a live macOS session. Electron's process-type transform is not reachable from the daemon HTTP layer, app-local logic, or Playwright, and `createDesktopPetWindow` builds a real Electron `BrowserWindow`. The guard pins the call shape; it mirrors the existing `*-host-boundary` source guards already in that directory. The live behavior is covered by the empirical proof below.

**Root cause + empirical proof** — downloaded R2 nightly-channel artifact, macOS 26.5 (Tahoe), Electron 41.3.0:

- The desktop-pet companion window (added recently) calls `setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })`. Electron's macOS implementation, by default, transforms the whole **process type** between `UIElementApplication` and `ForegroundApplication` to apply the all-Spaces behavior (the Electron docs note this "will hide the window and dock for a short time"). On Electron 41 / macOS 26 that round-trip races during the launch burst and the process can stay stuck as an accessory app.
- Buggy build: `lsappinfo` reported `type="Foreground"` at launch, then `type="UIElement"` ~12s in (when the pet window is created) — accessory, no Dock icon. The bundle `Info.plist` is a clean regular app (no `LSUIElement`/`LSBackgroundOnly`); there is no `setActivationPolicy`/`app.dock` call anywhere in the codebase.
- Fixed: patched that single call in the shipped `packaged-main.mjs` to add `skipTransformProcessType: true`, re-signed ad-hoc, relaunched — `lsappinfo` stayed `type="Foreground"` past 55s and the Dock icon was present. This is the exact code change this PR makes in source.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (all packages; `skipTransformProcessType` is in Electron 41's typings)
- `pnpm --filter @open-design/desktop test` — 7 files, 56 tests pass, including the new spec
- Empirical in-place fix verification on the real downloaded macOS artifact (above). Recommended reviewer end-to-end check: `pnpm tools-pack mac build` then launch and confirm the Dock icon persists.
