### PR TITLE
test(tools-dev): cover config parsers and sidecar-client null/timeout semantics

### DIFF
--- a/tools/dev/tests/config.test.ts
+++ b/tools/dev/tests/config.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { APP_KEYS } from "@open-design/sidecar-proto";
+
+import {
+  parsePortOption,
+  resolveRunApps,
+  resolveStartApps,
+  resolveStopApps,
+  resolveTargetApps,
+} from "../src/config.js";
+
+describe("parsePortOption", () => {
+  it("returns null when the value is null", () => {
+    assert.equal(parsePortOption(null, "--daemon-port"), null);
+  });
+
+  it("returns null when the value is undefined", () => {
+    assert.equal(parsePortOption(undefined, "--daemon-port"), null);
+  });
+
+  it("returns null when the value is the empty string", () => {
+    assert.equal(parsePortOption("", "--daemon-port"), null);
+  });
+
+  it("accepts a numeric string at the lower edge of the valid range", () => {
+    assert.equal(parsePortOption("1", "--daemon-port"), 1);
+  });
+
+  it("accepts a numeric string at the upper edge of the valid range", () => {
+    assert.equal(parsePortOption("65535", "--daemon-port"), 65535);
+  });
+
+  it("accepts a raw integer", () => {
+    assert.equal(parsePortOption(17456, "--daemon-port"), 17456);
+  });
+
+  it("throws when the value is one above the upper edge", () => {
+    assert.throws(() => parsePortOption("65536", "--daemon-port"), /--daemon-port must be an integer between 1 and 65535/);
+  });
+
+  it("throws when the value is zero", () => {
+    assert.throws(() => parsePortOption("0", "--daemon-port"), /--daemon-port must be an integer between 1 and 65535/);
+  });
+
+  it("throws when the value is non-numeric", () => {
+    assert.throws(() => parsePortOption("abc", "--web-port"), /--web-port must be an integer between 1 and 65535/);
+  });
+
+  it("throws when the value is a non-integer number", () => {
+    assert.throws(() => parsePortOption("3.14", "--daemon-port"), /--daemon-port must be an integer between 1 and 65535/);
+  });
+});
+
+describe("resolveStartApps", () => {
+  it("defaults to all three apps when no app name is given", () => {
+    assert.deepEqual(resolveStartApps(undefined), [APP_KEYS.DAEMON, APP_KEYS.WEB, APP_KEYS.DESKTOP]);
+  });
+
+  it("returns daemon+web when starting web", () => {
+    assert.deepEqual(resolveStartApps(APP_KEYS.WEB), [APP_KEYS.DAEMON, APP_KEYS.WEB]);
+  });
+
+  it("returns all three when starting desktop", () => {
+    assert.deepEqual(resolveStartApps(APP_KEYS.DESKTOP), [APP_KEYS.DAEMON, APP_KEYS.WEB, APP_KEYS.DESKTOP]);
+  });
+
+  it("returns daemon-only when starting daemon", () => {
+    assert.deepEqual(resolveStartApps(APP_KEYS.DAEMON), [APP_KEYS.DAEMON]);
+  });
+
+  it("throws on an unknown app name", () => {
+    assert.throws(() => resolveStartApps("api"), /unsupported tools-dev app: api/);
+  });
+});
+
+describe("resolveStopApps", () => {
+  it("defaults to desktop+web+daemon in shutdown order", () => {
+    assert.deepEqual(resolveStopApps(undefined), [APP_KEYS.DESKTOP, APP_KEYS.WEB, APP_KEYS.DAEMON]);
+  });
+
+  it("stops web+daemon (in that order) when stopping web", () => {
+    assert.deepEqual(resolveStopApps(APP_KEYS.WEB), [APP_KEYS.WEB, APP_KEYS.DAEMON]);
+  });
+
+  it("stops desktop only when stopping desktop (does NOT cascade to daemon)", () => {
+    assert.deepEqual(resolveStopApps(APP_KEYS.DESKTOP), [APP_KEYS.DESKTOP]);
+  });
+
+  it("stops daemon only when stopping daemon", () => {
+    assert.deepEqual(resolveStopApps(APP_KEYS.DAEMON), [APP_KEYS.DAEMON]);
+  });
+
+  it("throws on an unknown app name", () => {
+    assert.throws(() => resolveStopApps("api"), /unsupported tools-dev app: api/);
+  });
+});
+
+describe("resolveRunApps", () => {
+  it("defaults to daemon+web (does NOT include desktop)", () => {
+    assert.deepEqual(resolveRunApps(undefined), [APP_KEYS.DAEMON, APP_KEYS.WEB]);
+  });
+
+  it("delegates to resolveStartApps when an app name is given", () => {
+    assert.deepEqual(resolveRunApps(APP_KEYS.WEB), [APP_KEYS.DAEMON, APP_KEYS.WEB]);
+    assert.deepEqual(resolveRunApps(APP_KEYS.DESKTOP), [APP_KEYS.DAEMON, APP_KEYS.WEB, APP_KEYS.DESKTOP]);
+    assert.deepEqual(resolveRunApps(APP_KEYS.DAEMON), [APP_KEYS.DAEMON]);
+  });
+
+  it("throws on an unknown app name", () => {
+    assert.throws(() => resolveRunApps("api"), /unsupported tools-dev app: api/);
+  });
+});
+
+describe("resolveTargetApps", () => {
+  it("returns the defaults when no app name is given", () => {
+    const defaults = [APP_KEYS.DAEMON, APP_KEYS.WEB] as const;
+    assert.deepEqual(resolveTargetApps(undefined, defaults), [APP_KEYS.DAEMON, APP_KEYS.WEB]);
+  });
+
+  it("returns a single-element list when a known app name is given", () => {
+    assert.deepEqual(resolveTargetApps(APP_KEYS.WEB, [APP_KEYS.DAEMON]), [APP_KEYS.WEB]);
+  });
+
+  it("throws on an unknown app name", () => {
+    assert.throws(() => resolveTargetApps("api", [APP_KEYS.DAEMON]), /unsupported tools-dev app: api/);
+  });
+});

