### PR TITLE
fix(landing-page): restore 'tutorials' in Header active union

### DIFF
--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -28,6 +28,7 @@ export interface HeaderProps {
     | 'systems'
     | 'templates'
     | 'craft'
+    | 'tutorials'
     | 'blog';
   /**
    * Live counts from the Markdown catalogs. Required so we can never


### PR DESCRIPTION
## Why

PR #2452 (HTML Anything landing page) was branched from `main` before PR #2409 (tutorials channel) merged. When the patch was applied to current `main`, it replaced the entire `active` union literal — adding `'product' | 'html-anything'` but silently dropping `'tutorials'`. The conflict was invisible to `git apply` because neither PR touched the same context lines, so no merge marker was ever raised.

The result: `tutorials/index.astro` and `tutorials/[slug].astro` no longer typecheck against `HeaderProps`, breaking the `landing-page-deploy` workflow on every push to `main`. The site has been frozen on the pre-#2452 build since 2026-05-20T12:37 UTC.

## What

One line: add `'tutorials'` back to the `active` union in `apps/landing-page/app/_components/header.tsx`. Pure type fix, no runtime behavior change. The `/tutorials/` pages were already passing `active='tutorials'` and rendering correctly before #2452 — only the type was broken.

## Test plan

- [x] `pnpm --filter @open-design/landing-page typecheck` — 0 errors locally (was 2 errors on `main`).
- [ ] After merge, `landing-page-deploy` workflow runs to completion.
- [ ] `https://open-design.ai/` shows the new Product menu in the header.
- [ ] `https://open-design.ai/tutorials/` and `/tutorials/<slug>/` still render with the Tutorials nav highlight.

## Surface area

- [x] `apps/landing-page` — single line in `_components/header.tsx`
- [ ] no `apps/web`, no `apps/daemon`, no contracts, no CLI surfaces
- [ ] no new dependencies

## Notes for reviewer

This is the smallest possible fix to unstick deploys. No other changes bundled. Once landing-page-deploy succeeds, the home will pick up the Product menu and `/html-anything/` becomes discoverable from the nav.
