### PR TITLE
Support nightly and preview package identity

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -213,7 +213,7 @@ jobs:
             --dir "$tools_pack_dir"
             --namespace release-stable
             --portable
-            --app-version "${{ needs.metadata.outputs.stable_version }}"
+            --app-version "${{ needs.metadata.outputs.release_version }}"
             --mac-compression normal
             --to all
             --json
@@ -235,7 +235,11 @@ jobs:
           output="$RUNNER_TEMP/mac-framework-diagnostics.txt"
           source_resolve_log="$RUNNER_TEMP/mac-framework-source-resolve.err"
           source_framework="$(node -e 'const path = require("node:path"); const { createRequire } = require("node:module"); const requireFromDesktop = createRequire(path.join(process.cwd(), "apps/desktop/package.json")); const electron = requireFromDesktop.resolve("electron"); process.stdout.write(path.join(path.dirname(electron), "dist", "Electron.app", "Contents", "Frameworks", "Electron Framework.framework"));' 2>"$source_resolve_log" || true)"
-          built_framework="$RUNNER_TEMP/tools-pack/out/mac/namespaces/release-stable/builder/mac-arm64/Open Design.app/Contents/Frameworks/Electron Framework.framework"
+          app_name="Open Design.app"
+          if [ "${{ needs.metadata.outputs.channel }}" = "nightly" ]; then
+            app_name="Open Design Nightly.app"
+          fi
+          built_framework="$RUNNER_TEMP/tools-pack/out/mac/namespaces/release-stable/builder/mac-arm64/$app_name/Contents/Frameworks/Electron Framework.framework"
 
           dump_framework() {
             local label="$1"
@@ -392,7 +396,7 @@ jobs:
             --dir "$RUNNER_TEMP/tools-pack" \
             --namespace release-stable-intel \
             --portable \
-            --app-version "${{ needs.metadata.outputs.stable_version }}" \
+            --app-version "${{ needs.metadata.outputs.release_version }}" \
             --mac-compression normal \
             --to all \
             --json \
@@ -485,7 +489,7 @@ jobs:
             "--cache-dir", $cacheDir,
             "--namespace", "release-stable-win",
             "--portable",
-            "--app-version", "${{ needs.metadata.outputs.stable_version }}",
+            "--app-version", "${{ needs.metadata.outputs.release_version }}",
             "--to", "nsis",
             "--json"
           )
@@ -503,7 +507,7 @@ jobs:
               --dir $toolsPackDir `
               --namespace release-stable-win `
               --portable `
-              --app-version "${{ needs.metadata.outputs.stable_version }}" `
+              --app-version "${{ needs.metadata.outputs.release_version }}" `
               --to nsis `
               --json
             if ($LASTEXITCODE -ne 0) {
@@ -645,7 +649,7 @@ jobs:
             --dir "$tools_pack_dir"
             --namespace release-stable-linux
             --portable
-            --app-version "${{ needs.metadata.outputs.stable_version }}"
+            --app-version "${{ needs.metadata.outputs.release_version }}"
             --to appimage
             --containerized
             --json

--- a/apps/daemon/src/app-version.ts
+++ b/apps/daemon/src/app-version.ts
@@ -74,6 +74,13 @@ function cleanString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
 }
 
+function inferReleaseChannelFromVersion(version: string): string | null {
+  if (/(?:^|[-.])beta(?:[-.]|$)/i.test(version)) return 'beta';
+  if (/(?:^|[-.])preview(?:[-.]|$)/i.test(version)) return 'preview';
+  if (/(?:^|[-.])nightly(?:[-.]|$)/i.test(version)) return 'nightly';
+  return version.match(/^\d+\.\d+\.\d+-([0-9A-Za-z-]+)/)?.[1]?.split('.')[0] ?? null;
+}
+
 export function isPackagedRuntime({
   resourcesPath = processWithResources.resourcesPath,
   execPath = process.execPath,
@@ -109,10 +116,10 @@ export function resolveAppVersionInfo({
   const version = cleanString(env.OD_APP_VERSION)
     ?? cleanString(packageMetadata?.version)
     ?? APP_VERSION_FALLBACK;
-  const prereleaseChannel = version.match(/^\d+\.\d+\.\d+-([0-9A-Za-z-]+)/)?.[1]?.split('.')[0] ?? null;
+  const inferredChannel = inferReleaseChannelFromVersion(version);
   const channel = cleanString(env.OD_RELEASE_CHANNEL)
     ?? cleanString(env.OD_APP_CHANNEL)
-    ?? prereleaseChannel
+    ?? inferredChannel
     ?? (packaged ? 'stable' : 'development');
 
   return { version, channel, packaged, platform, arch };

--- a/apps/daemon/src/update-apply-observations.ts
+++ b/apps/daemon/src/update-apply-observations.ts
@@ -17,7 +17,7 @@ const INSTALLER_OBSERVATION_KIND = 'installer_apply_observation';
 const INSTALLER_OBSERVATION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 type InstallerObservationArtifactType = 'dmg' | 'installer';
-type InstallerObservationChannel = 'stable' | 'beta';
+type InstallerObservationChannel = 'stable' | 'beta' | 'nightly' | 'preview';
 type InstallerObservationDeliveryStatus =
   | 'submitted'
   | 'skipped_analytics_disabled'
@@ -96,7 +96,7 @@ function isInstallerObservationSummary(value: unknown): value is InstallerObserv
     typeof value.flowId === 'string' &&
     isSafeFlowId(value.flowId) &&
     typeof value.namespace === 'string' &&
-    (channel === 'stable' || channel === 'beta') &&
+    (channel === 'stable' || channel === 'beta' || channel === 'nightly' || channel === 'preview') &&
     typeof value.platform === 'string' &&
     typeof value.arch === 'string' &&
     (artifactType === 'dmg' || artifactType === 'installer') &&
@@ -134,11 +134,15 @@ async function writeSummary(filePath: string, summary: InstallerObservationSumma
 }
 
 export function normalizeUpdateObservationChannel(version: string, explicit?: string | null): InstallerObservationChannel {
-  if (explicit === 'stable' || explicit === 'beta') return explicit;
+  if (explicit === 'stable' || explicit === 'beta' || explicit === 'nightly' || explicit === 'preview') return explicit;
   if (explicit != null && explicit.startsWith('beta')) return 'beta';
+  if (explicit != null && explicit.startsWith('preview')) return 'preview';
+  if (explicit != null && explicit.startsWith('nightly')) return 'nightly';
   const cleaned = version.trim().replace(/^v/i, '');
   const prerelease = cleaned.split('-', 2)[1] ?? '';
   if (/(?:^|[-.])beta(?:[-.]|$)/i.test(version)) return 'beta';
+  if (/(?:^|[-.])preview(?:[-.]|$)/i.test(version)) return 'preview';
+  if (/(?:^|[-.])nightly(?:[-.]|$)/i.test(version)) return 'nightly';
   if (prerelease.length > 0 && /\.[0-9]+$/.test(prerelease)) return 'beta';
   return 'stable';
 }

--- a/apps/daemon/tests/app-version.test.ts
+++ b/apps/daemon/tests/app-version.test.ts
@@ -74,4 +74,15 @@ describe('app version helpers', () => {
       env: {},
     }).channel).toBe('beta');
   });
+
+  it('infers dotted nightly and preview release channels from app versions', () => {
+    expect(resolveAppVersionInfo({
+      packageMetadata: { version: '0.8.0.nightly.2' },
+      env: {},
+    }).channel).toBe('nightly');
+    expect(resolveAppVersionInfo({
+      packageMetadata: { version: '0.8.0-preview.1' },
+      env: {},
+    }).channel).toBe('preview');
+  });
 });

