### PR TITLE
test(registry-protocol,sidecar): cover schemas + path validators, wire registry-protocol into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,6 +497,7 @@ jobs:
           pnpm --filter @open-design/contracts test
           pnpm --filter @open-design/host test
           pnpm --filter @open-design/platform test
+          pnpm --filter @open-design/registry-protocol test
           pnpm --filter @open-design/sidecar test
           pnpm --filter @open-design/sidecar-proto test
           if [ "${{ needs.scopes.outputs.tools_dev_tests_required }}" = "true" ]; then

--- a/packages/registry-protocol/tests/schemas.test.ts
+++ b/packages/registry-protocol/tests/schemas.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RegistryDoctorIssueSchema,
+  RegistryDoctorReportSchema,
+  RegistryEntrySchema,
+  RegistrySearchQuerySchema,
+  RegistrySignatureSchema,
+  RegistryVersionSchema,
+  RegistryYankOutcomeSchema,
+  ResolvedRegistryEntrySchema,
+} from '../src/index.js';
+
+const entry = RegistryEntrySchema.parse({
+  name: 'vendor/example',
+  version: '1.0.0',
+  source: 'github:vendor/example@v1.0.0/plugin',
+});
+
+describe('RegistrySearchQuerySchema', () => {
+  it('defaults query to empty string when omitted', () => {
+    const parsed = RegistrySearchQuerySchema.parse({});
+    expect(parsed.query).toBe('');
+  });
+
+  it('accepts limit at the positive integer boundary', () => {
+    expect(RegistrySearchQuerySchema.parse({ query: 'x', limit: 1 }).limit).toBe(1);
+    expect(RegistrySearchQuerySchema.parse({ query: 'x', limit: 500 }).limit).toBe(500);
+  });
+
+  it('rejects limit outside positive integer bounds', () => {
+    expect(() => RegistrySearchQuerySchema.parse({ query: 'x', limit: 0 })).toThrow();
+    expect(() => RegistrySearchQuerySchema.parse({ query: 'x', limit: -1 })).toThrow();
+    expect(() => RegistrySearchQuerySchema.parse({ query: 'x', limit: 501 })).toThrow();
+    expect(() => RegistrySearchQuerySchema.parse({ query: 'x', limit: 1.5 })).toThrow();
+  });
+});
+
+describe('RegistryVersionSchema', () => {
+  it('treats deprecated, yanked, and yankReason as optional', () => {
+    const minimal = RegistryVersionSchema.parse({ version: '1.0.0' });
+    expect(minimal.deprecated).toBeUndefined();
+    expect(minimal.yanked).toBeUndefined();
+    expect(minimal.yankReason).toBeUndefined();
+  });
+
+  it('accepts boolean and string forms of deprecated', () => {
+    expect(RegistryVersionSchema.parse({ version: '1.0.0', deprecated: true }).deprecated).toBe(true);
+    expect(RegistryVersionSchema.parse({ version: '1.0.0', deprecated: 'use 2.x' }).deprecated).toBe('use 2.x');
+  });
+
+  it('captures yank metadata when present', () => {
+    const parsed = RegistryVersionSchema.parse({
+      version: '1.0.0',
+      yanked: true,
+      yankedAt: '2024-01-01T00:00:00Z',
+      yankReason: 'security advisory',
+    });
+    expect(parsed.yanked).toBe(true);
+    expect(parsed.yankReason).toBe('security advisory');
+  });
+});
+
+describe('RegistrySignatureSchema', () => {
+  it('requires a non-empty signature and a known kind', () => {
+    expect(() => RegistrySignatureSchema.parse({ kind: 'github-oidc', signature: '' })).toThrow();
+    expect(() => RegistrySignatureSchema.parse({ kind: 'unknown', signature: 'sha256-x' })).toThrow();
+    expect(RegistrySignatureSchema.parse({ kind: 'cosign', signature: 'sha256-x' }).kind).toBe('cosign');
+  });
+});
+
+describe('RegistryYankOutcomeSchema', () => {
+  it('defaults warnings to an empty array on success', () => {
+    const outcome = RegistryYankOutcomeSchema.parse({
+      ok: true,
+      name: 'vendor/example',
+      version: '1.0.0',
+      reason: 'security',
+    });
+    expect(outcome.warnings).toEqual([]);
+  });
+
+  it('rejects empty required identity fields', () => {
+    expect(() =>
+      RegistryYankOutcomeSchema.parse({ ok: false, name: '', version: '1.0.0', reason: 'x' }),
+    ).toThrow();
+    expect(() =>
+      RegistryYankOutcomeSchema.parse({ ok: false, name: 'vendor/example', version: '1.0.0', reason: '' }),
+    ).toThrow();
+  });
+});
+
+describe('RegistryDoctorReportSchema', () => {
+  it('restricts issue severity to error, warning, or info', () => {
+    expect(() => RegistryDoctorIssueSchema.parse({ severity: 'fatal', code: 'x', message: 'y' })).toThrow();
+    expect(RegistryDoctorIssueSchema.parse({ severity: 'warning', code: 'x', message: 'y' }).severity).toBe('warning');
+  });
+
+  it('requires an issues array even when empty', () => {
+    const report = RegistryDoctorReportSchema.parse({
+      ok: true,
+      backendId: 'fixture',
+      checkedAt: 123,
+      entriesChecked: 0,
+      issues: [],
+    });
+    expect(report.issues).toEqual([]);
+    expect(() =>
+      RegistryDoctorReportSchema.parse({ ok: true, backendId: 'fixture', checkedAt: 123, entriesChecked: 0 }),
+    ).toThrow();
+  });
+});
+
+describe('ResolvedRegistryEntrySchema', () => {
+  it('binds an entry to a backend identity with a chosen version', () => {
+    const resolved = ResolvedRegistryEntrySchema.parse({
+      backendId: 'fixture',
+      backendKind: 'local',
+      trust: 'restricted',
+      entry,
+      version: { version: entry.version, source: entry.source },
+      source: entry.source,
+    });
+    expect(resolved.backendKind).toBe('local');
+    expect(resolved.entry.name).toBe('vendor/example');
+    expect(resolved.version.version).toBe('1.0.0');
+  });
+
+  it('rejects unknown backend kind and trust values', () => {
+    const base = {
+      backendId: 'fixture',
+      entry,
+      version: { version: entry.version, source: entry.source },
+      source: entry.source,
+    };
+    expect(() => ResolvedRegistryEntrySchema.parse({ ...base, backendKind: 'svn', trust: 'restricted' })).toThrow();
+    expect(() => ResolvedRegistryEntrySchema.parse({ ...base, backendKind: 'local', trust: 'unknown' })).toThrow();
+  });
+});

