### PR TITLE
fix: add breathing room to conversation history button in chat header

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1747,7 +1747,7 @@ a.avatar-item:visited {
   color: var(--text);
   border-bottom-color: var(--text);
 }
-.chat-header-actions { display: inline-flex; gap: 4px; align-items: center; margin-left: auto; }
+.chat-header-actions { display: inline-flex; gap: 4px; align-items: center; }
 .chat-header-actions .icon-only {
   width: 28px; height: 28px;
   padding: 0;


### PR DESCRIPTION
## Summary

Fixes the spacing issue where the conversation history button in the chat panel header sits too close to the left edge.

## What changed

- Removed `margin-left: auto` from `.chat-header-actions` CSS rule
- This allows the button to utilize the header's existing 12px padding instead of being pushed flush against the edge

## Why

The `.chat-header-actions` container had `margin-left: auto` which is intended to push action buttons to the right side when tabs are present on the left. However, since the current implementation doesn't render tabs in the header, the auto margin has no effect and the buttons start from the left edge with insufficient spacing.

By removing the auto margin, the buttons now respect the header's padding, providing proper visual breathing room.

## Result

The conversation history button now has appropriate spacing from the panel edge, improving visual polish and alignment consistency.

Closes #2180