### PR TITLE
fix(desktop): keep macOS app visible in Dock

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -3,7 +3,7 @@ import { appendFile, mkdir, realpath, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { BrowserWindow, dialog, ipcMain, screen, shell } from "electron";
+import { BrowserWindow, app, dialog, ipcMain, screen, shell } from "electron";
 import {
   DESKTOP_UPDATE_CHANNELS,
   DESKTOP_UPDATE_MODES,
@@ -1095,8 +1095,11 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     }
   });
 
+  if (process.platform === "darwin") {
+    void app.dock?.show();
+  }
+
   const consoleEntries: DesktopConsoleEntry[] = [];
-  const petWindow = createDesktopPetWindow(preloadPath);
   const window = new BrowserWindow({
     height: 900,
     // Below this size the project page's left/right split (chat
@@ -1119,6 +1122,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   installWindowChromeCssHook(window);
   showWindowButtons(window);
   attachDownloadSaveAsDialog(window);
+  const petWindow = createDesktopPetWindow(preloadPath);
 
   const sendUpdaterStatus = (status = options.updater?.snapshot() ?? unavailableUpdaterStatus()) => {
     if (window.isDestroyed()) return;


### PR DESCRIPTION
## Why

While testing the macOS packaged preview app, I could interact with the Open Design window but the app did not appear in the Dock. System Events reported the app process as `background only: true`, even though the app bundle is a regular `APPL` bundle and does not set `LSUIElement` or `LSBackgroundOnly`.

The regression appears after the desktop pet window was introduced. The pet window is created before the main window and has `skipTaskbar: true`; on macOS/Electron this can leave the process registered as a background-style app even after the main window is shown.

## What users will see

On macOS, launching the packaged desktop app shows Open Design in the Dock as a normal foreground app while keeping the desktop pet window taskbar-hidden.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A. This is macOS Dock/process registration behavior rather than an in-app visual change.

## Bug fix verification

- Test path that reproduces the bug: packaged macOS app launch
- Did the test go red on `main` and green on this branch? No automated spec. I verified manually because this depends on macOS LaunchServices/Electron process activation behavior and is not cheap to exercise in the existing unit-test harness.
- Manual verification:
  - Before: `System Events` returned `{visible:false, frontmost:false, background only:true, count of windows:1}` for the packaged app process.
  - After: `System Events` returned `{visible:true, frontmost:true, background only:false, count of windows:1}` after launching the rebuilt packaged app.

## Validation

- `pnpm --filter @open-design/desktop build`
- `pnpm tools-pack mac build --to all --portable --namespace 0.8.0-preview --app-version 0.8.0-preview`
- `codesign --verify --deep --strict --verbose=2 /Applications/Open\ Design\ Preview.app`
- Packaged app smoke launch with daemon status OK (`version: 0.8.0-preview`)
