### PR TITLE
test(daemon): cover critique scoreboard, live-artifact render, home expansion

### DIFF
--- a/apps/daemon/tests/critique/scoreboard.test.ts
+++ b/apps/daemon/tests/critique/scoreboard.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { RoleWeights } from '@open-design/contracts/critique';
+import { computeComposite, type RoleScores } from '../../src/critique/scoreboard.js';
+
+// Default weights mirror defaultCritiqueConfig() in packages/contracts/src/critique.ts:
+// designer 0, critic 0.4, brand 0.2, a11y 0.2, copy 0.2. The composite formula
+// redistributes weight proportionally across roles that actually provided a
+// score, so absent panelists never silently anchor the composite to zero.
+const DEFAULT_WEIGHTS: RoleWeights = {
+  designer: 0,
+  critic: 0.4,
+  brand: 0.2,
+  a11y: 0.2,
+  copy: 0.2,
+};
+
+describe('computeComposite', () => {
+  it('returns 0 when no role has a score', () => {
+    // Spec § Composite score formula: empty input degenerates to zero so the
+    // round's mustFix gate still has a numeric composite to compare against.
+    expect(computeComposite({}, DEFAULT_WEIGHTS)).toBe(0);
+  });
+
+  it('weights all present roles per the configured RoleWeights map', () => {
+    // designer is weighted at 0, so its score drops out entirely even when
+    // present. critic/brand/a11y/copy together carry the full weight.
+    const scores: RoleScores = { designer: 10, critic: 8, brand: 6, a11y: 9, copy: 7 };
+    // 0.4*8 + 0.2*6 + 0.2*9 + 0.2*7 = 3.2 + 1.2 + 1.8 + 1.4 = 7.6
+    expect(computeComposite(scores, DEFAULT_WEIGHTS)).toBeCloseTo(7.6, 9);
+  });
+
+  it('redistributes weight proportionally when only a subset of roles scored', () => {
+    // Only critic and brand reported. Their nominal weights sum to 0.6, so
+    // each contribution is scaled by its share of that 0.6, not the full 1.0.
+    // (0.4/0.6)*9 + (0.2/0.6)*6 = 6 + 2 = 8.
+    const scores: RoleScores = { critic: 9, brand: 6 };
+    expect(computeComposite(scores, DEFAULT_WEIGHTS)).toBeCloseTo(8, 9);
+  });
+
+  it('returns the raw score when a single role with non-zero weight scored', () => {
+    // Single present role with non-zero weight: redistribution collapses to
+    // weight/weight=1, so the composite equals the raw score.
+    expect(computeComposite({ critic: 7 }, DEFAULT_WEIGHTS)).toBeCloseTo(7, 9);
+  });
+
+  it('returns 0 when the only present role has zero configured weight', () => {
+    // designer carries weight 0 in the default config. If designer is the
+    // only panelist that scored, totalWeight collapses to ~0 and the function
+    // returns 0 rather than dividing by zero.
+    expect(computeComposite({ designer: 9 }, DEFAULT_WEIGHTS)).toBe(0);
+  });
+
+  it('handles fractional weights and fractional scores without precision drift', () => {
+    // Custom weights that are deliberately not round fractions, paired with
+    // fractional scores, to guard against accumulated rounding error in the
+    // weighted-sum reducer.
+    const weights: RoleWeights = {
+      designer: 0.1,
+      critic: 0.35,
+      brand: 0.15,
+      a11y: 0.25,
+      copy: 0.15,
+    };
+    const scores: RoleScores = { designer: 8.5, critic: 7.25, brand: 9.1, a11y: 6.4, copy: 8.0 };
+    // Sum: 0.1*8.5 + 0.35*7.25 + 0.15*9.1 + 0.25*6.4 + 0.15*8.0
+    //    = 0.85 + 2.5375 + 1.365 + 1.6 + 1.2 = 7.5525
+    expect(computeComposite(scores, weights)).toBeCloseTo(7.5525, 9);
+  });
+});

