### PR TITLE
feat(observability): web lifecycle telemetry + stable installationId migration

### DIFF
--- a/apps/daemon/src/analytics.ts
+++ b/apps/daemon/src/analytics.ts
@@ -90,11 +90,29 @@ export interface AnalyticsService {
     properties: Record<string, unknown>;
     insertId: string;
   }): void;
+  /**
+   * Safety / reliability events (renderer crashes, daemon uncaught errors,
+   * SSE health, etc.) that intentionally BYPASS the user's analytics
+   * consent toggle. The product policy is: we always retain ground-truth
+   * stability data even for opted-out users — the user-facing consent copy
+   * in Settings → Privacy must call this out.
+   *
+   * Falls back to a synthetic distinctId when the installationId is not
+   * yet stamped (first-launch or fork builds without an app-config file).
+   */
+  captureSafety(args: {
+    eventName: string;
+    distinctId?: string;
+    appVersion: string;
+    properties: Record<string, unknown>;
+    insertId?: string;
+  }): void;
   shutdown(): Promise<void>;
 }
 
 const NOOP_SERVICE: AnalyticsService = {
   capture: () => undefined,
+  captureSafety: () => undefined,
   shutdown: async () => undefined,
 };
 
@@ -165,6 +183,39 @@ export function createAnalyticsService(args: {
         }
       })();
     },
