### PR TITLE
fix(daemon): clear stale BYOK key when switching back to Local CLI (#2420)

### DIFF
--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -15,6 +15,14 @@ type RuntimeEnvMap = NodeJS.ProcessEnv | Record<string, string>;
 // In that case claude login is meaningless, so preserve the API key so
 // the child can authenticate against the custom base URL.
 //
+// The codex adapter has the symmetric problem: a stale BYOK
+// OPENAI_API_KEY / CODEX_API_KEY left behind in app-config.json silently
+// outranks Codex CLI's own `~/.codex/auth.json` (codex login) and trips
+// 401 invalid_api_key whenever execution mode is switched back to
+// Local CLI. Strip both keys unless the user has also configured a
+// custom OPENAI_BASE_URL — i.e. they are intentionally routing Codex
+// CLI through a third-party OpenAI-compatible gateway. See issue #2420.
+//
 // Windows env-var names are case-insensitive at the kernel level
 // (`GetEnvironmentVariable`), but spreading `process.env` into a plain
 // object loses Node's case-insensitive accessor — `Anthropic_Api_Key`
@@ -29,16 +37,40 @@ export function spawnEnvForAgent(
     ...baseEnv,
     ...expandConfiguredEnv(configuredEnv),
   };
-  if (agentId !== 'claude') return env;
+  if (agentId === 'claude') {
+    stripUnlessCustomBaseUrl(env, 'ANTHROPIC_BASE_URL', ['ANTHROPIC_API_KEY']);
+    return env;
+  }
+  if (agentId === 'codex') {
+    stripUnlessCustomBaseUrl(env, 'OPENAI_BASE_URL', [
+      'OPENAI_API_KEY',
+      'CODEX_API_KEY',
+    ]);
+    return env;
+  }
+  return env;
+}
+
+// Remove `secretKeys` from `env` unless `baseUrlKey` is set to a non-empty
+// value — in which case the user is intentionally routing the CLI through
+// a custom endpoint and the secret is the credential that authenticates
+// against it. Comparison is case-insensitive so Windows env names with
+// mixed casing (`Openai_Api_Key`) cannot slip past a literal `delete`.
+function stripUnlessCustomBaseUrl(
+  env: NodeJS.ProcessEnv,
+  baseUrlKey: string,
+  secretKeys: readonly string[],
+): void {
+  const baseUrlKeyUpper = baseUrlKey.toUpperCase();
   const hasCustomBaseUrl = Object.keys(env).some(
     (k) =>
-      k.toUpperCase() === 'ANTHROPIC_BASE_URL' &&
+      k.toUpperCase() === baseUrlKeyUpper &&
       typeof env[k] === 'string' &&
       env[k].trim() !== '',
   );
-  if (hasCustomBaseUrl) return env;
+  if (hasCustomBaseUrl) return;
+  const secretKeysUpper = new Set(secretKeys.map((k) => k.toUpperCase()));
   for (const key of Object.keys(env)) {
-    if (key.toUpperCase() === 'ANTHROPIC_API_KEY') delete env[key];
+    if (secretKeysUpper.has(key.toUpperCase())) delete env[key];
   }
-  return env;
 }

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1180,6 +1180,7 @@ setImmediate(() => process.exit(0));
 const fs = require('node:fs');
 fs.writeFileSync(${JSON.stringify(envFile)}, JSON.stringify({
   CODEX_HOME: process.env.CODEX_HOME || null,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL || null,
   CODEX_API_KEY: process.env.CODEX_API_KEY || null,
   SHOULD_NOT_PASS: process.env.OD_CONNECTION_TEST_SHOULD_NOT_PASS || null,
 }));
