### PR TITLE
feat(desktop): follow OS language in packaged builds (cherry-pick of #2544 into release/v0.8.0)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -69,6 +69,32 @@ export {
 
 const TOOLS_DEV_PARENT_PID_ENV = SIDECAR_ENV.TOOLS_DEV_PARENT_PID;
 
+// Argv prefix the preload uses to recover the OS locale main process
+// read at startup. The renderer wires `__od__.client.osLocale` from it.
+export const OS_LOCALE_PRELOAD_ARG_PREFIX = "--od-os-locale=";
+
+/**
+ * Read the OS preferred language and, when Electron has not yet
+ * emitted `ready`, point Chromium's `--lang` flag at it so the
+ * renderer's `navigator.language` follows the OS instead of falling
+ * back to en-US. Returns the resolved BCP-47 string so callers can
+ * forward it to `BrowserWindow.webPreferences.additionalArguments`
+ * for the preload to expose to the renderer.
+ *
+ * Safe to call multiple times: `appendSwitch('lang', ...)` is a no-op
+ * once `app.isReady()` is true. The packaged entry calls this once
+ * before its own `whenReady` (so the switch lands) and `runDesktopMain`
+ * calls it again later to recover the same string for the BrowserWindow.
+ */
+export function applyOsLocaleSwitch(electronApp: Electron.App): string {
+  const preferred = electronApp.getPreferredSystemLanguages?.() ?? [];
+  const osLocale = preferred[0] ?? "en";
+  if (!electronApp.isReady()) {
+    electronApp.commandLine.appendSwitch("lang", osLocale);
+  }
+  return osLocale;
+}
+
 export type DesktopMainOptions = {
   beforeShutdown?: () => Promise<void>;
   discoverWebUrl?: () => Promise<string | null>;
@@ -290,6 +316,13 @@ export async function runDesktopMain(
   // helper is promoted to a shared workspace package.
   attachDesktopProcessErrorFilter();
 
+  // dev (tools-dev) enters here without a prior `whenReady` — so this
+  // is where the `--lang` switch actually lands. In packaged builds
+  // `apps/packaged/src/index.ts` has already applied the switch before
+  // its own `whenReady`; this call is then a no-op for the switch and
+  // only recovers the locale string for the BrowserWindow below.
+  const osLocale = applyOsLocaleSwitch(app);
+
   await app.whenReady();
 
   // PR #974: mint a per-process auth secret and hand it to the daemon
@@ -370,6 +403,7 @@ export async function runDesktopMain(
     desktopAuthSecret,
     discoverUrl: options.discoverWebUrl ?? createWebDiscovery(runtime),
     discoverDaemonUrl: options.discoverDaemonUrl,
+    osLocale,
     preloadPath: options.preloadPath,
     // Round-5 (lefarcen P1, mrcfps): runtime hands this back to itself
     // on `503 DESKTOP_AUTH_PENDING` to re-handshake with the daemon

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -26,7 +26,12 @@ function readOsLocaleFromArgv(): string | undefined {
   for (const arg of process.argv) {
     if (typeof arg === 'string' && arg.startsWith(OS_LOCALE_ARG_PREFIX)) {
       const value = arg.slice(OS_LOCALE_ARG_PREFIX.length);
-      if (value.length > 0) return value;
+      if (value.length === 0) return undefined;
+      try {
+        return decodeURIComponent(value);
+      } catch {
+        return value;
+      }
     }
   }
   return undefined;

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -15,6 +15,23 @@ const OPEN_DESIGN_HOST_GLOBAL: typeof import('@open-design/host').OPEN_DESIGN_HO
 const OPEN_DESIGN_HOST_VERSION: typeof import('@open-design/host').OPEN_DESIGN_HOST_VERSION = 1;
 const UPDATER_STATUS_EVENT = 'od:update:status-changed';
 
+// Mirror of the argv prefix used by main's `applyOsLocaleSwitch` and
+// runtime's `additionalArguments`. Duplicated literal on purpose: the
+// preload bundle must not pull in `@open-design/desktop/main` (it
+// transitively requires non-electron node modules that the sandboxed
+// preload can't load).
+const OS_LOCALE_ARG_PREFIX = '--od-os-locale=';
+
+function readOsLocaleFromArgv(): string | undefined {
+  for (const arg of process.argv) {
+    if (typeof arg === 'string' && arg.startsWith(OS_LOCALE_ARG_PREFIX)) {
+      const value = arg.slice(OS_LOCALE_ARG_PREFIX.length);
+      if (value.length > 0) return value;
+    }
+  }
+  return undefined;
+}
+
 type PrintPdfOptions = {
   deck?: boolean;
 };
@@ -197,11 +214,14 @@ const updater = {
   },
 };
 
+const osLocale = readOsLocaleFromArgv();
+
 const hostBridge = {
   version: OPEN_DESIGN_HOST_VERSION,
   client: {
     type: 'desktop',
     platform: process.platform,
+    ...(osLocale !== undefined ? { osLocale } : {}),
   },
   shell,
   project,

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -792,7 +792,14 @@ function desktopPetUrl(baseUrl: string): string {
   return url.toString();
 }
 
-function createDesktopPetWindow(preloadPath: string): BrowserWindow {
+// Encode the OS locale before stuffing it into a Chromium argv value
+// — BCP-47 region tags shouldn't contain `;` or `=`, but the renderer's
+// `process.argv` parser is happier if we never have to worry about it.
+function osLocaleAdditionalArguments(osLocale: string | undefined): string[] | undefined {
+  return osLocale ? [`--od-os-locale=${encodeURIComponent(osLocale)}`] : undefined;
+}
+
+function createDesktopPetWindow(preloadPath: string, osLocale: string | undefined): BrowserWindow {
   const { workArea } = screen.getPrimaryDisplay();
   const petWindow = new BrowserWindow({
     width: DESKTOP_PET_WINDOW_WIDTH,
@@ -809,6 +816,7 @@ function createDesktopPetWindow(preloadPath: string): BrowserWindow {
     hasShadow: false,
     focusable: false,
     webPreferences: {
+      additionalArguments: osLocaleAdditionalArguments(osLocale),
       contextIsolation: true,
       nodeIntegration: false,
       preload: preloadPath,
@@ -1180,7 +1188,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   });
 
   const consoleEntries: DesktopConsoleEntry[] = [];
-  const petWindow = createDesktopPetWindow(preloadPath);
+  const petWindow = createDesktopPetWindow(preloadPath, options.osLocale);
   const window = new BrowserWindow({
     height: 900,
     icon: resolveDesktopIconPath(),
@@ -1194,7 +1202,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     title: "Open Design",
     ...MAC_WINDOW_CHROME,
     webPreferences: {
-      additionalArguments: options.osLocale ? [`--od-os-locale=${options.osLocale}`] : undefined,
+      additionalArguments: osLocaleAdditionalArguments(options.osLocale),
       contextIsolation: true,
       nodeIntegration: false,
       preload: preloadPath,

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -307,6 +307,13 @@ export type DesktopRuntimeOptions = {
    * and the runtime falls back to `discoverUrl` for API calls too.
   */
   discoverDaemonUrl?: () => Promise<string | null>;
+  /**
+   * BCP-47 locale string read from the OS by main process, forwarded
+   * to the preload via `webPreferences.additionalArguments` so the
+   * renderer can mirror it onto `__od__.client.osLocale`. Optional;
+   * when omitted the renderer falls back to navigator/localStorage.
+   */
+  osLocale?: string;
   preloadPath?: string;
   /**
    * Round-5 (lefarcen P1, mrcfps): lazy re-handshake hook. The runtime
@@ -1187,6 +1194,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     title: "Open Design",
     ...MAC_WINDOW_CHROME,
     webPreferences: {
+      additionalArguments: options.osLocale ? [`--od-os-locale=${options.osLocale}`] : undefined,
       contextIsolation: true,
       nodeIntegration: false,
       preload: preloadPath,

--- a/apps/desktop/tests/main/preload-host-boundary.test.ts
+++ b/apps/desktop/tests/main/preload-host-boundary.test.ts
@@ -19,6 +19,12 @@ describe("desktop preload host boundary", () => {
     expect(source).toContain("exportDiagnostics");
     expect(source).toContain("satisfies OpenDesignHostBridge");
     expect(source).toContain("updater");
+    // OS locale forwarded from main via webPreferences.additionalArguments
+    // is mirrored onto __od__.client.osLocale. Pin the literal prefix
+    // here so it can't drift away from `applyOsLocaleSwitch`/runtime's
+    // additionalArguments without the test going red.
+    expect(source).toContain("'--od-os-locale='");
+    expect(source).toContain("osLocale");
     expect(source).toContain("invokeUpdater('install'");
     expect(source).toContain("od:update:quit");
     expect(source).toContain("od:update:status-changed");

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -10,6 +10,7 @@ import {
   createSidecarLaunchEnv,
   resolveAppIpcPath,
 } from "@open-design/sidecar";
+import { applyOsLocaleSwitch } from "@open-design/desktop/main";
 import { readProcessStamp } from "@open-design/platform";
 import { join } from "node:path";
 import { app, dialog } from "electron";
@@ -59,6 +60,13 @@ function applyLaunchEnv(base: string, stamp: SidecarStamp): void {
 }
 
 async function main(): Promise<void> {
+  // Must run BEFORE `app.whenReady()` below, because Chromium consumes
+  // `--lang` at session bootstrap. Doing it here lets the packaged
+  // renderer's `navigator.language` follow the OS instead of Chromium's
+  // en-US default. runDesktopMain (called later) calls the same helper
+  // again to recover the resolved locale string for the BrowserWindow.
+  applyOsLocaleSwitch(app);
+
   const config = await readPackagedConfig();
   const argvStamp = readProcessStamp(process.argv.slice(1), OPEN_DESIGN_SIDECAR_CONTRACT);
   const namespace = argvStamp?.namespace ?? config.namespace;

--- a/apps/web/src/i18n/index.tsx
+++ b/apps/web/src/i18n/index.tsx
@@ -59,6 +59,13 @@ const DICTS: Record<Locale, Dict> = {
 };
 
 const LS_KEY = 'open-design:locale';
+// Marker that says "the value in LS_KEY came from a deliberate user
+// action through setLocale, not from some auto-detection path". Only
+// values tagged this way win over the desktop host's injected OS
+// locale, so a stale auto-detected pick can't pin the app forever once
+// the user changes their system language.
+const LS_SOURCE_KEY = 'open-design:locale-source';
+const MANUAL_LOCALE_SOURCE = 'manual';
 
 export function resolveSystemLocale(languages: readonly string[]): Locale | null {
   const supported = LOCALES as readonly string[];
@@ -97,19 +104,29 @@ function readDesktopHostOsLocale(): string | undefined {
 }
 
 // First-run defaults to the user's OS / browser language when possible.
-// Priority: explicit user pick saved to localStorage > OS locale that the
-// desktop host injected (packaged Electron) > navigator.languages > 'en'.
+// Priority: explicit user pick saved to localStorage (only when tagged
+// as manual) > OS locale that the desktop host injected (packaged
+// Electron) > navigator.languages > 'en'. The source tag matters
+// because untagged localStorage values are treated as legacy /
+// auto-detected — they don't override a fresh OS locale read.
 // Exported so tests can pin the priority chain without spinning up the
 // full I18nProvider.
 export function detectInitialLocale(): Locale {
   if (typeof window === 'undefined') return 'en';
+  let storedLocale: string | null = null;
+  let storedSource: string | null = null;
   try {
-    const stored = window.localStorage.getItem(LS_KEY);
-    if (stored && (LOCALES as string[]).includes(stored)) {
-      return stored as Locale;
-    }
+    storedLocale = window.localStorage.getItem(LS_KEY);
+    storedSource = window.localStorage.getItem(LS_SOURCE_KEY);
   } catch {
     /* ignore */
+  }
+  if (
+    storedSource === MANUAL_LOCALE_SOURCE &&
+    storedLocale &&
+    (LOCALES as string[]).includes(storedLocale)
+  ) {
+    return storedLocale as Locale;
   }
   const hostOsLocale = readDesktopHostOsLocale();
   if (hostOsLocale) {
@@ -155,6 +172,9 @@ export function I18nProvider({ initial, children }: ProviderProps) {
     setLocaleState(next);
     try {
       window.localStorage.setItem(LS_KEY, next);
+      // Marker so detectInitialLocale knows this came from a deliberate
+      // user action and should beat the desktop host's OS locale.
+      window.localStorage.setItem(LS_SOURCE_KEY, MANUAL_LOCALE_SOURCE);
     } catch {
       /* ignore */
     }

--- a/apps/web/src/i18n/index.tsx
+++ b/apps/web/src/i18n/index.tsx
@@ -28,6 +28,7 @@ import { uk } from './locales/uk';
 import { tr } from './locales/tr';
 import { th } from './locales/th';
 import { it } from './locales/it';
+import { getOpenDesignHost } from '@open-design/host';
 import { LOCALES, type Dict, type Locale } from './types';
 
 export { LOCALES, LOCALE_LABEL } from './types';
@@ -82,12 +83,15 @@ export function resolveSystemLocale(languages: readonly string[]): Locale | null
   return null;
 }
 
-// Read the OS locale main process attached to `__od__.client.osLocale`.
+// Read the OS locale the desktop host attached to its client descriptor.
 // Packaged desktop builds need this because Chromium otherwise reports
-// en-US through navigator.language regardless of the OS setting.
+// en-US through navigator.language regardless of the OS setting. We go
+// through `getOpenDesignHost` rather than reading the bridge global by
+// name so the web/preload boundary stays single-source (see the
+// `host bridge boundary` guard test).
 function readDesktopHostOsLocale(): string | undefined {
   if (typeof window === 'undefined') return undefined;
-  const host = (window as { __od__?: { client?: { osLocale?: unknown } } }).__od__;
+  const host = getOpenDesignHost();
   const value = host?.client?.osLocale;
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }

--- a/apps/web/src/i18n/index.tsx
+++ b/apps/web/src/i18n/index.tsx
@@ -82,10 +82,22 @@ export function resolveSystemLocale(languages: readonly string[]): Locale | null
   return null;
 }
 
-// First-run defaults to the user's browser/system language when possible.
-// An explicit user pick saved to localStorage always wins; unsupported
-// languages fall back to English.
-function detectInitialLocale(): Locale {
+// Read the OS locale main process attached to `__od__.client.osLocale`.
+// Packaged desktop builds need this because Chromium otherwise reports
+// en-US through navigator.language regardless of the OS setting.
+function readDesktopHostOsLocale(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const host = (window as { __od__?: { client?: { osLocale?: unknown } } }).__od__;
+  const value = host?.client?.osLocale;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+// First-run defaults to the user's OS / browser language when possible.
+// Priority: explicit user pick saved to localStorage > OS locale that the
+// desktop host injected (packaged Electron) > navigator.languages > 'en'.
+// Exported so tests can pin the priority chain without spinning up the
+// full I18nProvider.
+export function detectInitialLocale(): Locale {
   if (typeof window === 'undefined') return 'en';
   try {
     const stored = window.localStorage.getItem(LS_KEY);
@@ -94,6 +106,11 @@ function detectInitialLocale(): Locale {
     }
   } catch {
     /* ignore */
+  }
+  const hostOsLocale = readDesktopHostOsLocale();
+  if (hostOsLocale) {
+    const fromHost = resolveSystemLocale([hostOsLocale]);
+    if (fromHost) return fromHost;
   }
   const detected = resolveSystemLocale(
     navigator.languages?.length ? navigator.languages : [navigator.language],

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -2032,6 +2032,702 @@
   }
 }
 
+.onboarding-view__primary:focus-visible,
+.onboarding-view__secondary:focus-visible,
+.onboarding-view__ghost:focus-visible,
+.onboarding-view__steps li button:focus-visible,
+.onboarding-view__card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.onboarding-view__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.onboarding-view__runtime-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.onboarding-view__alternatives {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.onboarding-view__alternatives .onboarding-view__card {
+  grid-template-columns: 34px minmax(0, 1fr);
+  min-height: 96px;
+  padding: 13px 14px;
+  gap: 11px;
+}
+
+.onboarding-view__alternatives .onboarding-view__icon {
+  width: 34px;
+  height: 34px;
+}
+
+.onboarding-view__alternatives .onboarding-view__card-top {
+  display: flex;
+  min-height: 0;
+}
+
+.onboarding-view__alternatives .onboarding-view__card strong {
+  font-size: 14px;
+  line-height: 1.2;
+}
+
+.onboarding-view__alternatives .onboarding-view__card small {
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
+.onboarding-view__alternatives .onboarding-view__card-action {
+  margin-top: 2px;
+  font-size: 11.5px;
+}
+
+.onboarding-view__setup-panel {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, var(--accent) 18%);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-panel) 97%, var(--accent) 3%);
+  box-shadow: var(--shadow-xs);
+}
+
+.onboarding-view__setup-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.onboarding-view__setup-head strong {
+  display: block;
+  color: var(--text-strong);
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.onboarding-view__setup-head p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.onboarding-view__setup-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: -2px;
+}
+
+.onboarding-view__setup-head-actions {
+  display: inline-flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.onboarding-view__mini-button,
+.onboarding-view__field-row button,
+.onboarding-view__protocol-strip button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0 11px;
+  color: var(--text);
+  background: var(--bg-panel);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+  box-shadow: var(--shadow-xs);
+}
+
+.onboarding-view__mini-button:hover,
+.onboarding-view__field-row button:hover,
+.onboarding-view__protocol-strip button:hover {
+  color: var(--text-strong);
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
+}
+
+.onboarding-view__mini-button:disabled {
+  cursor: default;
+  opacity: 0.58;
+}
+
+.onboarding-view__mini-button.is-loading {
+  color: var(--text-muted);
+}
+
+.onboarding-view__agent-strip {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.onboarding-view__agent-chip {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  min-height: 48px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  color: var(--text);
+  background: var(--bg-panel);
+  text-align: left;
+  cursor: pointer;
+  animation: onboarding-agent-pop 220ms cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+
+.onboarding-view__agent-chip.is-selected {
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--border));
+  background: color-mix(in srgb, var(--bg-panel) 92%, var(--accent) 8%);
+}
+
+.onboarding-view__agent-chip .agent-icon {
+  flex: 0 0 auto;
+}
+
+.onboarding-view__agent-chip span {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.onboarding-view__agent-chip strong,
+.onboarding-view__agent-chip small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.onboarding-view__agent-chip strong {
+  color: var(--text-strong);
+  font-size: 12.5px;
+  line-height: 1.2;
+}
+
+.onboarding-view__agent-chip small {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.onboarding-view__empty-slice {
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  padding: 13px;
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  font-size: 12px;
+}
+
+.onboarding-view__scan-copy {
+  display: grid;
+  gap: 6px;
+  justify-items: start;
+}
+
+.onboarding-view__scan-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.onboarding-view__scan-hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.onboarding-view__protocol-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.onboarding-view__protocol-strip button.is-selected {
+  color: var(--text-strong);
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+  background: color-mix(in srgb, var(--bg-panel) 90%, var(--accent) 10%);
+}
+
+.onboarding-view__inline-field {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.onboarding-view__inline-field input {
+  width: 100%;
+  min-width: 0;
+  min-height: 42px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0 12px;
+  color: var(--text-strong);
+  background: var(--bg-panel);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: var(--shadow-xs);
+}
+
+.onboarding-view__inline-field input:focus,
+.onboarding-view__inline-field input:focus-visible,
+.onboarding-view__agent-chip:focus-visible,
+.onboarding-view__mini-button:focus-visible,
+.onboarding-view__field-row button:focus-visible,
+.onboarding-view__protocol-strip button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.onboarding-view__field-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.onboarding-view__field-row button {
+  min-height: 42px;
+}
+
+.onboarding-view__compact-fields {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.onboarding-view__test-status {
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.onboarding-view__test-status.is-running {
+  color: var(--text-muted);
+  background: var(--bg-panel);
+}
+
+.onboarding-view__test-status.is-success {
+  color: var(--success-text, #166534);
+  border-color: color-mix(in srgb, var(--success, #22c55e) 34%, var(--border));
+  background: color-mix(in srgb, var(--success, #22c55e) 9%, var(--bg-panel));
+}
+
+.onboarding-view__test-status.is-warn {
+  color: var(--warning-text, #92400e);
+  border-color: color-mix(in srgb, var(--warning, #f59e0b) 34%, var(--border));
+  background: color-mix(in srgb, var(--warning, #f59e0b) 10%, var(--bg-panel));
+}
+
+.onboarding-view__test-status.is-error {
+  color: var(--danger-text, #991b1b);
+  border-color: color-mix(in srgb, var(--danger, #ef4444) 34%, var(--border));
+  background: color-mix(in srgb, var(--danger, #ef4444) 9%, var(--bg-panel));
+}
+
+@keyframes onboarding-agent-pop {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.onboarding-view__card {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+  min-height: 112px;
+  padding: 16px 18px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg-panel);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  box-shadow: var(--shadow-xs);
+  transition: background-color 160ms cubic-bezier(0.23, 1, 0.32, 1), border-color 160ms cubic-bezier(0.23, 1, 0.32, 1), transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.onboarding-view__card--featured {
+  grid-template-columns: 56px minmax(0, 1fr) auto;
+  min-height: 168px;
+  padding: 22px 24px;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--accent) 13%, var(--bg-panel)) 0%,
+      var(--bg-panel) 54%
+    );
+  border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
+  box-shadow: 0 18px 40px color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.onboarding-view__card.is-selected {
+  border-color: color-mix(in srgb, var(--accent) 52%, var(--border));
+  background: color-mix(in srgb, var(--bg-panel) 94%, var(--accent) 6%);
+}
+
+.onboarding-view__card--featured.is-selected {
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--accent) 16%, var(--bg-panel)) 0%,
+      color-mix(in srgb, var(--bg-panel) 96%, var(--accent) 4%) 54%
+    );
+}
+
+.onboarding-view__card:hover {
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
+  background: color-mix(in srgb, var(--bg-panel) 97%, var(--accent) 3%);
+  transform: translateY(-1px);
+}
+
+.onboarding-view__card-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 26px;
+  margin-bottom: 0;
+}
+
+.onboarding-view__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent) 9%, var(--bg-panel));
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
+}
+
+.onboarding-view__card--featured .onboarding-view__icon {
+  width: 52px;
+  height: 52px;
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-panel));
+}
+
+.onboarding-view__badge {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-height: 22px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.onboarding-view__badge {
+  color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-panel));
+}
+
+.onboarding-view__card-copy {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.onboarding-view__card strong {
+  display: block;
+  color: var(--text-strong);
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+.onboarding-view__card--featured strong {
+  font-size: 20px;
+}
+
+.onboarding-view__card small {
+  display: block;
+  margin-top: 0;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  line-height: 1.45;
+  white-space: pre-line;
+}
+
+.onboarding-view__card--featured small {
+  max-width: none;
+  font-size: 13px;
+}
+
+.onboarding-view__card-action {
+  grid-column: 2;
+  justify-self: start;
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+  opacity: 0.92;
+}
+
+.onboarding-view__card--featured .onboarding-view__card-action {
+  grid-column: auto;
+  justify-self: end;
+}
+
+.onboarding-view__check {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  color: var(--accent-contrast, #fff);
+  background: var(--accent);
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+.onboarding-view__form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.onboarding-view__select-field {
+  position: relative;
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.onboarding-view__select-label {
+  color: var(--text-strong);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.onboarding-view__select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0 12px 0 13px;
+  color: var(--text-muted);
+  background: var(--bg-panel);
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  box-shadow: var(--shadow-xs);
+  transition: background-color 160ms cubic-bezier(0.23, 1, 0.32, 1), border-color 160ms cubic-bezier(0.23, 1, 0.32, 1), color 160ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 160ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.onboarding-view__select-trigger svg {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  transition: transform 160ms cubic-bezier(0.23, 1, 0.32, 1), color 160ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.onboarding-view__select-trigger.has-value {
+  color: var(--text-strong);
+}
+
+.onboarding-view__select-trigger:hover,
+.onboarding-view__select-trigger.is-open {
+  color: var(--text-strong);
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
+  background: color-mix(in srgb, var(--bg-panel) 97%, var(--accent) 3%);
+}
+
+.onboarding-view__select-trigger.is-open {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.onboarding-view__select-trigger.is-open svg {
+  color: var(--accent-strong);
+  transform: rotate(180deg);
+}
+
+.onboarding-view__select-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.onboarding-view__select-menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  display: grid;
+  gap: 2px;
+  max-height: 240px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 6px;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, var(--accent) 18%);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-panel) 96%, var(--bg-subtle) 4%);
+  box-shadow: 0 14px 34px color-mix(in srgb, var(--shadow-color, #000) 12%, transparent);
+  scrollbar-gutter: stable;
+}
+
+.onboarding-view__select-field[data-placement='top'] .onboarding-view__select-menu {
+  top: auto;
+  bottom: calc(100% + 6px);
+}
+
+.onboarding-view__select-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 32px;
+  width: 100%;
+  border: 0;
+  border-radius: 6px;
+  padding: 0 10px;
+  color: var(--text);
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.onboarding-view__select-option:hover {
+  color: var(--text-strong);
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-panel));
+}
+
+.onboarding-view__select-option.is-selected {
+  color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-panel));
+  font-weight: 650;
+}
+
+.onboarding-view__select-option svg {
+  flex: 0 0 auto;
+}
+
+.onboarding-view__select-option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+}
+
+/* ============================================================
+   GitHub star pill — sticky top-bar CTA.
+
+   Mirrors the marketing landing-page "Star · <count>" affordance:
+   small chrome, low-emphasis, sits next to the model switcher and
+   settings cog. Hover swaps to the panel-strong palette so the call-
+   to-action still reads as clickable when the topbar is otherwise
+   sparse. The count slot animates in via `data-loading` so the
+   pill never visibly jumps when the API response arrives.
+   ============================================================ */
+.entry-star-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-panel);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  text-decoration: none;
+  cursor: pointer;
+  box-shadow: var(--shadow-xs);
+  transition: background-color 120ms ease, border-color 120ms ease,
+    color 120ms ease, transform 120ms ease;
+  white-space: nowrap;
+}
+.entry-star-badge:hover {
+  background: var(--bg-subtle);
+  border-color: var(--border-strong);
+  color: var(--text-strong);
+}
+.entry-star-badge:active {
+  transform: scale(0.98);
+}
+.entry-star-badge:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.entry-star-badge__icon {
+  color: var(--text-muted);
+  flex: 0 0 auto;
+}
+.entry-star-badge:hover .entry-star-badge__icon {
+  color: var(--text-strong);
+}
+.entry-star-badge__label {
+  color: var(--text-strong);
+  font-weight: 600;
+}
+.entry-star-badge__sep {
+  color: var(--text-faint);
+}
+.entry-star-badge__count {
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  transition: opacity 160ms ease;
+}
+.entry-star-badge__count[data-loading='true'] {
+  opacity: 0.55;
+}
+
+@media (max-width: 700px) {
+  .entry-star-badge__label {
+    display: none;
+  }
+  .entry-star-badge__sep {
+    display: none;
+  }
+}
+
 @media (max-width: 900px) {
   .entry-nav-rail {
     width: 56px;
@@ -2054,6 +2750,57 @@
   }
   .avatar-popover__divider--compact-only {
     display: block;
+  }
+}
+
+@media (max-width: 760px) {
+  .entry-shell--onboarding {
+    padding: 0;
+  }
+
+  .entry-onboarding-modal {
+    height: 100vh;
+    border-radius: 0;
+  }
+
+  .onboarding-view {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 28px 22px 32px;
+  }
+
+  .onboarding-view__hero h1 {
+    font-size: 32px;
+  }
+
+  .onboarding-view__panel {
+    min-height: 0;
+    padding: 18px;
+  }
+
+  .onboarding-view__steps {
+    grid-template-columns: 1fr;
+  }
+
+  .onboarding-view__ds-points {
+    grid-template-columns: 1fr;
+  }
+
+  .onboarding-view__card {
+    grid-template-columns: 40px minmax(0, 1fr);
+    min-height: 0;
+  }
+
+  .onboarding-view__card--featured,
+  .onboarding-view__alternatives,
+  .onboarding-view__agent-strip,
+  .onboarding-view__compact-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .onboarding-view__card-action {
+    grid-column: 2;
+    justify-self: start;
   }
 }
 

--- a/apps/web/tests/i18n/detect-initial-locale.test.ts
+++ b/apps/web/tests/i18n/detect-initial-locale.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { installMockOpenDesignHost } from '@open-design/host/testing';
 import { detectInitialLocale } from '../../src/i18n';
 
 const LS_KEY = 'open-design:locale';
@@ -16,31 +17,42 @@ function setNavigatorLanguages(languages: readonly string[]): void {
   });
 }
 
-function clearDesktopHost(): void {
-  delete (window as { __od__?: unknown }).__od__;
+// Track the installed mock so each test can swap it out without leaking
+// state into the next case (installMockOpenDesignHost returns an
+// uninstall callback that restores the previous value).
+let uninstallHost: (() => void) | null = null;
+
+function installHostWithOsLocale(value: unknown): void {
+  uninstallHost?.();
+  uninstallHost = installMockOpenDesignHost({
+    host: {
+      // The mock host's defaultHost() already sets client.type to
+      // 'desktop'; we only override the field exercised here.
+      client: { osLocale: value as string | undefined },
+    },
+  });
 }
 
-function setDesktopHostOsLocale(value: unknown): void {
-  (window as { __od__?: unknown }).__od__ = {
-    client: { type: 'desktop', osLocale: value },
-  };
+function clearHost(): void {
+  uninstallHost?.();
+  uninstallHost = null;
 }
 
 describe('detectInitialLocale priority chain', () => {
   beforeEach(() => {
     window.localStorage.clear();
-    clearDesktopHost();
+    clearHost();
     setNavigatorLanguages(['en-US']);
   });
 
   afterEach(() => {
     window.localStorage.clear();
-    clearDesktopHost();
+    clearHost();
   });
 
   it('prefers the user pick saved to localStorage over everything else', () => {
     window.localStorage.setItem(LS_KEY, 'ja');
-    setDesktopHostOsLocale('zh-CN');
+    installHostWithOsLocale('zh-CN');
     setNavigatorLanguages(['fr-FR']);
 
     expect(detectInitialLocale()).toBe('ja');
@@ -54,38 +66,38 @@ describe('detectInitialLocale priority chain', () => {
   });
 
   it('uses the desktop host OS locale when no localStorage pick exists', () => {
-    setDesktopHostOsLocale('zh-CN');
+    installHostWithOsLocale('zh-CN');
     setNavigatorLanguages(['en-US']);
 
     expect(detectInitialLocale()).toBe('zh-CN');
   });
 
   it('routes packaged OS locale strings through resolveSystemLocale (zh-Hant → zh-TW)', () => {
-    setDesktopHostOsLocale('zh-Hant-TW');
+    installHostWithOsLocale('zh-Hant-TW');
     setNavigatorLanguages(['en-US']);
 
     expect(detectInitialLocale()).toBe('zh-TW');
   });
 
   it('falls back to navigator when host osLocale is missing or not a string', () => {
-    setDesktopHostOsLocale(undefined);
+    installHostWithOsLocale(undefined);
     setNavigatorLanguages(['ko-KR']);
     expect(detectInitialLocale()).toBe('ko');
 
-    setDesktopHostOsLocale(42);
+    installHostWithOsLocale(42);
     setNavigatorLanguages(['fr-FR']);
     expect(detectInitialLocale()).toBe('fr');
   });
 
   it('falls back to navigator when host osLocale is not in the supported set', () => {
-    setDesktopHostOsLocale('nl-NL');
+    installHostWithOsLocale('nl-NL');
     setNavigatorLanguages(['pt-PT']);
 
     expect(detectInitialLocale()).toBe('pt-BR');
   });
 
   it('falls back to en when nothing else is available', () => {
-    clearDesktopHost();
+    clearHost();
     setNavigatorLanguages([]);
 
     expect(detectInitialLocale()).toBe('en');

--- a/apps/web/tests/i18n/detect-initial-locale.test.ts
+++ b/apps/web/tests/i18n/detect-initial-locale.test.ts
@@ -5,6 +5,16 @@ import { installMockOpenDesignHost } from '@open-design/host/testing';
 import { detectInitialLocale } from '../../src/i18n';
 
 const LS_KEY = 'open-design:locale';
+const LS_SOURCE_KEY = 'open-design:locale-source';
+
+function setStoredLocale(locale: string, source: 'manual' | 'untagged' = 'manual'): void {
+  window.localStorage.setItem(LS_KEY, locale);
+  if (source === 'manual') {
+    window.localStorage.setItem(LS_SOURCE_KEY, 'manual');
+  } else {
+    window.localStorage.removeItem(LS_SOURCE_KEY);
+  }
+}
 
 function setNavigatorLanguages(languages: readonly string[]): void {
   Object.defineProperty(window.navigator, 'languages', {
@@ -50,16 +60,23 @@ describe('detectInitialLocale priority chain', () => {
     clearHost();
   });
 
-  it('prefers the user pick saved to localStorage over everything else', () => {
-    window.localStorage.setItem(LS_KEY, 'ja');
+  it('prefers a manually-tagged localStorage pick over host and navigator', () => {
+    setStoredLocale('ja', 'manual');
     installHostWithOsLocale('zh-CN');
     setNavigatorLanguages(['fr-FR']);
 
     expect(detectInitialLocale()).toBe('ja');
   });
 
+  it('ignores an untagged localStorage value when a fresh host locale is available', () => {
+    setStoredLocale('ja', 'untagged');
+    installHostWithOsLocale('zh-CN');
+
+    expect(detectInitialLocale()).toBe('zh-CN');
+  });
+
   it('falls through to navigator when an unsupported locale was stored', () => {
-    window.localStorage.setItem(LS_KEY, 'xx-YY');
+    setStoredLocale('xx-YY', 'manual');
     setNavigatorLanguages(['de-DE']);
 
     expect(detectInitialLocale()).toBe('de');

--- a/apps/web/tests/i18n/detect-initial-locale.test.ts
+++ b/apps/web/tests/i18n/detect-initial-locale.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { detectInitialLocale } from '../../src/i18n';
+
+const LS_KEY = 'open-design:locale';
+
+function setNavigatorLanguages(languages: readonly string[]): void {
+  Object.defineProperty(window.navigator, 'languages', {
+    configurable: true,
+    get: () => languages,
+  });
+  Object.defineProperty(window.navigator, 'language', {
+    configurable: true,
+    get: () => languages[0] ?? 'en',
+  });
+}
+
+function clearDesktopHost(): void {
+  delete (window as { __od__?: unknown }).__od__;
+}
+
+function setDesktopHostOsLocale(value: unknown): void {
+  (window as { __od__?: unknown }).__od__ = {
+    client: { type: 'desktop', osLocale: value },
+  };
+}
+
+describe('detectInitialLocale priority chain', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    clearDesktopHost();
+    setNavigatorLanguages(['en-US']);
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    clearDesktopHost();
+  });
+
+  it('prefers the user pick saved to localStorage over everything else', () => {
+    window.localStorage.setItem(LS_KEY, 'ja');
+    setDesktopHostOsLocale('zh-CN');
+    setNavigatorLanguages(['fr-FR']);
+
+    expect(detectInitialLocale()).toBe('ja');
+  });
+
+  it('falls through to navigator when an unsupported locale was stored', () => {
+    window.localStorage.setItem(LS_KEY, 'xx-YY');
+    setNavigatorLanguages(['de-DE']);
+
+    expect(detectInitialLocale()).toBe('de');
+  });
+
+  it('uses the desktop host OS locale when no localStorage pick exists', () => {
+    setDesktopHostOsLocale('zh-CN');
+    setNavigatorLanguages(['en-US']);
+
+    expect(detectInitialLocale()).toBe('zh-CN');
+  });
+
+  it('routes packaged OS locale strings through resolveSystemLocale (zh-Hant → zh-TW)', () => {
+    setDesktopHostOsLocale('zh-Hant-TW');
+    setNavigatorLanguages(['en-US']);
+
+    expect(detectInitialLocale()).toBe('zh-TW');
+  });
+
+  it('falls back to navigator when host osLocale is missing or not a string', () => {
+    setDesktopHostOsLocale(undefined);
+    setNavigatorLanguages(['ko-KR']);
+    expect(detectInitialLocale()).toBe('ko');
+
+    setDesktopHostOsLocale(42);
+    setNavigatorLanguages(['fr-FR']);
+    expect(detectInitialLocale()).toBe('fr');
+  });
+
+  it('falls back to navigator when host osLocale is not in the supported set', () => {
+    setDesktopHostOsLocale('nl-NL');
+    setNavigatorLanguages(['pt-PT']);
+
+    expect(detectInitialLocale()).toBe('pt-BR');
+  });
+
+  it('falls back to en when nothing else is available', () => {
+    clearDesktopHost();
+    setNavigatorLanguages([]);
+
+    expect(detectInitialLocale()).toBe('en');
+  });
+});

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -9,6 +9,11 @@ export type OpenDesignHostClientType =
   (typeof OPEN_DESIGN_HOST_CLIENT_TYPES)[keyof typeof OPEN_DESIGN_HOST_CLIENT_TYPES];
 
 export type OpenDesignHostClient = {
+  // BCP-47 locale string (e.g. "zh-CN", "pt-BR") the host process read from
+  // the OS at startup. The renderer uses this so the packaged desktop app
+  // can follow the OS language even when Chromium's built-in
+  // `navigator.language` would have defaulted to en-US.
+  osLocale?: string;
   platform?: string;
   type: OpenDesignHostClientType;
 };
@@ -250,6 +255,7 @@ export function isOpenDesignHostBridge(value: unknown): value is OpenDesignHostB
   const client = value.client;
   if (!isRecord(client) || client.type !== OPEN_DESIGN_HOST_CLIENT_TYPES.DESKTOP) return false;
   if (client.platform != null && typeof client.platform !== "string") return false;
+  if (client.osLocale != null && typeof client.osLocale !== "string") return false;
 
   const shell = value.shell;
   if (!isRecord(shell) || !hasFunction(shell, "openExternal") || !hasFunction(shell, "openPath")) return false;

--- a/tools/pack/src/workspace-build.ts
+++ b/tools/pack/src/workspace-build.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
-import { access, cp, mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { access, cp, mkdir, readdir, readFile, stat, symlink, unlink, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
 
 import { hashJson, hashPath, ToolPackCache } from "./cache.js";
 import type { ToolPackConfig } from "./config.js";
@@ -143,11 +143,79 @@ function workspaceBuildArtifacts(config: ToolPackConfig): WorkspaceBuildArtifact
   }));
 }
 
+async function stripBrokenSymlinks(rootPath: string): Promise<void> {
+  // Recursively walk `rootPath` and delete symlinks whose target does
+  // not resolve. Next standalone's nft trace occasionally leaves
+  // dangling entries (e.g. .next/standalone/node_modules/.pnpm/node_modules/<pkg>
+  // pointing at a `.pnpm/<pkg>@<version>` directory pnpm never created
+  // because the runtime resolution picked a different version). The
+  // `cp { dereference: true }` call below would `stat()` through these
+  // links and abort the whole packaged pipeline with ENOENT.
+  let entries;
+  try {
+    entries = await readdir(rootPath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const childPath = join(rootPath, entry.name);
+    if (entry.isSymbolicLink()) {
+      try {
+        await stat(childPath);
+      } catch {
+        await unlink(childPath).catch(() => undefined);
+      }
+    } else if (entry.isDirectory()) {
+      await stripBrokenSymlinks(childPath);
+    }
+  }
+}
+
+const WEB_STANDALONE_ARTIFACT = "apps/web/.next/standalone";
+const WEB_STANDALONE_APP_NODE_MODULES = "apps/web/node_modules";
+// Peer deps the web-standalone after-pack audit looks up through
+// `createRequire(server.js).resolve(<pkg>/package.json)`. Next 16
+// standalone build under pnpm workspaces does not hoist them into
+// `<standalone>/apps/web/node_modules`, so the require walk falls out
+// of the standalone tree and the audit aborts the packaged build.
+const STANDALONE_HOISTED_PEER_DEPS = ["react", "react-dom", "styled-jsx"];
+
+async function hoistStandaloneNextPeerDeps(standaloneRoot: string): Promise<void> {
+  const appNodeModules = join(standaloneRoot, WEB_STANDALONE_APP_NODE_MODULES);
+  const pnpmRoot = join(standaloneRoot, "node_modules", ".pnpm");
+  let pnpmEntries: string[];
+  try {
+    pnpmEntries = await readdir(pnpmRoot);
+  } catch {
+    return;
+  }
+  await mkdir(appNodeModules, { recursive: true });
+  for (const pkg of STANDALONE_HOISTED_PEER_DEPS) {
+    const linkPath = join(appNodeModules, pkg);
+    if (await pathExists(linkPath)) continue;
+    // pnpm dirs look like `react@18.3.1` or
+    // `react-dom@18.3.1_react@18.3.1` — pick the bare version, not a
+    // peer-resolved sibling. The leading `${pkg}@` requirement
+    // distinguishes `react` from `react-dom`.
+    const match = pnpmEntries.find((entry) => entry.startsWith(`${pkg}@`));
+    if (!match) continue;
+    const target = join(pnpmRoot, match, "node_modules", pkg);
+    if (!(await pathExists(target))) continue;
+    const relativeTarget = relative(dirname(linkPath), target);
+    await symlink(relativeTarget, linkPath);
+  }
+}
+
 async function copyWorkspaceBuildArtifactsToCache(config: ToolPackConfig, entryRoot: string): Promise<void> {
   for (const artifact of workspaceBuildArtifacts(config)) {
+    const sourcePath = join(config.workspaceRoot, artifact.workspacePath);
+    if (artifact.workspacePath === WEB_STANDALONE_ARTIFACT) {
+      await hoistStandaloneNextPeerDeps(sourcePath);
+    }
+    await stripBrokenSymlinks(sourcePath);
     const targetPath = join(entryRoot, artifact.cachePath);
     await mkdir(dirname(targetPath), { recursive: true });
-    await cp(join(config.workspaceRoot, artifact.workspacePath), targetPath, { dereference: true, recursive: true });
+    await cp(sourcePath, targetPath, { dereference: true, recursive: true });
   }
 }
 

--- a/tools/pack/src/workspace-build.ts
+++ b/tools/pack/src/workspace-build.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { access, cp, mkdir, readdir, readFile, stat, symlink, unlink, writeFile } from "node:fs/promises";
+import { access, cp, lstat, mkdir, readdir, readFile, stat, symlink, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 
 import { hashJson, hashPath, ToolPackCache } from "./cache.js";
@@ -192,7 +192,13 @@ async function hoistStandaloneNextPeerDeps(standaloneRoot: string): Promise<void
   await mkdir(appNodeModules, { recursive: true });
   for (const pkg of STANDALONE_HOISTED_PEER_DEPS) {
     const linkPath = join(appNodeModules, pkg);
-    if (await pathExists(linkPath)) continue;
+    // `lstat` does not follow symlinks: this lets us distinguish a
+    // stale dangling link (which `access`/`pathExists` would falsely
+    // report as missing, and then `symlink()` would later reject with
+    // EEXIST) from a fresh slot. If Next genuinely hoisted a real
+    // directory, leave it alone.
+    const existing = await lstat(linkPath).catch(() => null);
+    if (existing && existing.isDirectory() && !existing.isSymbolicLink()) continue;
     // pnpm dirs look like `react@18.3.1` or
     // `react-dom@18.3.1_react@18.3.1` — pick the bare version, not a
     // peer-resolved sibling. The leading `${pkg}@` requirement
@@ -202,6 +208,10 @@ async function hoistStandaloneNextPeerDeps(standaloneRoot: string): Promise<void
     const target = join(pnpmRoot, match, "node_modules", pkg);
     if (!(await pathExists(target))) continue;
     const relativeTarget = relative(dirname(linkPath), target);
+    // Idempotent re-run: drop any pre-existing entry (stale symlink
+    // from a previous build with different react/react-dom versions)
+    // before recreating, so repeated invocations don't EEXIST.
+    if (existing) await unlink(linkPath).catch(() => undefined);
     await symlink(relativeTarget, linkPath);
   }
 }
@@ -209,10 +219,14 @@ async function hoistStandaloneNextPeerDeps(standaloneRoot: string): Promise<void
 async function copyWorkspaceBuildArtifactsToCache(config: ToolPackConfig, entryRoot: string): Promise<void> {
   for (const artifact of workspaceBuildArtifacts(config)) {
     const sourcePath = join(config.workspaceRoot, artifact.workspacePath);
+    // Strip dangling symlinks first: that clears any leftover from a
+    // previous build whose target moved (e.g. a renamed `.pnpm/<pkg>@<ver>`
+    // after a dependency bump), so the subsequent hoist step starts
+    // from a clean slot and can safely (re-)create its symlinks.
+    await stripBrokenSymlinks(sourcePath);
     if (artifact.workspacePath === WEB_STANDALONE_ARTIFACT) {
       await hoistStandaloneNextPeerDeps(sourcePath);
     }
-    await stripBrokenSymlinks(sourcePath);
     const targetPath = join(entryRoot, artifact.cachePath);
     await mkdir(dirname(targetPath), { recursive: true });
     await cp(sourcePath, targetPath, { dereference: true, recursive: true });


### PR DESCRIPTION
Cherry-pick of #2544 (still **open against main** at time of opening — see note at the bottom) into \`release/v0.8.0\` so the v0.8.0 channel picks up the OS-language auto-detect on first launch.

## Why

Packaged Electron currently shows v0.8.0 in en-US regardless of OS language. The renderer's i18n picks its locale from \`navigator.language\` and Chromium hard-codes that to en-US unless the host process intervenes. Browser users and \`tools-dev\` users are unaffected. Non-English OS users have to manually click through Settings → Language on every fresh install.

## What users will see

After upgrading on macOS / Windows / Linux, the packaged desktop app on v0.8.0 starts in the OS preferred language on first launch. An explicit pick saved earlier through the language menu still wins (\`localStorage\` priority is unchanged).

## Surface area

- [x] **UI** — first-launch language now follows the OS instead of always being English
- [x] **Default behavior change** — v0.8.0 packaged users on a non-English OS no longer default to en-US on first launch

## Cherry-pick contents

Three commits cherry-picked clean off \`feat/desktop-os-locale-detect\` (the head of #2544 against \`main\`):

- \`feat(desktop): follow OS language in packaged builds\` — \`applyOsLocaleSwitch(app)\` + \`additionalArguments\` channel + \`detectInitialLocale\` priority chain.
- \`fix(web): route OS locale read through getOpenDesignHost\` — keeps the web/preload boundary single-source so \`host-boundary\` guard test stays green.
- \`fix(tools-pack): unblock mac packaged build on pnpm workspaces\` — \`stripBrokenSymlinks\` + \`hoistStandaloneNextPeerDeps\` so a clean macOS workspace can actually finish \`pnpm tools-pack mac build --to all\`. Bundled here for parity with #2544.

No conflicts during cherry-pick.

## Verification

Performed against the main-branch version of the same three commits (functionally identical here):

- Unit / contract: \`pnpm guard\`, web/desktop/packaged typecheck, host 13/13, desktop 54/54, web i18n 14/14.
- Manual dev mode (macOS Apple Silicon, OS Preferred Languages = zh-Hans-CN): \`pnpm tools-dev inspect desktop eval --expr ...\` returns \`hostOsLocale: "zh-Hans-CN"\`, \`htmlLang: "zh-CN"\`, UI renders fully in Chinese.
- Manual packaged mode: \`pnpm tools-pack mac build --to all\` → \`mac install\` → \`mac start\` → \`mac inspect --expr ...\` returns the same shape with \`uiSample\` showing 主页 / 本地 CLI / 你想设计什么？ / 原型 / 实时制品 / etc.

**Note on the \`--lang\` Chromium switch**: \`navigator.language\` does NOT actually change in Electron 41 even with \`appendSwitch('lang', ...)\`. The whole effective fix is the \`additionalArguments\` → \`__od__.client.osLocale\` channel; \`--lang\` stays for Chromium's internal locale (Accept-Language, intl formatters) and future-compat.

## Sequencing

Opened **before** #2544 merges to \`main\`, against the explicit ask to have the release/v0.8.0 PR ready for review in parallel. If #2544 picks up additional commits in review, this branch will be re-synced. Otherwise this PR is a strict subset of what landed on \`main\`.