### PR TITLE
test(tools-pack): cover mac/win paths, registry, manifest, NSIS, config validators

### DIFF
--- a/tools/pack/tests/mac-paths.test.ts
+++ b/tools/pack/tests/mac-paths.test.ts
@@ -1,0 +1,50 @@
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { PRODUCT_NAME } from "../src/mac/constants.js";
+import {
+  macAppBundleName,
+  macAppExecutablePath,
+  resolveMacAppOutputDirectoryName,
+  sanitizeNamespace,
+} from "../src/mac/paths.js";
+
+describe("sanitizeNamespace", () => {
+  it("keeps alphanumerics, dots, hyphens, and underscores", () => {
+    expect(sanitizeNamespace("Open-Design.beta_1")).toBe("Open-Design.beta_1");
+  });
+
+  it("replaces forbidden chars with hyphens and collapses runs", () => {
+    expect(sanitizeNamespace("a/b c")).toBe("a-b-c");
+    expect(sanitizeNamespace("a   //  b")).toBe("a-b");
+    expect(sanitizeNamespace("中文/ns")).toBe("-ns");
+  });
+});
+
+describe("macAppBundleName", () => {
+  it("formats <PRODUCT_NAME>.<sanitized-namespace>.app", () => {
+    expect(macAppBundleName("release-beta")).toBe(`${PRODUCT_NAME}.release-beta.app`);
+    expect(macAppBundleName("a b/c")).toBe(`${PRODUCT_NAME}.a-b-c.app`);
+  });
+});
+
+describe("macAppExecutablePath", () => {
+  it("joins the Contents/MacOS executable path under the bundle", () => {
+    const appPath = "/tmp/out/mac/Open Design.app";
+    expect(macAppExecutablePath(appPath)).toBe(join(appPath, "Contents", "MacOS", PRODUCT_NAME));
+  });
+
+  it("honors a custom executable name", () => {
+    const appPath = "/tmp/out/mac/Open Design.app";
+    expect(macAppExecutablePath(appPath, "open-design-beta")).toBe(
+      join(appPath, "Contents", "MacOS", "open-design-beta"),
+    );
+  });
+});
+
+describe("resolveMacAppOutputDirectoryName", () => {
+  it("returns mac-arm64 on arm64 hosts, otherwise mac", () => {
+    expect(resolveMacAppOutputDirectoryName()).toBe(process.arch === "arm64" ? "mac-arm64" : "mac");
+  });
+});

