### PR TITLE
fix(daemon): honor hostname OD_ALLOWED_ORIGINS for no-Origin same-origin GETs

### DIFF
--- a/apps/daemon/src/origin-validation.ts
+++ b/apps/daemon/src/origin-validation.ts
@@ -8,6 +8,7 @@ export interface RequestWithOriginHeaders {
   headers?: {
     host?: unknown;
     origin?: unknown;
+    'sec-fetch-site'?: unknown;
   };
 }
 
@@ -166,7 +167,23 @@ export function isLocalSameOrigin(
   );
 
   const localHostAllowed = isAllowedBrowserHost(host, ports, bindHost, ipOnlyExtraOrigins);
-  if (origin == null || origin === '') return localHostAllowed;
+  if (origin == null || origin === '') {
+    if (localHostAllowed) return true;
+    // Browsers (Firefox, Chrome) omit Origin on same-origin GET subresource
+    // requests per the Fetch spec, which made hostname entries in
+    // OD_ALLOWED_ORIGINS unreachable for legitimate same-origin GETs
+    // through a reverse proxy. Sec-Fetch-Site is set by the user agent and
+    // cannot be modified by JavaScript, so a value of "same-origin"
+    // attests that the request originated from the same origin as the
+    // target — a cross-site `<img>`/`<script>` exploit would carry
+    // "cross-site" instead. Only consult the broader allow-list once that
+    // signal is present.
+    const fetchSite = headerValue(req.headers?.['sec-fetch-site']);
+    if (fetchSite === 'same-origin') {
+      return isAllowedBrowserHost(host, ports, bindHost, extraAllowedOrigins);
+    }
+    return false;
+  }
   // Reverse-proxy deployments (e.g. Nginx in front of the daemon) terminate
   // the browser connection at the proxy and open a fresh upstream
   // connection to the daemon. The Host header the daemon sees is the

--- a/apps/daemon/tests/origin-validation.test.ts
+++ b/apps/daemon/tests/origin-validation.test.ts
@@ -561,3 +561,78 @@ describe('isLocalSameOrigin: OD_ALLOWED_ORIGINS bypass for reverse-proxy deploym
     expect(isLocalSameOrigin(req, 7457, env)).toBe(false);
   });
 });
