### PR TITLE
Polish connector detail drawer

### DIFF
--- a/apps/web/src/components/ConnectorsBrowser.tsx
+++ b/apps/web/src/components/ConnectorsBrowser.tsx
@@ -1236,6 +1236,7 @@ function ConnectorDetailDrawer({
   const showToolsBadge = connector.toolCount !== undefined || actualToolCount > 0 || toolsLoaded;
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
   const categoryLabel = connectorCategoryLabel(connector.category, t);
+  const toolsBadgeLabel = formatToolsBadge(toolCount, t);
 
   function continueAuthorization(event: SyntheticEvent) {
     event.stopPropagation();
@@ -1293,9 +1294,8 @@ function ConnectorDetailDrawer({
                 {isAuthorizationPending ? t('connectors.authorizationPending') : statusLabel(connector.status, t)}
               </span>
               {showToolsBadge ? (
-                <span className="connector-tools-badge is-ready" title={formatToolsBadge(toolCount, t)}>
-                  <Icon name="settings" size={10} />
-                  <span>{formatToolsBadge(toolCount, t)}</span>
+                <span className="connector-drawer-tool-count-chip" title={toolsBadgeLabel}>
+                  <span>{toolsBadgeLabel}</span>
                 </span>
               ) : null}
             </div>
@@ -1347,7 +1347,21 @@ function ConnectorDetailDrawer({
           ) : null}
 
           <section className="connector-drawer-section">
-            <h3 className="connector-drawer-section-title">{t('connectors.detailsLabel')}</h3>
+            <div className="connector-drawer-section-head">
+              <h3 className="connector-drawer-section-title">{t('connectors.detailsLabel')}</h3>
+              {isConnected ? (
+                <button
+                  type="button"
+                  className={`ghost connector-drawer-inline-action connector-action is-disconnect${isDisconnecting ? ' is-loading' : ''}`}
+                  disabled={!canDisconnect}
+                  aria-busy={isDisconnecting || undefined}
+                  onClick={() => onDisconnect(connector.id)}
+                >
+                  {isDisconnecting ? <Icon name="spinner" size={12} /> : null}
+                  <span>{t('connectors.disconnect')}</span>
+                </button>
+              ) : null}
+            </div>
             <dl className="connector-drawer-details">
               <div>
                 <dt>{t('connectors.statusLabel')}</dt>
@@ -1423,19 +1437,8 @@ function ConnectorDetailDrawer({
           </section>
         </div>
 
-        <footer className="connector-drawer-foot">
-          {isConnected ? (
-            <button
-              type="button"
-              className={`ghost connector-action is-disconnect${isDisconnecting ? ' is-loading' : ''}`}
-              disabled={!canDisconnect}
-              aria-busy={isDisconnecting || undefined}
-              onClick={() => onDisconnect(connector.id)}
-            >
-              {isDisconnecting ? <Icon name="spinner" size={12} /> : null}
-              <span>{t('connectors.disconnect')}</span>
-            </button>
-          ) : (
+        {!isConnected ? (
+          <footer className="connector-drawer-foot">
             <button
               type="button"
               className={`primary connector-action is-connect${isConnecting || isAuthorizationPending ? ' is-loading' : ''}`}
@@ -1446,17 +1449,17 @@ function ConnectorDetailDrawer({
               {isConnecting || isAuthorizationPending ? <Icon name="spinner" size={12} /> : null}
               <span>{isAuthorizationPending ? t('connectors.authorizationPending') : t('connectors.connect')}</span>
             </button>
-          )}
-          {isAuthorizationPending ? (
-            <button
-              type="button"
-              className="ghost connector-action is-cancel-authorization"
-              onClick={() => onCancelAuthorization(connector.id)}
-            >
-              <span>{t('connectors.cancelAuthorization')}</span>
-            </button>
-          ) : null}
-        </footer>
+            {isAuthorizationPending ? (
+              <button
+                type="button"
+                className="ghost connector-action is-cancel-authorization"
+                onClick={() => onCancelAuthorization(connector.id)}
+              >
+                <span>{t('connectors.cancelAuthorization')}</span>
+              </button>
+            ) : null}
+          </footer>
+        ) : null}
       </aside>
     </div>
   );

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8206,12 +8206,14 @@ button.connector-action.is-loading {
   position: fixed;
   inset: 0;
   z-index: 100;
-  background: color-mix(in srgb, #000 42%, transparent);
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
+  background: color-mix(in srgb, #111827 18%, transparent);
+  backdrop-filter: blur(1px);
+  -webkit-backdrop-filter: blur(1px);
   display: flex;
   justify-content: flex-end;
-  animation: connector-drawer-fade 180ms ease;
+  align-items: flex-end;
+  padding: 24px 24px 12px;
+  animation: connector-drawer-fade 180ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 @keyframes connector-drawer-fade {
   from { opacity: 0; }
@@ -8221,25 +8223,27 @@ button.connector-action.is-loading {
   position: relative;
   display: flex;
   flex-direction: column;
-  width: min(480px, 92vw);
-  height: 100%;
+  width: min(456px, 92vw);
+  height: clamp(480px, 68vh, 640px);
+  max-height: calc(100vh - 36px);
   background: var(--bg-panel);
-  border-left: 1px solid var(--border);
-  box-shadow: -24px 0 48px -20px rgba(0, 0, 0, 0.32);
-  animation: connector-drawer-slide 240ms cubic-bezier(0.22, 0.9, 0.3, 1);
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: 12px;
+  box-shadow: 0 24px 64px -34px rgba(15, 23, 42, 0.5);
+  overflow: hidden;
+  animation: connector-drawer-slide 220ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 @keyframes connector-drawer-slide {
-  from { transform: translateX(24px); opacity: 0; }
+  from { transform: translateX(18px); opacity: 0; }
   to { transform: translateX(0); opacity: 1; }
 }
 .connector-drawer-head {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
-  padding: 20px 22px 16px;
-  border-bottom: 1px solid var(--border);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--bg-subtle) 60%, transparent) 0%, transparent 100%);
+  gap: 14px;
+  padding: 22px 22px 18px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  background: color-mix(in srgb, var(--bg-subtle) 36%, var(--bg-panel));
 }
 .connector-drawer-titles {
   flex: 1 1 auto;
@@ -8251,26 +8255,41 @@ button.connector-action.is-loading {
 .connector-drawer-eyebrow {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 6px;
   font-size: 11px;
   font-weight: 500;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.02em;
   text-transform: uppercase;
   color: var(--text-faint);
 }
 .connector-drawer-titles h2 {
   margin: 0;
-  font-size: 22px;
+  font-size: 21px;
   font-weight: 600;
   line-height: 1.2;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   color: var(--text);
 }
 .connector-drawer-status {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
   flex-wrap: wrap;
+}
+.connector-drawer-tool-count-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  max-width: 100%;
+  padding: 3px 9px;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  background: color-mix(in srgb, var(--bg-panel) 72%, var(--bg-subtle));
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1.2;
 }
 .connector-drawer-close {
   flex: 0 0 auto;
@@ -8289,16 +8308,24 @@ button.connector-action.is-loading {
 }
 .connector-drawer-body {
   flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
-  padding: 20px 22px 24px;
+  padding: 18px 22px 14px;
   display: flex;
   flex-direction: column;
-  gap: 22px;
+  gap: 20px;
 }
 .connector-drawer-section {
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+.connector-drawer-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
 }
 .connector-drawer-section-title {
   margin: 0;
@@ -8310,6 +8337,18 @@ button.connector-action.is-loading {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+.connector-drawer-inline-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  min-height: 28px;
+  padding: 4px 9px;
+  border-radius: var(--radius);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
 }
 .connector-drawer-count {
   display: inline-flex;
@@ -8331,34 +8370,30 @@ button.connector-action.is-loading {
   margin: 0;
   color: var(--text);
   font-size: 14px;
-  line-height: 1.6;
+  line-height: 1.55;
 }
 .connector-drawer-details {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 2px;
+  gap: 0;
   margin: 0;
-  padding: 2px 0;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: var(--bg-subtle);
-  overflow: hidden;
+  padding: 2px 0 0;
+  border-top: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
 }
 .connector-drawer-details > div {
   display: grid;
-  grid-template-columns: 110px 1fr;
+  grid-template-columns: minmax(96px, 0.38fr) minmax(0, 1fr);
   align-items: baseline;
   gap: 12px;
-  padding: 10px 14px;
-  background: var(--bg-panel);
+  padding: 8px 0;
 }
 .connector-drawer-details > div + div {
-  border-top: 1px solid var(--border);
+  border-top: 1px solid color-mix(in srgb, var(--border) 42%, transparent);
 }
 .connector-drawer-details dt {
   margin: 0;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 12.5px;
   font-weight: 500;
 }
 .connector-drawer-details dd {
@@ -8372,8 +8407,8 @@ button.connector-action.is-loading {
 }
 .connector-drawer-empty {
   margin: 0;
-  padding: 14px 16px;
-  border: 1px dashed var(--border);
+  padding: 12px 14px;
+  border: 1px dashed color-mix(in srgb, var(--border) 78%, transparent);
   border-radius: var(--radius);
   color: var(--text-muted);
   font-size: 13px;
@@ -8385,41 +8420,45 @@ button.connector-action.is-loading {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 .connector-drawer-tool {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 12px 14px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
+  gap: 5px;
+  padding: 9px 11px;
+  background: color-mix(in srgb, var(--bg-panel) 74%, var(--bg-subtle));
+  border: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
   border-radius: var(--radius);
   transition: border-color 140ms ease, background 140ms ease;
 }
 .connector-drawer-tool:hover {
-  border-color: color-mix(in srgb, var(--text) 20%, var(--border));
+  background: var(--bg-panel);
+  border-color: color-mix(in srgb, var(--text) 16%, var(--border));
 }
 .connector-drawer-tool-head {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 10px;
 }
 .connector-drawer-tool-title {
-  font-size: 13px;
+  min-width: 0;
+  font-size: 12.5px;
   font-weight: 600;
   color: var(--text);
+  line-height: 1.35;
 }
 .connector-drawer-tool-badge {
   display: inline-flex;
   align-items: center;
-  padding: 1px 7px;
+  flex: 0 0 auto;
+  padding: 1px 6px;
   border-radius: var(--radius-pill);
-  font-size: 10px;
+  font-size: 9.5px;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.04em;
   background: var(--bg-subtle);
   border: 1px solid var(--border);
   color: var(--text-muted);
@@ -8442,15 +8481,15 @@ button.connector-action.is-loading {
 .connector-drawer-tool-desc {
   margin: 0;
   color: var(--text-muted);
-  font-size: 12.5px;
-  line-height: 1.5;
+  font-size: 12px;
+  line-height: 1.42;
 }
 .connector-drawer-tool-name {
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 11px;
+  font-size: 10.5px;
   color: var(--text-faint);
-  background: var(--bg-subtle);
-  padding: 2px 6px;
+  background: color-mix(in srgb, var(--bg-subtle) 76%, transparent);
+  padding: 2px 5px;
   border-radius: 4px;
   align-self: flex-start;
   max-width: 100%;
@@ -8468,18 +8507,30 @@ button.connector-action.is-loading {
   padding: 7px 14px;
 }
 .connector-drawer-foot {
-  padding: 14px 22px 18px;
-  border-top: 1px solid var(--border);
+  padding: 12px 22px 16px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  background: var(--bg-panel);
+  background: color-mix(in srgb, var(--bg-subtle) 28%, var(--bg-panel));
 }
 .connector-drawer-foot button.connector-action {
   padding: 7px 18px;
   font-size: 13px;
 }
 @media (max-width: 520px) {
+  .connector-drawer-backdrop {
+    align-items: stretch;
+    padding: 0;
+  }
+  .connector-drawer {
+    width: 100%;
+    max-height: none;
+    height: 100%;
+    border-radius: 0;
+    border-right: 0;
+    border-left: 0;
+  }
   .connector-drawer-head {
     padding: 16px 16px 14px;
   }
@@ -8488,6 +8539,11 @@ button.connector-action.is-loading {
   }
   .connector-drawer-foot {
     padding: 12px 16px 16px;
+  }
+  .connector-drawer-section-head {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
   }
   .connector-drawer-details > div {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Fixes #2395

## Why

The connector detail drawer in Settings -> Connectors was hard to scan and felt visually detached from the settings modal. While checking connected connector details such as GitHub and Linear, the drawer header pills, heavy details table, large tool cards, and isolated disconnect footer made the panel feel crowded and unfinished.

This PR addresses the issue's UI polish request by making the drawer feel lighter, keeping it visually related to the settings modal, and preventing long tool lists from expanding the drawer after async tool details load.

## What users will see

Settings -> Connectors detail views now open as a lighter drawer with a softer backdrop, clearer header spacing, calmer status/tool-count chips, reduced details-row weight, and more compact tool cards.

For connected connectors, Disconnect now appears inline with the details section instead of sitting alone in a fixed footer. Long tool lists scroll inside the drawer instead of expanding it over the settings content.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Unconnected <img width="1407" height="636" alt="Screenshot 2026-05-20 at 11 39 43 PM" src="https://github.com/user-attachments/assets/15638fb4-3356-47ed-9333-ea5d773a719c" />

Connected: disconnect button no longer in fixed position <img width="1425" height="621" alt="Screenshot 2026-05-20 at 11 39 23 PM" src="https://github.com/user-attachments/assets/91c83494-5328-48af-95b8-5f0410598f0d" />

I18n check: <img width="1416" height="622" alt="Screenshot 2026-05-20 at 11 49 29 PM" src="https://github.com/user-attachments/assets/a878bc06-2012-48d9-8521-087c58d19903" />


## Bug fix verification

No red spec was added because this is a visual polish issue and the acceptance criteria are layout hierarchy, spacing, and drawer behavior during async tool-detail loading.

Manual verification target:
- Open Settings -> Connectors.
- Select a connected connector such as GitHub or Linear.
- Confirm the detail drawer remains visually scoped to the settings modal.
- Confirm the drawer does not expand after tool details load.
- Confirm long tool lists scroll inside the drawer.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
