### PR TITLE
Polish design systems library layout

### DIFF
--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -479,7 +479,6 @@ export function DesignSystemsTab({
                   });
                   onSelect(s.id);
                 }}
-                onOpenSystem={onOpenSystem ? () => onOpenSystem(s.id) : undefined}
                 onPreview={() => {
                   trackDesignSystemsTemplateCardClick(analytics.track, {
                     page_name: 'design_systems',
@@ -505,7 +504,6 @@ interface CardProps {
   thumbHtml: string | null | undefined;
   onIntersect: () => void;
   onSelect: () => void;
-  onOpenSystem?: () => void;
   onPreview: () => void;
 }
 
@@ -515,7 +513,6 @@ function DesignSystemCard({
   thumbHtml,
   onIntersect,
   onSelect,
-  onOpenSystem,
   onPreview,
 }: CardProps) {
   const { locale, t } = useI18n();
@@ -632,19 +629,6 @@ function DesignSystemCard({
             </div>
           ) : null}
         </div>
-        {onOpenSystem ? (
-          <button
-            type="button"
-            className="ghost"
-            onClick={(e) => {
-              e.stopPropagation();
-              onOpenSystem();
-            }}
-          >
-            <Icon name={system.isEditable ? 'edit' : 'external-link'} />
-            {system.isEditable ? 'Edit' : 'Open'}
-          </button>
-        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/styles/design-system-flow.css
+++ b/apps/web/src/styles/design-system-flow.css
@@ -1343,10 +1343,26 @@
 }
 .ds-manager-toolbar {
   align-items: stretch;
-  padding: 14px 18px 0;
+  width: min(100% - 36px, 1280px);
+  margin: 14px auto 0;
+  padding: 0;
 }
 .ds-manager-toolbar > input {
   min-height: 38px;
+}
+.design-systems-manager .examples-filter-row {
+  width: min(100% - 36px, 1280px);
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 14px;
+  padding: 0;
+  margin-bottom: 28px;
+}
+.design-systems-manager .ds-grid {
+  width: min(100% - 36px, 1280px);
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 0;
 }
 .ds-manager-eyebrow {
   display: block;

--- a/apps/web/tests/components/DesignSystemsTab.test.tsx
+++ b/apps/web/tests/components/DesignSystemsTab.test.tsx
@@ -102,6 +102,28 @@ describe('DesignSystemsTab', () => {
     fireEvent.click(screen.getByText('Edit'));
     expect(onOpenSystem).toHaveBeenCalledWith('user:acme');
   });
+
+  it('omits the built-in library Open button while keeping preview clicks', () => {
+    const onOpenSystem = vi.fn();
+    const onPreview = vi.fn();
+    render(
+      <DesignSystemsTab
+        systems={systems}
+        selectedId={null}
+        onSelect={() => {}}
+        onPreview={onPreview}
+        onCreate={() => {}}
+        onOpenSystem={onOpenSystem}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Open' })).toBeNull();
+
+    fireEvent.click(screen.getByTestId('design-system-preview-linear'));
+
+    expect(onPreview).toHaveBeenCalledWith('linear');
+    expect(onOpenSystem).not.toHaveBeenCalledWith('linear');
+  });
 });
 
 // --- #2062: built-in library surface-chip filtering -----------------------


### PR DESCRIPTION
## Why

The Design Systems library was visually crowded: built-in library cards included a separate Open button even though preview already opens from the card preview, and the filter row / three-column card grid felt too tight and too wide on large screens. This PR trims the duplicate action and gives the library browsing area a calmer layout.

## What users will see

In Design Systems → Built-in library, built-in cards no longer show an Open button. Users still click the preview thumbnail to open the existing preview modal. The search, category filter, surface filter row, and card grid are also centered within a narrower content width with clearer spacing around the surface tabs.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

User-provided before screenshots showed the crowded Design Systems library row and full-width three-column grid. This PR adjusts that entry point directly.

## Bug fix verification

- Not a bug-fix PR. Added a focused component regression test for the removed built-in library Open button while preserving preview clicks.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test -- DesignSystemsTab.test.tsx`

Note: this local shell is running Node `v22.22.0`, while the repo expects Node `~24`; pnpm printed engine warnings, but all commands completed successfully.