### PR TITLE
Polish onboarding dropdown presentation

### DIFF
--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1629,16 +1629,34 @@
   left: 0;
   right: 0;
   display: grid;
-  gap: 2px;
-  max-height: 240px;
+  gap: 1px;
+  max-height: min(224px, 36vh);
   overflow-y: auto;
+  overflow-x: hidden;
   overscroll-behavior: contain;
-  padding: 6px;
-  border: 1px solid color-mix(in srgb, var(--border) 82%, var(--accent) 18%);
+  padding: 4px;
+  border: 1px solid color-mix(in srgb, var(--border) 88%, var(--accent) 12%);
   border-radius: 8px;
-  background: color-mix(in srgb, var(--bg-panel) 96%, var(--bg-subtle) 4%);
-  box-shadow: 0 14px 34px color-mix(in srgb, var(--shadow-color, #000) 12%, transparent);
+  background: color-mix(in srgb, var(--bg-panel) 98%, var(--bg-subtle) 2%);
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--shadow-color, #000) 10%, transparent);
   scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--text-muted) 34%, transparent) transparent;
+}
+
+.onboarding-view__select-menu::-webkit-scrollbar {
+  width: 8px;
+}
+
+.onboarding-view__select-menu::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.onboarding-view__select-menu::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--text-muted) 28%, transparent);
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
 }
 
 .onboarding-view__select-field[data-placement='top'] .onboarding-view__select-menu {
@@ -1650,28 +1668,36 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  min-height: 32px;
+  gap: 10px;
+  min-height: 30px;
   width: 100%;
   border: 0;
   border-radius: 6px;
-  padding: 0 10px;
+  padding: 6px 8px 6px 10px;
   color: var(--text);
   background: transparent;
   font: inherit;
-  font-size: 13px;
+  font-size: 12.5px;
+  line-height: 1.25;
   text-align: left;
   cursor: pointer;
 }
 
+.onboarding-view__select-option span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .onboarding-view__select-option:hover {
   color: var(--text-strong);
-  background: color-mix(in srgb, var(--accent) 7%, var(--bg-panel));
+  background: color-mix(in srgb, var(--accent) 5%, var(--bg-panel));
 }
 
 .onboarding-view__select-option.is-selected {
   color: var(--accent-strong);
-  background: color-mix(in srgb, var(--accent) 10%, var(--bg-panel));
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-panel));
   font-weight: 650;
 }
 


### PR DESCRIPTION
Fixes #2512

## Why

I picked this up from the Windows onboarding dropdown polish issue. The onboarding page uses a custom DOM dropdown, not a native OS `<select>`, so the presentation can be improved and verified from the web onboarding page without requiring a Windows packaged-app run.

The pain being addressed is that long onboarding menus felt oversized and visually heavy for a setup flow.

## What users will see

Onboarding dropdown menus are a little more compact, with tighter option rows, a lighter menu border/shadow, hidden horizontal overflow, and subtler scrollbar styling. The existing trigger, selection, hover, and focus behavior stays the same.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before and after screenshots were captured locally from `/onboarding`, step 2, first dropdown open:

- Before: `/tmp/open-design-2512-before-dropdown.png`
- After: `/tmp/open-design-2512-after-dropdown-clean.png`

## Bug fix verification

- Test path that reproduces the bug: not added; this is a visual polish issue and is better verified with screenshots.
- Did the test go red on `main` and green on this branch? No; the validation is visual plus type/guard checks.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`
- Local Playwright/Chrome screenshot pass against `http://127.0.0.1:17573/onboarding`
