### PR TITLE
Lint craft section references

### DIFF
--- a/craft/FUTURE_SECTIONS.md
+++ b/craft/FUTURE_SECTIONS.md
@@ -1,0 +1,9 @@
+# Future Craft Sections
+
+These slugs are intentionally referenced by skills before their matching
+`craft/<slug>.md` sections ship. `pnpm lint:craft` treats them as planned
+forward references, while still failing on unlisted typos.
+
+- motion-discipline
+- pixel-discipline
+- typographic-rhythm

--- a/craft/README.md
+++ b/craft/README.md
@@ -41,6 +41,12 @@ od:
 Allowed values match the file names in this directory minus the `.md`
 extension. Unknown values are silently ignored (forward-compatible).
 
+Run `pnpm lint:craft` after adding or changing `od.craft.requires`. Template
+authors will see unresolved slugs grouped by name and manifest path, which makes
+typos like `typograpy` visible before they silently drop from the runtime prompt.
+If the slug is an intentional forward reference, add it to
+`craft/FUTURE_SECTIONS.md` until the matching `craft/<slug>.md` file ships.
+
 ### Why silent fallback instead of fail-fast?
 
 A skeptical reader will ask: "If a skill requests a planned-but-not-yet-vendored

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tools-pack": "pnpm exec tools-pack",
     "tools-serve": "pnpm exec tools-serve",
     "nix:update-hash": "node --experimental-strip-types ./scripts/update-nix-pnpm-deps-hash.ts",
-    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/approve-fork-pr-workflows.test.ts",
+    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/lint-craft-references.test.ts",
     "lint:craft": "tsx ./scripts/lint-craft-references.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",
     "i18n:coverage": "tsx ./scripts/i18n-coverage-report.ts",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "tools-serve": "pnpm exec tools-serve",
     "nix:update-hash": "node --experimental-strip-types ./scripts/update-nix-pnpm-deps-hash.ts",
     "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/approve-fork-pr-workflows.test.ts",
+    "lint:craft": "tsx ./scripts/lint-craft-references.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",
     "i18n:coverage": "tsx ./scripts/i18n-coverage-report.ts",
     "sync:community-pets": "node --experimental-strip-types scripts/sync-community-pets.ts",

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -14,6 +14,7 @@ import {
   checkDesignSystemTokenFixtureSync,
   checkDesignSystemUnknownTokens,
 } from "./check-tokens-fixture-sync.ts";
+import { checkCraftReferences } from "./lint-craft-references.ts";
 import { collectCssHardcodedColorMatches, cssWideAndSpecialColorKeywords, realNamedColors } from "./style-policy.ts";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
@@ -924,6 +925,7 @@ const checks: GuardCheck[] = [
   { name: "web test layout", run: checkWebTestLayout },
   { name: "tools layout", run: checkToolsLayout },
   { name: "style policy", run: checkStylePolicy },
+  { name: "craft references", run: checkCraftReferences },
   { name: "design system manifests", run: checkDesignSystemManifests },
   { name: "design system package quality", run: checkDesignSystemPackageQuality },
   { name: "design system component fixture report", run: checkDesignSystemComponentFixtureReport },

--- a/scripts/lint-craft-references.test.ts
+++ b/scripts/lint-craft-references.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  extractCraftRequiresSlugs,
+  findInvalidCraftReferences,
+} from "./lint-craft-references.ts";
+
+test("craft reference parser preserves invalid inline slugs for lint failures", () => {
+  const source = `---
+craft:
+  requires: [typography, typo_graphy]
+---
+`;
+
+  assert.deepEqual(extractCraftRequiresSlugs(source), ["typography", "typo_graphy"]);
+  assert.deepEqual(
+    findInvalidCraftReferences([
+      { manifestPath: "skills/example/SKILL.md", slug: "typography" },
+      { manifestPath: "skills/example/SKILL.md", slug: "typo_graphy" },
+    ]),
+    [{ manifestPath: "skills/example/SKILL.md", slug: "typo_graphy" }],
+  );
+});
+
+test("craft reference parser preserves invalid block-list slugs for lint failures", () => {
+  const source = `---
+craft:
+  requires:
+    - form-validation
+    - state_coverage
+---
+`;
+
+  assert.deepEqual(extractCraftRequiresSlugs(source), ["form-validation", "state_coverage"]);
+  assert.deepEqual(
+    findInvalidCraftReferences([
+      { manifestPath: "skills/example/SKILL.md", slug: "form-validation" },
+      { manifestPath: "skills/example/SKILL.md", slug: "state_coverage" },
+    ]),
+    [{ manifestPath: "skills/example/SKILL.md", slug: "state_coverage" }],
+  );
+});

