### PR TITLE
test(web): cover zip encoder, design-system audit, chat-events, mentions, utils

### DIFF
--- a/apps/web/src/runtime/zip.ts
+++ b/apps/web/src/runtime/zip.ts
@@ -54,13 +54,16 @@ export function buildZip(entries: ZipEntry[]): Blob {
     const dataBytes = enc.encode(entry.content);
     const crc = crc32(dataBytes);
     const size = dataBytes.length;
+    // General-purpose bit 11 (0x0800) signals UTF-8 filenames so readers
+    // decode non-ASCII names (e.g. 日本.md) correctly instead of CP437.
+    const flags = nameBytes.some((b) => b > 0x7f) ? 0x0800 : 0;
 
     // Local file header (30 bytes + name).
     const local = new Uint8Array(30 + nameBytes.length);
     const lv = new DataView(local.buffer);
     lv.setUint32(0, 0x04034b50, true); // signature
     lv.setUint16(4, 20, true);          // version needed
-    lv.setUint16(6, 0, true);           // flags
+    lv.setUint16(6, flags, true);       // flags (bit 11 = UTF-8 name)
     lv.setUint16(8, 0, true);           // method: stored
     lv.setUint16(10, now.time, true);   // mod time
     lv.setUint16(12, now.date, true);   // mod date
@@ -78,7 +81,7 @@ export function buildZip(entries: ZipEntry[]): Blob {
     cv.setUint32(0, 0x02014b50, true);  // signature
     cv.setUint16(4, 20, true);           // version made by
     cv.setUint16(6, 20, true);           // version needed
-    cv.setUint16(8, 0, true);            // flags
+    cv.setUint16(8, flags, true);        // flags (bit 11 = UTF-8 name)
     cv.setUint16(10, 0, true);           // method
     cv.setUint16(12, now.time, true);
     cv.setUint16(14, now.date, true);

--- a/apps/web/tests/design-system-auto-prompt.test.ts
+++ b/apps/web/tests/design-system-auto-prompt.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DESIGN_SYSTEM_WORKSPACE_PROMPT_PREFIX,
+  isDesignSystemWorkspacePrompt,
+} from '../src/design-system-auto-prompt';
+
+describe('isDesignSystemWorkspacePrompt', () => {
+  it('detects the sentinel prefix at the very start of the content', () => {
+    expect(isDesignSystemWorkspacePrompt(`${DESIGN_SYSTEM_WORKSPACE_PROMPT_PREFIX} Build a teal palette.`)).toBe(true);
+  });
+
+  it('still detects the prefix when the content has leading whitespace or newlines', () => {
+    expect(isDesignSystemWorkspacePrompt(`\n  ${DESIGN_SYSTEM_WORKSPACE_PROMPT_PREFIX} extra detail`)).toBe(true);
+  });
+
+  it('rejects content that mentions the sentinel mid-string', () => {
+    expect(isDesignSystemWorkspacePrompt(`Hello! ${DESIGN_SYSTEM_WORKSPACE_PROMPT_PREFIX}`)).toBe(false);
+  });
+
+  it('rejects empty and unrelated prompts', () => {
+    expect(isDesignSystemWorkspacePrompt('')).toBe(false);
+    expect(isDesignSystemWorkspacePrompt('Design me a logo.')).toBe(false);
+  });
+});

--- a/apps/web/tests/runtime/chat-events.test.ts
+++ b/apps/web/tests/runtime/chat-events.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendErrorStatusEvent } from '../../src/runtime/chat-events';
+import type { ChatMessage } from '../../src/types';
+
+const base: ChatMessage = { id: 'm1', role: 'assistant', content: '' };
+
+describe('appendErrorStatusEvent', () => {
+  it('returns the message unchanged when detail is empty or whitespace', () => {
+    expect(appendErrorStatusEvent(base, '')).toBe(base);
+    expect(appendErrorStatusEvent(base, '   ')).toBe(base);
+  });
+
+  it('appends a status event with the given detail when there are no prior events', () => {
+    const next = appendErrorStatusEvent(base, 'boom');
+    expect(next).not.toBe(base);
+    expect(next.events).toEqual([{ kind: 'status', label: 'error', detail: 'boom' }]);
+  });
+
+  it('does not duplicate when the last event is an identical error status', () => {
+    const seeded: ChatMessage = {
+      ...base,
+      events: [{ kind: 'status', label: 'error', detail: 'boom' }],
+    };
+    expect(appendErrorStatusEvent(seeded, 'boom')).toBe(seeded);
+  });
+
+  it('appends when the previous error status detail differs', () => {
+    const seeded: ChatMessage = {
+      ...base,
+      events: [{ kind: 'status', label: 'error', detail: 'first' }],
+    };
+    const next = appendErrorStatusEvent(seeded, 'second');
+    expect(next.events).toHaveLength(2);
+    expect(next.events?.[1]).toEqual({ kind: 'status', label: 'error', detail: 'second' });
+  });
+
+  it('preserves non-error events that precede the new one', () => {
+    const seeded: ChatMessage = {
+      ...base,
+      events: [{ kind: 'text', text: 'hi' }, { kind: 'status', label: 'ok' }],
+    };
+    const next = appendErrorStatusEvent(seeded, 'fail');
+    expect(next.events).toEqual([
+      { kind: 'text', text: 'hi' },
+      { kind: 'status', label: 'ok' },
+      { kind: 'status', label: 'error', detail: 'fail' },
+    ]);
+  });
+});

