### PR TITLE
fix(web): localize Automation page in Chinese

### DIFF
--- a/apps/web/src/components/NewAutomationModal.tsx
+++ b/apps/web/src/components/NewAutomationModal.tsx
@@ -19,6 +19,8 @@ import type { SkillSummary } from '../types';
 import { listPlugins } from '../state/projects';
 import { fetchMcpServers, type McpServerConfig } from '../state/mcp';
 import { inlineMentionToken } from '../utils/inlineMentions';
+import { useI18n } from '../i18n';
+import type { Locale } from '../i18n';
 
 type ProjectSummary = { id: string; name: string };
 type ScheduleKind = RoutineSchedule['kind'];
@@ -55,6 +57,22 @@ const WEEKDAY_LABELS: { value: Weekday; short: string; long: string }[] = [
   { value: 5, short: 'Fri', long: 'Friday' },
   { value: 6, short: 'Sat', long: 'Saturday' },
 ];
+
+function weekdayLabel(locale: Locale, value: Weekday): { short: string; long: string } {
+  const index = WEEKDAY_LABELS.find((day) => day.value === value);
+  if (!index) return { short: 'Sun', long: 'Sunday' };
+  if (locale === 'zh-CN') {
+    const short = ['日', '一', '二', '三', '四', '五', '六'][value] ?? '日';
+    const long = ['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六'][value] ?? '星期日';
+    return { short, long };
+  }
+  if (locale === 'zh-TW') {
+    const short = ['日', '一', '二', '三', '四', '五', '六'][value] ?? '日';
+    const long = ['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六'][value] ?? '星期日';
+    return { short, long };
+  }
+  return { short: index.short, long: index.long };
+}
 
 const FALLBACK_TIMEZONES = [
   'UTC',
@@ -97,6 +115,12 @@ function tzCityLabel(timezone: string): string {
   return last.replace(/_/g, ' ');
 }
 
+function zhLabel(locale: Locale, simplified: string, traditional: string, fallback: string): string {
+  if (locale === 'zh-CN') return simplified;
+  if (locale === 'zh-TW') return traditional;
+  return fallback;
+}
+
 function formatTime12h(time: string): string {
   const m = /^(\d{2}):(\d{2})$/.exec(time);
   if (!m) return time;
@@ -107,16 +131,29 @@ function formatTime12h(time: string): string {
   return `${h12}:${mm} ${suffix}`;
 }
 
-export function describeScheduleSummary(schedule: RoutineSchedule): string {
+function scheduleKindLabel(kind: ScheduleKind, locale: Locale): string {
+  if (kind === 'hourly') return zhLabel(locale, '每小时', '每小時', 'Hourly');
+  if (kind === 'daily') return zhLabel(locale, '每日', '每日', 'Daily');
+  if (kind === 'weekdays') return zhLabel(locale, '工作日', '工作日', 'Weekdays');
+  return zhLabel(locale, '每周', '每週', 'Weekly');
+}
+
+export function describeScheduleSummary(schedule: RoutineSchedule, locale: Locale = 'en'): string {
   if (schedule.kind === 'hourly') {
     const mm = String(schedule.minute).padStart(2, '0');
+    if (locale === 'zh-CN') return `每小时第 ${mm} 分钟`;
+    if (locale === 'zh-TW') return `每小時第 ${mm} 分鐘`;
     return `Hourly at :${mm}`;
   }
   const tz = tzCityLabel(schedule.timezone);
-  if (schedule.kind === 'daily') return `Daily at ${formatTime12h(schedule.time)} · ${tz}`;
-  if (schedule.kind === 'weekdays') return `Weekdays at ${formatTime12h(schedule.time)} · ${tz}`;
-  const day = WEEKDAY_LABELS.find((w) => w.value === schedule.weekday)?.long ?? 'Sunday';
-  return `${day} at ${formatTime12h(schedule.time)} · ${tz}`;
+  if (schedule.kind === 'daily') {
+    return `${scheduleKindLabel('daily', locale)}${locale === 'en' ? ' at ' : ' · '}${formatTime12h(schedule.time)} · ${tz}`;
+  }
+  if (schedule.kind === 'weekdays') {
+    return `${scheduleKindLabel('weekdays', locale)}${locale === 'en' ? ' at ' : ' · '}${formatTime12h(schedule.time)} · ${tz}`;
+  }
+  const day = weekdayLabel(locale, schedule.weekday).long;
+  return `${day}${locale === 'en' ? ' at ' : ' · '}${formatTime12h(schedule.time)} · ${tz}`;
 }
 
 type FormState = {
@@ -213,6 +250,7 @@ export function NewAutomationModal({
   onClose,
   onSaved,
 }: Props) {
+  const { locale } = useI18n();
   const editingId = initial?.routine?.id ?? null;
   const [form, setForm] = useState<FormState>(emptyForm);
   const [submitting, setSubmitting] = useState(false);
@@ -239,6 +277,45 @@ export function NewAutomationModal({
   const selectedTemplate = useMemo(
     () => templates.find((template) => template.id === selectedTemplateId) ?? null,
     [selectedTemplateId, templates],
+  );
+  const l = useMemo(
+    () => ({
+      editAutomation: zhLabel(locale, '编辑自动化', '編輯自動化', 'Edit automation'),
+      newAutomation: zhLabel(locale, '新建自动化', '新增自動化', 'New automation'),
+      automationTitle: zhLabel(locale, '自动化标题', '自動化標題', 'Automation title'),
+      useTemplate: zhLabel(locale, '使用模板', '使用範本', 'Use template'),
+      closeEsc: zhLabel(locale, '关闭（Esc）', '關閉（Esc）', 'Close (Esc)'),
+      promptPlaceholder: zhLabel(locale, '告诉代理按此计划执行什么，或用 @ 提及上下文……', '告訴代理按此排程執行什麼，或用 @ 提及脈絡……', 'Ask the agent what to run on this schedule, or @mention context...'),
+      contextResults: zhLabel(locale, '自动化上下文结果', '自動化脈絡結果', 'Automation context results'),
+      contextType: zhLabel(locale, '上下文类型', '脈絡類型', 'Context type'),
+      all: zhLabel(locale, '全部', '全部', 'All'),
+      skills: zhLabel(locale, '技能', '技能', 'Skills'),
+      plugins: zhLabel(locale, '插件', '外掛', 'Plugins'),
+      connectors: zhLabel(locale, '连接器', '連接器', 'Connectors'),
+      noResults: (q: string) => zhLabel(locale, `没有“${q}”的结果。`, `沒有「${q}」的結果。`, `No results for "${q}".`),
+      searchHelp: zhLabel(locale, '搜索技能、插件、MCP 服务器和连接器。', '搜尋技能、外掛、MCP 伺服器和連接器。', 'Search skills, plugins, MCP servers, and connectors.'),
+      selectedContext: zhLabel(locale, '已选择的自动化上下文', '已選取的自動化脈絡', 'Selected automation context'),
+      remove: (label: string) => zhLabel(locale, `移除 ${label}`, `移除 ${label}`, `Remove ${label}`),
+      newProjectEachRun: zhLabel(locale, '每次运行都创建新项目', '每次執行都建立新專案', 'New project each run'),
+      newProjectEachRunHint: zhLabel(locale, '每次运行都会开始一个全新的项目和对话。', '每次執行都會開始全新的專案與對話。', 'Each run starts a fresh project and conversation.'),
+      existingProjects: zhLabel(locale, '现有项目', '現有專案', 'Existing projects'),
+      cancel: zhLabel(locale, '取消', '取消', 'Cancel'),
+      saving: zhLabel(locale, '保存中…', '儲存中…', 'Saving...'),
+      save: zhLabel(locale, '保存', '儲存', 'Save'),
+      creating: zhLabel(locale, '创建中…', '建立中…', 'Creating...'),
+      create: zhLabel(locale, '创建', '建立', 'Create'),
+      done: zhLabel(locale, '完成', '完成', 'Done'),
+      minuteOfHour: zhLabel(locale, '每小时的第几分钟', '每小時的第幾分鐘', 'Minute of every hour'),
+      weekday: zhLabel(locale, '星期', '星期', 'Weekday'),
+      time: zhLabel(locale, '时间', '時間', 'Time'),
+      timezone: zhLabel(locale, '时区', '時區', 'Timezone'),
+      skill: zhLabel(locale, '技能', '技能', 'Skill'),
+      plugin: zhLabel(locale, '插件', '外掛', 'Plugin'),
+      connector: zhLabel(locale, '连接器', '連接器', 'Connector'),
+      liveArtifact: zhLabel(locale, '实时产物', '即時產物', 'Live artifact'),
+      automation: zhLabel(locale, '自动化', '自動化', 'Automation'),
+    }),
+    [locale],
   );
 
   useEffect(() => {
@@ -407,12 +484,12 @@ export function NewAutomationModal({
     e.preventDefault();
     setError(null);
     if (!form.name.trim()) {
-      setError('Add a title for this automation.');
+      setError(zhLabel(locale, '请为这个自动化添加标题。', '請為這個自動化加入標題。', 'Add a title for this automation.'));
       titleRef.current?.focus();
       return;
     }
     if (!form.prompt.trim()) {
-      setError('Add a prompt for the scheduled conversation.');
+      setError(zhLabel(locale, '请为定时对话添加提示词。', '請為排程對話加入提示詞。', 'Add a prompt for the scheduled conversation.'));
       return;
     }
     setSubmitting(true);
@@ -468,8 +545,8 @@ export function NewAutomationModal({
 
   const projectName = projects.find((p) => p.id === form.projectId)?.name ?? null;
   const projectLabel =
-    form.mode === 'reuse' && projectName ? projectName : 'New project each run';
-  const scheduleLabel = describeScheduleSummary(buildSchedule(form));
+    form.mode === 'reuse' && projectName ? projectName : l.newProjectEachRun;
+  const scheduleLabel = describeScheduleSummary(buildSchedule(form), locale);
   const mentionQueryNorm = (mention?.query ?? '').trim().toLowerCase();
   const filteredSkills = filterCapabilities(
     skills,
@@ -508,7 +585,7 @@ export function NewAutomationModal({
         kind: 'skills' as const,
         id,
         label: skill?.name ?? id,
-        meta: 'Skill',
+        meta: l.skill,
         icon: 'file' as IconName,
       };
     }),
@@ -518,7 +595,7 @@ export function NewAutomationModal({
         kind: 'plugins' as const,
         id,
         label: plugin?.title ?? id,
-        meta: 'Plugin',
+        meta: l.plugin,
         icon: 'sparkles' as IconName,
       };
     }),
@@ -538,7 +615,7 @@ export function NewAutomationModal({
         kind: 'connectors' as const,
         id,
         label: connector?.name ?? id,
-        meta: connector?.accountLabel ? `Connector · ${connector.accountLabel}` : 'Connector',
+        meta: connector?.accountLabel ? `${l.connector} · ${connector.accountLabel}` : l.connector,
         icon: 'link' as IconName,
       };
     }),
@@ -549,7 +626,7 @@ export function NewAutomationModal({
       className="automation-modal-backdrop"
       role="dialog"
       aria-modal="true"
-      aria-label={editingId ? 'Edit automation' : 'New automation'}
+      aria-label={editingId ? l.editAutomation : l.newAutomation}
       data-testid="automation-modal"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
@@ -566,10 +643,10 @@ export function NewAutomationModal({
             ref={titleRef}
             type="text"
             className="automation-modal__title-input"
-            placeholder="Automation title"
+            placeholder={l.automationTitle}
             value={form.name}
             onChange={(e) => setForm({ ...form, name: e.target.value })}
-            aria-label="Automation title"
+            aria-label={l.automationTitle}
             data-testid="automation-modal-title"
           />
           <div className="automation-modal__head-actions">
@@ -580,7 +657,7 @@ export function NewAutomationModal({
                 onClick={() => setPopover((p) => (p === 'template' ? null : 'template'))}
               >
                 <Icon name="sparkles" size={13} />
-                <span>{selectedTemplate?.defaultName ?? selectedTemplate?.title ?? 'Use template'}</span>
+                <span>{selectedTemplate?.defaultName ?? selectedTemplate?.title ?? l.useTemplate}</span>
                 <Icon name="chevron-down" size={11} />
               </button>
               {popover === 'template' ? (
@@ -595,7 +672,7 @@ export function NewAutomationModal({
               type="button"
               className="automation-modal__close"
               onClick={onClose}
-              aria-label="Close (Esc)"
+              aria-label={l.closeEsc}
             >
               <Icon name="close" size={14} />
             </button>
@@ -607,7 +684,7 @@ export function NewAutomationModal({
             <textarea
               ref={promptRef}
               className="automation-modal__prompt"
-              placeholder="Ask the agent what to run on this schedule, or @mention context..."
+              placeholder={l.promptPlaceholder}
               value={form.prompt}
               onChange={(e) => updatePrompt(e.target.value, e.target.selectionStart ?? e.target.value.length)}
               onClick={refreshMentionFromPrompt}
@@ -626,17 +703,17 @@ export function NewAutomationModal({
               id="automation-context-picker"
               className="automation-mention-popover"
               role="listbox"
-              aria-label="Automation context results"
+              aria-label={l.contextResults}
               data-testid="automation-mention-popover"
               onMouseDown={(e) => e.preventDefault()}
             >
-              <div className="automation-mention-tabs" role="tablist" aria-label="Context type">
+              <div className="automation-mention-tabs" role="tablist" aria-label={l.contextType}>
                 {[
-                  ['all', 'All'],
-                  ['skills', 'Skills'],
-                  ['plugins', 'Plugins'],
+                  ['all', l.all],
+                  ['skills', l.skills],
+                  ['plugins', l.plugins],
                   ['mcp', 'MCP'],
-                  ['connectors', 'Connectors'],
+                  ['connectors', l.connectors],
                 ].map(([id, label]) => (
                   <button
                     key={id}
@@ -656,11 +733,11 @@ export function NewAutomationModal({
               <div className="automation-mention-results">
                 {!hasMentionResults ? (
                   <div className="automation-mention-empty">
-                    {mention.query ? `No results for "${mention.query}".` : 'Search skills, plugins, MCP servers, and connectors.'}
+                    {mention.query ? l.noResults(mention.query) : l.searchHelp}
                   </div>
                 ) : null}
                 {showSkills && filteredSkills.length > 0 ? (
-                  <MentionSection label="Skills">
+                  <MentionSection label={l.skills}>
                     {filteredSkills.map((skill) => (
                       <MentionItem
                         key={`skill-${skill.id}`}
@@ -674,7 +751,7 @@ export function NewAutomationModal({
                   </MentionSection>
                 ) : null}
                 {showPlugins && filteredPlugins.length > 0 ? (
-                  <MentionSection label="Plugins">
+                  <MentionSection label={l.plugins}>
                     {filteredPlugins.map((plugin) => (
                       <MentionItem
                         key={`plugin-${plugin.id}`}
@@ -702,7 +779,7 @@ export function NewAutomationModal({
                   </MentionSection>
                 ) : null}
                 {showConnectors && filteredConnectors.length > 0 ? (
-                  <MentionSection label="Connectors">
+                  <MentionSection label={l.connectors}>
                     {filteredConnectors.map((connector) => (
                       <MentionItem
                         key={`connector-${connector.id}`}
@@ -720,14 +797,14 @@ export function NewAutomationModal({
           ) : null}
 
           {selectedContextItems.length > 0 ? (
-            <div className="automation-selected-context" aria-label="Selected automation context">
+            <div className="automation-selected-context" aria-label={l.selectedContext}>
               {selectedContextItems.map((item) => (
                 <button
                   key={`${item.kind}-${item.id}`}
                   type="button"
                   className={`automation-selected-context__chip is-${item.kind}`}
                   onClick={() => removeSelectedContext(item.kind, item.id)}
-                  title={`Remove ${item.label}`}
+                  title={l.remove(item.label)}
                 >
                   <Icon name={item.icon} size={11} />
                   <span>{item.label}</span>
@@ -760,12 +837,12 @@ export function NewAutomationModal({
                       setForm({ ...form, mode: 'create_each_run', projectId: '' });
                       setPopover(null);
                     }}
-                    label="New project each run"
-                    hint="Each run starts a fresh project and conversation."
+                    label={l.newProjectEachRun}
+                    hint={l.newProjectEachRunHint}
                   />
                   {projects.length > 0 ? (
                     <>
-                      <div className="automation-popover__section-label">Existing projects</div>
+                      <div className="automation-popover__section-label">{l.existingProjects}</div>
                       {projects.map((p) => (
                         <PopoverItem
                           key={p.id}
@@ -808,7 +885,7 @@ export function NewAutomationModal({
               className="automation-modal__cancel"
               onClick={onClose}
             >
-              Cancel
+              {l.cancel}
             </button>
             <button
               type="submit"
@@ -817,11 +894,11 @@ export function NewAutomationModal({
             >
               {editingId
                 ? submitting
-                  ? 'Saving...'
-                  : 'Save'
+                  ? l.saving
+                  : l.save
                 : submitting
-                  ? 'Creating...'
-                  : 'Create'}
+                  ? l.creating
+                  : l.create}
             </button>
           </div>
         </footer>
@@ -860,6 +937,9 @@ function TemplatePopover({
   selectedId: string | null;
   onSelect: (template: AutomationTemplate) => void;
 }) {
+  const { locale } = useI18n();
+  const liveArtifact = zhLabel(locale, '实时产物', '即時產物', 'Live artifact');
+  const automation = zhLabel(locale, '自动化', '自動化', 'Automation');
   return (
     <div className="automation-popover automation-popover--templates">
       {templates.map((template) => (
@@ -874,7 +954,7 @@ function TemplatePopover({
           </span>
           <span className="automation-template-option__body">
             <span className="automation-template-option__title">{template.defaultName ?? template.title}</span>
-            <span className="automation-template-option__meta">{kindLabel(template.kind)}</span>
+            <span className="automation-template-option__meta">{template.kind === 'orbit' ? 'Orbit' : template.kind === 'live-artifact' ? liveArtifact : automation}</span>
           </span>
           {selectedId === template.id ? <Icon name="check" size={13} /> : null}
         </button>
@@ -1005,6 +1085,17 @@ function SchedulePopover({
   timezones: string[];
   onDone: () => void;
 }) {
+  const { locale } = useI18n();
+  const l = useMemo(
+    () => ({
+      minuteOfHour: zhLabel(locale, '每小时的第几分钟', '每小時的第幾分鐘', 'Minute of every hour'),
+      weekday: zhLabel(locale, '星期', '星期', 'Weekday'),
+      time: zhLabel(locale, '时间', '時間', 'Time'),
+      timezone: zhLabel(locale, '时区', '時區', 'Timezone'),
+      done: zhLabel(locale, '完成', '完成', 'Done'),
+    }),
+    [locale],
+  );
   return (
     <div className="automation-popover automation-popover--schedule">
       <div className="automation-popover__kinds" role="tablist">
@@ -1017,14 +1108,14 @@ function SchedulePopover({
             className={`automation-popover__kind${form.kind === k.kind ? ' is-active' : ''}`}
             onClick={() => setForm({ ...form, kind: k.kind })}
           >
-            {k.label}
+            {scheduleKindLabel(k.kind, locale)}
           </button>
         ))}
       </div>
 
       {form.kind === 'hourly' ? (
         <label className="automation-popover__field">
-          <span>Minute of every hour</span>
+          <span>{l.minuteOfHour}</span>
           <input
             type="number"
             min={0}
@@ -1042,23 +1133,23 @@ function SchedulePopover({
       ) : (
         <>
           {form.kind === 'weekly' ? (
-            <div className="automation-popover__weekdays" aria-label="Weekday">
+            <div className="automation-popover__weekdays" aria-label={l.weekday}>
               {WEEKDAY_LABELS.map((d) => (
                 <button
                   key={d.value}
                   type="button"
                   className={`automation-popover__weekday${form.weekday === d.value ? ' is-active' : ''}`}
                   onClick={() => setForm({ ...form, weekday: d.value })}
-                  title={d.long}
+                  title={weekdayLabel(locale, d.value).long}
                 >
-                  {d.short}
+                  {weekdayLabel(locale, d.value).short}
                 </button>
               ))}
             </div>
           ) : null}
           <div className="automation-popover__row">
             <label className="automation-popover__field">
-              <span>Time</span>
+              <span>{l.time}</span>
               <input
                 type="time"
                 value={form.time}
@@ -1066,7 +1157,7 @@ function SchedulePopover({
               />
             </label>
             <label className="automation-popover__field">
-              <span>Timezone</span>
+              <span>{l.timezone}</span>
               <select
                 value={form.timezone}
                 onChange={(e) => setForm({ ...form, timezone: e.target.value })}
@@ -1088,7 +1179,7 @@ function SchedulePopover({
           className="automation-popover__done-btn"
           onClick={onDone}
         >
-          Done
+          {l.done}
         </button>
       </div>
     </div>

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1475,8 +1475,13 @@ export function SettingsDialog({
     composio: { title: t('connectors.title'), subtitle: t('connectors.subtitle') },
     orbit: { title: t('settings.orbit.title'), subtitle: t('settings.orbit.lede') },
     routines: {
-      title: 'Automations',
-      subtitle: 'Scheduled automations that run unattended.',
+      title: t('entry.navTasks'),
+      subtitle:
+        locale === 'zh-CN'
+          ? '按计划自动运行、无需值守的自动化。'
+          : locale === 'zh-TW'
+            ? '依排程自動執行、無需值守的自動化。'
+            : 'Scheduled automations that run unattended.',
     },
     integrations: { title: t('settings.mcpServerTitle'), subtitle: t('settings.mcpServerHint') },
     mcpClient: { title: t('settings.externalMcpTitle'), subtitle: t('settings.externalMcpHint') },

--- a/apps/web/src/components/TasksView.tsx
+++ b/apps/web/src/components/TasksView.tsx
@@ -22,6 +22,8 @@ import type {
 import { Icon, type IconName } from './Icon';
 import { navigate } from '../router';
 import type { SkillSummary } from '../types';
+import { useI18n } from '../i18n';
+import type { Locale } from '../i18n';
 import {
   NewAutomationModal,
   describeScheduleSummary,
@@ -195,16 +197,16 @@ const DEFAULT_SOURCE_FORM: SourceIngestionForm = {
   tokenCompression: 'balanced',
 };
 
-function scheduleStatusLabel(routine: Routine): string {
-  if (!routine.enabled) return 'Paused';
-  return describeScheduleSummary(routine.schedule);
+function scheduleStatusLabel(routine: Routine, locale: Locale, pausedLabel: string): string {
+  if (!routine.enabled) return pausedLabel;
+  return describeScheduleSummary(routine.schedule, locale);
 }
 
-function nextRunLabel(routine: Routine): string {
-  if (!routine.enabled) return 'Manual only';
-  if (!routine.nextRunAt) return 'Scheduled';
+function nextRunLabel(routine: Routine, locale: Locale): string {
+  if (!routine.enabled) return zhLabel(locale, '仅手动', '僅手動', 'Manual only');
+  if (!routine.nextRunAt) return zhLabel(locale, '已计划', '已排程', 'Scheduled');
   const date = new Date(routine.nextRunAt);
-  return `Next ${date.toLocaleString(undefined, {
+  return `${zhLabel(locale, '下次', '下次', 'Next')} ${date.toLocaleString(undefined, {
     dateStyle: 'medium',
     timeStyle: 'short',
   })}`;
@@ -218,8 +220,8 @@ function formatAutomationTimestamp(ts: number | null | undefined): string {
   });
 }
 
-function formatRunDuration(run: RoutineRun): string {
-  if (!run.completedAt) return 'In progress';
+function formatRunDuration(run: RoutineRun, locale: Locale): string {
+  if (!run.completedAt) return zhLabel(locale, '进行中', '進行中', 'In progress');
   const seconds = Math.max(1, Math.round((run.completedAt - run.startedAt) / 1000));
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
@@ -227,16 +229,17 @@ function formatRunDuration(run: RoutineRun): string {
   return remainder > 0 ? `${minutes}m ${remainder}s` : `${minutes}m`;
 }
 
-function statusLabel(status: RoutineRun['status']): string {
-  if (status === 'succeeded') return 'Succeeded';
-  if (status === 'failed') return 'Failed';
-  if (status === 'running') return 'Running';
-  if (status === 'queued') return 'Queued';
-  return 'Canceled';
+function statusLabel(status: RoutineRun['status'], locale: Locale): string {
+  if (status === 'succeeded') return zhLabel(locale, '成功', '成功', 'Succeeded');
+  if (status === 'failed') return zhLabel(locale, '失败', '失敗', 'Failed');
+  if (status === 'running') return zhLabel(locale, '运行中', '執行中', 'Running');
+  if (status === 'queued') return zhLabel(locale, '排队中', '排隊中', 'Queued');
+  return zhLabel(locale, '已取消', '已取消', 'Canceled');
 }
 
 function StatusPill({ status }: { status: RoutineRun['status'] }) {
-  return <span className={`automation-status is-${status}`}>{statusLabel(status)}</span>;
+  const { locale } = useI18n();
+  return <span className={`automation-status is-${status}`}>{statusLabel(status, locale)}</span>;
 }
 
 function templateFromSkill(skill: SkillSummary, kind: AutomationTemplateKind): AutomationTemplate {
@@ -329,9 +332,37 @@ function dedupeTemplates(templates: AutomationTemplate[]): AutomationTemplate[] 
   });
 }
 
+function localizeTemplate(template: AutomationTemplate, locale: Locale): AutomationTemplate {
+  const map: Record<string, Partial<AutomationTemplate>> = locale === 'zh-CN'
+    ? {
+        'memory-refresh': { title: '从近期工作刷新项目记忆。', description: '把重复决策、偏好和反馈整理成可复用的记忆更新。', defaultName: '记忆刷新' },
+        'design-system-refresh': { title: '从已交付制品更新设计系统。', description: '从近期设计工作中提炼可复用的 token、组件和规则。', defaultName: '设计系统维护' },
+        'live-artifact-registry': { title: '审计实时制品并刷新陈旧版本。', description: '让持久化仪表盘、报告和预览保持最新，而不是重复创建。', defaultName: '实时制品维护' },
+        'orbit-dashboard': { title: '构建连接器活动仪表盘。', description: '把已选连接器汇总成 Orbit 风格的实时仪表盘。', defaultName: '连接器活动仪表盘' },
+        'release-notes': { title: '从已交付设计工作起草发布说明。', description: '把已合并 PR、制品和面向用户的变更串成发布说明。', defaultName: '每周发布说明' },
+        'quality-regression-watch': { title: '监控设计与实现回归。', description: '将近期变更与基准、追踪和已接受参考进行比较。', defaultName: '回归监控' },
+        'orbit-daily': { title: '每日连接器摘要。', description: '按计划刷新连接器活动摘要。', defaultName: '每日连接器摘要' },
+        'live-status-board': { title: '保持实时状态制品最新。', description: '每次运行都更新同一个持久制品，而不是新建报告。', defaultName: '实时状态看板' },
+      }
+    : locale === 'zh-TW'
+      ? {
+          'memory-refresh': { title: '從近期工作刷新專案記憶。', description: '把重複決策、偏好與回饋整理成可重用的記憶更新。', defaultName: '記憶刷新' },
+          'design-system-refresh': { title: '從已交付制品更新設計系統。', description: '從近期設計工作中提煉可重用的 token、元件與規則。', defaultName: '設計系統維護' },
+          'live-artifact-registry': { title: '稽核即時制品並刷新陳舊版本。', description: '讓持久儀表板、報告與預覽保持最新，而不是重複建立。', defaultName: '即時制品維護' },
+          'orbit-dashboard': { title: '建立連接器活動儀表板。', description: '把已選連接器彙整成 Orbit 風格的即時儀表板。', defaultName: '連接器活動儀表板' },
+          'release-notes': { title: '從已交付設計工作起草發佈說明。', description: '把已合併 PR、制品與面向使用者的變更串成發佈說明。', defaultName: '每週發佈說明' },
+          'quality-regression-watch': { title: '監控設計與實作回歸。', description: '將近期變更與基準、追蹤和已接受參考進行比較。', defaultName: '回歸監控' },
+          'orbit-daily': { title: '每日連接器摘要。', description: '依排程刷新連接器活動摘要。', defaultName: '每日連接器摘要' },
+          'live-status-board': { title: '保持即時狀態制品最新。', description: '每次執行都更新同一個持久制品，而不是建立新報告。', defaultName: '即時狀態看板' },
+        }
+      : {};
+  return map[template.id] ? { ...template, ...map[template.id] } : template;
+}
+
 function buildAutomationTemplates(
   designTemplates: SkillSummary[],
   automationCatalog: ContractAutomationTemplate[],
+  locale: Locale,
 ): AutomationTemplate[] {
   const orbit = designTemplates
     .filter((skill) => skill.scenario === 'orbit')
@@ -345,7 +376,7 @@ function buildAutomationTemplates(
     ...(orbit.length > 0 ? orbit : [FALLBACK_ORBIT_TEMPLATE]),
     ...(live.length > 0 ? live : [FALLBACK_LIVE_TEMPLATE]),
     ...STATIC_TEMPLATES,
-  ]);
+  ]).map((template) => localizeTemplate(template, locale));
 }
 
 function filterTemplates(templates: AutomationTemplate[], filter: TemplateFilter) {
@@ -384,7 +415,14 @@ function proposalActionLabel(action: AutomationEvolutionProposal['action']): str
   return 'Promote';
 }
 
+function zhLabel(locale: Locale, simplified: string, traditional: string, fallback: string): string {
+  if (locale === 'zh-CN') return simplified;
+  if (locale === 'zh-TW') return traditional;
+  return fallback;
+}
+
 export function TasksView({ skills = [], designTemplates = [], connectors = [] }: Props) {
+  const { locale } = useI18n();
   const [routines, setRoutines] = useState<Routine[]>([]);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -403,12 +441,155 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
   const [historyTick, setHistoryTick] = useState(0);
 
   const templates = useMemo(
-    () => buildAutomationTemplates(designTemplates, automationCatalog),
-    [automationCatalog, designTemplates],
+    () => buildAutomationTemplates(designTemplates, automationCatalog, locale),
+    [automationCatalog, designTemplates, locale],
   );
   const filteredTemplates = useMemo(
     () => filterTemplates(templates, templateFilter),
     [templates, templateFilter],
+  );
+  const l = useMemo(
+    () => ({
+      scheduledAgentSessions: zhLabel(locale, '定时代理会话', '排程代理工作階段', 'Scheduled agent sessions'),
+      automations: zhLabel(locale, '自动化', '自動化', 'Automations'),
+      lede: zhLabel(locale, '为项目工作、Orbit 摘要和实时产物规划周期性对话。', '為專案工作、Orbit 摘要和即時產物規劃週期性對話。', 'Plan recurring conversations for project work, Orbit digests, and live artifacts.'),
+      automationSummary: zhLabel(locale, '自动化摘要', '自動化摘要', 'Automation summary'),
+      active: zhLabel(locale, '运行中', '運行中', 'Active'),
+      paused: zhLabel(locale, '已暂停', '已暫停', 'Paused'),
+      templates: zhLabel(locale, '模板', '範本', 'Templates'),
+      newAutomation: zhLabel(locale, '新建自动化', '新增自動化', 'New automation'),
+      yourAutomations: zhLabel(locale, '你的自动化', '你的自動化', 'Your automations'),
+      noAutomationsYet: zhLabel(locale, '还没有自动化', '還沒有自動化', 'No automations yet'),
+      createFromTemplate: zhLabel(locale, '从模板创建，或从空白计划开始。', '從範本建立，或從空白排程開始。', 'Create one from a template or start with a blank schedule.'),
+      newProjectEachRun: zhLabel(locale, '每次运行都创建新项目', '每次執行都建立新專案', 'New project each run'),
+      lastRun: zhLabel(locale, '上次运行', '上次執行', 'Last run'),
+      openResult: zhLabel(locale, '打开结果', '開啟結果', 'Open result'),
+      runNowTitle: zhLabel(locale, '立即运行并打开对话', '立即執行並開啟對話', 'Run now and open the conversation'),
+      run: zhLabel(locale, '运行', '執行', 'Run'),
+      hideHistory: zhLabel(locale, '隐藏历史', '隱藏歷史', 'Hide history'),
+      history: zhLabel(locale, '历史', '歷史', 'History'),
+      edit: zhLabel(locale, '编辑', '編輯', 'Edit'),
+      pause: zhLabel(locale, '暂停', '暫停', 'Pause'),
+      resume: zhLabel(locale, '恢复', '恢復', 'Resume'),
+      deleteAutomation: zhLabel(locale, '删除自动化', '刪除自動化', 'Delete automation'),
+      deleteAutomationTitle: zhLabel(locale, '删除此自动化', '刪除此自動化', 'Delete this automation'),
+      deleteConfirm: zhLabel(locale, '删除这个自动化？过去的运行和对应项目会保留。', '刪除這個自動化？過去的執行和對應專案會保留。', 'Delete this automation? Past runs and their projects are kept.'),
+      ingestSource: zhLabel(locale, '导入来源', '匯入來源', 'Ingest source'),
+      ingestSourceSub: zhLabel(locale, '将连接器、仓库、产物或聊天上下文转成可审查的演进提案。', '將連接器、儲存庫、產物或聊天脈絡轉成可審查的演進提案。', 'Turn connector, repo, artifact, or chat context into reviewable evolution proposals.'),
+      recent: zhLabel(locale, '最近', '最近', 'recent'),
+      template: zhLabel(locale, '模板', '範本', 'Template'),
+      source: zhLabel(locale, '来源', '來源', 'Source'),
+      compression: zhLabel(locale, '压缩', '壓縮', 'Compression'),
+      connector: zhLabel(locale, '连接器', '連接器', 'Connector'),
+      anyConnectedSource: zhLabel(locale, '任意已连接来源', '任何已連線來源', 'Any connected source'),
+      title: zhLabel(locale, '标题', '標題', 'Title'),
+      titlePlaceholder: zhLabel(locale, '决策、品牌备注、工作流模式……', '決策、品牌備註、工作流程模式……', 'Decision, brand notes, workflow pattern...'),
+      sourceRef: zhLabel(locale, '来源引用', '來源參照', 'Source ref'),
+      sourceRefPlaceholder: zhLabel(locale, 'URL、仓库路径、连接器事件 ID、产物 ID……', 'URL、儲存庫路徑、連接器事件 ID、產物 ID……', 'URL, repo path, connector event id, artifact id...'),
+      content: zhLabel(locale, '内容', '內容', 'Content'),
+      contentPlaceholder: zhLabel(locale, '粘贴要规范化为来源包和提案的内容。', '貼上要標準化為來源封包和提案的內容。', 'Paste the content to canonicalize into a source packet and proposals.'),
+      recentSourcePackets: zhLabel(locale, '最近来源包', '最近來源封包', 'Recent source packets'),
+      noSourcePacketsYet: zhLabel(locale, '还没有来源包。', '還沒有來源封包。', 'No source packets yet.'),
+      ingesting: zhLabel(locale, '导入中', '匯入中', 'Ingesting'),
+      ingest: zhLabel(locale, '导入', '匯入', 'Ingest'),
+      evolutionProposals: zhLabel(locale, '演进提案', '演進提案', 'Evolution proposals'),
+      evolutionProposalsSub: zhLabel(locale, '在变更记忆、技能或设计系统之前先审查自动化输出。', '在變更記憶、技能或設計系統之前先審查自動化輸出。', 'Review automation output before it changes memory, skills, or design systems.'),
+      pending: zhLabel(locale, '待处理', '待處理', 'pending'),
+      apply: zhLabel(locale, '应用', '套用', 'Apply'),
+      reject: zhLabel(locale, '拒绝', '拒絕', 'Reject'),
+      loading: zhLabel(locale, '加载中', '載入中', 'Loading'),
+      memory: zhLabel(locale, '记忆', '記憶', 'Memory'),
+      designSystem: zhLabel(locale, '设计系统', '設計系統', 'Design system'),
+      skill: zhLabel(locale, '技能', '技能', 'Skill'),
+      automationTemplate: zhLabel(locale, '自动化模板', '自動化範本', 'Automation template'),
+      create: zhLabel(locale, '创建', '建立', 'Create'),
+      update: zhLabel(locale, '更新', '更新', 'Update'),
+      merge: zhLabel(locale, '合并', '合併', 'Merge'),
+      move: zhLabel(locale, '移动', '移動', 'Move'),
+      delete: zhLabel(locale, '删除', '刪除', 'Delete'),
+      promote: zhLabel(locale, '提升', '提升', 'Promote'),
+      orbit: 'Orbit',
+      liveArtifact: zhLabel(locale, '实时产物', '即時產物', 'Live artifact'),
+      automation: zhLabel(locale, '自动化', '自動化', 'Automation'),
+      templatesSub: zhLabel(locale, 'Orbit 和实时产物都是同一自动化流程中的模板。', 'Orbit 和即時產物都是同一自動化流程中的範本。', 'Orbit and live artifacts are templates inside the same automation flow.'),
+      templateFilters: zhLabel(locale, '模板筛选', '範本篩選', 'Template filters'),
+      useTemplate: zhLabel(locale, '使用模板', '使用範本', 'Use template'),
+      all: zhLabel(locale, '全部', '全部', 'All'),
+      designSystems: zhLabel(locale, '设计系统', '設計系統', 'Design systems'),
+      skills: zhLabel(locale, '技能', '技能', 'Skills'),
+      connectorsPlural: zhLabel(locale, '连接器', '連接器', 'Connectors'),
+      compressionPlural: zhLabel(locale, '压缩', '壓縮', 'Compression'),
+      release: zhLabel(locale, '发布', '發佈', 'Release'),
+      quality: zhLabel(locale, '质量', '品質', 'Quality'),
+      repo: zhLabel(locale, '仓库', '儲存庫', 'Repo'),
+      artifact: zhLabel(locale, '产物', '產物', 'Artifact'),
+      chat: zhLabel(locale, '聊天', '聊天', 'Chat'),
+      upload: zhLabel(locale, '上传', '上傳', 'Upload'),
+      balanced: zhLabel(locale, '平衡', '平衡', 'Balanced'),
+      aggressive: zhLabel(locale, '激进', '積極', 'Aggressive'),
+      off: zhLabel(locale, '关闭', '關閉', 'Off'),
+      pasteSourceFirst: zhLabel(locale, '请先粘贴来源内容再导入。', '請先貼上來源內容再匯入。', 'Paste source content before ingesting it.'),
+    }),
+    [locale],
+  );
+  const templateFilters = useMemo(
+    () =>
+      TEMPLATE_FILTERS.map((filter) => ({
+        ...filter,
+        label:
+          filter.id === 'all'
+            ? l.all
+            : filter.id === 'orbit'
+              ? l.orbit
+              : filter.id === 'live-artifact'
+                ? l.liveArtifact
+                : filter.id === 'memory'
+                  ? l.memory
+                  : filter.id === 'design-system'
+                    ? l.designSystems
+                    : filter.id === 'skills'
+                      ? l.skills
+                      : filter.id === 'connectors'
+                        ? l.connectorsPlural
+                        : filter.id === 'compression'
+                          ? l.compressionPlural
+                          : filter.id === 'release'
+                            ? l.release
+                            : l.quality,
+      })),
+    [l],
+  );
+  const sourceKindOptions = useMemo(
+    () =>
+      SOURCE_KIND_OPTIONS.map((option) => ({
+        ...option,
+        label:
+          option.id === 'connector'
+            ? l.connector
+            : option.id === 'repo'
+              ? l.repo
+              : option.id === 'artifact'
+                ? l.artifact
+                : option.id === 'chat'
+                  ? l.chat
+                  : option.id === 'upload'
+                    ? l.upload
+                    : option.label,
+      })),
+    [l],
+  );
+  const compressionOptions = useMemo(
+    () =>
+      COMPRESSION_OPTIONS.map((option) => ({
+        ...option,
+        label:
+          option.id === 'balanced'
+            ? l.balanced
+            : option.id === 'aggressive'
+              ? l.aggressive
+              : l.off,
+      })),
+    [l],
   );
 
   const refresh = useCallback(async () => {
@@ -493,7 +674,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
 
   const submitSourceIngestion = async () => {
     if (!sourceForm.bodyMarkdown.trim()) {
-      setError('Paste source content before ingesting it.');
+      setError(l.pasteSourceFirst);
       return;
     }
     setIngestingSource(true);
@@ -627,7 +808,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
   };
 
   const remove = async (id: string) => {
-    if (!window.confirm('Delete this automation? Past runs and their projects are kept.'))
+    if (!window.confirm(l.deleteConfirm))
       return;
     setBusyId(id);
     try {
@@ -649,19 +830,19 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
     <section className="automations-view" aria-labelledby="automations-title" data-testid="tasks-view">
       <header className="automations-hero">
         <div className="automations-hero__copy">
-          <span className="automations-hero__eyebrow">Scheduled agent sessions</span>
+          <span className="automations-hero__eyebrow">{l.scheduledAgentSessions}</span>
           <h1 id="automations-title" className="automations-hero__title">
-            Automations
+            {l.automations}
           </h1>
           <p className="automations-hero__lede">
-            Plan recurring conversations for project work, Orbit digests, and live artifacts.
+            {l.lede}
           </p>
         </div>
         <div className="automations-hero__actions">
-          <div className="automations-metrics" aria-label="Automation summary">
-            <Metric label="Active" value={activeCount} />
-            <Metric label="Paused" value={pausedCount} />
-            <Metric label="Templates" value={templates.length} />
+          <div className="automations-metrics" aria-label={l.automationSummary}>
+            <Metric label={l.active} value={activeCount} />
+            <Metric label={l.paused} value={pausedCount} />
+            <Metric label={l.templates} value={templates.length} />
           </div>
           <button
             type="button"
@@ -670,7 +851,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
             data-testid="automations-new"
           >
             <Icon name="plus" size={14} />
-            <span>New automation</span>
+            <span>{l.newAutomation}</span>
           </button>
         </div>
       </header>
@@ -681,10 +862,10 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
         </div>
       ) : null}
 
-      <section className="automations-saved" aria-label="Your automations">
+      <section className="automations-saved" aria-label={l.yourAutomations}>
         <div className="automations-section-head">
-          <h2 className="automations-section__label">Your automations</h2>
-          {loading ? <span className="automations-section__meta">Loading</span> : null}
+          <h2 className="automations-section__label">{l.yourAutomations}</h2>
+          {loading ? <span className="automations-section__meta">{l.loading}</span> : null}
         </div>
         {!loading && routines.length === 0 ? (
           <button
@@ -696,8 +877,8 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
               <Icon name="plus" size={16} />
             </span>
             <span className="automation-empty__body">
-              <strong>No automations yet</strong>
-              <span>Create one from a template or start with a blank schedule.</span>
+              <strong>{l.noAutomationsYet}</strong>
+              <span>{l.createFromTemplate}</span>
             </span>
           </button>
         ) : null}
@@ -708,7 +889,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
               const targetLabel =
                 r.target.mode === 'reuse'
                   ? projectsById.get(r.target.projectId) ?? r.target.projectId
-                  : 'New project each run';
+                  : l.newProjectEachRun;
               const isExpanded = expandedId === r.id;
               return (
                 <li
@@ -722,11 +903,11 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                     <span className="automation-row__content">
                       <span className="automation-row__title">{r.name}</span>
                       <span className="automation-row__meta">
-                        <span>{scheduleStatusLabel(r)}</span>
+                        <span>{scheduleStatusLabel(r, locale, l.paused)}</span>
                         <span aria-hidden="true">·</span>
                         <span>{targetLabel}</span>
                         <span aria-hidden="true">·</span>
-                        <span>{nextRunLabel(r)}</span>
+                        <span>{nextRunLabel(r, locale)}</span>
                       </span>
                       {r.prompt ? (
                         <span className="automation-row__prompt">{r.prompt}</span>
@@ -734,7 +915,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                       {r.lastRun ? (
                         <span className="automation-row__last-run">
                           <StatusPill status={r.lastRun.status} />
-                          <span>Last run {formatAutomationTimestamp(r.lastRun.startedAt)}</span>
+                          <span>{l.lastRun} {formatAutomationTimestamp(r.lastRun.startedAt)}</span>
                           <span aria-hidden="true">·</span>
                           <button
                             type="button"
@@ -748,7 +929,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                               })
                             }
                           >
-                            Open result
+                            {l.openResult}
                           </button>
                         </span>
                       ) : null}
@@ -760,10 +941,10 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                       className="automation-row__btn"
                       onClick={() => runNow(r.id)}
                       disabled={isBusy}
-                      title="Run now and open the conversation"
+                      title={l.runNowTitle}
                     >
                       <Icon name="play" size={12} />
-                      <span>Run</span>
+                      <span>{l.run}</span>
                     </button>
                     <button
                       type="button"
@@ -775,7 +956,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                       aria-expanded={isExpanded}
                     >
                       <Icon name="history" size={12} />
-                      <span>{isExpanded ? 'Hide history' : 'History'}</span>
+                      <span>{isExpanded ? l.hideHistory : l.history}</span>
                     </button>
                     <button
                       type="button"
@@ -784,7 +965,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                       disabled={isBusy}
                     >
                       <Icon name="edit" size={12} />
-                      <span>Edit</span>
+                      <span>{l.edit}</span>
                     </button>
                     <button
                       type="button"
@@ -792,15 +973,15 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                       onClick={() => togglePaused(r)}
                       disabled={isBusy}
                     >
-                      {r.enabled ? 'Pause' : 'Resume'}
+                      {r.enabled ? l.pause : l.resume}
                     </button>
                     <button
                       type="button"
                       className="automation-row__btn automation-row__btn--danger"
                       onClick={() => remove(r.id)}
                       disabled={isBusy}
-                      aria-label="Delete automation"
-                      title="Delete this automation"
+                      aria-label={l.deleteAutomation}
+                      title={l.deleteAutomationTitle}
                     >
                       <Icon name="trash" size={12} />
                     </button>
@@ -820,20 +1001,20 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
         ) : null}
       </section>
 
-      <section className="automations-ingest" aria-label="Source ingestion">
+      <section className="automations-ingest" aria-label={l.ingestSource}>
         <div className="automations-section-head">
           <div>
-            <h2 className="automations-section__label">Ingest source</h2>
+            <h2 className="automations-section__label">{l.ingestSource}</h2>
             <p className="automations-section__sub">
-              Turn connector, repo, artifact, or chat context into reviewable evolution proposals.
+              {l.ingestSourceSub}
             </p>
           </div>
-          <span className="automations-section__meta">{sourcePackets.length} recent</span>
+          <span className="automations-section__meta">{sourcePackets.length} {l.recent}</span>
         </div>
         <div className="automation-ingest-panel">
           <div className="automation-ingest-controls">
             <label className="automation-ingest-field">
-              <span>Template</span>
+              <span>{l.template}</span>
               <select
                 value={sourceForm.templateId}
                 onChange={(event) => patchSourceForm({ templateId: event.currentTarget.value })}
@@ -849,14 +1030,14 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
               </select>
             </label>
             <label className="automation-ingest-field">
-              <span>Source</span>
+              <span>{l.source}</span>
               <select
                 value={sourceForm.sourceKind}
                 onChange={(event) =>
                   patchSourceForm({ sourceKind: event.currentTarget.value as AutomationSourceKind })
                 }
               >
-                {SOURCE_KIND_OPTIONS.map((option) => (
+                {sourceKindOptions.map((option) => (
                   <option key={option.id} value={option.id}>
                     {option.label}
                   </option>
@@ -864,7 +1045,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
               </select>
             </label>
             <label className="automation-ingest-field">
-              <span>Compression</span>
+              <span>{l.compression}</span>
               <select
                 value={sourceForm.tokenCompression}
                 onChange={(event) =>
@@ -873,7 +1054,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                   })
                 }
               >
-                {COMPRESSION_OPTIONS.map((option) => (
+                {compressionOptions.map((option) => (
                   <option key={option.id} value={option.id}>
                     {option.label}
                   </option>
@@ -882,12 +1063,12 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
             </label>
             {sourceForm.sourceKind === 'connector' ? (
               <label className="automation-ingest-field">
-                <span>Connector</span>
+                <span>{l.connector}</span>
                 <select
                   value={sourceForm.connectorId}
                   onChange={(event) => patchSourceForm({ connectorId: event.currentTarget.value })}
                 >
-                  <option value="">Any connected source</option>
+                  <option value="">{l.anyConnectedSource}</option>
                   {connectors.map((connector) => (
                     <option key={connector.id} value={connector.id}>
                       {connector.name}
@@ -900,33 +1081,33 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
           </div>
           <div className="automation-ingest-fields">
             <label className="automation-ingest-field">
-              <span>Title</span>
+              <span>{l.title}</span>
               <input
                 value={sourceForm.title}
                 onChange={(event) => patchSourceForm({ title: event.currentTarget.value })}
-                placeholder="Decision, brand notes, workflow pattern..."
+                placeholder={l.titlePlaceholder}
               />
             </label>
             <label className="automation-ingest-field">
-              <span>Source ref</span>
+              <span>{l.sourceRef}</span>
               <input
                 value={sourceForm.sourceRef}
                 onChange={(event) => patchSourceForm({ sourceRef: event.currentTarget.value })}
-                placeholder="URL, repo path, connector event id, artifact id..."
+                placeholder={l.sourceRefPlaceholder}
               />
             </label>
           </div>
           <label className="automation-ingest-field automation-ingest-field--body">
-            <span>Content</span>
+            <span>{l.content}</span>
             <textarea
               value={sourceForm.bodyMarkdown}
               onChange={(event) => patchSourceForm({ bodyMarkdown: event.currentTarget.value })}
-              placeholder="Paste the content to canonicalize into a source packet and proposals."
+              placeholder={l.contentPlaceholder}
             />
           </label>
           <div className="automation-ingest-footer">
             {sourcePackets.length > 0 ? (
-              <ul className="automation-ingest-recent" aria-label="Recent source packets">
+              <ul className="automation-ingest-recent" aria-label={l.recentSourcePackets}>
                 {sourcePackets.map((packet) => (
                   <li key={packet.id}>
                     <span>{packet.title}</span>
@@ -937,7 +1118,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                 ))}
               </ul>
             ) : (
-              <span className="automation-ingest-empty">No source packets yet.</span>
+              <span className="automation-ingest-empty">{l.noSourcePacketsYet}</span>
             )}
             <button
               type="button"
@@ -946,22 +1127,22 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
               disabled={ingestingSource}
             >
               <Icon name="sparkles" size={14} />
-              <span>{ingestingSource ? 'Ingesting' : 'Ingest'}</span>
+              <span>{ingestingSource ? l.ingesting : l.ingest}</span>
             </button>
           </div>
         </div>
       </section>
 
       {proposals.length > 0 ? (
-        <section className="automations-saved" aria-label="Automation evolution proposals">
+        <section className="automations-saved" aria-label={l.evolutionProposals}>
           <div className="automations-section-head">
             <div>
-              <h2 className="automations-section__label">Evolution proposals</h2>
+              <h2 className="automations-section__label">{l.evolutionProposals}</h2>
               <p className="automations-section__sub">
-                Review automation output before it changes memory, skills, or design systems.
+                {l.evolutionProposalsSub}
               </p>
             </div>
-            <span className="automations-section__meta">{proposals.length} pending</span>
+            <span className="automations-section__meta">{proposals.length} {l.pending}</span>
           </div>
           <ul className="automations-saved__list">
             {proposals.map((proposal) => {
@@ -978,9 +1159,29 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                     <span className="automation-row__content">
                       <span className="automation-row__title">{proposal.title}</span>
                       <span className="automation-row__meta">
-                        <span>{proposalTargetLabel(proposal.targetKind)}</span>
+                        <span>
+                          {proposal.targetKind === 'memory-node'
+                            ? l.memory
+                            : proposal.targetKind === 'design-system'
+                              ? l.designSystem
+                              : proposal.targetKind === 'skill'
+                                ? l.skill
+                                : l.automationTemplate}
+                        </span>
                         <span aria-hidden="true">·</span>
-                        <span>{proposalActionLabel(proposal.action)}</span>
+                        <span>
+                          {proposal.action === 'create'
+                            ? l.create
+                            : proposal.action === 'update'
+                              ? l.update
+                              : proposal.action === 'merge'
+                                ? l.merge
+                                : proposal.action === 'move'
+                                  ? l.move
+                                  : proposal.action === 'delete'
+                                    ? l.delete
+                                    : l.promote}
+                        </span>
                         <span aria-hidden="true">·</span>
                         <span>{proposal.reviewPolicy}</span>
                       </span>
@@ -1000,7 +1201,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                       disabled={isBusy}
                     >
                       <Icon name="check" size={12} />
-                      <span>Apply</span>
+                      <span>{l.apply}</span>
                     </button>
                     <button
                       type="button"
@@ -1008,7 +1209,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                       onClick={() => reviewProposal(proposal.id, 'reject')}
                       disabled={isBusy}
                     >
-                      Reject
+                      {l.reject}
                     </button>
                   </div>
                 </li>
@@ -1018,16 +1219,16 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
         </section>
       ) : null}
 
-      <section className="automations-templates" aria-label="Automation templates">
+      <section className="automations-templates" aria-label={l.templates}>
         <div className="automations-section-head">
           <div>
-            <h2 className="automations-section__label">Templates</h2>
+            <h2 className="automations-section__label">{l.templates}</h2>
             <p className="automations-section__sub">
-              Orbit and live artifacts are templates inside the same automation flow.
+              {l.templatesSub}
             </p>
           </div>
-          <div className="automations-template-tabs" role="tablist" aria-label="Template filters">
-            {TEMPLATE_FILTERS.map((filter) => (
+          <div className="automations-template-tabs" role="tablist" aria-label={l.templateFilters}>
+            {templateFilters.map((filter) => (
               <button
                 key={filter.id}
                 type="button"
@@ -1056,12 +1257,12 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
               <span className="automation-template-card__body">
                 <span className="automation-template-card__kicker">
                   <Icon name={kindIcon(template.kind)} size={11} />
-                  {kindLabel(template.kind)}
+                  {template.kind === 'orbit' ? l.orbit : template.kind === 'live-artifact' ? l.liveArtifact : l.automation}
                 </span>
                 <span className="automation-template-card__title">{template.title}</span>
                 <span className="automation-template-card__desc">{template.description}</span>
                 <span className="automation-template-card__cta">
-                  Use template
+                  {l.useTemplate}
                   <Icon name="chevron-right" size={12} />
                 </span>
               </span>
@@ -1112,6 +1313,21 @@ function AutomationRunHistory({
   crystallizingRunId: string | null;
   onCrystallizeRun: (routineId: string, runId: string) => void;
 }) {
+  const { locale } = useI18n();
+  const l = useMemo(
+    () => ({
+      loading: zhLabel(locale, '正在加载运行历史……', '正在載入執行歷史……', 'Loading run history...'),
+      empty: zhLabel(locale, '还没有运行记录。', '還沒有執行記錄。', 'No runs yet.'),
+      aria: zhLabel(locale, '自动化运行历史', '自動化執行歷史', 'Automation run history'),
+      title: zhLabel(locale, '运行历史', '執行歷史', 'Run history'),
+      latest10: zhLabel(locale, '最新 10 条', '最新 10 筆', 'Latest 10'),
+      crystallizeTitle: zhLabel(locale, '根据这次运行起草技能和记忆提案', '根據這次執行起草技能與記憶提案', 'Draft skill and memory proposals from this run'),
+      crystallizing: zhLabel(locale, '结晶中', '結晶中', 'Crystallizing'),
+      crystallize: zhLabel(locale, '结晶化', '結晶化', 'Crystallize'),
+      openConversation: zhLabel(locale, '打开对话', '開啟對話', 'Open conversation'),
+    }),
+    [locale],
+  );
   const [runs, setRuns] = useState<RoutineRun[] | null>(null);
 
   useEffect(() => {
@@ -1133,18 +1349,18 @@ function AutomationRunHistory({
   }, [refreshKey, routineId]);
 
   if (runs === null) {
-    return <div className="automation-history automation-history--empty">Loading run history...</div>;
+    return <div className="automation-history automation-history--empty">{l.loading}</div>;
   }
 
   if (runs.length === 0) {
-    return <div className="automation-history automation-history--empty">No runs yet.</div>;
+    return <div className="automation-history automation-history--empty">{l.empty}</div>;
   }
 
   return (
-    <div className="automation-history" aria-label="Automation run history">
+    <div className="automation-history" aria-label={l.aria}>
       <div className="automation-history__head">
-        <span>Run history</span>
-        <span>Latest 10</span>
+        <span>{l.title}</span>
+        <span>{l.latest10}</span>
       </div>
       <ul className="automation-history__list">
         {runs.map((run) => (
@@ -1172,10 +1388,10 @@ function AutomationRunHistory({
                   className="automation-history__open"
                   onClick={() => onCrystallizeRun(routineId, run.id)}
                   disabled={crystallizingRunId === run.id}
-                  title="Draft skill and memory proposals from this run"
+                  title={l.crystallizeTitle}
                 >
                   <Icon name="sparkles" size={12} />
-                  <span>{crystallizingRunId === run.id ? 'Crystallizing' : 'Crystallize'}</span>
+                  <span>{crystallizingRunId === run.id ? l.crystallizing : l.crystallize}</span>
                 </button>
               ) : null}
               <button
@@ -1190,7 +1406,7 @@ function AutomationRunHistory({
                   })
                 }
               >
-                Open conversation
+                {l.openConversation}
                 <Icon name="chevron-right" size={12} />
               </button>
             </div>


### PR DESCRIPTION
Closes #2078

## Why

I hit the Automation surface still rendering hardcoded English copy while the app language was set to Chinese. That left the sidebar-adjacent automation experience inconsistent with the rest of the localized UI and made the Automations page feel unfinished for Chinese-speaking users.

## What users will see

When Open Design is set to Simplified or Traditional Chinese, the Automation page and automation modal now show Chinese labels for the page header, section copy, buttons, empty states, schedule controls, run history, and built-in template cards instead of falling back to English.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached.

## Bug fix verification

- Test path that reproduces the bug: none added; this fix was verified by code inspection and targeted UI string updates across the automation page/modal/settings header.
- Did the test go red on `main` and green on this branch? no
- A red spec was not cheap here because the issue was broad UI copy fallback across an existing page rather than a single isolated state transition.

## Validation

- `pnpm --filter @open-design/web typecheck` *(fails in this workspace because the script runs `tsc -b --noEmit`, which errors with `TS5072`, and pnpm warns that local `node_modules` are missing)*
