### PR TITLE
Fix Windows reinstall detection and duplicate plugin nav

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -130,18 +130,6 @@ export function EntryNavRail({ view, onViewChange, onNewProject }: Props) {
         >
           <Icon name="puzzle" size={18} />
         </NavButton>
-      </div>
-      <div className="entry-nav-rail__footer">
-        <div className="entry-nav-rail__divider" role="separator" />
-        <NavButton
-          active={view === 'plugins'}
-          ariaLabel="Plugins"
-          tooltip="Plugins"
-          onClick={() => onViewChange('plugins')}
-          testId="entry-nav-plugins"
-        >
-          <Icon name="grid" size={18} />
-        </NavButton>
         <NavButton
           active={view === 'integrations'}
           ariaLabel={t('entry.navIntegrations')}

--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -383,6 +383,9 @@ valid_existing_location:
 
   IfSilent silent_check no_existing_install
 silent_check:
+  IfFileExists "$INSTDIR\\${exeName}" 0 silent_detect_running_instances
+  StrCpy $RunningInstancesInstallRoot "$INSTDIR"
+silent_detect_running_instances:
   Call DetectRunningInstances
   \${If} $RunningInstancesOutput != ""
     Push "running instances detected before silent install: $RunningInstancesOutput"

--- a/tools/pack/tests/win-identity.test.ts
+++ b/tools/pack/tests/win-identity.test.ts
@@ -75,4 +75,14 @@ describe("resolveWinInstallIdentity", () => {
     expect(source).toContain('WriteRegStr HKCU "${registryKey}" "DisplayName" "${productName}"');
     expect(source).not.toContain('"DisplayName" "${productName} \\${APP_VERSION}"');
   });
+
+  it("checks the silent install target directory for running instances before overwriting files", async () => {
+    const source = await readFile(new URL("../src/win/custom-installer.ts", import.meta.url), "utf8");
+    const silentCheck = source.slice(source.indexOf("silent_check:"), source.indexOf("IfFileExists \"$INSTDIR\\\\${exeName}\" existing_install"));
+    expect(silentCheck).toContain('IfFileExists "$INSTDIR\\\\${exeName}" 0 silent_detect_running_instances');
+    expect(silentCheck).toContain('StrCpy $RunningInstancesInstallRoot "$INSTDIR"');
+    expect(silentCheck.indexOf('StrCpy $RunningInstancesInstallRoot "$INSTDIR"')).toBeLessThan(
+      silentCheck.indexOf("Call DetectRunningInstances"),
+    );
+  });
 });


### PR DESCRIPTION
## Why

The `release-stable` Windows smoke in https://github.com/nexu-io/open-design/actions/runs/26163976301 failed in the direct-reinstall-while-running path. The installer overwrote the existing install, but the NSIS log never showed the expected running-process detection/close markers, so the smoke correctly treated the reinstall as unsafe.

The failure point was Windows installer behavior, not the nightly identity changes themselves: the silent install path could call `DetectRunningInstances` before anchoring detection to the actual `$INSTDIR` target when the registry-derived existing install location was not enough.

After opening the PR, release-branch CI also exposed a pre-existing UI critical-smoke blocker from https://github.com/nexu-io/open-design/actions/runs/26165372517: the entry rail rendered two Plugins nav buttons with the same `data-testid`, one of them hard-coded English. This PR removes that duplicate so the release branch can validate cleanly.

## What users will see

Silent Windows reinstalls and updater-driven reinstalls are more reliable when Open Design is already running: the installer checks the target install directory for the running app before overwriting files, then closes the running instance through the existing NSIS flow.

The entry navigation rail shows a single Plugins button again instead of two duplicate icon buttons.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The UI change removes a duplicate icon-only Plugins nav button and is covered by the existing critical smoke checks that were failing on `release/v0.8.0`.

## Bug fix verification

- Installer invariant test path: `tools/pack/tests/win-identity.test.ts`
- Windows red signal: `release-stable` run 26163976301 failed at `e2e/specs/win.spec.ts` direct reinstall while running because the NSIS log lacked `running instances detected before silent install` / `running instances close exit=0`.
- A cheap source-level red-on-main spec for the full NSIS timing/registry behavior was not practical. I added a source invariant test that pins the generated NSIS silent install order: check `$INSTDIR` for the app executable, set `RunningInstancesInstallRoot`, then call `DetectRunningInstances` before overwrite.
- Local targeted packaged check rebuilt the Windows installer and observed the repaired NSIS markers during a direct silent reinstall while the app was running: `running instances detected before silent install` and `running instances close exit=0`.
- UI red signal: `release/v0.8.0` CI run 26165372517 failed because `entry-nav-plugins` resolved to two elements in Playwright strict mode. The source now has one `entry-nav-plugins` occurrence in `EntryNavRail`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/tools-pack test -- tests/win-identity.test.ts`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/web typecheck`
- `git diff --check`
- `pnpm exec tools-pack win build --dir $env:TEMP\od-pack-win-ci-26163976301 --namespace release-stable-win --portable --app-version 0.8.0.nightly.4 --to nsis --json`
- Targeted local Windows install/start/health/direct silent reinstall while the app was running; verified the repaired NSIS log markers above.
- `pnpm guard`
- `pnpm -C e2e exec playwright test -c playwright.config.ts --grep 'entry top navigation matches|entry execution pill remains available|home starters can browse' ui/entry-chrome-flows.test.ts` attempted on Windows native, but the repo's Playwright `webServer.command` uses POSIX env assignment (`OD_DATA_DIR=...`) and cannot start under `cmd.exe`; CI is the authoritative validation for those Playwright cases.
- `pnpm typecheck` was attempted and is blocked locally by unrelated latest-branch landing-page errors in `apps/landing-page/app/pages/tutorials/[slug].astro` and `apps/landing-page/app/pages/tutorials/index.astro` (`active: "tutorials"` is outside the `Header` active union).