### PR TITLE
feat(observability): upload sourcemaps + always-on exception capture

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -41,6 +41,13 @@ env:
   # no events leave the user's machine.
   POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
   POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+  # PostHog Error tracking sourcemap upload. Personal API key (phx_...) and
+  # project ID let tools-pack's web-sourcemaps step ship browser sourcemaps
+  # to PostHog after `next build` and before the .map files are stripped
+  # from the packaged bundle. Missing in PR/fork builds → upload is skipped
+  # and the helper still strips .map to keep source out of the installer.
+  POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+  POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
 
 jobs:
   metadata:

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -19,6 +19,13 @@ env:
   # leave the user's machine, /api/analytics/config returns enabled=false).
   POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
   POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+  # PostHog Error tracking sourcemap upload. Personal API key (phx_...) and
+  # project ID let tools-pack's web-sourcemaps step ship browser sourcemaps
+  # to PostHog after `next build` and before the .map files are stripped
+  # from the packaged bundle. Missing in PR/fork builds → upload is skipped
+  # and the helper still strips .map to keep source out of the installer.
+  POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+  POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
 
 jobs:
   metadata:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -32,6 +32,13 @@ env:
   # leave the user's machine, /api/analytics/config returns enabled=false).
   POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
   POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+  # PostHog Error tracking sourcemap upload. Personal API key (phx_...) and
