### PR TITLE
Reject reserved project paths in HTML artifacts

### DIFF
--- a/apps/web/src/artifacts/validate.ts
+++ b/apps/web/src/artifacts/validate.ts
@@ -14,6 +14,8 @@
  * - the *first* non-whitespace token is `<!doctype html>` or `<html`
  *   (anchored at the start; mid-string mentions of these tags do NOT count —
  *   AI prose like "Updated the <html lang> attribute…" must be rejected)
+ * - URL-bearing attributes or CSS url(...) values do not point at internal
+ *   project storage paths such as `.live-artifacts/`, `.od/`, or `.tmp/`
  *
  * What this gate is NOT:
  * - It is **not** an HTML linter or validator. Malformed but recognizably
@@ -36,6 +38,15 @@
 
 const MIN_HTML_LENGTH = 64;
 const STARTS_WITH_DOCUMENT_RE = /^(?:<!doctype\s+html\b|<html\b)/i;
+const RESERVED_PROJECT_PATH_RE = /(?:^|\/|\.\/)(?:\.live-artifacts|\.od|\.tmp)(?=$|[/?#"'`\s>)])/i;
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+const URL_ATTRIBUTE_RE =
+  /\b(href|src|srcset|poster|action|formaction|data|xlink:href)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+))/gi;
+const STYLE_ATTRIBUTE_RE =
+  /\bstyle\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'`=<>]+))/gi;
+const HTML_TAG_RE = /<[a-z][^>]*>/gi;
+const STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+const CSS_URL_RE = /\burl\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*?))\s*\)/gi;
 
 export type HtmlArtifactValidationResult =
   | { ok: true }
@@ -52,5 +63,126 @@ export function validateHtmlArtifact(content: string): HtmlArtifactValidationRes
   if (!STARTS_WITH_DOCUMENT_RE.test(trimmed)) {
     return { ok: false, reason: 'content does not start with <!doctype html> or <html — looks like prose, not a complete HTML document' };
   }
+  if (referencesReservedProjectPath(trimmed)) {
+    return { ok: false, reason: 'content references an internal project storage path such as .live-artifacts, .od, or .tmp' };
+  }
   return { ok: true };
+}
+
+function referencesReservedProjectPath(content: string): boolean {
+  return hasReservedProjectPathInTags(content)
+    || hasReservedProjectPathInStyleBlocks(content);
+}
+
+function hasReservedProjectPathInTags(content: string): boolean {
+  HTML_TAG_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HTML_TAG_RE.exec(content)) !== null) {
+    const tag = match[0] ?? '';
+    if (hasReservedProjectPathAttribute(tag) || hasReservedProjectPathInStyleAttributes(tag)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasReservedProjectPathAttribute(tag: string): boolean {
+  URL_ATTRIBUTE_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = URL_ATTRIBUTE_RE.exec(tag)) !== null) {
+    const attributeName = match[1]?.toLowerCase();
+    const candidate = match[2] ?? match[3] ?? match[4] ?? '';
+    if (candidateReferencesReservedProjectPath(candidate, attributeName === 'srcset')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasReservedProjectPathInStyleAttributes(tag: string): boolean {
+  STYLE_ATTRIBUTE_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = STYLE_ATTRIBUTE_RE.exec(tag)) !== null) {
+    const cssText = match[1] ?? match[2] ?? match[3] ?? '';
+    if (cssTextReferencesReservedProjectPath(cssText)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasReservedProjectPathInStyleBlocks(content: string): boolean {
+  STYLE_BLOCK_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = STYLE_BLOCK_RE.exec(content)) !== null) {
+    const cssText = match[1] ?? '';
+    if (cssTextReferencesReservedProjectPath(cssText)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function cssTextReferencesReservedProjectPath(cssText: string): boolean {
+  CSS_URL_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = CSS_URL_RE.exec(cssText)) !== null) {
+    const candidate = match[1] ?? match[2] ?? match[3] ?? '';
+    if (candidateReferencesReservedProjectPath(candidate, false)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function candidateReferencesReservedProjectPath(candidate: string, splitCandidates: boolean): boolean {
+  const paths = splitCandidates ? srcsetCandidateUrls(candidate) : [firstUrlToken(candidate)];
+  return paths.some((path) => {
+    return isLocalPathLike(path) && RESERVED_PROJECT_PATH_RE.test(path);
+  });
+}
+
+function srcsetCandidateUrls(srcset: string): string[] {
+  const candidates: string[] = [];
+  let start = 0;
+  let sawCandidate = false;
+  let dataUrlCandidate = false;
+  let sawWhitespaceAfterUrl = false;
+
+  for (let index = 0; index < srcset.length; index += 1) {
+    const char = srcset[index]!;
+    if (!sawCandidate) {
+      if (char === ',' || /\s/.test(char)) {
+        start = index + 1;
+        continue;
+      }
+      sawCandidate = true;
+      dataUrlCandidate = /^data:/i.test(srcset.slice(index));
+    }
+    if (/\s/.test(char)) {
+      sawWhitespaceAfterUrl = true;
+      continue;
+    }
+    if (char === ',' && (!dataUrlCandidate || sawWhitespaceAfterUrl)) {
+      candidates.push(srcset.slice(start, index));
+      start = index + 1;
+      sawCandidate = false;
+      dataUrlCandidate = false;
+      sawWhitespaceAfterUrl = false;
+    }
+  }
+
+  candidates.push(srcset.slice(start));
+  return candidates.map(firstUrlToken).filter(Boolean);
+}
+
+function firstUrlToken(value: string): string {
+  return value.trim().split(/\s+/)[0] ?? '';
+}
+
+function isLocalPathLike(path: string): boolean {
+  return path.length > 0
+    && !path.startsWith('#')
+    && !path.startsWith('//')
+    && !URL_SCHEME_RE.test(path);
 }

--- a/apps/web/src/artifacts/validate.ts
+++ b/apps/web/src/artifacts/validate.ts
@@ -14,8 +14,8 @@
  * - the *first* non-whitespace token is `<!doctype html>` or `<html`
  *   (anchored at the start; mid-string mentions of these tags do NOT count —
  *   AI prose like "Updated the <html lang> attribute…" must be rejected)
- * - URL-bearing attributes or CSS url(...) values do not point at internal
- *   project storage paths such as `.live-artifacts/`, `.od/`, or `.tmp/`
+ * - URL-bearing attributes or CSS `url(...)` / `@import` values do not point at
+ *   internal project storage paths such as `.live-artifacts/`, `.od/`, or `.tmp/`
  *
  * What this gate is NOT:
  * - It is **not** an HTML linter or validator. Malformed but recognizably
@@ -47,6 +47,8 @@ const STYLE_ATTRIBUTE_RE =
 const HTML_TAG_RE = /<[a-z][^>]*>/gi;
 const STYLE_BLOCK_RE = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
 const CSS_URL_RE = /\burl\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*?))\s*\)/gi;
+const CSS_IMPORT_RE =
+  /@import\s+(?:url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*?))\s*\)|"([^"]*)"|'([^']*)')/gi;
 
 export type HtmlArtifactValidationResult =
   | { ok: true }
