### PR TITLE
test(daemon): cover library-install validators and prompt-template scanner

### DIFF
--- a/apps/daemon/src/library-install.ts
+++ b/apps/daemon/src/library-install.ts
@@ -12,8 +12,8 @@ import { listDesignSystems } from './design-systems/index.js';
 
 /** @typedef {{ source: 'github', url: string } | { source: 'local', path: string }} InstallTarget */
 
-const GITHUB_URL_RE = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/?$/;
-const SAFE_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
+export const GITHUB_URL_RE = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/?$/;
+export const SAFE_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
 
 export function sanitizeRepoName(url) {
   const trimmed = url.replace(/\/+$/, '');

--- a/apps/daemon/src/prompt-templates.ts
+++ b/apps/daemon/src/prompt-templates.ts
@@ -108,6 +108,14 @@ function validateTemplate(raw: unknown, expectedSurface: PromptTemplateSurface, 
     console.warn(`prompt-templates: ${fileName} missing source.repo / license`);
     return null;
   }
+  // The list exposes `id` and readPromptTemplate() resolves `${id}.json`, so an
+  // id that drifts from its filename would advertise a template the detail
+  // endpoint can't open. Reject the mismatch during scan/read.
+  const expectedId = fileName.replace(/\.json$/, '');
+  if (raw.id !== expectedId) {
+    console.warn(`prompt-templates: ${fileName} id=${raw.id} ≠ filename`);
+    return null;
+  }
   const template: PromptTemplate = {
     id: raw.id,
     surface: expectedSurface,

--- a/apps/daemon/tests/library-install.test.ts
+++ b/apps/daemon/tests/library-install.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sanitizeRepoName } from '../src/library-install.js';
-
-const GITHUB_URL_RE = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/?$/;
-const SAFE_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
+import { sanitizeRepoName, GITHUB_URL_RE, SAFE_NAME_RE } from '../src/library-install.js';
 
 describe('sanitizeRepoName', () => {
   it('extracts repo name from a github URL', () => {

--- a/apps/daemon/tests/library-install.test.ts
+++ b/apps/daemon/tests/library-install.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeRepoName } from '../src/library-install.js';
+
+const GITHUB_URL_RE = /^https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/?$/;
+const SAFE_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
+
+describe('sanitizeRepoName', () => {
+  it('extracts repo name from a github URL', () => {
+    expect(sanitizeRepoName('https://github.com/owner/repo')).toBe('repo');
+  });
+
+  it('strips a trailing .git suffix', () => {
+    expect(sanitizeRepoName('https://github.com/owner/repo.git')).toBe('repo');
+  });
+
+  it('tolerates trailing slashes', () => {
+    expect(sanitizeRepoName('https://github.com/owner/repo/')).toBe('repo');
+    expect(sanitizeRepoName('https://github.com/owner/repo///')).toBe('repo');
+  });
+
+  it('keeps hyphens, dots, and underscores', () => {
+    expect(sanitizeRepoName('https://github.com/owner/my-repo.v2_x')).toBe('my-repo.v2_x');
+  });
+
+  it('truncates to 64 characters', () => {
+    const longName = 'a'.repeat(120);
+    expect(sanitizeRepoName(`https://github.com/owner/${longName}`)).toBe('a'.repeat(64));
+  });
+
+  it('rejects names with forbidden characters via a generated fallback', () => {
+    expect(sanitizeRepoName('https://github.com/owner/bad name')).toMatch(/^skill-\d+$/);
+    expect(sanitizeRepoName('https://github.com/owner/bad$name')).toMatch(/^skill-\d+$/);
+  });
+
+  it('treats inner slashes as path separators and takes the last segment', () => {
+    expect(sanitizeRepoName('https://github.com/owner/bad/name')).toBe('name');
+  });
+
+  it('rejects non-ASCII names', () => {
+    expect(sanitizeRepoName('https://github.com/owner/测试')).toMatch(/^skill-\d+$/);
+  });
+});
+
+describe('GITHUB_URL_RE', () => {
+  it('accepts canonical owner/repo URLs', () => {
+    expect(GITHUB_URL_RE.test('https://github.com/owner/repo')).toBe(true);
+    expect(GITHUB_URL_RE.test('https://github.com/owner/repo/')).toBe(true);
+    expect(GITHUB_URL_RE.test('https://github.com/owner/repo.git')).toBe(true);
+    expect(GITHUB_URL_RE.test('https://github.com/my-org_1/my.repo-2')).toBe(true);
+  });
+
+  it('rejects non-https schemes', () => {
+    expect(GITHUB_URL_RE.test('http://github.com/owner/repo')).toBe(false);
+    expect(GITHUB_URL_RE.test('git@github.com:owner/repo.git')).toBe(false);
+  });
+
+  it('rejects non-github hosts', () => {
+    expect(GITHUB_URL_RE.test('https://gitlab.com/owner/repo')).toBe(false);
+    expect(GITHUB_URL_RE.test('https://example.com/owner/repo')).toBe(false);
+  });
+
+  it('rejects deeper paths and malformed inputs', () => {
+    expect(GITHUB_URL_RE.test('https://github.com/owner')).toBe(false);
+    expect(GITHUB_URL_RE.test('https://github.com/owner/repo/tree/main')).toBe(false);
+    expect(GITHUB_URL_RE.test('https://github.com/owner/repo with space')).toBe(false);
+    expect(GITHUB_URL_RE.test('')).toBe(false);
+  });
+});
+
+describe('SAFE_NAME_RE', () => {
+  it('accepts alphanumerics, dot, dash, underscore', () => {
+    expect(SAFE_NAME_RE.test('repo')).toBe(true);
+    expect(SAFE_NAME_RE.test('My-Repo_v2.0')).toBe(true);
+  });
+
+  it('rejects path separators', () => {
+    expect(SAFE_NAME_RE.test('foo/bar')).toBe(false);
+    expect(SAFE_NAME_RE.test('foo\\bar')).toBe(false);
+  });
+
+  it('rejects whitespace and non-ASCII characters', () => {
+    expect(SAFE_NAME_RE.test('foo bar')).toBe(false);
+    expect(SAFE_NAME_RE.test('测试')).toBe(false);
+    expect(SAFE_NAME_RE.test('repo!')).toBe(false);
+  });
+});

--- a/apps/daemon/tests/prompt-templates.test.ts
+++ b/apps/daemon/tests/prompt-templates.test.ts
@@ -1,0 +1,161 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { listPromptTemplates, readPromptTemplate } from '../src/prompt-templates.js';
+
+function makeTemplate(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'sample',
+    surface: 'image',
+    title: 'Sample template',
+    summary: 'A short description',
+    category: 'General',
+    tags: ['demo'],
+    prompt: 'Render a cinematic still life with even rim lighting.',
+    source: { repo: 'example/repo', license: 'MIT' },
+    ...overrides,
+  };
+}
+
+describe('listPromptTemplates', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-prompt-templates-'));
+    await mkdir(path.join(root, 'image'), { recursive: true });
+    await mkdir(path.join(root, 'video'), { recursive: true });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('returns an empty list when the root has no templates', async () => {
+    expect(await listPromptTemplates(root)).toEqual([]);
+  });
+
+  it('returns an empty list when the root directory is missing', async () => {
+    await rm(root, { recursive: true, force: true });
+    expect(await listPromptTemplates(root)).toEqual([]);
+  });
+
+  it('loads valid templates from both surfaces', async () => {
+    await writeFile(
+      path.join(root, 'image', 'still-life.json'),
+      JSON.stringify(makeTemplate({ id: 'still-life', title: 'Still life' })),
+    );
+    await writeFile(
+      path.join(root, 'video', 'pan-shot.json'),
+      JSON.stringify(makeTemplate({ id: 'pan-shot', surface: 'video', title: 'Pan shot' })),
+    );
+    const result = await listPromptTemplates(root);
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.id)).toEqual(['still-life', 'pan-shot']);
+  });
+
+  it('orders image surface before video, then alpha by title', async () => {
+    await writeFile(
+      path.join(root, 'image', 'b.json'),
+      JSON.stringify(makeTemplate({ id: 'b', title: 'Beta' })),
+    );
+    await writeFile(
+      path.join(root, 'image', 'a.json'),
+      JSON.stringify(makeTemplate({ id: 'a', title: 'Alpha' })),
+    );
+    await writeFile(
+      path.join(root, 'video', 'z.json'),
+      JSON.stringify(makeTemplate({ id: 'z', surface: 'video', title: 'Zeta' })),
+    );
+    const result = await listPromptTemplates(root);
+    expect(result.map((t) => t.title)).toEqual(['Alpha', 'Beta', 'Zeta']);
+  });
+
+  it('skips files whose surface does not match the folder', async () => {
+    await writeFile(
+      path.join(root, 'image', 'wrong.json'),
+      JSON.stringify(makeTemplate({ surface: 'video' })),
+    );
+    expect(await listPromptTemplates(root)).toEqual([]);
+  });
+
+  it('skips files missing id, title, prompt, or source', async () => {
+    await writeFile(
+      path.join(root, 'image', 'no-id.json'),
+      JSON.stringify(makeTemplate({ id: '' })),
+    );
+    await writeFile(
+      path.join(root, 'image', 'short-prompt.json'),
+      JSON.stringify(makeTemplate({ id: 'short', prompt: 'too short' })),
+    );
+    await writeFile(
+      path.join(root, 'image', 'no-source.json'),
+      JSON.stringify(makeTemplate({ id: 'no-src', source: undefined })),
+    );
+    expect(await listPromptTemplates(root)).toEqual([]);
+  });
+
+  it('skips malformed JSON without throwing', async () => {
+    await writeFile(path.join(root, 'image', 'bad.json'), '{not json');
+    await writeFile(
+      path.join(root, 'image', 'good.json'),
+      JSON.stringify(makeTemplate({ id: 'good' })),
+    );
+    const result = await listPromptTemplates(root);
+    expect(result.map((t) => t.id)).toEqual(['good']);
+  });
+
+  it('ignores non-json files in the surface directory', async () => {
+    await writeFile(path.join(root, 'image', 'README.md'), '# notes');
+    await writeFile(
+      path.join(root, 'image', 'real.json'),
+      JSON.stringify(makeTemplate({ id: 'real' })),
+    );
+    const result = await listPromptTemplates(root);
+    expect(result.map((t) => t.id)).toEqual(['real']);
+  });
+});
+
+describe('readPromptTemplate', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-prompt-templates-'));
+    await mkdir(path.join(root, 'image'), { recursive: true });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('returns the parsed template when the id exists', async () => {
+    await writeFile(
+      path.join(root, 'image', 'hero.json'),
+      JSON.stringify(makeTemplate({ id: 'hero', title: 'Hero shot' })),
+    );
+    const result = await readPromptTemplate(root, 'image', 'hero');
+    expect(result?.id).toBe('hero');
+    expect(result?.title).toBe('Hero shot');
+  });
+
+  it('returns null for an unknown id', async () => {
+    expect(await readPromptTemplate(root, 'image', 'missing')).toBeNull();
+  });
+
+  it('returns null for an unsupported surface', async () => {
+    expect(await readPromptTemplate(root, 'audio', 'anything')).toBeNull();
+  });
+
+  it('returns null when the JSON parses but fails validation', async () => {
+    await writeFile(
+      path.join(root, 'image', 'bad.json'),
+      JSON.stringify(makeTemplate({ id: 'bad', prompt: 'too short' })),
+    );
+    expect(await readPromptTemplate(root, 'image', 'bad')).toBeNull();
+  });
+});