+    captureSafety: ({ eventName, distinctId, appVersion, properties, insertId }) => {
+      // No consent re-check here — that's the entire point of this surface.
+      // We still fall back gracefully when the installationId is missing
+      // (cold start before the daemon has stamped one in app-config) by
+      // synthesizing an anonymous distinct id rooted at the process boot.
+      const resolvedInsertId = insertId ?? randomInsertId();
+      void (async () => {
+        try {
+          const resolvedDistinctId =
+            distinctId && distinctId.length > 0
+              ? distinctId
+              : await readInstallationIdSafe(args.dataDir);
+          client.capture({
+            distinctId: resolvedDistinctId,
+            event: eventName,
+            properties: {
+              ...properties,
+              event_id: resolvedInsertId,
+              event_schema_version: EVENT_SCHEMA_VERSION,
+              ui_version: appVersion,
+              app_version: appVersion,
+              device_id: resolvedDistinctId,
+              client_type: 'daemon',
+              capture_source: 'daemon/safety',
+              $insert_id: resolvedInsertId,
+            },
+          });
+        } catch {
+          // Capture failures must never propagate. The whole point of this
+          // path is best-effort observability into a degraded state.
+        }
+      })();
+    },
     shutdown: async () => {
       try {
         await client.shutdown();
@@ -173,6 +224,24 @@ export function createAnalyticsService(args: {
       }
     },
   };
+}
+
+const SYNTHETIC_DISTINCT_ID = `daemon-anon-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+
+async function readInstallationIdSafe(dataDir: string): Promise<string> {
+  try {
+    const cfg = await readAppConfig(dataDir);
+    if (typeof cfg.installationId === 'string' && cfg.installationId.length > 0) {
+      return cfg.installationId;
+    }
+  } catch {
+    // fall through to synthetic id
+  }
+  return SYNTHETIC_DISTINCT_ID;
+}
+
+function randomInsertId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 // Re-export so server.ts and route handlers don't need a second import

--- a/apps/daemon/src/analytics.ts
+++ b/apps/daemon/src/analytics.ts
@@ -99,6 +99,12 @@ export interface AnalyticsService {
    *
    * Falls back to a synthetic distinctId when the installationId is not
    * yet stamped (first-launch or fork builds without an app-config file).
+   *
+   * Returns a Promise that resolves AFTER the event has been enqueued in
+   * posthog-node's local buffer. Fire-and-forget callers (e.g. the
+   * /api/observability/event endpoint) can `void` it; fatal-exit paths
+   * MUST await before calling `shutdown()` so the crash event actually
+   * makes it into the flush.
    */
   captureSafety(args: {
     eventName: string;
@@ -106,13 +112,13 @@ export interface AnalyticsService {
     appVersion: string;
     properties: Record<string, unknown>;
     insertId?: string;
-  }): void;
+  }): Promise<void>;
   shutdown(): Promise<void>;
 }
 
 const NOOP_SERVICE: AnalyticsService = {
   capture: () => undefined,
-  captureSafety: () => undefined,
+  captureSafety: async () => undefined,
   shutdown: async () => undefined,
 };
 
@@ -183,38 +189,43 @@ export function createAnalyticsService(args: {
         }
       })();
     },
-    captureSafety: ({ eventName, distinctId, appVersion, properties, insertId }) => {
+    captureSafety: async ({ eventName, distinctId, appVersion, properties, insertId }) => {
       // No consent re-check here — that's the entire point of this surface.
       // We still fall back gracefully when the installationId is missing
       // (cold start before the daemon has stamped one in app-config) by
       // synthesizing an anonymous distinct id rooted at the process boot.
+      //
+      // Returns a Promise that resolves AFTER `client.capture()` has run.
+      // The fatal-shutdown path in server.ts awaits this before invoking
+      // `shutdown()` so the event is guaranteed to be in posthog-node's
+      // local queue when the flush starts — otherwise a fast `shutdown()`
+      // would drain an empty queue and the crash signal would be lost.
+      // See codex review on PR #2527 (Siri-Ray) for the original race.
       const resolvedInsertId = insertId ?? randomInsertId();
-      void (async () => {
-        try {
-          const resolvedDistinctId =
-            distinctId && distinctId.length > 0
-              ? distinctId
-              : await readInstallationIdSafe(args.dataDir);
-          client.capture({
-            distinctId: resolvedDistinctId,
-            event: eventName,
-            properties: {
-              ...properties,
-              event_id: resolvedInsertId,
-              event_schema_version: EVENT_SCHEMA_VERSION,
-              ui_version: appVersion,
-              app_version: appVersion,
-              device_id: resolvedDistinctId,
-              client_type: 'daemon',
-              capture_source: 'daemon/safety',
-              $insert_id: resolvedInsertId,
-            },
-          });
-        } catch {
-          // Capture failures must never propagate. The whole point of this
-          // path is best-effort observability into a degraded state.
-        }
-      })();
+      try {
+        const resolvedDistinctId =
+          distinctId && distinctId.length > 0
+            ? distinctId
+            : await readInstallationIdSafe(args.dataDir);
+        client.capture({
+          distinctId: resolvedDistinctId,
+          event: eventName,
+          properties: {
+            ...properties,
+            event_id: resolvedInsertId,
+            event_schema_version: EVENT_SCHEMA_VERSION,
+            ui_version: appVersion,
+            app_version: appVersion,
+            device_id: resolvedDistinctId,
+            client_type: 'daemon',
+            capture_source: 'daemon/safety',
+            $insert_id: resolvedInsertId,
+          },
+        });
+      } catch {
+        // Capture failures must never propagate. The whole point of this
+        // path is best-effort observability into a degraded state.
+      }
     },
     shutdown: async () => {
       try {

--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -16,6 +16,13 @@ import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
 import path from 'node:path';
 
+import {
+  readInstallationFile,
+  resolveInstallationDir,
+  writeInstallationFile,
+  type InstallationFilePatch,
+} from './installation.js';
+
 // Plugin-system env knobs. See docs/plans/plugins-implementation.md F6 / F9.
 // Phase 1 only reads them; the GC worker that enforces snapshot expiry lands
 // in Phase 5. Centralized here to keep daemon modules from sprinkling magic
@@ -326,6 +333,37 @@ function filterAllowedKeys(obj: Record<string, unknown>): AppConfigPrefs {
 }
 
 export async function readAppConfig(dataDir: string): Promise<AppConfigPrefs> {
+  const base = await readAppConfigFileOnly(dataDir);
+  // Channel-root installation file is the new authoritative source for the
+  // identity bits that must survive a namespace-scoped data-dir wipe. It
+  // lives outside `<namespace>/data/` so a reinstall of the same channel
+  // (which might churn the namespace token, or eventually clear per-
+  // namespace data) keeps the same id.
+  //
+  // Migration: when this daemon is the first to boot with installation.json
+  // support and finds an existing installationId in the legacy app-config
+  // path, mirror it forward exactly once so PostHog continues to see the
+  // same person across the 0.7.x → 0.8.0 upgrade. Without this mirror, the
+  // user count would double when 0.8.0 ships.
+  const installationDir = resolveInstallationDir(dataDir);
+  const installation = await readInstallationFile(installationDir);
+  if (typeof installation.installationId === 'string' && installation.installationId.length > 0) {
+    return { ...base, installationId: installation.installationId };
+  }
+  if (typeof base.installationId === 'string' && base.installationId.length > 0) {
+    // Best-effort migration. A write failure here doesn't break the read —
+    // we still serve the legacy id. The next write through writeAppConfig
+    // will retry the mirror.
+    try {
+      await writeInstallationFile(installationDir, { installationId: base.installationId });
+    } catch {
+      // swallow — observability beats correctness on this path
+    }
+  }
+  return base;
+}
+
+async function readAppConfigFileOnly(dataDir: string): Promise<AppConfigPrefs> {
   try {
     const raw = await readFile(configFile(dataDir), 'utf8');
     const parsed: unknown = JSON.parse(raw);
@@ -378,5 +416,26 @@ async function doWrite(
   const tmp = file + '.' + randomBytes(4).toString('hex') + '.tmp';
   await writeFile(tmp, JSON.stringify(next, null, 2), 'utf8');
   await rename(tmp, file);
+  // Mirror the identity bits to the channel-root installation file so they
+  // survive a namespace-scoped data-dir wipe. Only fires when the caller
+  // explicitly touched `installationId` (avoiding noisy writes on every
+  // unrelated app-config update). A write failure here doesn't roll back
+  // the app-config write — the next read merges them transparently.
+  if (Object.prototype.hasOwnProperty.call(partial, 'installationId')) {
+    const id = next.installationId;
+    // Caller explicitly touched installationId — mirror the outcome
+    // (including the clear case) to installation.json so a future read
+    // doesn't keep serving the old value out of the channel-root file.
+    // "Delete my data" relies on this clear path.
+    const installPatch: InstallationFilePatch = {
+      installationId: typeof id === 'string' && id.length > 0 ? id : null,
+    };
+    try {
+      await writeInstallationFile(resolveInstallationDir(dataDir), installPatch);
+    } catch {
+      // swallow — install file mirroring is best-effort; the canonical
+      // app-config write already succeeded.
+    }
+  }
   return next as AppConfigPrefs;
 }

--- a/apps/daemon/src/installation.ts
+++ b/apps/daemon/src/installation.ts
@@ -1,0 +1,144 @@
+// Channel-root installation identity.
+//
+// `installationId` was historically stored in `<dataRoot>/app-config.json`,
+// which lives at `<userData>/namespaces/<namespace>/data/app-config.json`
+// in packaged builds. Two reinstall scenarios then silently rotated the
+// id:
+//
+//   1. **Namespace churn.** If a packaged build bakes a different
+//      `namespace` token than the previous version, the daemon writes to
+//      a different `<namespace>/data/` subtree and the old installationId
+//      is invisible. The user shows up in PostHog as a brand-new person.
+//
+//   2. **Clean reinstall.** Even when the namespace is stable, anything
+//      that wipes `<userData>/namespaces/<ns>/data/` (a future installer
+//      that resets per-namespace data, a manual `rm -rf`) takes the id
+//      down with it.
+//
+// To preserve person continuity across both, we mirror the id into a
+// stable file at the **channel root** — one level above the namespaces
+// directory — and treat that file as authoritative on read. The legacy
+// app-config.json field is still written so any code path that reads it
+// directly (legacy / future fallbacks) keeps seeing the same value.
+//
+// Locations:
+//
+//   packaged (mac):    ~/Library/Application Support/Open Design Nightly/installation.json
+//   packaged (win):    %APPDATA%/Open Design Nightly/installation.json
+//   packaged (linux):  $XDG_CONFIG_HOME/Open Design Nightly/installation.json
+//   tools-dev / OSS:   <dataDir>/installation.json  (no namespace concept; fall back to dataDir)
+//
+// `OD_INSTALLATION_DIR` is the env override. Packaged sidecars.ts sets it
+// to the channel root explicitly; everything else falls back to dataDir
+// (where it sits next to app-config.json and behaves like the legacy
+// path — fine for dev because dev doesn't have namespace churn).
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+/**
+ * Wire shape persisted at `<installationDir>/installation.json`.
+ * Kept intentionally narrow: only fields that need to survive a
+ * namespace-scoped data-dir wipe belong here.
+ */
+export interface InstallationFile {
+  installationId?: string;
+  // Future fields (privacy decision timestamp, telemetry flags) can join
+  // this list as soon as we have a use case for "they must outlive a
+  // namespace reset". Today, only installationId carries that contract.
+}
+
+export function resolveInstallationDir(dataDir: string): string {
+  const env = process.env.OD_INSTALLATION_DIR;
+  if (env && env.length > 0) return env;
+  return dataDir;
+}
+
+function installationFilePath(installationDir: string): string {
+  return join(installationDir, 'installation.json');
+}
+
+export async function readInstallationFile(
+  installationDir: string,
+): Promise<InstallationFile> {
+  try {
+    const raw = await readFile(installationFilePath(installationDir), 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+    const obj = parsed as Record<string, unknown>;
+    const out: InstallationFile = {};
+    if (typeof obj.installationId === 'string' && obj.installationId.length > 0) {
+      out.installationId = obj.installationId;
+    }
+    return out;
+  } catch (err) {
+    const e = err as { code?: string; name?: string };
+    if (e.code === 'ENOENT') return {};
+    if (e.name === 'SyntaxError') return {};
+    // Anything else (permission denied, EIO) — treat as empty so the
+    // fallback path through app-config.json keeps the daemon alive.
+    return {};
+  }
+}
+
+// Serialize writes to the same installationDir so concurrent persists
+// can't truncate each other. Mirrors the writeAppConfig lock strategy.
+const writeLocks = new Map<string, Promise<unknown>>();
+
+/**
+ * Patch shape for {@link writeInstallationFile}.
+ *
+ * Distinct from `Partial<InstallationFile>` because `exactOptionalPropertyTypes`
+ * blocks `{ installationId: undefined }` and we explicitly need a way to
+ * **clear** the id (Settings → "Delete my data", or an explicit null write
+ * via `writeAppConfig`). The convention here:
+ *
+ *   - field present with a non-empty string  → assign the new value
+ *   - field present with null / empty string → delete the field on disk
+ *   - field absent                           → leave the existing value alone
+ */
+export type InstallationFilePatch = {
+  installationId?: string | null;
+};
+
+export async function writeInstallationFile(
+  installationDir: string,
+  patch: InstallationFilePatch,
+): Promise<InstallationFile> {
+  const prev = writeLocks.get(installationDir) ?? Promise.resolve();
+  const task = prev.catch(() => undefined).then(() => doWrite(installationDir, patch));
+  writeLocks.set(installationDir, task);
+  try {
+    return await task;
+  } finally {
+    if (writeLocks.get(installationDir) === task) writeLocks.delete(installationDir);
+  }
+}
+
+async function doWrite(
+  installationDir: string,
+  patch: InstallationFilePatch,
+): Promise<InstallationFile> {
+  const existing = await readInstallationFile(installationDir);
+  const next: InstallationFile = { ...existing };
+  if (Object.prototype.hasOwnProperty.call(patch, 'installationId')) {
+    if (typeof patch.installationId === 'string' && patch.installationId.length > 0) {
+      next.installationId = patch.installationId;
+    } else {
+      delete next.installationId;
+    }
+  }
+  await mkdir(dirname(installationFilePath(installationDir)), { recursive: true });
+  // The file is small, the user only writes it on consent + delete-my-data
+  // flows. We deliberately don't use a temp-file + rename dance: a partial
+  // write here just means `readInstallationFile` falls back to app-config.json,
+  // which is the same fallback we use when the file simply doesn't exist yet.
+  await writeFile(
+    installationFilePath(installationDir),
+    JSON.stringify(next, null, 2) + '\n',
+    'utf8',
+  );
+  return next;
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -195,6 +195,7 @@ import { observePendingInstallerApplyAttempts } from './update-apply-observation
 import {
   agentIdToTracking,
   deriveConfigureGlobals,
+  type ObservabilityEventRequest,
 } from '@open-design/contracts/analytics';
 import {
   redactSecrets,
@@ -4295,6 +4296,69 @@ export async function startServer({
         installationId: null,
       });
     }
+  });
+
+  // Cross-process safety-event bridge. Used by:
+  //   - Electron main process (renderer crash via render-process-gone)
+  //   - Any future helper / sidecar that needs to report a safety event
+  //     without owning its own posthog-node client
+  //
+  // The route DOES NOT check the user's analytics consent: this is the
+  // same "safety telemetry always flows" contract the web error-tracking
+  // module relies on. If POSTHOG_KEY is not set on the daemon (fork
+  // builds), captureSafety is a no-op on NOOP_SERVICE.
+  app.post('/api/observability/event', express.json({ limit: '64kb' }), (req, res) => {
+    const body = (req.body ?? {}) as Partial<ObservabilityEventRequest>;
+    const eventName = typeof body.event === 'string' ? body.event.trim() : '';
+    if (!eventName) {
+      res.status(400).json({ error: 'missing or invalid `event` field' });
+      return;
+    }
+    const properties =
+      body.properties != null && typeof body.properties === 'object' && !Array.isArray(body.properties)
+        ? (body.properties as Record<string, unknown>)
+        : {};
+    analyticsService.captureSafety({
+      eventName,
+      appVersion: cachedAppVersion?.version ?? '0.0.0',
+      properties,
+    });
+    res.json({ ok: true });
+  });
+
+  // Daemon-side uncaught errors. Without these, a crash in any daemon
+  // request handler or background task leaves no PostHog signal — the
+  // user sees a 500 (or worse, a connection drop) and we see nothing.
+  // Both listeners install AFTER the analyticsService is created so the
+  // captureSafety dispatch path is guaranteed to be ready.
+  process.on('uncaughtException', (error) => {
+    analyticsService.captureSafety({
+      eventName: 'daemon_uncaught_exception',
+      appVersion: cachedAppVersion?.version ?? '0.0.0',
+      properties: {
+        error_message: error?.message ?? String(error),
+        error_name: error?.name ?? 'Error',
+        // Stack truncation: 8 KB ceiling to keep the ingest payload bounded
+        // even when the stack contains huge native frames. Most actionable
+        // stacks fit in well under 2 KB.
+        error_stack: typeof error?.stack === 'string' ? error.stack.slice(0, 8192) : undefined,
+      },
+    });
+    // Re-throw is NOT what we want here — Node's default unhandled
+    // exception behavior is to exit. We log + dispatch and let the
+    // process die naturally so a supervisor restarts it cleanly.
+  });
+  process.on('unhandledRejection', (reason) => {
+    const asError = reason instanceof Error ? reason : null;
+    analyticsService.captureSafety({
+      eventName: 'daemon_unhandled_rejection',
+      appVersion: cachedAppVersion?.version ?? '0.0.0',
+      properties: {
+        error_message: asError?.message ?? (typeof reason === 'string' ? reason : String(reason)),
+        error_name: asError?.name ?? 'NonErrorRejection',
+        error_stack: typeof asError?.stack === 'string' ? asError.stack.slice(0, 8192) : undefined,
+      },
+    });
   });
 
   // Tracks runs whose completion has already been forwarded to Langfuse so

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4331,33 +4331,60 @@ export async function startServer({
   // user sees a 500 (or worse, a connection drop) and we see nothing.
   // Both listeners install AFTER the analyticsService is created so the
   // captureSafety dispatch path is guaranteed to be ready.
-  process.on('uncaughtException', (error) => {
-    analyticsService.captureSafety({
-      eventName: 'daemon_uncaught_exception',
-      appVersion: cachedAppVersion?.version ?? '0.0.0',
-      properties: {
-        error_message: error?.message ?? String(error),
-        error_name: error?.name ?? 'Error',
-        // Stack truncation: 8 KB ceiling to keep the ingest payload bounded
-        // even when the stack contains huge native frames. Most actionable
-        // stacks fit in well under 2 KB.
-        error_stack: typeof error?.stack === 'string' ? error.stack.slice(0, 8192) : undefined,
-      },
+  //
+  // IMPORTANT — these handlers MUST keep Node's fatal-exit semantics.
+  // Installing an `uncaughtException` listener silences Node's default
+  // crash/exit path, and Node 15+ does the same for `unhandledRejection`
+  // when a listener is present (the `--unhandled-rejections=throw` mode
+  // only fires when nothing has subscribed). We bounded-flush posthog-
+  // node and then call `process.exit(1)` explicitly so the supervisor
+  // (pm2, packaged updater, dev `tools-dev`) gets a fresh process and
+  // we don't leave a half-broken daemon answering requests with state
+  // corruption. See codex review on PR #2527 (Siri-Ray).
+  const FATAL_FLUSH_TIMEOUT_MS = 1000;
+  let fatalShuttingDown = false;
+  const triggerFatalShutdown = (
+    eventName: string,
+    properties: Record<string, unknown>,
+  ): void => {
+    if (fatalShuttingDown) return;
+    fatalShuttingDown = true;
+    try {
+      analyticsService.captureSafety({
+        eventName,
+        appVersion: cachedAppVersion?.version ?? '0.0.0',
+        properties,
+      });
+    } catch {
+      // capture must never block the exit path
+    }
+    // Race shutdown against a hard timeout. If posthog-node hangs on
+    // a slow flush we still die in bounded time — the supervisor will
+    // restart us, which is the whole point.
+    void Promise.race([
+      analyticsService.shutdown(),
+      new Promise<void>((resolve) => setTimeout(resolve, FATAL_FLUSH_TIMEOUT_MS).unref?.()),
+    ]).finally(() => {
+      process.exitCode = 1;
+      process.exit(1);
     });
-    // Re-throw is NOT what we want here — Node's default unhandled
-    // exception behavior is to exit. We log + dispatch and let the
-    // process die naturally so a supervisor restarts it cleanly.
+  };
+  process.on('uncaughtException', (error) => {
+    triggerFatalShutdown('daemon_uncaught_exception', {
+      error_message: error?.message ?? String(error),
+      error_name: error?.name ?? 'Error',
+      // Stack truncation: 8 KB ceiling to keep the ingest payload bounded
+      // even when the stack contains huge native frames. Most actionable
+      // stacks fit in well under 2 KB.
+      error_stack: typeof error?.stack === 'string' ? error.stack.slice(0, 8192) : undefined,
+    });
   });
   process.on('unhandledRejection', (reason) => {
     const asError = reason instanceof Error ? reason : null;
-    analyticsService.captureSafety({
-      eventName: 'daemon_unhandled_rejection',
-      appVersion: cachedAppVersion?.version ?? '0.0.0',
-      properties: {
-        error_message: asError?.message ?? (typeof reason === 'string' ? reason : String(reason)),
-        error_name: asError?.name ?? 'NonErrorRejection',
-        error_stack: typeof asError?.stack === 'string' ? asError.stack.slice(0, 8192) : undefined,
-      },
+    triggerFatalShutdown('daemon_unhandled_rejection', {
+      error_message: asError?.message ?? (typeof reason === 'string' ? reason : String(reason)),
+      error_name: asError?.name ?? 'NonErrorRejection',
+      error_stack: typeof asError?.stack === 'string' ? asError.stack.slice(0, 8192) : undefined,
     });
   });
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4349,21 +4349,34 @@ export async function startServer({
   ): void => {
     if (fatalShuttingDown) return;
     fatalShuttingDown = true;
-    try {
-      analyticsService.captureSafety({
-        eventName,
-        appVersion: cachedAppVersion?.version ?? '0.0.0',
-        properties,
-      });
-    } catch {
-      // capture must never block the exit path
-    }
-    // Race shutdown against a hard timeout. If posthog-node hangs on
-    // a slow flush we still die in bounded time — the supervisor will
-    // restart us, which is the whole point.
+    // CRITICAL — wait for captureSafety to ENQUEUE the event in
+    // posthog-node's local buffer before starting shutdown(). The
+    // captureSafety implementation does an `await readInstallationIdSafe()`
+    // before calling `client.capture()`; a sync fire-and-forget here would
+    // race shutdown() ahead of that await, drain an empty queue, and lose
+    // the crash event itself. See codex review on PR #2527 (Siri-Ray).
+    const flushSequence = (async () => {
+      try {
+        await analyticsService.captureSafety({
+          eventName,
+          appVersion: cachedAppVersion?.version ?? '0.0.0',
+          properties,
+        });
+      } catch {
+        // capture must never block the exit path
+      }
+      await analyticsService.shutdown();
+    })();
+    // Race the enqueue+shutdown sequence against a bounded timeout. If
+    // posthog-node hangs on a slow flush (or the installationId read
+    // hangs on the filesystem) we still die in bounded time — the
+    // supervisor will restart us, which is the whole point.
     void Promise.race([
-      analyticsService.shutdown(),
-      new Promise<void>((resolve) => setTimeout(resolve, FATAL_FLUSH_TIMEOUT_MS).unref?.()),
+      flushSequence,
+      new Promise<void>((resolve) => {
+        const handle = setTimeout(resolve, FATAL_FLUSH_TIMEOUT_MS);
+        handle.unref?.();
+      }),
     ]).finally(() => {
       process.exitCode = 1;
       process.exit(1);

--- a/apps/daemon/tests/installation.test.ts
+++ b/apps/daemon/tests/installation.test.ts
@@ -1,0 +1,153 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readAppConfig, writeAppConfig } from '../src/app-config.js';
+import {
+  readInstallationFile,
+  writeInstallationFile,
+} from '../src/installation.js';
+
+/**
+ * The contract these tests pin down is the **0.7.x → 0.8.0 person
+ * continuity guarantee**: an existing user upgrading from a daemon that
+ * only wrote to `app-config.json` must not produce a new PostHog person
+ * after the upgrade. They also pin the "namespace churn / clean
+ * reinstall" survival path: when `<dataDir>/app-config.json` disappears
+ * but `<installationDir>/installation.json` still has the id, reads must
+ * return that id so the next event ships with the same distinct_id.
+ *
+ * Two directories per test:
+ *   - `dataDir`     — simulates `<namespace>/data/`
+ *   - `installDir`  — simulates the channel root (`<userData>/`)
+ * They live as siblings so we can independently reset either side.
+ */
+
+let rootDir: string;
+let dataDir: string;
+let installDir: string;
+const SAVED_INSTALL_ENV = process.env.OD_INSTALLATION_DIR;
+
+beforeEach(async () => {
+  rootDir = await mkdtemp(join(tmpdir(), 'od-install-test-'));
+  dataDir = join(rootDir, 'namespace', 'data');
+  installDir = join(rootDir, 'channel-root');
+  await mkdir(dataDir, { recursive: true });
+  await mkdir(installDir, { recursive: true });
+  process.env.OD_INSTALLATION_DIR = installDir;
+});
+
+afterEach(async () => {
+  if (SAVED_INSTALL_ENV == null) {
+    delete process.env.OD_INSTALLATION_DIR;
+  } else {
+    process.env.OD_INSTALLATION_DIR = SAVED_INSTALL_ENV;
+  }
+  if (rootDir != null) {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});
+
+describe('installation.json migration', () => {
+  it('reads installationId from app-config when installation.json is absent (0.7.x state)', async () => {
+    await writeFile(
+      join(dataDir, 'app-config.json'),
+      JSON.stringify({ installationId: 'legacy-id-7' }),
+      'utf8',
+    );
+    const cfg = await readAppConfig(dataDir);
+    expect(cfg.installationId).toBe('legacy-id-7');
+  });
+
+  it('mirrors a legacy app-config installationId into installation.json on first read (0.7.x → 0.8.0)', async () => {
+    await writeFile(
+      join(dataDir, 'app-config.json'),
+      JSON.stringify({ installationId: 'legacy-id-8' }),
+      'utf8',
+    );
+    // No installation.json yet — readAppConfig should backfill it.
+    await readAppConfig(dataDir);
+    const persisted = await readInstallationFile(installDir);
+    expect(persisted.installationId).toBe('legacy-id-8');
+  });
+
+  it('serves installation.json even when app-config.json was wiped (namespace churn / clean reinstall)', async () => {
+    await writeInstallationFile(installDir, { installationId: 'stable-id' });
+    // dataDir is empty — no app-config.json
+    const cfg = await readAppConfig(dataDir);
+    expect(cfg.installationId).toBe('stable-id');
+  });
+
+  it('prefers installation.json over a divergent value in app-config.json (post-migration writes win)', async () => {
+    await writeInstallationFile(installDir, { installationId: 'new-id' });
+    await writeFile(
+      join(dataDir, 'app-config.json'),
+      JSON.stringify({ installationId: 'old-id' }),
+      'utf8',
+    );
+    const cfg = await readAppConfig(dataDir);
+    expect(cfg.installationId).toBe('new-id');
+  });
+
+  it('mirrors installationId from writeAppConfig into installation.json so reinstalls survive', async () => {
+    await writeAppConfig(dataDir, { installationId: 'fresh-id', telemetry: { metrics: true } });
+    const installContents = JSON.parse(
+      await readFile(join(installDir, 'installation.json'), 'utf8'),
+    ) as { installationId: string };
+    expect(installContents.installationId).toBe('fresh-id');
+    // Legacy app-config is also kept current so any code path that reads
+    // it directly (or a downgrade to 0.7.x) still sees the same id.
+    const appConfigContents = JSON.parse(
+      await readFile(join(dataDir, 'app-config.json'), 'utf8'),
+    ) as { installationId: string };
+    expect(appConfigContents.installationId).toBe('fresh-id');
+  });
+
+  it('does not touch installation.json on an unrelated writeAppConfig (no churn)', async () => {
+    await writeInstallationFile(installDir, { installationId: 'untouched' });
+    await writeAppConfig(dataDir, { telemetry: { metrics: true } });
+    const persisted = await readInstallationFile(installDir);
+    expect(persisted.installationId).toBe('untouched');
+  });
+
+  it('falls back to dataDir when OD_INSTALLATION_DIR is unset (dev / OSS / tools-dev paths)', async () => {
+    delete process.env.OD_INSTALLATION_DIR;
+    await writeAppConfig(dataDir, { installationId: 'devmode-id' });
+    // With no override, the install file should land next to app-config.json.
+    const persisted = JSON.parse(
+      await readFile(join(dataDir, 'installation.json'), 'utf8'),
+    ) as { installationId: string };
+    expect(persisted.installationId).toBe('devmode-id');
+  });
+
+  it('returns an empty object when neither file exists (cold first boot)', async () => {
+    const cfg = await readAppConfig(dataDir);
+    expect(cfg.installationId).toBeUndefined();
+    const persisted = await readInstallationFile(installDir);
+    expect(persisted.installationId).toBeUndefined();
+  });
+
+  it('clears installation.json when "Delete my data" sets installationId to null', async () => {
+    // First write a real id — both files now hold it.
+    await writeAppConfig(dataDir, { installationId: 'before-delete' });
+    expect((await readInstallationFile(installDir)).installationId).toBe('before-delete');
+    // "Delete my data" path: PUT /api/app-config with installationId: null.
+    // Without the mirror-on-clear in writeAppConfig, the next readAppConfig
+    // would still serve `before-delete` from installation.json and the
+    // user's reset action would silently no-op.
+    await writeAppConfig(dataDir, { installationId: null });
+    const persisted = await readInstallationFile(installDir);
+    expect(persisted.installationId).toBeUndefined();
+    const cfg = await readAppConfig(dataDir);
+    expect(cfg.installationId).toBeNull();
+  });
+
+  it('overwrites installation.json when "Delete my data" rotates to a fresh id', async () => {
+    await writeAppConfig(dataDir, { installationId: 'old' });
+    await writeAppConfig(dataDir, { installationId: 'new' });
+    const persisted = await readInstallationFile(installDir);
+    expect(persisted.installationId).toBe('new');
+  });
+});

--- a/apps/daemon/tests/uncaught-fatal-shutdown.test.ts
+++ b/apps/daemon/tests/uncaught-fatal-shutdown.test.ts
@@ -1,0 +1,143 @@
+// The daemon's `uncaughtException` / `unhandledRejection` handlers must
+// preserve Node's fatal-exit semantics. Installing a listener silences
+// Node's default crash path, so we have to call `process.exit(1)`
+// explicitly after a bounded posthog-node flush. Without this guarantee
+// the process would log telemetry and then keep serving requests with a
+// corrupted state — the codex-reviewed regression on PR #2527.
+//
+// This file pins the contract that's hard to assert from the server.ts
+// integration suite (which has no way to throw inside Express handlers
+// without crashing vitest). We re-implement the relevant shutdown helper
+// shape here and verify:
+//
+//   - captureSafety is invoked exactly once even on repeated faults
+//   - shutdown() is invoked and either resolves or times out
+//   - process.exit(1) is called after the race resolves
+//   - the bounded timeout fires when shutdown hangs
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const FATAL_FLUSH_TIMEOUT_MS = 1000;
+
+type CaptureSafetyArgs = {
+  eventName: string;
+  appVersion: string;
+  properties: Record<string, unknown>;
+};
+
+interface FakeAnalyticsService {
+  captureSafety: (args: CaptureSafetyArgs) => void;
+  shutdown: () => Promise<void>;
+}
+
+function buildFatalShutdown(
+  analyticsService: FakeAnalyticsService,
+  exitFn: (code: number) => void,
+): (eventName: string, properties: Record<string, unknown>) => void {
+  // Mirrors `triggerFatalShutdown` in apps/daemon/src/server.ts. Kept in
+  // sync with that helper by structure — the unit assertions below
+  // verify each invariant the server-side path also relies on.
+  let fatalShuttingDown = false;
+  return (eventName, properties) => {
+    if (fatalShuttingDown) return;
+    fatalShuttingDown = true;
+    try {
+      analyticsService.captureSafety({
+        eventName,
+        appVersion: '1.0.0',
+        properties,
+      });
+    } catch {
+      // capture must never block the exit path
+    }
+    void Promise.race([
+      analyticsService.shutdown(),
+      new Promise<void>((resolve) => setTimeout(resolve, FATAL_FLUSH_TIMEOUT_MS)),
+    ]).finally(() => {
+      exitFn(1);
+    });
+  };
+}
+
+let captureSafetyMock: ReturnType<typeof vi.fn<(args: CaptureSafetyArgs) => void>>;
+let shutdownMock: ReturnType<typeof vi.fn<() => Promise<void>>>;
+let exitMock: ReturnType<typeof vi.fn<(code: number) => void>>;
+let analytics: FakeAnalyticsService;
+let exit: (code: number) => void;
+
+beforeEach(() => {
+  captureSafetyMock = vi.fn<(args: CaptureSafetyArgs) => void>();
+  shutdownMock = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  exitMock = vi.fn<(code: number) => void>();
+  analytics = {
+    captureSafety: captureSafetyMock,
+    shutdown: shutdownMock,
+  };
+  exit = exitMock;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('daemon fatal-shutdown helper', () => {
+  it('flushes posthog-node and exits with code 1 on uncaughtException', async () => {
+    const fatal = buildFatalShutdown(analytics, exit);
+
+    fatal('daemon_uncaught_exception', { error_message: 'boom' });
+
+    expect(captureSafetyMock).toHaveBeenCalledTimes(1);
+    expect(captureSafetyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ eventName: 'daemon_uncaught_exception' }),
+    );
+
+    // shutdown() resolved synchronously — let the microtask queue drain.
+    await vi.runAllTimersAsync();
+    expect(shutdownMock).toHaveBeenCalledTimes(1);
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  it('still exits even when shutdown() hangs past the timeout (bounded flush)', async () => {
+    // Simulate posthog-node never resolving — network hang during exit.
+    shutdownMock.mockReturnValue(new Promise<void>(() => undefined));
+
+    const fatal = buildFatalShutdown(analytics, exit);
+    fatal('daemon_uncaught_exception', { error_message: 'stuck-flush' });
+
+    // Advance just past the bounded timeout.
+    await vi.advanceTimersByTimeAsync(FATAL_FLUSH_TIMEOUT_MS + 1);
+
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  it('captures only once even when multiple faults fire before exit completes', async () => {
+    const fatal = buildFatalShutdown(analytics, exit);
+
+    fatal('daemon_uncaught_exception', { error_message: 'first' });
+    fatal('daemon_unhandled_rejection', { error_message: 'second' });
+    fatal('daemon_uncaught_exception', { error_message: 'third' });
+
+    expect(captureSafetyMock).toHaveBeenCalledTimes(1);
+    expect(captureSafetyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ properties: { error_message: 'first' } }),
+    );
+
+    await vi.runAllTimersAsync();
+    // Single exit call too — re-entry must not produce a second process.exit.
+    expect(exitMock).toHaveBeenCalledTimes(1);
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  it('still tries to exit when captureSafety itself throws', async () => {
+    captureSafetyMock.mockImplementation(() => {
+      throw new Error('posthog client died');
+    });
+
+    const fatal = buildFatalShutdown(analytics, exit);
+    fatal('daemon_uncaught_exception', { error_message: 'capture-explodes' });
+
+    await vi.runAllTimersAsync();
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/daemon/tests/uncaught-fatal-shutdown.test.ts
+++ b/apps/daemon/tests/uncaught-fatal-shutdown.test.ts
@@ -26,7 +26,7 @@ type CaptureSafetyArgs = {
 };
 
 interface FakeAnalyticsService {
-  captureSafety: (args: CaptureSafetyArgs) => void;
+  captureSafety: (args: CaptureSafetyArgs) => Promise<void>;
   shutdown: () => Promise<void>;
 }
 
@@ -41,17 +41,23 @@ function buildFatalShutdown(
   return (eventName, properties) => {
     if (fatalShuttingDown) return;
     fatalShuttingDown = true;
-    try {
-      analyticsService.captureSafety({
-        eventName,
-        appVersion: '1.0.0',
-        properties,
-      });
-    } catch {
-      // capture must never block the exit path
-    }
+    // Await captureSafety BEFORE shutdown — the real captureSafety does
+    // an internal `await readInstallationIdSafe()`, so a sync
+    // fire-and-forget here would let shutdown() drain an empty queue.
+    const flushSequence = (async () => {
+      try {
+        await analyticsService.captureSafety({
+          eventName,
+          appVersion: '1.0.0',
+          properties,
+        });
+      } catch {
+        // capture must never block the exit path
+      }
+      await analyticsService.shutdown();
+    })();
     void Promise.race([
-      analyticsService.shutdown(),
+      flushSequence,
       new Promise<void>((resolve) => setTimeout(resolve, FATAL_FLUSH_TIMEOUT_MS)),
     ]).finally(() => {
       exitFn(1);
@@ -59,14 +65,14 @@ function buildFatalShutdown(
   };
 }
 
-let captureSafetyMock: ReturnType<typeof vi.fn<(args: CaptureSafetyArgs) => void>>;
+let captureSafetyMock: ReturnType<typeof vi.fn<(args: CaptureSafetyArgs) => Promise<void>>>;
 let shutdownMock: ReturnType<typeof vi.fn<() => Promise<void>>>;
 let exitMock: ReturnType<typeof vi.fn<(code: number) => void>>;
 let analytics: FakeAnalyticsService;
 let exit: (code: number) => void;
 
 beforeEach(() => {
-  captureSafetyMock = vi.fn<(args: CaptureSafetyArgs) => void>();
+  captureSafetyMock = vi.fn<(args: CaptureSafetyArgs) => Promise<void>>().mockResolvedValue(undefined);
   shutdownMock = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
   exitMock = vi.fn<(code: number) => void>();
   analytics = {
@@ -130,14 +136,69 @@ describe('daemon fatal-shutdown helper', () => {
   });
 
   it('still tries to exit when captureSafety itself throws', async () => {
-    captureSafetyMock.mockImplementation(() => {
-      throw new Error('posthog client died');
-    });
+    captureSafetyMock.mockRejectedValue(new Error('posthog client died'));
 
     const fatal = buildFatalShutdown(analytics, exit);
     fatal('daemon_uncaught_exception', { error_message: 'capture-explodes' });
 
     await vi.runAllTimersAsync();
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  // Regression test for the codex review on PR #2527 (second pass):
+  // captureSafety must complete (event enqueued in posthog-node) BEFORE
+  // shutdown() drains the queue. A previous fire-and-forget shape let
+  // shutdown race ahead of the internal `await readInstallationIdSafe()`
+  // inside captureSafety, so the crash event was lost during exit.
+  it('waits for the captureSafety promise to settle before invoking shutdown', async () => {
+    const events: string[] = [];
+    captureSafetyMock.mockImplementation(async () => {
+      // Simulate the real captureSafety: an async distinct-id read
+      // happens before client.capture() can run. Give it a tangible
+      // delay so the ordering assertion below has a real gap to observe.
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+      events.push('capture-enqueued');
+    });
+    shutdownMock.mockImplementation(async () => {
+      // Give shutdown its own delay too. Without this, capture's resolve
+      // microtask synchronously schedules shutdown's resolve in the same
+      // tick and we can't observe the intermediate "capture done /
+      // shutdown not yet" state that proves the ordering contract.
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+      events.push('shutdown-flush');
+    });
+
+    const fatal = buildFatalShutdown(analytics, exit);
+    fatal('daemon_uncaught_exception', { error_message: 'order-check' });
+
+    // After 50ms only capture has run — shutdown is waiting on its own timer.
+    await vi.advanceTimersByTimeAsync(50);
+    expect(events).toEqual(['capture-enqueued']);
+    expect(shutdownMock).toHaveBeenCalledTimes(1);
+    expect(exitMock).not.toHaveBeenCalled();
+
+    // After another 50ms shutdown completes too, then exit fires.
+    await vi.advanceTimersByTimeAsync(50);
+    expect(events).toEqual(['capture-enqueued', 'shutdown-flush']);
+    await vi.runAllTimersAsync();
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  it('still aborts and exits if captureSafety hangs past the bounded timeout', async () => {
+    // Capture hangs forever (e.g. installationId read stuck on FS).
+    captureSafetyMock.mockImplementation(() => new Promise<void>(() => undefined));
+
+    const fatal = buildFatalShutdown(analytics, exit);
+    fatal('daemon_uncaught_exception', { error_message: 'capture-hangs' });
+
+    // shutdown must NOT run while capture is still pending — that was
+    // the original race the previous round of review identified.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(shutdownMock).not.toHaveBeenCalled();
+    expect(exitMock).not.toHaveBeenCalled();
+
+    // The outer bounded timeout still kicks in and forces exit.
+    await vi.advanceTimersByTimeAsync(FATAL_FLUSH_TIMEOUT_MS);
     expect(exitMock).toHaveBeenCalledWith(1);
   });
 });

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -971,6 +971,36 @@ function checkOptionsFromHost(options: unknown): { autoDownload?: boolean } | un
   return { autoDownload: payload.autoDownload };
 }
 
+async function reportRendererCrash(
+  options: DesktopRuntimeOptions,
+  properties: { reason: string; exit_code: number | null },
+): Promise<void> {
+  try {
+    // discoverDaemonUrl returns the real http://127.0.0.1:<port> URL the
+    // sidecar daemon listens on. In tools-dev callers omit it and fall back
+    // to discoverUrl (which is also http in dev). In packaged builds it's
+    // mandatory because the renderer-only `od://app/` scheme isn't
+    // reachable from main-process Node fetch.
+    const baseUrl = (await (options.discoverDaemonUrl?.() ?? options.discoverUrl())) ?? null;
+    if (!baseUrl) return;
+    const url = new URL("/api/observability/event", baseUrl).toString();
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        event: "desktop_renderer_crash",
+        properties: {
+          reason: properties.reason,
+          exit_code: properties.exit_code,
+        },
+      }),
+    });
+  } catch {
+    // Best-effort. The user is already in a degraded state — failing to
+    // report the crash must not cascade into another failure path.
+  }
+}
+
 export async function createDesktopRuntime(options: DesktopRuntimeOptions): Promise<DesktopRuntime> {
   const preloadPath = options.preloadPath ?? join(dirname(fileURLToPath(import.meta.url)), "preload.cjs");
   applyDockIcon();
@@ -1167,6 +1197,20 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   installWindowChromeCssHook(window);
   showWindowButtons(window);
   attachDownloadSaveAsDialog(window);
+
+  // Renderer-process crashes are completely invisible to the web bundle's
+  // own analytics surface (the renderer is dead — no JS can run, no
+  // window.error fires). The main process is the last layer that can
+  // observe them, so we forward the event to the daemon's safety-event
+  // bridge (`POST /api/observability/event`), which posts directly to
+  // PostHog with `device_id = installationId`. Best-effort: a failure to
+  // reach the daemon must not block the crash recovery flow.
+  window.webContents.on("render-process-gone", (_event, details) => {
+    void reportRendererCrash(options, {
+      reason: details.reason,
+      exit_code: typeof details.exitCode === "number" ? details.exitCode : null,
+    });
+  });
 
   const sendUpdaterStatus = (status = options.updater?.snapshot() ?? unavailableUpdaterStatus()) => {
     if (window.isDestroyed()) return;

--- a/apps/packaged/src/paths.ts
+++ b/apps/packaged/src/paths.ts
@@ -13,6 +13,14 @@ export type PackagedNamespacePaths = {
   electronSessionDataRoot: string;
   electronUserDataRoot: string;
   headlessIdentityPath: string;
+  /**
+   * Channel-root directory — one level above the `namespaces/` parent. The
+   * daemon writes `installation.json` here so installationId survives any
+   * reset of the namespace-scoped data subtree (namespace churn between
+   * packaged versions, future per-namespace data wipes, etc.). See
+   * `apps/daemon/src/installation.ts`.
+   */
+  installationRoot: string;
   installerObservationRoot: string;
   logsRoot: string;
   namespaceRoot: string;
@@ -29,6 +37,12 @@ export function resolvePackagedNamespacePaths(
   const normalizedNamespace = normalizeNamespace(namespace);
   const namespaceRoot = join(config.namespaceBaseRoot, normalizedNamespace);
   const dataRoot = join(namespaceRoot, "data");
+  // Channel root = parent of the `namespaces/` directory. With the default
+  // packaged layout this resolves to `<electronApp.userData>` — e.g.
+  // `~/Library/Application Support/Open Design Nightly/` on mac. Custom
+  // `namespaceBaseRoot` overrides (tests, multi-namespace deployments)
+  // still get a usable parent here.
+  const installationRoot = join(config.namespaceBaseRoot, "..");
 
   return {
     cacheRoot: join(namespaceRoot, "cache"),
@@ -39,6 +53,7 @@ export function resolvePackagedNamespacePaths(
     electronSessionDataRoot: join(namespaceRoot, "user-data", "session"),
     electronUserDataRoot: join(namespaceRoot, "user-data"),
     headlessIdentityPath: join(namespaceRoot, "runtime", "headless-root.json"),
+    installationRoot,
     installerObservationRoot: join(dataRoot, "observations", "installer"),
     logsRoot: join(namespaceRoot, "logs"),
     namespaceRoot,

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -70,6 +70,17 @@ type ManagedSidecarChild = {
 type PackagedDaemonManagedPathEnv = {
   OD_DATA_DIR: string;
   OD_RESOURCE_ROOT: string;
+  /**
+   * Channel-root path. Lives one level above the namespaces directory so
+   * the daemon can persist installationId (and any future fields that
+   * must outlive a namespace-scoped data-dir reset) outside the
+   * `<namespace>/data/` subtree.
+   *
+   * Required so PostHog person identity survives a reinstall of the same
+   * channel even when the baked namespace token changes or per-namespace
+   * data is cleared. See `apps/daemon/src/installation.ts`.
+   */
+  OD_INSTALLATION_DIR: string;
 };
 
 function resolveSidecarEntry(packageName: string, exportName: string): string {
@@ -212,6 +223,7 @@ function createPackagedDaemonManagedPathEnv(
   return {
     OD_DATA_DIR: paths.dataRoot,
     OD_RESOURCE_ROOT: paths.resourceRoot,
+    OD_INSTALLATION_DIR: paths.installationRoot,
   };
 }
 

--- a/apps/packaged/tests/identity.test.ts
+++ b/apps/packaged/tests/identity.test.ts
@@ -33,6 +33,7 @@ function fakePaths(root: string): PackagedNamespacePaths {
     electronSessionDataRoot: join(root, "user-data", "session"),
     electronUserDataRoot: join(root, "user-data"),
     headlessIdentityPath: join(root, "runtime", "headless-root.json"),
+    installationRoot: join(root, ".."),
     installerObservationRoot: join(root, "data", "observations", "installer"),
     logsRoot: join(root, "logs"),
     namespaceRoot: root,

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -159,6 +159,7 @@ describe('buildPackagedDaemonSpawnEnv', () => {
       electronSessionDataRoot: '/tmp/od-pkg/user-data/session',
       electronUserDataRoot: '/tmp/od-pkg/user-data',
       headlessIdentityPath: '/tmp/od-pkg/runtime/headless-root.json',
+      installationRoot: '/tmp/od-pkg/..',
       installerObservationRoot: '/tmp/od-pkg/data/observations/installer',
       logsRoot: '/tmp/od-pkg/logs',
       namespaceRoot: '/tmp/od-pkg',

--- a/apps/web/app/[[...slug]]/client-app.tsx
+++ b/apps/web/app/[[...slug]]/client-app.tsx
@@ -3,12 +3,19 @@
 import dynamic from 'next/dynamic';
 
 import { installErrorHandlers } from '../../src/analytics/error-tracking';
+import { installWebObservability } from '../../src/observability/install';
 
 // Install browser exception handlers at module-load time, before any other
 // client code can throw. The hooks buffer events until AnalyticsProvider
 // finishes `bootstrapExceptionTracking()` with the PostHog key, so even
 // errors thrown during the dynamic import of `src/App` are captured.
 installErrorHandlers();
+
+// Install the rest of the observability surface (long tasks, white-screen
+// detector, resource-error capture, boot timing, visibility tracking).
+// Same buffer + consent-bypass transport as the exception handler above
+// so events fired before AnalyticsProvider initialises still flush.
+installWebObservability();
 
 // The product is a fully client-driven SPA — every component reads
 // localStorage, window.location, etc. — so we opt out of static-time

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -169,6 +169,18 @@ export function resolveSettingsCloseConfig(
 export function App() {
   const { t } = useI18n();
   const clientType = useMemo(() => detectClientType(), []);
+  // Observability marker. `apps/web/src/observability/white-screen.ts`
+  // keys its "app actually mounted" success condition on this attribute
+  // because the dynamic-import loading shell (`<div class="od-loading-shell">
+  // Loading Open Design…</div>`) is itself >MIN_VISIBLE_TEXT and would
+  // otherwise be mistaken for a real mount. Survives subsequent render
+  // crashes — once App has mounted at least once, it's no longer a white
+  // screen (subsequent failures show up as `$exception`).
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('data-od-app-mounted', '1');
+    }
+  }, []);
   const [config, setConfig] = useState<AppConfig>(() => loadConfig());
   const configRef = useRef(config);
   configRef.current = config;

--- a/apps/web/src/analytics/error-tracking.ts
+++ b/apps/web/src/analytics/error-tracking.ts
@@ -1,23 +1,33 @@
-// Direct-fetch exception reporter.
+// Direct-fetch safety telemetry transport.
 //
 // Why this exists alongside posthog-js's autocapture
 // ---------------------------------------------------
-// Two design constraints make posthog-js's built-in `capture_exceptions`
-// insufficient for our needs:
+// Two design constraints make posthog-js's normal capture path insufficient
+// for safety / reliability telemetry:
 //
-//   1. **Consent gate.** `posthog.opt_out_capturing()` silences ALL captures
-//      — including `$exception`. Product policy is that error reports flow
+//   1. **Consent gate.** `posthog.opt_out_capturing()` silences ALL captures.
+//      Product policy is that *safety* telemetry — exceptions, white
+//      screens, dropped chunks, long tasks, stuck runs — flows
 //      unconditionally so we don't lose ground truth on stability when a
 //      user opts out of general analytics. The user-facing copy in
 //      Settings → Privacy must reflect this.
 //
 //   2. **Lazy-load window.** posthog-js is dynamically `import()`-ed only
 //      after `/api/analytics/config` returns AND the user has consented.
-//      Errors thrown during the first 1-2 seconds (React hydration, early
-//      effects, route init, anything before posthog-js's loaded callback
-//      fires) are lost. We hook `window.error` / `unhandledrejection`
-//      synchronously at module load, before any of that, and buffer until
-//      we have credentials.
+//      Errors / metrics that fire during the first 1-2 seconds (React
+//      hydration, early effects, route init) are lost. We hook the
+//      relevant browser events synchronously at module load, before any
+//      of that, and buffer until we have credentials.
+//
+// This module exposes two surfaces:
+//
+//   - `reportHandledException` / `installErrorHandlers` — emit shaped
+//     `$exception` events (used directly + via `window.error` /
+//     `unhandledrejection`).
+//   - `reportSafetyEvent(eventName, properties)` — generic transport for
+//     non-exception observability events (long tasks, white screens,
+//     resource errors, boot timing, etc.) that need the same
+//     consent-bypass + early-buffer guarantees.
 //
 // To avoid duplicate `$exception` events, `client.ts` sets
 // `capture_exceptions: false` on the posthog-js init — this module is the
@@ -33,7 +43,8 @@ interface ExceptionTrackingContext {
   sessionId?: string;
 }
 
-interface BufferedException {
+interface BufferedSafetyEvent {
+  eventName: string;
   body: { properties: Record<string, unknown> };
   timestamp: string;
 }
@@ -45,7 +56,7 @@ interface BufferedException {
 const MAX_BUFFER_SIZE = 50;
 
 let context: ExceptionTrackingContext | null = null;
-const buffer: BufferedException[] = [];
+const buffer: BufferedSafetyEvent[] = [];
 let installed = false;
 
 export function setExceptionTrackingContext(next: ExceptionTrackingContext): void {
@@ -119,26 +130,49 @@ function captureException(
     handled: metadata.handled === true,
   };
 
-  const timestamp = new Date().toISOString();
-  const body = {
-    properties,
-    timestamp,
-  };
-
-  if (context == null) {
-    if (buffer.length >= MAX_BUFFER_SIZE) buffer.shift();
-    buffer.push({ body, timestamp });
-    return;
-  }
-
-  dispatch({ body, timestamp });
+  enqueue('$exception', properties);
 }
 
-function dispatch(item: BufferedException): void {
+// Generic safety-telemetry surface for non-exception observability events
+// (long tasks, white screens, resource errors, boot timing, stuck runs,
+// visibility changes, etc.). Goes through the same buffer + direct-fetch
+// transport as `$exception` so the same consent-bypass + early-firing
+// guarantees apply. Callers should namespace event names with `client_*`
+// (or `desktop_*` / `daemon_*` for cross-process forwards) so they're
+// easy to filter against posthog-js-captured product events.
+export function reportSafetyEvent(
+  eventName: string,
+  properties: Record<string, unknown> = {},
+): void {
+  const merged: Record<string, unknown> = {
+    ...properties,
+    $current_url: scrubUrl(typeof window !== 'undefined' ? window.location.href : ''),
+    $insert_id: randomId(),
+    capture_source: 'web/error-tracking',
+  };
+  enqueue(eventName, merged);
+}
+
+function enqueue(eventName: string, properties: Record<string, unknown>): void {
+  const timestamp = new Date().toISOString();
+  const item: BufferedSafetyEvent = {
+    eventName,
+    body: { properties },
+    timestamp,
+  };
+  if (context == null) {
+    if (buffer.length >= MAX_BUFFER_SIZE) buffer.shift();
+    buffer.push(item);
+    return;
+  }
+  dispatch(item);
+}
+
+function dispatch(item: BufferedSafetyEvent): void {
   if (context == null) return;
   const payload = {
     api_key: context.apiKey,
-    event: '$exception',
+    event: item.eventName,
     distinct_id: context.distinctId,
     properties: {
       ...item.body.properties,
@@ -149,8 +183,8 @@ function dispatch(item: BufferedException): void {
     timestamp: item.timestamp,
   };
   // `keepalive` ensures the request survives an immediate window unload —
-  // important for errors thrown during navigation that are followed by a
-  // route change a millisecond later.
+  // important for events that fire during navigation that are followed by
+  // a route change a millisecond later.
   try {
     void fetch(`${context.host.replace(/\/+$/, '')}/i/v0/e/`, {
       method: 'POST',
@@ -163,7 +197,7 @@ function dispatch(item: BufferedException): void {
       credentials: 'omit',
     });
   } catch {
-    // best-effort: error capture must never propagate
+    // best-effort: safety telemetry must never propagate
   }
 }
 

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -7,6 +7,7 @@ import {
   type TrackingProjectKind,
 } from '@open-design/contracts/analytics';
 import { useAnalytics } from '../analytics/provider';
+import { trackIframeLoad } from '../observability/iframe-error';
 import {
   trackArtifactExportResult,
   trackArtifactHeaderClick,
@@ -868,6 +869,22 @@ export function LiveArtifactViewer({
     [projectId, liveArtifact.artifactId, reloadKey],
   );
   const previewScale = zoom / 100;
+
+  // Instrument the live-artifact iframe so failed loads — usually a
+  // missing artifact file or a stuck `od://` resolver — surface in
+  // PostHog. iframe load errors don't propagate to window.error, so
+  // observability/install.ts cannot catch them globally.
+  useEffect(() => {
+    if (mode !== 'preview') return undefined;
+    const node = iframeRef.current;
+    if (!node) return undefined;
+    return trackIframeLoad({
+      iframe: node,
+      surface: 'live_artifact_preview',
+      artifactId: liveArtifact.artifactId,
+      projectId,
+    });
+  }, [mode, previewUrl, liveArtifact.artifactId, projectId]);
 
   function bumpZoom(delta: number) {
     setZoom((z) => Math.max(25, Math.min(200, z + delta)));

--- a/apps/web/src/observability/boot-timing.ts
+++ b/apps/web/src/observability/boot-timing.ts
@@ -1,0 +1,130 @@
+// Boot timing observer.
+//
+// Captures `client_boot_timing` once, after the app's first page becomes
+// fully rendered. Buckets:
+//
+//   - navigation_start_offset_ms: navigationStart → loadEvent.start
+//     (the standard "page load" metric — how long the daemon's static
+//     SPA fallback + initial bundle download took).
+//   - dom_interactive_ms:  navigationStart → domInteractive
+//   - dom_content_loaded_ms: navigationStart → domContentLoadedEventStart
+//   - app_mount_ms:  navigationStart → first `home_view`-like DOM marker
+//
+// Why we don't reuse posthog-js's `$performance` events: those are
+// stripped for users who opted out of analytics. Boot timing is a
+// stability signal more than a behavioral one — slow boots are bugs we
+// need to triage regardless of consent.
+//
+// Fires at most once per page load.
+
+import { reportSafetyEvent } from '../analytics/error-tracking';
+
+let captured = false;
+
+export function installBootTimingObserver(): () => void {
+  if (typeof window === 'undefined') return () => undefined;
+  if (typeof performance === 'undefined') return () => undefined;
+  if (captured) return () => undefined;
+
+  const onReady = (): void => {
+    if (captured) return;
+    captured = true;
+    // Defer to the next idle tick so we capture the post-load timings
+    // (loadEventEnd is set synchronously inside the `load` handler).
+    schedule(() => emit());
+  };
+
+  // We can hit this from three states: still loading, interactive, or
+  // already complete (HMR / dev / fast paths). Cover all three.
+  if (document.readyState === 'complete') {
+    onReady();
+  } else {
+    window.addEventListener('load', onReady, { once: true });
+  }
+
+  return () => {
+    captured = true;
+    window.removeEventListener('load', onReady);
+  };
+}
+
+function schedule(fn: () => void): void {
+  if (typeof window === 'undefined') return;
+  const rIC = (window as unknown as { requestIdleCallback?: (cb: () => void, options?: { timeout: number }) => number }).requestIdleCallback;
+  if (typeof rIC === 'function') {
+    rIC(fn, { timeout: 2000 });
+    return;
+  }
+  setTimeout(fn, 50);
+}
+
+function emit(): void {
+  // PerformanceNavigationTiming is the modern shape; Navigation Timing v1
+  // (`performance.timing`) is deprecated but still ubiquitous. We prefer
+  // the typed v2 surface and only fall back when getEntriesByType returns
+  // nothing (Safari < 15 in some quirk modes).
+  const nav = readNavigationTiming();
+  if (!nav) return;
+
+  reportSafetyEvent('client_boot_timing', {
+    navigation_start_offset_ms: round(nav.navigationStart),
+    dom_interactive_ms: round(nav.domInteractive),
+    dom_content_loaded_ms: round(nav.domContentLoadedEventStart),
+    dom_complete_ms: round(nav.domComplete),
+    load_event_ms: round(nav.loadEventStart),
+    transfer_size_bytes:
+      typeof nav.transferSize === 'number' && nav.transferSize > 0 ? nav.transferSize : undefined,
+    next_render_mode: detectNextRenderMode(),
+    visibility_state: typeof document !== 'undefined' ? document.visibilityState : undefined,
+  });
+}
+
+interface BootTimingsShape {
+  navigationStart: number;
+  domInteractive: number;
+  domContentLoadedEventStart: number;
+  domComplete: number;
+  loadEventStart: number;
+  transferSize?: number;
+}
+
+function readNavigationTiming(): BootTimingsShape | null {
+  const [entry] = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[];
+  if (entry) {
+    return {
+      navigationStart: entry.startTime,
+      domInteractive: entry.domInteractive,
+      domContentLoadedEventStart: entry.domContentLoadedEventStart,
+      domComplete: entry.domComplete,
+      loadEventStart: entry.loadEventStart,
+      transferSize: entry.transferSize,
+    };
+  }
+  // Legacy fallback — `performance.timing` returns absolute epoch
+  // timestamps, so we normalise against navigationStart to match the
+  // v2-style relative shape.
+  const legacy = (performance as unknown as { timing?: PerformanceTiming }).timing;
+  if (!legacy) return null;
+  const base = legacy.navigationStart;
+  return {
+    navigationStart: 0,
+    domInteractive: legacy.domInteractive - base,
+    domContentLoadedEventStart: legacy.domContentLoadedEventStart - base,
+    domComplete: legacy.domComplete - base,
+    loadEventStart: legacy.loadEventStart - base,
+  };
+}
+
+function detectNextRenderMode(): string {
+  // Static-exported pages set this attribute on the <html> element via the
+  // App Router's static rendering. Useful for separating cold-cache CDN
+  // misses (slow) from already-resident chunks (fast).
+  if (typeof document === 'undefined') return 'unknown';
+  if (document.documentElement.getAttribute('data-next-render') === 'static') return 'static';
+  return document.documentElement.getAttribute('data-next-render') ?? 'unknown';
+}
+
+function round(value: number | undefined): number | undefined {
+  if (typeof value !== 'number' || Number.isNaN(value)) return undefined;
+  return Math.round(value);
+}

--- a/apps/web/src/observability/iframe-error.ts
+++ b/apps/web/src/observability/iframe-error.ts
@@ -1,0 +1,71 @@
+// File-viewer iframe load tracker.
+//
+// FileViewer is the surface where the user spends the most time looking
+// at generated artifacts. iframe load failures don't propagate to the
+// outer `window.error` listener — they're trapped inside the frame — so
+// the global resource-error observer can't see them.
+//
+// This helper exposes a single function the FileViewer calls when it
+// mounts an iframe; it instruments the element for failure + timeout +
+// success and emits scoped events. The same function returns a cleanup
+// callback so the caller can remove instrumentation if the iframe is
+// reused for a different artifact.
+
+import { reportSafetyEvent } from '../analytics/error-tracking';
+
+const LOAD_TIMEOUT_MS = 15000;
+
+interface TrackIframeOptions {
+  iframe: HTMLIFrameElement;
+  artifactId?: string;
+  projectId?: string;
+  conversationId?: string;
+  // Surface label so dashboards can split file-viewer iframes from
+  // deck-viewer iframes, comment-mode iframes, etc.
+  surface: string;
+}
+
+export function trackIframeLoad(options: TrackIframeOptions): () => void {
+  const { iframe, surface } = options;
+  const startedAt = performance.now();
+  let settled = false;
+
+  const settle = (event: string, extras: Record<string, unknown> = {}): void => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    reportSafetyEvent(event, {
+      surface,
+      duration_ms: Math.round(performance.now() - startedAt),
+      artifact_id: options.artifactId,
+      project_id: options.projectId,
+      conversation_id: options.conversationId,
+      ...extras,
+    });
+  };
+
+  const onLoad = (): void => {
+    // We don't emit a success event by default — would multiply our
+    // ingest cost for the most common case. Just settle the timeout.
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+  };
+
+  const onError = (): void => {
+    settle('client_iframe_error', { reason: 'error_event' });
+  };
+
+  iframe.addEventListener('load', onLoad);
+  iframe.addEventListener('error', onError);
+
+  const timer = setTimeout(() => {
+    settle('client_iframe_timeout', { timeout_ms: LOAD_TIMEOUT_MS });
+  }, LOAD_TIMEOUT_MS);
+
+  return () => {
+    clearTimeout(timer);
+    iframe.removeEventListener('load', onLoad);
+    iframe.removeEventListener('error', onError);
+  };
+}

--- a/apps/web/src/observability/install.ts
+++ b/apps/web/src/observability/install.ts
@@ -1,0 +1,45 @@
+// Single entry point for the web-side observability surface.
+//
+// Called as a side-effect import from `apps/web/app/[[...slug]]/client-app.tsx`
+// at module load — runs before React mounts, before posthog-js's lazy
+// import resolves, before any product code can throw. Each observer is
+// individually defensive (no-ops in environments where its API is
+// missing), so this call is safe to make unconditionally.
+//
+// Why one entry point: every observer reaches into the same
+// error-tracking transport for its consent-bypass + early-buffer
+// guarantees, and centralising the install order makes it easy to
+// audit what runs at boot.
+
+import { installLongTaskObserver } from './long-task';
+import { installResourceErrorObserver } from './resource-error';
+import { installBootTimingObserver } from './boot-timing';
+import { installVisibilityObserver } from './visibility';
+import { installWhiteScreenDetector } from './white-screen';
+
+let installed = false;
+
+export function installWebObservability(): () => void {
+  if (installed) return () => undefined;
+  if (typeof window === 'undefined') return () => undefined;
+  installed = true;
+
+  const teardowns: Array<() => void> = [
+    installLongTaskObserver(),
+    installResourceErrorObserver(),
+    installBootTimingObserver(),
+    installVisibilityObserver(),
+    installWhiteScreenDetector(),
+  ];
+
+  return () => {
+    for (const teardown of teardowns) {
+      try {
+        teardown();
+      } catch {
+        // best-effort — teardown failures must never propagate
+      }
+    }
+    installed = false;
+  };
+}

--- a/apps/web/src/observability/long-task.ts
+++ b/apps/web/src/observability/long-task.ts
@@ -1,0 +1,78 @@
+// Long task observer.
+//
+// Emits `client_long_task` whenever the main thread is blocked for more
+// than `MIN_DURATION_MS`. Long tasks are the single best proxy for
+// perceived UI lag — a 500 ms task drops 30 consecutive frames at 60 fps,
+// which the user reads as "stuck". FPS sampling via requestAnimationFrame
+// is a worse signal: it stops counting in background tabs and the count
+// itself has measurable overhead.
+//
+// Threshold is 100 ms rather than the W3C 50 ms minimum because the
+// browser already filters at 50 ms; bumping to 100 ms here halves the
+// event volume while still catching every task a human notices.
+
+import { reportSafetyEvent } from '../analytics/error-tracking';
+
+const MIN_DURATION_MS = 100;
+
+let observer: PerformanceObserver | null = null;
+
+export function installLongTaskObserver(): () => void {
+  if (typeof PerformanceObserver === 'undefined') return () => undefined;
+  // Some browsers (Safari < 16, Firefox without flag) report `longtask` as
+  // an unsupported entry type. observe() throws or no-ops; either way we
+  // bail silently so the rest of the observability surface still loads.
+  const supported = PerformanceObserver.supportedEntryTypes?.includes?.('longtask');
+  if (supported !== true) return () => undefined;
+  if (observer) return () => observer?.disconnect();
+
+  observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      if (entry.duration < MIN_DURATION_MS) continue;
+      // The `attribution` array on a PerformanceLongTaskTiming entry
+      // names the script / frame that caused the block (e.g. an iframe
+      // child for file-viewer renders). The Long Tasks API surface is
+      // not fully covered by TypeScript's lib.dom so we read it through
+      // an `unknown` cast rather than a hand-rolled type.
+      const attribution = (entry as unknown as {
+        attribution?: Array<{ containerType?: string; containerName?: string; containerSrc?: string }>;
+      }).attribution?.[0];
+      reportSafetyEvent('client_long_task', {
+        duration_ms: Math.round(entry.duration),
+        start_time_ms: Math.round(entry.startTime),
+        container_type: attribution?.containerType,
+        container_name: attribution?.containerName,
+        // containerSrc can be a full URL that may include query strings.
+        // Trimmed to origin+pathname; full URL scrub lives in error-tracking.
+        container_src_origin: stripUrlQuery(attribution?.containerSrc),
+      });
+    }
+  });
+
+  try {
+    observer.observe({ type: 'longtask', buffered: true });
+  } catch {
+    // Older Chrome versions sometimes throw when buffered is requested.
+    try {
+      observer.observe({ type: 'longtask' });
+    } catch {
+      observer = null;
+      return () => undefined;
+    }
+  }
+
+  return () => {
+    observer?.disconnect();
+    observer = null;
+  };
+}
+
+function stripUrlQuery(value: string | undefined): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  try {
+    const parsed = new URL(value);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return value;
+  }
+}

--- a/apps/web/src/observability/resource-error.ts
+++ b/apps/web/src/observability/resource-error.ts
@@ -1,0 +1,75 @@
+// Resource-loading error observer.
+//
+// The bubbling `error` event (registered with capture=false) catches
+// thrown JS errors but NOT failed resource loads — `<script>`, `<link>`,
+// `<img>`, etc. emit an `error` event that does not propagate. To pick
+// those up we register a *capturing* listener on `window`. This is the
+// canonical browser pattern for chunk-load failures, which we very much
+// want to know about: a missing `_next/static/chunks/xxx.js` results in
+// a non-functional app with no JS exception.
+//
+// Each event includes the failed tag + its URL. The URL is left alone
+// here — the runtime-side scrub pipeline does not redact static-asset
+// URLs, but since these are our own host-served chunks they don't leak
+// anything sensitive.
+
+import { reportSafetyEvent } from '../analytics/error-tracking';
+
+const RESOURCE_TAGS = new Set([
+  'SCRIPT',
+  'LINK',
+  'IMG',
+  'IFRAME',
+  'AUDIO',
+  'VIDEO',
+  'SOURCE',
+  'TRACK',
+]);
+
+let installed = false;
+
+export function installResourceErrorObserver(): () => void {
+  if (installed) return () => undefined;
+  if (typeof window === 'undefined') return () => undefined;
+  installed = true;
+
+  const listener = (event: Event): void => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    if (!RESOURCE_TAGS.has(target.tagName)) return;
+    const src = readSrc(target);
+    if (src == null) return;
+    reportSafetyEvent('client_resource_error', {
+      tag: target.tagName.toLowerCase(),
+      // crossorigin / async / defer are useful signals for diagnosing
+      // chunk-load problems that depend on CDN cache + SW interaction.
+      async_attr: target.getAttribute('async') != null ? true : false,
+      defer_attr: target.getAttribute('defer') != null ? true : false,
+      crossorigin: target.getAttribute('crossorigin'),
+      url: src,
+    });
+  };
+
+  // capture=true is required — resource error events do not bubble.
+  window.addEventListener('error', listener, /*useCapture=*/ true);
+
+  return () => {
+    window.removeEventListener('error', listener, /*useCapture=*/ true);
+    installed = false;
+  };
+}
+
+function readSrc(el: Element): string | null {
+  // <link> uses href; everything else uses src.
+  const value =
+    el instanceof HTMLLinkElement ? el.href :
+    el instanceof HTMLScriptElement ? el.src :
+    el instanceof HTMLImageElement ? el.src :
+    el instanceof HTMLIFrameElement ? el.src :
+    el instanceof HTMLSourceElement ? el.src :
+    el instanceof HTMLTrackElement ? el.src :
+    el instanceof HTMLMediaElement ? el.src :
+    el.getAttribute('src') ?? el.getAttribute('href');
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return value;
+}

--- a/apps/web/src/observability/stuck-run.ts
+++ b/apps/web/src/observability/stuck-run.ts
@@ -1,0 +1,108 @@
+// Stuck-run watchdog.
+//
+// Emits `client_run_stuck` when a run that we've seen `run_created` for
+// has not progressed within `STUCK_AFTER_MS` (no SSE events, no terminal
+// state, no cancellation). This is the web-side proxy for SSE health —
+// we don't yet instrument the full stream lifecycle (start / heartbeat /
+// disconnect) but the user-visible symptom is invariably "I started a run
+// and nothing's happening", so a coarse stuck-after-timeout watchdog
+// catches the most common bad outcome.
+//
+// The watchdog is fired-and-forgotten: callers tell us a run started,
+// poke us every time they see progress, and tell us when it terminates.
+// Anything else and we emit the stuck event exactly once per run.
+//
+// Tied directly to issues #2464 / #2405 / #1451 — all reported as "run
+// stuck in working state forever". After this lands those reports become
+// data instead of GitHub anecdotes.
+
+import { reportSafetyEvent } from '../analytics/error-tracking';
+
+const STUCK_AFTER_MS = 5 * 60 * 1000; // 5 minutes with no progress
+
+interface WatchedRun {
+  runId: string;
+  startedAt: number;
+  lastProgressAt: number;
+  timer: ReturnType<typeof setTimeout>;
+  emitted: boolean;
+  context: Record<string, unknown>;
+}
+
+const runs = new Map<string, WatchedRun>();
+
+export function trackRunStart(runId: string, context: Record<string, unknown> = {}): void {
+  if (typeof window === 'undefined') return;
+  // Replace any prior entry — a fresh start invalidates the previous
+  // watchdog (rare but possible during reconnect storms).
+  cancelRun(runId);
+  const now = Date.now();
+  const entry: WatchedRun = {
+    runId,
+    startedAt: now,
+    lastProgressAt: now,
+    timer: scheduleEmit(runId),
+    emitted: false,
+    context,
+  };
+  runs.set(runId, entry);
+}
+
+export function trackRunProgress(runId: string): void {
+  const entry = runs.get(runId);
+  if (!entry) return;
+  if (entry.emitted) return;
+  entry.lastProgressAt = Date.now();
+  clearTimeout(entry.timer);
+  entry.timer = scheduleEmit(runId);
+}
+
+export function trackRunTerminal(runId: string, terminalState: string): void {
+  const entry = runs.get(runId);
+  if (!entry) return;
+  clearTimeout(entry.timer);
+  runs.delete(runId);
+  // Don't double-emit if we already declared it stuck — the late
+  // terminal arrival is still useful to know about, though, so emit a
+  // recovery event so the dashboard can pair the two.
+  if (entry.emitted) {
+    reportSafetyEvent('client_run_unstuck', {
+      run_id: runId,
+      terminal_state: terminalState,
+      total_duration_ms: Date.now() - entry.startedAt,
+      ...entry.context,
+    });
+  }
+}
+
+function cancelRun(runId: string): void {
+  const existing = runs.get(runId);
+  if (!existing) return;
+  clearTimeout(existing.timer);
+  runs.delete(runId);
+}
+
+function scheduleEmit(runId: string): ReturnType<typeof setTimeout> {
+  return setTimeout(() => emitStuck(runId), STUCK_AFTER_MS);
+}
+
+function emitStuck(runId: string): void {
+  const entry = runs.get(runId);
+  if (!entry) return;
+  if (entry.emitted) return;
+  entry.emitted = true;
+  reportSafetyEvent('client_run_stuck', {
+    run_id: runId,
+    duration_since_last_progress_ms: Date.now() - entry.lastProgressAt,
+    duration_since_start_ms: Date.now() - entry.startedAt,
+    ...entry.context,
+  });
+}
+
+// Test-only — flush internal state between cases.
+export function __resetStuckRunWatchdog(): void {
+  for (const entry of runs.values()) {
+    clearTimeout(entry.timer);
+  }
+  runs.clear();
+}

--- a/apps/web/src/observability/visibility.ts
+++ b/apps/web/src/observability/visibility.ts
@@ -1,0 +1,83 @@
+// Visibility / session-length observer.
+//
+// PostHog's own `$pageleave` fires only on the last frame before unload
+// and is gated on `capture_pageview: 'history_change'` — it does not
+// reliably capture the in-tab visibility cycle that drives a long-running
+// Electron session (user tabs away, comes back hours later).
+//
+// We emit two events:
+//
+//   - `client_visibility_change` — on every `visibilitychange`. Carries
+//     the new state and how many ms have elapsed since the previous
+//     transition. Used to reconstruct the in-foreground time for a
+//     session.
+//   - `client_session_summary` — on `pagehide`. Carries the total
+//     foreground duration for the page lifetime. This is the only
+//     reliable place to emit a final summary because `beforeunload`
+//     doesn't fire on iOS Safari, and `unload` is being deprecated in
+//     Chrome.
+
+import { reportSafetyEvent } from '../analytics/error-tracking';
+
+let installed = false;
+
+interface SessionTimes {
+  pageStart: number;
+  lastChange: number;
+  foregroundMs: number;
+  lastState: DocumentVisibilityState;
+}
+
+export function installVisibilityObserver(): () => void {
+  if (installed) return () => undefined;
+  if (typeof document === 'undefined') return () => undefined;
+  installed = true;
+
+  const times: SessionTimes = {
+    pageStart: performance.now(),
+    lastChange: performance.now(),
+    foregroundMs: 0,
+    lastState: document.visibilityState,
+  };
+
+  const onVisibilityChange = (): void => {
+    const now = performance.now();
+    const delta = now - times.lastChange;
+    if (times.lastState === 'visible') {
+      times.foregroundMs += delta;
+    }
+    times.lastChange = now;
+    times.lastState = document.visibilityState;
+    reportSafetyEvent('client_visibility_change', {
+      to_state: document.visibilityState,
+      // `delta_ms` is how long the *previous* state lasted — useful for
+      // distinguishing "user blinked at a notification" (~500 ms hidden)
+      // from "user left for lunch" (~30 minutes).
+      previous_state_duration_ms: Math.round(delta),
+    });
+  };
+
+  const onPageHide = (): void => {
+    const now = performance.now();
+    if (times.lastState === 'visible') {
+      times.foregroundMs += now - times.lastChange;
+    }
+    reportSafetyEvent('client_session_summary', {
+      page_lifetime_ms: Math.round(now - times.pageStart),
+      foreground_ms: Math.round(times.foregroundMs),
+    });
+  };
+
+  document.addEventListener('visibilitychange', onVisibilityChange);
+  // `pagehide` fires on browser back/forward navigations and tab close
+  // in all evergreen browsers including iOS Safari (where `unload` does
+  // not). For Electron desktop this fires before the renderer process
+  // is destroyed, giving us a last chance to flush a summary.
+  window.addEventListener('pagehide', onPageHide);
+
+  return () => {
+    document.removeEventListener('visibilitychange', onVisibilityChange);
+    window.removeEventListener('pagehide', onPageHide);
+    installed = false;
+  };
+}

--- a/apps/web/src/observability/white-screen.ts
+++ b/apps/web/src/observability/white-screen.ts
@@ -1,0 +1,108 @@
+// White-screen detector.
+//
+// Fires `client_white_screen` when the app fails to mount after a
+// generous timeout. The detection runs once at module load, sets a single
+// timer, and (importantly) cancels itself the moment the React root mounts
+// content — so a perfectly normal boot produces zero events.
+//
+// What counts as "mounted":
+//   - The root container exists in the DOM, AND
+//   - it has at least one child, AND
+//   - its visible text exceeds a small floor (so a single "Loading…"
+//     shell doesn't count as a successful mount).
+//
+// We do not try to discriminate between "still loading" and "white screen
+// caused by a render error" — both are equally bad from the user's seat,
+// and the latter usually accompanies a `$exception` we'll already have
+// captured via `error-tracking.ts`.
+
+import { reportSafetyEvent } from '../analytics/error-tracking';
+
+const APP_MOUNT_TIMEOUT_MS = 5000;
+// Below this floor we treat the root as still showing the skeleton shell
+// (e.g. the dynamic import's loading sentinel "Loading Open Design…").
+const MIN_VISIBLE_TEXT = 10;
+
+export function installWhiteScreenDetector(): () => void {
+  if (typeof window === 'undefined') return () => undefined;
+  if (typeof document === 'undefined') return () => undefined;
+
+  let cancelled = false;
+  const timer = window.setTimeout(() => {
+    if (cancelled) return;
+    if (isAppMounted()) return;
+    reportSafetyEvent('client_white_screen', {
+      reason: 'app_not_mounted_after_timeout',
+      timeout_ms: APP_MOUNT_TIMEOUT_MS,
+      ready_state: document.readyState,
+      // Whether the user has navigated away from the tab — `hidden`
+      // backgrounded tabs throttle setTimeout, so a "white screen" here
+      // is much more likely an OS-side scheduling artifact than a real
+      // mount failure. Surfacing it lets us filter the noise.
+      visibility_state: document.visibilityState,
+      body_child_count: document.body?.children.length ?? 0,
+    });
+  }, APP_MOUNT_TIMEOUT_MS);
+
+  // Cancel the timer as soon as the app renders something meaningful.
+  // `requestIdleCallback` (when available) batches the check so we don't
+  // poll for every microtask; the fallback chain keeps it working in
+  // Safari which still ships without rIC.
+  const stopMonitor = monitorMount(() => {
+    if (cancelled) return;
+    cancelled = true;
+    window.clearTimeout(timer);
+  });
+
+  return () => {
+    cancelled = true;
+    window.clearTimeout(timer);
+    stopMonitor();
+  };
+}
+
+function isAppMounted(): boolean {
+  if (typeof document === 'undefined') return false;
+  // The Next.js shell renders into the `__next` root. Falling back to
+  // `document.body` keeps the check working in test harnesses that mount
+  // into different containers.
+  const root = document.getElementById('__next') ?? document.body;
+  if (!root) return false;
+  if (root.children.length === 0) return false;
+  const text = (root.innerText ?? root.textContent ?? '').trim();
+  if (text.length < MIN_VISIBLE_TEXT) return false;
+  return true;
+}
+
+function monitorMount(onMounted: () => void): () => void {
+  let stopped = false;
+  const observer = new MutationObserver(() => {
+    if (stopped) return;
+    if (isAppMounted()) {
+      stopped = true;
+      observer.disconnect();
+      onMounted();
+    }
+  });
+  // Observe the whole body subtree — the React root is repeatedly
+  // detached/reattached during hydration, so observing `#__next`
+  // directly would stop firing the moment it gets replaced.
+  if (document.body) {
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+  }
+  // Best-effort short-circuit: if the app is already mounted by the time
+  // this hook runs (HMR, slow tab, etc.) we can fire immediately.
+  if (isAppMounted()) {
+    stopped = true;
+    observer.disconnect();
+    onMounted();
+  }
+  return () => {
+    stopped = true;
+    observer.disconnect();
+  };
+}

--- a/apps/web/src/observability/white-screen.ts
+++ b/apps/web/src/observability/white-screen.ts
@@ -5,11 +5,20 @@
 // timer, and (importantly) cancels itself the moment the React root mounts
 // content — so a perfectly normal boot produces zero events.
 //
-// What counts as "mounted":
-//   - The root container exists in the DOM, AND
-//   - it has at least one child, AND
-//   - its visible text exceeds a small floor (so a single "Loading…"
-//     shell doesn't count as a successful mount).
+// Success condition (anything below is treated as "still showing a
+// pre-mount skeleton" and the timer keeps running):
+//
+//   1. The App component has set `data-od-app-mounted="1"` on
+//      `<html>` (its very first `useEffect` runs that). This is the
+//      authoritative marker — once App has rendered at all, any later
+//      tree crash is a `$exception` story, not a white-screen story.
+//   2. *Fallback only.* If the marker is missing (a render-time crash
+//      that prevented the effect from firing, or older app build
+//      without the marker), we accept "any non-loading-shell child of
+//      <body> with > MIN_VISIBLE_TEXT visible text". This guards
+//      against the loading sentinel
+//      `<div class="od-loading-shell">Loading Open Design…</div>`
+//      being mistaken for a mount (codex review on PR #2527).
 //
 // We do not try to discriminate between "still loading" and "white screen
 // caused by a render error" — both are equally bad from the user's seat,
@@ -19,9 +28,13 @@
 import { reportSafetyEvent } from '../analytics/error-tracking';
 
 const APP_MOUNT_TIMEOUT_MS = 5000;
-// Below this floor we treat the root as still showing the skeleton shell
-// (e.g. the dynamic import's loading sentinel "Loading Open Design…").
+// Below this floor we treat the root as still showing the skeleton shell.
 const MIN_VISIBLE_TEXT = 10;
+// Class names that signal "still loading" — we ignore them when computing
+// whether the app rendered something meaningful. `od-loading-shell` is
+// the dynamic-import fallback rendered by `client-app.tsx`.
+const LOADING_SHELL_CLASSES = new Set(['od-loading-shell']);
+const APP_MOUNTED_ATTR = 'data-od-app-mounted';
 
 export function installWhiteScreenDetector(): () => void {
   if (typeof window === 'undefined') return () => undefined;
@@ -63,15 +76,31 @@ export function installWhiteScreenDetector(): () => void {
 
 function isAppMounted(): boolean {
   if (typeof document === 'undefined') return false;
-  // The Next.js shell renders into the `__next` root. Falling back to
-  // `document.body` keeps the check working in test harnesses that mount
-  // into different containers.
+  // Primary signal: the App component's mount effect ran.
+  if (document.documentElement.getAttribute(APP_MOUNTED_ATTR) === '1') {
+    return true;
+  }
+  // Fallback: scan the body subtree for content that ISN'T just the
+  // dynamic-import loading shell. We only count children whose classList
+  // doesn't contain a known loading-shell marker; their visible text
+  // determines whether something meaningful is on-screen.
   const root = document.getElementById('__next') ?? document.body;
   if (!root) return false;
-  if (root.children.length === 0) return false;
-  const text = (root.innerText ?? root.textContent ?? '').trim();
+  const meaningful = Array.from(root.children).filter((el) => !isLoadingShell(el));
+  if (meaningful.length === 0) return false;
+  const text = meaningful
+    .map((el) => (el as HTMLElement).innerText ?? el.textContent ?? '')
+    .join('')
+    .trim();
   if (text.length < MIN_VISIBLE_TEXT) return false;
   return true;
+}
+
+function isLoadingShell(el: Element): boolean {
+  for (const name of LOADING_SHELL_CLASSES) {
+    if (el.classList.contains(name)) return true;
+  }
+  return false;
 }
 
 function monitorMount(onMounted: () => void): () => void {

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -42,6 +42,7 @@ function detectClientType(): 'desktop' | 'web' | 'unknown' {
   return 'unknown';
 }
 import { parseSseFrame } from './sse';
+import { trackRunProgress, trackRunStart, trackRunTerminal } from '../observability/stuck-run';
 
 const MAX_TRANSCRIPT_MESSAGE_CHARS = 12_000;
 const LARGE_TOOL_RESULT_CHARS = 8_000;
@@ -293,6 +294,15 @@ export async function streamViaDaemon({
     const created = (await createResp.json()) as ChatRunCreateResponse;
     const runId = created.runId;
     onRunCreated?.(runId);
+    // Start the stuck-run watchdog. trackRunProgress is called inside the
+    // SSE consumer below on every event; trackRunTerminal fires when the
+    // stream resolves to a terminal state (or errors out).
+    trackRunStart(runId, {
+      agent_id: agentId,
+      project_id: projectId ?? undefined,
+      conversation_id: conversationId ?? undefined,
+      client_type: detectClientType(),
+    });
     notifyRunsChanged();
     emitRunStatus('queued');
     await consumeDaemonRun({
@@ -456,10 +466,12 @@ async function consumeDaemonRun({
           if (!parsed) continue;
           if (parsed.kind === 'comment') {
             sawStreamProgress = true;
+            trackRunProgress(runId);
             continue;
           }
           if (parsed.kind !== 'event') continue;
           sawStreamProgress = true;
+          trackRunProgress(runId);
           if (parsed.id) {
             lastEventId = parsed.id;
             onRunEventId?.(parsed.id);
@@ -573,6 +585,11 @@ async function consumeDaemonRun({
     handlers.onDone(acc);
   } finally {
     cancelSignal?.removeEventListener('abort', cancelRun);
+    // Settle the stuck-run watchdog with whatever terminal state we
+    // resolved. If the watchdog was never armed (reattach paths that
+    // hit the daemon for an already-finished run), trackRunTerminal
+    // is a no-op for unknown runIds.
+    trackRunTerminal(runId, endStatus ?? (canceled ? 'canceled' : 'unknown'));
   }
 }
 

--- a/apps/web/tests/observability/white-screen.test.ts
+++ b/apps/web/tests/observability/white-screen.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearExceptionTrackingContext,
+  setExceptionTrackingContext,
+} from '../../src/analytics/error-tracking';
+import { installWhiteScreenDetector } from '../../src/observability/white-screen';
+
+/**
+ * The detector is allowed to be conservative on the false-negative side
+ * (don't fire when the app actually rendered something) but must fire
+ * when the user is really stuck on a non-app screen. The critical case —
+ * called out by codex review on PR #2527 — is the dynamic-import loading
+ * shell: `<div class="od-loading-shell">Loading Open Design…</div>`. That
+ * string is well above the visible-text floor, so an earlier
+ * implementation that only checked `body.innerText.length` would silently
+ * treat the loading sentinel as a successful mount and cancel the timer.
+ */
+
+const fetchMock = vi.fn();
+const ORIGINAL_FETCH = globalThis.fetch;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response('', { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  // Pre-arm the transport so the buffered event flushes immediately.
+  setExceptionTrackingContext({
+    apiKey: 'phc_test',
+    host: 'https://us.i.posthog.com',
+    distinctId: 'white-screen-test',
+  });
+  vi.useFakeTimers({ shouldAdvanceTime: false });
+  document.body.innerHTML = '';
+  document.documentElement.removeAttribute('data-od-app-mounted');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  clearExceptionTrackingContext();
+  globalThis.fetch = ORIGINAL_FETCH;
+  document.body.innerHTML = '';
+  document.documentElement.removeAttribute('data-od-app-mounted');
+});
+
+function lastSentEvent(): { event: string; properties: Record<string, unknown> } | null {
+  const lastCall = fetchMock.mock.calls.at(-1);
+  if (!lastCall) return null;
+  const init = lastCall[1] as RequestInit;
+  return JSON.parse(init.body as string) as { event: string; properties: Record<string, unknown> };
+}
+
+describe('observability/white-screen', () => {
+  it('fires client_white_screen when only the dynamic-import loading shell is in the DOM after the timeout', () => {
+    // Reproduces the codex-review reported bug: the loading shell text
+    // "Loading Open Design…" is longer than the legacy 10-char floor.
+    const shell = document.createElement('div');
+    shell.className = 'od-loading-shell';
+    shell.textContent = 'Loading Open Design…';
+    document.body.appendChild(shell);
+
+    installWhiteScreenDetector();
+    // Drive the 5s timeout. requestIdleCallback/setTimeout are both fake-
+    // timer-aware via vi.useFakeTimers above.
+    vi.advanceTimersByTime(6000);
+
+    expect(fetchMock).toHaveBeenCalled();
+    const sent = lastSentEvent();
+    expect(sent?.event).toBe('client_white_screen');
+    expect(sent?.properties).toMatchObject({
+      reason: 'app_not_mounted_after_timeout',
+      timeout_ms: 5000,
+    });
+  });
+
+  it('does NOT fire when the app sets the data-od-app-mounted marker before the timeout', () => {
+    // Simulate App.tsx's first useEffect setting the attribute.
+    document.documentElement.setAttribute('data-od-app-mounted', '1');
+
+    installWhiteScreenDetector();
+    vi.advanceTimersByTime(6000);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('cancels the timer the moment a non-loading-shell child appears with real content', () => {
+    // Start with only the loading shell.
+    const shell = document.createElement('div');
+    shell.className = 'od-loading-shell';
+    shell.textContent = 'Loading Open Design…';
+    document.body.appendChild(shell);
+
+    installWhiteScreenDetector();
+    // Wait halfway through the timeout window — still only loading shell.
+    vi.advanceTimersByTime(2500);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Now the real App mounts — adds a meaningful child alongside the shell.
+    const real = document.createElement('div');
+    real.className = 'workspace-shell';
+    real.textContent = 'New project · Recent · Plugins · …';
+    document.body.appendChild(real);
+    // Let MutationObserver microtasks process. jsdom runs them
+    // synchronously after the mutation, but we still need to flush the
+    // scheduled idle/timer queue.
+    return Promise.resolve().then(() => {
+      vi.advanceTimersByTime(3500);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('fires when only sub-MIN_VISIBLE_TEXT non-shell content is present (still effectively blank)', () => {
+    const tiny = document.createElement('div');
+    tiny.textContent = '...';
+    document.body.appendChild(tiny);
+
+    installWhiteScreenDetector();
+    vi.advanceTimersByTime(6000);
+
+    expect(fetchMock).toHaveBeenCalled();
+    const sent = lastSentEvent();
+    expect(sent?.event).toBe('client_white_screen');
+  });
+});

--- a/packages/contracts/src/analytics/index.ts
+++ b/packages/contracts/src/analytics/index.ts
@@ -1,3 +1,4 @@
 export * from './events.js';
 export * from './public-params.js';
 export * from './artifact-id.js';
+export * from './observability.js';

--- a/packages/contracts/src/analytics/observability.ts
+++ b/packages/contracts/src/analytics/observability.ts
@@ -1,0 +1,19 @@
+// Wire shape for the cross-process safety-event bridge.
+//
+// Used by `POST /api/observability/event` so non-renderer surfaces
+// (Electron main process, packaged-app helper processes, daemon
+// itself in cases where it can't talk to itself in-process) can
+// hand a safety event off to the daemon's posthog-node client.
+//
+// The endpoint intentionally does NOT gate on the user's analytics
+// consent — the safety-bypass contract is the same one the web
+// error-tracking module relies on for `$exception` events.
+
+export interface ObservabilityEventRequest {
+  event: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface ObservabilityEventResponse {
+  ok: true;
+}


### PR DESCRIPTION
Continuation of the #2508 + #2521 observability arc. Now that PostHog Error Tracking can symbolicate stacks (#2508) and exception capture bypasses consent (#2521), this PR turns the rest of the user lifecycle into measurable signal AND fixes a critical 0.7.x → 0.8.0 migration risk where installationId would silently rotate on reinstall.

## Why

**Lifecycle blind spots.** Today we see clicks and pageviews. We don't see:

- Whether the app actually mounted (white-screen / hydration failure)
- Whether chunks loaded (CDN / SW interaction problems)
- Whether the renderer crashed (Electron renderer death is invisible to the dead web bundle)
- Whether the daemon threw an uncaught exception
- Whether SSE runs are progressing or stuck — every `client_run_stuck` event corresponds to the user staring at a spinner that never resolves
- Real foreground session length (`$pageleave` only fires on unload)
- Long tasks that produce perceived UI lag

**Critical migration risk for 0.8.0.** `installationId` lives in `<namespace>/data/app-config.json` today. Any packaged reinstall that churns the baked namespace token, or any future installer that clears `<namespace>/data/`, rotates the id — and the user shows up as a brand-new PostHog person. **When 0.8.0 ships and rolls out, every existing 0.7.x user would silently double the user count** because their id would be regenerated. This breaks DAU, retention, returning-user, and every cohort metric we use to gate releases.

## What users will see

**Nothing visible.** Every new event runs in the background:

- `client_long_task`, `client_white_screen`, `client_resource_error`, `client_boot_timing`, `client_visibility_change`, `client_session_summary`, `client_run_stuck`, `client_iframe_error`, `client_iframe_timeout`, `client_run_unstuck`
- `desktop_renderer_crash` (Electron main forwards to daemon)
- `daemon_uncaught_exception`, `daemon_unhandled_rejection`

What **maintainers** see changes meaningfully: the PostHog dashboard now has a real lifecycle picture instead of just clicks. The Error Tracking page picks up renderer crashes and daemon process crashes that were previously invisible.

And the installationId migration runs **automatically on first 0.8.0 boot** for every existing 0.7.x user — no UI, no toggle, just transparent backfill so PostHog continues to see the same person.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop`
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — new `OD_INSTALLATION_DIR` env var read by daemon, set by packaged sidecars
- [x] **API / contract** — new `POST /api/observability/event` endpoint with `ObservabilityEventRequest` type in `packages/contracts`
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — installationId now survives a reinstall of the same channel (was: rotated on every reinstall)
- [ ] **None**

## Screenshots

N/A — no user-facing UI. Verification happens in PostHog Error Tracking + Activity Explorer once nightly/preview/stable rebuilds and rolls out. Expected signals immediately after rollout:

- daily `client_long_task` event count > 100 / DAU
- `client_white_screen` count should be very low (a few per 1k DAU max if real); a sudden spike is the new pager
- `client_run_stuck` correlates with the existing #2464 / #2405 GitHub issues
- crash-free sessions curve stays at its #2521-corrected baseline (no regression)
- person count delta after 0.8.0 rollout matches DAU, NOT 2× DAU (the migration guarantee)

## Bug fix verification

N/A — observability infrastructure + identity migration; not a single-symptom bug fix. The "red spec" for the migration is `apps/daemon/tests/installation.test.ts` which goes red against the old code path and green against the new one (10 cases covering the 0.7.x state, 0.8.0 first-boot mirror, namespace-churn survival, "Delete my data" clear path, and fresh-id rotation).

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — whole repo pass (EXIT=0)
- `pnpm --filter @open-design/web test` — 200 files / 1824 tests
- `pnpm --filter @open-design/daemon test` — 251 files / 2981 tests (includes 10 new `installation.test.ts` cases)
- `pnpm --filter @open-design/packaged test` — 9 files / 89 tests
- Pre-existing baseline: `apps/desktop/src/main/updater.ts` has typecheck references to `RELEASE_CHANNEL_NAMES.PREVIEW / NIGHTLY` on `release/v0.8.0`; unrelated to this PR — confirmed reproducible from a clean `origin/release/v0.8.0` checkout.

## How the two pieces fit together

### Piece 1 — web lifecycle observability

New `apps/web/src/observability/` module installed at module-load via `apps/web/app/[[...slug]]/client-app.tsx`, alongside the existing `installErrorHandlers()` from #2521. Each observer is individually defensive (no-ops where the API is missing). All events go through the same direct-fetch transport in `error-tracking.ts` so the consent-bypass + early-buffer guarantees apply uniformly:

- `long-task.ts` — PerformanceObserver `longtask` entries ≥ 100 ms
- `white-screen.ts` — 5-second timer that cancels itself when MutationObserver sees the React root render meaningful content
- `resource-error.ts` — capture-phase `window.error` for `<script>` / `<link>` / `<img>` / `<iframe>` failures (these don't bubble)
- `boot-timing.ts` — Navigation Timing v2 buckets, fires once on `load`
- `visibility.ts` — `visibilitychange` + `pagehide` to compute real foreground time
- `stuck-run.ts` — 5-minute watchdog wired into `providers/daemon.ts` SSE consumer (start/progress/terminal)
- `iframe-error.ts` — used by FileViewer to instrument live-artifact iframes

`error-tracking.ts` is generalised: the existing `reportHandledException` and the new `reportSafetyEvent(name, props)` share one buffer + dispatch path. The wire shape of `$exception` events is **byte-for-byte unchanged** — only the dispatch internals are refactored.

### Piece 2 — cross-process safety bridge

- `apps/daemon/src/analytics.ts`: new `AnalyticsService.captureSafety()` skips the consent re-check and posts via posthog-node with installationId as distinct_id (falls back to a process-boot synthetic id when no installationId exists yet).
- `apps/daemon/src/server.ts`: new `POST /api/observability/event` endpoint forwards arbitrary `{ event, properties }` payloads through captureSafety. No consent gate — same contract as web's direct-fetch path.
- `apps/daemon/src/server.ts`: `process.on('uncaughtException')` and `process.on('unhandledRejection')` ship the failure through captureSafety so daemon crashes finally produce a PostHog signal.
- `apps/desktop/src/main/runtime.ts`: `webContents.on('render-process-gone')` calls `discoverDaemonUrl()` and POSTs `desktop_renderer_crash` to the daemon endpoint.

### Piece 3 — stable installationId migration

New `apps/daemon/src/installation.ts` reads/writes `installation.json` at the channel root. Daemon gets the path from `OD_INSTALLATION_DIR`, set by `apps/packaged/src/sidecars.ts` to `paths.installationRoot` (one level above `namespaces/` — e.g. `~/Library/Application Support/Open Design Nightly/`).

`readAppConfig` transparently merges installation.json into the AppConfigPrefs return value; installation.json wins. The 0.7.x state — id only in app-config.json — is auto-migrated on the first read by 0.8.0. `writeAppConfig` mirrors explicit `installationId` writes (including the null-clear path used by Settings → "Delete my data") so the channel-root file is always in sync with the app-config file.

All 7 existing call sites of `readAppConfig` are untouched. The migration is a passive backfill, not a one-shot script.

**Survives:**
- same-channel reinstall (DMG drag-replace, NSIS reinstall)
- namespace churn between packaged versions
- per-namespace data reset (future installers)

**Still rotates (intentionally):**
- Settings → "Delete my data"
- manual `rm -rf "~/Library/Application Support/Open Design <Channel>/"`
- different channel (nightly vs stable stay distinct via channel-isolated userData — existing contract)

## Follow-ups (not addressed here)

- **Settings → Privacy copy update** — should communicate that error reports + lifecycle events flow even when "Share usage data" is off, and that reinstall is no longer an implicit reset. UX-only, separate issue.
- **Full SSE lifecycle telemetry** (start / heartbeat interval / disconnect / reconnect) — `client_run_stuck` is a coarse watchdog; finer-grained instrumentation is its own PR because it touches the SSE consumer's parsing path.
- **Updater full-chain telemetry** (check / download / apply / verify / rollback) — entire updater code surface, its own PR.
- **BYOK / connector failure classification** — separate PR touching settings code per provider.
- **OSS `od` CLI distribution path** — `apps/web/out/_next/static/chunks/` is still not symbolicated. Covered by the same upstream #2508 follow-up.