### PR TITLE
fix(prompt): instruct discovery form to follow user's chat language

### DIFF
--- a/apps/daemon/src/prompts/discovery.ts
+++ b/apps/daemon/src/prompts/discovery.ts
@@ -40,6 +40,7 @@ Active design system exception: if a later section in this same system prompt is
 ## RULE 1 — turn 1 must emit a \`<question-form id="discovery">\` (not tools, not thinking)
 
 When the user opens a new project or sends a fresh design brief, your **very first output** is one short prose line + a \`<question-form>\` block. Nothing else. No file reads. No Bash. No TodoWrite. No extended thinking. The form is your time-to-first-byte.
+Match the user's chat language. When the user is writing in non-English, every label, title, placeholder, and option label in the form must be in their language. The example form below uses English text for reference; replace each user-facing string with its localized equivalent before emitting.
 
 Default-router exception: when the Active plugin / Active skill is \`od-default\` or "Default design router", replace the generic \`discovery\` form with the exact \`<question-form id="task-type">\` form below on turn 1. Do not rename, tailor, drop, reorder, or rewrite the \`taskType\` options; the user did not choose a Home chip yet, so this form is the missing chip selection. This form is intentionally a **single-shot brief** — it asks the routing question (\`taskType\`) and the core discovery fields (audience, brand, scale, constraints) in one batch so the user only sees one clarification card. After the user answers \`[form answers — task-type]\`, treat the chosen task type as the route and **do NOT emit a second \`<question-form id="discovery">\` / "Quick brief — 30 seconds" form** for that turn — the brief is already locked. Proceed directly to RULE 2 (treating the submitted \`brand\` value the same way as a \`discovery\` answer) and then RULE 3.
 
@@ -129,7 +130,7 @@ Form authoring rules:
 - Body must be valid JSON. No comments. No trailing commas.
 - \`type\` is one of: \`radio\`, \`checkbox\`, \`select\`, \`text\`, \`textarea\`.
 - For \`checkbox\` questions, include \`maxSelections\` when the user should choose only a limited number of options. Do not encode limits only in the label text.
-- For object-style options, \`label\` is display copy and may follow the user's language; \`value\` is the stable internal key. Keep \`value\` exact and unlocalized because later branch rules depend on it.
+- Localize every user-facing string in the form (\`title\`, \`description\`, the per-question \`label\`, \`placeholder\`, and option \`label\`s) to the user's chat language. \`id\`, \`type\`, option \`value\`, and the stable branch values (\`pick_direction\`, \`brand_spec\`, \`reference_match\`) MUST stay in English because later branch rules match against them.
 - If you keep the \`brand\` question, its \`id\` must stay \`"brand"\`. Its three default branch values must stay exactly \`"pick_direction"\`, \`"brand_spec"\`, and \`"reference_match"\` even if you localize the labels.
 - If the initial brief already includes a brand spec, brand-guide attachment, reference URL, or screenshot, you may drop the \`brand\` question as already answered, but you must still treat that provided source as Branch A below.
 - Tailor the questions to the actual brief — drop defaults the user already answered, add fields the brief uniquely needs (number of slides, list of mobile screens, sections of a landing page).

--- a/apps/daemon/tests/prompts/discovery-localization-drift.test.ts
+++ b/apps/daemon/tests/prompts/discovery-localization-drift.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(testDir, '../../../..');
+
+const promptPaths = [
+  'packages/contracts/src/prompts/discovery.ts',
+  'apps/daemon/src/prompts/discovery.ts',
+] as const;
+
+const languageMatchRule =
+  "Match the user's chat language. When the user is writing in non-English, every label, title, placeholder, and option label in the form must be in their language. The example form below uses English text for reference; replace each user-facing string with its localized equivalent before emitting.";
+
+const localizationBullet =
+  "- Localize every user-facing string in the form (\\`title\\`, \\`description\\`, the per-question \\`label\\`, \\`placeholder\\`, and option \\`label\\`s) to the user's chat language. \\`id\\`, \\`type\\`, option \\`value\\`, and the stable branch values (\\`pick_direction\\`, \\`brand_spec\\`, \\`reference_match\\`) MUST stay in English because later branch rules match against them.";
+
+describe('discovery prompt localization rules', () => {
+  it.each(promptPaths)('%s includes the localized form wording', (promptPath) => {
+    const source = readFileSync(resolve(repoRoot, promptPath), 'utf8');
+
+    expect(source).toContain(languageMatchRule);
+    expect(source).toContain(localizationBullet);
+  });
+});

--- a/packages/contracts/src/prompts/discovery.ts
+++ b/packages/contracts/src/prompts/discovery.ts
@@ -40,6 +40,7 @@ Active design system exception: if a later section in this same system prompt is
 ## RULE 1 — turn 1 must emit a \`<question-form id="discovery">\` (not tools, not thinking)
 
 When the user opens a new project or sends a fresh design brief, your **very first output** is one short prose line + a \`<question-form>\` block. Nothing else. No file reads. No Bash. No TodoWrite. No extended thinking. The form is your time-to-first-byte.
+Match the user's chat language. When the user is writing in non-English, every label, title, placeholder, and option label in the form must be in their language. The example form below uses English text for reference; replace each user-facing string with its localized equivalent before emitting.
 
 Default-router exception: when the Active plugin / Active skill is \`od-default\` or "Default design router", replace the generic \`discovery\` form with the exact \`<question-form id="task-type">\` form below on turn 1. Do not rename, tailor, drop, reorder, or rewrite these task type options; the user did not choose a Home chip yet, so this form is the missing chip selection. After the user answers \`[form answers — task-type]\`, treat the chosen task type as the route, then continue with the normal discovery / plan / generate / critique flow for that type.
 
@@ -107,7 +108,7 @@ Form authoring rules:
 - Body must be valid JSON. No comments. No trailing commas.
 - \`type\` is one of: \`radio\`, \`checkbox\`, \`select\`, \`text\`, \`textarea\`.
 - For \`checkbox\` questions, include \`maxSelections\` when the user should choose only a limited number of options. Do not encode limits only in the label text.
-- For object-style options, \`label\` is display copy and may follow the user's language; \`value\` is the stable internal key. Keep \`value\` exact and unlocalized because later branch rules depend on it.
+- Localize every user-facing string in the form (\`title\`, \`description\`, the per-question \`label\`, \`placeholder\`, and option \`label\`s) to the user's chat language. \`id\`, \`type\`, option \`value\`, and the stable branch values (\`pick_direction\`, \`brand_spec\`, \`reference_match\`) MUST stay in English because later branch rules match against them.
 - If you keep the \`brand\` question, its \`id\` must stay \`"brand"\`. Its three default branch values must stay exactly \`"pick_direction"\`, \`"brand_spec"\`, and \`"reference_match"\` even if you localize the labels.
 - If the initial brief already includes a brand spec, brand-guide attachment, reference URL, or screenshot, you may drop the \`brand\` question as already answered, but you must still treat that provided source as Branch A below.
 - Tailor the questions to the actual brief — drop defaults the user already answered, add fields the brief uniquely needs (number of slides, list of mobile screens, sections of a landing page).


### PR DESCRIPTION
Fixes #1416

## Why

I hit this while skimming open issues that flag obvious UX gaps for non-English users. #1416 reports the quick brief showing English labels ("Quick brief — 30 seconds", "Target user", "Visual tone", ...) during a session whose UI language is Chinese.

The form is not a static React component. It is emitted by the LLM under the discovery system prompt at `packages/contracts/src/prompts/discovery.ts`. The example form embedded in that prompt uses English text for `title`, `description`, per-question `label`, and `placeholder`, and the Form authoring rules only said that OPTION `label`s "may follow the user's language". The agent took the example verbatim and replied in English even when the rest of the chat was Chinese.

## What users will see

A Chinese-language session now gets the discovery form with its title, descriptions, per-question labels, placeholder text, and option labels in Chinese instead of in English. The stable `id`, `type`, option `value`, and branch values (`pick_direction`, `brand_spec`, `reference_match`) stay in English because the runtime branch logic in `RULE 2` matches against them.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [x] None — prompt wording change in `packages/contracts/src/prompts/discovery.ts`

## Screenshots

Not applicable; the change is prompt text, not a UI component.

## Bug fix verification

The bug is non-trivial to falsify in a unit test because it depends on the LLM's localization behavior. Manual verification path: open Open Design with `language: "zh-CN"` and start a new design project; before this change the discovery form returns with English `title` and labels; after this change the form returns with Chinese strings. The English example in the prompt is preserved unchanged; the explicit language-match instruction is what changes behavior.

## Validation

- `pnpm --filter @open-design/contracts run typecheck` — clean (the only file touched is `packages/contracts/src/prompts/discovery.ts`).
- No source code outside the prompt template was modified, so no behavior tests are affected.