--- a/apps/web/tests/runtime/design-system-package-audit.test.ts
+++ b/apps/web/tests/runtime/design-system-package-audit.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildDesignSystemPackageAuditRepairPrompt,
+  designSystemPackageAuditHasFindings,
+  summarizeDesignSystemPackageAudit,
+} from '../../src/runtime/design-system-package-audit';
+import type {
+  DesignSystemPackageAudit,
+  DesignSystemPackageAuditIssue,
+} from '../../src/types';
+
+function audit(
+  errors: DesignSystemPackageAuditIssue[] = [],
+  warnings: DesignSystemPackageAuditIssue[] = [],
+  filesInspected = 12,
+): DesignSystemPackageAudit {
+  return { ok: errors.length === 0, projectPath: '/tmp/p', filesInspected, errors, warnings };
+}
+
+const issue = (
+  code: string,
+  severity: 'error' | 'warning' = 'error',
+  path?: string,
+): DesignSystemPackageAuditIssue => ({ severity, code, message: `${code} detail`, path });
+
+describe('summarizeDesignSystemPackageAudit', () => {
+  it('reports inspected file count using singular/plural label when there are no findings', () => {
+    expect(summarizeDesignSystemPackageAudit(audit([], [], 1))).toBe(
+      'Package audit passed (1 file inspected).',
+    );
+    expect(summarizeDesignSystemPackageAudit(audit([], [], 3))).toBe(
+      'Package audit passed (3 files inspected).',
+    );
+  });
+
+  it('lists up to five findings and appends a +N more tail', () => {
+    const errs = Array.from({ length: 7 }, (_, i) => issue(`code_${i}`));
+    const text = summarizeDesignSystemPackageAudit(audit(errs));
+    expect(text).toContain('7 errors');
+    expect(text).toContain('code_0');
+    expect(text).toContain('code_4');
+    expect(text).toContain('+2 more');
+  });
+
+  it('joins error and warning counts with "and" and includes path tags when present', () => {
+    const text = summarizeDesignSystemPackageAudit(
+      audit([issue('missing_skill_frontmatter', 'error', 'SKILL.md')], [issue('readme_thin', 'warning')]),
+    );
+    expect(text).toContain('1 error and 1 warning');
+    expect(text).toContain('missing_skill_frontmatter (SKILL.md)');
+    expect(text).toContain('readme_thin');
+  });
+});
+
+describe('buildDesignSystemPackageAuditRepairPrompt', () => {
+  it('returns null when the audit has no findings', () => {
+    expect(buildDesignSystemPackageAuditRepairPrompt(audit())).toBeNull();
+  });
+
+  it('emits a targeted UI-kit repair action when ui_kit codes appear', () => {
+    const prompt = buildDesignSystemPackageAuditRepairPrompt(
+      audit([issue('ui_kit_index_missing_runtime_bootstrap')]),
+    );
+    expect(prompt).not.toBeNull();
+    expect(prompt!).toContain('Targeted repair actions:');
+    expect(prompt!).toContain('ui_kits/app/index.html');
+  });
+
+  it('truncates the findings list at 16 entries with a more-N suffix', () => {
+    const errs = Array.from({ length: 20 }, (_, i) => issue(`c_${i}`));
+    const prompt = buildDesignSystemPackageAuditRepairPrompt(audit(errs))!;
+    expect(prompt).toContain('...and 4 more audit finding(s).');
+  });
+});
+
+describe('designSystemPackageAuditHasFindings', () => {
+  it('returns true when there are errors or warnings, false otherwise', () => {
+    expect(designSystemPackageAuditHasFindings(audit())).toBe(false);
+    expect(designSystemPackageAuditHasFindings(audit([issue('x')]))).toBe(true);
+    expect(designSystemPackageAuditHasFindings(audit([], [issue('y', 'warning')]))).toBe(true);
+  });
+});

