### PR TITLE
fix(web): show feedback prompt on every successful assistant turn (cherry-pick of #2529 into release/v0.8.0)

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -168,7 +168,6 @@ export function AssistantMessage({
       message,
       hasEmptyResponse,
       hasUnfinishedTodos: unfinishedTodos.length > 0,
-      hasArtifactWork: hasArtifactWorkSignal(message, produced.length),
     });
   const showCompletionRow =
     showFeedback ||
@@ -359,56 +358,15 @@ function isFeedbackEligible({
   message,
   hasEmptyResponse,
   hasUnfinishedTodos,
-  hasArtifactWork,
 }: {
   streaming: boolean;
   message: ChatMessage;
   hasEmptyResponse: boolean;
   hasUnfinishedTodos: boolean;
-  hasArtifactWork: boolean;
 }): boolean {
   if (streaming || hasEmptyResponse || hasUnfinishedTodos) return false;
-  if (!hasArtifactWork) return false;
   if (message.runStatus) return message.runStatus === "succeeded";
   return !!message.endedAt;
-}
-
-function hasArtifactWorkSignal(message: ChatMessage, producedFileCount: number): boolean {
-  if (producedFileCount > 0) return true;
-  if (message.content.includes("<artifact")) return true;
-  if (hasLiveArtifactMutation(message.events ?? [])) return true;
-  return hasSuccessfulFileMutation(message.events ?? []);
-}
-
-function hasLiveArtifactMutation(events: AgentEvent[]): boolean {
-  return events.some((event) => {
-    if (event.kind !== "live_artifact") return false;
-    return event.action === "created" || event.action === "updated";
-  });
-}
-
-function hasSuccessfulFileMutation(events: AgentEvent[]): boolean {
-  const errorByToolId = new Map<string, boolean>();
-  for (const event of events) {
-    if (event.kind === "tool_result") {
-      errorByToolId.set(event.toolUseId, event.isError);
-    }
-  }
-  return events.some((event) => {
-    if (event.kind !== "tool_use") return false;
-    if (!isFileMutationToolName(event.name)) return false;
-    return errorByToolId.get(event.id) !== true;
-  });
-}
-
-function isFileMutationToolName(name: string): boolean {
-  return (
-    name === "Write" ||
-    name === "write" ||
-    name === "create_file" ||
-    name === "Edit" ||
-    name === "str_replace_edit"
-  );
 }
 
 function MessageTimestamp({

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -1,10 +1,9 @@
 // @vitest-environment jsdom
 
 /**
- * Visibility-gate coverage for assistant artifact feedback (issue #1288).
- * Feedback should only appear for successful assistant turns that produce
- * or update an artifact, not for text-only acknowledgements, failed runs,
- * streaming turns, or empty responses.
+ * Visibility-gate coverage for the assistant feedback widget. It should
+ * appear after any successfully completed turn, and stay hidden for
+ * streaming turns, failed runs, and empty responses.
  */
 
 import { cleanup, render, screen } from '@testing-library/react';
@@ -61,7 +60,7 @@ function producedFile(name: string): ProjectFile {
   } as ProjectFile;
 }
 
-describe('AssistantMessage feedback gate (issue #1288)', () => {
+describe('AssistantMessage feedback gate', () => {
   it('shows the feedback widget after a successful turn that produced files', () => {
     render(
       <AssistantMessage
@@ -76,11 +75,7 @@ describe('AssistantMessage feedback gate (issue #1288)', () => {
     expect(screen.getByRole('button', { name: 'Not helpful' })).toBeTruthy();
   });
 
-  it('hides the feedback widget for a successful text-only turn with no producedFiles', () => {
-    // Regression for lefarcen P2: the issue scopes feedback to
-    // turns that delivered a final artifact, not every successful
-    // turn. Text-only acknowledgements ("Got it.") must not prompt
-    // for feedback.
+  it('shows the feedback widget for a successful text-only turn with no producedFiles', () => {
     render(
       <AssistantMessage
         message={baseMessage({ producedFiles: [] })}
@@ -89,7 +84,7 @@ describe('AssistantMessage feedback gate (issue #1288)', () => {
         onFeedback={vi.fn()}
       />,
     );
-    expect(screen.queryByRole('group', { name: 'Feedback' })).toBeNull();
+    expect(screen.getByRole('group', { name: 'Feedback' })).toBeTruthy();
   });
 
   it('hides the feedback widget while the turn is still streaming', () => {

--- a/apps/web/tests/components/chat-feedback.test.tsx
+++ b/apps/web/tests/components/chat-feedback.test.tsx
@@ -144,12 +144,12 @@ describe('chat assistant feedback', () => {
     vi.restoreAllMocks();
   });
 
-  it('collects feedback only after an assistant turn produces an artifact', () => {
+  it('collects feedback after any successfully completed assistant turn', () => {
     renderChatPane({
       messages: [completedAssistant()],
     });
 
-    expect(screen.queryByRole('group', { name: 'Feedback' })).toBeNull();
+    expect(screen.getByRole('group', { name: 'Feedback' })).toBeTruthy();
   });
 
   it('collects positive and negative feedback on completed artifact results', () => {


### PR DESCRIPTION
Cherry-pick of #2529 (merged to `main` as `abfe7ba0`) into `release/v0.8.0`.

## Why

So v0.8.0 picks up the same widened feedback widget rule as `main`. Without this, users on the v0.8.0 release channel still see the thumbs-up/down chip only on artifact-producing turns (plugin creation, file writes), but not after home-page example prompts that go through `generate_image` / `generate_video`, MCP tool runs, or plain text answers.

## What users will see

Same as #2529: after any successfully completed assistant turn, the thumbs-up / thumbs-down chip now appears in the footer next to the Done pill — including image, video and audio generations from the home example prompts, MCP tool runs, and plain text answers. Turns still streaming, returning empty, with unfinished todos, or that did not reach `runStatus = "succeeded"` are still excluded.

## Surface area

- [x] **UI** — visibility-rule change for the existing `AssistantFeedback` chip
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — v0.8.0 users will start seeing the feedback chip on turns where it used to be hidden
- [ ] **None**

## Cherry-pick verification

- `git cherry-pick abfe7ba0` applied clean against `release/v0.8.0` at `09399872` (no conflicts).
- Diff matches the merged PR exactly: 3 files, +8/-55.
  - `apps/web/src/components/AssistantMessage.tsx`
  - `apps/web/tests/components/AssistantMessage.test.tsx`
  - `apps/web/tests/components/chat-feedback.test.tsx`
- The original PR went green on every check (Web workspace tests, Playwright critical, visual, build) — see #2529.

## Validation

Skipped local re-run on `release/v0.8.0` (worktree didn't have dependencies installed). Relying on:
- Clean cherry-pick over the current `release/v0.8.0` head
- Green CI on #2529 against `main`
- The PR-branch CI on this PR