--- a/apps/daemon/tests/home-expansion.test.ts
+++ b/apps/daemon/tests/home-expansion.test.ts
@@ -1,0 +1,72 @@
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { expandHomePrefix, resolveProjectRelativePath } from '../src/home-expansion.js';
+
+describe('expandHomePrefix', () => {
+  // Pin homedir once: os.homedir() reads HOME/USERPROFILE eagerly, so any
+  // future env-mutation test added next to these cases would otherwise drift.
+  const home = os.homedir();
+
+  it('expands a bare tilde to the user home directory', () => {
+    expect(expandHomePrefix('~')).toBe(home);
+  });
+
+  it('expands ~/sub to a joined absolute path under home', () => {
+    expect(expandHomePrefix('~/projects/open-design')).toBe(path.join(home, 'projects', 'open-design'));
+  });
+
+  it('expands $HOME bare to the user home directory', () => {
+    expect(expandHomePrefix('$HOME')).toBe(home);
+  });
+
+  it('expands $HOME/sub to a joined path under home', () => {
+    expect(expandHomePrefix('$HOME/.open-design')).toBe(path.join(home, '.open-design'));
+  });
+
+  it('expands the ${HOME} braced form bare and prefixed', () => {
+    // The braced form is what shells emit when interpolation needs to be
+    // disambiguated from a longer identifier, so launchers may produce it.
+    expect(expandHomePrefix('${HOME}')).toBe(home);
+    expect(expandHomePrefix('${HOME}/data')).toBe(path.join(home, 'data'));
+  });
+
+  it('accepts backslash separators so Windows-style launchers expand identically', () => {
+    // The docblock on expandHomePrefix calls this out explicitly: forward and
+    // back slashes are both accepted at the prefix boundary; the output is
+    // rebuilt with path.join so the platform separator decides the result.
+    expect(expandHomePrefix('~\\sub')).toBe(path.join(home, 'sub'));
+    expect(expandHomePrefix('$HOME\\sub')).toBe(path.join(home, 'sub'));
+    expect(expandHomePrefix('${HOME}\\sub')).toBe(path.join(home, 'sub'));
+  });
+
+  it('returns non-home inputs unchanged (absolute, relative, other $VAR)', () => {
+    // Anything outside the documented shorthand set must pass through; the
+    // resolver layer above will handle absolute vs relative semantics.
+    expect(expandHomePrefix('/etc/passwd')).toBe('/etc/passwd');
+    expect(expandHomePrefix('./relative/path')).toBe('./relative/path');
+    expect(expandHomePrefix('plain')).toBe('plain');
+    expect(expandHomePrefix('$OTHER/path')).toBe('$OTHER/path');
+  });
+});
+
+describe('resolveProjectRelativePath', () => {
+  const home = os.homedir();
+  const projectRoot = path.resolve('/var/lib/od-daemon');
+
+  it('anchors a relative path to the supplied project root', () => {
+    expect(resolveProjectRelativePath('artifacts/cache', projectRoot)).toBe(
+      path.resolve(projectRoot, 'artifacts/cache'),
+    );
+  });
+
+  it('returns absolute inputs unchanged', () => {
+    expect(resolveProjectRelativePath('/srv/data', projectRoot)).toBe('/srv/data');
+  });
+
+  it('expands ~ and joins the remainder under home before absolute-vs-relative dispatch', () => {
+    // The expansion runs first, so '~/data' resolves to an absolute path
+    // under home and the projectRoot anchor never applies.
+    expect(resolveProjectRelativePath('~/data', projectRoot)).toBe(path.join(home, 'data'));
+  });
+});

