### PR TITLE
fix(web): make PPTX export prompt availability-safe

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -116,6 +116,7 @@ import {
   mergeAttachedComments,
   removeAttachedComment,
 } from '../comments';
+import { buildPptxExportPrompt } from '../lib/build-pptx-export-prompt';
 import { AppChromeHeader } from './AppChromeHeader';
 import { AvatarMenu } from './AvatarMenu';
 import { HandoffButton } from './HandoffButton';
@@ -2744,36 +2745,7 @@ export function ProjectView({
   const handleExportAsPptx = useCallback(
     (fileName: string) => {
       if (currentConversationActionDisabled) return;
-      const baseTitle = fileName.replace(/\.html?$/i, '') || fileName;
-      const prompt =
-        `Export @${fileName} as an editable PPTX file titled "${baseTitle}".\n\n` +
-        `**Generate.** Use python-pptx (preferred — full XML control). Apply the ` +
-        `footer-rail + cursor-flow discipline from \`skills/pptx-html-fidelity-audit/SKILL.md\` ` +
-        `Step 4 from the start: define \`CONTENT_MAX_Y = 6.70"\` and \`FOOTER_TOP = 6.85"\` ` +
-        `as constants, route every content block through a \`Cursor\` that refuses to cross ` +
-        `the rail, and use budget centering (not \`MARGIN_TOP\`) for hero/cover slides. ` +
-        `Preserve \`<em>\` / \`<i>\` as \`italic=True\` on Latin runs only — never on CJK. ` +
-        `Set the \`<a:latin>\` and \`<a:ea>\` typeface slots explicitly so Chinese runs ` +
-        `don't fall back to Microsoft JhengHei.\n\n` +
-        `**Verify (mandatory gate).** After writing, run ` +
-        `\`python skills/pptx-html-fidelity-audit/scripts/verify_layout.py "${baseTitle}.pptx"\` ` +
-        `(quote the path — filenames may contain spaces). Zero rail violations is the gate ` +
-        `for "shippable". If violations remain, walk Steps 2-4 of the SKILL.md ` +
-        `(extract dump → audit table → re-export) — do not declare done by eyeballing the ` +
-        `deck. If 🟡 typography issues surface (italic missing, unexpected \`Calibri\` / ` +
-        `\`Microsoft JhengHei\` in the XML), consult ` +
-        `\`skills/pptx-html-fidelity-audit/references/font-discipline.md\` for the ` +
-        `five-layer font audit.\n\n` +
-        `**Customizing rails.** The default \`CONTENT_MAX_Y = 6.70"\` / ` +
-        `\`FOOTER_TOP = 6.85"\` constants suit a 16:9 canvas with a slim footer. If the ` +
-        `design system needs different rails (wider footer, 4:3 canvas), pass ` +
-        `\`--content-max-y\` / \`--canvas-h\` to \`verify_layout.py\` and update the matching ` +
-        `constants in the export script — see \`references/layout-discipline.md\` §1.\n\n` +
-        `If \`python-pptx\` or the verifier is unavailable in this environment, say so ` +
-        `explicitly — don't claim fidelity is correct without evidence.\n\n` +
-        `Save into the current project folder (this conversation's working directory) as ` +
-        `\`${baseTitle}.pptx\`. Report the on-disk path and a 1-line fidelity summary ` +
-        `(e.g. "0 rail violations across 14 slides") when done.`;
+      const prompt = buildPptxExportPrompt(fileName);
       const attachment: ChatAttachment = {
         path: fileName,
         name: fileName,

--- a/apps/web/src/lib/build-pptx-export-prompt.ts
+++ b/apps/web/src/lib/build-pptx-export-prompt.ts
@@ -1,0 +1,21 @@
+export function buildPptxExportPrompt(fileName: string): string {
+  const baseTitle = fileName.replace(/\.html?$/i, '') || fileName;
+
+  return (
+    `Export @${fileName} as an editable PPTX file titled "${baseTitle}".\n\n` +
+    `Save it in the current project folder (this conversation's working directory) as ` +
+    `\`${baseTitle}.pptx\`.\n\n` +
+    `Use any PPTX-capable toolchain that is actually available in this environment. ` +
+    `Prefer preserving slide structure, editable text, layout, colors, and fonts over ` +
+    `producing a rasterized screenshot deck. If multiple approaches are available, choose ` +
+    `the one that keeps the output most editable.\n\n` +
+    `Do not refuse solely because a specific library, skill, or verifier is unavailable. ` +
+    `If \`python-pptx\`, PptxGenJS, or a PPTX verification helper is missing, try another ` +
+    `available approach instead. Only report that export is impossible if no available ` +
+    `toolchain here can write a PPTX file at all.\n\n` +
+    `After creating the file, run whatever lightweight validation is possible in this ` +
+    `environment and report: (1) the on-disk path, (2) whether the deck remains editable ` +
+    `or fell back to mostly images, and (3) a 1-line fidelity summary. Do not claim the ` +
+    `fidelity is verified if you could not run a real validation step.`
+  );
+}

--- a/apps/web/src/lib/build-pptx-export-prompt.ts
+++ b/apps/web/src/lib/build-pptx-export-prompt.ts
@@ -5,17 +5,25 @@ export function buildPptxExportPrompt(fileName: string): string {
     `Export @${fileName} as an editable PPTX file titled "${baseTitle}".\n\n` +
     `Save it in the current project folder (this conversation's working directory) as ` +
     `\`${baseTitle}.pptx\`.\n\n` +
-    `Use any PPTX-capable toolchain that is actually available in this environment. ` +
-    `Prefer preserving slide structure, editable text, layout, colors, and fonts over ` +
-    `producing a rasterized screenshot deck. If multiple approaches are available, choose ` +
-    `the one that keeps the output most editable.\n\n` +
-    `Do not refuse solely because a specific library, skill, or verifier is unavailable. ` +
-    `If \`python-pptx\`, PptxGenJS, or a PPTX verification helper is missing, try another ` +
-    `available approach instead. Only report that export is impossible if no available ` +
-    `toolchain here can write a PPTX file at all.\n\n` +
-    `After creating the file, run whatever lightweight validation is possible in this ` +
-    `environment and report: (1) the on-disk path, (2) whether the deck remains editable ` +
-    `or fell back to mostly images, and (3) a 1-line fidelity summary. Do not claim the ` +
-    `fidelity is verified if you could not run a real validation step.`
+    `Prefer the checked-in \`skills/pptx-html-fidelity-audit\` flow when that repo path is ` +
+    `accessible here and the environment can run it. In that case, use \`python-pptx\` ` +
+    `(preferred — full XML control), apply the footer-rail + cursor-flow discipline from ` +
+    `\`skills/pptx-html-fidelity-audit/SKILL.md\` Step 4, preserve \`<em>\` / \`<i>\` as ` +
+    `\`italic=True\` on Latin runs only, set the \`<a:latin>\` and \`<a:ea>\` typeface ` +
+    `slots explicitly, and gate the result with \`python ` +
+    `skills/pptx-html-fidelity-audit/scripts/verify_layout.py "${baseTitle}.pptx"\`.\n\n` +
+    `If that audited repo flow is genuinely unavailable, use any other PPTX-capable toolchain ` +
+    `that is actually available in this environment. Do not refuse solely because a specific ` +
+    `library, skill, or verifier is unavailable. If \`python-pptx\`, PptxGenJS, or a PPTX ` +
+    `verification helper is missing, try another available approach instead. Only report that ` +
+    `editable export is impossible if no available toolchain here can produce materially ` +
+    `editable slides.\n\n` +
+    `After creating the file, run the strongest validation that is actually available in this ` +
+    `environment and report: (1) the on-disk path, (2) whether editable export succeeded, ` +
+    `(3) which validation you ran, and (4) a 1-line fidelity summary. If the only possible ` +
+    `output would be a mostly rasterized or image-heavy deck, do not present that as a ` +
+    `successful editable export — explicitly report that materially editable export was not ` +
+    `possible in the current environment. Do not claim the fidelity is verified if you could ` +
+    `not run a real validation step.`
   );
 }

--- a/apps/web/tests/lib/build-pptx-export-prompt.test.ts
+++ b/apps/web/tests/lib/build-pptx-export-prompt.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPptxExportPrompt } from '../../src/lib/build-pptx-export-prompt';
+
+describe('buildPptxExportPrompt', () => {
+  it('builds an availability-safe prompt for deck HTML exports', () => {
+    const prompt = buildPptxExportPrompt('Quarterly Plan.html');
+
+    expect(prompt).toContain('Export @Quarterly Plan.html as an editable PPTX file titled "Quarterly Plan".');
+    expect(prompt).toContain('`Quarterly Plan.pptx`');
+    expect(prompt).toContain('Use any PPTX-capable toolchain that is actually available in this environment.');
+    expect(prompt).toContain('Do not refuse solely because a specific library, skill, or verifier is unavailable.');
+    expect(prompt).toContain('Only report that export is impossible if no available toolchain here can write a PPTX file at all.');
+    expect(prompt).toContain('Do not claim the fidelity is verified if you could not run a real validation step.');
+  });
+
+  it('does not require the old python-only audit flow', () => {
+    const prompt = buildPptxExportPrompt('deck.html');
+
+    expect(prompt).not.toContain('skills/pptx-html-fidelity-audit');
+    expect(prompt).not.toContain('verify_layout.py');
+    expect(prompt).not.toContain('mandatory gate');
+    expect(prompt).not.toContain('Use python-pptx');
+  });
+});

--- a/apps/web/tests/lib/build-pptx-export-prompt.test.ts
+++ b/apps/web/tests/lib/build-pptx-export-prompt.test.ts
@@ -8,18 +8,24 @@ describe('buildPptxExportPrompt', () => {
 
     expect(prompt).toContain('Export @Quarterly Plan.html as an editable PPTX file titled "Quarterly Plan".');
     expect(prompt).toContain('`Quarterly Plan.pptx`');
-    expect(prompt).toContain('Use any PPTX-capable toolchain that is actually available in this environment.');
+    expect(prompt).toContain('Prefer the checked-in `skills/pptx-html-fidelity-audit` flow when that repo path is accessible here and the environment can run it.');
+    expect(prompt).toContain('python skills/pptx-html-fidelity-audit/scripts/verify_layout.py "Quarterly Plan.pptx"');
     expect(prompt).toContain('Do not refuse solely because a specific library, skill, or verifier is unavailable.');
-    expect(prompt).toContain('Only report that export is impossible if no available toolchain here can write a PPTX file at all.');
+    expect(prompt).toContain('Only report that editable export is impossible if no available toolchain here can produce materially editable slides.');
     expect(prompt).toContain('Do not claim the fidelity is verified if you could not run a real validation step.');
   });
 
-  it('does not require the old python-only audit flow', () => {
+  it('falls back only when the audited repo flow is genuinely unavailable', () => {
     const prompt = buildPptxExportPrompt('deck.html');
 
-    expect(prompt).not.toContain('skills/pptx-html-fidelity-audit');
-    expect(prompt).not.toContain('verify_layout.py');
-    expect(prompt).not.toContain('mandatory gate');
-    expect(prompt).not.toContain('Use python-pptx');
+    expect(prompt).toContain('If that audited repo flow is genuinely unavailable, use any other PPTX-capable toolchain that is actually available in this environment.');
+    expect(prompt).toContain('If `python-pptx`, PptxGenJS, or a PPTX verification helper is missing, try another available approach instead.');
+  });
+
+  it('does not treat a mostly image-based deck as a successful editable export', () => {
+    const prompt = buildPptxExportPrompt('deck.html');
+
+    expect(prompt).toContain('If the only possible output would be a mostly rasterized or image-heavy deck, do not present that as a successful editable export');
+    expect(prompt).toContain('explicitly report that materially editable export was not possible in the current environment.');
   });
 });


### PR DESCRIPTION
Closes #715

## Why

I worked on this because the current HTML→PPTX export prompt hard-requires `python-pptx` and the repo-local `pptx-html-fidelity-audit` verifier flow. In environments where those tools are unavailable, agents refuse the export outright even when another PPTX-capable approach might exist.

This PR removes that brittle requirement so the export action asks for the best available editable PPTX instead of failing fast on one missing toolchain.

## What users will see

When they choose to export an HTML presentation as PPTX, the agent now asks for an editable `.pptx` using whatever PPTX-capable tooling is actually available locally. It will no longer refuse solely because `python-pptx` or the old verifier script is missing, and it must report whether fidelity was actually validated.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the regression guard: `apps/web/tests/lib/build-pptx-export-prompt.test.ts`
- Did the test go red on `main` and green on this branch? no — the fix first extracts the inline prompt into a dedicated helper, so the regression was verified by the previous inline prompt content plus the issue reproduction, then locked with the new focused test.

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test -- apps/web/tests/lib/build-pptx-export-prompt.test.ts`