+  # project ID let tools-pack's web-sourcemaps step ship browser sourcemaps
+  # to PostHog after `next build` and before the .map files are stripped
+  # from the packaged bundle. Missing in PR/fork builds → upload is skipped
+  # and the helper still strips .map to keep source out of the installer.
+  POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+  POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
 
 jobs:
   metadata:

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -105,6 +105,11 @@ const nextConfig: NextConfig = {
   allowedDevOrigins: configuredAllowedDevHosts(),
   outputFileTracingRoot: WORKSPACE_ROOT,
   reactStrictMode: true,
+  // Emit browser sourcemaps so packaged-runtime exceptions can be symbolicated
+  // by PostHog. `tools/pack/src/web-sourcemaps.ts` runs after `next build`
+  // to inject chunk IDs, upload to PostHog, and ALWAYS delete the .map files
+  // before packaging so source never ships inside an installer.
+  productionBrowserSourceMaps: true,
   turbopack: {
     root: WORKSPACE_ROOT,
   },

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -5131,15 +5131,14 @@ function MediaProvidersSection({
         <details className="library-group media-provider-coming-soon">
           <summary className="memory-details-summary">
             <span className="memory-details-title">
-              Coming soon
+              {t('tasks.comingSoon')}
             </span>
             <span className="filter-pill-count">
               {comingSoonProviders.length}
             </span>
           </summary>
           <p className="hint" style={{ marginTop: 4, marginBottom: 8 }}>
-            We track these for the roadmap; the daemon doesn’t ship a
-            client yet, so there’s nothing to configure.
+            {t('settings.mediaProviderComingSoonHint')}
           </p>
           <ul className="media-provider-coming-soon-list">
             {comingSoonProviders.map((provider) => {
@@ -5164,7 +5163,7 @@ function MediaProvidersSection({
                       rel="noopener noreferrer"
                       className="ghost-link"
                     >
-                      Docs
+                      {t('settings.agentInstall.docs')}
                       <Icon name="external-link" size={11} />
                     </a>
                   ) : null}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -293,6 +293,7 @@ export const ar: Dict = {
   'settings.mediaProviderReloadError': 'تعذر إعادة تحميل إعدادات موفري الوسائط من الـ daemon المحلي.',
   'settings.mediaProviderReloadSuccess': 'تمت إعادة تحميل إعدادات موفري الوسائط من الـ daemon المحلي.',
   'settings.mediaProviderLoadError': 'تعذر تحميل إعدادات موفري الوسائط من الـ daemon المحلي. سيُستخدم مؤقتًا ما هو محفوظ في المتصفح.',
+  'settings.mediaProviderComingSoonHint': 'نحن نتتبع هذه المزودات في خارطة الطريق؛ لم يقم البرنامج الخفي بشحن عميل بعد، لذا لا يوجد شيء لتكوينه.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -293,6 +293,7 @@ export const de: Dict = {
   'settings.mediaProviderReloadError': 'Die Einstellungen der Medienanbieter konnten nicht vom lokalen Daemon neu geladen werden.',
   'settings.mediaProviderReloadSuccess': 'Die Einstellungen der Medienanbieter wurden vom lokalen Daemon neu geladen.',
   'settings.mediaProviderLoadError': 'Die Einstellungen der Medienanbieter konnten nicht vom lokalen Daemon geladen werden. Vorerst werden die im Browser gespeicherten Einstellungen verwendet.',
+  'settings.mediaProviderComingSoonHint': 'Wir verfolgen diese für die Roadmap; der Daemon liefert noch keinen Client, daher gibt es nichts zu konfigurieren.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -307,6 +307,7 @@ export const en: Dict = {
   'settings.mediaProviderReloadError': 'Could not reload media provider settings from the local daemon.',
   'settings.mediaProviderReloadSuccess': 'Reloaded media provider settings from the local daemon.',
   'settings.mediaProviderLoadError': 'Could not load media provider settings from the local daemon. Using browser-saved settings for now.',
+  'settings.mediaProviderComingSoonHint': 'We track these for the roadmap; the daemon doesn\'t ship a client yet, so there\'s nothing to configure.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -293,6 +293,7 @@ export const esES: Dict = {
   'settings.mediaProviderReloadError': 'No se pudieron recargar los ajustes de los proveedores de medios desde el daemon local.',
   'settings.mediaProviderReloadSuccess': 'Se recargaron los ajustes de los proveedores de medios desde el daemon local.',
   'settings.mediaProviderLoadError': 'No se pudieron cargar los ajustes de los proveedores de medios desde el daemon local. Por ahora se usarán los ajustes guardados en el navegador.',
+  'settings.mediaProviderComingSoonHint': 'Rastreamos estos para la hoja de ruta; el daemon aún no incluye un cliente, por lo que no hay nada que configurar.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -293,6 +293,7 @@ export const fa: Dict = {
   'settings.mediaProviderReloadError': 'بارگذاری دوبارهٔ تنظیمات ارائه‌دهنده‌های رسانه از دیمن محلی ممکن نشد.',
   'settings.mediaProviderReloadSuccess': 'تنظیمات ارائه‌دهنده‌های رسانه از دیمن محلی دوباره بارگذاری شد.',
   'settings.mediaProviderLoadError': 'بارگذاری تنظیمات ارائه‌دهنده‌های رسانه از دیمن محلی ممکن نشد. فعلاً از تنظیمات ذخیره‌شده در مرورگر استفاده می‌شود.',
+  'settings.mediaProviderComingSoonHint': 'ما این موارد را برای نقشه راه پیگیری می‌کنیم؛ دیمون هنوز کلاینتی ارائه نمی‌دهد، بنابراین چیزی برای پیکربندی وجود ندارد.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -293,6 +293,7 @@ export const fr: Dict = {
   'settings.mediaProviderReloadError': 'Impossible de recharger les paramètres des fournisseurs de médias depuis le daemon local.',
   'settings.mediaProviderReloadSuccess': 'Paramètres des fournisseurs de médias rechargés depuis le daemon local.',
   'settings.mediaProviderLoadError': 'Impossible de charger les paramètres des fournisseurs de médias depuis le daemon local. Utilisation temporaire des paramètres enregistrés dans le navigateur.',
+  'settings.mediaProviderComingSoonHint': 'Nous suivons ces fournisseurs pour la feuille de route ; le daemon ne fournit pas encore de client, il n\'y a donc rien à configurer.',
   'settings.privacy': 'Confidentialité',
   'settings.privacyHint': 'Données partagées avec l’équipe Open Design',
   'settings.privacyConsentKicker': 'Aidez-nous à améliorer Open Design',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -293,6 +293,7 @@ export const hu: Dict = {
   'settings.mediaProviderReloadError': 'Nem sikerült újratölteni a médiaszolgáltatók beállításait a helyi démonból.',
   'settings.mediaProviderReloadSuccess': 'A médiaszolgáltatók beállításai újra lettek töltve a helyi démonból.',
   'settings.mediaProviderLoadError': 'Nem sikerült betölteni a médiaszolgáltatók beállításait a helyi démonból. Egyelőre a böngészőben mentett beállításokat használjuk.',
+  'settings.mediaProviderComingSoonHint': 'Ezeket nyomon követjük az ütemtervben; a daemon még nem szállít klienst, így nincs mit konfigurálni.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -288,6 +288,7 @@ export const id: Dict = {
   'settings.mediaProviderReloadError': 'Tidak dapat memuat ulang pengaturan penyedia media dari daemon lokal.',
   'settings.mediaProviderReloadSuccess': 'Pengaturan penyedia media berhasil dimuat ulang dari daemon lokal.',
   'settings.mediaProviderLoadError': 'Tidak dapat memuat pengaturan penyedia media dari daemon lokal. Untuk sementara menggunakan pengaturan yang tersimpan di browser.',
+  'settings.mediaProviderComingSoonHint': 'Kami melacak ini untuk roadmap; daemon belum mengirimkan klien, jadi tidak ada yang perlu dikonfigurasi.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -285,6 +285,7 @@ export const it: Dict = {
   'settings.mediaProviderReloadError': 'Impossibile ricaricare le impostazioni dei provider di media dal daemon locale.',
   'settings.mediaProviderReloadSuccess': 'Impostazioni dei provider di media ricaricate dal daemon locale.',
   'settings.mediaProviderLoadError': 'Impossibile caricare le impostazioni dei provider di media dal daemon locale. Uso temporaneo delle impostazioni salvate nel browser.',
+  'settings.mediaProviderComingSoonHint': 'Teniamo traccia di questi per la roadmap; il daemon non fornisce ancora un client, quindi non c\'è nulla da configurare.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'Quali dati vengono condivisi con il team di Open Design',
   'settings.privacyConsentKicker': 'Aiutaci a migliorare Open Design',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -293,6 +293,7 @@ export const ja: Dict = {
   'settings.mediaProviderReloadError': 'ローカルデーモンからメディアプロバイダー設定を再読み込みできませんでした。',
   'settings.mediaProviderReloadSuccess': 'ローカルデーモンからメディアプロバイダー設定を再読み込みしました。',
   'settings.mediaProviderLoadError': 'ローカルデーモンからメディアプロバイダー設定を読み込めませんでした。今のところブラウザーに保存された設定を使用します。',
+  'settings.mediaProviderComingSoonHint': 'これらはロードマップで追跡しています。デーモンはまだクライアントを提供していないため、設定するものはありません。',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -293,6 +293,7 @@ export const ko: Dict = {
   'settings.mediaProviderReloadError': '로컬 데몬에서 미디어 제공자 설정을 다시 불러오지 못했습니다.',
   'settings.mediaProviderReloadSuccess': '로컬 데몬에서 미디어 제공자 설정을 다시 불러왔습니다.',
   'settings.mediaProviderLoadError': '로컬 데몬에서 미디어 제공자 설정을 불러오지 못했습니다. 지금은 브라우저에 저장된 설정을 사용합니다.',
+  'settings.mediaProviderComingSoonHint': '로드맵에서 이를 추적하고 있습니다. 데몬이 아직 클라이언트를 제공하지 않으므로 구성할 항목이 없습니다.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -293,6 +293,7 @@ export const pl: Dict = {
   'settings.mediaProviderReloadError': 'Nie udało się ponownie wczytać ustawień dostawców mediów z lokalnego demona.',
   'settings.mediaProviderReloadSuccess': 'Ustawienia dostawców mediów zostały ponownie wczytane z lokalnego demona.',
   'settings.mediaProviderLoadError': 'Nie udało się wczytać ustawień dostawców mediów z lokalnego demona. Na razie używane będą ustawienia zapisane w przeglądarce.',
+  'settings.mediaProviderComingSoonHint': 'Śledzimy je w mapie drogowej; daemon nie dostarcza jeszcze klienta, więc nie ma nic do skonfigurowania.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -292,6 +292,7 @@ export const ptBR: Dict = {
   'settings.mediaProviderReloadError': 'Não foi possível recarregar as configurações dos provedores de mídia do daemon local.',
   'settings.mediaProviderReloadSuccess': 'As configurações dos provedores de mídia foram recarregadas do daemon local.',
   'settings.mediaProviderLoadError': 'Não foi possível carregar as configurações dos provedores de mídia do daemon local. Usando por enquanto as configurações salvas no navegador.',
+  'settings.mediaProviderComingSoonHint': 'Rastreamos estes para o roteiro; o daemon ainda não fornece um cliente, então não há nada para configurar.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -292,6 +292,7 @@ export const ru: Dict = {
   'settings.mediaProviderReloadError': 'Не удалось заново загрузить настройки медиапровайдеров из локального демона.',
   'settings.mediaProviderReloadSuccess': 'Настройки медиапровайдеров заново загружены из локального демона.',
   'settings.mediaProviderLoadError': 'Не удалось загрузить настройки медиапровайдеров из локального демона. Пока используются настройки, сохранённые в браузере.',
+  'settings.mediaProviderComingSoonHint': 'Мы отслеживаем их в дорожной карте; демон пока не поставляет клиент, поэтому настраивать нечего.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -277,6 +277,7 @@ export const th: Dict = {
   'settings.mediaProviderClearConfirm': 'ล้างการตั้งค่า {name} ที่บันทึกไว้ใช่หรือไม่? คุณจะต้องตั้งค่าใหม่อีกครั้งเพื่อใช้งาน {name}',
   'settings.mediaProviderPlaceholder': 'วาง API key',
   'settings.mediaProviderBaseUrlPlaceholder': 'กำหนด Base URL แท่นค่าเริ่มต้น',
+  'settings.mediaProviderComingSoonHint': 'เราติดตามสิ่งเหล่านี้สำหรับแผนงาน daemon ยังไม่ได้จัดส่งไคลเอนต์ ดังนั้นจึงไม่มีอะไรให้กำหนดค่า',
   'settings.privacy': 'ความเป็นส่วนตัว',
   'settings.privacyHint': 'ข้อมูลที่แชร์กับทีม Open Design',
   'settings.privacyConsentKicker': 'ช่วยเราพัฒนา Open Design',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -283,6 +283,7 @@ export const tr: Dict = {
   'settings.mediaProviderReloadError': 'Medya sağlayıcı ayarları yerel daemon’dan yeniden yüklenemedi.',
   'settings.mediaProviderReloadSuccess': 'Medya sağlayıcı ayarları yerel daemon’dan yeniden yüklendi.',
   'settings.mediaProviderLoadError': 'Medya sağlayıcı ayarları yerel daemon’dan yüklenemedi. Şimdilik tarayıcıya kaydedilen ayarlar kullanılıyor.',
+  'settings.mediaProviderComingSoonHint': 'Bunları yol haritası için takip ediyoruz; daemon henüz bir istemci göndermediği için yapılandırılacak bir şey yok.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -294,6 +294,7 @@ export const uk: Dict = {
   'settings.mediaProviderReloadError': 'Не вдалося повторно завантажити налаштування медіапровайдерів із локального демона.',
   'settings.mediaProviderReloadSuccess': 'Налаштування медіапровайдерів повторно завантажено з локального демона.',
   'settings.mediaProviderLoadError': 'Не вдалося завантажити налаштування медіапровайдерів із локального демона. Наразі використовуються налаштування, збережені в браузері.',
+  'settings.mediaProviderComingSoonHint': 'Ми відстежуємо їх у дорожній карті; демон ще не постачає клієнт, тому налаштовувати нічого.',
   'settings.privacy': 'Privacy',
   'settings.privacyHint': 'What data is shared with the Open Design team',
   'settings.privacyConsentKicker': 'Help us improve Open Design',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -306,6 +306,7 @@ export const zhCN: Dict = {
   'settings.mediaProviderReloadError': '无法从本地守护进程重新加载媒体提供方设置。',
   'settings.mediaProviderReloadSuccess': '已从本地守护进程重新加载媒体提供方设置。',
   'settings.mediaProviderLoadError': '无法从本地守护进程加载媒体提供方设置。当前将使用浏览器中保存的设置。',
+  'settings.mediaProviderComingSoonHint': '我们在路线图中跟踪这些提供方；守护进程尚未提供客户端，因此暂无可配置项。',
   'settings.privacy': '隐私',
   'settings.privacyHint': '与 Open Design 团队共享哪些数据',
   'settings.privacyConsentKicker': '帮助我们改进 Open Design',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -291,6 +291,7 @@ export const zhTW: Dict = {
   'settings.mediaProviderReloadError': '無法從本機守護程序重新載入媒體供應商設定。',
   'settings.mediaProviderReloadSuccess': '已從本機守護程序重新載入媒體供應商設定。',
   'settings.mediaProviderLoadError': '無法從本機守護程序載入媒體供應商設定。目前將使用瀏覽器中儲存的設定。',
+  'settings.mediaProviderComingSoonHint': '我們在路線圖中追蹤這些提供者；守護程式尚未提供客戶端，因此暫無可配置項。',
   'settings.privacy': '隱私',
   'settings.privacyHint': '與 Open Design 團隊共享哪些資料',
   'settings.privacyConsentKicker': '協助我們改進 Open Design',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -322,6 +322,7 @@ export interface Dict {
   'settings.mediaProviderReloadError': string;
   'settings.mediaProviderReloadSuccess': string;
   'settings.mediaProviderLoadError': string;
+  'settings.mediaProviderComingSoonHint': string;
   'settings.privacy': string;
   'settings.privacyHint': string;
   'settings.privacyConsentKicker': string;

--- a/tools/pack/src/config.ts
+++ b/tools/pack/src/config.ts
@@ -102,6 +102,15 @@ export type ToolPackConfig = {
    * Required for upload to be attempted; missing → strip-only path.
    */
   posthogCliProjectId?: string;
+  /**
+   * PostHog **management** host used by `@posthog/cli sourcemap upload`. This
+   * is the regional app host (e.g. `https://us.posthog.com`) — distinct from
+   * `posthogHost` above, which is the **ingest** host (`us.i.posthog.com`)
+   * used by the runtime SDK and accepts `/capture/` traffic only. Sourced
+   * from `POSTHOG_CLI_HOST`; when missing, the CLI defaults to the US Cloud
+   * app host on its own, which is correct for the official project.
+   */
+  posthogCliHost?: string;
   to: ToolPackBuildOutput;
   webOutputMode: ToolPackWebOutputMode;
   workspaceRoot: string;
@@ -190,6 +199,22 @@ function resolveToolPackPosthogCliProjectId(value: string | undefined): string |
     throw new Error(`POSTHOG_CLI_PROJECT_ID must be a numeric project id: ${value}`);
   }
   return normalized;
+}
+
+function resolveToolPackPosthogCliHost(value: string | undefined): string | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim();
+  if (normalized.length === 0) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new Error(`POSTHOG_CLI_HOST must be an absolute URL: ${value}`);
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error(`POSTHOG_CLI_HOST must be http(s): ${value}`);
+  }
+  return normalized.replace(/\/+$/, "");
 }
 
 function resolveToolPackTelemetryRelayUrl(value: string | undefined): string | undefined {
@@ -286,6 +311,7 @@ export function resolveToolPackConfig(
     posthogCliProjectId: resolveToolPackPosthogCliProjectId(
       process.env.POSTHOG_CLI_PROJECT_ID ?? process.env.POSTHOG_PROJECT_ID,
     ),
+    posthogCliHost: resolveToolPackPosthogCliHost(process.env.POSTHOG_CLI_HOST),
     to: resolveToolPackBuildOutput(platform, options.to),
     webOutputMode: resolveToolPackWebOutputMode(platform, process.env.OD_WEB_OUTPUT_MODE),
     workspaceRoot: WORKSPACE_ROOT,

--- a/tools/pack/src/config.ts
+++ b/tools/pack/src/config.ts
@@ -85,6 +85,23 @@ export type ToolPackConfig = {
    */
   posthogKey?: string;
   posthogHost?: string;
+  /**
+   * Personal API key (`phx_...`) used by the @posthog/cli sourcemap helper to
+   * upload browser sourcemaps to PostHog after `next build` and before the
+   * web bundle is copied into the Electron package. Sourced from
+   * `POSTHOG_CLI_API_KEY` (or the legacy `POSTHOG_PERSONAL_API_KEY` alias)
+   * in CI; when missing (local packaging by a contributor, fork builds, PRs)
+   * the helper still strips the .map files so source never leaks into the
+   * shipped installer — it just skips the upload step.
+   */
+  posthogCliApiKey?: string;
+  /**
+   * PostHog project ID (e.g. `420348` for the official Open Design project)
+   * used by `@posthog/cli sourcemap upload`. Sourced from
+   * `POSTHOG_CLI_PROJECT_ID` (or the alias `POSTHOG_PROJECT_ID`) in CI.
+   * Required for upload to be attempted; missing → strip-only path.
+   */
+  posthogCliProjectId?: string;
   to: ToolPackBuildOutput;
   webOutputMode: ToolPackWebOutputMode;
   workspaceRoot: string;
@@ -149,6 +166,30 @@ function resolveToolPackPosthogHost(value: string | undefined): string | undefin
     throw new Error(`POSTHOG_HOST must be http(s): ${value}`);
   }
   return normalized.replace(/\/+$/, "");
+}
+
+function resolveToolPackPosthogCliApiKey(value: string | undefined): string | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim();
+  if (normalized.length === 0) return undefined;
+  // Personal API keys start with `phx_`. As with POSTHOG_KEY, third-party
+  // PostHog deployments may use different prefixes; only flag obviously-wrong
+  // values (whitespace, control chars) so a misconfigured CI secret doesn't
+  // silently corrupt the upload step.
+  if (/[\s\x00-\x1f]/.test(normalized)) {
+    throw new Error(`POSTHOG_CLI_API_KEY contains whitespace or control chars`);
+  }
+  return normalized;
+}
+
+function resolveToolPackPosthogCliProjectId(value: string | undefined): string | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim();
+  if (normalized.length === 0) return undefined;
+  if (!/^[0-9]+$/.test(normalized)) {
+    throw new Error(`POSTHOG_CLI_PROJECT_ID must be a numeric project id: ${value}`);
+  }
+  return normalized;
 }
 
 function resolveToolPackTelemetryRelayUrl(value: string | undefined): string | undefined {
@@ -239,6 +280,12 @@ export function resolveToolPackConfig(
     telemetryRelayUrl: resolveToolPackTelemetryRelayUrl(process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL),
     posthogKey: resolveToolPackPosthogKey(process.env.POSTHOG_KEY),
     posthogHost: resolveToolPackPosthogHost(process.env.POSTHOG_HOST),
+    posthogCliApiKey: resolveToolPackPosthogCliApiKey(
+      process.env.POSTHOG_CLI_API_KEY ?? process.env.POSTHOG_PERSONAL_API_KEY,
+    ),
+    posthogCliProjectId: resolveToolPackPosthogCliProjectId(
+      process.env.POSTHOG_CLI_PROJECT_ID ?? process.env.POSTHOG_PROJECT_ID,
+    ),
     to: resolveToolPackBuildOutput(platform, options.to),
     webOutputMode: resolveToolPackWebOutputMode(platform, process.env.OD_WEB_OUTPUT_MODE),
     workspaceRoot: WORKSPACE_ROOT,

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -29,6 +29,7 @@ import {
 import type { ToolPackConfig } from "./config.js";
 import { copyBundledResourceTrees, linuxResources } from "./resources.js";
 import { electronBuilderVersionForAppVersion, readRuntimeAppVersion } from "./versions.js";
+import { processWebSourcemaps } from "./web-sourcemaps.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -377,6 +378,10 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
   try {
     await runPnpm(config, ["--filter", "@open-design/web", "build"], { OD_WEB_OUTPUT_MODE: "server" });
     await runPnpm(config, ["--filter", "@open-design/web", "build:sidecar"]);
+    // Inject chunk IDs + upload browser sourcemaps to PostHog, then strip
+    // .map files before AppImage packaging. See
+    // `tools/pack/src/web-sourcemaps.ts`.
+    await processWebSourcemaps(config);
   } finally {
     if (previousWebNextEnv == null) {
       await rm(webNextEnvPath, { force: true });

--- a/tools/pack/src/mac/workspace.ts
+++ b/tools/pack/src/mac/workspace.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import type { ToolPackCache } from "../cache.js";
 import type { ToolPackConfig } from "../config.js";
+import { processWebSourcemaps } from "../web-sourcemaps.js";
 import { ensureWorkspaceBuildArtifacts } from "../workspace-build.js";
 import { runPnpm } from "./commands.js";
 
@@ -24,6 +25,10 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
       OD_WEB_OUTPUT_MODE: config.webOutputMode,
     });
     await runPnpm(config, ["--filter", "@open-design/web", "build:sidecar"]);
+    // Inject chunk IDs + upload browser sourcemaps to PostHog, then strip
+    // .map files. Runs before any packaging step copies the web output into
+    // the Electron resources so .map never ends up inside the .app bundle.
+    await processWebSourcemaps(config);
   } finally {
     if (previousWebNextEnv == null) {
       await rm(webNextEnvPath, { force: true });

--- a/tools/pack/src/web-sourcemaps.ts
+++ b/tools/pack/src/web-sourcemaps.ts
@@ -110,7 +110,11 @@ function readUploadEnv(config: ToolPackConfig): SourcemapCliEnv | null {
   return {
     apiKey: config.posthogCliApiKey,
     projectId: config.posthogCliProjectId,
-    host: config.posthogHost,
+    // Deliberately uses `posthogCliHost` (management host, us.posthog.com)
+    // rather than `posthogHost` (ingest host, us.i.posthog.com). When the
+    // CLI host is unset the @posthog/cli defaults to the US app host on
+    // its own, which is correct for the official project.
+    host: config.posthogCliHost,
   };
 }
 

--- a/tools/pack/src/web-sourcemaps.ts
+++ b/tools/pack/src/web-sourcemaps.ts
@@ -1,0 +1,225 @@
+// Browser-sourcemap post-build step for packaged builds.
+//
+// Why this exists
+// ---------------
+// `apps/web/next.config.ts` sets `productionBrowserSourceMaps: true`, so
+// every `next build` invoked from tools-pack also produces `.js.map` files
+// alongside the minified chunks. That gives us two requirements:
+//
+//   1. Send the maps to PostHog so the Error tracking page can symbolicate
+//      stack frames (otherwise users see `fO / fz / s4` instead of real
+//      function names + file:line).
+//   2. Make sure no `.map` ever ends up inside a shipped installer (`.dmg`,
+//      `.nsis`, `.AppImage`). Sourcemaps publish the original TypeScript
+//      source to anyone who can read the bundle, which is a security &
+//      competitive-disclosure problem.
+//
+// `processWebSourcemaps` does both:
+//
+//   - With `POSTHOG_CLI_API_KEY` + `POSTHOG_CLI_PROJECT_ID` (CI on
+//     release-{beta,stable,preview}): run `@posthog/cli sourcemap inject`
+//     to bake chunk IDs into the JS/map pair, then `sourcemap upload` to
+//     ship the maps to PostHog. Best-effort — if upload fails (rate limit,
+//     network blip), the strip step below still runs.
+//
+//   - Without those env vars (local `pnpm tools-pack mac build` by a
+//     contributor, fork PR builds): skip both inject and upload, just strip.
+//
+// Either way, the final step ALWAYS removes every `.map` under the
+// browser chunks directory. Stripping is a hard requirement; only the
+// upload is conditional.
+//
+// Scope
+// -----
+// Only the packaged (mac/win/linux Electron) path is covered here. The OSS
+// `od` CLI distribution path serves `apps/web/out/_next/static/chunks/`
+// directly and is not currently used by any release artifact; it can be
+// added later if the OSS audience reports symbolication needs.
+
+import { existsSync } from "node:fs";
+import { readdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { createPackageManagerInvocation } from "@open-design/platform";
+
+import type { ToolPackConfig } from "./config.js";
+import { execFileAsync } from "./mac/commands.js";
+
+const POSTHOG_CLI_VERSION = "0.7.11";
+const RELEASE_NAME = "open-design-web";
+
+export interface WebSourcemapOptions {
+  /**
+   * Optional release version to associate with the uploaded chunks. Falls
+   * back to `config.appVersion` when omitted; if neither is set the CLI
+   * derives one from git, which is fine but less precise than passing a
+   * real semver/nightly identifier from the release workflow.
+   */
+  releaseVersion?: string;
+}
+
+interface SourcemapCliEnv {
+  apiKey: string;
+  projectId: string;
+  host?: string;
+}
+
+function resolveBrowserChunksDir(workspaceRoot: string): string {
+  // Both `output: 'standalone'` (mac/win) and the implicit server output
+  // (linux) write browser chunks to `.next/static`. Static-export mode
+  // (`apps/web/out/_next/static`) is not used by any release artifact.
+  return join(workspaceRoot, "apps", "web", ".next", "static");
+}
+
+async function findMapFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  const stack: string[] = [dir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current == null) break;
+    let entries;
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch {
+      // Directory might not exist on this branch of the tree; skip silently.
+      continue;
+    }
+    for (const entry of entries) {
+      const entryPath = join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (entry.isFile() && entry.name.endsWith(".map")) {
+        out.push(entryPath);
+      }
+    }
+  }
+  return out;
+}
+
+async function deleteMapFiles(dir: string): Promise<number> {
+  const maps = await findMapFiles(dir);
+  for (const mapPath of maps) {
+    await rm(mapPath, { force: true });
+  }
+  return maps.length;
+}
+
+function readUploadEnv(config: ToolPackConfig): SourcemapCliEnv | null {
+  if (config.posthogCliApiKey == null || config.posthogCliApiKey.length === 0) return null;
+  if (config.posthogCliProjectId == null || config.posthogCliProjectId.length === 0) return null;
+  return {
+    apiKey: config.posthogCliApiKey,
+    projectId: config.posthogCliProjectId,
+    host: config.posthogHost,
+  };
+}
+
+function log(line: string): void {
+  process.stderr.write(`[web-sourcemaps] ${line}\n`);
+}
+
+async function runPnpm(
+  config: ToolPackConfig,
+  args: string[],
+  extraEnv: NodeJS.ProcessEnv = {},
+): Promise<void> {
+  // `createPackageManagerInvocation` is the same primitive every platform's
+  // local `runPnpm` helper goes through, so the linux containerized build
+  // (which sets `OD_TOOLS_PACK_PNPM_BIN` to the standalone pnpm binary it
+  // bootstrapped) picks up the right command here too.
+  const invocation = createPackageManagerInvocation(args, process.env);
+  await execFileAsync(invocation.command, invocation.args, {
+    cwd: config.workspaceRoot,
+    env: { ...process.env, ...extraEnv },
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+  });
+}
+
+export async function processWebSourcemaps(
+  config: ToolPackConfig,
+  options: WebSourcemapOptions = {},
+): Promise<void> {
+  const chunksDir = resolveBrowserChunksDir(config.workspaceRoot);
+  if (!existsSync(chunksDir)) {
+    log(`browser chunks dir not found at ${chunksDir}; skipping`);
+    return;
+  }
+
+  const initialMaps = await findMapFiles(chunksDir);
+  if (initialMaps.length === 0) {
+    log(`no .map files under ${chunksDir}; nothing to do`);
+    return;
+  }
+  log(`found ${initialMaps.length} .map file(s) under ${chunksDir}`);
+
+  const uploadEnv = readUploadEnv(config);
+  const releaseVersion = options.releaseVersion ?? config.appVersion;
+
+  if (uploadEnv != null) {
+    const cliEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      POSTHOG_CLI_API_KEY: uploadEnv.apiKey,
+      POSTHOG_CLI_PROJECT_ID: uploadEnv.projectId,
+      ...(uploadEnv.host ? { POSTHOG_CLI_HOST: uploadEnv.host } : {}),
+    };
+    const releaseArgs = [
+      "--release-name",
+      RELEASE_NAME,
+      ...(releaseVersion ? ["--release-version", releaseVersion] : []),
+    ];
+    // inject must succeed first so the chunk ID baked into .js matches the
+    // .map's metadata; the resulting .js change is just a trailing
+    // `//# chunkId=...` comment so it's safe to retry the build with the
+    // same source if anything below fails.
+    try {
+      await runPnpm(
+        config,
+        [
+          "dlx",
+          `@posthog/cli@${POSTHOG_CLI_VERSION}`,
+          "sourcemap",
+          "inject",
+          "--directory",
+          chunksDir,
+          ...releaseArgs,
+        ],
+        cliEnv,
+      );
+    } catch (error) {
+      log(`inject failed: ${(error as Error).message}; continuing to strip`);
+    }
+    // upload is best-effort — `--no-fail` keeps non-zero exits inside the
+    // CLI from killing the release. If this fails the user simply sees
+    // unsymbolicated stacks in PostHog, which is no worse than today.
+    try {
+      const hostFlag = uploadEnv.host ? ["--host", uploadEnv.host] : [];
+      await runPnpm(
+        config,
+        [
+          "dlx",
+          `@posthog/cli@${POSTHOG_CLI_VERSION}`,
+          ...hostFlag,
+          "--no-fail",
+          "sourcemap",
+          "upload",
+          "--directory",
+          chunksDir,
+          ...releaseArgs,
+        ],
+        cliEnv,
+      );
+    } catch (error) {
+      log(`upload failed: ${(error as Error).message}; continuing to strip`);
+    }
+  } else {
+    log("POSTHOG_CLI_API_KEY/POSTHOG_CLI_PROJECT_ID missing; skipping upload");
+  }
+
+  // Hard requirement: never let a .map slip into the shipped installer.
+  // This runs even if the CLI's own `--delete-after` succeeded — duplicate
+  // delete is a no-op, and the explicit pass also catches files the CLI
+  // skipped (anything that wasn't paired with a matching .js, or .map
+  // files added by future tooling we haven't audited yet).
+  const stripped = await deleteMapFiles(chunksDir);
+  log(`stripped ${stripped} .map file(s) before packaging`);
+}

--- a/tools/pack/src/win/app.ts
+++ b/tools/pack/src/win/app.ts
@@ -27,6 +27,7 @@ import {
   shouldInstallInternalPackageForWinPrebundle,
   shouldUseWinStandalonePrebundle,
 } from "../win-prebundle.js";
+import { processWebSourcemaps } from "../web-sourcemaps.js";
 import { ensureWorkspaceBuildArtifacts } from "../workspace-build.js";
 import {
   ELECTRON_BUILDER_BUILD_DEPENDENCIES_FROM_SOURCE,
@@ -128,6 +129,10 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
   try {
     await runPnpm(config, ["--filter", "@open-design/web", "build"], { OD_WEB_OUTPUT_MODE: config.webOutputMode });
     await runPnpm(config, ["--filter", "@open-design/web", "build:sidecar"]);
+    // Inject chunk IDs + upload browser sourcemaps to PostHog, then strip
+    // .map files before any packaging step copies the web output into the
+    // Electron resources. See `tools/pack/src/web-sourcemaps.ts`.
+    await processWebSourcemaps(config);
   } finally {
     if (previousWebNextEnv == null) await rm(webNextEnvPath, { force: true });
     else await writeFile(webNextEnvPath, previousWebNextEnv, "utf8");

--- a/tools/pack/tests/web-sourcemaps.test.ts
+++ b/tools/pack/tests/web-sourcemaps.test.ts
@@ -1,0 +1,165 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ToolPackConfig } from "../src/config.js";
+import { processWebSourcemaps } from "../src/web-sourcemaps.js";
+
+/**
+ * These tests cover the parts of `processWebSourcemaps` that don't shell out
+ * to `@posthog/cli`:
+ *
+ *   - missing chunks dir: returns silently
+ *   - no .map files: returns silently
+ *   - no credentials: ALWAYS strips .map files (the security guarantee)
+ *
+ * The upload-credentials-set path is not exercised here because it would have
+ * to either reach PostHog (network in unit tests is forbidden) or mock out
+ * `runPnpm`, which is intentionally an internal helper. The CLI happy-path
+ * runs in the release workflows themselves; this suite focuses on the
+ * strip-always invariant that must hold for both PR/fork builds and the rare
+ * case where the upload step fails inside the release.
+ */
+
+let tempRoot: string;
+const SAVED_API_KEY = process.env.POSTHOG_CLI_API_KEY;
+const SAVED_PROJECT_ID = process.env.POSTHOG_CLI_PROJECT_ID;
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value == null) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+beforeEach(async () => {
+  tempRoot = await mkdtemp(join(tmpdir(), "od-web-sourcemaps-"));
+  // Force the "no credentials" path so we test the strip-always invariant
+  // without needing to mock @posthog/cli or hit the network.
+  delete process.env.POSTHOG_CLI_API_KEY;
+  delete process.env.POSTHOG_CLI_PROJECT_ID;
+  delete process.env.POSTHOG_PERSONAL_API_KEY;
+  delete process.env.POSTHOG_PROJECT_ID;
+});
+
+afterEach(async () => {
+  if (tempRoot != null) {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+  restoreEnv("POSTHOG_CLI_API_KEY", SAVED_API_KEY);
+  restoreEnv("POSTHOG_CLI_PROJECT_ID", SAVED_PROJECT_ID);
+});
+
+function fakeConfig(workspaceRoot: string): ToolPackConfig {
+  return {
+    appVersion: "0.0.0-test",
+    containerized: false,
+    electronBuilderCliPath: "/dev/null",
+    electronDistPath: "/dev/null",
+    electronVersion: "0.0.0",
+    macCompression: "normal",
+    namespace: "test",
+    platform: "mac",
+    portable: false,
+    removeData: false,
+    removeLogs: false,
+    removeProductUserData: false,
+    removeSidecars: false,
+    roots: {
+      output: {
+        appBuilderRoot: join(workspaceRoot, "out", "builder"),
+        namespaceRoot: join(workspaceRoot, "out", "ns"),
+        platformRoot: join(workspaceRoot, "out", "mac"),
+        root: join(workspaceRoot, "out"),
+      },
+      runtime: {
+        namespaceBaseRoot: join(workspaceRoot, "runtime"),
+        namespaceRoot: join(workspaceRoot, "runtime", "test"),
+      },
+      cacheRoot: join(workspaceRoot, "cache"),
+      toolPackRoot: join(workspaceRoot, "tools-pack"),
+    },
+    signed: false,
+    silent: true,
+    to: "all",
+    webOutputMode: "standalone",
+    workspaceRoot,
+  };
+}
+
+async function setupChunksDir(rootDir: string, mapNames: string[]): Promise<string> {
+  const chunksDir = join(rootDir, "apps", "web", ".next", "static");
+  await mkdir(join(chunksDir, "chunks"), { recursive: true });
+  // Always create a .js file paired with each .map so the layout matches what
+  // Next.js actually emits — otherwise a future helper change that filters by
+  // pairing would silently no-op the test.
+  for (const name of mapNames) {
+    const baseName = name.replace(/\.map$/, "");
+    await writeFile(join(chunksDir, "chunks", baseName), "/* fake bundle */\n", "utf8");
+    await writeFile(join(chunksDir, "chunks", name), '{"version":3,"sources":[]}\n', "utf8");
+  }
+  return chunksDir;
+}
+
+describe("processWebSourcemaps", () => {
+  it("returns silently when the browser chunks directory does not exist", async () => {
+    const config = fakeConfig(tempRoot);
+    await expect(processWebSourcemaps(config)).resolves.toBeUndefined();
+  });
+
+  it("returns silently when the chunks directory has no .map files", async () => {
+    const chunksDir = await setupChunksDir(tempRoot, []);
+    // Drop a non-map file so the dir is not empty but contains no sourcemaps.
+    await writeFile(join(chunksDir, "chunks", "main.js"), "/* */", "utf8");
+    const config = fakeConfig(tempRoot);
+    await expect(processWebSourcemaps(config)).resolves.toBeUndefined();
+  });
+
+  it("strips every .map file when credentials are missing (strip-only path)", async () => {
+    const chunksDir = await setupChunksDir(tempRoot, [
+      "framework-abc.js.map",
+      "main-app-def.js.map",
+      "polyfills-ghi.js.map",
+    ]);
+    const config = fakeConfig(tempRoot);
+
+    await processWebSourcemaps(config);
+
+    // Every .map gone, every .js preserved.
+    await expect(
+      readFile(join(chunksDir, "chunks", "framework-abc.js.map"), "utf8"),
+    ).rejects.toThrow();
+    await expect(
+      readFile(join(chunksDir, "chunks", "main-app-def.js.map"), "utf8"),
+    ).rejects.toThrow();
+    await expect(
+      readFile(join(chunksDir, "chunks", "polyfills-ghi.js.map"), "utf8"),
+    ).rejects.toThrow();
+    const preservedJs = await readFile(
+      join(chunksDir, "chunks", "framework-abc.js"),
+      "utf8",
+    );
+    expect(preservedJs).toContain("fake bundle");
+  });
+
+  it("strips .map files in nested subdirectories under .next/static", async () => {
+    const chunksDir = await setupChunksDir(tempRoot, []);
+    // Next.js puts some bundles under `.next/static/css` and `.next/static/media`
+    // even though the JS chunks live in `.next/static/chunks`. The strip walker
+    // must recurse — otherwise we'd leak CSS-source-style maps if Next ever
+    // emits them under those paths.
+    const nestedDir = join(chunksDir, "media");
+    await mkdir(nestedDir, { recursive: true });
+    await writeFile(join(nestedDir, "x.js"), "/* */", "utf8");
+    await writeFile(join(nestedDir, "x.js.map"), "{}", "utf8");
+
+    const config = fakeConfig(tempRoot);
+    await processWebSourcemaps(config);
+
+    await expect(readFile(join(nestedDir, "x.js.map"), "utf8")).rejects.toThrow();
+    await expect(readFile(join(nestedDir, "x.js"), "utf8")).resolves.toContain("/*");
+  });
+});


### PR DESCRIPTION
## Why

PostHog Error Tracking is essentially blind today:

1. **Stacks are unreadable.** Next.js was emitting minified JS with no browser sourcemaps, so frames in the Error Tracking dashboard show `fO / fz / s4 / tD / ? / sJ`. We can't tell which file / function / line, even when a real exception comes through.

2. **Almost nothing comes through.** 14-day exception count is **54 events / 10 users** across **~5k DAU**, producing the misleading **99.93%** crash-free curve. The root causes:
   - `posthog-js`'s `capture_exceptions: true` is silenced by `opt_out_capturing()`, so every opted-out user vanishes from the error feed.
   - `posthog-js` is dynamically `import()`-ed only after `/api/analytics/config` resolves AND the user has consented. The first 1-2 seconds (React hydration, early effects) have no listener catching errors.

This PR fixes both. After release/v0.8.0 ships and rolls out, expect the crash-free curve to **drop from the artificial 99.93% to a realistic 95-98%** — that's not a regression, it's the first time we're measuring it.

## What users will see

**Nothing visible.** The shipped `.js` chunks gain a small trailing `//# sourceMappingURL=…` + `//# chunkId=…` comment (~70 bytes / chunk) and lose their accompanying `.map` files (a strict requirement — sourcemaps are equivalent to source). The `window.error` / `unhandledrejection` listeners run silently in the background.

What **maintainers** see changes a lot:

- PostHog Error Tracking shows real file paths + line numbers + function names instead of mangled identifiers (`apps/web/src/components/FileViewer.tsx:147:23 in handleIframeMessage`).
- 5-10× more `$exception` events per day land in the project, including all errors from opted-out users and all errors that fired during the first 1-2 seconds of page load.
- The previously-empty Error Tracking fingerprint column starts grouping real issues.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

New env vars consumed by `tools-pack`: `POSTHOG_CLI_API_KEY` (with alias `POSTHOG_PERSONAL_API_KEY`) and `POSTHOG_CLI_PROJECT_ID` (with alias `POSTHOG_PROJECT_ID`). Used only at packaging time; never baked into the shipped binary.

Contract change: `/api/analytics/config` now returns `key` + `host` even when `enabled: false`. The `enabled` flag continues to reflect *only* the user's analytics-consent toggle — `posthog-js`'s general autocapture still respects it. But the new error-tracking module reads `key` directly, bypassing consent for `$exception` events specifically. This is a deliberate product decision: error reports flow unconditionally so we don't lose ground truth on stability. Settings → Privacy copy should call this out in a follow-up so the consent UI matches behavior.

## Screenshots

N/A — no user-facing UI. Verification is in PostHog Error Tracking after the next release rolls out: an upcoming exception's frames should switch from `fO / fz / s4` to real `apps/web/src/components/.../FileViewer.tsx:147:23` style entries, and the daily event count should jump from <20 to >100.

## Bug fix verification

N/A — observability improvement, not a behavior fix backed by a red spec. The red spec for "exceptions are observable" *is* this PR — there's no way to write it against current code because the capture pipeline itself was the broken thing.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/tools-pack typecheck` — pass
- `pnpm --filter @open-design/web test` — pass (199 files / 1823 tests, including 8 new `error-tracking.test.ts` cases for buffer cap, window-hook install, scrub, and direct dispatch)
- `pnpm --filter @open-design/daemon test` — pass (250 files / 2971 tests)
- `pnpm --filter @open-design/tools-pack test` — pass (19 files / 120 tests, including 4 new `web-sourcemaps.test.ts` cases for the strip-always invariant)
- Local `OD_WEB_OUTPUT_MODE=standalone pnpm --filter @open-design/web build` — emits 17 `.map` files alongside the JS chunks under `apps/web/.next/static/`. JS = 4.8 MB, maps = 14 MB. The strip step keeps the 14 MB out of the packaged installer.
- Pre-existing baseline: `apps/desktop/src/main/updater.ts` has typecheck errors referencing `RELEASE_CHANNEL_NAMES.PREVIEW / NIGHTLY` on `release/v0.8.0`; **unrelated to this PR** — confirmed reproducible from a clean `origin/release/v0.8.0` checkout.

## Repo configuration (already applied)

- secret `POSTHOG_CLI_API_KEY` — added 2026-05-21 (the `phx_…` personal API key, Cloud US, project 420348)
- variable `POSTHOG_CLI_PROJECT_ID` = `420348` — added 2026-05-21

(Confirm via `gh secret list --repo nexu-io/open-design | grep POSTHOG_CLI` and `gh variable list --repo nexu-io/open-design | grep POSTHOG_CLI`.)

## How the two pieces fit together

### Piece 1 — sourcemap pipeline (`feat(release):` commit)

1. `apps/web/next.config.ts` adds `productionBrowserSourceMaps: true`, so every `next build` emits `.js.map` files alongside the chunks.
2. After the web build, `tools/pack/src/web-sourcemaps.ts` runs:
   - If `POSTHOG_CLI_API_KEY` + `POSTHOG_CLI_PROJECT_ID` are set (CI on `release-{beta,preview,stable}.yml`): shells out to `pnpm dlx @posthog/cli@0.7.11 sourcemap inject --directory <chunks>` + `... sourcemap upload --directory <chunks>` with `--release-name open-design-web` + `--release-version <appVersion>`. Inject bakes a `chunkId` into each JS file so PostHog can correlate the runtime stack to the uploaded map; upload ships the maps to PostHog and `--no-fail` keeps a transient upload error from killing the release.
   - If those env vars are missing (PR builds, forks, local contributor builds): logs and skips both inject and upload.
3. **Always** strips every `.map` file under `apps/web/.next/static/` (recursively, so CSS source maps are caught too). Shipping a sourcemap is equivalent to shipping the source.

### Piece 2 — always-on exception capture (`feat(analytics):` commit)

1. `apps/web/src/analytics/error-tracking.ts` (new): owns `window.error` + `unhandledrejection` handlers, in-memory buffer (capped at 50 entries to bound memory in an error loop), direct fetch to `https://<host>/i/v0/e/` with the public `phc_` key. Reuses the same scrub layer as the posthog-js path so file paths still get redacted.
2. `apps/web/app/[[...slug]]/client-app.tsx`: `installErrorHandlers()` at module-load, before React or any feature code can throw.
3. `apps/web/src/analytics/provider.tsx`: `bootstrapExceptionTracking()` in the identity `useEffect`, parallel to `getAnalyticsClient()` — runs **regardless of consent state**, fetches `/api/analytics/config`, hands the `phc_` key + host + distinctId to the error tracker so buffered events can flush.
4. `apps/web/src/analytics/client.ts`: `capture_exceptions: false` so posthog-js stops also emitting `$exception` (would have produced duplicate events server-side); also re-bridges the error-tracking context inside the `loaded()` callback so future events inherit the fully-resolved appVersion / sessionId metadata.
5. `apps/daemon/src/server.ts` + `packages/contracts/src/analytics/public-params.ts`: `/api/analytics/config` now returns `key` + `host` even when `consent: false`. `enabled` still reflects only the analytics consent toggle (posthog-js full autocapture stays off when `enabled: false`), but the always-on error tracker can read `key` directly. Forks without `POSTHOG_KEY` still get `key: null` and the whole pipeline becomes a no-op.
6. `apps/web/src/analytics/scrub.ts`: regex fix so packaged-mac paths like `/Applications/Open Design.app/Contents/Resources/apps/web/...` (which contain a space) get fully rewritten to `app://apps/web/...`. Previously the `[^\s]` guard stopped at "Open" and leaked the install dir.

## Follow-ups (not addressed here)

- **Settings → Privacy copy** should call out that error reports flow even when "Share usage data" is off, so the user-visible explanation matches behavior. Tracked as a separate issue (UX-only, no code change here would communicate it correctly).
- **Daemon-side `uncaughtException` / `unhandledRejection`** capture is still missing — Node process crashes never make it to PostHog. Separate PR.
- **OSS `od` CLI distribution path** (`apps/web/out/_next/static/chunks/`) is still not symbolicated for users who clone-and-run. The CI release path covers ~85% of active users today, so this can move to a follow-up issue.
