### PR TITLE
fix: prevent CLI path overflow in chat status card

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -14841,6 +14841,10 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   padding: 1px 6px;
   border-radius: 4px;
   color: var(--text-muted);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .op-waiting-hint {
   flex-basis: 100%;


### PR DESCRIPTION
## Summary

Fixes long CLI startup paths overflowing the chat status card boundary.

## What changed

Added text-overflow handling to `.op-waiting-detail`:
- `max-width: 100%` - constrains to parent card width
- `overflow: hidden` - clips overflowing text
- `text-overflow: ellipsis` - shows `...` for truncated content
- `white-space: nowrap` - prevents line wrapping

## Why

The CLI startup status displays the daemon path in a `<code>` element with class `.op-waiting-detail`. Long filesystem paths (common on Linux/macOS with deep project directories) would extend beyond the card boundary, breaking the layout and making the status message hard to read.

## Result

Long CLI paths now truncate cleanly with an ellipsis, staying within the card boundary while still showing the beginning of the path (which typically contains the most relevant context).

Closes #2206