### PR TITLE
fix(ci): fall back to manifest PR number for visual comments

### DIFF
--- a/.github/workflows/visual-pr-comment.yml
+++ b/.github/workflows/visual-pr-comment.yml
@@ -99,10 +99,13 @@ jobs:
           fi
           pr_number="$WORKFLOW_PR_NUMBER"
           if [ -z "$pr_number" ]; then
+            pr_number="$manifest_pr_number"
+          fi
+          if [ -z "$pr_number" ] && [ -n "$WORKFLOW_HEAD_SHA" ]; then
             pr_number="$(gh api "repos/$GITHUB_REPOSITORY/commits/$WORKFLOW_HEAD_SHA/pulls" --jq '.[0].number // empty')"
           fi
           if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
-            echo "Unable to derive PR number for workflow head $WORKFLOW_HEAD_SHA from GitHub event/API." >&2
+            echo "Unable to derive PR number from workflow event, capture manifest, or GitHub API for workflow head $WORKFLOW_HEAD_SHA." >&2
             exit 1
           fi
           if [ "$manifest_pr_number" != "$pr_number" ]; then

--- a/.github/workflows/visual-pr-comment.yml
+++ b/.github/workflows/visual-pr-comment.yml
@@ -97,19 +97,20 @@ jobs:
             echo "Invalid manifest pr_number: $manifest_pr_number" >&2
             exit 1
           fi
-          pr_number="$WORKFLOW_PR_NUMBER"
+          derived_pr_number="$WORKFLOW_PR_NUMBER"
+          if [ -z "$derived_pr_number" ] && [ -n "$WORKFLOW_HEAD_SHA" ]; then
+            derived_pr_number="$(gh api "repos/$GITHUB_REPOSITORY/commits/$WORKFLOW_HEAD_SHA/pulls" --jq '.[0].number // empty')"
+          fi
+          pr_number="$derived_pr_number"
           if [ -z "$pr_number" ]; then
             pr_number="$manifest_pr_number"
-          fi
-          if [ -z "$pr_number" ] && [ -n "$WORKFLOW_HEAD_SHA" ]; then
-            pr_number="$(gh api "repos/$GITHUB_REPOSITORY/commits/$WORKFLOW_HEAD_SHA/pulls" --jq '.[0].number // empty')"
           fi
           if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
             echo "Unable to derive PR number from workflow event, capture manifest, or GitHub API for workflow head $WORKFLOW_HEAD_SHA." >&2
             exit 1
           fi
-          if [ "$manifest_pr_number" != "$pr_number" ]; then
-            echo "Manifest pr_number ($manifest_pr_number) does not match GitHub-derived PR number ($pr_number)." >&2
+          if [ -n "$derived_pr_number" ] && [ "$manifest_pr_number" != "$derived_pr_number" ]; then
+            echo "Manifest pr_number ($manifest_pr_number) does not match GitHub-derived PR number ($derived_pr_number)." >&2
             exit 1
           fi
           if ! [[ "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then


### PR DESCRIPTION
## Why

I investigated a failing `visual-pr-comment` run after the workflow stopped in `Read capture manifest` while trying to derive the PR number from a `workflow_run` event.
The event payload and commit→pulls API can both be empty for some runs, which turns a valid visual artifact into a failed comment workflow.

## What users will see

PR visual comment runs no longer fail just because GitHub omitted the PR number from the `workflow_run` event.
If the event payload is missing that field, the workflow reuses the capture manifest's `pr_number` and still posts the visual diff comment.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the bug: no existing automated workflow test harness for this GitHub Actions path.
- Did the test go red on `main` and green on this branch? no
- Verification instead: confirmed `gh api repos/nexu-io/open-design/commits/9edd2509cb4e2db83a02c6b5f7ad72c23e2bbaf3/pulls` returns `[]` for the failing run SHA, then locally simulated the `Read capture manifest` shell logic with an empty `WORKFLOW_PR_NUMBER` and verified the updated fallback resolves `pr_number` from the capture manifest.

## Validation

- `gh api repos/nexu-io/open-design/commits/9edd2509cb4e2db83a02c6b5f7ad72c23e2bbaf3/pulls`
- Local shell simulation of the updated `Read capture manifest` fallback path with an empty `WORKFLOW_PR_NUMBER` (resolved `pr_number=2500` from manifest)