### PR TITLE
test(daemon): cover runtimes models/paths, registry versioning, inline-assets

### DIFF
--- a/apps/daemon/tests/inline-assets.test.ts
+++ b/apps/daemon/tests/inline-assets.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  InlineAssetsLimitError,
+  inlineRelativeAssets,
+  type AssetHandle,
+  type InlineAssetReader,
+} from '../src/inline-assets.js';
+
+// FS-backed reader that mirrors the production GET /api/projects/:id/export
+// shape — stat for size, readFile for body — so this suite exercises the
+// helper through the same handle contract callers use in apps/daemon/src/
+// import-export-routes.ts. The in-memory-reader edge cases live in
+// export-inline-route.test.ts; this file covers FS round-trip,
+// top-level-vs-nested scoping, and the byte-cap surface that maps to the
+// 413 PAYLOAD_TOO_LARGE envelope.
+
+describe('inlineRelativeAssets (FS-backed)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'od-inline-assets-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function write(rel: string, body: string | Buffer) {
+    const target = path.join(root, rel);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, body);
+  }
+
+  function fsReader(): InlineAssetReader {
+    return async (rel) => {
+      const abs = path.join(root, rel);
+      try {
+        const s = await stat(abs);
+        const handle: AssetHandle = {
+          size: s.size,
+          read: async () => {
+            try {
+              return await readFile(abs, 'utf8');
+            } catch {
+              return null;
+            }
+          },
+        };
+        return handle;
+      } catch {
+        return null;
+      }
+    };
+  }
+
+  it('inlines a top-level <link rel=stylesheet> as a <style> block', async () => {
+    write('a.css', 'body{color:red}');
+    const html = '<!doctype html><html><head><link rel="stylesheet" href="a.css"></head><body></body></html>';
+    const out = await inlineRelativeAssets(html, 'index.html', fsReader());
+    expect(out).toContain('<style data-od-inline-asset="a.css">');
+    expect(out).toContain('body{color:red}');
+    expect(out).not.toContain('<link rel="stylesheet" href="a.css">');
+  });
+
+  it('inlines a top-level <script src> as an inline <script> with the file body', async () => {
+    write('app.js', 'window.OD_OK = 1;');
+    const html = '<html><head><script src="app.js"></script></head></html>';
+    const out = await inlineRelativeAssets(html, 'index.html', fsReader());
+    expect(out).toContain('window.OD_OK = 1;');
+    expect(out).not.toContain('src="app.js"');
+    expect(out.match(/<script[^>]*>/g)?.length).toBe(1);
+  });
+
+  it('does NOT inline a <script> that has no src attribute (already inline)', async () => {
+    const html = '<html><head><script>console.log("hi")</script></head></html>';
+    const out = await inlineRelativeAssets(html, 'index.html', fsReader());
+    // The matcher requires a src=… capture, so a srcless inline script is
+    // left exactly as written.
+    expect(out).toBe(html);
+  });
+
+  it('does NOT inline <link rel=preload> (only rel=stylesheet is in scope)', async () => {
+    write('x.css', '.x{}');
+    const html = '<link rel="preload" href="x.css">';
+    const out = await inlineRelativeAssets(html, 'index.html', fsReader());
+    expect(out).toBe(html);
+  });
+
+  it('skips absolute http:// and https:// references (only project-relative paths are inlined)', async () => {
+    const cases = [
+      '<link rel="stylesheet" href="https://cdn.example.com/x.css">',
+      '<link rel="stylesheet" href="http://cdn.example.com/x.css">',
+      '<script src="https://cdn.example.com/x.js"></script>',
+      '<script src="http://cdn.example.com/x.js"></script>',
+    ];
+    for (const html of cases) {
+      const out = await inlineRelativeAssets(html, 'index.html', fsReader());
+      expect(out).toBe(html);
+    }
+  });
+
+  it('skips data: / blob: / leading-slash absolute refs', async () => {
+    const cases = [
+      '<link rel="stylesheet" href="data:text/css,body{}">',
+      '<link rel="stylesheet" href="blob:abc">',
+      '<link rel="stylesheet" href="/abs/path.css">',
+      '<script src="data:text/javascript,1+1"></script>',
+      '<script src="/abs/x.js"></script>',
+    ];
+    for (const html of cases) {
+      const out = await inlineRelativeAssets(html, 'index.html', fsReader());
+      expect(out).toBe(html);
+    }
+  });
+
+  it('leaves a referenced file alone (URL ref preserved) when the file is missing on disk', async () => {
+    const html = '<link rel="stylesheet" href="missing.css">';
+    const out = await inlineRelativeAssets(html, 'index.html', fsReader());
+    expect(out).toContain('<link rel="stylesheet" href="missing.css">');
+  });
+
+  it('mixes a present and a missing asset — the present one inlines, the missing one stays as a URL ref', async () => {
+    write('present.js', 'ok');
+    const html =
+      '<link rel="stylesheet" href="missing.css"><script src="present.js"></script>';
+    const out = await inlineRelativeAssets(html, 'index.html', fsReader());
+    expect(out).toContain('<link rel="stylesheet" href="missing.css">');
+    expect(out).toContain('ok');
+    expect(out).not.toContain('src="present.js"');
+  });
+
+  it('resolves a sibling asset relative to a nested owner path (../shared/util.js)', async () => {
+    write('shared/util.js', 'export const N = 7;');
+    const html = '<script src="../shared/util.js"></script>';
+    const out = await inlineRelativeAssets(html, 'pages/index.html', fsReader());
+    expect(out).toContain('export const N = 7;');
+    expect(out).not.toContain('src="../shared/util.js"');
+  });
+
+  it('throws InlineAssetsLimitError("owner") with limit="owner" when the owner HTML exceeds maxOwnerBytes', async () => {
+    const html = '<html><head>' + 'x'.repeat(500) + '</head></html>';
+    await expect(
+      inlineRelativeAssets(html, 'index.html', fsReader(), { maxOwnerBytes: 100 }),
+    ).rejects.toBeInstanceOf(InlineAssetsLimitError);
+    await expect(
+      inlineRelativeAssets(html, 'index.html', fsReader(), { maxOwnerBytes: 100 }),
+    ).rejects.toMatchObject({ name: 'InlineAssetsLimitError', limit: 'owner' });
+  });
+
+  it('throws InlineAssetsLimitError("candidates") when tag matches exceed maxCandidates', async () => {
+    const html = Array.from({ length: 5 }, (_, i) =>
+      `<link rel="stylesheet" href="a${i}.css">`,
+    ).join('');
+    await expect(
+      inlineRelativeAssets(html, 'index.html', fsReader(), { maxCandidates: 3 }),
+    ).rejects.toMatchObject({ name: 'InlineAssetsLimitError', limit: 'candidates' });
+  });
+
+  it('throws InlineAssetsLimitError("total") when the assembled output exceeds maxTotalBytes', async () => {
+    write('a.css', 'x'.repeat(800));
+    write('b.css', 'x'.repeat(800));
+    const html = '<link rel="stylesheet" href="a.css"><link rel="stylesheet" href="b.css">';
+    await expect(
+      inlineRelativeAssets(html, 'index.html', fsReader(), { maxTotalBytes: 1000 }),
+    ).rejects.toMatchObject({ name: 'InlineAssetsLimitError', limit: 'total' });
+  });
+
+  it('leaves a single oversize asset as a URL ref (graceful per-asset fallback) without throwing', async () => {
+    write('big.css', 'a'.repeat(2000));
+    write('small.css', '.s{}');
+    const html =
+      '<link rel="stylesheet" href="big.css"><link rel="stylesheet" href="small.css">';
+    const out = await inlineRelativeAssets(html, 'index.html', fsReader(), {
+      maxAssetBytes: 1000,
+    });
+    expect(out).toContain('<link rel="stylesheet" href="big.css">');
+    expect(out).toContain('.s{}');
+    expect(out).not.toContain('href="small.css"');
+  });
+});

