### PR TITLE
feat(web): polish automation schedule picker and summary pill UI

### DIFF
--- a/apps/web/src/components/NewAutomationModal.tsx
+++ b/apps/web/src/components/NewAutomationModal.tsx
@@ -107,16 +107,57 @@ function formatTime12h(time: string): string {
   return `${h12}:${mm} ${suffix}`;
 }
 
-export function describeScheduleSummary(schedule: RoutineSchedule): string {
+/**
+ * Extracts the schedule's display parts once.
+ * Both the string formatter and the node builder consume this so they can
+ * never silently desync (weekday labels, time format, timezone label, etc.).
+ */
+type ScheduleParts =
+  | { kind: 'hourly'; minute: string }
+  | { kind: 'timed'; freq: string; time: string; tz: string };
+
+function decomposeSchedule(schedule: RoutineSchedule): ScheduleParts {
   if (schedule.kind === 'hourly') {
-    const mm = String(schedule.minute).padStart(2, '0');
-    return `Hourly at :${mm}`;
+    return { kind: 'hourly', minute: String(schedule.minute).padStart(2, '0') };
   }
   const tz = tzCityLabel(schedule.timezone);
-  if (schedule.kind === 'daily') return `Daily at ${formatTime12h(schedule.time)} · ${tz}`;
-  if (schedule.kind === 'weekdays') return `Weekdays at ${formatTime12h(schedule.time)} · ${tz}`;
-  const day = WEEKDAY_LABELS.find((w) => w.value === schedule.weekday)?.long ?? 'Sunday';
-  return `${day} at ${formatTime12h(schedule.time)} · ${tz}`;
+  const time = formatTime12h(schedule.time);
+  const freq =
+    schedule.kind === 'daily'
+      ? 'Daily'
+      : schedule.kind === 'weekdays'
+        ? 'Weekdays'
+        : WEEKDAY_LABELS.find((w) => w.value === schedule.weekday)?.long ?? 'Sunday';
+  return { kind: 'timed', freq, time, tz };
+}
+
+export function describeScheduleSummary(schedule: RoutineSchedule): string {
+  const parts = decomposeSchedule(schedule);
+  if (parts.kind === 'hourly') return `Hourly at :${parts.minute}`;
+  return `${parts.freq} at ${parts.time} · ${parts.tz}`;
+}
+
+/** Renders the schedule summary as structured pill segments for better visual hierarchy. */
+function buildScheduleSummaryNode(schedule: RoutineSchedule): ReactNode {
+  const parts = decomposeSchedule(schedule);
+  if (parts.kind === 'hourly') {
+    return (
+      <>
+        <span className="automation-pill__freq">Hourly</span>
+        <span className="automation-pill__sep">·</span>
+        <span className="automation-pill__time">:{parts.minute}</span>
+      </>
+    );
+  }
+  return (
+    <>
+      <span className="automation-pill__freq">{parts.freq}</span>
+      <span className="automation-pill__sep">·</span>
+      <span className="automation-pill__time">{parts.time}</span>
+      <span className="automation-pill__sep">·</span>
+      <span className="automation-pill__tz">{parts.tz}</span>
+    </>
+  );
 }
 
 type FormState = {
@@ -470,6 +511,7 @@ export function NewAutomationModal({
   const projectLabel =
     form.mode === 'reuse' && projectName ? projectName : 'New project each run';
   const scheduleLabel = describeScheduleSummary(buildSchedule(form));
+  const scheduleLabelNode = buildScheduleSummaryNode(buildSchedule(form));
   const mentionQueryNorm = (mention?.query ?? '').trim().toLowerCase();
   const filteredSkills = filterCapabilities(
     skills,
@@ -786,7 +828,8 @@ export function NewAutomationModal({
             <PillButton
               icon="history"
               active={popover === 'schedule'}
-              label={scheduleLabel}
+              label={scheduleLabelNode}
+              aria-label={scheduleLabel}
               onClick={() =>
                 setPopover((p) => (p === 'schedule' ? null : 'schedule'))
               }
@@ -937,12 +980,14 @@ function PillButton({
   icon,
   label,
   active,
+  'aria-label': ariaLabel,
   onClick,
   children,
 }: {
   icon: 'folder' | 'history';
-  label: string;
+  label: ReactNode;
   active?: boolean;
+  'aria-label'?: string;
   onClick: () => void;
   children?: ReactNode;
 }) {
@@ -951,6 +996,7 @@ function PillButton({
       <button
         type="button"
         className={`automation-pill${active ? ' is-active' : ''}`}
+        aria-label={ariaLabel}
         onClick={onClick}
       >
         <Icon name={icon} size={12} />

--- a/apps/web/src/components/NewAutomationModal.tsx
+++ b/apps/web/src/components/NewAutomationModal.tsx
@@ -143,21 +143,21 @@ function buildScheduleSummaryNode(schedule: RoutineSchedule): ReactNode {
   const parts = decomposeSchedule(schedule);
   if (parts.kind === 'hourly') {
     return (
-      <>
+      <span className="automation-pill__segments">
         <span className="automation-pill__freq">Hourly</span>
         <span className="automation-pill__sep">·</span>
         <span className="automation-pill__time">:{parts.minute}</span>
-      </>
+      </span>
     );
   }
   return (
-    <>
+    <span className="automation-pill__segments">
       <span className="automation-pill__freq">{parts.freq}</span>
       <span className="automation-pill__sep">·</span>
       <span className="automation-pill__time">{parts.time}</span>
       <span className="automation-pill__sep">·</span>
       <span className="automation-pill__tz">{parts.tz}</span>
-    </>
+    </span>
   );
 }
 

--- a/apps/web/src/components/NewAutomationModal.tsx
+++ b/apps/web/src/components/NewAutomationModal.tsx
@@ -108,9 +108,10 @@ function formatTime12h(time: string): string {
 }
 
 /**
- * Extracts the schedule's display parts once.
- * Both the string formatter and the node builder consume this so they can
- * never silently desync (weekday labels, time format, timezone label, etc.).
+ * Shared schedule display parts — single source of truth for both the
+ * string formatter (describeScheduleSummary) and the node builder
+ * (buildScheduleSummaryNode). Any change to labels, time format, or
+ * weekday names only needs to happen here.
  */
 type ScheduleParts =
   | { kind: 'hourly'; minute: string }
@@ -480,13 +481,13 @@ export function NewAutomationModal({
       const url = isEdit ? `/api/routines/${editingId}` : '/api/routines';
       const payload = isEdit
         ? {
-            name: body.name,
-            prompt: body.prompt,
-            schedule: body.schedule,
-            target: body.target,
-            skillId: body.skillId,
-            context: body.context,
-          }
+          name: body.name,
+          prompt: body.prompt,
+          schedule: body.schedule,
+          target: body.target,
+          skillId: body.skillId,
+          context: body.context,
+        }
         : body;
       const res = await fetch(url, {
         method: isEdit ? 'PATCH' : 'POST',

--- a/apps/web/src/styles/home/tasks.css
+++ b/apps/web/src/styles/home/tasks.css
@@ -1337,10 +1337,40 @@
   transition:
     background-color 120ms cubic-bezier(0.23, 1, 0.32, 1),
     border-color 120ms cubic-bezier(0.23, 1, 0.32, 1);
-  max-width: 260px;
+  max-width: 320px;
 }
 
 .automation-pill > span:not(:first-child):not(:last-child) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+/* Schedule summary segments inside the pill */
+.automation-pill__freq {
+  font-weight: 700;
+  color: var(--text-strong);
+  flex-shrink: 0;
+}
+
+.automation-pill__sep {
+  color: var(--text-muted);
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+
+.automation-pill__time {
+  color: var(--text);
+  flex-shrink: 0;
+}
+
+.automation-pill__tz {
+  color: var(--text-muted);
+  font-weight: 500;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1448,10 +1478,10 @@
 }
 
 .automation-popover--schedule {
-  width: min(360px, calc(100vw - 48px));
+  width: min(380px, calc(100vw - 48px));
   min-width: 320px;
-  padding: 10px;
-  gap: 8px;
+  padding: 12px;
+  gap: 10px;
 }
 
 .automation-popover--templates {
@@ -1608,8 +1638,8 @@
 
 .automation-popover__row {
   display: grid;
-  grid-template-columns: 120px minmax(0, 1fr);
-  gap: 8px;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
 }
 
 .automation-popover__field {
@@ -1632,13 +1662,22 @@
   -webkit-appearance: none;
   width: 100%;
   min-width: 0;
-  height: 32px;
-  padding: 0 30px 0 8px;
+  height: 36px;
+  padding: 0 10px;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-panel);
   color: var(--text);
   font-size: 12.5px;
+}
+
+/* Hide the browser-native clock icon so it doesn't crowd the time field */
+.automation-popover__field > input[type='time']::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
+.automation-popover__field > input[type='time']::-webkit-inner-spin-button {
+  display: none;
 }
 
 .automation-popover__field > select {

--- a/apps/web/src/styles/home/tasks.css
+++ b/apps/web/src/styles/home/tasks.css
@@ -109,8 +109,7 @@
   gap: 6px;
   height: 34px;
   padding: 0 13px;
-  border: 1px solid
-    color-mix(in srgb, var(--accent, #79a8ff) 48%, var(--border));
+  border: 1px solid color-mix(in srgb, var(--accent, #79a8ff) 48%, var(--border));
   border-radius: 8px;
   background: color-mix(in srgb, var(--accent, #79a8ff) 16%, var(--bg-panel));
   color: var(--text-strong);
@@ -211,8 +210,7 @@
   width: 100%;
   min-height: 84px;
   padding: 18px 20px;
-  border: 1px dashed
-    color-mix(in srgb, var(--border-strong, var(--border)) 72%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--border-strong, var(--border)) 72%, transparent);
   border-radius: 12px;
   background: color-mix(in srgb, var(--bg-panel) 70%, transparent);
   color: var(--text);
@@ -226,11 +224,7 @@
 
 .automation-empty:hover {
   border-style: solid;
-  border-color: color-mix(
-    in srgb,
-    var(--accent, #79a8ff) 38%,
-    var(--border-strong, var(--border))
-  );
+  border-color: color-mix(in srgb, var(--accent, #79a8ff) 38%, var(--border-strong, var(--border)));
   background: var(--bg-panel);
   box-shadow: var(--shadow-xs);
 }
@@ -647,8 +641,7 @@
 .automation-ingest-field textarea:focus {
   outline: none;
   border-color: color-mix(in srgb, var(--accent, #79a8ff) 44%, var(--border));
-  box-shadow: 0 0 0 3px
-    color-mix(in srgb, var(--accent, #79a8ff) 14%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #79a8ff) 14%, transparent);
 }
 
 .automation-ingest-field--body {
@@ -752,7 +745,8 @@
   font-weight: 600;
   letter-spacing: -0.005em;
   cursor: pointer;
-  transition: color 140ms cubic-bezier(0.23, 1, 0.32, 1);
+  transition: 
+    color 140ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .automations-template-tab:hover {
@@ -795,8 +789,7 @@
   gap: 12px;
   align-items: center;
   padding: 14px 16px;
-  border: 1px dashed
-    color-mix(in srgb, var(--border-strong, var(--border)) 70%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--border-strong, var(--border)) 70%, transparent);
   border-radius: 10px;
   background: color-mix(in srgb, var(--bg-panel) 76%, transparent);
 }
@@ -949,22 +942,14 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: color-mix(
-    in srgb,
-    var(--scrim, rgba(0, 0, 0, 0.45)) 92%,
-    transparent
-  );
+  background: color-mix(in srgb, var(--scrim, rgba(0, 0, 0, 0.45)) 92%, transparent);
   backdrop-filter: blur(3px);
   animation: automation-modal-fade-in 160ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 @keyframes automation-modal-fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .automation-modal {
@@ -1109,8 +1094,7 @@
 .automation-modal__prompt:focus {
   outline: none;
   border-color: color-mix(in srgb, var(--accent, #79a8ff) 44%, var(--border));
-  box-shadow: 0 0 0 3px
-    color-mix(in srgb, var(--accent, #79a8ff) 14%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #79a8ff) 14%, transparent);
 }
 
 .automation-modal__prompt-wrap.is-mentioning .automation-modal__prompt {
@@ -1360,6 +1344,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
+}
+
+.automation-pill__segments {
   display: inline-flex;
   align-items: center;
   gap: 5px;

--- a/apps/web/src/styles/home/tasks.css
+++ b/apps/web/src/styles/home/tasks.css
@@ -109,7 +109,8 @@
   gap: 6px;
   height: 34px;
   padding: 0 13px;
-  border: 1px solid color-mix(in srgb, var(--accent, #79a8ff) 48%, var(--border));
+  border: 1px solid
+    color-mix(in srgb, var(--accent, #79a8ff) 48%, var(--border));
   border-radius: 8px;
   background: color-mix(in srgb, var(--accent, #79a8ff) 16%, var(--bg-panel));
   color: var(--text-strong);
@@ -210,7 +211,8 @@
   width: 100%;
   min-height: 84px;
   padding: 18px 20px;
-  border: 1px dashed color-mix(in srgb, var(--border-strong, var(--border)) 72%, transparent);
+  border: 1px dashed
+    color-mix(in srgb, var(--border-strong, var(--border)) 72%, transparent);
   border-radius: 12px;
   background: color-mix(in srgb, var(--bg-panel) 70%, transparent);
   color: var(--text);
@@ -224,7 +226,11 @@
 
 .automation-empty:hover {
   border-style: solid;
-  border-color: color-mix(in srgb, var(--accent, #79a8ff) 38%, var(--border-strong, var(--border)));
+  border-color: color-mix(
+    in srgb,
+    var(--accent, #79a8ff) 38%,
+    var(--border-strong, var(--border))
+  );
   background: var(--bg-panel);
   box-shadow: var(--shadow-xs);
 }
@@ -641,7 +647,8 @@
 .automation-ingest-field textarea:focus {
   outline: none;
   border-color: color-mix(in srgb, var(--accent, #79a8ff) 44%, var(--border));
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #79a8ff) 14%, transparent);
+  box-shadow: 0 0 0 3px
+    color-mix(in srgb, var(--accent, #79a8ff) 14%, transparent);
 }
 
 .automation-ingest-field--body {
@@ -745,8 +752,7 @@
   font-weight: 600;
   letter-spacing: -0.005em;
   cursor: pointer;
-  transition:
-    color 140ms cubic-bezier(0.23, 1, 0.32, 1);
+  transition: color 140ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .automations-template-tab:hover {
@@ -789,7 +795,8 @@
   gap: 12px;
   align-items: center;
   padding: 14px 16px;
-  border: 1px dashed color-mix(in srgb, var(--border-strong, var(--border)) 70%, transparent);
+  border: 1px dashed
+    color-mix(in srgb, var(--border-strong, var(--border)) 70%, transparent);
   border-radius: 10px;
   background: color-mix(in srgb, var(--bg-panel) 76%, transparent);
 }
@@ -942,14 +949,22 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: color-mix(in srgb, var(--scrim, rgba(0, 0, 0, 0.45)) 92%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--scrim, rgba(0, 0, 0, 0.45)) 92%,
+    transparent
+  );
   backdrop-filter: blur(3px);
   animation: automation-modal-fade-in 160ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 @keyframes automation-modal-fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .automation-modal {
@@ -1094,7 +1109,8 @@
 .automation-modal__prompt:focus {
   outline: none;
   border-color: color-mix(in srgb, var(--accent, #79a8ff) 44%, var(--border));
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #79a8ff) 14%, transparent);
+  box-shadow: 0 0 0 3px
+    color-mix(in srgb, var(--accent, #79a8ff) 14%, transparent);
 }
 
 .automation-modal__prompt-wrap.is-mentioning .automation-modal__prompt {
@@ -1374,6 +1390,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
 }
 
 .automation-pill:hover {
@@ -1383,7 +1400,8 @@
 
 .automation-pill.is-active {
   border-color: color-mix(in srgb, var(--accent, #79a8ff) 58%, var(--border));
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #79a8ff) 18%, transparent);
+  box-shadow: 0 0 0 3px
+    color-mix(in srgb, var(--accent, #79a8ff) 18%, transparent);
 }
 
 .automation-modal__actions {
@@ -1672,11 +1690,12 @@
 }
 
 /* Hide the browser-native clock icon so it doesn't crowd the time field */
-.automation-popover__field > input[type='time']::-webkit-calendar-picker-indicator {
+.automation-popover__field
+  > input[type="time"]::-webkit-calendar-picker-indicator {
   display: none;
 }
 
-.automation-popover__field > input[type='time']::-webkit-inner-spin-button {
+.automation-popover__field > input[type="time"]::-webkit-inner-spin-button {
   display: none;
 }
 
@@ -1688,7 +1707,9 @@
     calc(100% - 15px) 50%,
     calc(100% - 10px) 50%;
   background-repeat: no-repeat;
-  background-size: 5px 5px, 5px 5px;
+  background-size:
+    5px 5px,
+    5px 5px;
 }
 
 .automation-popover__done {


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #2526

## Why

I hit this while reviewing the Automation flow for the v0.8.0 / preview polish pass. The schedule picker's time input was cramped — the native browser clock icon competed with the typed value — and the summary pill in the modal footer ("Daily at 9:00 AM · Shanghai") compressed frequency, time, and timezone into one undifferentiated string that was hard to scan at a glance.  This is a pure UI-quality issue with clear acceptance criteria, so a focused CSS + rendering pass was the right fix before the preview cut.


## What users will see


- The time field in the schedule picker is taller (36 px vs 32 px), has symmetric padding, and no longer shows the browser-native clock icon competing with the typed time value.
- The Time and Timezone fields now share equal horizontal space (50/50)  instead of the time column being pinned to 120 px.
- The schedule popover has slightly more internal padding and a wider max-width for better readability.
- The schedule summary pill in the footer now renders three visually distinct segments: **frequency** (bold, strong color) · time (normal) · timezone (muted, truncates last). The plain string is still used as `aria-label` for screen readers.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<img width="1918" height="930" alt="image" src="https://github.com/user-attachments/assets/5526c3fb-9cd0-49c7-9bc0-e7701de21835" />

## Bug fix verification

   Not a bug fix — enhancement only.

## Validation

- `pnpm typecheck` — exit 0, no new errors
- Manually verified schedule popover renders correctly for all four kinds (Hourly, Daily, Weekdays, Weekly) and the footer pill segments update as expected when the schedule changes.