### PR TITLE
fix: polish homepage prefilled prompt token UI

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -511,11 +511,11 @@
   display: inline;
   max-width: min(100%, 52ch);
   margin: 0;
-  padding: 0;
+  padding: 0 2px;
   border: 0;
-  border-radius: 5px;
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 16%, transparent);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 14%, transparent);
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
   color: var(--accent);
@@ -538,8 +538,8 @@
 }
 .home-hero__prompt-slot--button:hover,
 .home-hero__prompt-slot--button:focus-visible {
-  background: color-mix(in srgb, var(--accent) 15%, transparent);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 24%, transparent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent);
   outline: none;
 }
 .home-hero__prompt-option-popover {
@@ -590,8 +590,8 @@
   color: #9f3a1a;
 }
 .home-hero__prompt-slot[data-filled='false'] {
-  background: color-mix(in srgb, var(--accent) 7%, transparent);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 12%, transparent);
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 10%, transparent);
   color: color-mix(in srgb, var(--accent) 74%, var(--text-muted));
 }
 .home-hero__prompt-mention {


### PR DESCRIPTION
## Summary

Refines the visual appearance of inline parameter tokens in homepage prefilled prompts to feel more compact and balanced with surrounding text.

## What changed

Optimized `.home-hero__prompt-slot` and related state styles:

**Base state:**
- Reduced `box-shadow` from `2px` to `1px` for lighter visual weight
- Reduced `border-radius` from `5px` to `4px` for tighter appearance  
- Added horizontal `padding: 0 2px` so text doesn't touch edges
- Lightened background from `10%` to `8%` opacity for subtler presence

**Hover/focus state:**
- Reduced `box-shadow` from `2px` to `1px`
- Adjusted background and shadow opacity for consistency

**Unfilled state:**
- Applied same `box-shadow` and background refinements

## Why

The current inline parameter tokens (e.g., aspect ratio chips like "16:9" in Image/Video presets) appear visually oversized and unbalanced relative to the surrounding prompt text. The thick 2px box-shadow ring and lack of internal padding make them feel heavy and awkward, reducing the overall sense of polish in the homepage composer.

## Result

Inline parameter tokens now feel properly sized and weighted relative to the prompt text. The thinner border, tighter radius, and subtle padding create a more refined, cohesive appearance that improves the visual balance of prefilled prompts.

Closes #2086