--- a/apps/daemon/tests/registry/versioning.test.ts
+++ b/apps/daemon/tests/registry/versioning.test.ts
@@ -1,0 +1,183 @@
+import type { MarketplacePluginEntry } from '@open-design/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+  parsePluginSpecifier,
+  resolveMarketplaceEntryVersion,
+} from '../../src/registry/versioning.js';
+
+describe('parsePluginSpecifier', () => {
+  it('returns the name alone when no range suffix is present (vendor/name form)', () => {
+    expect(parsePluginSpecifier('vendor/name')).toEqual({ name: 'vendor/name' });
+  });
+
+  it('splits a vendor/name@version specifier into name + range', () => {
+    expect(parsePluginSpecifier('vendor/name@1.0.0')).toEqual({
+      name: 'vendor/name',
+      range: '1.0.0',
+    });
+  });
+
+  it('preserves caret/tilde range markers in the range field', () => {
+    expect(parsePluginSpecifier('vendor/name@^1.0.0')).toEqual({
+      name: 'vendor/name',
+      range: '^1.0.0',
+    });
+    expect(parsePluginSpecifier('vendor/name@~1.2.3')).toEqual({
+      name: 'vendor/name',
+      range: '~1.2.3',
+    });
+  });
+
+  it('preserves dist-tag style ranges like "latest"', () => {
+    expect(parsePluginSpecifier('vendor/name@latest')).toEqual({
+      name: 'vendor/name',
+      range: 'latest',
+    });
+  });
+
+  it('trims surrounding whitespace before parsing', () => {
+    expect(parsePluginSpecifier('  vendor/name@1.0.0  ')).toEqual({
+      name: 'vendor/name',
+      range: '1.0.0',
+    });
+  });
+
+  it('treats a bare name without a slash as the whole specifier (no range split)', () => {
+    // Without a `vendor/` segment, the `@` is interpreted as part of the name
+    // (e.g. an org-scoped namespace), not a version separator.
+    expect(parsePluginSpecifier('name@1.0.0')).toEqual({ name: 'name@1.0.0' });
+  });
+});
+
+function entry(overrides: Partial<MarketplacePluginEntry> = {}): MarketplacePluginEntry {
+  return {
+    name: 'vendor/example',
+    source: 'github:vendor/example@v1.0.0/plugin',
+    version: '1.0.0',
+    ...overrides,
+  } as MarketplacePluginEntry;
+}
+
+describe('resolveMarketplaceEntryVersion', () => {
+  it('returns null for a yanked entry regardless of requested range', () => {
+    const e = entry({ yanked: true, version: '1.0.0' });
+    expect(resolveMarketplaceEntryVersion(e)).toBeNull();
+    expect(resolveMarketplaceEntryVersion(e, '1.0.0')).toBeNull();
+  });
+
+  it('defaults to distTags.latest when no range is requested', () => {
+    const e = entry({
+      version: '1.0.0',
+      distTags: { latest: '1.2.0' },
+      versions: [
+        { version: '1.0.0', source: 'github:vendor/example@v1.0.0/plugin' },
+        { version: '1.2.0', source: 'github:vendor/example@v1.2.0/plugin' },
+      ],
+    });
+    expect(resolveMarketplaceEntryVersion(e)?.version).toBe('1.2.0');
+  });
+
+  it('picks the highest matching version for a caret range, ignoring out-of-major candidates', () => {
+    const e = entry({
+      version: '2.0.0',
+      versions: [
+        { version: '1.0.0', source: 's1' },
+        { version: '1.1.5', source: 's115' },
+        { version: '1.2.0', source: 's120' },
+        { version: '2.0.0', source: 's200' },
+      ],
+    });
+    const resolved = resolveMarketplaceEntryVersion(e, '^1.0.0');
+    expect(resolved?.version).toBe('1.2.0');
+    expect(resolved?.source).toBe('s120');
+  });
+
+  it('respects tilde ranges (locks minor)', () => {
+    const e = entry({
+      version: '1.2.5',
+      versions: [
+        { version: '1.2.0', source: 's' },
+        { version: '1.2.5', source: 's' },
+        { version: '1.3.0', source: 's' },
+      ],
+    });
+    expect(resolveMarketplaceEntryVersion(e, '~1.2.0')?.version).toBe('1.2.5');
+  });
+
+  it('filters yanked version records from caret matches', () => {
+    const e = entry({
+      version: '1.2.0',
+      versions: [
+        { version: '1.0.0', source: 's1' },
+        { version: '1.2.0', source: 's12', yanked: true },
+      ],
+    });
+    // 1.2.0 is yanked, so the highest non-yanked match is 1.0.0.
+    expect(resolveMarketplaceEntryVersion(e, '^1.0.0')?.version).toBe('1.0.0');
+  });
+
+  it('returns null when a specific yanked version is requested directly', () => {
+    const e = entry({
+      version: '1.0.0',
+      versions: [
+        { version: '1.0.0', source: 's1', yanked: true },
+      ],
+    });
+    expect(resolveMarketplaceEntryVersion(e, '1.0.0')).toBeNull();
+  });
+
+  it('returns null when no version matches the caret range', () => {
+    const e = entry({
+      version: '2.0.0',
+      versions: [{ version: '2.0.0', source: 's2' }],
+    });
+    expect(resolveMarketplaceEntryVersion(e, '^1.0.0')).toBeNull();
+  });
+
+  it('resolves a dist-tag (non-latest) name to its pinned version', () => {
+    const e = entry({
+      version: '1.0.0',
+      distTags: { latest: '1.0.0', beta: '2.0.0-beta.1' },
+      versions: [
+        { version: '1.0.0', source: 's1' },
+        { version: '2.0.0-beta.1', source: 'sb' },
+      ],
+    });
+    expect(resolveMarketplaceEntryVersion(e, 'beta')?.version).toBe('2.0.0-beta.1');
+  });
+
+  it('carries through integrity / manifestDigest / ref / deprecated when present on the version record', () => {
+    const e = entry({
+      version: '1.0.0',
+      versions: [
+        {
+          version: '1.0.0',
+          source: 's1',
+          ref: 'refs/tags/v1.0.0',
+          integrity: 'sha256:abc',
+          manifestDigest: 'sha256:def',
+          deprecated: 'use 2.x',
+        },
+      ],
+    });
+    const r = resolveMarketplaceEntryVersion(e, '1.0.0');
+    expect(r).toMatchObject({
+      version: '1.0.0',
+      source: 's1',
+      ref: 'refs/tags/v1.0.0',
+      archiveIntegrity: 'sha256:abc',
+      manifestDigest: 'sha256:def',
+      deprecated: 'use 2.x',
+    });
+  });
+
+  it('returns null when neither version record nor entry has a source', () => {
+    const e = {
+      name: 'vendor/example',
+      version: '1.0.0',
+      versions: [{ version: '1.0.0' }],
+    } as unknown as MarketplacePluginEntry;
+    expect(resolveMarketplaceEntryVersion(e, '1.0.0')).toBeNull();
+  });
+});