+
+// Firefox and Chrome omit the Origin header on same-origin GET requests per
+// the Fetch spec. When the daemon runs behind a remote-access proxy whose
+// public hostname is listed in OD_ALLOWED_ORIGINS, those legitimate
+// same-origin GETs (e.g. /api/app-config) get rejected by the no-Origin
+// host check because hostname entries in OD_ALLOWED_ORIGINS are only
+// honored via the IP-literal subset in that branch. Sec-Fetch-Site is set
+// by the browser and cannot be modified by JavaScript, so a value of
+// "same-origin" is a trustworthy substitute for the missing Origin header.
+describe('isLocalSameOrigin: Sec-Fetch-Site fallback for no-Origin same-origin GETs', () => {
+  const ALLOWED = 'https://nas.example.ts.net';
+  const previousAllowedOrigins = process.env.OD_ALLOWED_ORIGINS;
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OD_ALLOWED_ORIGINS: ALLOWED,
+    OD_BIND_HOST: '127.0.0.1',
+  };
+
+  beforeAll(() => {
+    process.env.OD_ALLOWED_ORIGINS = ALLOWED;
+  });
+  afterAll(() => {
+    if (previousAllowedOrigins === undefined) delete process.env.OD_ALLOWED_ORIGINS;
+    else process.env.OD_ALLOWED_ORIGINS = previousAllowedOrigins;
+  });
+
+  it('accepts a no-Origin request whose Host matches OD_ALLOWED_ORIGINS when Sec-Fetch-Site is same-origin', () => {
+    const req = {
+      headers: {
+        host: 'nas.example.ts.net',
+        'sec-fetch-site': 'same-origin',
+      },
+    };
+    expect(isLocalSameOrigin(req, 7456, env)).toBe(true);
+  });
+
+  it('still rejects a no-Origin request whose Host matches the allow-list but Sec-Fetch-Site is cross-site', () => {
+    const req = {
+      headers: {
+        host: 'nas.example.ts.net',
+        'sec-fetch-site': 'cross-site',
+      },
+    };
+    expect(isLocalSameOrigin(req, 7456, env)).toBe(false);
+  });
+
+  it('still rejects a no-Origin request whose Host matches the allow-list but Sec-Fetch-Site is same-site', () => {
+    const req = {
+      headers: {
+        host: 'nas.example.ts.net',
+        'sec-fetch-site': 'same-site',
+      },
+    };
+    expect(isLocalSameOrigin(req, 7456, env)).toBe(false);
+  });
+
+  it('still rejects a no-Origin request whose Host is foreign even with Sec-Fetch-Site: same-origin (Host alone is forgeable)', () => {
+    const req = {
+      headers: {
+        host: 'evil.example.com',
+        'sec-fetch-site': 'same-origin',
+      },
+    };
+    expect(isLocalSameOrigin(req, 7456, env)).toBe(false);
+  });
+
+  it('preserves no-Sec-Fetch-Site rejection (older / non-browser clients fall back to host-only check)', () => {
+    const req = {
+      headers: {
+        host: 'nas.example.ts.net',
+      },
+    };
+    expect(isLocalSameOrigin(req, 7456, env)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #2477

## Why

I'm running the daemon as a TrueNAS Docker app fronted by a remote-access proxy whose public hostname is listed in `OD_ALLOWED_ORIGINS=https://nas.example.ts.net`. Every page-initiated GET — `/api/app-config`, `/api/mcp/servers`, connector configs — 403s with `cross-origin request rejected`, while the matching POST/PUTs succeed. The UI loads its shell but every panel that depends on app-config is empty.

Root cause is in `apps/daemon/src/origin-validation.ts:154` `isLocalSameOrigin`. The no-Origin host-only fallback consults `ipOnlyExtraOrigins` (line 164-166), which filters `OD_ALLOWED_ORIGINS` down to IP-literal entries. Hostname entries are dropped, so `Host: nas.example.ts.net` matching `OD_ALLOWED_ORIGINS=https://nas.example.ts.net` doesn't pass. Per the Fetch spec, browsers omit Origin on same-origin GETs, so all same-origin GETs to a hostname-allowed deployment 403. The reverse-proxy escape hatch on line 178 only fires when Origin is present.

Naively widening line 168 to pass `extraAllowedOrigins` would regress CSRF protection — cross-site `<img>`/`<script>` subresource fetches also arrive without Origin, and the existing test on line 261 specifically asserts they get rejected. The proper signal is `Sec-Fetch-Site`, which is browser-set and cannot be modified by JavaScript: same-origin GETs carry `same-origin`, cross-site subresource fetches carry `cross-site`.

## What users will see

Hostname entries in `OD_ALLOWED_ORIGINS` (Tailscale Serve, Caddy, Cloudflare Tunnel, etc.) now work the same way IP-literal entries already do — page-initiated GETs and POSTs both succeed against the configured proxy hostname. Previously, only POST/PUT/DELETE (which always carry Origin) worked; same-origin GETs 403'd.

No default behavior change for loopback or private-LAN deployments. No change to the with-Origin path.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [x] CLI / env var
- [x] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [x] None — internal change to existing `OD_ALLOWED_ORIGINS` semantics

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow":

- Red spec: `apps/daemon/tests/origin-validation.test.ts` — new describe block `isLocalSameOrigin: Sec-Fetch-Site fallback for no-Origin same-origin GETs` (5 cases).
- The acceptance case (`accepts a no-Origin request whose Host matches OD_ALLOWED_ORIGINS when Sec-Fetch-Site is same-origin`) went red on `main` and green on this branch.
- The four negative cases (cross-site, same-site, foreign host, no-Sec-Fetch-Site) all pass on both `main` and this branch — they document the invariants the fix must preserve.

Direct reproduction against a running daemon (same Host, only Origin toggled):

```
$ node -e "http.request({host:'127.0.0.1',port:7456,path:'/api/app-config',headers:{Host:'nas.example.ts.net'}},r=>r.on('data',c=>process.stdout.write(c))).end()"
403 {"error":"cross-origin request rejected"}

$ node -e "http.request({host:'127.0.0.1',port:7456,path:'/api/app-config',headers:{Host:'nas.example.ts.net',Origin:'https://nas.example.ts.net'}},r=>r.on('data',c=>process.stdout.write(c))).end()"
200 {"config":{...}}
```

After the fix, the no-Origin request also returns 200 *only when* the request also carries `Sec-Fetch-Site: same-origin` (which the browser sets on legitimate same-origin GETs and cannot be set by JavaScript).

## Validation

- `pnpm --filter @open-design/daemon test -- tests/origin-validation.test.ts` → 43 passed (5 new cases) on this branch; 42 passed / 1 failed on `main` (the new acceptance case).
- Local `pnpm guard` / `pnpm typecheck` blocked by an unrelated Node version mismatch on my machine (Node 26 vs repo `~24`); standalone `tsc --noEmit` on the modified file is clean. CI on this branch will be the authoritative validation.

## Adjacent / out of scope

Worth a follow-up but deliberately not in this PR: `apps/daemon/src/origin-validation.ts:164-166` keeps the `ipOnlyExtraOrigins` filter for the no-Sec-Fetch-Site fallback path. That preserves the historical behavior for non-browser clients but means a curl call (no Sec-Fetch-Site, hostname in allow-list) still 403s. Whether to widen that path further is a separate policy question — the current PR is the minimum that unblocks browser deployments behind a hostname proxy.