### PR TITLE
fix(ci): catch nix hash drift before merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       web_tests_required: ${{ steps.detect.outputs.web_tests_required }}
       tools_dev_tests_required: ${{ steps.detect.outputs.tools_dev_tests_required }}
       tools_pack_tests_required: ${{ steps.detect.outputs.tools_pack_tests_required }}
+      nix_validation_required: ${{ steps.detect.outputs.nix_validation_required }}
       workspace_validation_required: ${{ steps.detect.outputs.workspace_validation_required }}
 
     steps:
@@ -49,6 +50,7 @@ jobs:
           web_tests_required=false
           tools_dev_tests_required=false
           tools_pack_tests_required=false
+          nix_validation_required=false
           workspace_validation_required=false
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             gh api --paginate \
@@ -71,16 +73,19 @@ jobs:
               if [[ "$file" == "tools/pack/"* || "$file" == "apps/packaged/"* || "$file" == "apps/desktop/"* || "$file" == "packages/host/"* || "$file" == "packages/platform/"* || "$file" == "packages/sidecar/"* || "$file" == "packages/sidecar-proto/"* ]]; then
                 tools_pack_tests_required=true
               fi
-              if [[ "$file" == "package.json" || "$file" == "pnpm-lock.yaml" || "$file" == "pnpm-workspace.yaml" || "$file" == ".github/workflows/ci.yml" ]]; then
+              if [[ "$file" == "package.json" || "$file" == "apps/"*/"package.json" || "$file" == "packages/"*/"package.json" || "$file" == "tools/"*/"package.json" || "$file" == "e2e/package.json" || "$file" == "pnpm-lock.yaml" || "$file" == "pnpm-workspace.yaml" || "$file" == ".github/workflows/ci.yml" ]]; then
                 daemon_tests_required=true
                 web_tests_required=true
                 tools_dev_tests_required=true
                 tools_pack_tests_required=true
               fi