--- a/tools/pack/tests/win-manifest.test.ts
+++ b/tools/pack/tests/win-manifest.test.ts
@@ -1,0 +1,146 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { ToolPackConfig } from "../src/config.js";
+import { readBuiltAppManifest, writePackagedConfigFile } from "../src/win/manifest.js";
+import type { WinBuiltAppManifest, WinPaths } from "../src/win/types.js";
+
+function makePaths(root: string): Pick<WinPaths, "builtManifestPath"> {
+  return { builtManifestPath: join(root, "manifest.json") };
+}
+
+function makeConfig(overrides: Partial<ToolPackConfig> = {}): ToolPackConfig {
+  return {
+    containerized: false,
+    electronBuilderCliPath: "/unused",
+    electronDistPath: "/unused",
+    electronVersion: "0.0.0",
+    macCompression: "normal",
+    namespace: "test-namespace",
+    platform: "win",
+    portable: false,
+    removeData: false,
+    removeLogs: false,
+    removeProductUserData: false,
+    removeSidecars: false,
+    roots: {
+      output: {
+        appBuilderRoot: "/unused/builder",
+        namespaceRoot: "/unused/ns",
+        platformRoot: "/unused/platform",
+        root: "/unused/root",
+      },
+      runtime: {
+        namespaceBaseRoot: "C:/users/test/AppData/Local/open-design/runtime/win/namespaces",
+        namespaceRoot: "C:/users/test/AppData/Local/open-design/runtime/win/namespaces/test-namespace",
+      },
+      cacheRoot: "/unused/cache",
+      toolPackRoot: "/unused/tools-pack",
+    },
+    signed: false,
+    silent: true,
+    to: "nsis",
+    webOutputMode: "standalone",
+    workspaceRoot: "/unused/workspace",
+    ...overrides,
+  };
+}
+
+describe("readBuiltAppManifest", () => {
+  it("returns null when the manifest file is missing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-manifest-"));
+    try {
+      const paths = makePaths(root) as WinPaths;
+      await expect(readBuiltAppManifest(paths)).resolves.toBeNull();
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects manifests whose version is not 1", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-manifest-"));
+    try {
+      const paths = makePaths(root) as WinPaths;
+      await writeFile(paths.builtManifestPath, JSON.stringify({ version: 2, executablePath: "/x" }), "utf8");
+      await expect(readBuiltAppManifest(paths)).resolves.toBeNull();
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("returns the parsed manifest when the version matches", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-manifest-"));
+    try {
+      const paths = makePaths(root) as WinPaths;
+      const manifest: WinBuiltAppManifest = {
+        appBuilderOutputRoot: join(root, "builder"),
+        cacheEntryPath: null,
+        configPath: join(root, "config.json"),
+        executablePath: join(root, "Open Design.exe"),
+        source: "namespace",
+        unpackedRoot: join(root, "unpacked"),
+        version: 1,
+        webStandaloneHookAuditPath: null,
+      };
+      await writeFile(paths.builtManifestPath, JSON.stringify(manifest), "utf8");
+      await expect(readBuiltAppManifest(paths)).resolves.toEqual(manifest);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("returns null when requireExecutable is set and the executable is missing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-manifest-"));
+    try {
+      const paths = makePaths(root) as WinPaths;
+      const manifest: WinBuiltAppManifest = {
+        appBuilderOutputRoot: join(root, "builder"),
+        cacheEntryPath: null,
+        configPath: join(root, "config.json"),
+        executablePath: join(root, "missing.exe"),
+        source: "namespace",
+        unpackedRoot: join(root, "unpacked"),
+        version: 1,
+        webStandaloneHookAuditPath: null,
+      };
+      await writeFile(paths.builtManifestPath, JSON.stringify(manifest), "utf8");
+      await expect(readBuiltAppManifest(paths, { requireExecutable: true })).resolves.toBeNull();
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("writePackagedConfigFile", () => {
+  it("omits namespaceBaseRoot for portable builds", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-config-"));
+    try {
+      const filePath = join(root, "config", "open-design-config.json");
+      await writePackagedConfigFile(filePath, makeConfig({ portable: true }), "1.2.3");
+      const written = JSON.parse(await readFile(filePath, "utf8"));
+      expect(written.namespace).toBe("test-namespace");
+      expect(written.appVersion).toBe("1.2.3");
+      expect(written).not.toHaveProperty("namespaceBaseRoot");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("includes namespaceBaseRoot for non-portable builds", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-config-"));
+    try {
+      const filePath = join(root, "config", "open-design-config.json");
+      await writePackagedConfigFile(filePath, makeConfig({ portable: false }), "1.2.3");
+      const written = JSON.parse(await readFile(filePath, "utf8"));
+      expect(written.namespaceBaseRoot).toBe(
+        "C:/users/test/AppData/Local/open-design/runtime/win/namespaces",
+      );
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tools/pack/tests/win-manifest.test.ts
+++ b/tools/pack/tests/win-manifest.test.ts
@@ -27,6 +27,7 @@ function makeConfig(overrides: Partial<ToolPackConfig> = {}): ToolPackConfig {
     removeLogs: false,
     removeProductUserData: false,
     removeSidecars: false,
+    requireVelaCli: false,
     roots: {
       output: {
         appBuilderRoot: "/unused/builder",

--- a/tools/pack/tests/win-nsis.test.ts
+++ b/tools/pack/tests/win-nsis.test.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { ToolPackConfig } from "../src/config.js";
+import { writeNsisInclude } from "../src/win/nsis.js";
+import type { WinPaths } from "../src/win/types.js";
+
+function makeConfig(namespaceRoot: string): ToolPackConfig {
+  return {
+    containerized: false,
+    electronBuilderCliPath: "/unused",
+    electronDistPath: "/unused",
+    electronVersion: "0.0.0",
+    macCompression: "normal",
+    namespace: "test-namespace",
+    platform: "win",
+    portable: false,
+    removeData: false,
+    removeLogs: false,
+    removeProductUserData: false,
+    removeSidecars: false,
+    roots: {
+      output: {
+        appBuilderRoot: "/unused/builder",
+        namespaceRoot: "/unused/ns",
+        platformRoot: "/unused/platform",
+        root: "/unused/root",
+      },
+      runtime: {
+        namespaceBaseRoot: "/unused/base",
+        namespaceRoot,
+      },
+      cacheRoot: "/unused/cache",
+      toolPackRoot: "/unused/tools-pack",
+    },
+    signed: false,
+    silent: true,
+    to: "nsis",
+    webOutputMode: "standalone",
+    workspaceRoot: "/unused/workspace",
+  };
+}
+
+describe("writeNsisInclude", () => {
+  it("escapes double quotes and newlines in the local-data root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-nsis-"));
+    try {
+      const includePath = join(root, "include", "open-design.nsh");
+      const paths = { nsisIncludePath: includePath } as WinPaths;
+      const config = makeConfig('C:\\Open "Design"\nbeta');
+
+      await writeNsisInclude(config, paths);
+      const written = await readFile(includePath, "utf8");
+
+      expect(written).toContain('C:\\Open $\\"Design$\\"$\\r$\\nbeta');
+      expect(written).not.toContain('C:\\Open "Design"\n');
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tools/pack/tests/win-nsis.test.ts
+++ b/tools/pack/tests/win-nsis.test.ts
@@ -22,6 +22,7 @@ function makeConfig(namespaceRoot: string): ToolPackConfig {
     removeLogs: false,
     removeProductUserData: false,
     removeSidecars: false,
+    requireVelaCli: false,
     roots: {
       output: {
         appBuilderRoot: "/unused/builder",

--- a/tools/pack/tests/win-registry.test.ts
+++ b/tools/pack/tests/win-registry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { stripRegistryQuotedValue } from "../src/win/registry.js";
+
+describe("stripRegistryQuotedValue", () => {
+  it("returns the quoted body when the value is fully quoted", () => {
+    expect(stripRegistryQuotedValue('"C:\\Program Files\\Open Design\\Uninstall.exe"')).toBe(
+      "C:\\Program Files\\Open Design\\Uninstall.exe",
+    );
+  });
+
+  it("returns the inner segment when the quoted region carries trailing flags", () => {
+    expect(stripRegistryQuotedValue('"C:\\Program Files\\Open Design\\Uninstall.exe" /S')).toBe(
+      "C:\\Program Files\\Open Design\\Uninstall.exe",
+    );
+  });
+
+  it("trims unquoted values and leaves them otherwise unchanged", () => {
+    expect(stripRegistryQuotedValue("  C:\\Open Design\\Uninstall.exe  ")).toBe(
+      "C:\\Open Design\\Uninstall.exe",
+    );
+  });
+
+  it("returns an empty string for null or undefined input", () => {
+    expect(stripRegistryQuotedValue(null)).toBe("");
+    expect(stripRegistryQuotedValue(undefined)).toBe("");
+  });
+
+  it("returns the trimmed value when only a leading quote is present", () => {
+    expect(stripRegistryQuotedValue('"unterminated')).toBe('"unterminated');
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for `tools/pack` Windows/macOS path & packaging modules that previously had little or no coverage:
- `src/mac/constants.ts` / mac path helpers — product-name and bundle path derivation.
- `src/win/registry.ts`: `stripRegistryQuotedValue` quoted / unquoted / null branches.
- `src/win/manifest.ts`: `readBuiltAppManifest` version mismatch, missing file, `requireExecutable` enforcement; `writePackagedConfigFile` portable-flag handling.
- `src/win/nsis.ts`: `writeNsisInclude` double-quote and newline escaping (exercises private `escapeNsisString` via real fixture).

(The original `config.test.ts` was dropped on rebase — it targeted `resolveToolPack{BuildOutput,MacCompression,AppVersion,WebOutputMode}`, which `main` has since refactored into `resolveToolPackConfig` and already covers.)

## Why
Filling untested pure-logic helpers in `tools/pack`. Tests-only; no `src` behavior change.

## What users will see
Nothing — internal test coverage only.

## Surface area
- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — tests only.

## Validation
- The `ToolPackConfig` test fixtures now include the required `requireVelaCli: false` (production default), so `pnpm --filter @open-design/tools-pack typecheck` passes; verified the explicit-before-spread shape with `tsc --strict` (compiles, vs. the field-only-from-`Partial`-spread shape which fails `TS2322 'boolean | undefined' is not assignable to 'boolean'`).
- Per-file unit tests cover the modules listed above.
