### PR TITLE
fix(web): compact plugin authoring composer

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -412,7 +412,8 @@ export const HomeHero = forwardRef<HTMLTextAreaElement, Props>(function HomeHero
     if (!workingDir) return null;
     return workingDir.split(/[\\/]/).filter(Boolean).slice(-1)[0] ?? workingDir;
   }, [workingDir]);
-  const authoringLayoutActive = activeChipId === 'create-plugin';
+  const authoringLayoutActive =
+    activeChipId === 'create-plugin' || pendingChipId === 'create-plugin';
   const promptMaxHeight = authoringLayoutActive
     ? HOME_HERO_AUTHORING_PROMPT_MAX_HEIGHT
     : HOME_HERO_PROMPT_MAX_HEIGHT;

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -408,10 +408,6 @@ export const HomeHero = forwardRef<HTMLTextAreaElement, Props>(function HomeHero
       : [],
     [activeChipId, activeExamplePlugins.length, locale],
   );
-  const workingDirLabel = useMemo(() => {
-    if (!workingDir) return null;
-    return workingDir.split(/[\\/]/).filter(Boolean).slice(-1)[0] ?? workingDir;
-  }, [workingDir]);
   const authoringLayoutActive =
     activeChipId === 'create-plugin' || pendingChipId === 'create-plugin';
   const promptMaxHeight = authoringLayoutActive

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -17,12 +17,13 @@ import {
   useState,
 } from 'react';
 import type {
+  CSSProperties,
   ClipboardEvent as ReactClipboardEvent,
   DragEvent as ReactDragEvent,
   ForwardedRef,
   KeyboardEvent as ReactKeyboardEvent,
-  RefObject,
   ReactNode,
+  RefObject,
 } from 'react';
 import type {
   ConnectorDetail,
@@ -407,6 +408,18 @@ export const HomeHero = forwardRef<HTMLTextAreaElement, Props>(function HomeHero
       : [],
     [activeChipId, activeExamplePlugins.length, locale],
   );
+  const workingDirLabel = useMemo(() => {
+    if (!workingDir) return null;
+    return workingDir.split(/[\\/]/).filter(Boolean).slice(-1)[0] ?? workingDir;
+  }, [workingDir]);
+  const authoringLayoutActive = activeChipId === 'create-plugin';
+  const promptMaxHeight = authoringLayoutActive
+    ? HOME_HERO_AUTHORING_PROMPT_MAX_HEIGHT
+    : HOME_HERO_PROMPT_MAX_HEIGHT;
+  const inputCardStyle = {
+    '--home-hero-prompt-max-height': `${promptMaxHeight}px`,
+  } as CSSProperties;
+
   useEffect(() => {
     if (selectedIndex >= visiblePickerOptions.length) setSelectedIndex(0);
   }, [selectedIndex, visiblePickerOptions.length]);
@@ -448,16 +461,16 @@ export const HomeHero = forwardRef<HTMLTextAreaElement, Props>(function HomeHero
     const el = inputElementRef.current;
     if (!el) return;
     el.style.height = 'auto';
-    const nextHeight = Math.min(el.scrollHeight, HOME_HERO_PROMPT_MAX_HEIGHT);
+    const nextHeight = Math.min(el.scrollHeight, promptMaxHeight);
     el.style.height = `${nextHeight}px`;
-    el.style.overflowY = el.scrollHeight > HOME_HERO_PROMPT_MAX_HEIGHT ? 'auto' : 'hidden';
-    if (el.scrollHeight <= HOME_HERO_PROMPT_MAX_HEIGHT && el.scrollTop !== 0) {
+    el.style.overflowY = el.scrollHeight > promptMaxHeight ? 'auto' : 'hidden';
+    if (el.scrollHeight <= promptMaxHeight && el.scrollTop !== 0) {
       el.scrollTop = 0;
       setPromptScrollTop(0);
     } else {
       setPromptScrollTop(el.scrollTop);
     }
-  }, [pluginInputValues, prompt, promptOverlayParts]);
+  }, [pluginInputValues, prompt, promptMaxHeight, promptOverlayParts]);
 
   const setInputRef = useCallback(
     (node: HTMLTextAreaElement | null) => {
@@ -601,7 +614,10 @@ export const HomeHero = forwardRef<HTMLTextAreaElement, Props>(function HomeHero
       </p>
 
       <div
-        className={`home-hero__input-card${dragActive ? ' is-drag-active' : ''}`}
+        className={`home-hero__input-card${
+          authoringLayoutActive ? ' home-hero__input-card--compact-authoring' : ''
+        }${dragActive ? ' is-drag-active' : ''}`}
+        style={inputCardStyle}
         onDragEnter={(event) => {
           if (event.dataTransfer.types.includes('Files')) setDragActive(true);
         }}
@@ -1280,6 +1296,7 @@ interface PromptHighlightPart {
 
 const INPUT_PLACEHOLDER_PATTERN = /\{\{\s*([a-zA-Z_][\w-]*)\s*\}\}/g;
 const HOME_HERO_PROMPT_MAX_HEIGHT = 180;
+const HOME_HERO_AUTHORING_PROMPT_MAX_HEIGHT = 132;
 
 function buildPromptHighlightParts(
   template: string | null,

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -417,6 +417,7 @@ export function HomeView({
     setPendingAuthoringPrompt(promptHandoff.prompt);
     setPendingAuthoringInputs(promptHandoff.inputs);
     setPendingAuthoringChipId('create-plugin');
+    setPendingChipId('create-plugin');
   }, [promptHandoff]);
 
   const activeContextItemCount = useMemo(

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -1032,6 +1032,7 @@ export function HomeView({
       setPendingAuthoringPrompt(nextPrompt);
       setPendingAuthoringInputs(nextInputs);
       setPendingAuthoringChipId(chipId ?? 'create-plugin');
+      setPendingChipId(chipId ?? 'create-plugin');
       focusPromptAtEnd();
     }, {
       before: active?.record.id ?? null,
@@ -1045,6 +1046,7 @@ export function HomeView({
     const record = authoringRecord ?? plugins.find((plugin) => plugin.id === 'od-new-generation');
     setPendingAuthoringChipId(null);
     if (!record) {
+      setPendingChipId(null);
       // The authoring scenario can be absent in a long-running dev
       // daemon that started before the bundled plugin was added. If
       // even the default scenario is missing, do not block the user:

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -266,6 +266,10 @@
   margin-top: 0;
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
+.home-hero__input-card--compact-authoring {
+  max-width: 640px;
+  padding-block: 12px 10px;
+}
 .home-hero__input-card:focus-within {
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
   box-shadow: var(--shadow-md);

--- a/apps/web/tests/components/HomeView.prefill.test.tsx
+++ b/apps/web/tests/components/HomeView.prefill.test.tsx
@@ -783,6 +783,11 @@ describe('HomeView prompt handoff', () => {
       expect(badge.textContent).toContain('Create plugin');
       expect(badge.textContent).not.toContain('Plugin authoring');
     });
+    const input = screen.getByTestId('home-hero-input') as HTMLTextAreaElement;
+    const inputCard = input.closest('.home-hero__input-card') as HTMLElement | null;
+    expect(input.value).toBe(PLUGIN_AUTHORING_PROMPT);
+    expect(inputCard?.classList.contains('home-hero__input-card--compact-authoring')).toBe(true);
+    expect(inputCard?.style.getPropertyValue('--home-hero-prompt-max-height')).toBe('132px');
     fireEvent.click(await screen.findByTestId('home-hero-submit'));
 
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({

--- a/apps/web/tests/components/HomeView.prefill.test.tsx
+++ b/apps/web/tests/components/HomeView.prefill.test.tsx
@@ -276,7 +276,11 @@ describe('HomeView prompt handoff', () => {
   });
 
   it('consumes a plugin authoring handoff once and focuses the textarea', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url) => {
+    let resolveApply: (response: Response) => void = () => undefined;
+    const applyResponse = new Promise<Response>((resolve) => {
+      resolveApply = resolve;
+    });
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
       if (typeof url === 'string' && url === '/api/plugins') {
         return new Response(JSON.stringify({ plugins: [AUTHORING_PLUGIN, WEB_PROTOTYPE_PLUGIN] }), {
           status: 200,
@@ -284,13 +288,11 @@ describe('HomeView prompt handoff', () => {
         });
       }
       if (typeof url === 'string' && url.includes('/api/plugins/od-plugin-authoring/apply')) {
-        return new Response(JSON.stringify(AUTHORING_APPLY_RESULT), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        });
+        return applyResponse;
       }
       throw new Error(`unexpected fetch ${url}`);
-    }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
     stubAnimationFrame();
 
     const { rerender } = render(
@@ -307,6 +309,21 @@ describe('HomeView prompt handoff', () => {
     await waitFor(() => {
       expect((input as HTMLTextAreaElement).value).toBe(PLUGIN_AUTHORING_PROMPT);
       expect(document.activeElement).toBe(input);
+    });
+    const inputCard = input.closest('.home-hero__input-card') as HTMLElement | null;
+    expect(inputCard?.classList.contains('home-hero__input-card--compact-authoring')).toBe(true);
+    expect(inputCard?.style.getPropertyValue('--home-hero-prompt-max-height')).toBe('132px');
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      '/api/plugins/od-plugin-authoring/apply',
+      expect.anything(),
+    ));
+    resolveApply(new Response(JSON.stringify(AUTHORING_APPLY_RESULT), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    await waitFor(() => {
+      expect((screen.getByTestId('home-hero-submit') as HTMLButtonElement).disabled).toBe(false);
     });
 
     fireEvent.change(input, { target: { value: 'User edited prompt' } });

--- a/apps/web/tests/components/HomeView.prefill.test.tsx
+++ b/apps/web/tests/components/HomeView.prefill.test.tsx
@@ -891,6 +891,11 @@ describe('HomeView prompt handoff', () => {
 
     await clearActiveTypeChip();
     await clickHomeShortcut('create-plugin');
+    const input = screen.getByTestId('home-hero-input') as HTMLTextAreaElement;
+    const inputCard = input.closest('.home-hero__input-card') as HTMLElement | null;
+    expect(input.value).toBe(PLUGIN_AUTHORING_PROMPT);
+    expect(inputCard?.classList.contains('home-hero__input-card--compact-authoring')).toBe(true);
+    expect(inputCard?.style.getPropertyValue('--home-hero-prompt-max-height')).toBe('132px');
     fireEvent.click(await screen.findByTestId('home-hero-submit'));
     expect(onSubmit).not.toHaveBeenCalled();
 


### PR DESCRIPTION
Fixes #2432

## Why

I picked this up because the reported plugin creation flow preloads a long agent-authoring prompt into the Home composer. That made the input area feel like it took over the page before the user had a chance to scan, edit, or run the prompt.

This keeps the existing plugin-authoring behavior while constraining that specific layout so the long prompt scrolls inside a more focused composer.

## What users will see

Clicking Create plugin still preloads the same authoring prompt and keeps the same plugin input/submission payload, but the Home composer switches to a compact authoring layout with a narrower card and shorter prompt scroll cap.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from this CLI submission. The before screenshot is in #2432; this PR constrains the Create plugin composer path and verifies the compact authoring class plus prompt height cap in the HomeView regression test.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/HomeView.prefill.test.tsx`
- Did the test go red on `main` and green on this branch? No. This is a layout constraint regression assertion added to the existing create-plugin flow test rather than a screenshot/visual red spec.
- Verification: the test now asserts the Create plugin flow still preserves `PLUGIN_AUTHORING_PROMPT` while applying the compact authoring composer class and `132px` prompt cap.

## Validation

- `corepack pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/HomeView.prefill.test.tsx --reporter verbose --testTimeout=10000 --hookTimeout=10000` — 12 tests passed.
- `corepack pnpm --filter @open-design/web typecheck` — passed.
- `corepack pnpm guard` — passed.
- `git diff --check` — passed.
- `git diff | gitleaks detect --pipe --redact --no-banner` — no leaks found.

Note: local validation emitted the repo's Node engine warning because this machine is currently on Node `v22.16.0`; the repo wants Node `~24`.