@@ -124,12 +126,14 @@ function hasReservedProjectPathInStyleBlocks(content: string): boolean {
 }
 
 function cssTextReferencesReservedProjectPath(cssText: string): boolean {
-  CSS_URL_RE.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = CSS_URL_RE.exec(cssText)) !== null) {
-    const candidate = match[1] ?? match[2] ?? match[3] ?? '';
-    if (candidateReferencesReservedProjectPath(candidate, false)) {
-      return true;
+  for (const pattern of [CSS_URL_RE, CSS_IMPORT_RE]) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(cssText)) !== null) {
+      const candidate = match.slice(1).find((value) => value !== undefined) ?? '';
+      if (candidateReferencesReservedProjectPath(candidate, false)) {
+        return true;
+      }
     }
   }
   return false;
@@ -138,8 +142,19 @@ function cssTextReferencesReservedProjectPath(cssText: string): boolean {
 function candidateReferencesReservedProjectPath(candidate: string, splitCandidates: boolean): boolean {
   const paths = splitCandidates ? srcsetCandidateUrls(candidate) : [firstUrlToken(candidate)];
   return paths.some((path) => {
-    return isLocalPathLike(path) && RESERVED_PROJECT_PATH_RE.test(path);
+    if (!isLocalPathLike(path)) {
+      return false;
+    }
+    return RESERVED_PROJECT_PATH_RE.test(pathnameOnly(path));
   });
+}
+
+function pathnameOnly(path: string): string {
+  const separator = path.search(/[?#]/);
+  if (separator === -1) {
+    return path;
+  }
+  return path.slice(0, separator);
 }
 
 function srcsetCandidateUrls(srcset: string): string[] {

--- a/apps/web/tests/artifacts/validate.test.ts
+++ b/apps/web/tests/artifacts/validate.test.ts
@@ -78,6 +78,12 @@ describe('validateHtmlArtifact', () => {
     expect(result.ok).toBe(false);
   });
 
+  it('rejects CSS import references to reserved storage', () => {
+    const html = '<!doctype html><html><head><style>@import "/.od/foo.css";@import url(./.tmp/theme.css);</style></head><body><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(false);
+  });
+
   it('rejects inline style url references to reserved storage', () => {
     const html = '<!doctype html><html><body><div style="background-image:url(./.tmp/preview.png)">Preview</div><p>Enough content to look like a real document.</p></body></html>';
     const result = validateHtmlArtifact(html);
@@ -98,6 +104,12 @@ describe('validateHtmlArtifact', () => {
 
   it('accepts external URLs with reserved-looking path segments', () => {
     const html = '<!doctype html><html><body><a href="https://example.test/.od/reference.html">External docs</a><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts local URLs that only mention reserved paths in query or hash', () => {
+    const html = '<!doctype html><html><head><style>.card{background-image:url("/docs?example=/.od/ref")}</style></head><body><a href="/docs?example=/.od/ref">Query docs</a><a href="/docs#/.tmp/ref">Hash docs</a><p>Enough content to look like a real document.</p></body></html>';
     const result = validateHtmlArtifact(html);
     expect(result.ok).toBe(true);
   });

--- a/apps/web/tests/artifacts/validate.test.ts
+++ b/apps/web/tests/artifacts/validate.test.ts
@@ -52,6 +52,86 @@ describe('validateHtmlArtifact', () => {
     expect(result.ok).toBe(false);
   });
 
+  it('rejects links to reserved project storage paths', () => {
+    const html = '<!doctype html><html><body><iframe src=".live-artifacts/artifact-1/index.html"></iframe><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/internal project storage path/i);
+  });
+
+  it('rejects root reserved project storage paths in URL attributes', () => {
+    const html = '<!doctype html><html><body><a href="/.live-artifacts">Preview</a><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/internal project storage path/i);
+  });
+
+  it('rejects unquoted URL attributes that reference reserved storage', () => {
+    const html = '<!doctype html><html><body><img src=./.od/thumb.png alt="Preview"><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects CSS url references to reserved storage', () => {
+    const html = '<!doctype html><html><head><style>.card{background-image:url("/.tmp/preview.png")}</style></head><body><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects inline style url references to reserved storage', () => {
+    const html = '<!doctype html><html><body><div style="background-image:url(./.tmp/preview.png)">Preview</div><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects srcset candidates that reference reserved storage', () => {
+    const html = '<!doctype html><html><body><img srcset="assets/preview.png 1x, /.live-artifacts/artifact-1/preview.png 2x" alt="Preview"><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts plain text mentions of reserved directory names', () => {
+    const html = '<!doctype html><html><body><p>The .od folder and .tmp files are mentioned as documentation text only, not linked paths.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts external URLs with reserved-looking path segments', () => {
+    const html = '<!doctype html><html><body><a href="https://example.test/.od/reference.html">External docs</a><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts text-node mentions of CSS url syntax for reserved names', () => {
+    const html = '<!doctype html><html><body><p>Documentation can mention CSS examples like url("/.tmp/foo.png") without linking to project storage.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts text-node mentions of HTML attribute syntax for reserved names', () => {
+    const html = '<!doctype html><html><body><p>Documentation can mention examples like href="/.od/reference.html" without linking to project storage.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts data URLs with reserved-looking payload text', () => {
+    const html = '<!doctype html><html><body><img src="data:text/plain,/.od/foo" alt="Inline payload"><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts data URLs with reserved-looking payload text in srcset', () => {
+    const html = '<!doctype html><html><body><img srcset="data:text/plain,/.od/foo 1x" alt="Inline payload"><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts the supported live artifact preview API route', () => {
+    const html = '<!doctype html><html><body><iframe src="/api/live-artifacts/artifact-1/preview"></iframe><p>Enough content to look like a real document.</p></body></html>';
+    const result = validateHtmlArtifact(html);
+    expect(result.ok).toBe(true);
+  });
+
   it('accepts a complete <!doctype html> document', () => {
     const html = '<!doctype html><html><head><title>x</title></head><body><h1>hello</h1></body></html>';
     const result = validateHtmlArtifact(html);


### PR DESCRIPTION
Fixes #1665

## Why

Orbit follow-up artifacts can embed internal project storage paths such as `.live-artifacts/` in iframe or asset references. Those HTML artifacts can save successfully, but later fail to preview because the file API treats `.live-artifacts`, `.od`, and `.tmp` as reserved project storage segments.

## What users will see

AI-emitted HTML artifacts that link directly to `.live-artifacts`, `.od`, or `.tmp` through URL attributes or CSS `url(...)` are rejected during artifact validation instead of saving a preview that fails later. Plain text mentions, external URLs, data URLs, and the supported `/api/live-artifacts/:artifactId/preview` route remain allowed.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — validation-only bug fix with no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/artifacts/validate.test.ts`
- Did the test go red on `main` and green on this branch? Yes for the regression behavior: a direct `origin/main` validator check accepted 6/6 reserved-path fixtures that these tests now expect to reject; this branch passes the focused Vitest suite.
- The new coverage rejects direct `.live-artifacts`, root reserved paths, unquoted `.od`, CSS `.tmp`, inline-style `.tmp`, and `srcset` reserved candidates, while keeping text mentions, external URLs, data URLs, data-URL `srcset`, and `/api/live-artifacts/:id/preview` allowed.

## Validation

- `corepack pnpm --filter @open-design/web exec vitest run tests/artifacts/validate.test.ts --pool=threads` — passed, 25 tests
- `corepack pnpm --filter @open-design/web typecheck` — passed
- `corepack pnpm guard` — passed
- `git diff --check` — passed
- `git diff | gitleaks stdin --no-banner --redact --timeout 30` — no leaks found

Note: local validation ran under Node `v22.16.0`; pnpm reported the repo engine warning for expected Node `~24`.
