### PR TITLE
feat(daemon): structured diagnostics for agent connection test results (#2248 PR 1/N)

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1183,7 +1183,10 @@ async function testAgentConnectionInternal(
     };
   };
 
-  const resultFromAgentText = (text: string): ConnectionTestResponse => {
+  const resultFromAgentText = (
+    text: string,
+    exit?: { code: number | null; signal: NodeJS.Signals | null },
+  ): ConnectionTestResponse => {
     const latencyMs = Date.now() - start;
     const rawSample = truncateSample(text);
     const sample = redactSecrets(rawSample);
@@ -1199,7 +1202,10 @@ async function testAgentConnectionInternal(
         model,
         agentName: def.name,
         detail,
-        diagnostics: buildDiagnostics({ phase: 'output_parse' }),
+        diagnostics: buildDiagnostics({
+          phase: 'output_parse',
+          ...(exit ? { exitCode: exit.code, signal: exit.signal } : {}),
+        }),
       };
     }
     if (!isSmokeOkReply(text)) {
@@ -1208,6 +1214,14 @@ async function testAgentConnectionInternal(
       );
     }
     console.log(`[test:agent] ${def.name} → ok in ${(latencyMs / 1000).toFixed(1)}s`);
+    // resultFromChildExit can route ACP forced shutdown (code === null,
+    // signal === 'SIGTERM' + acpCleanCompletion) through this success
+    // helper. Hard-coding `exitCode: 0` would silently overwrite the
+    // SIGTERM signal and violate the raw code/signal contract in
+    // packages/contracts/src/api/connectionTest.ts. Pass through the
+    // real `winner.code` / `winner.signal` when the caller has them and
+    // only synthesize `exitCode: 0` when no exit context is available
+    // (theoretical text-without-exit path).
     return {
       ok: true,
       kind: 'success',
@@ -1215,7 +1229,11 @@ async function testAgentConnectionInternal(
       model,
       agentName: def.name,
       sample,
-      diagnostics: buildDiagnostics({ phase: 'connection_smoke_test', exitCode: 0 }),
+      diagnostics: buildDiagnostics(
+        exit
+          ? { phase: 'connection_smoke_test', exitCode: exit.code, signal: exit.signal }
+          : { phase: 'connection_smoke_test', exitCode: 0 },
+      ),
     };
   };
 
@@ -1292,6 +1310,10 @@ async function testAgentConnectionInternal(
       );
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
+      // buildArgs runs *after* binary resolution but *before* spawn, so
+      // phase is still 'binary_resolution' here. Stamp diagnostics so the
+      // contract advertised in packages/contracts/src/api/connectionTest.ts
+      // ("Always set on local agent test responses") actually holds.
       return {
         ok: false,
         kind: 'agent_spawn_failed',
@@ -1299,6 +1321,7 @@ async function testAgentConnectionInternal(
         model,
         agentName: def.name,
         detail: redactSecrets(detail),
+        diagnostics: buildDiagnostics(),
       };
     }
     const stdinMode =
@@ -1314,6 +1337,11 @@ async function testAgentConnectionInternal(
     const env = applyAgentLaunchEnv(baseEnv, executableResolution);
     const auth = await probeAgentAuthStatus(input.agentId, executableResolution.launchPath, env);
     if (auth?.status === 'missing') {
+      // Preflight auth probe runs after binary resolution but before the
+      // smoke spawn — phase is still 'binary_resolution'. Without
+      // diagnostics here, Cursor-style auth failures never get the
+      // binaryPath/stderrTail context the rest of the local agent
+      // surface promises.
       return {
         ok: false,
         kind: 'agent_auth_required',
@@ -1321,6 +1349,7 @@ async function testAgentConnectionInternal(
         model,
         agentName: def.name,
         detail: auth.message ?? cursorAuthGuidance(),
+        diagnostics: buildDiagnostics(),
       };
     }
     const invocation = createCommandInvocation({
@@ -1419,10 +1448,11 @@ async function testAgentConnectionInternal(
         (winner.code === 0 && !winner.signal) || acpForcedShutdown;
       if (buffered) {
         const rawSample = truncateSample(buffered);
+        const exitInfo = { code: winner.code, signal: winner.signal };
         if (rawSample && isLikelyModelErrorText(rawSample)) {
-          return resultFromAgentText(buffered);
+          return resultFromAgentText(buffered, exitInfo);
         }
-        if (exitedCleanly) return resultFromAgentText(buffered);
+        if (exitedCleanly) return resultFromAgentText(buffered, exitInfo);
       }
       const stderrTail = sink.getStderrTail().trim();
       const rawStdoutTail = sink.getRawStdoutTail().trim();
@@ -1563,6 +1593,10 @@ async function testAgentConnectionInternal(
     return resultFromChildExit(winner);
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
+    // Outer catch — the failure may have happened at any phase between
+    // binary_resolution and output_parse, so stamp the current phase as
+    // observed. buildDiagnostics is defined in the enclosing scope and
+    // is safe to call here.
     return {
       ok: false,
       kind: 'agent_spawn_failed',
@@ -1570,6 +1604,7 @@ async function testAgentConnectionInternal(
       model,
       agentName: def.name,
       detail: redactSecrets(detail),
+      diagnostics: buildDiagnostics(),
     };
   } finally {
     if (timer) clearTimeout(timer);

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -48,7 +48,9 @@ import {
   validateBaseUrl,
   type AgentTestRequest,
   type BaseUrlValidationResult,
+  type ConnectionTestDiagnostics,
   type ConnectionTestKind,
+  type ConnectionTestPhase,
   type ConnectionTestProtocol,
   type ConnectionTestResponse,
   type ParsedBaseUrl,
@@ -1126,6 +1128,7 @@ async function testAgentConnectionInternal(
       model,
       agentName: input.agentId,
       detail: `Unknown agent id: ${input.agentId}`,
+      diagnostics: { phase: 'binary_resolution' },
     };
   }
   const configuredAgentEnv = agentCliEnvForAgent(
@@ -1141,6 +1144,7 @@ async function testAgentConnectionInternal(
       latencyMs: Date.now() - start,
       model,
       agentName: def.name,
+      diagnostics: { phase: 'binary_resolution' },
     };
   }
 
@@ -1151,6 +1155,33 @@ async function testAgentConnectionInternal(
   let timer: ReturnType<typeof setTimeout> | null = null;
   let abortHandler: (() => void) | null = null;
   const sink = createAgentSink();
+
+  // Phase tracker for structured diagnostics (#2248). The order matches
+  // the lifecycle: binary_resolution → spawn → connection_smoke_test →
+  // output_parse. Each result helper below stamps the *current* phase
+  // into the response so consumers don't have to scrape `detail` to
+  // know how far the test got. Phase is mutated at the points where
+  // the daemon meaningfully advances (just before spawn, when the
+  // child first produces stdout, etc.) — not on every event.
+  let phase: ConnectionTestPhase = 'binary_resolution';
+  const buildDiagnostics = (
+    overrides: Partial<ConnectionTestDiagnostics> = {},
+  ): ConnectionTestDiagnostics => {
+    const rawStderr = sink.getStderrTail().trim();
+    const rawStdout = sink.getRawStdoutTail().trim();
+    // `exactOptionalPropertyTypes: true` means we can't pass `undefined`
+    // to an optional field directly — conditionally spread instead so
+    // empty values just don't appear in the response.
+    return {
+      phase,
+      ...(executableResolution.launchPath
+        ? { binaryPath: executableResolution.launchPath }
+        : {}),
+      ...(rawStderr ? { stderrTail: redactSecrets(rawStderr) } : {}),
+      ...(rawStdout ? { stdoutTail: redactSecrets(rawStdout) } : {}),
+      ...overrides,
+    };
+  };
 
   const resultFromAgentText = (text: string): ConnectionTestResponse => {
     const latencyMs = Date.now() - start;
@@ -1168,6 +1199,7 @@ async function testAgentConnectionInternal(
         model,
         agentName: def.name,
         detail,
+        diagnostics: buildDiagnostics({ phase: 'output_parse' }),
       };
     }
     if (!isSmokeOkReply(text)) {
@@ -1183,6 +1215,7 @@ async function testAgentConnectionInternal(
       model,
       agentName: def.name,
       sample,
+      diagnostics: buildDiagnostics({ phase: 'connection_smoke_test', exitCode: 0 }),
     };
   };
 
@@ -1201,6 +1234,7 @@ async function testAgentConnectionInternal(
         model,
         agentName: def.name,
         detail: auth.message ?? cursorAuthGuidance(),
+        diagnostics: buildDiagnostics(),
       };
     }
     if (detail && isLikelyModelErrorText(detail)) {
@@ -1214,6 +1248,7 @@ async function testAgentConnectionInternal(
         model,
         agentName: def.name,
         detail,
+        diagnostics: buildDiagnostics({ phase: 'output_parse' }),
       };
     }
     console.warn(
@@ -1226,6 +1261,7 @@ async function testAgentConnectionInternal(
       model,
       agentName: def.name,
       detail,
+      diagnostics: buildDiagnostics(),
     };
   };
 
@@ -1240,6 +1276,7 @@ async function testAgentConnectionInternal(
       latencyMs,
       model,
       agentName: def.name,
+      diagnostics: buildDiagnostics(),
     };
   };
 
@@ -1291,6 +1328,12 @@ async function testAgentConnectionInternal(
       args,
       env,
     });
+    // We are about to hand off to child_process.spawn(). Any failure
+    // from here on (ENOENT, bad argv, non-zero exit) belongs to the
+    // 'spawn' phase rather than 'binary_resolution', so flip the tracker
+    // *before* spawning. resultFromAgentText flips it again to
+    // 'connection_smoke_test' / 'output_parse' once we get text out.
+    phase = 'spawn';
     child = spawn(invocation.command, invocation.args, {
       env,
       stdio: [stdinMode, 'pipe', 'pipe'],
@@ -1344,6 +1387,9 @@ async function testAgentConnectionInternal(
           model,
           agentName: def.name,
           detail: `${detail}${guidance}`,
+          diagnostics: buildDiagnostics({
+            phase: isMissing ? 'binary_resolution' : 'spawn',
+          }),
         };
       }
 
@@ -1401,6 +1447,11 @@ async function testAgentConnectionInternal(
           model,
           agentName: def.name,
           detail: auth.message ?? cursorAuthGuidance(),
+          diagnostics: buildDiagnostics({
+            phase: 'connection_smoke_test',
+            exitCode: winner.code,
+            signal: winner.signal,
+          }),
         };
       }
       const claudeDiagnostic = diagnoseClaudeCliFailure({
@@ -1422,6 +1473,11 @@ async function testAgentConnectionInternal(
           model,
           agentName: def.name,
           detail: claudeDiagnostic.detail,
+          diagnostics: buildDiagnostics({
+            phase: 'spawn',
+            exitCode: winner.code,
+            signal: winner.signal,
+          }),
         };
       }
       const detail = redactSecrets(
@@ -1446,6 +1502,11 @@ async function testAgentConnectionInternal(
         agentName: def.name,
         detail:
           `${detail || 'Agent exited without producing assistant text'}${guidance}`,
+        diagnostics: buildDiagnostics({
+          phase: buffered ? 'output_parse' : 'spawn',
+          exitCode: winner.code,
+          signal: winner.signal,
+        }),
       };
     };
 

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1338,10 +1338,16 @@ async function testAgentConnectionInternal(
     const auth = await probeAgentAuthStatus(input.agentId, executableResolution.launchPath, env);
     if (auth?.status === 'missing') {
       // Preflight auth probe runs after binary resolution but before the
-      // smoke spawn — phase is still 'binary_resolution'. Without
-      // diagnostics here, Cursor-style auth failures never get the
-      // binaryPath/stderrTail context the rest of the local agent
-      // surface promises.
+      // smoke spawn — phase is still 'binary_resolution'. The smoke
+      // sink is empty here (no spawn happened), so the probe itself is
+      // the only source of stderr/stdout/exit context. Fold what the
+      // probe captured into the diagnostics block; `...overrides` in
+      // buildDiagnostics() lets these win over the empty sink tails.
+      const probeOverrides: Partial<ConnectionTestDiagnostics> = {};
+      if (auth.stdoutTail) probeOverrides.stdoutTail = redactSecrets(auth.stdoutTail);
+      if (auth.stderrTail) probeOverrides.stderrTail = redactSecrets(auth.stderrTail);
+      if (auth.exitCode !== undefined) probeOverrides.exitCode = auth.exitCode;
+      if (auth.signal !== undefined) probeOverrides.signal = auth.signal;
       return {
         ok: false,
         kind: 'agent_auth_required',
@@ -1349,7 +1355,7 @@ async function testAgentConnectionInternal(
         model,
         agentName: def.name,
         detail: auth.message ?? cursorAuthGuidance(),
-        diagnostics: buildDiagnostics(),
+        diagnostics: buildDiagnostics(probeOverrides),
       };
     }
     const invocation = createCommandInvocation({

--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -4,6 +4,16 @@ import type { RuntimeEnv } from './types.js';
 export type AgentAuthProbeResult = {
   status: 'ok' | 'missing' | 'unknown';
   message?: string;
+  // Output captured from the probe child process (e.g.
+  // `cursor-agent status`). Exposed so callers like the connection
+  // test layer can fold the probe's own stderr/exit context into their
+  // structured diagnostics — the probe runs before the smoke spawn,
+  // so without this the diagnostics block would otherwise drop the
+  // probe output entirely.
+  stdoutTail?: string;
+  stderrTail?: string;
+  exitCode?: number | null;
+  signal?: string | null;
 };
 
 const CURSOR_AUTH_GUIDANCE =
@@ -66,6 +76,30 @@ export function classifyAgentAuthFailure(
   return null;
 }
 
+// Tail length matches the smoke-test sink so the diagnostics block
+// stays compact when it folds probe output back into its overrides.
+const PROBE_TAIL_BYTES = 400;
+
+function tailString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > PROBE_TAIL_BYTES ? trimmed.slice(-PROBE_TAIL_BYTES) : trimmed;
+}
+
+function withProbeTails(
+  base: AgentAuthProbeResult,
+  stdoutText: string,
+  stderrText: string,
+): AgentAuthProbeResult {
+  const result: AgentAuthProbeResult = { ...base };
+  const stdoutTail = tailString(stdoutText);
+  const stderrTail = tailString(stderrText);
+  if (stdoutTail) result.stdoutTail = stdoutTail;
+  if (stderrTail) result.stderrTail = stderrTail;
+  return result;
+}
+
 export async function probeAgentAuthStatus(
   agentId: string,
   resolvedBin: string,
@@ -78,27 +112,54 @@ export async function probeAgentAuthStatus(
       timeout: 5000,
       maxBuffer: 1024 * 1024,
     });
-    const output = `${stdout ?? ''}\n${stderr ?? ''}`;
+    const stdoutText = typeof stdout === 'string' ? stdout : '';
+    const stderrText = typeof stderr === 'string' ? stderr : '';
+    const output = `${stdoutText}\n${stderrText}`;
     if (isCursorAuthFailureText(output)) {
-      return { status: 'missing', message: cursorAuthGuidance() };
+      return withProbeTails(
+        { status: 'missing', message: cursorAuthGuidance(), exitCode: 0, signal: null },
+        stdoutText,
+        stderrText,
+      );
     }
     return { status: 'ok' };
   } catch (error) {
     const err = error as NodeJS.ErrnoException & {
       stdout?: unknown;
       stderr?: unknown;
+      code?: string | number;
+      signal?: string;
     };
-    const output = [
-      err.message,
-      typeof err.stdout === 'string' ? err.stdout : '',
-      typeof err.stderr === 'string' ? err.stderr : '',
-    ].join('\n');
+    const stdoutText = typeof err.stdout === 'string' ? err.stdout : '';
+    const stderrText = typeof err.stderr === 'string' ? err.stderr : '';
+    const output = [err.message, stdoutText, stderrText].join('\n');
+    // util.promisify(execFile) attaches `code` and `signal` to the
+    // rejection error. `code` may be a number (real non-zero exit) or
+    // a Node ErrnoException string ("ENOENT"); only the numeric form
+    // is meaningful as an exit code.
+    const numericExit = typeof err.code === 'number' ? err.code : null;
+    const childSignal = typeof err.signal === 'string' ? err.signal : null;
     if (isCursorAuthFailureText(output)) {
-      return { status: 'missing', message: cursorAuthGuidance() };
+      return withProbeTails(
+        {
+          status: 'missing',
+          message: cursorAuthGuidance(),
+          exitCode: numericExit,
+          signal: childSignal,
+        },
+        stdoutText,
+        stderrText,
+      );
     }
-    return {
-      status: 'unknown',
-      message: 'Cursor Agent authentication status could not be verified with `cursor-agent status`.',
-    };
+    return withProbeTails(
+      {
+        status: 'unknown',
+        message: 'Cursor Agent authentication status could not be verified with `cursor-agent status`.',
+        exitCode: numericExit,
+        signal: childSignal,
+      },
+      stdoutText,
+      stderrText,
+    );
   }
 }

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2196,6 +2196,45 @@ process.stdin.on('end', () => {
       process.env.PATH = oldPath;
     }
   });
+
+  it('attaches diagnostics when the preflight auth probe reports missing auth (#2248)', async () => {
+    // Cursor Agent's preflight `cursor-agent status` check rejects the
+    // smoke run before the daemon ever spawns the smoke prompt. The
+    // initial #2248 pass forgot to stamp diagnostics on that return
+    // path, which contradicted the "Always set on local agent test
+    // responses" contract in packages/contracts. Lock the contract.
+    await withFakeCursorAgent(
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('2026.05.07-test');
+  process.exit(0);
+}
+if (args[0] === 'models') {
+  console.log('auto');
+  process.exit(0);
+}
+if (args[0] === 'status') {
+  console.error('Not logged in');
+  process.exit(1);
+}
+console.error('smoke prompt should not run when status reports missing auth');
+process.exit(1);
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'cursor-agent' });
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'agent_auth_required',
+        });
+        expect(result.diagnostics).toBeDefined();
+        // Preflight runs after binary resolution but before the smoke
+        // spawn, so phase should still be 'binary_resolution'.
+        expect(result.diagnostics?.phase).toBe('binary_resolution');
+        expect(result.diagnostics?.binaryPath ?? '').toMatch(/cursor-agent/);
+      },
+    );
+  });
 });
 
 describe('connection test helpers', () => {

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2202,7 +2202,11 @@ process.stdin.on('end', () => {
     // smoke run before the daemon ever spawns the smoke prompt. The
     // initial #2248 pass forgot to stamp diagnostics on that return
     // path, which contradicted the "Always set on local agent test
-    // responses" contract in packages/contracts. Lock the contract.
+    // responses" contract in packages/contracts. Lock the contract,
+    // and additionally lock the probe's own stderr/exit metadata —
+    // without those, the diagnostics block would drop the only context
+    // a caller has on a missing-auth failure (no smoke spawn ever ran,
+    // so the smoke sink is empty).
     await withFakeCursorAgent(
       `
 const args = process.argv.slice(2);
@@ -2232,6 +2236,11 @@ process.exit(1);
         // spawn, so phase should still be 'binary_resolution'.
         expect(result.diagnostics?.phase).toBe('binary_resolution');
         expect(result.diagnostics?.binaryPath ?? '').toMatch(/cursor-agent/);
+        // The probe child wrote "Not logged in" on stderr and exited
+        // 1; both must propagate into diagnostics so Settings/CLI can
+        // render the structured auth-failure context.
+        expect(result.diagnostics?.stderrTail ?? '').toContain('Not logged in');
+        expect(result.diagnostics?.exitCode).toBe(1);
       },
     );
   });

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2109,6 +2109,93 @@ setInterval(() => {}, 1000);
     });
     expect(res.status).toBe(400);
   });
+
+  // Regression coverage for #2248: the daemon must return structured
+  // diagnostics next to the existing `kind`/`detail` strings so Settings
+  // and CLI consumers don't have to scrape the human-readable detail
+  // line to know what phase failed, which binary path was used, or what
+  // the child's exit metadata was. The legacy fields stay unchanged so
+  // older clients keep rendering.
+  it('attaches structured diagnostics on Claude smoke-test success (#2248)', async () => {
+    await withFakeClaude(
+      `
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  try {
+    JSON.parse(input.trim());
+    console.log(JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg_1',
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn',
+      },
+    }));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+});
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'claude' });
+
+        expect(result).toMatchObject({ ok: true, kind: 'success' });
+        expect(result.diagnostics).toBeDefined();
+        expect(result.diagnostics?.phase).toBe('connection_smoke_test');
+        // The binary path is whatever fake bin the test harness installed
+        // on PATH (a temp directory). All we want here is that the
+        // daemon actually fills it in, not that it matches an exact path.
+        expect(typeof result.diagnostics?.binaryPath).toBe('string');
+        expect(result.diagnostics?.binaryPath ?? '').toMatch(/claude/);
+        expect(result.diagnostics?.exitCode).toBe(0);
+      },
+    );
+  });
+
+  it('attaches structured diagnostics on Claude exit-failed (#2248)', async () => {
+    await withFakeClaude(
+      `console.error('boom-on-stderr'); process.exit(7);`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'claude' });
+
+        expect(result.ok).toBe(false);
+        // Back-compat: existing kind + detail keep their shape.
+        expect(typeof result.kind).toBe('string');
+        expect(typeof result.detail).toBe('string');
+        // New: structured fields are attached.
+        expect(result.diagnostics).toBeDefined();
+        expect(result.diagnostics?.phase).toBe('spawn');
+        expect(result.diagnostics?.exitCode).toBe(7);
+        expect(result.diagnostics?.stderrTail ?? '').toContain('boom-on-stderr');
+        expect(result.diagnostics?.binaryPath ?? '').toMatch(/claude/);
+      },
+    );
+  });
+
+  it('reports an early-phase diagnostics block when the agent CLI is missing (#2248)', async () => {
+    // Clear PATH so the daemon cannot locate `claude`. We restore the
+    // env in `finally` to avoid leaking the empty PATH to later tests.
+    // Depending on whether the resolver short-circuits or the spawn
+    // itself ENOENTs, the kind may be agent_not_installed or
+    // agent_spawn_failed and the phase may be 'binary_resolution' or
+    // 'spawn'. Both are valid "we never reached the smoke test" shapes
+    // — the actionable bit for the UI is that diagnostics arrived at
+    // all and that the phase is one of the two early values.
+    const oldPath = process.env.PATH;
+    process.env.PATH = '';
+    try {
+      const result = await testAgentConnection({ agentId: 'claude' });
+      expect(result.ok).toBe(false);
+      expect(['agent_not_installed', 'agent_spawn_failed']).toContain(result.kind);
+      expect(result.diagnostics).toBeDefined();
+      expect(['binary_resolution', 'spawn']).toContain(result.diagnostics?.phase);
+    } finally {
+      process.env.PATH = oldPath;
+    }
+  });
 });
 
 describe('connection test helpers', () => {

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -139,6 +139,41 @@ export type ConnectionTestKind =
   | 'agent_spawn_failed'
   | 'unknown';
 
+// Phase markers describing how far the local agent connection test
+// progressed before it produced its result. Used inside
+// `ConnectionTestResponse.diagnostics.phase` and intended to be stable
+// across daemon versions so Settings UI and CLI consumers can render
+// phase-aware copy without re-deriving it from the free-form `detail`
+// string. See issue #2248.
+export type ConnectionTestPhase =
+  | 'binary_resolution'
+  | 'version_probe'
+  | 'model_list'
+  | 'spawn'
+  | 'connection_smoke_test'
+  | 'output_parse';
+
+export interface ConnectionTestDiagnostics {
+  // How far the test progressed before producing the result. Always
+  // set on local agent test responses.
+  phase: ConnectionTestPhase;
+  // Absolute filesystem path of the executable the daemon actually
+  // attempted to run, when resolution succeeded.
+  binaryPath?: string;
+  // Best-effort version string captured during `version_probe`. Null
+  // when the CLI exposes no machine-parseable version output.
+  binaryVersion?: string | null;
+  // Child process exit metadata. Both fields keep the raw `code` /
+  // `signal` shape from `child_process` so consumers can distinguish
+  // a clean non-zero exit from a SIGTERM teardown.
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | string | null;
+  // Last ~400 bytes of the child's streams, already passed through
+  // the daemon's secret redactor.
+  stdoutTail?: string;
+  stderrTail?: string;
+}
+
 export type ConnectionTestProtocol = 'anthropic' | 'openai' | 'azure' | 'google' | 'ollama' | 'senseaudio';
 
 export interface ProviderTestRequest {
@@ -183,4 +218,9 @@ export interface ConnectionTestResponse {
   detectedExecutablePath?: string;
   usedExecutablePath?: string;
   usedExecutableSource?: 'configured' | 'path' | 'fallback_invalid' | 'fallback_failed';
+  // Structured diagnostics for the local agent connection test path
+  // (#2248). Optional and additive: existing consumers that only read
+  // `kind` and `detail` keep working unchanged. Populated only when the
+  // test actually spawned an agent CLI, so provider tests omit it.
+  diagnostics?: ConnectionTestDiagnostics;
 }

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -220,7 +220,9 @@ export interface ConnectionTestResponse {
   usedExecutableSource?: 'configured' | 'path' | 'fallback_invalid' | 'fallback_failed';
   // Structured diagnostics for the local agent connection test path
   // (#2248). Optional and additive: existing consumers that only read
-  // `kind` and `detail` keep working unchanged. Populated only when the
-  // test actually spawned an agent CLI, so provider tests omit it.
+  // `kind` and `detail` keep working unchanged. Populated on local
+  // agent test responses — including early failures that never reach
+  // the spawn step (unknown agent id, unresolved binary, preflight
+  // auth probe). Provider tests omit it.
   diagnostics?: ConnectionTestDiagnostics;
 }

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -165,9 +165,13 @@ export interface ConnectionTestDiagnostics {
   binaryVersion?: string | null;
   // Child process exit metadata. Both fields keep the raw `code` /
   // `signal` shape from `child_process` so consumers can distinguish
-  // a clean non-zero exit from a SIGTERM teardown.
+  // a clean non-zero exit from a SIGTERM teardown. `signal` is typed as
+  // `string | null` (not `NodeJS.Signals`) so the generated `.d.ts`
+  // stays browser-safe — the daemon writes one of the
+  // `NodeJS.Signals` literals here but consumers never need to import
+  // ambient Node namespaces just to read an HTTP response shape.
   exitCode?: number | null;
-  signal?: NodeJS.Signals | string | null;
+  signal?: string | null;
   // Last ~400 bytes of the child's streams, already passed through
   // the daemon's secret redactor.
   stdoutTail?: string;


### PR DESCRIPTION
Refs #2248

## Why

Local agent connection-test failures today flatten everything into a single free-form \`detail\` string like \`exit 1\`. Settings UI and CLI consumers can't tell:

- which **phase** failed (binary resolution? spawn? smoke-test response? output parse?)
- which **binary path** the daemon actually picked (matters when \`fallbackBins\`/PATH override is in play)
- the child's **exit metadata** (\`exitCode\`, \`signal\`, stderr tail)

…without scraping the human-readable text. That's the gap #2248 calls out. The data already exists (\`createAgentSink\` buffers stdout/stderr tails; \`resultFromChildExit\` sees \`winner.code\`/\`winner.signal\`; \`executableResolution.launchPath\` is set at resolution time) — it just isn't returned.

This PR closes that gap with the smallest possible change.

## What users will see

Nothing visually different yet. \`kind\` and \`detail\` are kept bit-for-bit identical, so the existing Settings copy ("Agent exited without producing assistant text" etc.) renders unchanged. What changes is the response body: every local agent connection-test response now carries an optional \`diagnostics\` block with structured fields.

UI / CLI consumers that opt in (a planned "View details" disclosure in Settings; \`od\` automation scripts) can render:

\`\`\`json
{
  "ok": false,
  "kind": "agent_spawn_failed",
  "detail": "exit 7 · stderr: boom-on-stderr",
  "diagnostics": {
    "phase": "spawn",
    "binaryPath": "/usr/local/bin/claude",
    "exitCode": 7,
    "stderrTail": "boom-on-stderr"
  }
}
\`\`\`

## Scope (this PR vs. the rest of #2248)

This is **PR 1 of an N-PR plan** for #2248. Scope here is intentionally minimal: contract shape + minimum daemon fill, no behavior change.

Follow-ups, each their own PR:

1. **Normalized failure classifier** — map \`{phase, exitCode, stderrTail, stdoutTail}\` into the 9 normalized kinds the issue lists (\`binary_not_found\`, \`unsupported_version\`, \`auth_failed\`, \`quota_exceeded\`, \`network_failed\`, \`unsupported_flags\`, \`no_text_output\`, \`output_parse_failed\`, \`spawn_failed\`).
2. **Candidate alternatives + version probe phase** — extend \`inspectAgentExecutableResolution\` to surface all \`fallbackBins\` matches; call \`probeVersionAtPath\` as an explicit \`version_probe\` step so \`diagnostics.binaryVersion\` is populated and unsupported versions get their own classifier kind.
3. **Settings "View details" disclosure** — render the new diagnostics as a collapsible block; add the corresponding i18n key.

Keeping the contract shape PR separate lets the rest land incrementally without a giant migration; the optional \`diagnostics\` field means PR 2-4 can ship before the UI catches up.

## Implementation notes

- New \`ConnectionTestPhase\` union in \`packages/contracts/src/api/connectionTest.ts\`, plus a \`ConnectionTestDiagnostics\` interface with all optional fields.
- \`testAgentConnectionInternal\` gets a single mutable \`phase\` tracker that flips at meaningful boundaries: \`binary_resolution\` at entry → \`spawn\` immediately before \`child_process.spawn()\` → \`connection_smoke_test\` / \`output_parse\` inside \`resultFromAgentText\`.
- All four result helpers (\`resultFromAgentText\`, \`resultFromStreamError\`, \`resultFromCancellation\`, \`resultFromChildExit\`) and both early-return branches (unknown agent id, unresolved binary) call a shared \`buildDiagnostics()\` helper. The helper reuses the existing \`sink.getStderrTail()\`/\`sink.getRawStdoutTail()\` buffers — no new child capture machinery.
- \`exactOptionalPropertyTypes: true\` is honored via conditional spreads (no \`field: undefined\` assignments).
- Provider connection tests are unaffected — \`diagnostics\` is only attached on local agent test results.

## Surface area

- [ ] **UI** — no (PR 3 will add the "View details" disclosure)
- [ ] **Keyboard shortcut** — no
- [ ] **CLI / env var** — no
- [x] **API / contract** — yes (additive only, \`diagnostics?\` is optional)
- [ ] **Extension point** — no
- [ ] **i18n keys** — no (PR 3 will add the disclosure copy)
- [ ] **New top-level dependency** — no
- [ ] **Default behavior change** — no (\`kind\`/\`detail\` strings preserved bit-for-bit)

## Verification

- \`pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts -t 2248\` — 3 passed (3 new specs).
- \`pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts\` — 247/248 files pass; 1 pre-existing flaky failure in \`tests/orbit.test.ts > tracks the most recent run per template alongside the global last run\` that passes 14/14 when run in isolation, reproduces unchanged against \`main\`.
- \`pnpm --filter @open-design/daemon typecheck\` — passed (had to use conditional-spread to satisfy \`exactOptionalPropertyTypes\`).
- \`pnpm guard\` — passed.