### PR TITLE
fix(ci): stabilize GitHub star badge in visual captures

### DIFF
--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1748,6 +1748,8 @@
   color: var(--text-faint);
 }
 .entry-star-badge__count {
+  display: inline-block;
+  min-width: 5ch;
   color: var(--text);
   font-variant-numeric: tabular-nums;
   transition: opacity 160ms ease;

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -4,7 +4,11 @@ import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 
 const STORAGE_KEY = 'open-design:config';
+const GITHUB_STARS_STORAGE_KEY = 'open-design:gh-stars';
 const VISUAL_STYLE_ID = 'od-visual-stability-style';
+// Keep this exact-route mock narrow so unrelated GitHub UI still behaves normally.
+const VISUAL_GITHUB_REPO_API = 'https://api.github.com/repos/nexu-io/open-design';
+const VISUAL_GITHUB_STARS = 40_000;
 
 const VISUAL_CONFIG = {
   mode: 'daemon',
@@ -129,9 +133,13 @@ const VISUAL_DESIGN_SYSTEMS = [
 export async function configureVisualPage(page: Page, options: VisualPageOptions = {}): Promise<void> {
   const projects = options.projects ?? VISUAL_PROJECTS;
 
-  await page.addInitScript(([key, config]) => {
+  await page.addInitScript(([key, config, githubStarsKey, githubStarsCount]) => {
     window.localStorage.setItem(key, JSON.stringify(config));
-  }, [STORAGE_KEY, VISUAL_CONFIG] as const);
+    window.localStorage.setItem(
+      githubStarsKey,
+      JSON.stringify({ count: githubStarsCount, ts: Date.now() }),
+    );
+  }, [STORAGE_KEY, VISUAL_CONFIG, GITHUB_STARS_STORAGE_KEY, VISUAL_GITHUB_STARS] as const);
 
   await page.route('**/api/app-config', async (route) => {
     await fulfillGet(route, { config: VISUAL_CONFIG });
@@ -139,6 +147,17 @@ export async function configureVisualPage(page: Page, options: VisualPageOptions
 
   await page.route('**/api/agents', async (route) => {
     await fulfillGet(route, { agents: [MOCK_AGENT] });
+  });
+
+  await page.route(VISUAL_GITHUB_REPO_API, async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      json: { stargazers_count: VISUAL_GITHUB_STARS },
+    });
   });
 
   await page.route('**/api/projects', async (route) => {


### PR DESCRIPTION
## Why

Recent visual PR diffs have been noisy because the GitHub star badge in the top bar depends on live external data. Baseline and PR captures can see different star counts, loading states, or GitHub API outcomes, which creates false positives and makes visual review less trustworthy.

## What users will see

The GitHub star badge in the top bar keeps the same appearance, but its count area now reserves stable width so the surrounding header chrome no longer shifts when the value changes.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This change is a small topbar-width stabilization, and the current local runtime is blocked by an unrelated daemon/contracts mismatch.

## Bug fix verification

- Test path that reproduces the bug: not added; the issue is flaky visual nondeterminism caused by live GitHub data in the Playwright visual harness rather than a cheap unit-level red spec.
- Did the test go red on `main` and green on this branch? no
- Verification instead: froze the GitHub stars value inside `configureVisualPage()` via both localStorage seeding and an exact-route GitHub API mock, then re-ran package typechecks relevant to the visual harness. The web runtime and Playwright visual server are currently blocked on pre-existing contracts/daemon startup failures unrelated to this diff.

## Validation

- `pnpm typecheck` (in `e2e`) ✅
- `pnpm --filter @open-design/web typecheck` ❌ pre-existing repository failure unrelated to this diff (`@open-design/contracts` export mismatches in current branch)
- `pnpm exec playwright test -c playwright.visual.config.ts ui/visual-home.test.ts --grep "captures the default home screen"` ❌ blocked because `tools-dev run web` cannot start the daemon due to the same pre-existing contracts mismatch