### PR TITLE
Fix Simple Deck discovery question form contract

### DIFF
--- a/apps/daemon/tests/plugins-discovery-question-form-contract.test.ts
+++ b/apps/daemon/tests/plugins-discovery-question-form-contract.test.ts
@@ -1,0 +1,43 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const discoveryAtomPath = fileURLToPath(
+  new URL('../../../plugins/_official/atoms/discovery-question-form/SKILL.md', import.meta.url),
+);
+const simpleDeckManifestPath = fileURLToPath(
+  new URL('../../../plugins/_official/examples/simple-deck/open-design.json', import.meta.url),
+);
+
+describe('bundled discovery-question-form atom prompt contract', () => {
+  it('is included in Simple Deck before generation starts', async () => {
+    const manifest = JSON.parse(await readFile(simpleDeckManifestPath, 'utf8')) as {
+      od?: { pipeline?: { stages?: Array<{ id?: string; atoms?: string[] }> } };
+    };
+    const stages = manifest.od?.pipeline?.stages ?? [];
+
+    expect(stages.map((stage) => stage.id)).toEqual(['discovery', 'generate']);
+    expect(stages[0]?.atoms).toContain('discovery-question-form');
+    expect(stages[1]?.atoms).toEqual(['file-write', 'live-artifact']);
+  });
+
+  it('teaches agents to emit the wrapped question-form renderer contract', async () => {
+    const body = await readFile(discoveryAtomPath, 'utf8');
+
+    expect(body).toContain('<question-form id="discovery"');
+    expect(body).toContain('"questions": [');
+    expect(body).toContain('</question-form>');
+    expect(body).toMatch(/Do not emit a bare question object by itself/);
+  });
+
+  it('does not present a bare keyed question JSON object as the canonical emission shape', async () => {
+    const body = await readFile(discoveryAtomPath, 'utf8');
+    const emissionShape = body.slice(
+      body.indexOf('## Emission shape'),
+      body.indexOf('## Question object shape'),
+    );
+
+    expect(emissionShape).not.toMatch(/```jsonc\s*\{\s*"id":/s);
+    expect(body).not.toMatch(/```jsonc[\s\S]*"id": "audience"/);
+  });
+});

--- a/plugins/_official/atoms/discovery-question-form/SKILL.md
+++ b/plugins/_official/atoms/discovery-question-form/SKILL.md
@@ -20,18 +20,43 @@ up turn doesn't re-ask).
 - Brief explicitly invites questions ("ask me anything if unclear").
 - The discovery skill or pipeline declares a `discovery` stage.
 
-## Question shape (as the agent emits one)
+## Emission shape
 
-```jsonc
+Emit the form as a `question-form` block whose body is a JSON object with a
+top-level `questions` array. Do not emit a bare question object by itself; the
+renderer only recognizes the wrapped form contract.
+
+```html
+<question-form id="discovery" title="Quick brief — 30 seconds">
 {
-  "id": "audience",
-  "label": "Who's the primary audience?",
-  "type": "checkbox",      // or 'radio' | 'text' | 'number'
-  "options": ["VC", "Customer", "Internal team"],
-  "maxSelections": 2,
-  "required": true
+  "description": "I'll lock these in before building. Skip what doesn't apply — I'll fill defaults.",
+  "questions": [
+    {
+      "id": "audience",
+      "label": "Who's the primary audience?",
+      "type": "checkbox",
+      "options": ["VC", "Customer", "Internal team"],
+      "maxSelections": 2,
+      "required": true
+    }
+  ]
 }
+</question-form>
 ```
+
+## Question object shape
+
+Each entry in the top-level `questions` array uses:
+
+- `id`: stable answer key, for example `audience`.
+- `label`: user-facing question copy.
+- `type`: one of `radio`, `checkbox`, `select`, `text`, or `textarea`.
+- `options`: required for choice controls; strings are allowed, or objects with
+  localized `label` and stable `value`.
+- `maxSelections`: include this for checkbox controls with a limited selection
+  count.
+- `required`: set to `true` only when the answer is needed before work can
+  continue.
 
 ## Convergence
 

--- a/plugins/_official/examples/simple-deck/open-design.json
+++ b/plugins/_official/examples/simple-deck/open-design.json
@@ -126,6 +126,12 @@
     "pipeline": {
       "stages": [
         {
+          "id": "discovery",
+          "atoms": [
+            "discovery-question-form"
+          ]
+        },
+        {
           "id": "generate",
           "atoms": [
             "file-write",


### PR DESCRIPTION
Fixes #2499

## Why

I hit this while following up on the Simple Deck discovery-form bug report. Simple Deck declares its own pipeline, so it bypassed the default new-generation discovery stage and could miss the `discovery-question-form` atom guidance. At the same time, the bundled discovery atom still documented a bare question JSON object, which conflicted with the web renderer contract.

The user-facing pain is that the first clarification turn can show raw keyed JSON instead of the interactive form, and can re-ask fields that the plugin inputs already supplied.

## What users will see

Simple Deck runs now start with the discovery stage before generation, so first-turn clarifying questions are guided through the same `<question-form>` contract as the rest of Open Design. The discovery atom docs now teach the renderer-recognized wrapper plus a top-level `questions` array instead of a bare question object.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is a prompt/manifest contract fix. The visual symptom is covered by the linked issue screenshot.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/plugins-discovery-question-form-contract.test.ts`
- Did the test go red on `main` and green on this branch? The test is new. On `origin/main`, Simple Deck's pipeline only contains `generate`, and the discovery atom shows a bare `jsonc` question object; both are the old states asserted against by the new test. The test is green on this branch.

## Validation

- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/plugins-discovery-question-form-contract.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `git diff --check`
