### PR TITLE
feat(mcp): add write_file, delete_file, delete_project tools

### DIFF
--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -635,14 +635,19 @@ async function deleteProject(baseUrl: string, args: McpArgs) {
   if (args.confirm !== true) {
     return errorResult('confirm:true is required to delete a project (this cannot be undone).');
   }
-  const { id } = await resolveProjectArg(baseUrl, args.project);
+  const { id, resolved } = await resolveProjectArg(baseUrl, args.project);
   const url = `${baseUrl}/api/projects/${encodeURIComponent(id)}`;
   const resp = await fetch(url, { method: 'DELETE' });
   if (!resp.ok) {
     return errorResult(await formatDaemonError(resp, url));
   }
   const json = (await resp.json()) as JsonObject;
-  return ok(json);
+  // The tool accepts a name substring (see resolveProjectId), so the
+  // caller needs the resolvedProject echo to confirm which project was
+  // actually destroyed — same contract write_file/delete_file follow
+  // via withActiveEcho. active is always null here because the
+  // active-context fallback is intentionally disabled above.
+  return ok(withActiveEcho(json, null, resolved));
 }
 
 async function formatDaemonError(resp: Response, url: string): Promise<string> {

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -35,7 +35,7 @@ interface ProjectPayload { project?: ProjectSummary; id?: string; name?: string;
 interface ActiveContext { active?: boolean; projectId?: string; projectName?: string | null; fileName?: string | null; ageMs?: number | null }
 type ResolvedProject = { id: string; name: string; source: 'uuid' | 'id' | 'exact' | 'slug' | 'substring' };
 interface ProjectListCache { baseUrl: string; t: number; list: ProjectSummary[] }
-interface McpArgs extends JsonObject { project?: unknown; entry?: unknown; include?: unknown; maxBytes?: unknown; path?: unknown; offset?: unknown; limit?: unknown; since?: unknown; query?: unknown; pattern?: unknown; max?: unknown; name?: unknown; content?: unknown; encoding?: unknown; artifactManifest?: unknown }
+interface McpArgs extends JsonObject { project?: unknown; entry?: unknown; include?: unknown; maxBytes?: unknown; path?: unknown; offset?: unknown; limit?: unknown; since?: unknown; query?: unknown; pattern?: unknown; max?: unknown; name?: unknown; content?: unknown; encoding?: unknown; artifactManifest?: unknown; confirm?: unknown }
 interface ProjectFileBundleEntry { name: string; mime: string; size: number | null; content: string | null; binary: boolean }
 interface BundleInput { project: ProjectPayload | ProjectSummary; entry: string; files: ProjectFileBundleEntry[]; truncated: boolean; active: ActiveContext | null; resolved?: ResolvedProject | null }
 interface ErrorWithCode { message?: string; code?: string; cause?: { code?: string } }
@@ -236,6 +236,72 @@ const TOOL_DEFS = [
     },
     annotations: { ...WRITE_ANNOTATIONS, title: 'Create Open Design artifact' },
   },
+  {
+    name: 'write_file',
+    description:
+      'Write (or overwrite) a project file. Unlike create_artifact this does not require an ArtifactManifest and tolerates existing targets, so it is the right tool for iterating on a file the agent (or the user) already created. Project optional; defaults to the active project.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: PROJECT_ARG,
+        path: {
+          type: 'string',
+          description: 'Output path relative to the project root, e.g. "deck.html" or "components/Hero.tsx".',
+        },
+        content: {
+          type: 'string',
+          description: 'File contents. Use encoding="base64" for binary payloads.',
+        },
+        encoding: {
+          type: 'string',
+          enum: ['utf8', 'base64'],
+          description: 'utf8 (default) | base64',
+        },
+      },
+      required: ['path', 'content'],
+      additionalProperties: false,
+    },
+    annotations: { ...WRITE_ANNOTATIONS, title: 'Write Open Design project file' },
+  },
+  {
+    name: 'delete_file',
+    description:
+      'Delete one file from a project. Supports nested paths (e.g. "codex-product/index.html"). Project optional; defaults to the active project.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: PROJECT_ARG,
+        path: {
+          type: 'string',
+          description: 'Project-relative path of the file to delete.',
+        },
+      },
+      required: ['path'],
+      additionalProperties: false,
+    },
+    annotations: { ...WRITE_ANNOTATIONS, destructiveHint: true, title: 'Delete Open Design project file' },
+  },
+  {
+    name: 'delete_project',
+    description:
+      'Permanently delete an Open Design project including its files and conversations. Requires both an explicit project id/name AND confirm:true — there is no active-project fallback because the operation is irreversible.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project: {
+          type: 'string',
+          description: 'Project id (UUID) or name substring. Required — active-context fallback is intentionally disabled.',
+        },
+        confirm: {
+          type: 'boolean',
+          description: 'Must be literally true. Guards against an agent accidentally deleting a project while cleaning up.',
+        },
+      },
+      required: ['project', 'confirm'],
+      additionalProperties: false,
+    },
+    annotations: { ...WRITE_ANNOTATIONS, destructiveHint: true, title: 'Delete Open Design project' },
+  },
   // Catalog (skills, design systems) is intentionally NOT exposed as
   // MCP tools. Skills are recipes that Open Design itself uses to
   // generate artifacts; an external coding agent consuming Open
