### PR TITLE
fix(web): show feedback prompt on every successful assistant turn

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -168,7 +168,6 @@ export function AssistantMessage({
       message,
       hasEmptyResponse,
       hasUnfinishedTodos: unfinishedTodos.length > 0,
-      hasArtifactWork: hasArtifactWorkSignal(message, produced.length),
     });
   const showCompletionRow =
     showFeedback ||
@@ -359,56 +358,15 @@ function isFeedbackEligible({
   message,
   hasEmptyResponse,
   hasUnfinishedTodos,
-  hasArtifactWork,
 }: {
   streaming: boolean;
   message: ChatMessage;
   hasEmptyResponse: boolean;
   hasUnfinishedTodos: boolean;
-  hasArtifactWork: boolean;
 }): boolean {
   if (streaming || hasEmptyResponse || hasUnfinishedTodos) return false;
-  if (!hasArtifactWork) return false;
   if (message.runStatus) return message.runStatus === "succeeded";
   return !!message.endedAt;
-}
-
-function hasArtifactWorkSignal(message: ChatMessage, producedFileCount: number): boolean {
-  if (producedFileCount > 0) return true;
-  if (message.content.includes("<artifact")) return true;
-  if (hasLiveArtifactMutation(message.events ?? [])) return true;
-  return hasSuccessfulFileMutation(message.events ?? []);
-}
-
-function hasLiveArtifactMutation(events: AgentEvent[]): boolean {
-  return events.some((event) => {
-    if (event.kind !== "live_artifact") return false;
-    return event.action === "created" || event.action === "updated";
-  });
-}
-
-function hasSuccessfulFileMutation(events: AgentEvent[]): boolean {
-  const errorByToolId = new Map<string, boolean>();
-  for (const event of events) {
-    if (event.kind === "tool_result") {
-      errorByToolId.set(event.toolUseId, event.isError);
-    }
-  }
-  return events.some((event) => {
-    if (event.kind !== "tool_use") return false;
-    if (!isFileMutationToolName(event.name)) return false;
-    return errorByToolId.get(event.id) !== true;
-  });
-}
-
-function isFileMutationToolName(name: string): boolean {
-  return (
-    name === "Write" ||
-    name === "write" ||
-    name === "create_file" ||
-    name === "Edit" ||
-    name === "str_replace_edit"
-  );
 }
 
 function MessageTimestamp({

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -1,10 +1,9 @@
 // @vitest-environment jsdom
 
 /**
- * Visibility-gate coverage for assistant artifact feedback (issue #1288).
- * Feedback should only appear for successful assistant turns that produce
- * or update an artifact, not for text-only acknowledgements, failed runs,
- * streaming turns, or empty responses.
+ * Visibility-gate coverage for the assistant feedback widget. It should
+ * appear after any successfully completed turn, and stay hidden for
+ * streaming turns, failed runs, and empty responses.
  */
 
 import { cleanup, render, screen } from '@testing-library/react';
@@ -61,7 +60,7 @@ function producedFile(name: string): ProjectFile {
   } as ProjectFile;
 }
 
-describe('AssistantMessage feedback gate (issue #1288)', () => {
+describe('AssistantMessage feedback gate', () => {
   it('shows the feedback widget after a successful turn that produced files', () => {
     render(
       <AssistantMessage
@@ -76,11 +75,7 @@ describe('AssistantMessage feedback gate (issue #1288)', () => {
     expect(screen.getByRole('button', { name: 'Not helpful' })).toBeTruthy();
   });
 
-  it('hides the feedback widget for a successful text-only turn with no producedFiles', () => {
-    // Regression for lefarcen P2: the issue scopes feedback to
-    // turns that delivered a final artifact, not every successful
-    // turn. Text-only acknowledgements ("Got it.") must not prompt
-    // for feedback.
+  it('shows the feedback widget for a successful text-only turn with no producedFiles', () => {
     render(
       <AssistantMessage
         message={baseMessage({ producedFiles: [] })}
@@ -89,7 +84,7 @@ describe('AssistantMessage feedback gate (issue #1288)', () => {
         onFeedback={vi.fn()}
       />,
     );
-    expect(screen.queryByRole('group', { name: 'Feedback' })).toBeNull();
+    expect(screen.getByRole('group', { name: 'Feedback' })).toBeTruthy();
   });
 
   it('hides the feedback widget while the turn is still streaming', () => {

--- a/apps/web/tests/components/chat-feedback.test.tsx
+++ b/apps/web/tests/components/chat-feedback.test.tsx
@@ -144,12 +144,12 @@ describe('chat assistant feedback', () => {
     vi.restoreAllMocks();
   });
 
-  it('collects feedback only after an assistant turn produces an artifact', () => {
+  it('collects feedback after any successfully completed assistant turn', () => {
     renderChatPane({
       messages: [completedAssistant()],
     });
 
-    expect(screen.queryByRole('group', { name: 'Feedback' })).toBeNull();
+    expect(screen.getByRole('group', { name: 'Feedback' })).toBeTruthy();
   });
 
   it('collects positive and negative feedback on completed artifact results', () => {


### PR DESCRIPTION
## Why

- **Use case**: noticed mid-session that the thumbs-up/down widget under the assistant footer only appears for some turns. Creating a plugin (writes a manifest via `Write`) gets the widget; clicking the home-page example prompts that route through `generate_image` / `generate_video` does not. Same for MCP-driven turns and plain text answers.
- **Pain**: PR #1379 deliberately scoped the widget to *artifact-producing* turns. In practice that excludes most of what the home example prompts actually do, so users have no way to rate those outputs even though the turn finished cleanly. Feedback collection for image/video/audio and conversational turns is just silently disabled.

## What users will see

After any successfully completed assistant turn, the thumbs-up / thumbs-down chip now appears in the footer next to the Done pill — including image, video and audio generations from the home example prompts, MCP tool runs, and plain text answers. Turns that are still streaming, returned empty, have unfinished todos, or did not reach `runStatus = "succeeded"` are still excluded.

## Surface area

- [x] **UI** — thumbs-up/down chip in the assistant message footer now shows up after every successful turn, not only artifact-producing ones
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — existing users will start seeing the feedback chip on turns where it used to be hidden (text answers, media generation, MCP tools)
- [ ] **None**

## Screenshots

No new UI was introduced — this is a visibility-rule change for the existing widget. The chip itself is unchanged (`AssistantFeedback` component). To verify locally: send any home-page example prompt (e.g. one of the IMAGE_STARTERS / VIDEO_SEEDANCE_STARTERS in `apps/web/src/components/ChatPane.tsx`), wait for the turn to finish, and observe the thumbs-up/down chip under the Done pill.

## Bug fix verification

Not a bug fix in the strict `red-spec → fix → green` sense — this is a deliberate widening of an existing product rule. The pre-existing assertion in `apps/web/tests/components/chat-feedback.test.tsx` that encoded the old narrow rule was flipped:

- Old: `collects feedback only after an assistant turn produces an artifact` → asserted `queryByRole('group', { name: 'Feedback' })` was `null` for a non-artifact completed turn.
- New: `collects feedback after any successfully completed assistant turn` → asserts the same widget is now present.

The other artifact-shape tests (`completedArtifactAssistant`, `completedEditAssistant`, `completedLiveArtifactAssistant`) still pass — they were narrower assertions that the widget shows for those shapes, which is still true.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/chat-feedback.test.tsx` (13/13 pass)

### Notes for reviewers

- `producedFileCount` is still passed into `AssistantFeedback` because the PostHog `has_produced_files` field on `trackAssistantFeedbackButtonClick` is unchanged — analytics can still slice feedback by whether the rated turn produced artifacts.
- The four helpers that fed the old `hasArtifactWork` gate (`hasArtifactWorkSignal`, `hasLiveArtifactMutation`, `hasSuccessfulFileMutation`, `isFileMutationToolName`) are removed as dead code.