### PR TITLE
feat(daemon): preserve multi-page prototype scroll position on the url-load preview path

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -13,6 +13,7 @@ import {
   listInstalledPlugins,
   resolvePluginSnapshot,
 } from './plugins/index.js';
+import { injectScrollRelay } from './prototype-scroll-relay.js';
 import type { RouteDeps } from './server-context.js';
 import { listSkills } from './skills.js';
 import { auditDesignSystemPackage } from './tools-connectors-cli.js';
@@ -942,6 +943,13 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       }
 
       const file = await readProjectFile(PROJECTS_DIR, req.params.id, relPath, project?.metadata);
+      // url-load HTML is served raw; inject the scroll-position relay so
+      // multi-page prototypes keep their place on back-navigation without any
+      // per-project code. Non-HTML files are sent byte-for-byte.
+      if (file.mime.startsWith('text/html')) {
+        res.type(file.mime).send(injectScrollRelay(file.buffer.toString('utf8')));
+        return;
+      }
       res.type(file.mime).send(file.buffer);
     } catch (err: any) {
       const status = err && err.code === 'ENOENT' ? 404 : 400;

--- a/apps/daemon/src/prototype-scroll-relay.ts
+++ b/apps/daemon/src/prototype-scroll-relay.ts
@@ -1,0 +1,58 @@
+/**
+ * Scroll-position relay injected into HTML served on the url-load preview path
+ * (`GET /api/projects/:id/raw/*`).
+ *
+ * Multi-page prototypes navigate between separate files (e.g. an entry gallery
+ * that links out to `screens/*.html` and back). Each "back to list" is a full
+ * page load, so the list snaps to 0,0 and the user loses their place. The
+ * srcDoc preview path already augments served HTML (see
+ * `apps/web/src/runtime/srcdoc.ts`); url-load served raw HTML untouched, so
+ * generated prototypes had to hand-roll their own position keeping.
+ *
+ * This injects a tiny per-pathname scroll memory so it works with zero markup
+ * and zero per-project code. It relays through `window.name` because the
+ * preview iframe is sandboxed `allow-scripts` without `allow-same-origin`,
+ * where `localStorage`/`sessionStorage` reset on every reload while
+ * `window.name` survives same-context navigation.
+ *
+ * Coexistence guard: the relay only reads/writes `window.name` when it is
+ * empty or already holds our `ODSCROLL:` map. If a project uses `window.name`
+ * for its own purpose, the relay yields entirely and never clobbers it.
+ */
+
+export const SCROLL_RELAY_MARKER = 'data-od-scroll-relay';
+
+const SCROLL_RELAY_SCRIPT = `<script ${SCROLL_RELAY_MARKER}>(function(){
+  if (window.__odScrollRelay) return; window.__odScrollRelay = 1;
+  var K = 'ODSCROLL:';
+  function nm(){ try { return String(window.name || ''); } catch (e) { return ''; } }
+  function ours(){ var n = nm(); return n === '' || n.indexOf(K) === 0; }
+  function load(){ if (!ours()) return null; var n = nm(); if (n.indexOf(K) !== 0) return {}; try { return JSON.parse(n.slice(K.length)) || {}; } catch (e) { return {}; } }
+  function store(m){ if (!ours()) return; try { window.name = K + JSON.stringify(m); } catch (e) {} }
+  var path = location.pathname;
+  var map = load();
+  if (map && Object.prototype.hasOwnProperty.call(map, path)) {
+    var y = map[path] | 0;
+    var apply = function(){ window.scrollTo(0, y); };
+    apply();
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', apply);
+    requestAnimationFrame(apply);
+  }
+  function remember(){ var m = load(); if (!m) return; m[path] = Math.round(window.scrollY); store(m); }
+  window.addEventListener('pagehide', remember);
+  document.addEventListener('visibilitychange', function(){ if (document.visibilityState === 'hidden') remember(); });
+  document.addEventListener('click', function(e){ var a = e.target && e.target.closest && e.target.closest('a[href]'); if (a) remember(); }, true);
+})();</script>`;
+
+/**
+ * Inject the scroll relay into an HTML document string. Idempotent (a document
+ * already carrying the marker is returned unchanged). Prefers to land just
+ * before `</body>`, then `</head>`, then appends as a last resort so even
+ * fragment-like HTML still gets it.
+ */
+export function injectScrollRelay(html: string): string {
+  if (html.includes(SCROLL_RELAY_MARKER)) return html;
+  if (/<\/body\s*>/i.test(html)) return html.replace(/<\/body\s*>/i, (m) => `${SCROLL_RELAY_SCRIPT}${m}`);
+  if (/<\/head\s*>/i.test(html)) return html.replace(/<\/head\s*>/i, (m) => `${SCROLL_RELAY_SCRIPT}${m}`);
+  return html + SCROLL_RELAY_SCRIPT;
+}


### PR DESCRIPTION
## Why

Multi-page prototypes navigate between separate files — an entry gallery/list that links out to `screens/*.html`, with a "back to list" link. Each "back" is a full page load, so the list snaps back to 0,0 and the user loses their place in a long list. I hit this repeatedly while building multi-screen prototypes on top of Open Design.

The fix can't live in the generated artifact reliably: the preview iframe is sandboxed `allow-scripts` **without** `allow-same-origin` (`apps/web/src/components/FileViewer.tsx`), so `localStorage`/`sessionStorage` reset on every reload (`apps/web/src/runtime/srcdoc.ts`). The srcDoc preview path already augments served HTML, but the **url-load** path — which is what multi-file prototypes use when navigating between pages — served raw HTML untouched, leaving each generated project to hand-roll its own `window.name` bookkeeping.

## What users will see

Multi-page prototypes keep their place automatically: returning to a gallery/list via a back link restores the previous scroll position instead of jumping to the top. No per-project code, no markup, no opt-in — it works for every project the moment it's previewed.

## Surface area

- [x] **Default behavior change** — HTML served on the url-load preview path (`GET /api/projects/:id/raw/*`) now carries a small scroll-memory relay; non-HTML responses are unchanged and sent byte-for-byte.

## Screenshots

None — server-side behavior on a preview transport route; no `apps/web`/`apps/desktop` UI surface changes.

## Bug fix verification

Verified end-to-end against the running daemon (a deterministic unit spec isn't a clean fit — the relay runs in a sandboxed browser iframe):

- **Auto-injection**: `GET /api/projects/<id>/raw/index.html` returns the HTML with the relay injected (marker present); non-HTML responses are untouched.
- **Real preview sandbox condition**: drove a sandboxed iframe (`sandbox="allow-scripts"`, no `allow-same-origin`) loading the daemon's raw route. Confirmed the relay auto-injected (no `<script>` in the source file), scrolled the list to 1500, opened a screen, returned via a back link → list restored to **1500 at DOMContentLoaded and load** (no 0,0 flash). Scroll is stored per-pathname in `window.name` (`ODSCROLL:{...}`), the one channel that survives same-context navigation/reload in the sandbox.
- **Coexistence / no regression**: the relay only reads/writes `window.name` when it is empty or already holds its own `ODSCROLL:` map. Any project that uses `window.name` for its own purpose makes the relay yield entirely, so it can never clobber an existing relay.

`pnpm guard` passes; `apps/daemon` builds clean (`tsc`). The only typecheck error in my tree is an unrelated untracked local test file, not part of this PR.