@@ -1187,6 +1188,11 @@ console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_messag
 setImmediate(() => process.exit(0));
 `,
         async () => {
+          // CODEX_API_KEY only flows through when the user has also
+          // configured a custom OPENAI_BASE_URL — i.e. they intend to
+          // authenticate Codex CLI against a third-party gateway. Without
+          // the base URL, spawnEnvForAgent strips the credential so Codex
+          // CLI's own `codex login` wins (issue #2420).
           const res = await realFetch(`${baseUrl}/api/test/connection`, {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
@@ -1196,6 +1202,7 @@ setImmediate(() => process.exit(0));
               agentCliEnv: {
                 codex: {
                   CODEX_HOME: codexHome,
+                  OPENAI_BASE_URL: 'https://proxy.example.com/v1',
                   CODEX_API_KEY: 'codex-key',
                   OD_CONNECTION_TEST_SHOULD_NOT_PASS: 'leaked',
                 },
@@ -1214,8 +1221,67 @@ setImmediate(() => process.exit(0));
           await expect(fsp.readFile(envFile, 'utf8')).resolves.toBe(
             JSON.stringify({
               CODEX_HOME: codexHome,
+              OPENAI_BASE_URL: 'https://proxy.example.com/v1',
               CODEX_API_KEY: 'codex-key',
               SHOULD_NOT_PASS: null,
+            }),
+          );
+        },
+      );
+    } finally {
+      await fsp.rm(markerDir, { recursive: true, force: true });
+    }
+  });
+
+  it('strips stale Codex API keys when no custom OPENAI_BASE_URL is configured', async () => {
+    const markerDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-codex-strip-'));
+    const envFile = path.join(markerDir, 'env.json');
+    const codexHome = path.join(markerDir, 'codex-home');
+    try {
+      await withFakeCodex(
+        `
+const fs = require('node:fs');
+fs.writeFileSync(${JSON.stringify(envFile)}, JSON.stringify({
+  CODEX_HOME: process.env.CODEX_HOME || null,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY || null,
+  CODEX_API_KEY: process.env.CODEX_API_KEY || null,
+}));
+console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }));
+setImmediate(() => process.exit(0));
+`,
+        async () => {
+          // Simulates the user flow that triggered issue #2420: a stale
+          // BYOK OPENAI_API_KEY sat in agentCliEnv.codex from a previous
+          // session, the user cleared the BYOK dialog (which doesn't
+          // touch agentCliEnv) and switched back to Local CLI. Without
+          // an OPENAI_BASE_URL the daemon must keep the secret out of
+          // the spawn so Codex CLI's own `codex login` wins.
+          const res = await realFetch(`${baseUrl}/api/test/connection`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              mode: 'agent',
+              agentId: 'codex',
+              agentCliEnv: {
+                codex: {
+                  CODEX_HOME: codexHome,
+                  OPENAI_API_KEY: 'sk-stale-byok',
+                  CODEX_API_KEY: 'sk-stale-byok',
+                },
+              },
+            }),
+          });
+          expect(res.status).toBe(200);
+          await expect(res.json()).resolves.toMatchObject({
+            ok: true,
+            kind: 'success',
+            agentName: 'Codex CLI',
+          });
+          await expect(fsp.readFile(envFile, 'utf8')).resolves.toBe(
+            JSON.stringify({
+              CODEX_HOME: codexHome,
+              OPENAI_API_KEY: null,
+              CODEX_API_KEY: null,
             }),
           );
         },

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -567,6 +567,161 @@ test('spawnEnvForAgent preserves ANTHROPIC_API_KEY for non-claude adapters', () 
   }
 });
 
+// Issue #2420: Codex CLI prefers OPENAI_API_KEY / CODEX_API_KEY over its own
+// `codex login` OAuth credentials when both are set. When the user has not
+// pointed Codex at a custom proxy via OPENAI_BASE_URL, a stale BYOK key
+// silently outranks `~/.codex/auth.json` and trips 401 invalid_api_key.
+// Strip the API keys in that case so Codex CLI's own auth resolution wins —
+// mirroring the existing ANTHROPIC_API_KEY behavior the claude adapter has
+// for issue #398.
+test('spawnEnvForAgent strips OPENAI_API_KEY for the codex adapter when OPENAI_BASE_URL is absent', () => {
+  const env = spawnEnvForAgent('codex', {
+    OPENAI_API_KEY: 'sk-stale-byok',
+    PATH: '/usr/bin',
+    OD_DAEMON_URL: 'http://127.0.0.1:7456',
+  });
+
+  assert.equal('OPENAI_API_KEY' in env, false);
+  assert.equal(env.PATH, '/usr/bin');
+  assert.equal(env.OD_DAEMON_URL, 'http://127.0.0.1:7456');
+});
+
+test('spawnEnvForAgent strips CODEX_API_KEY for the codex adapter when OPENAI_BASE_URL is absent', () => {
+  const env = spawnEnvForAgent('codex', {
+    CODEX_API_KEY: 'sk-stale-byok',
+    PATH: '/usr/bin',
+  });
+
+  assert.equal('CODEX_API_KEY' in env, false);
+  assert.equal(env.PATH, '/usr/bin');
+});
+
+test('spawnEnvForAgent strips Codex API keys when OPENAI_BASE_URL is empty', () => {
+  const env = spawnEnvForAgent('codex', {
+    OPENAI_API_KEY: 'sk-stale-byok',
+    CODEX_API_KEY: 'sk-stale-byok',
+    OPENAI_BASE_URL: '',
+    PATH: '/usr/bin',
+  });
+
+  assert.equal('OPENAI_API_KEY' in env, false);
+  assert.equal('CODEX_API_KEY' in env, false);
+  assert.equal(env.PATH, '/usr/bin');
+});
+
+test('spawnEnvForAgent strips Codex API keys when OPENAI_BASE_URL is whitespace', () => {
+  const env = spawnEnvForAgent('codex', {
+    OPENAI_API_KEY: 'sk-stale-byok',
+    OPENAI_BASE_URL: '   ',
+    PATH: '/usr/bin',
+  });
+
+  assert.equal('OPENAI_API_KEY' in env, false);
+  assert.equal(env.PATH, '/usr/bin');
+});
+
+test('spawnEnvForAgent preserves Codex API keys when OPENAI_BASE_URL is set to a custom proxy', () => {
+  const env = spawnEnvForAgent('codex', {
+    OPENAI_API_KEY: 'sk-proxy',
+    OPENAI_BASE_URL: 'https://proxy.example.com/v1',
+    PATH: '/usr/bin',
+  });
+
+  assert.equal(env.OPENAI_API_KEY, 'sk-proxy');
+  assert.equal(env.OPENAI_BASE_URL, 'https://proxy.example.com/v1');
+  assert.equal(env.PATH, '/usr/bin');
+});
+
+test('spawnEnvForAgent preserves CODEX_API_KEY when OPENAI_BASE_URL is set to a custom proxy', () => {
+  const env = spawnEnvForAgent('codex', {
+    CODEX_API_KEY: 'sk-proxy',
+    OPENAI_BASE_URL: 'https://proxy.example.com/v1',
+    PATH: '/usr/bin',
+  });
+
+  assert.equal(env.CODEX_API_KEY, 'sk-proxy');
+  assert.equal(env.OPENAI_BASE_URL, 'https://proxy.example.com/v1');
+});
+
+test('spawnEnvForAgent strips Codex API keys case-insensitively when OPENAI_BASE_URL is absent', () => {
+  const env = spawnEnvForAgent('codex', {
+    Openai_Api_Key: 'sk-mixed-case',
+    openai_api_key: 'sk-lower-case',
+    Codex_Api_Key: 'sk-mixed-case',
+    PATH: '/usr/bin',
+  });
+
+  const remainingOpenAi = Object.keys(env).filter(
+    (k) => k.toUpperCase() === 'OPENAI_API_KEY',
+  );
+  const remainingCodex = Object.keys(env).filter(
+    (k) => k.toUpperCase() === 'CODEX_API_KEY',
+  );
+  assert.deepEqual(remainingOpenAi, []);
+  assert.deepEqual(remainingCodex, []);
+  assert.equal(env.PATH, '/usr/bin');
+});
+
+test('spawnEnvForAgent preserves Codex API keys for non-codex adapters', () => {
+  for (const agentId of ['claude', 'gemini', 'opencode', 'devin']) {
+    const env = spawnEnvForAgent(agentId, {
+      OPENAI_API_KEY: 'sk-keep',
+      CODEX_API_KEY: 'sk-keep',
+      PATH: '/usr/bin',
+    });
+    assert.equal(
+      env.OPENAI_API_KEY,
+      'sk-keep',
+      `expected ${agentId} to preserve OPENAI_API_KEY`,
+    );
+    assert.equal(
+      env.CODEX_API_KEY,
+      'sk-keep',
+      `expected ${agentId} to preserve CODEX_API_KEY`,
+    );
+  }
+});
+
+// When the user has explicitly configured a BYOK Codex base URL through the
+// Settings → Execution mode → Local CLI form, the configured API key in
+// `agentCliEnv.codex.OPENAI_API_KEY` (or CODEX_API_KEY) flows through to the
+// spawn alongside the base URL. The stripping helper must keep both in sync
+// so the configured proxy actually authenticates.
+test('spawnEnvForAgent applies configured codex env and preserves API key when base URL is configured', () => {
+  const env = spawnEnvForAgent(
+    'codex',
+    { PATH: '/usr/bin' },
+    {
+      OPENAI_BASE_URL: 'https://proxy.example.com/v1',
+      OPENAI_API_KEY: 'sk-configured',
+    },
+  );
+
+  assert.equal(env.OPENAI_BASE_URL, 'https://proxy.example.com/v1');
+  assert.equal(env.OPENAI_API_KEY, 'sk-configured');
+});
+
+// The dual-key shape every BYOK Codex user hits in production: prior session
+// left OPENAI_API_KEY in the daemon's app-config, the user cleared the BYOK
+// dialog but never opened Settings → Local CLI → Codex env to also clear
+// OPENAI_API_KEY, then switched execution mode back to Local CLI. spawnEnv
+// must strip the stale BYOK key so Codex CLI's own `codex login` wins.
+test('spawnEnvForAgent strips stale configured OPENAI_API_KEY when configured base URL was also cleared', () => {
+  const env = spawnEnvForAgent(
+    'codex',
+    { PATH: '/usr/bin' },
+    {
+      // Empty OPENAI_BASE_URL — i.e. user is on Local CLI mode without a
+      // custom proxy. validateAgentCliEnv would drop the empty string in
+      // practice; we pass it explicitly here to lock the spawn-side guard.
+      OPENAI_API_KEY: 'sk-stale-byok',
+    },
+  );
+
+  assert.equal('OPENAI_API_KEY' in env, false);
+  assert.equal(env.PATH, '/usr/bin');
+});
+
 test('spawnEnvForAgent preserves ANTHROPIC_API_KEY when ANTHROPIC_BASE_URL is set', () => {
   const env = spawnEnvForAgent('claude', {
     ANTHROPIC_API_KEY: 'sk-kimi',


### PR DESCRIPTION
Fixes #2420

## Why

I'm building on top of Open Design's Codex CLI path and hit issue #2420 myself: after experimenting with a third-party OpenAI-compatible API key in BYOK mode, the only way to recover working Codex auth was to wipe `~/.od/app-config.json` by hand. That's not a thing I want to ship to users who paid for the BYOK key, briefly tested it, and then went back to Codex's own `codex login`.

The pain being addressed is the user-facing p1 reported in #2420: after clearing the BYOK key and switching execution mode back to Local CLI, every Codex CLI invocation still trips `401 invalid_api_key`. The stale key was no longer visible in BYOK settings but kept reaching the Codex child process — Codex CLI prefers `OPENAI_API_KEY` / `CODEX_API_KEY` over its own `~/.codex/auth.json`, so a stale value from a previous BYOK session silently outranks the user's real local credentials.

Root cause: `spawnEnvForAgent` already strips `ANTHROPIC_API_KEY` for the `claude` adapter (issue #398) when no `ANTHROPIC_BASE_URL` is configured, but there was no symmetric handling for the `codex` adapter. The configured `agentCliEnv.codex.OPENAI_API_KEY` flowed through to the child env untouched.

## What users will see

After this fix, the recovery flow from #2420 just works:

- A stale BYOK `OPENAI_API_KEY` left behind from an earlier session no longer reaches Codex CLI when execution mode is Local CLI. Codex CLI's own `codex login` credential resolution wins, so `~/.codex/auth.json` is honored again and the 401 goes away.
- Users who *intentionally* route Codex CLI through a third-party OpenAI-compatible gateway (Settings → Execution mode → Local CLI → Codex env: `OPENAI_BASE_URL` + `OPENAI_API_KEY` / `CODEX_API_KEY`) are unaffected — the keys still flow through because the user has explicitly opted in by setting a custom base URL.
- No UI changes; no settings to flip.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

Note on the "Default behavior change" tick: this only fires when the user has *not* configured a custom `OPENAI_BASE_URL`. For users on a vanilla Local CLI Codex setup the behavior change is "stale BYOK key is no longer silently inherited", which is the intended fix. Users who deliberately configured `OPENAI_BASE_URL` + an API key for proxy/legacy routing are untouched.

Surface-area dual-track note: this is a daemon-internal env-stripping fix that runs inside `spawnEnvForAgent` for both the UI chat path (`POST /api/runs` via `apps/daemon/src/server.ts`) and the CLI / connection-test path (`POST /api/test/connection` via `apps/daemon/src/connectionTest.ts`). Both surfaces share the same code path, so there is no new HTTP endpoint, no new `od` subcommand, and no new UI control to add.

## Screenshots

N/A — daemon-internal env handling, no UI surface.

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow":

- Test paths that reproduce the bug:
  - `apps/daemon/tests/runtimes/env-and-detection.test.ts` — unit-level: 8 new tests around `spawnEnvForAgent('codex', ...)` covering the absent / empty / whitespace `OPENAI_BASE_URL` case, custom-proxy preservation, case-insensitive stripping, and the dual-key shape the user hit in production.
  - `apps/daemon/tests/connection-test.test.ts` — integration: new "strips stale Codex API keys when no custom OPENAI_BASE_URL is configured" test that spawns a fake `codex` binary through the live `/api/test/connection` route and asserts the child sees `OPENAI_API_KEY === null` and `CODEX_API_KEY === null`. The existing "spawns agent tests with draft allowlisted CLI env" test was updated to pair `CODEX_API_KEY` with `OPENAI_BASE_URL` so it still locks the allowlist behavior while reflecting the new stripping invariant.
- Did the test go red on `main` and green on this branch? **yes** — confirmed locally: with the source change reverted, the 6 `spawnEnvForAgent` codex-stripping tests in `env-and-detection.test.ts` and the new `connection-test.test.ts` strip case all fail with the expected "key still present in env" assertion; with the fix applied, all of them pass.

## Validation

- `pnpm typecheck` — all packages green.
- `pnpm guard` — green.
- `pnpm --filter @open-design/daemon test` — 247 of 248 test files pass (2961 tests). The remaining failure, `tests/orbit.test.ts > tracks the most recent run per template alongside the global last run`, also fails on `upstream/main` (`agentRunId: 'agent-2'` vs expected `'agent-3'`) and is unrelated to this PR.
- `pnpm --filter @open-design/contracts test` — green (sanity, contracts package is untouched).