+              if [[ "$file" == "package.json" || "$file" == "apps/"*/"package.json" || "$file" == "packages/"*/"package.json" || "$file" == "tools/"*/"package.json" || "$file" == "e2e/package.json" || "$file" == "pnpm-lock.yaml" || "$file" == "pnpm-workspace.yaml" || "$file" == "flake.nix" || "$file" == "flake.lock" || "$file" == "nix/"* || "$file" == ".github/workflows/ci.yml" || "$file" == ".github/workflows/nix-check.yml" ]]; then
+                nix_validation_required=true
+              fi
               case "$file" in
                 *.md|*.mdx|*.txt|LICENSE|.gitignore|.editorconfig|.vscode/*|.idea/*|docs/*|.github/ISSUE_TEMPLATE/*|.github/CODEOWNERS)
                   ;;
-                apps/landing-page/*|.github/workflows/landing-page-ci.yml|.github/workflows/landing-page-deploy.yml|.github/workflows/blog-indexing-on-deploy.yml|.github/workflows/blog-indexing-monitor.yml)
+                apps/landing-page/*|flake.nix|flake.lock|nix/*|.github/workflows/nix-check.yml|.github/workflows/landing-page-ci.yml|.github/workflows/landing-page-deploy.yml|.github/workflows/blog-indexing-on-deploy.yml|.github/workflows/blog-indexing-monitor.yml)
                   ;;
                 *)
                   workspace_validation_required=true
@@ -90,6 +95,7 @@ jobs:
                 && [ "$web_tests_required" = "true" ] \
                 && [ "$tools_dev_tests_required" = "true" ] \
                 && [ "$tools_pack_tests_required" = "true" ] \
+                && [ "$nix_validation_required" = "true" ] \
                 && [ "$workspace_validation_required" = "true" ]; then
                 break
               fi
@@ -105,6 +111,7 @@ jobs:
             web_tests_required=true
             tools_dev_tests_required=true
             tools_pack_tests_required=true
+            nix_validation_required=true
             workspace_validation_required=true
           fi
           {
@@ -112,8 +119,30 @@ jobs:
             echo "web_tests_required=$web_tests_required"
             echo "tools_dev_tests_required=$tools_dev_tests_required"
             echo "tools_pack_tests_required=$tools_pack_tests_required"
+            echo "nix_validation_required=$nix_validation_required"
             echo "workspace_validation_required=$workspace_validation_required"
           } >> "$GITHUB_OUTPUT"
+
+  nix_validation:
+    name: Validate Nix flake
+    needs: [change_scopes]
+    if: ${{ needs.change_scopes.outputs.nix_validation_required == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: nix flake check
+        run: nix flake check --print-build-logs --keep-going
 
   preflight:
     name: Preflight
@@ -583,7 +612,9 @@ jobs:
   validate:
     name: Validate workspace
     needs:
+      - change_scopes
       - preflight
+      - nix_validation
       - core_tests
       - app_tests
       - e2e_vitest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ For the full tag dictionary, operational playbook (direct merge / duplicate-titl
 ## Validation strategy
 
 - After package, workspace, or command-entry changes, run `pnpm install` so workspace links and generated dist entries stay fresh.
-- Treat every `pnpm-lock.yaml` change as requiring a Nix pnpm deps hash refresh check. Use `pnpm nix:update-hash` to regenerate `nix/pnpm-deps.nix`, then re-run `nix flake check --print-build-logs --keep-going` (or rely on the PR `Validate workspace` gate if Nix is unavailable locally). `pnpm nix:update-pnpm-deps-hash` remains as a compatibility alias.
+- Treat every `pnpm-lock.yaml` change as requiring a Nix pnpm deps hash refresh check. Use `pnpm nix:update-hash` to regenerate `nix/pnpm-deps.nix`, then re-run `nix flake check --print-build-logs --keep-going` (or rely on the PR `Validate workspace` gate if Nix is unavailable locally).
 - Before marking regular work ready, run at least `pnpm guard` and `pnpm typecheck`, plus the package-scoped tests/builds that match the files changed. Do not use or add root `pnpm test`/`pnpm build` aliases.
 - For local web runtime loops, prefer `pnpm tools-dev run web --daemon-port <port> --web-port <port>`.
 - On a GUI-capable machine, validate desktop by running `pnpm tools-dev`, then `pnpm tools-dev inspect desktop status`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,7 @@ For the full tag dictionary, operational playbook (direct merge / duplicate-titl
 ## Validation strategy
 
 - After package, workspace, or command-entry changes, run `pnpm install` so workspace links and generated dist entries stay fresh.
+- Treat every `pnpm-lock.yaml` change as requiring a Nix pnpm deps hash refresh check. Use `pnpm nix:update-hash` to regenerate `nix/pnpm-deps.nix`, then re-run `nix flake check --print-build-logs --keep-going` (or rely on the PR `Validate workspace` gate if Nix is unavailable locally). `pnpm nix:update-pnpm-deps-hash` remains as a compatibility alias.
 - Before marking regular work ready, run at least `pnpm guard` and `pnpm typecheck`, plus the package-scoped tests/builds that match the files changed. Do not use or add root `pnpm test`/`pnpm build` aliases.
 - For local web runtime loops, prefer `pnpm tools-dev run web --daemon-port <port> --web-port <port>`.
 - On a GUI-capable machine, validate desktop by running `pnpm tools-dev`, then `pnpm tools-dev inspect desktop status`.
@@ -188,6 +189,7 @@ For a worked example of one full loop (red e2e spec → fix → green), see `e2e
 
 ```bash
 pnpm install
+pnpm nix:update-hash
 pnpm tools-dev
 pnpm tools-serve start updater
 pnpm tools-dev start web

--- a/nix/README.md
+++ b/nix/README.md
@@ -220,18 +220,22 @@ Never inline a secret with `pkgs.writeText` or `home.file`.
 
 ## First-build hash pinning
 
-Both `nix/package-daemon.nix` and `nix/package-web.nix` vendor the pnpm
-store via a fixed-output derivation (`pnpmDeps`). The `outputHash`
-defaults to `lib.fakeSha256` so `nix build` will fail with the expected
-hash printed. Copy that value into the matching `pnpmDepsHash` constant
-at the top of each file and re-run. Bump the hash whenever
-`pnpm-lock.yaml` changes.
+`nix/pnpm-deps.nix` is the single source of truth for the vendored pnpm
+store hash used by both `nix/package-daemon.nix` and
+`nix/package-web.nix`. If `pnpm-lock.yaml` changes, temporarily switch the
+`hash = pnpmDepsHash;` line in one of those package files to
+`hash = lib.fakeHash;`, run the relevant `nix build` or
+`nix flake check`, then copy the expected hash back into
+`nix/pnpm-deps.nix`.
 
 ## CI
 
 `.github/workflows/nix-check.yml` runs `nix flake check` on pushes to
-`main` and can also be started manually with `workflow_dispatch`. It is
-not a default pull request gate: the flake is a community installation
-and deployment surface, while regular PR validation stays focused on the
-primary product delivery checks. The flake check already builds the
-`daemon` and `web` checks declared in `flake.nix`.
+`main` and can also be started manually with `workflow_dispatch`.
+
+Pull requests that touch Nix or dependency inputs are validated earlier in
+`.github/workflows/ci.yml` via the required `Validate workspace` gate.
+That PR path runs `nix flake check` when `pnpm-lock.yaml`, package
+manifests, `flake.*`, `nix/**`, or the Nix workflows change, so fixed-
+output hash drift is caught before merge while keeping unrelated PRs off
+the slower Nix path.

--- a/nix/README.md
+++ b/nix/README.md
@@ -222,11 +222,16 @@ Never inline a secret with `pkgs.writeText` or `home.file`.
 
 `nix/pnpm-deps.nix` is the single source of truth for the vendored pnpm
 store hash used by both `nix/package-daemon.nix` and
-`nix/package-web.nix`. If `pnpm-lock.yaml` changes, temporarily switch the
-`hash = pnpmDepsHash;` line in one of those package files to
-`hash = lib.fakeHash;`, run the relevant `nix build` or
-`nix flake check`, then copy the expected hash back into
-`nix/pnpm-deps.nix`.
+`nix/package-web.nix`. If `pnpm-lock.yaml` changes, run:
+
+```bash
+pnpm nix:update-hash
+```
+
+The script temporarily swaps one consumer to `lib.fakeHash`, runs
+`nix build .#web --print-build-logs`, extracts the expected hash from the
+failure output, writes it back into `nix/pnpm-deps.nix`, and restores the
+consumer file.
 
 ## CI
 

--- a/nix/package-daemon.nix
+++ b/nix/package-daemon.nix
@@ -39,12 +39,7 @@ let
   pname = "open-design-daemon";
   version = (lib.importJSON ../package.json).version;
 
-  # Vendored pnpm store. The hash MUST be pinned on first build:
-  # `nix build .#daemon` will fail with the expected hash printed; copy
-  # that into `pnpmDepsHash` below. Bump it whenever pnpm-lock.yaml
-  # changes.
-  pnpmDepsHash = "sha256-TI7gjjF47YIkLblWjG9flG3E1mg310AI5S4uZ+9B2kI=";
-  # pnpmDepsHash = lib.fakeHash;
+  pnpmDepsHash = (import ./pnpm-deps.nix).hash;
 in
   stdenv.mkDerivation (finalAttrs: {
     inherit pname version src;

--- a/nix/package-web.nix
+++ b/nix/package-web.nix
@@ -26,12 +26,7 @@ let
   pname = "open-design-web";
   version = (lib.importJSON ../package.json).version;
 
-  # Vendored pnpm store. The hash MUST be pinned on first build:
-  # `nix build .#web` will fail with the expected hash printed; copy
-  # that into `pnpmDepsHash` below. Bump it whenever pnpm-lock.yaml
-  # changes.
-  pnpmDepsHash = "sha256-TI7gjjF47YIkLblWjG9flG3E1mg310AI5S4uZ+9B2kI=";
-  # pnpmDepsHash = lib.fakeHash;
+  pnpmDepsHash = (import ./pnpm-deps.nix).hash;
 in
   stdenv.mkDerivation (finalAttrs: {
     inherit pname version src;

--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -1,0 +1,9 @@
+{
+  # Vendored pnpm store for the workspace packages built by the flake.
+  #
+  # Refresh this hash whenever pnpm-lock.yaml changes:
+  # 1. Temporarily set the consuming `hash = lib.fakeHash;`
+  # 2. Run the relevant nix build/flake check
+  # 3. Copy the expected hash printed by Nix into `hash` below
+  hash = "sha256-EqvfkMBoYHuGIu8mXYnUjXTUhKVhgqOg32mr2EzPkgs=";
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "tools-pr": "pnpm exec tools-pr",
     "tools-serve": "pnpm exec tools-serve",
     "nix:update-hash": "tsx ./scripts/update-nix-pnpm-deps-hash.ts",
-    "nix:update-pnpm-deps-hash": "pnpm nix:update-hash",
     "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",
     "i18n:coverage": "tsx ./scripts/i18n-coverage-report.ts",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "tools-pack": "pnpm exec tools-pack",
     "tools-pr": "pnpm exec tools-pr",
     "tools-serve": "pnpm exec tools-serve",
+    "nix:update-hash": "tsx ./scripts/update-nix-pnpm-deps-hash.ts",
+    "nix:update-pnpm-deps-hash": "pnpm nix:update-hash",
     "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",
     "i18n:coverage": "tsx ./scripts/i18n-coverage-report.ts",

--- a/scripts/update-nix-pnpm-deps-hash.ts
+++ b/scripts/update-nix-pnpm-deps-hash.ts
@@ -1,0 +1,92 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const consumerPath = path.join(repoRoot, "nix/package-web.nix");
+const sharedHashPath = path.join(repoRoot, "nix/pnpm-deps.nix");
+
+const consumerHashLine = "      hash = pnpmDepsHash;";
+const fakeHashLine = "      hash = lib.fakeHash;";
+const nixCommand = ["build", ".#web", "--print-build-logs"];
+
+function extractExpectedHash(output: string): string | null {
+  const patterns = [
+    /got:\s*(sha256-[A-Za-z0-9+/=]+)/g,
+    /(sha256-[A-Za-z0-9+/=]+)/g,
+  ];
+
+  for (const pattern of patterns) {
+    const matches = [...output.matchAll(pattern)];
+    if (matches.length === 0) {
+      continue;
+    }
+    const hash = matches.at(-1)?.[1];
+    if (hash) {
+      return hash;
+    }
+  }
+
+  return null;
+}
+
+async function main(): Promise<void> {
+  const originalConsumer = await readFile(consumerPath, "utf8");
+  if (!originalConsumer.includes(consumerHashLine)) {
+    throw new Error(
+      `Expected to find \`${consumerHashLine.trim()}\` in ${path.relative(repoRoot, consumerPath)}`,
+    );
+  }
+
+  const fakeHashConsumer = originalConsumer.replace(consumerHashLine, fakeHashLine);
+
+  await writeFile(consumerPath, fakeHashConsumer, "utf8");
+
+  try {
+    const result = spawnSync("nix", nixCommand, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+
+    if (result.error) {
+      throw new Error(`Failed to execute nix: ${result.error.message}`);
+    }
+
+    const combinedOutput = `${result.stdout}${result.stderr}`;
+    const nextHash = extractExpectedHash(combinedOutput);
+    if (!nextHash) {
+      throw new Error(
+        `Could not parse the expected pnpm deps hash from nix output.\n\n${combinedOutput}`,
+      );
+    }
+
+    const originalSharedHash = await readFile(sharedHashPath, "utf8");
+    const updatedSharedHash = originalSharedHash.replace(
+      /hash = "sha256-[A-Za-z0-9+/=]+";/,
+      `hash = "${nextHash}";`,
+    );
+
+    if (updatedSharedHash === originalSharedHash) {
+      throw new Error(
+        `Expected to update the hash assignment in ${path.relative(repoRoot, sharedHashPath)}`,
+      );
+    }
+
+    await writeFile(sharedHashPath, updatedSharedHash, "utf8");
+
+    if (result.status === 0) {
+      process.stdout.write(`nix build succeeded; ${nextHash} is already current.\n`);
+    } else {
+      process.stdout.write(
+        `Updated ${path.relative(repoRoot, sharedHashPath)} to ${nextHash}.\n` +
+          `Re-run \`nix flake check --print-build-logs --keep-going\` to confirm.\n`,
+      );
+    }
+  } finally {
+    await writeFile(consumerPath, originalConsumer, "utf8");
+  }
+}
+
+await main();

--- a/scripts/update-nix-pnpm-deps-hash.ts
+++ b/scripts/update-nix-pnpm-deps-hash.ts
@@ -13,23 +13,8 @@ const nixCommand = ["build", ".#web", "--print-build-logs"];
 const maxNixOutputBufferBytes = 32 * 1024 * 1024;
 
 function extractExpectedHash(output: string): string | null {
-  const patterns = [
-    /got:\s*(sha256-[A-Za-z0-9+/=]+)/g,
-    /(sha256-[A-Za-z0-9+/=]+)/g,
-  ];
-
-  for (const pattern of patterns) {
-    const matches = [...output.matchAll(pattern)];
-    if (matches.length === 0) {
-      continue;
-    }
-    const hash = matches.at(-1)?.[1];
-    if (hash) {
-      return hash;
-    }
-  }
-
-  return null;
+  const matches = [...output.matchAll(/got:\s*(sha256-[A-Za-z0-9+/=]+)/g)];
+  return matches.at(-1)?.[1] ?? null;
 }
 
 async function main(): Promise<void> {
@@ -56,11 +41,18 @@ async function main(): Promise<void> {
       throw new Error(`Failed to execute nix: ${result.error.message}`);
     }
 
+    if (result.status === 0) {
+      throw new Error(
+        "nix build unexpectedly succeeded after replacing the fixed-output hash with lib.fakeHash.",
+      );
+    }
+
     const combinedOutput = `${result.stdout}${result.stderr}`;
     const nextHash = extractExpectedHash(combinedOutput);
     if (!nextHash) {
       throw new Error(
-        `Could not parse the expected pnpm deps hash from nix output.\n\n${combinedOutput}`,
+        "nix build failed without reporting a fixed-output hash mismatch (`got: sha256-...`). " +
+          `Refusing to update ${path.relative(repoRoot, sharedHashPath)}.\n\n${combinedOutput}`,
       );
     }
 

--- a/scripts/update-nix-pnpm-deps-hash.ts
+++ b/scripts/update-nix-pnpm-deps-hash.ts
@@ -10,6 +10,7 @@ const sharedHashPath = path.join(repoRoot, "nix/pnpm-deps.nix");
 const consumerHashLine = "      hash = pnpmDepsHash;";
 const fakeHashLine = "      hash = lib.fakeHash;";
 const nixCommand = ["build", ".#web", "--print-build-logs"];
+const maxNixOutputBufferBytes = 32 * 1024 * 1024;
 
 function extractExpectedHash(output: string): string | null {
   const patterns = [
@@ -47,6 +48,7 @@ async function main(): Promise<void> {
     const result = spawnSync("nix", nixCommand, {
       cwd: repoRoot,
       encoding: "utf8",
+      maxBuffer: maxNixOutputBufferBytes,
       stdio: ["inherit", "pipe", "pipe"],
     });
 

--- a/scripts/update-nix-pnpm-deps-hash.ts
+++ b/scripts/update-nix-pnpm-deps-hash.ts
@@ -71,21 +71,17 @@ async function main(): Promise<void> {
     );
 
     if (updatedSharedHash === originalSharedHash) {
-      throw new Error(
-        `Expected to update the hash assignment in ${path.relative(repoRoot, sharedHashPath)}`,
+      process.stdout.write(
+        `${path.relative(repoRoot, sharedHashPath)} already pins ${nextHash}; no update needed.\n`,
       );
+      return;
     }
 
     await writeFile(sharedHashPath, updatedSharedHash, "utf8");
-
-    if (result.status === 0) {
-      process.stdout.write(`nix build succeeded; ${nextHash} is already current.\n`);
-    } else {
-      process.stdout.write(
-        `Updated ${path.relative(repoRoot, sharedHashPath)} to ${nextHash}.\n` +
-          `Re-run \`nix flake check --print-build-logs --keep-going\` to confirm.\n`,
-      );
-    }
+    process.stdout.write(
+      `Updated ${path.relative(repoRoot, sharedHashPath)} to ${nextHash}.\n` +
+        `Re-run \`nix flake check --print-build-logs --keep-going\` to confirm.\n`,
+    );
   } finally {
     await writeFile(consumerPath, originalConsumer, "utf8");
   }


### PR DESCRIPTION
## Why

`nix-check` was only running after merge on `main`, so fixed-output pnpm hash drift could still land even when the required PR checks were green. The hash was also duplicated in both Nix package builders, which made dependency updates easier to miss.

This moves Nix validation into the already-required `Validate workspace` gate for Nix- and dependency-sensitive PRs, and reduces the hash to one shared source of truth.

## What users will see

- PRs that touch Nix inputs, lockfiles, or workspace manifests now fail before merge when the vendored pnpm hash is stale.
- Post-merge `nix-check` on `main` still runs as a second line of defense.
- Nix maintainers update one shared pnpm deps hash file instead of editing both package builders.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

- Not applicable

## Bug fix verification

- Pre-merge CI now runs `nix flake check` through `Validate workspace` when PRs touch `pnpm-lock.yaml`, workspace package manifests, `flake.*`, `nix/**`, or Nix workflow files.
- Shared `nix/pnpm-deps.nix` updates both daemon and web builders, so hash bumps cannot diverge across the two packages.

## Validation

- `pnpm guard`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/nix-check.yml")'`
- `pnpm typecheck` *(fails on an existing unrelated `apps/desktop` typecheck error: missing `OpenDesignHostProjectReplaceWorkingDirResult` export from `@open-design/host`)*
- `nix flake check --print-build-logs --keep-going` *(not runnable in this environment because `nix` is not installed locally; CI will exercise it on the PR)*