--- a/apps/daemon/tests/prompt-templates.test.ts
+++ b/apps/daemon/tests/prompt-templates.test.ts
@@ -102,6 +102,19 @@ describe('listPromptTemplates', () => {
     expect(await listPromptTemplates(root)).toEqual([]);
   });
 
+  it('skips a file whose id does not match its filename', async () => {
+    // The list exposes `id` and readPromptTemplate resolves `${id}.json`; if a
+    // file's id drifts from its filename the gallery would advertise a template
+    // the detail endpoint immediately 404s. Both paths must reject it.
+    await writeFile(
+      path.join(root, 'image', 'real-name.json'),
+      JSON.stringify(makeTemplate({ id: 'different-id' })),
+    );
+    expect(await listPromptTemplates(root)).toEqual([]);
+    expect(await readPromptTemplate(root, 'image', 'different-id')).toBeNull();
+    expect(await readPromptTemplate(root, 'image', 'real-name')).toBeNull();
+  });
+
   it('skips malformed JSON without throwing', async () => {
     await writeFile(path.join(root, 'image', 'bad.json'), '{not json');
     await writeFile(

--- a/apps/daemon/tests/prompt-templates.test.ts
+++ b/apps/daemon/tests/prompt-templates.test.ts
@@ -95,6 +95,10 @@ describe('listPromptTemplates', () => {
       path.join(root, 'image', 'no-source.json'),
       JSON.stringify(makeTemplate({ id: 'no-src', source: undefined })),
     );
+    await writeFile(
+      path.join(root, 'image', 'no-title.json'),
+      JSON.stringify(makeTemplate({ id: 'no-title', title: '' })),
+    );
     expect(await listPromptTemplates(root)).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
Adds unit tests for two daemon modules, and fixes a prompt-template id/filename drift bug surfaced while adding that coverage.

Test coverage:
- `src/library-install.ts`: `sanitizeRepoName` accepting GitHub-style slugs / rejecting path-traversal and non-ASCII; `GITHUB_URL_RE` matching `https://github.com/owner/repo[.git]` and rejecting malformed URLs; `SAFE_NAME_RE` boundary cases. (`installFromTarget` does network/FS IO and is out of unit-test scope.)
- `src/prompt-templates.ts`: `listPromptTemplates` directory scanning with valid/invalid JSON, missing-field skip, unsupported-surface filtering, and id≠filename rejection; `readPromptTemplate(root, surface, id)` unknown-id, unsupported-surface, and validation-failure paths.

Small source changes (to make the tests meaningful / address review):
- export `GITHUB_URL_RE` / `SAFE_NAME_RE` so the test exercises the module's real validators instead of local copies.
- `validateTemplate` now rejects a template whose `id` differs from its filename (see Bug fix verification).

## Why
Filling untested pure-logic helpers; the prompt-template test surfaced a real list/detail drift, so this fixes it rather than letting the test paper over it (per reviewer feedback).

## What users will see
For the bug fix: a prompt-template file whose JSON `id` doesn't match its filename is no longer shown in the gallery (previously it was listed but the detail view 404'd). Correctly-authored templates (id == filename) are unaffected. Otherwise internal test coverage only.

## Surface area
- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — no new product surface. Behavior note: the scanner now skips prompt-template files whose `id` drifts from their filename (already-broken entries that 404'd on detail); all 104 committed templates already satisfy `id == filename`, so none are affected.

## Bug fix verification
- **Bug:** `listPromptTemplates` surfaced `raw.id` while `readPromptTemplate` resolves `${id}.json`; a file whose id drifted from its filename was advertised by the list but 404'd on detail.
- **Test:** `apps/daemon/tests/prompt-templates.test.ts` → "skips a file whose id does not match its filename" writes `image/real-name.json` with `id: 'different-id'` and asserts it is skipped by `listPromptTemplates` and rejected by `readPromptTemplate` for both the advertised id and the real filename.
- **Red on main, green here?** Yes — without the `validateTemplate` guard the list would include the drifted entry; with it the list is empty and both read paths return null.

## Validation
- `pnpm --filter @open-design/daemon test` covering library-install + prompt-templates (incl. the new id/filename case).
