### PR TITLE
Fix home tab singleton behavior

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -202,6 +202,23 @@ function activateTabInState(
   });
 }
 
+function openRouteInState(
+  state: WorkspaceTabsState,
+  route: Route,
+  timestamp = Date.now(),
+): WorkspaceTabsState {
+  const normalized = normalizeTabsState(state);
+  const reusableTab = findReusableTabForRoute(normalized.tabs, route);
+  if (reusableTab) {
+    return activateTabInState(normalized, reusableTab.id, timestamp);
+  }
+  const nextTab = tabFromRoute(route, timestamp);
+  return normalizeTabsState({
+    tabs: [...normalized.tabs, nextTab],
+    activeTabId: nextTab.id,
+  });
+}
+
 function normalizeTabsState(state: WorkspaceTabsState): WorkspaceTabsState {
   const sourceTabs = state.tabs.length > 0 ? state.tabs : [createEntryTab('home')];
   const usedIds = new Set<string>();
@@ -379,18 +396,7 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
       const detail = (event as CustomEvent<{ route?: Route }>).detail;
       const nextRoute = detail?.route;
       if (!nextRoute) return;
-      const nextTab = tabFromRoute(nextRoute);
-      setState((current) => {
-        const normalized = normalizeTabsState(current);
-        const reusableTab = findReusableTabForRoute(normalized.tabs, nextRoute);
-        if (reusableTab) {
-          return activateTabInState(normalized, reusableTab.id);
-        }
-        return normalizeTabsState({
-          tabs: [...normalized.tabs, nextTab],
-          activeTabId: nextTab.id,
-        });
-      });
+      setState((current) => openRouteInState(current, nextRoute));
       setTabsMenuOpen(false);
     }
 
@@ -467,7 +473,7 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
 
   function createNewTab() {
     const nextRoute: Route = { kind: 'home', view: 'home' };
-    setState((current) => syncStateToRoute(current, nextRoute));
+    setState((current) => openRouteInState(current, nextRoute));
     setTabsMenuOpen(false);
     navigate(nextRoute);
   }

--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -167,19 +167,66 @@ function uniqueIdForTab(tab: WorkspaceChromeTab): string {
   return `entry:${tab.view}:${nowId()}`;
 }
 