--- a/scripts/lint-craft-references.ts
+++ b/scripts/lint-craft-references.ts
@@ -84,15 +84,15 @@ function stripSlugDecorators(value: string): string {
   return value.trim().replace(/^["'`]+/, "").replace(/["'`]+$/, "").trim();
 }
 
-function parseInlineSlugList(rawValue: string): string[] {
+function parseInlineSlugList(rawValue: string): string[] | null {
   const trimmed = rawValue.trim();
-  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return [];
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return null;
 
   return trimmed
     .slice(1, -1)
     .split(",")
     .map(stripSlugDecorators)
-    .filter((value) => slugPattern.test(value));
+    .filter((value) => value.length > 0);
 }
 
 function parseBlockSlugList(lines: string[], startIndex: number, parentIndent: number): string[] {
@@ -109,7 +109,7 @@ function parseBlockSlugList(lines: string[], startIndex: number, parentIndent: n
     if (!match) continue;
 
     const slug = stripSlugDecorators(match[1] ?? "");
-    if (slugPattern.test(slug)) slugs.push(slug);
+    if (slug) slugs.push(slug);
   }
 
   return slugs;
@@ -130,7 +130,7 @@ function extractRequiresFromCraftBlock(lines: string[], craftIndex: number): str
     if (!match) continue;
 
     const inlineSlugs = parseInlineSlugList(match[1] ?? "");
-    if (inlineSlugs.length > 0) {
+    if (inlineSlugs) {
       slugs.push(...inlineSlugs);
       continue;
     }
@@ -141,7 +141,7 @@ function extractRequiresFromCraftBlock(lines: string[], craftIndex: number): str
   return slugs;
 }
 
-function extractCraftRequiresSlugs(source: string): string[] {
+export function extractCraftRequiresSlugs(source: string): string[] {
   const frontmatter = extractFrontmatter(source);
   if (!frontmatter) return [];
 
@@ -239,6 +239,21 @@ function groupReferencesBySlug(references: CraftReference[]): Map<string, string
   );
 }
 
+export function findInvalidCraftReferences(references: CraftReference[]): CraftReference[] {
+  return references.filter((reference) => !slugPattern.test(reference.slug));
+}
+
+function printInvalidReferences(invalid: Map<string, string[]>): void {
+  console.error(`Invalid craft slug syntax: ${invalid.size}`);
+  for (const [slug, manifestPaths] of invalid) {
+    console.error(`  '${slug}' is not a valid craft slug and is referenced by ${manifestPaths.length} manifest(s):`);
+    for (const manifestPath of manifestPaths) {
+      console.error(`    - ${manifestPath}`);
+    }
+  }
+  console.error("Use lowercase letters, digits, and hyphens only; slugs must start with a letter or digit.");
+}
+
 function printUnresolvedReferences(unresolved: Map<string, string[]>): void {
   console.error(`Unresolved craft slugs: ${unresolved.size}`);
   for (const [slug, manifestPaths] of unresolved) {
@@ -261,17 +276,21 @@ export async function checkCraftReferences(options: CraftLintOptions = {}): Prom
   console.log(`craft sections present: ${existingSlugs.size} (${formatSlugList(existingSlugs)})`);
   console.log(`craft sections marked future-only: ${futureSlugs.size} (${formatSlugList(futureSlugs)})`);
 
-  const unresolvedReferences = references.filter(
+  const invalidReferences = findInvalidCraftReferences(references);
+  const validReferences = references.filter((reference) => slugPattern.test(reference.slug));
+  const unresolvedReferences = validReferences.filter(
     (reference) => !existingSlugs.has(reference.slug) && !futureSlugs.has(reference.slug),
   );
+  const invalid = groupReferencesBySlug(invalidReferences);
   const unresolved = groupReferencesBySlug(unresolvedReferences);
 
-  if (unresolved.size === 0) {
+  if (invalid.size === 0 && unresolved.size === 0) {
     console.log("Craft reference check passed: every od.craft.requires slug resolves or is listed as planned.");
     return true;
   }
 
-  printUnresolvedReferences(unresolved);
+  if (invalid.size > 0) printInvalidReferences(invalid);
+  if (unresolved.size > 0) printUnresolvedReferences(unresolved);
   return !strict;
 }
 

--- a/scripts/lint-craft-references.ts
+++ b/scripts/lint-craft-references.ts
@@ -1,0 +1,287 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const craftRoot = path.join(repoRoot, "craft");
+const futureSectionsPath = path.join(craftRoot, "FUTURE_SECTIONS.md");
+const manifestRoots = [
+  "skills",
+  "design-templates",
+  "plugins/_official/examples",
+  "docs/examples",
+];
+
+const slugPattern = /^[a-z0-9][a-z0-9-]*$/;
+
+type CraftReference = {
+  manifestPath: string;
+  slug: string;
+};
+
+type CraftLintOptions = {
+  strict?: boolean;
+};
+
+function toRepositoryPath(filePath: string): string {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/");
+}
+
+function isRecord(value: unknown): value is { code?: unknown } {
+  return typeof value === "object" && value !== null;
+}
+
+function isAbsenceError(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+  return error.code === "ENOENT" || error.code === "ENOTDIR";
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    if (isAbsenceError(error)) return false;
+    throw error;
+  }
+}
+
+async function collectSkillManifests(rootDirectory: string): Promise<string[]> {
+  if (!(await pathExists(rootDirectory))) return [];
+
+  const entries = await readdir(rootDirectory, { withFileTypes: true });
+  const manifests: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(rootDirectory, entry.name);
+    if (entry.isDirectory()) {
+      manifests.push(...(await collectSkillManifests(fullPath)));
+      continue;
+    }
+    if (entry.isFile() && entry.name === "SKILL.md") {
+      manifests.push(fullPath);
+    }
+  }
+
+  return manifests;
+}
+
+function extractFrontmatter(source: string): string | null {
+  const lines = source.split(/\r?\n/);
+  if (lines[0]?.trim() !== "---") return null;
+
+  const endIndex = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+  if (endIndex === -1) return null;
+  return lines.slice(1, endIndex).join("\n");
+}
+
+function indentation(line: string): number {
+  const match = /^ */.exec(line);
+  return match?.[0].length ?? 0;
+}
+
+function stripSlugDecorators(value: string): string {
+  return value.trim().replace(/^["'`]+/, "").replace(/["'`]+$/, "").trim();
+}
+
+function parseInlineSlugList(rawValue: string): string[] {
+  const trimmed = rawValue.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return [];
+
+  return trimmed
+    .slice(1, -1)
+    .split(",")
+    .map(stripSlugDecorators)
+    .filter((value) => slugPattern.test(value));
+}
+
+function parseBlockSlugList(lines: string[], startIndex: number, parentIndent: number): string[] {
+  const slugs: string[] = [];
+
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (!line.trim()) continue;
+
+    const lineIndent = indentation(line);
+    if (lineIndent <= parentIndent) break;
+
+    const match = /^\s*-\s+(.+?)\s*$/.exec(line);
+    if (!match) continue;
+
+    const slug = stripSlugDecorators(match[1] ?? "");
+    if (slugPattern.test(slug)) slugs.push(slug);
+  }
+
+  return slugs;
+}
+
+function extractRequiresFromCraftBlock(lines: string[], craftIndex: number): string[] {
+  const slugs: string[] = [];
+  const craftIndent = indentation(lines[craftIndex] ?? "");
+
+  for (let index = craftIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (!line.trim()) continue;
+
+    const lineIndent = indentation(line);
+    if (lineIndent <= craftIndent) break;
+
+    const match = /^\s*requires:\s*(.*?)\s*$/.exec(line);
+    if (!match) continue;
+
+    const inlineSlugs = parseInlineSlugList(match[1] ?? "");
+    if (inlineSlugs.length > 0) {
+      slugs.push(...inlineSlugs);
+      continue;
+    }
+
+    slugs.push(...parseBlockSlugList(lines, index, lineIndent));
+  }
+
+  return slugs;
+}
+
+function extractCraftRequiresSlugs(source: string): string[] {
+  const frontmatter = extractFrontmatter(source);
+  if (!frontmatter) return [];
+
+  const lines = frontmatter.split(/\r?\n/);
+  const slugs: string[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (/^\s*craft:\s*$/.test(lines[index] ?? "")) {
+      slugs.push(...extractRequiresFromCraftBlock(lines, index));
+    }
+  }
+
+  return slugs;
+}
+
+async function collectCraftReferences(): Promise<CraftReference[]> {
+  const manifests = (
+    await Promise.all(manifestRoots.map((root) => collectSkillManifests(path.join(repoRoot, root))))
+  ).flat();
+  const references: CraftReference[] = [];
+
+  for (const manifest of manifests) {
+    const source = await readFile(manifest, "utf8");
+    const manifestPath = toRepositoryPath(manifest);
+    for (const slug of extractCraftRequiresSlugs(source)) {
+      references.push({ manifestPath, slug });
+    }
+  }
+
+  return references.sort((a, b) => (
+    a.slug.localeCompare(b.slug) || a.manifestPath.localeCompare(b.manifestPath)
+  ));
+}
+
+async function collectExistingCraftSlugs(): Promise<Set<string>> {
+  const entries = await readdir(craftRoot, { withFileTypes: true });
+  const slugs = new Set<string>();
+
+  for (const entry of entries) {
+    if (!entry.isFile() || path.extname(entry.name) !== ".md") continue;
+    const slug = path.basename(entry.name, ".md");
+    if (slug === "README" || slug === "FUTURE_SECTIONS") continue;
+    if (slugPattern.test(slug)) slugs.add(slug);
+  }
+
+  return slugs;
+}
+
+function extractFutureSlug(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) return null;
+
+  const listMatch = /^[-*]\s+`?([a-z0-9][a-z0-9-]*)`?(?:\s*(?:#.*)?)?$/.exec(trimmed);
+  if (listMatch) return listMatch[1] ?? null;
+
+  const bareMatch = /^`?([a-z0-9][a-z0-9-]*)`?$/.exec(trimmed);
+  return bareMatch?.[1] ?? null;
+}
+
+async function collectFutureCraftSlugs(): Promise<Set<string>> {
+  if (!(await pathExists(futureSectionsPath))) return new Set();
+
+  const source = await readFile(futureSectionsPath, "utf8");
+  const slugs = new Set<string>();
+
+  for (const line of source.split(/\r?\n/)) {
+    const slug = extractFutureSlug(line);
+    if (slug) slugs.add(slug);
+  }
+
+  return slugs;
+}
+
+function formatSlugList(slugs: Set<string>): string {
+  const values = [...slugs].sort();
+  if (values.length === 0) return "none";
+  return values.join(", ");
+}
+
+function groupReferencesBySlug(references: CraftReference[]): Map<string, string[]> {
+  const grouped = new Map<string, Set<string>>();
+
+  for (const reference of references) {
+    if (!grouped.has(reference.slug)) {
+      grouped.set(reference.slug, new Set());
+    }
+    grouped.get(reference.slug)?.add(reference.manifestPath);
+  }
+
+  return new Map(
+    [...grouped.entries()].map(([slug, manifestPaths]) => [
+      slug,
+      [...manifestPaths].sort(),
+    ]),
+  );
+}
+
+function printUnresolvedReferences(unresolved: Map<string, string[]>): void {
+  console.error(`Unresolved craft slugs: ${unresolved.size}`);
+  for (const [slug, manifestPaths] of unresolved) {
+    console.error(`  '${slug}' is referenced by ${manifestPaths.length} manifest(s):`);
+    for (const manifestPath of manifestPaths) {
+      console.error(`    - ${manifestPath}`);
+    }
+  }
+  console.error("Add a matching craft/<slug>.md file, fix the typo, or list the planned slug in craft/FUTURE_SECTIONS.md.");
+}
+
+export async function checkCraftReferences(options: CraftLintOptions = {}): Promise<boolean> {
+  const strict = options.strict ?? true;
+  const references = await collectCraftReferences();
+  const existingSlugs = await collectExistingCraftSlugs();
+  const futureSlugs = await collectFutureCraftSlugs();
+  const referencedManifestCount = new Set(references.map((reference) => reference.manifestPath)).size;
+
+  console.log(`craft references: ${references.length} total across ${referencedManifestCount} manifests`);
+  console.log(`craft sections present: ${existingSlugs.size} (${formatSlugList(existingSlugs)})`);
+  console.log(`craft sections marked future-only: ${futureSlugs.size} (${formatSlugList(futureSlugs)})`);
+
+  const unresolvedReferences = references.filter(
+    (reference) => !existingSlugs.has(reference.slug) && !futureSlugs.has(reference.slug),
+  );
+  const unresolved = groupReferencesBySlug(unresolvedReferences);
+
+  if (unresolved.size === 0) {
+    console.log("Craft reference check passed: every od.craft.requires slug resolves or is listed as planned.");
+    return true;
+  }
+
+  printUnresolvedReferences(unresolved);
+  return !strict;
+}
+
+async function main(): Promise<void> {
+  const warnOnly = process.argv.includes("--warn-only");
+  const passed = await checkCraftReferences({ strict: !warnOnly });
+  if (!passed) process.exitCode = 1;
+}
+
+const executedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+if (executedPath === fileURLToPath(import.meta.url)) {
+  await main();
+}


### PR DESCRIPTION
Fixes #1886

## Why

I opened this because `od.craft.requires` had no guardrail between legitimate forward references and plain typos. That leaves skill/template authors guessing whether a missing craft section is planned or broken, and it lets misspelled references drift into manifests until someone notices by hand.

This PR keeps the scope to contributor tooling: fail on typo-shaped craft references, and make intentional forward references explicit in `craft/FUTURE_SECTIONS.md`.

## What users will see

Template and skill authors who run `pnpm lint:craft` or `pnpm guard` get a focused report when a manifest references an invalid, missing, or unplanned craft slug. Invalid slug syntax is now reported directly with the manifest path instead of being silently dropped by the parser.

Example shape:

```text
Invalid craft slug syntax: 1
  'typo_graphy' is not a valid craft slug and is referenced by 1 manifest(s):
    - skills/example/SKILL.md
```

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A - no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `scripts/lint-craft-references.test.ts`
- Did the test go red on `main` and green on this branch? Not run separately on `main`; the fixture covers the old failure mode where invalid inline/block slugs were filtered out before linting.
- Additional verification: `pnpm guard` now runs the craft-reference parser fixture alongside the existing style-policy test.

## Validation

- `COREPACK_HOME=/private/tmp/corepack corepack pnpm lint:craft`
- `./node_modules/.bin/tsc -p scripts/tsconfig.json --noEmit`
- `COREPACK_HOME=/private/tmp/corepack corepack pnpm exec tsx scripts/guard.ts`
- `node --import tsx --test scripts/lint-craft-references.test.ts`
- `COREPACK_HOME=/private/tmp/corepack corepack pnpm guard`
- `git diff --check`

No payment expected upfront. If this PR is useful and gets merged, an optional tip/donation is appreciated so I can keep doing small maintainer-unblocking fixes.