@@ -281,6 +347,12 @@ export async function runMcpStdio({ daemonUrl }: RunMcpOptions): Promise<void> {
         ' - create_artifact(name, content) to create one normal artifact',
         '    entry file in the active or specified project. It rejects',
         '    existing targets and can accept an artifactManifest sidecar.',
+        ' - write_file(path, content) to overwrite or freshly create any',
+        '    project file when an ArtifactManifest is not required.',
+        '    Use this to iterate on a file create_artifact already wrote.',
+        ' - delete_file(path) to remove one project file (nested paths ok).',
+        ' - delete_project(project, confirm:true) for irreversible project',
+        '    removal — requires explicit project + confirm:true.',
         ' - list_projects to discover what is available on this daemon.',
         ' - get_active_context() if you want the active project/file',
         '    explicitly without making any other tool call.',
@@ -495,12 +567,96 @@ async function handleMcpToolCall(baseUrl: string, name: unknown, args: McpArgs) 
       }
       case 'create_artifact':
         return await createArtifact(baseUrl, args);
+      case 'write_file':
+        return await writeFile(baseUrl, args);
+      case 'delete_file':
+        return await deleteFile(baseUrl, args);
+      case 'delete_project':
+        return await deleteProject(baseUrl, args);
       default:
         return errorResult(`unknown tool: ${name}`);
     }
   } catch (err) {
     return errorResult(formatError(err, baseUrl));
   }
