### PR TITLE
fix(daemon): isolate per-agent detection failures so one bad probe cannot blank the picker (#2297)

### DIFF
--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -220,11 +220,29 @@ function stripFns(
   return rest;
 }
 
+async function safeProbe(
+  def: RuntimeAgentDef,
+  configuredEnv: Record<string, string> = {},
+): Promise<DetectedAgent> {
+  try {
+    return await probe(def, configuredEnv);
+  } catch {
+    // Fault isolation (issue #2297): one adapter's probe blowing up
+    // — e.g. a synchronous filesystem throw during PATH walking on a
+    // packaged Windows daemon, or an async rejection from one of the
+    // post-launch probes — must not collapse the whole agent picker.
+    // Without this guard the bare `Promise.all` rejected and the
+    // `/api/agents` catch arm returned `[]`, so the UI silently lost
+    // every CLI option and fell back to BYOK / Cloud only.
+    return unavailableAgent(def);
+  }
+}
+
 export async function detectAgents(
   configuredEnvByAgent: Record<string, Record<string, string>> = {},
 ) {
   const results = await Promise.all(
-    AGENT_DEFS.map((def) => probe(def, configuredEnvByAgent?.[def.id] ?? {})),
+    AGENT_DEFS.map((def) => safeProbe(def, configuredEnvByAgent?.[def.id] ?? {})),
   );
   // Refresh the validation cache from whatever we just surfaced to the UI
   // so /api/chat can accept any model the user could have just picked,

--- a/apps/daemon/tests/runtimes/detection-resilience.test.ts
+++ b/apps/daemon/tests/runtimes/detection-resilience.test.ts
@@ -1,0 +1,91 @@
+// Regression coverage for issue #2297: when a single agent's launch
+// resolution throws (e.g. a transient filesystem error during PATH
+// walking on Windows packaged builds), `detectAgents()` used to reject
+// the whole `Promise.all` and the `/api/agents` route caught it back to
+// an empty array. The UI then showed only the cloud/BYOK fallback even
+// though every other CLI was healthy. These tests pin the per-probe
+// isolation invariant: one broken adapter must not blank the picker.
+import { afterEach, expect, test, vi } from 'vitest';
+
+vi.mock('../../src/runtimes/launch.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/runtimes/launch.js')>();
+  return {
+    ...actual,
+    resolveAgentLaunch: vi.fn(actual.resolveAgentLaunch),
+    applyAgentLaunchEnv: vi.fn(actual.applyAgentLaunchEnv),
+  };
+});
+
+import * as launchModule from '../../src/runtimes/launch.js';
+import { detectAgents } from '../../src/runtimes/detection.js';
+import { AGENT_DEFS } from '../../src/runtimes/registry.js';
+
+const mockedResolveAgentLaunch = vi.mocked(launchModule.resolveAgentLaunch);
+const mockedApplyAgentLaunchEnv = vi.mocked(launchModule.applyAgentLaunchEnv);
+const originalResolveImpl = mockedResolveAgentLaunch.getMockImplementation()!;
+const originalApplyImpl = mockedApplyAgentLaunchEnv.getMockImplementation()!;
+
+afterEach(() => {
+  mockedResolveAgentLaunch.mockImplementation(originalResolveImpl);
+  mockedApplyAgentLaunchEnv.mockImplementation(originalApplyImpl);
+});
+
+test('detectAgents isolates a single agent probe throw so the picker still lists every adapter', async () => {
+  // Simulate the failure shape that issue #2297 attributes to packaged
+  // Windows daemons: one adapter's launch resolution throws because the
+  // FS walk hits a permission error, a malformed PATH entry, or a
+  // broken symlink (`accessSync`/`readdirSync` can surface either as a
+  // throw). Before the per-probe guard the whole `Promise.all`
+  // rejected; the `/api/agents` route's `catch(() => [])` then handed
+  // the UI an empty list and the model picker collapsed to Cloud only.
+  mockedResolveAgentLaunch.mockImplementation((def, env) => {
+    if (def.id === 'claude') {
+      throw new Error('synthetic FS throw during PATH walk');
+    }
+    return originalResolveImpl(def, env);
+  });
+
+  const agents = await detectAgents();
+
+  // Every adapter from the registry must still appear, including the
+  // one whose probe blew up — it just gets surfaced as unavailable so
+  // the rest of the picker (and the BYOK fallback row) stays intact.
+  expect(agents.length).toBe(AGENT_DEFS.length);
+  const claude = agents.find((a) => a.id === 'claude');
+  expect(claude, 'broken adapter must still appear in the detection result').toBeDefined();
+  expect(claude?.available).toBe(false);
+  // And the other adapters must keep whatever availability the real
+  // probe would have returned — none of them get blanket-marked
+  // unavailable just because claude's slot threw.
+  expect(agents.filter((a) => a.id !== 'claude').length).toBe(AGENT_DEFS.length - 1);
+});
+
+test('detectAgents isolates a probe throw from applyAgentLaunchEnv just like resolveAgentLaunch', async () => {
+  // The same per-probe guard has to cover both synchronous sites in
+  // `probe()` that sit outside the existing inner try/catch blocks:
+  // `resolveAgentLaunch` (above) and `applyAgentLaunchEnv` (here). A
+  // single test for each anchors the invariant against future code
+  // that adds a third pre-try synchronous call.
+  let thrown = false;
+  mockedApplyAgentLaunchEnv.mockImplementation((env, launch, nodeBinDir) => {
+    // We cannot tell which agent this env belongs to from arguments
+    // alone, so throw on the first call and pass through afterwards.
+    // detectAgents runs probes in parallel via Promise.all so the
+    // "first" call is non-deterministic but for fault-isolation that
+    // does not matter — any single throw blanking the whole list is
+    // the bug.
+    if (!thrown) {
+      thrown = true;
+      throw new Error('synthetic env construction error');
+    }
+    return originalApplyImpl(env, launch, nodeBinDir);
+  });
+
+  const agents = await detectAgents();
+
+  expect(agents.length).toBe(AGENT_DEFS.length);
+  // At least one adapter is marked unavailable because of the throw;
+  // every other adapter keeps its real availability.
+  const unavailableFromThrow = agents.filter((a) => a.available === false);
+  expect(unavailableFromThrow.length).toBeGreaterThanOrEqual(1);
+});


