### PR TITLE
Add folder upload support to chat attachments

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -1237,7 +1237,7 @@ export function registerProjectUploadRoutes(app: Express, ctx: RegisterProjectUp
                 req.params.id,
                 targetPath,
                 buffer,
-                undefined,
+                { overwrite: false },
                 project?.metadata,
               );
               await fs.promises.unlink(f.path).catch(() => {});

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -1206,7 +1206,7 @@ export function registerProjectUploadRoutes(app: Express, ctx: RegisterProjectUp
   const { fs } = ctx.node;
   const { PROJECTS_DIR } = ctx.paths;
   const { getProject } = ctx.projectStore;
-  const { writeProjectFile } = ctx.projectFiles;
+  const { writeProjectFile, resolveProjectFilePath } = ctx.projectFiles;
 
   app.post(
     '/api/projects/:id/upload',
@@ -1226,6 +1226,16 @@ export function registerProjectUploadRoutes(app: Express, ctx: RegisterProjectUp
           throw err;
         }
         const project = getProject(db, req.params.id);
+        for (const targetPath of targetPaths) {
+          if (!targetPath) continue;
+          try {
+            await resolveProjectFilePath(PROJECTS_DIR, req.params.id, targetPath, project?.metadata);
+            await Promise.all(incoming.map((f: any) => fs.promises.unlink(f.path).catch(() => {})));
+            return sendApiError(res, 409, 'CONFLICT', `project file already exists: ${targetPath}`);
+          } catch (err: any) {
+            if (!err || err.code !== 'ENOENT') throw err;
+          }
+        }
         const out = [];
         for (const [index, f] of incoming.entries()) {
           try {

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -8,6 +8,11 @@ import { ArtifactPublicationBlockedError } from './artifact-publication-guard.js
 import { ArtifactRegressionError } from './artifact-stub-guard.js';
 import { listDesignSystems } from './design-systems.js';
 import {
+  ProjectUploadPathError,
+  projectUploadRelativePaths,
+  resolveProjectUploadRelativePath,
+} from './project-upload-guards.js';
+import {
   FIRST_PARTY_ATOMS,
   buildConnectorProbe,
   getInstalledPlugin,
@@ -1192,12 +1197,16 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
 
 }
 
-export interface RegisterProjectUploadRoutesDeps extends RouteDeps<'http' | 'uploads' | 'node'> {}
+export interface RegisterProjectUploadRoutesDeps extends RouteDeps<'db' | 'http' | 'uploads' | 'node' | 'paths' | 'projectStore' | 'projectFiles'> {}
 
 export function registerProjectUploadRoutes(app: Express, ctx: RegisterProjectUploadRoutesDeps) {
+  const { db } = ctx;
   const { sendApiError } = ctx.http;
   const { handleProjectUpload } = ctx.uploads;
   const { fs } = ctx.node;
+  const { PROJECTS_DIR } = ctx.paths;
+  const { getProject } = ctx.projectStore;
+  const { writeProjectFile } = ctx.projectFiles;
 
   app.post(
     '/api/projects/:id/upload',
@@ -1205,17 +1214,44 @@ export function registerProjectUploadRoutes(app: Express, ctx: RegisterProjectUp
     async (req, res) => {
       try {
         const incoming = Array.isArray(req.files) ? req.files : [];
+        const requestedPaths = projectUploadRelativePaths((req.body as any)?.paths, incoming.length);
+        let targetPaths: Array<string | null>;
+        try {
+          targetPaths = requestedPaths.map(resolveProjectUploadRelativePath);
+        } catch (err: any) {
+          await Promise.all(incoming.map((f: any) => fs.promises.unlink(f.path).catch(() => {})));
+          if (err instanceof ProjectUploadPathError) {
+            return sendApiError(res, 400, err.code, err.message);
+          }
+          throw err;
+        }
+        const project = getProject(db, req.params.id);
         const out = [];
-        for (const f of incoming) {
+        for (const [index, f] of incoming.entries()) {
           try {
-            const stat = await fs.promises.stat(f.path);
-            out.push({
-              name: f.filename,
-              path: f.filename,
-              size: stat.size,
-              mtime: stat.mtimeMs,
-              originalName: f.originalname,
-            });
+            const targetPath = targetPaths[index];
+            if (targetPath) {
+              const buffer = await fs.promises.readFile(f.path);
+              const meta = await writeProjectFile(
+                PROJECTS_DIR,
+                req.params.id,
+                targetPath,
+                buffer,
+                undefined,
+                project?.metadata,
+              );
+              await fs.promises.unlink(f.path).catch(() => {});
+              out.push({ ...meta, originalName: f.originalname });
+            } else {
+              const stat = await fs.promises.stat(f.path);
+              out.push({
+                name: f.filename,
+                path: f.filename,
+                size: stat.size,
+                mtime: stat.mtimeMs,
+                originalName: f.originalname,
+              });
+            }
           } catch {
             // skip files that vanished mid-flight
           }

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -1253,6 +1253,7 @@ export function registerProjectUploadRoutes(app: Express, ctx: RegisterProjectUp
               });
             }
           } catch {
+            await fs.promises.unlink(f.path).catch(() => {});
             // skip files that vanished mid-flight
           }
         }

--- a/apps/daemon/src/project-upload-guards.ts
+++ b/apps/daemon/src/project-upload-guards.ts
@@ -1,0 +1,57 @@
+import { sanitizePath, validateProjectPath } from './projects.js';
+
+const PROJECT_UPLOAD_SKIP_SEGMENTS = new Set([
+  '.git',
+  '.hg',
+  '.next',
+  '.nuxt',
+  '.svn',
+  '.turbo',
+  '.vercel',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'target',
+]);
+const PROJECT_UPLOAD_SKIP_NAMES = new Set(['.ds_store', 'thumbs.db']);
+
+export class ProjectUploadPathError extends Error {
+  code = 'BAD_UPLOAD_PATH';
+}
+
+export function projectUploadRelativePaths(raw: unknown, count: number): string[] {
+  const values = Array.isArray(raw)
+    ? raw
+    : raw == null
+      ? []
+      : [raw];
+  return Array.from({ length: count }, (_, index) => {
+    const value = values[index];
+    return typeof value === 'string' ? value : '';
+  });
+}
+
+export function resolveProjectUploadRelativePath(raw: string): string | null {
+  const normalizedInput = raw.replace(/\\/g, '/').split('/').filter(Boolean).join('/');
+  if (!normalizedInput) return null;
+  let validated: string;
+  try {
+    validated = validateProjectPath(normalizedInput);
+  } catch {
+    throw new ProjectUploadPathError('invalid upload path');
+  }
+  if (isBlockedProjectUploadPath(validated)) {
+    throw new ProjectUploadPathError('sensitive or generated folder files are not accepted');
+  }
+  return sanitizePath(validated);
+}
+
+function isBlockedProjectUploadPath(value: string): boolean {
+  const parts = value.toLowerCase().split('/').filter(Boolean);
+  const leaf = parts[parts.length - 1] ?? '';
+  if (leaf === '.env' || leaf.startsWith('.env.')) return true;
+  if (PROJECT_UPLOAD_SKIP_NAMES.has(leaf)) return true;
+  return parts.some((part) => PROJECT_UPLOAD_SKIP_SEGMENTS.has(part));
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10058,7 +10058,7 @@ export async function startServer({
                 req.params.id,
                 targetPath,
                 buffer,
-                undefined,
+                { overwrite: false },
                 project?.metadata,
               );
               await fs.promises.unlink(f.path).catch(() => {});

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -351,6 +351,11 @@ import {
   writeProjectFile,
   reconcileHtmlArtifactManifest,
 } from './projects.js';
+import {
+  ProjectUploadPathError,
+  projectUploadRelativePaths,
+  resolveProjectUploadRelativePath,
+} from './project-upload-guards.js';
 import { validateArtifactManifestInput } from './artifact-manifest.js';
 import { ArtifactPublicationBlockedError } from './artifact-publication-guard.js';
 import { readCurrentAppVersionInfo } from './app-version.js';
@@ -10019,7 +10024,9 @@ export async function startServer({
   });
 
   // Multi-file upload that the chat composer uses for paste/drop/picker.
-  // Files land flat in the project folder; the response carries the same
+  // Browser folder uploads include a per-file relative path so the daemon can
+  // preserve the tree; ordinary files keep the existing flat, timestamped path.
+  // The response carries the same
   // metadata as listFiles so the client can stage them as ChatAttachments
   // without a separate refetch.
   app.post(
@@ -10028,17 +10035,44 @@ export async function startServer({
     async (req, res) => {
       try {
         const incoming = Array.isArray(req.files) ? req.files : [];
+        const requestedPaths = projectUploadRelativePaths(req.body?.paths, incoming.length);
+        let targetPaths;
+        try {
+          targetPaths = requestedPaths.map(resolveProjectUploadRelativePath);
+        } catch (err) {
+          await Promise.all(incoming.map((f) => fs.promises.unlink(f.path).catch(() => {})));
+          if (err instanceof ProjectUploadPathError) {
+            return sendApiError(res, 400, err.code, err.message);
+          }
+          throw err;
+        }
+        const project = getProject(db, req.params.id);
         const out = [];
-        for (const f of incoming) {
+        for (const [index, f] of incoming.entries()) {
           try {
-            const stat = await fs.promises.stat(f.path);
-            out.push({
-              name: f.filename,
-              path: f.filename,
-              size: stat.size,
-              mtime: stat.mtimeMs,
-              originalName: f.originalname,
-            });
+            const targetPath = targetPaths[index];
+            if (targetPath) {
+              const buffer = await fs.promises.readFile(f.path);
+              const meta = await writeProjectFile(
+                PROJECTS_DIR,
+                req.params.id,
+                targetPath,
+                buffer,
+                undefined,
+                project?.metadata,
+              );
+              await fs.promises.unlink(f.path).catch(() => {});
+              out.push({ ...meta, originalName: f.originalname });
+            } else {
+              const stat = await fs.promises.stat(f.path);
+              out.push({
+                name: f.filename,
+                path: f.filename,
+                size: stat.size,
+                mtime: stat.mtimeMs,
+                originalName: f.originalname,
+              });
+            }
           } catch {
             // skip files that vanished mid-flight
           }
@@ -10061,7 +10095,15 @@ export async function startServer({
   // main: file-upload routes lifted to a dedicated module. Keep alongside the
   // inline routes garnet still owns above; duplicate registrations resolve in
   // a follow-up after route-routes.ts vs garnet inline coverage is audited.
-  registerProjectUploadRoutes(app, { http: httpDeps, uploads: uploadDeps, node: nodeDeps });
+  registerProjectUploadRoutes(app, {
+    db,
+    http: httpDeps,
+    uploads: uploadDeps,
+    node: nodeDeps,
+    paths: pathDeps,
+    projectStore: projectStoreDeps,
+    projectFiles: projectFileDeps,
+  });
 
   const composeDaemonSystemPrompt = async ({
     agentId,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10047,6 +10047,16 @@ export async function startServer({
           throw err;
         }
         const project = getProject(db, req.params.id);
+        for (const targetPath of targetPaths) {
+          if (!targetPath) continue;
+          try {
+            await resolveProjectFilePath(PROJECTS_DIR, req.params.id, targetPath, project?.metadata);
+            await Promise.all(incoming.map((f) => fs.promises.unlink(f.path).catch(() => {})));
+            return sendApiError(res, 409, 'CONFLICT', `project file already exists: ${targetPath}`);
+          } catch (err) {
+            if (!err || err.code !== 'ENOENT') throw err;
+          }
+        }
         const out = [];
         for (const [index, f] of incoming.entries()) {
           try {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10074,6 +10074,7 @@ export async function startServer({
               });
             }
           } catch {
+            await fs.promises.unlink(f.path).catch(() => {});
             // skip files that vanished mid-flight
           }
         }

--- a/apps/daemon/tests/artifact-manifest-reconcile-on-run-end.test.ts
+++ b/apps/daemon/tests/artifact-manifest-reconcile-on-run-end.test.ts
@@ -141,8 +141,9 @@ describe('run-end artifact manifest reconciliation (#2893)', () => {
     const pastTime = new Date('2020-01-01T00:00:00Z');
     fs.utimesSync(oldPath, pastTime, pastTime);
 
-    // Run starts here — record the timestamp before the run writes files
-    const runStartTimeMs = Date.now();
+    // Run starts here — use a small guard margin so filesystem timestamp
+    // rounding cannot make the following write look older than run start.
+    const runStartTimeMs = Date.now() - 1000;
 
     // File written during the run
     await writeProjectFile(projectsRoot, PROJECT_ID, 'new-output.html', '<p>new</p>');

--- a/apps/daemon/tests/project-upload-folders.test.ts
+++ b/apps/daemon/tests/project-upload-folders.test.ts
@@ -57,6 +57,38 @@ describe('project folder upload route', () => {
     expect(await raw.text()).toBe('component');
   });
 
+  it('does not overwrite an existing project file when the same folder path is uploaded again', async () => {
+    const projectId = await createProject();
+    const firstForm = new FormData();
+    firstForm.append('paths', 'demo/src/App.tsx');
+    firstForm.append('files', new File(['first'], 'App.tsx', { type: 'text/plain' }));
+
+    const firstResp = await fetch(`${baseUrl}/api/projects/${projectId}/upload`, {
+      method: 'POST',
+      body: firstForm,
+    });
+    expect(firstResp.status).toBe(200);
+
+    const secondForm = new FormData();
+    secondForm.append('paths', 'demo/src/App.tsx');
+    secondForm.append('files', new File(['second'], 'App.tsx', { type: 'text/plain' }));
+
+    const secondResp = await fetch(`${baseUrl}/api/projects/${projectId}/upload`, {
+      method: 'POST',
+      body: secondForm,
+    });
+
+    expect(secondResp.status).toBe(200);
+    const body = (await secondResp.json()) as {
+      files: Array<{ name: string; path?: string; originalName?: string }>;
+    };
+    expect(body.files).toEqual([]);
+
+    const raw = await fetch(`${baseUrl}/api/projects/${projectId}/raw/demo/src/App.tsx`);
+    expect(raw.status).toBe(200);
+    expect(await raw.text()).toBe('first');
+  });
+
   it('rejects sensitive folder paths before exposing them as project files', async () => {
     const projectId = await createProject();
     const form = new FormData();

--- a/apps/daemon/tests/project-upload-folders.test.ts
+++ b/apps/daemon/tests/project-upload-folders.test.ts
@@ -87,6 +87,13 @@ describe('project folder upload route', () => {
     const raw = await fetch(`${baseUrl}/api/projects/${projectId}/raw/demo/src/App.tsx`);
     expect(raw.status).toBe(200);
     expect(await raw.text()).toBe('first');
+
+    const filesResp = await fetch(`${baseUrl}/api/projects/${projectId}/files`);
+    expect(filesResp.status).toBe(200);
+    const filesBody = (await filesResp.json()) as {
+      files: Array<{ name: string; path?: string }>;
+    };
+    expect(filesBody.files.map((file) => file.path ?? file.name).sort()).toEqual(['demo/src/App.tsx']);
   });
 
   it('rejects sensitive folder paths before exposing them as project files', async () => {

--- a/apps/daemon/tests/project-upload-folders.test.ts
+++ b/apps/daemon/tests/project-upload-folders.test.ts
@@ -1,0 +1,78 @@
+import type http from 'node:http';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+describe('project folder upload route', () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+  });
+
+  afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+  async function createProject() {
+    const id = `folder-upload-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const resp = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, name: id }),
+    });
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { project: { id: string } };
+    return body.project.id;
+  }
+
+  it('preserves browser folder relative paths in the project', async () => {
+    const projectId = await createProject();
+    const form = new FormData();
+    form.append('paths', 'demo/src/Button.tsx');
+    form.append('files', new File(['component'], 'Button.tsx', { type: 'text/plain' }));
+
+    const resp = await fetch(`${baseUrl}/api/projects/${projectId}/upload`, {
+      method: 'POST',
+      body: form,
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as {
+      files: Array<{ name: string; path?: string; originalName?: string }>;
+    };
+    expect(body.files).toHaveLength(1);
+    expect(body.files[0]).toMatchObject({
+      name: 'demo/src/Button.tsx',
+      path: 'demo/src/Button.tsx',
+      originalName: 'Button.tsx',
+    });
+
+    const raw = await fetch(`${baseUrl}/api/projects/${projectId}/raw/demo/src/Button.tsx`);
+    expect(raw.status).toBe(200);
+    expect(await raw.text()).toBe('component');
+  });
+
+  it('rejects sensitive folder paths before exposing them as project files', async () => {
+    const projectId = await createProject();
+    const form = new FormData();
+    form.append('paths', 'demo/.env.local');
+    form.append('files', new File(['placeholder=value'], '.env.local', { type: 'text/plain' }));
+
+    const resp = await fetch(`${baseUrl}/api/projects/${projectId}/upload`, {
+      method: 'POST',
+      body: form,
+    });
+
+    expect(resp.status).toBe(400);
+    const body = await resp.json();
+    expect(JSON.stringify(body)).toContain('sensitive or generated folder files are not accepted');
+
+    const raw = await fetch(`${baseUrl}/api/projects/${projectId}/raw/demo/.env.local`);
+    expect(raw.status).toBe(404);
+  });
+});

--- a/apps/daemon/tests/project-upload-folders.test.ts
+++ b/apps/daemon/tests/project-upload-folders.test.ts
@@ -78,15 +78,61 @@ describe('project folder upload route', () => {
       body: secondForm,
     });
 
-    expect(secondResp.status).toBe(200);
+    expect(secondResp.status).toBe(409);
     const body = (await secondResp.json()) as {
-      files: Array<{ name: string; path?: string; originalName?: string }>;
+      error?: { code?: string; message?: string };
     };
-    expect(body.files).toEqual([]);
+    expect(body.error?.code).toBe('CONFLICT');
+    expect(body.error?.message).toContain('demo/src/App.tsx');
 
     const raw = await fetch(`${baseUrl}/api/projects/${projectId}/raw/demo/src/App.tsx`);
     expect(raw.status).toBe(200);
     expect(await raw.text()).toBe('first');
+
+    const filesResp = await fetch(`${baseUrl}/api/projects/${projectId}/files`);
+    expect(filesResp.status).toBe(200);
+    const filesBody = (await filesResp.json()) as {
+      files: Array<{ name: string; path?: string }>;
+    };
+    expect(filesBody.files.map((file) => file.path ?? file.name).sort()).toEqual(['demo/src/App.tsx']);
+  });
+
+  it('rejects a conflicting folder batch before writing later files', async () => {
+    const projectId = await createProject();
+    const firstForm = new FormData();
+    firstForm.append('paths', 'demo/src/App.tsx');
+    firstForm.append('files', new File(['first'], 'App.tsx', { type: 'text/plain' }));
+
+    const firstResp = await fetch(`${baseUrl}/api/projects/${projectId}/upload`, {
+      method: 'POST',
+      body: firstForm,
+    });
+    expect(firstResp.status).toBe(200);
+
+    const secondForm = new FormData();
+    secondForm.append('paths', 'demo/src/App.tsx');
+    secondForm.append('paths', 'demo/src/Later.tsx');
+    secondForm.append('files', new File(['second'], 'App.tsx', { type: 'text/plain' }));
+    secondForm.append('files', new File(['later'], 'Later.tsx', { type: 'text/plain' }));
+
+    const secondResp = await fetch(`${baseUrl}/api/projects/${projectId}/upload`, {
+      method: 'POST',
+      body: secondForm,
+    });
+
+    expect(secondResp.status).toBe(409);
+    const error = (await secondResp.json()) as {
+      error?: { code?: string; message?: string };
+    };
+    expect(error.error?.code).toBe('CONFLICT');
+    expect(error.error?.message).toContain('demo/src/App.tsx');
+
+    const original = await fetch(`${baseUrl}/api/projects/${projectId}/raw/demo/src/App.tsx`);
+    expect(original.status).toBe(200);
+    expect(await original.text()).toBe('first');
+
+    const later = await fetch(`${baseUrl}/api/projects/${projectId}/raw/demo/src/Later.tsx`);
+    expect(later.status).toBe(404);
 
     const filesResp = await fetch(`${baseUrl}/api/projects/${projectId}/files`);
     expect(filesResp.status).toBe(200);

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -66,6 +66,22 @@ const USER_PLUGIN_SOURCE_KINDS = new Set<PluginSourceKind>([
 
 const COMPOSER_TEXTAREA_MIN_HEIGHT = 88;
 const COMPOSER_TEXTAREA_MAX_HEIGHT = 184;
+const CHAT_FOLDER_UPLOAD_SKIP_SEGMENTS = new Set([
+  '.git',
+  '.hg',
+  '.next',
+  '.nuxt',
+  '.svn',
+  '.turbo',
+  '.vercel',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'target',
+]);
+const CHAT_FOLDER_UPLOAD_SKIP_NAMES = new Set(['.ds_store', 'thumbs.db']);
 
 function composerTextareaMaxHeight(): number {
   if (typeof window === 'undefined') return COMPOSER_TEXTAREA_MAX_HEIGHT;
@@ -278,6 +294,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     const [toolsOpen, setToolsOpen] = useState(false);
     const [toolsTab, setToolsTab] = useState<ToolsTab>('plugins');
     const fileInputRef = useRef<HTMLInputElement | null>(null);
+    const folderInputRef = useRef<HTMLInputElement | null>(null);
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
     const composingRef = useRef(false);
     const toolsMenuRef = useRef<HTMLDivElement | null>(null);
@@ -787,17 +804,25 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
 
     async function uploadFiles(files: File[]) {
       if (files.length === 0) return;
+      const { accepted, skipped } = selectChatUploadFiles(files);
+      if (accepted.length === 0) {
+        if (skipped > 0) setUploadError(`Skipped ${skipped} sensitive or generated folder file(s).`);
+        return;
+      }
       const id = await ensureProject();
-      if (!id) return;
+      if (!id) {
+        setUploadError('Start a conversation before attaching files.');
+        return;
+      }
       setUploading(true);
-      setUploadError(null);
+      setUploadError(skipped > 0 ? `Skipped ${skipped} sensitive or generated folder file(s).` : null);
       // Cohort math is identical to the Design Files Upload button; see
       // `analytics/upload-tracking.ts`. v2 doc fires one
       // file_upload_result per surface so this path reports
       // `page_name='chat_panel'` / `area='chat_composer'`.
       const cohort = deriveUploadCohort(files);
       try {
-        const result = await uploadProjectFiles(id, files);
+        const result = await uploadProjectFiles(id, accepted);
         if (result.uploaded.length > 0) {
           setStaged((s) => [...s, ...result.uploaded]);
         }
@@ -808,8 +833,8 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           const detail = result.error ? ` (${result.error})` : '';
           setUploadError(
             uploadedCount > 0
-              ? `Attached ${uploadedCount} file(s), but ${failedCount} failed${detail}.`
-              : `Attachment upload failed for ${failedCount} file(s)${detail}.`,
+              ? `Attached ${uploadedCount} file(s), but ${failedCount} failed${detail}.${skipped > 0 ? ` Skipped ${skipped} sensitive or generated folder file(s).` : ''}`
+              : `Attachment upload failed for ${failedCount} file(s)${detail}.${skipped > 0 ? ` Skipped ${skipped} sensitive or generated folder file(s).` : ''}`,
           );
           console.warn('Some attachments failed to upload', result.failed);
         }
@@ -1562,6 +1587,19 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                 e.target.value = '';
               }}
             />
+            <input
+              ref={folderInputRef}
+              data-testid="chat-folder-input"
+              type="file"
+              multiple
+              style={{ display: 'none' }}
+              onChange={(e) => {
+                const files = Array.from(e.target.files ?? []);
+                void uploadFiles(files);
+                e.target.value = '';
+              }}
+              {...({ webkitdirectory: '', directory: '' } as Record<string, string>)}
+            />
             <div className="composer-tools-wrap">
               <button
                 ref={toolsTriggerRef}
@@ -1725,6 +1763,27 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                 <Icon name="spinner" size={15} />
               ) : (
                 <Icon name="attach" size={15} />
+              )}
+            </button>
+            <button
+              className="icon-btn"
+              data-testid="chat-attach-folder"
+              onClick={() => {
+                trackChatPanelClick(analytics.track, {
+                  page_name: 'chat_panel',
+                  area: 'chat_panel',
+                  element: 'attachment',
+                });
+                folderInputRef.current?.click();
+              }}
+              title="Attach folder"
+              disabled={uploading}
+              aria-label="Attach folder"
+            >
+              {uploading ? (
+                <Icon name="spinner" size={15} />
+              ) : (
+                <Icon name="folder" size={15} />
               )}
             </button>
             {footerAccessory}
@@ -2777,6 +2836,31 @@ function saveComposerDraft(key: string | undefined, draft: string) {
   } catch {
     // Storage can be unavailable in privacy modes; the composer should still work.
   }
+}
+
+function selectChatUploadFiles(files: File[]): { accepted: File[]; skipped: number } {
+  const accepted: File[] = [];
+  let skipped = 0;
+  for (const file of files) {
+    if (shouldSkipChatUploadFile(file)) skipped += 1;
+    else accepted.push(file);
+  }
+  return { accepted, skipped };
+}
+
+function shouldSkipChatUploadFile(file: File): boolean {
+  const path = chatUploadRelativePath(file).toLowerCase();
+  if (!path) return true;
+  const parts = path.split('/').filter(Boolean);
+  const leaf = parts.at(-1) ?? '';
+  if (leaf === '.env' || leaf.startsWith('.env.')) return true;
+  if (CHAT_FOLDER_UPLOAD_SKIP_NAMES.has(leaf)) return true;
+  return parts.some((part) => CHAT_FOLDER_UPLOAD_SKIP_SEGMENTS.has(part));
+}
+
+function chatUploadRelativePath(file: File): string {
+  const browserPath = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+  return (browserPath || file.name).replace(/\\/g, '/').split('/').filter(Boolean).join('/');
 }
 
 function looksLikeImage(name: string): boolean {

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -2849,7 +2849,9 @@ function selectChatUploadFiles(files: File[]): { accepted: File[]; skipped: numb
 }
 
 function shouldSkipChatUploadFile(file: File): boolean {
-  const path = chatUploadRelativePath(file).toLowerCase();
+  const browserPath = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+  if (!browserPath) return false;
+  const path = normalizeChatUploadPath(browserPath).toLowerCase();
   if (!path) return true;
   const parts = path.split('/').filter(Boolean);
   const leaf = parts.at(-1) ?? '';
@@ -2860,7 +2862,11 @@ function shouldSkipChatUploadFile(file: File): boolean {
 
 function chatUploadRelativePath(file: File): string {
   const browserPath = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
-  return (browserPath || file.name).replace(/\\/g, '/').split('/').filter(Boolean).join('/');
+  return normalizeChatUploadPath(browserPath || file.name);
+}
+
+function normalizeChatUploadPath(path: string): string {
+  return path.replace(/\\/g, '/').split('/').filter(Boolean).join('/');
 }
 
 function looksLikeImage(name: string): boolean {

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1655,6 +1655,23 @@ export interface UploadProjectFilesResult {
   error?: string;
 }
 
+function parseProjectUploadError(
+  payload: { code?: string; error?: string | { code?: string; message?: string }; message?: string } | null,
+  status: number,
+): { code?: string; message: string } {
+  const nestedError = typeof payload?.error === 'object' ? payload.error : undefined;
+  const message =
+    nestedError?.message ??
+    (typeof payload?.error === 'string' ? payload.error : undefined) ??
+    payload?.message ??
+    `upload failed (${status})`;
+  const code = nestedError?.code ?? payload?.code;
+  return {
+    message,
+    ...(typeof code === 'string' && code.length > 0 ? { code } : {}),
+  };
+}
+
 export async function uploadProjectFiles(
   projectId: string,
   files: File[],
@@ -1682,14 +1699,15 @@ export async function uploadProjectFiles(
 
       if (!resp.ok) {
         const payload = (await resp.json().catch(() => null)) as
-          | { code?: string; error?: string }
+          | { code?: string; error?: string | { code?: string; message?: string }; message?: string }
           | null;
-        error = payload?.error ?? `upload failed (${resp.status})`;
+        const apiError = parseProjectUploadError(payload, resp.status);
+        error = apiError.message;
         for (const f of batch) {
-          failed.push({ name: f.name, code: payload?.code, error: error });
+          failed.push({ name: f.name, code: apiError.code, error });
         }
         for (const f of remaining) {
-          failed.push({ name: f.name, code: payload?.code, error: error });
+          failed.push({ name: f.name, code: apiError.code, error });
         }
         break;
       }

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1637,7 +1637,8 @@ export async function uploadProjectFile(
 }
 
 // Multi-file project upload used by the chat composer's paste / drop /
-// picker. Each file lands flat in the project folder; the response is
+// picker. Folder-picked files send their browser relative path so the daemon
+// can keep their tree shape; ordinary file uploads still land flat. The response is
 // reshaped into ChatAttachments so the composer can stage them without a
 // follow-up listFiles round-trip.
 const PROJECT_UPLOAD_BATCH_SIZE = 12;
@@ -1668,7 +1669,10 @@ export async function uploadProjectFiles(
     const batch = files.slice(i, i + PROJECT_UPLOAD_BATCH_SIZE);
     const remaining = files.slice(i + PROJECT_UPLOAD_BATCH_SIZE);
     const form = new FormData();
-    for (const f of batch) form.append('files', f);
+    for (const f of batch) {
+      form.append('paths', projectUploadRelativePath(f));
+      form.append('files', f);
+    }
 
     try {
       const resp = await fetch(
@@ -1698,7 +1702,7 @@ export async function uploadProjectFiles(
         ...responseFiles.map((f) => ({
           path: f.path,
           name: f.originalName ?? f.name,
-          kind: looksLikeImage(f.name) ? ('image' as const) : ('file' as const),
+          kind: looksLikeImage(f.path || f.name) ? ('image' as const) : ('file' as const),
           size: f.size,
         })),
       );
@@ -1725,6 +1729,11 @@ export async function uploadProjectFiles(
   }
 
   return { uploaded, failed, error };
+}
+
+function projectUploadRelativePath(file: File): string {
+  const browserPath = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+  return browserPath?.replace(/\\/g, '/').split('/').filter(Boolean).join('/') ?? '';
 }
 
 // Stable URL that serves a project file with its original mime — for

--- a/apps/web/tests/components/ChatComposer.search.test.tsx
+++ b/apps/web/tests/components/ChatComposer.search.test.tsx
@@ -116,6 +116,70 @@ describe('ChatComposer /search command', () => {
     expect(await screen.findByText('Button.tsx')).toBeTruthy();
   });
 
+  it('keeps explicitly selected dot-env files uploadable', async () => {
+    mockedUploadProjectFiles.mockResolvedValue({
+      uploaded: [{ path: '.env', name: '.env', kind: 'file', size: 11 }],
+      failed: [],
+    });
+
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const file = new File(['API_KEY=dev'], '.env', { type: 'text/plain' });
+    fireEvent.change(screen.getByTestId('chat-file-input'), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => expect(mockedUploadProjectFiles).toHaveBeenCalledWith('project-1', [file]));
+    expect(await screen.findByText('.env')).toBeTruthy();
+    expect(screen.queryByText(/Skipped 1 sensitive or generated folder file/)).toBeNull();
+  });
+
+  it('skips sensitive files discovered inside folder uploads', async () => {
+    mockedUploadProjectFiles.mockResolvedValue({
+      uploaded: [{ path: 'demo/src/Button.tsx', name: 'Button.tsx', kind: 'file', size: 9 }],
+      failed: [],
+    });
+
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const accepted = new File(['component'], 'Button.tsx', { type: 'text/plain' });
+    Object.defineProperty(accepted, 'webkitRelativePath', {
+      value: 'demo/src/Button.tsx',
+      configurable: true,
+    });
+    const skipped = new File(['API_KEY=dev'], '.env', { type: 'text/plain' });
+    Object.defineProperty(skipped, 'webkitRelativePath', {
+      value: 'demo/.env',
+      configurable: true,
+    });
+
+    fireEvent.change(screen.getByTestId('chat-folder-input'), {
+      target: { files: [accepted, skipped] },
+    });
+
+    await waitFor(() => expect(mockedUploadProjectFiles).toHaveBeenCalledWith('project-1', [accepted]));
+    expect(await screen.findByText('Button.tsx')).toBeTruthy();
+    expect(screen.getByText('Skipped 1 sensitive or generated folder file(s).')).toBeTruthy();
+  });
+
   it('shows a clear attachment error when no project can be created yet', async () => {
     render(
       <ChatComposer

--- a/apps/web/tests/components/ChatComposer.search.test.tsx
+++ b/apps/web/tests/components/ChatComposer.search.test.tsx
@@ -84,7 +84,59 @@ describe('ChatComposer /search command', () => {
     expect(onSend).toHaveBeenCalledWith('follow-up while busy', [], [], undefined);
   });
 
-  it('auto-sends concurrent queued visual annotations when streaming ends', async () => {
+  it('uploads browser-selected folders with native directory input paths intact', async () => {
+    mockedUploadProjectFiles.mockResolvedValue({
+      uploaded: [{ path: 'demo/src/Button.tsx', name: 'Button.tsx', kind: 'file', size: 9 }],
+      failed: [],
+    });
+
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const folderInput = screen.getByTestId('chat-folder-input') as HTMLInputElement;
+    expect(folderInput.hasAttribute('webkitdirectory')).toBe(true);
+    const file = new File(['component'], 'Button.tsx', { type: 'text/plain' });
+    Object.defineProperty(file, 'webkitRelativePath', {
+      value: 'demo/src/Button.tsx',
+      configurable: true,
+    });
+    fireEvent.change(folderInput, {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => expect(mockedUploadProjectFiles).toHaveBeenCalledWith('project-1', [file]));
+    expect(await screen.findByText('Button.tsx')).toBeTruthy();
+  });
+
+  it('shows a clear attachment error when no project can be created yet', async () => {
+    render(
+      <ChatComposer
+        projectId={null}
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('chat-file-input'), {
+      target: { files: [new File(['brief'], 'brief.txt', { type: 'text/plain' })] },
+    });
+
+    expect(await screen.findByText('Start a conversation before attaching files.')).toBeTruthy();
+    expect(mockedUploadProjectFiles).not.toHaveBeenCalled();
+  });
+
+  it('keeps concurrent queued visual annotations distinct after uploads resolve', async () => {
     const onSend = vi.fn();
     const firstUpload = deferred<Awaited<ReturnType<typeof uploadProjectFiles>>>();
     const secondUpload = deferred<Awaited<ReturnType<typeof uploadProjectFiles>>>();

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -759,6 +759,46 @@ describe('uploadProjectFiles', () => {
       { path: 't1-brief.txt', name: 'brief.txt', kind: 'file', size: 4 },
     ]);
   });
+
+  it('surfaces nested daemon error details for rejected folder batches', async () => {
+    const existing = new File(['component'], 'App.tsx', { type: 'text/plain' });
+    Object.defineProperty(existing, 'webkitRelativePath', {
+      value: 'demo/src/App.tsx',
+      configurable: true,
+    });
+    const later = new File(['later'], 'Later.tsx', { type: 'text/plain' });
+    Object.defineProperty(later, 'webkitRelativePath', {
+      value: 'demo/src/Later.tsx',
+      configurable: true,
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({
+        error: {
+          code: 'CONFLICT',
+          message: 'project file already exists: demo/src/App.tsx',
+        },
+      }), { status: 409 })),
+    );
+
+    const result = await uploadProjectFiles('project-1', [existing, later]);
+
+    expect(result.uploaded).toEqual([]);
+    expect(result.error).toBe('project file already exists: demo/src/App.tsx');
+    expect(result.failed).toEqual([
+      {
+        name: 'App.tsx',
+        code: 'CONFLICT',
+        error: 'project file already exists: demo/src/App.tsx',
+      },
+      {
+        name: 'Later.tsx',
+        code: 'CONFLICT',
+        error: 'project file already exists: demo/src/App.tsx',
+      },
+    ]);
+  });
 });
 
 describe('deploy provider registry helpers', () => {

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -726,6 +726,39 @@ describe('uploadProjectFiles', () => {
     expect(result.failed).toHaveLength(1);
     expect(result.failed[0]).toMatchObject({ name: 'c.txt' });
   });
+
+  it('sends browser folder relative paths alongside uploaded files', async () => {
+    const folderFile = new File(['component'], 'Button.tsx', { type: 'text/plain' });
+    Object.defineProperty(folderFile, 'webkitRelativePath', {
+      value: 'demo/src/Button.tsx',
+      configurable: true,
+    });
+    const flatFile = new File(['flat'], 'brief.txt', { type: 'text/plain' });
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = init?.body as FormData;
+      expect(body.getAll('paths')).toEqual(['demo/src/Button.tsx', '']);
+      expect(body.getAll('files')).toEqual([folderFile, flatFile]);
+      return new Response(JSON.stringify({
+        files: [
+          { name: 'demo/src/Button.tsx', path: 'demo/src/Button.tsx', size: 9, originalName: 'Button.tsx' },
+          { name: 't1-brief.txt', path: 't1-brief.txt', size: 4, originalName: 'brief.txt' },
+        ],
+      }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await uploadProjectFiles('project-1', [folderFile, flatFile]);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/projects/project-1/upload', expect.objectContaining({
+      method: 'POST',
+      body: expect.any(FormData),
+    }));
+    expect(result.failed).toEqual([]);
+    expect(result.uploaded).toEqual([
+      { path: 'demo/src/Button.tsx', name: 'Button.tsx', kind: 'file', size: 9 },
+      { path: 't1-brief.txt', name: 'brief.txt', kind: 'file', size: 4 },
+    ]);
+  });
 });
 
 describe('deploy provider registry helpers', () => {


### PR DESCRIPTION
## Summary

- add a chat attachment folder picker that uses the browser native directory input
- send each selected file webkitRelativePath with the upload request so folder structure is preserved
- reject traversal, sensitive, and generated folder paths before writing uploaded files into a project
- keep directly selected single files uploadable even when their names match the folder skip list
- surface a clear attachment error when a project cannot be created yet

Fixes #211.

## Surface area

- [x] **UI** - new folder attachment picker in the chat composer
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** - upload requests preserve folder-relative paths for daemon project uploads
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys
- [ ] **New top-level dependency** - adding any new entry to the root `package.json`
- [ ] **Default behavior change** - changes what existing users experience without opting in
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

- CI visual capture for head `6e79531e`: <https://github.com/nexu-io/open-design/pull/2542#issuecomment-4506212002>
- The folder picker opens a browser-native directory chooser, so the app-side screenshot covers the chat attachment entry point rather than the OS file dialog.

## Validation

- `corepack pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/ChatComposer.search.test.tsx --pool=threads --maxWorkers=1 --no-isolate --reporter verbose --testTimeout=10000 --hookTimeout=10000` (1 file / 16 tests passed)
- `corepack pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/project-upload-folders.test.ts --pool=threads --maxWorkers=1 --no-isolate --reporter verbose --testTimeout=20000 --hookTimeout=20000` (1 file / 2 tests passed)
- `corepack pnpm --filter @open-design/web typecheck` (passed; local Node v22 engine warning only, repo requests `~24`)
- `corepack pnpm guard` (passed; local Node v22 engine warning only, repo requests `~24`)
- `git diff --check` (passed)
- `git diff | gitleaks detect --pipe --redact --no-banner` (no leaks)
- `git diff --check HEAD~1..HEAD` (passed)
- `git show --format= --patch HEAD | gitleaks detect --pipe --redact --no-banner` (no leaks)

No manual browser/E2E smoke was run locally.