### PR TITLE
fix: localize 'use everywhere' tab hint in integrations page

### DIFF
--- a/apps/web/src/components/IntegrationsView.tsx
+++ b/apps/web/src/components/IntegrationsView.tsx
@@ -206,6 +206,6 @@ function integrationTabHint(id: IntegrationTab, t: ReturnType<typeof useT>): str
     case 'mcp': return t('integrations.tabHint.mcp');
     case 'connectors': return t('integrations.tabHint.connectors');
     case 'skills': return t('tasks.comingSoon');
-    case 'use-everywhere': return 'CLI, HTTP, MCP';
+    case 'use-everywhere': return t('integrations.tabHint.useEverywhere');
   }
 }

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -589,6 +589,7 @@ export const en: Dict = {
   'integrations.areasAria': 'Integration areas',
   'integrations.tabHint.mcp': 'External tools',
   'integrations.tabHint.connectors': 'Accounts and APIs',
+  'integrations.tabHint.useEverywhere': 'CLI, HTTP, MCP',
   'integrations.skillsTitle': 'Skills integrations',
   'integrations.skillsBody': 'Skill-level integration management is being carried over from another branch. This tab is reserved so MCP, Connectors, and future Skills setup live in the same Integration route.',
   'mcpClient.title': 'External MCP servers',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -589,6 +589,7 @@ export const zhCN: Dict = {
   'integrations.areasAria': '集成区域',
   'integrations.tabHint.mcp': '外部工具',
   'integrations.tabHint.connectors': '账号和 API',
+  'integrations.tabHint.useEverywhere': 'CLI、HTTP、MCP',
   'integrations.skillsTitle': '技能集成',
   'integrations.skillsBody': '技能级集成管理正在从另一个分支迁移过来。此标签页预留给 MCP、连接器和未来技能设置，使它们位于同一个集成路由中。',
   'mcpClient.title': '外部 MCP 服务器',


### PR DESCRIPTION
## Summary

Fixes the hardcoded English string in the Integrations page 'Use Everywhere' tab hint to support Chinese localization.

## What changed

- Replaced hardcoded `'CLI, HTTP, MCP'` string with i18n key `'integrations.tabHint.useEverywhere'`
- Added English translation: `'CLI, HTTP, MCP'`
- Added Chinese translation: `'CLI、HTTP、MCP'` (using Chinese punctuation)

## Why

The 'Use Everywhere' tab hint was the only remaining hardcoded English string in the Integrations page. All other UI elements (sidebar label, page title, section labels, buttons) already have proper i18n support. This change completes the localization coverage for the Integrations page.

## Result

Chinese-speaking users now see a fully localized Integrations page with consistent language across all UI elements.

Closes #2081