### PR DESCRIPTION
Fixes #2297

## Why

I'm building on top of Open Design's daemon and noticed `apps/daemon/src/runtimes/detection.ts` runs every adapter probe in a bare `Promise.all`. That made the agent list a single-fault domain: any one probe throwing synchronously — or any one of the post-launch awaited helpers rejecting unhandled — rejected the whole batch, the `/api/agents` route's `catch(() => [])` then handed the UI an empty list, and the model picker collapsed to the BYOK / Cloud fallback row only. That collapse matches what @USFHunTer reported in #2297 on packaged Windows: the first launch lists every installed CLI, but after one or two app restarts the picker shows only "cloud" and the other CLIs disappear, even though the same tools are still on PATH.

The pain being addressed is the user-facing p1 from #2297: a user with healthy CLI installs (Claude Code, Codex, Cursor Agent, OpenCode, …) is silently downgraded to BYOK-only mode and has no way to recover except a full restart, with no signal in the UI about which adapter actually failed. Inside the codebase the same pattern is also a future-risk shape — any new adapter or any new sync call added to `probe()` outside the existing inner `try/catch` blocks is one throw away from blanking the whole picker.

## What users will see

After this fix:

- If a single adapter's probe blows up for any reason (sync FS throw during PATH walking, unhandled async rejection in a post-launch helper, malformed config in `agentCliEnv` for one adapter), **only that adapter** shows as unavailable in the picker. Every other installed CLI keeps its real availability.
- The BYOK / Cloud fallback row is no longer the only thing rendered when one adapter misbehaves.
- No UI changes; no settings to flip; no new permissions or env vars.

This is a defensive guard, not a Windows-only diagnosis. I cannot reproduce #2297's specific Windows path here on macOS, but the fault-isolation invariant fixes the broadest class of "agent picker silently collapses to Cloud" failures regardless of which sync site actually threw. If a user still hits #2297 after this lands, the daemon log will identify which adapter failed (the existing `catch` in `safeProbe` swallows the throw, so a follow-up could log the error — left out of this PR to keep the change strictly defensive).

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

Note on the "Default behavior change" tick: the response shape of `GET /api/agents` is byte-identical for the happy path. The behavior change is strictly "if one adapter throws, the other adapters survive instead of returning `[]`" — i.e. moving from blanket-failure to single-failure surface. The shared contract (`DetectedAgent[]`) is unchanged.

Surface-area dual-track note: this is a daemon-internal fix that touches a single helper inside `apps/daemon/src/runtimes/detection.ts`. The web UI (`/api/agents`) and the CLI (`od test`, `od chat`, all internal callers) reach `detectAgents()` through the same code path, so there is no new HTTP endpoint, no new `od` subcommand, and no new UI control to add — the behavior change reaches both surfaces by virtue of the shared call site.

## Screenshots

N/A — daemon-internal fault isolation, no UI surface.

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow":

- Test path that reproduces the bug:
  `apps/daemon/tests/runtimes/detection-resilience.test.ts` — two synthetic-failure tests that mock the `launch.js` named exports (`resolveAgentLaunch`, `applyAgentLaunchEnv`) so exactly one adapter's probe throws synchronously. Both tests assert that `detectAgents()` still returns an array of length `AGENT_DEFS.length` and that the broken adapter is marked `available: false` while the rest keep their real availability.
- Did the test go red on `main` and green on this branch? **yes** — confirmed locally: with the source change reverted to `Promise.all((def) => probe(...))`, both synthetic-failure specs fail with `Error: synthetic FS throw during PATH walk` and `Error: synthetic env construction error` (the unhandled probe throw rejects the whole `Promise.all` and `detectAgents()` re-throws); with the `safeProbe` wrapper applied, both pass.

## Validation

- `pnpm guard` — passed (TypeScript-only check, dependency spec check, test layout check, design-system manifests, style policy, all green).
- `pnpm typecheck` — all packages clean (0 errors).
- `pnpm --filter @open-design/daemon test` — 249 of 249 test files pass, 2953 tests passed / 1 skipped / 4 todo. (The previously-flaky `tests/orbit.test.ts > tracks the most recent run per template alongside the global last run` happened to pass on this run; it has been called out as a pre-existing baseline flake in other open PRs and is unrelated to this change.)

## Adjacent issues

Surfacing the swallowed error to the daemon log would help future debugging of #2297-class failures (e.g. `console.warn` inside the `safeProbe` catch with the adapter id and a redacted error message). Intentionally left out of this PR to keep the change minimal and strictly defensive — happy to follow up if maintainers want it.
