### PR TITLE
fix(codex): save detected executable path

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -258,6 +258,12 @@ function codexConfiguredPathSuccessDetail(
   return `This test used the configured Codex path: ${configuredOverridePath}.`;
 }
 
+function codexDetectedPathSuccessDetail(
+  usedExecutablePath: string,
+): string {
+  return `This test used the detected Codex path: ${usedExecutablePath}. Save this path in Execution settings so macOS app launches use the same executable.`;
+}
+
 function codexInvalidConfiguredPathFallbackDetail(
   configuredValue: string,
   pathResolvedPath: string,
@@ -1572,7 +1578,7 @@ export async function testAgentConnection(
   if (
     input.agentId === 'codex' &&
     primaryResult.ok &&
-    configuredCodexBin
+    (configuredCodexBin || executableResolution.pathResolvedPath)
   ) {
     if (executableResolution.configuredOverridePath) {
       return {
@@ -1590,7 +1596,7 @@ export async function testAgentConnection(
         ),
       };
     }
-    if (executableResolution.pathResolvedPath) {
+    if (configuredCodexBin && executableResolution.pathResolvedPath) {
       return {
         ...primaryResult,
         configuredExecutablePath: configuredCodexBin,
@@ -1602,6 +1608,18 @@ export async function testAgentConnection(
             configuredCodexBin,
             executableResolution.pathResolvedPath,
           ),
+        ),
+      };
+    }
+    if (executableResolution.pathResolvedPath) {
+      const usedExecutablePath = executableResolution.launchPath ?? executableResolution.pathResolvedPath;
+      return {
+        ...primaryResult,
+        detectedExecutablePath: executableResolution.pathResolvedPath,
+        usedExecutablePath,
+        usedExecutableSource: 'path',
+        detail: redactSecrets(
+          codexDetectedPathSuccessDetail(usedExecutablePath),
         ),
       };
     }

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1634,25 +1634,34 @@ export async function testAgentConnection(
   ) {
     return primaryResult;
   }
+  const fallbackPrefs = stripCodexBinOverride(validatedPrefs);
+  const fallbackAgentEnv = agentCliEnvForAgent(fallbackPrefs, input.agentId);
+  const fallbackExecutableResolution = def
+    ? resolveAgentLaunch(def, fallbackAgentEnv)
+    : executableResolution;
   const fallbackResult = await testAgentConnectionInternal(
     {
       ...input,
-      agentCliEnv: stripCodexBinOverride(validatedPrefs),
+      agentCliEnv: fallbackPrefs,
     },
   );
   if (!fallbackResult.ok) {
     return primaryResult;
   }
+  const fallbackPathResolvedPath =
+    fallbackExecutableResolution.pathResolvedPath ?? executableResolution.pathResolvedPath;
+  const fallbackUsedExecutablePath =
+    fallbackExecutableResolution.launchPath ?? fallbackPathResolvedPath;
   return {
     ...fallbackResult,
     configuredExecutablePath: executableResolution.configuredOverridePath,
-    detectedExecutablePath: executableResolution.pathResolvedPath,
-    usedExecutablePath: executableResolution.launchPath ?? executableResolution.pathResolvedPath,
+    detectedExecutablePath: fallbackPathResolvedPath,
+    usedExecutablePath: fallbackUsedExecutablePath,
     usedExecutableSource: 'fallback_failed',
     detail: redactSecrets(
       codexExecutableFallbackSuccessDetail(
         executableResolution.configuredOverridePath,
-        executableResolution.pathResolvedPath,
+        fallbackPathResolvedPath,
       ),
     ),
   };

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -86,6 +86,14 @@ async function withFakeCodex<T>(script: string, run: () => Promise<T>): Promise<
   return withFakeAgent('codex', script, run);
 }
 
+function codexNativeTargetTripleForTest(): string {
+  if (process.platform === 'darwin' && process.arch === 'arm64') return 'aarch64-apple-darwin';
+  if (process.platform === 'darwin' && process.arch === 'x64') return 'x86_64-apple-darwin';
+  if (process.platform === 'linux' && process.arch === 'arm64') return 'aarch64-unknown-linux-musl';
+  if (process.platform === 'linux' && process.arch === 'x64') return 'x86_64-unknown-linux-musl';
+  return `${process.platform}-${process.arch}`;
+}
+
 async function withFakeClaude<T>(script: string, run: () => Promise<T>): Promise<T> {
   return withFakeAgent('claude', script, run);
 }
@@ -1168,6 +1176,80 @@ setImmediate(() => process.exit(0));
         });
       },
     );
