### PR TITLE
[codex] Seed release smoke onboarding state

### DIFF
--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { execFile, spawn, type ChildProcessByStdio } from 'node:child_process';
-import { access, mkdir, stat } from 'node:fs/promises';
+import { access, mkdir, stat, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import type { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
@@ -191,6 +191,7 @@ macDescribe('packaged mac runtime smoke', () => {
 
       updaterFixture = await startUpdaterFixtureProcess(updateScenario);
       applyPackagedUpdateEnv(process.env, updateScenario, updaterFixture.info.metadataUrl);
+      await seedPackagedOnboardingComplete();
 
       const start = await runToolsPackJson<MacStartResult>('start');
       started = true;
@@ -1798,6 +1799,12 @@ async function pathExists(filePath: string): Promise<boolean> {
 
 async function fileSizeBytes(filePath: string): Promise<number> {
   return (await stat(filePath)).size;
+}
+
+async function seedPackagedOnboardingComplete(): Promise<void> {
+  const configPath = join(runtimeNamespaceRoot, 'data', 'app-config.json');
+  await mkdir(dirname(configPath), { recursive: true });
+  await writeFile(configPath, `${JSON.stringify({ onboardingCompleted: true }, null, 2)}\n`, 'utf8');
 }
 
 function resolveFromWorkspace(filePath: string): string {

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { execFile, spawn, type ChildProcessByStdio } from 'node:child_process';
-import { mkdir, readFile, stat } from 'node:fs/promises';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import type { Readable } from 'node:stream';
@@ -261,6 +261,7 @@ winDescribe('packaged windows runtime smoke', () => {
 
       updaterFixture = await startUpdaterFixtureProcess(updateScenario);
       applyPackagedUpdateEnv(process.env, updateScenario, updaterFixture.info.metadataUrl);
+      await seedPackagedOnboardingComplete();
 
       let start = await measureSmokeStep(timings, 'start', async () => runToolsPackJson<WinStartResult>('start'));
       started = true;
@@ -760,6 +761,12 @@ async function fileSizeBytes(filePath: string): Promise<number> {
 
 async function readTiming(filePath: string): Promise<TimingResult> {
   return JSON.parse(await readFile(filePath, 'utf8')) as TimingResult;
+}
+
+async function seedPackagedOnboardingComplete(): Promise<void> {
+  const configPath = join(runtimeNamespaceRoot, 'data', 'app-config.json');
+  await mkdir(dirname(configPath), { recursive: true });
+  await writeFile(configPath, `${JSON.stringify({ onboardingCompleted: true }, null, 2)}\n`, 'utf8');
 }
 
 async function resolveExpectedUpdateRoot(installDir: string): Promise<string> {


### PR DESCRIPTION
## Why

The latest release-stable run failed after the mac arm64 and win x64 packages were already built and their updater runtimes had downloaded the next nightly fixture. The smoke test was waiting for the updater popup while the clean packaged app was still on first-run onboarding, where the top-bar updater UI is not mounted.

This PR makes the release smoke model the existing-user updater path by seeding onboarding completion before launching the packaged app.

## What users will see

Nothing changes in the product. This only changes release validation state setup.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `e2e/specs/mac.spec.ts` and `e2e/specs/win.spec.ts` in release-stable packaged smoke.
- Did the test go red on `main` and green on this branch? No local full red/green run; the red evidence is GitHub Actions run `26222565426`, where both failing smoke payloads showed `update.state=downloaded` but no updater popup DOM while the clean app was still on onboarding.
- Local verification used the cheapest checks for this harness-only change; the platform release smoke will provide the full green signal.

## Validation

- `pnpm --filter @open-design/e2e typecheck`
- `pnpm --filter @open-design/e2e test specs/mac.spec.ts specs/win.spec.ts`
- `pnpm guard`
- `git diff --check`
