### PR TITLE
fix platform corepack pnpm fallback when npm_execpath is missing

### DIFF
--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -195,6 +195,17 @@ function buildCmdShimInvocation(command: string, args: string[], env: NodeJS.Pro
 
 const nodeLoadablePackageManagerExtensions = new Set([".js", ".cjs", ".mjs"]);
 
+function isPnpmUserAgent(value: string | undefined): boolean {
+  return typeof value === "string" && /^pnpm\//i.test(value);
+}
+
+function createCorepackPnpmInvocation(args: string[], env: NodeJS.ProcessEnv): CommandInvocation {
+  if (process.platform === "win32") {
+    return buildCmdShimInvocation("corepack", ["pnpm", ...args], env);
+  }
+  return { args: ["pnpm", ...args], command: "corepack" };
+}
+
 export function createCommandInvocation({ args = [], command, env = process.env }: CommandInvocationRequest): CommandInvocation {
   if (process.platform === "win32" && /\.(bat|cmd)$/i.test(command)) {
     return buildCmdShimInvocation(command, args, env);
@@ -209,6 +220,9 @@ export function createPackageManagerInvocation(args: string[], env: NodeJS.Proce
       return { args: [execPath, ...args], command: process.execPath };
     }
     return createCommandInvocation({ args, command: execPath, env });
+  }
+  if (typeof env.COREPACK_ROOT === "string" && env.COREPACK_ROOT.length > 0 && isPnpmUserAgent(env.npm_config_user_agent)) {
+    return createCorepackPnpmInvocation(args, env);
   }
   if (process.platform === "win32") {
     return buildCmdShimInvocation("pnpm", args, env);

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -309,6 +309,35 @@ describe("createPackageManagerInvocation", () => {
     ]);
   });
 
+  it("re-enters through corepack pnpm on Windows when pnpm exec omits npm_execpath", () => {
+    setPlatform("win32");
+    const invocation = createPackageManagerInvocation(["install"], {
+      COREPACK_ROOT: "C:\\Program Files\\nodejs\\node_modules\\corepack",
+      ComSpec: "cmd.exe",
+      npm_config_user_agent: "pnpm/10.33.2 npm/? node/v24.9.0 win32 x64",
+    } as NodeJS.ProcessEnv);
+    expect(invocation.command).toBe("cmd.exe");
+    expect(invocation.windowsVerbatimArguments).toBe(true);
+    expect(invocation.args).toEqual([
+      "/d",
+      "/s",
+      "/c",
+      '"corepack pnpm install"',
+    ]);
+  });
+
+  it("re-enters through corepack pnpm on POSIX when pnpm exec omits npm_execpath", () => {
+    setPlatform("linux");
+    const invocation = createPackageManagerInvocation(["install"], {
+      COREPACK_ROOT: "/usr/local/lib/node_modules/corepack",
+      npm_config_user_agent: "pnpm/10.33.2 npm/? node/v24.9.0 linux x64",
+    } as NodeJS.ProcessEnv);
+    expect(invocation).toEqual({
+      args: ["pnpm", "install"],
+      command: "corepack",
+    });
+  });
+
   it("returns plain pnpm invocation on POSIX without npm_execpath", () => {
     setPlatform("linux");
     const invocation = createPackageManagerInvocation(["install"], {} as NodeJS.ProcessEnv);


### PR DESCRIPTION
Fixes #2438

## Why

I hit this locally on native Windows PowerShell while starting Open Design from source with the documented Corepack flow.

`corepack pnpm --version` and `corepack pnpm install` worked, but a later `tools-dev` child-process build step still fell back to plain `pnpm` and failed because `pnpm` was not on PATH as a standalone global command.

The issue turned out to be in `createPackageManagerInvocation(...)`: it already respects `npm_execpath` when present, but under a real `corepack pnpm exec ...` / `corepack pnpm tools-dev ...` launch I observed `npm_execpath === null` while Corepack-specific env (`COREPACK_ROOT`) and a pnpm user agent were still present. In that case the old fallback path still spawned bare `pnpm`.

This PR keeps the change narrowly scoped to package-manager invocation so `tools-dev` can re-enter through `corepack pnpm ...` when the process is clearly running under a Corepack-managed pnpm session but `npm_execpath` is missing.

## What users will see

Windows contributors who start Open Design from source via the documented Corepack flow are less likely to hit a later startup failure that says `pnpm` is not recognized.

In practice, if `corepack pnpm ...` is working for the outer command, the daemon/web build path now follows the same package-manager route instead of assuming a separate global `pnpm` command is available on PATH.

## Surface area

- [x] **Default behavior change** — package-manager invocation now prefers `corepack pnpm ...` in a specific fallback case instead of dropping straight to bare `pnpm`
- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **None**

## Screenshots

None.

## Bug fix verification

- Test path that reproduces the bug:
  - `packages/platform/tests/index.test.ts`
- Did the test go red on main and green on this branch?
  - No, I did not run a separate pre-patch checkout just to record a red run.
- Verification I did instead:
  - Reproduced the real failure locally from the `tools-dev` daemon build path on Windows (`'pnpm' is not recognized ...`).
  - Added targeted regression coverage for the missing-`npm_execpath` Corepack fallback path on both Windows and POSIX.
  - Confirmed the targeted `createPackageManagerInvocation` tests pass on this branch.
  - Confirmed under a real `corepack pnpm exec ...` session that the invocation now resolves to:
    - `corepack pnpm --filter @open-design/daemon build`

## Validation

- `corepack pnpm --filter @open-design/platform exec vitest run tests/index.test.ts -t createPackageManagerInvocation`
- `corepack pnpm --filter @open-design/platform typecheck`

Additional notes:
- I also attempted `corepack pnpm --filter @open-design/platform test -- index.test.ts`, but one unrelated existing Windows symlink-permission test failed in `wellKnownUserToolchainBins`.
- I also tried `corepack pnpm typecheck`, but the current root script still shells out to bare `pnpm` and fails on this machine for the same broader class of issue. I did not expand this PR to change root workspace scripts because I wanted to keep the scope limited to the `#2438` `tools-dev` startup path.