--- a/apps/daemon/tests/live-artifacts/render.test.ts
+++ b/apps/daemon/tests/live-artifacts/render.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+  escapeHtmlTemplateValue,
+  renderHtmlTemplateV1,
+  validateHtmlTemplateV1Security,
+} from '../../src/live-artifacts/render.js';
+
+describe('validateHtmlTemplateV1Security', () => {
+  it('rejects script elements', () => {
+    // Inline scripts are the highest-impact escape; even a malformed <script>
+    // tag with attributes must trip the validator.
+    expect(() => validateHtmlTemplateV1Security('<div><script>alert(1)</script></div>'))
+      .toThrow(/script elements/i);
+  });
+
+  it('rejects iframe elements', () => {
+    // iframes can host arbitrary cross-origin content, including js, even
+    // without explicit sandbox attributes.
+    expect(() => validateHtmlTemplateV1Security('<iframe src="/evil.html"></iframe>'))
+      .toThrow(/iframe elements/i);
+  });
+
+  it('rejects srcdoc attributes that would inline a nested document', () => {
+    // srcdoc would inline a parsable HTML document into the host context.
+    // The iframe check fires first if the element is <iframe>; use a custom
+    // element so the srcdoc-specific branch is the one that trips.
+    expect(() => validateHtmlTemplateV1Security('<my-frame srcdoc="<b>x</b>"></my-frame>'))
+      .toThrow(/srcdoc attributes/i);
+  });
+
+  it('rejects inline event handler attributes', () => {
+    // onclick / onerror / onload etc.; the regex is case-insensitive so
+    // mixed-case bypass attempts also fail.
+    expect(() => validateHtmlTemplateV1Security('<img src="x" onerror="alert(1)">'))
+      .toThrow(/event handler attributes/i);
+  });
+
+  it('rejects javascript: URLs in href/src/action/formaction', () => {
+    // href=javascript:..., src=javascript:..., action=javascript:..., and
+    // formaction=javascript:... must all surface the same diagnostic so the
+    // user sees a coherent failure mode.
+    expect(() => validateHtmlTemplateV1Security('<a href="javascript:alert(1)">x</a>'))
+      .toThrow(/javascript: URLs/i);
+  });
+
+  it('rejects raw HTML insertion directives', () => {
+    // data-od-html / data-od-raw / data-od-bind-html are application-level
+    // opt-outs of escaping; banning them keeps the renderer to a single
+    // escape path.
+    expect(() => validateHtmlTemplateV1Security('<div data-od-html="x"></div>'))
+      .toThrow(/raw HTML insertion directives/i);
+  });
+
+  it('accepts a clean template without any executable patterns', () => {
+    // Sanity check: a plain template body with text and safe attributes must
+    // pass without throwing, otherwise the validator would block every
+    // legitimate render.
+    expect(() => validateHtmlTemplateV1Security('<div class="card"><p>Hello {{ data.name }}</p></div>'))
+      .not.toThrow();
+  });
+});
+
+describe('escapeHtmlTemplateValue', () => {
+  it('escapes the five HTML-significant characters', () => {
+    // Each character maps to its named or numeric entity; the result must be
+    // safe to paste into element text content or an attribute value.
+    expect(escapeHtmlTemplateValue('<')).toBe('&lt;');
+    expect(escapeHtmlTemplateValue('>')).toBe('&gt;');
+    expect(escapeHtmlTemplateValue('&')).toBe('&amp;');
+    expect(escapeHtmlTemplateValue('"')).toBe('&quot;');
+    expect(escapeHtmlTemplateValue("'")).toBe('&#39;');
+  });
+
+  it('escapes ampersand first so existing entities are not double-decoded', () => {
+    // If `<` were escaped before `&`, the resulting `&lt;` would itself get
+    // re-escaped on the `&` pass into `&amp;lt;`. The ordering of replaceAll
+    // calls in render.ts guards against that.
+    expect(escapeHtmlTemplateValue('<a&b>')).toBe('&lt;a&amp;b&gt;');
+  });
+
+  it('coerces non-string inputs through String() before escaping', () => {
+    // Numbers, booleans, and null must all render as their string form so
+    // template authors do not have to pre-cast every binding.
+    expect(escapeHtmlTemplateValue(42)).toBe('42');
+    expect(escapeHtmlTemplateValue(true)).toBe('true');
+    expect(escapeHtmlTemplateValue(null)).toBe('null');
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(escapeHtmlTemplateValue('hello world')).toBe('hello world');
+  });
+});
+
+describe('renderHtmlTemplateV1', () => {
+  it('substitutes a data binding with the escaped value from dataJson', () => {
+    // Happy path: a single {{ data.name }} binding resolves to the
+    // corresponding key and the surrounding markup is preserved verbatim.
+    const result = renderHtmlTemplateV1({
+      templateHtml: '<p>Hello, {{ data.name }}!</p>',
+      dataJson: { name: 'Ada' },
+    });
+    expect(result.html).toBe('<p>Hello, Ada!</p>');
+  });
+
+  it('escapes substituted values so injected markup cannot break out of text', () => {
+    // The whole reason the renderer routes through escapeHtmlTemplateValue:
+    // a user-controlled value containing tags is rendered as text, not DOM.
+    const result = renderHtmlTemplateV1({
+      templateHtml: '<p>{{ data.note }}</p>',
+      dataJson: { note: '<script>x</script>' },
+    });
+    expect(result.html).toBe('<p>&lt;script&gt;x&lt;/script&gt;</p>');
+  });
+
+  it('walks nested keys via dotted paths', () => {
+    // data.user.name reads dataJson.user.name; missing intermediate keys
+    // resolve to '' rather than throwing, so partial data renders cleanly.
+    const result = renderHtmlTemplateV1({
+      templateHtml: '<p>{{ data.user.name }}</p>',
+      dataJson: { user: { name: 'Grace' } },
+    });
+    expect(result.html).toBe('<p>Grace</p>');
+  });
+
+  it('rejects raw interpolation syntax (triple-brace) before substitution', () => {
+    // {{{ ... }}} would bypass HTML escaping; the renderer must surface a
+    // clear error rather than silently passing the value through.
+    expect(() => renderHtmlTemplateV1({
+      templateHtml: '<p>{{{ data.note }}}</p>',
+      dataJson: { note: 'x' },
+    })).toThrow(/raw template interpolation/i);
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for three previously-untested daemon modules whose logic is pure-branching and high-ROI:
- `src/critique/scoreboard.ts`: `computeComposite` weight-redistribution across present roles, empty-input guard (returns 0), fractional weights, single-role edges.
- `src/live-artifacts/render.ts`: `validateHtmlTemplateV1Security` blocks each of the 6 patterns (script, iframe, srcdoc on non-iframe hosts, event handlers, `javascript:` URLs, raw directives) plus a clean-template pass; `escapeHtmlTemplateValue` round-trip on `<>&"'`; `renderHtmlTemplateV1` happy-path substitution.
- `src/home-expansion.ts`: `expandHomePrefix` for `~`, `~/path`, `$HOME`, `${HOME}`, non-prefix pass-through; `resolveProjectRelativePath` relative + absolute inputs.

Tests-only — no source changes.

## What users will see
Nothing — internal test coverage only.

## Surface area
- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — tests only.

## Validation
- 31 tests added across the three files, all green locally.