--- a/apps/web/tests/runtime/zip.test.ts
+++ b/apps/web/tests/runtime/zip.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildZip } from '../../src/runtime/zip';
+
+const LOCAL_SIG = 0x04034b50;
+const CENTRAL_SIG = 0x02014b50;
+const EOCD_SIG = 0x06054b50;
+
+function crc32(bytes: Uint8Array): number {
+  const table: number[] = new Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  let c = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) {
+    c = table[(c ^ bytes[i]!) & 0xff]! ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+async function readBytes(blob: Blob): Promise<Uint8Array> {
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
+function findEocd(bytes: Uint8Array): number {
+  for (let i = bytes.length - 22; i >= 0; i--) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset + i, 4);
+    if (view.getUint32(0, true) === EOCD_SIG) return i;
+  }
+  return -1;
+}
+
+describe('buildZip', () => {
+  it('produces a stored-mode archive whose CRC matches the entry bytes', async () => {
+    const content = 'hello world';
+    const blob = await readBytes(buildZip([{ path: 'a.txt', content }]));
+    const view = new DataView(blob.buffer, blob.byteOffset, blob.byteLength);
+    expect(view.getUint32(0, true)).toBe(LOCAL_SIG);
+    expect(view.getUint16(8, true)).toBe(0);
+    const expectedCrc = crc32(new TextEncoder().encode(content));
+    expect(view.getUint32(14, true)).toBe(expectedCrc);
+    const size = new TextEncoder().encode(content).length;
+    expect(view.getUint32(18, true)).toBe(size);
+    expect(view.getUint32(22, true)).toBe(size);
+    expect(view.getUint16(26, true)).toBe(5);
+    const nameStart = 30;
+    const name = new TextDecoder().decode(blob.slice(nameStart, nameStart + 5));
+    expect(name).toBe('a.txt');
+    const stored = new TextDecoder().decode(blob.slice(nameStart + 5, nameStart + 5 + size));
+    expect(stored).toBe(content);
+  });
+
+  it('writes one central directory entry per file and points EOCD at it', async () => {
+    const bytes = await readBytes(
+      buildZip([
+        { path: 'one.txt', content: 'one' },
+        { path: 'two.md', content: 'two two' },
+      ]),
+    );
+    const eocdOffset = findEocd(bytes);
+    expect(eocdOffset).toBeGreaterThan(0);
+    const eocd = new DataView(bytes.buffer, bytes.byteOffset + eocdOffset, 22);
+    expect(eocd.getUint32(0, true)).toBe(EOCD_SIG);
+    expect(eocd.getUint16(8, true)).toBe(2);
+    expect(eocd.getUint16(10, true)).toBe(2);
+    const centralSize = eocd.getUint32(12, true);
+    const centralOffset = eocd.getUint32(16, true);
+    expect(centralOffset + centralSize).toBe(eocdOffset);
+    const firstCentral = new DataView(bytes.buffer, bytes.byteOffset + centralOffset, 4);
+    expect(firstCentral.getUint32(0, true)).toBe(CENTRAL_SIG);
+  });
+
+  it('encodes non-ASCII file names as UTF-8 in the local and central headers', async () => {
+    const bytes = await readBytes(buildZip([{ path: '日本.md', content: 'x' }]));
+    const localView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const nameLen = localView.getUint16(26, true);
+    const expectedName = new TextEncoder().encode('日本.md');
+    expect(nameLen).toBe(expectedName.length);
+    const nameBytes = bytes.slice(30, 30 + nameLen);
+    expect(Array.from(nameBytes)).toEqual(Array.from(expectedName));
+  });
+
+  it('emits an empty-but-valid archive when given no entries', async () => {
+    const bytes = await readBytes(buildZip([]));
+    expect(bytes.length).toBe(22);
+    const view = new DataView(bytes.buffer, bytes.byteOffset, 22);
+    expect(view.getUint32(0, true)).toBe(EOCD_SIG);
+    expect(view.getUint16(8, true)).toBe(0);
+    expect(view.getUint16(10, true)).toBe(0);
+    expect(view.getUint32(12, true)).toBe(0);
+    expect(view.getUint32(16, true)).toBe(0);
+  });
+});

