### PR TITLE
test(tools-pr): cover bot/lane/tag detectors, wire into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       web_tests_required: ${{ steps.detect.outputs.web_tests_required }}
       tools_dev_tests_required: ${{ steps.detect.outputs.tools_dev_tests_required }}
       tools_pack_tests_required: ${{ steps.detect.outputs.tools_pack_tests_required }}
+      tools_pr_tests_required: ${{ steps.detect.outputs.tools_pr_tests_required }}
       workspace_validation_required: ${{ steps.detect.outputs.workspace_validation_required }}
 
     steps:
@@ -49,6 +50,7 @@ jobs:
           web_tests_required=false
           tools_dev_tests_required=false
           tools_pack_tests_required=false
+          tools_pr_tests_required=false
           workspace_validation_required=false
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             gh api --paginate \
@@ -71,11 +73,15 @@ jobs:
               if [[ "$file" == "tools/pack/"* || "$file" == "apps/packaged/"* || "$file" == "apps/desktop/"* || "$file" == "packages/host/"* || "$file" == "packages/platform/"* || "$file" == "packages/sidecar/"* || "$file" == "packages/sidecar-proto/"* ]]; then
                 tools_pack_tests_required=true
               fi
+              if [[ "$file" == "tools/pr/"* ]]; then
+                tools_pr_tests_required=true
+              fi
               if [[ "$file" == "package.json" || "$file" == "pnpm-lock.yaml" || "$file" == "pnpm-workspace.yaml" || "$file" == ".github/workflows/ci.yml" ]]; then
                 daemon_tests_required=true
                 web_tests_required=true
                 tools_dev_tests_required=true
                 tools_pack_tests_required=true