+  });
+
+  it('returns the Codex executable path that successful connection tests should save', async () => {
+    await withFakeCodex(
+      `
+console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }));
+setImmediate(() => process.exit(0));
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'codex' });
+
+        expect(result).toMatchObject({
+          ok: true,
+          kind: 'success',
+          agentName: 'Codex CLI',
+          usedExecutableSource: 'path',
+          detectedExecutablePath: expect.any(String),
+          usedExecutablePath: expect.any(String),
+        });
+        expect(result.detail).toContain('Save this path in Execution settings');
+      },
+    );
+  });
+
+  it('reports the native Codex launch path instead of the PATH wrapper when available', async () => {
+    if (process.platform === 'win32') return;
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-codex-native-'));
+    const oldPath = process.env.PATH;
+    try {
+      const wrapperPkgDir = path.join(root, 'node_modules', '@openai', 'codex');
+      const wrapperRealPath = path.join(wrapperPkgDir, 'bin', 'codex.js');
+      const wrapperLinkDir = path.join(root, 'node_modules', '.bin');
+      const wrapperLinkPath = path.join(wrapperLinkDir, 'codex');
+      const nativeBin = path.join(
+        root,
+        'node_modules',
+        '@openai',
+        `codex-${process.platform}-${process.arch}`,
+        'vendor',
+        codexNativeTargetTripleForTest(),
+        'codex',
+        'codex',
+      );
+      await fsp.mkdir(path.dirname(wrapperRealPath), { recursive: true });
+      await fsp.mkdir(wrapperLinkDir, { recursive: true });
+      await fsp.mkdir(path.dirname(nativeBin), { recursive: true });
+      await fsp.writeFile(wrapperRealPath, '#!/usr/bin/env node\nrequire("@openai/codex");\n');
+      await fsp.writeFile(
+        nativeBin,
+        `#!/usr/bin/env node
+console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }));
+setImmediate(() => process.exit(0));
+`,
+      );
+      await fsp.chmod(wrapperRealPath, 0o755);
+      await fsp.chmod(nativeBin, 0o755);
+      await fsp.symlink(wrapperRealPath, wrapperLinkPath);
+      process.env.PATH = `${wrapperLinkDir}${path.delimiter}${oldPath ?? ''}`;
+
+      const result = await testAgentConnection({ agentId: 'codex' });
+
+      expect(result).toMatchObject({
+        ok: true,
+        kind: 'success',
+        agentName: 'Codex CLI',
+        usedExecutableSource: 'path',
+        detectedExecutablePath: wrapperLinkPath,
+        usedExecutablePath: nativeBin,
+      });
+      expect(result.detail).toContain(nativeBin);
+    } finally {
+      process.env.PATH = oldPath;
+      await fsp.rm(root, { recursive: true, force: true });
+    }
   });
 
   it('spawns agent tests with draft allowlisted CLI env', async () => {

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1630,45 +1630,74 @@ process.stdin.on('end', () => {
   });
 
   it('falls back to PATH Codex during connection tests when a configured CODEX_BIN fails', async () => {
-    await withFakeCodex(
-      `console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }));\n`,
-      async () => {
-        const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-codex-fallback-'));
-        try {
-          const bin = path.join(dir, 'codex-bad');
-          await fsp.writeFile(
-            bin,
-            `#!/usr/bin/env node\nconsole.error('macOS blocked this Codex binary');\nprocess.exit(1);\n`,
-          );
-          await fsp.chmod(bin, 0o755);
+    if (process.platform === 'win32') return;
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-codex-fallback-'));
+    const badRoot = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-codex-bad-'));
+    const oldPath = process.env.PATH;
+    try {
+      const bin = path.join(badRoot, 'codex-bad');
+      const wrapperPkgDir = path.join(root, 'node_modules', '@openai', 'codex');
+      const wrapperRealPath = path.join(wrapperPkgDir, 'bin', 'codex.js');
+      const wrapperLinkDir = path.join(root, 'node_modules', '.bin');
+      const wrapperLinkPath = path.join(wrapperLinkDir, 'codex');
+      const nativeBin = path.join(
+        root,
+        'node_modules',
+        '@openai',
+        `codex-${process.platform}-${process.arch}`,
+        'vendor',
+        codexNativeTargetTripleForTest(),
+        'codex',
+        'codex',
+      );
+      await fsp.mkdir(path.dirname(wrapperRealPath), { recursive: true });
+      await fsp.mkdir(wrapperLinkDir, { recursive: true });
+      await fsp.mkdir(path.dirname(nativeBin), { recursive: true });
+      await fsp.writeFile(
+        bin,
+        `#!/usr/bin/env node\nconsole.error('macOS blocked this Codex binary');\nprocess.exit(1);\n`,
+      );
+      await fsp.writeFile(wrapperRealPath, '#!/usr/bin/env node\nrequire("@openai/codex");\n');
+      await fsp.writeFile(
+        nativeBin,
+        `#!/usr/bin/env node
+console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } }));
+setImmediate(() => process.exit(0));
+`,
+      );
+      await fsp.chmod(bin, 0o755);
+      await fsp.chmod(wrapperRealPath, 0o755);
+      await fsp.chmod(nativeBin, 0o755);
+      await fsp.symlink(wrapperRealPath, wrapperLinkPath);
+      process.env.PATH = `${wrapperLinkDir}${path.delimiter}${oldPath ?? ''}`;
 
-          const result = await testAgentConnection({
-            agentId: 'codex',
-            agentCliEnv: {
-              codex: {
-                CODEX_BIN: bin,
-              },
-            },
-          });
+      const result = await testAgentConnection({
+        agentId: 'codex',
+        agentCliEnv: {
+          codex: {
+            CODEX_BIN: bin,
+          },
+        },
+      });
 
-          expect(result).toMatchObject({
-            ok: true,
-            kind: 'success',
-            agentName: 'Codex CLI',
-            sample: 'ok',
-            usedExecutableSource: 'fallback_failed',
-            configuredExecutablePath: bin,
-            detectedExecutablePath: expect.any(String),
-            usedExecutablePath: expect.any(String),
-          });
-          expect(result.detail).toContain(`Configured Codex path failed: ${bin}.`);
-          expect(result.detail).toContain('This test succeeded with the PATH Codex CLI at');
-          expect(result.detail).toContain('Update CODEX_BIN or clear the custom path');
-        } finally {
-          await fsp.rm(dir, { recursive: true, force: true });
-        }
-      },
-    );
+      expect(result).toMatchObject({
+        ok: true,
+        kind: 'success',
+        agentName: 'Codex CLI',
+        sample: 'ok',
+        usedExecutableSource: 'fallback_failed',
+        configuredExecutablePath: bin,
+        detectedExecutablePath: wrapperLinkPath,
+        usedExecutablePath: nativeBin,
+      });
+      expect(result.detail).toContain(`Configured Codex path failed: ${bin}.`);
+      expect(result.detail).toContain(`This test succeeded with the PATH Codex CLI at ${wrapperLinkPath}.`);
+      expect(result.detail).toContain('Update CODEX_BIN or clear the custom path');
+    } finally {
+      process.env.PATH = oldPath;
+      await fsp.rm(root, { recursive: true, force: true });
+      await fsp.rm(badRoot, { recursive: true, force: true });
+    }
   });
 
   it('falls back to PATH Codex when a configured shim spawns ENOENT', async () => {

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -186,10 +186,12 @@ export interface AgentRefreshOptions {
 function codexPathStrings(locale: Locale) {
   if (locale === 'zh-CN') {
     return {
-      repairHint: '当前保存的 Codex 路径不适合继续使用。',
-      useDetected: '使用检测到的 Codex',
+      repairHint: '将此 Codex 可执行文件路径保存到执行设置。',
+      useDetected: '保存 Codex 路径',
       clearCustom: '清空自定义路径',
       configuredSuccess: (path: string) => `本次测试使用的是已配置的 Codex 路径：${path}。`,
+      detectedSuccess: (path: string) =>
+        `本次测试使用的是检测到的 Codex 路径：${path}。请将此路径保存到执行设置，以便 macOS 应用启动时使用同一个可执行文件。`,
       invalidFallback: (configuredPath: string, detectedPath: string) =>
         `已配置的 Codex 路径无效或不可执行：${configuredPath}。本次测试改用 PATH 中的 Codex CLI：${detectedPath}。建议更新 CODEX_BIN 或清空自定义路径。`,
       failedFallback: (configuredPath: string, detectedPath: string) =>
@@ -198,10 +200,12 @@ function codexPathStrings(locale: Locale) {
   }
   if (locale === 'zh-TW') {
     return {
-      repairHint: '目前儲存的 Codex 路徑不適合繼續使用。',
-      useDetected: '使用偵測到的 Codex',
+      repairHint: '將此 Codex 可執行檔路徑儲存到執行設定。',
+      useDetected: '儲存 Codex 路徑',
       clearCustom: '清除自訂路徑',
       configuredSuccess: (path: string) => `本次測試使用的是已設定的 Codex 路徑：${path}。`,
+      detectedSuccess: (path: string) =>
+        `本次測試使用的是偵測到的 Codex 路徑：${path}。請將此路徑儲存到執行設定，以便 macOS 應用程式啟動時使用同一個可執行檔。`,
       invalidFallback: (configuredPath: string, detectedPath: string) =>
         `已設定的 Codex 路徑無效或不可執行：${configuredPath}。本次測試改用 PATH 中的 Codex CLI：${detectedPath}。建議更新 CODEX_BIN 或清除自訂路徑。`,
       failedFallback: (configuredPath: string, detectedPath: string) =>
@@ -209,11 +213,13 @@ function codexPathStrings(locale: Locale) {
     };
   }
   return {
-    repairHint: 'The saved Codex path is not the binary this test should keep using.',
-    useDetected: 'Use detected Codex',
+    repairHint: 'Save this Codex executable path in Execution settings.',
+    useDetected: 'Save Codex path',
     clearCustom: 'Clear custom path',
     configuredSuccess: (path: string) =>
       `This test used the configured Codex path: ${path}.`,
+    detectedSuccess: (path: string) =>
+      `This test used the detected Codex path: ${path}. Save this path in Execution settings so macOS app launches use the same executable.`,
     invalidFallback: (configuredPath: string, detectedPath: string) =>
       `Configured Codex path is invalid or not executable: ${configuredPath}. This test used the PATH Codex CLI at ${detectedPath}. Update CODEX_BIN or clear the custom path to use the detected binary.`,
     failedFallback: (configuredPath: string, detectedPath: string) =>
@@ -664,18 +670,25 @@ function apiModelOptionLabel(model: ProviderModelOption): string {
     : model.id;
 }
 
-function codexPathRepairState(
+export function codexPathRepairState(
+  cfg: AppConfig,
   result: ConnectionTestResponse,
 ): { detectedPath: string; canUseDetected: boolean } | null {
   if (!result.ok) return null;
   if (
+    result.usedExecutableSource !== 'path' &&
     result.usedExecutableSource !== 'fallback_invalid' &&
     result.usedExecutableSource !== 'fallback_failed'
   ) {
     return null;
   }
-  const detectedPath = result.detectedExecutablePath?.trim() || '';
+  const detectedPath =
+    result.usedExecutablePath?.trim() ||
+    result.detectedExecutablePath?.trim() ||
+    '';
   if (!detectedPath) return null;
+  const savedPath = cfg.agentCliEnv?.codex?.CODEX_BIN?.trim() || '';
+  if (savedPath === detectedPath) return null;
   return {
     detectedPath,
     canUseDetected: true,
@@ -1417,6 +1430,12 @@ export function SettingsDialog({
           result.configuredExecutablePath
         ) {
           return `${baseMessage} ${codexStrings.configuredSuccess(result.configuredExecutablePath)}`;
+        }
+        if (
+          result.usedExecutableSource === 'path' &&
+          result.usedExecutablePath
+        ) {
+          return `${baseMessage} ${codexStrings.detectedSuccess(result.usedExecutablePath)}`;
         }
         if (
           result.usedExecutableSource === 'fallback_invalid' &&
@@ -2487,6 +2506,7 @@ export function SettingsDialog({
                                     ) : null}
                                     {cfg.agentId === 'codex' && (() => {
                                       const repair = codexPathRepairState(
+                                        cfg,
                                         agentTestState.result,
                                       );
                                       if (!repair) return null;

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -192,10 +192,18 @@ function codexPathStrings(locale: Locale) {
       configuredSuccess: (path: string) => `本次测试使用的是已配置的 Codex 路径：${path}。`,
       detectedSuccess: (path: string) =>
         `本次测试使用的是检测到的 Codex 路径：${path}。请将此路径保存到执行设置，以便 macOS 应用启动时使用同一个可执行文件。`,
-      invalidFallback: (configuredPath: string, detectedPath: string) =>
-        `已配置的 Codex 路径无效或不可执行：${configuredPath}。本次测试改用 PATH 中的 Codex CLI：${detectedPath}。建议更新 CODEX_BIN 或清空自定义路径。`,
-      failedFallback: (configuredPath: string, detectedPath: string) =>
-        `已配置的 Codex 路径启动失败：${configuredPath}。本次测试改用 PATH 中的 Codex CLI：${detectedPath}。建议更新 CODEX_BIN 或清空自定义路径。`,
+      invalidFallback: (
+        configuredPath: string,
+        launchedPath: string,
+        pathWrapper?: string,
+      ) =>
+        `已配置的 Codex 路径无效或不可执行：${configuredPath}。本次测试启动的 Codex 可执行文件是：${launchedPath}。${pathWrapper ? `PATH 中检测到的 Codex CLI 是：${pathWrapper}。` : ''}建议更新 CODEX_BIN 或清空自定义路径。`,
+      failedFallback: (
+        configuredPath: string,
+        launchedPath: string,
+        pathWrapper?: string,
+      ) =>
+        `已配置的 Codex 路径启动失败：${configuredPath}。本次测试启动的 Codex 可执行文件是：${launchedPath}。${pathWrapper ? `PATH 中检测到的 Codex CLI 是：${pathWrapper}。` : ''}建议更新 CODEX_BIN 或清空自定义路径。`,
     };
   }
   if (locale === 'zh-TW') {
@@ -206,10 +214,18 @@ function codexPathStrings(locale: Locale) {
       configuredSuccess: (path: string) => `本次測試使用的是已設定的 Codex 路徑：${path}。`,
       detectedSuccess: (path: string) =>
         `本次測試使用的是偵測到的 Codex 路徑：${path}。請將此路徑儲存到執行設定，以便 macOS 應用程式啟動時使用同一個可執行檔。`,
-      invalidFallback: (configuredPath: string, detectedPath: string) =>
-        `已設定的 Codex 路徑無效或不可執行：${configuredPath}。本次測試改用 PATH 中的 Codex CLI：${detectedPath}。建議更新 CODEX_BIN 或清除自訂路徑。`,
-      failedFallback: (configuredPath: string, detectedPath: string) =>
-        `已設定的 Codex 路徑啟動失敗：${configuredPath}。本次測試改用 PATH 中的 Codex CLI：${detectedPath}。建議更新 CODEX_BIN 或清除自訂路徑。`,
+      invalidFallback: (
+        configuredPath: string,
+        launchedPath: string,
+        pathWrapper?: string,
+      ) =>
+        `已設定的 Codex 路徑無效或不可執行：${configuredPath}。本次測試啟動的 Codex 可執行檔是：${launchedPath}。${pathWrapper ? `PATH 中偵測到的 Codex CLI 是：${pathWrapper}。` : ''}建議更新 CODEX_BIN 或清除自訂路徑。`,
+      failedFallback: (
+        configuredPath: string,
+        launchedPath: string,
+        pathWrapper?: string,
+      ) =>
+        `已設定的 Codex 路徑啟動失敗：${configuredPath}。本次測試啟動的 Codex 可執行檔是：${launchedPath}。${pathWrapper ? `PATH 中偵測到的 Codex CLI 是：${pathWrapper}。` : ''}建議更新 CODEX_BIN 或清除自訂路徑。`,
     };
   }
   return {
@@ -220,11 +236,64 @@ function codexPathStrings(locale: Locale) {
       `This test used the configured Codex path: ${path}.`,
     detectedSuccess: (path: string) =>
       `This test used the detected Codex path: ${path}. Save this path in Execution settings so macOS app launches use the same executable.`,
-    invalidFallback: (configuredPath: string, detectedPath: string) =>
-      `Configured Codex path is invalid or not executable: ${configuredPath}. This test used the PATH Codex CLI at ${detectedPath}. Update CODEX_BIN or clear the custom path to use the detected binary.`,
-    failedFallback: (configuredPath: string, detectedPath: string) =>
-      `Configured Codex path failed: ${configuredPath}. This test succeeded with the PATH Codex CLI at ${detectedPath}. Update CODEX_BIN or clear the custom path to use the detected binary.`,
+    invalidFallback: (
+      configuredPath: string,
+      launchedPath: string,
+      pathWrapper?: string,
+    ) =>
+      `Configured Codex path is invalid or not executable: ${configuredPath}. This test launched Codex at ${launchedPath}.${pathWrapper ? ` PATH resolved to ${pathWrapper}.` : ''} Update CODEX_BIN or clear the custom path to use the launched binary.`,
+    failedFallback: (
+      configuredPath: string,
+      launchedPath: string,
+      pathWrapper?: string,
+    ) =>
+      `Configured Codex path failed: ${configuredPath}. This test launched Codex at ${launchedPath}.${pathWrapper ? ` PATH resolved to ${pathWrapper}.` : ''} Update CODEX_BIN or clear the custom path to use the launched binary.`,
   };
+}
+
+export function codexConnectionSuccessMessageSuffix(
+  locale: Locale,
+  result: ConnectionTestResponse,
+): string | null {
+  const codexStrings = codexPathStrings(locale);
+  if (
+    result.usedExecutableSource === 'configured' &&
+    result.configuredExecutablePath
+  ) {
+    return codexStrings.configuredSuccess(result.configuredExecutablePath);
+  }
+  if (
+    result.usedExecutableSource === 'path' &&
+    result.usedExecutablePath
+  ) {
+    return codexStrings.detectedSuccess(result.usedExecutablePath);
+  }
+  if (
+    (result.usedExecutableSource === 'fallback_invalid' ||
+      result.usedExecutableSource === 'fallback_failed') &&
+    result.configuredExecutablePath
+  ) {
+    const launchedPath =
+      result.usedExecutablePath?.trim() ||
+      result.detectedExecutablePath?.trim() ||
+      '';
+    if (!launchedPath) return null;
+    const pathWrapper =
+      result.detectedExecutablePath?.trim() &&
+      result.detectedExecutablePath.trim() !== launchedPath
+        ? result.detectedExecutablePath.trim()
+        : undefined;
+    const fallbackMessage =
+      result.usedExecutableSource === 'fallback_invalid'
+        ? codexStrings.invalidFallback
+        : codexStrings.failedFallback;
+    return fallbackMessage(
+      result.configuredExecutablePath,
+      launchedPath,
+      pathWrapper,
+    );
+  }
+  return null;
 }
 
 function sanitizeHttpsUrl(url: string | undefined): string | undefined {
@@ -1429,38 +1498,9 @@ export function SettingsDialog({
         ? t('settings.testSuccessApi', { ms, sample })
         : t('settings.testSuccessCli', { agentName, ms, sample });
       if (kindForSuccess === 'cli' && cfg.agentId === 'codex') {
-        const codexStrings = codexPathStrings(locale);
-        if (
-          result.usedExecutableSource === 'configured' &&
-          result.configuredExecutablePath
-        ) {
-          return `${baseMessage} ${codexStrings.configuredSuccess(result.configuredExecutablePath)}`;
-        }
-        if (
-          result.usedExecutableSource === 'path' &&
-          result.usedExecutablePath
-        ) {
-          return `${baseMessage} ${codexStrings.detectedSuccess(result.usedExecutablePath)}`;
-        }
-        if (
-          result.usedExecutableSource === 'fallback_invalid' &&
-          result.configuredExecutablePath &&
-          result.detectedExecutablePath
-        ) {
-          return `${baseMessage} ${codexStrings.invalidFallback(
-            result.configuredExecutablePath,
-            result.detectedExecutablePath,
-          )}`;
-        }
-        if (
-          result.usedExecutableSource === 'fallback_failed' &&
-          result.configuredExecutablePath &&
-          result.detectedExecutablePath
-        ) {
-          return `${baseMessage} ${codexStrings.failedFallback(
-            result.configuredExecutablePath,
-            result.detectedExecutablePath,
-          )}`;
+        const codexSuffix = codexConnectionSuccessMessageSuffix(locale, result);
+        if (codexSuffix) {
+          return `${baseMessage} ${codexSuffix}`;
         }
       }
       return result.detail ? `${baseMessage} ${result.detail}` : baseMessage;

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -673,7 +673,11 @@ function apiModelOptionLabel(model: ProviderModelOption): string {
 export function codexPathRepairState(
   cfg: AppConfig,
   result: ConnectionTestResponse,
-): { detectedPath: string; canUseDetected: boolean } | null {
+): {
+  detectedPath: string;
+  canUseDetected: boolean;
+  hasSavedCustomPath: boolean;
+} | null {
   if (!result.ok) return null;
   if (
     result.usedExecutableSource !== 'path' &&
@@ -692,6 +696,7 @@ export function codexPathRepairState(
   return {
     detectedPath,
     canUseDetected: true,
+    hasSavedCustomPath: Boolean(savedPath),
   };
 }
 
@@ -2530,13 +2535,15 @@ export function SettingsDialog({
                                                 {codexStrings.useDetected}
                                               </button>
                                             ) : null}
-                                            <button
-                                              type="button"
-                                              className="ghost icon-btn settings-rescan-btn"
-                                              onClick={clearCodexCustomPath}
-                                            >
-                                              {codexStrings.clearCustom}
-                                            </button>
+                                            {repair.hasSavedCustomPath ? (
+                                              <button
+                                                type="button"
+                                                className="ghost icon-btn settings-rescan-btn"
+                                                onClick={clearCodexCustomPath}
+                                              >
+                                                {codexStrings.clearCustom}
+                                              </button>
+                                            ) : null}
                                           </div>
                                         </div>
                                       );

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -3,6 +3,7 @@ import {
   agentRefreshOptionsForConfig,
   canFetchProviderModels,
   canRunProviderConnectionTest,
+  codexPathRepairState,
   deriveComposioCredentialState,
   configForManualOrbitRun,
   isOrbitRunDisabled,
@@ -396,6 +397,43 @@ describe('SettingsDialog agent CLI env settings', () => {
       throwOnError: true,
       agentCliEnv: {},
     });
+  });
+
+  it('offers to save the detected Codex launch path when no executable path is configured', () => {
+    const result: ConnectionTestResponse = {
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      agentName: 'Codex CLI',
+      usedExecutableSource: 'path',
+      detectedExecutablePath: '/opt/homebrew/bin/codex',
+      usedExecutablePath: '/Users/test/.npm/_npx/codex-native',
+    };
+
+    expect(codexPathRepairState(baseConfig, result)).toEqual({
+      detectedPath: '/Users/test/.npm/_npx/codex-native',
+      canUseDetected: true,
+    });
+  });
+
+  it('does not offer a Codex path action when the used executable is already saved', () => {
+    const config: AppConfig = {
+      ...baseConfig,
+      agentCliEnv: {
+        codex: { CODEX_BIN: '/Users/test/bin/codex' },
+      },
+    };
+    const result: ConnectionTestResponse = {
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      agentName: 'Codex CLI',
+      usedExecutableSource: 'path',
+      detectedExecutablePath: '/opt/homebrew/bin/codex',
+      usedExecutablePath: '/Users/test/bin/codex',
+    };
+
+    expect(codexPathRepairState(config, result)).toBeNull();
   });
 });
 

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -413,6 +413,31 @@ describe('SettingsDialog agent CLI env settings', () => {
     expect(codexPathRepairState(baseConfig, result)).toEqual({
       detectedPath: '/Users/test/.npm/_npx/codex-native',
       canUseDetected: true,
+      hasSavedCustomPath: false,
+    });
+  });
+
+  it('marks Codex repair state as having a saved custom path only when one exists', () => {
+    const config: AppConfig = {
+      ...baseConfig,
+      agentCliEnv: {
+        codex: { CODEX_BIN: '/Users/test/bin/stale-codex' },
+      },
+    };
+    const result: ConnectionTestResponse = {
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      agentName: 'Codex CLI',
+      usedExecutableSource: 'fallback_invalid',
+      detectedExecutablePath: '/opt/homebrew/bin/codex',
+      usedExecutablePath: '/Users/test/.npm/_npx/codex-native',
+    };
+
+    expect(codexPathRepairState(config, result)).toEqual({
+      detectedPath: '/Users/test/.npm/_npx/codex-native',
+      canUseDetected: true,
+      hasSavedCustomPath: true,
     });
   });
 

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -3,6 +3,7 @@ import {
   agentRefreshOptionsForConfig,
   canFetchProviderModels,
   canRunProviderConnectionTest,
+  codexConnectionSuccessMessageSuffix,
   codexPathRepairState,
   deriveComposioCredentialState,
   configForManualOrbitRun,
@@ -507,6 +508,42 @@ describe('deriveComposioCredentialState', () => {
     expect(
       deriveComposioCredentialState({ apiKey: '   \t\n', apiKeyConfigured: true }),
     ).toBe('saved');
+  });
+});
+
+describe('SettingsDialog Codex connection test messaging', () => {
+  it('describes the launched Codex binary for fallback-invalid wrapper resolution', () => {
+    const result: ConnectionTestResponse = {
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      agentName: 'Codex CLI',
+      usedExecutableSource: 'fallback_invalid',
+      configuredExecutablePath: '/Users/test/bin/stale-codex',
+      detectedExecutablePath: '/opt/homebrew/bin/codex',
+      usedExecutablePath: '/Users/test/.npm/_npx/codex-native',
+    };
+
+    expect(codexConnectionSuccessMessageSuffix('en', result)).toBe(
+      'Configured Codex path is invalid or not executable: /Users/test/bin/stale-codex. This test launched Codex at /Users/test/.npm/_npx/codex-native. PATH resolved to /opt/homebrew/bin/codex. Update CODEX_BIN or clear the custom path to use the launched binary.',
+    );
+  });
+
+  it('describes the launched Codex binary for fallback-failed wrapper resolution', () => {
+    const result: ConnectionTestResponse = {
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      agentName: 'Codex CLI',
+      usedExecutableSource: 'fallback_failed',
+      configuredExecutablePath: '/Users/test/bin/broken-codex',
+      detectedExecutablePath: '/opt/homebrew/bin/codex',
+      usedExecutablePath: '/Users/test/.npm/_npx/codex-native',
+    };
+
+    expect(codexConnectionSuccessMessageSuffix('en', result)).toBe(
+      'Configured Codex path failed: /Users/test/bin/broken-codex. This test launched Codex at /Users/test/.npm/_npx/codex-native. PATH resolved to /opt/homebrew/bin/codex. Update CODEX_BIN or clear the custom path to use the launched binary.',
+    );
   });
 });
 


### PR DESCRIPTION
Closes #1912

## Why

A macOS user hit Codex connection-test failures from the app even though Codex was installed. The connection test could resolve and launch a Codex executable path that was different from the PATH shim, but Settings did not surface that successful launch path for persistence unless it was repairing a stale custom CODEX_BIN.

This PR makes the successful test path actionable so users can pin the exact Codex executable in Execution settings and avoid macOS GUI PATH/shim drift.

## What users will see

After a successful Codex connection test with no saved Codex executable path, Settings shows a “Save Codex path” action. The saved value is the executable actually launched by the daemon, including the native Codex binary when the resolver upgrades from a PATH wrapper. Existing stale custom-path repair actions continue to work.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not captured; this is a conditional Settings action shown only after a local Codex connection-test result. The UI state is covered by the Settings helper tests.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/connection-test.test.ts` verifies Codex connection tests return the executable path to save, including native launch path instead of PATH wrapper; `apps/web/tests/components/SettingsDialog.test.ts` verifies Settings offers to save that path and suppresses the action once it is already saved.
- Did the test go red on `main` and green on this branch? No; I added the regression tests in this branch and verified they pass.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/daemon test -- connection-test.test.ts`
- `pnpm --filter @open-design/web test -- SettingsDialog.test.ts`
- `pnpm guard`
- `pnpm typecheck`