### PR TITLE
ci(tools-serve): wire tools-serve workspace tests into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       web_tests_required: ${{ steps.detect.outputs.web_tests_required }}
       tools_dev_tests_required: ${{ steps.detect.outputs.tools_dev_tests_required }}
       tools_pack_tests_required: ${{ steps.detect.outputs.tools_pack_tests_required }}
+      tools_serve_tests_required: ${{ steps.detect.outputs.tools_serve_tests_required }}
       nix_validation_required: ${{ steps.detect.outputs.nix_validation_required }}
       ui_p0_validation_required: ${{ steps.detect.outputs.ui_p0_validation_required }}
       visual_validation_required: ${{ steps.detect.outputs.visual_validation_required }}
@@ -504,6 +505,9 @@ jobs:
           fi
           if [ "${{ needs.scopes.outputs.tools_pack_tests_required }}" = "true" ]; then
             pnpm --filter @open-design/tools-pack test
+          fi
+          if [ "${{ needs.scopes.outputs.tools_serve_tests_required }}" = "true" ]; then
+            pnpm --filter @open-design/tools-serve test
           fi
 
       - name: Probe watcher environment

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -236,6 +236,44 @@ describe("packaged smoke workflow", () => {
     expect(validate).toContain("windows_tools_pack_payload_tests");
   });
 
