### PR TITLE
fix(web): decouple privacy banner from onboarding and Settings lifecycles

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -322,19 +322,18 @@ export function App() {
   // Gate the privacy banner on three things:
   //   1. Daemon config has hydrated (privacyDecisionAt is daemon-owned).
   //   2. The user has not yet made a privacy decision.
-  //   3. Onboarding is complete AND the user is on a home view.
-  // (3) covers both onboarding paths: Skip lands on home directly, finish
-  // routes through a project view first and the banner waits for the user
-  // to return to home. Existing users (onboardingCompleted=true from any
-  // prior session) get the banner the moment they land on home. Settings
-  // has no influence on visibility; the banner sits above the modal-backdrop
-  // layer in index.css so opening Settings does not hide it.
-  const onHomeRoute = route.kind === 'home';
+  //   3. Onboarding is complete (Skip and design-system creation both flip
+  //      onboardingCompleted to true; see handleCompleteOnboarding wiring).
+  // Once onboarding is done the banner is allowed on any route — including
+  // the project view the design-system finish path drops the user into, so
+  // they can read and acknowledge the disclosure while the first generation
+  // is running. Settings is irrelevant to visibility; the banner sits above
+  // the modal-backdrop layer in index.css so opening Settings does not hide
+  // it.
   const showPrivacyConsent =
     daemonConfigLoaded &&
     config.privacyDecisionAt == null &&
-    config.onboardingCompleted === true &&
-    onHomeRoute;
+    config.onboardingCompleted === true;
   useEffect(() => {
     const body = activeProjectId
       ? { projectId: activeProjectId, fileName: activeFileName }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -319,8 +319,22 @@ export function App() {
   // {active:false} if this hasn't run.
   const activeProjectId = route.kind === 'project' ? route.projectId : null;
   const activeFileName = route.kind === 'project' ? route.fileName : null;
+  // Gate the privacy banner on three things:
+  //   1. Daemon config has hydrated (privacyDecisionAt is daemon-owned).
+  //   2. The user has not yet made a privacy decision.
+  //   3. Onboarding is complete AND the user is on a home view.
+  // (3) covers both onboarding paths: Skip lands on home directly, finish
+  // routes through a project view first and the banner waits for the user
+  // to return to home. Existing users (onboardingCompleted=true from any
+  // prior session) get the banner the moment they land on home. Settings
+  // has no influence on visibility; the banner sits above the modal-backdrop
+  // layer in index.css so opening Settings does not hide it.
+  const onHomeRoute = route.kind === 'home';
   const showPrivacyConsent =
-    daemonConfigLoaded && config.privacyDecisionAt == null;
+    daemonConfigLoaded &&
+    config.privacyDecisionAt == null &&
+    config.onboardingCompleted === true &&
+    onHomeRoute;
   useEffect(() => {
     const body = activeProjectId
       ? { projectId: activeProjectId, fileName: activeFileName }
@@ -1379,6 +1393,13 @@ export function App() {
                   ...curr.filter((p) => p.id !== project.id),
                 ]);
               }
+              // Creating a design system from the onboarding step 2 panel
+              // counts as completing onboarding, even though the user is
+              // about to leave the entry shell for the project view. The
+              // Skip path already marks completion via finishOnboarding;
+              // mirror that here so the first-run privacy banner can
+              // surface when the user later returns to home.
+              handleCompleteOnboarding();
               navigate({ kind: 'project', projectId, conversationId: null, fileName: null });
             }}
             onProjectPrepared={(project) => {
@@ -1455,10 +1476,11 @@ export function App() {
       <MemoryToast onOpenMemory={() => openSettings('memory')} />
       {/* First-run privacy consent banner. It waits for daemon config
           hydration because privacyDecisionAt is daemon-owned and stripped
-          from localStorage. Lifecycle is independent of Settings and
-          onboarding — the banner stays mounted until the user clicks
-          "I get it", regardless of which view is active. Its z-index in
-          index.css sits above modal backdrops so it stays actionable. */}
+          from localStorage. It waits for `onboardingCompleted` so first-run
+          users see the welcome panel before the disclosure (Skip and
+          finish both flip the flag). Independent of Settings: z-index in
+          index.css sits above modal backdrops so opening Settings does
+          not hide the banner. */}
       {showPrivacyConsent ? (
         <PrivacyConsentModal
           onAccept={() => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -320,7 +320,7 @@ export function App() {
   const activeProjectId = route.kind === 'project' ? route.projectId : null;
   const activeFileName = route.kind === 'project' ? route.fileName : null;
   const showPrivacyConsent =
-    daemonConfigLoaded && config.privacyDecisionAt == null && !settingsOpen;
+    daemonConfigLoaded && config.privacyDecisionAt == null;
   useEffect(() => {
     const body = activeProjectId
       ? { projectId: activeProjectId, fileName: activeFileName }
@@ -443,43 +443,53 @@ export function App() {
             ? t('settings.mediaProviderLoadError')
             : null,
         );
-        setConfig((prev) => {
-          const migratedLocalMediaProviders = shouldSyncLocalMediaProvidersToDaemon(
-            prev.mediaProviders,
-            daemonMediaProvidersLoaded,
-          );
-          const next = mergeDaemonMediaProviders(
-            mergeDaemonConfig(prev, daemonConfig),
-            daemonMediaProvidersLoaded,
-          );
-          const hasLocalComposioKey = Boolean(next.composio?.apiKey?.trim());
-          if (!hasLocalComposioKey && daemonComposioConfig) {
-            next.composio = daemonComposioConfig;
-          }
-          saveConfig(next);
-          if (
-            daemonMediaProvidersResult.status === 'ok' &&
-            migratedLocalMediaProviders &&
-            hasAnyConfiguredProvider(next.mediaProviders)
-          ) {
-            void syncMediaProvidersToDaemon(next.mediaProviders, {
-              daemonProviders: daemonMediaProvidersLoaded,
-            });
-          }
-          // Migrate localStorage prefs to daemon on first boot with the new
-          // endpoint. If daemon already had values the merge above used them;
-          // writing back is idempotent and keeps both sides in sync.
-          void syncConfigToDaemon(next);
-          void syncComposioConfigToDaemon(next.composio);
+        // Compute the next config outside the setConfig updater so we can
+        // both (a) call navigate() after setConfig returns — calling it
+        // inside the updater would trigger a Router setState during React's
+        // render phase — and (b) read next.onboardingCompleted synchronously,
+        // since React batches setConfig and the updater doesn't run until
+        // the next render. latestPersistedConfigRef is kept in sync with
+        // the rendered config and is safe to read here.
+        const baseConfig = latestPersistedConfigRef.current;
+        const migratedLocalMediaProviders = shouldSyncLocalMediaProvidersToDaemon(
+          baseConfig.mediaProviders,
+          daemonMediaProvidersLoaded,
+        );
+        const next = mergeDaemonMediaProviders(
+          mergeDaemonConfig(baseConfig, daemonConfig),
+          daemonMediaProvidersLoaded,
+        );
+        const hasLocalComposioKey = Boolean(next.composio?.apiKey?.trim());
+        if (!hasLocalComposioKey && daemonComposioConfig) {
+          next.composio = daemonComposioConfig;
+        }
+        saveConfig(next);
+        if (
+          daemonMediaProvidersResult.status === 'ok' &&
+          migratedLocalMediaProviders &&
+          hasAnyConfiguredProvider(next.mediaProviders)
+        ) {
+          void syncMediaProvidersToDaemon(next.mediaProviders, {
+            daemonProviders: daemonMediaProvidersLoaded,
+          });
+        }
+        // Migrate localStorage prefs to daemon on first boot with the new
+        // endpoint. If daemon already had values the merge above used them;
+        // writing back is idempotent and keeps both sides in sync.
+        void syncConfigToDaemon(next);
+        void syncComposioConfigToDaemon(next.composio);
+        latestPersistedConfigRef.current = next;
+        setConfig(next);
 
-          // Route first-run users through the global onboarding panel after
-          // privacy is resolved. The panel owns completion; Settings stays a
-          // configuration surface rather than the product onboarding path.
-          if (!next.onboardingCompleted && next.privacyDecisionAt != null) {
-            navigate({ kind: 'home', view: 'onboarding' }, { replace: true });
-          }
-          return next;
-        });
+        // Route first-run users through the global onboarding panel.
+        // The onboarding panel and the privacy banner have independent
+        // lifecycles: onboarding keys off `onboardingCompleted`, the
+        // banner keys off `privacyDecisionAt`. They may coexist on the
+        // first launch; the banner sits above the modal layer so it
+        // stays actionable regardless of the active view.
+        if (!next.onboardingCompleted) {
+          navigate({ kind: 'home', view: 'onboarding' }, { replace: true });
+        }
         setDaemonConfigLoaded(true);
         // Composio key hydration is part of this same daemon-config
         // fetch — by the time we land here the daemon has either
@@ -1445,8 +1455,10 @@ export function App() {
       <MemoryToast onOpenMemory={() => openSettings('memory')} />
       {/* First-run privacy consent banner. It waits for daemon config
           hydration because privacyDecisionAt is daemon-owned and stripped
-          from localStorage. It also yields while Settings is open so the
-          floating banner never intercepts modal interactions. */}
+          from localStorage. Lifecycle is independent of Settings and
+          onboarding — the banner stays mounted until the user clicks
+          "I get it", regardless of which view is active. Its z-index in
+          index.css sits above modal backdrops so it stays actionable. */}
       {showPrivacyConsent ? (
         <PrivacyConsentModal
           onAccept={() => {
@@ -1454,6 +1466,9 @@ export function App() {
             // surface the previous two-button "Share usage data" path opted
             // into. The banner footer + PrivacySection give the user a
             // one-click path to flip everything off later.
+            // The banner owns only the privacy decision; it does not drive
+            // navigation. Onboarding is gated by `onboardingCompleted` on
+            // its own and runs in parallel.
             const installationId = generateInstallationIdSafe();
             void handleConfigPersist({
               ...latestPersistedConfigRef.current,
@@ -1461,9 +1476,6 @@ export function App() {
               privacyDecisionAt: Date.now(),
               telemetry: { metrics: true, content: true, artifactManifest: false },
             });
-            if (!latestPersistedConfigRef.current.onboardingCompleted) {
-              navigate({ kind: 'home', view: 'onboarding' });
-            }
           }}
         />
       ) : null}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -22266,8 +22266,11 @@ body.desktop-pet-shell .pet-task-item {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  /* Below modal backdrops; App.tsx hides the banner while Settings is open. */
-  z-index: 90;
+  /* Above modal backdrops (z-index 100) so the banner remains visible and
+     actionable even while Settings or any other modal is open. The banner
+     uses pointer-events:none on the card itself with opt-in on interactive
+     children, so it never intercepts clicks meant for the layer below. */
+  z-index: 110;
   width: 380px;
   max-width: calc(100vw - 32px);
   display: flex;

--- a/apps/web/tests/components/App.connectors.test.tsx
+++ b/apps/web/tests/components/App.connectors.test.tsx
@@ -316,11 +316,12 @@ describe('App connectors settings flows', () => {
     });
   });
 
-  it('withholds the privacy banner outside the home route', async () => {
-    // After completing onboarding via the design-system step the user
-    // routes into a project view. The banner must wait until they return
-    // to a home view — otherwise the disclosure surfaces over an open
-    // project, which the product flow rejects.
+  it('shows the privacy banner on non-home routes once onboarding completes', async () => {
+    // The design-system finish path drops the user into a project view
+    // (the first generation runs there). Product wants the disclosure to
+    // appear in that view too — the user is already waiting for output,
+    // so there is no benefit to delaying the banner until they navigate
+    // back to home.
     useRouteMock.mockReturnValue({
       kind: 'project',
       projectId: 'proj-1',
@@ -332,10 +333,7 @@ describe('App connectors settings flows', () => {
       const { container } = render(<App />);
 
       await waitFor(() => {
-        expect(mockedFetchDaemonConfig).toHaveBeenCalled();
-      });
-      await waitFor(() => {
-        expect(container.querySelector('.privacy-consent-banner')).toBeNull();
+        expect(container.querySelector('.privacy-consent-banner')).toBeTruthy();
       });
     } finally {
       useRouteMock.mockReturnValue({

--- a/apps/web/tests/components/App.connectors.test.tsx
+++ b/apps/web/tests/components/App.connectors.test.tsx
@@ -278,7 +278,11 @@ describe('App connectors settings flows', () => {
     );
   });
 
-  it('hides first-run privacy consent while settings is open', async () => {
+  it('keeps the first-run privacy banner mounted while settings is open', async () => {
+    // The banner and Settings have independent lifecycles. The banner's
+    // z-index in index.css sits above the modal backdrop, so opening
+    // Settings (or any other modal) must not unmount the banner — the
+    // user has to be able to acknowledge the disclosure from any view.
     const { container } = render(<App />);
 
     await waitFor(() => {
@@ -290,7 +294,7 @@ describe('App connectors settings flows', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog', { name: 'Settings dialog' })).toBeTruthy();
     });
-    expect(container.querySelector('.privacy-consent-banner')).toBeNull();
+    expect(container.querySelector('.privacy-consent-banner')).toBeTruthy();
   });
 
   it('normalizes local persistence but sends the raw replacement key to the daemon on save', async () => {

--- a/apps/web/tests/components/App.connectors.test.tsx
+++ b/apps/web/tests/components/App.connectors.test.tsx
@@ -297,6 +297,54 @@ describe('App connectors settings flows', () => {
     expect(container.querySelector('.privacy-consent-banner')).toBeTruthy();
   });
 
+  it('withholds the privacy banner until onboarding completes', async () => {
+    // First-run users should land on the welcome panel without the
+    // privacy disclosure layered on top. The banner appears only after
+    // onboardingCompleted flips to true (Skip and finish both flip it).
+    mockedLoadConfig.mockReturnValue({ ...baseConfig, onboardingCompleted: false });
+    mockedFetchDaemonConfig.mockResolvedValue({ onboardingCompleted: false });
+
+    const { container } = render(<App />);
+
+    await waitFor(() => {
+      expect(mockedFetchDaemonConfig).toHaveBeenCalled();
+    });
+    // Give the bootstrap microtasks a turn to settle; banner must still
+    // be absent because onboardingCompleted is false.
+    await waitFor(() => {
+      expect(container.querySelector('.privacy-consent-banner')).toBeNull();
+    });
+  });
+
+  it('withholds the privacy banner outside the home route', async () => {
+    // After completing onboarding via the design-system step the user
+    // routes into a project view. The banner must wait until they return
+    // to a home view — otherwise the disclosure surfaces over an open
+    // project, which the product flow rejects.
+    useRouteMock.mockReturnValue({
+      kind: 'project',
+      projectId: 'proj-1',
+      conversationId: null,
+      fileName: null,
+    } as never);
+
+    try {
+      const { container } = render(<App />);
+
+      await waitFor(() => {
+        expect(mockedFetchDaemonConfig).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(container.querySelector('.privacy-consent-banner')).toBeNull();
+      });
+    } finally {
+      useRouteMock.mockReturnValue({
+        kind: 'home' as const,
+        view: 'home' as const,
+      } as never);
+    }
+  });
+
   it('normalizes local persistence but sends the raw replacement key to the daemon on save', async () => {
     mockedLoadConfig.mockReturnValue({
       ...baseConfig,


### PR DESCRIPTION
## Why

While exercising the first-run flow on a freshly cleared install, we noticed
the privacy banner and the onboarding panel were tightly entangled — clicking
the privacy disclosure was a hard prerequisite for the welcome view appearing,
and opening Settings would silently unmount the banner. The coupling was
intentional but indirect: the banner's `z-index` sat below the modal backdrop,
so showing it alongside Settings caused visual collisions, and the
banner+onboarding were linearized to avoid two unfinished surfaces racing on
the first launch.

The result was confusing in practice: users with daemon state in a "no
privacy decision yet" shape never reached onboarding, and anyone who happened
to open Settings before the banner saw it disappear without warning. Product
clarified the desired flow: the welcome panel should run first, and the
privacy disclosure should only surface once the user is done with onboarding.

## What users will see

First-run lifecycle:

- **Welcome / onboarding panel** shows on launch. The privacy banner does
  **not** appear yet — the user reads the welcome flow without overlay.
- **Skip path**: clicking "Skip for now" lands the user on home, and the
  privacy banner appears in the bottom-right.
- **Finish path**: clicking through to step 2 and creating a design system
  drops the user into the new project view where the first generation runs.
  The banner appears in the bottom-right of that project view too — the
  user is already waiting for output, so the disclosure can be acknowledged
  inline.
- **Existing users** (onboarding completed in a prior session, no privacy
  decision recorded): banner appears immediately on any view.
- Opening **Settings** while the banner is showing no longer hides it; it
  stays in the bottom-right above the Settings backdrop and remains
  clickable. Clicking "I get it" only records the privacy decision — it no
  longer also forces a route change.

The banner only stays suppressed while the user is still inside the
`/onboarding` welcome panel. Everywhere else, once onboarding is done and
no privacy decision exists, the banner is visible.

## Surface area

- [x] **UI** — `.privacy-consent-banner` lifts above the modal-backdrop layer; banner visibility is gated by `onboardingCompleted`; design-system step 2 now marks `onboardingCompleted` on create so the banner can surface in the project view the user is routed into.
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

<!-- Maintainer: attach these from the PR author's local environment —
     /tmp/od-first-no-banner.png, /tmp/od-after-skip.png — or re-capture
     by clearing daemon state (rm -rf .od/app-config.json .od/app.sqlite*)
     and walking the flow. -->

1. **On `/onboarding`** — welcome panel renders, banner suppressed.
2. **After Skip** — URL is `/`, onboarding gone, banner in bottom-right.
3. **After finish (project view)** — banner in bottom-right while the
   first generation is running.

## Bug fix verification

Three contract tests in `apps/web/tests/components/App.connectors.test.tsx`
lock in the new lifecycle:

- `keeps the first-run privacy banner mounted while settings is open` —
  banner stays mounted when Settings opens (inverted from the old test,
  which asserted the opposite coupling).
- `withholds the privacy banner until onboarding completes` —
  `onboardingCompleted=false` on first launch keeps the banner hidden.
- `shows the privacy banner on non-home routes once onboarding completes` —
  with `onboardingCompleted=true` and the route mocked to a project, the
  banner is visible (locks in the finish-path behavior).

Manual verification (clean daemon + cleared localStorage on a `banner-fix`
namespace worktree, daemon=18456 / web=18573):

- Clean launch → URL replaces to `/onboarding`, welcome panel renders,
  banner absent.
- Click "Skip for now" → URL becomes `/`, onboarding panel unmounts,
  banner appears in bottom-right.
- Walk steps 1–2 and create a design system → routes into the project
  view, banner appears in bottom-right while generation runs.
- Open Settings while banner is visible → banner stays, fully clickable.
- Click "I get it" → banner dismounts, no route change.

## Notes for reviewers

Bootstrap had a latent React 18+ batching bug exposed by the first commit
in this PR: the bootstrap `useEffect` previously did

```ts
setConfig((prev) => { /* …compute next… */; navigate(...); return next; });
```

Calling `navigate` inside the updater triggered a Router `setState` during
React's render phase ("Cannot update a component (`Router`) while rendering
`App`"). A captured-flag fix (set a boolean in the updater, consume it after
`setConfig`) also silently no-ops because the updater doesn't run until the
next render. This PR computes the merged config outside `setConfig`, calls
`setConfig(next)` with the resolved value, and routes synchronously off
`next.onboardingCompleted`. `latestPersistedConfigRef.current` serves as
the base for the merge.

The finish-path completion marker is wired in `App.tsx`'s onboarding-specific
`renderDesignSystemCreation` render prop, not inside `DesignSystemFlow`
itself — that component is shared with the standalone "Create design system"
entry from Settings, and we don't want creating a design system in that
context to silently mark onboarding complete.

### Commit history

This PR landed in three commits as product feedback came in:

1. **Decouple privacy banner from onboarding and Settings lifecycles** —
   lift z-index above modal-backdrop, drop the `!settingsOpen` guard,
   drop the `privacyDecisionAt != null` precondition on the onboarding
   route, drop the `navigate(... onboarding)` side effect from `onAccept`,
   and fix the bootstrap render-phase navigate.
2. **Defer privacy banner until onboarding is done and user lands on home**
   — gate the banner on `onboardingCompleted` so the welcome panel runs
   first, and wire `handleCompleteOnboarding()` into the design-system
   creation `onCreated` callback.
3. **Allow privacy banner to surface on non-home routes after onboarding**
   — drop the `route.kind === 'home'` guard so the banner can also appear
   in the project view where the first generation is running.