### PR TITLE
fix(daemon-cli): accept BYOK via --api-key-file or ANTHROPIC_API_KEY env var on od project handoff

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -3690,7 +3690,8 @@ async function runProject(args) {
   od project open-in <id> --editor <slug> Open the project's working directory
                                           in the chosen editor (cursor, zed,
                                           vscode, finder, terminal, …).
-  od project handoff <id> --conversation <id> --api-key <key> --model <model>
+  od project handoff <id> --conversation <id> --model <model>
+                    (--api-key-file <path|-> | --api-key <key> | $ANTHROPIC_API_KEY)
                     [--base-url <url>] [--max-tokens <n>]
                     Synthesize a resume-conversation handoff prompt.
 

--- a/apps/daemon/src/handoff-cli.ts
+++ b/apps/daemon/src/handoff-cli.ts
@@ -35,12 +35,19 @@ function isHandoffResponse(value: unknown): value is HandoffResponse {
 }
 
 const USAGE = `Usage:
-  od project handoff <projectId> --conversation <id> --api-key <key> --model <model>
+  od project handoff <projectId> --conversation <id> --model <model>
+                     (--api-key-file <path|-> | --api-key <key> | $ANTHROPIC_API_KEY)
                      [--base-url <url>] [--max-tokens <n>] [--daemon-url <url>] [--json]
 
 Synthesizes a "resume conversation" handoff prompt from one conversation's
 transcript via the local daemon. Prints the prompt to stdout; --json emits
 the full response (prompt + model + token usage).
+
+API key transport (one of, in precedence order):
+  --api-key-file <path|->   Read the key from a file or stdin ("-").  Safe.
+  ANTHROPIC_API_KEY env var Read from the environment.  Safe.
+  --api-key <key>           Pass the key directly.  DEPRECATED — leaks
+                            credentials into shell history, ps, and CI logs.
 `;
 
 function writeJson(value: unknown, stream: NodeJS.WriteStream = process.stdout): void {
@@ -59,10 +66,34 @@ function fail(message: string, code?: unknown, status?: number): HandoffCliResul
   return { exitCode: 1 };
 }
 
+/**
+ * Reads an API key from a file path or stdin. `'-'` means stdin; any other
+ * value is treated as a filesystem path read as UTF-8. Trims trailing
+ * whitespace so a key written with a final newline (the common case for
+ * `echo $KEY > key.txt`) still validates.
+ *
+ * Mirrors the `--prompt-file <path|->` / `--body-file <path|->` precedent
+ * documented in AGENTS.md (Capability exposure — UI/CLI dual-track) and
+ * implemented in cli.ts `readMemoryBodyFromFlags` / `readPromptFromFlags`.
+ */
+async function readApiKeyFromFile(path: string): Promise<string> {
+  if (path === '-') {
+    let buf = '';
+    for await (const chunk of process.stdin) {
+      buf += typeof chunk === 'string' ? chunk : (chunk as Buffer).toString('utf8');
+    }
+    return buf.trim();
+  }
+  const { readFile } = await import('node:fs/promises');
+  const raw = await readFile(path, 'utf8');
+  return raw.trim();
+}
+
 interface ParsedHandoffOptions {
   projectId?: string;
   conversationId?: string;
   apiKey?: string;
+  apiKeyFile?: string;
   model?: string;
   baseUrl?: string;
   maxTokens?: number;
@@ -88,6 +119,10 @@ function parseOptions(args: string[]): ParsedHandoffOptions | { error: string } 
       const value = args[++index];
       if (!value) return { error: '--api-key requires a value' };
       options.apiKey = value;
+    } else if (arg === '--api-key-file') {
+      const value = args[++index];
+      if (!value) return { error: '--api-key-file requires a value' };
+      options.apiKeyFile = value;
     } else if (arg === '--model') {
       const value = args[++index];
       if (!value) return { error: '--model requires a value' };
@@ -128,8 +163,44 @@ export async function runProjectHandoff(args: string[]): Promise<HandoffCliResul
   }
   if (!options.projectId) return fail('handoff requires <projectId>');
   if (!options.conversationId) return fail('handoff requires --conversation <id>');
-  if (!options.apiKey) return fail('handoff requires --api-key <key>');
   if (!options.model) return fail('handoff requires --model <model>');
+
+  // Resolve the API key from (in precedence order): --api-key, --api-key-file
+  // (file or stdin via '-'), then ANTHROPIC_API_KEY env var.
+  //
+  // --api-key in argv leaks credentials into shell history, `ps` output, CI
+  // logs, process accounting, and crash dumps. We keep it working for
+  // back-compat (the CLI shipped 2026-05-20 and may already be wired into
+  // local scripts) but emit a one-line stderr warning when used so the
+  // safer paths stay discoverable.
+  let apiKey = options.apiKey;
+  if (apiKey) {
+    process.stderr.write(
+      '[od handoff] warning: --api-key in argv leaks credentials via shell ' +
+        'history, ps, and CI logs. Prefer --api-key-file <path|-> or the ' +
+        'ANTHROPIC_API_KEY environment variable.\n',
+    );
+  } else if (options.apiKeyFile) {
+    try {
+      apiKey = await readApiKeyFromFile(options.apiKeyFile);
+    } catch (err) {
+      return fail(
+        `failed to read --api-key-file ${options.apiKeyFile}: ${(err as Error).message}`,
+      );
+    }
+    if (!apiKey) {
+      return fail(`--api-key-file ${options.apiKeyFile} produced an empty key`);
+    }
+  } else {
+    const envKey = process.env.ANTHROPIC_API_KEY?.trim();
+    if (envKey) apiKey = envKey;
+  }
+  if (!apiKey) {
+    return fail(
+      'handoff requires an API key — pass --api-key-file <path|->, set ' +
+        'ANTHROPIC_API_KEY in the environment, or (less safe) use --api-key <key>',
+    );
+  }
 
   try {
     const daemonUrl = (
@@ -137,7 +208,7 @@ export async function runProjectHandoff(args: string[]): Promise<HandoffCliResul
     ).replace(/\/$/, '');
     const body: HandoffRequest = {
       conversationId: options.conversationId,
-      apiKey: options.apiKey,
+      apiKey,
       model: options.model,
       ...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
       ...(options.maxTokens === undefined ? {} : { maxTokens: options.maxTokens }),

--- a/apps/daemon/src/handoff-cli.ts
+++ b/apps/daemon/src/handoff-cli.ts
@@ -43,7 +43,8 @@ Synthesizes a "resume conversation" handoff prompt from one conversation's
 transcript via the local daemon. Prints the prompt to stdout; --json emits
 the full response (prompt + model + token usage).
 
-API key transport (one of, in precedence order):
+API key transport (one of — listed safest-first; when more than one is
+given, --api-key wins, then --api-key-file, then the env var):
   --api-key-file <path|->   Read the key from a file or stdin ("-").  Safe.
   ANTHROPIC_API_KEY env var Read from the environment.  Safe.
   --api-key <key>           Pass the key directly.  DEPRECATED — leaks

--- a/apps/daemon/tests/handoff-cli.test.ts
+++ b/apps/daemon/tests/handoff-cli.test.ts
@@ -53,6 +53,7 @@ describe('od project handoff CLI', () => {
     stdoutSpy.mockRestore();
     stderrSpy.mockRestore();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
     vi.clearAllMocks();
   });
 
@@ -224,5 +225,227 @@ describe('od project handoff CLI', () => {
     expect(result.exitCode).toBe(1);
     expect(fetchMock).not.toHaveBeenCalled();
     expect(stderr.join('')).toContain('max-tokens');
+  });
+
+  // BYOK transport — the next block covers --api-key-file <path|->, the
+  // ANTHROPIC_API_KEY env-var fallback, the deprecation warning emitted on
+  // raw --api-key use, and the precedence chain between all three. Filed in
+  // response to nettee's review on PR #1718 (the daemon-endpoint base of the
+  // #462 stack), which flagged the argv-only credential transport as a
+  // secret-handling regression.
+
+  it('reads --api-key-file <path> from disk and uses it as the api key', async () => {
+    const { writeFile, unlink } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const nodePath = await import('node:path');
+    const filePath = nodePath.join(tmpdir(), `od-handoff-test-${Date.now()}-disk.key`);
+    await writeFile(filePath, 'sk-ant-from-file', 'utf8');
+    try {
+      const result = await runProjectHandoff([
+        'proj-1',
+        '--conversation', 'conv-9',
+        '--api-key-file', filePath,
+        '--model', 'claude-opus-4-7',
+        '--daemon-url', DAEMON,
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body)) as {
+        apiKey: string;
+      };
+      expect(body.apiKey).toBe('sk-ant-from-file');
+      // No --api-key in argv ⇒ no security warning.
+      expect(stderr.join('')).not.toContain('leaks credentials');
+    } finally {
+      await unlink(filePath).catch(() => {});
+    }
+  });
+
+  it('reads --api-key-file - from stdin and uses it as the api key', async () => {
+    const { Readable } = await import('node:stream');
+    const originalStdin = Object.getOwnPropertyDescriptor(process, 'stdin');
+    Object.defineProperty(process, 'stdin', {
+      value: Readable.from(['sk-ant-from-stdin\n']),
+      configurable: true,
+      writable: true,
+    });
+    try {
+      const result = await runProjectHandoff([
+        'proj-1',
+        '--conversation', 'conv-9',
+        '--api-key-file', '-',
+        '--model', 'claude-opus-4-7',
+        '--daemon-url', DAEMON,
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body)) as {
+        apiKey: string;
+      };
+      // Trailing newline must be trimmed — the `echo $KEY > -` ergonomic case.
+      expect(body.apiKey).toBe('sk-ant-from-stdin');
+      expect(stderr.join('')).not.toContain('leaks credentials');
+    } finally {
+      if (originalStdin) Object.defineProperty(process, 'stdin', originalStdin);
+    }
+  });
+
+  it('falls back to ANTHROPIC_API_KEY env var when no --api-key or --api-key-file is given', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-from-env');
+    const result = await runProjectHandoff([
+      'proj-1',
+      '--conversation', 'conv-9',
+      '--model', 'claude-opus-4-7',
+      '--daemon-url', DAEMON,
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body)) as {
+      apiKey: string;
+    };
+    expect(body.apiKey).toBe('sk-ant-from-env');
+    expect(stderr.join('')).not.toContain('leaks credentials');
+  });
+
+  it('emits a security warning to stderr when --api-key is used', async () => {
+    const result = await runProjectHandoff([
+      'proj-1',
+      '--conversation', 'conv-9',
+      '--api-key', 'sk-ant-argv',
+      '--model', 'claude-opus-4-7',
+      '--daemon-url', DAEMON,
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body)) as {
+      apiKey: string;
+    };
+    expect(body.apiKey).toBe('sk-ant-argv');
+    // Substring assertion — avoid coupling to the exact wording of the warning.
+    expect(stderr.join('')).toContain('leaks credentials');
+  });
+
+  it('prefers --api-key over --api-key-file and the env var (warning fires)', async () => {
+    const { writeFile, unlink } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const nodePath = await import('node:path');
+    const filePath = nodePath.join(tmpdir(), `od-handoff-test-${Date.now()}-prec1.key`);
+    await writeFile(filePath, 'sk-from-file', 'utf8');
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-from-env');
+    try {
+      const result = await runProjectHandoff([
+        'proj-1',
+        '--conversation', 'conv-9',
+        '--api-key', 'sk-from-argv',
+        '--api-key-file', filePath,
+        '--model', 'claude-opus-4-7',
+        '--daemon-url', DAEMON,
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body)) as {
+        apiKey: string;
+      };
+      expect(body.apiKey).toBe('sk-from-argv');
+      // --api-key in argv ⇒ warning fires even when other sources are present.
+      expect(stderr.join('')).toContain('leaks credentials');
+    } finally {
+      await unlink(filePath).catch(() => {});
+    }
+  });
+
+  it('prefers --api-key-file over the env var when --api-key is not given', async () => {
+    const { writeFile, unlink } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const nodePath = await import('node:path');
+    const filePath = nodePath.join(tmpdir(), `od-handoff-test-${Date.now()}-prec2.key`);
+    await writeFile(filePath, 'sk-from-file', 'utf8');
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-from-env');
+    try {
+      const result = await runProjectHandoff([
+        'proj-1',
+        '--conversation', 'conv-9',
+        '--api-key-file', filePath,
+        '--model', 'claude-opus-4-7',
+        '--daemon-url', DAEMON,
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const body = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body)) as {
+        apiKey: string;
+      };
+      expect(body.apiKey).toBe('sk-from-file');
+      expect(stderr.join('')).not.toContain('leaks credentials');
+    } finally {
+      await unlink(filePath).catch(() => {});
+    }
+  });
+
+  it('fails when neither --api-key, --api-key-file, nor ANTHROPIC_API_KEY is set', async () => {
+    // Stub to empty so the test passes on machines that export the env var.
+    vi.stubEnv('ANTHROPIC_API_KEY', '');
+    const result = await runProjectHandoff([
+      'proj-1',
+      '--conversation', 'conv-9',
+      '--model', 'claude-opus-4-7',
+      '--daemon-url', DAEMON,
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    // Error message must name all three transports so the user can pick one.
+    const msg = stderr.join('');
+    expect(msg).toContain('handoff requires an API key');
+    expect(msg).toContain('--api-key-file');
+    expect(msg).toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('fails when --api-key-file points at a non-existent file', async () => {
+    const result = await runProjectHandoff([
+      'proj-1',
+      '--conversation', 'conv-9',
+      '--api-key-file', `/tmp/od-handoff-nonexistent-${Date.now()}-${Math.random().toString(36).slice(2)}.key`,
+      '--model', 'claude-opus-4-7',
+      '--daemon-url', DAEMON,
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderr.join('')).toContain('failed to read --api-key-file');
+  });
+
+  it('fails when --api-key-file produces an empty key (whitespace-only file)', async () => {
+    const { writeFile, unlink } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const nodePath = await import('node:path');
+    const filePath = nodePath.join(tmpdir(), `od-handoff-test-${Date.now()}-empty.key`);
+    await writeFile(filePath, '   \n', 'utf8');
+    try {
+      const result = await runProjectHandoff([
+        'proj-1',
+        '--conversation', 'conv-9',
+        '--api-key-file', filePath,
+        '--model', 'claude-opus-4-7',
+        '--daemon-url', DAEMON,
+      ]);
+
+      expect(result.exitCode).toBe(1);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(stderr.join('')).toContain('empty key');
+    } finally {
+      await unlink(filePath).catch(() => {});
+    }
+  });
+
+  it('--api-key-file with no value fails fast in the parser', async () => {
+    const result = await runProjectHandoff([
+      'proj-1',
+      '--conversation', 'conv-9',
+      '--api-key-file',
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(stderr.join('')).toContain('--api-key-file requires a value');
   });
 });


### PR DESCRIPTION
Fixes #2456

## Why

**Use case:** I built the `od project handoff` CLI on PR #1718 and wrote the web wiring on PR #2264 (the #462 resume-conversation feature). PR #2264 squash-merged the whole stack to `main` on 2026-05-20 (commit `c530d163`), before Looper reviewer `nettee`'s blocking review on PR #1718 was addressed. One of nettee's two findings was real and is now live on `main`; this PR fixes it.

**Pain being addressed:** The shipped CLI accepts the Anthropic BYOK API key only as a raw argv flag (`--api-key <key>`), which leaks credentials into shell history, `ps`, CI logs, process accounting, and crash dumps. nettee's exact text on `apps/daemon/src/handoff-cli.ts:44`:

> "this usage text, the parser below, and the `handoff requires --api-key <key>` guard at lines 129-132 make a raw argv secret the only supported way to call the new CLI. That leaks BYOK credentials into shell history, `ps` output, CI logs, and any wrapper that records command lines, which is a concrete secret-handling regression for a user-facing surface. Suggested fix: add a non-argv transport such as `--api-key-file <path|->` and/or an environment-variable path, make that the documented flow here, and cover it in `apps/daemon/tests/handoff-cli.test.ts` so the safer path stays wired."

**Scope note:** this is a CLI-only transport fix on an already-shipped capability. The `/api/projects/:id/handoff` HTTP contract is unchanged (`HandoffRequest.apiKey` stays a required string in the body); the web surface stores the key in `localStorage` and is unaffected; no new endpoint, no new web entry point. AGENTS.md "three-step closure" (UI + HTTP + CLI in the same PR) was satisfied by #2264's squash-merge of the full stack on 2026-05-20.

The fix didn't land on #1718 because the squash-merge left `feat/handoff-endpoint @ bd8b9d3c` structurally unmergeable (its content is on `main` as a different commit shape, so every file conflicts with itself). This PR is the follow-up off `main`.

## What users will see

`od project handoff --help` and the parent `od project` help text now document three transports for the Anthropic key:

```
API key transport (one of, in precedence order):
  --api-key-file <path|->   Read the key from a file or stdin ("-").  Safe.
  ANTHROPIC_API_KEY env var Read from the environment.  Safe.
  --api-key <key>           Pass the key directly.  DEPRECATED — leaks
                            credentials into shell history, ps, and CI logs.
```

- `--api-key-file <path|->` is the new flag. `-` reads from stdin so `echo $KEY | od project handoff ... --api-key-file -` works.
- `ANTHROPIC_API_KEY` is the implicit fallback when no key flag is given. Same env var the web Settings UI and `memory-llm.ts` already use; no new env var was invented.
- `--api-key <key>` still works (no breakage for any 1-day-old script) but emits a one-line stderr warning:
  > `[od handoff] warning: --api-key in argv leaks credentials via shell history, ps, and CI logs. Prefer --api-key-file <path|-> or the ANTHROPIC_API_KEY environment variable.`

Precedence on use: `--api-key` (warned) > `--api-key-file` > `ANTHROPIC_API_KEY`. Mirrors `aws`/`gh`/`gcloud` conventions and the layered behavior in `apps/daemon/src/memory-llm.ts:135-156`.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — new `--api-key-file <path|->` flag on `od project handoff`; new `ANTHROPIC_API_KEY` env-var lookup. Parent `od project` help text updated to match.
- [ ] **API / contract** — unchanged. `HandoffRequest.apiKey` stays a required string on the HTTP body.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — existing `--api-key` invocations still work; they now emit a stderr warning. The new flag and env var are additive.
- [ ] **None**

## Screenshots

Not applicable — no UI surface changed.

## Bug fix verification

- Test path: `apps/daemon/tests/handoff-cli.test.ts` (10 new tests added; 19 total after the change).
- Did the tests go red on `main` and green on this branch?  **Yes.** All 10 of the new tests fail against `origin/main` source (the parser at `apps/daemon/src/handoff-cli.ts:111-117` rejects `--api-key-file` with `unknown option: --api-key-file`, so every assertion that depends on the new flag/env behavior fails). On this branch all 10 are green; the 9 pre-existing tests stay green throughout.
- Reproduce locally:
  ```bash
  git checkout origin/main -- apps/daemon/src/handoff-cli.ts apps/daemon/src/cli.ts
  # keep the new test file from this branch in place
  pnpm --filter @open-design/daemon test handoff-cli   # 10 fail, 9 pass
  ```

The new branch coverage matches Rule 13 (TDD: full branch coverage): file-path read, stdin (`-`) read, env-var fallback, deprecation warning emission, all three precedence chains, all-missing failure with three-transport error message, `--api-key-file` ENOENT failure, empty-key file failure, and parser no-value failure.

## Validation

Ran on the branch at `54d9a44f`:

- `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm --filter @open-design/daemon test handoff-cli` — 19 passed (1 file, 9 existing + 10 new)
- `pnpm --filter @open-design/daemon test` — 2958 passed; 3 pre-existing failures in `tests/project-watchers.test.ts` (chokidar `waitFor timeout`). Same 3 failures on a clean `origin/main` checkout — out of scope for this PR.
- `pnpm guard` — pass
- `pnpm typecheck` (root, all workspaces) — pass

## Adjacent issues

- `scripts/guard.ts:899-917` has no `checkRawSecretsInArgv` rule. A CI guard would prevent regression of this exact class of bug. Reasonable as a separate follow-up issue.
- `tests/project-watchers.test.ts` has 3 pre-existing chokidar `waitFor` timeouts on `origin/main`. Unrelated to this PR; flagging for separate triage.

