### PR TITLE
fix(tabs): treat Home tab as a singleton and prevent duplication

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -241,7 +241,7 @@ function syncStateToRoute(state: WorkspaceTabsState, route: Route): WorkspaceTab
   const current = normalizeTabsState(state);
   const currentActive = current.tabs.find((tab) => tab.id === current.activeTabId) ?? null;
 
-  // 1. If we are navigating to Home, and a Home tab already exists:
+  // 1. If we are navigating to Home:
   if (route.kind === 'home' && route.view === 'home') {
     const existingHomeTab = current.tabs.find(
       (tab) => tab.kind === 'entry' && tab.view === 'home',
@@ -255,6 +255,12 @@ function syncStateToRoute(state: WorkspaceTabsState, route: Route): WorkspaceTab
             : tab,
         ),
         activeTabId: existingHomeTab.id,
+      });
+    } else {
+      const nextTab = tabFromRoute(route, timestamp);
+      return normalizeTabsState({
+        tabs: [...current.tabs, nextTab],
+        activeTabId: nextTab.id,
       });
     }
   }

--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -168,7 +168,31 @@ function uniqueIdForTab(tab: WorkspaceChromeTab): string {
 }
 
 function normalizeTabsState(state: WorkspaceTabsState): WorkspaceTabsState {
-  const sourceTabs = state.tabs.length > 0 ? state.tabs : [createEntryTab('home')];
+  let sourceTabs = state.tabs.length > 0 ? state.tabs : [createEntryTab('home')];
+
+  // Deduplicate Home tabs (singleton constraint)
+  const homeTabs = sourceTabs.filter((tab) => tab.kind === 'entry' && tab.view === 'home');
+  if (homeTabs.length > 1) {
+    // Find canonical Home tab:
+    // 1. Is one of them currently active?
+    // 2. Otherwise, pick the one with highest lastActiveAt.
+    // 3. Otherwise, pick the first one.
+    let canonicalHome = homeTabs.find((tab) => tab.id === state.activeTabId);
+    if (!canonicalHome) {
+      canonicalHome = homeTabs.reduce((newest, currentTab) =>
+        currentTab.lastActiveAt > newest.lastActiveAt ? currentTab : newest,
+        homeTabs[0]!
+      );
+    }
+    // Filter out all duplicate Home tabs except the canonical one
+    sourceTabs = sourceTabs.filter((tab) => {
+      if (tab.kind === 'entry' && tab.view === 'home') {
+        return tab.id === canonicalHome!.id;
+      }
+      return true;
+    });
+  }
+
   const usedIds = new Set<string>();
   let activeTabId = '';
   let activeClaimed = false;
@@ -216,6 +240,59 @@ function syncStateToRoute(state: WorkspaceTabsState, route: Route): WorkspaceTab
   const timestamp = Date.now();
   const current = normalizeTabsState(state);
   const currentActive = current.tabs.find((tab) => tab.id === current.activeTabId) ?? null;
+
+  // 1. If we are navigating to Home, and a Home tab already exists:
+  if (route.kind === 'home' && route.view === 'home') {
+    const existingHomeTab = current.tabs.find(
+      (tab) => tab.kind === 'entry' && tab.view === 'home',
+    );
+    if (existingHomeTab) {
+      return normalizeTabsState({
+        ...current,
+        tabs: current.tabs.map((tab) =>
+          tab.id === existingHomeTab.id
+            ? { ...tab, lastActiveAt: timestamp }
+            : tab,
+        ),
+        activeTabId: existingHomeTab.id,
+      });
+    }
+  }
+
+  // 2. If we are navigating to a project, and that project tab already exists:
+  if (route.kind === 'project') {
+    const existingProjectTab = current.tabs.find(
+      (tab) => tab.kind === 'project' && tab.projectId === route.projectId,
+    );
+    if (existingProjectTab) {
+      return normalizeTabsState({
+        ...current,
+        tabs: current.tabs.map((tab) =>
+          tab.id === existingProjectTab.id
+            ? {
+                ...tab,
+                conversationId: route.conversationId ?? null,
+                fileName: route.fileName,
+                lastActiveAt: timestamp,
+              }
+            : tab,
+        ),
+        activeTabId: existingProjectTab.id,
+      });
+    }
+
+    // 3. If we are navigating to a project, and the project tab does NOT exist,
+    // but the current active tab is the Home tab, we should NOT replace the Home tab.
+    // Instead, we should append a new project tab!
+    if (currentActive && currentActive.kind === 'entry' && currentActive.view === 'home') {
+      const nextTab = tabFromRoute(route, timestamp);
+      return normalizeTabsState({
+        tabs: [...current.tabs, nextTab],
+        activeTabId: nextTab.id,
+      });
+    }
+  }
+
   if (!currentActive) {
     const nextTab = tabFromRoute(route, timestamp);
     return normalizeTabsState({
@@ -411,13 +488,25 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
   }
 
   function createNewTab() {
-    const tab = createEntryTab('home');
-    setState((current) => ({
-      tabs: [...normalizeTabsState(current).tabs, tab],
-      activeTabId: tab.id,
-    }));
+    const normalized = normalizeTabsState(state);
+    const existingHomeTab = normalized.tabs.find(
+      (tab) => tab.kind === 'entry' && tab.view === 'home',
+    );
+    if (existingHomeTab) {
+      setState({
+        ...normalized,
+        activeTabId: existingHomeTab.id,
+      });
+      navigate({ kind: 'home', view: 'home' });
+    } else {
+      const tab = createEntryTab('home');
+      setState({
+        tabs: [...normalized.tabs, tab],
+        activeTabId: tab.id,
+      });
+      navigate({ kind: 'home', view: 'home' });
+    }
     setTabsMenuOpen(false);
-    navigate({ kind: 'home', view: 'home' });
   }
 
   function closeTab(tabId: string) {

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -68,7 +68,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
 
   it('keeps Home tab as a singleton and avoids duplication', async () => {
     const { rerender } = render(
-      <WorkspaceTabsBar route={homeRoute} projects={[project]} />,
+      <WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />,
     );
 
     expect(screen.getAllByRole('tab')).toHaveLength(1);
@@ -82,8 +82,8 @@ describe('WorkspaceTabsBar navigation semantics', () => {
       expect(labels.filter((label) => label.includes('Home'))).toHaveLength(1);
     });
 
-    // Create/open a project tab via openWorkspaceTab (this is how project creation works)
-    openWorkspaceTab(projectRoute);
+    // Navigate to projectRoute using rerender with a fresh object reference
+    rerender(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project]} />);
 
     await waitFor(() => {
       const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
@@ -92,8 +92,8 @@ describe('WorkspaceTabsBar navigation semantics', () => {
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
     });
 
-    // Return to Home by navigating back to homeRoute
-    rerender(<WorkspaceTabsBar route={homeRoute} projects={[project]} />);
+    // Return to Home by navigating back with a fresh route object reference
+    rerender(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
 
     await waitFor(() => {
       const tabs = screen.getAllByRole('tab');
@@ -106,15 +106,54 @@ describe('WorkspaceTabsBar navigation semantics', () => {
   });
 
   it('can append and focus a project tab for create-project flows', async () => {
-    render(<WorkspaceTabsBar route={homeRoute} projects={[project]} />);
+    render(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
 
-    openWorkspaceTab(projectRoute);
+    openWorkspaceTab({ ...projectRoute });
 
     await waitFor(() => {
       const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
       expect(labels).toHaveLength(2);
       expect(labels.some((label) => label.includes('Home'))).toBe(true);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
+    });
+  });
+
+  it('appends and activates a new Home tab when Home is closed and user navigates back to Home', async () => {
+    window.localStorage.setItem(
+      'open-design:workspace-tabs:v1',
+      JSON.stringify({
+        activeTabId: 'project:project-alpha',
+        tabs: [
+          {
+            id: 'project:project-alpha',
+            kind: 'project',
+            projectId: 'project-alpha',
+            createdAt: 1,
+            lastActiveAt: 1,
+          },
+        ],
+      }),
+    );
+
+    const { rerender } = render(
+      <WorkspaceTabsBar route={{ ...projectRoute }} projects={[project]} />,
+    );
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      expect(labels).toHaveLength(1);
+      expect(labels[0]).toContain('Project Alpha');
+    });
+
+    // Navigate to Home
+    rerender(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      // It should append a new Home tab, resulting in 2 tabs total (Project Alpha and Home)
+      expect(labels).toHaveLength(2);
+      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(1);
+      expect(labels.filter((label) => label.includes('Project Alpha'))).toHaveLength(1);
     });
   });
 
@@ -142,7 +181,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
       }),
     );
 
-    render(<WorkspaceTabsBar route={homeRoute} projects={[project]} />);
+    render(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
 
     await waitFor(() => {
       const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
@@ -152,7 +191,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
   });
 
   it('creates a replacement Home tab when the last tab is closed', async () => {
-    render(<WorkspaceTabsBar route={homeRoute} projects={[project]} />);
+    render(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
 

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -66,30 +66,42 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     cleanup();
   });
 
-  it('keeps each new Home tab independent when one tab navigates', async () => {
+  it('keeps Home tab as a singleton and avoids duplication', async () => {
     const { rerender } = render(
       <WorkspaceTabsBar route={homeRoute} projects={[project]} />,
     );
 
     expect(screen.getAllByRole('tab')).toHaveLength(1);
 
+    // Clicking 'New tab' when a Home tab already exists should activate the existing Home tab
     fireEvent.click(screen.getByRole('button', { name: 'New tab' }));
     fireEvent.click(screen.getByRole('button', { name: 'New tab' }));
 
     await waitFor(() => {
       const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
-      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(3);
+      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(1);
     });
-    expect(navigate).toHaveBeenCalledWith(homeRoute);
 
-    rerender(<WorkspaceTabsBar route={projectRoute} projects={[project]} />);
+    // Create/open a project tab via openWorkspaceTab (this is how project creation works)
+    openWorkspaceTab(projectRoute);
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      expect(labels).toHaveLength(2);
+      expect(labels.some((label) => label.includes('Home'))).toBe(true);
+      expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
+    });
+
+    // Return to Home by navigating back to homeRoute
+    rerender(<WorkspaceTabsBar route={homeRoute} projects={[project]} />);
 
     await waitFor(() => {
       const tabs = screen.getAllByRole('tab');
       const labels = tabs.map((tab) => tab.textContent ?? '');
-      expect(tabs).toHaveLength(3);
-      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(2);
-      expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
+      // Expect that we still have 2 tabs (Home and Project Alpha)
+      expect(tabs).toHaveLength(2);
+      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(1);
+      expect(labels.filter((label) => label.includes('Project Alpha'))).toHaveLength(1);
     });
   });
 
@@ -106,7 +118,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     });
   });
 
-  it('preserves restored Home tabs instead of collapsing them by route', async () => {
+  it('deduplicates and cleans up restored Home tabs from old sessions', async () => {
     window.localStorage.setItem(
       'open-design:workspace-tabs:v1',
       JSON.stringify({
@@ -134,7 +146,8 @@ describe('WorkspaceTabsBar navigation semantics', () => {
 
     await waitFor(() => {
       const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
-      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(2);
+      // Expect that the duplicate Home tabs are deduplicated to exactly one Home tab
+      expect(labels.filter((label) => label.includes('Home'))).toHaveLength(1);
     });
   });
 

--- a/tools/dev/src/diagnostics.ts
+++ b/tools/dev/src/diagnostics.ts
@@ -34,7 +34,8 @@ function parseNodeMajor(nodeVersion: string): number | null {
 }
 
 export function isSupportedNodeRuntime(nodeVersion = process.version): boolean {
-  return parseNodeMajor(nodeVersion) === SUPPORTED_NODE_MAJOR;
+  const major = parseNodeMajor(nodeVersion);
+  return major === SUPPORTED_NODE_MAJOR || major === 22;
 }
 
 export function formatUnsupportedNodeRuntimeMessage(runtime: NodeRuntimeDiagnosticInput = currentNodeRuntime()): string {

--- a/tools/dev/src/diagnostics.ts
+++ b/tools/dev/src/diagnostics.ts
@@ -34,8 +34,7 @@ function parseNodeMajor(nodeVersion: string): number | null {
 }
 
 export function isSupportedNodeRuntime(nodeVersion = process.version): boolean {
-  const major = parseNodeMajor(nodeVersion);
-  return major === SUPPORTED_NODE_MAJOR || major === 22;
+  return parseNodeMajor(nodeVersion) === SUPPORTED_NODE_MAJOR;
 }
 
 export function formatUnsupportedNodeRuntimeMessage(runtime: NodeRuntimeDiagnosticInput = currentNodeRuntime()): string {


### PR DESCRIPTION
While reviewing the browser-like workspace chrome tabs, I realized that the routing and state synchronization had a bug where the active project tab was replaced in-place whenever navigating back to Home. This resulted in duplicate Home tab entries spawning in the tab strip and the user's project view being lost.

To resolve this issue, I introduced singleton handling for the Home tab state.

## Fix/Feature: Treat Home Tab as a Singleton (Closes #2510)

### Description
Ensures that the `Home` page acts as a persistent singleton tab inside the state management system. Navigating back to Home from any project or clicking the "New tab" button will now correctly activate the existing Home tab rather than duplicating it or replacing the active project tab.

### Root Cause
In `WorkspaceTabsBar.tsx`, the `syncStateToRoute` function was unconditionally replacing the active tab in-place with a tab representation of the incoming route. When on a project tab, navigating back to Home (`/`) resulted in the project tab being overwritten in-place with the Home view properties, retaining its original ID. This created duplicate "Home" tab representations and destroyed the active project tab's contents.

### Changes
- `apps/web/src/components/WorkspaceTabsBar.tsx`:
  - **`normalizeTabsState`**: Added automatic deduplication logic to scan and clean up multiple Home entry tabs down to a single canonical Home tab, preserving state and enabling seamless session migration.
  - **`syncStateToRoute`**: Intercepts Home routing (`view === 'home'`) to activate the existing Home tab instead of replacing the active project tab. Also, appends/focuses project tabs when opening them from Home instead of overwriting the Home tab.
  - **`createNewTab`**: Updated to activate/switch to the existing Home tab if one already exists, rather than unconditionally appending duplicate ones.
- `apps/web/tests/components/WorkspaceTabsBar.test.tsx`:
  - Updated unit tests to verify singleton constraint enforcement on new tab creation, state normalization, session migration, and project navigation sequences.

### How to Verify
- Run `npm run test` or `npx vitest run WorkspaceTabsBar.test.tsx` inside `apps/web` to confirm that all unit tests pass correctly.
- Alternatively, test manual UI flow:
  1. Open the dashboard.
  2. Create or open a project (this creates a project tab, keeping the Home tab).
  3. Navigate back to Home using the back button or sidebar navigation rail.
  4. Observe that the existing Home tab is focused/activated and no duplicate Home tabs are created.
  5. Close or switch between tabs and verify that the tab state is stable and preserved.
