### PR TITLE
feat(analytics): emit file_upload_result from all three upload entries

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { flushSync } from 'react-dom';
 import { useAnalytics } from './analytics/provider';
-import { trackProjectCreateResult } from './analytics/events';
+import {
+  trackFileUploadResult,
+  trackProjectCreateResult,
+} from './analytics/events';
+import { deriveUploadCohort } from './analytics/upload-tracking';
 import { detectClientType } from './analytics/identity';
 import {
   deriveConfigureGlobals,
@@ -852,11 +856,28 @@ export function App() {
         : [];
       let firstMessageAttachments: ChatAttachment[] = [];
       if (pendingFiles.length > 0) {
+        // Home composer attaches stay client-side until submit lands a
+        // project; the actual upload happens here. v2 doc wants one
+        // file_upload_result per surface — `page_name='home'` /
+        // `area='chat_composer'` so it's distinguishable from the
+        // file_manager Upload button and the chat_panel composer.
+        const cohort = deriveUploadCohort(pendingFiles);
         const uploadResult = await uploadProjectFiles(result.project.id, pendingFiles);
         firstMessageAttachments = uploadResult.uploaded;
-        if (uploadResult.failed.length > 0) {
+        const partial = uploadResult.failed.length > 0;
+        if (partial) {
           console.warn('Some Home attachments failed to upload', uploadResult.failed);
         }
+        trackFileUploadResult(analytics.track, {
+          page_name: 'home',
+          area: 'chat_composer',
+          project_id: result.project.id,
+          ...cohort,
+          result: partial ? 'failed' : 'success',
+          ...(partial && uploadResult.error
+            ? { error_code: uploadResult.error }
+            : {}),
+        });
       }
       trackProjectCreateResult(
         analytics.track,

--- a/apps/web/src/analytics/upload-tracking.ts
+++ b/apps/web/src/analytics/upload-tracking.ts
@@ -1,0 +1,48 @@
+// Shared `file_upload_result` cohort derivation.
+//
+// Three surfaces fire `file_upload_result`:
+//   1. Design Files Upload button on the project page (`file_manager`)
+//   2. Chat composer paperclip on the project page (`chat_panel`)
+//   3. Home composer paperclip (`home`)
+//
+// All three share the same cohort math: total bytes for the size bucket,
+// per-file mime → TrackingFileType, mixed batches collapsed to `'other'`
+// so the dashboard breakdown stays interpretable. Earlier, only the
+// `file_manager` surface emitted; the other two were silent. Extracting
+// the math keeps the three call sites one-liners and prevents drift.
+
+import type {
+  TrackingFileSizeBucket,
+  TrackingFileType,
+} from '@open-design/contracts/analytics';
+import {
+  fileSizeBucketToTracking,
+  fileTypeToTracking,
+} from '@open-design/contracts/analytics';
+
+export interface UploadCohort {
+  file_count: number;
+  file_type: TrackingFileType;
+  file_size_bucket: TrackingFileSizeBucket;
+}
+
+export function deriveUploadCohort(files: File[]): UploadCohort {
+  const totalBytes = files.reduce((sum, file) => sum + (file.size || 0), 0);
+  const perFileTrackingTypes = files.map((file) => {
+    const mime = file.type ?? '';
+    const name = file.name ?? '';
+    const isZip =
+      mime === 'application/zip' || name.toLowerCase().endsWith('.zip');
+    return fileTypeToTracking({ mime, isFolder: false, isZip });
+  });
+  const uniqueTrackingTypes = new Set(perFileTrackingTypes);
+  const file_type: TrackingFileType =
+    uniqueTrackingTypes.size <= 1
+      ? perFileTrackingTypes[0] ?? 'other'
+      : 'other';
+  return {
+    file_count: files.length,
+    file_type,
+    file_size_bucket: fileSizeBucketToTracking(totalBytes),
+  };
+}

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -13,7 +13,9 @@ import type { Dict } from '../i18n/types';
 import { useAnalytics } from '../analytics/provider';
 import {
   trackChatPanelClick,
+  trackFileUploadResult,
 } from '../analytics/events';
+import { deriveUploadCohort } from '../analytics/upload-tracking';
 import { IMAGE_MODELS } from "../media/models";
 import { projectRawUrl, uploadProjectFiles, openFolderDialog, fetchConnectors } from "../providers/registry";
 import { patchProject } from "../state/projects";
@@ -732,12 +734,18 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       if (!id) return;
       setUploading(true);
       setUploadError(null);
+      // Cohort math is identical to the Design Files Upload button; see
+      // `analytics/upload-tracking.ts`. v2 doc fires one
+      // file_upload_result per surface so this path reports
+      // `page_name='chat_panel'` / `area='chat_composer'`.
+      const cohort = deriveUploadCohort(files);
       try {
         const result = await uploadProjectFiles(id, files);
         if (result.uploaded.length > 0) {
           setStaged((s) => [...s, ...result.uploaded]);
         }
-        if (result.failed.length > 0) {
+        const partial = result.failed.length > 0;
+        if (partial) {
           const failedCount = result.failed.length;
           const uploadedCount = result.uploaded.length;
           const detail = result.error ? ` (${result.error})` : '';
@@ -748,6 +756,25 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           );
           console.warn('Some attachments failed to upload', result.failed);
         }
+        trackFileUploadResult(analytics.track, {
+          page_name: 'chat_panel',
+          area: 'chat_composer',
+          project_id: id,
+          ...cohort,
+          result: partial ? 'failed' : 'success',
+          ...(partial && result.error ? { error_code: result.error } : {}),
+        });
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        setUploadError(`Attachment upload failed (${detail}).`);
+        trackFileUploadResult(analytics.track, {
+          page_name: 'chat_panel',
+          area: 'chat_composer',
+          project_id: id,
+          ...cohort,
+          result: 'failed',
+          error_code: detail,
+        });
       } finally {
         setUploading(false);
       }

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -12,10 +12,7 @@ import {
   trackFileUploadResult,
   trackPageView,
 } from '../analytics/events';
-import {
-  fileSizeBucketToTracking,
-  fileTypeToTracking,
-} from '@open-design/contracts/analytics';
+import { deriveUploadCohort } from '../analytics/upload-tracking';
 import { useT } from '../i18n';
 import { isMacPlatform } from '../utils/platform';
 import {
@@ -377,28 +374,9 @@ export function FileWorkspace({
     if (picked.length === 0) return;
 
     setUploadError(null);
-    // Compute the cohort's representative file_type / file_size_bucket
-    // up front so the result event reports the same shape whether the
-    // upload itself succeeded, failed, or threw. The cohort is summed
-    // (size) and bucketed by the primary mime; mixed batches collapse
-    // to `other` so the bucket stays interpretable.
-    const totalBytes = picked.reduce((sum, file) => sum + (file.size || 0), 0);
-    const perFileTrackingTypes = picked.map((file) => {
-      const mime = file.type ?? '';
-      const name = file.name ?? '';
-      const isZip =
-        mime === 'application/zip' || name.toLowerCase().endsWith('.zip');
-      return fileTypeToTracking({ mime, isFolder: false, isZip });
-    });
-    // Heterogeneous batch (more than one distinct tracking type) → 'other'
-    // so the breakdowns dashboards build off `file_type` do not get skewed
-    // by whichever file happened to land first.
-    const uniqueTrackingTypes = new Set(perFileTrackingTypes);
-    const trackingFileType =
-      uniqueTrackingTypes.size <= 1
-        ? perFileTrackingTypes[0] ?? 'other'
-        : 'other';
-    const trackingFileSizeBucket = fileSizeBucketToTracking(totalBytes);
+    // Cohort math is shared across all three upload surfaces; see
+    // `analytics/upload-tracking.ts` for the per-file → batch reduction.
+    const cohort = deriveUploadCohort(picked);
     let result: UploadProjectFilesResult;
     try {
       result = await uploadProjectFiles(projectId, picked);
@@ -409,9 +387,7 @@ export function FileWorkspace({
         page_name: 'file_manager',
         area: 'file_manager',
         project_id: projectId,
-        file_count: picked.length,
-        file_type: trackingFileType,
-        file_size_bucket: trackingFileSizeBucket,
+        ...cohort,
         result: 'failed',
         error_code: detail,
       });
@@ -437,9 +413,7 @@ export function FileWorkspace({
         page_name: 'file_manager',
         area: 'file_manager',
         project_id: projectId,
-        file_count: picked.length,
-        file_type: trackingFileType,
-        file_size_bucket: trackingFileSizeBucket,
+        ...cohort,
         result: 'failed',
         ...(result.error ? { error_code: result.error } : {}),
       });
@@ -448,9 +422,7 @@ export function FileWorkspace({
         page_name: 'file_manager',
         area: 'file_manager',
         project_id: projectId,
-        file_count: picked.length,
-        file_type: trackingFileType,
-        file_size_bucket: trackingFileSizeBucket,
+        ...cohort,
         result: 'success',
       });
     }

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -33,6 +33,8 @@ import type {
 import type { SkillSummary } from '../types';
 import { Icon, type IconName } from './Icon';
 import { PluginInputsForm } from './PluginInputsForm';
+import { useAnalytics } from '../analytics/provider';
+import { trackHomeChatComposerClick } from '../analytics/events';
 import {
   chipsForGroup,
   type ChipGroup,
@@ -182,6 +184,7 @@ export const HomeHero = forwardRef<HTMLTextAreaElement, Props>(function HomeHero
   ref,
 ) {
   const { locale, t } = useI18n();
+  const analytics = useAnalytics();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [mentionTab, setMentionTab] = useState<HomeMentionTab>('all');
   const [hoveredPlugin, setHoveredPlugin] = useState<InstalledPluginRecord | null>(null);
@@ -998,7 +1001,14 @@ export const HomeHero = forwardRef<HTMLTextAreaElement, Props>(function HomeHero
               type="button"
               className="home-hero__attach"
               data-testid="home-hero-attach"
-              onClick={() => fileInputRef.current?.click()}
+              onClick={() => {
+                trackHomeChatComposerClick(analytics.track, {
+                  page_name: 'home',
+                  area: 'chat_composer',
+                  element: 'attachment',
+                });
+                fileInputRef.current?.click();
+              }}
               title={t('chat.attachAria')}
               aria-label={t('chat.attachAria')}
             >

--- a/apps/web/tests/analytics/upload-tracking.test.ts
+++ b/apps/web/tests/analytics/upload-tracking.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+
+import { deriveUploadCohort } from '../../src/analytics/upload-tracking';
+
+// `deriveUploadCohort` only reads `name`, `type`, `size` — keep the
+// fixture lightweight so 100 MB boundary cases don't allocate real bytes.
+function makeFile(name: string, type: string, size: number): File {
+  return { name, type, size } as unknown as File;
+}
+
+describe('deriveUploadCohort', () => {
+  it('classifies a homogeneous image batch as image', () => {
+    const cohort = deriveUploadCohort([
+      makeFile('a.png', 'image/png', 1024),
+      makeFile('b.jpg', 'image/jpeg', 2048),
+    ]);
+    expect(cohort).toEqual({
+      file_count: 2,
+      file_type: 'image',
+      file_size_bucket: '0_1mb',
+    });
+  });
+
+  it('detects zip by MIME', () => {
+    const cohort = deriveUploadCohort([
+      makeFile('bundle.zip', 'application/zip', 500),
+    ]);
+    expect(cohort.file_type).toBe('zip');
+  });
+
+  it('detects zip by .zip extension when MIME is missing', () => {
+    const cohort = deriveUploadCohort([
+      makeFile('bundle.ZIP', '', 500),
+      makeFile('also.zip', 'application/octet-stream', 500),
+    ]);
+    expect(cohort.file_type).toBe('zip');
+  });
+
+  it('collapses mixed-type batches to other', () => {
+    const cohort = deriveUploadCohort([
+      makeFile('a.png', 'image/png', 100),
+      makeFile('b.pdf', 'application/pdf', 100),
+    ]);
+    expect(cohort.file_type).toBe('other');
+  });
+
+  it('returns other for an empty batch', () => {
+    expect(deriveUploadCohort([])).toEqual({
+      file_count: 0,
+      file_type: 'other',
+      file_size_bucket: '0_1mb',
+    });
+  });
+
+  it('buckets total bytes across the 1/10/100 MB thresholds', () => {
+    const MB = 1024 * 1024;
+    const cases: Array<{ total: number; bucket: string }> = [
+      { total: MB - 1, bucket: '0_1mb' },
+      { total: MB, bucket: '1_10mb' },
+      { total: 10 * MB - 1, bucket: '1_10mb' },
+      { total: 10 * MB, bucket: '10_100mb' },
+      { total: 100 * MB - 1, bucket: '10_100mb' },
+      { total: 100 * MB, bucket: '100mb_plus' },
+    ];
+    for (const { total, bucket } of cases) {
+      const cohort = deriveUploadCohort([
+        makeFile('blob.bin', 'application/octet-stream', total),
+      ]);
+      expect(cohort.file_size_bucket, `total=${total}`).toBe(bucket);
+    }
+  });
+
+  it('sums sizes across multiple files for the bucket', () => {
+    const MB = 1024 * 1024;
+    const cohort = deriveUploadCohort([
+      makeFile('a.png', 'image/png', 0.6 * MB),
+      makeFile('b.png', 'image/png', 0.6 * MB),
+    ]);
+    expect(cohort.file_size_bucket).toBe('1_10mb');
+  });
+
+  it('treats missing size/type defensively', () => {
+    const cohort = deriveUploadCohort([
+      { name: 'x', type: '', size: 0 } as unknown as File,
+    ]);
+    expect(cohort).toEqual({
+      file_count: 1,
+      file_type: 'other',
+      file_size_bucket: '0_1mb',
+    });
+  });
+});

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -394,7 +394,11 @@ export interface HomeChatComposerClickProps {
     | 'chat_input'
     | 'send_button'
     | 'plugin_chip'
-    | 'action_chip';
+    | 'action_chip'
+    // Paperclip icon opening the file picker. Mirrors the chat_panel
+    // composer's `element: 'attachment'` so the same dashboard counts
+    // "user opened the file picker" across both surfaces.
+    | 'attachment';
   // For plugin / action chips, the specific id (e.g. `prototype`, `from_figma`).
   chip_id?: string;
 }
@@ -1166,16 +1170,19 @@ export interface UpdateApplyObservedProps {
   elapsed_bucket: TrackingUpdateApplyElapsedBucket;
 }
 
-export interface FileUploadResultProps {
-  page_name: 'file_manager';
-  area: 'file_manager';
+export type TrackingFileUploadSurface =
+  | { page_name: 'file_manager'; area: 'file_manager' }
+  | { page_name: 'chat_panel'; area: 'chat_composer' }
+  | { page_name: 'home'; area: 'chat_composer' };
+
+export type FileUploadResultProps = TrackingFileUploadSurface & {
   project_id: string;
   file_count: number;
   file_type: TrackingFileType;
   file_size_bucket: TrackingFileSizeBucket;
   result: TrackingRunResult;
   error_code?: string;
-}
+};
 
 export interface ArtifactExportResultProps {
   page_name: 'artifact';


### PR DESCRIPTION
## Why

Use case: spot-checked PostHog after PR #2390 landed and noticed that the project page Design Files **Upload** button is the only surface emitting `file_upload_result`. The chat composer paperclip on the project page (image #2) and the Home composer paperclip (image #1) both upload files silently — `file_upload_result` was never fired from those code paths. So PostHog dashboards saw upload activity from only one of three real entry points.

Pain addressed: every cross-surface funnel that depends on knowing where the user uploaded a file (Home composer → first message attachment funnel, in-chat reference attachment rate, file-type breakdowns by entry point) was running on partial data. Totals were also undercounted on the order of 2/3 of all uploads.

## What users will see

No UI change. On PostHog, `file_upload_result` will now fire from three surfaces instead of one:

| Surface | `page_name` | `area` |
| --- | --- | --- |
| Design Files Upload button (existing) | `file_manager` | `file_manager` |
| Project page chat composer 📎 | `chat_panel` | `chat_composer` |
| Home composer 📎 | `home` | `chat_composer` |

Plus the home composer's paperclip click now fires `ui_click` with `element: 'attachment'`, mirroring the chat_panel composer.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var**
- [x] **API / contract** — `packages/contracts/src/analytics/events.ts`: (a) `FileUploadResultProps` becomes a discriminated union over the three surfaces via `TrackingFileUploadSurface`; (b) `HomeChatComposerClickProps.element` adds `'attachment'`.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — analytics emits new events from two surfaces; from a user standpoint this is invisible, but downstream PostHog totals for `file_upload_result` will go up
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — pure analytics wire-format addition. The three upload entry points render identically; only the events they emit are new.

## Bug fix verification

Not a bug fix — feature add to plug instrumentation gaps. Verified by code search before/after:

| Surface | Before | After |
| --- | --- | --- |
| `HomeHero.tsx` paperclip click | no analytics import in the file | `trackHomeChatComposerClick element='attachment'` |
| `App.tsx` Home submit upload | `uploadProjectFiles` called silently | `trackFileUploadResult page_name='home'` on success / partial |
| `ChatComposer.uploadFiles` | only the upstream `ui_click` paperclip fires | `trackFileUploadResult page_name='chat_panel'` on success / failed / throw |
| `FileWorkspace.uploadFiles` | 3 inline `trackFileUploadResult` calls (already correct) | same 3 calls, refactored to share `deriveUploadCohort` so drift is impossible |

## Validation

- `pnpm --filter @open-design/contracts build` ✅
- `pnpm --filter @open-design/web typecheck` ✅
- `pnpm --filter @open-design/daemon typecheck` ✅
- `pnpm --filter @open-design/web test` ✅ 193 files / 1793 tests
- `pnpm --filter @open-design/daemon test` ✅ 248 files / 2951 tests
- `pnpm guard` ✅

## Implementation notes

- Cohort math (total bytes → size bucket, per-file mime → file_type, mixed → `'other'`) was duplicated about to be triplicated across three call sites. Extracted to `apps/web/src/analytics/upload-tracking.ts#deriveUploadCohort` so the three surfaces emit identical-shape events and a future change lands in one place.
- The Home composer's upload is deferred — users add files via the picker, then the actual `uploadProjectFiles` call only happens at submit time once a project ID exists. The `ui_click attachment` fires at click time (in `HomeHero.tsx`); the `file_upload_result` fires after the deferred upload settles (in `App.tsx`).