### PR TITLE
fix(nix): force http:// scheme on bundled caddy site address

### DIFF
--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -54,6 +54,10 @@
   #     in browsers (same failure mode QUICKSTART.md calls out for
   #     nginx).
   #   * generous read/write timeouts for long-running streams.
+  #
+  # Site address is explicitly `http://` — a bare `host:port` lets Caddy
+  # pick the listener scheme by port, which collides with `auto_https
+  # off` and surfaces as TLS errors when the browser hits plain HTTP.
   caddyfile = pkgs.writeText "open-design-web.Caddyfile" ''
     {
       auto_https off
@@ -61,7 +65,7 @@
       persist_config off
     }
 
-    ${cfg.webFrontend.host}:${toString cfg.webFrontend.port} {
+    http://${cfg.webFrontend.host}:${toString cfg.webFrontend.port} {
       handle /api/* {
         reverse_proxy 127.0.0.1:${toString cfg.port} {
           flush_interval -1

--- a/nix/nixos.nix
+++ b/nix/nixos.nix
@@ -41,7 +41,7 @@
       persist_config off
     }
 
-    ${cfg.webFrontend.host}:${toString cfg.webFrontend.port} {
+    http://${cfg.webFrontend.host}:${toString cfg.webFrontend.port} {
       handle /api/* {
         reverse_proxy 127.0.0.1:${toString cfg.port} {
           flush_interval -1


### PR DESCRIPTION
## Why

Hit this myself running the nix flake: the bundled caddy's site address was bare `${host}:${port}`, so Caddy's parser picked the listener scheme from port heuristics and fought `auto_https off`. Browser hits
plain HTTP, listener thought it should be doing TLS, and you get an unhelpful error mid-load. Forcing `http://` in the Caddyfile is the canonical fix and matches the module's actual contract — the bundled
proxy is plaintext-only by design; HTTPS is the BYO-front-end path (`webFrontend.enable = false`).

## What users will see

Nothing visible. People running the Home Manager / NixOS module with the bundled `webFrontend` stop hitting the scheme-mismatch error on first load. Everyone else is unaffected.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — nix module fix, no user-facing surface change

## Screenshots

n/a

## Bug fix verification

No red spec. The repo doesn't have a nix-module eval harness, and the symptom (Caddy listener scheme negotiation vs. browser scheme) only reproduces against a live listener, not in a unit. Verified by hand:
with the bare site address the bundled web frontend fails to load in the browser; with the `http://` prefix it loads cleanly.

## Validation

- `nix-instantiate --parse nix/home-manager.nix` and `nix-instantiate --parse nix/nixos.nix` — both parse
- Manually exercised the bundled `webFrontend` against a local daemon — SPA loads, `/api`, `/artifacts`, `/frames` all proxy correctly
- No TS / JS surface touched, so `pnpm guard` / `pnpm typecheck` aren't load-bearing here