### PR TITLE
Fix sketch default color in dark mode

### DIFF
--- a/apps/web/src/components/SketchEditor.tsx
+++ b/apps/web/src/components/SketchEditor.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useT } from '../i18n';
+import { readDefaultSketchToolColor } from './sketch-colors';
 import type { SketchItem } from './sketch-model';
 
 export type Tool = 'select' | 'pen' | 'text' | 'rect' | 'arrow' | 'eraser';
@@ -34,7 +35,7 @@ export function SketchEditor({
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const [tool, setTool] = useState<Tool>('pen');
-  const [color, setColor] = useState('#1c1b1a');
+  const [color, setColor] = useState(() => readDefaultSketchToolColor());
   const [size, setSize] = useState(2);
   const drawingRef = useRef<SketchItem | null>(null);
   const [, force] = useState(0);

--- a/apps/web/src/components/sketch-colors.ts
+++ b/apps/web/src/components/sketch-colors.ts
@@ -1,0 +1,18 @@
+export const DEFAULT_SKETCH_LIGHT_TOOL_COLOR = '#1c1b1a';
+export const DEFAULT_SKETCH_DARK_TOOL_COLOR = '#ffffff';
+
+export function resolveDefaultSketchToolColor(
+  theme: string | null,
+  prefersDark: boolean,
+): string {
+  if (theme === 'dark') return DEFAULT_SKETCH_DARK_TOOL_COLOR;
+  if (theme === 'light') return DEFAULT_SKETCH_LIGHT_TOOL_COLOR;
+  return prefersDark ? DEFAULT_SKETCH_DARK_TOOL_COLOR : DEFAULT_SKETCH_LIGHT_TOOL_COLOR;
+}
+
+export function readDefaultSketchToolColor(): string {
+  if (typeof document === 'undefined') return DEFAULT_SKETCH_LIGHT_TOOL_COLOR;
+  const theme = document.documentElement.getAttribute('data-theme');
+  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches === true;
+  return resolveDefaultSketchToolColor(theme, prefersDark);
+}

--- a/apps/web/tests/components/SketchEditor.default-color.test.tsx
+++ b/apps/web/tests/components/SketchEditor.default-color.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SketchEditor } from '../../src/components/SketchEditor';
+import { I18nProvider } from '../../src/i18n';
+
+class ResizeObserverMock {
+  observe() {}
+  disconnect() {}
+}
+
+function renderEditor() {
+  return render(
+    <I18nProvider initial="en">
+      <SketchEditor
+        items={[]}
+        onItemsChange={vi.fn()}
+        onSave={vi.fn()}
+        fileName="scratch.sketch.json"
+      />
+    </I18nProvider>,
+  );
+}
+
+describe('SketchEditor default color', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      setTransform: vi.fn(),
+      clearRect: vi.fn(),
+      save: vi.fn(),
+      fillRect: vi.fn(),
+      restore: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      stroke: vi.fn(),
+      strokeRect: vi.fn(),
+      fillText: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.documentElement.removeAttribute('data-theme');
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('starts with a light pen color under the dark theme', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+
+    const { container } = renderEditor();
+
+    const colorInput = container.querySelector<HTMLInputElement>('input[type="color"]');
+    expect(colorInput?.value).toBe('#ffffff');
+  });
+
+  it('keeps the existing default pen color under the light theme', () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+
+    const { container } = renderEditor();
+
+    const colorInput = container.querySelector<HTMLInputElement>('input[type="color"]');
+    expect(colorInput?.value).toBe('#1c1b1a');
+  });
+});

--- a/apps/web/tests/components/sketch-colors.test.ts
+++ b/apps/web/tests/components/sketch-colors.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_SKETCH_DARK_TOOL_COLOR,
+  DEFAULT_SKETCH_LIGHT_TOOL_COLOR,
+  resolveDefaultSketchToolColor,
+} from '../../src/components/sketch-colors';
+
+describe('sketch-colors', () => {
+  it('uses a light tool color for an explicit dark theme', () => {
+    expect(resolveDefaultSketchToolColor('dark', false)).toBe(DEFAULT_SKETCH_DARK_TOOL_COLOR);
+  });
+
+  it('keeps the existing dark tool color for an explicit light theme', () => {
+    expect(resolveDefaultSketchToolColor('light', true)).toBe(DEFAULT_SKETCH_LIGHT_TOOL_COLOR);
+  });
+
+  it('follows the system dark preference when no explicit theme is set', () => {
+    expect(resolveDefaultSketchToolColor(null, true)).toBe(DEFAULT_SKETCH_DARK_TOOL_COLOR);
+  });
+
+  it('keeps the light-mode default when system mode is not dark', () => {
+    expect(resolveDefaultSketchToolColor(null, false)).toBe(DEFAULT_SKETCH_LIGHT_TOOL_COLOR);
+  });
+});


### PR DESCRIPTION
Fixes #2487

## Why

In dark mode the sketch editor started new drawings with `#1c1b1a`, which is hard to see against the themed canvas until the user changes the color manually.

## What users will see

New sketch editor sessions start with a white tool color in dark or system-dark mode. Light mode keeps the existing `#1c1b1a` default. Existing saved sketch item colors are not rewritten.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No screenshots attached; the changed behavior is covered by a component test that renders the sketch editor under dark and light themes and checks the color input default.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SketchEditor.default-color.test.tsx`
- Did the test go red on `main` and green on this branch? Not rerun on `main`; before this change `SketchEditor.tsx` hard-coded `#1c1b1a`, so the dark-theme default-color assertion would fail there.
- The helper tests also cover explicit light/dark plus system preference resolution.

## Validation

- `corepack pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/sketch-colors.test.ts tests/components/SketchEditor.default-color.test.tsx --pool=threads` — passed, 2 files / 6 tests
- `corepack pnpm --filter @open-design/web typecheck` — passed; pnpm printed Node engine warnings because this machine is on Node v22.16.0 while the repo requests `~24`
- `git diff --check` — passed
- `git show --format= --patch HEAD | gitleaks detect --pipe --redact --no-banner` — no leaks found