### PR TITLE
Add packaged update apply observations

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -190,6 +190,7 @@ import {
   readAnalyticsContext,
   readPublicConfigResponse,
 } from './analytics.js';
+import { observePendingInstallerApplyAttempts } from './update-apply-observations.js';
 import {
   agentIdToTracking,
   deriveConfigureGlobals,
@@ -4163,6 +4164,15 @@ export async function startServer({
   void (async () => {
     try {
       cachedAppVersion = await readCurrentAppVersionInfo();
+      await observePendingInstallerApplyAttempts({
+        analytics: analyticsService,
+        appVersion: cachedAppVersion.version,
+        currentChannel: cachedAppVersion.channel,
+        currentVersion: cachedAppVersion.version,
+        dataRoot: RUNTIME_DATA_DIR,
+        logger: console,
+        namespace: process.env[SIDECAR_ENV.NAMESPACE] ?? SIDECAR_DEFAULTS.namespace,
+      });
     } catch {
       // Telemetry is best-effort; appVersion is omitted when unavailable.
     }

--- a/apps/daemon/src/update-apply-observations.ts
+++ b/apps/daemon/src/update-apply-observations.ts
@@ -1,0 +1,299 @@
+import { readdir, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type {
+  TrackingUpdateApplyElapsedBucket,
+  TrackingUpdateApplyReason,
+  TrackingUpdateApplyResult,
+  UpdateApplyObservedProps,
+} from '@open-design/contracts/analytics';
+
+import type { AnalyticsContext, AnalyticsService } from './analytics.js';
+import { readPosthogConfig } from './analytics.js';
+import { readAppConfig, type AppConfigPrefs } from './app-config.js';
+
+const INSTALLER_OBSERVATION_SCHEMA_VERSION = 1;
+const INSTALLER_OBSERVATION_KIND = 'installer_apply_observation';
+const INSTALLER_OBSERVATION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+type InstallerObservationArtifactType = 'dmg' | 'installer';
+type InstallerObservationChannel = 'stable' | 'beta';
+type InstallerObservationDeliveryStatus =
+  | 'submitted'
+  | 'skipped_analytics_disabled'
+  | 'skipped_missing_identity'
+  | 'skipped_no_consent'
+  | 'failed';
+
+export type InstallerObservationSummary = {
+  arch: string;
+  artifactType: InstallerObservationArtifactType;
+  attemptedAt: string;
+  channel: InstallerObservationChannel;
+  delivery?: {
+    eventName: 'update_apply_observed';
+    insertId?: string;
+    status: InstallerObservationDeliveryStatus;
+    updatedAt: string;
+  };
+  elapsedBucket?: TrackingUpdateApplyElapsedBucket;
+  flowId: string;
+  fromVersion: string;
+  kind: typeof INSTALLER_OBSERVATION_KIND;
+  namespace: string;
+  observedAt?: string;
+  platform: string;
+  reason: 'installer_open_requested' | 'installer_open_failed' | TrackingUpdateApplyReason;
+  result: 'pending' | TrackingUpdateApplyResult;
+  schemaVersion: typeof INSTALLER_OBSERVATION_SCHEMA_VERSION;
+  toVersion: string;
+  updatedAt: string;
+};
+
+type InstallerObservationDelivery = NonNullable<InstallerObservationSummary['delivery']>;
+
+export type InstallerObservationClassification = {
+  elapsedBucket: TrackingUpdateApplyElapsedBucket;
+  reason: TrackingUpdateApplyReason;
+  result: TrackingUpdateApplyResult;
+};
+
+export type ObservePendingInstallerApplyAttemptsOptions = {
+  analytics: Pick<AnalyticsService, 'capture'>;
+  appVersion: string;
+  currentChannel?: string | null;
+  currentVersion: string;
+  dataRoot: string;
+  env?: NodeJS.ProcessEnv;
+  logger?: Pick<Console, 'warn'>;
+  namespace: string;
+  now?: () => Date;
+  readConfig?: (dataRoot: string) => Promise<AppConfigPrefs>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value != null && !Array.isArray(value);
+}
+
+function isSafeFlowId(flowId: string): boolean {
+  return (
+    flowId.length > 0 &&
+    flowId.length <= 128 &&
+    flowId !== '.' &&
+    flowId !== '..' &&
+    /^[A-Za-z0-9._-]+$/.test(flowId)
+  );
+}
+
+function isInstallerObservationSummary(value: unknown): value is InstallerObservationSummary {
+  if (!isRecord(value)) return false;
+  const artifactType = value.artifactType;
+  const channel = value.channel;
+  const result = value.result;
+  return (
+    value.schemaVersion === INSTALLER_OBSERVATION_SCHEMA_VERSION &&
+    value.kind === INSTALLER_OBSERVATION_KIND &&
+    typeof value.flowId === 'string' &&
+    isSafeFlowId(value.flowId) &&
+    typeof value.namespace === 'string' &&
+    (channel === 'stable' || channel === 'beta') &&
+    typeof value.platform === 'string' &&
+    typeof value.arch === 'string' &&
+    (artifactType === 'dmg' || artifactType === 'installer') &&
+    typeof value.fromVersion === 'string' &&
+    typeof value.toVersion === 'string' &&
+    typeof value.attemptedAt === 'string' &&
+    typeof value.updatedAt === 'string' &&
+    (result === 'pending' || result === 'success' || result === 'not_applied' || result === 'unknown') &&
+    typeof value.reason === 'string'
+  );
+}
+
+export function installerObservationRoot(dataRoot: string): string {
+  return path.join(dataRoot, 'observations', 'installer');
+}
+
+function summaryPath(root: string, flowId: string): string {
+  if (!isSafeFlowId(flowId)) throw new Error(`unsafe installer observation flow_id: ${flowId}`);
+  return path.join(root, flowId, 'summary.json');
+}
+
+async function readSummary(filePath: string): Promise<InstallerObservationSummary | null> {
+  try {
+    const parsed = JSON.parse(await readFile(filePath, 'utf8')) as unknown;
+    return isInstallerObservationSummary(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeSummary(filePath: string, summary: InstallerObservationSummary): Promise<void> {
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmpPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+  await rename(tmpPath, filePath);
+}
+
+export function normalizeUpdateObservationChannel(version: string, explicit?: string | null): InstallerObservationChannel {
+  if (explicit === 'stable' || explicit === 'beta') return explicit;
+  if (explicit != null && explicit.startsWith('beta')) return 'beta';
+  const cleaned = version.trim().replace(/^v/i, '');
+  const prerelease = cleaned.split('-', 2)[1] ?? '';
+  if (/(?:^|[-.])beta(?:[-.]|$)/i.test(version)) return 'beta';
+  if (prerelease.length > 0 && /\.[0-9]+$/.test(prerelease)) return 'beta';
+  return 'stable';
+}
+
+export function elapsedBucket(elapsedMs: number): TrackingUpdateApplyElapsedBucket {
+  if (!Number.isFinite(elapsedMs) || elapsedMs < 0) return 'unknown';
+  if (elapsedMs < 5 * 60 * 1000) return 'lt_5m';
+  if (elapsedMs < 60 * 60 * 1000) return '5m_1h';
+  if (elapsedMs < 6 * 60 * 60 * 1000) return '1h_6h';
+  if (elapsedMs < 24 * 60 * 60 * 1000) return '6h_24h';
+  if (elapsedMs < INSTALLER_OBSERVATION_TTL_MS) return '1d_7d';
+  return 'gt_7d';
+}
+
+export function classifyInstallerObservation(
+  summary: InstallerObservationSummary,
+  options: {
+    currentChannel: InstallerObservationChannel;
+    currentVersion: string;
+    namespace: string;
+    now: Date;
+    ttlMs?: number;
+  },
+): InstallerObservationClassification {
+  const attemptedAtMs = Date.parse(summary.attemptedAt);
+  const elapsedMs = Number.isFinite(attemptedAtMs) ? options.now.getTime() - attemptedAtMs : Number.NaN;
+  const bucket = elapsedBucket(elapsedMs);
+  if (summary.namespace !== options.namespace || summary.channel !== options.currentChannel) {
+    return { elapsedBucket: bucket, result: 'unknown', reason: 'identity_mismatch' };
+  }
+  if (options.currentVersion === summary.toVersion) {
+    return { elapsedBucket: bucket, result: 'success', reason: 'app_version_matches' };
+  }
+  if (options.currentVersion === summary.fromVersion) {
+    return { elapsedBucket: bucket, result: 'not_applied', reason: 'app_version_unchanged' };
+  }
+  if (!Number.isFinite(elapsedMs) || elapsedMs >= (options.ttlMs ?? INSTALLER_OBSERVATION_TTL_MS)) {
+    return { elapsedBucket: bucket, result: 'unknown', reason: 'expired' };
+  }
+  return { elapsedBucket: bucket, result: 'unknown', reason: 'identity_mismatch' };
+}
+
+function eventProperties(
+  summary: InstallerObservationSummary,
+  classification: InstallerObservationClassification,
+): Record<string, unknown> {
+  const props = {
+    flow_id: summary.flowId,
+    channel: summary.channel,
+    namespace: summary.namespace,
+    platform: summary.platform,
+    arch: summary.arch,
+    artifact_type: summary.artifactType,
+    from_version: summary.fromVersion,
+    to_version: summary.toVersion,
+    result: classification.result,
+    reason: classification.reason,
+    elapsed_bucket: classification.elapsedBucket,
+  } satisfies UpdateApplyObservedProps;
+  return props as unknown as Record<string, unknown>;
+}
+
+function deliveryForConfig(
+  appConfig: AppConfigPrefs,
+  env: NodeJS.ProcessEnv,
+  updatedAt: string,
+): { context?: AnalyticsContext; delivery: InstallerObservationDelivery } {
+  if (appConfig.telemetry?.metrics !== true) {
+    return { delivery: { eventName: 'update_apply_observed', status: 'skipped_no_consent', updatedAt } };
+  }
+  if (readPosthogConfig(env) == null) {
+    return { delivery: { eventName: 'update_apply_observed', status: 'skipped_analytics_disabled', updatedAt } };
+  }
+  const deviceId = typeof appConfig.installationId === 'string' && appConfig.installationId.length > 0
+    ? appConfig.installationId
+    : null;
+  if (deviceId == null) {
+    return { delivery: { eventName: 'update_apply_observed', status: 'skipped_missing_identity', updatedAt } };
+  }
+  return {
+    context: {
+      deviceId,
+      sessionId: deviceId,
+      clientType: 'desktop',
+      locale: 'en',
+      requestId: null,
+    },
+    delivery: { eventName: 'update_apply_observed', status: 'submitted', updatedAt },
+  };
+}
+
+export async function observePendingInstallerApplyAttempts(
+  options: ObservePendingInstallerApplyAttemptsOptions,
+): Promise<{ observed: number }> {
+  const now = options.now?.() ?? new Date();
+  const observedAt = now.toISOString();
+  const root = installerObservationRoot(options.dataRoot);
+  let entries: Array<{ name: string; isDirectory(): boolean }>;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return { observed: 0 };
+  }
+
+  const summaries: Array<{ filePath: string; summary: InstallerObservationSummary }> = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !isSafeFlowId(entry.name)) continue;
+    const filePath = summaryPath(root, entry.name);
+    const summary = await readSummary(filePath);
+    if (summary == null || summary.result !== 'pending' || summary.delivery != null) continue;
+    if (summary.flowId !== entry.name) continue;
+    summaries.push({ filePath, summary });
+  }
+  if (summaries.length === 0) return { observed: 0 };
+
+  const appConfig = await (options.readConfig ?? readAppConfig)(options.dataRoot).catch(() => ({} as AppConfigPrefs));
+  const currentChannel = normalizeUpdateObservationChannel(options.currentVersion, options.currentChannel);
+  let observed = 0;
+  for (const { filePath, summary } of summaries) {
+    const classification = classifyInstallerObservation(summary, {
+      currentChannel,
+      currentVersion: options.currentVersion,
+      namespace: options.namespace,
+      now,
+    });
+    const insertId = `update_apply_observed:${summary.flowId}`;
+    const deliveryDecision = deliveryForConfig(appConfig, options.env ?? process.env, observedAt);
+    const next: InstallerObservationSummary = {
+      ...summary,
+      delivery: {
+        ...deliveryDecision.delivery,
+        ...(deliveryDecision.delivery.status === 'submitted' ? { insertId } : {}),
+      },
+      elapsedBucket: classification.elapsedBucket,
+      observedAt,
+      reason: classification.reason,
+      result: classification.result,
+      updatedAt: observedAt,
+    };
+    if (deliveryDecision.context != null && next.delivery?.status === 'submitted') {
+      try {
+        options.analytics.capture({
+          eventName: 'update_apply_observed',
+          context: deliveryDecision.context,
+          appVersion: options.appVersion,
+          properties: eventProperties(summary, classification),
+          insertId,
+        });
+      } catch (error) {
+        options.logger?.warn?.('[open-design updater] failed to submit update apply observation', error);
+        next.delivery = { eventName: 'update_apply_observed', status: 'failed', updatedAt: observedAt };
+      }
+    }
+    await writeSummary(filePath, next);
+    observed += 1;
+  }
+  return { observed };
+}

--- a/apps/daemon/tests/update-apply-observations.test.ts
+++ b/apps/daemon/tests/update-apply-observations.test.ts
@@ -1,0 +1,173 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  classifyInstallerObservation,
+  installerObservationRoot,
+  observePendingInstallerApplyAttempts,
+  type InstallerObservationSummary,
+} from '../src/update-apply-observations.js';
+
+function pendingSummary(overrides: Partial<InstallerObservationSummary> = {}): InstallerObservationSummary {
+  return {
+    arch: 'x64',
+    artifactType: 'installer',
+    attemptedAt: '2026-05-20T00:00:00.000Z',
+    channel: 'beta',
+    flowId: 'flow-1',
+    fromVersion: '0.8.0-beta.5',
+    kind: 'installer_apply_observation',
+    namespace: 'release-beta-win',
+    platform: 'win32',
+    reason: 'installer_open_requested',
+    result: 'pending',
+    schemaVersion: 1,
+    toVersion: '0.8.0-beta.6',
+    updatedAt: '2026-05-20T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+async function writeSummary(dataRoot: string, summary: InstallerObservationSummary): Promise<string> {
+  const filePath = path.join(installerObservationRoot(dataRoot), summary.flowId, 'summary.json');
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+  return filePath;
+}
+
+describe('update apply observations', () => {
+  it('classifies next-launch version matches and unchanged versions', () => {
+    const now = new Date('2026-05-20T00:03:00.000Z');
+    expect(classifyInstallerObservation(pendingSummary(), {
+      currentChannel: 'beta',
+      currentVersion: '0.8.0-beta.6',
+      namespace: 'release-beta-win',
+      now,
+    })).toMatchObject({
+      elapsedBucket: 'lt_5m',
+      reason: 'app_version_matches',
+      result: 'success',
+    });
+
+    expect(classifyInstallerObservation(pendingSummary(), {
+      currentChannel: 'beta',
+      currentVersion: '0.8.0-beta.5',
+      namespace: 'release-beta-win',
+      now,
+    })).toMatchObject({
+      reason: 'app_version_unchanged',
+      result: 'not_applied',
+    });
+  });
+
+  it('classifies mismatched runtime identity without using raw paths or errors', () => {
+    expect(classifyInstallerObservation(pendingSummary(), {
+      currentChannel: 'stable',
+      currentVersion: '0.8.0-beta.6',
+      namespace: 'release-beta-win',
+      now: new Date('2026-05-20T00:03:00.000Z'),
+    })).toMatchObject({
+      reason: 'identity_mismatch',
+      result: 'unknown',
+    });
+  });
+
+  it('submits one sanitized analytics event and marks delivery metadata', async () => {
+    const dataRoot = await mkdtemp(path.join(tmpdir(), 'od-update-observe-'));
+    const capture = vi.fn();
+    try {
+      const summaryPath = await writeSummary(dataRoot, pendingSummary());
+
+      await expect(observePendingInstallerApplyAttempts({
+        analytics: { capture },
+        appVersion: '0.8.0-beta.6',
+        currentChannel: 'beta',
+        currentVersion: '0.8.0-beta.6',
+        dataRoot,
+        env: { POSTHOG_KEY: 'ph_test' },
+        namespace: 'release-beta-win',
+        now: () => new Date('2026-05-20T00:03:00.000Z'),
+        readConfig: async () => ({
+          installationId: 'install-1',
+          telemetry: { metrics: true },
+        }),
+      })).resolves.toEqual({ observed: 1 });
+
+      expect(capture).toHaveBeenCalledTimes(1);
+      expect(capture.mock.calls[0]?.[0]).toMatchObject({
+        eventName: 'update_apply_observed',
+        appVersion: '0.8.0-beta.6',
+        insertId: 'update_apply_observed:flow-1',
+        properties: {
+          arch: 'x64',
+          artifact_type: 'installer',
+          channel: 'beta',
+          elapsed_bucket: 'lt_5m',
+          flow_id: 'flow-1',
+          from_version: '0.8.0-beta.5',
+          namespace: 'release-beta-win',
+          platform: 'win32',
+          reason: 'app_version_matches',
+          result: 'success',
+          to_version: '0.8.0-beta.6',
+        },
+      });
+      const updated = JSON.parse(await readFile(summaryPath, 'utf8')) as Record<string, unknown>;
+      expect(updated).toMatchObject({
+        delivery: {
+          eventName: 'update_apply_observed',
+          insertId: 'update_apply_observed:flow-1',
+          status: 'submitted',
+        },
+        reason: 'app_version_matches',
+        result: 'success',
+      });
+
+      await observePendingInstallerApplyAttempts({
+        analytics: { capture },
+        appVersion: '0.8.0-beta.6',
+        currentVersion: '0.8.0-beta.6',
+        dataRoot,
+        env: { POSTHOG_KEY: 'ph_test' },
+        namespace: 'release-beta-win',
+      });
+      expect(capture).toHaveBeenCalledTimes(1);
+    } finally {
+      await rm(dataRoot, { force: true, recursive: true });
+    }
+  });
+
+  it('marks no-consent observations without submitting analytics', async () => {
+    const dataRoot = await mkdtemp(path.join(tmpdir(), 'od-update-observe-'));
+    const capture = vi.fn();
+    try {
+      const summaryPath = await writeSummary(dataRoot, pendingSummary());
+      await observePendingInstallerApplyAttempts({
+        analytics: { capture },
+        appVersion: '0.8.0-beta.6',
+        currentVersion: '0.8.0-beta.6',
+        dataRoot,
+        env: { POSTHOG_KEY: 'ph_test' },
+        namespace: 'release-beta-win',
+        readConfig: async () => ({
+          installationId: null,
+          telemetry: { metrics: false },
+        }),
+      });
+
+      expect(capture).not.toHaveBeenCalled();
+      const updated = JSON.parse(await readFile(summaryPath, 'utf8')) as Record<string, unknown>;
+      expect(updated).toMatchObject({
+        delivery: {
+          eventName: 'update_apply_observed',
+          status: 'skipped_no_consent',
+        },
+      });
+    } finally {
+      await rm(dataRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -86,6 +86,7 @@ export type DesktopMainOptions = {
   update?: {
     currentVersion?: string | null;
     downloadRoot?: string | null;
+    installerObservationRoot?: string | null;
   };
 };
 
@@ -321,6 +322,8 @@ export async function runDesktopMain(
     {
       currentVersion: options.update?.currentVersion,
       downloadRoot: options.update?.downloadRoot,
+      installerObservationRoot: options.update?.installerObservationRoot,
+      namespace: runtime.namespace,
       runtimeBase: runtime.base,
       source: runtime.source,
     },

--- a/apps/desktop/src/main/installer-observations.ts
+++ b/apps/desktop/src/main/installer-observations.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+
+import type { DesktopUpdateChannel } from "@open-design/sidecar-proto";
+
+export const INSTALLER_OBSERVATION_SCHEMA_VERSION = 1;
+export const INSTALLER_OBSERVATION_KIND = "installer_apply_observation";
+
+export type InstallerObservationArtifactType = "dmg" | "installer";
+export type InstallerObservationResult = "pending" | "success" | "not_applied" | "unknown";
+export type InstallerObservationReason =
+  | "installer_open_requested"
+  | "installer_open_failed"
+  | "app_version_matches"
+  | "app_version_unchanged"
+  | "expired"
+  | "identity_mismatch";
+
+export type InstallerObservationSummary = {
+  arch: string;
+  artifactType: InstallerObservationArtifactType;
+  attemptedAt: string;
+  channel: DesktopUpdateChannel;
+  flowId: string;
+  fromVersion: string;
+  kind: typeof INSTALLER_OBSERVATION_KIND;
+  namespace: string;
+  platform: string;
+  reason: InstallerObservationReason;
+  result: InstallerObservationResult;
+  schemaVersion: typeof INSTALLER_OBSERVATION_SCHEMA_VERSION;
+  toVersion: string;
+  updatedAt: string;
+};
+
+export type PendingInstallerObservationInput = {
+  arch: string;
+  artifactType: InstallerObservationArtifactType;
+  attemptedAt: string;
+  channel: DesktopUpdateChannel;
+  flowId?: string;
+  fromVersion: string;
+  namespace: string;
+  platform: string;
+  root: string;
+  toVersion: string;
+};
+
+export type InstallerObservationHandle = {
+  flowId: string;
+  summaryPath: string;
+};
+
+export function isSafeInstallerObservationFlowId(flowId: string): boolean {
+  return (
+    flowId.length > 0 &&
+    flowId.length <= 128 &&
+    flowId !== "." &&
+    flowId !== ".." &&
+    /^[A-Za-z0-9._-]+$/.test(flowId)
+  );
+}
+
+function assertSafeFlowId(flowId: string): void {
+  if (!isSafeInstallerObservationFlowId(flowId)) {
+    throw new Error(`installer observation flow_id is not a safe path segment: ${flowId}`);
+  }
+}
+
+function containsPath(root: string, path: string): boolean {
+  const rel = relative(root, path);
+  return rel === "" || (rel.length > 0 && !rel.startsWith("..") && !isAbsolute(rel));
+}
+
+export function installerObservationSummaryPath(root: string, flowId: string): string {
+  if (!isAbsolute(root)) throw new Error(`installer observation root must be absolute: ${root}`);
+  assertSafeFlowId(flowId);
+  const resolvedRoot = resolve(root);
+  const summaryPath = resolve(resolvedRoot, flowId, "summary.json");
+  if (!containsPath(resolvedRoot, summaryPath)) {
+    throw new Error("installer observation summary path escaped observation root");
+  }
+  return summaryPath;
+}
+
+async function writeJson(path: string, payload: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmpPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmpPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  await rename(tmpPath, path);
+}
+
+export async function writePendingInstallerObservation(
+  input: PendingInstallerObservationInput,
+): Promise<InstallerObservationHandle> {
+  const flowId = input.flowId ?? randomUUID();
+  const summaryPath = installerObservationSummaryPath(input.root, flowId);
+  const summary: InstallerObservationSummary = {
+    arch: input.arch,
+    artifactType: input.artifactType,
+    attemptedAt: input.attemptedAt,
+    channel: input.channel,
+    flowId,
+    fromVersion: input.fromVersion,
+    kind: INSTALLER_OBSERVATION_KIND,
+    namespace: input.namespace,
+    platform: input.platform,
+    reason: "installer_open_requested",
+    result: "pending",
+    schemaVersion: INSTALLER_OBSERVATION_SCHEMA_VERSION,
+    toVersion: input.toVersion,
+    updatedAt: input.attemptedAt,
+  };
+  await writeJson(summaryPath, summary);
+  return { flowId, summaryPath };
+}
+
+export async function markInstallerObservationOpenFailed(
+  handle: InstallerObservationHandle,
+  failedAt: string,
+): Promise<void> {
+  const parsed = JSON.parse(await readFile(handle.summaryPath, "utf8")) as Record<string, unknown>;
+  await writeJson(handle.summaryPath, {
+    ...parsed,
+    reason: "installer_open_failed",
+    result: "unknown",
+    updatedAt: failedAt,
+  });
+}

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -33,6 +33,13 @@ import {
   type SidecarSource,
 } from "@open-design/sidecar-proto";
 
+import {
+  markInstallerObservationOpenFailed,
+  writePendingInstallerObservation,
+  type InstallerObservationArtifactType,
+  type InstallerObservationHandle,
+} from "./installer-observations.js";
+
 export const DESKTOP_UPDATE_ENV = Object.freeze({
   ARCH: "OD_UPDATE_ARCH",
   AUTO_CHECK: "OD_UPDATE_AUTO_CHECK",
@@ -72,7 +79,9 @@ export type DesktopUpdaterConfigInput = {
   currentVersion?: string | null;
   downloadRoot?: string | null;
   env?: NodeJS.ProcessEnv;
+  installerObservationRoot?: string | null;
   mode?: DesktopUpdateMode;
+  namespace?: string | null;
   platform?: string;
   runtimeBase?: string | null;
   source: SidecarSource;
@@ -91,8 +100,10 @@ export type DesktopUpdaterConfig = {
   currentVersion: string;
   downloadRoot: string;
   enabled: boolean;
+  installerObservationRoot?: string;
   metadataUrl: string;
   mode: DesktopUpdateMode;
+  namespace?: string;
   openDryRun: boolean;
   platform: string;
   source: SidecarSource;
@@ -212,6 +223,19 @@ function normalizeDownloadRoot(value: string): string {
   return resolve(value);
 }
 
+function normalizeOptionalRoot(value: string | null | undefined, label: string): string | undefined {
+  if (value == null || value.length === 0) return undefined;
+  if (value.includes("\0")) throw new Error(`${label} must not contain null bytes`);
+  if (!isAbsolute(value)) throw new Error(`${label} must be absolute: ${value}`);
+  return resolve(value);
+}
+
+function normalizeOptionalNonEmpty(value: string | null | undefined): string | undefined {
+  if (value == null) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
 function durationEnv(value: string | undefined, fallback: number, name: string): number {
   if (value == null || value.length === 0) return fallback;
   const parsed = Number(value);
@@ -240,6 +264,8 @@ export function resolveDesktopUpdaterConfig(input: DesktopUpdaterConfigInput): D
     input.appVersion ??
     "0.0.0";
   const channel = normalizeChannel(env[DESKTOP_UPDATE_ENV.CHANNEL], defaultChannelForVersion(currentVersion));
+  const installerObservationRoot = normalizeOptionalRoot(input.installerObservationRoot, "installer observation root");
+  const namespace = normalizeOptionalNonEmpty(input.namespace);
 
   return {
     arch: env[DESKTOP_UPDATE_ENV.ARCH] ?? input.arch ?? process.arch,
@@ -270,8 +296,10 @@ export function resolveDesktopUpdaterConfig(input: DesktopUpdaterConfigInput): D
     currentVersion,
     downloadRoot,
     enabled,
+    ...(installerObservationRoot == null ? {} : { installerObservationRoot }),
     metadataUrl: env[DESKTOP_UPDATE_ENV.METADATA_URL] ?? defaultMetadataUrl(channel),
     mode,
+    ...(namespace == null ? {} : { namespace }),
     openDryRun: isTruthyEnv(env[DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]) ?? false,
     platform: env[DESKTOP_UPDATE_ENV.PLATFORM] ?? input.platform ?? process.platform,
     source: input.source,
@@ -694,6 +722,11 @@ function selectedPackageLauncherArtifact(config: DesktopUpdaterConfig): {
       platformKey: selectedWinPlatformKey(config.arch),
     };
   }
+  return null;
+}
+
+function installerObservationArtifactType(value: string | undefined): InstallerObservationArtifactType | null {
+  if (value === "dmg" || value === "installer") return value;
   return null;
 }
 
@@ -1328,6 +1361,42 @@ export function createDesktopUpdater(
     }
   }
 
+  async function writeInstallObservation(attemptedAt: string): Promise<InstallerObservationHandle | null> {
+    if (config.openDryRun) return null;
+    if (config.installerObservationRoot == null || config.namespace == null) return null;
+    if (activeRelease == null) return null;
+    const artifactType = installerObservationArtifactType(activeRelease.ref.artifact.type);
+    if (artifactType == null) return null;
+    try {
+      return await writePendingInstallerObservation({
+        arch: activeRelease.ref.arch,
+        artifactType,
+        attemptedAt,
+        channel: activeRelease.ref.channel,
+        fromVersion: config.currentVersion,
+        namespace: config.namespace,
+        platform: config.platform,
+        root: config.installerObservationRoot,
+        toVersion: activeRelease.ref.version,
+      });
+    } catch (observationError) {
+      logger.warn("[open-design updater] failed to write installer observation", observationError);
+      return null;
+    }
+  }
+
+  async function markInstallObservationOpenFailed(
+    observation: InstallerObservationHandle | null,
+    failedAt: string,
+  ): Promise<void> {
+    if (observation == null) return;
+    try {
+      await markInstallerObservationOpenFailed(observation, failedAt);
+    } catch (observationError) {
+      logger.warn("[open-design updater] failed to update installer observation", observationError);
+    }
+  }
+
   async function installUpdate(): Promise<DesktopUpdateStatusSnapshot> {
     const unsupported = unsupportedStatus();
     if (unsupported != null) return unsupported;
@@ -1367,11 +1436,14 @@ export function createDesktopUpdater(
         }),
       );
     }
+    let observation: InstallerObservationHandle | null = null;
     try {
       const openedAt = now().toISOString();
+      observation = await writeInstallObservation(openedAt);
       if (!config.openDryRun) {
         const openError = await openPath(resolvedDownload);
         if (openError.length > 0) {
+          await markInstallObservationOpenFailed(observation, now().toISOString());
           return setState(DESKTOP_UPDATE_STATES.ERROR, createError("open-installer-failed", openError));
         }
       }
@@ -1392,6 +1464,7 @@ export function createDesktopUpdater(
       });
       return setState(DESKTOP_UPDATE_STATES.DOWNLOADED);
     } catch (installError) {
+      await markInstallObservationOpenFailed(observation, now().toISOString());
       return setState(
         DESKTOP_UPDATE_STATES.ERROR,
         createError("open-installer-failed", installError instanceof Error ? installError.message : String(installError)),

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
-import { readFile, realpath, writeFile } from "node:fs/promises";
+import { readdir, readFile, realpath, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
@@ -20,6 +20,7 @@ import {
   DESKTOP_UPDATE_ENV,
   resolveDesktopUpdaterConfig,
 } from "../../src/main/updater.js";
+import { installerObservationSummaryPath } from "../../src/main/installer-observations.js";
 
 type FixtureServer = {
   artifactRequests: () => number;
@@ -192,6 +193,17 @@ function metadataResponse(version: string): Response {
 }
 
 describe("desktop updater", () => {
+  it("derives installer observation summary paths from safe flow ids only", () => {
+    const root = makeRoot();
+    try {
+      expect(installerObservationSummaryPath(root, "flow-1")).toBe(join(root, "flow-1", "summary.json"));
+      expect(() => installerObservationSummaryPath(root, "../escape")).toThrow(/flow_id/);
+      expect(() => installerObservationSummaryPath(root, "..")).toThrow(/flow_id/);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("downloads, verifies, persists, and dry-runs opening a mac package", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture();
@@ -253,6 +265,57 @@ describe("desktop updater", () => {
       expect(installed.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(installed.installResult?.dryRun).toBe(true);
       expect(installed.installResult?.path).toBe(checked.downloadPath);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("writes a pending installer observation before opening the installer", async () => {
+    const root = makeRoot();
+    const observationRoot = join(root, "observations", "installer");
+    const fixture = await createUpdaterFixture();
+    const openedPaths: string[] = [];
+    try {
+      const updater = createDesktopUpdater(
+        {
+          arch: "arm64",
+          downloadRoot: join(root, "updates"),
+          env: {
+            ...updaterEnv(fixture.metadataUrl),
+            [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
+          },
+          installerObservationRoot: observationRoot,
+          namespace: "release",
+          source: SIDECAR_SOURCES.TOOLS_PACK,
+        },
+        { openPath: async (path) => {
+          openedPaths.push(path);
+          return "";
+        } },
+      );
+
+      const checked = await updater.checkForUpdates();
+      const installed = await updater.installUpdate();
+      const flowIds = await readdir(observationRoot);
+      const summary = JSON.parse(await readFile(join(observationRoot, flowIds[0] ?? "", "summary.json"), "utf8")) as Record<string, unknown>;
+
+      expect(installed.installResult?.path).toBe(checked.downloadPath);
+      expect(openedPaths).toEqual([checked.downloadPath]);
+      expect(flowIds).toHaveLength(1);
+      expect(summary).toMatchObject({
+        arch: "arm64",
+        artifactType: "dmg",
+        channel: "stable",
+        fromVersion: "1.0.0",
+        kind: "installer_apply_observation",
+        namespace: "release",
+        platform: "darwin",
+        reason: "installer_open_requested",
+        result: "pending",
+        schemaVersion: 1,
+        toVersion: "1.0.1",
+      });
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -122,6 +122,7 @@ async function main(): Promise<void> {
     update: {
       currentVersion: config.appVersion,
       downloadRoot: paths.updateRoot,
+      installerObservationRoot: paths.installerObservationRoot,
     },
   });
 }

--- a/apps/packaged/src/paths.ts
+++ b/apps/packaged/src/paths.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import { APP_KEYS } from "@open-design/sidecar-proto";
+import { APP_KEYS, normalizeNamespace } from "@open-design/sidecar-proto";
 
 import type { PackagedConfig } from "./config.js";
 
@@ -13,6 +13,7 @@ export type PackagedNamespacePaths = {
   electronSessionDataRoot: string;
   electronUserDataRoot: string;
   headlessIdentityPath: string;
+  installerObservationRoot: string;
   logsRoot: string;
   namespaceRoot: string;
   resourceRoot: string;
@@ -25,17 +26,20 @@ export function resolvePackagedNamespacePaths(
   config: PackagedConfig,
   namespace = config.namespace,
 ): PackagedNamespacePaths {
-  const namespaceRoot = join(config.namespaceBaseRoot, namespace);
+  const normalizedNamespace = normalizeNamespace(namespace);
+  const namespaceRoot = join(config.namespaceBaseRoot, normalizedNamespace);
+  const dataRoot = join(namespaceRoot, "data");
 
   return {
     cacheRoot: join(namespaceRoot, "cache"),
     desktopIdentityPath: join(namespaceRoot, "runtime", "desktop-root.json"),
     desktopLogPath: join(namespaceRoot, "logs", APP_KEYS.DESKTOP, "latest.log"),
-    dataRoot: join(namespaceRoot, "data"),
+    dataRoot,
     desktopLogsRoot: join(namespaceRoot, "logs", APP_KEYS.DESKTOP),
     electronSessionDataRoot: join(namespaceRoot, "user-data", "session"),
     electronUserDataRoot: join(namespaceRoot, "user-data"),
     headlessIdentityPath: join(namespaceRoot, "runtime", "headless-root.json"),
+    installerObservationRoot: join(dataRoot, "observations", "installer"),
     logsRoot: join(namespaceRoot, "logs"),
     namespaceRoot,
     resourceRoot: config.resourceRoot,

--- a/apps/packaged/tests/identity.test.ts
+++ b/apps/packaged/tests/identity.test.ts
@@ -33,6 +33,7 @@ function fakePaths(root: string): PackagedNamespacePaths {
     electronSessionDataRoot: join(root, "user-data", "session"),
     electronUserDataRoot: join(root, "user-data"),
     headlessIdentityPath: join(root, "runtime", "headless-root.json"),
+    installerObservationRoot: join(root, "data", "observations", "installer"),
     logsRoot: join(root, "logs"),
     namespaceRoot: root,
     resourceRoot: join(root, "resources"),

--- a/apps/packaged/tests/paths.test.ts
+++ b/apps/packaged/tests/paths.test.ts
@@ -27,5 +27,26 @@ describe("resolvePackagedNamespacePaths", () => {
     expect(paths.namespaceRoot).toBe(join(config.namespaceBaseRoot, "release"));
     expect(paths.dataRoot).toBe(join(paths.namespaceRoot, "data"));
     expect(paths.updateRoot).toBe(join(paths.namespaceRoot, "updates"));
+    expect(paths.installerObservationRoot).toBe(join(paths.dataRoot, "observations", "installer"));
+  });
+
+  it("rejects namespace overrides that would escape the namespace base root", () => {
+    const config: PackagedConfig = {
+      appVersion: "1.2.3",
+      daemonCliEntry: null,
+      daemonSidecarEntry: null,
+      namespace: "release",
+      namespaceBaseRoot: "/tmp/open-design-packaged/namespaces",
+      nodeCommand: null,
+      resourceRoot: "/tmp/open-design-packaged/resources",
+      telemetryRelayUrl: null,
+      posthogKey: null,
+      posthogHost: null,
+      webSidecarEntry: null,
+      webStandaloneRoot: null,
+      webOutputMode: "server",
+    };
+
+    expect(() => resolvePackagedNamespacePaths(config, "../release")).toThrow(/namespace/);
   });
 });

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -159,6 +159,7 @@ describe('buildPackagedDaemonSpawnEnv', () => {
       electronSessionDataRoot: '/tmp/od-pkg/user-data/session',
       electronUserDataRoot: '/tmp/od-pkg/user-data',
       headlessIdentityPath: '/tmp/od-pkg/runtime/headless-root.json',
+      installerObservationRoot: '/tmp/od-pkg/data/observations/installer',
       logsRoot: '/tmp/od-pkg/logs',
       namespaceRoot: '/tmp/od-pkg',
       resourceRoot: '/tmp/od-pkg/resources',

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -25,6 +25,8 @@ export type AnalyticsEventName =
   // Run lifecycle (daemon authoritative)
   | 'run_created'
   | 'run_finished'
+  // Packaged updater lifecycle
+  | 'update_apply_observed'
   // File manager
   | 'file_upload_result'
   // Artifact
@@ -1004,6 +1006,37 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   total_duration_ms: number;
 }
 
+export type TrackingUpdateApplyResult = 'success' | 'not_applied' | 'unknown';
+
+export type TrackingUpdateApplyReason =
+  | 'app_version_matches'
+  | 'app_version_unchanged'
+  | 'expired'
+  | 'identity_mismatch';
+
+export type TrackingUpdateApplyElapsedBucket =
+  | 'lt_5m'
+  | '5m_1h'
+  | '1h_6h'
+  | '6h_24h'
+  | '1d_7d'
+  | 'gt_7d'
+  | 'unknown';
+
+export interface UpdateApplyObservedProps {
+  flow_id: string;
+  channel: 'stable' | 'beta';
+  namespace: string;
+  platform: string;
+  arch: string;
+  artifact_type: 'dmg' | 'installer';
+  from_version: string;
+  to_version: string;
+  result: TrackingUpdateApplyResult;
+  reason: TrackingUpdateApplyReason;
+  elapsed_bucket: TrackingUpdateApplyElapsedBucket;
+}
+
 export interface FileUploadResultProps {
   page_name: 'file_manager';
   area: 'file_manager';
@@ -1091,6 +1124,7 @@ export type AnalyticsEventPayload =
   | { event: 'plugin_replacement_result'; props: PluginReplacementResultProps }
   | { event: 'run_created'; props: RunCreatedProps }
   | { event: 'run_finished'; props: RunFinishedProps }
+  | { event: 'update_apply_observed'; props: UpdateApplyObservedProps }
   | { event: 'file_upload_result'; props: FileUploadResultProps }
   | { event: 'artifact_export_result'; props: ArtifactExportResultProps }
   | { event: 'feedback_submit_result'; props: FeedbackSubmitResultProps }


### PR DESCRIPTION
## Why

While working through packaged update reliability for the v0.8.0 release branch, I needed a way to tell whether a user who clicked `Open installer` later relaunched on the target app version. The updater previously stopped at download/open success, so release validation and analytics could not distinguish an applied installer from a user who opened it but never completed installation.

This PR adds a coarse, consent-gated apply observation that stays namespace/channel scoped and avoids uploading raw local paths, URLs, logs, process lists, errors, or stacks.

## What users will see

No new UI is shown. In packaged desktop builds, opening a downloaded installer now records a local pending apply observation. On the next packaged launch, the daemon compares the current app version with the target update version and records `success`, `not_applied`, or `unknown`; if metrics telemetry is enabled, it submits the sanitized `update_apply_observed` event once.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this has no visible UI surface.

## Bug fix verification

Not a bug fix. New coverage is in:

- `apps/desktop/tests/main/updater.test.ts`
- `apps/daemon/tests/update-apply-observations.test.ts`
- `apps/packaged/tests/paths.test.ts`

## Validation

- `pnpm install`
- `pnpm --filter @open-design/packaged test -- tests/paths.test.ts`
- `pnpm --filter @open-design/desktop test -- tests/main/updater.test.ts`
- `pnpm --filter @open-design/daemon test -- tests/update-apply-observations.test.ts`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/packaged typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/desktop test -- tests/main/updater.test.ts tests/main/updater-host-boundary.test.ts tests/main/preload-host-boundary.test.ts`
- `pnpm --filter @open-design/packaged test`
- `pnpm --filter @open-design/daemon test -- tests/update-apply-observations.test.ts tests/analytics.test.ts`
- `git diff --check`
- `pnpm guard`
- `pnpm typecheck`
- Full local Windows tools-pack loop under `C:\odtpv` / namespace `odv`:
  - built and installed `0.8.0-beta.5`
  - built real `0.8.0-beta.6` NSIS artifact
  - served local updater metadata pointing at the real artifact
  - ran `tools-pack win inspect --update-action status|check|download|install`
  - confirmed pending `summary.json` before install completion
  - silently installed `0.8.0-beta.6`
  - cold-started packaged app and confirmed `success/app_version_matches`, `delivery.status=submitted`, and one local PostHog `/ph/batch/`
  - restarted again and confirmed no duplicate `/ph/batch/`
  - stopped, uninstalled, and cleaned namespace residue

Attempted broader check:

- `pnpm --filter @open-design/daemon test` failed on pre-existing Windows-native/environment-sensitive harness issues outside this change, including temp-dir `EBUSY`, sidecar socket `EACCES`, executable resolution, connector/git harness, and symlink/path cases. The new daemon observation suite passed independently.
