### PR TITLE
fix: polish Windows onboarding dropdown presentation

### DIFF
--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1629,16 +1629,17 @@
   left: 0;
   right: 0;
   display: grid;
-  gap: 2px;
-  max-height: 240px;
+  gap: 1px;
+  max-height: 180px;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: 6px;
+  padding: 4px;
   border: 1px solid color-mix(in srgb, var(--border) 82%, var(--accent) 18%);
   border-radius: 8px;
   background: color-mix(in srgb, var(--bg-panel) 96%, var(--bg-subtle) 4%);
-  box-shadow: 0 14px 34px color-mix(in srgb, var(--shadow-color, #000) 12%, transparent);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--shadow-color, #000) 10%, transparent);
   scrollbar-gutter: stable;
+  scrollbar-width: thin;
 }
 
 .onboarding-view__select-field[data-placement='top'] .onboarding-view__select-menu {
@@ -1650,29 +1651,30 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  min-height: 32px;
+  gap: 10px;
+  min-height: 28px;
   width: 100%;
   border: 0;
-  border-radius: 6px;
-  padding: 0 10px;
+  border-radius: 5px;
+  padding: 0 9px;
   color: var(--text);
   background: transparent;
   font: inherit;
-  font-size: 13px;
+  font-size: 12.5px;
   text-align: left;
   cursor: pointer;
+  transition: background-color 100ms ease, color 100ms ease;
 }
 
 .onboarding-view__select-option:hover {
   color: var(--text-strong);
-  background: color-mix(in srgb, var(--accent) 7%, var(--bg-panel));
+  background: color-mix(in srgb, var(--accent) 5%, var(--bg-panel));
 }
 
 .onboarding-view__select-option.is-selected {
   color: var(--accent-strong);
-  background: color-mix(in srgb, var(--accent) 10%, var(--bg-panel));
-  font-weight: 650;
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-panel));
+  font-weight: 600;
 }
 
 .onboarding-view__select-option svg {

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1663,7 +1663,7 @@
   font-size: 12.5px;
   text-align: left;
   cursor: pointer;
-  transition: background-color 100ms ease, color 100ms ease;
+  transition: background-color 120ms cubic-bezier(0.23, 1, 0.32, 1), color 120ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .onboarding-view__select-option:hover {


### PR DESCRIPTION
## Summary

Polishes the onboarding dropdown menus on Windows to feel lighter, more compact, and better integrated with the form.

Fixes #2512

## Surface area

- [x] UI / visual polish (onboarding dropdown component)
- [ ] API / daemon
- [ ] CLI
- [ ] Desktop shell
- [ ] Documentation

## Changes

### Visual density improvements
- Reduced max-height from 240px to 180px for more compact menu
- Decreased row height from 32px to 28px for better density
- Tighter padding and gaps (6px→4px, 2px→1px)
- Smaller font size (13px→12.5px) and spacing (gap 12px→10px)

### Visual weight refinements
- Softer hover state (7%→5% accent mix)
- Softer selected state (10%→8% accent mix, font-weight 650→600)
- Reduced shadow intensity (14px 34px 12%→8px 24px 10%)
- Added `scrollbar-width: thin` for refined scrollbar appearance

### Interaction polish
- Added smooth transitions using project-standard cubic-bezier curve (120ms)

## Testing

Tested the dropdown presentation on the onboarding flow:
- Menu feels more anchored to the trigger field
- Rows are easier to scan with improved density
- Hover and selected states feel less heavy
- Scrollbar is less prominent
- Overall component feels more balanced and polished

## Screenshots

Before: Heavy, tall menu with prominent scrollbar and strong hover states
After: Compact, refined menu with softer states and better visual hierarchy

---

**Note:** This is a CSS-only change focused on visual polish. No functional changes to dropdown behavior.