--- a/apps/web/tests/runtime/zip.test.ts
+++ b/apps/web/tests/runtime/zip.test.ts
@@ -74,14 +74,47 @@ describe('buildZip', () => {
     expect(firstCentral.getUint32(0, true)).toBe(CENTRAL_SIG);
   });
 
-  it('encodes non-ASCII file names as UTF-8 in the local and central headers', async () => {
+  it('flags non-ASCII file names as UTF-8 (bit 11) in the local and central headers', async () => {
     const bytes = await readBytes(buildZip([{ path: '日本.md', content: 'x' }]));
-    const localView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-    const nameLen = localView.getUint16(26, true);
     const expectedName = new TextEncoder().encode('日本.md');
-    expect(nameLen).toBe(expectedName.length);
-    const nameBytes = bytes.slice(30, 30 + nameLen);
-    expect(Array.from(nameBytes)).toEqual(Array.from(expectedName));
+
+    // Local header: UTF-8 flag (bit 11) set + filename bytes match.
+    const localView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    expect(localView.getUint32(0, true)).toBe(LOCAL_SIG);
+    expect(localView.getUint16(6, true) & 0x0800).toBe(0x0800);
+    const localNameLen = localView.getUint16(26, true);
+    expect(localNameLen).toBe(expectedName.length);
+    expect(Array.from(bytes.slice(30, 30 + localNameLen))).toEqual(Array.from(expectedName));
+
+    // Central header: locate via EOCD, assert UTF-8 flag + filename bytes too.
+    const eocdOffset = findEocd(bytes);
+    expect(eocdOffset).toBeGreaterThan(0);
+    const eocd = new DataView(bytes.buffer, bytes.byteOffset + eocdOffset, 22);
+    const centralOffset = eocd.getUint32(16, true);
+    const centralView = new DataView(
+      bytes.buffer,
+      bytes.byteOffset + centralOffset,
+      bytes.byteLength - centralOffset,
+    );
+    expect(centralView.getUint32(0, true)).toBe(CENTRAL_SIG);
+    expect(centralView.getUint16(8, true) & 0x0800).toBe(0x0800);
+    const centralNameLen = centralView.getUint16(28, true);
+    expect(centralNameLen).toBe(expectedName.length);
+    const centralNameStart = centralOffset + 46;
+    expect(Array.from(bytes.slice(centralNameStart, centralNameStart + centralNameLen))).toEqual(
+      Array.from(expectedName),
+    );
+  });
+
+  it('does not set the UTF-8 flag for pure-ASCII file names', async () => {
+    const bytes = await readBytes(buildZip([{ path: 'a.txt', content: 'x' }]));
+    const localView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    expect(localView.getUint16(6, true) & 0x0800).toBe(0);
+    const eocdOffset = findEocd(bytes);
+    const eocd = new DataView(bytes.buffer, bytes.byteOffset + eocdOffset, 22);
+    const centralOffset = eocd.getUint32(16, true);
+    const centralView = new DataView(bytes.buffer, bytes.byteOffset + centralOffset, 12);
+    expect(centralView.getUint16(8, true) & 0x0800).toBe(0);
   });
 
   it('emits an empty-but-valid archive when given no entries', async () => {

--- a/apps/web/tests/utils/agentLabels.test.ts
+++ b/apps/web/tests/utils/agentLabels.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  agentDisplayName,
+  agentModelDisplayName,
+  exactAgentDisplayName,
+} from '../../src/utils/agentLabels';
+
+describe('agentDisplayName', () => {
+  it('returns the canonical label for known agent ids', () => {
+    expect(agentDisplayName('claude')).toBe('Claude');
+    expect(agentDisplayName('codex')).toBe('Codex');
+    expect(agentDisplayName('cursor-agent')).toBe('Cursor');
+  });
+
+  it('resolves common aliases like "claude code" and "qodercli"', () => {
+    expect(agentDisplayName('Claude Code')).toBe('Claude');
+    expect(agentDisplayName('qodercli')).toBe('Qoder');
+  });
+
+  it('matches embedded substrings such as cursor-agent in a longer path', () => {
+    expect(agentDisplayName('/opt/bin/cursor-agent')).toBe('Cursor');
+  });
+
+  it('falls back to a trimmed name when the id is unknown but the fallback is safe', () => {
+    expect(agentDisplayName('unknown-id', '  My Bot  ')).toBe('My Bot');
+  });
+
+  it('rejects path-like id and fallback so unknown filesystem hints do not leak', () => {
+    expect(agentDisplayName('/opt/unknown/runner', 'C:\\Tools\\runner.exe')).toBeNull();
+  });
+
+  it('returns null when both id and fallback are missing', () => {
+    expect(agentDisplayName(undefined, null)).toBeNull();
+  });
+});
+
+describe('exactAgentDisplayName', () => {
+  it('returns the label only when the exact normalized key is a known agent', () => {
+    expect(exactAgentDisplayName('Qoder CLI')).toBe('Qoder');
+    expect(exactAgentDisplayName('qodercli.cmd')).toBe('Qoder');
+    expect(exactAgentDisplayName('cursor-agent-fork')).toBeNull();
+  });
+
+  it('returns null for empty or nullish input', () => {
+    expect(exactAgentDisplayName(null)).toBeNull();
+    expect(exactAgentDisplayName('')).toBeNull();
+  });
+});
+
+describe('agentModelDisplayName', () => {
+  it('omits the model when it is undefined or the literal "default"', () => {
+    expect(agentModelDisplayName('claude', 'Claude Code', undefined)).toBe('Claude');
+    expect(agentModelDisplayName('claude', 'Claude Code', 'default')).toBe('Claude');
+  });
+
+  it('joins the agent label and model with a middle dot', () => {
+    expect(agentModelDisplayName('codex', null, 'gpt-5.4')).toBe('Codex · gpt-5.4');
+  });
+
+  it('returns just the model id when no agent label can be derived', () => {
+    expect(agentModelDisplayName(null, null, 'sonnet-4-6')).toBe('sonnet-4-6');
+  });
+});

--- a/apps/web/tests/utils/pickAndImportError.test.ts
+++ b/apps/web/tests/utils/pickAndImportError.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatPickAndImportErrorDetails } from '../../src/utils/pickAndImportError';
+
+describe('formatPickAndImportErrorDetails', () => {
+  it('returns a non-empty string input unchanged', () => {
+    expect(formatPickAndImportErrorDetails('disk full')).toBe('disk full');
+  });
+
+  it('returns undefined for empty string, null, or unsupported scalar input', () => {
+    expect(formatPickAndImportErrorDetails('')).toBeUndefined();
+    expect(formatPickAndImportErrorDetails(null)).toBeUndefined();
+    expect(formatPickAndImportErrorDetails(42)).toBeUndefined();
+  });
+
+  it('surfaces error.message from a structured envelope', () => {
+    expect(
+      formatPickAndImportErrorDetails({ error: { message: 'permission denied' } }),
+    ).toBe('permission denied');
+  });
+
+  it('appends nested reason in parentheses when both message and reason are present', () => {
+    expect(
+      formatPickAndImportErrorDetails({
+        error: { message: 'open folder failed', details: { reason: 'not a directory' } },
+      }),
+    ).toBe('open folder failed (not a directory)');
+  });
+
+  it('returns undefined when the envelope has no usable message', () => {
+    expect(formatPickAndImportErrorDetails({ error: {} })).toBeUndefined();
+    expect(formatPickAndImportErrorDetails({ unrelated: true })).toBeUndefined();
+    expect(formatPickAndImportErrorDetails({ error: { message: '' } })).toBeUndefined();
+  });
+});

--- a/apps/web/tests/utils/promptTemplateDsCategories.test.ts
+++ b/apps/web/tests/utils/promptTemplateDsCategories.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { inferPromptTemplateCategoriesForDs } from '../../src/utils/promptTemplateDsCategories';
+import type { DesignSystemSummary } from '../../src/types';
+
+const ds = (partial: Partial<DesignSystemSummary> = {}): DesignSystemSummary => ({
+  id: 'ds1',
+  title: '',
+  category: '',
+  summary: '',
+  ...partial,
+});
+
+describe('inferPromptTemplateCategoriesForDs', () => {
+  it('returns null when no keyword in title/category/summary matches', () => {
+    expect(inferPromptTemplateCategoriesForDs(ds({ title: 'plain', category: 'misc', summary: 'nothing here' }))).toBeNull();
+  });
+
+  it('maps anime/illustration keywords to the illustration bucket', () => {
+    const cats = inferPromptTemplateCategoriesForDs(ds({ category: 'Anime', title: 'Slice of life' }));
+    expect(cats).toEqual(expect.arrayContaining(['Anime', 'Illustration', 'Profile / Avatar']));
+  });
+
+  it('maps gaming/UI keywords to Game UI and App/Web Design', () => {
+    expect(
+      inferPromptTemplateCategoriesForDs(ds({ summary: 'cozy game UI inspired by retro consoles' })),
+    ).toEqual(expect.arrayContaining(['Game UI', 'App / Web Design']));
+  });
+
+  it('maps fintech keywords to data and branding categories', () => {
+    const cats = inferPromptTemplateCategoriesForDs(ds({ title: 'Crypto', summary: 'payment dashboards' }));
+    expect(cats).toEqual(expect.arrayContaining(['App / Web Design', 'Data', 'Marketing', 'Branding']));
+  });
+
+  it('deduplicates overlapping buckets when multiple rules fire', () => {
+    const cats = inferPromptTemplateCategoriesForDs(
+      ds({ category: 'product', title: 'automotive', summary: 'cinematic brand work' }),
+    )!;
+    expect(new Set(cats).size).toBe(cats.length);
+    expect(cats).toEqual(expect.arrayContaining(['Product', 'Cinematic', 'Branding']));
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests across the `apps/web` pure-logic surface that was previously uncovered, **and fixes a ZIP UTF-8 filename bug** that the new ZIP test surfaced.

Test coverage:
- `src/runtime/zip.ts`: stored-mode ZIP encoder — single / multi entry archives, CRC-32 correctness on known bytes, central-directory shape, **UTF-8 filename flag in both headers** (see fix below).
- `src/runtime/design-system-package-audit.ts`: `summarize*` / `buildRepairPrompt` wrappers.
- `src/runtime/chat-events.ts`: `appendErrorStatusEvent` dedup, non-error preservation, blank-detail handling.
- `src/utils/agentLabels.ts`: alias resolution, embedded-substring match, path-like fallback rejection, default-model omission.
- `src/utils/pickAndImportError.ts`: `formatPickAndImportErrorDetails` for string / object / null envelopes.
- `src/utils/promptTemplateDsCategories.ts`: `inferPromptTemplateCategoriesForDs` regex branches.
- `src/design-system-auto-prompt.ts`: `isDesignSystemWorkspacePrompt` sentinel detection.

(The `inlineMentions` test was dropped on rebase — `main` already covers it.)

## Why
Filling untested pure-logic helpers in `apps/web`. Writing the ZIP test exposed a real encoder bug, so this PR also fixes it rather than letting the test paper over it (per reviewer feedback).

## What users will see
For the bug fix: ZIP files exported via "Download as ZIP" that contain **non-ASCII filenames** (e.g. `日本.md`) now carry the UTF-8 flag, so unzip tools show the correct names instead of mojibake. Pure-ASCII archives are byte-identical to before. Otherwise internal test coverage only.

## Surface area
- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — no new product surface. Behavior note: `buildZip` output changes **only** for entries whose filename has non-ASCII bytes (sets general-purpose bit 11 / EFS); pure-ASCII archives are unchanged.

## Bug fix verification
- **Bug:** `buildZip` wrote UTF-8 filename bytes but left the general-purpose flag word at `0` in both the local and central headers, so readers fall back to CP437 and mis-decode non-ASCII names.
- **Test path:** `apps/web/tests/runtime/zip.test.ts` — the UTF-8 case now asserts the filename **and** bit 11 (`0x0800`) in both local (offset 6) and central (offset 8) flag fields, parsing the central directory via EOCD; a new case asserts pure-ASCII names do **not** set the flag.
- **Red on `main`, green on this branch?** Yes — the strengthened assertions fail against the old `flags = 0` encoder and pass after the fix. Verified at the byte level against PKWARE APPNOTE offsets.

## Validation
- Byte-level verification of `buildZip` output (local+central bit-11 set for `日本.md`, cleared for `a.txt`, filename bytes match in both headers).
- `actionlint` / type resolution N/A (no workflow change); per-file unit tests cover the modules listed above.