+function isHomeRoute(route: Route): boolean {
+  return route.kind === 'home' && route.view === 'home';
+}
+
+function isHomeTab(tab: WorkspaceChromeTab): boolean {
+  return tab.kind === 'entry' && tab.view === 'home';
+}
+
+function singletonKeyForTab(tab: WorkspaceChromeTab): string | null {
+  return isHomeTab(tab) ? 'entry:home' : null;
+}
+
+function findReusableTabForRoute(
+  tabs: WorkspaceChromeTab[],
+  route: Route,
+): WorkspaceChromeTab | null {
+  if (isHomeRoute(route)) {
+    return tabs.find(isHomeTab) ?? null;
+  }
+  return null;
+}
+
+function activateTabInState(
+  state: WorkspaceTabsState,
+  tabId: string,
+  timestamp = Date.now(),
+): WorkspaceTabsState {
+  return normalizeTabsState({
+    tabs: state.tabs.map((tab) =>
+      tab.id === tabId ? { ...tab, lastActiveAt: timestamp } : tab,
+    ),
+    activeTabId: tabId,
+  });
+}
+
 function normalizeTabsState(state: WorkspaceTabsState): WorkspaceTabsState {
   const sourceTabs = state.tabs.length > 0 ? state.tabs : [createEntryTab('home')];
   const usedIds = new Set<string>();
+  const singletonIds = new Map<string, string>();
   let activeTabId = '';
   let activeClaimed = false;
-  const tabs = sourceTabs.map((tab) => {
+  const tabs: WorkspaceChromeTab[] = [];
+  for (const tab of sourceTabs) {
     const wasActive = tab.id === state.activeTabId && !activeClaimed;
-    if (wasActive) activeClaimed = true;
+    const singletonKey = singletonKeyForTab(tab);
+    const existingSingletonId = singletonKey ? singletonIds.get(singletonKey) : null;
+    if (existingSingletonId) {
+      if (wasActive) {
+        activeTabId = existingSingletonId;
+        activeClaimed = true;
+      }
+      continue;
+    }
     const id = tab.id && !usedIds.has(tab.id) ? tab.id : uniqueIdForTab(tab);
     usedIds.add(id);
+    if (singletonKey) singletonIds.set(singletonKey, id);
+    if (wasActive) activeClaimed = true;
     if (wasActive) activeTabId = id;
-    return id === tab.id ? tab : { ...tab, id };
-  });
+    tabs.push(id === tab.id ? tab : { ...tab, id });
+  }
   return {
     tabs,
     activeTabId: activeTabId || tabs[0]!.id,
@@ -215,6 +262,10 @@ function initialTabsState(route: Route): WorkspaceTabsState {
 function syncStateToRoute(state: WorkspaceTabsState, route: Route): WorkspaceTabsState {
   const timestamp = Date.now();
   const current = normalizeTabsState(state);
+  const reusableTab = findReusableTabForRoute(current.tabs, route);
+  if (reusableTab && reusableTab.id !== current.activeTabId) {
+    return activateTabInState(current, reusableTab.id, timestamp);
+  }
   const currentActive = current.tabs.find((tab) => tab.id === current.activeTabId) ?? null;
   if (!currentActive) {
     const nextTab = tabFromRoute(route, timestamp);
@@ -331,6 +382,10 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
       const nextTab = tabFromRoute(nextRoute);
       setState((current) => {
         const normalized = normalizeTabsState(current);
+        const reusableTab = findReusableTabForRoute(normalized.tabs, nextRoute);
+        if (reusableTab) {
+          return activateTabInState(normalized, reusableTab.id);
+        }
         return normalizeTabsState({
           tabs: [...normalized.tabs, nextTab],
           activeTabId: nextTab.id,
@@ -411,13 +466,10 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
   }
 
   function createNewTab() {
-    const tab = createEntryTab('home');
-    setState((current) => ({
-      tabs: [...normalizeTabsState(current).tabs, tab],
-      activeTabId: tab.id,
-    }));
+    const nextRoute: Route = { kind: 'home', view: 'home' };
+    setState((current) => syncStateToRoute(current, nextRoute));
     setTabsMenuOpen(false);
-    navigate({ kind: 'home', view: 'home' });
+    navigate(nextRoute);
   }
 
   function closeTab(tabId: string) {

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -127,6 +127,27 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     expect(navigate).toHaveBeenCalledWith(homeRoute);
   });
 
+  it('adds Home without replacing the active project tab', async () => {
+    render(<WorkspaceTabsBar route={projectRoute} projects={[project]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'New tab' }));
+
+    await waitFor(() => {
+      const tabs = screen.getAllByRole('tab');
+      const labels = tabs.map((tab) => tab.textContent ?? '');
+      const selectedLabels = tabs
+        .filter((tab) => tab.getAttribute('aria-selected') === 'true')
+        .map((tab) => tab.textContent ?? '');
+
+      expect(tabs).toHaveLength(2);
+      expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
+      expect(labels.some((label) => label.includes('Home'))).toBe(true);
+      expect(selectedLabels).toHaveLength(1);
+      expect(selectedLabels[0]).toContain('Home');
+    });
+    expect(navigate).toHaveBeenCalledWith(homeRoute);
+  });
+
   it('collapses restored duplicate Home tabs to a single Home tab', async () => {
     window.localStorage.setItem(
       'open-design:workspace-tabs:v1',

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -66,30 +66,38 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     cleanup();
   });
 
-  it('keeps each new Home tab independent when one tab navigates', async () => {
+  it('reuses the existing Home tab when returning from a project', async () => {
     const { rerender } = render(
       <WorkspaceTabsBar route={homeRoute} projects={[project]} />,
     );
 
     expect(screen.getAllByRole('tab')).toHaveLength(1);
 
-    fireEvent.click(screen.getByRole('button', { name: 'New tab' }));
-    fireEvent.click(screen.getByRole('button', { name: 'New tab' }));
+    openWorkspaceTab(projectRoute);
 
     await waitFor(() => {
       const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
-      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(3);
+      expect(labels).toHaveLength(2);
+      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(1);
+      expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
     });
-    expect(navigate).toHaveBeenCalledWith(homeRoute);
 
     rerender(<WorkspaceTabsBar route={projectRoute} projects={[project]} />);
+
+    rerender(<WorkspaceTabsBar route={homeRoute} projects={[project]} />);
 
     await waitFor(() => {
       const tabs = screen.getAllByRole('tab');
       const labels = tabs.map((tab) => tab.textContent ?? '');
-      expect(tabs).toHaveLength(3);
-      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(2);
+      const selectedLabels = tabs
+        .filter((tab) => tab.getAttribute('aria-selected') === 'true')
+        .map((tab) => tab.textContent ?? '');
+
+      expect(tabs).toHaveLength(2);
+      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(1);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
+      expect(selectedLabels).toHaveLength(1);
+      expect(selectedLabels[0]).toContain('Home');
     });
   });
 
@@ -106,7 +114,20 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     });
   });
 
-  it('preserves restored Home tabs instead of collapsing them by route', async () => {
+  it('keeps Home singleton when the new-tab action targets Home', async () => {
+    render(<WorkspaceTabsBar route={homeRoute} projects={[project]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'New tab' }));
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      expect(labels).toHaveLength(1);
+      expect(labels[0]).toContain('Home');
+    });
+    expect(navigate).toHaveBeenCalledWith(homeRoute);
+  });
+
+  it('collapses restored duplicate Home tabs to a single Home tab', async () => {
     window.localStorage.setItem(
       'open-design:workspace-tabs:v1',
       JSON.stringify({
@@ -134,7 +155,16 @@ describe('WorkspaceTabsBar navigation semantics', () => {
 
     await waitFor(() => {
       const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
-      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(2);
+      const saved = JSON.parse(
+        window.localStorage.getItem('open-design:workspace-tabs:v1') ?? '{}',
+      ) as {
+        tabs?: Array<{ kind?: string; view?: string }>;
+      };
+
+      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(1);
+      expect(
+        saved.tabs?.filter((tab) => tab.kind === 'entry' && tab.view === 'home'),
+      ).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
Fixes #2510

## Why

I picked this up from #2510. Workspace tabs should treat Home as a single destination, but returning from a project could leave the original Home tab in place while the active project tab was rewritten into another Home tab. Persisted duplicate Home tabs were also restored as-is.

## What users will see

Returning to Home activates the existing Home tab instead of adding another Home tab. The new-tab action and restored saved workspace state also keep Home as a single tab.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual layout change. This is a workspace-tab state behavior fix covered by regression tests.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/WorkspaceTabsBar.test.tsx`
- Did the test go red on `main` and green on this branch? yes. The new Home singleton specs failed before the source change and pass on this branch.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/web run typecheck`
- `NODE_OPTIONS=--localstorage-file=/tmp/open-design-vitest-localstorage pnpm --dir apps/web exec vitest run -c vitest.config.ts --reporter=dot` — 199 files / 1814 tests passed
