### PR TITLE
Fix pet hover preview edge clipping

### DIFF
--- a/apps/web/src/components/pet/PetSettings.tsx
+++ b/apps/web/src/components/pet/PetSettings.tsx
@@ -73,7 +73,7 @@ export function codexPreviewOffsetForViewport(
 
 function codexPreviewWidthFromThumb(thumb: HTMLElement) {
   const preview = thumb.querySelector<HTMLElement>('.pet-codex-thumb-preview');
-  const measuredWidth = preview?.getBoundingClientRect().width ?? 0;
+  const measuredWidth = preview?.offsetWidth ?? 0;
   if (measuredWidth > 0) return measuredWidth;
 
   const cssWidth = Number.parseFloat(

--- a/apps/web/src/components/pet/PetSettings.tsx
+++ b/apps/web/src/components/pet/PetSettings.tsx
@@ -51,6 +51,24 @@ const ACCENT_SWATCHES = [
   '#0d0c0a',
 ];
 
+const CODEX_PREVIEW_WIDTH = 128;
+const CODEX_PREVIEW_VIEWPORT_MARGIN = 12;
+
+function codexPreviewOffsetForViewport(
+  anchorRect: Pick<DOMRect, 'left' | 'width'>,
+  viewportWidth: number,
+) {
+  const anchorCenter = anchorRect.left + anchorRect.width / 2;
+  const preferredLeft = anchorCenter - CODEX_PREVIEW_WIDTH / 2;
+  const minLeft = CODEX_PREVIEW_VIEWPORT_MARGIN;
+  const maxLeft = Math.max(
+    minLeft,
+    viewportWidth - CODEX_PREVIEW_WIDTH - CODEX_PREVIEW_VIEWPORT_MARGIN,
+  );
+  const clampedLeft = Math.min(Math.max(preferredLeft, minLeft), maxLeft);
+  return Math.round(clampedLeft + CODEX_PREVIEW_WIDTH / 2 - anchorCenter);
+}
+
 export function PetSettings({ cfg, setCfg }: Props) {
   const t = useT();
   const analytics = useAnalytics();
@@ -100,6 +118,7 @@ export function PetSettings({ cfg, setCfg }: Props) {
     | { kind: 'error'; error: string }
     | null
   >(null);
+  const [codexPreviewOffsets, setCodexPreviewOffsets] = useState<Record<string, number>>({});
 
   // Tab routing — split the panel into three exclusive surfaces
   // (built-in / custom / community) so each "where do my pets come
@@ -164,6 +183,18 @@ export function PetSettings({ cfg, setCfg }: Props) {
       setCommunitySyncing(false);
     }
   }, [refreshCodexPets]);
+
+  const clampCodexPreview = useCallback((petId: string, card: HTMLElement) => {
+    const thumb = card.querySelector<HTMLElement>('.pet-codex-thumb');
+    if (!thumb) return;
+    const nextOffset = codexPreviewOffsetForViewport(
+      thumb.getBoundingClientRect(),
+      window.innerWidth,
+    );
+    setCodexPreviewOffsets((curr) =>
+      curr[petId] === nextOffset ? curr : { ...curr, [petId]: nextOffset },
+    );
+  }, []);
 
   useEffect(() => {
     void refreshCodexPets();
@@ -473,10 +504,15 @@ export function PetSettings({ cfg, setCfg }: Props) {
       <div
         className={`pet-codex-card${isActive ? ' active' : ''}`}
         key={p.id}
+        onFocus={(event) => clampCodexPreview(p.id, event.currentTarget)}
+        onMouseEnter={(event) => clampCodexPreview(p.id, event.currentTarget)}
       >
         <div
           className="pet-codex-thumb"
-          style={{ ['--pet-codex-src' as string]: spritesheet }}
+          style={{
+            ['--pet-codex-src' as string]: spritesheet,
+            ['--pet-codex-preview-offset' as string]: `${codexPreviewOffsets[p.id] ?? 0}px`,
+          }}
           aria-hidden
         >
           <span className="pet-codex-thumb-preview" aria-hidden />

--- a/apps/web/src/components/pet/PetSettings.tsx
+++ b/apps/web/src/components/pet/PetSettings.tsx
@@ -51,22 +51,35 @@ const ACCENT_SWATCHES = [
   '#0d0c0a',
 ];
 
-const CODEX_PREVIEW_WIDTH = 128;
+const CODEX_PREVIEW_WIDTH_CSS_VAR = '--pet-codex-preview-width';
+const CODEX_PREVIEW_WIDTH_FALLBACK = 128;
 const CODEX_PREVIEW_VIEWPORT_MARGIN = 12;
 
-function codexPreviewOffsetForViewport(
+export function codexPreviewOffsetForViewport(
   anchorRect: Pick<DOMRect, 'left' | 'width'>,
   viewportWidth: number,
+  previewWidth = CODEX_PREVIEW_WIDTH_FALLBACK,
 ) {
   const anchorCenter = anchorRect.left + anchorRect.width / 2;
-  const preferredLeft = anchorCenter - CODEX_PREVIEW_WIDTH / 2;
+  const preferredLeft = anchorCenter - previewWidth / 2;
   const minLeft = CODEX_PREVIEW_VIEWPORT_MARGIN;
   const maxLeft = Math.max(
     minLeft,
-    viewportWidth - CODEX_PREVIEW_WIDTH - CODEX_PREVIEW_VIEWPORT_MARGIN,
+    viewportWidth - previewWidth - CODEX_PREVIEW_VIEWPORT_MARGIN,
   );
   const clampedLeft = Math.min(Math.max(preferredLeft, minLeft), maxLeft);
-  return Math.round(clampedLeft + CODEX_PREVIEW_WIDTH / 2 - anchorCenter);
+  return Math.round(clampedLeft + previewWidth / 2 - anchorCenter);
+}
+
+function codexPreviewWidthFromThumb(thumb: HTMLElement) {
+  const preview = thumb.querySelector<HTMLElement>('.pet-codex-thumb-preview');
+  const measuredWidth = preview?.getBoundingClientRect().width ?? 0;
+  if (measuredWidth > 0) return measuredWidth;
+
+  const cssWidth = Number.parseFloat(
+    window.getComputedStyle(thumb).getPropertyValue(CODEX_PREVIEW_WIDTH_CSS_VAR),
+  );
+  return Number.isFinite(cssWidth) && cssWidth > 0 ? cssWidth : CODEX_PREVIEW_WIDTH_FALLBACK;
 }
 
 export function PetSettings({ cfg, setCfg }: Props) {
@@ -190,6 +203,7 @@ export function PetSettings({ cfg, setCfg }: Props) {
     const nextOffset = codexPreviewOffsetForViewport(
       thumb.getBoundingClientRect(),
       window.innerWidth,
+      codexPreviewWidthFromThumb(thumb),
     );
     setCodexPreviewOffsets((curr) =>
       curr[petId] === nextOffset ? curr : { ...curr, [petId]: nextOffset },

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19144,8 +19144,8 @@ body.desktop-pet-shell .pet-task-item {
   box-shadow: 0 14px 28px rgba(0, 0, 0, 0.22);
   opacity: 0;
   pointer-events: none;
-  transform: translate(-50%, 6px) scale(0.82);
-  transform-origin: 50% 100%;
+  transform: translate(calc(-50% + var(--pet-codex-preview-offset, 0px)), 6px) scale(0.82);
+  transform-origin: calc(50% - var(--pet-codex-preview-offset, 0px)) 100%;
   transition:
     opacity 140ms ease,
     transform 160ms ease;
@@ -19155,7 +19155,7 @@ body.desktop-pet-shell .pet-task-item {
 .pet-codex-card:hover .pet-codex-thumb-preview,
 .pet-codex-card:focus-within .pet-codex-thumb-preview {
   opacity: 1;
-  transform: translate(-50%, 0) scale(1);
+  transform: translate(calc(-50% + var(--pet-codex-preview-offset, 0px)), 0) scale(1);
   /* 8 column steps (1 row) in 0.6s → ~13 fps per animation, then the row
      index advances every 0.6s for a full 5.4s sweep through all 9 rows.
      Animating background-position-x + -y as two independent animations

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19104,6 +19104,7 @@ body.desktop-pet-shell .pet-task-item {
 }
 
 .pet-codex-thumb {
+  --pet-codex-preview-width: 128px;
   position: relative;
   width: 56px;
   height: 56px;
@@ -19130,9 +19131,8 @@ body.desktop-pet-shell .pet-task-item {
   position: absolute;
   bottom: calc(100% + 8px);
   left: 50%;
-  width: 128px;
-  /* 128 * (208/192) ≈ 138.7 — matches a single atlas cell aspect. */
-  height: 139px;
+  width: var(--pet-codex-preview-width);
+  aspect-ratio: 192 / 208;
   border-radius: 10px;
   border: 1px solid var(--border);
   background-color: var(--surface-2, #f6f4ee);

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -2276,10 +2276,25 @@ describe('SettingsDialog pets interactions', () => {
     const thumb = card.querySelector('.pet-codex-thumb') as HTMLElement;
     const preview = thumb.querySelector('.pet-codex-thumb-preview') as HTMLElement;
     const rectSpy = vi.spyOn(thumb, 'getBoundingClientRect');
+    const previewRectSpy = vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      width: 96,
+      height: 104,
+      right: 96,
+      bottom: 104,
+      toJSON: () => ({}),
+    });
     const originalInnerWidth = window.innerWidth;
 
     expect(preview).toBeTruthy();
     thumb.style.setProperty('--pet-codex-preview-width', '160px');
+    Object.defineProperty(preview, 'offsetWidth', {
+      configurable: true,
+      value: 160,
+    });
 
     const mockThumbRect = (left: number) =>
       rectSpy.mockReturnValue({
@@ -2317,6 +2332,8 @@ describe('SettingsDialog pets interactions', () => {
         value: originalInnerWidth,
       });
       rectSpy.mockRestore();
+      previewRectSpy.mockRestore();
+      Reflect.deleteProperty(preview, 'offsetWidth');
     }
   });
 

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -65,6 +65,7 @@ vi.mock('../../src/providers/provider-models', () => ({
 
 import { SettingsDialog } from '../../src/components/SettingsDialog';
 import type { AgentRefreshOptions, SettingsSection } from '../../src/components/SettingsDialog';
+import { codexPreviewOffsetForViewport } from '../../src/components/pet/PetSettings';
 import { I18nProvider } from '../../src/i18n';
 import { LOCALES } from '../../src/i18n/types';
 import type { AgentInfo, AppConfig, AppVersionInfo } from '../../src/types';
@@ -2241,6 +2242,21 @@ describe('SettingsDialog pets interactions', () => {
     expect(screen.getByText('Voidling')).toBeTruthy();
   });
 
+  it('clamps Codex pet preview offsets to the viewport', () => {
+    const viewportWidth = 320;
+    const previewWidth = 160;
+
+    expect(
+      codexPreviewOffsetForViewport({ left: 0, width: 56 }, viewportWidth, previewWidth),
+    ).toBe(64);
+    expect(
+      codexPreviewOffsetForViewport({ left: 270, width: 56 }, viewportWidth, previewWidth),
+    ).toBe(-70);
+    expect(
+      codexPreviewOffsetForViewport({ left: 100, width: 56 }, viewportWidth, previewWidth),
+    ).toBe(0);
+  });
+
   it('keeps Codex pet hover previews inside viewport edges', async () => {
     fetchCodexPetsMock.mockResolvedValue({
       pets: sampleBundledPets,
@@ -2258,8 +2274,12 @@ describe('SettingsDialog pets interactions', () => {
 
     const card = screen.getByText('Dario').closest('.pet-codex-card') as HTMLElement;
     const thumb = card.querySelector('.pet-codex-thumb') as HTMLElement;
+    const preview = thumb.querySelector('.pet-codex-thumb-preview') as HTMLElement;
     const rectSpy = vi.spyOn(thumb, 'getBoundingClientRect');
     const originalInnerWidth = window.innerWidth;
+
+    expect(preview).toBeTruthy();
+    thumb.style.setProperty('--pet-codex-preview-width', '160px');
 
     const mockThumbRect = (left: number) =>
       rectSpy.mockReturnValue({
@@ -2282,11 +2302,11 @@ describe('SettingsDialog pets interactions', () => {
 
       mockThumbRect(0);
       fireEvent.mouseEnter(card);
-      expect(thumb.style.getPropertyValue('--pet-codex-preview-offset')).toBe('48px');
+      expect(thumb.style.getPropertyValue('--pet-codex-preview-offset')).toBe('64px');
 
       mockThumbRect(270);
       fireEvent.mouseEnter(card);
-      expect(thumb.style.getPropertyValue('--pet-codex-preview-offset')).toBe('-54px');
+      expect(thumb.style.getPropertyValue('--pet-codex-preview-offset')).toBe('-70px');
 
       mockThumbRect(100);
       fireEvent.mouseEnter(card);

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -2241,6 +2241,65 @@ describe('SettingsDialog pets interactions', () => {
     expect(screen.getByText('Voidling')).toBeTruthy();
   });
 
+  it('keeps Codex pet hover previews inside viewport edges', async () => {
+    fetchCodexPetsMock.mockResolvedValue({
+      pets: sampleBundledPets,
+      rootDir: '/Users/test/.codex/pets',
+    });
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'codex' },
+      { initialSection: 'pet' },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Dario')).toBeTruthy();
+    });
+
+    const card = screen.getByText('Dario').closest('.pet-codex-card') as HTMLElement;
+    const thumb = card.querySelector('.pet-codex-thumb') as HTMLElement;
+    const rectSpy = vi.spyOn(thumb, 'getBoundingClientRect');
+    const originalInnerWidth = window.innerWidth;
+
+    const mockThumbRect = (left: number) =>
+      rectSpy.mockReturnValue({
+        x: left,
+        y: 0,
+        left,
+        top: 0,
+        width: 56,
+        height: 56,
+        right: left + 56,
+        bottom: 56,
+        toJSON: () => ({}),
+      });
+
+    try {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: 320,
+      });
+
+      mockThumbRect(0);
+      fireEvent.mouseEnter(card);
+      expect(thumb.style.getPropertyValue('--pet-codex-preview-offset')).toBe('48px');
+
+      mockThumbRect(270);
+      fireEvent.mouseEnter(card);
+      expect(thumb.style.getPropertyValue('--pet-codex-preview-offset')).toBe('-54px');
+
+      mockThumbRect(100);
+      fireEvent.mouseEnter(card);
+      expect(thumb.style.getPropertyValue('--pet-codex-preview-offset')).toBe('0px');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+      rectSpy.mockRestore();
+    }
+  });
+
   it('supports editing and persisting a custom pet', async () => {
     const { onPersist } = renderSettingsDialog(
       { mode: 'daemon', agentId: 'codex' },


### PR DESCRIPTION
Fixes #2475

## Why

The Codex pet hover preview is a fixed 128px overlay centered on a 56px thumb. Near either viewport edge, that centered position can push part of the preview off-screen.

## What users will see

Hovering or focusing a Codex pet card near the left or right edge keeps the larger preview inside the viewport. Centered cards keep their current centered preview.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from this headless run. The change is covered by a regression test that verifies the computed left, right, and centered offsets.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SettingsDialog.execution.test.tsx`
- Did the test go red on `main` and green on this branch? No; I added the regression on this branch and verified it passes with the fix.
- The regression renders the Settings pet cards, mocks a 320px viewport, and confirms the preview offset clamps at the left edge (`48px`), right edge (`-54px`), and stays centered in the middle (`0px`).

## Validation

- `corepack pnpm install --frozen-lockfile` (passes; warns current Node `v22.16.0` is below repo engine `~24`)
- `corepack pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx` (1 file, 82 tests passed)
- `corepack pnpm --filter @open-design/web typecheck` (passes; same Node engine warnings)
- `git diff --check`
- `git diff | gitleaks stdin --no-banner --redact --timeout 30`