+  it("[P2] wires the tools-serve suite into the workspace_unit_tests CI scope", async () => {
+    const workflow = await readFile(ciWorkflowPath, "utf8");
+    const scopes = sectionBetween(workflow, "  scopes:", "  static_gate:");
+    const workspaceUnitTests = sectionBetween(
+      workflow,
+      "  workspace_unit_tests:",
+      "  windows_tools_pack_payload_tests:",
+    );
+
+    // The scopes job exposes the new output, and workspace_unit_tests runs the
+    // tools-serve package suite gated on that scope.
+    expect(scopes).toContain(
+      "tools_serve_tests_required: ${{ steps.detect.outputs.tools_serve_tests_required }}",
+    );
+    expect(workspaceUnitTests).toMatch(
+      /needs\.scopes\.outputs\.tools_serve_tests_required[^\n]*\n\s*pnpm --filter @open-design\/tools-serve test/,
+    );
+
+    // scopes.ts maps tools/serve/* changes onto the new scope and nothing else;
+    // unrelated tools-pack changes trip tools-pack but not tools-serve.
+    await expect(
+      runScopesPrint("workflow_dispatch", { inputs: { ci_mode: "hot" } }, [
+        "tools/serve/src/updater-fixture.ts",
+      ]),
+    ).resolves.toMatchObject({
+      tools_serve_tests_required: true,
+      tools_pack_tests_required: false,
+    });
+    await expect(
+      runScopesPrint("workflow_dispatch", { inputs: { ci_mode: "hot" } }, [
+        "tools/pack/src/config.ts",
+      ]),
+    ).resolves.toMatchObject({
+      tools_serve_tests_required: false,
+      tools_pack_tests_required: true,
+    });
+  });
+
   it("[P2] limits manual blob guard checks to changed files against main", async () => {
     const workflow = await readFile(ciWorkflowPath, "utf8");
     const blobGuard = sectionBetween(workflow, "  static_gate:", "  nix_validation:");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -272,6 +272,17 @@ describe("packaged smoke workflow", () => {
       tools_serve_tests_required: false,
       tools_pack_tests_required: true,
     });
+
+    // tools-serve imports @open-design/release, so a packages/release change
+    // must run its suite too (release is a shared dep of tools-pack as well).
+    await expect(
+      runScopesPrint("workflow_dispatch", { inputs: { ci_mode: "hot" } }, [
+        "packages/release/src/index.ts",
+      ]),
+    ).resolves.toMatchObject({
+      tools_serve_tests_required: true,
+      tools_pack_tests_required: true,
+    });
   });
 
   it("[P2] limits manual blob guard checks to changed files against main", async () => {

--- a/scripts/scopes.ts
+++ b/scripts/scopes.ts
@@ -222,7 +222,9 @@ function applyChangedFile(file: string, target: ScopeOutputs): void {
     target.tools_dev_tests_required = true;
   }
 
-  if (startsWithAny(file, ["tools/serve/"])) {
+  // tools-serve depends on @open-design/release (packages/release), so a
+  // change there must also run its suite.
+  if (startsWithAny(file, ["tools/serve/", "packages/release/"])) {
     target.tools_serve_tests_required = true;
   }
 

--- a/scripts/scopes.ts
+++ b/scripts/scopes.ts
@@ -10,6 +10,7 @@ type ScopeOutputs = {
   web_tests_required: boolean;
   tools_dev_tests_required: boolean;
   tools_pack_tests_required: boolean;
+  tools_serve_tests_required: boolean;
   nix_validation_required: boolean;
   ui_p0_validation_required: boolean;
   visual_validation_required: boolean;
@@ -62,6 +63,7 @@ function createScopePlan(): ScopePlan {
     web_tests_required: false,
     tools_dev_tests_required: false,
     tools_pack_tests_required: false,
+    tools_serve_tests_required: false,
     nix_validation_required: false,
     ui_p0_validation_required: false,
     visual_validation_required: false,
@@ -82,7 +84,8 @@ function createScopePlan(): ScopePlan {
       outputs.daemon_tests_required ||
       outputs.web_tests_required ||
       outputs.tools_dev_tests_required ||
-      outputs.tools_pack_tests_required
+      outputs.tools_pack_tests_required ||
+      outputs.tools_serve_tests_required
     ) {
       outputs.workspace_validation_required = true;
     }
@@ -96,6 +99,7 @@ function createScopePlan(): ScopePlan {
     outputs.web_tests_required = true;
     outputs.tools_dev_tests_required = true;
     outputs.tools_pack_tests_required = true;
+    outputs.tools_serve_tests_required = true;
     outputs.nix_validation_required = true;
     outputs.ui_p0_validation_required = true;
     outputs.visual_validation_required = true;
@@ -218,6 +222,10 @@ function applyChangedFile(file: string, target: ScopeOutputs): void {
     target.tools_dev_tests_required = true;
   }
 
+  if (startsWithAny(file, ["tools/serve/"])) {
+    target.tools_serve_tests_required = true;
+  }
+
   if (
     startsWithAny(file, [
       "tools/pack/",
@@ -239,6 +247,7 @@ function applyChangedFile(file: string, target: ScopeOutputs): void {
     target.web_tests_required = true;
     target.tools_dev_tests_required = true;
     target.tools_pack_tests_required = true;
+    target.tools_serve_tests_required = true;
   }
 
   if (isUiP0RelevantFile(file)) {


### PR DESCRIPTION
## Summary
`tools/serve` ships a real vitest suite (`updater-fixture`, `release-metadata-publish`, `beta-version-reservation`, `release-storage-fixture`) but **CI never runs it** — there is no `tools-serve` scope in the CI scope detector.

This wires it in, mirroring how `tools-pack` is handled:
- `scripts/scopes.ts` — add a `tools_serve_tests_required` scope (type, init, the workspace-validation aggregate, the full-run setter, a `tools/serve/` path-detection rule, and the workspace-manifest/CI-file trigger).
- `.github/workflows/ci.yml` — expose the new `scopes` output and run `pnpm --filter @open-design/tools-serve test` in `workspace_unit_tests` when that scope trips.

## Why
The `tools/serve` package has test coverage that silently never executes in CI, so regressions there ship unnoticed. This closes that gap.

> **Reworked on rebase:** the original branch also added a `tools/serve/tests/updater-fixture.test.ts`. `main` now ships a more comprehensive version of that file (9 cases vs. this branch's 5, written against the since-rewritten fixture API), so the test file is dropped and only the still-missing CI wiring remains.

## What users will see
Nothing — CI/tooling only.

## Surface area
- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — CI scope-detection + workflow wiring only (`scripts/scopes.ts`, `.github/workflows/ci.yml`); no product surface.

## Validation
- `actionlint .github/workflows/ci.yml` — clean.
- `scopes.ts` change is a type-complete mirror of the existing `tools_pack` scope; CI type-checks and exercises it on this run.
- Added topology coverage in `e2e/tests/packaged-smoke-workflow.test.ts`: asserts the `workspace_unit_tests` job runs the tools-serve suite gated on `tools_serve_tests_required`, and that `runScopesPrint` maps `tools/serve/*` → that scope (and `tools/pack/*` does not), so the lane cannot be silently dropped.
