### PR TITLE
feat(desktop): follow OS language in packaged builds

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -69,6 +69,32 @@ export {
 
 const TOOLS_DEV_PARENT_PID_ENV = SIDECAR_ENV.TOOLS_DEV_PARENT_PID;
 
+// Argv prefix the preload uses to recover the OS locale main process
+// read at startup. The renderer wires `__od__.client.osLocale` from it.
+export const OS_LOCALE_PRELOAD_ARG_PREFIX = "--od-os-locale=";
+
+/**
+ * Read the OS preferred language and, when Electron has not yet
+ * emitted `ready`, point Chromium's `--lang` flag at it so the
+ * renderer's `navigator.language` follows the OS instead of falling
+ * back to en-US. Returns the resolved BCP-47 string so callers can
+ * forward it to `BrowserWindow.webPreferences.additionalArguments`
+ * for the preload to expose to the renderer.
+ *
+ * Safe to call multiple times: `appendSwitch('lang', ...)` is a no-op
+ * once `app.isReady()` is true. The packaged entry calls this once
+ * before its own `whenReady` (so the switch lands) and `runDesktopMain`
+ * calls it again later to recover the same string for the BrowserWindow.
+ */
+export function applyOsLocaleSwitch(electronApp: Electron.App): string {
+  const preferred = electronApp.getPreferredSystemLanguages?.() ?? [];
+  const osLocale = preferred[0] ?? "en";
+  if (!electronApp.isReady()) {
+    electronApp.commandLine.appendSwitch("lang", osLocale);
+  }
+  return osLocale;
+}
+
 export type DesktopMainOptions = {
   beforeShutdown?: () => Promise<void>;
   discoverWebUrl?: () => Promise<string | null>;
@@ -289,6 +315,13 @@ export async function runDesktopMain(
   // helper is promoted to a shared workspace package.
   attachDesktopProcessErrorFilter();
 
+  // dev (tools-dev) enters here without a prior `whenReady` — so this
+  // is where the `--lang` switch actually lands. In packaged builds
+  // `apps/packaged/src/index.ts` has already applied the switch before
+  // its own `whenReady`; this call is then a no-op for the switch and
+  // only recovers the locale string for the BrowserWindow below.
+  const osLocale = applyOsLocaleSwitch(app);
+
   await app.whenReady();
 
   // PR #974: mint a per-process auth secret and hand it to the daemon
@@ -367,6 +400,7 @@ export async function runDesktopMain(
     desktopAuthSecret,
     discoverUrl: options.discoverWebUrl ?? createWebDiscovery(runtime),
     discoverDaemonUrl: options.discoverDaemonUrl,
+    osLocale,
     preloadPath: options.preloadPath,
     // Round-5 (lefarcen P1, mrcfps): runtime hands this back to itself
     // on `503 DESKTOP_AUTH_PENDING` to re-handshake with the daemon

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -15,6 +15,23 @@ const OPEN_DESIGN_HOST_GLOBAL: typeof import('@open-design/host').OPEN_DESIGN_HO
 const OPEN_DESIGN_HOST_VERSION: typeof import('@open-design/host').OPEN_DESIGN_HOST_VERSION = 1;
 const UPDATER_STATUS_EVENT = 'od:update:status-changed';
 
+// Mirror of the argv prefix used by main's `applyOsLocaleSwitch` and
+// runtime's `additionalArguments`. Duplicated literal on purpose: the
+// preload bundle must not pull in `@open-design/desktop/main` (it
+// transitively requires non-electron node modules that the sandboxed
+// preload can't load).
+const OS_LOCALE_ARG_PREFIX = '--od-os-locale=';
+
+function readOsLocaleFromArgv(): string | undefined {
+  for (const arg of process.argv) {
+    if (typeof arg === 'string' && arg.startsWith(OS_LOCALE_ARG_PREFIX)) {
+      const value = arg.slice(OS_LOCALE_ARG_PREFIX.length);
+      if (value.length > 0) return value;
+    }
+  }
+  return undefined;
+}
+
 type PrintPdfOptions = {
   deck?: boolean;
 };
@@ -197,11 +214,14 @@ const updater = {
   },
 };
 
+const osLocale = readOsLocaleFromArgv();
+
 const hostBridge = {
   version: OPEN_DESIGN_HOST_VERSION,
   client: {
     type: 'desktop',
     platform: process.platform,
+    ...(osLocale !== undefined ? { osLocale } : {}),
   },
   shell,
   project,

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -306,6 +306,13 @@ export type DesktopRuntimeOptions = {
    * and the runtime falls back to `discoverUrl` for API calls too.
   */
   discoverDaemonUrl?: () => Promise<string | null>;
+  /**
+   * BCP-47 locale string read from the OS by main process, forwarded
+   * to the preload via `webPreferences.additionalArguments` so the
+   * renderer can mirror it onto `__od__.client.osLocale`. Optional;
+   * when omitted the renderer falls back to navigator/localStorage.
+   */
+  osLocale?: string;
   preloadPath?: string;
   /**
    * Round-5 (lefarcen P1, mrcfps): lazy re-handshake hook. The runtime
@@ -1109,6 +1116,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     title: "Open Design",
     ...MAC_WINDOW_CHROME,
     webPreferences: {
+      additionalArguments: options.osLocale ? [`--od-os-locale=${options.osLocale}`] : undefined,
       contextIsolation: true,
       nodeIntegration: false,
       preload: preloadPath,

--- a/apps/desktop/tests/main/preload-host-boundary.test.ts
+++ b/apps/desktop/tests/main/preload-host-boundary.test.ts
@@ -19,6 +19,12 @@ describe("desktop preload host boundary", () => {
     expect(source).toContain("exportDiagnostics");
     expect(source).toContain("satisfies OpenDesignHostBridge");
     expect(source).toContain("updater");
+    // OS locale forwarded from main via webPreferences.additionalArguments
+    // is mirrored onto __od__.client.osLocale. Pin the literal prefix
+    // here so it can't drift away from `applyOsLocaleSwitch`/runtime's
+    // additionalArguments without the test going red.
+    expect(source).toContain("'--od-os-locale='");
+    expect(source).toContain("osLocale");
     expect(source).toContain("invokeUpdater('install'");
     expect(source).toContain("od:update:quit");
     expect(source).toContain("od:update:status-changed");

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -10,6 +10,7 @@ import {
   createSidecarLaunchEnv,
   resolveAppIpcPath,
 } from "@open-design/sidecar";
+import { applyOsLocaleSwitch } from "@open-design/desktop/main";
 import { readProcessStamp } from "@open-design/platform";
 import { join } from "node:path";
 import { app, dialog } from "electron";
@@ -59,6 +60,13 @@ function applyLaunchEnv(base: string, stamp: SidecarStamp): void {
 }
 
 async function main(): Promise<void> {
+  // Must run BEFORE `app.whenReady()` below, because Chromium consumes
+  // `--lang` at session bootstrap. Doing it here lets the packaged
+  // renderer's `navigator.language` follow the OS instead of Chromium's
+  // en-US default. runDesktopMain (called later) calls the same helper
+  // again to recover the resolved locale string for the BrowserWindow.
+  applyOsLocaleSwitch(app);
+
   const config = await readPackagedConfig();
   const argvStamp = readProcessStamp(process.argv.slice(1), OPEN_DESIGN_SIDECAR_CONTRACT);
   const namespace = argvStamp?.namespace ?? config.namespace;

--- a/apps/web/src/i18n/index.tsx
+++ b/apps/web/src/i18n/index.tsx
@@ -28,6 +28,7 @@ import { uk } from './locales/uk';
 import { tr } from './locales/tr';
 import { th } from './locales/th';
 import { it } from './locales/it';
+import { getOpenDesignHost } from '@open-design/host';
 import { LOCALES, type Dict, type Locale } from './types';
 
 export { LOCALES, LOCALE_LABEL } from './types';
@@ -82,12 +83,15 @@ export function resolveSystemLocale(languages: readonly string[]): Locale | null
   return null;
 }
 
-// Read the OS locale main process attached to `__od__.client.osLocale`.
+// Read the OS locale the desktop host attached to its client descriptor.
 // Packaged desktop builds need this because Chromium otherwise reports
-// en-US through navigator.language regardless of the OS setting.
+// en-US through navigator.language regardless of the OS setting. We go
+// through `getOpenDesignHost` rather than reading the bridge global by
+// name so the web/preload boundary stays single-source (see the
+// `host bridge boundary` guard test).
 function readDesktopHostOsLocale(): string | undefined {
   if (typeof window === 'undefined') return undefined;
-  const host = (window as { __od__?: { client?: { osLocale?: unknown } } }).__od__;
+  const host = getOpenDesignHost();
   const value = host?.client?.osLocale;
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }

--- a/apps/web/src/i18n/index.tsx
+++ b/apps/web/src/i18n/index.tsx
@@ -82,10 +82,22 @@ export function resolveSystemLocale(languages: readonly string[]): Locale | null
   return null;
 }
 
-// First-run defaults to the user's browser/system language when possible.
-// An explicit user pick saved to localStorage always wins; unsupported
-// languages fall back to English.
-function detectInitialLocale(): Locale {
+// Read the OS locale main process attached to `__od__.client.osLocale`.
+// Packaged desktop builds need this because Chromium otherwise reports
+// en-US through navigator.language regardless of the OS setting.
+function readDesktopHostOsLocale(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const host = (window as { __od__?: { client?: { osLocale?: unknown } } }).__od__;
+  const value = host?.client?.osLocale;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+// First-run defaults to the user's OS / browser language when possible.
+// Priority: explicit user pick saved to localStorage > OS locale that the
+// desktop host injected (packaged Electron) > navigator.languages > 'en'.
+// Exported so tests can pin the priority chain without spinning up the
+// full I18nProvider.
+export function detectInitialLocale(): Locale {
   if (typeof window === 'undefined') return 'en';
   try {
     const stored = window.localStorage.getItem(LS_KEY);
@@ -94,6 +106,11 @@ function detectInitialLocale(): Locale {
     }
   } catch {
     /* ignore */
+  }
+  const hostOsLocale = readDesktopHostOsLocale();
+  if (hostOsLocale) {
+    const fromHost = resolveSystemLocale([hostOsLocale]);
+    if (fromHost) return fromHost;
   }
   const detected = resolveSystemLocale(
     navigator.languages?.length ? navigator.languages : [navigator.language],

--- a/apps/web/tests/i18n/detect-initial-locale.test.ts
+++ b/apps/web/tests/i18n/detect-initial-locale.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { installMockOpenDesignHost } from '@open-design/host/testing';
 import { detectInitialLocale } from '../../src/i18n';
 
 const LS_KEY = 'open-design:locale';
@@ -16,31 +17,42 @@ function setNavigatorLanguages(languages: readonly string[]): void {
   });
 }
 
-function clearDesktopHost(): void {
-  delete (window as { __od__?: unknown }).__od__;
+// Track the installed mock so each test can swap it out without leaking
+// state into the next case (installMockOpenDesignHost returns an
+// uninstall callback that restores the previous value).
+let uninstallHost: (() => void) | null = null;
+
+function installHostWithOsLocale(value: unknown): void {
+  uninstallHost?.();
+  uninstallHost = installMockOpenDesignHost({
+    host: {
+      // The mock host's defaultHost() already sets client.type to
+      // 'desktop'; we only override the field exercised here.
+      client: { osLocale: value as string | undefined },
+    },
+  });
 }
 
-function setDesktopHostOsLocale(value: unknown): void {
-  (window as { __od__?: unknown }).__od__ = {
-    client: { type: 'desktop', osLocale: value },
-  };
+function clearHost(): void {
+  uninstallHost?.();
+  uninstallHost = null;
 }
 
 describe('detectInitialLocale priority chain', () => {
   beforeEach(() => {
     window.localStorage.clear();
-    clearDesktopHost();
+    clearHost();
     setNavigatorLanguages(['en-US']);
   });
 
   afterEach(() => {
     window.localStorage.clear();
-    clearDesktopHost();
+    clearHost();
   });
 
   it('prefers the user pick saved to localStorage over everything else', () => {
     window.localStorage.setItem(LS_KEY, 'ja');
-    setDesktopHostOsLocale('zh-CN');
+    installHostWithOsLocale('zh-CN');
     setNavigatorLanguages(['fr-FR']);
 
     expect(detectInitialLocale()).toBe('ja');
@@ -54,38 +66,38 @@ describe('detectInitialLocale priority chain', () => {
   });
 
   it('uses the desktop host OS locale when no localStorage pick exists', () => {
-    setDesktopHostOsLocale('zh-CN');
+    installHostWithOsLocale('zh-CN');
     setNavigatorLanguages(['en-US']);
 
     expect(detectInitialLocale()).toBe('zh-CN');
   });
 
   it('routes packaged OS locale strings through resolveSystemLocale (zh-Hant → zh-TW)', () => {
-    setDesktopHostOsLocale('zh-Hant-TW');
+    installHostWithOsLocale('zh-Hant-TW');
     setNavigatorLanguages(['en-US']);
 
     expect(detectInitialLocale()).toBe('zh-TW');
   });
 
   it('falls back to navigator when host osLocale is missing or not a string', () => {
-    setDesktopHostOsLocale(undefined);
+    installHostWithOsLocale(undefined);
     setNavigatorLanguages(['ko-KR']);
     expect(detectInitialLocale()).toBe('ko');
 
-    setDesktopHostOsLocale(42);
+    installHostWithOsLocale(42);
     setNavigatorLanguages(['fr-FR']);
     expect(detectInitialLocale()).toBe('fr');
   });
 
   it('falls back to navigator when host osLocale is not in the supported set', () => {
-    setDesktopHostOsLocale('nl-NL');
+    installHostWithOsLocale('nl-NL');
     setNavigatorLanguages(['pt-PT']);
 
     expect(detectInitialLocale()).toBe('pt-BR');
   });
 
   it('falls back to en when nothing else is available', () => {
-    clearDesktopHost();
+    clearHost();
     setNavigatorLanguages([]);
 
     expect(detectInitialLocale()).toBe('en');

--- a/apps/web/tests/i18n/detect-initial-locale.test.ts
+++ b/apps/web/tests/i18n/detect-initial-locale.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { detectInitialLocale } from '../../src/i18n';
+
+const LS_KEY = 'open-design:locale';
+
+function setNavigatorLanguages(languages: readonly string[]): void {
+  Object.defineProperty(window.navigator, 'languages', {
+    configurable: true,
+    get: () => languages,
+  });
+  Object.defineProperty(window.navigator, 'language', {
+    configurable: true,
+    get: () => languages[0] ?? 'en',
+  });
+}
+
+function clearDesktopHost(): void {
+  delete (window as { __od__?: unknown }).__od__;
+}
+
+function setDesktopHostOsLocale(value: unknown): void {
+  (window as { __od__?: unknown }).__od__ = {
+    client: { type: 'desktop', osLocale: value },
+  };
+}
+
+describe('detectInitialLocale priority chain', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    clearDesktopHost();
+    setNavigatorLanguages(['en-US']);
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    clearDesktopHost();
+  });
+
+  it('prefers the user pick saved to localStorage over everything else', () => {
+    window.localStorage.setItem(LS_KEY, 'ja');
+    setDesktopHostOsLocale('zh-CN');
+    setNavigatorLanguages(['fr-FR']);
+
+    expect(detectInitialLocale()).toBe('ja');
+  });
+
+  it('falls through to navigator when an unsupported locale was stored', () => {
+    window.localStorage.setItem(LS_KEY, 'xx-YY');
+    setNavigatorLanguages(['de-DE']);
+
+    expect(detectInitialLocale()).toBe('de');
+  });
+
+  it('uses the desktop host OS locale when no localStorage pick exists', () => {
+    setDesktopHostOsLocale('zh-CN');
+    setNavigatorLanguages(['en-US']);
+
+    expect(detectInitialLocale()).toBe('zh-CN');
+  });
+
+  it('routes packaged OS locale strings through resolveSystemLocale (zh-Hant → zh-TW)', () => {
+    setDesktopHostOsLocale('zh-Hant-TW');
+    setNavigatorLanguages(['en-US']);
+
+    expect(detectInitialLocale()).toBe('zh-TW');
+  });
+
+  it('falls back to navigator when host osLocale is missing or not a string', () => {
+    setDesktopHostOsLocale(undefined);
+    setNavigatorLanguages(['ko-KR']);
+    expect(detectInitialLocale()).toBe('ko');
+
+    setDesktopHostOsLocale(42);
+    setNavigatorLanguages(['fr-FR']);
+    expect(detectInitialLocale()).toBe('fr');
+  });
+
+  it('falls back to navigator when host osLocale is not in the supported set', () => {
+    setDesktopHostOsLocale('nl-NL');
+    setNavigatorLanguages(['pt-PT']);
+
+    expect(detectInitialLocale()).toBe('pt-BR');
+  });
+
+  it('falls back to en when nothing else is available', () => {
+    clearDesktopHost();
+    setNavigatorLanguages([]);
+
+    expect(detectInitialLocale()).toBe('en');
+  });
+});

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -9,6 +9,11 @@ export type OpenDesignHostClientType =
   (typeof OPEN_DESIGN_HOST_CLIENT_TYPES)[keyof typeof OPEN_DESIGN_HOST_CLIENT_TYPES];
 
 export type OpenDesignHostClient = {
+  // BCP-47 locale string (e.g. "zh-CN", "pt-BR") the host process read from
+  // the OS at startup. The renderer uses this so the packaged desktop app
+  // can follow the OS language even when Chromium's built-in
+  // `navigator.language` would have defaulted to en-US.
+  osLocale?: string;
   platform?: string;
   type: OpenDesignHostClientType;
 };
@@ -250,6 +255,7 @@ export function isOpenDesignHostBridge(value: unknown): value is OpenDesignHostB
   const client = value.client;
   if (!isRecord(client) || client.type !== OPEN_DESIGN_HOST_CLIENT_TYPES.DESKTOP) return false;
   if (client.platform != null && typeof client.platform !== "string") return false;
+  if (client.osLocale != null && typeof client.osLocale !== "string") return false;
 
   const shell = value.shell;
   if (!isRecord(shell) || !hasFunction(shell, "openExternal") || !hasFunction(shell, "openPath")) return false;

--- a/tools/pack/src/workspace-build.ts
+++ b/tools/pack/src/workspace-build.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
-import { access, cp, mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { access, cp, mkdir, readdir, readFile, stat, symlink, unlink, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
 
 import { hashJson, hashPath, ToolPackCache } from "./cache.js";
 import type { ToolPackConfig } from "./config.js";
@@ -143,11 +143,79 @@ function workspaceBuildArtifacts(config: ToolPackConfig): WorkspaceBuildArtifact
   }));
 }
 
+async function stripBrokenSymlinks(rootPath: string): Promise<void> {
+  // Recursively walk `rootPath` and delete symlinks whose target does
+  // not resolve. Next standalone's nft trace occasionally leaves
+  // dangling entries (e.g. .next/standalone/node_modules/.pnpm/node_modules/<pkg>
+  // pointing at a `.pnpm/<pkg>@<version>` directory pnpm never created
+  // because the runtime resolution picked a different version). The
+  // `cp { dereference: true }` call below would `stat()` through these
+  // links and abort the whole packaged pipeline with ENOENT.
+  let entries;
+  try {
+    entries = await readdir(rootPath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const childPath = join(rootPath, entry.name);
+    if (entry.isSymbolicLink()) {
+      try {
+        await stat(childPath);
+      } catch {
+        await unlink(childPath).catch(() => undefined);
+      }
+    } else if (entry.isDirectory()) {
+      await stripBrokenSymlinks(childPath);
+    }
+  }
+}
+
+const WEB_STANDALONE_ARTIFACT = "apps/web/.next/standalone";
+const WEB_STANDALONE_APP_NODE_MODULES = "apps/web/node_modules";
+// Peer deps the web-standalone after-pack audit looks up through
+// `createRequire(server.js).resolve(<pkg>/package.json)`. Next 16
+// standalone build under pnpm workspaces does not hoist them into
+// `<standalone>/apps/web/node_modules`, so the require walk falls out
+// of the standalone tree and the audit aborts the packaged build.
+const STANDALONE_HOISTED_PEER_DEPS = ["react", "react-dom", "styled-jsx"];
+
+async function hoistStandaloneNextPeerDeps(standaloneRoot: string): Promise<void> {
+  const appNodeModules = join(standaloneRoot, WEB_STANDALONE_APP_NODE_MODULES);
+  const pnpmRoot = join(standaloneRoot, "node_modules", ".pnpm");
+  let pnpmEntries: string[];
+  try {
+    pnpmEntries = await readdir(pnpmRoot);
+  } catch {
+    return;
+  }
+  await mkdir(appNodeModules, { recursive: true });
+  for (const pkg of STANDALONE_HOISTED_PEER_DEPS) {
+    const linkPath = join(appNodeModules, pkg);
+    if (await pathExists(linkPath)) continue;
+    // pnpm dirs look like `react@18.3.1` or
+    // `react-dom@18.3.1_react@18.3.1` — pick the bare version, not a
+    // peer-resolved sibling. The leading `${pkg}@` requirement
+    // distinguishes `react` from `react-dom`.
+    const match = pnpmEntries.find((entry) => entry.startsWith(`${pkg}@`));
+    if (!match) continue;
+    const target = join(pnpmRoot, match, "node_modules", pkg);
+    if (!(await pathExists(target))) continue;
+    const relativeTarget = relative(dirname(linkPath), target);
+    await symlink(relativeTarget, linkPath);
+  }
+}
+
 async function copyWorkspaceBuildArtifactsToCache(config: ToolPackConfig, entryRoot: string): Promise<void> {
   for (const artifact of workspaceBuildArtifacts(config)) {
+    const sourcePath = join(config.workspaceRoot, artifact.workspacePath);
+    if (artifact.workspacePath === WEB_STANDALONE_ARTIFACT) {
+      await hoistStandaloneNextPeerDeps(sourcePath);
+    }
+    await stripBrokenSymlinks(sourcePath);
     const targetPath = join(entryRoot, artifact.cachePath);
     await mkdir(dirname(targetPath), { recursive: true });
-    await cp(join(config.workspaceRoot, artifact.workspacePath), targetPath, { dereference: true, recursive: true });
+    await cp(sourcePath, targetPath, { dereference: true, recursive: true });
   }
 }
 


### PR DESCRIPTION
## Why

- **Use case**: I noticed mid-session that the packaged desktop app stays in en-US no matter what language my macOS is set to. Browser and `tools-dev` users don't see this because their `navigator.language` already mirrors the OS / browser preference — packaged Chromium hard-codes it to en-US unless the host process tells it otherwise.
- **Pain**: Non-English OS users have to manually click through to Settings → Language on every fresh install before they get a UI in their language. The 18 locales we already ship are simply hidden behind that click.

## What users will see

After upgrading on macOS / Windows / Linux, the packaged desktop app starts in the OS preferred language on first launch — Chinese OS → Chinese UI, Brazilian Portuguese OS → pt-BR UI, etc. An explicit pick saved earlier through the language menu still wins (`localStorage` priority is unchanged), so users who chose a non-OS language stay on that language.

## Surface area

- [x] **UI** — first-launch language now follows the OS instead of always being English
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — packaged Electron on a non-English OS no longer defaults to en-US on first launch
- [ ] **None**

## Design

Two channels, intentionally redundant:

1. `apps/desktop/src/main/index.ts` exports a new `applyOsLocaleSwitch(app)` helper. It reads `app.getPreferredSystemLanguages()[0]` and, before Electron's `ready`, points Chromium's `--lang` flag at it. `apps/packaged/src/index.ts` calls it before its own `whenReady`; `runDesktopMain` calls it again for tools-dev parity.
2. The same resolved locale is also forwarded through `BrowserWindow.webPreferences.additionalArguments` as `--od-os-locale=<bcp-47>`, parsed by the preload and exposed on `window.__od__.client.osLocale` via `@open-design/host`'s `getOpenDesignHost()`. `detectInitialLocale` in `apps/web/src/i18n/index.tsx` reads it as a new step between localStorage and navigator.

**Local verification revealed channel 1 (`--lang`) does NOT change `navigator.language` on Electron 41 — the entire effective fix is channel 2 (`osLocale`)**. Keeping `--lang` is still useful for Chromium's internal locale (Accept-Language header, intl formatters) and as future-compat if Chromium tightens that behavior, but the runtime contract the renderer relies on is the explicit channel.

## Bundled tools-pack fix

This PR also lands two fixes in `tools/pack/src/workspace-build.ts` that were blocking local packaged builds on pnpm workspaces:

1. `stripBrokenSymlinks` removes dangling symlinks left by Next's nft trace under `.next/standalone/node_modules/.pnpm/node_modules/<pkg>` before the `cp { dereference: true }` step that copies artifacts into the tools-pack cache.
2. `hoistStandaloneNextPeerDeps` symlinks react / react-dom / styled-jsx from the standalone `.pnpm/<pkg>@<ver>` directories into `<standalone>/apps/web/node_modules/`, because Next 16's standalone build under pnpm does not hoist them and the downstream `web-standalone-after-pack.cjs` audit then `createRequire(server.js).resolve('react/package.json')` walks out of the standalone tree.

Both are independent of the locale change but bundled here because verifying the locale fix end-to-end required the packaged pipeline to actually finish.

## Verification

### Unit / contract (CI)

- `pnpm guard`
- `pnpm --filter @open-design/web typecheck` / `desktop typecheck` / `packaged typecheck`
- `pnpm --filter @open-design/host test` (13/13)
- `pnpm --filter @open-design/desktop test` (54/54 — includes updated `preload-host-boundary` source scan for `--od-os-locale=`)
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/i18n/detect-initial-locale.test.ts tests/i18n/locales.test.ts tests/host-boundary.test.ts` (14/14)

### Manual (local macOS Apple Silicon, OS Preferred Languages = zh-Hans-CN)

**dev mode** (`pnpm tools-dev restart`) →
`pnpm tools-dev inspect desktop eval --expr '...'`:
```json
{
  "navLang": "en-US",
  "navLangs": ["en-US", "zh-Hans-CN"],
  "hostOsLocale": "zh-Hans-CN",
  "htmlLang": "zh-CN",
  "stored": null
}
```
UI renders fully in Chinese (主页 / 本地 CLI / 你想设计什么？/ 原型 / 实时制品...).

**packaged mode** (`pnpm tools-pack mac build --to all` → `mac install` → `mac start`) →
`pnpm exec tools-pack mac inspect --expr '...'`:
```json
{
  "navLang": "en-US",
  "navLangs": ["en-US", "zh-Hans-CN"],
  "hostOsLocale": "zh-Hans-CN",
  "htmlLang": "zh-CN",
  "stored": null,
  "uiSample": "主页 / Star / 本地 CLI / 默认 / 你想设计什么？ / 原型 / 实时制品 / 幻灯片 / 图片 / 视频 / HyperFrames / 音频 / Community / 浏览插件市场 / Saved / 全部..."
}
```
The packaged app under namespace-isolated `Open Design.default.app` renders fully in Chinese, confirming the sandbox preload → `additionalArguments` → `__od__.client.osLocale` → `detectInitialLocale` chain is intact across the asar / electron-builder packaging path. `navigator.language` staying `en-US` is the symptom that made channel 2 load-bearing.

Still unverified locally: Windows / Linux (the same code path applies but only macOS was on hand), explicit `localStorage` precedence (covered by unit tests but not exercised manually in packaged mode this round).