+                tools_pr_tests_required=true
               fi
               case "$file" in
                 *.md|*.mdx|*.txt|LICENSE|.gitignore|.editorconfig|.vscode/*|.idea/*|docs/*|.github/ISSUE_TEMPLATE/*|.github/CODEOWNERS)
@@ -90,6 +96,7 @@ jobs:
                 && [ "$web_tests_required" = "true" ] \
                 && [ "$tools_dev_tests_required" = "true" ] \
                 && [ "$tools_pack_tests_required" = "true" ] \
+                && [ "$tools_pr_tests_required" = "true" ] \
                 && [ "$workspace_validation_required" = "true" ]; then
                 break
               fi
@@ -97,7 +104,8 @@ jobs:
             if [ "$daemon_tests_required" = "true" ] \
               || [ "$web_tests_required" = "true" ] \
               || [ "$tools_dev_tests_required" = "true" ] \
-              || [ "$tools_pack_tests_required" = "true" ]; then
+              || [ "$tools_pack_tests_required" = "true" ] \
+              || [ "$tools_pr_tests_required" = "true" ]; then
               workspace_validation_required=true
             fi
           else
@@ -105,6 +113,7 @@ jobs:
             web_tests_required=true
             tools_dev_tests_required=true
             tools_pack_tests_required=true
+            tools_pr_tests_required=true
             workspace_validation_required=true
           fi
           {
@@ -112,6 +121,7 @@ jobs:
             echo "web_tests_required=$web_tests_required"
             echo "tools_dev_tests_required=$tools_dev_tests_required"
             echo "tools_pack_tests_required=$tools_pack_tests_required"
+            echo "tools_pr_tests_required=$tools_pr_tests_required"
             echo "workspace_validation_required=$workspace_validation_required"
           } >> "$GITHUB_OUTPUT"
 
@@ -230,7 +240,7 @@ jobs:
   tools_workspace_tests:
     name: Tools workspace tests
     needs: [change_scopes]
-    if: ${{ needs.change_scopes.outputs.tools_dev_tests_required == 'true' || needs.change_scopes.outputs.tools_pack_tests_required == 'true' }}
+    if: ${{ needs.change_scopes.outputs.tools_dev_tests_required == 'true' || needs.change_scopes.outputs.tools_pack_tests_required == 'true' || needs.change_scopes.outputs.tools_pr_tests_required == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -270,6 +280,9 @@ jobs:
           fi
           if [ "${{ needs.change_scopes.outputs.tools_pack_tests_required }}" = "true" ]; then
             pnpm --filter @open-design/tools-pack test
+          fi
+          if [ "${{ needs.change_scopes.outputs.tools_pr_tests_required }}" = "true" ]; then
+            pnpm --filter @open-design/tools-pr test
           fi
 
   daemon_workspace_tests:
@@ -367,7 +380,7 @@ jobs:
       - tools_workspace_tests
       - daemon_workspace_tests
       - web_workspace_tests
-    if: ${{ always() && needs.change_scopes.result == 'success' && (needs.change_scopes.outputs.tools_dev_tests_required == 'true' || needs.change_scopes.outputs.tools_pack_tests_required == 'true' || needs.change_scopes.outputs.daemon_tests_required == 'true' || needs.change_scopes.outputs.web_tests_required == 'true') }}
+    if: ${{ always() && needs.change_scopes.result == 'success' && (needs.change_scopes.outputs.tools_dev_tests_required == 'true' || needs.change_scopes.outputs.tools_pack_tests_required == 'true' || needs.change_scopes.outputs.tools_pr_tests_required == 'true' || needs.change_scopes.outputs.daemon_tests_required == 'true' || needs.change_scopes.outputs.web_tests_required == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -375,7 +388,7 @@ jobs:
       - name: Check app workspace test jobs
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
-          TOOLS_REQUIRED: ${{ needs.change_scopes.outputs.tools_dev_tests_required == 'true' || needs.change_scopes.outputs.tools_pack_tests_required == 'true' }}
+          TOOLS_REQUIRED: ${{ needs.change_scopes.outputs.tools_dev_tests_required == 'true' || needs.change_scopes.outputs.tools_pack_tests_required == 'true' || needs.change_scopes.outputs.tools_pr_tests_required == 'true' }}
           DAEMON_REQUIRED: ${{ needs.change_scopes.outputs.daemon_tests_required }}
           WEB_REQUIRED: ${{ needs.change_scopes.outputs.web_tests_required }}
         run: |

--- a/tools/pr/tests/bot.test.ts
+++ b/tools/pr/tests/bot.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Bot detection / marker stripping / latest-review reduction.
+ *
+ * These detectors gate `bot-only-approval` and the human-vs-bot split in the
+ * `awaiting-*` timing rules; their behavior is consumed by `tags.ts` without
+ * further sanity checks, so a regression here silently changes which PRs
+ * land in `merge-ready`.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  condense,
+  isBotAuthored,
+  isBotOnlyApproval,
+  reduceLatestReviewsByAuthor,
+  stripBotMarkers,
+} from "../src/bot.js";
+
+describe("isBotAuthored", () => {
+  it("matches actor login suffixed with [bot]", () => {
+    assert.equal(isBotAuthored({ login: "dependabot[bot]" }, ""), true);
+  });
+
+  it("matches looper HTML-comment stamp in body", () => {
+    const body = "<!-- looper: review v1 -->\nlgtm";
+    assert.equal(isBotAuthored({ login: "mrcfps" }, body), true);
+  });
+
+  it("matches Powered by Looper footer in body", () => {
+    const body = `Looks good.\n<sub>Powered by <a href="https://looper.dev">Looper</a></sub>`;
+    assert.equal(isBotAuthored({ login: "mrcfps" }, body), true);
+  });
+
+  it("returns false for a human actor with a clean body", () => {
+    assert.equal(isBotAuthored({ login: "alice" }, "please fix the typo"), false);
+  });
+
+  it("returns false when actor is null and body has no markers", () => {
+    assert.equal(isBotAuthored(null, "no markers here"), false);
+  });
+});
+
+describe("stripBotMarkers", () => {
+  it("removes looper html-comment stamp", () => {
+    const out = stripBotMarkers("<!-- looper: v1 -->\nhello");
+    assert.equal(out, "hello");
+  });
+
+  it("removes Powered by Looper <sub> footer", () => {
+    const out = stripBotMarkers("body\n<sub>Powered by <a>Looper</a></sub>");
+    assert.equal(out, "body");
+  });
+
+  it("leaves unrelated content untouched", () => {
+    const out = stripBotMarkers("just plain text");
+    assert.equal(out, "just plain text");
+  });
+});
+
+describe("condense", () => {
+  it("returns the cleaned body unchanged when under the limit", () => {
+    assert.equal(condense("hello   world", 50), "hello world");
+  });
+
+  it("truncates with an ellipsis when over the limit", () => {
+    const out = condense("a".repeat(40), 10);
+    assert.equal(out.length, 10);
+    assert.equal(out.endsWith("…"), true);
+  });
+
+  it("strips bot markers before measuring length", () => {
+    const out = condense("<!-- looper: v1 -->\nhello", 20);
+    assert.equal(out, "hello");
+  });
+});
+
+describe("isBotOnlyApproval", () => {
+  it("returns false when reviewDecision is not APPROVED", () => {
+    const reviews = [
+      { author: { login: "looper[bot]" }, body: "", state: "APPROVED" },
+    ];
+    assert.equal(isBotOnlyApproval("CHANGES_REQUESTED", reviews), false);
+  });
+
+  it("returns false when at least one APPROVED review is human-authored", () => {
+    const reviews = [
+      { author: { login: "looper[bot]" }, body: "", state: "APPROVED" },
+      { author: { login: "alice" }, body: "lgtm", state: "APPROVED" },
+    ];
+    assert.equal(isBotOnlyApproval("APPROVED", reviews), false);
+  });
+
+  it("returns true when every APPROVED review is bot-authored", () => {
+    const reviews = [
+      { author: { login: "looper[bot]" }, body: "", state: "APPROVED" },
+      { author: { login: "mrcfps" }, body: "<!-- looper: v1 -->", state: "APPROVED" },
+    ];
+    assert.equal(isBotOnlyApproval("APPROVED", reviews), true);
+  });
+
+  it("returns false when there are no APPROVED reviews at all", () => {
+    const reviews = [
+      { author: { login: "looper[bot]" }, body: "", state: "COMMENTED" },
+    ];
+    assert.equal(isBotOnlyApproval("APPROVED", reviews), false);
+  });
+});
+
+describe("reduceLatestReviewsByAuthor", () => {
+  it("returns the latest review per author by submittedAt", () => {
+    const history = [
+      { author: { login: "alice" }, submittedAt: "2026-05-01T00:00:00Z", state: "COMMENTED" },
+      { author: { login: "alice" }, submittedAt: "2026-05-10T00:00:00Z", state: "APPROVED" },
+      { author: { login: "bob" }, submittedAt: "2026-05-05T00:00:00Z", state: "CHANGES_REQUESTED" },
+    ];
+    const reduced = reduceLatestReviewsByAuthor(history);
+    const byLogin = new Map(reduced.map((r) => [r.author?.login, r]));
+    assert.equal(reduced.length, 2);
+    assert.equal(byLogin.get("alice")?.state, "APPROVED");
+    assert.equal(byLogin.get("bob")?.state, "CHANGES_REQUESTED");
+  });
+
+  it("drops entries with a null author", () => {
+    const history = [
+      { author: null, submittedAt: "2026-05-01T00:00:00Z" },
+      { author: { login: "alice" }, submittedAt: "2026-05-01T00:00:00Z" },
+    ];
+    const reduced = reduceLatestReviewsByAuthor(history);
+    assert.equal(reduced.length, 1);
+    assert.equal(reduced[0]?.author?.login, "alice");
+  });
+
+  it("returns an empty array for empty history", () => {
+    assert.deepEqual(reduceLatestReviewsByAuthor([]), []);
+  });
+});

--- a/tools/pr/tests/lane.test.ts
+++ b/tools/pr/tests/lane.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Lane derivation, forbidden-surface detection, seam detection, and the
+ * noisy-file filter. These rules track docs/code-review-guidelines.md §2 and
+ * §4, and AGENTS.md "Inactive or placeholder directories".
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  deriveForbidden,
+  deriveLane,
+  deriveSeams,
+  isNoisyFile,
+} from "../src/lane.js";
+
+describe("deriveLane", () => {
+  it("returns default with empty paths", () => {
+    const { lane, hits } = deriveLane([]);
+    assert.equal(lane, "default");
+    assert.deepEqual([...hits], ["default"]);
+  });
+
+  it("classifies a single skill-only PR as skill", () => {
+    const { lane, hits } = deriveLane(["skills/brief-packager/skill.md"]);
+    assert.equal(lane, "skill");
+    assert.deepEqual([...hits], ["skill"]);
+  });
+
+  it("classifies a single contract-only PR as contract", () => {
+    const { lane, hits } = deriveLane(["packages/contracts/src/api/run.ts"]);
+    assert.equal(lane, "contract");
+    assert.deepEqual([...hits], ["contract"]);
+  });
+
+  it("classifies sidecar-proto edits as contract", () => {
+    const { lane } = deriveLane(["packages/sidecar-proto/src/messages.ts"]);
+    assert.equal(lane, "contract");
+  });
+
+  it("classifies a single design-system-only PR as design-system", () => {
+    const { lane, hits } = deriveLane(["design-systems/nexu/DESIGN.md"]);
+    assert.equal(lane, "design-system");
+    assert.deepEqual([...hits], ["design-system"]);
+  });
+
+  it("classifies a single craft-only PR as craft", () => {
+    const { lane, hits } = deriveLane(["craft/typography.md"]);
+    assert.equal(lane, "craft");
+    assert.deepEqual([...hits], ["craft"]);
+  });
+
+  it("returns docs when every path matches DOCS_ONLY", () => {
+    const { lane } = deriveLane(["README.md", "docs/spec.md", "CHANGELOG.md"]);
+    assert.equal(lane, "docs");
+  });
+
+  it("returns multi when paths cross more than one lane", () => {
+    const { lane, hits } = deriveLane([
+      "skills/brief-packager/skill.md",
+      "packages/contracts/src/api/run.ts",
+    ]);
+    assert.equal(lane, "multi");
+    assert.equal(hits.has("skill"), true);
+    assert.equal(hits.has("contract"), true);
+  });
+
+  it("returns default for a plain app source change", () => {
+    const { lane } = deriveLane(["apps/web/src/foo.ts"]);
+    assert.equal(lane, "default");
+  });
+});
+
+describe("deriveForbidden", () => {
+  it("returns an empty array when no forbidden path is touched", () => {
+    assert.deepEqual(deriveForbidden(["apps/web/src/foo.ts"]), []);
+  });
+
+  it("flags apps/nextjs restoration", () => {
+    const hits = deriveForbidden(["apps/nextjs/pages/index.tsx"]);
+    assert.deepEqual(hits, ["restores-apps/nextjs"]);
+  });
+
+  it("flags packages/shared restoration", () => {
+    const hits = deriveForbidden(["packages/shared/src/util.ts"]);
+    assert.deepEqual(hits, ["restores-packages/shared"]);
+  });
+
+  it("flags both forbidden surfaces independently", () => {
+    const hits = deriveForbidden([
+      "apps/nextjs/pages/index.tsx",
+      "packages/shared/src/util.ts",
+    ]);
+    assert.deepEqual(hits.sort(), ["restores-apps/nextjs", "restores-packages/shared"]);
+  });
+
+  it("does not flag unrelated apps or packages with matching prefixes", () => {
+    const hits = deriveForbidden([
+      "apps/web/src/foo.ts",
+      "packages/contracts/src/api/run.ts",
+    ]);
+    assert.deepEqual(hits, []);
+  });
+});
+
+describe("deriveSeams", () => {
+  it("returns an empty array when no seam is touched", () => {
+    assert.deepEqual(deriveSeams(["apps/web/src/foo.ts"]), []);
+  });
+
+  it("flags packages/contracts and daemon HTTP routes together", () => {
+    const seams = deriveSeams([
+      "packages/contracts/src/api/run.ts",
+      "apps/daemon/src/runs/routes.ts",
+    ]);
+    assert.equal(seams.includes("packages/contracts"), true);
+    assert.equal(seams.includes("daemon HTTP/SSE routes"), true);
+  });
+
+  it("flags persisted-schema changes via migration / schema / sql tokens", () => {
+    assert.deepEqual(deriveSeams(["db/0001_init.sql"]), ["persisted schema"]);
+  });
+
+  it("flags root package.json and pnpm-workspace.yaml", () => {
+    const seams = deriveSeams(["package.json", "pnpm-workspace.yaml"]);
+    assert.equal(seams.includes("workspace layout"), true);
+    assert.equal(seams.includes("root package.json"), true);
+  });
+});
+
+describe("isNoisyFile", () => {
+  it("flags pnpm-lock.yaml as noisy", () => {
+    assert.equal(isNoisyFile("pnpm-lock.yaml"), true);
+  });
+
+  it("flags localized README variants as noisy", () => {
+    assert.equal(isNoisyFile("README.zh-CN.md"), true);
+  });
+
+  it("flags generated/ output as noisy", () => {
+    assert.equal(isNoisyFile("generated/types.ts"), true);
+  });
+
+  it("does not flag a regular source file", () => {
+    assert.equal(isNoisyFile("apps/web/src/foo.ts"), false);
+  });
+
+  it("does not flag the canonical English README", () => {
+    assert.equal(isNoisyFile("README.md"), false);
+  });
+});

--- a/tools/pr/tests/tags-detectors.test.ts
+++ b/tools/pr/tests/tags-detectors.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Exercises the remaining `classifyPr` detectors that aren't already covered
+ * by `tags-unresolved-cr.test.ts`: stale-approval, the three awaiting-*
+ * timing tags, bot-only-approval, duplicate-title, unlabeled, and
+ * non-ascii-slug.
+ *
+ * Detectors are pure functions of `PrFacts` + `ClassifyContext` — no
+ * mocking is needed; we just shape the facts so the rule under test is the
+ * one that emits.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { classifyPr } from "../src/tags.js";
+import type { PrFacts } from "../src/types.js";
+
+function makeFacts(overrides: Partial<PrFacts> = {}): PrFacts {
+  return {
+    number: 1,
+    author: "alice",
+    title: "test PR",
+    createdAt: "2026-05-10T00:00:00Z",
+    updatedAt: "2026-05-10T00:00:00Z",
+    isDraft: false,
+    reviewDecision: "",
+    mergeStateStatus: "CLEAN",
+    maintainerCanModify: true,
+    isOrgMember: false,
+    headRefOid: "abc1234",
+    assignees: [],
+    labels: [{ name: "size/S" }, { name: "risk/low" }, { name: "type/bugfix" }],
+    filePaths: ["apps/web/src/foo.ts"],
+    reviews: [],
+    comments: [],
+    commits: [],
+    ...overrides,
+  };
+}
+
+const EMPTY_CTX = { titleIndexByAuthor: new Map<string, number[]>() };
+
+// All timing detectors compare against Date.now(); pick a baseline well in the
+// past so a 24h-floor gap is unambiguous regardless of when the test runs.
+const LONG_AGO = "2024-01-01T00:00:00Z";
+const SLIGHTLY_AFTER_LONG_AGO = "2024-01-02T00:00:00Z";
+
+describe("tagStaleApproval", () => {
+  it("fires when an APPROVED review's commit oid predates headRefOid", () => {
+    const facts = makeFacts({
+      headRefOid: "ffffff7",
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "lgtm",
+          state: "APPROVED",
+          submittedAt: "2026-05-10T00:00:00Z",
+          commit: { oid: "0000000" },
+        },
+      ],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "stale-approval");
+    assert.ok(tag, "stale-approval should fire");
+    assert.match(tag?.reason ?? "", /bob@0000000/);
+    assert.match(tag?.reason ?? "", /ffffff7/);
+  });
+
+  it("does not fire when the APPROVED review's commit oid equals headRefOid", () => {
+    const facts = makeFacts({
+      headRefOid: "abc1234",
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "lgtm",
+          state: "APPROVED",
+          submittedAt: "2026-05-10T00:00:00Z",
+          commit: { oid: "abc1234" },
+        },
+      ],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "stale-approval");
+    assert.equal(tag, undefined);
+  });
+});
+
+describe("tagAwaitingAuthorResponse", () => {
+  it("fires when the latest human-reviewer signal is newer than the latest author signal and >=24h old", () => {
+    const facts = makeFacts({
+      author: "alice",
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "please fix",
+          state: "COMMENTED",
+          submittedAt: SLIGHTLY_AFTER_LONG_AGO,
+        },
+      ],
+      commits: [
+        { committedDate: LONG_AGO, authorLogin: "alice" },
+      ],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "awaiting-author-response-24h");
+    assert.ok(tag, "awaiting-author-response-24h should fire");
+    assert.equal(typeof tag?.awaitingHours, "number");
+    assert.equal((tag?.awaitingHours ?? 0) >= 24, true);
+  });
+
+  it("does not fire when the latest author signal is newer than the latest reviewer signal", () => {
+    const facts = makeFacts({
+      author: "alice",
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "please fix",
+          state: "COMMENTED",
+          submittedAt: LONG_AGO,
+        },
+      ],
+      commits: [
+        { committedDate: SLIGHTLY_AFTER_LONG_AGO, authorLogin: "alice" },
+      ],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "awaiting-author-response-24h");
+    assert.equal(tag, undefined);
+  });
+});
+
+describe("tagAwaitingReviewerResponse", () => {
+  it("fires when the latest author signal is newer than the latest human-reviewer signal and >=24h old", () => {
+    const facts = makeFacts({
+      author: "alice",
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "please fix",
+          state: "COMMENTED",
+          submittedAt: LONG_AGO,
+        },
+      ],
+      commits: [
+        { committedDate: SLIGHTLY_AFTER_LONG_AGO, authorLogin: "alice" },
+      ],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "awaiting-reviewer-response-24h");
+    assert.ok(tag, "awaiting-reviewer-response-24h should fire");
+    assert.equal((tag?.awaitingHours ?? 0) >= 24, true);
+  });
+
+  it("ignores commits authored by someone other than the PR author", () => {
+    // maintainerCanModify=true: a maintainer push must not count as an
+    // author signal. Without an author signal the rule cannot fire.
+    const facts = makeFacts({
+      author: "alice",
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "please fix",
+          state: "COMMENTED",
+          submittedAt: LONG_AGO,
+        },
+      ],
+      commits: [
+        { committedDate: SLIGHTLY_AFTER_LONG_AGO, authorLogin: "maintainer" },
+      ],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "awaiting-reviewer-response-24h");
+    assert.equal(tag, undefined);
+  });
+});
+
+describe("tagAwaitingFirstReview", () => {
+  it("fires when there is no human-reviewer signal and the PR is >=24h old", () => {
+    const facts = makeFacts({
+      createdAt: LONG_AGO,
+      reviews: [],
+      comments: [],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "awaiting-first-review-24h");
+    assert.ok(tag, "awaiting-first-review-24h should fire");
+    assert.equal((tag?.awaitingHours ?? 0) >= 24, true);
+  });
+
+  it("does not fire when a human-reviewer signal already exists", () => {
+    const facts = makeFacts({
+      createdAt: LONG_AGO,
+      reviews: [
+        {
+          author: { login: "bob" },
+          body: "looking",
+          state: "COMMENTED",
+          submittedAt: LONG_AGO,
+        },
+      ],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "awaiting-first-review-24h");
+    assert.equal(tag, undefined);
+  });
+
+  it("ignores bot reviews when deciding whether a first review exists", () => {
+    const facts = makeFacts({
+      createdAt: LONG_AGO,
+      reviews: [
+        {
+          author: { login: "dependabot[bot]" },
+          body: "",
+          state: "COMMENTED",
+          submittedAt: LONG_AGO,
+        },
+      ],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "awaiting-first-review-24h");
+    assert.ok(tag, "awaiting-first-review-24h should still fire when only a bot has reviewed");
+  });
+});
+
+describe("tagBotOnlyApproval", () => {
+  it("fires when reviewDecision=APPROVED and every APPROVED review is bot-authored", () => {
+    const facts = makeFacts({
+      reviewDecision: "APPROVED",
+      reviews: [
+        {
+          author: { login: "looper[bot]" },
+          body: "",
+          state: "APPROVED",
+          submittedAt: "2026-05-10T00:00:00Z",
+          commit: { oid: "abc1234" },
+        },
+      ],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "bot-only-approval");
+    assert.ok(tag, "bot-only-approval should fire");
+    assert.equal(tag?.source, "gh.reviewDecision+latestReviews");
+  });
+
+  it("does not fire when a human APPROVED review is present alongside the bot one", () => {
+    const facts = makeFacts({
+      reviewDecision: "APPROVED",
+      reviews: [
+        {
+          author: { login: "looper[bot]" },
+          body: "",
+          state: "APPROVED",
+          submittedAt: "2026-05-10T00:00:00Z",
+          commit: { oid: "abc1234" },
+        },
+        {
+          author: { login: "alice" },
+          body: "lgtm",
+          state: "APPROVED",
+          submittedAt: "2026-05-10T00:01:00Z",
+          commit: { oid: "abc1234" },
+        },
+      ],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "bot-only-approval");
+    assert.equal(tag, undefined);
+  });
+});
+
+describe("tagDuplicateTitle", () => {
+  it("fires when the same author has another open PR with the byte-for-byte title", () => {
+    const ctx = {
+      titleIndexByAuthor: new Map<string, number[]>([
+        ["alice test PR", [1, 7]],
+      ]),
+    };
+    const facts = makeFacts({ number: 1, author: "alice", title: "test PR" });
+    const tag = classifyPr(facts, ctx).find((t) => t.name === "duplicate-title");
+    assert.ok(tag, "duplicate-title should fire");
+    assert.match(tag?.reason ?? "", /#7/);
+  });
+
+  it("does not fire when the title appears only on the current PR", () => {
+    const ctx = {
+      titleIndexByAuthor: new Map<string, number[]>([
+        ["alice test PR", [1]],
+      ]),
+    };
+    const facts = makeFacts({ number: 1, author: "alice", title: "test PR" });
+    const tag = classifyPr(facts, ctx).find((t) => t.name === "duplicate-title");
+    assert.equal(tag, undefined);
+  });
+});
+
+describe("tagUnlabeled", () => {
+  it("fires when none of the required label prefixes are present", () => {
+    const facts = makeFacts({ labels: [] });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "unlabeled");
+    assert.ok(tag, "unlabeled should fire");
+    assert.match(tag?.reason ?? "", /size\//);
+    assert.match(tag?.reason ?? "", /risk\//);
+    assert.match(tag?.reason ?? "", /type\//);
+  });
+
+  it("fires when one of the required prefixes is missing", () => {
+    const facts = makeFacts({
+      labels: [{ name: "size/S" }, { name: "risk/low" }],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "unlabeled");
+    assert.ok(tag, "unlabeled should fire for missing type/");
+    assert.match(tag?.reason ?? "", /type\//);
+  });
+
+  it("does not fire when all three required prefixes are present", () => {
+    const facts = makeFacts({
+      labels: [
+        { name: "size/M" },
+        { name: "risk/medium" },
+        { name: "type/feature" },
+      ],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "unlabeled");
+    assert.equal(tag, undefined);
+  });
+});
+
+describe("tagNonAsciiSlug", () => {
+  it("fires when a design-system slug contains non-ASCII characters", () => {
+    const facts = makeFacts({
+      filePaths: ["design-systems/品牌/DESIGN.md"],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "non-ascii-slug");
+    assert.ok(tag, "non-ascii-slug should fire");
+    assert.match(tag?.reason ?? "", /品牌/);
+  });
+
+  it("does not fire for an ASCII-only design-system slug", () => {
+    const facts = makeFacts({
+      filePaths: ["design-systems/nexu/DESIGN.md"],
+    });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "non-ascii-slug");
+    assert.equal(tag, undefined);
+  });
+
+  it("does not fire when the PR has no design-system paths at all", () => {
+    const facts = makeFacts({ filePaths: ["apps/web/src/foo.ts"] });
+    const tag = classifyPr(facts, EMPTY_CTX).find((t) => t.name === "non-ascii-slug");
+    assert.equal(tag, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for `tools/pr` core modules and wires the package into `tools_workspace_tests` (it was not covered by any CI job prior to this change). A `tools_pr_tests_required` change-scope output is added so PRs touching `tools/pr/**` actually trigger the new job — mirrors the existing tools-dev / tools-pack plumbing.

- `src/bot.ts`: `isBotAuthored`, `stripBotMarkers`, `condense`, `isBotOnlyApproval`, `reduceLatestReviewsByAuthor`.
- `src/lane.ts`: `deriveLane` (empty / single / multi / docs), `deriveForbidden`, `deriveSeams`, `isNoisyFile`.
- `src/tags.ts`: `tagStaleApproval`, `tagAwaitingAuthorResponse24h`, `tagAwaitingReviewerResponse24h`, `tagAwaitingFirstReview24h`, `tagBotOnlyApproval`, `tagDuplicateTitle`, `tagUnlabeled`, `tagNonAsciiSlug` (the existing `tagUnresolvedChangesRequested` test stays as-is).

Tests-only + CI wiring; no source changes.

## Validation
- `pnpm --filter @open-design/tools-pr test` — green locally (66 tests; +60 new).