### PR TITLE
feat(daemon): add CTA hierarchy static QA pass (refs #2251)

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -44,6 +44,7 @@
     "@opentelemetry/api": "1.9.1",
     "better-sqlite3": "12.10.0",
     "blake3-wasm": "2.1.5",
+    "cheerio": "1.2.0",
     "chokidar": "5.0.0",
     "express": "4.22.1",
     "jszip": "3.10.1",

--- a/apps/daemon/src/qa/cta-hierarchy.ts
+++ b/apps/daemon/src/qa/cta-hierarchy.ts
@@ -248,9 +248,22 @@ function computeContainerKey($: CheerioAPI, el: CheerioCollection): string {
       }
     }
   }
+  // Keyed by parent-node identity, not just tag name: two sibling <div>s
+  // each holding one .btn-primary CTA must NOT collapse into the same
+  // bucket, otherwise detectMultiplePrimary() reports a shared-section
+  // conflict on a flat layout where each card has only one CTA.
   const parent = el.parent();
-  const parentTag = parent.length > 0 ? ((parent[0] as { tagName?: string; name?: string }).tagName ?? (parent[0] as { name?: string }).name ?? 'root') : 'root';
-  return `parent:${parentTag}`;
+  if (parent.length > 0) {
+    const parentNode = parent[0];
+    if (parentNode) {
+      const parentTag =
+        (parentNode as { tagName?: string }).tagName ?? (parentNode as { name?: string }).name ?? 'root';
+      const all = $(parentTag).toArray();
+      const index = all.indexOf(parentNode);
+      return `parent:${parentTag}:${index}`;
+    }
+  }
+  return 'parent:root';
 }
 
 function detectMultiplePrimary(candidates: CtaCandidate[]): CtaHierarchyIssue[] {
@@ -282,22 +295,35 @@ function detectMultiplePrimary(candidates: CtaCandidate[]): CtaHierarchyIssue[] 
 
 function detectAmbiguousWeight(candidates: CtaCandidate[]): CtaHierarchyIssue[] {
   if (candidates.length < 2) return [];
-  const first = candidates[0];
-  if (!first) return [];
-  const reference = signature(first);
-  const allIdentical = candidates.every((cta) => signature(cta) === reference);
-  if (!allIdentical) return [];
-  // Report the second one (the first is the natural anchor; subsequent
-  // identical CTAs are the ones a reviewer would diff against).
-  const cta = candidates[1];
-  if (!cta) return [];
-  return [
-    {
+  // Bucket by containerKey first: comparing signatures across the
+  // entire document yields false positives when two unrelated sections
+  // happen to share the same `.btn` styling but each holds only one
+  // CTA. The rule is "every CTA in a container shares the same class +
+  // inline style", so the container boundary must hold.
+  const byContainer = new Map<string, CtaCandidate[]>();
+  for (const cta of candidates) {
+    const bucket = byContainer.get(cta.containerKey) ?? [];
+    bucket.push(cta);
+    byContainer.set(cta.containerKey, bucket);
+  }
+  const issues: CtaHierarchyIssue[] = [];
+  for (const bucket of byContainer.values()) {
+    if (bucket.length < 2) continue;
+    const first = bucket[0];
+    if (!first) continue;
+    const reference = signature(first);
+    if (!bucket.every((cta) => signature(cta) === reference)) continue;
+    // Report the second one (the first is the natural anchor; subsequent
+    // identical CTAs are the ones a reviewer would diff against).
+    const cta = bucket[1];
+    if (!cta) continue;
+    issues.push({
       kind: 'ambiguous-weight',
       selector: cta.selector,
       message: `All CTAs share identical class and inline style; the visual hierarchy is ambiguous.`,
-    },
-  ];
+    });
+  }
+  return issues;
 }
 
 function detectMisleadingProminence(candidates: CtaCandidate[]): CtaHierarchyIssue[] {

--- a/apps/daemon/src/qa/cta-hierarchy.ts
+++ b/apps/daemon/src/qa/cta-hierarchy.ts
@@ -1,0 +1,352 @@
+// Post-generation static QA pass for CTA (call-to-action) hierarchy.
+//
+// Background: Open Design's generated HTML/CSS prototypes are sometimes
+// "functionally correct but feel unfinished" — a primary commerce action
+// renders as a neutral button, two equally-styled CTAs compete for the
+// same conversion slot, or a "Learn more" link is styled like the buy
+// button. See nexu-io/open-design#2251 for the motivating bug report.
+//
+// `analyseCtaHierarchy` parses the rendered HTML and returns a small set
+// of conservative findings. It is intentionally precision-biased: when
+// the signal is weak, the function says nothing. The output is the
+// first-useful-version of the QA pass; HTTP/CLI exposure and auto-repair
+// are explicit follow-ups.
+
+import { type CheerioAPI, load } from 'cheerio';
+
+// Cheerio 1.x doesn't re-export the underlying `AnyNode`/`Element` types
+// from `domhandler`. Importing `domhandler` directly would punch through
+// daemon's declared dependency boundary, so we derive a generic "node
+// collection" type from the API surface we actually use.
+type CheerioCollection = ReturnType<CheerioAPI>;
+type CheerioNode = CheerioCollection extends ArrayLike<infer N> ? N : never;
+
+export interface CtaHierarchyIssue {
+  /** Category of the finding; the UI may surface different copy per kind. */
+  kind: 'multiple-primary' | 'ambiguous-weight' | 'misleading-prominence';
+  /** Short CSS-like selector for the offending element, e.g. `a.btn.btn-primary`. */
+  selector: string;
+  /** One-sentence English description of the issue, suitable for a warning UI. */
+  message: string;
+}
+
+export interface CtaHierarchyReport {
+  issues: CtaHierarchyIssue[];
+  primaryCount: number;
+  secondaryCount: number;
+}
+
+/**
+ * Parse the rendered HTML and return CTA-hierarchy findings.
+ *
+ * The function is deterministic and side-effect free. Returns an empty
+ * report (no issues, zero counts) when the document has no CTA-shaped
+ * elements. The set of rules is intentionally narrow — see the issue list
+ * in this file for the categories we currently surface.
+ */
+export function analyseCtaHierarchy(html: string): CtaHierarchyReport {
+  const $ = load(html);
+  const candidates = collectCtaCandidates($);
+
+  if (candidates.length === 0) {
+    return { issues: [], primaryCount: 0, secondaryCount: 0 };
+  }
+
+  const primaryCount = candidates.filter((cta) => cta.weight === 'primary').length;
+  const secondaryCount = candidates.length - primaryCount;
+
+  const issues: CtaHierarchyIssue[] = [
+    ...detectMultiplePrimary(candidates),
+    ...detectAmbiguousWeight(candidates),
+    ...detectMisleadingProminence(candidates),
+  ];
+
+  return { issues, primaryCount, secondaryCount };
+}
+
+// ---------- internals --------------------------------------------------------
+
+type Weight = 'primary' | 'secondary';
+
+interface CtaCandidate {
+  el: CheerioCollection;
+  text: string;
+  classes: string[];
+  inlineStyle: string;
+  weight: Weight;
+  selector: string;
+  /** Section/container key used to group multiple-primary findings. */
+  containerKey: string;
+}
+
+// Conversion-oriented copy that strongly suggests the element is the page's
+// commercial action. Mix of English and Simplified Chinese, matched
+// case-insensitively as substrings on the element's text content.
+const CTA_KEYWORDS = [
+  // English
+  'get started',
+  'sign up',
+  'sign in',
+  'log in',
+  'buy',
+  'shop now',
+  'subscribe',
+  'subscribe now',
+  'try it free',
+  'start free trial',
+  'free trial',
+  'add to cart',
+  'order now',
+  'checkout',
+  'continue',
+  'submit',
+  // Secondary English (still CTA-shaped — flagged separately below).
+  'learn more',
+  'read more',
+  'more info',
+  'see more',
+  // Chinese
+  '开始',
+  '立即',
+  '查看',
+  '购买',
+  '选购',
+  '下单',
+  '提交',
+  '加入购物车',
+  '加入询价车',
+  '免费试用',
+  '了解更多',
+  '更多',
+  '详情',
+];
+
+// Copy that signals a SECONDARY CTA. If the visual weight on these elements
+// reads as primary, that's the misleading-prominence case.
+const SECONDARY_KEYWORDS = [
+  'learn more',
+  'read more',
+  'more info',
+  'see more',
+  '了解更多',
+  '更多',
+  '详情',
+];
+
+function collectCtaCandidates($: CheerioAPI): CtaCandidate[] {
+  const candidates: CtaCandidate[] = [];
+
+  // 1. Every <button>, every <a>, and anything with role="button" is a
+  //    structural candidate. We then filter on copy + class signals.
+  const selector = 'button, a, [role="button"]';
+  $(selector).each((_, node) => {
+    const el = $(node);
+    const text = normaliseText(el.text());
+    const classes = parseClasses(el.attr('class'));
+    const role = el.attr('role') ?? '';
+    const tag = (node as { tagName?: string; name?: string }).tagName ?? (node as { name?: string }).name ?? '';
+
+    // A button-shaped element is a CTA candidate when EITHER:
+    //   (a) its class list contains a btn/button/cta marker, OR
+    //   (b) its tag is <button> AND the copy matches a CTA keyword, OR
+    //   (c) it carries role="button".
+    // Plain anchors without any of these signals are skipped — there are
+    // usually many of them in nav menus and they'd produce noise.
+    const hasButtonClass = classes.some((c) => /(^|-)btn$|(^|-)button$|(^|-)cta$|^btn(-|$)|^button(-|$)|^cta(-|$)/i.test(c));
+    const isButtonTag = tag.toLowerCase() === 'button';
+    const isRoleButton = role.toLowerCase() === 'button';
+    const hasCtaCopy = matchesAnyKeyword(text, CTA_KEYWORDS);
+
+    if (!hasButtonClass && !isRoleButton && !(isButtonTag && hasCtaCopy)) {
+      return;
+    }
+
+    // Even after the structural filter, drop elements whose copy is not
+    // CTA-shaped at all (e.g. icon toggles like "+" / "−"). Anchors with a
+    // .btn class but no actionable copy frequently appear as inert chips.
+    if (!hasCtaCopy) {
+      return;
+    }
+
+    const inlineStyle = normaliseStyle(el.attr('style'));
+    const weight = classifyWeight(classes, inlineStyle);
+    const containerKey = computeContainerKey($, el);
+
+    candidates.push({
+      el,
+      text,
+      classes,
+      inlineStyle,
+      weight,
+      selector: buildSelector(tag, classes, role),
+      containerKey,
+    });
+  });
+
+  return candidates;
+}
+
+function classifyWeight(classes: string[], inlineStyle: string): Weight {
+  // Class-name signals are the strongest tell — design systems almost
+  // always tag the primary variant with one of these tokens.
+  const PRIMARY_CLASS_TOKENS = /(^|[-_])(primary|solid|filled|accent|cta)([-_]|$)/i;
+  if (classes.some((c) => PRIMARY_CLASS_TOKENS.test(c))) {
+    return 'primary';
+  }
+
+  // Otherwise infer from inline style: a non-transparent background colour
+  // is the dominant visual signal users read as "this is the main button".
+  // We don't try to evaluate computed CSS — that would require a full
+  // rendering layer; inline style is enough for the precision-biased pass.
+  if (hasNonTransparentBackground(inlineStyle)) {
+    return 'primary';
+  }
+
+  return 'secondary';
+}
+
+function hasNonTransparentBackground(inlineStyle: string): boolean {
+  const bg = extractStyleValue(inlineStyle, 'background-color') ?? extractStyleValue(inlineStyle, 'background');
+  if (!bg) return false;
+  const value = bg.toLowerCase().trim();
+  if (!value) return false;
+  if (value === 'transparent' || value === 'none' || value === 'inherit' || value === 'initial') return false;
+  if (/^rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*0(?:\.0+)?\s*\)$/.test(value)) return false;
+  return true;
+}
+
+function extractStyleValue(inlineStyle: string, property: string): string | null {
+  if (!inlineStyle) return null;
+  // Tolerant declaration parser — we don't need full CSS fidelity here.
+  const declarations = inlineStyle.split(';');
+  for (const decl of declarations) {
+    const colon = decl.indexOf(':');
+    if (colon < 0) continue;
+    const name = decl.slice(0, colon).trim().toLowerCase();
+    if (name === property.toLowerCase()) {
+      return decl.slice(colon + 1).trim();
+    }
+  }
+  return null;
+}
+
+function computeContainerKey($: CheerioAPI, el: CheerioCollection): string {
+  // Group CTAs by their nearest landmark/section ancestor. Falls back to
+  // the direct parent so that a flat document (no <section>) still gives
+  // us a meaningful grouping for the multiple-primary rule.
+  const landmarks = ['section', 'header', 'footer', 'nav', 'main', 'aside', 'article'];
+  for (const tag of landmarks) {
+    const ancestor = el.closest(tag);
+    if (ancestor.length > 0) {
+      const node = ancestor[0];
+      if (node) {
+        // The DOM identity of the ancestor is stable within one parse, so
+        // we can use a positional index to differentiate two <section>s.
+        const all = $(tag).toArray();
+        const index = all.indexOf(node);
+        return `${tag}:${index}`;
+      }
+    }
+  }
+  const parent = el.parent();
+  const parentTag = parent.length > 0 ? ((parent[0] as { tagName?: string; name?: string }).tagName ?? (parent[0] as { name?: string }).name ?? 'root') : 'root';
+  return `parent:${parentTag}`;
+}
+
+function detectMultiplePrimary(candidates: CtaCandidate[]): CtaHierarchyIssue[] {
+  const byContainer = new Map<string, CtaCandidate[]>();
+  for (const cta of candidates) {
+    if (cta.weight !== 'primary') continue;
+    const bucket = byContainer.get(cta.containerKey) ?? [];
+    bucket.push(cta);
+    byContainer.set(cta.containerKey, bucket);
+  }
+
+  const issues: CtaHierarchyIssue[] = [];
+  for (const bucket of byContainer.values()) {
+    if (bucket.length < 2) continue;
+    // Report the SECOND+ primary CTA in each container as the offender:
+    // the first one is the legitimate primary, the rest dilute it.
+    for (let i = 1; i < bucket.length; i += 1) {
+      const cta = bucket[i];
+      if (!cta) continue;
+      issues.push({
+        kind: 'multiple-primary',
+        selector: cta.selector,
+        message: `Multiple primary CTAs share the same section; "${truncate(cta.text)}" competes with the section's main action.`,
+      });
+    }
+  }
+  return issues;
+}
+
+function detectAmbiguousWeight(candidates: CtaCandidate[]): CtaHierarchyIssue[] {
+  if (candidates.length < 2) return [];
+  const first = candidates[0];
+  if (!first) return [];
+  const reference = signature(first);
+  const allIdentical = candidates.every((cta) => signature(cta) === reference);
+  if (!allIdentical) return [];
+  // Report the second one (the first is the natural anchor; subsequent
+  // identical CTAs are the ones a reviewer would diff against).
+  const cta = candidates[1];
+  if (!cta) return [];
+  return [
+    {
+      kind: 'ambiguous-weight',
+      selector: cta.selector,
+      message: `All CTAs share identical class and inline style; the visual hierarchy is ambiguous.`,
+    },
+  ];
+}
+
+function detectMisleadingProminence(candidates: CtaCandidate[]): CtaHierarchyIssue[] {
+  const issues: CtaHierarchyIssue[] = [];
+  for (const cta of candidates) {
+    if (cta.weight !== 'primary') continue;
+    if (!matchesAnyKeyword(cta.text, SECONDARY_KEYWORDS)) continue;
+    issues.push({
+      kind: 'misleading-prominence',
+      selector: cta.selector,
+      message: `"${truncate(cta.text)}" reads as a secondary action but is styled with primary-weight visuals.`,
+    });
+  }
+  return issues;
+}
+
+function signature(cta: CtaCandidate): string {
+  const classes = [...cta.classes].sort().join('.');
+  return `${classes}|${cta.inlineStyle}`;
+}
+
+function buildSelector(tag: string, classes: string[], role: string): string {
+  const tagPart = tag.toLowerCase() || 'element';
+  const classPart = classes.length > 0 ? `.${classes.join('.')}` : '';
+  const rolePart = role && tagPart !== 'button' ? `[role="${role.toLowerCase()}"]` : '';
+  return `${tagPart}${classPart}${rolePart}`;
+}
+
+function parseClasses(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw.split(/\s+/).filter(Boolean);
+}
+
+function normaliseText(raw: string): string {
+  return raw.replace(/\s+/g, ' ').trim();
+}
+
+function normaliseStyle(raw: string | undefined): string {
+  if (!raw) return '';
+  return raw.replace(/\s+/g, ' ').trim();
+}
+
+function matchesAnyKeyword(text: string, keywords: readonly string[]): boolean {
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  return keywords.some((kw) => lower.includes(kw.toLowerCase()));
+}
+
+function truncate(text: string, max = 40): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1)}…`;
+}

--- a/apps/daemon/tests/qa-cta-hierarchy.test.ts
+++ b/apps/daemon/tests/qa-cta-hierarchy.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { analyseCtaHierarchy } from '../src/qa/cta-hierarchy.js';
+
+// These tests pin down the first-useful-version contract for the CTA hierarchy
+// static QA pass. The function is intentionally conservative: precision > recall.
+// Adding new heuristics is fine, but they must not regress any case here.
+
+describe('analyseCtaHierarchy', () => {
+  it('returns an empty report when the document has no buttons or anchors', () => {
+    const report = analyseCtaHierarchy('<main><p>Welcome to the site</p></main>');
+    expect(report.issues).toEqual([]);
+    expect(report.primaryCount).toBe(0);
+    expect(report.secondaryCount).toBe(0);
+  });
+
+  it('does not flag a single clear primary CTA paired with a secondary CTA', () => {
+    const html = `
+      <section>
+        <a class="btn btn-primary" href="/signup">Get started</a>
+        <a class="btn" href="/learn-more">Learn more</a>
+      </section>
+    `;
+    const report = analyseCtaHierarchy(html);
+    expect(report.issues).toEqual([]);
+    expect(report.primaryCount).toBe(1);
+    expect(report.secondaryCount).toBe(1);
+  });
+
+  it('flags two primary CTAs sharing the same section as multiple-primary', () => {
+    const html = `
+      <section>
+        <a class="btn btn-primary" href="/signup">Sign up</a>
+        <a class="btn btn-primary" href="/buy">Buy now</a>
+      </section>
+    `;
+    const report = analyseCtaHierarchy(html);
+    const kinds = report.issues.map((issue) => issue.kind);
+    expect(kinds).toContain('multiple-primary');
+    expect(report.primaryCount).toBe(2);
+    // The selector should be short enough to surface in a one-line UI hint.
+    const offender = report.issues.find((issue) => issue.kind === 'multiple-primary');
+    expect(offender?.selector.length ?? 0).toBeLessThan(80);
+  });
+
+  it('flags ambiguous-weight when every CTA is rendered with identical class and inline style', () => {
+    const html = `
+      <header>
+        <a class="btn" href="/a">Get started</a>
+        <a class="btn" href="/b">Subscribe</a>
+        <a class="btn" href="/c">Buy</a>
+      </header>
+    `;
+    const report = analyseCtaHierarchy(html);
+    const kinds = report.issues.map((issue) => issue.kind);
+    expect(kinds).toContain('ambiguous-weight');
+    // None of these were tagged primary, so primaryCount stays at zero.
+    expect(report.primaryCount).toBe(0);
+    expect(report.secondaryCount).toBe(3);
+  });
+
+  it('flags misleading-prominence when secondary-coded copy uses solid primary styling', () => {
+    const html = `
+      <section>
+        <a class="btn btn-primary" href="/buy">Buy now</a>
+        <a class="btn" style="background-color: #1d4ed8; color: white; font-size: 20px" href="/learn-more">Learn more</a>
+      </section>
+    `;
+    const report = analyseCtaHierarchy(html);
+    const misleading = report.issues.find((issue) => issue.kind === 'misleading-prominence');
+    expect(misleading).toBeDefined();
+    expect(misleading?.message.toLowerCase()).toContain('learn more');
+  });
+
+  it('detects Chinese CTA copy such as "立即购买" and applies the same heuristics', () => {
+    const html = `
+      <section>
+        <button class="btn btn-primary">立即购买</button>
+        <button class="btn btn-primary">立即下单</button>
+      </section>
+    `;
+    const report = analyseCtaHierarchy(html);
+    const kinds = report.issues.map((issue) => issue.kind);
+    expect(kinds).toContain('multiple-primary');
+    expect(report.primaryCount).toBe(2);
+  });
+
+  it('treats inline background-color as a primary-weight signal even without a primary class', () => {
+    // Mirrors the issue #2251 inverse: a "btn" element styled with a solid
+    // accent color is still effectively a primary CTA in the rendered page.
+    const html = `
+      <section>
+        <a class="btn" style="background-color: #1d4ed8; color: white">查看到港货盘</a>
+        <a class="btn btn-primary" href="/checkout">立即下单</a>
+      </section>
+    `;
+    const report = analyseCtaHierarchy(html);
+    expect(report.primaryCount).toBe(2);
+    expect(report.issues.map((issue) => issue.kind)).toContain('multiple-primary');
+  });
+
+  it('ignores non-CTA buttons such as icon toggles with no actionable copy', () => {
+    // Buttons without CTA-style copy (e.g. a "+" toggle) should not be picked
+    // up as CTA candidates; otherwise the hierarchy checks become noisy.
+    const html = `
+      <section>
+        <button class="btn">+</button>
+        <button class="btn">−</button>
+      </section>
+    `;
+    const report = analyseCtaHierarchy(html);
+    expect(report.issues).toEqual([]);
+    expect(report.primaryCount).toBe(0);
+    expect(report.secondaryCount).toBe(0);
+  });
+});

--- a/apps/daemon/tests/qa-cta-hierarchy.test.ts
+++ b/apps/daemon/tests/qa-cta-hierarchy.test.ts
@@ -113,4 +113,39 @@ describe('analyseCtaHierarchy', () => {
     expect(report.primaryCount).toBe(0);
     expect(report.secondaryCount).toBe(0);
   });
+
+  it('does not collapse sibling <div> wrappers without a landmark ancestor', () => {
+    // Flat card-grid layout with no landmark ancestor: two sibling
+    // <div>s each carry one primary CTA. With a tag-only parent
+    // fallback ("parent:div") both CTAs land in the same bucket and
+    // detectMultiplePrimary() reports a fake shared-section conflict.
+    // The container key must include the parent's identity, not just
+    // its tag name.
+    const html = `
+      <div>
+        <div><a class="btn btn-primary" href="/a">Get started</a></div>
+        <div><a class="btn btn-primary" href="/b">Sign up</a></div>
+      </div>
+    `;
+    const report = analyseCtaHierarchy(html);
+    const kinds = report.issues.map((issue) => issue.kind);
+    expect(kinds).not.toContain('multiple-primary');
+    expect(report.primaryCount).toBe(2);
+  });
+
+  it('does not flag ambiguous-weight when two unrelated sections each contain a single .btn CTA', () => {
+    // Cross-section signature coincidence should not be a hierarchy
+    // warning: each section has only one CTA, so there is no
+    // "everything in this container looks the same" condition to
+    // satisfy. The rule must respect container boundaries.
+    const html = `
+      <article>
+        <section><a class="btn" href="/a">Get started</a></section>
+        <section><a class="btn" href="/b">Subscribe</a></section>
+      </article>
+    `;
+    const report = analyseCtaHierarchy(html);
+    const kinds = report.issues.map((issue) => issue.kind);
+    expect(kinds).not.toContain('ambiguous-weight');
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       blake3-wasm:
         specifier: 2.1.5
         version: 2.1.5
+      cheerio:
+        specifier: 1.2.0
+        version: 1.2.0
       chokidar:
         specifier: 5.0.0
         version: 5.0.0
@@ -2430,6 +2433,13 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -2764,6 +2774,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -2777,6 +2790,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   entities@8.0.0:
@@ -3148,6 +3165,9 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -3876,6 +3896,12 @@ packages:
 
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -4932,6 +4958,15 @@ packages:
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -7042,6 +7077,29 @@ snapshots:
 
   character-entities@2.0.2: {}
 
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.25.0
+      whatwg-mimetype: 4.0.0
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -7395,6 +7453,11 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -7407,6 +7470,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   entities@8.0.0: {}
 
@@ -7969,6 +8034,13 @@ snapshots:
   html-escaper@3.0.3: {}
 
   html-void-elements@3.0.0: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   http-cache-semantics@4.2.0: {}
 
@@ -8798,6 +8870,15 @@ snapshots:
       unist-util-modify-children: 4.0.0
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
 
   parse5@7.3.0:
     dependencies:
@@ -9971,6 +10052,12 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
 


### PR DESCRIPTION
Refs #2251

## Why

[#2251](https://github.com/nexu-io/open-design/issues/2251) reports that generated prototypes are sometimes "functionally correct but feel unfinished" — header CTAs render as neutral \`.btn\`, two equally-styled CTAs compete for the same conversion slot, or a "Learn more" link is styled like a buy button. The issue asks for a post-generation Design QA pass that surfaces these regressions before the artifact reaches the user.

The whole QA pass eventually wants four pieces: detector → HTTP endpoint → CLI surface → auto-repair loop. This PR lands the **detector** as a pure, easily-testable function. The other three layers are explicit follow-ups so the detector can be reviewed and tuned without dragging in route wiring or UI work.

## What users will see

**Nothing yet, by design.** This PR adds an internal module under \`apps/daemon/src/qa/\` plus its unit tests; no HTTP route, no CLI subcommand, no UI surface, no i18n key. The next PR exposes \`POST /api/qa/cta-hierarchy\`, \`od qa cta-hierarchy <html-file>\`, and a Settings-side Design QA result card — together so the three-surface rule from \`AGENTS.md\` is satisfied in a single follow-up PR, not split across multiple half-shipped surfaces.

## What landed

\`apps/daemon/src/qa/cta-hierarchy.ts\` exports \`analyseCtaHierarchy(html: string): CtaHierarchyReport\`. Three categories, intentionally precision-biased (the function says nothing when the signal is weak — false positives are worse than false negatives for a QA pass the agent will read every turn):

1. **\`multiple-primary\`** — two or more primary-weight CTAs inside the same logical section.
2. **\`ambiguous-weight\`** — every CTA in a container shares the same class + inline style, so the user has no visual hierarchy to follow.
3. **\`misleading-prominence\`** — a CTA whose copy is semantically secondary ("Learn more", "了解更多") but whose styling reads as primary.

Heuristics: class-token matching (\`primary\`/\`solid\`/\`filled\`/\`cta\`), inline \`background-color\` as a primary-weight signal, and a small CTA-copy lexicon covering English + Chinese conversion language ("Buy", "Sign up", "Get started", "Subscribe", "Learn more", "立即购买", "立即下单", "了解更多", "免费试用", …). No paint/CSSOM calls — the function stays pure and side-effect-free, which keeps it cheap to call from any layer later.

Selectors in the report are short and CSS-like (\`a.btn.btn-primary\`, \`button.cta\`) so the eventual UI can render an inline indicator without re-querying the document.

## Surface area

- [ ] **UI** — no (follow-up will add the Design QA result card)
- [ ] **Keyboard shortcut** — no
- [ ] **CLI / env var** — no (follow-up will add \`od qa cta-hierarchy\`)
- [ ] **API / contract** — no (follow-up will add \`POST /api/qa/cta-hierarchy\`)
- [ ] **Extension point** — no
- [ ] **i18n keys** — no
- [x] **New top-level dependency** — yes, \`cheerio@1.2.0\` added to \`apps/daemon\`. Picked cheerio over jsdom because daemon doesn't currently declare jsdom as a direct dependency (it's only a transitive vitest dep, and reaching across to \`apps/web\` would break the daemon dependency boundary spelled out in \`AGENTS.md\`). Cheerio is also lighter — we don't need DOM/CSS rendering, just server-side HTML parsing — and the API is closer to "grep over the rendered tree" which is what the heuristics want. Lockfile is included in the commit.
- [ ] **Default behavior change** — no (the function is unwired)

## Verification

- \`pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/qa-cta-hierarchy.test.ts\` — 8 passed (8 new specs, TDD red → green).
- \`pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts\` — 249 files / 2959 tests pass / 0 fail / 1 skipped / 4 todo. The pre-existing \`tests/orbit.test.ts\` flaky failure I have been seeing in recent PRs does not reproduce in this run.
- \`pnpm --filter @open-design/daemon typecheck\` — passed (also threaded through cheerio's CheerioAPI / domhandler boundary without punching through to domhandler directly).
- \`pnpm guard\` — passed.

## Follow-up

A single follow-up PR will wire the detector into the **three surfaces together** so the AGENTS.md dual-track rule isn't half-shipped:

1. \`POST /api/qa/cta-hierarchy { html }\` returning a \`CtaHierarchyReport\` (contract type lifts into \`packages/contracts\`).
2. \`od qa cta-hierarchy <html-file>\` (and \`--json\`) wrapping the same endpoint.
3. Settings / DesignFilesPanel surface that renders the report next to the artifact preview so the user sees the findings before promoting the design.

Auto-repair (feeding findings back into the agent loop) is a separate piece after the manual surface is in.