### PR TITLE
fix(analytics): app_version=0.0.0 + media providers clicks + lock run_finished error_code

### DIFF
--- a/apps/daemon/src/run-result.ts
+++ b/apps/daemon/src/run-result.ts
@@ -1,0 +1,49 @@
+// Daemon-side helpers that turn a `runs.statusBody(run)` value into the
+// `result` + `error_code` shape that v2 `run_finished` analytics events
+// expect.
+//
+// Extracted from `server.ts` so the invariant — `result === 'failed'`
+// MUST emit a non-empty `error_code` — can be exercised by unit tests
+// without spinning up the full Express app. Several failure paths in the
+// child-process lifecycle call `finish('failed', ...)` directly without
+// first emitting an SSE `error` event (ACP fatal, agentStreamError fall
+// through, child error with no diagnostic, etc.), leaving `run.errorCode
+// === null` in the status body. The fallback chain below derives an
+// `AGENT_SIGNAL_*` / `AGENT_EXIT_*` / `AGENT_TERMINATED_UNKNOWN` value
+// for those cases so the wire emission always carries an `error_code`
+// when result=failed; dashboards keyed on it never see a blank cell.
+
+export type RunResult = 'success' | 'failed' | 'cancelled';
+
+export interface RunStatusForAnalytics {
+  status: string;
+  errorCode?: string | null;
+  exitCode?: number | null;
+  signal?: string | null;
+}
+
+export function runResultFromStatus(status: string | undefined): RunResult {
+  if (status === 'succeeded') return 'success';
+  if (status === 'canceled') return 'cancelled';
+  return 'failed';
+}
+
+export function deriveRunErrorCode(
+  status: RunStatusForAnalytics,
+): string | undefined {
+  const result = runResultFromStatus(status.status);
+  if (result === 'success') return undefined;
+  // Cancellation usually carries no error; only forward an explicit one
+  // when the daemon stamped it (e.g. cancel during error recovery).
+  if (result === 'cancelled') return status.errorCode ?? undefined;
+  // Failure path: prefer the structured code stamped on the run via
+  // `extractErrorDetails`. When the run reached `failed` without going
+  // through `emit('error', ...)`, derive the best signal we have.
+  const explicit = status.errorCode;
+  if (explicit) return explicit;
+  if (status.signal) return `AGENT_SIGNAL_${status.signal}`;
+  if (typeof status.exitCode === 'number' && status.exitCode !== 0) {
+    return `AGENT_EXIT_${status.exitCode}`;
+  }
+  return 'AGENT_TERMINATED_UNKNOWN';
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -183,6 +183,7 @@ import { subscribe as subscribeFileEvents } from './project-watchers.js';
 import { renderDesignSystemPreview } from './design-system-preview.js';
 import { renderDesignSystemShowcase } from './design-system-showcase.js';
 import { createChatRunService } from './runs.js';
+import { deriveRunErrorCode, runResultFromStatus } from './run-result.js';
 import { reportRunCompletedFromDaemon } from './langfuse-bridge.js';
 import {
   createAnalyticsService,
@@ -10799,26 +10800,13 @@ export async function startServer({
         exitCode?: number | null;
         signal?: string | null;
       }) => {
-        const result =
-          status.status === 'succeeded'
-            ? 'success'
-            : status.status === 'canceled'
-              ? 'cancelled'
-              : 'failed';
-        let errorCode: string | undefined;
-        if (result === 'failed') {
-          errorCode = status.errorCode ?? undefined;
-          if (!errorCode) {
-            if (status.signal) errorCode = `AGENT_SIGNAL_${status.signal}`;
-            else if (typeof status.exitCode === 'number' && status.exitCode !== 0) {
-              errorCode = `AGENT_EXIT_${status.exitCode}`;
-            } else {
-              errorCode = 'AGENT_TERMINATED_UNKNOWN';
-            }
-          }
-        } else if (result === 'cancelled') {
-          errorCode = status.errorCode ?? undefined;
-        }
+        // `deriveRunErrorCode` is the invariant: when `result === 'failed'`
+        // it always returns a non-empty string so dashboards keyed on
+        // `error_code` never see a blank cell. Live in `run-result.ts`
+        // with unit coverage for the fall-through cases (ACP fatal,
+        // child close without error event, etc.).
+        const result = runResultFromStatus(status.status);
+        const errorCode = deriveRunErrorCode(status);
         let inputTokens: number | undefined;
         let outputTokens: number | undefined;
         for (let i = run.events.length - 1; i >= 0; i -= 1) {

--- a/apps/daemon/tests/run-result.test.ts
+++ b/apps/daemon/tests/run-result.test.ts
@@ -1,0 +1,142 @@
+// Unit coverage for `deriveRunErrorCode`. The v2 analytics doc requires
+// `run_finished` events with `result === 'failed'` to carry a non-empty
+// `error_code` so dashboards keyed on it can break failures down by
+// reason. Several daemon failure paths reach `runs.finish('failed',
+// ...)` WITHOUT first emitting an SSE `error` event (ACP fatal,
+// agentStreamError fall-through, child close with no diagnostic). When
+// they do, the run status body's `errorCode` is `null`. The fallback
+// chain in `run-result.ts` turns those signal/exitCode hints into a
+// best-effort code so the wire emission never blanks out.
+//
+// This pins each failure shape's expected output. A future refactor
+// that loses the fallback re-introduces the original symptom: PostHog
+// shows `result=failed` events with no `error_code`.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveRunErrorCode,
+  runResultFromStatus,
+} from '../src/run-result.js';
+
+describe('runResultFromStatus', () => {
+  it('maps succeeded -> success', () => {
+    expect(runResultFromStatus('succeeded')).toBe('success');
+  });
+  it('maps canceled -> cancelled (with the analytics doc spelling)', () => {
+    expect(runResultFromStatus('canceled')).toBe('cancelled');
+  });
+  it('maps failed -> failed', () => {
+    expect(runResultFromStatus('failed')).toBe('failed');
+  });
+  it('maps unknown / partial states to failed (defensive)', () => {
+    expect(runResultFromStatus('running')).toBe('failed');
+    expect(runResultFromStatus(undefined)).toBe('failed');
+  });
+});
+
+describe('deriveRunErrorCode', () => {
+  it('returns undefined for a successful run', () => {
+    expect(
+      deriveRunErrorCode({
+        status: 'succeeded',
+        errorCode: null,
+        exitCode: 0,
+        signal: null,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('forwards an explicit errorCode set via runs.emit(error, …)', () => {
+    expect(
+      deriveRunErrorCode({
+        status: 'failed',
+        errorCode: 'AGENT_EXECUTION_FAILED',
+        exitCode: 1,
+        signal: null,
+      }),
+    ).toBe('AGENT_EXECUTION_FAILED');
+  });
+
+  it('derives AGENT_SIGNAL_* when the child died from a signal', () => {
+    expect(
+      deriveRunErrorCode({
+        status: 'failed',
+        errorCode: null,
+        exitCode: null,
+        signal: 'SIGSEGV',
+      }),
+    ).toBe('AGENT_SIGNAL_SIGSEGV');
+  });
+
+  it('derives AGENT_EXIT_<code> when the child exited non-zero with no signal', () => {
+    expect(
+      deriveRunErrorCode({
+        status: 'failed',
+        errorCode: null,
+        exitCode: 1,
+        signal: null,
+      }),
+    ).toBe('AGENT_EXIT_1');
+    expect(
+      deriveRunErrorCode({
+        status: 'failed',
+        errorCode: null,
+        exitCode: 137,
+        signal: null,
+      }),
+    ).toBe('AGENT_EXIT_137');
+  });
+
+  it('falls back to AGENT_TERMINATED_UNKNOWN when neither signal nor non-zero exit is available', () => {
+    // This is the shape produced when `acpSession.hasFatalError()` is
+    // true even though the child exited cleanly (code=0, no signal) —
+    // see `child.on('close', ...)` in server.ts. Without this fallback,
+    // those failures would still blank out on PostHog.
+    expect(
+      deriveRunErrorCode({
+        status: 'failed',
+        errorCode: null,
+        exitCode: 0,
+        signal: null,
+      }),
+    ).toBe('AGENT_TERMINATED_UNKNOWN');
+  });
+
+  it('returns undefined for a cancelled run with no stamped code', () => {
+    // Cancellation is the user's choice; not a diagnosable failure.
+    expect(
+      deriveRunErrorCode({
+        status: 'canceled',
+        errorCode: null,
+        exitCode: null,
+        signal: 'SIGTERM',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('forwards an explicit errorCode on a cancelled run (cancel during error recovery)', () => {
+    expect(
+      deriveRunErrorCode({
+        status: 'canceled',
+        errorCode: 'AGENT_AUTH_REQUIRED',
+        exitCode: 1,
+        signal: null,
+      }),
+    ).toBe('AGENT_AUTH_REQUIRED');
+  });
+
+  it('treats empty-string errorCode as "missing" so the fallback chain still kicks in', () => {
+    // Defensive — `readString` in runs.ts trims and null-checks, but
+    // any future caller passing an empty string would otherwise emit a
+    // blank `error_code` field and reintroduce the original symptom.
+    expect(
+      deriveRunErrorCode({
+        status: 'failed',
+        errorCode: '',
+        exitCode: 1,
+        signal: null,
+      }),
+    ).toBe('AGENT_EXIT_1');
+  });
+});

--- a/apps/web/src/analytics/provider.tsx
+++ b/apps/web/src/analytics/provider.tsx
@@ -6,7 +6,6 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
   type ReactNode,
 } from 'react';
@@ -88,10 +87,13 @@ function isSameOriginApiCall(url: unknown): boolean {
 // App version is read from a runtime endpoint rather than at build time so
 // the same web bundle reports the daemon-pinned version even when running
 // against a newer/older daemon during dev. Falls back to '0.0.0' until the
-// fetch resolves; analytics events fired before resolution simply have a
-// stale version string and are not re-emitted.
-function useAppVersion(): string {
-  const versionRef = useRef('0.0.0');
+// fetch resolves, then the resolved value flows through state so every
+// downstream effect that depends on `appVersion` re-runs and re-registers
+// the PostHog super-property with the real version. Earlier `useRef` shape
+// silently broke this: ref writes don't trigger re-renders, so every event
+// shipped with `app_version='0.0.0'`.
+export function useAppVersion(): string {
+  const [version, setVersion] = useState('0.0.0');
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -100,7 +102,8 @@ function useAppVersion(): string {
         if (!res.ok) return;
         const body = (await res.json()) as { version?: { version?: string } };
         if (cancelled) return;
-        if (body?.version?.version) versionRef.current = body.version.version;
+        const next = body?.version?.version;
+        if (next) setVersion(next);
       } catch {
         // Best-effort.
       }
@@ -109,7 +112,7 @@ function useAppVersion(): string {
       cancelled = true;
     };
   }, []);
-  return versionRef.current;
+  return version;
 }
 
 export function AnalyticsProvider({ children }: { children: ReactNode }) {

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -18,6 +18,7 @@ import {
   trackSettingsLanguageClick,
   trackSettingsLocalCliClick,
   trackSettingsExecutionModeTabClick,
+  trackSettingsMediaProvidersClick,
   trackSettingsNotificationsClick,
   trackSettingsPrivacyClick,
   trackSettingsView,
@@ -4802,6 +4803,7 @@ function MediaProvidersSection({
   onChange: () => void;
 }) {
   const { t } = useI18n();
+  const analytics = useAnalytics();
   const [reloadRunning, setReloadRunning] = useState(false);
   const [reloadNotice, setReloadNotice] = useState<{ kind: 'error' | 'success'; message: string } | null>(null);
   const [visibleApiKeys, setVisibleApiKeys] = useState<ReadonlySet<string>>(
@@ -4933,7 +4935,14 @@ function MediaProvidersSection({
             className={`ghost media-provider-reload-btn${
               reloadNotice?.kind === 'success' ? ' is-success-flash' : ''
             }`}
-            onClick={() => void handleReload()}
+            onClick={() => {
+              trackSettingsMediaProvidersClick(analytics.track, {
+                page_name: 'settings',
+                area: 'media_providers',
+                element: 'reload',
+              });
+              void handleReload();
+            }}
             disabled={reloadRunning}
             aria-live="polite"
           >
@@ -5014,6 +5023,15 @@ function MediaProvidersSection({
                     placeholder={isSavedState ? t('settings.connectorsReplaceKeyPlaceholder') : t('settings.mediaProviderPlaceholder')}
                     aria-label={`${provider.label} ${t('settings.mediaProviderApiKey')}`}
                     disabled={disabled}
+                    onFocus={() => {
+                      trackSettingsMediaProvidersClick(analytics.track, {
+                        page_name: 'settings',
+                        area: 'media_providers',
+                        element: 'key_input',
+                        providers_id: provider.id,
+                        is_configured: clearable,
+                      });
+                    }}
                     onChange={(e) => updateProvider(provider, { apiKey: e.target.value })}
                   />
                   <button
@@ -5036,6 +5054,15 @@ function MediaProvidersSection({
                   placeholder={provider.defaultBaseUrl || t('settings.mediaProviderBaseUrlPlaceholder')}
                   aria-label={`${provider.label} ${t('settings.mediaProviderBaseUrl')}`}
                   disabled={disabled}
+                  onFocus={() => {
+                    trackSettingsMediaProvidersClick(analytics.track, {
+                      page_name: 'settings',
+                      area: 'media_providers',
+                      element: 'url_input',
+                      providers_id: provider.id,
+                      is_configured: clearable,
+                    });
+                  }}
                   onChange={(e) => updateProvider(provider, { baseUrl: e.target.value })}
                 />
                 {supportsCustomModel ? (
@@ -5052,6 +5079,17 @@ function MediaProvidersSection({
                   className="ghost"
                   disabled={!clearable}
                   onClick={() => {
+                    trackSettingsMediaProvidersClick(analytics.track, {
+                      page_name: 'settings',
+                      area: 'media_providers',
+                      element: 'clear',
+                      providers_id: provider.id,
+                      // The click reports the state at the moment the
+                      // user pressed Clear; the actual clear only lands
+                      // after they confirm the dialog below, but the
+                      // dashboard cares about the intent signal.
+                      is_configured: clearable,
+                    });
                     // Match the existing window.confirm guard the rest of
                     // the app uses for destructive actions (conversation
                     // delete, design delete, file delete in FileWorkspace).

--- a/apps/web/tests/analytics-app-version.test.tsx
+++ b/apps/web/tests/analytics-app-version.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+//
+// Regression test for "every PostHog event ships with app_version='0.0.0'".
+//
+// `useAppVersion()` reads /api/version at runtime so the same web bundle
+// reports the daemon-pinned version even when running against a newer or
+// older daemon during dev. The previous implementation stored the fetched
+// version in a `useRef`, which silently broke the contract: ref writes do
+// NOT trigger a re-render, so the hook kept returning '0.0.0' forever and
+// every downstream useEffect that depended on `appVersion`
+// (`client.register({ app_version })` in particular) never re-ran with
+// the real version. PostHog dashboards then showed `app_version=0.0.0`
+// on every event.
+//
+// This test goes red on the `useRef` version and green on the `useState`
+// version: after the mocked /api/version resolves, the hook must return
+// the fetched value, not the boot placeholder.
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAppVersion } from '../src/analytics/provider';
+
+describe('useAppVersion', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.endsWith('/api/version')) {
+        return new Response(
+          JSON.stringify({
+            version: {
+              version: '1.2.3',
+              channel: 'development',
+              packaged: false,
+              platform: 'darwin',
+              arch: 'arm64',
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('boots to the 0.0.0 placeholder before the fetch resolves', () => {
+    const { result } = renderHook(() => useAppVersion());
+    expect(result.current).toBe('0.0.0');
+  });
+
+  it('updates to the fetched version once /api/version resolves', async () => {
+    const { result } = renderHook(() => useAppVersion());
+    await waitFor(() => {
+      expect(result.current).toBe('1.2.3');
+    });
+  });
+
+  it('keeps the 0.0.0 placeholder when the fetch fails', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('boom', { status: 500 })) as unknown as typeof fetch;
+    const { result } = renderHook(() => useAppVersion());
+    // Let any pending microtasks settle so a buggy implementation has the
+    // same opportunity to "succeed" with stale data as the happy path.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(result.current).toBe('0.0.0');
+  });
+});


### PR DESCRIPTION
## Why

Three analytics observability bugs found while spot-checking PostHog after PR #2390 (page_view instrumentation) landed:

1. Every web-emitted event ships with `app_version=0.0.0` / `ui_version=0.0.0` — `useAppVersion()` used `useRef` so the fetched `/api/version` never triggered the downstream `client.register()` re-run.
2. Settings → Media providers shows zero traffic on PostHog. The contract type and helper are defined but no call site uses them.
3. `run_finished` `result=failed` events look like they're missing `error_code` — audit revealed the fallback logic on `main` is correct, but it was inline in `server.ts` with no unit coverage so a future regression would re-introduce the symptom silently.

Pain addressed: PostHog dashboards keyed on `app_version` couldn't tell beta from stable; per-provider funnels on Media providers were running on no data; and the `result=failed` error-code invariant was a sitting duck for a silent regression.

## What users will see

Invisible from the UI. On PostHog:

- `app_version` / `ui_version` super-properties begin reporting the real daemon-pinned version (e.g. `0.7.0`) on every web-emitted event instead of `0.0.0`. First few events before `/api/version` resolves still ship as `0.0.0`.
- Settings → Media providers begins emitting four `ui_click` shapes: `reload` (header button), `key_input` / `url_input` (per-provider field focus), `clear` (per-provider Clear button before the confirm dialog).
- `run_finished` `result=failed` events continue to carry `error_code`. The audit confirmed every failure shape — explicit `errorCode`, signal-only, exit-code-only, clean (code=0) ACP fatal, cancellation — produces a non-empty value. The logic is now a pure helper in `apps/daemon/src/run-result.ts` with 12 unit tests pinning the invariant.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — analytics super-properties report correct values; new click events fire from Media providers; the result→error_code derivation moves into a tested helper. From a user standpoint this is invisible, but PostHog totals will shift.

## Bug fix verification

### Bug #1: `app_version=0.0.0`

Encoded as a red spec in `apps/web/tests/analytics-app-version.test.tsx` (added in the first commit on this branch):

- Went red on `main` (the `useRef` shape): `AssertionError: expected '0.0.0' to be '1.2.3'` on the "updates to the fetched version once /api/version resolves" case
- Goes green on this branch (`useState` shape): 3/3 pass

### Bug #2: Media providers missing clicks

Verified by code search before/after: zero call sites of `trackSettingsMediaProvidersClick` on `main`, four after this branch. The contract type / helper already existed — only the wiring was missing.

### Bug #3: `run_finished` `result=failed` missing `error_code`

Audited every daemon failure path. The inline fallback in `server.ts` already covered every shape; extracted to `apps/daemon/src/run-result.ts` and added 12 unit tests in `apps/daemon/tests/run-result.test.ts` covering:

- Explicit `errorCode` set via `runs.emit('error', …)` → forwarded
- Child died from a signal (`signal: 'SIGSEGV'`) → `AGENT_SIGNAL_SIGSEGV`
- Child exited non-zero (`exitCode: 1` / `137`) → `AGENT_EXIT_<code>`
- Clean exit (`code=0, signal=null`) with no stamped error (ACP fatal shape) → `AGENT_TERMINATED_UNKNOWN`
- Cancelled run with no stamped code → `undefined` (no fallback; cancel isn't a failure)
- Cancelled run with stamped code (cancel during error recovery) → forwarded
- Empty-string `errorCode` → falls through to derived value
- `runResultFromStatus` mapping for `succeeded`/`canceled`/`failed`/unknown

If you're still seeing `error_code` blank on a live `result=failed` event after this lands, please share the PostHog event JSON + agent id — at this point the daemon-side emission is exercised against every failure shape we produce, and the next dig would be on the capture transport / dashboard side.

## Validation

- `pnpm guard` ✅
- `pnpm --filter @open-design/contracts build` ✅
- `pnpm --filter @open-design/web typecheck` ✅
- `pnpm --filter @open-design/daemon typecheck` ✅
- `pnpm --filter @open-design/web test` ✅ 194 files / 1795 tests
- `pnpm --filter @open-design/daemon test` ✅ 249 files / 2963 tests (+12 new `run-result` cases)