--- a/apps/daemon/tests/runtimes/models-and-paths.test.ts
+++ b/apps/daemon/tests/runtimes/models-and-paths.test.ts
@@ -1,0 +1,136 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  isKnownModel,
+  rememberLiveModels,
+  sanitizeCustomModel,
+} from '../../src/runtimes/models.js';
+import { expandConfiguredEnv, expandHomePath } from '../../src/runtimes/paths.js';
+import type { RuntimeAgentDef } from '../../src/runtimes/types.js';
+
+function defWith(id: string, fallbackIds: string[]): RuntimeAgentDef {
+  return {
+    id,
+    name: id,
+    bin: id,
+    versionArgs: ['--version'],
+    fallbackModels: fallbackIds.map((mid) => ({ id: mid, label: mid })),
+    buildArgs: () => [],
+    streamFormat: 'text',
+  };
+}
+
+describe('isKnownModel', () => {
+  it('accepts a model id present in the live cache', () => {
+    const def = defWith('alpha-isknown-live', []);
+    rememberLiveModels(def.id, [{ id: 'live-1', label: 'live-1' }]);
+    expect(isKnownModel(def, 'live-1')).toBe(true);
+  });
+
+  it('falls back to the static fallbackModels list when no live cache entry matches', () => {
+    const def = defWith('alpha-isknown-fallback', ['static-1']);
+    expect(isKnownModel(def, 'static-1')).toBe(true);
+  });
+
+  it('rejects an unknown model id (not in live cache and not in fallback)', () => {
+    const def = defWith('alpha-isknown-unknown', ['static-1']);
+    rememberLiveModels(def.id, [{ id: 'live-1', label: 'live-1' }]);
+    expect(isKnownModel(def, 'nope')).toBe(false);
+  });
+
+  it('rejects empty or nullish modelId', () => {
+    const def = defWith('alpha-isknown-empty', ['static-1']);
+    expect(isKnownModel(def, '')).toBe(false);
+    expect(isKnownModel(def, null)).toBe(false);
+    expect(isKnownModel(def, undefined)).toBe(false);
+  });
+});
+
+describe('rememberLiveModels', () => {
+  it('overwrites the per-agent live cache so the most recent listing wins', () => {
+    const def = defWith('alpha-remember-overwrite', []);
+    rememberLiveModels(def.id, [{ id: 'a', label: 'a' }]);
+    rememberLiveModels(def.id, [{ id: 'b', label: 'b' }]);
+    expect(isKnownModel(def, 'a')).toBe(false);
+    expect(isKnownModel(def, 'b')).toBe(true);
+  });
+
+  it('is idempotent: repeating the same call leaves cache membership unchanged', () => {
+    const def = defWith('alpha-remember-idempotent', []);
+    const list = [{ id: 'x', label: 'x' }];
+    rememberLiveModels(def.id, list);
+    rememberLiveModels(def.id, list);
+    expect(isKnownModel(def, 'x')).toBe(true);
+  });
+
+  it('ignores a non-array input without throwing', () => {
+    const def = defWith('alpha-remember-nonarray', []);
+    expect(() => rememberLiveModels(def.id, undefined as never)).not.toThrow();
+    expect(isKnownModel(def, 'anything')).toBe(false);
+  });
+});
+
+describe('sanitizeCustomModel', () => {
+  it('accepts a valid model id (alphanumeric with permitted punctuation)', () => {
+    expect(sanitizeCustomModel('claude-3-5-sonnet-20241022')).toBe('claude-3-5-sonnet-20241022');
+    expect(sanitizeCustomModel('vendor/model:tag@1.0')).toBe('vendor/model:tag@1.0');
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(sanitizeCustomModel('  gpt-4o  ')).toBe('gpt-4o');
+  });
+
+  it('rejects flag-like strings that start with a dash', () => {
+    expect(sanitizeCustomModel('--inject-flag')).toBeNull();
+    expect(sanitizeCustomModel('-x')).toBeNull();
+  });
+
+  it('rejects strings containing whitespace or control characters', () => {
+    expect(sanitizeCustomModel('model name')).toBeNull();
+    expect(sanitizeCustomModel('model\nname')).toBeNull();
+  });
+
+  it('rejects empty / whitespace-only / non-string / oversize input', () => {
+    expect(sanitizeCustomModel('')).toBeNull();
+    expect(sanitizeCustomModel('   ')).toBeNull();
+    expect(sanitizeCustomModel(null)).toBeNull();
+    expect(sanitizeCustomModel(undefined)).toBeNull();
+    expect(sanitizeCustomModel('a'.repeat(201))).toBeNull();
+  });
+});
+
+describe('expandHomePath', () => {
+  it('returns the home directory for a bare "~"', () => {
+    expect(expandHomePath('~')).toBe(homedir());
+  });
+
+  it('expands "~/relative" to <home>/relative', () => {
+    expect(expandHomePath('~/projects')).toBe(path.join(homedir(), 'projects'));
+  });
+
+  it('leaves non-tilde paths untouched', () => {
+    expect(expandHomePath('/abs/path')).toBe('/abs/path');
+    expect(expandHomePath('relative/path')).toBe('relative/path');
+  });
+});
+
+describe('expandConfiguredEnv', () => {
+  it('expands tilde paths in each string value', () => {
+    const out = expandConfiguredEnv({
+      CLAUDE_CONFIG_DIR: '~/.claude',
+      OTHER: '/etc/x',
+    });
+    expect(out.CLAUDE_CONFIG_DIR).toBe(path.join(homedir(), '.claude'));
+    expect(out.OTHER).toBe('/etc/x');
+  });
+
+  it('skips non-string values and returns an empty object for non-object input', () => {
+    const out = expandConfiguredEnv({ A: 'str', B: 42, C: null });
+    expect(out).toEqual({ A: 'str' });
+    expect(expandConfiguredEnv(null)).toEqual({});
+    expect(expandConfiguredEnv(undefined)).toEqual({});
+    expect(expandConfiguredEnv('not-an-object' as never)).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for three daemon modules that previously had no direct coverage:
- `src/runtimes/models.ts` + `src/runtimes/paths.ts`: `isKnownModel` live-cache vs static fallback, `rememberLiveModels` idempotency, `sanitizeCustomModel` flag-string rejection, `expandHomePath` (`~`, `~/path`), `expandConfiguredEnv` tilde-expansion of string values.
- `src/registry/versioning.ts`: `parsePluginSpecifier` for bare names / scoped names / semver ranges, `resolveMarketplaceEntryVersion` highest-match selection with yanked-entry filtering.
- `src/inline-assets.ts`: `inlineRelativeAssets` top-level `<link rel=stylesheet>` and `<script src>` inlining, byte-cap (`owner`/`candidates`/`total` surfaces) throwing `InlineAssetsLimitError`, absolute-URL skip, missing-file behavior — complements existing `export-inline-route.test.ts` with FS-backed reader fixtures.

Tests-only — no source changes.

## What users will see
Nothing — internal test coverage only.

## Surface area
- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — tests only.

## Validation
- 46 tests passing locally across the three files.