--- a/apps/daemon/tests/update-apply-observations.test.ts
+++ b/apps/daemon/tests/update-apply-observations.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   classifyInstallerObservation,
   installerObservationRoot,
+  normalizeUpdateObservationChannel,
   observePendingInstallerApplyAttempts,
   type InstallerObservationSummary,
 } from '../src/update-apply-observations.js';
@@ -73,6 +74,12 @@ describe('update apply observations', () => {
       reason: 'identity_mismatch',
       result: 'unknown',
     });
+  });
+
+  it('normalizes nightly and preview observation channels without collapsing them to beta', () => {
+    expect(normalizeUpdateObservationChannel('0.8.0.nightly.2')).toBe('nightly');
+    expect(normalizeUpdateObservationChannel('0.8.0-preview.2')).toBe('preview');
+    expect(normalizeUpdateObservationChannel('0.8.0', 'nightly')).toBe('nightly');
   });
 
   it('submits one sanitized analytics event and marks delivery metadata', async () => {

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -72,6 +72,7 @@ const STABLE_POLL_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const DEFAULT_POLL_INITIAL_DELAY_MS = 5000;
 const DEFAULT_POLL_BACKOFF_INITIAL_MS = 60 * 1000;
 const DEFAULT_POLL_BACKOFF_MAX_MS = 30 * 60 * 1000;
+const DESKTOP_UPDATE_CHANNEL_VALUES = new Set<string>(Object.values(DESKTOP_UPDATE_CHANNELS));
 
 export type DesktopUpdaterConfigInput = {
   appVersion?: string | null;
@@ -209,8 +210,12 @@ function normalizeMode(value: string | undefined, fallback: DesktopUpdateMode): 
 
 function normalizeChannel(value: string | undefined, fallback: DesktopUpdateChannel): DesktopUpdateChannel {
   if (value == null || value.length === 0) return fallback;
-  if (value === DESKTOP_UPDATE_CHANNELS.STABLE || value === DESKTOP_UPDATE_CHANNELS.BETA) return value;
+  if (isDesktopUpdateChannel(value)) return value;
   throw new Error(`unsupported desktop update channel: ${value}`);
+}
+
+function isDesktopUpdateChannel(value: unknown): value is DesktopUpdateChannel {
+  return typeof value === "string" && DESKTOP_UPDATE_CHANNEL_VALUES.has(value);
 }
 
 function defaultMetadataUrl(channel: DesktopUpdateChannel): string {
@@ -244,7 +249,7 @@ function durationEnv(value: string | undefined, fallback: number, name: string):
 }
 
 function defaultPollIntervalMs(channel: DesktopUpdateChannel): number {
-  return channel === DESKTOP_UPDATE_CHANNELS.BETA ? BETA_POLL_INTERVAL_MS : STABLE_POLL_INTERVAL_MS;
+  return channel === DESKTOP_UPDATE_CHANNELS.STABLE ? STABLE_POLL_INTERVAL_MS : BETA_POLL_INTERVAL_MS;
 }
 
 export function resolveDesktopUpdaterConfig(input: DesktopUpdaterConfigInput): DesktopUpdaterConfig {
@@ -482,7 +487,7 @@ function isUpdateReleaseRef(value: unknown): value is UpdateReleaseRef {
     stringField(value, "artifactPath") != null &&
     isChecksumSnapshot(value.checksum) &&
     stringField(value, "checksumPath") != null &&
-    (value.channel === DESKTOP_UPDATE_CHANNELS.STABLE || value.channel === DESKTOP_UPDATE_CHANNELS.BETA) &&
+    isDesktopUpdateChannel(value.channel) &&
     stringField(value, "downloadedAt") != null &&
     stringField(value, "key") != null &&
     isRecord(value.metadata) &&
@@ -495,7 +500,7 @@ function isIncomingRef(value: unknown): value is IncomingRef {
   if (!isRecord(value)) return false;
   return stringField(value, "arch") != null &&
     isArtifactSnapshot(value.artifact) &&
-    (value.channel === DESKTOP_UPDATE_CHANNELS.STABLE || value.channel === DESKTOP_UPDATE_CHANNELS.BETA) &&
+    isDesktopUpdateChannel(value.channel) &&
     stringField(value, "cycleId") != null &&
     isRecord(value.metadata) &&
     stringField(value, "platformKey") != null &&
@@ -642,9 +647,10 @@ function hasCountedPrerelease(version: string): boolean {
 }
 
 function defaultChannelForVersion(version: string): DesktopUpdateChannel {
-  return /(?:^|[-.])beta(?:[-.]|$)/i.test(version) || hasCountedPrerelease(version)
-    ? DESKTOP_UPDATE_CHANNELS.BETA
-    : DESKTOP_UPDATE_CHANNELS.STABLE;
+  if (/(?:^|[-.])beta(?:[-.]|$)/i.test(version)) return DESKTOP_UPDATE_CHANNELS.BETA;
+  if (/(?:^|[-.])preview(?:[-.]|$)/i.test(version)) return DESKTOP_UPDATE_CHANNELS.PREVIEW;
+  if (/(?:^|[-.])nightly(?:[-.]|$)/i.test(version)) return DESKTOP_UPDATE_CHANNELS.NIGHTLY;
+  return hasCountedPrerelease(version) ? DESKTOP_UPDATE_CHANNELS.BETA : DESKTOP_UPDATE_CHANNELS.STABLE;
 }
 
 function compareIdentifier(a: string, b: string): number {
@@ -680,12 +686,13 @@ export function compareVersions(a: string, b: string): number {
 
 function metadataChannel(metadata: Record<string, unknown>): DesktopUpdateChannel | null {
   const channel = stringField(metadata, "channel");
-  if (channel === DESKTOP_UPDATE_CHANNELS.STABLE || channel === DESKTOP_UPDATE_CHANNELS.BETA) return channel;
-  return null;
+  return isDesktopUpdateChannel(channel) ? channel : null;
 }
 
 function releaseVersionForChannel(metadata: Record<string, unknown>, channel: DesktopUpdateChannel): string | null {
   if (channel === DESKTOP_UPDATE_CHANNELS.BETA) return stringField(metadata, "betaVersion");
+  if (channel === DESKTOP_UPDATE_CHANNELS.NIGHTLY) return stringField(metadata, "nightlyVersion") ?? stringField(metadata, "releaseVersion");
+  if (channel === DESKTOP_UPDATE_CHANNELS.PREVIEW) return stringField(metadata, "previewVersion") ?? stringField(metadata, "releaseVersion");
   return stringField(metadata, "releaseVersion") ?? stringField(metadata, "stableVersion");
 }
 

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -30,6 +30,7 @@ type FixtureServer = {
 };
 
 type FixturePlatform = "mac" | "win";
+type FixtureChannel = "stable" | "beta" | "nightly" | "preview";
 
 function prereleaseCounterParts(version: string): { baseVersion: string; number: number } | null {
   const prerelease = /^(\d+\.\d+\.\d+)-.+\.(\d+)$/.exec(version);
@@ -43,9 +44,44 @@ function prereleaseCounterParts(version: string): { baseVersion: string; number:
   return null;
 }
 
+function channelMetadata(channel: FixtureChannel, version: string): Record<string, unknown> {
+  if (channel === "stable") {
+    return {
+      baseVersion: version,
+      releaseVersion: version,
+      stableVersion: version,
+    };
+  }
+
+  const countedVersion = prereleaseCounterParts(version);
+  if (countedVersion == null) throw new Error(`fixture ${channel} version must be counted: ${version}`);
+  if (channel === "beta") {
+    return {
+      baseVersion: countedVersion.baseVersion,
+      betaNumber: countedVersion.number,
+      betaVersion: version,
+    };
+  }
+  if (channel === "nightly") {
+    return {
+      baseVersion: countedVersion.baseVersion,
+      nightlyNumber: countedVersion.number,
+      nightlyVersion: version,
+      releaseVersion: version,
+      stableVersion: countedVersion.baseVersion,
+    };
+  }
+  return {
+    baseVersion: countedVersion.baseVersion,
+    previewNumber: countedVersion.number,
+    previewVersion: version,
+    releaseVersion: version,
+  };
+}
+
 async function createUpdaterFixture(options: {
   artifactBody?: string;
-  channel?: "stable" | "beta";
+  channel?: FixtureChannel;
   platform?: FixturePlatform;
   version?: string;
 } = {}): Promise<FixtureServer> {
@@ -69,20 +105,9 @@ async function createUpdaterFixture(options: {
     if (url === "/metadata.json") {
       metadataRequests += 1;
       response.setHeader("content-type", "application/json");
-      const betaVersion = prereleaseCounterParts(version);
       response.end(JSON.stringify({
         channel,
-        ...(channel === "beta"
-          ? {
-              baseVersion: betaVersion?.baseVersion,
-              betaNumber: betaVersion?.number,
-              betaVersion: version,
-            }
-          : {
-              baseVersion: version,
-              releaseVersion: version,
-              stableVersion: version,
-            }),
+        ...channelMetadata(channel, version),
         platforms: {
           [platformKey]: {
             arch,
@@ -490,6 +515,54 @@ describe("desktop updater", () => {
     }
   });
 
+  it("accepts nightly metadata that exposes nightlyVersion", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture({ channel: "nightly", version: "1.0.1.nightly.2" });
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: {
+          ...updaterEnv(fixture.metadataUrl),
+          [DESKTOP_UPDATE_ENV.CURRENT_VERSION]: "1.0.1.nightly.1",
+        },
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const checked = await updater.checkForUpdates();
+      expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.NIGHTLY);
+      expect(checked.availableVersion).toBe("1.0.1.nightly.2");
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("accepts preview metadata that exposes previewVersion", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture({ channel: "preview", version: "1.0.1-preview.2" });
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: {
+          ...updaterEnv(fixture.metadataUrl),
+          [DESKTOP_UPDATE_ENV.CURRENT_VERSION]: "1.0.1-preview.1",
+        },
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const checked = await updater.checkForUpdates();
+      expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.PREVIEW);
+      expect(checked.availableVersion).toBe("1.0.1-preview.2");
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("re-verifies a downloaded package before opening it", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture();
@@ -738,6 +811,44 @@ describe("desktop updater", () => {
 
       expect(config.channel).toBe(DESKTOP_UPDATE_CHANNELS.BETA);
       expect(config.metadataUrl).toContain("/beta/latest/metadata.json");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("defaults dotted nightly builds to the nightly update channel", () => {
+    const root = makeRoot();
+    try {
+      const config = resolveDesktopUpdaterConfig({
+        currentVersion: "1.2.3.nightly.4",
+        downloadRoot: root,
+        env: {
+          [DESKTOP_UPDATE_ENV.ENABLED]: "1",
+        },
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+
+      expect(config.channel).toBe(DESKTOP_UPDATE_CHANNELS.NIGHTLY);
+      expect(config.metadataUrl).toContain("/nightly/latest/metadata.json");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("defaults preview builds to the preview update channel", () => {
+    const root = makeRoot();
+    try {
+      const config = resolveDesktopUpdaterConfig({
+        currentVersion: "1.2.3-preview.4",
+        downloadRoot: root,
+        env: {
+          [DESKTOP_UPDATE_ENV.ENABLED]: "1",
+        },
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+
+      expect(config.channel).toBe(DESKTOP_UPDATE_CHANNELS.PREVIEW);
+      expect(config.metadataUrl).toContain("/preview/latest/metadata.json");
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/apps/web/src/components/UpdaterPopup.tsx
+++ b/apps/web/src/components/UpdaterPopup.tsx
@@ -32,6 +32,21 @@ function navLabel(t: Translator, model: UpdaterModel): string {
   return t('updater.available');
 }
 
+function channelLabelFor(channel: string | null | undefined): string | null {
+  switch (channel) {
+    case 'beta':
+      return 'Beta channel';
+    case 'nightly':
+      return 'Nightly channel';
+    case 'preview':
+      return 'Preview channel';
+    case 'stable':
+      return 'Stable channel';
+    default:
+      return null;
+  }
+}
+
 export function UpdaterPopup() {
   const t = useT();
   const wrapRef = useRef<HTMLDivElement | null>(null);
@@ -180,11 +195,7 @@ export function UpdaterPopup() {
     : model.hasDownloadedInstaller
     ? ' is-ready'
     : ' is-available';
-  const channelLabel = model.status?.channel === 'beta'
-    ? 'Beta channel'
-    : model.status?.channel === 'stable'
-    ? 'Stable channel'
-    : null;
+  const channelLabel = channelLabelFor(model.status?.channel);
 
   return (
     <div className="entry-updater-menu" ref={wrapRef}>

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -1025,7 +1025,7 @@ export type TrackingUpdateApplyElapsedBucket =
 
 export interface UpdateApplyObservedProps {
   flow_id: string;
-  channel: 'stable' | 'beta';
+  channel: 'stable' | 'beta' | 'nightly' | 'preview';
   namespace: string;
   platform: string;
   arch: string;

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -79,7 +79,7 @@ export type OpenDesignHostUpdaterState =
   (typeof OPEN_DESIGN_HOST_UPDATER_STATES)[keyof typeof OPEN_DESIGN_HOST_UPDATER_STATES];
 
 export type OpenDesignHostUpdaterMode = "js-incremental" | "package-launcher";
-export type OpenDesignHostUpdaterChannel = "beta" | "stable";
+export type OpenDesignHostUpdaterChannel = "beta" | "nightly" | "preview" | "stable";
 
 export type OpenDesignHostUpdaterActionOptions = {
   payload?: Record<string, unknown>;

--- a/packages/sidecar-proto/src/index.ts
+++ b/packages/sidecar-proto/src/index.ts
@@ -97,6 +97,8 @@ export type DesktopUpdateMode = (typeof DESKTOP_UPDATE_MODES)[keyof typeof DESKT
 
 export const DESKTOP_UPDATE_CHANNELS = Object.freeze({
   BETA: "beta",
+  NIGHTLY: "nightly",
+  PREVIEW: "preview",
   STABLE: "stable",
 } as const);
 

--- a/packages/sidecar-proto/tests/index.test.ts
+++ b/packages/sidecar-proto/tests/index.test.ts
@@ -42,6 +42,7 @@ describe("open-design sidecar contract", () => {
     });
     expect(OPEN_DESIGN_SIDECAR_CONTRACT.updateActions).toBe(DESKTOP_UPDATE_ACTIONS);
     expect(OPEN_DESIGN_SIDECAR_CONTRACT.updateChannels).toBe(DESKTOP_UPDATE_CHANNELS);
+    expect(Object.values(DESKTOP_UPDATE_CHANNELS)).toEqual(["beta", "nightly", "preview", "stable"]);
     expect(OPEN_DESIGN_SIDECAR_CONTRACT.updateModes).toBe(DESKTOP_UPDATE_MODES);
     expect(OPEN_DESIGN_SIDECAR_CONTRACT.updateStates).toBe(DESKTOP_UPDATE_STATES);
   });

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -28,6 +28,7 @@ import {
 
 import type { ToolPackConfig } from "./config.js";
 import { copyBundledResourceTrees, linuxResources } from "./resources.js";
+import { electronBuilderVersionForAppVersion, readRuntimeAppVersion } from "./versions.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -357,13 +358,7 @@ async function runProductionInstall(appRoot: string): Promise<void> {
 }
 
 async function readPackagedVersion(config: ToolPackConfig): Promise<string> {
-  if (config.appVersion != null) return config.appVersion;
-  const packageJsonPath = join(config.workspaceRoot, "apps", "packaged", "package.json");
-  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as { version?: unknown };
-  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
-    throw new Error(`missing apps/packaged package version in ${packageJsonPath}`);
-  }
-  return packageJson.version;
+  return readRuntimeAppVersion(config);
 }
 
 async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
@@ -453,9 +448,10 @@ async function writeAssembledApp(
   }
 
   const version = await readPackagedVersion(config);
+  const packageVersion = electronBuilderVersionForAppVersion(version);
   const packageJson = {
     name: "open-design-packaged",
-    version,
+    version: packageVersion,
     private: true,
     main: "main.cjs",
     dependencies,
@@ -492,6 +488,7 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
   const target = config.to === "dir" ? ["dir"] : ["AppImage"];
   const namespaceToken = sanitizeNamespace(config.namespace);
   const packagedVersion = await readPackagedVersion(config);
+  const packageVersion = electronBuilderVersionForAppVersion(packagedVersion);
 
   const builderConfig: Record<string, unknown> = {
     appId: "io.open-design.desktop",
@@ -511,7 +508,7 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
       main: "./main.cjs",
       name: "open-design-packaged-app",
       productName: PRODUCT_NAME,
-      version: packagedVersion,
+      version: packageVersion,
       ...(config.portable ? {} : { odToolsPackRuntimeRoot: config.roots.runtime.namespaceBaseRoot }),
     },
     extraResources: [

--- a/tools/pack/src/mac/app.ts
+++ b/tools/pack/src/mac/app.ts
@@ -16,6 +16,7 @@ import {
   shouldUseMacStandalonePrebundle,
 } from "../mac-prebundle.js";
 import { copyBundledResourceTrees } from "../resources.js";
+import { electronBuilderVersionForAppVersion } from "../versions.js";
 import { runEsbuild, runNpmInstall, runPnpm } from "./commands.js";
 import { INTERNAL_PACKAGES } from "./constants.js";
 import { resolveMacInstallIdentity } from "./identity.js";
@@ -177,6 +178,7 @@ export async function writeAssembledApp(
   packedTarballs: PackedTarballInfo[],
 ): Promise<void> {
   const packagedVersion = await readPackagedVersion(config);
+  const packageVersion = electronBuilderVersionForAppVersion(packagedVersion);
   const identity = resolveMacInstallIdentity(config);
   await rm(join(config.roots.output.namespaceRoot, "assembled"), { force: true, recursive: true });
   await mkdir(paths.assembledAppRoot, { recursive: true });
@@ -215,7 +217,7 @@ export async function writeAssembledApp(
         name: "open-design-packaged-app",
         private: true,
         productName: identity.productName,
-        version: packagedVersion,
+        version: packageVersion,
       },
       null,
       2,

--- a/tools/pack/src/mac/builder.ts
+++ b/tools/pack/src/mac/builder.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 
 import type { ToolPackConfig } from "../config.js";
 import { macResources } from "../resources.js";
+import { electronBuilderVersionForAppVersion } from "../versions.js";
 import { execFileAsync } from "./commands.js";
 import {
   ELECTRON_BUILDER_ASAR,
@@ -83,6 +84,7 @@ export async function runElectronBuilder(
   const namespaceToken = sanitizeNamespace(config.namespace);
   const identity = resolveMacInstallIdentity(config);
   const packagedVersion = await readPackagedVersion(config);
+  const packageVersion = electronBuilderVersionForAppVersion(packagedVersion);
   const webStandaloneHookConfigPath = config.webOutputMode === "standalone"
     ? await writeWebStandaloneHookConfig(config, paths)
     : null;
@@ -100,7 +102,7 @@ export async function runElectronBuilder(
     dmg: {
       icon: macResources.icon,
       iconSize: 96,
-      title: `${identity.productName}-${namespaceToken}`,
+      title: identity.installerTitle,
     },
     electronDist: config.electronDistPath,
     electronVersion: config.electronVersion,
@@ -109,7 +111,7 @@ export async function runElectronBuilder(
       main: "./main.cjs",
       name: "open-design-packaged-app",
       productName: identity.productName,
-      version: packagedVersion,
+      version: packageVersion,
     },
     extraResources: [
       { from: paths.resourceRoot, to: "open-design" },

--- a/tools/pack/src/mac/identity.ts
+++ b/tools/pack/src/mac/identity.ts
@@ -6,12 +6,15 @@ import { PRODUCT_NAME } from "./constants.js";
 export type MacInstallIdentity = {
   appId: string;
   executableName: string;
+  installerTitle: string;
   productName: string;
   publicAppBundleName: string;
   systemAppBundleName: string;
 };
 
-function isChannelNamespace(namespace: string, channel: "beta" | "preview"): boolean {
+type ReleaseChannelIdentity = "stable" | "beta" | "nightly" | "preview";
+
+function isChannelNamespace(namespace: string, channel: ReleaseChannelIdentity): boolean {
   return new RegExp(`(^|[-_.])${channel}($|[-_.])`, "i").test(namespace);
 }
 
@@ -19,25 +22,51 @@ function sanitizeNamespace(value: string): string {
   return value.replace(/[^A-Za-z0-9._-]+/g, "-");
 }
 
-export function resolveMacInstallIdentity(config: Pick<ToolPackConfig, "namespace">): MacInstallIdentity {
+function channelFromVersion(version: string | null | undefined): ReleaseChannelIdentity | null {
+  if (version == null || version.length === 0) return null;
+  if (/(?:^|[-.])beta(?:[-.]|$)/i.test(version)) return "beta";
+  if (/(?:^|[-.])preview(?:[-.]|$)/i.test(version)) return "preview";
+  if (/(?:^|[-.])nightly(?:[-.]|$)/i.test(version)) return "nightly";
+  return null;
+}
+
+function channelFromNamespace(namespace: string): ReleaseChannelIdentity | null {
+  if (namespace === SIDECAR_DEFAULTS.namespace || isChannelNamespace(namespace, "stable")) return "stable";
+  if (isChannelNamespace(namespace, "beta")) return "beta";
+  if (isChannelNamespace(namespace, "nightly")) return "nightly";
+  if (isChannelNamespace(namespace, "preview")) return "preview";
+  return null;
+}
+
+function productNameForChannel(channel: ReleaseChannelIdentity): string {
+  if (channel === "beta") return `${PRODUCT_NAME} Beta`;
+  if (channel === "nightly") return `${PRODUCT_NAME} Nightly`;
+  if (channel === "preview") return `${PRODUCT_NAME} Preview`;
+  return PRODUCT_NAME;
+}
+
+function appIdForChannel(channel: ReleaseChannelIdentity): string {
+  if (channel === "beta") return "io.open-design.desktop.beta";
+  if (channel === "nightly") return "io.open-design.desktop.nightly";
+  if (channel === "preview") return "io.open-design.desktop.preview";
+  return "io.open-design.desktop";
+}
+
+export function resolveMacInstallIdentity(config: Pick<ToolPackConfig, "namespace" | "appVersion">): MacInstallIdentity {
   const namespaceToken = sanitizeNamespace(config.namespace);
-  const channelIdentity = isChannelNamespace(config.namespace, "beta")
-    ? { appId: "io.open-design.desktop.beta", productName: `${PRODUCT_NAME} Beta` }
-    : isChannelNamespace(config.namespace, "preview")
-      ? { appId: "io.open-design.desktop.preview", productName: `${PRODUCT_NAME} Preview` }
-      : { appId: "io.open-design.desktop", productName: PRODUCT_NAME };
+  const channel = channelFromVersion(config.appVersion) ?? channelFromNamespace(config.namespace);
+  const channelIdentity = channel == null
+    ? { appId: "io.open-design.desktop", productName: PRODUCT_NAME }
+    : { appId: appIdForChannel(channel), productName: productNameForChannel(channel) };
   const publicAppBundleName = `${channelIdentity.productName}.app`;
-  const systemAppBundleName = (
-    config.namespace === SIDECAR_DEFAULTS.namespace ||
-    isChannelNamespace(config.namespace, "beta") ||
-    isChannelNamespace(config.namespace, "preview")
-  )
+  const systemAppBundleName = channel != null
     ? publicAppBundleName
     : `${PRODUCT_NAME}.${namespaceToken}.app`;
 
   return {
     ...channelIdentity,
     executableName: channelIdentity.productName,
+    installerTitle: channel == null ? `${PRODUCT_NAME}-${namespaceToken}` : channelIdentity.productName,
     publicAppBundleName,
     systemAppBundleName,
   };

--- a/tools/pack/src/mac/manifest.ts
+++ b/tools/pack/src/mac/manifest.ts
@@ -1,14 +1,6 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-
 import type { ToolPackConfig } from "../config.js";
+import { readRuntimeAppVersion } from "../versions.js";
 
 export async function readPackagedVersion(config: ToolPackConfig): Promise<string> {
-  if (config.appVersion != null) return config.appVersion;
-  const packageJsonPath = join(config.workspaceRoot, "apps", "packaged", "package.json");
-  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as { version?: unknown };
-  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
-    throw new Error(`missing apps/packaged package version in ${packageJsonPath}`);
-  }
-  return packageJson.version;
+  return readRuntimeAppVersion(config);
 }

--- a/tools/pack/src/mac/paths.ts
+++ b/tools/pack/src/mac/paths.ts
@@ -44,7 +44,7 @@ export function resolveMacPaths(config: ToolPackConfig): MacPaths {
     identity.publicAppBundleName,
   );
   const installApplicationsRoot = join(namespaceRoot, "install", "Applications");
-  const installedAppPath = join(installApplicationsRoot, macAppBundleName(config.namespace));
+  const installedAppPath = join(installApplicationsRoot, identity.systemAppBundleName);
 
   return {
     appBuilderConfigPath: join(namespaceRoot, "builder-config.json"),

--- a/tools/pack/src/versions.ts
+++ b/tools/pack/src/versions.ts
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { ToolPackConfig } from "./config.js";
+
+export async function readRuntimeAppVersion(config: ToolPackConfig): Promise<string> {
+  if (config.appVersion != null) return config.appVersion;
+  const packageJsonPath = join(config.workspaceRoot, "apps", "packaged", "package.json");
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as { version?: unknown };
+  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
+    throw new Error(`missing apps/packaged package version in ${packageJsonPath}`);
+  }
+  return packageJson.version;
+}
+
+export function electronBuilderVersionForAppVersion(appVersion: string): string {
+  const nightly = /^(\d+\.\d+\.\d+)\.nightly\.(\d+)$/i.exec(appVersion);
+  if (nightly?.[1] != null && nightly[2] != null) return `${nightly[1]}-nightly.${nightly[2]}`;
+  return appVersion;
+}

--- a/tools/pack/src/win/app.ts
+++ b/tools/pack/src/win/app.ts
@@ -9,6 +9,7 @@ import { createCommandInvocation, createPackageManagerInvocation } from "@open-d
 import { hashJson, hashPath, ToolPackCache } from "../cache.js";
 import type { ToolPackConfig } from "../config.js";
 import { hashPackageSourcePath } from "../package-source-hash.js";
+import { electronBuilderVersionForAppVersion } from "../versions.js";
 import {
   WIN_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER,
   WIN_PREBUNDLE_ESBUILD_TARGET,
@@ -235,6 +236,7 @@ async function writeAssembledAppEntrypoints(
   packagedVersion: string,
   options: { dependencies?: Record<string, string>; usePrebundle?: boolean } = {},
 ): Promise<void> {
+  const packageVersion = electronBuilderVersionForAppVersion(packagedVersion);
   await mkdir(paths.assembledAppRoot, { recursive: true });
   await cp(
     join(config.workspaceRoot, "apps", "desktop", "dist", "main", "preload.cjs"),
@@ -250,7 +252,7 @@ async function writeAssembledAppEntrypoints(
         name: "open-design-packaged-app",
         private: true,
         productName: PRODUCT_NAME,
-        version: packagedVersion,
+        version: packageVersion,
       },
       null,
       2,

--- a/tools/pack/src/win/builder.ts
+++ b/tools/pack/src/win/builder.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import { hashJson, hashPath, ToolPackCache } from "../cache.js";
 import type { ToolPackConfig } from "../config.js";
 import { winResources } from "../resources.js";
+import { electronBuilderVersionForAppVersion } from "../versions.js";
 import {
   WIN_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH,
   WIN_PREBUNDLED_DAEMON_SIDECAR_RELATIVE_PATH,
@@ -89,6 +90,7 @@ async function writeWebStandaloneHookConfig(config: ToolPackConfig, paths: WinPa
 async function runElectronBuilderRaw(config: ToolPackConfig, paths: WinPaths, projectDir: string): Promise<void> {
   const namespaceToken = sanitizeNamespace(config.namespace);
   const packagedVersion = await readPackagedVersion(config);
+  const packageVersion = electronBuilderVersionForAppVersion(packagedVersion);
   const webStandaloneHookConfigPath = config.webOutputMode === "standalone"
     ? await writeWebStandaloneHookConfig(config, paths)
     : null;
@@ -106,7 +108,7 @@ async function runElectronBuilderRaw(config: ToolPackConfig, paths: WinPaths, pr
       main: "./main.cjs",
       name: "open-design-packaged-app",
       productName: PRODUCT_NAME,
-      version: packagedVersion,
+      version: packageVersion,
     },
     extraResources: [
       { from: paths.resourceRoot, to: "open-design" },
@@ -218,7 +220,7 @@ async function rewriteUnpackedAppPackageVersion(unpackedRoot: string, packagedVe
   const packageJsonPath = join(unpackedRoot, "resources", "app", "package.json");
   if (!(await pathExists(packageJsonPath))) return;
   const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as Record<string, unknown>;
-  packageJson.version = packagedVersion;
+  packageJson.version = electronBuilderVersionForAppVersion(packagedVersion);
   await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
 }
 

--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -598,7 +598,7 @@ skip_silent_desktop_shortcut:
   !insertmacro LOG_PATH_STATE "start_menu_shortcut_before_create" "$SMPROGRAMS\\${shortcutName}"
   CreateShortCut "$SMPROGRAMS\\${shortcutName}" "$INSTDIR\\${exeName}" "" "$INSTDIR\\${exeName}" 0
   !insertmacro LOG_PATH_STATE "start_menu_shortcut_after_create" "$SMPROGRAMS\\${shortcutName}"
-  WriteRegStr HKCU "${registryKey}" "DisplayName" "${productName} \${APP_VERSION}"
+  WriteRegStr HKCU "${registryKey}" "DisplayName" "${productName}"
   WriteRegStr HKCU "${registryKey}" "DisplayVersion" "\${APP_VERSION}"
   WriteRegStr HKCU "${registryKey}" "InstallLocation" "$INSTDIR"
   WriteRegStr HKCU "${registryKey}" "UninstallString" '"$INSTDIR\\${uninstallerName}" /currentuser'

--- a/tools/pack/src/win/identity.ts
+++ b/tools/pack/src/win/identity.ts
@@ -12,23 +12,43 @@ export type WinInstallIdentity = {
   uninstallerName: string;
 };
 
-function isChannelNamespace(namespace: string, channel: "beta" | "preview"): boolean {
+type ReleaseChannelIdentity = "stable" | "beta" | "nightly" | "preview";
+
+function isChannelNamespace(namespace: string, channel: ReleaseChannelIdentity): boolean {
   return namespace.toLowerCase() === `release-${channel}-win`;
+}
+
+function channelFromVersion(version: string | null | undefined): ReleaseChannelIdentity | null {
+  if (version == null || version.length === 0) return null;
+  if (/(?:^|[-.])beta(?:[-.]|$)/i.test(version)) return "beta";
+  if (/(?:^|[-.])preview(?:[-.]|$)/i.test(version)) return "preview";
+  if (/(?:^|[-.])nightly(?:[-.]|$)/i.test(version)) return "nightly";
+  return null;
+}
+
+function channelFromNamespace(namespace: string): ReleaseChannelIdentity | null {
+  if (namespace === SIDECAR_DEFAULTS.namespace || isChannelNamespace(namespace, "stable")) return "stable";
+  if (isChannelNamespace(namespace, "beta")) return "beta";
+  if (isChannelNamespace(namespace, "nightly")) return "nightly";
+  if (isChannelNamespace(namespace, "preview")) return "preview";
+  return null;
+}
+
+function displayNameForChannel(channel: ReleaseChannelIdentity): string {
+  if (channel === "beta") return `${PRODUCT_NAME} Beta`;
+  if (channel === "nightly") return `${PRODUCT_NAME} Nightly`;
+  if (channel === "preview") return `${PRODUCT_NAME} Preview`;
+  return PRODUCT_NAME;
 }
 
 function sanitizeNamespace(value: string): string {
   return value.replace(/[^A-Za-z0-9._-]+/g, "-");
 }
 
-export function resolveWinInstallIdentity(config: Pick<ToolPackConfig, "namespace">): WinInstallIdentity {
+export function resolveWinInstallIdentity(config: Pick<ToolPackConfig, "namespace" | "appVersion">): WinInstallIdentity {
   const namespaceToken = sanitizeNamespace(config.namespace);
-  const displayName = isChannelNamespace(config.namespace, "beta")
-    ? `${PRODUCT_NAME} Beta`
-    : isChannelNamespace(config.namespace, "preview")
-      ? `${PRODUCT_NAME} Preview`
-    : config.namespace === SIDECAR_DEFAULTS.namespace
-      ? PRODUCT_NAME
-      : `${PRODUCT_NAME} ${namespaceToken}`;
+  const channel = channelFromVersion(config.appVersion) ?? channelFromNamespace(config.namespace);
+  const displayName = channel == null ? `${PRODUCT_NAME} ${namespaceToken}` : displayNameForChannel(channel);
 
   return {
     appPathsKey: `Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\${displayName}.exe`,

--- a/tools/pack/src/win/manifest.ts
+++ b/tools/pack/src/win/manifest.ts
@@ -2,17 +2,12 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import type { ToolPackConfig } from "../config.js";
+import { readRuntimeAppVersion } from "../versions.js";
 import { pathExists } from "./fs.js";
 import type { WinBuiltAppManifest, WinPaths } from "./types.js";
 
 export async function readPackagedVersion(config: ToolPackConfig): Promise<string> {
-  if (config.appVersion != null) return config.appVersion;
-  const packageJsonPath = join(config.workspaceRoot, "apps", "packaged", "package.json");
-  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as { version?: unknown };
-  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
-    throw new Error(`missing apps/packaged package version in ${packageJsonPath}`);
-  }
-  return packageJson.version;
+  return readRuntimeAppVersion(config);
 }
 
 type PackagedConfigEntrypoints = {

--- a/tools/pack/tests/mac-identity.test.ts
+++ b/tools/pack/tests/mac-identity.test.ts
@@ -46,8 +46,10 @@ describe("resolveMacInstallIdentity", () => {
   it("keeps stable builds on the canonical mac identity", () => {
     expect(resolveMacInstallIdentity(makeConfig("/work", "release-stable"))).toMatchObject({
       appId: "io.open-design.desktop",
+      installerTitle: "Open Design",
       productName: "Open Design",
       publicAppBundleName: "Open Design.app",
+      systemAppBundleName: "Open Design.app",
     });
   });
 
@@ -57,6 +59,7 @@ describe("resolveMacInstallIdentity", () => {
     expect(resolveMacInstallIdentity(config)).toEqual({
       appId: "io.open-design.desktop.beta",
       executableName: "Open Design Beta",
+      installerTitle: "Open Design Beta",
       productName: "Open Design Beta",
       publicAppBundleName: "Open Design Beta.app",
       systemAppBundleName: "Open Design Beta.app",
@@ -70,10 +73,33 @@ describe("resolveMacInstallIdentity", () => {
     expect(resolveMacInstallIdentity(config)).toEqual({
       appId: "io.open-design.desktop.preview",
       executableName: "Open Design Preview",
+      installerTitle: "Open Design Preview",
       productName: "Open Design Preview",
       publicAppBundleName: "Open Design Preview.app",
       systemAppBundleName: "Open Design Preview.app",
     });
     expect(resolveMacPaths(config).appPath).toMatch(/Open Design Preview\.app$/);
+  });
+
+  it("uses first-class nightly app identity for nightly release versions and namespaces", () => {
+    const nightlyVersionConfig = {
+      ...makeConfig("/work", "release-stable"),
+      appVersion: "0.8.0.nightly.2",
+    };
+    const nightlyNamespaceConfig = makeConfig("/work", "release-nightly");
+
+    expect(resolveMacInstallIdentity(nightlyVersionConfig)).toEqual({
+      appId: "io.open-design.desktop.nightly",
+      executableName: "Open Design Nightly",
+      installerTitle: "Open Design Nightly",
+      productName: "Open Design Nightly",
+      publicAppBundleName: "Open Design Nightly.app",
+      systemAppBundleName: "Open Design Nightly.app",
+    });
+    expect(resolveMacPaths(nightlyVersionConfig).appPath).toMatch(/Open Design Nightly\.app$/);
+    expect(resolveMacInstallIdentity(nightlyNamespaceConfig)).toMatchObject({
+      productName: "Open Design Nightly",
+      publicAppBundleName: "Open Design Nightly.app",
+    });
   });
 });

--- a/tools/pack/tests/versions.test.ts
+++ b/tools/pack/tests/versions.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { electronBuilderVersionForAppVersion } from "../src/versions.js";
+
+describe("tools-pack version helpers", () => {
+  it("keeps runtime app versions intact except when adapting dotted nightly for electron-builder", () => {
+    expect(electronBuilderVersionForAppVersion("0.8.0")).toBe("0.8.0");
+    expect(electronBuilderVersionForAppVersion("0.8.0-beta.6")).toBe("0.8.0-beta.6");
+    expect(electronBuilderVersionForAppVersion("0.8.0-preview.1")).toBe("0.8.0-preview.1");
+    expect(electronBuilderVersionForAppVersion("0.8.0.nightly.2")).toBe("0.8.0-nightly.2");
+  });
+});

--- a/tools/pack/tests/win-identity.test.ts
+++ b/tools/pack/tests/win-identity.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+
 import { describe, expect, it } from "vitest";
 
 import { resolveWinInstallIdentity } from "../src/win/identity.js";
@@ -6,6 +8,16 @@ describe("resolveWinInstallIdentity", () => {
   it("keeps the default namespace on the canonical Windows display name", () => {
     expect(resolveWinInstallIdentity({ namespace: "default" })).toMatchObject({
       displayName: "Open Design",
+      shortcutName: "Open Design.lnk",
+      uninstallerName: "Uninstall Open Design.exe",
+    });
+  });
+
+  it("uses the canonical Windows display name for stable release namespaces", () => {
+    expect(resolveWinInstallIdentity({ namespace: "release-stable-win" })).toMatchObject({
+      appPathsKey: "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\Open Design.exe",
+      displayName: "Open Design",
+      registryKey: "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Open Design-release-stable-win",
       shortcutName: "Open Design.lnk",
       uninstallerName: "Uninstall Open Design.exe",
     });
@@ -39,5 +51,28 @@ describe("resolveWinInstallIdentity", () => {
       shortcutName: "Open Design Preview.lnk",
       uninstallerName: "Uninstall Open Design Preview.exe",
     });
+  });
+
+  it("uses first-class nightly display identity for nightly release versions and namespaces", () => {
+    expect(resolveWinInstallIdentity({
+      appVersion: "0.8.0.nightly.2",
+      namespace: "release-stable-win",
+    })).toMatchObject({
+      appPathsKey: "Software\\Microsoft\\Windows\\CurrentVersion\\App Paths\\Open Design Nightly.exe",
+      displayName: "Open Design Nightly",
+      registryKey: "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Open Design-release-stable-win",
+      shortcutName: "Open Design Nightly.lnk",
+      uninstallerName: "Uninstall Open Design Nightly.exe",
+    });
+    expect(resolveWinInstallIdentity({ namespace: "release-nightly-win" })).toMatchObject({
+      displayName: "Open Design Nightly",
+      shortcutName: "Open Design Nightly.lnk",
+    });
+  });
+
+  it("keeps the registry DisplayName free of the package version", async () => {
+    const source = await readFile(new URL("../src/win/custom-installer.ts", import.meta.url), "utf8");
+    expect(source).toContain('WriteRegStr HKCU "${registryKey}" "DisplayName" "${productName}"');
+    expect(source).not.toContain('"DisplayName" "${productName} \\${APP_VERSION}"');
   });
 });

--- a/tools/serve/src/index.ts
+++ b/tools/serve/src/index.ts
@@ -3,7 +3,7 @@ import { cac } from "cac";
 import { startUpdaterFixtureServer } from "./updater-fixture.js";
 
 type CliOptions = {
-  channel?: "stable" | "beta";
+  channel?: "stable" | "beta" | "nightly" | "preview";
   host?: string;
   json?: boolean;
   platform?: "mac" | "win";
@@ -65,7 +65,7 @@ const cli = cac("tools-serve");
 
 cli
   .command("start <service>", "Start a local fixture service")
-  .option("--channel <channel>", "Updater channel: stable|beta", { default: "stable" })
+  .option("--channel <channel>", "Updater channel: stable|beta|nightly|preview", { default: "stable" })
   .option("--host <host>", "Host to bind", { default: "127.0.0.1" })
   .option("--json", "Print JSON")
   .option("--platform <platform>", "Updater platform: mac|win", { default: "mac" })

--- a/tools/serve/src/updater-fixture.ts
+++ b/tools/serve/src/updater-fixture.ts
@@ -1,9 +1,11 @@
 import { createHash } from "node:crypto";
 import { createServer, type Server } from "node:http";
 
+type UpdaterFixtureChannel = "stable" | "beta" | "nightly" | "preview";
+
 export type UpdaterFixtureOptions = {
   artifactBody?: Buffer | string;
-  channel?: "stable" | "beta";
+  channel?: UpdaterFixtureChannel;
   host?: string;
   platform?: "mac" | "win";
   port?: number;
@@ -12,7 +14,7 @@ export type UpdaterFixtureOptions = {
 
 export type UpdaterFixtureInfo = {
   artifactUrl: string;
-  channel: "stable" | "beta";
+  channel: UpdaterFixtureChannel;
   checksumUrl: string;
   metadataUrl: string;
   origin: string;
@@ -60,7 +62,13 @@ function prereleaseCounterParts(version: string): { baseVersion: string; number:
   return null;
 }
 
-function channelMetadata(channel: "stable" | "beta", version: string): Record<string, unknown> {
+function normalizeChannel(value: string | undefined): UpdaterFixtureChannel {
+  if (value == null || value.length === 0) return "stable";
+  if (value === "stable" || value === "beta" || value === "nightly" || value === "preview") return value;
+  throw new Error(`unsupported updater fixture channel: ${value}`);
+}
+
+function channelMetadata(channel: UpdaterFixtureChannel, version: string): Record<string, unknown> {
   if (channel === "stable") {
     return {
       baseVersion: version,
@@ -69,19 +77,42 @@ function channelMetadata(channel: "stable" | "beta", version: string): Record<st
     };
   }
 
+  if (channel === "beta") {
+    const countedVersion = prereleaseCounterParts(version);
+    if (countedVersion == null) {
+      throw new Error(`beta updater fixture version must match x.y.z-<label>.N; got ${version}`);
+    }
+    return {
+      baseVersion: countedVersion.baseVersion,
+      betaNumber: countedVersion.number,
+      betaVersion: version,
+    };
+  }
+
   const countedVersion = prereleaseCounterParts(version);
   if (countedVersion == null) {
-    throw new Error(`beta updater fixture version must match x.y.z-<label>.N; got ${version}`);
+    throw new Error(`${channel} updater fixture version must match x.y.z-<label>.N; got ${version}`);
   }
+  if (channel === "nightly") {
+    return {
+      baseVersion: countedVersion.baseVersion,
+      nightlyNumber: countedVersion.number,
+      nightlyVersion: version,
+      releaseVersion: version,
+      stableVersion: countedVersion.baseVersion,
+    };
+  }
+
   return {
     baseVersion: countedVersion.baseVersion,
-    betaNumber: countedVersion.number,
-    betaVersion: version,
+    previewNumber: countedVersion.number,
+    previewVersion: version,
+    releaseVersion: version,
   };
 }
 
 export async function startUpdaterFixtureServer(options: UpdaterFixtureOptions = {}): Promise<UpdaterFixtureServer> {
-  const channel = options.channel ?? "stable";
+  const channel = normalizeChannel(options.channel);
   const host = options.host ?? "127.0.0.1";
   const platform = options.platform ?? "mac";
   const port = options.port ?? 0;

--- a/tools/serve/tests/updater-fixture.test.ts
+++ b/tools/serve/tests/updater-fixture.test.ts
@@ -68,4 +68,43 @@ describe("updater fixture server", () => {
       await server.close();
     }
   });
+
+  it("serves nightly and preview channel-specific release versions", async () => {
+    const nightly = await startUpdaterFixtureServer({
+      channel: "nightly",
+      version: "2.0.0.nightly.3",
+    });
+    const preview = await startUpdaterFixtureServer({
+      channel: "preview",
+      version: "2.0.0-preview.4",
+    });
+    try {
+      const nightlyMetadata = await (await fetch(nightly.info.metadataUrl)).json() as {
+        channel?: string;
+        nightlyNumber?: number;
+        nightlyVersion?: string;
+        releaseVersion?: string;
+        stableVersion?: string;
+      };
+      expect(nightlyMetadata.channel).toBe("nightly");
+      expect(nightlyMetadata.nightlyNumber).toBe(3);
+      expect(nightlyMetadata.nightlyVersion).toBe("2.0.0.nightly.3");
+      expect(nightlyMetadata.releaseVersion).toBe("2.0.0.nightly.3");
+      expect(nightlyMetadata.stableVersion).toBe("2.0.0");
+
+      const previewMetadata = await (await fetch(preview.info.metadataUrl)).json() as {
+        channel?: string;
+        previewNumber?: number;
+        previewVersion?: string;
+        releaseVersion?: string;
+      };
+      expect(previewMetadata.channel).toBe("preview");
+      expect(previewMetadata.previewNumber).toBe(4);
+      expect(previewMetadata.previewVersion).toBe("2.0.0-preview.4");
+      expect(previewMetadata.releaseVersion).toBe("2.0.0-preview.4");
+    } finally {
+      await nightly.close();
+      await preview.close();
+    }
+  });
 });


### PR DESCRIPTION
## Why

Nightly packages currently carry stable runtime identity in the packaged config, so a locally installed `0.8.0-nightly.1` app can resolve as stable and poll the stable feed instead of seeing `nightly.2`. While tightening that, the obvious channel display seams should also be removed: users should see `Open Design Nightly`, `Open Design Beta`, or `Open Design Preview` in installer/app/registry surfaces without version suffixes, while machine-readable version fields stay exact.

## What users will see

Nightly builds present as `Open Design Nightly` in the installer title, shortcuts, mac app bundle display, and Windows uninstall DisplayName. Beta and Preview keep the same channel-branded display treatment without appending the version to the Windows DisplayName. Runtime updater status and feed selection now understand `nightly` and `preview` channels.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI entry point. The web updater popup only learns channel labels for nightly/preview.

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/updater.test.ts`, `tools/pack/tests/win-identity.test.ts`, `tools/pack/tests/versions.test.ts`
- Did the test go red on `main` and green on this branch? no; I validated the branch behavior directly and the local tools-pack build exposed the dotted-nightly Electron semver failure before the final fix.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/desktop test -- tests/main/updater.test.ts`
- `pnpm --filter @open-design/daemon test -- tests/app-version.test.ts tests/update-apply-observations.test.ts`
- `pnpm --filter @open-design/tools-serve test -- tests/updater-fixture.test.ts`
- `pnpm --filter @open-design/tools-pack test -- tests/versions.test.ts tests/win-identity.test.ts tests/win-builder.test.ts tests/win-app.test.ts tests/mac-identity.test.ts tests/mac.test.ts tests/mac-lifecycle.test.ts`
- `pnpm --filter @open-design/sidecar-proto test`
- `pnpm --filter @open-design/host test`
- `pnpm --filter @open-design/web test -- tests/lib/updater.test.ts tests/components/UpdaterPopup.test.tsx`
- `pnpm --filter @open-design/tools-pack build`
- `pnpm guard`
- `pnpm typecheck`
- Local Windows tools-pack loop: `win build --to nsis`, inspect generated config/package/NSIS script, `win install`, `win start`, `win inspect --update-action status`, `win stop`, `win uninstall`, `win cleanup --remove-data --remove-logs --remove-sidecars --remove-product-user-data` using namespace `od-nightly-check` and app version `0.8.0.nightly.2`.