+}
+
+async function writeFile(baseUrl: string, args: McpArgs) {
+  const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
+  // The daemon route requires its argv field to be called `name`; the
+  // MCP-facing surface uses `path` to match the rest of the file tools.
+  requireString(args.path, 'path');
+  requireString(args.content, 'content');
+  const encoding = args.encoding === 'base64' ? 'base64' : 'utf8';
+  // No `artifact: true` and no `overwrite: false`: the route then takes
+  // the default writeProjectFile path, which overwrites the target. This
+  // is the exact shape `od files write` uses (see apps/daemon/src/cli.ts).
+  const url = `${baseUrl}/api/projects/${encodeURIComponent(id)}/files`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: args.path, content: args.content, encoding }),
+  });
+  if (!resp.ok) {
+    return errorResult(await formatDaemonError(resp, url));
+  }
+  const json = (await resp.json()) as JsonObject;
+  return ok(withActiveEcho(json, active, resolved));
+}
+
+async function deleteFile(baseUrl: string, args: McpArgs) {
+  const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
+  requireString(args.path, 'path');
+  // /api/projects/:id/raw/* accepts nested paths; /api/projects/:id/files/:name
+  // does not. Mirror the create_artifact surface, which already lets agents
+  // address files like "codex-product/index.html".
+  const segments = args.path
+    .split('/')
+    .filter((s) => s.length > 0)
+    .map(encodeURIComponent);
+  const url = `${baseUrl}/api/projects/${encodeURIComponent(id)}/raw/${segments.join('/')}`;
+  const resp = await fetch(url, { method: 'DELETE' });
+  if (!resp.ok) {
+    return errorResult(await formatDaemonError(resp, url));
+  }
+  const json = (await resp.json()) as JsonObject;
+  return ok(withActiveEcho(json, active, resolved));
+}
+
+async function deleteProject(baseUrl: string, args: McpArgs) {
+  // Active-context fallback is intentionally disabled: the daemon's
+  // DELETE /api/projects/:id is irreversible (purges the row and the
+  // on-disk project directory), so we never want it to fire against the
+  // wrong project just because the user happened to have one open. The
+  // confirm flag is a second belt for agents that auto-clean.
+  if (typeof args.project !== 'string' || args.project.length === 0) {
+    return errorResult('project is required (no active-context fallback for delete_project).');
+  }
+  if (args.confirm !== true) {
+    return errorResult('confirm:true is required to delete a project (this cannot be undone).');
+  }
+  const { id } = await resolveProjectArg(baseUrl, args.project);
+  const url = `${baseUrl}/api/projects/${encodeURIComponent(id)}`;
+  const resp = await fetch(url, { method: 'DELETE' });
+  if (!resp.ok) {
+    return errorResult(await formatDaemonError(resp, url));
+  }
+  const json = (await resp.json()) as JsonObject;
+  return ok(json);
+}
+
+async function formatDaemonError(resp: Response, url: string): Promise<string> {
+  const body = await safeText(resp);
+  let detail = body || resp.statusText;
+  try {
+    const parsed = JSON.parse(body) as { error?: { message?: string; code?: string } };
+    if (parsed?.error?.message) {
+      detail = `${parsed.error.code ?? 'error'}: ${parsed.error.message}`;
+    }
+  } catch {
+    // body wasn't JSON; fall through with the raw text.
+  }
+  return `daemon ${resp.status} on ${url}: ${detail}`;
 }
 
 async function createArtifact(baseUrl: string, args: McpArgs) {

--- a/apps/daemon/tests/mcp-write-tools.test.ts
+++ b/apps/daemon/tests/mcp-write-tools.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { handleMcpToolCall } from '../src/mcp.js';
+
+const originalFetch = globalThis.fetch;
+
+function firstText(result: { content: Array<{ text: string }> }): string {
+  const item = result.content[0];
+  if (!item) throw new Error('expected MCP text content');
+  return item.text;
+}
+
+// mcp.ts caches the project list per baseUrl for 5 s, so two tests
+// that share a baseUrl can see each other's fixtures and lookups fail
+// in the second test. Hand each test its own baseUrl to keep the cache
+// from leaking across cases.
+let portCounter = 18000;
+function nextBaseUrl(): string {
+  portCounter += 1;
+  return `http://127.0.0.1:${portCounter}`;
+}
+
+// Round out the MCP write surface. Today agents can `create_artifact`
+// (which rejects existing targets) but cannot iterate on a file they
+// already created, cannot delete a stale file, and cannot remove a
+// throwaway project they spun up via `create_project` (#2356).
+// Add three matching write tools so external coding agents can drive
+// the full file/project lifecycle through MCP, not just the create
+// half of it.
+
+describe('public MCP write_file', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('posts an overwrite-allowed write through the daemon files endpoint', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+      if (url.endsWith('/api/projects')) {
+        return new Response(
+          JSON.stringify({ projects: [{ id: 'project-1', name: 'Demo' }] }),
+          { status: 200 },
+        );
+      }
+      return new Response(
+        JSON.stringify({ file: { name: 'deck.html' } }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(base, 'write_file', {
+      project: 'Demo',
+      path: 'deck.html',
+      content: '<!doctype html><h1>v2</h1>',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [filesUrl, filesInit] = fetchMock.mock.calls[1]!;
+    expect(filesUrl).toBe(`${base}/api/projects/project-1/files`);
+    expect(filesInit?.method).toBe('POST');
+    const body = JSON.parse(String(filesInit?.body));
+    // The daemon's POST /api/projects/:id/files defaults to overwrite
+    // when neither `artifact: true` nor `overwrite: false` is present,
+    // which is what write_file must rely on. Spelling out the absence
+    // here would be brittle, so the deep-equal already enforces that
+    // both keys are omitted.
+    expect(body).toEqual({
+      name: 'deck.html',
+      content: '<!doctype html><h1>v2</h1>',
+      encoding: 'utf8',
+    });
+    expect(JSON.parse(firstText(result))).toMatchObject({
+      file: { name: 'deck.html' },
+    });
+  });
+
+  it('passes base64 encoding through unchanged', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+      if (url.endsWith('/api/projects')) {
+        return new Response(
+          JSON.stringify({ projects: [{ id: 'p1', name: 'P' }] }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ file: { name: 'logo.png' } }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await handleMcpToolCall(base, 'write_file', {
+      project: 'P',
+      path: 'logo.png',
+      content: 'AAA=',
+      encoding: 'base64',
+    });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(body.encoding).toBe('base64');
+  });
+
+  it('uses the active project when project is omitted', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+      if (url.endsWith('/api/active')) {
+        return new Response(
+          JSON.stringify({ active: true, projectId: 'active-1', projectName: 'Active', fileName: null }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ file: { name: 'index.html' } }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(base, 'write_file', {
+      path: 'index.html',
+      content: '<!doctype html>',
+    });
+
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(`${base}/api/projects/active-1/files`);
+    expect(JSON.parse(firstText(result))).toMatchObject({
+      usedActiveContext: { projectId: 'active-1' },
+    });
+  });
+
+  it('rejects missing path or content before hitting the network', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
+      if (url.endsWith('/api/projects')) {
+        return new Response(
+          JSON.stringify({ projects: [{ id: 'p1', name: 'P' }] }),
+          { status: 200 },
+        );
+      }
+      return new Response('{}', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const missingPath = await handleMcpToolCall(base, 'write_file', {
+      project: 'P',
+      content: 'x',
+    });
+    expect(missingPath).toMatchObject({ isError: true });
+    expect(firstText(missingPath)).toContain('path is required');
+
+    const missingContent = await handleMcpToolCall(base, 'write_file', {
+      project: 'P',
+      path: 'a.html',
+    });
+    expect(missingContent).toMatchObject({ isError: true });
+    expect(firstText(missingContent)).toContain('content is required');
+
+    // Neither call should have reached /files; resolveProjectArg may have
+    // hit /api/projects, which is harmless.
+    expect(fetchMock.mock.calls.some((call) => String(call[0]).includes('/files'))).toBe(false);
+  });
+});
+
+describe('public MCP delete_file', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('issues DELETE through the nested-path raw endpoint', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/projects')) {
+        return new Response(
+          JSON.stringify({ projects: [{ id: 'p1', name: 'Demo' }] }),
+          { status: 200 },
+        );
+      }
+      expect(init?.method).toBe('DELETE');
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(base, 'delete_file', {
+      project: 'Demo',
+      path: 'codex-product/index.html',
+    });
+
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      `${base}/api/projects/p1/raw/codex-product/index.html`,
+    );
+    expect(JSON.parse(firstText(result))).toMatchObject({ ok: true });
+  });
+
+  it('refuses to delete with no path supplied', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) =>
+      url.endsWith('/api/projects')
+        ? new Response(JSON.stringify({ projects: [{ id: 'p1', name: 'Demo' }] }), { status: 200 })
+        : new Response('{}', { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(base, 'delete_file', {
+      project: 'Demo',
+    });
+    expect(result).toMatchObject({ isError: true });
+    expect(firstText(result)).toContain('path is required');
+    // Should not have touched /raw/ at all.
+    expect(fetchMock.mock.calls.some((call) => String(call[0]).includes('/raw/'))).toBe(false);
+  });
+});
+
+describe('public MCP delete_project', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('issues DELETE /api/projects/:id when project + confirm are provided', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/projects')) {
+        return new Response(
+          JSON.stringify({ projects: [{ id: 'p1', name: 'Demo' }] }),
+          { status: 200 },
+        );
+      }
+      expect(init?.method).toBe('DELETE');
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(base, 'delete_project', {
+      project: 'Demo',
+      confirm: true,
+    });
+
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(`${base}/api/projects/p1`);
+    expect(JSON.parse(firstText(result))).toMatchObject({ ok: true });
+  });
+
+  it('requires explicit confirm:true so agents cannot silently nuke a project', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string, _init?: RequestInit) =>
+      url.endsWith('/api/projects')
+        ? new Response(JSON.stringify({ projects: [{ id: 'p1', name: 'Demo' }] }), { status: 200 })
+        : new Response('{}', { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const missing = await handleMcpToolCall(base, 'delete_project', {
+      project: 'Demo',
+    });
+    expect(missing).toMatchObject({ isError: true });
+    expect(firstText(missing)).toContain('confirm');
+
+    const falseConfirm = await handleMcpToolCall(base, 'delete_project', {
+      project: 'Demo',
+      confirm: false,
+    });
+    expect(falseConfirm).toMatchObject({ isError: true });
+
+    // Neither call should have reached the DELETE endpoint.
+    expect(
+      fetchMock.mock.calls.some(
+        (call) =>
+          /\/api\/projects\/[^/]+$/.test(String(call[0])) &&
+          String(call[1]?.method ?? '').toUpperCase() === 'DELETE',
+      ),
+    ).toBe(false);
+  });
+
+  it('requires an explicit project — never falls back to the active project for delete', async () => {
+    const base = nextBaseUrl();
+    // No /api/projects call is needed; the tool should reject before
+    // resolving anything. We still stub fetch so an accidental call is
+    // obvious.
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      new Response('{}', { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(base, 'delete_project', {
+      confirm: true,
+    });
+    expect(result).toMatchObject({ isError: true });
+    expect(firstText(result)).toMatch(/project (id|is required)/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/daemon/tests/mcp-write-tools.test.ts
+++ b/apps/daemon/tests/mcp-write-tools.test.ts
@@ -284,4 +284,116 @@ describe('public MCP delete_project', () => {
     expect(firstText(result)).toMatch(/project (id|is required)/i);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it('echoes resolvedProject when the caller passed a name substring', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/projects') && (!init || init.method === undefined || init.method === 'GET')) {
+        return new Response(
+          JSON.stringify({ projects: [{ id: 'p1', name: 'Throwaway demo' }] }),
+          { status: 200 },
+        );
+      }
+      expect(init?.method).toBe('DELETE');
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // 'throwaway' is a substring of 'Throwaway demo' — the tool accepts
+    // substrings per inputSchema, so the response must carry
+    // resolvedProject so the agent can confirm which row got destroyed.
+    const result = await handleMcpToolCall(base, 'delete_project', {
+      project: 'throwaway',
+      confirm: true,
+    });
+    expect(result).not.toMatchObject({ isError: true });
+    const body = JSON.parse(firstText(result as { content: Array<{ text: string }> }));
+    expect(body).toMatchObject({
+      ok: true,
+      resolvedProject: { id: 'p1', name: 'Throwaway demo' },
+    });
+  });
+});
+
+describe('formatDaemonError (shared error mapper)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('reformats a structured daemon error body as "code: message"', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string) =>
+      url.endsWith('/api/projects')
+        ? new Response(JSON.stringify({ projects: [{ id: 'p1', name: 'Demo' }] }), { status: 200 })
+        : new Response(
+            JSON.stringify({ error: { code: 'FILE_NOT_FOUND', message: 'no such file' } }),
+            { status: 404 },
+          ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(base, 'delete_file', {
+      project: 'Demo',
+      path: 'gone.html',
+    });
+    expect(result).toMatchObject({ isError: true });
+    const text = firstText(result as { content: Array<{ text: string }> });
+    // The mapper should fold the structured error into "code: message"
+    // and prefix the daemon status, so agents can branch on either.
+    expect(text).toContain('FILE_NOT_FOUND');
+    expect(text).toContain('no such file');
+    expect(text).toContain('404');
+  });
+
+  it('falls back to the raw body when the daemon does not return JSON', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string) =>
+      url.endsWith('/api/projects')
+        ? new Response(JSON.stringify({ projects: [{ id: 'p1', name: 'Demo' }] }), { status: 200 })
+        : new Response('upstream boom', { status: 502 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(base, 'delete_file', {
+      project: 'Demo',
+      path: 'gone.html',
+    });
+    expect(result).toMatchObject({ isError: true });
+    const text = firstText(result as { content: Array<{ text: string }> });
+    // JSON.parse throws on the non-JSON body and the catch fallthrough
+    // must preserve the raw text so the agent still sees the upstream
+    // signal.
+    expect(text).toContain('upstream boom');
+    expect(text).toContain('502');
+  });
+
+  it('surfaces a non-2xx that is also non-JSON on delete_project', async () => {
+    const base = nextBaseUrl();
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/projects') && (!init || init.method === undefined || init.method === 'GET')) {
+        return new Response(
+          JSON.stringify({ projects: [{ id: 'p1', name: 'Demo' }] }),
+          { status: 200 },
+        );
+      }
+      // 409 with structured body — verifies the irreversible tool's
+      // error path also flows through formatDaemonError.
+      return new Response(
+        JSON.stringify({ error: { code: 'PROJECT_LOCKED', message: 'in use' } }),
+        { status: 409 },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(base, 'delete_project', {
+      project: 'Demo',
+      confirm: true,
+    });
+    expect(result).toMatchObject({ isError: true });
+    const text = firstText(result as { content: Array<{ text: string }> });
+    expect(text).toContain('PROJECT_LOCKED');
+    expect(text).toContain('in use');
+    expect(text).toContain('409');
+  });
 });


### PR DESCRIPTION
## Why

External coding agents (Claude Code, Cursor, Zed) driving Open Design through MCP can today:

- create new artifacts (\`create_artifact\` — but it rejects existing targets)
- inspect files (\`get_file\`, \`get_artifact\`, \`list_files\`, \`search_files\`)
- discover projects (\`list_projects\`, \`get_project\`, \`get_active_context\`)
- start fresh projects (\`create_project\`, just landed in #2404)

What they **cannot** do is iterate on a file once written, remove a stale file, or tear down a throwaway project they spun up to try something. So the very common loop "agent creates → user iterates with the agent → agent updates the same file" stalls one turn in: \`create_artifact\` 409s on the second write, and the agent has to fall back to telling the user to delete the file by hand or open the desktop UI.

This PR closes that loop by adding three matching write tools so the same agent can drive the full file/project lifecycle end-to-end.

## What users will see

In an MCP \`tools/list\` response, three new tools alongside the existing ones:

- **\`write_file(path, content, [encoding])\`** — overwrites or freshly creates any project file when an ArtifactManifest is not required. Use this to iterate on a file \`create_artifact\` already wrote.
- **\`delete_file(path)\`** — removes one project file. Supports nested paths (e.g. \`codex-product/index.html\`), mirroring \`create_artifact\`'s nested name argument.
- **\`delete_project(project, confirm:true)\`** — permanently deletes a project (SQLite row + on-disk dir). Marked \`destructiveHint:true\`. Requires both an **explicit \`project\` argument** (no active-context fallback) and \`confirm:true\` (so an agent cleaning up cannot silently nuke the user's currently-open project).

The MCP \`instructions\` block is updated so agents discover the new write tools and the create/write/delete relationship.

Existing tools and HTTP routes are unchanged. No contract changes; the three tools wrap existing daemon endpoints:

| MCP tool | HTTP route |
|---|---|
| \`write_file\` | \`POST /api/projects/:id/files\` (no \`artifact: true\`, no \`overwrite: false\` → daemon defaults to overwrite) |
| \`delete_file\` | \`DELETE /api/projects/:id/raw/<path>\` (the nested-path variant; \`/files/:name\` would only support top-level files) |
| \`delete_project\` | \`DELETE /api/projects/:id\` |

## Surface area

- [ ] **UI** — no
- [ ] **Keyboard shortcut** — no
- [ ] **CLI / env var** — no (\`od files write/delete\` and \`od project delete\` already cover CLI; this PR only adds the MCP-client surface for the same capabilities)
- [ ] **API / contract** — no
- [x] **Extension point** — three new MCP tool definitions
- [ ] **i18n keys** — no
- [ ] **New top-level dependency** — no
- [ ] **Default behavior change** — no

## Verification

- \`pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/mcp-write-tools.test.ts\` — 9 passed (new file).
- \`pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts\` — 249 files, 2959 passed. One pre-existing flaky failure in \`tests/orbit.test.ts > tracks the most recent run per template alongside the global last run\` that passes 14/14 when the file is run in isolation; reproduced unchanged against \`main\`, so not introduced by this PR.
- \`pnpm guard\` — passed.
- \`pnpm --filter @open-design/daemon typecheck\` — passed.

## Design notes

- \`write_file\` is intentionally separate from \`create_artifact\` rather than gaining an \`overwrite:true\` flag, so the existing \`create_artifact\` annotation (which guarantees a non-overwriting write + ArtifactManifest validation) stays as a stable contract for agents that rely on it. The two tools then read as a clear "new file vs. edit-in-place" pair.
- \`delete_file\` uses the \`/raw/*\` endpoint (not \`/files/:name\`) so nested paths work; this matches the asymmetry in the daemon routes and keeps the agent surface consistent with \`create_artifact\`'s nested \`name\`.
- \`delete_project\` is the only write tool here that disables the active-context fallback. The intent is to make "agent garbage-collected my project" structurally impossible without an explicit user-supplied project + \`confirm:true\`. The annotation also carries \`destructiveHint:true\` so MCP UIs can render the warning in their UX.
- Tests use per-test unique \`baseUrl\`s to bypass mcp.ts's 5-second module-level \`projectListCache\` — without that, a fixture installed in one test leaks into the next and the second resolveProjectArg call hits the cached fixture instead of the test's mock.