### PR TITLE
i18n: add translations for media provider coming soon section

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -5093,15 +5093,14 @@ function MediaProvidersSection({
         <details className="library-group media-provider-coming-soon">
           <summary className="memory-details-summary">
             <span className="memory-details-title">
-              Coming soon
+              {t('tasks.comingSoon')}
             </span>
             <span className="filter-pill-count">
               {comingSoonProviders.length}
             </span>
           </summary>
           <p className="hint" style={{ marginTop: 4, marginBottom: 8 }}>
-            We track these for the roadmap; the daemon doesn’t ship a
-            client yet, so there’s nothing to configure.
+            {t('settings.mediaProviderComingSoonHint')}
           </p>
           <ul className="media-provider-coming-soon-list">
             {comingSoonProviders.map((provider) => {
@@ -5126,7 +5125,7 @@ function MediaProvidersSection({
                       rel="noopener noreferrer"
                       className="ghost-link"
                     >
-                      Docs
+                      {t('settings.agentInstall.docs')}
                       <Icon name="external-link" size={11} />
                     </a>
                   ) : null}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -269,6 +269,7 @@ export const ar: Dict = {
   'settings.mediaProviderReloadError': 'تعذر إعادة تحميل إعدادات موفري الوسائط من الـ daemon المحلي.',
   'settings.mediaProviderReloadSuccess': 'تمت إعادة تحميل إعدادات موفري الوسائط من الـ daemon المحلي.',
   'settings.mediaProviderLoadError': 'تعذر تحميل إعدادات موفري الوسائط من الـ daemon المحلي. سيُستخدم مؤقتًا ما هو محفوظ في المتصفح.',
+  'settings.mediaProviderComingSoonHint': 'نحن نتتبع هذه المزودات في خارطة الطريق؛ لم يقم البرنامج الخفي بشحن عميل بعد، لذا لا يوجد شيء لتكوينه.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -269,6 +269,7 @@ export const de: Dict = {
   'settings.mediaProviderReloadError': 'Die Einstellungen der Medienanbieter konnten nicht vom lokalen Daemon neu geladen werden.',
   'settings.mediaProviderReloadSuccess': 'Die Einstellungen der Medienanbieter wurden vom lokalen Daemon neu geladen.',
   'settings.mediaProviderLoadError': 'Die Einstellungen der Medienanbieter konnten nicht vom lokalen Daemon geladen werden. Vorerst werden die im Browser gespeicherten Einstellungen verwendet.',
+  'settings.mediaProviderComingSoonHint': 'Wir verfolgen diese für die Roadmap; der Daemon liefert noch keinen Client, daher gibt es nichts zu konfigurieren.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -307,7 +307,7 @@ export const en: Dict = {
   'settings.mediaProviderReloadError': 'Could not reload media provider settings from the local daemon.',
   'settings.mediaProviderReloadSuccess': 'Reloaded media provider settings from the local daemon.',
   'settings.mediaProviderLoadError': 'Could not load media provider settings from the local daemon. Using browser-saved settings for now.',
-  'settings.mediaProviderComingSoonHint': 'We track these for the roadmap; the daemon doesn\'t ship a client yet, so there's nothing to configure.',
+  'settings.mediaProviderComingSoonHint': 'We track these for the roadmap; the daemon doesn\'t ship a client yet, so there\'s nothing to configure.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -307,7 +307,7 @@ export const en: Dict = {
   'settings.mediaProviderReloadError': 'Could not reload media provider settings from the local daemon.',
   'settings.mediaProviderReloadSuccess': 'Reloaded media provider settings from the local daemon.',
   'settings.mediaProviderLoadError': 'Could not load media provider settings from the local daemon. Using browser-saved settings for now.',
-  'settings.mediaProviderComingSoonHint': 'We track these for the roadmap; the daemon doesn't ship a client yet, so there's nothing to configure.',
+  'settings.mediaProviderComingSoonHint': 'We track these for the roadmap; the daemon doesn\'t ship a client yet, so there's nothing to configure.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -307,6 +307,7 @@ export const en: Dict = {
   'settings.mediaProviderReloadError': 'Could not reload media provider settings from the local daemon.',
   'settings.mediaProviderReloadSuccess': 'Reloaded media provider settings from the local daemon.',
   'settings.mediaProviderLoadError': 'Could not load media provider settings from the local daemon. Using browser-saved settings for now.',
+  'settings.mediaProviderComingSoonHint': 'We track these for the roadmap; the daemon doesn't ship a client yet, so there's nothing to configure.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -269,6 +269,7 @@ export const esES: Dict = {
   'settings.mediaProviderReloadError': 'No se pudieron recargar los ajustes de los proveedores de medios desde el daemon local.',
   'settings.mediaProviderReloadSuccess': 'Se recargaron los ajustes de los proveedores de medios desde el daemon local.',
   'settings.mediaProviderLoadError': 'No se pudieron cargar los ajustes de los proveedores de medios desde el daemon local. Por ahora se usarán los ajustes guardados en el navegador.',
+  'settings.mediaProviderComingSoonHint': 'Rastreamos estos para la hoja de ruta; el daemon aún no incluye un cliente, por lo que no hay nada que configurar.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -269,6 +269,7 @@ export const fa: Dict = {
   'settings.mediaProviderReloadError': 'بارگذاری دوبارهٔ تنظیمات ارائه‌دهنده‌های رسانه از دیمن محلی ممکن نشد.',
   'settings.mediaProviderReloadSuccess': 'تنظیمات ارائه‌دهنده‌های رسانه از دیمن محلی دوباره بارگذاری شد.',
   'settings.mediaProviderLoadError': 'بارگذاری تنظیمات ارائه‌دهنده‌های رسانه از دیمن محلی ممکن نشد. فعلاً از تنظیمات ذخیره‌شده در مرورگر استفاده می‌شود.',
+  'settings.mediaProviderComingSoonHint': 'ما این موارد را برای نقشه راه پیگیری می‌کنیم؛ دیمون هنوز کلاینتی ارائه نمی‌دهد، بنابراین چیزی برای پیکربندی وجود ندارد.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -269,6 +269,7 @@ export const fr: Dict = {
   'settings.mediaProviderReloadError': 'Impossible de recharger les paramètres des fournisseurs de médias depuis le daemon local.',
   'settings.mediaProviderReloadSuccess': 'Paramètres des fournisseurs de médias rechargés depuis le daemon local.',
   'settings.mediaProviderLoadError': 'Impossible de charger les paramètres des fournisseurs de médias depuis le daemon local. Utilisation temporaire des paramètres enregistrés dans le navigateur.',
+  'settings.mediaProviderComingSoonHint': 'Nous suivons ces fournisseurs pour la feuille de route ; le daemon ne fournit pas encore de client, il n'y a donc rien à configurer.',
   'settings.privacy': 'Confidentialité',
   'settings.privacyHint': 'Données partagées avec l’équipe Open Design',
   'settings.privacyConsentKicker': 'Aidez-nous à améliorer Open Design',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -269,7 +269,7 @@ export const fr: Dict = {
   'settings.mediaProviderReloadError': 'Impossible de recharger les paramètres des fournisseurs de médias depuis le daemon local.',
   'settings.mediaProviderReloadSuccess': 'Paramètres des fournisseurs de médias rechargés depuis le daemon local.',
   'settings.mediaProviderLoadError': 'Impossible de charger les paramètres des fournisseurs de médias depuis le daemon local. Utilisation temporaire des paramètres enregistrés dans le navigateur.',
-  'settings.mediaProviderComingSoonHint': 'Nous suivons ces fournisseurs pour la feuille de route ; le daemon ne fournit pas encore de client, il n'y a donc rien à configurer.',
+  'settings.mediaProviderComingSoonHint': 'Nous suivons ces fournisseurs pour la feuille de route ; le daemon ne fournit pas encore de client, il n\'y a donc rien à configurer.',
   'settings.privacy': 'Confidentialité',
   'settings.privacyHint': 'Données partagées avec l’équipe Open Design',
   'settings.privacyConsentKicker': 'Aidez-nous à améliorer Open Design',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -269,6 +269,7 @@ export const hu: Dict = {
   'settings.mediaProviderReloadError': 'Nem sikerült újratölteni a médiaszolgáltatók beállításait a helyi démonból.',
   'settings.mediaProviderReloadSuccess': 'A médiaszolgáltatók beállításai újra lettek töltve a helyi démonból.',
   'settings.mediaProviderLoadError': 'Nem sikerült betölteni a médiaszolgáltatók beállításait a helyi démonból. Egyelőre a böngészőben mentett beállításokat használjuk.',
+  'settings.mediaProviderComingSoonHint': 'Ezeket nyomon követjük az ütemtervben; a daemon még nem szállít klienst, így nincs mit konfigurálni.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -264,6 +264,7 @@ export const id: Dict = {
   'settings.mediaProviderReloadError': 'Tidak dapat memuat ulang pengaturan penyedia media dari daemon lokal.',
   'settings.mediaProviderReloadSuccess': 'Pengaturan penyedia media berhasil dimuat ulang dari daemon lokal.',
   'settings.mediaProviderLoadError': 'Tidak dapat memuat pengaturan penyedia media dari daemon lokal. Untuk sementara menggunakan pengaturan yang tersimpan di browser.',
+  'settings.mediaProviderComingSoonHint': 'Kami melacak ini untuk roadmap; daemon belum mengirimkan klien, jadi tidak ada yang perlu dikonfigurasi.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -261,7 +261,7 @@ export const it: Dict = {
   'settings.mediaProviderReloadError': 'Impossibile ricaricare le impostazioni dei provider di media dal daemon locale.',
   'settings.mediaProviderReloadSuccess': 'Impostazioni dei provider di media ricaricate dal daemon locale.',
   'settings.mediaProviderLoadError': 'Impossibile caricare le impostazioni dei provider di media dal daemon locale. Uso temporaneo delle impostazioni salvate nel browser.',
-  'settings.mediaProviderComingSoonHint': 'Teniamo traccia di questi per la roadmap; il daemon non fornisce ancora un client, quindi non c'è nulla da configurare.',
+  'settings.mediaProviderComingSoonHint': 'Teniamo traccia di questi per la roadmap; il daemon non fornisce ancora un client, quindi non c\'è nulla da configurare.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'Quali dati vengono condivisi con il team di Open Design',
   'settings.privacyConsentKicker': 'Aiutaci a migliorare Open Design',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -261,6 +261,7 @@ export const it: Dict = {
   'settings.mediaProviderReloadError': 'Impossibile ricaricare le impostazioni dei provider di media dal daemon locale.',
   'settings.mediaProviderReloadSuccess': 'Impostazioni dei provider di media ricaricate dal daemon locale.',
   'settings.mediaProviderLoadError': 'Impossibile caricare le impostazioni dei provider di media dal daemon locale. Uso temporaneo delle impostazioni salvate nel browser.',
+  'settings.mediaProviderComingSoonHint': 'Teniamo traccia di questi per la roadmap; il daemon non fornisce ancora un client, quindi non c'è nulla da configurare.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'Quali dati vengono condivisi con il team di Open Design',
   'settings.privacyConsentKicker': 'Aiutaci a migliorare Open Design',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -269,6 +269,7 @@ export const ja: Dict = {
   'settings.mediaProviderReloadError': 'ローカルデーモンからメディアプロバイダー設定を再読み込みできませんでした。',
   'settings.mediaProviderReloadSuccess': 'ローカルデーモンからメディアプロバイダー設定を再読み込みしました。',
   'settings.mediaProviderLoadError': 'ローカルデーモンからメディアプロバイダー設定を読み込めませんでした。今のところブラウザーに保存された設定を使用します。',
+  'settings.mediaProviderComingSoonHint': 'これらはロードマップで追跡しています。デーモンはまだクライアントを提供していないため、設定するものはありません。',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -269,6 +269,7 @@ export const ko: Dict = {
   'settings.mediaProviderReloadError': '로컬 데몬에서 미디어 제공자 설정을 다시 불러오지 못했습니다.',
   'settings.mediaProviderReloadSuccess': '로컬 데몬에서 미디어 제공자 설정을 다시 불러왔습니다.',
   'settings.mediaProviderLoadError': '로컬 데몬에서 미디어 제공자 설정을 불러오지 못했습니다. 지금은 브라우저에 저장된 설정을 사용합니다.',
+  'settings.mediaProviderComingSoonHint': '로드맵에서 이를 추적하고 있습니다. 데몬이 아직 클라이언트를 제공하지 않으므로 구성할 항목이 없습니다.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -269,6 +269,7 @@ export const pl: Dict = {
   'settings.mediaProviderReloadError': 'Nie udało się ponownie wczytać ustawień dostawców mediów z lokalnego demona.',
   'settings.mediaProviderReloadSuccess': 'Ustawienia dostawców mediów zostały ponownie wczytane z lokalnego demona.',
   'settings.mediaProviderLoadError': 'Nie udało się wczytać ustawień dostawców mediów z lokalnego demona. Na razie używane będą ustawienia zapisane w przeglądarce.',
+  'settings.mediaProviderComingSoonHint': 'Śledzimy je w mapie drogowej; daemon nie dostarcza jeszcze klienta, więc nie ma nic do skonfigurowania.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -268,6 +268,7 @@ export const ptBR: Dict = {
   'settings.mediaProviderReloadError': 'Não foi possível recarregar as configurações dos provedores de mídia do daemon local.',
   'settings.mediaProviderReloadSuccess': 'As configurações dos provedores de mídia foram recarregadas do daemon local.',
   'settings.mediaProviderLoadError': 'Não foi possível carregar as configurações dos provedores de mídia do daemon local. Usando por enquanto as configurações salvas no navegador.',
+  'settings.mediaProviderComingSoonHint': 'Rastreamos estes para o roteiro; o daemon ainda não fornece um cliente, então não há nada para configurar.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -268,6 +268,7 @@ export const ru: Dict = {
   'settings.mediaProviderReloadError': 'Не удалось заново загрузить настройки медиапровайдеров из локального демона.',
   'settings.mediaProviderReloadSuccess': 'Настройки медиапровайдеров заново загружены из локального демона.',
   'settings.mediaProviderLoadError': 'Не удалось загрузить настройки медиапровайдеров из локального демона. Пока используются настройки, сохранённые в браузере.',
+  'settings.mediaProviderComingSoonHint': 'Мы отслеживаем их в дорожной карте; демон пока не поставляет клиент, поэтому настраивать нечего.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -253,6 +253,7 @@ export const th: Dict = {
   'settings.mediaProviderClearConfirm': 'ล้างการตั้งค่า {name} ที่บันทึกไว้ใช่หรือไม่? คุณจะต้องตั้งค่าใหม่อีกครั้งเพื่อใช้งาน {name}',
   'settings.mediaProviderPlaceholder': 'วาง API key',
   'settings.mediaProviderBaseUrlPlaceholder': 'กำหนด Base URL แท่นค่าเริ่มต้น',
+  'settings.mediaProviderComingSoonHint': 'เราติดตามสิ่งเหล่านี้สำหรับแผนงาน daemon ยังไม่ได้จัดส่งไคลเอนต์ ดังนั้นจึงไม่มีอะไรให้กำหนดค่า',
   'settings.privacy': 'ความเป็นส่วนตัว',
   'settings.privacyHint': 'ข้อมูลที่แชร์กับทีม Open Design',
   'settings.privacyConsentKicker': 'ช่วยเราพัฒนา Open Design',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -259,6 +259,7 @@ export const tr: Dict = {
   'settings.mediaProviderReloadError': 'Medya sağlayıcı ayarları yerel daemon’dan yeniden yüklenemedi.',
   'settings.mediaProviderReloadSuccess': 'Medya sağlayıcı ayarları yerel daemon’dan yeniden yüklendi.',
   'settings.mediaProviderLoadError': 'Medya sağlayıcı ayarları yerel daemon’dan yüklenemedi. Şimdilik tarayıcıya kaydedilen ayarlar kullanılıyor.',
+  'settings.mediaProviderComingSoonHint': 'Bunları yol haritası için takip ediyoruz; daemon henüz bir istemci göndermediği için yapılandırılacak bir şey yok.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -270,6 +270,7 @@ export const uk: Dict = {
   'settings.mediaProviderReloadError': 'Не вдалося повторно завантажити налаштування медіапровайдерів із локального демона.',
   'settings.mediaProviderReloadSuccess': 'Налаштування медіапровайдерів повторно завантажено з локального демона.',
   'settings.mediaProviderLoadError': 'Не вдалося завантажити налаштування медіапровайдерів із локального демона. Наразі використовуються налаштування, збережені в браузері.',
+  'settings.mediaProviderComingSoonHint': 'Ми відстежуємо їх у дорожній карті; демон ще не постачає клієнт, тому налаштовувати нічого.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -306,6 +306,7 @@ export const zhCN: Dict = {
   'settings.mediaProviderReloadError': '无法从本地守护进程重新加载媒体提供方设置。',
   'settings.mediaProviderReloadSuccess': '已从本地守护进程重新加载媒体提供方设置。',
   'settings.mediaProviderLoadError': '无法从本地守护进程加载媒体提供方设置。当前将使用浏览器中保存的设置。',
+  'settings.mediaProviderComingSoonHint': '我们在路线图中跟踪这些提供方；守护进程尚未提供客户端，因此暂无可配置项。',
   'settings.privacy': '隐私',
   'settings.privacyHint': '与 Open Design 团队共享哪些数据',
   'settings.privacyConsentKicker': '帮助我们改进 Open Design',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -267,6 +267,7 @@ export const zhTW: Dict = {
   'settings.mediaProviderReloadError': '無法從本機守護程序重新載入媒體供應商設定。',
   'settings.mediaProviderReloadSuccess': '已從本機守護程序重新載入媒體供應商設定。',
   'settings.mediaProviderLoadError': '無法從本機守護程序載入媒體供應商設定。目前將使用瀏覽器中儲存的設定。',
+  'settings.mediaProviderComingSoonHint': '我們在路線圖中追蹤這些提供者；守護程式尚未提供客戶端，因此暫無可配置項。',
   'settings.privacy': '隱私',
   'settings.privacyHint': '與 Open Design 團隊共享哪些資料',
   'settings.privacyConsentKicker': '協助我們改進 Open Design',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -322,6 +322,7 @@ export interface Dict {
   'settings.mediaProviderReloadError': string;
   'settings.mediaProviderReloadSuccess': string;
   'settings.mediaProviderLoadError': string;
+  'settings.mediaProviderComingSoonHint': string;
   'settings.privacy': string;
   'settings.privacyHint': string;
   'settings.privacyConsentKicker': string;


### PR DESCRIPTION
## Summary
Resolves the TODO(i18n) comment at line 5091 in SettingsDialog.tsx by adding proper i18n support for the media provider "Coming soon" section.

## Changes
- Added `settings.mediaProviderComingSoonHint` translation key to all 19 locale files
- Replaced hardcoded English strings with i18n function calls:
  - "Coming soon" → `t('tasks.comingSoon')` (reused existing key)
  - Description text → `t('settings.mediaProviderComingSoonHint')`
  - "Docs" → `t('settings.agentInstall.docs')` (reused existing key)
- Updated TypeScript types to include the new translation key

## Testing
- All 19 locales updated with appropriate translations
- No functional changes, only i18n improvements