### PR TITLE
fix(web): retry failed chat runs without duplicating user message

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -235,6 +235,7 @@ interface Props {
     commentAttachments: ChatCommentAttachment[],
     meta?: ChatSendMeta,
   ) => void;
+  onRetry?: (assistantMessage: ChatMessage) => void;
   onStop: () => void;
   // Skills available for @-mention assembly. ProjectView filters out the
   // user's disabled set before passing them in here.
@@ -321,6 +322,7 @@ export function ChatPane({
   onDetachComment,
   onDeleteComment,
   onSend,
+  onRetry,
   onStop,
   onRequestOpenFile,
   onRequestPluginFolderAgentAction,
@@ -383,6 +385,7 @@ export function ChatPane({
   const hasActiveRunMessage = messages.some(
     (m) => m.role === 'assistant' && isActiveRunStatus(m.runStatus),
   );
+  const retryAssistant = retryableAssistantMessage(messages, lastAssistantId, streaming);
   // Only the first user message gets the active-plugin chip — the
   // plugin is project-scoped so re-stamping it on every reply would be
   // noise. Subsequent messages still run under the same snapshot.
@@ -1038,7 +1041,20 @@ export function ChatPane({
                   </Fragment>
                 );
               })}
-              {error ? <div className="msg error">{error}</div> : null}
+              {error ? (
+                <div className="msg error">
+                  <span className="chat-error-text">{error}</span>
+                  {retryAssistant && onRetry ? (
+                    <button
+                      type="button"
+                      className="ghost chat-error-retry"
+                      onClick={() => onRetry(retryAssistant)}
+                    >
+                      {t('promptTemplates.retry')}
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
             {/* Always mounted so the CSS transition can play in both
                 directions; the `chat-jump-btn-active` class flips the
@@ -1273,6 +1289,18 @@ function isActiveRunStatus(status: ChatMessage['runStatus']): boolean {
 
 function isTerminalRunStatus(status: ChatMessage['runStatus']): boolean {
   return status === 'succeeded' || status === 'failed' || status === 'canceled';
+}
+
+export function retryableAssistantMessage(
+  messages: ChatMessage[],
+  lastAssistantId: string | null | undefined,
+  paneStreaming: boolean,
+): ChatMessage | null {
+  if (paneStreaming) return null;
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== 'assistant') return null;
+  if (last.id !== lastAssistantId) return null;
+  return last.runStatus === 'failed' ? last : null;
 }
 
 export function isAssistantMessageStreaming(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -146,6 +146,10 @@ import { buildClipboardPrompt } from '../lib/build-clipboard-prompt';
 import { copyToClipboard } from '../lib/copy-to-clipboard';
 import { effectiveMaxTokens } from '../state/maxTokens';
 
+type ProjectChatSendMeta = ChatSendMeta & {
+  retryOfAssistantId?: string;
+};
+
 interface Props {
   project: Project;
   routeFileName: string | null;
@@ -2002,17 +2006,26 @@ export function ProjectView({
       prompt: string,
       attachments: ChatAttachment[],
       commentAttachments: ChatCommentAttachment[] = commentsToAttachments(attachedComments),
-      meta?: ChatSendMeta,
+      meta?: ProjectChatSendMeta,
     ) => {
       if (!activeConversationId) return;
       if (messagesConversationIdRef.current !== activeConversationId) return;
       if (currentConversationBusy) return;
-      if (!prompt.trim() && attachments.length === 0 && commentAttachments.length === 0) return;
+      const retryTarget = meta?.retryOfAssistantId
+        ? resolveRetryTarget(messages, meta.retryOfAssistantId)
+        : null;
+      if (meta?.retryOfAssistantId && !retryTarget) return;
+      if (
+        !retryTarget &&
+        !prompt.trim() &&
+        attachments.length === 0 &&
+        commentAttachments.length === 0
+      ) return;
       setChatSeed(null);
       const runConversationId = activeConversationId;
       setError(null);
       const startedAt = Date.now();
-      const userMsg: ChatMessage = {
+      const userMsg: ChatMessage = retryTarget?.userMsg ?? {
         id: randomUUID(),
         role: 'user',
         content: prompt,
@@ -2020,6 +2033,8 @@ export function ProjectView({
         attachments: attachments.length > 0 ? attachments : undefined,
         commentAttachments: commentAttachments.length > 0 ? commentAttachments : undefined,
       };
+      const runAttachments = userMsg.attachments ?? [];
+      const runCommentAttachments = userMsg.commentAttachments ?? [];
       const selectedAgent =
         config.mode === 'daemon' && config.agentId
           ? agentsById.get(config.agentId)
@@ -2040,8 +2055,8 @@ export function ProjectView({
               selectedAgentChoice?.model,
             )
           : apiProtocolModelLabel(config.apiProtocol, config.model);
-      const assistantId = randomUUID();
       const preTurnFileNames = projectFiles.map((f) => f.name);
+      const assistantId = retryTarget?.failedAssistant.id ?? randomUUID();
       const assistantMsg: ChatMessage = {
         id: assistantId,
         role: 'assistant',
@@ -2049,7 +2064,7 @@ export function ProjectView({
         agentId: assistantAgentId,
         agentName: assistantAgentName,
         events: [],
-        createdAt: startedAt,
+        createdAt: retryTarget?.failedAssistant.createdAt ?? startedAt,
         runStatus: config.mode === 'daemon' ? 'running' : undefined,
         startedAt,
         preTurnFileNames,
@@ -2081,14 +2096,16 @@ export function ProjectView({
         );
       };
       activeCompletionNotificationRunsRef.current.add(assistantId);
-      const nextHistory = [...messages, userMsg];
+      const nextHistory = retryTarget
+        ? [...retryTarget.priorMessages, userMsg]
+        : [...messages, userMsg];
       setMessages([...nextHistory, assistantMsg]);
       markStreamingConversation(runConversationId);
       updateConversationLatestRun(config.mode === 'daemon' ? 'running' : 'queued');
       setArtifact(null);
       savedArtifactRef.current = null;
       onTouchProject();
-      persistMessage(userMsg);
+      if (!retryTarget) persistMessage(userMsg);
       // Intentionally do NOT persist `assistantMsg` here. In daemon mode it
       // starts as runStatus='running' with no runId, which the source-level
       // guard treats as a phantom — the first DB write happens inside
@@ -2096,14 +2113,14 @@ export function ProjectView({
       // mode there is no runStatus, and the buffered text path will persist
       // as soon as the first delta lands.
       persistMessage(assistantMsg);
-      if (commentAttachments.length > 0) {
-        void patchAttachedStatuses(commentAttachments, 'applying');
+      if (runCommentAttachments.length > 0) {
+        void patchAttachedStatuses(runCommentAttachments, 'applying');
         setAttachedComments([]);
       }
       // If this is the first turn, derive a working title from the prompt
       // so the conversation is identifiable in the dropdown without a
       // round-trip through the agent.
-      if (messages.length === 0) {
+      if (!retryTarget && messages.length === 0) {
         const title = isDesignSystemWorkspacePrompt(prompt)
           ? DESIGN_SYSTEM_WORKSPACE_DISPLAY_TITLE
           : prompt.slice(0, 60).trim();
@@ -2331,8 +2348,8 @@ export function ProjectView({
               true,
               { telemetryFinalized: true },
             );
-            if (commentAttachments.length > 0) {
-              void patchAttachedStatuses(commentAttachments, 'failed');
+            if (runCommentAttachments.length > 0) {
+              void patchAttachedStatuses(runCommentAttachments, 'failed');
             }
             clearActiveRunRefs(runConversationId, controller, cancelController);
             clearStreamingMarker(runConversationId);
@@ -2351,8 +2368,8 @@ export function ProjectView({
               runStatus: finalRunStatus,
             };
           });
-          if (commentAttachments.length > 0) {
-            void patchAttachedStatuses(commentAttachments, 'needs_review');
+          if (runCommentAttachments.length > 0) {
+            void patchAttachedStatuses(runCommentAttachments, 'needs_review');
           }
           clearActiveRunRefs(runConversationId, controller, cancelController);
           clearStreamingMarker(runConversationId);
@@ -2396,8 +2413,8 @@ export function ProjectView({
               ? 'failed'
               : prev.runStatus,
           }));
-          if (commentAttachments.length > 0) {
-            void patchAttachedStatuses(commentAttachments, 'failed');
+          if (runCommentAttachments.length > 0) {
+            void patchAttachedStatuses(runCommentAttachments, 'failed');
           }
           clearActiveRunRefs(runConversationId, controller, cancelController);
           clearStreamingMarker(runConversationId);
@@ -2431,8 +2448,8 @@ export function ProjectView({
           skillIds: Array.isArray(meta?.skillIds) ? meta.skillIds : [],
           context: meta?.context,
           designSystemId: project.designSystemId ?? null,
-          attachments: attachments.map((a) => a.path),
-          commentAttachments,
+          attachments: runAttachments.map((a) => a.path),
+          commentAttachments: runCommentAttachments,
           research: meta?.research,
           model: choice?.model ?? null,
           reasoning: choice?.reasoning ?? null,
@@ -2595,6 +2612,14 @@ export function ProjectView({
       onProjectsRefresh,
       onProjectChange,
     ],
+  );
+
+  const handleRetry = useCallback(
+    (assistantMessage: ChatMessage) => {
+      if (currentConversationActionDisabled) return;
+      void handleSend('', [], [], { retryOfAssistantId: assistantMessage.id });
+    },
+    [currentConversationActionDisabled, handleSend],
   );
 
   useEffect(() => {
@@ -3724,6 +3749,7 @@ export function ProjectView({
               onDetachComment={detachPreviewComment}
               onDeleteComment={(commentId) => void removePreviewComment(commentId)}
               onSend={handleSend}
+              onRetry={handleRetry}
               onStop={handleStop}
               onRequestOpenFile={requestOpenFile}
               onRequestPluginFolderAgentAction={handlePluginFolderAgentAction}
@@ -3910,6 +3936,35 @@ function isTerminalRunStatus(status: ChatMessage['runStatus']): boolean {
 
 function isActiveRunStatus(status: ChatMessage['runStatus']): boolean {
   return status === 'queued' || status === 'running';
+}
+
+export interface RetryTarget {
+  failedAssistant: ChatMessage;
+  userMsg: ChatMessage;
+  priorMessages: ChatMessage[];
+}
+
+export function resolveRetryTarget(
+  messages: ChatMessage[],
+  failedAssistantId: string,
+): RetryTarget | null {
+  const failedIndex = messages.findIndex(
+    (message) =>
+      message.id === failedAssistantId &&
+      message.role === 'assistant' &&
+      message.runStatus === 'failed',
+  );
+  if (failedIndex <= 0 || failedIndex !== messages.length - 1) return null;
+
+  const userMsg = messages[failedIndex - 1];
+  const failedAssistant = messages[failedIndex];
+  if (!userMsg || userMsg.role !== 'user' || !failedAssistant) return null;
+
+  return {
+    failedAssistant,
+    userMsg,
+    priorMessages: messages.slice(0, failedIndex - 1),
+  };
 }
 
 function latestDesignSystemActivityEvents(messages: ChatMessage[]): AgentEvent[] {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2050,6 +2050,17 @@ a.avatar-item:visited {
   color: var(--red);
   padding: 10px 12px;
   border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.chat-error-text { min-width: 0; }
+.chat-error-retry {
+  flex: 0 0 auto;
+  border-color: var(--red-border);
+  color: var(--red);
+  padding: 4px 10px;
 }
 
 /* -------- Composer -------------------------------------------------- */

--- a/apps/web/tests/components/ChatPane.streaming.test.tsx
+++ b/apps/web/tests/components/ChatPane.streaming.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { forwardRef } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { ChatPane } from '../../src/components/ChatPane';
+import { ChatPane, retryableAssistantMessage } from '../../src/components/ChatPane';
 import { DESIGN_SYSTEM_WORKSPACE_PROMPT_PREFIX } from '../../src/design-system-auto-prompt';
 import type { ChatMessage, Conversation, ProjectMetadata } from '../../src/types';
 
@@ -34,6 +34,25 @@ afterEach(() => {
 });
 
 describe('ChatPane streaming state', () => {
+  it('exposes retry only for the last failed assistant when the pane is idle', () => {
+    const failed: ChatMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'Generation failed',
+      createdAt: 1,
+      runStatus: 'failed',
+    };
+    const messages: ChatMessage[] = [
+      { id: 'user-1', role: 'user', content: 'Create a login page', createdAt: 0 },
+      failed,
+    ];
+
+    expect(retryableAssistantMessage(messages, failed.id, false)).toBe(failed);
+    expect(retryableAssistantMessage(messages, failed.id, true)).toBeNull();
+    expect(retryableAssistantMessage([...messages, { ...messages[0]!, id: 'user-2' }], failed.id, false))
+      .toBeNull();
+  });
+
   it('renders user turns with the chat bubble styling hook', () => {
     const messages: ChatMessage[] = [
       {

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -132,6 +132,7 @@ vi.mock('../../src/components/ChatPane', () => ({
   ChatPane: ({
     messages,
     onSend,
+    onRetry,
     error,
   }: {
     messages: ChatMessage[];
@@ -140,10 +141,21 @@ vi.mock('../../src/components/ChatPane', () => ({
       attachments: ChatAttachment[],
       commentAttachments: ChatCommentAttachment[],
     ) => void;
+    onRetry?: (assistantMessage: ChatMessage) => void;
     error?: string | null;
-  }) => (
-    <div>
-      {error ? <div>{error}</div> : null}
+  }) => {
+    const lastMessage = messages[messages.length - 1];
+    const retryMessage = lastMessage?.role === 'assistant' && lastMessage.runStatus === 'failed'
+      ? lastMessage
+      : null;
+    return (
+      <div>
+        {error ? <div>{error}</div> : null}
+        {error && retryMessage && onRetry ? (
+          <button type="button" onClick={() => onRetry(retryMessage)}>
+            retry
+          </button>
+        ) : null}
       <button
         type="button"
         onClick={() => onSend('Create a login page', chatPaneMockState.attachments, chatPaneMockState.commentAttachments)}
@@ -162,8 +174,9 @@ vi.mock('../../src/components/ChatPane', () => ({
           ))}
         </article>
       ))}
-    </div>
-  ),
+      </div>
+    );
+  },
 }));
 
 const mockedStreamMessage = vi.mocked(streamMessage);
@@ -293,6 +306,40 @@ describe('ProjectView API empty response handling', () => {
       ).toBe(true);
     });
     expect(mockedPlaySound).toHaveBeenCalledWith('failure-sound');
+  });
+
+  it('retries a failed API turn without appending a duplicate user message', async () => {
+    let callCount = 0;
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      callCount += 1;
+      if (callCount === 1) {
+        handlers.onError(new Error('model crashed'));
+      }
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => expect(screen.getByText('model crashed')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }));
+
+    await waitFor(() => expect(mockedStreamMessage).toHaveBeenCalledTimes(2));
+    const retryHistory = mockedStreamMessage.mock.calls[1]![2] as ChatMessage[];
+    expect(retryHistory.map((message) => `${message.role}:${message.content}`)).toEqual([
+      'user:Create a login page',
+    ]);
+    expect(
+      mockedSaveMessage.mock.calls.filter((call) => {
+        const message = call[2] as ChatMessage;
+        return message.role === 'user' && message.content === 'Create a login page';
+      }),
+    ).toHaveLength(1);
   });
 
   it('renders the workspace without the removed project action toolbar', async () => {

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -38,10 +38,6 @@ vi.mock('../../src/i18n', () => ({
     t: (value: string) => value,
   }),
   useT: () => ((value: string) => value),
-  useI18n: () => ({
-    locale: 'en',
-    t: (value: string) => value,
-  }),
 }));
 
 vi.mock('../../src/providers/anthropic', () => ({

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -7,6 +7,7 @@ import {
   clearStreamingConversationMarker,
   finalizeActiveAssistantMessagesOnStop,
   findExistingArtifactProjectFile,
+  resolveRetryTarget,
   resolveSucceededRunStatus,
   shouldClearActiveRunRefs,
 } from '../../src/components/ProjectView';
@@ -164,6 +165,46 @@ describe('terminal replay artifact recovery', () => {
       .toBeNull();
     expect(findExistingArtifactProjectFile(replayArtifact, [stale, current], { minMtime: runCreatedAt }))
       .toBe(current);
+  });
+});
+
+describe('retry target resolution', () => {
+  const userMessage: ChatMessage = {
+    id: 'user-1',
+    role: 'user',
+    content: 'Create a login page',
+    createdAt: 1,
+  };
+  const failedAssistant: ChatMessage = {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: 'Generation failed',
+    createdAt: 2,
+    runStatus: 'failed',
+  };
+
+  it('returns the prior transcript and original user turn for the last failed assistant', () => {
+    const systemContext: ChatMessage = {
+      id: 'assistant-0',
+      role: 'assistant',
+      content: 'Earlier result',
+      createdAt: 0,
+      runStatus: 'succeeded',
+    };
+
+    expect(resolveRetryTarget([systemContext, userMessage, failedAssistant], failedAssistant.id)).toEqual({
+      failedAssistant,
+      userMsg: userMessage,
+      priorMessages: [systemContext],
+    });
+  });
+
+  it('rejects non-terminal, non-last, or non-user-preceded retry targets', () => {
+    expect(resolveRetryTarget([userMessage, { ...failedAssistant, runStatus: 'running' }], failedAssistant.id))
+      .toBeNull();
+    expect(resolveRetryTarget([userMessage, failedAssistant, { ...userMessage, id: 'user-2' }], failedAssistant.id))
+      .toBeNull();
+    expect(resolveRetryTarget([failedAssistant], failedAssistant.id)).toBeNull();
   });
 });
 


### PR DESCRIPTION
Fixes #475

## Why

I claimed #475 because failed chat retries were still available for community help after the prior PR attempts closed unmerged. The bug is user-facing: retrying a failed generation should reuse the original user turn, not append a duplicate prompt into the visible chat history or the model context.

## What users will see

When the current chat run fails and the error pill is shown, it now includes a Retry button. Clicking Retry starts a new run from the original user message without adding another user bubble or sending the prompt twice.

## Surface area

- [x] **UI** — adds a Retry button to the existing chat error pill
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — Retry now reuses the failed turn's original user message instead of sending through the normal append path
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The UI change is limited to the existing chat error pill; verification is covered by focused component/regression tests below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ProjectView.api-empty-response.test.tsx` (`retries a failed API turn without appending a duplicate user message`)
- Did the test go red on `main` and green on this branch? No separate `main` run; the new regression assertion checks that retry history contains the original user prompt exactly once and that the user message is not persisted again.

## Validation

- `corepack pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/ProjectView.api-empty-response.test.tsx tests/components/ProjectView.run-cleanup.test.tsx tests/components/ChatPane.streaming.test.tsx --pool=threads` — passed, 3 files / 31 tests
- `corepack pnpm --filter @open-design/web typecheck` — passed; local Node v22.16.0 produced repo-known `node ~24` engine warnings
- `corepack pnpm guard` — passed; local Node v22.16.0 produced the same repo-known engine warning
- `git diff HEAD~1..HEAD --check` — passed
- `git show --format= --patch HEAD | gitleaks detect --pipe --redact --no-banner` — no leaks found