### PR TITLE
feat(cli): add od templates subcommand for user-saved templates

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -155,6 +155,14 @@ const PROJECT_STRING_FLAGS = new Set([
   'title', 'against',
 ]);
 const PROJECT_BOOLEAN_FLAGS = new Set(['help', 'h', 'json', 'follow']);
+// `od templates …` mirrors NewProjectPanel / ExamplesTab. Same surface,
+// same /api/templates store. The CLI form is the embeddability contract:
+// external agents (hermes-agent, openclaw, ...) can snapshot, list, or
+// remove user-saved project templates without going through the web UI.
+const TEMPLATES_STRING_FLAGS = new Set([
+  'daemon-url', 'name', 'description',
+]);
+const TEMPLATES_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
 // `od automation …` mirrors the Automations tab. Same surface, same
 // /api/routines store. The CLI form is the embeddability contract:
 // external agents (hermes-agent, openclaw, etc.) can drive Open Design
@@ -222,6 +230,7 @@ const SUBCOMMAND_MAP = {
   memory: runMemory,
   run: runRun,
   files: runFiles,
+  templates: runTemplates,
   conversation: runConversation,
   daemon: runDaemon,
   atoms: runAtoms,
@@ -4969,6 +4978,104 @@ function diffLine(prefix, line) {
 
 function renderDiffLineContent(value) {
   return String(value).replace(/\r/g, '\\r');
+}
+
+// `od templates …` is the headless face of NewProjectPanel /
+// ExamplesTab — same /api/templates store, same DTO shapes. External
+// agents (hermes-agent, openclaw, custom bots) use these to snapshot a
+// project as a reusable starting point, list everything the user has
+// saved, or drop one that is no longer needed. The web UI and the CLI
+// share the daemon HTTP layer so neither can drift out of step.
+async function runTemplates(args) {
+  if (args.length === 0 || args[0] === 'help' || args.includes('--help') || args.includes('-h')) {
+    console.log(`Usage:
+  od templates list                                  List user-saved templates.
+  od templates save  <projectId> --name <name>      Snapshot a project's current
+                                                    files as a new template.
+                     [--description <text>]
+  od templates delete <id>                          Delete a saved template by id.
+
+Common options:
+  --daemon-url <url>   Open Design daemon HTTP base.
+  --json               Emit raw JSON.`);
+    process.exit(args.length === 0 ? 2 : 0);
+  }
+  const sub = args[0];
+  const rest = args.slice(1);
+  let flags;
+  try {
+    flags = parseFlags(rest, { string: TEMPLATES_STRING_FLAGS, boolean: TEMPLATES_BOOLEAN_FLAGS });
+  } catch (err) {
+    console.error(err.message);
+    process.exit(2);
+  }
+  const base = (await cliDaemonBaseUrl(flags));
+  switch (sub) {
+    case 'list': {
+      const resp = await fetch(`${base}/api/templates`);
+      if (!resp.ok) return structuredHttpFailure(resp);
+      const data = await resp.json();
+      if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+      const templates = Array.isArray(data?.templates) ? data.templates : [];
+      if (templates.length === 0) {
+        console.log('No templates. Save one with `od templates save <projectId> --name "..."`.');
+        return;
+      }
+      for (const t of templates) console.log(`${t.id}\t${t.name}`);
+      return;
+    }
+    case 'save': {
+      // Require <projectId> as the first positional. Scanning the
+      // whole `rest` would happily pick up the value of `--name`
+      // ("Cards") and silently use it as the project id, so we
+      // anchor on the head and bail out the moment it looks like a
+      // flag.
+      const projectId = rest.length > 0 && !rest[0].startsWith('-') ? rest[0] : '';
+      if (!projectId) {
+        console.error('Usage: od templates save <projectId> --name <name> [--description <text>]');
+        process.exit(2);
+      }
+      const name = typeof flags.name === 'string' ? flags.name.trim() : '';
+      if (!name) {
+        console.error('--name required');
+        process.exit(2);
+      }
+      const body = { name, sourceProjectId: projectId };
+      if (typeof flags.description === 'string' && flags.description.length > 0) {
+        body.description = flags.description;
+      }
+      const resp = await fetch(`${base}/api/templates`, {
+        method:  'POST',
+        headers: { 'content-type': 'application/json' },
+        body:    JSON.stringify(body),
+      });
+      if (!resp.ok) return structuredHttpFailure(resp);
+      const data = await resp.json();
+      if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+      const id = data?.template?.id ?? '';
+      const savedName = data?.template?.name ?? name;
+      console.log(`[templates] saved ${savedName}${id ? ` (${id})` : ''}`);
+      return;
+    }
+    case 'delete': {
+      const id = rest.length > 0 && !rest[0].startsWith('-') ? rest[0] : '';
+      if (!id) {
+        console.error('Usage: od templates delete <id>');
+        process.exit(2);
+      }
+      const resp = await fetch(`${base}/api/templates/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      if (!resp.ok) return structuredHttpFailure(resp);
+      if (flags.json) {
+        const data = await resp.json().catch(() => ({ ok: true }));
+        return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+      }
+      console.log(`[templates] deleted ${id}`);
+      return;
+    }
+    default:
+      console.error(`unknown subcommand: od templates ${sub}`);
+      process.exit(2);
+  }
 }
 
 async function runConversation(args) {

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -206,6 +206,11 @@ const RECOVERABLE_EXIT_CODES = {
   'genui-surface-awaiting':   73,
   'desktop-auth-pending':     74,
   'desktop-import-token-rejected': 75,
+  // `od templates delete <id>` returns 404 from the daemon when the
+  // template id is unknown. Share the same exit-code lane as the
+  // other "thing-not-found" classes so agents can branch on the
+  // exit number alone without parsing the error envelope.
+  'template-not-found':       76,
 };
 const PLUGIN_LIST_FILTER_FLAGS = new Set([
   ...PLUGIN_STRING_FLAGS,
@@ -5010,6 +5015,29 @@ Common options:
     process.exit(2);
   }
   const base = (await cliDaemonBaseUrl(flags));
+  // Extract positional arguments while stepping past `--flag value`
+  // pairs for any string-valued template flag. Without this the id has
+  // to be the very first token after the sub-verb, so a headless caller
+  // that prefixes shared options (`od templates save --daemon-url ...
+  // proj-1 --name Cards`) would hit the missing-id usage path before
+  // ever reaching the daemon. Mirrors the `positionalArgs` helper in
+  // `runAutomation`.
+  const positionalArgs = (values) => {
+    const out = [];
+    for (let i = 0; i < values.length; i++) {
+      const value = values[i];
+      if (!value) continue;
+      if (value.startsWith('--')) {
+        const eq = value.indexOf('=');
+        const key = eq >= 0 ? value.slice(2, eq) : value.slice(2);
+        if (eq < 0 && TEMPLATES_STRING_FLAGS.has(key)) i++;
+        continue;
+      }
+      if (value.startsWith('-')) continue;
+      out.push(value);
+    }
+    return out;
+  };
   switch (sub) {
     case 'list': {
       // Wrap every fetch in try/catch so the user sees a clean
@@ -5037,12 +5065,10 @@ Common options:
       return;
     }
     case 'save': {
-      // Require <projectId> as the first positional. Scanning the
-      // whole `rest` would happily pick up the value of `--name`
-      // ("Cards") and silently use it as the project id, so we
-      // anchor on the head and bail out the moment it looks like a
-      // flag.
-      const projectId = rest.length > 0 && !rest[0].startsWith('-') ? rest[0] : '';
+      // Pull <projectId> from anywhere among the positional args
+      // (`positionalArgs` already skipped past `--flag value` pairs)
+      // so callers can put shared options before or after the id.
+      const projectId = positionalArgs(rest)[0] ?? '';
       if (!projectId) {
         console.error('Usage: od templates save <projectId> --name <name> [--description <text>]');
         process.exit(2);
@@ -5067,7 +5093,19 @@ Common options:
         surfaceFetchError(err, base);
         process.exit(3);
       }
-      if (!resp.ok) return structuredHttpFailure(resp);
+      // Templates POST returns 404 when sourceProjectId is unknown,
+      // and 400 for body validation failures (missing name, too-long
+      // fields). Both are reachable user errors with the daemon
+      // already running, so default-classifying them as
+      // `daemon-not-running` would send agents down the wrong recovery
+      // branch. Map 404 → project-not-found and 400 → missing-input,
+      // keep the default for 5xx so genuine daemon trouble still
+      // surfaces as `daemon-not-running`.
+      if (!resp.ok) {
+        if (resp.status === 404) return structuredHttpFailure(resp, 'project-not-found');
+        if (resp.status === 400) return structuredHttpFailure(resp, 'missing-input');
+        return structuredHttpFailure(resp);
+      }
       const data = await resp.json();
       if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
       const id = data?.template?.id ?? '';
@@ -5076,7 +5114,7 @@ Common options:
       return;
     }
     case 'delete': {
-      const id = rest.length > 0 && !rest[0].startsWith('-') ? rest[0] : '';
+      const id = positionalArgs(rest)[0] ?? '';
       if (!id) {
         console.error('Usage: od templates delete <id>');
         process.exit(2);
@@ -5088,7 +5126,15 @@ Common options:
         surfaceFetchError(err, base);
         process.exit(3);
       }
-      if (!resp.ok) return structuredHttpFailure(resp);
+      // DELETE /api/templates/:id returns 404 when the template id is
+      // unknown — that's a stable user-error class agents can act on
+      // (don't retry, surface to the user) so route it to
+      // `template-not-found` rather than the default
+      // `daemon-not-running`.
+      if (!resp.ok) {
+        if (resp.status === 404) return structuredHttpFailure(resp, 'template-not-found');
+        return structuredHttpFailure(resp);
+      }
       if (flags.json) {
         const data = await resp.json().catch(() => ({ ok: true }));
         return process.stdout.write(JSON.stringify(data, null, 2) + '\n');

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -5012,7 +5012,19 @@ Common options:
   const base = (await cliDaemonBaseUrl(flags));
   switch (sub) {
     case 'list': {
-      const resp = await fetch(`${base}/api/templates`);
+      // Wrap every fetch in try/catch so the user sees a clean
+      // "failed to reach daemon at <url>: <code>" error from
+      // surfaceFetchError when the daemon isn't running. Without
+      // this Node throws a raw `TypeError: fetch failed`, which
+      // matches the pattern the rest of the CLI uses
+      // (runAutomation, the project verbs, runResearch).
+      let resp;
+      try {
+        resp = await fetch(`${base}/api/templates`);
+      } catch (err) {
+        surfaceFetchError(err, base);
+        process.exit(3);
+      }
       if (!resp.ok) return structuredHttpFailure(resp);
       const data = await resp.json();
       if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
@@ -5044,11 +5056,17 @@ Common options:
       if (typeof flags.description === 'string' && flags.description.length > 0) {
         body.description = flags.description;
       }
-      const resp = await fetch(`${base}/api/templates`, {
-        method:  'POST',
-        headers: { 'content-type': 'application/json' },
-        body:    JSON.stringify(body),
-      });
+      let resp;
+      try {
+        resp = await fetch(`${base}/api/templates`, {
+          method:  'POST',
+          headers: { 'content-type': 'application/json' },
+          body:    JSON.stringify(body),
+        });
+      } catch (err) {
+        surfaceFetchError(err, base);
+        process.exit(3);
+      }
       if (!resp.ok) return structuredHttpFailure(resp);
       const data = await resp.json();
       if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
@@ -5063,7 +5081,13 @@ Common options:
         console.error('Usage: od templates delete <id>');
         process.exit(2);
       }
-      const resp = await fetch(`${base}/api/templates/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      let resp;
+      try {
+        resp = await fetch(`${base}/api/templates/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      } catch (err) {
+        surfaceFetchError(err, base);
+        process.exit(3);
+      }
       if (!resp.ok) return structuredHttpFailure(resp);
       if (flags.json) {
         const data = await resp.json().catch(() => ({ ok: true }));

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -917,21 +917,35 @@ function exitWithStructuredError({ code, message, data }) {
 
 // Map a daemon HTTP response into the exit-code envelope. Returns the
 // parsed body (so the caller can keep going if it doesn't want to exit).
+//
+// Daemon error envelopes come in two shapes in practice:
+//   { error: { code, message, ... } }  — newer routes using sendApiError
+//   { error: '<message>' }             — older flat-string routes
+//                                         (e.g. POST /api/templates at
+//                                         project-routes.ts:667-680)
+// Normalize so a flat-string body still surfaces its message to the
+// structured envelope instead of collapsing to `HTTP <status>: `, which
+// would drop the only diagnostic the daemon actually returned to a
+// headless caller.
 async function structuredHttpFailure(resp, fallbackCode = 'daemon-not-running') {
   let parsed;
   try { parsed = await resp.json(); } catch { parsed = {}; }
-  const errCode = normalizeRecoverableErrorCode(parsed?.error?.code, parsed?.error?.message);
+  const errorObj =
+    typeof parsed?.error === 'string'
+      ? { message: parsed.error }
+      : parsed?.error;
+  const errCode = normalizeRecoverableErrorCode(errorObj?.code, errorObj?.message);
   if (errCode && errCode in RECOVERABLE_EXIT_CODES) {
     exitWithStructuredError({
       code:    errCode,
-      message: parsed.error.message ?? `HTTP ${resp.status}`,
-      data:    structuredErrorData(parsed.error),
+      message: errorObj?.message ?? `HTTP ${resp.status}`,
+      data:    structuredErrorData(errorObj),
     });
   }
   exitWithStructuredError({
     code:    fallbackCode,
-    message: parsed?.error?.message ?? `HTTP ${resp.status}: ${await resp.text().catch(() => '')}`,
-    data:    structuredErrorData(parsed?.error),
+    message: errorObj?.message ?? `HTTP ${resp.status}: ${await resp.text().catch(() => '')}`,
+    data:    structuredErrorData(errorObj),
   });
 }
 

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -206,11 +206,6 @@ const RECOVERABLE_EXIT_CODES = {
   'genui-surface-awaiting':   73,
   'desktop-auth-pending':     74,
   'desktop-import-token-rejected': 75,
-  // `od templates delete <id>` returns 404 from the daemon when the
-  // template id is unknown. Share the same exit-code lane as the
-  // other "thing-not-found" classes so agents can branch on the
-  // exit number alone without parsing the error envelope.
-  'template-not-found':       76,
 };
 const PLUGIN_LIST_FILTER_FLAGS = new Set([
   ...PLUGIN_STRING_FLAGS,
@@ -5126,15 +5121,13 @@ Common options:
         surfaceFetchError(err, base);
         process.exit(3);
       }
-      // DELETE /api/templates/:id returns 404 when the template id is
-      // unknown — that's a stable user-error class agents can act on
-      // (don't retry, surface to the user) so route it to
-      // `template-not-found` rather than the default
-      // `daemon-not-running`.
-      if (!resp.ok) {
-        if (resp.status === 404) return structuredHttpFailure(resp, 'template-not-found');
-        return structuredHttpFailure(resp);
-      }
+      // The daemon route `DELETE /api/templates/:id` is intentionally
+      // idempotent (returns `{ ok: true }` for unknown ids), so this
+      // CLI verb mirrors that contract instead of inventing a
+      // template-not-found exit code the production route never emits.
+      // Any unexpected non-2xx still falls through to the generic
+      // structured-failure envelope.
+      if (!resp.ok) return structuredHttpFailure(resp);
       if (flags.json) {
         const data = await resp.json().catch(() => ({ ok: true }));
         return process.stdout.write(JSON.stringify(data, null, 2) + '\n');

--- a/apps/daemon/tests/cli-templates.test.ts
+++ b/apps/daemon/tests/cli-templates.test.ts
@@ -1,0 +1,333 @@
+// Contract test for the `od templates` CLI surface. Keeps the
+// UI / API / CLI triple wired together (AGENTS.md "Capability exposure"):
+// the CLI must drive the same /api/templates endpoints the web UI uses
+// (NewProjectPanel / ExamplesTab), with --json support for headless
+// agents that pipe through jq / xargs.
+//
+// We spin up a tiny stub HTTP server to capture requests instead of
+// booting the full daemon: `execFile` is enough to prove that
+// SUBCOMMAND_MAP routes `templates`, parseFlags accepts the documented
+// flags, and the right HTTP call is emitted for each sub-verb.
+
+import http from 'node:http';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve as pathResolve } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+const execFileP = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DAEMON_ROOT = pathResolve(__dirname, '..');
+const REPO_ROOT = pathResolve(__dirname, '../../..');
+const CLI_SRC = pathResolve(__dirname, '../src/cli.ts');
+const TSX_CLI = pathResolve(REPO_ROOT, 'node_modules/tsx/dist/cli.mjs');
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  body: string;
+}
+
+interface StubServer {
+  baseUrl: string;
+  requests: CapturedRequest[];
+  setResponder: (
+    fn: (req: CapturedRequest) => { status: number; body: unknown } | null,
+  ) => void;
+  close: () => Promise<void>;
+}
+
+async function startStubServer(): Promise<StubServer> {
+  const requests: CapturedRequest[] = [];
+  let responder:
+    | ((req: CapturedRequest) => { status: number; body: unknown } | null)
+    | null = null;
+
+  const server = http.createServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk) => {
+      raw += chunk;
+    });
+    req.on('end', () => {
+      const captured: CapturedRequest = {
+        method: req.method ?? '',
+        url: req.url ?? '',
+        body: raw,
+      };
+      requests.push(captured);
+      const response = responder?.(captured) ?? { status: 200, body: { ok: true } };
+      res.statusCode = response.status;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(response.body));
+    });
+  });
+
+  await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('stub server has no address');
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+  return {
+    baseUrl,
+    requests,
+    setResponder: (fn) => {
+      responder = fn;
+    },
+    close: () =>
+      new Promise<void>((resolveClose, rejectClose) => {
+        server.close((err) => (err ? rejectClose(err) : resolveClose()));
+      }),
+  };
+}
+
+async function runCli(
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv } = {},
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...options.env,
+  };
+  delete env.NODE_OPTIONS;
+  try {
+    const { stdout, stderr } = await execFileP(
+      process.execPath,
+      [TSX_CLI, CLI_SRC, ...args],
+      {
+        cwd: DAEMON_ROOT,
+        env,
+        timeout: 15_000,
+        maxBuffer: 4 * 1024 * 1024,
+      },
+    );
+    return { stdout, stderr, code: 0 };
+  } catch (err) {
+    const failed = err as { stdout?: string; stderr?: string; code?: number | null };
+    return {
+      stdout: failed.stdout ?? '',
+      stderr: failed.stderr ?? '',
+      code: failed.code ?? 1,
+    };
+  }
+}
+
+describe('od templates CLI', () => {
+  let stub: StubServer;
+
+  beforeAll(async () => {
+    stub = await startStubServer();
+  });
+
+  afterAll(async () => {
+    await stub.close();
+  });
+
+  beforeEach(() => {
+    stub.requests.length = 0;
+    stub.setResponder(() => ({ status: 200, body: { ok: true } }));
+  });
+
+  afterEach(() => {
+    stub.setResponder(() => ({ status: 200, body: { ok: true } }));
+  });
+
+  it('prints usage on `od templates help` and exits 0', async () => {
+    const result = await runCli(['templates', 'help']);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toMatch(/od templates/);
+    expect(result.stdout).toMatch(/save/);
+    expect(result.stdout).toMatch(/delete/);
+    expect(stub.requests).toHaveLength(0);
+  });
+
+  it('lists user-saved templates as `id\\tname` lines by default', async () => {
+    stub.setResponder((req) => {
+      if (req.method === 'GET' && req.url === '/api/templates') {
+        return {
+          status: 200,
+          body: {
+            templates: [
+              { id: 't-1', name: 'Cards', sourceProjectId: 'proj-1' },
+              { id: 't-2', name: 'Pricing', sourceProjectId: 'proj-2' },
+            ],
+          },
+        };
+      }
+      return { status: 404, body: { error: 'unexpected' } };
+    });
+
+    const result = await runCli(['templates', 'list', '--daemon-url', stub.baseUrl]);
+
+    expect(result.code).toBe(0);
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0]).toMatchObject({
+      method: 'GET',
+      url: '/api/templates',
+    });
+    expect(result.stdout).toContain('t-1\tCards');
+    expect(result.stdout).toContain('t-2\tPricing');
+  });
+
+  it('emits the raw GET /api/templates body under --json', async () => {
+    const payload = {
+      templates: [{ id: 't-1', name: 'Cards', sourceProjectId: 'proj-1', files: [] }],
+    };
+    stub.setResponder(() => ({ status: 200, body: payload }));
+
+    const result = await runCli([
+      'templates',
+      'list',
+      '--daemon-url',
+      stub.baseUrl,
+      '--json',
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual(payload);
+  });
+
+  it('POSTs /api/templates with name + sourceProjectId on `templates save`', async () => {
+    stub.setResponder((req) => {
+      if (req.method === 'POST' && req.url === '/api/templates') {
+        return {
+          status: 200,
+          body: { template: { id: 't-new', name: 'Cards', sourceProjectId: 'proj-1' } },
+        };
+      }
+      return { status: 404, body: { error: 'unexpected' } };
+    });
+
+    const result = await runCli([
+      'templates',
+      'save',
+      'proj-1',
+      '--name',
+      'Cards',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(stub.requests).toHaveLength(1);
+    const req = stub.requests[0]!;
+    expect(req.method).toBe('POST');
+    expect(req.url).toBe('/api/templates');
+    expect(JSON.parse(req.body)).toEqual({
+      name: 'Cards',
+      sourceProjectId: 'proj-1',
+    });
+    expect(result.stdout).toContain('t-new');
+  });
+
+  it('forwards an optional --description into the POST body', async () => {
+    stub.setResponder(() => ({
+      status: 200,
+      body: { template: { id: 't-2', name: 'Pricing', description: 'About pricing' } },
+    }));
+
+    const result = await runCli([
+      'templates',
+      'save',
+      'proj-9',
+      '--name',
+      'Pricing',
+      '--description',
+      'About pricing',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+
+    expect(result.code).toBe(0);
+    const req = stub.requests[0]!;
+    expect(JSON.parse(req.body)).toEqual({
+      name: 'Pricing',
+      description: 'About pricing',
+      sourceProjectId: 'proj-9',
+    });
+  });
+
+  it('exits 2 and emits no HTTP request when `templates save` lacks --name', async () => {
+    const result = await runCli([
+      'templates',
+      'save',
+      'proj-1',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+
+    expect(result.code).toBe(2);
+    expect(stub.requests).toHaveLength(0);
+    expect(result.stderr).toMatch(/--name/);
+  });
+
+  it('exits 2 and emits no HTTP request when `templates save` lacks a projectId', async () => {
+    const result = await runCli([
+      'templates',
+      'save',
+      '--name',
+      'Cards',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+
+    expect(result.code).toBe(2);
+    expect(stub.requests).toHaveLength(0);
+    expect(result.stderr).toMatch(/projectId/i);
+  });
+
+  it('DELETEs /api/templates/:id on `templates delete <id>`', async () => {
+    stub.setResponder((req) => {
+      if (req.method === 'DELETE' && req.url === '/api/templates/t-1') {
+        return { status: 200, body: { ok: true } };
+      }
+      return { status: 404, body: { error: 'unexpected' } };
+    });
+
+    const result = await runCli([
+      'templates',
+      'delete',
+      't-1',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0]).toMatchObject({
+      method: 'DELETE',
+      url: '/api/templates/t-1',
+    });
+    expect(result.stdout).toContain('t-1');
+  });
+
+  it('exits 2 and emits no HTTP request when `templates delete` lacks an id', async () => {
+    const result = await runCli([
+      'templates',
+      'delete',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+
+    expect(result.code).toBe(2);
+    expect(stub.requests).toHaveLength(0);
+    expect(result.stderr).toMatch(/<id>/);
+  });
+
+  it('prints usage on `od templates` with no sub-verb and exits 2', async () => {
+    const result = await runCli(['templates']);
+    expect(result.code).toBe(2);
+    expect(result.stdout).toMatch(/od templates/);
+  });
+
+  it('exits non-zero on unknown sub-verb', async () => {
+    const result = await runCli([
+      'templates',
+      'frobnicate',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/unknown subcommand/i);
+  });
+});

--- a/apps/daemon/tests/cli-templates.test.ts
+++ b/apps/daemon/tests/cli-templates.test.ts
@@ -377,4 +377,106 @@ describe('od templates CLI', () => {
     expect(result.stderr).toMatch(/failed to reach daemon at http:\/\/127\.0\.0\.1:/);
     expect(result.stderr).not.toMatch(/TypeError: fetch failed/);
   });
+
+  // Reviewer-correctness fixes from #2428 round 3.
+  // (1) positional id must work even when shared flags come first.
+  // (2) `templates save` 404 / 400 must map to project-not-found /
+  //     missing-input — not the default `daemon-not-running`, which
+  //     would send agents down the wrong recovery branch.
+  it('accepts positional projectId after --daemon-url for `templates save` (flag-before-id)', async () => {
+    stub.setResponder(() => ({
+      status: 200,
+      body: { template: { id: 't-after-flag', name: 'Cards' } },
+    }));
+    const result = await runCli([
+      'templates',
+      'save',
+      '--daemon-url',
+      stub.baseUrl,
+      'proj-1',
+      '--name',
+      'Cards',
+    ]);
+    expect(result.code).toBe(0);
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0]?.method).toBe('POST');
+    expect(JSON.parse(stub.requests[0]?.body ?? '{}')).toMatchObject({
+      sourceProjectId: 'proj-1',
+      name: 'Cards',
+    });
+  });
+
+  it('accepts positional id after --daemon-url for `templates delete` (flag-before-id)', async () => {
+    stub.setResponder(() => ({ status: 200, body: { ok: true } }));
+    const result = await runCli([
+      'templates',
+      'delete',
+      '--daemon-url',
+      stub.baseUrl,
+      't-after-flag',
+    ]);
+    expect(result.code).toBe(0);
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0]?.method).toBe('DELETE');
+    expect(stub.requests[0]?.url).toBe('/api/templates/t-after-flag');
+  });
+
+  it('reports project-not-found (not daemon-not-running) when `templates save` gets 404', async () => {
+    // structuredHttpFailure → exitWithStructuredError writes a
+    // { error: { code, message, data } } envelope to STDERR and exits
+    // with the per-code exit number (68 for project-not-found, see
+    // RECOVERABLE_EXIT_CODES).
+    stub.setResponder(() => ({
+      status: 404,
+      body: { error: { code: 'TEMPLATE_SOURCE_NOT_FOUND', message: 'project not found' } },
+    }));
+    const result = await runCli([
+      'templates',
+      'save',
+      'missing-project',
+      '--name',
+      'Cards',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+    expect(result.code).toBe(68);
+    const envelope = JSON.parse(result.stderr.trim());
+    expect(envelope.error.code).toBe('project-not-found');
+  });
+
+  it('reports missing-input (not daemon-not-running) when `templates save` gets 400', async () => {
+    stub.setResponder(() => ({
+      status: 400,
+      body: { error: { code: 'BAD_REQUEST', message: 'name required' } },
+    }));
+    const result = await runCli([
+      'templates',
+      'save',
+      'proj-1',
+      '--name',
+      'Cards',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+    expect(result.code).toBe(67);
+    const envelope = JSON.parse(result.stderr.trim());
+    expect(envelope.error.code).toBe('missing-input');
+  });
+
+  it('reports template-not-found (not daemon-not-running) when `templates delete` gets 404', async () => {
+    stub.setResponder(() => ({
+      status: 404,
+      body: { error: { code: 'TEMPLATE_NOT_FOUND', message: 'template not found' } },
+    }));
+    const result = await runCli([
+      'templates',
+      'delete',
+      'gone',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+    expect(result.code).toBe(76);
+    const envelope = JSON.parse(result.stderr.trim());
+    expect(envelope.error.code).toBe('template-not-found');
+  });
 });

--- a/apps/daemon/tests/cli-templates.test.ts
+++ b/apps/daemon/tests/cli-templates.test.ts
@@ -112,11 +112,42 @@ async function runCli(
   }
 }
 
+// Reserve a port the OS just told us is free, then close it before
+// any test runs so connections to it fail with ECONNREFUSED. The
+// previous `port + 1` heuristic only assumed the stub's ephemeral port
+// was free — `+1` could already be bound by an unrelated process on a
+// shared CI host, which would silently route the "unreachable daemon"
+// tests at a real server and let them pass (or fail) for the wrong
+// reason (#2428 round-4 reviewer-correctness fix).
+async function reserveAndReleasePort(): Promise<{ host: string; port: number }> {
+  return new Promise((resolveListen, rejectListen) => {
+    const probe = http.createServer();
+    probe.unref();
+    probe.once('error', rejectListen);
+    probe.listen(0, '127.0.0.1', () => {
+      const addr = probe.address();
+      if (!addr || typeof addr === 'string') {
+        probe.close();
+        rejectListen(new Error('probe server has no address'));
+        return;
+      }
+      const { port } = addr;
+      probe.close((err) => {
+        if (err) rejectListen(err);
+        else resolveListen({ host: '127.0.0.1', port });
+      });
+    });
+  });
+}
+
 describe('od templates CLI', () => {
   let stub: StubServer;
+  let unreachableDaemonUrl: string;
 
   beforeAll(async () => {
     stub = await startStubServer();
+    const reserved = await reserveAndReleasePort();
+    unreachableDaemonUrl = `http://${reserved.host}:${reserved.port}`;
   });
 
   afterAll(async () => {
@@ -335,16 +366,14 @@ describe('od templates CLI', () => {
   // running, every sub-verb must surface the same clean
   // "failed to reach daemon at <url>: <code>" error that the rest of
   // the CLI emits via `surfaceFetchError`, not a raw
-  // `TypeError: fetch failed`. We point the CLI at a port nothing is
-  // listening on (the stub server's, +1) so fetch fails connection-
-  // refused on every platform.
-  function unreachableUrl(): string {
-    const u = new URL(stub.baseUrl);
-    return `http://${u.hostname}:${Number(u.port) + 1}`;
-  }
+  // `TypeError: fetch failed`. The CLI is pointed at a port the OS
+  // just told us was free and which we immediately released — see
+  // `reserveAndReleasePort` above — so the connection fails with
+  // ECONNREFUSED rather than silently routing to whatever happens to
+  // be bound nearby.
 
   it('surfaces a clean fetch error from `templates list` when the daemon is unreachable', async () => {
-    const result = await runCli(['templates', 'list', '--daemon-url', unreachableUrl()]);
+    const result = await runCli(['templates', 'list', '--daemon-url', unreachableDaemonUrl]);
     expect(result.code).toBe(3);
     expect(result.stderr).toMatch(/failed to reach daemon at http:\/\/127\.0\.0\.1:/);
     expect(result.stderr).not.toMatch(/TypeError: fetch failed/);
@@ -358,7 +387,7 @@ describe('od templates CLI', () => {
       '--name',
       'Cards',
       '--daemon-url',
-      unreachableUrl(),
+      unreachableDaemonUrl,
     ]);
     expect(result.code).toBe(3);
     expect(result.stderr).toMatch(/failed to reach daemon at http:\/\/127\.0\.0\.1:/);
@@ -371,7 +400,7 @@ describe('od templates CLI', () => {
       'delete',
       't-1',
       '--daemon-url',
-      unreachableUrl(),
+      unreachableDaemonUrl,
     ]);
     expect(result.code).toBe(3);
     expect(result.stderr).toMatch(/failed to reach daemon at http:\/\/127\.0\.0\.1:/);

--- a/apps/daemon/tests/cli-templates.test.ts
+++ b/apps/daemon/tests/cli-templates.test.ts
@@ -330,4 +330,51 @@ describe('od templates CLI', () => {
     expect(result.code).not.toBe(0);
     expect(result.stderr).toMatch(/unknown subcommand/i);
   });
+
+  // Reviewer-correctness fix from #2428: when the daemon isn't
+  // running, every sub-verb must surface the same clean
+  // "failed to reach daemon at <url>: <code>" error that the rest of
+  // the CLI emits via `surfaceFetchError`, not a raw
+  // `TypeError: fetch failed`. We point the CLI at a port nothing is
+  // listening on (the stub server's, +1) so fetch fails connection-
+  // refused on every platform.
+  function unreachableUrl(): string {
+    const u = new URL(stub.baseUrl);
+    return `http://${u.hostname}:${Number(u.port) + 1}`;
+  }
+
+  it('surfaces a clean fetch error from `templates list` when the daemon is unreachable', async () => {
+    const result = await runCli(['templates', 'list', '--daemon-url', unreachableUrl()]);
+    expect(result.code).toBe(3);
+    expect(result.stderr).toMatch(/failed to reach daemon at http:\/\/127\.0\.0\.1:/);
+    expect(result.stderr).not.toMatch(/TypeError: fetch failed/);
+  });
+
+  it('surfaces a clean fetch error from `templates save` when the daemon is unreachable', async () => {
+    const result = await runCli([
+      'templates',
+      'save',
+      'proj-1',
+      '--name',
+      'Cards',
+      '--daemon-url',
+      unreachableUrl(),
+    ]);
+    expect(result.code).toBe(3);
+    expect(result.stderr).toMatch(/failed to reach daemon at http:\/\/127\.0\.0\.1:/);
+    expect(result.stderr).not.toMatch(/TypeError: fetch failed/);
+  });
+
+  it('surfaces a clean fetch error from `templates delete` when the daemon is unreachable', async () => {
+    const result = await runCli([
+      'templates',
+      'delete',
+      't-1',
+      '--daemon-url',
+      unreachableUrl(),
+    ]);
+    expect(result.code).toBe(3);
+    expect(result.stderr).toMatch(/failed to reach daemon at http:\/\/127\.0\.0\.1:/);
+    expect(result.stderr).not.toMatch(/TypeError: fetch failed/);
+  });
 });

--- a/apps/daemon/tests/cli-templates.test.ts
+++ b/apps/daemon/tests/cli-templates.test.ts
@@ -451,13 +451,17 @@ describe('od templates CLI', () => {
   });
 
   it('reports project-not-found (not daemon-not-running) when `templates save` gets 404', async () => {
-    // structuredHttpFailure → exitWithStructuredError writes a
-    // { error: { code, message, data } } envelope to STDERR and exits
-    // with the per-code exit number (68 for project-not-found, see
-    // RECOVERABLE_EXIT_CODES).
+    // POST /api/templates returns a flat `{ error: '<message>' }` body
+    // (project-routes.ts:679), so the stub mirrors that exact shape
+    // rather than the nested `{ error: { code, message } }` envelope.
+    // structuredHttpFailure normalises the flat string into the
+    // structured envelope, mapping the 404 to project-not-found via
+    // the fallback code passed at the call site and surfacing the
+    // daemon's literal message so headless callers don't lose the
+    // only diagnostic the route emitted.
     stub.setResponder(() => ({
       status: 404,
-      body: { error: { code: 'TEMPLATE_SOURCE_NOT_FOUND', message: 'project not found' } },
+      body: { error: 'source project not found' },
     }));
     const result = await runCli([
       'templates',
@@ -471,12 +475,16 @@ describe('od templates CLI', () => {
     expect(result.code).toBe(68);
     const envelope = JSON.parse(result.stderr.trim());
     expect(envelope.error.code).toBe('project-not-found');
+    expect(envelope.error.message).toBe('source project not found');
   });
 
   it('reports missing-input (not daemon-not-running) when `templates save` gets 400', async () => {
+    // 400 from POST /api/templates is also a flat `{ error: '<msg>' }`
+    // body (project-routes.ts:669, :675). Same normalisation contract
+    // as the 404 case above.
     stub.setResponder(() => ({
       status: 400,
-      body: { error: { code: 'BAD_REQUEST', message: 'name required' } },
+      body: { error: 'name required' },
     }));
     const result = await runCli([
       'templates',
@@ -490,5 +498,6 @@ describe('od templates CLI', () => {
     expect(result.code).toBe(67);
     const envelope = JSON.parse(result.stderr.trim());
     expect(envelope.error.code).toBe('missing-input');
+    expect(envelope.error.message).toBe('name required');
   });
 });

--- a/apps/daemon/tests/cli-templates.test.ts
+++ b/apps/daemon/tests/cli-templates.test.ts
@@ -491,21 +491,4 @@ describe('od templates CLI', () => {
     const envelope = JSON.parse(result.stderr.trim());
     expect(envelope.error.code).toBe('missing-input');
   });
-
-  it('reports template-not-found (not daemon-not-running) when `templates delete` gets 404', async () => {
-    stub.setResponder(() => ({
-      status: 404,
-      body: { error: { code: 'TEMPLATE_NOT_FOUND', message: 'template not found' } },
-    }));
-    const result = await runCli([
-      'templates',
-      'delete',
-      'gone',
-      '--daemon-url',
-      stub.baseUrl,
-    ]);
-    expect(result.code).toBe(76);
-    const envelope = JSON.parse(result.stderr.trim());
-    expect(envelope.error.code).toBe('template-not-found');
-  });
 });


### PR DESCRIPTION
## Why

External agents (hermes-agent, openclaw, custom Slack/Discord bots) can already snapshot a project as a reusable template through \`POST /api/templates\`, and the Web UI exposes the same store under **New Project → Templates** (\`apps/web/src/components/NewProjectPanel.tsx\`, \`ExamplesTab.tsx\`). The CLI — which \`AGENTS.md\` → "Capability exposure (UI/CLI dual-track)" calls *the* embeddability contract for the agent ecosystem — was missing. Agents had to fall back to raw HTTP calls, breaking the documented UI/API/CLI triple and forcing every embedding integration to re-implement URL construction, error handling, and JSON formatting.

## What users will see

\`od templates --help\` now prints three sub-verbs:

- **\`od templates list\`** — \`<id>\\t<name>\` lines for every saved template (or the raw \`GET /api/templates\` JSON under \`--json\`).
- **\`od templates save <projectId> --name <name> [--description <text>]\`** — snapshots the project's current files into a new template, sending the same body \`NewProjectPanel\` already sends.
- **\`od templates delete <id>\`** — removes a saved template.

Each sub-verb accepts the standard \`--daemon-url\` / \`--json\` flags. \`od templates help\` (and \`od templates\` with no sub-verb) prints usage; help exits 0, the no-sub-verb form exits 2 to match the existing CLI convention.

## Surface area

- [ ] **UI** — no change (already shipped)
- [ ] **Keyboard shortcut** — no
- [x] **CLI / env var** — yes, new \`od templates\` subcommand with \`list\`/\`save\`/\`delete\` verbs and a new \`--description\` flag
- [ ] **API / contract** — no change (already shipped — \`GET\`/\`POST\`/\`DELETE /api/templates\` all exist; this PR just wraps them)
- [ ] **Extension point** — no
- [ ] **i18n keys** — no
- [ ] **New top-level dependency** — no
- [ ] **Default behavior change** — no

## Implementation notes

- \`apps/daemon/src/cli.ts\`: new \`runTemplates(args)\` wired into \`SUBCOMMAND_MAP\` next to \`runProject\`/\`runFiles\`. Adds \`TEMPLATES_STRING_FLAGS\` / \`TEMPLATES_BOOLEAN_FLAGS\` constants so flag parsing stays consistent with the existing CLI style.
- Error handling reuses \`structuredHttpFailure(resp)\` for HTTP failures, matching \`runProject\` / \`runFiles\`.
- The Agent that built this PR found \`GET /api/templates\` already exists (\`apps/daemon/src/project-routes.ts\`), so \`list\` ships in this PR rather than as a follow-up.

## Validation

This is a feature PR, not a bug fix, but it follows the same TDD shape:

- **Red spec first**: new \`apps/daemon/tests/cli-templates.test.ts\` with 11 cases — help, list (default + \`--json\`), save (basic + \`--description\` + missing-name + missing-projectId), delete (basic + missing-id), no-sub-verb, unknown-sub-verb. The file went red on \`main\` before \`runTemplates\` existed.
- **Green after implementation**: 11/11 pass.
- \`pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/cli-templates.test.ts\` — 11 passed.
- \`pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts\` — 2961 passed, 1 pre-existing failure in \`tests/origin-validation.test.ts > allows requests from OD_WEB_PORT\` confirmed to reproduce against \`main\` (env-dependent, unrelated to this PR).
- \`pnpm --filter @open-design/daemon typecheck\` — passed.
- \`pnpm guard\` — passed.

## Related issues

No specific tracking issue. \`AGENTS.md\` → "Capability exposure (UI/CLI dual-track)" is the source of the rule this PR satisfies — every user-facing capability must be reachable through both the Web UI **and** the \`od\` CLI, and templates were one of the remaining gaps.
