### PR TITLE
Create design-system conversations from New action

### DIFF
--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -705,6 +705,7 @@ export function DesignSystemDetailView({
   const pendingWorkspaceFileWritesRef = useRef<Map<string, string>>(new Map());
   const workspaceTabsLoadedRef = useRef(false);
   const openedProjectRef = useRef<string | null>(null);
+  const suppressedInitialConversationProjectIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     let cancelled = false;
@@ -722,6 +723,7 @@ export function DesignSystemDetailView({
     setWorkspaceOpenRequest(null);
     openedProjectRef.current = null;
     workspaceTabsLoadedRef.current = false;
+    suppressedInitialConversationProjectIdsRef.current.clear();
     pendingWorkspaceFileWritesRef.current.clear();
     void fetchDesignSystem(id).then((detail) => {
       if (cancelled) return;
@@ -767,6 +769,9 @@ export function DesignSystemDetailView({
   useEffect(() => {
     if (!workspaceProjectId) return undefined;
     const projectId = workspaceProjectId;
+    if (suppressedInitialConversationProjectIdsRef.current.delete(projectId)) {
+      return undefined;
+    }
     let cancelled = false;
     async function loadWorkspaceConversation() {
       const existing = await listConversations(projectId);
@@ -1025,11 +1030,14 @@ export function DesignSystemDetailView({
     setStatusLine(updated ? (next ? 'Published' : 'Moved back to draft') : 'Could not update status');
   }
 
-  async function ensureWorkspaceProject() {
+  async function ensureWorkspaceProject(options?: { suppressInitialConversation?: boolean }) {
     if (!system) return workspaceProjectId;
     if (workspaceProjectId) return workspaceProjectId;
     const resolved = await resolveDesignSystemWorkspaceProject(system);
     if (!resolved) return null;
+    if (options?.suppressInitialConversation) {
+      suppressedInitialConversationProjectIdsRef.current.add(resolved.projectId);
+    }
     setWorkspaceProjectId(resolved.projectId);
     setWorkspaceProjectFiles(resolved.files);
     return resolved.projectId;
@@ -1351,25 +1359,29 @@ export function DesignSystemDetailView({
   }, []);
 
   const createProjectChatConversation = useCallback(() => {
-    const projectId = workspaceProjectId;
-    if (!projectId) {
-      setChatSeed({
-        id: `general-${Date.now()}`,
-        text: 'Update this design system: ',
+    void (async () => {
+      const projectId = workspaceProjectId ?? await ensureWorkspaceProject({
+        suppressInitialConversation: true,
       });
-      return;
-    }
-    void createConversation(projectId, 'Design system').then((fresh) => {
-      if (!fresh) return;
+      if (!projectId) {
+        setChatError('Could not open the design system workspace.');
+        return;
+      }
+      const fresh = await createConversation(projectId, 'Design system');
+      if (!fresh) {
+        setChatError('Could not create a design system conversation.');
+        return;
+      }
       setConversations((current) => [fresh, ...current]);
       setActiveConversationId(fresh.id);
       setProjectChatMessages([]);
+      setChatError(null);
       setChatSeed({
         id: `general-${Date.now()}`,
         text: 'Update this design system: ',
       });
-    });
-  }, [workspaceProjectId]);
+    })();
+  }, [ensureWorkspaceProject, workspaceProjectId]);
 
   async function resolveRevision(
     revision: DesignSystemRevision,

--- a/apps/web/tests/components/DesignSystemFlow.test.tsx
+++ b/apps/web/tests/components/DesignSystemFlow.test.tsx
@@ -12,7 +12,7 @@ import {
   DesignSystemCreationFlow,
   DesignSystemDetailView,
 } from '../../src/components/DesignSystemFlow';
-import type { AppConfig, DesignSystemDetail, Project, ProjectFile } from '../../src/types';
+import type { AppConfig, Conversation, DesignSystemDetail, Project, ProjectFile } from '../../src/types';
 import { I18nProvider } from '../../src/i18n';
 
 const mocks = vi.hoisted(() => ({
@@ -42,17 +42,31 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../../src/components/ChatPane', () => ({
   ChatPane: ({
+    error,
+    onNewConversation,
     onSend,
   }: {
+    error?: string | null;
+    onNewConversation?: () => void;
     onSend: (prompt: string, attachments: unknown[], commentAttachments: unknown[]) => void;
   }) => (
-    <button
-      type="button"
-      data-testid="design-system-chat-send"
-      onClick={() => onSend('Update the design tokens', [], [])}
-    >
-      send
-    </button>
+    <>
+      {error ? <div role="alert">{error}</div> : null}
+      <button
+        type="button"
+        data-testid="new-conversation"
+        onClick={() => onNewConversation?.()}
+      >
+        New
+      </button>
+      <button
+        type="button"
+        data-testid="design-system-chat-send"
+        onClick={() => onSend('Update the design tokens', [], [])}
+      >
+        send
+      </button>
+    </>
   ),
 }));
 
@@ -2045,6 +2059,134 @@ describe('DesignSystemDetailView', () => {
       }),
     );
     expect(screen.queryByText('Could not open the design system workspace.')).toBeNull();
+  });
+
+  it('starts a new design-system conversation by opening the workspace first', async () => {
+    const system: DesignSystemDetail = {
+      id: 'installed:acme-design-system',
+      title: 'Acme Design System',
+      category: 'Custom',
+      summary: 'Acme product workspace.',
+      swatches: [],
+      surface: 'web',
+      body: '# Acme Design System\n',
+      source: 'installed',
+      status: 'published',
+      isEditable: true,
+    };
+    const project: Project = {
+      id: 'ds-acme-design-system',
+      name: 'Acme Design System',
+      skillId: null,
+      designSystemId: system.id,
+      createdAt: 1,
+      updatedAt: 1,
+      metadata: {
+        kind: 'other',
+        importedFrom: 'design-system',
+        entryFile: 'DESIGN.md',
+        sourceFileName: system.id,
+      },
+    };
+    const fresh: Conversation = {
+      id: 'conv-new',
+      projectId: project.id,
+      title: 'Design system',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    mocks.fetchDesignSystem.mockResolvedValue(system);
+    mocks.ensureDesignSystemWorkspace
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValue({ project, files: [] });
+    mocks.createConversation.mockResolvedValue(fresh);
+
+    render(
+      <DesignSystemDetailView
+        id={system.id}
+        selectedId={null}
+        config={{ mode: 'daemon', agentId: 'codex' } as AppConfig}
+        agents={[]}
+        onBack={() => {}}
+        onSetDefault={() => {}}
+      />,
+    );
+
+    const button = await screen.findByTestId('new-conversation');
+    fireEvent.click(button);
+
+    await waitFor(() => expect(mocks.ensureDesignSystemWorkspace).toHaveBeenCalledWith(system.id));
+    await waitFor(() => expect(mocks.createConversation).toHaveBeenCalledWith(project.id, 'Design system'));
+    expect(mocks.createConversation).toHaveBeenCalledTimes(1);
+    expect(mocks.listConversations).not.toHaveBeenCalled();
+    await waitFor(() => expect(mocks.listMessages).toHaveBeenCalledWith(project.id, fresh.id));
+  });
+
+  it('clears a stale creation error after a successful new conversation retry', async () => {
+    const system: DesignSystemDetail = {
+      id: 'installed:acme-design-system',
+      title: 'Acme Design System',
+      category: 'Custom',
+      summary: 'Acme product workspace.',
+      swatches: [],
+      surface: 'web',
+      body: '# Acme Design System\n',
+      source: 'installed',
+      status: 'published',
+      isEditable: true,
+    };
+    const project: Project = {
+      id: 'ds-acme-design-system',
+      name: 'Acme Design System',
+      skillId: null,
+      designSystemId: system.id,
+      createdAt: 1,
+      updatedAt: 1,
+      metadata: {
+        kind: 'other',
+        importedFrom: 'design-system',
+        entryFile: 'DESIGN.md',
+        sourceFileName: system.id,
+      },
+    };
+    const fresh: Conversation = {
+      id: 'conv-new',
+      projectId: project.id,
+      title: 'Design system',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    mocks.fetchDesignSystem.mockResolvedValue(system);
+    mocks.ensureDesignSystemWorkspace
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValue({ project, files: [] });
+    mocks.createConversation
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(fresh);
+
+    render(
+      <DesignSystemDetailView
+        id={system.id}
+        selectedId={null}
+        config={{ mode: 'daemon', agentId: 'codex' } as AppConfig}
+        agents={[]}
+        onBack={() => {}}
+        onSetDefault={() => {}}
+      />,
+    );
+
+    const button = await screen.findByTestId('new-conversation');
+    fireEvent.click(button);
+
+    await screen.findByText('Could not create a design system conversation.');
+
+    fireEvent.click(button);
+
+    await waitFor(() => expect(mocks.createConversation).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      expect(screen.queryByText('Could not create a design system conversation.')).toBeNull();
+    });
+    await waitFor(() => expect(mocks.listMessages).toHaveBeenCalledWith(project.id, fresh.id));
   });
 
   it('passes the current UI locale to daemon workspace chat runs', async () => {

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -38,10 +38,6 @@ vi.mock('../../src/i18n', () => ({
     t: (value: string) => value,
   }),
   useT: () => ((value: string) => value),
-  useI18n: () => ({
-    locale: 'en',
-    t: (value: string) => value,
-  }),
 }));
 
 vi.mock('../../src/providers/anthropic', () => ({


### PR DESCRIPTION
Fixes #2410

## Why

The Design System conversation panel showed an enabled New action, but installed design systems could reach that state without a workspace project id. Clicking New only seeded draft text, so no project conversation was created or selected.

## What users will see

Clicking New in the Design System conversation panel now opens the design-system workspace first when needed, creates a Design system conversation, selects it, and prepares the initial draft prompt.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not included; this changes the existing button behavior and adds no visible UI.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/DesignSystemFlow.test.tsx`
- Did the test go red on `main` and green on this branch? No; I did not run the new regression on `main`. The test covers the installed design-system path by asserting the New action ensures the workspace, creates exactly one conversation, skips the initial auto-loader race, and loads messages for the fresh conversation.

## Validation

- `corepack pnpm --filter @open-design/web exec vitest run tests/components/DesignSystemFlow.test.tsx -t "starts a new design-system conversation" --pool=threads` — passed, 1 test / 17 skipped
- `corepack pnpm --filter @open-design/web exec vitest run tests/components/DesignSystemFlow.test.tsx --pool=threads` — passed, 18 tests
- `corepack pnpm --filter @open-design/web typecheck` — passed
- `corepack pnpm guard` — passed
- `git diff --check` — passed
- `git diff | gitleaks stdin --no-banner --redact --timeout 30` — no leaks found

Note: local commands emitted the existing engine warning because this machine is on Node v22.16.0 while the repo requests Node ~24.