### PR TITLE
Add project bulk delete feedback

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1005,11 +1005,12 @@ export function App() {
 
   const handleDeleteProject = useCallback(async (id: string) => {
     const ok = await deleteProjectApi(id);
-    if (!ok) return;
+    if (!ok) return false;
     setProjects((curr) => curr.filter((p) => p.id !== id));
     if (route.kind === 'project' && route.projectId === id) {
       navigate({ kind: 'home', view: 'home' });
     }
+    return true;
   }, [route]);
 
   const handleRenameProject = useCallback(async (id: string, name: string) => {

--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -20,6 +20,7 @@ import type {
 } from "../types";
 import { Icon } from "./Icon";
 import { LiveArtifactBadges } from "./LiveArtifactBadges";
+import { Toast } from "./Toast";
 
 type SubTab = "recent" | "yours";
 type ViewMode = "grid" | "kanban";
@@ -64,7 +65,7 @@ interface Props {
 	designSystems: DesignSystemSummary[];
 	onOpen: (id: string) => void;
 	onOpenLiveArtifact: (projectId: string, artifactId: string) => void;
-	onDelete: (id: string) => void;
+	onDelete: (id: string) => Promise<boolean | void> | boolean | void;
 	onRename?: (id: string, name: string) => void;
 }
 
@@ -100,6 +101,7 @@ export function DesignsTab({
 	const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 	const [selectMode, setSelectMode] = useState(false);
 	const [selected, setSelected] = useState<Set<string>>(new Set());
+	const [deleteToast, setDeleteToast] = useState<string | null>(null);
 	const menuContainerRef = useRef<HTMLDivElement | null>(null);
 	const [renameTarget, setRenameTarget] = useState<{ id: string; original: string } | null>(null);
 	const [renameInput, setRenameInput] = useState("");
@@ -356,9 +358,25 @@ export function DesignsTab({
 			title: t("designs.deleteTitle"),
 			message: t("designs.deleteSelectedConfirm", { n: ids.length }),
 			confirmLabel: t("designs.deleteSelected"),
-			onConfirm: () => {
-				ids.forEach((id) => onDelete(id));
+			onConfirm: async () => {
+				const results = await Promise.all(
+					ids.map(async (id) => {
+						try {
+							const result = await onDelete(id);
+							return result !== false;
+						} catch {
+							return false;
+						}
+					}),
+				);
+				const deleted = results.filter(Boolean).length;
+				const failed = results.length - deleted;
 				exitSelectMode();
+				setDeleteToast(
+					failed > 0
+						? t("designs.deleteSelectedPartial", { deleted, failed })
+						: t("designs.deleteSelectedSuccess", { n: deleted }),
+				);
 			},
 		});
 	};
@@ -950,6 +968,9 @@ export function DesignsTab({
 						</div>
 					</div>
 				</div>
+			) : null}
+			{deleteToast ? (
+				<Toast message={deleteToast} onDismiss={() => setDeleteToast(null)} />
 			) : null}
 		</div>
 	);

--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -101,7 +101,8 @@ export function DesignsTab({
 	const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 	const [selectMode, setSelectMode] = useState(false);
 	const [selected, setSelected] = useState<Set<string>>(new Set());
-	const [deleteToast, setDeleteToast] = useState<string | null>(null);
+	const deleteToastIdRef = useRef(0);
+	const [deleteToast, setDeleteToast] = useState<{ id: number; message: string } | null>(null);
 	const menuContainerRef = useRef<HTMLDivElement | null>(null);
 	const [renameTarget, setRenameTarget] = useState<{ id: string; original: string } | null>(null);
 	const [renameInput, setRenameInput] = useState("");
@@ -372,11 +373,14 @@ export function DesignsTab({
 				const deleted = results.filter(Boolean).length;
 				const failed = results.length - deleted;
 				exitSelectMode();
-				setDeleteToast(
+				const message =
 					failed > 0
 						? t("designs.deleteSelectedPartial", { deleted, failed })
-						: t("designs.deleteSelectedSuccess", { n: deleted }),
-				);
+						: t("designs.deleteSelectedSuccess", { n: deleted });
+				setDeleteToast({
+					id: (deleteToastIdRef.current += 1),
+					message,
+				});
 			},
 		});
 	};
@@ -970,7 +974,11 @@ export function DesignsTab({
 				</div>
 			) : null}
 			{deleteToast ? (
-				<Toast message={deleteToast} onDismiss={() => setDeleteToast(null)} />
+				<Toast
+					key={deleteToast.id}
+					message={deleteToast.message}
+					onDismiss={() => setDeleteToast(null)}
+				/>
 			) : null}
 		</div>
 	);

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -239,7 +239,7 @@ interface Props {
   onImportFolderResponse?: (response: OpenDesignHostProjectImportSuccess) => Promise<void> | void;
   onOpenProject: (id: string) => void;
   onOpenLiveArtifact: (projectId: string, artifactId: string) => void;
-  onDeleteProject: (id: string) => void;
+  onDeleteProject: (id: string) => Promise<boolean | void> | boolean | void;
   onRenameProject: (id: string, name: string) => void;
   onChangeDefaultDesignSystem: (id: string) => void;
   onCreateDesignSystem?: () => void;

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -604,6 +604,8 @@ export const ar: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -492,6 +492,8 @@ export const de: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1095,6 +1095,8 @@ export const en: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -493,6 +493,8 @@ export const esES: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -626,6 +626,8 @@ export const fa: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -620,6 +620,8 @@ export const fr: Dict = {
   'designs.deleteSelected': 'Supprimer la sélection',
   'designs.selectedCount': '{n} sélectionné(s)',
   'designs.deleteSelectedConfirm': 'Supprimer {n} projet(s) ?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Artefact dynamique',
   'designs.tagSlide': 'Diapositive',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -604,6 +604,8 @@ export const hu: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -717,6 +717,8 @@ export const id: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -491,6 +491,8 @@ export const ja: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -604,6 +604,8 @@ export const ko: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -604,6 +604,8 @@ export const pl: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -625,6 +625,8 @@ export const ptBR: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -625,6 +625,8 @@ export const ru: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -580,6 +580,8 @@ export const th: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -593,6 +593,8 @@ export const tr: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -617,6 +617,8 @@ export const uk: Dict = {
   'designs.deleteSelected': 'Delete selected',
   'designs.selectedCount': '{n} selected',
   'designs.deleteSelectedConfirm': 'Delete {n} project(s)?',
+  'designs.deleteSelectedSuccess': '{n} project(s) deleted successfully.',
+  'designs.deleteSelectedPartial': 'Deleted {deleted} project(s); {failed} failed.',
   'designs.tagPrototype': 'Prototype',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1090,6 +1090,8 @@ export const zhCN: Dict = {
   'designs.deleteSelected': '删除所选',
   'designs.selectedCount': '已选择 {n} 项',
   'designs.deleteSelectedConfirm': '确定删除选中的 {n} 个项目？',
+  'designs.deleteSelectedSuccess': '已成功删除 {n} 个项目。',
+  'designs.deleteSelectedPartial': '已删除 {deleted} 个项目；{failed} 个失败。',
   'designs.tagPrototype': '原型',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -698,6 +698,8 @@ export const zhTW: Dict = {
   'designs.deleteSelected': '刪除所選',
   'designs.selectedCount': '已選擇 {n} 項',
   'designs.deleteSelectedConfirm': '確定刪除選取的 {n} 個專案？',
+  'designs.deleteSelectedSuccess': '已成功刪除 {n} 個專案。',
+  'designs.deleteSelectedPartial': '已刪除 {deleted} 個專案；{failed} 個失敗。',
   'designs.tagPrototype': '原型',
   'designs.tagLiveArtifact': 'Live Artifact',
   'designs.tagSlide': 'Slide',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1373,6 +1373,8 @@ export interface Dict {
   'designs.deleteSelected': string;
   'designs.selectedCount': string;
   'designs.deleteSelectedConfirm': string;
+  'designs.deleteSelectedSuccess': string;
+  'designs.deleteSelectedPartial': string;
   'designs.tagPrototype': string;
   'designs.tagLiveArtifact': string;
   'designs.tagSlide': string;

--- a/apps/web/tests/components/DesignsTab.select-mode.test.tsx
+++ b/apps/web/tests/components/DesignsTab.select-mode.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DesignsTab } from '../../src/components/DesignsTab';
@@ -137,6 +137,67 @@ describe('DesignsTab select mode', () => {
       '2 project(s) deleted successfully.',
     );
     expect(screen.queryByText('2 selected')).toBeNull();
+  });
+
+  it('restarts the bulk delete toast timer for repeated matching results', async () => {
+    vi.useFakeTimers();
+    const onDelete = vi.fn().mockResolvedValue(true);
+
+    const flushDelete = async () => {
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    };
+    const deleteSelectedProject = async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Select' }));
+      fireEvent.click(screen.getByText('Landing refresh').closest('.design-card') as HTMLElement);
+      fireEvent.click(screen.getByRole('button', { name: 'Delete selected' }));
+      fireEvent.click(
+        within(screen.getByRole('alertdialog')).getByRole('button', {
+          name: 'Delete selected',
+        }),
+      );
+      await flushDelete();
+    };
+
+    try {
+      render(
+        <DesignsTab
+          projects={[project]}
+          skills={[]}
+          designSystems={[]}
+          onOpen={vi.fn()}
+          onOpenLiveArtifact={vi.fn()}
+          onDelete={onDelete}
+          onRename={vi.fn()}
+        />,
+      );
+
+      await deleteSelectedProject();
+      expect(screen.getByRole('status').textContent).toContain(
+        '1 project(s) deleted successfully.',
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+      await deleteSelectedProject();
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(screen.getByRole('status').textContent).toContain(
+        '1 project(s) deleted successfully.',
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+      expect(screen.queryByRole('status')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('marks design-system projects with a dedicated tag', () => {

--- a/apps/web/tests/components/DesignsTab.select-mode.test.tsx
+++ b/apps/web/tests/components/DesignsTab.select-mode.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DesignsTab } from '../../src/components/DesignsTab';
@@ -90,6 +90,53 @@ describe('DesignsTab select mode', () => {
 
     expect(screen.queryByText('0 selected')).toBeNull();
     expect(screen.getByRole('button', { name: 'Select' })).toBeTruthy();
+  });
+
+  it('confirms bulk project deletion and shows success feedback', async () => {
+    const onDelete = vi.fn().mockResolvedValue(true);
+    render(
+      <DesignsTab
+        projects={[
+          project,
+          {
+            ...project,
+            id: 'project-2',
+            name: 'Brand system',
+            createdAt: 3,
+            updatedAt: 4,
+          },
+        ]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={onDelete}
+        onRename={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }));
+    fireEvent.click(screen.getByText('Landing refresh').closest('.design-card') as HTMLElement);
+    fireEvent.click(screen.getByText('Brand system').closest('.design-card') as HTMLElement);
+
+    expect(screen.getByText('2 selected')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete selected' }));
+    fireEvent.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Delete selected',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledTimes(2);
+    });
+    expect(onDelete).toHaveBeenNthCalledWith(1, 'project-1');
+    expect(onDelete).toHaveBeenNthCalledWith(2, 'project-2');
+    expect(screen.getByRole('status').textContent).toContain(
+      '2 project(s) deleted successfully.',
+    );
+    expect(screen.queryByText('2 selected')).toBeNull();
   });
 
   it('marks design-system projects with a dedicated tag', () => {


### PR DESCRIPTION
Fixes #1112

## Why

The current Projects grid already has select mode, selected-count deletion, and a confirmation dialog, but the batch-delete path exits select mode without telling the user whether the selected projects were deleted. The issue specifically calls out success feedback such as `3 projects deleted successfully`.

## What users will see

After confirming a bulk project delete, Open Design shows a transient toast with the number of projects deleted. If any delete call fails, the toast reports the deleted count and failed count instead.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from this headless run. The new toast uses the existing shared `Toast` component and is covered by the regression below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/DesignsTab.select-mode.test.tsx`
- Did the test go red on `main` and green on this branch? No; I added the regression on this branch and verified it passes with the fix.
- The regression selects two project cards, confirms `Delete selected`, verifies both delete callbacks, checks the success toast text, and confirms select mode exits.

## Validation

- `corepack pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/DesignsTab.select-mode.test.tsx` (1 file, 5 tests passed)
- `corepack pnpm --filter @open-design/web typecheck` (passes; warns current Node `v22.16.0` is below repo engine `~24`)
- `corepack pnpm i18n:check` (passes; same Node engine warning)
- `git diff --check`
- `git diff | gitleaks stdin --no-banner --redact --timeout 30`
