### PR TITLE
[codex] Clear applied updater install state

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1410,8 +1410,27 @@ export function createDesktopUpdater(
     const loadedActive = await loadActiveRelease(opened.root, opened.metadata, config, logger);
     if (!loadedActive.ok) return setState(DESKTOP_UPDATE_STATES.ERROR, loadedActive.error);
     activeRelease = loadedActive.active;
-    installFrozen = opened.metadata.installFrozen === true;
-    installResult = opened.metadata.installResult;
+    // If the app now runs at or beyond the stored active release, the
+    // external installer succeeded and its one-shot UI state is stale.
+    const clearedAppliedRelease =
+      activeRelease == null &&
+      (
+        opened.metadata.active != null ||
+        opened.metadata.installFrozen === true ||
+        opened.metadata.installResult != null
+      );
+    if (clearedAppliedRelease) {
+      await writeStoreMetadata(opened.root, {
+        ...opened.metadata,
+        active: undefined,
+        incoming: undefined,
+        installFrozen: undefined,
+        installResult: undefined,
+        version: STORE_METADATA_VERSION,
+      });
+    }
+    installFrozen = clearedAppliedRelease ? false : opened.metadata.installFrozen === true;
+    installResult = clearedAppliedRelease ? undefined : opened.metadata.installResult;
     lastCheckedAt = opened.metadata.lastCheckedAt;
     metadata = activeRelease?.ref.metadata ?? null;
     candidate = null;

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -934,6 +934,50 @@ describe("desktop updater", () => {
     }
   });
 
+  it("clears installer-open freeze once the restarted app matches the downloaded update", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const downloaded = await updater.checkForUpdates();
+      const installed = await updater.installUpdate();
+      expect(installed.installResult?.path).toBe(downloaded.downloadPath);
+
+      const restarted = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: {
+          ...updaterEnv(fixture.metadataUrl),
+          [DESKTOP_UPDATE_ENV.CURRENT_VERSION]: "1.0.1",
+        },
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+      const restored = await restarted.status();
+
+      expect(restored.state).toBe(DESKTOP_UPDATE_STATES.IDLE);
+      expect(restored.installResult).toBeUndefined();
+      expect(restored.downloadPath).toBeUndefined();
+
+      const store = JSON.parse(await readFile(join(root, "metadata.json"), "utf8")) as Record<string, unknown>;
+      expect(store.active).toBeUndefined();
+      expect(store.installFrozen).toBeUndefined();
+      expect(store.installResult).toBeUndefined();
+
+      const checked = await restarted.checkForUpdates();
+      expect(checked.state).toBe(DESKTOP_UPDATE_STATES.NOT_AVAILABLE);
+      expect(checked.installResult).toBeUndefined();
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("defaults counted beta nightly builds to the beta update channel", () => {
     const root = makeRoot();
     try {


### PR DESCRIPTION
## Why

After a successful overwrite update, the newly launched app could still show the updater popup as "Installer opened" / "Open Design is quitting". The live Nightly repro showed the app was already running the new version, and installer observation had recorded `app_version_matches`, but the updater store still retained the prior `installFrozen` and `installResult` fields.

That left the web updater model stuck in installer-opened state even though the external installer had already completed.

## What users will see

After installing an update and launching the new version, the updater control no longer keeps showing the stale installer-opened prompt.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is updater state restoration behavior.

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/updater.test.ts`
- Did the test go red on `main` and green on this branch? Red was confirmed locally before the fix: the new restart test still restored `installResult` after currentVersion matched the downloaded update. Green after the fix.
- Live evidence: `/Applications/Open Design Nightly.app` was running `0.8.0.nightly.8`, installer observation recorded `app_version_matches`, but `updates/metadata.json` still carried `installFrozen=true` and `installResult`.

## Validation

- `pnpm --filter @open-design/desktop test -- tests/main/updater.test.ts -t "clears installer-open freeze"` red before fix, green after fix
- `pnpm --filter @open-design/desktop test -- tests/main/updater.test.ts`
- `pnpm --filter @open-design/desktop test -- tests/main/updater-host-boundary.test.ts tests/main/preload-host-boundary.test.ts`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/lib/updater.test.ts tests/components/UpdaterPopup.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
