### PR TITLE
fix(web): localize quick brief forms

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8987,6 +8987,38 @@ export async function startServer({
     });
   };
 
+  const renderLocaleInstructionPrompt = (locale) => {
+    if (typeof locale !== 'string' || locale.trim().length === 0 || locale === 'en') {
+      return '';
+    }
+    const languageName = {
+      'zh-CN': 'Simplified Chinese',
+      'zh-TW': 'Traditional Chinese',
+      ja: 'Japanese',
+      ko: 'Korean',
+      de: 'German',
+      fr: 'French',
+      'es-ES': 'Spanish',
+      'pt-BR': 'Brazilian Portuguese',
+      ru: 'Russian',
+      ar: 'Arabic',
+      fa: 'Persian',
+      id: 'Indonesian',
+      pl: 'Polish',
+      hu: 'Hungarian',
+      uk: 'Ukrainian',
+      tr: 'Turkish',
+      th: 'Thai',
+      it: 'Italian',
+    }[locale] ?? locale;
+    return [
+      '## UI language',
+      `The Open Design UI is currently set to ${languageName} (${locale}).`,
+      'All user-visible prose and any <question-form> title, description, labels, placeholders, helper text, and option labels must use that language.',
+      'Keep internal identifiers, JSON field names, and stable option values unchanged.',
+    ].join('\n');
+  };
+
   const startChatRun = async (chatBody, run) => {
     /** @type {Partial<ChatRequest> & { imagePaths?: string[] }} */
     chatBody = chatBody || {};
@@ -9006,6 +9038,7 @@ export async function startServer({
       commentAttachments = [],
       model,
       reasoning,
+      locale,
       research,
       context,
     } = chatBody;
@@ -9330,7 +9363,8 @@ export async function startServer({
       message,
       currentPrompt,
     );
-    const clientInstructionPrompt = [researchCommandContract, runContextPrompt, systemPrompt]
+    const localeInstructionPrompt = renderLocaleInstructionPrompt(locale);
+    const clientInstructionPrompt = [researchCommandContract, runContextPrompt, localeInstructionPrompt, systemPrompt]
       .map((part) => (typeof part === 'string' ? part.trim() : ''))
       .filter(Boolean)
       .join('\n\n---\n\n');

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -17,14 +17,14 @@ import {
   type QuestionForm,
 } from "../artifacts/question-form";
 import { stripArtifact } from "../artifacts/strip";
-import { QuestionFormView, parseSubmittedAnswers } from "./QuestionForm";
+import { QuestionFormView, localizeQuestionForm, parseSubmittedAnswers } from "./QuestionForm";
 import {
   getPluginFolderCandidates,
   type PluginFolderCandidate,
 } from "./design-files/pluginFolders";
 import type { PluginFolderAgentAction } from "./design-files/pluginFolderActions";
 import { Icon } from "./Icon";
-import { useT } from "../i18n";
+import { useI18n, useT } from "../i18n";
 import { deriveFileOps, type FileOpEntry } from "../runtime/file-ops";
 import { unfinishedTodosFromEvents, type TodoItem } from "../runtime/todos";
 import type { Dict } from "../i18n/types";
@@ -1296,12 +1296,14 @@ function FormBlock({
   locallySubmitted: Set<string>;
   onSubmitForm: (formId: string, text: string) => void;
 }) {
+  const { locale } = useI18n();
+  const localizedForm = useMemo(() => localizeQuestionForm(form, locale), [form, locale]);
   // Reconstruct prior answers from a follow-up user message so older
   // forms in the scrollback render in their answered state.
   const submittedFromHistory = useMemo(() => {
     if (!nextUserContent) return null;
-    return parseSubmittedAnswers(form, nextUserContent);
-  }, [form, nextUserContent]);
+    return parseSubmittedAnswers(localizedForm, nextUserContent);
+  }, [localizedForm, nextUserContent]);
   const wasSubmittedLocally = locallySubmitted.has(form.id);
   const interactive =
     isLastAssistant &&
@@ -1310,7 +1312,7 @@ function FormBlock({
     !wasSubmittedLocally;
   return (
     <QuestionFormView
-      form={form}
+      form={localizedForm}
       interactive={interactive}
       submittedAnswers={submittedFromHistory ?? undefined}
       onSubmit={(text) => onSubmitForm(form.id, text)}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -195,6 +195,23 @@ interface Props {
 
 let liveArtifactEventSequence = 0;
 const CHAT_PANEL_WIDTH_STORAGE_KEY = 'open-design.project.chatPanelWidth';
+const LOCALE_STORAGE_KEY = 'open-design:locale';
+
+function readCurrentUiLocale(): string | undefined {
+  if (typeof document !== 'undefined') {
+    const htmlLang = document.documentElement.getAttribute('lang')?.trim();
+    if (htmlLang) return htmlLang;
+  }
+  if (typeof window !== 'undefined') {
+    try {
+      const stored = window.localStorage.getItem(LOCALE_STORAGE_KEY)?.trim();
+      if (stored) return stored;
+    } catch {
+      /* ignore */
+    }
+  }
+  return undefined;
+}
 const DEFAULT_CHAT_PANEL_WIDTH = 460;
 const MIN_CHAT_PANEL_WIDTH = 345;
 const MAX_CHAT_PANEL_WIDTH = 720;
@@ -2417,6 +2434,7 @@ export function ProjectView({
           research: meta?.research,
           model: choice?.model ?? null,
           reasoning: choice?.reasoning ?? null,
+          locale: readCurrentUiLocale(),
           onRunCreated: (runId) => {
             const pinnedAssistant = {
               ...latestAssistantMsg,

--- a/apps/web/src/components/QuestionForm.tsx
+++ b/apps/web/src/components/QuestionForm.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useT } from '../i18n';
+import { useI18n, useT, type Locale } from '../i18n';
 import type { DirectionCard, FormOption, QuestionForm } from '../artifacts/question-form';
 import { formatFormAnswers, formOptionValueForLabel } from '../artifacts/question-form';
 
@@ -16,9 +16,203 @@ interface Props {
   onSubmit?: (text: string, answers: Record<string, string | string[]>) => void;
 }
 
+type QuestionFormCopy = {
+  strings: Record<string, string>;
+  patterns?: Array<{ pattern: RegExp; replace: (match: RegExpMatchArray) => string }>;
+};
+
+const ZH_CN_QUESTION_FORM_COPY: QuestionFormCopy = {
+  strings: {
+    'Quick brief': '快速简报',
+    'Quick brief — 30 seconds': '快速简报 - 30 秒',
+    'Choose the task type': '选择任务类型',
+    "I'll route this through the right Open Design workflow and lock the brief in one shot. Skip what doesn't apply — I'll fill defaults.":
+      '我会把它路由到合适的 Open Design 工作流，并一次性锁定简报。不适用的可跳过，我会补默认值。',
+    "I'll route the free-form prompt through the right Open Design workflow.":
+      '我会把自由输入的需求路由到合适的 Open Design 工作流。',
+    "I'll lock these in before building. Skip what doesn't apply — I'll fill defaults.":
+      '开始构建前我会先锁定这些信息。不适用的可跳过，我会补默认值。',
+    'What should I build?': '要构建什么？',
+    'What are we making?': '我们要做什么？',
+    'Target platform': '目标平台',
+    'Target user': '目标用户',
+    'Who is this for?': '面向谁？',
+    'Visual tone': '视觉调性',
+    'Brand context': '品牌背景',
+    'Roughly how much?': '大致规模？',
+    'Any important constraints?': '有什么重要限制？',
+    'Anything else I should know?': '还有什么需要我知道？',
+    "What's the angle / hook of this dating app?": '这个约会应用的切入点 / 亮点是什么？',
+    'Prototype': '原型',
+    'Live artifact': '实时产物',
+    'Slide deck': '演示文稿',
+    'Image': '图片',
+    'Video': '视频',
+    'HyperFrames': 'HyperFrames',
+    'Audio': '音频',
+    'Other': '其他',
+    'Slide deck / pitch': '演示文稿 / 路演',
+    'Single web prototype / landing': '单页网页原型 / 落地页',
+    'Multi-screen app prototype': '多屏应用原型',
+    'Dashboard / tool UI': '仪表盘 / 工具界面',
+    'Editorial / marketing page': '编辑式 / 营销页面',
+    "Other — I'll describe": '其他 - 我来描述',
+    'Responsive web': '响应式网页',
+    'Desktop web': '桌面网页',
+    'iOS app': 'iOS 应用',
+    'Android app': 'Android 应用',
+    'Tablet': '平板',
+    'Tablet app': '平板应用',
+    'Desktop app': '桌面应用',
+    'Fixed canvas (1920×1080)': '固定画布 (1920×1080)',
+    'Editorial / magazine': '编辑 / 杂志感',
+    'Modern minimal': '现代极简',
+    'Playful / illustrative': '活泼 / 插画感',
+    'Tech / utility': '科技 / 工具感',
+    'Luxury / refined': '奢华 / 精致',
+    'Brutalist / experimental': '粗野主义 / 实验性',
+    'Human / approachable': '亲和 / 易接近',
+    'Pick a direction for me': '帮我选一个方向',
+    "I have a brand spec — I'll share it": '我有品牌规范 - 稍后分享',
+    "Match a reference site / screenshot — I'll attach it": '匹配参考网站 / 截图 - 稍后上传',
+    'Audience, brand, format, length, aspect ratio, references, things to avoid...':
+      '受众、品牌、格式、长度、宽高比、参考资料、需要避免的内容...',
+    'e.g. early-stage investors, dev-tools buyers, internal exec review':
+      '例如：早期投资人、开发者工具买家、内部高管评审',
+    'e.g. 8 slides, 1 landing + 3 sub-pages, 4 mobile screens, 30s video':
+      '例如：8 页幻灯片、1 个落地页 + 3 个子页面、4 个移动端界面、30 秒视频',
+    'e.g. 8 slides, 1 landing + 3 sub-pages, 4 mobile screens':
+      '例如：8 页幻灯片、1 个落地页 + 3 个子页面、4 个移动端界面',
+    'Real copy, fonts you must use, things to avoid, deadline…':
+      '真实文案、必须使用的字体、需要避免的内容、截止时间等...',
+  },
+  patterns: [
+    {
+      pattern: /^What's the angle \/ hook of this (.+)\?$/i,
+      replace: (match) => `这个${match[1] ?? '项目'}的切入点 / 亮点是什么？`,
+    },
+  ],
+};
+
+const ZH_TW_QUESTION_FORM_COPY: QuestionFormCopy = {
+  strings: {
+    ...ZH_CN_QUESTION_FORM_COPY.strings,
+    'Quick brief': '快速簡報',
+    'Quick brief — 30 seconds': '快速簡報 - 30 秒',
+    'Choose the task type': '選擇任務類型',
+    "I'll route this through the right Open Design workflow and lock the brief in one shot. Skip what doesn't apply — I'll fill defaults.":
+      '我會把它路由到合適的 Open Design 工作流程，並一次性鎖定簡報。不適用的可跳過，我會補預設值。',
+    "I'll route the free-form prompt through the right Open Design workflow.":
+      '我會把自由輸入的需求路由到合適的 Open Design 工作流程。',
+    "I'll lock these in before building. Skip what doesn't apply — I'll fill defaults.":
+      '開始建構前我會先鎖定這些資訊。不適用的可跳過，我會補預設值。',
+    'What should I build?': '要建構什麼？',
+    'What are we making?': '我們要做什麼？',
+    'Target platform': '目標平台',
+    'Target user': '目標使用者',
+    'Who is this for?': '面向誰？',
+    'Visual tone': '視覺調性',
+    'Brand context': '品牌背景',
+    'Roughly how much?': '大致規模？',
+    'Any important constraints?': '有什麼重要限制？',
+    'Anything else I should know?': '還有什麼需要我知道？',
+    "What's the angle / hook of this dating app?": '這個約會應用的切入點 / 亮點是什麼？',
+    'Slide deck': '簡報',
+    'Image': '圖片',
+    'Video': '影片',
+    'Audio': '音訊',
+    'Other': '其他',
+    'Slide deck / pitch': '簡報 / 路演',
+    'Single web prototype / landing': '單頁網頁原型 / 落地頁',
+    'Multi-screen app prototype': '多螢幕應用原型',
+    'Dashboard / tool UI': '儀表板 / 工具介面',
+    'Editorial / marketing page': '編輯式 / 行銷頁面',
+    "Other — I'll describe": '其他 - 我來描述',
+    'Responsive web': '響應式網頁',
+    'Desktop web': '桌面網頁',
+    'iOS app': 'iOS 應用',
+    'Android app': 'Android 應用',
+    'Tablet': '平板',
+    'Tablet app': '平板應用',
+    'Desktop app': '桌面應用',
+    'Fixed canvas (1920×1080)': '固定畫布 (1920×1080)',
+    'Editorial / magazine': '編輯 / 雜誌感',
+    'Modern minimal': '現代極簡',
+    'Playful / illustrative': '活潑 / 插畫感',
+    'Tech / utility': '科技 / 工具感',
+    'Luxury / refined': '奢華 / 精緻',
+    'Brutalist / experimental': '粗野主義 / 實驗性',
+    'Human / approachable': '親和 / 易接近',
+    'Pick a direction for me': '幫我選一個方向',
+    "I have a brand spec — I'll share it": '我有品牌規範 - 稍後分享',
+    "Match a reference site / screenshot — I'll attach it": '匹配參考網站 / 截圖 - 稍後上傳',
+    'Audience, brand, format, length, aspect ratio, references, things to avoid...':
+      '受眾、品牌、格式、長度、長寬比、參考資料、需要避免的內容...',
+    'e.g. early-stage investors, dev-tools buyers, internal exec review':
+      '例如：早期投資人、開發者工具買家、內部高層評審',
+    'e.g. 8 slides, 1 landing + 3 sub-pages, 4 mobile screens, 30s video':
+      '例如：8 頁簡報、1 個落地頁 + 3 個子頁面、4 個行動端畫面、30 秒影片',
+    'e.g. 8 slides, 1 landing + 3 sub-pages, 4 mobile screens':
+      '例如：8 頁簡報、1 個落地頁 + 3 個子頁面、4 個行動端畫面',
+    'Real copy, fonts you must use, things to avoid, deadline…':
+      '真實文案、必須使用的字體、需要避免的內容、截止時間等...',
+  },
+  patterns: [
+    {
+      pattern: /^What's the angle \/ hook of this (.+)\?$/i,
+      replace: (match) => `這個${match[1] ?? '專案'}的切入點 / 亮點是什麼？`,
+    },
+  ],
+};
+
+const QUESTION_FORM_COPY_BY_LOCALE: Partial<Record<Locale, QuestionFormCopy>> = {
+  'zh-CN': ZH_CN_QUESTION_FORM_COPY,
+  'zh-TW': ZH_TW_QUESTION_FORM_COPY,
+};
+
+export function localizeQuestionForm(form: QuestionForm, locale: Locale): QuestionForm {
+  const copy = QUESTION_FORM_COPY_BY_LOCALE[locale];
+  if (!copy) return form;
+  const tr = (value: string | undefined): string | undefined => {
+    if (value === undefined) return undefined;
+    const exact = copy.strings[value];
+    if (exact !== undefined) return exact;
+    for (const entry of copy.patterns ?? []) {
+      const match = value.match(entry.pattern);
+      if (match) return entry.replace(match);
+    }
+    return value;
+  };
+  return {
+    ...form,
+    title: tr(form.title) ?? form.title,
+    ...(form.description ? { description: tr(form.description) ?? form.description } : {}),
+    ...(form.submitLabel ? { submitLabel: tr(form.submitLabel) ?? form.submitLabel } : {}),
+    questions: form.questions.map((question) => ({
+      ...question,
+      label: tr(question.label) ?? question.label,
+      ...(question.placeholder ? { placeholder: tr(question.placeholder) ?? question.placeholder } : {}),
+      ...(question.help ? { help: tr(question.help) ?? question.help } : {}),
+      ...(question.options
+        ? {
+            options: question.options.map((option) => ({
+              ...option,
+              label: tr(option.label) ?? option.label,
+              ...(option.description ? { description: tr(option.description) ?? option.description } : {}),
+            })),
+          }
+        : {}),
+    })),
+  };
+}
+
 export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit }: Props) {
-  const t = useT();
-  const initial = useMemo(() => buildInitialState(form, submittedAnswers), [form, submittedAnswers]);
+  const { locale, t } = useI18n();
+  const visibleForm = useMemo(() => localizeQuestionForm(form, locale), [form, locale]);
+  const initial = useMemo(
+    () => buildInitialState(visibleForm, submittedAnswers),
+    [visibleForm, submittedAnswers],
+  );
   const [answers, setAnswers] = useState<Record<string, string | string[]>>(initial);
   const locked = !interactive || !onSubmit || submittedAnswers !== undefined;
   const currentAnswers = submittedAnswers ?? answers;
@@ -42,7 +236,7 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
   }
 
   function missingRequired(): string | null {
-    for (const q of form.questions) {
+    for (const q of visibleForm.questions) {
       if (!q.required) continue;
       const v = currentAnswers[q.id];
       if (Array.isArray(v) ? v.length === 0 : !(typeof v === 'string' && v.trim().length > 0)) {
@@ -61,11 +255,11 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
       // state of the submit button covers most cases.
       return;
     }
-    onSubmit(formatFormAnswers(form, answers), answers);
+    onSubmit(formatFormAnswers(visibleForm, answers), answers);
   }
 
-  const required = form.questions.filter((q) => q.required);
-  const withinSelectionLimits = form.questions.every((q) => {
+  const required = visibleForm.questions.filter((q) => q.required);
+  const withinSelectionLimits = visibleForm.questions.every((q) => {
     if (q.type !== 'checkbox' || q.maxSelections === undefined) return true;
     const v = currentAnswers[q.id];
     return !Array.isArray(v) || v.length <= q.maxSelections;
@@ -76,19 +270,19 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
   });
 
   return (
-    <div className={`question-form${locked ? ' question-form-locked' : ''}`} data-form-id={form.id}>
+    <div className={`question-form${locked ? ' question-form-locked' : ''}`} data-form-id={visibleForm.id}>
       <div className="question-form-head">
         <span className="question-form-icon" aria-hidden>?</span>
         <div className="question-form-titles">
-          <div className="question-form-title">{form.title}</div>
-          {form.description ? (
-            <div className="question-form-desc">{form.description}</div>
+          <div className="question-form-title">{visibleForm.title}</div>
+          {visibleForm.description ? (
+            <div className="question-form-desc">{visibleForm.description}</div>
           ) : null}
         </div>
         {locked ? <span className="question-form-pill">{t('qf.answered')}</span> : null}
       </div>
       <div className="question-form-body">
-        {form.questions.map((q) => {
+        {visibleForm.questions.map((q) => {
           const value = currentAnswers[q.id];
           return (
             <div key={q.id} className="qf-field">
@@ -109,7 +303,7 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
                     >
                       <input
                         type="radio"
-                        name={`${form.id}-${q.id}`}
+                        name={`${visibleForm.id}-${q.id}`}
                         value={opt.value}
                         checked={value === opt.value}
                         disabled={locked}
@@ -191,7 +385,7 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
                     <DirectionCardView
                       key={card.id}
                       card={card}
-                      formId={form.id}
+                      formId={visibleForm.id}
                       questionId={q.id}
                       selected={value === card.id || value === card.label}
                       disabled={locked}
@@ -220,7 +414,7 @@ export function QuestionFormView({ form, interactive, submittedAnswers, onSubmit
             disabled={!ready}
             title={ready ? t('qf.submitTitle') : t('qf.submitDisabledTitle')}
           >
-            {form.submitLabel ?? t('qf.submitDefault')}
+            {visibleForm.submitLabel ?? t('qf.submitDefault')}
           </button>
         ) : null}
       </div>

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -179,6 +179,7 @@ export interface DaemonStreamOptions {
   // options and falls back to the CLI default when missing.
   model?: string | null;
   reasoning?: string | null;
+  locale?: string;
   research?: ResearchOptions;
   context?: RunContextSelection;
   initialLastEventId?: string | null;
@@ -234,6 +235,7 @@ export async function streamViaDaemon({
   commentAttachments,
   model,
   reasoning,
+  locale,
   research,
   context,
   initialLastEventId,
@@ -264,6 +266,7 @@ export async function streamViaDaemon({
     commentAttachments: commentAttachments ?? [],
     model: model ?? null,
     reasoning: reasoning ?? null,
+    ...(locale ? { locale } : {}),
     ...(context ? { context } : {}),
     ...(research ? { research } : {}),
   };

--- a/apps/web/tests/components/QuestionForm.test.tsx
+++ b/apps/web/tests/components/QuestionForm.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { QuestionFormView, parseSubmittedAnswers } from '../../src/components/QuestionForm';
 import type { QuestionForm } from '../../src/artifacts/question-form';
+import { I18nProvider } from '../../src/i18n';
 
 const form: QuestionForm = {
   id: 'discovery',
@@ -102,6 +103,38 @@ const selectObjectForm = {
       options: [
         { label: 'Mobile (iOS/Android)', value: 'mobile' },
         { label: 'Desktop web', value: 'desktop-web' },
+      ],
+    },
+  ],
+} as QuestionForm;
+
+const quickBriefForm = {
+  id: 'discovery',
+  title: 'Quick brief — 30 seconds',
+  description: "I'll lock these in before building. Skip what doesn't apply — I'll fill defaults.",
+  questions: [
+    {
+      id: 'hook',
+      label: "What's the angle / hook of this dating app?",
+      type: 'text',
+      placeholder: 'Target user',
+    },
+    {
+      id: 'tone',
+      label: 'Visual tone',
+      type: 'checkbox',
+      options: [
+        { label: 'Modern minimal', value: 'Modern minimal' },
+        { label: 'Human / approachable', value: 'Human / approachable' },
+      ],
+    },
+    {
+      id: 'brand',
+      label: 'Brand context',
+      type: 'radio',
+      options: [
+        { label: 'Pick a direction for me', value: 'pick_direction' },
+        { label: "I have a brand spec — I'll share it", value: 'brand_spec' },
       ],
     },
   ],
@@ -241,5 +274,33 @@ describe('QuestionFormView', () => {
       '- Primary surface: Mobile (iOS/Android) [value: mobile]',
     );
     expect(onSubmit.mock.calls[0]?.[1]).toEqual({ platform: 'mobile' });
+  });
+
+  it('localizes the quick brief form in Simplified Chinese while preserving stable values', () => {
+    const onSubmit = vi.fn();
+    render(
+      <I18nProvider initial="zh-CN">
+        <QuestionFormView form={quickBriefForm} interactive onSubmit={onSubmit} />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('快速简报 - 30 秒')).toBeTruthy();
+    expect(screen.getByText('这个约会应用的切入点 / 亮点是什么？')).toBeTruthy();
+    expect(screen.getByText('视觉调性')).toBeTruthy();
+    expect(screen.getByText('现代极简')).toBeTruthy();
+    expect(screen.getByText('品牌背景')).toBeTruthy();
+    expect(screen.getByText('帮我选一个方向')).toBeTruthy();
+    expect(screen.queryByText('Quick brief — 30 seconds')).toBeNull();
+    expect(screen.queryByText('Visual tone')).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('帮我选一个方向'));
+    fireEvent.click(screen.getByRole('button', { name: '发送答案' }));
+
+    expect(onSubmit.mock.calls[0]?.[0]).toContain('- 品牌背景: 帮我选一个方向 [value: pick_direction]');
+    expect(onSubmit.mock.calls[0]?.[1]).toEqual({
+      brand: 'pick_direction',
+      hook: '',
+      tone: [],
+    });
   });
 });

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -33,6 +33,8 @@ export interface ChatRequest {
   commentAttachments?: ChatCommentAttachment[];
   model?: string | null;
   reasoning?: string | null;
+  /** Current UI locale so daemon-authored prompts can keep visible form copy localized. */
+  locale?: string;
   research?: ResearchOptions;
   context?: RunContextSelection;
 }


### PR DESCRIPTION
Closes #1416

## Why

Chinese users were seeing the design-generation quick brief in English even when the Open Design UI was set to Chinese. That broke localization in the first guided-brief step and made the core generation flow harder to use for Chinese-speaking users.

## What users will see

When the UI language is Simplified or Traditional Chinese, the quick brief card renders its title, descriptions, prompts, placeholders, and default option labels in Chinese while preserving stable internal option values for the agent. New daemon runs also receive the current UI locale so future agent-authored question forms are instructed to use the selected language.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — existing Chinese UI sessions now see localized quick brief copy
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is generated chat-card copy rather than a persistent entry-point surface; the regression is covered by the component test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/QuestionForm.test.tsx`
- Did the test go red on `main` and green on this branch? Not re-run on `main`; the first red-spec attempt was blocked by missing dependencies in this worktree, then the regression test was added and verified green after `pnpm install`.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/QuestionForm.test.tsx`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/ProjectView.pendingPrompt.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>