### PR TITLE
Fix nightly release smoke identity

### DIFF
--- a/e2e/lib/vitest/packaged-release-version.ts
+++ b/e2e/lib/vitest/packaged-release-version.ts
@@ -1,0 +1,4 @@
+export function releaseAppVersionArgs(releaseVersion: string | null | undefined): string[] {
+  const normalized = releaseVersion?.trim();
+  return normalized == null || normalized.length === 0 ? [] : ["--app-version", normalized];
+}

--- a/e2e/lib/vitest/packaged-win-identity.ts
+++ b/e2e/lib/vitest/packaged-win-identity.ts
@@ -1,5 +1,7 @@
 type ReleaseChannelIdentity = "stable" | "beta" | "nightly" | "preview";
 
+export { releaseAppVersionArgs } from "./packaged-release-version.js";
+
 export type PackagedWinInstallIdentity = {
   displayName: string;
   namespaceToken: string;
@@ -35,11 +37,6 @@ function displayNameForChannel(channel: ReleaseChannelIdentity): string {
   if (channel === "nightly") return "Open Design Nightly";
   if (channel === "preview") return "Open Design Preview";
   return "Open Design";
-}
-
-export function releaseAppVersionArgs(releaseVersion: string | null | undefined): string[] {
-  const normalized = releaseVersion?.trim();
-  return normalized == null || normalized.length === 0 ? [] : ["--app-version", normalized];
 }
 
 export function resolvePackagedWinInstallIdentity(options: {

--- a/e2e/lib/vitest/packaged-win-identity.ts
+++ b/e2e/lib/vitest/packaged-win-identity.ts
@@ -1,0 +1,53 @@
+type ReleaseChannelIdentity = "stable" | "beta" | "nightly" | "preview";
+
+export type PackagedWinInstallIdentity = {
+  displayName: string;
+  namespaceToken: string;
+};
+
+function sanitizeNamespace(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, "-");
+}
+
+function isChannelNamespace(namespace: string, channel: ReleaseChannelIdentity): boolean {
+  return namespace.toLowerCase() === `release-${channel}-win`;
+}
+
+function channelFromVersion(version: string | null | undefined): ReleaseChannelIdentity | null {
+  const normalized = version?.trim();
+  if (normalized == null || normalized.length === 0) return null;
+  if (/(?:^|[-.])beta(?:[-.]|$)/i.test(normalized)) return "beta";
+  if (/(?:^|[-.])preview(?:[-.]|$)/i.test(normalized)) return "preview";
+  if (/(?:^|[-.])nightly(?:[-.]|$)/i.test(normalized)) return "nightly";
+  return null;
+}
+
+function channelFromNamespace(namespace: string): ReleaseChannelIdentity | null {
+  if (namespace === "default" || isChannelNamespace(namespace, "stable")) return "stable";
+  if (isChannelNamespace(namespace, "beta")) return "beta";
+  if (isChannelNamespace(namespace, "nightly")) return "nightly";
+  if (isChannelNamespace(namespace, "preview")) return "preview";
+  return null;
+}
+
+function displayNameForChannel(channel: ReleaseChannelIdentity): string {
+  if (channel === "beta") return "Open Design Beta";
+  if (channel === "nightly") return "Open Design Nightly";
+  if (channel === "preview") return "Open Design Preview";
+  return "Open Design";
+}
+
+export function releaseAppVersionArgs(releaseVersion: string | null | undefined): string[] {
+  const normalized = releaseVersion?.trim();
+  return normalized == null || normalized.length === 0 ? [] : ["--app-version", normalized];
+}
+
+export function resolvePackagedWinInstallIdentity(options: {
+  namespace: string;
+  releaseVersion: string | null | undefined;
+}): PackagedWinInstallIdentity {
+  const namespaceToken = sanitizeNamespace(options.namespace);
+  const channel = channelFromVersion(options.releaseVersion) ?? channelFromNamespace(options.namespace);
+  const displayName = channel == null ? `Open Design ${namespaceToken}` : displayNameForChannel(channel);
+  return { displayName, namespaceToken };
+}

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -10,6 +10,7 @@ import { promisify } from 'node:util';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 import { createPackagedSmokeReport } from '@/vitest/packaged-report';
+import { releaseAppVersionArgs } from '@/vitest/packaged-release-version';
 import { createDesktopHarness, STORAGE_KEY, waitFor } from '../lib/desktop/desktop-test-helpers.ts';
 
 const execFileAsync = promisify(execFile);
@@ -17,6 +18,8 @@ const e2eRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const workspaceRoot = dirname(e2eRoot);
 const toolsPackDir = resolveFromWorkspace(process.env.OD_PACKAGED_E2E_TOOLS_PACK_DIR ?? '.tmp/tools-pack');
 const namespace = process.env.OD_PACKAGED_E2E_NAMESPACE ?? 'release-beta';
+const releaseVersion = process.env.OD_PACKAGED_E2E_RELEASE_VERSION;
+const toolsPackReleaseVersionArgs = releaseAppVersionArgs(releaseVersion);
 const pnpmCommand = process.env.OD_E2E_PNPM_COMMAND ?? 'pnpm';
 const screenshotPath = join(toolsPackDir, 'screenshots', `${namespace}.png`);
 
@@ -1112,6 +1115,7 @@ async function runToolsPackJson<T>(action: string, extraArgs: string[] = []): Pr
     toolsPackDir,
     '--namespace',
     namespace,
+    ...toolsPackReleaseVersionArgs,
     '--json',
     ...extraArgs,
   ];

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -11,6 +11,7 @@ import { promisify } from 'node:util';
 import { describe, expect, test } from 'vitest';
 
 import { createPackagedSmokeReport } from '@/vitest/packaged-report';
+import { releaseAppVersionArgs, resolvePackagedWinInstallIdentity } from '@/vitest/packaged-win-identity';
 
 const execFileAsync = promisify(execFile);
 const e2eRoot = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -21,7 +22,9 @@ const toolsPackBin = join(workspaceRoot, 'tools', 'pack', 'bin', 'tools-pack.mjs
 const toolsServeBin = join(workspaceRoot, 'tools', 'serve', 'bin', 'tools-serve.mjs');
 const maxInstallDurationMs = Number.parseInt(process.env.OD_PACKAGED_E2E_WIN_MAX_INSTALL_MS ?? '120000', 10);
 const verifyReinstallWhileRunning = process.env.OD_PACKAGED_E2E_WIN_VERIFY_REINSTALL !== '0';
-const installIdentity = resolveInstallIdentity(namespace);
+const releaseVersion = process.env.OD_PACKAGED_E2E_RELEASE_VERSION;
+const installIdentity = resolvePackagedWinInstallIdentity({ namespace, releaseVersion });
+const toolsPackReleaseVersionArgs = releaseAppVersionArgs(releaseVersion);
 
 const outputNamespaceRoot = join(toolsPackDir, 'out', 'win', 'namespaces', namespace);
 const runtimeNamespaceRoot = join(toolsPackDir, 'runtime', 'win', 'namespaces', namespace);
@@ -450,6 +453,7 @@ async function runToolsPackJson<T>(action: string, extraArgs: string[] = []): Pr
     toolsPackDir,
     '--namespace',
     namespace,
+    ...toolsPackReleaseVersionArgs,
     '--json',
     ...extraArgs,
   ];
@@ -768,18 +772,6 @@ function defaultWindowsAppDataRoot(appName: string): string {
 
 function resolveFromWorkspace(filePath: string): string {
   return isAbsolute(filePath) ? filePath : resolve(workspaceRoot, filePath);
-}
-
-function resolveInstallIdentity(value: string): { displayName: string; namespaceToken: string } {
-  const namespaceToken = value.replace(/[^A-Za-z0-9._-]+/g, '-');
-  const displayName = /(^|[-_.])beta($|[-_.])/i.test(value)
-    ? 'Open Design Beta'
-    : /(^|[-_.])preview($|[-_.])/i.test(value)
-      ? 'Open Design Preview'
-    : value === 'default'
-      ? 'Open Design'
-      : `Open Design ${namespaceToken}`;
-  return { displayName, namespaceToken };
 }
 
 function delay(ms: number): Promise<void> {

--- a/e2e/tests/packaged-release-version.test.ts
+++ b/e2e/tests/packaged-release-version.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { releaseAppVersionArgs } from "@/vitest/packaged-release-version";
+
+describe("packaged release version tools-pack args", () => {
+  it("passes nightly release versions through to smoke lifecycle actions", () => {
+    expect(releaseAppVersionArgs("0.8.0.nightly.3")).toEqual(["--app-version", "0.8.0.nightly.3"]);
+  });
+
+  it("omits empty release versions for local smoke defaults", () => {
+    expect(releaseAppVersionArgs(undefined)).toEqual([]);
+    expect(releaseAppVersionArgs("   ")).toEqual([]);
+  });
+});

--- a/e2e/tests/packaged-win-identity.test.ts
+++ b/e2e/tests/packaged-win-identity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { releaseAppVersionArgs, resolvePackagedWinInstallIdentity } from "@/vitest/packaged-win-identity";
+
+describe("packaged windows smoke identity", () => {
+  it("lets a nightly release version override the stable release namespace", () => {
+    expect(resolvePackagedWinInstallIdentity({
+      namespace: "release-stable-win",
+      releaseVersion: "0.8.0.nightly.2",
+    })).toEqual({
+      displayName: "Open Design Nightly",
+      namespaceToken: "release-stable-win",
+    });
+    expect(releaseAppVersionArgs("0.8.0.nightly.2")).toEqual(["--app-version", "0.8.0.nightly.2"]);
+  });
+
+  it("keeps stable release namespaces on the canonical display identity", () => {
+    expect(resolvePackagedWinInstallIdentity({
+      namespace: "release-stable-win",
+      releaseVersion: "0.8.0",
+    })).toEqual({
+      displayName: "Open Design",
+      namespaceToken: "release-stable-win",
+    });
+    expect(resolvePackagedWinInstallIdentity({
+      namespace: "default",
+      releaseVersion: undefined,
+    })).toEqual({
+      displayName: "Open Design",
+      namespaceToken: "default",
+    });
+  });
+
+  it("matches first-class preview and beta release identities", () => {
+    expect(resolvePackagedWinInstallIdentity({
+      namespace: "release-stable-win",
+      releaseVersion: "0.8.0-preview.1",
+    }).displayName).toBe("Open Design Preview");
+    expect(resolvePackagedWinInstallIdentity({
+      namespace: "release-beta-win",
+      releaseVersion: undefined,
+    }).displayName).toBe("Open Design Beta");
+  });
+
+  it("keeps ad hoc namespaces isolated from release channel identities", () => {
+    expect(resolvePackagedWinInstallIdentity({
+      namespace: "beta-local-flow",
+      releaseVersion: undefined,
+    })).toEqual({
+      displayName: "Open Design beta-local-flow",
+      namespaceToken: "beta-local-flow",
+    });
+    expect(releaseAppVersionArgs("   ")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

The `release-stable` workflow failed on the Windows packaged smoke for nightly release run https://github.com/nexu-io/open-design/actions/runs/26160481493. The NSIS artifact was built with `0.8.0.nightly.3`, so the installed user-visible identity was `Open Design Nightly`, but the e2e smoke did not pass the release version back into `tools-pack win install/start/...` and its local assertion still derived identity from namespace-only rules.

This PR keeps the Windows smoke harness aligned with the artifact it is validating, so `release-stable-win + X.Y.Z.nightly.N` is checked as `Open Design Nightly` instead of a stable or ad hoc namespace name.

## What users will see

Nothing changes in the product. Release maintainers should see nightly Windows release smoke validate the same `Open Design Nightly` installer identity that NSIS actually installs.

## Surface area

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** - adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** - changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `e2e/tests/packaged-win-identity.test.ts` covers the nightly release-version override; the original red signal was Windows smoke in run 26160481493.
- Did the test go red on `main` and green on this branch? No. The focused helper test is new; the CI smoke failure was already red on `release/v0.8.0`.
- Additional verification: ran a real local Windows NSIS build and release smoke with `release-stable-win` + `0.8.0.nightly.3`, which exercises install/start/updater popup/screenshot/logs/stop/uninstall.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/e2e test tests/packaged-win-identity.test.ts`
- `pnpm --filter @open-design/e2e typecheck`
- `git diff --check`
- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts tests/packaged-win-identity.test.ts`
- `pnpm guard`
- `pnpm typecheck`
- Local Windows NSIS build: `pnpm exec tools-pack win build --dir $env:TEMP\od-pack-win-ci-26160481493 --namespace release-stable-win --portable --app-version 0.8.0.nightly.3 --to nsis --json`
- Local Windows release smoke: `pnpm exec tsx scripts/release-smoke.ts win specs/win.spec.ts` with `OD_PACKAGED_E2E_WIN=1`, `OD_PACKAGED_E2E_NAMESPACE=release-stable-win`, `OD_PACKAGED_E2E_RELEASE_CHANNEL=nightly`, `OD_PACKAGED_E2E_RELEASE_VERSION=0.8.0.nightly.3`
- Cleanup: `pnpm exec tools-pack win cleanup --dir $env:TEMP\od-pack-win-ci-26160481493 --namespace release-stable-win --remove-product-user-data --remove-data --remove-logs --remove-sidecars --json`