--- a/tools/dev/tests/sidecar-client.test.ts
+++ b/tools/dev/tests/sidecar-client.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, before, describe, it } from "node:test";
+
+import { APP_KEYS, OPEN_DESIGN_SIDECAR_CONTRACT, SIDECAR_ENV } from "@open-design/sidecar-proto";
+import { resolveAppIpcPath } from "@open-design/sidecar";
+
+import {
+  inspectDaemonRuntime,
+  waitForDaemonRuntime,
+} from "../src/sidecar-client.js";
+
+function uniqueNamespace(label: string): string {
+  return `tools-dev-test-${label}-${process.pid}-${Date.now()}`;
+}
+
+function startSocketServer(socketPath: string, response: unknown): Server {
+  mkdirSync(path.dirname(socketPath), { recursive: true });
+  const server = createServer((socket) => {
+    socket.on("data", () => {
+      socket.write(`${JSON.stringify({ ok: true, result: response })}\n`);
+      socket.end();
+    });
+  });
+  server.listen(socketPath);
+  return server;
+}
+
+describe("inspectDaemonRuntime", () => {
+  it("returns null when the IPC socket does not exist", async () => {
+    const runtime = { base: tmpdir(), namespace: uniqueNamespace("inspect-missing") };
+    const snapshot = await inspectDaemonRuntime(runtime, 100);
+    assert.equal(snapshot, null);
+  });
+
+  it("returns the parsed snapshot when the daemon responds", async () => {
+    const namespace = uniqueNamespace("inspect-ok");
+    const ipcBase = mkdtempSync(path.join(tmpdir(), "tools-dev-ipc-"));
+    const prev = process.env[SIDECAR_ENV.IPC_BASE];
+    process.env[SIDECAR_ENV.IPC_BASE] = ipcBase;
+    const socketPath = resolveAppIpcPath({ app: APP_KEYS.DAEMON, contract: OPEN_DESIGN_SIDECAR_CONTRACT, namespace });
+    const server = startSocketServer(socketPath, {
+      desktopAuthGateActive: true,
+      pid: 4242,
+      state: "running",
+      url: "http://127.0.0.1:7456",
+    });
+    try {
+      const snapshot = await inspectDaemonRuntime({ base: tmpdir(), namespace }, 1500);
+      assert.notEqual(snapshot, null);
+      assert.equal(snapshot?.url, "http://127.0.0.1:7456");
+      assert.equal(snapshot?.desktopAuthGateActive, true);
+    } finally {
+      await new Promise((done) => server.close(() => done(undefined)));
+      if (prev == null) delete process.env[SIDECAR_ENV.IPC_BASE];
+      else process.env[SIDECAR_ENV.IPC_BASE] = prev;
+      rmSync(ipcBase, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("waitForDaemonRuntime", () => {
+  it("throws when the daemon never responds before the timeout elapses", async () => {
+    const runtime = { base: tmpdir(), namespace: uniqueNamespace("wait-timeout") };
+    await assert.rejects(
+      () => waitForDaemonRuntime(runtime, 200),
+      /daemon did not expose status in time/,
+    );
+  });
+
+  it("resolves on the first successful inspect", async () => {
+    const namespace = uniqueNamespace("wait-ok");
+    const ipcBase = mkdtempSync(path.join(tmpdir(), "tools-dev-ipc-"));
+    const prev = process.env[SIDECAR_ENV.IPC_BASE];
+    process.env[SIDECAR_ENV.IPC_BASE] = ipcBase;
+    const socketPath = resolveAppIpcPath({ app: APP_KEYS.DAEMON, contract: OPEN_DESIGN_SIDECAR_CONTRACT, namespace });
+    const server = startSocketServer(socketPath, {
+      desktopAuthGateActive: false,
+      pid: 99,
+      state: "running",
+      url: "http://127.0.0.1:17456",
+    });
+    try {
+      const snapshot = await waitForDaemonRuntime({ base: tmpdir(), namespace }, 2000);
+      assert.equal(snapshot.url, "http://127.0.0.1:17456");
+    } finally {
+      await new Promise((done) => server.close(() => done(undefined)));
+      if (prev == null) delete process.env[SIDECAR_ENV.IPC_BASE];
+      else process.env[SIDECAR_ENV.IPC_BASE] = prev;
+      rmSync(ipcBase, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for two `tools/dev` modules that previously had no direct coverage:
- `tools/dev/src/config.ts`: `parsePortOption` validation (null/empty/0/65535/65536/non-numeric), `resolveStartApps` / `resolveStopApps` / `resolveRunApps` expansion rules (including the asymmetric "desktop stops desktop only, no daemon cascade" contract and the "default run excludes desktop" distinction), and `resolveTargetApps` known/unknown handling.
- `tools/dev/src/sidecar-client.ts`: `inspectDaemonRuntime` null-on-error path (no socket) and the success path against a real Unix-domain-socket fixture, plus `waitForDaemonRuntime` resolve-on-first-success and timeout-on-always-failing branches.

Tests-only — no source changes.

## What users will see
Nothing — internal test coverage only.

## Surface area
- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — tests only.

## Validation
- `pnpm --filter @open-design/tools-dev test` — green locally (43 tests passing, +30 new).
