### PR TITLE
feat(runtimes): add OpenClaw ACP adapter

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -168,6 +168,7 @@ const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['qwen', new Set(['QWEN_BIN'])],
   ['trae-cli', new Set(['TRAE_CLI_BIN'])],
   ['vibe', new Set(['VIBE_BIN'])],
+  ['openclaw', new Set(['OD_OPENCLAW_SESSION'])],
 ]);
 
 function isValidAgentModelEntry(v: unknown): v is AgentModelPrefs {

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1835,7 +1835,10 @@ async function testAgentConnectionInternal(
         [],
         [],
         { model: input.model ?? null, reasoning: input.reasoning ?? null },
-        { cwd: tempDir },
+        {
+          cwd: tempDir,
+          env: { ...process.env, ...configuredAgentEnv },
+        },
       );
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);

--- a/apps/daemon/src/runtimes/defs/openclaw.ts
+++ b/apps/daemon/src/runtimes/defs/openclaw.ts
@@ -26,8 +26,20 @@ export const openclawAgentDef = {
   // whatever argv we pass — so `openclaw-acp-shim --version` prints the
   // real OpenClaw version. We don't override `versionArgs` because OD's
   // detection runs that against `bin` directly.
+  //
+  // No `fallbackBins: ['openclaw']`. PR #2556 review (@mrcfps,
+  // @Siri-Ray): `fallbackBins` participates in the same
+  // executable-resolution path used for actual chat spawns
+  // (`resolveAgentExecutable` walks `[bin, ...fallbackBins]`), so a
+  // bare-`openclaw` fallback would let OD mark the runtime
+  // `available: true` for users who have the official OpenClaw CLI
+  // but not this shim — and then chat spawn would launch
+  // `openclaw acp` and hit the stdin-EOF disconnect mid-`session/new`
+  // described above. Better to keep this runtime gated on the shim
+  // being present and surface an install hint (see
+  // `installMetaForAgent('openclaw')` in `metadata.ts`) than to
+  // silently advertise a broken chat path.
   bin: 'openclaw-acp-shim',
-  fallbackBins: ['openclaw'],
   versionArgs: ['--version'],
   // `openclaw acp` enumerates the gateway's configured model providers via the
   // standard ACP initialize handshake. The default session targets the main

--- a/apps/daemon/src/runtimes/defs/openclaw.ts
+++ b/apps/daemon/src/runtimes/defs/openclaw.ts
@@ -59,7 +59,24 @@ export const openclawAgentDef = {
     },
   ],
   buildArgs: (_prompt, _imagePaths, _extraAllowedDirs, options, runtimeContext) => {
-    const args = ['acp', '--session', process.env.OD_OPENCLAW_SESSION || 'agent:main:main'];
+    // Read `OD_OPENCLAW_SESSION` from the merged spawn env passed in
+    // via `runtimeContext.env`, not from `process.env`. PR #2556
+    // review (Siri-Ray): `fetchModels` above reads the merged env, so
+    // the model probe enumerated session A; reading `process.env`
+    // here would silently fall back to `agent:main:main` whenever the
+    // user configured the override through OD's per-agent env
+    // settings rather than the daemon's own launch env, routing real
+    // chat work to a different gateway session than discovery did.
+    //
+    // Fall back to `process.env` for backwards compatibility — older
+    // server.ts revisions don't populate `runtimeContext.env`, and
+    // `connectionTest.ts` / `memory-llm.ts` still pass `{ cwd }`
+    // only. Final fallback is the canonical default session.
+    const session =
+      runtimeContext?.env?.OD_OPENCLAW_SESSION ||
+      process.env.OD_OPENCLAW_SESSION ||
+      'agent:main:main';
+    const args = ['acp', '--session', session];
     if (options?.model && options.model !== 'default') {
       // Forward chosen model id as a `--model` override for the agent turn.
       args.push('--model', options.model);

--- a/apps/daemon/src/runtimes/defs/openclaw.ts
+++ b/apps/daemon/src/runtimes/defs/openclaw.ts
@@ -1,0 +1,84 @@
+import { detectAcpModels, DEFAULT_MODEL_OPTION } from './shared.js';
+import type { RuntimeAgentDef } from '../types.js';
+
+// OpenClaw runs as a long-lived gateway daemon; `openclaw acp` is the official
+// ACP bridge that translates JSON-RPC stdio into a gateway session. This lets
+// OD treat OpenClaw like any other ACP-native agent (Hermes/Kimi/Kilo/Kiro/
+// Vibe/Devin), without writing a custom shim.
+//
+// OpenClaw brings its own tools (web_search, web_fetch, image, sub-agents,
+// memory, channels, etc.) which become available to OD's design loop on top
+// of whatever model the gateway is configured to call.
+//
+// Docs: https://docs.openclaw.ai/cli/acp
+export const openclawAgentDef = {
+  id: 'openclaw',
+  name: 'OpenClaw',
+  // Use a small Node wrapper instead of `openclaw` directly: OD's ACP runner
+  // closes stdin too aggressively (it does `child.stdin.end()` right after
+  // writing each JSON-RPC frame), which makes OpenClaw's ACP bridge see a
+  // disconnected client mid-`session/new` and reply with
+  // `{code:-32603,message:"Internal error",data:{details:"ACP connection closed"}}`.
+  //
+  // `openclaw-acp-shim` (at ~/bin) forwards stdin to `openclaw acp ...` but
+  // never propagates EOF, keeping the bridge happy until the child exits.
+  // The shim version request still works because it exec's `openclaw` with
+  // whatever argv we pass — so `openclaw-acp-shim --version` prints the
+  // real OpenClaw version. We don't override `versionArgs` because OD's
+  // detection runs that against `bin` directly.
+  bin: 'openclaw-acp-shim',
+  fallbackBins: ['openclaw'],
+  versionArgs: ['--version'],
+  // `openclaw acp` enumerates the gateway's configured model providers via the
+  // standard ACP initialize handshake. The default session targets the main
+  // agent session; users can override per-project via `OD_OPENCLAW_SESSION`.
+  fetchModels: async (resolvedBin, env) =>
+    detectAcpModels({
+      bin: resolvedBin,
+      args: ['acp', '--session', env.OD_OPENCLAW_SESSION || 'agent:main:main'],
+      env,
+      timeoutMs: 15_000,
+      defaultModelOption: DEFAULT_MODEL_OPTION,
+    }),
+  // Surfaced as model picker hints if the live probe above fails (e.g. the
+  // gateway daemon isn't running yet). The actual model is selected by
+  // OpenClaw's own routing config, so `default` is the most useful entry.
+  fallbackModels: [
+    DEFAULT_MODEL_OPTION,
+    {
+      id: 'anthropic/claude-opus-4-5',
+      label: 'claude-opus-4-5 (Anthropic via OpenClaw)',
+    },
+    {
+      id: 'anthropic/claude-sonnet-4-5',
+      label: 'claude-sonnet-4-5 (Anthropic via OpenClaw)',
+    },
+    {
+      id: 'anthropic/claude-haiku-4-5',
+      label: 'claude-haiku-4-5 (Anthropic via OpenClaw)',
+    },
+  ],
+  buildArgs: (_prompt, _imagePaths, _extraAllowedDirs, options, runtimeContext) => {
+    const args = ['acp', '--session', process.env.OD_OPENCLAW_SESSION || 'agent:main:main'];
+    if (options?.model && options.model !== 'default') {
+      // Forward chosen model id as a `--model` override for the agent turn.
+      args.push('--model', options.model);
+    }
+    return args;
+  },
+  streamFormat: 'acp-json-rpc',
+  // OpenClaw's ACP bridge does NOT accept per-session MCP servers. The
+  // bridge surfaces the gateway's already-configured MCP layer to every
+  // session. Passing `mcpServers` in `session/new` makes OpenClaw reply
+  // with `-32603 Internal error: ACP bridge mode does not support per-session
+  // MCP servers. Configure MCP on the OpenClaw gateway or agent instead.`
+  // → leave `externalMcpInjection` and `mcpDiscovery` UNSET so OD never
+  // attaches its `open-design-live-artifacts` MCP descriptor. This costs
+  // OD's live-artifact write-back path, but the chat still runs end-to-end
+  // and OpenClaw's own tools (web_search, web_fetch, image, sub-agents)
+  // remain available.
+  // mcpDiscovery: 'mature-acp',           // disabled
+  // externalMcpInjection: 'acp-merge',    // disabled — see above
+  installUrl: 'https://github.com/openclaw/openclaw',
+  docsUrl: 'https://docs.openclaw.ai/cli/acp',
+} satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/metadata.ts
+++ b/apps/daemon/src/runtimes/metadata.ts
@@ -75,6 +75,18 @@ const AGENT_INSTALL_LINKS: Record<
     installUrl: 'https://github.com/Hmbown/CodeWhale',
     docsUrl: 'https://github.com/Hmbown/CodeWhale/blob/main/README.md',
   },
+  // PR #2556 review (@mrcfps, @Siri-Ray): OpenClaw's adapter binds to
+  // `openclaw-acp-shim` only — the bare `openclaw` CLI hits the
+  // stdin-EOF disconnect mid-`session/new` described in
+  // `defs/openclaw.ts`. When the shim isn't on PATH the runtime falls
+  // out of the picker as `available: false`; surfacing
+  // `installUrl` here is what tells users where to get the shim
+  // instead of falling back to a bare `openclaw` spawn that is
+  // known-broken for the main chat flow.
+  openclaw: {
+    installUrl: 'https://github.com/openclaw/openclaw#acp-shim',
+    docsUrl: 'https://docs.openclaw.ai/cli/acp',
+  },
 };
 
 function sanitizeHttpsUrl(value: string | undefined): string | undefined {

--- a/apps/daemon/src/runtimes/registry.ts
+++ b/apps/daemon/src/runtimes/registry.ts
@@ -19,6 +19,7 @@ import { vibeAgentDef } from './defs/vibe.js';
 import { deepseekAgentDef } from './defs/deepseek.js';
 import { aiderAgentDef } from './defs/aider.js';
 import { reasonixAgentDef } from './defs/reasonix.js';
+import { openclawAgentDef } from './defs/openclaw.js';
 import { readLocalAgentProfileDefs as readLocalAgentProfileDefsFromFile } from './local-profiles.js';
 import type { RuntimeAgentDef } from './types.js';
 
@@ -44,6 +45,7 @@ const BASE_AGENT_DEFS: RuntimeAgentDef[] = [
   deepseekAgentDef,
   aiderAgentDef,
   reasonixAgentDef,
+  openclawAgentDef,
 ];
 
 export function readLocalAgentProfileDefs(

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -18,6 +18,16 @@ export type RuntimeBuildOptions = {
 
 export type RuntimeContext = {
   cwd?: string;
+  // Merged environment that will be made available to the spawned
+  // agent (host process.env overlaid with the per-agent overrides
+  // returned by `agentCliEnvForAgent(...)`). Adapters that surface a
+  // user-tunable behaviour via an env var should read it from this
+  // map rather than from `process.env`, so configured-env and
+  // process-env both resolve to the same value at argv-build time.
+  // PR #2556 (Siri-Ray): the OpenClaw adapter pulls
+  // `OD_OPENCLAW_SESSION` from here so model probe and chat spawn
+  // agree on the same gateway session id.
+  env?: Record<string, string | undefined>;
 };
 
 export type RuntimeCapabilityMap = Record<string, boolean>;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11027,12 +11027,22 @@ export async function startServer({
       }
     }
 
+    // PR #2556 (Siri-Ray): pass the merged spawn env into `buildArgs`
+    // so adapters can read user-configured env vars (e.g.
+    // OpenClaw's OD_OPENCLAW_SESSION) from the same source the child
+    // process will see. Reading `process.env` inside `buildArgs`
+    // would only see the daemon's launch env and miss anything the
+    // user set through OD's per-agent CLI env settings, so model
+    // probe and chat spawn would resolve to different values.
     const args = def.buildArgs(
       composed,
       safeImages,
       extraAllowedDirs,
       agentOptions,
-      { cwd: effectiveCwd },
+      {
+        cwd: effectiveCwd,
+        env: { ...process.env, ...configuredAgentEnv },
+      },
     );
 
     // Second-pass budget check that knows about the Windows `.cmd` shim

--- a/apps/daemon/tests/app-config.test.ts
+++ b/apps/daemon/tests/app-config.test.ts
@@ -326,6 +326,10 @@ describe('app-config', () => {
           'trae-cli': {
             TRAE_CLI_BIN: '  ~/bin/traecli-public  ',
           },
+          openclaw: {
+            OD_OPENCLAW_SESSION: '  agent:designs:hero  ',
+            SOME_RANDOM_KEY: 'should-not-persist',
+          },
           gemini: {
             GEMINI_API_KEY: 'should-not-persist',
           },
@@ -346,6 +350,7 @@ describe('app-config', () => {
           OPENCODE_TEST_HOME: '~/.open-design-amr-opencode',
         },
         'trae-cli': { TRAE_CLI_BIN: '~/bin/traecli-public' },
+        openclaw: { OD_OPENCLAW_SESSION: 'agent:designs:hero' },
       });
     });
 

--- a/apps/daemon/tests/runtimes/helpers/test-helpers.ts
+++ b/apps/daemon/tests/runtimes/helpers/test-helpers.ts
@@ -87,6 +87,7 @@ export const qoder = requireAgent('qoder');
 export const qwen = requireAgent('qwen');
 export const opencode = requireAgent('opencode');
 export const aider = requireAgent('aider');
+export const openclaw = requireAgent('openclaw');
 export const deepseekMaxPromptArgBytes = (() => {
   assert.ok(
     deepseek.maxPromptArgBytes !== undefined,

--- a/apps/daemon/tests/runtimes/openclaw-args.test.ts
+++ b/apps/daemon/tests/runtimes/openclaw-args.test.ts
@@ -166,3 +166,32 @@ test('openclaw buildArgs skips --model when default is selected', () => {
     '`--model default` would route to a literal model id; must be elided',
   );
 });
+
+// PR #2556 review (@mrcfps): connectionTest.ts also calls buildArgs —
+// verify that it honours runtimeContext.env the same way server.ts does,
+// so "Test connection" targets the user-configured session rather than
+// falling back to process.env / agent:main:main.
+test('openclaw buildArgs honours runtimeContext.env in connection-test shape (cwd + env)', () => {
+  withEnvSnapshot(['OD_OPENCLAW_SESSION'], () => {
+    // Simulate connectionTest.ts passing merged env — the same shape
+    // the fix now threads through.
+    process.env.OD_OPENCLAW_SESSION = 'agent:host:stale';
+
+    const args = openclaw.buildArgs(
+      '',
+      [],
+      [],
+      { model: null, reasoning: null },
+      {
+        cwd: '/tmp/od-connection-test',
+        env: { OD_OPENCLAW_SESSION: 'agent:conntest:override' },
+      },
+    );
+
+    assert.equal(
+      sessionArgOf(args),
+      'agent:conntest:override',
+      'connection-test buildArgs must prefer runtimeContext.env over process.env',
+    );
+  });
+});

--- a/apps/daemon/tests/runtimes/openclaw-args.test.ts
+++ b/apps/daemon/tests/runtimes/openclaw-args.test.ts
@@ -1,0 +1,168 @@
+import { test } from 'vitest';
+import {
+  assert,
+  openclaw,
+  withEnvSnapshot,
+} from './helpers/test-helpers.js';
+
+// Regression guard for PR #2556 review (@Siri-Ray). The OpenClaw adapter
+// reads `OD_OPENCLAW_SESSION` from two places — `fetchModels` reads it
+// from the env passed into the live model probe, and `buildArgs` reads
+// it from `runtimeContext.env` (with a `process.env` fallback). The two
+// paths must agree on the same source so that the session a user
+// configures via OD's per-agent CLI env settings is the same session
+// the model picker enumerates AND the spawned chat sends `session/new`
+// against. Argv overrides env at the gateway, so if `buildArgs` read
+// `process.env` while the user configured the override via OD agent
+// env settings, real chat work would route to `agent:main:main` while
+// model discovery enumerated the configured session.
+//
+// Assertions are intentionally written as invariants on the resolved
+// session value (and the `--session` flag's presence) rather than as
+// `deepEqual` checks against the full argv array. PR #2557 review
+// (@PerishCode): invariant-style assertions "guard intent without
+// making a future value tweak look like a regression" — adding an
+// unrelated flag (`--quiet`, `--cwd`, etc.) to `buildArgs` later
+// should not turn this suite red.
+
+function sessionArgOf(args: readonly string[]): string | undefined {
+  const i = args.indexOf('--session');
+  if (i < 0) return undefined;
+  return args[i + 1];
+}
+
+function modelArgOf(args: readonly string[]): string | undefined {
+  const i = args.indexOf('--model');
+  if (i < 0) return undefined;
+  return args[i + 1];
+}
+
+test('openclaw buildArgs uses runtimeContext.env for OD_OPENCLAW_SESSION', () => {
+  withEnvSnapshot(['OD_OPENCLAW_SESSION'], () => {
+    // Intentionally clear the host env so we don't accidentally fall
+    // through to `process.env` and pass the assertion for the wrong
+    // reason.
+    delete process.env.OD_OPENCLAW_SESSION;
+
+    const args = openclaw.buildArgs(
+      '',
+      [],
+      [],
+      {},
+      {
+        cwd: '/tmp/od-project',
+        env: { OD_OPENCLAW_SESSION: 'agent:designs:hero' },
+      },
+    );
+
+    assert.equal(args[0], 'acp', 'first arg is the acp subcommand');
+    assert.equal(
+      sessionArgOf(args),
+      'agent:designs:hero',
+      'session value comes from runtimeContext.env',
+    );
+  });
+});
+
+test('openclaw buildArgs prefers runtimeContext.env over process.env', () => {
+  // Demonstrates the bug @Siri-Ray flagged: if both are set and the
+  // adapter reads `process.env`, the configured override is silently
+  // dropped at argv-build time.
+  withEnvSnapshot(['OD_OPENCLAW_SESSION'], () => {
+    process.env.OD_OPENCLAW_SESSION = 'agent:host:main';
+
+    const args = openclaw.buildArgs(
+      '',
+      [],
+      [],
+      {},
+      {
+        cwd: '/tmp/od-project',
+        env: { OD_OPENCLAW_SESSION: 'agent:user:override' },
+      },
+    );
+
+    assert.equal(
+      sessionArgOf(args),
+      'agent:user:override',
+      'runtimeContext.env wins over process.env',
+    );
+  });
+});
+
+test('openclaw buildArgs falls back to process.env when runtimeContext.env is absent', () => {
+  // Older callsites (connectionTest, memory-llm) still pass `{ cwd }`
+  // only. Those code paths don't exercise OpenClaw today, but the
+  // fallback keeps the adapter safe if someone wires a new caller
+  // without populating `runtimeContext.env`.
+  withEnvSnapshot(['OD_OPENCLAW_SESSION'], () => {
+    process.env.OD_OPENCLAW_SESSION = 'agent:env:fallback';
+
+    const args = openclaw.buildArgs(
+      '',
+      [],
+      [],
+      {},
+      { cwd: '/tmp/od-project' },
+    );
+
+    assert.equal(sessionArgOf(args), 'agent:env:fallback');
+  });
+});
+
+test('openclaw buildArgs falls back to agent:main:main with no override', () => {
+  withEnvSnapshot(['OD_OPENCLAW_SESSION'], () => {
+    delete process.env.OD_OPENCLAW_SESSION;
+
+    const args = openclaw.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+
+    assert.equal(
+      sessionArgOf(args),
+      'agent:main:main',
+      'canonical default session when neither env source supplies one',
+    );
+  });
+});
+
+test('openclaw buildArgs forwards model override when set', () => {
+  withEnvSnapshot(['OD_OPENCLAW_SESSION'], () => {
+    delete process.env.OD_OPENCLAW_SESSION;
+
+    const args = openclaw.buildArgs(
+      '',
+      [],
+      [],
+      { model: 'anthropic/claude-sonnet-4-5' },
+      {
+        cwd: '/tmp/od-project',
+        env: { OD_OPENCLAW_SESSION: 'agent:designs:hero' },
+      },
+    );
+
+    assert.equal(sessionArgOf(args), 'agent:designs:hero');
+    assert.equal(modelArgOf(args), 'anthropic/claude-sonnet-4-5');
+  });
+});
+
+test('openclaw buildArgs skips --model when default is selected', () => {
+  // The model picker surfaces "Default (CLI config)" as id `default`,
+  // and OpenClaw's own routing config picks the real model. We must
+  // not pass `--model default` through, which OpenClaw would treat as
+  // a literal model id and fail to resolve.
+  const args = openclaw.buildArgs(
+    '',
+    [],
+    [],
+    { model: 'default' },
+    {
+      cwd: '/tmp/od-project',
+      env: { OD_OPENCLAW_SESSION: 'agent:main:main' },
+    },
+  );
+
+  assert.equal(
+    args.includes('--model'),
+    false,
+    '`--model default` would route to a literal model id; must be elided',
+  );
+});

--- a/apps/daemon/tests/runtimes/openclaw-shim-availability.test.ts
+++ b/apps/daemon/tests/runtimes/openclaw-shim-availability.test.ts
@@ -1,0 +1,158 @@
+import { test } from 'vitest';
+import {
+  assert,
+  chmodSync,
+  inspectAgentExecutableResolution,
+  join,
+  mkdtempSync,
+  openclaw,
+  rmSync,
+  tmpdir,
+  writeFileSync,
+} from './helpers/test-helpers.js';
+import { installMetaForAgent } from '../../src/runtimes/metadata.js';
+
+// Regression guard for PR #2556 review (@mrcfps, @Siri-Ray). Both
+// reviewers asked, independently and minutes apart, that the OpenClaw
+// adapter not advertise a bare-`openclaw` fallback for chat spawn:
+// `resolveAgentExecutable` walks `[def.bin, ...def.fallbackBins]`
+// looking for a launchable binary, and the same resolution path is
+// reused for both detection AND the actual chat spawn. With
+// `fallbackBins: ['openclaw']` left in, OD would mark OpenClaw
+// `available: true` whenever a user had the official OpenClaw CLI on
+// PATH but not the `openclaw-acp-shim` wrapper \u2014 and then chat spawn
+// would launch bare `openclaw acp`, which hits the stdin-EOF
+// disconnect mid-`session/new` documented inline in
+// `defs/openclaw.ts`. So the user would see "OpenClaw available" in
+// the picker and then have every session die immediately.
+//
+// The fix is to drop the `fallbackBins` entry entirely so the runtime
+// only surfaces when the shim is actually present, and to populate
+// `installMetaForAgent('openclaw')` so the unavailable-agent record
+// carries an install hint to the picker.
+//
+// Following PR #2557 review style (@PerishCode): assertions are
+// written as invariants on the resolved behaviour, not as
+// `deepEqual`/magic-string comparisons against the AGENT_DEF. A later
+// adapter tweak that, say, renames the shim or adds an unrelated
+// declarative field shouldn't turn this suite red \u2014 only a
+// regression that lets bare `openclaw` win chat-spawn resolution, or
+// that hides the install hint, should.
+
+const fsTest = process.platform === 'win32' ? test.skip : test;
+
+// --- Invariant 1: no bare-`openclaw` fallback at the adapter level. ---
+//
+// This is the declarative half. `fallbackBins` is read by
+// `resolveAgentExecutable` (and by extension every detection /
+// chat-spawn caller), so if it ever contains `'openclaw'` again, the
+// known-broken bare-CLI path is back on the menu regardless of what
+// the comment block says.
+
+test('openclaw adapter does not declare a bare `openclaw` fallback bin', () => {
+  const fallbacks = Array.isArray(openclaw.fallbackBins)
+    ? openclaw.fallbackBins
+    : [];
+  assert.ok(
+    !fallbacks.includes('openclaw'),
+    `openclaw.fallbackBins must not include 'openclaw' \u2014 the bare CLI hits the stdin-EOF disconnect mid-session/new; got ${JSON.stringify(fallbacks)}`,
+  );
+});
+
+// --- Invariant 2: resolution-layer behaviour with shim missing. ---
+//
+// The declarative invariant above is necessary but not sufficient: a
+// future refactor could introduce a different bare-`openclaw`
+// fallback (env var override, hard-coded second candidate, etc.) and
+// still satisfy "fallbackBins doesn't include openclaw". Pin the
+// observable resolution behaviour: when only the bare `openclaw` CLI
+// exists on PATH and no shim is present, `selectedPath` is null. Any
+// future code path that resurrects bare-`openclaw` chat spawn fails
+// here even if it bypasses `fallbackBins`.
+
+fsTest(
+  'inspectAgentExecutableResolution returns null when only bare `openclaw` is on PATH',
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), 'od-openclaw-shim-missing-'));
+    try {
+      // Only the official OpenClaw CLI exists; the shim is absent
+      // \u2014 the exact "user installed OpenClaw but not the shim"
+      // setup the reviewers flagged.
+      writeFileSync(join(dir, 'openclaw'), '');
+      chmodSync(join(dir, 'openclaw'), 0o755);
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+
+      const resolution = inspectAgentExecutableResolution(openclaw);
+      assert.equal(
+        resolution.selectedPath,
+        null,
+        'bare `openclaw` must not be picked as the chat-spawn binary',
+      );
+      assert.equal(
+        resolution.pathResolvedPath,
+        null,
+        'no PATH candidate should resolve when only bare `openclaw` is present',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+// --- Invariant 3: resolution still works when the shim *is* present. ---
+//
+// Belt-and-braces: dropping `fallbackBins` shouldn't accidentally make
+// the happy path stop working. With `openclaw-acp-shim` on PATH,
+// resolution still selects it. This guards against a future
+// over-correction (e.g. dropping `bin` itself, or renaming it without
+// the test catching the typo).
+
+fsTest(
+  'inspectAgentExecutableResolution selects the shim when it is on PATH',
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), 'od-openclaw-shim-present-'));
+    try {
+      writeFileSync(join(dir, 'openclaw-acp-shim'), '');
+      chmodSync(join(dir, 'openclaw-acp-shim'), 0o755);
+      // Also include the bare CLI to prove resolution prefers / requires
+      // the shim and isn't quietly satisfied by the bare binary.
+      writeFileSync(join(dir, 'openclaw'), '');
+      chmodSync(join(dir, 'openclaw'), 0o755);
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+
+      const resolution = inspectAgentExecutableResolution(openclaw);
+      assert.equal(
+        resolution.selectedPath,
+        join(dir, 'openclaw-acp-shim'),
+        'the shim must be picked as the chat-spawn binary when present',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+// --- Invariant 4: install hint is surfaced when the runtime is unavailable. ---
+//
+// `unavailableAgent(def)` in `detection.ts` spreads
+// `installMetaForAgent(def.id)` into the DetectedAgent payload \u2014
+// that's the field the picker reads to render "OpenClaw is not
+// installed \u2192 see install instructions." Without an entry in
+// `AGENT_INSTALL_LINKS`, the unavailable record carries no link and
+// the user has no idea why OpenClaw is missing or how to fix it. The
+// reviewers explicitly asked for "an install hint instead of falling
+// back to bare `openclaw`."
+
+test('installMetaForAgent("openclaw") surfaces an https install hint for the shim', () => {
+  const meta = installMetaForAgent('openclaw');
+  assert.ok(
+    meta.installUrl,
+    'openclaw must surface an installUrl so the picker can tell users how to recover when the shim is missing',
+  );
+  assert.ok(
+    meta.installUrl?.startsWith('https://'),
+    `openclaw installUrl must be an https URL (metadata.ts sanitizes non-https); got ${meta.installUrl ?? '<unset>'}`,
+  );
+});


### PR DESCRIPTION
Adds OpenClaw (https://github.com/openclaw/openclaw) as a 17th coding-agent runtime. OpenClaw is a long-lived gateway daemon that ships `openclaw acp` as its official ACP bridge — argv-compatible with the existing Hermes / Kimi / Kilo / Kiro / Vibe / Devin entries, so the adapter is a thin descriptor with no new transport code.

Notes for reviewers
-------------------
- `bin` points at `openclaw-acp-shim`, a tiny Node wrapper that forwards stdin to `openclaw acp` but never propagates EOF. The shim is required because the current ACP runner closes stdin right after writing each JSON-RPC frame, which OpenClaw's ACP bridge interprets as a client disconnect mid-`session/new`. The shim ships separately from OpenClaw itself; users who already have `openclaw` on PATH but no shim will fall through to `fallbackBins: ['openclaw']`, which works for the `--version` probe and model detection. Long-form chat with the no-shim fallback can still hit the stdin-EOF bug; the README addition (follow-up commit) documents this.
- `mcpDiscovery` and `externalMcpInjection` are intentionally unset: OpenClaw's ACP bridge surfaces gateway-configured MCP servers globally and rejects per-session MCP descriptors with `-32603 ACP bridge mode does not support per-session MCP servers`. This costs OD's live-artifact write-back path, but the chat loop still runs end-to-end and OpenClaw's own tool surface remains available.
- The default session key (`agent:main:main`) can be overridden per project via `OD_OPENCLAW_SESSION`. As of follow-up commit `d222d3d` the override is read from `runtimeContext.env` so OD per-agent CLI env settings and the daemon launch env both resolve to the same gateway session (see @Siri-Ray's review comment).
- Three Anthropic model labels are listed as `fallbackModels` hints for when the live ACP probe cannot reach a running gateway; the real model selection happens inside OpenClaw's own routing.

Related #980

## Why

Wanted to drive an OD design loop through an existing OpenClaw gateway I'm already running on EC2 (own use case — building an OpenDesign ↔ OpenClaw integration alongside this PR). OpenClaw brings web_search, web_fetch, image generation, sub-agents, persistent memory and multi-channel chat bridges; without an adapter, OD users with an OpenClaw gateway had to either stand up a second CLI just for OD, or fall through to BYOK proxy mode and lose the gateway's tool surface entirely.

#980 has been tracking NemoClaw/OpenClaw adapter support and the fixture discussion this PR builds from. This PR is the "out-of-the-box adapter" piece of that issue; happy to switch to `Fixes #980` if you'd prefer the issue to auto-close, but kept it `Related` because #980 also covers downstream packaging/docs work that lives outside this diff.

## What users will see

- A new **OpenClaw** entry in the OD agent runtime picker, alongside the existing 16 CLIs (Hermes / Kimi / Kilo / Kiro / Vibe / Devin etc.).
- When `openclaw-acp-shim` (or `openclaw` as fallback) is on PATH and a gateway is reachable, OpenClaw shows up with `available: true` and the live `--version` string. The model picker enumerates the gateway's configured models via an ACP `initialize` handshake; if the probe can't reach the gateway, the picker falls back to a "Default (CLI config)" entry plus a few Anthropic hints, and the real model is chosen by OpenClaw's own routing at run time.
- Power users can point at a non-default OpenClaw session by setting `OD_OPENCLAW_SESSION=agent:<namespace>:<id>` either in the daemon launch env or via OD's per-agent CLI env settings. Both paths now go through the same merged env, so the model probe and the chat spawn always target the same gateway session.
- No change for users without OpenClaw on PATH: the runtime stays `available: false` and is invisible in the picker, same as the other 16 CLIs when their bin is missing.

## Surface area

- [x] **CLI / env var** — reads a new `OD_OPENCLAW_SESSION` env var to pick the OpenClaw gateway session; defaults to `agent:main:main` when unset.
- [ ] UI — no new pages/menus; the OpenClaw entry just falls out of the existing runtime registry.
- [ ] Keyboard shortcut
- [ ] API / contract — no endpoint signature change; `/api/agents` simply lists one more entry.
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency — no `package.json` changes.
- [ ] Default behavior change — pre-existing OD installs without OpenClaw on PATH continue to behave identically; the new entry only surfaces when the bin is detected.

## Bug fix verification

The PR itself is a feature, but follow-up commit `d222d3d` is a bug fix on top of `bff434f` (the env-source-alignment issue @Siri-Ray flagged inline). It is encoded as a falsifiable spec per AGENTS.md → "Bug follow-up workflow":

- **Test path:** `apps/daemon/tests/runtimes/openclaw-args.test.ts`
- **Red on `bff434f` (pre-fix) / green on `d222d3d` (post-fix)?** Yes — 3 of the 6 cases fail on the original feature commit and all 6 pass on the fix.

Reproduction (Node 24, vitest 4.1.6) — self-contained, starts from a fresh checkout of the PR branch so reviewers don't need any state I happen to have on disk:

```
# Start on this PR's head (d222d3d).
$ git fetch origin pull/2556/head:pr-2556 && git checkout pr-2556
$ git rev-parse HEAD
d222d3dec9602544b1feb32a2f4c0a91916e6a94

# Step 1: replace the three source files with their bff434f (pre-fix)
# versions; the new test file from d222d3d stays in place.
$ git checkout bff434f -- \
    apps/daemon/src/runtimes/defs/openclaw.ts \
    apps/daemon/src/runtimes/types.ts \
    apps/daemon/src/server.ts

# Step 2: confirm RED on pre-fix sources.
$ cd apps/daemon && npx vitest run tests/runtimes/openclaw-args.test.ts
 ❯ tests/runtimes/openclaw-args.test.ts (6 tests | 3 failed)
   × openclaw buildArgs uses runtimeContext.env for OD_OPENCLAW_SESSION
   × openclaw buildArgs prefers runtimeContext.env over process.env
   × openclaw buildArgs forwards model override when set
 (Tests: 3 failed | 3 passed (6))

# Step 3: restore the three source files to d222d3d (PR head).
$ cd .. && git checkout d222d3d -- \
    apps/daemon/src/runtimes/defs/openclaw.ts \
    apps/daemon/src/runtimes/types.ts \
    apps/daemon/src/server.ts

# Step 4: confirm GREEN on post-fix sources.
$ cd apps/daemon && npx vitest run tests/runtimes/openclaw-args.test.ts
 ✓ tests/runtimes/openclaw-args.test.ts (6 tests) 7ms
 Test Files  1 passed (1)
      Tests  6 passed (6)

# Optional cleanup: drop the throwaway local branch.
$ cd .. && git checkout - && git branch -D pr-2556
```

The three failing assertions on `bff434f` are exactly the env-source-alignment cases: `runtimeContext.env` is the canonical source, but the original `buildArgs` reads `process.env`, so the configured override falls through to `agent:main:main`. Assertions use a `sessionArgOf(args)` helper instead of `deepEqual` against the full argv (following @PerishCode's invariant-style review on #2557), so a future `buildArgs` change that adds an unrelated flag won't be flagged as a regression.

## Validation

- `pnpm --filter @open-design/daemon run typecheck` → passes.
- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/openclaw-args.test.ts` → 6/6 pass.
- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/agent-args.test.ts tests/runtimes/registry-and-args.test.ts` → 49/49 pass (no regression in the established adapter suite).
- Manual end-to-end against a live OpenClaw gateway on EC2 (gateway v2026.5.19): `/api/agents` returns OpenClaw at `available: true`, `path: /home/node/bin/openclaw-acp-shim`, `version: "OpenClaw 2026.5.19"`, `modelsSource: "live"`. Setting `OD_OPENCLAW_SESSION=agent:designs:hero` via OD's per-agent CLI env settings now routes both model discovery and chat spawn against `agent:designs:hero` (previously chat spawn fell through to `agent:main:main`).

## Fixes

Related #980