### PR TITLE
fix: add confirmation dialog for extraction history deletion

### DIFF
--- a/apps/web/src/components/MemorySection.tsx
+++ b/apps/web/src/components/MemorySection.tsx
@@ -1364,6 +1364,7 @@ export function MemorySection({
   }, [indexDraft, fireFlash]);
 
   const onDeleteExtraction = useCallback(async (id: string) => {
+    if (!window.confirm(t('settings.memoryExtractionDeleteConfirm'))) return;
     // Optimistic removal: drop the row immediately so the click feels
     // instant. The SSE 'deleted' event will arrive moments later and is
     // a no-op against an already-removed id; if the request fails we
@@ -1373,7 +1374,7 @@ export function MemorySection({
     if (!ok) {
       void reloadExtractions();
     }
-  }, [reloadExtractions]);
+  }, [reloadExtractions, t]);
 
   const onClearExtractions = useCallback(async () => {
     if (!window.confirm(t('settings.memoryExtractionsClearConfirm'))) return;

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -2148,6 +2148,8 @@ export const en: Dict = {
   'settings.memoryExtractionWritten': 'written',
   'settings.memoryExtractionDuration': 'in',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm':
+    'Delete this extraction record? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.memoryExtractionsClearConfirm':

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -2114,6 +2114,7 @@ export const zhCN: Dict = {
   'settings.memoryExtractionWritten': '写入',
   'settings.memoryExtractionDuration': '耗时',
   'settings.memoryExtractionDelete': '删除',
+  'settings.memoryExtractionDeleteConfirm': '确定要删除此抽取记录吗？此操作无法撤销。',
   'settings.memoryExtractionsClear': '清空',
   'settings.memoryExtractionsClearTitle': '清空整个抽取历史',
   'settings.memoryExtractionsClearConfirm': '确定要清空整个抽取历史吗？此操作无法撤销。',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -564,6 +564,7 @@ export interface Dict {
   'settings.memoryExtractionWritten': string;
   'settings.memoryExtractionDuration': string;
   'settings.memoryExtractionDelete': string;
+  'settings.memoryExtractionDeleteConfirm': string;
   'settings.memoryExtractionsClear': string;
   'settings.memoryExtractionsClearTitle': string;
   'settings.memoryExtractionsClearConfirm': string;

--- a/apps/web/tests/components/MemorySection.test.tsx
+++ b/apps/web/tests/components/MemorySection.test.tsx
@@ -1475,6 +1475,10 @@ describe('MemorySection', () => {
       .closest('.library-card') as HTMLElement;
     fireEvent.click(within(row).getByRole('button', { name: 'Delete' }));
 
+    // Confirm the deletion in the dialog
+    const confirmButton = await screen.findByRole('button', { name: 'Delete' });
+    fireEvent.click(confirmButton);
+
     await waitFor(() => {
       expect(screen.queryByText('Remember I prefer dark mode')).toBeNull();
     });

--- a/apps/web/tests/components/MemorySection.test.tsx
+++ b/apps/web/tests/components/MemorySection.test.tsx
@@ -1476,7 +1476,8 @@ describe('MemorySection', () => {
     fireEvent.click(within(row).getByRole('button', { name: 'Delete' }));
 
     // Confirm the deletion in the dialog
-    const confirmButton = await screen.findByRole('button', { name: 'Delete' });
+    const dialog = await screen.findByRole('dialog');
+    const confirmButton = within(dialog).getByRole('button', { name: 'Delete' });
     fireEvent.click(confirmButton);
 
     await waitFor(() => {


### PR DESCRIPTION
## What happened?

Individual extraction history records were being deleted immediately without any confirmation, creating a risk of accidental data loss. This was inconsistent with the bulk clear operation which does require confirmation.

## Changes

This PR adds a confirmation dialog before deleting individual extraction records:

1. **Added confirmation check**: Calls  before proceeding with deletion
2. **New i18n key**: Added  with message "Delete this extraction record? This cannot be undone."
3. **Updated dependencies**: Added  to the  callback dependencies

## Result

Users now see a confirmation dialog when clicking delete on an individual extraction history item, matching the UX pattern used for the bulk clear operation and providing a safer experience for destructive actions.

## Testing

- [x] Verified confirmation dialog appears when clicking delete
- [x] Verified deletion proceeds when user confirms
- [x] Verified deletion is cancelled when user cancels
- [x] Verified i18n key is properly defined

Closes #2249