### PR TITLE
fix: Source section text is misaligned in plugin details(#2211) The c…

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -24105,90 +24105,6 @@ body.desktop-pet-shell .pet-task-item {
     grid-template-columns: 1fr;
   }
 }
-
-/* Plugin info pane — adapter for embedding the manifest-driven meta
-   sections inside narrow contexts (PreviewModal sidebar, design-system
-   sidebar). Tightens padding, shrinks chip type, and wraps long file
-   paths so the section list reads cleanly in a 320–540px column. */
-.plugin-info-pane {
-  padding: 16px 18px 24px;
-  background: var(--bg-panel);
-}
-.plugin-info-pane .plugin-meta-sections {
-  display: block;
-}
-.plugin-info-pane .plugin-meta-sections.is-compact {
-  font-size: 12px;
-}
-.plugin-info-pane .plugin-details-modal__section {
-  padding: 12px 0;
-}
-.plugin-info-pane .plugin-details-modal__section-title {
-  font-size: 11.5px;
-}
-.plugin-info-pane .plugin-details-modal__section-hint {
-  font-size: 11.5px;
-}
-.plugin-info-pane .plugin-details-modal__source {
-  grid-template-columns: 84px 1fr;
-  font-size: 11.5px;
-  gap: 6px 10px;
-}
-.plugin-info-pane .plugin-details-modal__source dd code {
-  word-break: break-all;
-}
-.plugin-info-pane .plugin-details-modal__chip,
-.plugin-info-pane .plugin-details-modal__atom {
-  font-size: 11px;
-}
-/* Compact byline — drop the capsule shape so the author block can
-   shrink, wrap, and stack inside narrow PreviewModal sidebars
-   (~320–400px) without overflowing the pane or breaking the rounded
-   pill into a stretched ellipse. The name + links wrap onto separate
-   lines when there isn't room, the links lose their border-left
-   separator (stacks vertically), and long author / handle strings
-   ellipsis-truncate against the available column width. */
-.plugin-info-pane .plugin-details-modal__byline {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px 10px;
-  padding: 6px 10px 6px 6px;
-  border-radius: 12px;
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
-}
-.plugin-info-pane .plugin-details-modal__byline-meta {
-  flex: 1 1 auto;
-  min-width: 0;
-  flex-wrap: wrap;
-  gap: 4px 8px;
-}
-.plugin-info-pane .plugin-details-modal__byline-name {
-  flex: 0 1 auto;
-  min-width: 0;
-  max-width: 100%;
-}
-.plugin-info-pane .plugin-details-modal__byline .plugin-details-modal__author-name {
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.plugin-info-pane .plugin-details-modal__byline-links {
-  flex: 1 1 100%;
-  flex-wrap: wrap;
-  gap: 4px 6px;
-  padding-left: 0;
-  border-left: 0;
-}
-.plugin-info-pane .plugin-details-modal__byline-links .plugin-details-modal__ext-link {
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
 /* Design-system sidebar keeps the plugin inspector first, then exposes
    DESIGN.md as a secondary spec section. This makes design systems read
    like first-class plugins instead of a special DESIGN.md-only viewer. */
@@ -26417,4 +26333,87 @@ body.desktop-pet-shell .pet-task-item {
 .app .df-drop .desc {
   font-size: 12px;
   max-width: 48ch;
+}
+/* Plugin info pane — adapter for embedding the manifest-driven meta
+  sections inside narrow contexts (PreviewModal sidebar, design-system
+  sidebar). Tightens padding, shrinks chip type, and wraps long file
+  paths so the section list reads cleanly in a 320–540px column. */
+.plugin-info-pane {
+  padding: 0px 18px 24px;
+  background: var(--bg-panel);
+}
+.plugin-info-pane .plugin-meta-sections {
+  display: block;
+}
+.plugin-info-pane .plugin-meta-sections.is-compact {
+  font-size: 12px;
+}
+.plugin-info-pane .plugin-details-modal__section {
+  padding: 12px 0;
+}
+.plugin-info-pane .plugin-details-modal__section-title {
+  font-size: 11.5px;
+}
+.plugin-info-pane .plugin-details-modal__section-hint {
+  font-size: 11.5px;
+}
+.plugin-info-pane .plugin-details-modal__source {
+  grid-template-columns: 84px 1fr;
+  font-size: 11.5px;
+  gap: 6px 10px;
+}
+.plugin-info-pane .plugin-details-modal__source dd code {
+  word-break: break-all;
+}
+.plugin-info-pane .plugin-details-modal__chip,
+.plugin-info-pane .plugin-details-modal__atom {
+  font-size: 11px;
+}
+/* Compact byline — drop the capsule shape so the author block can
+    shrink, wrap, and stack inside narrow PreviewModal sidebars
+    (~320–400px) without overflowing the pane or breaking the rounded
+    pill into a stretched ellipse. The name + links wrap onto separate
+    lines when there isn't room, the links lose their border-left
+    separator (stacks vertically), and long author / handle strings
+    ellipsis-truncate against the available column width. */
+.plugin-info-pane .plugin-details-modal__byline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 10px;
+  padding: 6px 10px 6px 6px;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+.plugin-info-pane .plugin-details-modal__byline-meta {
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+}
+.plugin-info-pane .plugin-details-modal__byline-name {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100%;
+}
+.plugin-info-pane .plugin-details-modal__byline .plugin-details-modal__author-name {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.plugin-info-pane .plugin-details-modal__byline-links {
+  flex: 1 1 100%;
+  flex-wrap: wrap;
+  gap: 4px 6px;
+  padding-left: 0;
+  border-left: 0;
+}
+.plugin-info-pane .plugin-details-modal__byline-links .plugin-details-modal__ext-link {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }


### PR DESCRIPTION
…lass "plugin-info-pane" was wrongly placed under the class "plugin-details-modal__stage-num". It should be moved out to the root level of the CSS file. Additionally, after being moved out, the "padding-top: 16px" value is too high. I have set it to 0.

 ---

  Fixes #2211

  ## Why

  While organizing the CSS files, it was discovered that the style block of `.plugin-info-pane` was mistakenly nested within the `.plugin-details-modal__stage-num` rule, causing the style of the plugin info pane to rely on an irrelevant parent selector. This resulted in the Source section text being misaligned in the plugin details. Moving it to the root level of the CSS can restore the correct style scope. After moving it out, the `padding-top: 16px` became too large and was changed to `0px`.

  ## What users will see

The "Plugin info" section in the "Plugin details" sidebar's Source section
The text alignment has returned to normal, and the misalignment issue has been resolved. The excessive blank space at the top has also been eliminated.

  ## Surface area

  - [x] **UI** — plugin details modal 侧边栏中 plugin info pane 的样式修复
  - [ ] **Keyboard shortcut** — new or changed
  - [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new
  - [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
  - [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or
  change to the skills protocol
  - [ ] **i18n keys** — added new translation keys
  - [ ] **New top-level dependency** — adding any new entry to the root `package.json`
  - [ ] **Default behavior change** — changes what existing users experience without opting in
  - [ ] **None** — internal refactor, docs, tests, or translation update only

  ## Screenshots
before:
<img width="1039" height="760" alt="image" src="https://github.com/user-attachments/assets/3f9d581c-d95c-4f3a-ba3a-ff4b99d13d0f" />
after:
<img width="1033" height="761" alt="image" src="https://github.com/user-attachments/assets/1db739d7-e378-4288-86ce-a898f9dcadcb" />
  
  ## Bug verification
  
  - Test path that reproduces the bug: `apps/web/tests/components/PluginDetailsModal.dispatch.test.tsx`（There is a rendering assertion for `plugin-info-pane`, as shown in lines 217, 240, and 259.）
  - Did the test go red on `main` and green on this branch? （yes）
  - This issue is a pure CSS scope error. It has been confirmed that the fix has taken effect through manual verification of the styles before and after the correction.

  ## Validation
  
  - `pnpm guard`
  - `pnpm typecheck`
  - `pnpm --filter @open-design/web typecheck`
  - `pnpm --filter @open-design/web test`

  ---
