### PR TITLE
fix: constrain width of numeric inline controls in prompts

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -525,6 +525,12 @@
   line-height: inherit;
   vertical-align: baseline;
 }
+/* Tighter max-width for numeric fields (page count, duration, etc.)
+   so they don't stretch unnecessarily wide in the prompt. */
+.home-hero__prompt-slot[data-field-type='integer'],
+.home-hero__prompt-slot[data-field-type='number'] {
+  max-width: min(100%, 12ch);
+}
 .home-hero__prompt-option-shell {
   position: relative;
   z-index: 3;


### PR DESCRIPTION
## Summary

Fixes oversized numeric inline controls (page count, duration, etc.) in homepage prefilled prompts by constraining their max-width.

## What changed

Added a CSS rule targeting `.home-hero__prompt-slot[data-field-type='integer']` and `[data-field-type='number']`:

- Reduced `max-width` from `52ch` to `12ch` for numeric field tokens
- Keeps the default `52ch` for text/string fields that need more space

## Why

After selecting Slide deck (or other presets with numeric parameters), inline controls like page count stretch unnecessarily wide — up to 52 characters — even though they only display 1-2 digit numbers. This makes the prompt feel visually unbalanced and awkward.

Numeric fields rarely need more than ~12 characters of width (enough for "10 pages" or "30 seconds"), so constraining them creates better visual proportion.

## Result

Numeric inline controls now appear compact and properly sized relative to their content, improving the visual balance and polish of prefilled prompts across all creation types (Slide deck, Video, Audio, etc.).

Closes #2085