--- a/packages/sidecar/tests/path-validators.test.ts
+++ b/packages/sidecar/tests/path-validators.test.ts
@@ -107,7 +107,7 @@ describe("resolveProjectRoot", () => {
 
   it("resolves relative paths against the current working directory", () => {
     expect(resolveProjectRoot("./repo")).toBe(resolve("./repo"));
-    expect(resolveProjectRoot("/repo/product")).toBe("/repo/product");
+    expect(resolveProjectRoot("/repo/product")).toBe(resolve("/repo/product"));
   });
 });
 

--- a/packages/sidecar/tests/path-validators.test.ts
+++ b/packages/sidecar/tests/path-validators.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { join, resolve } from "node:path";
+
+import {
+  isWindowsNamedPipePath,
+  normalizeIpcPath,
+  resolveAppRuntimePath,
+  resolveLogFilePath,
+  resolveLogsDir,
+  resolveManifestPath,
+  resolvePointerPath,
+  resolveProjectRoot,
+  resolveProjectTmpRoot,
+  resolveRuntimeRoot,
+  type SidecarContractDescriptor,
+  type SidecarStampShape,
+} from "../src/index.js";
+
+type FakeStamp = SidecarStampShape & {
+  app: "api" | "ui";
+  mode: "dev" | "prod";
+  source: "tool" | "pack";
+};
+
+const fakeContract: SidecarContractDescriptor<FakeStamp> = {
+  defaults: {
+    host: "127.0.0.1",
+    ipcBase: "/tmp/fake-product/ipc",
+    namespace: "default",
+    projectTmpDirName: ".fake-tmp",
+    windowsPipePrefix: "fake-product",
+  },
+  env: {
+    base: "FAKE_BASE",
+    ipcBase: "FAKE_IPC_BASE",
+    ipcPath: "FAKE_IPC_PATH",
+    namespace: "FAKE_NAMESPACE",
+    source: "FAKE_SOURCE",
+  },
+  normalizeApp(value) {
+    if (value === "api" || value === "ui") return value;
+    throw new Error(`unsupported fake app: ${String(value)}`);
+  },
+  normalizeNamespace(value) {
+    if (typeof value !== "string" || !/^[a-z0-9-]+$/.test(value)) {
+      throw new Error("invalid fake namespace");
+    }
+    return value;
+  },
+  normalizeSource(value) {
+    if (value === "tool" || value === "pack") return value;
+    throw new Error(`unsupported fake source: ${String(value)}`);
+  },
+  normalizeStamp(value) {
+    const stamp = value as Partial<FakeStamp>;
+    return {
+      app: this.normalizeApp(stamp.app),
+      ipc: String(stamp.ipc),
+      mode: stamp.mode === "prod" ? "prod" : "dev",
+      namespace: this.normalizeNamespace(stamp.namespace),
+      source: this.normalizeSource(stamp.source),
+    };
+  },
+};
+
+describe("normalizeIpcPath", () => {
+  it("rejects non-string inputs", () => {
+    expect(() => normalizeIpcPath(undefined)).toThrow(/must be a string/);
+    expect(() => normalizeIpcPath(42)).toThrow(/must be a string/);
+    expect(() => normalizeIpcPath(null)).toThrow(/must be a string/);
+  });
+
+  it("rejects empty and whitespace-padded strings", () => {
+    expect(() => normalizeIpcPath("")).toThrow(/must not be empty/);
+    expect(() => normalizeIpcPath(" /tmp/sock ")).toThrow(/leading or trailing whitespace/);
+    expect(() => normalizeIpcPath("\t/tmp/sock")).toThrow(/leading or trailing whitespace/);
+  });
+
+  it("rejects null bytes embedded in the path", () => {
+    expect(() => normalizeIpcPath("/tmp/sock\0evil")).toThrow(/null bytes/);
+  });
+
+  it("accepts Windows named pipe paths verbatim", () => {
+    const pipe = "\\\\.\\pipe\\open-design-default-api";
+    expect(isWindowsNamedPipePath(pipe)).toBe(true);
+    expect(normalizeIpcPath(pipe)).toBe(pipe);
+  });
+
+  it("rejects non-absolute POSIX paths", () => {
+    expect(() => normalizeIpcPath("relative/sock")).toThrow(/must be absolute/);
+    expect(() => normalizeIpcPath("./sock")).toThrow(/must be absolute/);
+  });
+
+  it("accepts absolute POSIX paths verbatim", () => {
+    expect(normalizeIpcPath("/tmp/open-design/ipc/default/api.sock")).toBe(
+      "/tmp/open-design/ipc/default/api.sock",
+    );
+  });
+});
+
+describe("resolveProjectRoot", () => {
+  it("rejects non-string and empty inputs", () => {
+    expect(() => resolveProjectRoot(undefined as unknown as string)).toThrow(/non-empty string/);
+    expect(() => resolveProjectRoot("")).toThrow(/non-empty string/);
+    expect(() => resolveProjectRoot("   ")).toThrow(/non-empty string/);
+  });
+
+  it("resolves relative paths against the current working directory", () => {
+    expect(resolveProjectRoot("./repo")).toBe(resolve("./repo"));
+    expect(resolveProjectRoot("/repo/product")).toBe("/repo/product");
+  });
+});
+
+describe("runtime path resolvers", () => {
+  const projectRoot = "/repo/product";
+  const base = resolve(projectRoot, ".fake-tmp", "tool");
+  const namespaceRoot = join(base, "alpha");
+
+  it("anchors the project tmp root to the descriptor directory name", () => {
+    expect(resolveProjectTmpRoot({ contract: fakeContract, projectRoot })).toBe(
+      resolve(projectRoot, ".fake-tmp"),
+    );
+  });
+
+  it("nests runtime roots under the namespace and runs directory", () => {
+    expect(resolveRuntimeRoot({ base, contract: fakeContract, namespace: "alpha", runId: "run-42" })).toBe(
+      join(namespaceRoot, "runs", "run-42"),
+    );
+  });
+
+  it("places pointer and manifest files in their expected slots", () => {
+    expect(resolvePointerPath({ base, contract: fakeContract, namespace: "alpha" })).toBe(
+      join(namespaceRoot, "current.json"),
+    );
+    const runtimeRoot = join(namespaceRoot, "runs", "run-42");
+    expect(resolveManifestPath({ runtimeRoot })).toBe(join(runtimeRoot, "manifest.json"));
+  });
+
+  it("scopes log directories and files to the requested app", () => {
+    const runtimeRoot = join(namespaceRoot, "runs", "run-42");
+    expect(resolveLogsDir({ app: "api", contract: fakeContract, runtimeRoot })).toBe(
+      join(runtimeRoot, "logs", "api"),
+    );
+    expect(resolveLogFilePath({ app: "api", contract: fakeContract, runtimeRoot })).toBe(
+      join(runtimeRoot, "logs", "api", "latest.log"),
+    );
+    expect(
+      resolveLogFilePath({ app: "ui", contract: fakeContract, fileName: "stderr.log", runtimeRoot }),
+    ).toBe(join(runtimeRoot, "logs", "ui", "stderr.log"));
+  });
+});
+
+describe("resolveAppRuntimePath fileName validation", () => {
+  const namespaceRoot = "/repo/product/.fake-tmp/tool/alpha";
+
+  it("rejects empty file names", () => {
+    expect(() =>
+      resolveAppRuntimePath({ app: "ui", contract: fakeContract, fileName: "", namespaceRoot }),
+    ).toThrow(/simple path segment/);
+  });
+
+  it("rejects file names containing null bytes", () => {
+    expect(() =>
+      resolveAppRuntimePath({ app: "ui", contract: fakeContract, fileName: "cache\0evil", namespaceRoot }),
+    ).toThrow(/simple path segment/);
+  });
+
+  it("rejects file names containing path separators", () => {
+    expect(() =>
+      resolveAppRuntimePath({ app: "ui", contract: fakeContract, fileName: "nested/file", namespaceRoot }),
+    ).toThrow(/simple path segment/);
+    expect(() =>
+      resolveAppRuntimePath({ app: "ui", contract: fakeContract, fileName: "nested\\file", namespaceRoot }),
+    ).toThrow(/simple path segment/);
+  });
+
+  it("accepts simple segment names", () => {
+    expect(
+      resolveAppRuntimePath({ app: "ui", contract: fakeContract, fileName: "cache.json", namespaceRoot }),
+    ).toBe(join(namespaceRoot, "ui", "cache.json"));
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for two `packages/*` modules that previously had little or no coverage, and wires `registry-protocol` into `core_tests` (it was not invoked by any CI job before). `sidecar` was already wired — only its test surface changed.

- `packages/registry-protocol`: schema bounds (`RegistrySearchQuerySchema.limit`), optional-field handling (`RegistryVersionSchema.deprecated/yanked/yankedReason`), signature presence, yank outcome shapes, doctor report severities, resolved-entry extensions.
- `packages/sidecar`: `normalizeIpcPath` validation branches (non-string, empty, whitespace, null-byte, Windows pipe, non-absolute POSIX) and the `resolveProjectRoot` / `resolveRuntimeRoot` / `resolvePointerPath` / `resolveManifestPath` / `resolveLogsDir` / `resolveLogFilePath` / `resolveAppRuntimePath` family.

Tests-only + CI wiring; no product source changes.

## What users will see
Nothing — internal test coverage + CI wiring only.

## Surface area
- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — tests + a one-line CI wiring add (run `registry-protocol`'s suite in `core_tests`); no product surface.

## Validation
- `pnpm --filter @open-design/registry-protocol test` — green locally (16 tests).
- `pnpm --filter @open-design/sidecar test` — green locally (20 tests).
