### PR TITLE
feat(daemon): P0 — git-integration foundation (substrate + identity seam + lifecycle hooks)

### DIFF
--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -127,7 +127,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     if (isDaemonShuttingDown()) {
       return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', 'daemon is shutting down');
     }
-    const run = design.runs.create();
+    const run = design.runs.create({ identity: req.identity });
     design.runs.stream(run, req, res);
     design.runs.start(run, () => startChatRun(req.body || {}, run));
   });

--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -127,7 +127,10 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     if (isDaemonShuttingDown()) {
       return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', 'daemon is shutting down');
     }
-    const run = design.runs.create({ identity: req.identity });
+    const run = design.runs.create({
+      identity: req.identity,
+      message: typeof req.body?.message === 'string' ? req.body.message : null,
+    });
     design.runs.stream(run, req, res);
     design.runs.start(run, () => startChatRun(req.body || {}, run));
   });

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -11,6 +11,7 @@ import { randomUUID } from 'node:crypto';
 import { migrateCritique } from './critique/persistence.js';
 import { migrateMediaTasks } from './media-tasks.js';
 import { migratePlugins } from './plugins/persistence.js';
+import { migrateProjectRevisions } from './history/persistence.js';
 
 type SqliteDb = Database.Database;
 type DbRow = Record<string, any>;
@@ -275,6 +276,7 @@ function migrate(db: SqliteDb): void {
   migrateCritique(db);
   migrateMediaTasks(db);
   migratePlugins(db);
+  migrateProjectRevisions(db);
 }
 
 // ---------- deployments ----------

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -896,6 +896,15 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
     .prepare(`SELECT position FROM messages WHERE id = ?`)
     .get(m.id) as DbRow | undefined;
   const now = Date.now();
+  // actor_* columns from the history feature (#1241). Optional in the
+  // input shape — callers without access to a resolved identity (e.g.,
+  // background message inserts, replay flows) leave them null. UPDATE
+  // path only overwrites when explicitly provided so an attribution
+  // populated by an earlier call isn't blanked by a later one that
+  // happens not to carry identity.
+  const actorIdentityId = m.actorIdentityId ?? null;
+  const actorDisplayName = m.actorDisplayName ?? null;
+  const actorSourceIp = m.actorSourceIp ?? null;
   if (existing) {
     db.prepare(
       `UPDATE messages
@@ -904,7 +913,10 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
               events_json = ?, attachments_json = ?, comment_attachments_json = ?,
               produced_files_json = ?, feedback_json = ?,
               pre_turn_file_names_json = ?,
-              started_at = ?, ended_at = ?
+              started_at = ?, ended_at = ?,
+              actor_identity_id = COALESCE(?, actor_identity_id),
+              actor_display_name = COALESCE(?, actor_display_name),
+              actor_source_ip = COALESCE(?, actor_source_ip)
         WHERE id = ?`,
     ).run(
       m.role,
@@ -922,6 +934,9 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       m.preTurnFileNames ? JSON.stringify(m.preTurnFileNames) : null,
       m.startedAt ?? null,
       m.endedAt ?? null,
+      actorIdentityId,
+      actorDisplayName,
+      actorSourceIp,
       m.id,
     );
   } else {
@@ -931,18 +946,20 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       )
       .get(conversationId) as DbRow | undefined;
     const position = (max?.m ?? -1) + 1;
-    // 19 values: id, conversation_id, role, content, agent_id, agent_name,
+    // 22 values: id, conversation_id, role, content, agent_id, agent_name,
     // run_id, run_status, last_run_event_id, events_json, attachments_json,
     // comment_attachments_json, produced_files_json, feedback_json,
-    // pre_turn_file_names_json, started_at, ended_at, position, created_at.
+    // pre_turn_file_names_json, started_at, ended_at, position, created_at,
+    // actor_identity_id, actor_display_name, actor_source_ip.
     db.prepare(
       `INSERT INTO messages
          (id, conversation_id, role, content, agent_id, agent_name,
           run_id, run_status, last_run_event_id, events_json,
           attachments_json, comment_attachments_json, produced_files_json,
           feedback_json, pre_turn_file_names_json,
-          started_at, ended_at, position, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          started_at, ended_at, position, created_at,
+          actor_identity_id, actor_display_name, actor_source_ip)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       m.id,
       conversationId,
@@ -963,6 +980,9 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       m.endedAt ?? null,
       position,
       now,
+      actorIdentityId,
+      actorDisplayName,
+      actorSourceIp,
     );
   }
   // Bump conversation activity so the sidebar's recency sort works.

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -896,12 +896,10 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
     .prepare(`SELECT position FROM messages WHERE id = ?`)
     .get(m.id) as DbRow | undefined;
   const now = Date.now();
-  // actor_* columns from the history feature (#1241). Optional in the
-  // input shape — callers without access to a resolved identity (e.g.,
-  // background message inserts, replay flows) leave them null. UPDATE
-  // path only overwrites when explicitly provided so an attribution
-  // populated by an earlier call isn't blanked by a later one that
-  // happens not to carry identity.
+  // actor_* columns from the history feature (#1241). Optional: callers
+  // without a resolved identity (background inserts, replay flows) leave
+  // them null. UPDATE path COALESCEs so a later call without identity
+  // doesn't blank an attribution set by an earlier one.
   const actorIdentityId = m.actorIdentityId ?? null;
   const actorDisplayName = m.actorDisplayName ?? null;
   const actorSourceIp = m.actorSourceIp ?? null;

--- a/apps/daemon/src/git/exec.ts
+++ b/apps/daemon/src/git/exec.ts
@@ -1,0 +1,57 @@
+// Shared helper for shelling out to `git`. Originally defined inline in
+// apps/daemon/src/live-artifacts/refresh.ts where it backed the read-only
+// `git.summary` agent tool; promoted to a shared module so the upcoming
+// history feature (#1241) can reuse it without duplication.
+//
+// Kept deliberately small — one function, one contract. Callers with
+// substantially different needs (long-running clones, large logs) should
+// construct their own execFile call rather than threading options
+// through this helper; keeping the surface tight makes its semantics
+// easy to reason about.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Spawn `git` with the given args in `projectPath` and return stdout.
+ *
+ * **Soft failure on exit code 128.** Git uses exit code 128 for a family
+ * of "fatal" conditions including `not a git repository`, `unknown revision`,
+ * and friends. The caller often wants to detect those by inspecting empty
+ * output rather than catching exceptions (the original `git.summary` tool's
+ * "is this a repo?" probe relies on this), so 128 is mapped to `''`.
+ * All other non-zero exits throw with the git stderr (or message) as text.
+ *
+ * **Defaults**: 10s timeout, 128KB stdout buffer. These match the limits
+ * the original `git.summary` tool used. They're tight enough that no one
+ * tool can monopolize daemon resources, and the buffer is large enough for
+ * typical `log --max-count=50` / `status --short` / `diff --stat` output.
+ */
+export async function runGit(
+  projectPath: string,
+  args: string[],
+  signal: AbortSignal | undefined,
+): Promise<string> {
+  try {
+    const result = await execFileAsync('git', args, {
+      cwd: projectPath,
+      signal,
+      timeout: 10_000,
+      maxBuffer: 128 * 1024,
+    });
+    return result.stdout.toString();
+  } catch (error) {
+    const maybeError = error as {
+      stdout?: string | Buffer;
+      stderr?: string | Buffer;
+      message?: string;
+      code?: unknown;
+    };
+    if (maybeError.code === 128) return '';
+    throw new Error(
+      maybeError.stderr?.toString().trim() || maybeError.message || 'git command failed',
+    );
+  }
+}

--- a/apps/daemon/src/git/exec.ts
+++ b/apps/daemon/src/git/exec.ts
@@ -3,36 +3,54 @@
 // `git.summary` agent tool; promoted to a shared module so the upcoming
 // history feature (#1241) can reuse it without duplication.
 //
-// Kept deliberately small — one function, one contract. Callers with
-// substantially different needs (long-running clones, large logs) should
-// construct their own execFile call rather than threading options
-// through this helper; keeping the surface tight makes its semantics
-// easy to reason about.
+// Kept deliberately small — one function with one option, one contract.
+// Callers with substantially different needs (long-running clones, large
+// logs) should construct their own execFile call rather than threading
+// options through this helper; keeping the surface tight makes its
+// semantics easy to reason about.
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
+export interface RunGitOptions {
+  /**
+   * When true, exit code 128 is mapped to `''` (soft failure). Used
+   * by read-only probes ("is this a repo?", "does this rev exist?")
+   * where exit 128 carries a meaningful "no" answer — the original
+   * `git.summary` agent tool relies on this for its
+   * `rev-parse --is-inside-work-tree` probe.
+   *
+   * Off by default. Mutating callers (history feature commits, init,
+   * config writes) MUST NOT pass this — silently swallowing exit 128
+   * on a `git status` invocation against a corrupted gitdir would
+   * make the caller read the empty stdout as "clean tree" and skip
+   * a needed commit (silent data loss). Strict callers see exit 128
+   * surface as a thrown Error with the stderr message.
+   */
+  softFail128?: boolean;
+}
+
 /**
  * Spawn `git` with the given args in `projectPath` and return stdout.
  *
- * **Soft failure on exit code 128.** Git uses exit code 128 for a family
- * of "fatal" conditions including `not a git repository`, `unknown revision`,
- * and friends. The caller often wants to detect those by inspecting empty
- * output rather than catching exceptions (the original `git.summary` tool's
- * "is this a repo?" probe relies on this), so 128 is mapped to `''`.
- * All other non-zero exits throw with the git stderr (or message) as text.
+ * Non-zero exits throw with the git stderr (or message) as text, with
+ * one opt-in exception: callers that pass `{ softFail128: true }`
+ * receive `''` on exit 128 instead of an exception. See `RunGitOptions`
+ * for the rationale.
  *
- * **Defaults**: 10s timeout, 128KB stdout buffer. These match the limits
- * the original `git.summary` tool used. They're tight enough that no one
- * tool can monopolize daemon resources, and the buffer is large enough for
- * typical `log --max-count=50` / `status --short` / `diff --stat` output.
+ * **Defaults**: 10s timeout, 128KB stdout buffer. These match the
+ * limits the original `git.summary` tool used. They're tight enough
+ * that no one tool can monopolize daemon resources, and the buffer is
+ * large enough for typical `log --max-count=50` / `status --short` /
+ * `diff --stat` output.
  */
 export async function runGit(
   projectPath: string,
   args: string[],
   signal: AbortSignal | undefined,
+  options: RunGitOptions = {},
 ): Promise<string> {
   try {
     const result = await execFileAsync('git', args, {
@@ -49,7 +67,7 @@ export async function runGit(
       message?: string;
       code?: unknown;
     };
-    if (maybeError.code === 128) return '';
+    if (maybeError.code === 128 && options.softFail128) return '';
     throw new Error(
       maybeError.stderr?.toString().trim() || maybeError.message || 'git command failed',
     );

--- a/apps/daemon/src/git/exec.ts
+++ b/apps/daemon/src/git/exec.ts
@@ -1,13 +1,7 @@
-// Shared helper for shelling out to `git`. Originally defined inline in
-// apps/daemon/src/live-artifacts/refresh.ts where it backed the read-only
-// `git.summary` agent tool; promoted to a shared module so the upcoming
-// history feature (#1241) can reuse it without duplication.
-//
-// Kept deliberately small — one function with one option, one contract.
-// Callers with substantially different needs (long-running clones, large
-// logs) should construct their own execFile call rather than threading
-// options through this helper; keeping the surface tight makes its
-// semantics easy to reason about.
+// Shared helper for shelling out to `git`. Promoted from the
+// `git.summary` agent tool's inline impl so the history feature
+// (#1241) can reuse it. Kept deliberately small — one function,
+// one option, one contract.
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -18,33 +12,23 @@ export interface RunGitOptions {
   /**
    * When true, exit code 128 is mapped to `''` (soft failure). Used
    * by read-only probes ("is this a repo?", "does this rev exist?")
-   * where exit 128 carries a meaningful "no" answer — the original
-   * `git.summary` agent tool relies on this for its
-   * `rev-parse --is-inside-work-tree` probe.
+   * where exit 128 carries a meaningful "no" answer.
    *
-   * Off by default. Mutating callers (history feature commits, init,
-   * config writes) MUST NOT pass this — silently swallowing exit 128
-   * on a `git status` invocation against a corrupted gitdir would
-   * make the caller read the empty stdout as "clean tree" and skip
-   * a needed commit (silent data loss). Strict callers see exit 128
-   * surface as a thrown Error with the stderr message.
+   * Off by default. Mutating callers MUST NOT pass this — silently
+   * swallowing exit 128 on `git status` against a corrupted gitdir
+   * would make the caller read empty stdout as "clean tree" and skip
+   * a needed commit (silent data loss).
    */
   softFail128?: boolean;
 }
 
 /**
  * Spawn `git` with the given args in `projectPath` and return stdout.
+ * Non-zero exits throw with the git stderr as text, except when
+ * `softFail128: true` is passed and exit code is 128.
  *
- * Non-zero exits throw with the git stderr (or message) as text, with
- * one opt-in exception: callers that pass `{ softFail128: true }`
- * receive `''` on exit 128 instead of an exception. See `RunGitOptions`
- * for the rationale.
- *
- * **Defaults**: 10s timeout, 128KB stdout buffer. These match the
- * limits the original `git.summary` tool used. They're tight enough
- * that no one tool can monopolize daemon resources, and the buffer is
- * large enough for typical `log --max-count=50` / `status --short` /
- * `diff --stat` output.
+ * 10s timeout, 128KB stdout buffer — matches the original
+ * `git.summary` limits.
  */
 export async function runGit(
   projectPath: string,

--- a/apps/daemon/src/history/ensure-hook.ts
+++ b/apps/daemon/src/history/ensure-hook.ts
@@ -1,0 +1,95 @@
+// Glue between the projects-module ensure-hook surface
+// (setProjectEnsuredHook) and the history substrate (initProjectHistory).
+//
+// Installed once at daemon startup. Every ensureProject call thereafter
+// runs initProjectHistory under the feature flag, idempotently. When
+// the flag is off, the hook short-circuits — no git invocations, no
+// DB writes, no side effects.
+
+import type Database from 'better-sqlite3';
+
+import { setProjectEnsuredHook } from '../projects.js';
+import { LocalFallbackProvider } from '../identity/types.js';
+import { isHistoryEnabled } from './feature-flag.js';
+import { initProjectHistory, projectRepoPath } from './repo.js';
+
+export interface InstallHistoryEnsureHookArgs {
+  db: Database.Database;
+  /**
+   * Absolute path to the directory that holds per-project gitdirs.
+   * Typically `<OD_DATA_DIR>/repos/` — sibling of the projects root.
+   */
+  reposRoot: string;
+  /**
+   * Lets the integration test override the env read; production
+   * callers pass nothing and the hook reads `process.env`.
+   */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Install the post-ensureProject hook that auto-initializes the
+ * history substrate when the feature flag is on. Idempotent across
+ * calls (the projects module's hook is a single slot; calling this
+ * twice just re-registers).
+ *
+ * The migration commit's author is the LocalFallbackProvider's
+ * identity — substrate init runs in a non-request-scoped context
+ * (ensure happens from many paths, not all HTTP-driven) so we
+ * deliberately don't try to thread req.identity here. User-driven
+ * commits land via the chat-run lifecycle hook (P0.7), where
+ * req.identity is properly available via run.identity.
+ */
+/**
+ * Shape the projects-module hook passes to its registered callback.
+ * Defined here because projects.ts is `@ts-nocheck` and can't export
+ * the type; consumers that want it can import from this module.
+ */
+export interface ProjectEnsuredHookArgs {
+  projectsRoot: string;
+  projectId: string;
+  projectDir: string;
+  metadata?: { baseDir?: string } | null;
+}
+
+export function installHistoryEnsureHook(args: InstallHistoryEnsureHookArgs): void {
+  const { db, reposRoot, env = process.env } = args;
+
+  setProjectEnsuredHook(async ({ projectId, projectDir, metadata }: ProjectEnsuredHookArgs) => {
+    if (!isHistoryEnabled(env)) return;
+    // Linked-folder projects (metadata.baseDir set) point at the user's
+    // own tree, which may already be a git repo. initProjectHistory's
+    // foreign-git-collision branch handles that case — but the user's
+    // expectation for those is "OD does not touch my git repo," so we
+    // skip linked projects entirely rather than relying on collision
+    // detection.
+    if (typeof metadata?.baseDir === 'string') return;
+
+    const repoDir = projectRepoPath(reposRoot, projectId);
+    const identity = LocalFallbackProvider.resolve({}, env) ?? {
+      id: 'local:default',
+      displayName: 'Local User',
+      source: 'local-fallback',
+    };
+
+    const result = await initProjectHistory({
+      projectId,
+      projectDir,
+      repoDir,
+      identity,
+      db,
+    });
+
+    if (result.kind === 'foreign-git-collision') {
+      // Surface but don't throw — ensureProject's contract is "return
+      // the directory." Project file ops continue to work; the
+      // History pane (later phase) will show "not available" for this
+      // project with a link to settings explaining why.
+      console.warn(
+        `[history] project ${projectId} has a foreign .git${
+          result.target ? ` (gitlink → ${result.target})` : ' directory'
+        }; history disabled for this project.`,
+      );
+    }
+  });
+}

--- a/apps/daemon/src/history/ensure-hook.ts
+++ b/apps/daemon/src/history/ensure-hook.ts
@@ -96,6 +96,16 @@ export function installHistoryEnsureHook(args: InstallHistoryEnsureHookArgs): vo
           result.target ? ` (gitlink → ${result.target})` : ' directory'
         }; history disabled for this project.`,
       );
+    } else if (result.kind === 'repaired') {
+      // The substrate was half-initialized (gitdir present on disk,
+      // no migration row in the DB) from a prior init that crashed
+      // between the migration commit and the SQLite INSERT. We
+      // reconstructed the missing row from HEAD. Logged at info-level
+      // so the recovery is observable in normal logs — it indicates
+      // a prior crash/abort during init that's now self-healed.
+      console.log(
+        `[history] project ${projectId} substrate was half-initialized; repaired migration revision ${result.revisionId.slice(0, 8)} from HEAD.`,
+      );
     }
   });
 }

--- a/apps/daemon/src/history/ensure-hook.ts
+++ b/apps/daemon/src/history/ensure-hook.ts
@@ -1,10 +1,7 @@
 // Glue between the projects-module ensure-hook surface
 // (setProjectEnsuredHook) and the history substrate (initProjectHistory).
-//
-// Installed once at daemon startup. Every ensureProject call thereafter
-// runs initProjectHistory under the feature flag, idempotently. When
-// the flag is off, the hook short-circuits — no git invocations, no
-// DB writes, no side effects.
+// Installed once at daemon startup; when the feature flag is off the
+// hook short-circuits.
 
 import type Database from 'better-sqlite3';
 
@@ -16,37 +13,12 @@ import { initProjectHistory, projectRepoPath } from './repo.js';
 
 export interface InstallHistoryEnsureHookArgs {
   db: Database.Database;
-  /**
-   * Absolute path to the directory that holds per-project gitdirs.
-   * Typically `<OD_DATA_DIR>/repos/` — sibling of the projects root.
-   */
+  /** Absolute path to the directory holding per-project gitdirs. */
   reposRoot: string;
-  /**
-   * Lets the integration test override the env read; production
-   * callers pass nothing and the hook reads `process.env`.
-   */
+  /** Lets tests override the env read; production passes nothing. */
   env?: NodeJS.ProcessEnv;
 }
 
-/**
- * Install the post-ensureProject hook that auto-initializes the
- * history substrate when the feature flag is on. Idempotent across
- * calls (the projects module's hook is a single slot; calling this
- * twice just re-registers).
- *
- * The migration commit's author comes from the identity seam's
- * resolveIdentity(emptyReq, env) — substrate init runs in a non-
- * request-scoped context (ensure happens from many paths, not all
- * HTTP-driven) so we pass an empty req-shape and let the registered
- * provider chain do its job. Today only LocalFallbackProvider is
- * registered, so this returns the placeholder identity. When future
- * providers register ahead of the fallback, those would (correctly)
- * fail to match against an empty request and fall through; new
- * substrate init paths that want to attribute to a specific user
- * should pass the real req through instead. User-driven commits
- * land via the chat-run lifecycle hook (P0.7), where req.identity
- * is properly available via run.identity.
- */
 /**
  * Shape the projects-module hook passes to its registered callback.
  * Defined here because projects.ts is `@ts-nocheck` and can't export
@@ -64,21 +36,20 @@ export function installHistoryEnsureHook(args: InstallHistoryEnsureHookArgs): vo
 
   setProjectEnsuredHook(async ({ projectId, projectDir, metadata }: ProjectEnsuredHookArgs) => {
     if (!isHistoryEnabled(env)) return;
-    // Linked-folder projects (metadata.baseDir set) point at the user's
-    // own tree; we must not init substrate over them. Several
-    // ensureProject callers omit `metadata` from the args, so trust the
-    // caller's value only when present; otherwise look it up so the
-    // skip guarantee doesn't depend on every call site remembering.
+    // Linked-folder projects (metadata.baseDir set) point at the
+    // user's own tree; we must not init substrate over them. Several
+    // ensureProject callers omit `metadata`, so look it up when absent
+    // — the skip guarantee can't depend on every call site remembering.
     const effectiveMetadata = (metadata && typeof metadata === 'object')
       ? metadata
       : (getProject(db, projectId)?.metadata ?? null) as { baseDir?: string } | null;
     if (typeof effectiveMetadata?.baseDir === 'string') return;
 
     const repoDir = projectRepoPath(reposRoot, projectId);
-    // Route through the identity seam, not LocalFallbackProvider directly:
-    // when future multi-user providers register ahead of the fallback,
-    // they get a chance to match (and correctly fall through to the
-    // fallback for empty-req substrate-init paths).
+    // Route through the identity seam, not LocalFallbackProvider
+    // directly: when future multi-user providers register ahead of
+    // the fallback they get a chance to match (and correctly fall
+    // through to the fallback for empty-req substrate-init paths).
     const identity = resolveIdentity({}, env);
 
     const result = await initProjectHistory({
@@ -92,20 +63,13 @@ export function installHistoryEnsureHook(args: InstallHistoryEnsureHookArgs): vo
     if (result.kind === 'foreign-git-collision') {
       // Surface but don't throw — ensureProject's contract is "return
       // the directory." Project file ops continue to work; the
-      // History pane (later phase) will show "not available" for this
-      // project with a link to settings explaining why.
+      // History pane will show "not available" for this project.
       console.warn(
         `[history] project ${projectId} has a foreign .git${
           result.target ? ` (gitlink → ${result.target})` : ' directory'
         }; history disabled for this project.`,
       );
     } else if (result.kind === 'repaired') {
-      // The substrate was half-initialized (gitdir present on disk,
-      // no migration row in the DB) from a prior init that crashed
-      // between the migration commit and the SQLite INSERT. We
-      // reconstructed the missing row from HEAD. Logged at info-level
-      // so the recovery is observable in normal logs — it indicates
-      // a prior crash/abort during init that's now self-healed.
       console.log(
         `[history] project ${projectId} substrate was half-initialized; repaired migration revision ${result.revisionId.slice(0, 8)} from HEAD.`,
       );

--- a/apps/daemon/src/history/ensure-hook.ts
+++ b/apps/daemon/src/history/ensure-hook.ts
@@ -36,13 +36,23 @@ export function installHistoryEnsureHook(args: InstallHistoryEnsureHookArgs): vo
 
   setProjectEnsuredHook(async ({ projectId, projectDir, metadata }: ProjectEnsuredHookArgs) => {
     if (!isHistoryEnabled(env)) return;
+    // initProjectHistory inserts a project_revisions row keyed by
+    // projectId; without a projects row the FK fails. Callers must
+    // insertProject first.
+    const projectRow = getProject(db, projectId);
+    if (!projectRow) {
+      console.warn(
+        `[history] ensure-hook fired before projects row exists for ${projectId}; skipping substrate init.`,
+      );
+      return;
+    }
     // Linked-folder projects (metadata.baseDir set) point at the
     // user's own tree; we must not init substrate over them. Several
     // ensureProject callers omit `metadata`, so look it up when absent
     // — the skip guarantee can't depend on every call site remembering.
     const effectiveMetadata = (metadata && typeof metadata === 'object')
       ? metadata
-      : (getProject(db, projectId)?.metadata ?? null) as { baseDir?: string } | null;
+      : (projectRow.metadata ?? null) as { baseDir?: string } | null;
     if (typeof effectiveMetadata?.baseDir === 'string') return;
 
     const repoDir = projectRepoPath(reposRoot, projectId);

--- a/apps/daemon/src/history/ensure-hook.ts
+++ b/apps/daemon/src/history/ensure-hook.ts
@@ -9,7 +9,7 @@
 import type Database from 'better-sqlite3';
 
 import { setProjectEnsuredHook } from '../projects.js';
-import { LocalFallbackProvider } from '../identity/types.js';
+import { resolveIdentity } from '../identity/types.js';
 import { isHistoryEnabled } from './feature-flag.js';
 import { initProjectHistory, projectRepoPath } from './repo.js';
 
@@ -33,12 +33,18 @@ export interface InstallHistoryEnsureHookArgs {
  * calls (the projects module's hook is a single slot; calling this
  * twice just re-registers).
  *
- * The migration commit's author is the LocalFallbackProvider's
- * identity — substrate init runs in a non-request-scoped context
- * (ensure happens from many paths, not all HTTP-driven) so we
- * deliberately don't try to thread req.identity here. User-driven
- * commits land via the chat-run lifecycle hook (P0.7), where
- * req.identity is properly available via run.identity.
+ * The migration commit's author comes from the identity seam's
+ * resolveIdentity(emptyReq, env) — substrate init runs in a non-
+ * request-scoped context (ensure happens from many paths, not all
+ * HTTP-driven) so we pass an empty req-shape and let the registered
+ * provider chain do its job. Today only LocalFallbackProvider is
+ * registered, so this returns the placeholder identity. When future
+ * providers register ahead of the fallback, those would (correctly)
+ * fail to match against an empty request and fall through; new
+ * substrate init paths that want to attribute to a specific user
+ * should pass the real req through instead. User-driven commits
+ * land via the chat-run lifecycle hook (P0.7), where req.identity
+ * is properly available via run.identity.
  */
 /**
  * Shape the projects-module hook passes to its registered callback.
@@ -66,11 +72,11 @@ export function installHistoryEnsureHook(args: InstallHistoryEnsureHookArgs): vo
     if (typeof metadata?.baseDir === 'string') return;
 
     const repoDir = projectRepoPath(reposRoot, projectId);
-    const identity = LocalFallbackProvider.resolve({}, env) ?? {
-      id: 'local:default',
-      displayName: 'Local User',
-      source: 'local-fallback',
-    };
+    // Route through the identity seam, not LocalFallbackProvider directly:
+    // when future multi-user providers register ahead of the fallback,
+    // they get a chance to match (and correctly fall through to the
+    // fallback for empty-req substrate-init paths).
+    const identity = resolveIdentity({}, env);
 
     const result = await initProjectHistory({
       projectId,

--- a/apps/daemon/src/history/ensure-hook.ts
+++ b/apps/daemon/src/history/ensure-hook.ts
@@ -10,6 +10,7 @@ import type Database from 'better-sqlite3';
 
 import { setProjectEnsuredHook } from '../projects.js';
 import { resolveIdentity } from '../identity/types.js';
+import { getProject } from '../db.js';
 import { isHistoryEnabled } from './feature-flag.js';
 import { initProjectHistory, projectRepoPath } from './repo.js';
 
@@ -64,12 +65,14 @@ export function installHistoryEnsureHook(args: InstallHistoryEnsureHookArgs): vo
   setProjectEnsuredHook(async ({ projectId, projectDir, metadata }: ProjectEnsuredHookArgs) => {
     if (!isHistoryEnabled(env)) return;
     // Linked-folder projects (metadata.baseDir set) point at the user's
-    // own tree, which may already be a git repo. initProjectHistory's
-    // foreign-git-collision branch handles that case — but the user's
-    // expectation for those is "OD does not touch my git repo," so we
-    // skip linked projects entirely rather than relying on collision
-    // detection.
-    if (typeof metadata?.baseDir === 'string') return;
+    // own tree; we must not init substrate over them. Several
+    // ensureProject callers omit `metadata` from the args, so trust the
+    // caller's value only when present; otherwise look it up so the
+    // skip guarantee doesn't depend on every call site remembering.
+    const effectiveMetadata = (metadata && typeof metadata === 'object')
+      ? metadata
+      : (getProject(db, projectId)?.metadata ?? null) as { baseDir?: string } | null;
+    if (typeof effectiveMetadata?.baseDir === 'string') return;
 
     const repoDir = projectRepoPath(reposRoot, projectId);
     // Route through the identity seam, not LocalFallbackProvider directly:

--- a/apps/daemon/src/history/feature-flag.ts
+++ b/apps/daemon/src/history/feature-flag.ts
@@ -1,0 +1,23 @@
+// Feature-flag gate for the history feature (#1241).
+//
+// Off by default in the first PR so the change lands without
+// user-visible behavior change. A follow-up PR will flip the default
+// on after a release cycle of reference-deployment validation.
+//
+// Callers should read through this helper rather than checking the env
+// var directly, so we have a single place to evolve the flag's shape
+// (e.g., per-project opt-in, "deny-list of project ids that opt out")
+// without touching every call site.
+
+export const HISTORY_FEATURE_FLAG_ENV = 'OD_GIT_INTEGRATION_ENABLED';
+
+/**
+ * Returns true when the operator has explicitly enabled the history
+ * feature via the OD_GIT_INTEGRATION_ENABLED env var. Accepts the
+ * common truthy spellings (`1`, `true`, `yes`, case-insensitive); any
+ * other value (including unset) is treated as off.
+ */
+export function isHistoryEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = (env[HISTORY_FEATURE_FLAG_ENV] ?? '').trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}

--- a/apps/daemon/src/history/feature-flag.ts
+++ b/apps/daemon/src/history/feature-flag.ts
@@ -1,21 +1,15 @@
 // Feature-flag gate for the history feature (#1241).
 //
 // Off by default in the first PR so the change lands without
-// user-visible behavior change. A follow-up PR will flip the default
-// on after a release cycle of reference-deployment validation.
-//
-// Callers should read through this helper rather than checking the env
-// var directly, so we have a single place to evolve the flag's shape
-// (e.g., per-project opt-in, "deny-list of project ids that opt out")
-// without touching every call site.
+// user-visible behavior change. Callers read through this helper
+// rather than checking the env var directly so the flag's shape
+// (per-project opt-in, deny-list, etc.) can evolve in one place.
 
 export const HISTORY_FEATURE_FLAG_ENV = 'OD_GIT_INTEGRATION_ENABLED';
 
 /**
- * Returns true when the operator has explicitly enabled the history
- * feature via the OD_GIT_INTEGRATION_ENABLED env var. Accepts the
- * common truthy spellings (`1`, `true`, `yes`, case-insensitive); any
- * other value (including unset) is treated as off.
+ * True when OD_GIT_INTEGRATION_ENABLED is set to `1`/`true`/`yes`
+ * (case-insensitive). Any other value, including unset, is off.
  */
 export function isHistoryEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = (env[HISTORY_FEATURE_FLAG_ENV] ?? '').trim().toLowerCase();

--- a/apps/daemon/src/history/persistence.ts
+++ b/apps/daemon/src/history/persistence.ts
@@ -2,18 +2,10 @@
 // rows + the durable "current revision" pointer on projects, plus
 // chat-run attribution columns on messages.
 //
-// Follows the daemon's existing migrateMediaTasks / migrateCritique /
-// migratePlugins convention: idempotent CREATE TABLE IF NOT EXISTS for
-// new tables, PRAGMA table_info + conditional ALTER TABLE ADD COLUMN
-// for adding columns to existing tables. The function is called once
-// from the main migrate() in db.ts when the database is opened.
-//
 // Substrate-agnostic schema by design — the same columns work under a
-// git substrate (where `id` is a commit SHA and the table is a
-// materialized view of `git log`) or an OD-owned revision store (where
-// the table IS the source of truth and blobs live in a content store).
-// Picking the substrate is implementation work that lands later;
-// the schema doesn't care.
+// git substrate (where `git_sha` is the commit SHA) or an OD-owned
+// revision store (where the table IS the source of truth and blobs
+// live in a content store).
 
 import type Database from 'better-sqlite3';
 
@@ -21,29 +13,18 @@ type DbRow = Record<string, unknown>;
 
 export function migrateProjectRevisions(db: Database.Database): void {
   // Migration order matters:
-  //   1. Create the table (fresh installs get git_sha built in).
-  //   2. Create the cheap index that only references columns from the
-  //      CREATE TABLE definition.
-  //   3. Backfill git_sha on legacy tables via ALTER TABLE ADD COLUMN —
-  //      necessary for any DB that already has project_revisions from
-  //      a pre-fix branch version where id was the SHA and git_sha did
-  //      not exist as a column.
-  //   4. Only then create the partial unique index on (project_id,
-  //      git_sha) — it references the column added in step 3, so doing
-  //      this earlier blows up on legacy DBs with `no such column: git_sha`.
+  //   1. CREATE TABLE (fresh installs get git_sha built in).
+  //   2. Cheap created_at index (only references CREATE TABLE columns).
+  //   3. ALTER TABLE ADD COLUMN git_sha for legacy DBs.
+  //   4. Partial unique index on (project_id, git_sha) — MUST come
+  //      after step 3, otherwise legacy DBs abort with "no such
+  //      column: git_sha".
   //
-  // Background on the UUID id + separate git_sha shape:
-  //   `id` is a substrate-opaque UUID, not the git commit SHA. SHA1
-  //   commits are only unique within a repo, so two separate project
-  //   gitdirs with identical initial content / author / message /
-  //   second-level timestamp can produce the same SHA (the empty-tree
-  //   migration commit being the most likely collision). Using a
-  //   synthetic id sidesteps that and leaves room for a future
-  //   OD-owned substrate that doesn't use SHAs at all.
+  // `id` is a substrate-opaque UUID, not the git SHA. Two separate
+  // gitdirs with identical initial content/author/message/timestamp
+  // can produce the same SHA (the empty-tree migration commit being
+  // the most likely collision); the synthetic id sidesteps that.
 
-  // Step 1 + 2: create the table (with git_sha included for fresh
-  // installs) plus the cheap created_at index. No column references
-  // anything that needs backfill.
   db.exec(`
     CREATE TABLE IF NOT EXISTS project_revisions (
       id                    TEXT PRIMARY KEY,
@@ -67,18 +48,11 @@ export function migrateProjectRevisions(db: Database.Database): void {
       ON project_revisions(project_id, created_at DESC);
   `);
 
-  // Step 3: backfill git_sha if the table predates the column.
-  // Idempotent — silently no-ops on fresh installs where the column
-  // is already part of CREATE TABLE.
   const revisionCols = db.prepare(`PRAGMA table_info(project_revisions)`).all() as DbRow[];
   if (!revisionCols.some((c) => c.name === 'git_sha')) {
     db.exec(`ALTER TABLE project_revisions ADD COLUMN git_sha TEXT`);
   }
 
-  // Step 4: partial unique index on (project_id, git_sha). MUST run
-  // after the column-add for legacy DBs — referencing git_sha in the
-  // index definition while the column is missing aborts the whole
-  // migration with `no such column: git_sha`.
   db.exec(`
     CREATE UNIQUE INDEX IF NOT EXISTS idx_project_revisions_project_sha
       ON project_revisions(project_id, git_sha)
@@ -92,12 +66,11 @@ export function migrateProjectRevisions(db: Database.Database): void {
     db.exec(`ALTER TABLE projects ADD COLUMN current_revision_id TEXT`);
   }
 
-  // Chat-run attribution columns on messages. Denormalized
-  // actor_display_name + actor_identity_id keep historical attribution
-  // intact even if the identity provider's mapping changes later.
-  // actor_source_ip captures the Express trust-proxy-resolved client IP
-  // (set via OD_TRUST_PROXY); useful for audit "which device" separate
-  // from "which person".
+  // Chat-run attribution on messages. Denormalized name + id keep
+  // historical attribution intact if the provider mapping changes
+  // later. actor_source_ip captures the Express trust-proxy-resolved
+  // client IP (set via OD_TRUST_PROXY); useful for "which device"
+  // separate from "which person".
   const messageCols = db.prepare(`PRAGMA table_info(messages)`).all() as DbRow[];
   if (!messageCols.some((c) => c.name === 'actor_identity_id')) {
     db.exec(`ALTER TABLE messages ADD COLUMN actor_identity_id TEXT`);

--- a/apps/daemon/src/history/persistence.ts
+++ b/apps/daemon/src/history/persistence.ts
@@ -94,10 +94,10 @@ export function migrateProjectRevisions(db: Database.Database): void {
 
   // Chat-run attribution columns on messages. Denormalized
   // actor_display_name + actor_identity_id keep historical attribution
-  // intact even if the identity provider's mapping changes later
-  // (e.g., a user is renamed by their auth provider). actor_source_ip
-  // records the X-Forwarded-For value when behind a proxy, useful for
-  // audit ("which device" separate from "which person").
+  // intact even if the identity provider's mapping changes later.
+  // actor_source_ip captures the Express trust-proxy-resolved client IP
+  // (set via OD_TRUST_PROXY); useful for audit "which device" separate
+  // from "which person".
   const messageCols = db.prepare(`PRAGMA table_info(messages)`).all() as DbRow[];
   if (!messageCols.some((c) => c.name === 'actor_identity_id')) {
     db.exec(`ALTER TABLE messages ADD COLUMN actor_identity_id TEXT`);

--- a/apps/daemon/src/history/persistence.ts
+++ b/apps/daemon/src/history/persistence.ts
@@ -1,0 +1,70 @@
+// SQLite schema for the history feature (#1241): per-project revision
+// rows + the durable "current revision" pointer on projects, plus
+// chat-run attribution columns on messages.
+//
+// Follows the daemon's existing migrateMediaTasks / migrateCritique /
+// migratePlugins convention: idempotent CREATE TABLE IF NOT EXISTS for
+// new tables, PRAGMA table_info + conditional ALTER TABLE ADD COLUMN
+// for adding columns to existing tables. The function is called once
+// from the main migrate() in db.ts when the database is opened.
+//
+// Substrate-agnostic schema by design — the same columns work under a
+// git substrate (where `id` is a commit SHA and the table is a
+// materialized view of `git log`) or an OD-owned revision store (where
+// the table IS the source of truth and blobs live in a content store).
+// Picking the substrate is implementation work that lands later;
+// the schema doesn't care.
+
+import type Database from 'better-sqlite3';
+
+type DbRow = Record<string, unknown>;
+
+export function migrateProjectRevisions(db: Database.Database): void {
+  // project_revisions — one row per recorded revision on a project. ON
+  // DELETE CASCADE so removing a project cleans up its history rows.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS project_revisions (
+      id                    TEXT PRIMARY KEY,
+      project_id            TEXT NOT NULL,
+      parent_id             TEXT,
+      created_at            INTEGER NOT NULL,
+      source                TEXT NOT NULL CHECK (source IN
+        ('agent-run','manual-snapshot','restore','migration')),
+      message               TEXT NOT NULL,
+      actor_identity_id     TEXT,
+      actor_display_name    TEXT,
+      run_id                TEXT,
+      files_changed_count   INTEGER NOT NULL DEFAULT 0,
+      bytes_added           INTEGER NOT NULL DEFAULT 0,
+      bytes_removed         INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_project_revisions_project_created
+      ON project_revisions(project_id, created_at DESC);
+  `);
+
+  // current_revision_id pointer on projects. Nullable — populated once
+  // the project's first revision exists.
+  const projectCols = db.prepare(`PRAGMA table_info(projects)`).all() as DbRow[];
+  if (!projectCols.some((c) => c.name === 'current_revision_id')) {
+    db.exec(`ALTER TABLE projects ADD COLUMN current_revision_id TEXT`);
+  }
+
+  // Chat-run attribution columns on messages. Denormalized
+  // actor_display_name + actor_identity_id keep historical attribution
+  // intact even if the identity provider's mapping changes later
+  // (e.g., a user is renamed by their auth provider). actor_source_ip
+  // records the X-Forwarded-For value when behind a proxy, useful for
+  // audit ("which device" separate from "which person").
+  const messageCols = db.prepare(`PRAGMA table_info(messages)`).all() as DbRow[];
+  if (!messageCols.some((c) => c.name === 'actor_identity_id')) {
+    db.exec(`ALTER TABLE messages ADD COLUMN actor_identity_id TEXT`);
+  }
+  if (!messageCols.some((c) => c.name === 'actor_display_name')) {
+    db.exec(`ALTER TABLE messages ADD COLUMN actor_display_name TEXT`);
+  }
+  if (!messageCols.some((c) => c.name === 'actor_source_ip')) {
+    db.exec(`ALTER TABLE messages ADD COLUMN actor_source_ip TEXT`);
+  }
+}

--- a/apps/daemon/src/history/persistence.ts
+++ b/apps/daemon/src/history/persistence.ts
@@ -20,18 +20,30 @@ import type Database from 'better-sqlite3';
 type DbRow = Record<string, unknown>;
 
 export function migrateProjectRevisions(db: Database.Database): void {
-  // project_revisions — one row per recorded revision on a project. ON
-  // DELETE CASCADE so removing a project cleans up its history rows.
+  // Migration order matters:
+  //   1. Create the table (fresh installs get git_sha built in).
+  //   2. Create the cheap index that only references columns from the
+  //      CREATE TABLE definition.
+  //   3. Backfill git_sha on legacy tables via ALTER TABLE ADD COLUMN —
+  //      necessary for any DB that already has project_revisions from
+  //      a pre-fix branch version where id was the SHA and git_sha did
+  //      not exist as a column.
+  //   4. Only then create the partial unique index on (project_id,
+  //      git_sha) — it references the column added in step 3, so doing
+  //      this earlier blows up on legacy DBs with `no such column: git_sha`.
   //
-  // `id` is a substrate-opaque UUID, not the git commit SHA. SHA1
-  // commits are only unique within a repo: two separate project
-  // gitdirs with identical initial content / author / message /
-  // second-level timestamp can produce the same commit SHA (e.g.,
-  // two empty-tree migration commits created in the same second by
-  // LocalFallbackProvider). Using a synthetic id sidesteps that
-  // collision and lets a future OD-owned substrate plug in without
-  // schema changes. The actual git commit SHA lives in `git_sha`,
-  // unique per project via a partial index.
+  // Background on the UUID id + separate git_sha shape:
+  //   `id` is a substrate-opaque UUID, not the git commit SHA. SHA1
+  //   commits are only unique within a repo, so two separate project
+  //   gitdirs with identical initial content / author / message /
+  //   second-level timestamp can produce the same SHA (the empty-tree
+  //   migration commit being the most likely collision). Using a
+  //   synthetic id sidesteps that and leaves room for a future
+  //   OD-owned substrate that doesn't use SHAs at all.
+
+  // Step 1 + 2: create the table (with git_sha included for fresh
+  // installs) plus the cheap created_at index. No column references
+  // anything that needs backfill.
   db.exec(`
     CREATE TABLE IF NOT EXISTS project_revisions (
       id                    TEXT PRIMARY KEY,
@@ -53,24 +65,25 @@ export function migrateProjectRevisions(db: Database.Database): void {
 
     CREATE INDEX IF NOT EXISTS idx_project_revisions_project_created
       ON project_revisions(project_id, created_at DESC);
-
-    -- (project_id, git_sha) is unique when git_sha is set. Lets the
-    -- substrate map "parent SHA" → "parent's project_revisions.id"
-    -- at insert time without a full table scan, and prevents the
-    -- (project_id, git_sha) pair from ever being duplicated.
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_project_revisions_project_sha
-      ON project_revisions(project_id, git_sha)
-      WHERE git_sha IS NOT NULL;
   `);
 
-  // Idempotent column-add for git_sha (in case a pre-fix migration
-  // ran against this database with id=SHA). Existing rows get NULL
-  // git_sha — that's a one-time inconsistency only relevant for the
-  // author's reference deployment (no one else has run P0 yet).
+  // Step 3: backfill git_sha if the table predates the column.
+  // Idempotent — silently no-ops on fresh installs where the column
+  // is already part of CREATE TABLE.
   const revisionCols = db.prepare(`PRAGMA table_info(project_revisions)`).all() as DbRow[];
   if (!revisionCols.some((c) => c.name === 'git_sha')) {
     db.exec(`ALTER TABLE project_revisions ADD COLUMN git_sha TEXT`);
   }
+
+  // Step 4: partial unique index on (project_id, git_sha). MUST run
+  // after the column-add for legacy DBs — referencing git_sha in the
+  // index definition while the column is missing aborts the whole
+  // migration with `no such column: git_sha`.
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_project_revisions_project_sha
+      ON project_revisions(project_id, git_sha)
+      WHERE git_sha IS NOT NULL;
+  `);
 
   // current_revision_id pointer on projects. Nullable — populated once
   // the project's first revision exists.

--- a/apps/daemon/src/history/persistence.ts
+++ b/apps/daemon/src/history/persistence.ts
@@ -22,11 +22,22 @@ type DbRow = Record<string, unknown>;
 export function migrateProjectRevisions(db: Database.Database): void {
   // project_revisions — one row per recorded revision on a project. ON
   // DELETE CASCADE so removing a project cleans up its history rows.
+  //
+  // `id` is a substrate-opaque UUID, not the git commit SHA. SHA1
+  // commits are only unique within a repo: two separate project
+  // gitdirs with identical initial content / author / message /
+  // second-level timestamp can produce the same commit SHA (e.g.,
+  // two empty-tree migration commits created in the same second by
+  // LocalFallbackProvider). Using a synthetic id sidesteps that
+  // collision and lets a future OD-owned substrate plug in without
+  // schema changes. The actual git commit SHA lives in `git_sha`,
+  // unique per project via a partial index.
   db.exec(`
     CREATE TABLE IF NOT EXISTS project_revisions (
       id                    TEXT PRIMARY KEY,
       project_id            TEXT NOT NULL,
       parent_id             TEXT,
+      git_sha               TEXT,
       created_at            INTEGER NOT NULL,
       source                TEXT NOT NULL CHECK (source IN
         ('agent-run','manual-snapshot','restore','migration')),
@@ -42,7 +53,24 @@ export function migrateProjectRevisions(db: Database.Database): void {
 
     CREATE INDEX IF NOT EXISTS idx_project_revisions_project_created
       ON project_revisions(project_id, created_at DESC);
+
+    -- (project_id, git_sha) is unique when git_sha is set. Lets the
+    -- substrate map "parent SHA" → "parent's project_revisions.id"
+    -- at insert time without a full table scan, and prevents the
+    -- (project_id, git_sha) pair from ever being duplicated.
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_project_revisions_project_sha
+      ON project_revisions(project_id, git_sha)
+      WHERE git_sha IS NOT NULL;
   `);
+
+  // Idempotent column-add for git_sha (in case a pre-fix migration
+  // ran against this database with id=SHA). Existing rows get NULL
+  // git_sha — that's a one-time inconsistency only relevant for the
+  // author's reference deployment (no one else has run P0 yet).
+  const revisionCols = db.prepare(`PRAGMA table_info(project_revisions)`).all() as DbRow[];
+  if (!revisionCols.some((c) => c.name === 'git_sha')) {
+    db.exec(`ALTER TABLE project_revisions ADD COLUMN git_sha TEXT`);
+  }
 
   // current_revision_id pointer on projects. Nullable — populated once
   // the project's first revision exists.

--- a/apps/daemon/src/history/project-lock.ts
+++ b/apps/daemon/src/history/project-lock.ts
@@ -60,8 +60,9 @@ export async function withProjectLock<T>(
 }
 
 /**
- * For tests: drain all pending project locks and clear the map.
- * Production code should never call this.
+ * For tests: clear the per-project tail map. In-flight operations
+ * continue to run but become untracked by future callers (which see
+ * an empty queue). Use only between tests that don't share lock state.
  */
 export function __resetProjectLocksForTests(): void {
   tails.clear();

--- a/apps/daemon/src/history/project-lock.ts
+++ b/apps/daemon/src/history/project-lock.ts
@@ -1,30 +1,21 @@
 // Per-project async serialization for history operations.
 //
 // Two concurrent chat runs finishing close together on the same
-// project will race on the shared working tree without this lock:
-// both call `git add -A`, one `git commit` absorbs the other's
-// staged changes, and the loser sees a clean tree and no-ops — one
-// commit ends up attributed to one run but containing both runs'
-// work. This is the "one revision per run" contract holding only
-// under serial finishes.
+// project race on the shared working tree without this lock: both call
+// `git add -A`, one `git commit` absorbs the other's staged changes,
+// and the loser sees a clean tree — one commit attributed to one run
+// but containing both runs' work (silent provenance loss).
 //
-// The lock is a per-project Promise tail-chain: each new operation
-// `await`s the project's current tail before proceeding, then becomes
-// the new tail. Different projects are independent; their tails
-// never block each other.
-//
-// In-process only. A future multi-daemon / multi-replica deployment
-// would need a distributed lock (advisory file lock in the gitdir,
-// or external coordination); that's out of scope for P0 since the
-// daemon runs as a single process today.
+// In-process only. A future multi-daemon deployment would need a
+// distributed lock (advisory file lock in the gitdir, or external
+// coordination); out of scope for P0.
 
 const tails = new Map<string, Promise<unknown>>();
 
 /**
- * Serialize `fn()` against any other in-flight `withProjectLock`
- * calls for the same `projectId`. Different project ids run
- * concurrently. Throws from `fn` propagate to the caller; the lock
- * is released either way.
+ * Serialize `fn()` against other in-flight calls for the same
+ * `projectId`. Different projects run concurrently. Throws from `fn`
+ * propagate; the lock is released either way.
  */
 export async function withProjectLock<T>(
   projectId: string,
@@ -35,24 +26,21 @@ export async function withProjectLock<T>(
   const currentSlot = new Promise<void>((resolve) => {
     release = resolve;
   });
-  // Chain the new slot behind the previous tail so a later caller
-  // sees the queue extended even if `fn` is still running. The
-  // `.catch` is critical: a failing fn must not leave a rejected
-  // Promise as the project's tail (later callers would inherit the
-  // rejection just by `await`ing it).
+  // The `.catch` is critical: a failing fn must not leave a rejected
+  // Promise as the project's tail — later callers would inherit the
+  // rejection just by `await`ing it.
   const newTail = previousTail.then(() => currentSlot).catch(() => currentSlot);
   tails.set(projectId, newTail);
   try {
     await previousTail.catch(() => {
-      // Previous holder's error is not this caller's problem — they
-      // own their own rejection. We just need to know it's done.
+      // Previous holder's error is not this caller's problem.
     });
     return await fn();
   } finally {
     release();
     // Clean up the map entry if no one else queued behind us. Safe
-    // because Node is single-threaded — between the `if` check and
-    // the `delete`, no other code can run.
+    // because Node is single-threaded — between the `if` and the
+    // `delete`, no other code can run.
     if (tails.get(projectId) === newTail) {
       tails.delete(projectId);
     }
@@ -61,8 +49,7 @@ export async function withProjectLock<T>(
 
 /**
  * For tests: clear the per-project tail map. In-flight operations
- * continue to run but become untracked by future callers (which see
- * an empty queue). Use only between tests that don't share lock state.
+ * continue to run but become untracked by future callers.
  */
 export function __resetProjectLocksForTests(): void {
   tails.clear();

--- a/apps/daemon/src/history/project-lock.ts
+++ b/apps/daemon/src/history/project-lock.ts
@@ -1,0 +1,68 @@
+// Per-project async serialization for history operations.
+//
+// Two concurrent chat runs finishing close together on the same
+// project will race on the shared working tree without this lock:
+// both call `git add -A`, one `git commit` absorbs the other's
+// staged changes, and the loser sees a clean tree and no-ops — one
+// commit ends up attributed to one run but containing both runs'
+// work. This is the "one revision per run" contract holding only
+// under serial finishes.
+//
+// The lock is a per-project Promise tail-chain: each new operation
+// `await`s the project's current tail before proceeding, then becomes
+// the new tail. Different projects are independent; their tails
+// never block each other.
+//
+// In-process only. A future multi-daemon / multi-replica deployment
+// would need a distributed lock (advisory file lock in the gitdir,
+// or external coordination); that's out of scope for P0 since the
+// daemon runs as a single process today.
+
+const tails = new Map<string, Promise<unknown>>();
+
+/**
+ * Serialize `fn()` against any other in-flight `withProjectLock`
+ * calls for the same `projectId`. Different project ids run
+ * concurrently. Throws from `fn` propagate to the caller; the lock
+ * is released either way.
+ */
+export async function withProjectLock<T>(
+  projectId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previousTail = tails.get(projectId) ?? Promise.resolve();
+  let release!: () => void;
+  const currentSlot = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // Chain the new slot behind the previous tail so a later caller
+  // sees the queue extended even if `fn` is still running. The
+  // `.catch` is critical: a failing fn must not leave a rejected
+  // Promise as the project's tail (later callers would inherit the
+  // rejection just by `await`ing it).
+  const newTail = previousTail.then(() => currentSlot).catch(() => currentSlot);
+  tails.set(projectId, newTail);
+  try {
+    await previousTail.catch(() => {
+      // Previous holder's error is not this caller's problem — they
+      // own their own rejection. We just need to know it's done.
+    });
+    return await fn();
+  } finally {
+    release();
+    // Clean up the map entry if no one else queued behind us. Safe
+    // because Node is single-threaded — between the `if` check and
+    // the `delete`, no other code can run.
+    if (tails.get(projectId) === newTail) {
+      tails.delete(projectId);
+    }
+  }
+}
+
+/**
+ * For tests: drain all pending project locks and clear the map.
+ * Production code should never call this.
+ */
+export function __resetProjectLocksForTests(): void {
+  tails.clear();
+}

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -4,11 +4,9 @@
 // per-run "commit if dirty" path that records a revision when a chat
 // run leaves changes on disk.
 //
-// The substrate is git. The API surface (the names of the functions
-// this module exports and the shape of their arguments / results) is
-// substrate-agnostic by design so a future OD-owned implementation
-// could replace `repo-git.ts` without changing call sites in
-// `ensureProject` / `startChatRun` / route handlers.
+// The substrate is git. The API surface is substrate-agnostic so a
+// future OD-owned implementation could replace it without changing
+// call sites in ensureProject / startChatRun / route handlers.
 
 import { promises as fs } from 'node:fs';
 import { randomUUID } from 'node:crypto';
@@ -27,21 +25,11 @@ const DEFAULT_GITIGNORE = `# Open Design auto-generated; commit or edit as neede
 const MIGRATION_COMMIT_MESSAGE = 'chore(init): import existing project tree';
 const DEFAULT_COMMIT_MESSAGE = 'Agent run';
 
-// Patterns the history substrate manages on the daemon's behalf — kept
-// in `<repoDir>/info/exclude` rather than the project's `.gitignore`
-// because they're runtime-scratch implementation details the user
-// shouldn't have to know about or maintain. `info/exclude` is git's
-// canonical place for "this clone wants to ignore these paths" without
-// affecting the project's tracked state.
-//
-//   .od-skills/  — apps/daemon/src/server.ts stages active skills into
-//                  `<cwd>/.od-skills/<folder>/` before every agent run
-//                  so any CLI can reach the staged files via a path
-//                  inside its working directory. The directory is pure
-//                  runtime scratch; without this exclude, runs that
-//                  wrote no user files would still produce a revision
-//                  capturing the staged skill copies, violating the
-//                  "clean tree = no-op" contract.
+// Patterns kept in `<repoDir>/info/exclude` rather than the project's
+// `.gitignore` because they're runtime scratch (e.g., `.od-skills/` is
+// staged into the cwd per run by server.ts). info/exclude is local to
+// the gitdir, doesn't pollute the user's .gitignore, and survives clones
+// without affecting the clone target.
 const HISTORY_EXCLUDE_HEADER = `# Open Design: runtime scratch the history feature ignores.`;
 const HISTORY_EXCLUDE_PATTERNS = [
   '.od-skills/',
@@ -58,23 +46,12 @@ export function projectRepoPath(repoRoot: string, projectId: string): string {
   return path.join(repoRoot, `${projectId}.gitdir`);
 }
 
-/** State of the project tree's `.git` entry — used for substrate init + collision detection. */
 type DotGitState =
   | { kind: 'absent' }
   | { kind: 'ours' }
   | { kind: 'foreign-dir' }
   | { kind: 'foreign-link'; target: string };
 
-/**
- * Inspect the project tree's `.git` entry. Returns:
- * - `absent`     — no .git, ready for first init
- * - `ours`       — .git is a gitlink file pointing at our `repoDir`
- * - `foreign-dir`  — .git is a regular directory (someone else's repo, possibly cloned)
- * - `foreign-link` — .git is a gitlink pointing somewhere else
- *
- * The caller decides what to do: continue (absent), no-op (ours), or
- * refuse with a clear user-facing error (foreign-*).
- */
 async function readDotGitState(projectDir: string, repoDir: string): Promise<DotGitState> {
   const dotGit = path.join(projectDir, '.git');
   let stat;
@@ -85,7 +62,6 @@ async function readDotGitState(projectDir: string, repoDir: string): Promise<Dot
   }
   if (stat.isDirectory()) return { kind: 'foreign-dir' };
   if (!stat.isFile()) return { kind: 'foreign-dir' };
-  // Gitlink file: contents `gitdir: <absolute path>`
   const content = await fs.readFile(dotGit, 'utf8');
   const match = /^gitdir:\s*(.+)\s*$/m.exec(content);
   const linkRaw = match?.[1];
@@ -93,13 +69,10 @@ async function readDotGitState(projectDir: string, repoDir: string): Promise<Dot
   const linkedAbsolute = path.isAbsolute(linkRaw)
     ? linkRaw
     : path.resolve(projectDir, linkRaw);
-  // `git init --separate-git-dir` canonicalizes its path via the OS
-  // (resolving symlinks), so on platforms where the storage root is
-  // under a symlink (macOS's /tmp → /private/tmp, common deployment
-  // setups where /var or /home is a symlink) a naive string compare
-  // against our unresolved `repoDir` fails. Resolve both sides where
-  // possible — fall back to lexical compare when realpath errors
-  // (e.g., the linked target no longer exists).
+  // `git init --separate-git-dir` canonicalizes via realpath, so a
+  // naive string compare fails when the storage root is under a
+  // symlink (macOS /tmp -> /private/tmp). Resolve both sides; fall
+  // back to lexical compare if realpath fails.
   if (await sameDirectoryPath(linkedAbsolute, repoDir)) {
     return { kind: 'ours' };
   }
@@ -115,17 +88,8 @@ async function sameDirectoryPath(a: string, b: string): Promise<boolean> {
 }
 
 /**
- * Append the daemon-managed exclude patterns (`.od-skills/`, etc.) to
- * `<repoDir>/info/exclude`. Idempotent: looks for a marker line and
- * only appends if not already present. Preserves any existing content
- * (`git init` writes a default header to this file, which we keep).
- *
- * `info/exclude` is the right home for these because:
- *   - It's local to the gitdir, not tracked in the working tree
- *   - It doesn't show up in the user's `.gitignore` (which is part of
- *     project source-of-truth and may be reviewed / customized)
- *   - It survives `git clone` of the project without polluting the
- *     clone target's exclusion set
+ * Append daemon-managed exclude patterns to `<repoDir>/info/exclude`.
+ * Idempotent via the marker line; preserves any existing content.
  */
 async function ensureHistoryManagedExcludes(repoDir: string): Promise<void> {
   const excludePath = path.join(repoDir, 'info', 'exclude');
@@ -145,10 +109,9 @@ async function ensureHistoryManagedExcludes(repoDir: string): Promise<void> {
 }
 
 /**
- * Construct a git author email when the resolved Identity didn't carry
- * one. Single-user / LocalFallbackProvider deployments commonly leave
- * email unset; this synthesizes a stable, ASCII-safe email derived from
- * the identity's id so git commit doesn't refuse the author line.
+ * Synthesize an ASCII-safe author email when the resolved Identity has
+ * none. Single-user / LocalFallbackProvider deployments commonly leave
+ * email unset; without this, `git commit` refuses the author line.
  */
 function syntheticAuthorEmail(identity: Identity): string {
   if (identity.email && identity.email.trim().length > 0) return identity.email.trim();
@@ -157,10 +120,8 @@ function syntheticAuthorEmail(identity: Identity): string {
 }
 
 /**
- * Apply the resolved Identity to git's per-repo `user.name` / `user.email`
- * config. Per-repo (not --global) so we don't perturb the operator's
- * own git config, and the commit gets the right author line even when
- * multiple identities operate against the same daemon.
+ * Apply Identity to per-repo (not --global) git config so the commit
+ * author line is right without perturbing the operator's git config.
  */
 async function applyAuthorConfig(
   projectDir: string,
@@ -172,10 +133,32 @@ async function applyAuthorConfig(
 }
 
 /**
+ * Read HEAD's SHA, returning null when HEAD is unborn. Always passes
+ * softFail128 because callers handle the "no HEAD" case explicitly.
+ */
+async function readHeadSha(
+  projectDir: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  const out = await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true });
+  return out.trim() || null;
+}
+
+/**
+ * Read HEAD's parent SHA, returning null on initial commit (no parent).
+ */
+async function readHeadParentSha(
+  projectDir: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  const out = await runGit(projectDir, ['rev-parse', 'HEAD^'], signal, { softFail128: true });
+  return out.trim() || null;
+}
+
+/**
  * Repair `projects.current_revision_id` when it doesn't match HEAD's row.
  * Covers legacy state from pre-transaction-wrap days where INSERT
- * landed but UPDATE didn't, plus any external interference. Skips
- * when HEAD is unborn (nothing to point to) or HEAD has no row
+ * landed but UPDATE didn't. No-op when HEAD is unborn or has no row
  * (caller's orphan-backfill handles that case).
  */
 function ensureHeadPointerInvariant(
@@ -192,8 +175,83 @@ function ensureHeadPointerInvariant(
     `SELECT current_revision_id FROM projects WHERE id = ?`,
   ).get(projectId) as { current_revision_id: string | null } | undefined;
   if (projectRow?.current_revision_id !== headRow.id) {
-    db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(headRow.id, projectId);
+    setCurrentRevision(db, projectId, headRow.id);
   }
+}
+
+/** Look up an existing revision row's id by (project_id, git_sha). */
+function revisionIdForSha(
+  db: Database.Database,
+  projectId: string,
+  sha: string | null,
+): string | null {
+  if (!sha) return null;
+  const row = db.prepare(
+    `SELECT id FROM project_revisions WHERE project_id = ? AND git_sha = ?`,
+  ).get(projectId, sha) as { id: string } | undefined;
+  return row?.id ?? null;
+}
+
+function setCurrentRevision(
+  db: Database.Database,
+  projectId: string,
+  revisionId: string,
+): void {
+  db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(revisionId, projectId);
+}
+
+interface RevisionRow {
+  id: string;
+  projectId: string;
+  parentId: string | null;
+  gitSha: string | null;
+  createdAt: number;
+  source: 'agent-run' | 'manual-snapshot' | 'restore' | 'migration';
+  message: string;
+  actorIdentityId: string | null;
+  actorDisplayName: string | null;
+  runId: string | null;
+  filesChanged: number;
+  bytesAdded: number;
+  bytesRemoved: number;
+}
+
+const INSERT_PROJECT_REVISION_SQL = `INSERT INTO project_revisions (
+  id, project_id, parent_id, git_sha, created_at, source, message,
+  actor_identity_id, actor_display_name, run_id,
+  files_changed_count, bytes_added, bytes_removed
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+function insertRevision(db: Database.Database, row: RevisionRow): void {
+  db.prepare(INSERT_PROJECT_REVISION_SQL).run(
+    row.id,
+    row.projectId,
+    row.parentId,
+    row.gitSha,
+    row.createdAt,
+    row.source,
+    row.message,
+    row.actorIdentityId,
+    row.actorDisplayName,
+    row.runId,
+    row.filesChanged,
+    row.bytesAdded,
+    row.bytesRemoved,
+  );
+}
+
+/**
+ * Atomic INSERT + pointer-advance. Without the transaction, a crash
+ * between the two statements leaves a row in project_revisions with
+ * `projects.current_revision_id` pointing at the previous revision —
+ * the same partial-multi-write defect the orphan-HEAD backfill catches
+ * on retry, applied to the SQL-write boundary.
+ */
+function insertRevisionAndAdvancePointer(db: Database.Database, row: RevisionRow): void {
+  db.transaction(() => {
+    insertRevision(db, row);
+    setCurrentRevision(db, row.projectId, row.id);
+  })();
 }
 
 interface CommitMetadata {
@@ -204,9 +262,8 @@ interface CommitMetadata {
 }
 
 /**
- * Read author name, author date, and message for a commit ref from
- * the existing git history. Used by the repair paths so reconstructed
- * `project_revisions` rows reflect the actual commit, not the
+ * Read author name, date, and message for a commit ref. Used by repair
+ * paths so reconstructed rows reflect the actual commit, not the
  * currently retrying call's identity / clock.
  */
 async function readCommitMetadata(
@@ -284,16 +341,73 @@ export type InitProjectHistoryResult =
  *
  * And the DB state is:
  *  - one row inserted in project_revisions with source='migration'
- *  - projects.current_revision_id advanced to that revision's id (the commit SHA)
+ *  - projects.current_revision_id advanced to that revision's id (a UUID)
  */
 export async function initProjectHistory(
   args: InitProjectHistoryArgs,
 ): Promise<InitProjectHistoryResult> {
-  // Serialize against any concurrent init/record on the same project.
-  // Two callers racing initProjectHistory could otherwise both pass
-  // the readDotGitState() check and both run `git init`, producing
-  // duplicate migration revisions or corrupt state.
+  // Serialize against any concurrent init/record on the same project,
+  // otherwise two callers can both pass readDotGitState and both
+  // `git init`, producing duplicate migration revisions.
   return withProjectLock(args.projectId, () => initProjectHistoryLocked(args));
+}
+
+/**
+ * Substrate exists on disk but no migration row in the DB — repair by
+ * either attributing from the existing commit (case-a: HEAD exists,
+ * commit is durable history we did not author) or completing the init
+ * (case-b: HEAD unborn, we author the migration commit ourselves).
+ */
+async function repairHalfInitializedSubstrate(
+  args: InitProjectHistoryArgs,
+): Promise<{ kind: 'repaired'; revisionId: string }> {
+  const { projectId, projectDir, repoDir, identity, db, signal } = args;
+  const headSha = await readHeadSha(projectDir, signal);
+  const revisionId = randomUUID();
+
+  if (headSha) {
+    // (a) Attribute from the existing commit, not this retrying call.
+    const meta = await readCommitMetadata(projectDir, 'HEAD', signal);
+    insertRevisionAndAdvancePointer(db, {
+      id: revisionId,
+      projectId,
+      parentId: null,
+      gitSha: meta?.sha ?? headSha,
+      createdAt: meta?.authorDateMs ?? Date.now(),
+      source: 'migration',
+      message: meta?.message || MIGRATION_COMMIT_MESSAGE,
+      actorIdentityId: null,
+      actorDisplayName: meta?.authorName || null,
+      runId: null,
+      filesChanged: 0,
+      bytesAdded: 0,
+      bytesRemoved: 0,
+    });
+    return { kind: 'repaired', revisionId };
+  }
+
+  // (b) Resume the remaining init steps; we author the new commit.
+  await ensureHistoryManagedExcludes(repoDir);
+  await applyAuthorConfig(projectDir, identity, signal);
+  await runGit(projectDir, ['add', '-A'], signal);
+  await runGit(projectDir, ['commit', '--allow-empty', '-m', MIGRATION_COMMIT_MESSAGE], signal);
+  const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
+  insertRevisionAndAdvancePointer(db, {
+    id: revisionId,
+    projectId,
+    parentId: null,
+    gitSha: sha,
+    createdAt: Date.now(),
+    source: 'migration',
+    message: MIGRATION_COMMIT_MESSAGE,
+    actorIdentityId: identity.id,
+    actorDisplayName: identity.displayName,
+    runId: null,
+    filesChanged: 0,
+    bytesAdded: 0,
+    bytesRemoved: 0,
+  });
+  return { kind: 'repaired', revisionId };
 }
 
 async function initProjectHistoryLocked(
@@ -303,13 +417,10 @@ async function initProjectHistoryLocked(
 
   const state = await readDotGitState(projectDir, repoDir);
   if (state.kind === 'ours') {
-    // Substrate exists on disk. Normally this is the no-op fast path,
-    // but if a prior init crashed (or the post-commit DB write failed)
-    // between the migration commit and the `project_revisions` INSERT,
-    // the gitdir is in place but no migration row exists for this
-    // project. Detect that half-init state and repair it from HEAD's
-    // SHA — without this branch, `readDotGitState() === 'ours'` would
-    // short-circuit forever and the project would stay broken.
+    // Substrate exists on disk. Fast path is no-op when the migration
+    // row also exists; otherwise repair from HEAD — without this,
+    // `readDotGitState() === 'ours'` short-circuits forever and the
+    // project stays broken.
     const existing = db
       .prepare(
         `SELECT id FROM project_revisions
@@ -318,83 +429,12 @@ async function initProjectHistoryLocked(
       )
       .get(projectId) as { id: string } | undefined;
     if (existing) {
-      // Substrate fully set up. Defensively re-assert that
-      // current_revision_id matches HEAD's row — a legacy partial
-      // write or external DB edit could have left it stale.
-      const headSha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim() || null;
-      ensureHeadPointerInvariant(db, projectId, headSha);
+      // Defensively re-assert pointer: a legacy partial write or
+      // external DB edit could have left it stale.
+      ensureHeadPointerInvariant(db, projectId, await readHeadSha(projectDir, signal));
       return { kind: 'already-initialized' };
     }
-
-    // Half-init detected. Two sub-cases differ on what's recoverable:
-    //
-    //   (a) HEAD exists — prior init committed but its DB write
-    //       failed. The commit is durable history we did not author;
-    //       reconstruct the row's actor / created_at / message from
-    //       the commit itself, NOT from this retrying call.
-    //   (b) HEAD unborn — prior init crashed before the initial
-    //       commit. Resume the remaining init steps (excludes,
-    //       author config, add, commit) so this call DOES author
-    //       the commit, then attribute the row to this identity.
-    const headProbe = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim();
-
-    const revisionId = randomUUID();
-    if (headProbe) {
-      // (a) Attribute from the existing commit, not this call.
-      const meta = await readCommitMetadata(projectDir, 'HEAD', signal);
-      const sha = meta?.sha ?? headProbe;
-      db.transaction(() => {
-        db.prepare(
-          `INSERT INTO project_revisions (
-             id, project_id, parent_id, git_sha, created_at, source, message,
-             actor_identity_id, actor_display_name, run_id,
-             files_changed_count, bytes_added, bytes_removed
-           ) VALUES (?, ?, NULL, ?, ?, 'migration', ?, NULL, ?, NULL, 0, 0, 0)`,
-        ).run(
-          revisionId,
-          projectId,
-          sha,
-          meta?.authorDateMs ?? Date.now(),
-          meta?.message || MIGRATION_COMMIT_MESSAGE,
-          meta?.authorName || null,
-        );
-        db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(
-          revisionId,
-          projectId,
-        );
-      })();
-      return { kind: 'repaired', revisionId };
-    }
-
-    // (b) Resume the remaining init steps; we author the new commit.
-    await ensureHistoryManagedExcludes(repoDir);
-    await applyAuthorConfig(projectDir, identity, signal);
-    await runGit(projectDir, ['add', '-A'], signal);
-    await runGit(projectDir, ['commit', '--allow-empty', '-m', MIGRATION_COMMIT_MESSAGE], signal);
-    const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
-    const now = Date.now();
-    db.transaction(() => {
-      db.prepare(
-        `INSERT INTO project_revisions (
-           id, project_id, parent_id, git_sha, created_at, source, message,
-           actor_identity_id, actor_display_name, run_id,
-           files_changed_count, bytes_added, bytes_removed
-         ) VALUES (?, ?, NULL, ?, ?, 'migration', ?, ?, ?, NULL, 0, 0, 0)`,
-      ).run(
-        revisionId,
-        projectId,
-        sha,
-        now,
-        MIGRATION_COMMIT_MESSAGE,
-        identity.id,
-        identity.displayName,
-      );
-      db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(
-        revisionId,
-        projectId,
-      );
-    })();
-    return { kind: 'repaired', revisionId };
+    return repairHalfInitializedSubstrate(args);
   }
   if (state.kind === 'foreign-dir') return { kind: 'foreign-git-collision' };
   if (state.kind === 'foreign-link') {
@@ -404,8 +444,7 @@ async function initProjectHistoryLocked(
   await fs.mkdir(path.dirname(repoDir), { recursive: true });
 
   // `git init --separate-git-dir=<repoDir>` puts the object database
-  // at repoDir and writes a `.git` gitlink file in projectDir. Main
-  // is the canonical branch.
+  // at repoDir and writes a `.git` gitlink file in projectDir.
   await runGit(
     projectDir,
     ['init', '--separate-git-dir', repoDir, '--initial-branch', 'main'],
@@ -419,17 +458,16 @@ async function initProjectHistoryLocked(
     await fs.writeFile(gitignorePath, DEFAULT_GITIGNORE, 'utf8');
   }
 
-  // Daemon-managed exclusions live in info/exclude so they stay out of
-  // the user-visible .gitignore. `git init` may have written its own
-  // sample content to info/exclude; we append ours idempotently rather
-  // than overwriting.
+  // Daemon-managed exclusions go in info/exclude (out of the
+  // user-visible .gitignore). git init may have written its own
+  // sample content; we append idempotently rather than overwriting.
   await ensureHistoryManagedExcludes(repoDir);
 
   await applyAuthorConfig(projectDir, identity, signal);
   await runGit(projectDir, ['add', '-A'], signal);
 
-  // Allow an empty initial commit so brand-new projects (no files yet)
-  // still have a starting SHA we can record on the migration row.
+  // --allow-empty so brand-new projects (no files yet) still get a
+  // starting SHA for the migration row.
   await runGit(
     projectDir,
     ['commit', '--allow-empty', '-m', MIGRATION_COMMIT_MESSAGE],
@@ -438,19 +476,21 @@ async function initProjectHistoryLocked(
 
   const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
   const revisionId = randomUUID();
-  const now = Date.now();
-  // Atomic INSERT + pointer-advance so a crash between can't leave a
-  // half-written substrate (row but stale pointer is its own bug).
-  db.transaction(() => {
-    db.prepare(
-      `INSERT INTO project_revisions (
-         id, project_id, parent_id, git_sha, created_at, source, message,
-         actor_identity_id, actor_display_name, run_id,
-         files_changed_count, bytes_added, bytes_removed
-       ) VALUES (?, ?, NULL, ?, ?, 'migration', ?, ?, ?, NULL, 0, 0, 0)`,
-    ).run(revisionId, projectId, sha, now, MIGRATION_COMMIT_MESSAGE, identity.id, identity.displayName);
-    db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(revisionId, projectId);
-  })();
+  insertRevisionAndAdvancePointer(db, {
+    id: revisionId,
+    projectId,
+    parentId: null,
+    gitSha: sha,
+    createdAt: Date.now(),
+    source: 'migration',
+    message: MIGRATION_COMMIT_MESSAGE,
+    actorIdentityId: identity.id,
+    actorDisplayName: identity.displayName,
+    runId: null,
+    filesChanged: 0,
+    bytesAdded: 0,
+    bytesRemoved: 0,
+  });
 
   return { kind: 'initialized', revisionId };
 }
@@ -468,9 +508,9 @@ export interface RecordRevisionForRunArgs {
    * Whether this run is known to have invoked a file-write tool. Gates
    * marker creation in the sibling-absorbed branch: a purely
    * conversational run must not produce a marker row even if a sibling
-   * advanced HEAD during its lock wait. Default false (no marker) — safer
-   * to lose provenance for an edge case than to write a false marker
-   * that pollutes durable history data.
+   * advanced HEAD during its lock wait. Default false (no marker) —
+   * safer to lose provenance for an edge case than to write a false
+   * marker that pollutes durable history data.
    */
   runTouchedFiles?: boolean;
 }
@@ -493,45 +533,105 @@ export type RecordRevisionForRunResult =
   | { kind: 'not-initialized' };
 
 /**
- * At chat-run end, if the project's working tree has uncommitted changes,
- * stage and commit them as a revision authored by the run's resolved
- * identity. Inserts a `project_revisions` row and advances the project's
- * `current_revision_id` pointer.
+ * At chat-run end, if the project's working tree has uncommitted
+ * changes, stage and commit them as a revision authored by the run's
+ * identity. Returns `clean` when nothing to do (expected case) and
+ * `not-initialized` when the caller should init first.
  *
- * Returns `clean` (no-op) when the tree is clean — the daemon's chat-run
- * lifecycle calls this unconditionally at run end; it's expected to
- * sometimes have nothing to do.
- *
- * Returns `not-initialized` if the substrate isn't in place for this
- * project — the caller (P0.7 lifecycle hook) decides whether to call
- * `initProjectHistory` first or skip silently.
- *
- * Errors from git (timeout, unexpected exit) propagate as thrown
- * exceptions; the caller wraps in try/catch and logs without failing
- * the run (auto-commit is best-effort, not part of the run's contract).
+ * Errors from git propagate; the caller wraps in try/catch and logs
+ * (auto-commit is best-effort, not part of the run's contract).
  */
 export async function recordRevisionForRun(
   args: RecordRevisionForRunArgs,
 ): Promise<RecordRevisionForRunResult> {
-  // The lock alone is not sufficient to preserve the "one revision per
-  // run" contract: two runs finishing close together both have dirty
-  // workdirs, but the first to acquire the lock `git add -A`s the
-  // *combined* dirty state and commits everything; the second acquires
-  // a clean tree and would otherwise no-op (silent provenance loss).
-  // To preserve provenance we capture HEAD *before* queueing for the
-  // lock; if the locked critical section finds the tree clean AND HEAD
-  // has advanced from what we saw, we know a sibling absorbed our
-  // changes and record a marker row attributed to this run.
+  // The lock alone is not sufficient for "one revision per run". When
+  // two runs finish close together both with dirty workdirs, the first
+  // to acquire the lock `git add -A`s the *combined* dirty state; the
+  // second acquires a clean tree and would silently lose provenance.
+  // To preserve it, capture HEAD *before* queueing for the lock; if
+  // the locked critical section finds the tree clean AND HEAD has
+  // advanced, we know a sibling absorbed our changes and record a
+  // marker row attributed to this run.
   let headBeforeLock: string | null = null;
   try {
-    headBeforeLock =
-      (await runGit(args.projectDir, ['rev-parse', 'HEAD'], args.signal, { softFail128: true })).trim() || null;
+    headBeforeLock = await readHeadSha(args.projectDir, args.signal);
   } catch {
     // HEAD may not resolve if the substrate isn't initialized yet —
     // recordRevisionForRunLocked handles that case explicitly via the
     // readDotGitState check at its head.
   }
   return withProjectLock(args.projectId, () => recordRevisionForRunLocked(args, headBeforeLock));
+}
+
+/**
+ * Invariant: at the end of the locked critical section, HEAD's SHA
+ * must have a corresponding `project_revisions` row. If a prior call
+ * crashed between `git commit` and the SQLite INSERT, HEAD is one
+ * commit ahead of the table. Reconstruct the missing row from the
+ * commit itself (attributing to this retrying run would be durable
+ * false provenance). Single-orphan repair only — multi-orphan chains
+ * recover naturally on successive calls.
+ */
+async function repairOrphanHead(
+  args: RecordRevisionForRunArgs,
+  headSha: string,
+): Promise<void> {
+  const { projectId, projectDir, db, signal } = args;
+  if (revisionIdForSha(db, projectId, headSha)) {
+    // Row for HEAD exists; only thing that could be wrong is a stale
+    // pointer from a legacy partial-write.
+    ensureHeadPointerInvariant(db, projectId, headSha);
+    return;
+  }
+  const meta = await readCommitMetadata(projectDir, 'HEAD', signal);
+  const parentSha = await readHeadParentSha(projectDir, signal);
+  insertRevisionAndAdvancePointer(db, {
+    id: randomUUID(),
+    projectId,
+    parentId: revisionIdForSha(db, projectId, parentSha),
+    gitSha: headSha,
+    createdAt: meta?.authorDateMs ?? Date.now(),
+    source: 'agent-run',
+    message: meta?.message || DEFAULT_COMMIT_MESSAGE,
+    actorIdentityId: null,
+    actorDisplayName: meta?.authorName || null,
+    runId: null,
+    filesChanged: 0,
+    bytesAdded: 0,
+    bytesRemoved: 0,
+  });
+}
+
+/**
+ * Sibling-absorbed marker: tree was clean at lock acquisition but HEAD
+ * advanced during the wait and this run did invoke a file-write tool.
+ * Record git_sha=NULL (partial unique index on (project_id, git_sha)
+ * is WHERE git_sha IS NOT NULL) with parent_id pointing at the sibling's
+ * revision. Do NOT advance current_revision_id; the sibling owns head.
+ */
+function recordSiblingAbsorbedMarker(
+  args: RecordRevisionForRunArgs,
+  headNow: string,
+): { kind: 'marker'; revisionId: string; absorbedIntoRevisionId: string | null } {
+  const { projectId, run, message, db } = args;
+  const absorbedIntoRevisionId = revisionIdForSha(db, projectId, headNow);
+  const revisionId = randomUUID();
+  insertRevision(db, {
+    id: revisionId,
+    projectId,
+    parentId: absorbedIntoRevisionId,
+    gitSha: null,
+    createdAt: Date.now(),
+    source: 'agent-run',
+    message,
+    actorIdentityId: run.identity.id,
+    actorDisplayName: run.identity.displayName,
+    runId: run.id,
+    filesChanged: 0,
+    bytesAdded: 0,
+    bytesRemoved: 0,
+  });
+  return { kind: 'marker', revisionId, absorbedIntoRevisionId };
 }
 
 async function recordRevisionForRunLocked(
@@ -543,112 +643,30 @@ async function recordRevisionForRunLocked(
   const state = await readDotGitState(projectDir, repoDir);
   if (state.kind !== 'ours') return { kind: 'not-initialized' };
 
-  // Belt-and-suspenders: re-assert the daemon-managed excludes before
-  // every status check. Idempotent, near-zero cost (single fs read
-  // looking for a marker). Catches the legacy case where the substrate
-  // was initialized before this fix landed — those repos don't have
-  // info/exclude populated, so without this call .od-skills/ would
+  // Belt-and-suspenders: re-assert daemon-managed excludes before
+  // every status check. Idempotent and cheap. Catches the legacy case
+  // where substrates initialized before this fix landed don't have
+  // info/exclude populated, so without this call `.od-skills/` would
   // be reported dirty and the next commit would absorb runtime scratch.
   await ensureHistoryManagedExcludes(repoDir);
 
-  // Repair-on-retry: invariant — at the end of this locked critical
-  // section, HEAD's SHA must have a corresponding `project_revisions`
-  // row for this project. If a prior call crashed between its
-  // `git commit` and the SQLite INSERT, HEAD is one commit ahead of
-  // the table. Reconstruct the missing row from the commit itself
-  // (parent from HEAD^, actor / created_at / message from `git log`);
-  // attributing to this retrying run would be durable false
-  // provenance. Single-orphan repair only — multi-orphan chains
-  // require either an external `git log` walker or successive call
-  // through this same path, which is the natural recovery on the
-  // next chat run.
-  const headForRepair =
-    (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim() || null;
+  const headForRepair = await readHeadSha(projectDir, signal);
   if (headForRepair) {
-    const existingForHead = db
-      .prepare(`SELECT id FROM project_revisions WHERE project_id = ? AND git_sha = ? LIMIT 1`)
-      .get(projectId, headForRepair) as { id: string } | undefined;
-    if (existingForHead) {
-      // Row for HEAD exists; the only thing that might be wrong is a
-      // stale pointer from a legacy partial-write.
-      ensureHeadPointerInvariant(db, projectId, headForRepair);
-    } else {
-      const meta = await readCommitMetadata(projectDir, 'HEAD', signal);
-      const parentSha = (await runGit(projectDir, ['rev-parse', 'HEAD^'], signal, { softFail128: true })).trim() || null;
-      const parentId = parentSha
-        ? (db.prepare(
-            `SELECT id FROM project_revisions WHERE project_id = ? AND git_sha = ?`,
-          ).get(projectId, parentSha) as { id: string } | undefined)?.id ?? null
-        : null;
-      const orphanRevisionId = randomUUID();
-      db.transaction(() => {
-        db.prepare(
-          `INSERT INTO project_revisions (
-             id, project_id, parent_id, git_sha, created_at, source, message,
-             actor_identity_id, actor_display_name, run_id,
-             files_changed_count, bytes_added, bytes_removed
-           ) VALUES (?, ?, ?, ?, ?, 'agent-run', ?, NULL, ?, NULL, 0, 0, 0)`,
-        ).run(
-          orphanRevisionId,
-          projectId,
-          parentId,
-          headForRepair,
-          meta?.authorDateMs ?? Date.now(),
-          meta?.message || DEFAULT_COMMIT_MESSAGE,
-          meta?.authorName || null,
-        );
-        db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(
-          orphanRevisionId,
-          projectId,
-        );
-      })();
-    }
+    await repairOrphanHead(args, headForRepair);
   }
 
   const status = await runGit(projectDir, ['status', '--short'], signal);
   if (status.trim().length === 0) {
-    // Marker row only when (a) this run actually invoked a file-write
+    // Marker only when (a) this run actually invoked a file-write
     // tool AND (b) HEAD advanced during our lock wait. Without (a) a
-    // purely conversational run running in parallel with a real
-    // file-writing sibling would get a false marker that pollutes
-    // durable provenance data; the sibling owns history alone.
+    // purely conversational run running parallel with a file-writing
+    // sibling would get a false marker that pollutes provenance data.
     if (!args.runTouchedFiles) return { kind: 'clean' };
-    const headNow =
-      (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim() || null;
+    const headNow = await readHeadSha(projectDir, signal);
     const advancedDuringWait =
       headBeforeLock !== null && headNow !== null && headNow !== headBeforeLock;
-    if (!advancedDuringWait) return { kind: 'clean' };
-
-    // Sibling-absorbed path: record a marker row. git_sha=NULL so
-    // the partial unique index (project_id, git_sha) WHERE git_sha
-    // IS NOT NULL doesn't collide. parent_id points at the
-    // sibling's revision row so History UI consumers can show the
-    // marker under its absorbing commit.
-    const absorbedRow = db
-      .prepare(`SELECT id FROM project_revisions WHERE project_id = ? AND git_sha = ?`)
-      .get(projectId, headNow) as { id: string } | undefined;
-    const absorbedIntoRevisionId = absorbedRow?.id ?? null;
-    const markerRevisionId = randomUUID();
-    const markerNow = Date.now();
-    db.prepare(
-      `INSERT INTO project_revisions (
-         id, project_id, parent_id, git_sha, created_at, source, message,
-         actor_identity_id, actor_display_name, run_id,
-         files_changed_count, bytes_added, bytes_removed
-       ) VALUES (?, ?, ?, NULL, ?, 'agent-run', ?, ?, ?, ?, 0, 0, 0)`,
-    ).run(
-      markerRevisionId,
-      projectId,
-      absorbedIntoRevisionId,
-      markerNow,
-      message,
-      run.identity.id,
-      run.identity.displayName,
-      run.id,
-    );
-    // Do NOT advance projects.current_revision_id — the sibling's
-    // recorded row already owns the head pointer.
-    return { kind: 'marker', revisionId: markerRevisionId, absorbedIntoRevisionId };
+    if (!advancedDuringWait || !headNow) return { kind: 'clean' };
+    return recordSiblingAbsorbedMarker(args, headNow);
   }
 
   await applyAuthorConfig(projectDir, run.identity, signal);
@@ -656,55 +674,27 @@ async function recordRevisionForRunLocked(
   await runGit(projectDir, ['commit', '-m', message], signal);
 
   const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
-  // Probe for the parent SHA — exit 128 means HEAD has no parent
-  // (initial commit). Under recordRevisionForRun's normal flow this
-  // can't happen because initProjectHistory's migration commit is
-  // always present, but defending against an orphaned HEAD
-  // (corrupted gitdir, manual history rewrite) keeps the contract clean.
-  const parentSha = (await runGit(projectDir, ['rev-parse', 'HEAD^'], signal, { softFail128: true })).trim() || null;
+  // parent_id is a UUID, not a SHA; resolve via (project_id, git_sha)
+  // unique index. Initial commit -> null.
+  const parentSha = await readHeadParentSha(projectDir, signal);
   const stats = await parseLastCommitStats(projectDir, signal);
 
-  // project_revisions.parent_id refers to the parent's id (UUID),
-  // not its git SHA. Resolve via the (project_id, git_sha) unique
-  // index. A null parentSha (initial commit) maps to null parent_id.
-  const parentId = parentSha
-    ? (db.prepare(
-        `SELECT id FROM project_revisions WHERE project_id = ? AND git_sha = ?`,
-      ).get(projectId, parentSha) as { id: string } | undefined)?.id ?? null
-    : null;
-
   const revisionId = randomUUID();
-  const now = Date.now();
-  // Atomic INSERT + pointer-advance — without the transaction, a crash
-  // between the two statements would leave a row in `project_revisions`
-  // with `projects.current_revision_id` still pointing at the previous
-  // revision (stale pointer / un-pointed row). db.transaction makes
-  // them a single commit; either both land or neither does. This is
-  // the same partial-multi-write defect class as the orphan-HEAD case
-  // we back-fill at function entry, applied to the SQL-write boundary.
-  db.transaction(() => {
-    db.prepare(
-      `INSERT INTO project_revisions (
-         id, project_id, parent_id, git_sha, created_at, source, message,
-         actor_identity_id, actor_display_name, run_id,
-         files_changed_count, bytes_added, bytes_removed
-       ) VALUES (?, ?, ?, ?, ?, 'agent-run', ?, ?, ?, ?, ?, ?, ?)`,
-    ).run(
-      revisionId,
-      projectId,
-      parentId,
-      sha,
-      now,
-      message,
-      run.identity.id,
-      run.identity.displayName,
-      run.id,
-      stats.filesChanged,
-      stats.bytesAdded,
-      stats.bytesRemoved,
-    );
-    db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(revisionId, projectId);
-  })();
+  insertRevisionAndAdvancePointer(db, {
+    id: revisionId,
+    projectId,
+    parentId: revisionIdForSha(db, projectId, parentSha),
+    gitSha: sha,
+    createdAt: Date.now(),
+    source: 'agent-run',
+    message,
+    actorIdentityId: run.identity.id,
+    actorDisplayName: run.identity.displayName,
+    runId: run.id,
+    filesChanged: stats.filesChanged,
+    bytesAdded: stats.bytesAdded,
+    bytesRemoved: stats.bytesRemoved,
+  });
 
   return {
     kind: 'recorded',
@@ -722,17 +712,13 @@ interface CommitStats {
 }
 
 /**
- * Parse `git show --shortstat --format= HEAD` output to extract counts
- * for the most recent commit. Format example:
+ * Parse `git show --shortstat --format= HEAD` output. Format example:
  *   ` 3 files changed, 7 insertions(+), 2 deletions(-)`
- * Missing components default to 0 — `git show` may omit insertions or
- * deletions if zero, or omit the line entirely for an empty commit.
+ * Missing components default to 0.
  *
- * Note: insertions/deletions are line counts in git's output, not byte
- * counts. The column is named `bytes_*` in the schema for forward
- * compatibility with a future OD-owned substrate that may track actual
- * bytes; under the git substrate we populate the line-count value
- * which is a useful proxy for "size of change."
+ * Note: bytes_added/bytes_removed columns hold line counts under the
+ * git substrate (named for forward-compat with a future OD-owned
+ * substrate that may track actual bytes).
  */
 async function parseLastCommitStats(
   projectDir: string,

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -388,6 +388,15 @@ export interface RecordRevisionForRunArgs {
   message: string;
   db: Database.Database;
   signal?: AbortSignal;
+  /**
+   * Whether this run is known to have invoked a file-write tool. Gates
+   * marker creation in the sibling-absorbed branch: a purely
+   * conversational run must not produce a marker row even if a sibling
+   * advanced HEAD during its lock wait. Default false (no marker) — safer
+   * to lose provenance for an edge case than to write a false marker
+   * that pollutes durable history data.
+   */
+  runTouchedFiles?: boolean;
 }
 
 export type RecordRevisionForRunResult =
@@ -530,20 +539,12 @@ async function recordRevisionForRunLocked(
 
   const status = await runGit(projectDir, ['status', '--short'], signal);
   if (status.trim().length === 0) {
-    // Tree is clean. Two cases to distinguish:
-    //   (a) The run genuinely wrote nothing — pure conversational
-    //       reply, no provenance row is needed. (Step 4 contract.)
-    //   (b) A sibling concurrent run absorbed our changes into its
-    //       commit while we were queued at the lock. Compare HEAD
-    //       now against the snapshot we took before queueing — if it
-    //       has advanced, a sibling moved it, and we need a marker
-    //       row so this run's provenance survives.
-    //
-    // Edge case: if a sibling fires AND this run was purely
-    // conversational, we'll log a false-positive marker. That's a
-    // benign data-quality cost for preserving provenance in (b);
-    // the History UI can filter marker rows whose run wrote no
-    // files via cross-referencing tool-use events. See spec §6.
+    // Marker row only when (a) this run actually invoked a file-write
+    // tool AND (b) HEAD advanced during our lock wait. Without (a) a
+    // purely conversational run running in parallel with a real
+    // file-writing sibling would get a false marker that pollutes
+    // durable provenance data; the sibling owns history alone.
+    if (!args.runTouchedFiles) return { kind: 'clean' };
     const headNow =
       (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim() || null;
     const advancedDuringWait =

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -251,10 +251,46 @@ async function initProjectHistoryLocked(
       .get(projectId) as { id: string } | undefined;
     if (existing) return { kind: 'already-initialized' };
 
-    // Half-init detected; reconstruct the missing migration row from
-    // the actual git HEAD so the schema and on-disk substrate are
-    // re-synchronized.
-    const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
+    // Half-init detected. Two sub-cases — probe HEAD with softFail128
+    // to distinguish:
+    //
+    //   (a) HEAD exists — the prior init got as far as `git commit
+    //       --allow-empty` but its post-commit DB write failed. We
+    //       just need to reconstruct the missing migration row from
+    //       the existing HEAD.
+    //   (b) HEAD is unborn (git rev-parse exits 128) — the prior
+    //       init crashed BEFORE the initial commit, after `git init`
+    //       created the gitdir and gitlink. We need to resume the
+    //       remaining init steps (excludes, author config, add,
+    //       initial commit) and only THEN write the DB row.
+    //
+    // Without the (b) branch, retries on the unborn-HEAD state would
+    // throw on rev-parse forever and the project would stay
+    // permanently broken.
+    let sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim();
+
+    if (!sha) {
+      // (b) Unborn HEAD — resume the remaining init steps. Each is
+      // idempotent / safe to re-run against partial state from the
+      // crashed prior attempt:
+      //   - ensureHistoryManagedExcludes is marker-guarded
+      //   - applyAuthorConfig writes per-repo config, overwriting any prior
+      //   - git add -A is unconditional
+      //   - the commit creates the missing initial commit
+      await ensureHistoryManagedExcludes(repoDir);
+      await applyAuthorConfig(projectDir, identity, signal);
+      await runGit(projectDir, ['add', '-A'], signal);
+      await runGit(
+        projectDir,
+        ['commit', '--allow-empty', '-m', MIGRATION_COMMIT_MESSAGE],
+        signal,
+      );
+      sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
+    }
+
+    // Reconstruct the missing migration row from HEAD's SHA (either
+    // the pre-existing one in case (a), or the one we just created
+    // in case (b)).
     const revisionId = randomUUID();
     const now = Date.now();
     db.prepare(

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -136,7 +136,7 @@ async function applyAuthorConfig(
  * Read HEAD's SHA, returning null when HEAD is unborn. Always passes
  * softFail128 because callers handle the "no HEAD" case explicitly.
  */
-async function readHeadSha(
+export async function readHeadSha(
   projectDir: string,
   signal?: AbortSignal,
 ): Promise<string | null> {
@@ -507,6 +507,14 @@ export interface RecordRevisionForRunArgs {
    * marker that pollutes durable history data.
    */
   runTouchedFiles?: boolean;
+  /**
+   * HEAD SHA observed at run-create time. Preferred baseline for the
+   * sibling-absorbed marker check: catches the sequential-completion
+   * case where a sibling commits and releases before this run's
+   * finish hook even enters `recordRevisionForRun`. When null the
+   * marker falls back to the lock-entry baseline only.
+   */
+  runHeadAtCreate?: string | null;
 }
 
 export type RecordRevisionForRunResult =
@@ -694,9 +702,13 @@ async function recordRevisionForRunLocked(
   if (status.trim().length === 0) {
     if (!args.runTouchedFiles) return { kind: 'clean' };
     const headNow = await readHeadSha(projectDir, signal);
-    const advancedDuringWait =
-      headBeforeLock !== null && headNow !== null && headNow !== headBeforeLock;
-    if (!advancedDuringWait || !headNow) return { kind: 'clean' };
+    // Prefer the earliest baseline available: HEAD at run-create catches
+    // the sequential-completion case (sibling committed and released
+    // before this hook entered), HEAD at lock-entry catches the
+    // overlapping-lock case. Either advancing → marker.
+    const baseline = args.runHeadAtCreate ?? headBeforeLock;
+    const advanced = baseline !== null && headNow !== null && headNow !== baseline;
+    if (!advanced || !headNow) return { kind: 'clean' };
     return recordSiblingAbsorbedMarker(args, headNow);
   }
 

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -616,13 +616,14 @@ async function repairOrphanHead(
 
   db.transaction(() => {
     orphans.forEach((meta, i) => {
+      const isRootBoundary = i === 0 && oldestParentSha === null;
       insertRevision(db, {
         id: ids[i]!,
         projectId,
         parentId: i === 0 ? oldestParentId : ids[i - 1]!,
         gitSha: meta.sha,
         createdAt: meta.authorDateMs,
-        source: 'agent-run',
+        source: isRootBoundary ? 'migration' : 'agent-run',
         message: meta.message || DEFAULT_COMMIT_MESSAGE,
         actorIdentityId: null,
         actorDisplayName: meta.authorName || null,

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -609,6 +609,10 @@ async function repairOrphanHead(
   const oldestParentSha = await readParentSha(projectDir, orphans[0]!.sha, signal);
   const oldestParentId = revisionIdForSha(db, projectId, oldestParentSha);
   const ids = orphans.map(() => randomUUID());
+  const stats: CommitStats[] = [];
+  for (const meta of orphans) {
+    stats.push(await parseCommitStats(projectDir, meta.sha, signal));
+  }
 
   db.transaction(() => {
     orphans.forEach((meta, i) => {
@@ -623,9 +627,9 @@ async function repairOrphanHead(
         actorIdentityId: null,
         actorDisplayName: meta.authorName || null,
         runId: null,
-        filesChanged: 0,
-        bytesAdded: 0,
-        bytesRemoved: 0,
+        filesChanged: stats[i]!.filesChanged,
+        bytesAdded: stats[i]!.bytesAdded,
+        bytesRemoved: stats[i]!.bytesRemoved,
       });
     });
     setCurrentRevision(db, projectId, ids[ids.length - 1]!);
@@ -687,10 +691,6 @@ async function recordRevisionForRunLocked(
 
   const status = await runGit(projectDir, ['status', '--short'], signal);
   if (status.trim().length === 0) {
-    // Marker only when (a) this run actually invoked a file-write
-    // tool AND (b) HEAD advanced during our lock wait. Without (a) a
-    // purely conversational run running parallel with a file-writing
-    // sibling would get a false marker that pollutes provenance data.
     if (!args.runTouchedFiles) return { kind: 'clean' };
     const headNow = await readHeadSha(projectDir, signal);
     const advancedDuringWait =
@@ -698,6 +698,13 @@ async function recordRevisionForRunLocked(
     if (!advancedDuringWait || !headNow) return { kind: 'clean' };
     return recordSiblingAbsorbedMarker(args, headNow);
   }
+
+  // Dirty tree, but this run didn't invoke a file-write tool — the
+  // dirt is pre-existing (uploads, sibling, or template seeds). Don't
+  // commit it as this run's work; let a future file-writing run pick
+  // it up. Avoids attributing other actors' content to a conversational
+  // run that happened to win the lock.
+  if (!args.runTouchedFiles) return { kind: 'clean' };
 
   await applyAuthorConfig(projectDir, run.identity, signal);
   await runGit(projectDir, ['add', '-A'], signal);
@@ -707,7 +714,7 @@ async function recordRevisionForRunLocked(
   // parent_id is a UUID, not a SHA; resolve via (project_id, git_sha)
   // unique index. Initial commit -> null.
   const parentSha = await readHeadParentSha(projectDir, signal);
-  const stats = await parseLastCommitStats(projectDir, signal);
+  const stats = await parseCommitStats(projectDir, 'HEAD', signal);
 
   const revisionId = randomUUID();
   insertRevisionAndAdvancePointer(db, {
@@ -750,15 +757,12 @@ interface CommitStats {
  * git substrate (named for forward-compat with a future OD-owned
  * substrate that may track actual bytes).
  */
-async function parseLastCommitStats(
+async function parseCommitStats(
   projectDir: string,
+  ref: string,
   signal?: AbortSignal,
 ): Promise<CommitStats> {
-  const out = await runGit(
-    projectDir,
-    ['show', '--shortstat', '--format=', 'HEAD'],
-    signal,
-  );
+  const out = await runGit(projectDir, ['show', '--shortstat', '--format=', ref], signal);
   const line = out.split('\n').find((l) => l.includes('changed')) ?? '';
   const files = /(\d+)\s+files? changed/.exec(line)?.[1];
   const added = /(\d+)\s+insertions?\(\+\)/.exec(line)?.[1];

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -26,6 +26,27 @@ const DEFAULT_GITIGNORE = `# Open Design auto-generated; commit or edit as neede
 
 const MIGRATION_COMMIT_MESSAGE = 'chore(init): import existing project tree';
 
+// Patterns the history substrate manages on the daemon's behalf — kept
+// in `<repoDir>/info/exclude` rather than the project's `.gitignore`
+// because they're runtime-scratch implementation details the user
+// shouldn't have to know about or maintain. `info/exclude` is git's
+// canonical place for "this clone wants to ignore these paths" without
+// affecting the project's tracked state.
+//
+//   .od-skills/  — apps/daemon/src/server.ts stages active skills into
+//                  `<cwd>/.od-skills/<folder>/` before every agent run
+//                  so any CLI can reach the staged files via a path
+//                  inside its working directory. The directory is pure
+//                  runtime scratch; without this exclude, runs that
+//                  wrote no user files would still produce a revision
+//                  capturing the staged skill copies, violating the
+//                  "clean tree = no-op" contract.
+const HISTORY_EXCLUDE_HEADER = `# Open Design: runtime scratch the history feature ignores.`;
+const HISTORY_EXCLUDE_PATTERNS = [
+  '.od-skills/',
+];
+const HISTORY_EXCLUDE_MARKER = '# open-design:history-managed';
+
 /**
  * Resolve the on-disk path of the substrate's gitdir for a project.
  * Lives next to projects/ under OD_DATA_DIR so backups already cover
@@ -90,6 +111,36 @@ async function sameDirectoryPath(a: string, b: string): Promise<boolean> {
   try { aResolved = await fs.realpath(aResolved); } catch { /* fall back to lexical */ }
   try { bResolved = await fs.realpath(bResolved); } catch { /* fall back to lexical */ }
   return aResolved === bResolved;
+}
+
+/**
+ * Append the daemon-managed exclude patterns (`.od-skills/`, etc.) to
+ * `<repoDir>/info/exclude`. Idempotent: looks for a marker line and
+ * only appends if not already present. Preserves any existing content
+ * (`git init` writes a default header to this file, which we keep).
+ *
+ * `info/exclude` is the right home for these because:
+ *   - It's local to the gitdir, not tracked in the working tree
+ *   - It doesn't show up in the user's `.gitignore` (which is part of
+ *     project source-of-truth and may be reviewed / customized)
+ *   - It survives `git clone` of the project without polluting the
+ *     clone target's exclusion set
+ */
+async function ensureHistoryManagedExcludes(repoDir: string): Promise<void> {
+  const excludePath = path.join(repoDir, 'info', 'exclude');
+  await fs.mkdir(path.dirname(excludePath), { recursive: true });
+  let existing = '';
+  try { existing = await fs.readFile(excludePath, 'utf8'); } catch { /* no prior content */ }
+  if (existing.includes(HISTORY_EXCLUDE_MARKER)) return;
+  const separator = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
+  const block = [
+    '',
+    HISTORY_EXCLUDE_MARKER,
+    HISTORY_EXCLUDE_HEADER,
+    ...HISTORY_EXCLUDE_PATTERNS,
+    '',
+  ].join('\n');
+  await fs.writeFile(excludePath, existing + separator + block, 'utf8');
 }
 
 /**
@@ -197,6 +248,12 @@ async function initProjectHistoryLocked(
     await fs.writeFile(gitignorePath, DEFAULT_GITIGNORE, 'utf8');
   }
 
+  // Daemon-managed exclusions live in info/exclude so they stay out of
+  // the user-visible .gitignore. `git init` may have written its own
+  // sample content to info/exclude; we append ours idempotently rather
+  // than overwriting.
+  await ensureHistoryManagedExcludes(repoDir);
+
   await applyAuthorConfig(projectDir, identity, signal);
   await runGit(projectDir, ['add', '-A'], signal);
 
@@ -279,6 +336,14 @@ async function recordRevisionForRunLocked(
 
   const state = await readDotGitState(projectDir, repoDir);
   if (state.kind !== 'ours') return { kind: 'not-initialized' };
+
+  // Belt-and-suspenders: re-assert the daemon-managed excludes before
+  // every status check. Idempotent, near-zero cost (single fs read
+  // looking for a marker). Catches the legacy case where the substrate
+  // was initialized before this fix landed — those repos don't have
+  // info/exclude populated, so without this call .od-skills/ would
+  // be reported dirty and the next commit would absorb runtime scratch.
+  await ensureHistoryManagedExcludes(repoDir);
 
   const status = await runGit(projectDir, ['status', '--short'], signal);
   if (status.trim().length === 0) return { kind: 'clean' };

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -25,6 +25,7 @@ const DEFAULT_GITIGNORE = `# Open Design auto-generated; commit or edit as neede
 `;
 
 const MIGRATION_COMMIT_MESSAGE = 'chore(init): import existing project tree';
+const DEFAULT_COMMIT_MESSAGE = 'Agent run';
 
 // Patterns the history substrate manages on the daemon's behalf — kept
 // in `<repoDir>/info/exclude` rather than the project's `.gitignore`
@@ -170,6 +171,73 @@ async function applyAuthorConfig(
   await runGit(projectDir, ['config', 'user.name', identity.displayName], signal);
 }
 
+/**
+ * Repair `projects.current_revision_id` when it doesn't match HEAD's row.
+ * Covers legacy state from pre-transaction-wrap days where INSERT
+ * landed but UPDATE didn't, plus any external interference. Skips
+ * when HEAD is unborn (nothing to point to) or HEAD has no row
+ * (caller's orphan-backfill handles that case).
+ */
+function ensureHeadPointerInvariant(
+  db: Database.Database,
+  projectId: string,
+  headSha: string | null,
+): void {
+  if (!headSha) return;
+  const headRow = db.prepare(
+    `SELECT id FROM project_revisions WHERE project_id = ? AND git_sha = ? LIMIT 1`,
+  ).get(projectId, headSha) as { id: string } | undefined;
+  if (!headRow) return;
+  const projectRow = db.prepare(
+    `SELECT current_revision_id FROM projects WHERE id = ?`,
+  ).get(projectId) as { current_revision_id: string | null } | undefined;
+  if (projectRow?.current_revision_id !== headRow.id) {
+    db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(headRow.id, projectId);
+  }
+}
+
+interface CommitMetadata {
+  sha: string;
+  authorName: string;
+  authorDateMs: number;
+  message: string;
+}
+
+/**
+ * Read author name, author date, and message for a commit ref from
+ * the existing git history. Used by the repair paths so reconstructed
+ * `project_revisions` rows reflect the actual commit, not the
+ * currently retrying call's identity / clock.
+ */
+async function readCommitMetadata(
+  projectDir: string,
+  ref: string,
+  signal?: AbortSignal,
+): Promise<CommitMetadata | null> {
+  try {
+    // %H, %an, %aI are single-line by spec. %B (raw body) goes last
+    // so its trailing newlines join cleanly via Array.join.
+    const out = await runGit(
+      projectDir,
+      ['log', '-1', '--format=%H%n%an%n%aI%n%B', ref],
+      signal,
+    );
+    const lines = out.split('\n');
+    if (lines.length < 4) return null;
+    const [sha, authorName, authorIso, ...messageLines] = lines;
+    const authorDateMs = Date.parse(authorIso ?? '');
+    if (!sha || Number.isNaN(authorDateMs)) return null;
+    return {
+      sha,
+      authorName: (authorName ?? '').trim(),
+      authorDateMs,
+      message: messageLines.join('\n').trim(),
+    };
+  } catch {
+    return null;
+  }
+}
+
 export interface InitProjectHistoryArgs {
   projectId: string;
   projectDir: string;
@@ -249,54 +317,62 @@ async function initProjectHistoryLocked(
           LIMIT 1`,
       )
       .get(projectId) as { id: string } | undefined;
-    if (existing) return { kind: 'already-initialized' };
-
-    // Half-init detected. Two sub-cases — probe HEAD with softFail128
-    // to distinguish:
-    //
-    //   (a) HEAD exists — the prior init got as far as `git commit
-    //       --allow-empty` but its post-commit DB write failed. We
-    //       just need to reconstruct the missing migration row from
-    //       the existing HEAD.
-    //   (b) HEAD is unborn (git rev-parse exits 128) — the prior
-    //       init crashed BEFORE the initial commit, after `git init`
-    //       created the gitdir and gitlink. We need to resume the
-    //       remaining init steps (excludes, author config, add,
-    //       initial commit) and only THEN write the DB row.
-    //
-    // Without the (b) branch, retries on the unborn-HEAD state would
-    // throw on rev-parse forever and the project would stay
-    // permanently broken.
-    let sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim();
-
-    if (!sha) {
-      // (b) Unborn HEAD — resume the remaining init steps. Each is
-      // idempotent / safe to re-run against partial state from the
-      // crashed prior attempt:
-      //   - ensureHistoryManagedExcludes is marker-guarded
-      //   - applyAuthorConfig writes per-repo config, overwriting any prior
-      //   - git add -A is unconditional
-      //   - the commit creates the missing initial commit
-      await ensureHistoryManagedExcludes(repoDir);
-      await applyAuthorConfig(projectDir, identity, signal);
-      await runGit(projectDir, ['add', '-A'], signal);
-      await runGit(
-        projectDir,
-        ['commit', '--allow-empty', '-m', MIGRATION_COMMIT_MESSAGE],
-        signal,
-      );
-      sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
+    if (existing) {
+      // Substrate fully set up. Defensively re-assert that
+      // current_revision_id matches HEAD's row — a legacy partial
+      // write or external DB edit could have left it stale.
+      const headSha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim() || null;
+      ensureHeadPointerInvariant(db, projectId, headSha);
+      return { kind: 'already-initialized' };
     }
 
-    // Reconstruct the missing migration row from HEAD's SHA (either
-    // the pre-existing one in case (a), or the one we just created
-    // in case (b)).
+    // Half-init detected. Two sub-cases differ on what's recoverable:
+    //
+    //   (a) HEAD exists — prior init committed but its DB write
+    //       failed. The commit is durable history we did not author;
+    //       reconstruct the row's actor / created_at / message from
+    //       the commit itself, NOT from this retrying call.
+    //   (b) HEAD unborn — prior init crashed before the initial
+    //       commit. Resume the remaining init steps (excludes,
+    //       author config, add, commit) so this call DOES author
+    //       the commit, then attribute the row to this identity.
+    const headProbe = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim();
+
     const revisionId = randomUUID();
+    if (headProbe) {
+      // (a) Attribute from the existing commit, not this call.
+      const meta = await readCommitMetadata(projectDir, 'HEAD', signal);
+      const sha = meta?.sha ?? headProbe;
+      db.transaction(() => {
+        db.prepare(
+          `INSERT INTO project_revisions (
+             id, project_id, parent_id, git_sha, created_at, source, message,
+             actor_identity_id, actor_display_name, run_id,
+             files_changed_count, bytes_added, bytes_removed
+           ) VALUES (?, ?, NULL, ?, ?, 'migration', ?, NULL, ?, NULL, 0, 0, 0)`,
+        ).run(
+          revisionId,
+          projectId,
+          sha,
+          meta?.authorDateMs ?? Date.now(),
+          meta?.message || MIGRATION_COMMIT_MESSAGE,
+          meta?.authorName || null,
+        );
+        db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(
+          revisionId,
+          projectId,
+        );
+      })();
+      return { kind: 'repaired', revisionId };
+    }
+
+    // (b) Resume the remaining init steps; we author the new commit.
+    await ensureHistoryManagedExcludes(repoDir);
+    await applyAuthorConfig(projectDir, identity, signal);
+    await runGit(projectDir, ['add', '-A'], signal);
+    await runGit(projectDir, ['commit', '--allow-empty', '-m', MIGRATION_COMMIT_MESSAGE], signal);
+    const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
     const now = Date.now();
-    // Atomic INSERT + pointer-advance — a crash between these would
-    // leave the row written but `current_revision_id` stale, which is
-    // its own partial-write defect. db.transaction makes them a single
-    // commit; either both land or neither does.
     db.transaction(() => {
       db.prepare(
         `INSERT INTO project_revisions (
@@ -475,59 +551,51 @@ async function recordRevisionForRunLocked(
   // be reported dirty and the next commit would absorb runtime scratch.
   await ensureHistoryManagedExcludes(repoDir);
 
-  // Repair-on-retry — analogous to initProjectHistoryLocked's repair
-  // path. Invariant: at the end of the locked critical section, HEAD's
-  // SHA should always have a corresponding `project_revisions` row for
-  // this project (the migration row from init, plus one row per
-  // recorded run). If a prior recordRevisionForRun crashed between its
+  // Repair-on-retry: invariant — at the end of this locked critical
+  // section, HEAD's SHA must have a corresponding `project_revisions`
+  // row for this project. If a prior call crashed between its
   // `git commit` and the SQLite INSERT, HEAD is one commit ahead of
-  // the table — an orphan. The next call would see status='' clean and
-  // (without this check) return 'clean' without ever back-filling the
-  // missing row, leaving history permanently broken.
-  //
-  // Detect the orphan by comparing HEAD's SHA against `project_revisions`.
-  // If absent, back-fill a row pointing at the latest known revision as
-  // its parent and advance `current_revision_id`. The lost run_id from
-  // the crashed prior call cannot be recovered, so the back-fill row
-  // sets run_id=NULL and uses a marker commit message.
+  // the table. Reconstruct the missing row from the commit itself
+  // (parent from HEAD^, actor / created_at / message from `git log`);
+  // attributing to this retrying run would be durable false
+  // provenance. Single-orphan repair only — multi-orphan chains
+  // require either an external `git log` walker or successive call
+  // through this same path, which is the natural recovery on the
+  // next chat run.
   const headForRepair =
     (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim() || null;
   if (headForRepair) {
     const existingForHead = db
-      .prepare(
-        `SELECT id FROM project_revisions
-          WHERE project_id = ? AND git_sha = ?
-          LIMIT 1`,
-      )
+      .prepare(`SELECT id FROM project_revisions WHERE project_id = ? AND git_sha = ? LIMIT 1`)
       .get(projectId, headForRepair) as { id: string } | undefined;
-    if (!existingForHead) {
-      const latestRow = db
-        .prepare(
-          `SELECT id FROM project_revisions
-            WHERE project_id = ? AND git_sha IS NOT NULL
-            ORDER BY created_at DESC LIMIT 1`,
-        )
-        .get(projectId) as { id: string } | undefined;
+    if (existingForHead) {
+      // Row for HEAD exists; the only thing that might be wrong is a
+      // stale pointer from a legacy partial-write.
+      ensureHeadPointerInvariant(db, projectId, headForRepair);
+    } else {
+      const meta = await readCommitMetadata(projectDir, 'HEAD', signal);
+      const parentSha = (await runGit(projectDir, ['rev-parse', 'HEAD^'], signal, { softFail128: true })).trim() || null;
+      const parentId = parentSha
+        ? (db.prepare(
+            `SELECT id FROM project_revisions WHERE project_id = ? AND git_sha = ?`,
+          ).get(projectId, parentSha) as { id: string } | undefined)?.id ?? null
+        : null;
       const orphanRevisionId = randomUUID();
-      const orphanNow = Date.now();
-      // Atomic INSERT + pointer-advance — a crash mid-pair would re-
-      // create the same partial-write defect we're here to repair.
       db.transaction(() => {
         db.prepare(
           `INSERT INTO project_revisions (
              id, project_id, parent_id, git_sha, created_at, source, message,
              actor_identity_id, actor_display_name, run_id,
              files_changed_count, bytes_added, bytes_removed
-           ) VALUES (?, ?, ?, ?, ?, 'agent-run', ?, ?, ?, NULL, 0, 0, 0)`,
+           ) VALUES (?, ?, ?, ?, ?, 'agent-run', ?, NULL, ?, NULL, 0, 0, 0)`,
         ).run(
           orphanRevisionId,
           projectId,
-          latestRow?.id ?? null,
+          parentId,
           headForRepair,
-          orphanNow,
-          '(recovered: orphan commit from prior crashed agent run)',
-          run.identity.id,
-          run.identity.displayName,
+          meta?.authorDateMs ?? Date.now(),
+          meta?.message || DEFAULT_COMMIT_MESSAGE,
+          meta?.authorName || null,
         );
         db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(
           orphanRevisionId,

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -11,6 +11,7 @@
 // `ensureProject` / `startChatRun` / route handlers.
 
 import { promises as fs } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import type Database from 'better-sqlite3';
 
@@ -208,19 +209,19 @@ async function initProjectHistoryLocked(
   );
 
   const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
-
+  const revisionId = randomUUID();
   const now = Date.now();
   db.prepare(
     `INSERT INTO project_revisions (
-       id, project_id, parent_id, created_at, source, message,
+       id, project_id, parent_id, git_sha, created_at, source, message,
        actor_identity_id, actor_display_name, run_id,
        files_changed_count, bytes_added, bytes_removed
-     ) VALUES (?, ?, NULL, ?, 'migration', ?, ?, ?, NULL, 0, 0, 0)`,
-  ).run(sha, projectId, now, MIGRATION_COMMIT_MESSAGE, identity.id, identity.displayName);
+     ) VALUES (?, ?, NULL, ?, ?, 'migration', ?, ?, ?, NULL, 0, 0, 0)`,
+  ).run(revisionId, projectId, sha, now, MIGRATION_COMMIT_MESSAGE, identity.id, identity.displayName);
 
-  db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(sha, projectId);
+  db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(revisionId, projectId);
 
-  return { kind: 'initialized', revisionId: sha };
+  return { kind: 'initialized', revisionId };
 }
 
 export interface RecordRevisionForRunArgs {
@@ -287,25 +288,36 @@ async function recordRevisionForRunLocked(
   await runGit(projectDir, ['commit', '-m', message], signal);
 
   const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
-  // Probe for the parent — exit 128 means HEAD has no parent (initial
-  // commit). Under recordRevisionForRun's normal flow this can't
-  // happen because initProjectHistory's migration commit is always
-  // present, but defending against an orphaned HEAD (corrupted
-  // gitdir, manual history rewrite) keeps the contract clean.
-  const parent = (await runGit(projectDir, ['rev-parse', 'HEAD^'], signal, { softFail128: true })).trim() || null;
+  // Probe for the parent SHA — exit 128 means HEAD has no parent
+  // (initial commit). Under recordRevisionForRun's normal flow this
+  // can't happen because initProjectHistory's migration commit is
+  // always present, but defending against an orphaned HEAD
+  // (corrupted gitdir, manual history rewrite) keeps the contract clean.
+  const parentSha = (await runGit(projectDir, ['rev-parse', 'HEAD^'], signal, { softFail128: true })).trim() || null;
   const stats = await parseLastCommitStats(projectDir, signal);
 
+  // project_revisions.parent_id refers to the parent's id (UUID),
+  // not its git SHA. Resolve via the (project_id, git_sha) unique
+  // index. A null parentSha (initial commit) maps to null parent_id.
+  const parentId = parentSha
+    ? (db.prepare(
+        `SELECT id FROM project_revisions WHERE project_id = ? AND git_sha = ?`,
+      ).get(projectId, parentSha) as { id: string } | undefined)?.id ?? null
+    : null;
+
+  const revisionId = randomUUID();
   const now = Date.now();
   db.prepare(
     `INSERT INTO project_revisions (
-       id, project_id, parent_id, created_at, source, message,
+       id, project_id, parent_id, git_sha, created_at, source, message,
        actor_identity_id, actor_display_name, run_id,
        files_changed_count, bytes_added, bytes_removed
-     ) VALUES (?, ?, ?, ?, 'agent-run', ?, ?, ?, ?, ?, ?, ?)`,
+     ) VALUES (?, ?, ?, ?, ?, 'agent-run', ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
-    sha,
+    revisionId,
     projectId,
-    parent,
+    parentId,
+    sha,
     now,
     message,
     run.identity.id,
@@ -316,11 +328,11 @@ async function recordRevisionForRunLocked(
     stats.bytesRemoved,
   );
 
-  db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(sha, projectId);
+  db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(revisionId, projectId);
 
   return {
     kind: 'recorded',
-    revisionId: sha,
+    revisionId,
     filesChanged: stats.filesChanged,
     bytesAdded: stats.bytesAdded,
     bytesRemoved: stats.bytesRemoved,

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -185,6 +185,16 @@ export type InitProjectHistoryResult =
   /** Substrate was already initialized for this project; no-op. */
   | { kind: 'already-initialized' }
   /**
+   * Substrate was initialized on disk by a prior call that crashed or
+   * had its post-commit DB write fail, leaving the gitdir and gitlink
+   * in place but no `project_revisions` migration row. This call
+   * detected the half-init state, read HEAD's SHA from the existing
+   * gitdir, inserted the missing migration row, and advanced
+   * `current_revision_id`. From the caller's perspective the project
+   * is now fully initialized — same end-state as `'initialized'`.
+   */
+  | { kind: 'repaired'; revisionId: string }
+  /**
    * Project tree already contains a `.git` we don't manage. Refuse to
    * take ownership; the caller surfaces a project-level error. The
    * `target` field is set when the foreign entry is a gitlink (the
@@ -224,7 +234,50 @@ async function initProjectHistoryLocked(
   const { projectId, projectDir, repoDir, identity, db, signal } = args;
 
   const state = await readDotGitState(projectDir, repoDir);
-  if (state.kind === 'ours') return { kind: 'already-initialized' };
+  if (state.kind === 'ours') {
+    // Substrate exists on disk. Normally this is the no-op fast path,
+    // but if a prior init crashed (or the post-commit DB write failed)
+    // between the migration commit and the `project_revisions` INSERT,
+    // the gitdir is in place but no migration row exists for this
+    // project. Detect that half-init state and repair it from HEAD's
+    // SHA — without this branch, `readDotGitState() === 'ours'` would
+    // short-circuit forever and the project would stay broken.
+    const existing = db
+      .prepare(
+        `SELECT id FROM project_revisions
+          WHERE project_id = ? AND source = 'migration'
+          LIMIT 1`,
+      )
+      .get(projectId) as { id: string } | undefined;
+    if (existing) return { kind: 'already-initialized' };
+
+    // Half-init detected; reconstruct the missing migration row from
+    // the actual git HEAD so the schema and on-disk substrate are
+    // re-synchronized.
+    const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
+    const revisionId = randomUUID();
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO project_revisions (
+         id, project_id, parent_id, git_sha, created_at, source, message,
+         actor_identity_id, actor_display_name, run_id,
+         files_changed_count, bytes_added, bytes_removed
+       ) VALUES (?, ?, NULL, ?, ?, 'migration', ?, ?, ?, NULL, 0, 0, 0)`,
+    ).run(
+      revisionId,
+      projectId,
+      sha,
+      now,
+      MIGRATION_COMMIT_MESSAGE,
+      identity.id,
+      identity.displayName,
+    );
+    db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(
+      revisionId,
+      projectId,
+    );
+    return { kind: 'repaired', revisionId };
+  }
   if (state.kind === 'foreign-dir') return { kind: 'foreign-git-collision' };
   if (state.kind === 'foreign-link') {
     return { kind: 'foreign-git-collision', target: state.target };

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -293,25 +293,31 @@ async function initProjectHistoryLocked(
     // in case (b)).
     const revisionId = randomUUID();
     const now = Date.now();
-    db.prepare(
-      `INSERT INTO project_revisions (
-         id, project_id, parent_id, git_sha, created_at, source, message,
-         actor_identity_id, actor_display_name, run_id,
-         files_changed_count, bytes_added, bytes_removed
-       ) VALUES (?, ?, NULL, ?, ?, 'migration', ?, ?, ?, NULL, 0, 0, 0)`,
-    ).run(
-      revisionId,
-      projectId,
-      sha,
-      now,
-      MIGRATION_COMMIT_MESSAGE,
-      identity.id,
-      identity.displayName,
-    );
-    db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(
-      revisionId,
-      projectId,
-    );
+    // Atomic INSERT + pointer-advance — a crash between these would
+    // leave the row written but `current_revision_id` stale, which is
+    // its own partial-write defect. db.transaction makes them a single
+    // commit; either both land or neither does.
+    db.transaction(() => {
+      db.prepare(
+        `INSERT INTO project_revisions (
+           id, project_id, parent_id, git_sha, created_at, source, message,
+           actor_identity_id, actor_display_name, run_id,
+           files_changed_count, bytes_added, bytes_removed
+         ) VALUES (?, ?, NULL, ?, ?, 'migration', ?, ?, ?, NULL, 0, 0, 0)`,
+      ).run(
+        revisionId,
+        projectId,
+        sha,
+        now,
+        MIGRATION_COMMIT_MESSAGE,
+        identity.id,
+        identity.displayName,
+      );
+      db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(
+        revisionId,
+        projectId,
+      );
+    })();
     return { kind: 'repaired', revisionId };
   }
   if (state.kind === 'foreign-dir') return { kind: 'foreign-git-collision' };
@@ -357,15 +363,18 @@ async function initProjectHistoryLocked(
   const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
   const revisionId = randomUUID();
   const now = Date.now();
-  db.prepare(
-    `INSERT INTO project_revisions (
-       id, project_id, parent_id, git_sha, created_at, source, message,
-       actor_identity_id, actor_display_name, run_id,
-       files_changed_count, bytes_added, bytes_removed
-     ) VALUES (?, ?, NULL, ?, ?, 'migration', ?, ?, ?, NULL, 0, 0, 0)`,
-  ).run(revisionId, projectId, sha, now, MIGRATION_COMMIT_MESSAGE, identity.id, identity.displayName);
-
-  db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(revisionId, projectId);
+  // Atomic INSERT + pointer-advance so a crash between can't leave a
+  // half-written substrate (row but stale pointer is its own bug).
+  db.transaction(() => {
+    db.prepare(
+      `INSERT INTO project_revisions (
+         id, project_id, parent_id, git_sha, created_at, source, message,
+         actor_identity_id, actor_display_name, run_id,
+         files_changed_count, bytes_added, bytes_removed
+       ) VALUES (?, ?, NULL, ?, ?, 'migration', ?, ?, ?, NULL, 0, 0, 0)`,
+    ).run(revisionId, projectId, sha, now, MIGRATION_COMMIT_MESSAGE, identity.id, identity.displayName);
+    db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(revisionId, projectId);
+  })();
 
   return { kind: 'initialized', revisionId };
 }
@@ -457,6 +466,68 @@ async function recordRevisionForRunLocked(
   // be reported dirty and the next commit would absorb runtime scratch.
   await ensureHistoryManagedExcludes(repoDir);
 
+  // Repair-on-retry — analogous to initProjectHistoryLocked's repair
+  // path. Invariant: at the end of the locked critical section, HEAD's
+  // SHA should always have a corresponding `project_revisions` row for
+  // this project (the migration row from init, plus one row per
+  // recorded run). If a prior recordRevisionForRun crashed between its
+  // `git commit` and the SQLite INSERT, HEAD is one commit ahead of
+  // the table — an orphan. The next call would see status='' clean and
+  // (without this check) return 'clean' without ever back-filling the
+  // missing row, leaving history permanently broken.
+  //
+  // Detect the orphan by comparing HEAD's SHA against `project_revisions`.
+  // If absent, back-fill a row pointing at the latest known revision as
+  // its parent and advance `current_revision_id`. The lost run_id from
+  // the crashed prior call cannot be recovered, so the back-fill row
+  // sets run_id=NULL and uses a marker commit message.
+  const headForRepair =
+    (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim() || null;
+  if (headForRepair) {
+    const existingForHead = db
+      .prepare(
+        `SELECT id FROM project_revisions
+          WHERE project_id = ? AND git_sha = ?
+          LIMIT 1`,
+      )
+      .get(projectId, headForRepair) as { id: string } | undefined;
+    if (!existingForHead) {
+      const latestRow = db
+        .prepare(
+          `SELECT id FROM project_revisions
+            WHERE project_id = ? AND git_sha IS NOT NULL
+            ORDER BY created_at DESC LIMIT 1`,
+        )
+        .get(projectId) as { id: string } | undefined;
+      const orphanRevisionId = randomUUID();
+      const orphanNow = Date.now();
+      // Atomic INSERT + pointer-advance — a crash mid-pair would re-
+      // create the same partial-write defect we're here to repair.
+      db.transaction(() => {
+        db.prepare(
+          `INSERT INTO project_revisions (
+             id, project_id, parent_id, git_sha, created_at, source, message,
+             actor_identity_id, actor_display_name, run_id,
+             files_changed_count, bytes_added, bytes_removed
+           ) VALUES (?, ?, ?, ?, ?, 'agent-run', ?, ?, ?, NULL, 0, 0, 0)`,
+        ).run(
+          orphanRevisionId,
+          projectId,
+          latestRow?.id ?? null,
+          headForRepair,
+          orphanNow,
+          '(recovered: orphan commit from prior crashed agent run)',
+          run.identity.id,
+          run.identity.displayName,
+        );
+        db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(
+          orphanRevisionId,
+          projectId,
+        );
+      })();
+    }
+  }
+
   const status = await runGit(projectDir, ['status', '--short'], signal);
   if (status.trim().length === 0) {
     // Tree is clean. Two cases to distinguish:
@@ -535,28 +606,36 @@ async function recordRevisionForRunLocked(
 
   const revisionId = randomUUID();
   const now = Date.now();
-  db.prepare(
-    `INSERT INTO project_revisions (
-       id, project_id, parent_id, git_sha, created_at, source, message,
-       actor_identity_id, actor_display_name, run_id,
-       files_changed_count, bytes_added, bytes_removed
-     ) VALUES (?, ?, ?, ?, ?, 'agent-run', ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    revisionId,
-    projectId,
-    parentId,
-    sha,
-    now,
-    message,
-    run.identity.id,
-    run.identity.displayName,
-    run.id,
-    stats.filesChanged,
-    stats.bytesAdded,
-    stats.bytesRemoved,
-  );
-
-  db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(revisionId, projectId);
+  // Atomic INSERT + pointer-advance — without the transaction, a crash
+  // between the two statements would leave a row in `project_revisions`
+  // with `projects.current_revision_id` still pointing at the previous
+  // revision (stale pointer / un-pointed row). db.transaction makes
+  // them a single commit; either both land or neither does. This is
+  // the same partial-multi-write defect class as the orphan-HEAD case
+  // we back-fill at function entry, applied to the SQL-write boundary.
+  db.transaction(() => {
+    db.prepare(
+      `INSERT INTO project_revisions (
+         id, project_id, parent_id, git_sha, created_at, source, message,
+         actor_identity_id, actor_display_name, run_id,
+         files_changed_count, bytes_added, bytes_removed
+       ) VALUES (?, ?, ?, ?, ?, 'agent-run', ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      revisionId,
+      projectId,
+      parentId,
+      sha,
+      now,
+      message,
+      run.identity.id,
+      run.identity.displayName,
+      run.id,
+      stats.filesChanged,
+      stats.bytesAdded,
+      stats.bytesRemoved,
+    );
+    db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(revisionId, projectId);
+  })();
 
   return {
     kind: 'recorded',

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -261,38 +261,32 @@ interface CommitMetadata {
   message: string;
 }
 
-/**
- * Read author name, date, and message for a commit ref. Used by repair
- * paths so reconstructed rows reflect the actual commit, not the
- * currently retrying call's identity / clock.
- */
 async function readCommitMetadata(
   projectDir: string,
   ref: string,
   signal?: AbortSignal,
-): Promise<CommitMetadata | null> {
-  try {
-    // %H, %an, %aI are single-line by spec. %B (raw body) goes last
-    // so its trailing newlines join cleanly via Array.join.
-    const out = await runGit(
-      projectDir,
-      ['log', '-1', '--format=%H%n%an%n%aI%n%B', ref],
-      signal,
-    );
-    const lines = out.split('\n');
-    if (lines.length < 4) return null;
-    const [sha, authorName, authorIso, ...messageLines] = lines;
-    const authorDateMs = Date.parse(authorIso ?? '');
-    if (!sha || Number.isNaN(authorDateMs)) return null;
-    return {
-      sha,
-      authorName: (authorName ?? '').trim(),
-      authorDateMs,
-      message: messageLines.join('\n').trim(),
-    };
-  } catch {
-    return null;
+): Promise<CommitMetadata> {
+  const out = await runGit(
+    projectDir,
+    ['log', '-1', '--format=%H%n%an%n%aI%n%B', ref],
+    signal,
+  );
+  const lines = out.split('\n');
+  if (lines.length < 4) {
+    throw new Error(`readCommitMetadata(${ref}): malformed git log output`);
   }
+  const [sha, authorName, authorIso, ...messageLines] = lines;
+  const authorDateMs = Date.parse(authorIso ?? '');
+  if (!sha) throw new Error(`readCommitMetadata(${ref}): empty SHA`);
+  if (Number.isNaN(authorDateMs)) {
+    throw new Error(`readCommitMetadata(${ref}): unparseable author date "${authorIso}"`);
+  }
+  return {
+    sha,
+    authorName: (authorName ?? '').trim(),
+    authorDateMs,
+    message: messageLines.join('\n').trim(),
+  };
 }
 
 export interface InitProjectHistoryArgs {
@@ -372,12 +366,12 @@ async function repairHalfInitializedSubstrate(
       id: revisionId,
       projectId,
       parentId: null,
-      gitSha: meta?.sha ?? headSha,
-      createdAt: meta?.authorDateMs ?? Date.now(),
+      gitSha: meta.sha,
+      createdAt: meta.authorDateMs,
       source: 'migration',
-      message: meta?.message || MIGRATION_COMMIT_MESSAGE,
+      message: meta.message || MIGRATION_COMMIT_MESSAGE,
       actorIdentityId: null,
-      actorDisplayName: meta?.authorName || null,
+      actorDisplayName: meta.authorName || null,
       runId: null,
       filesChanged: 0,
       bytesAdded: 0,
@@ -564,13 +558,41 @@ export async function recordRevisionForRun(
 }
 
 /**
- * Invariant: at the end of the locked critical section, HEAD's SHA
- * must have a corresponding `project_revisions` row. If a prior call
- * crashed between `git commit` and the SQLite INSERT, HEAD is one
- * commit ahead of the table. Reconstruct the missing row from the
- * commit itself (attributing to this retrying run would be durable
- * false provenance). Single-orphan repair only — multi-orphan chains
- * recover naturally on successive calls.
+ * Walk back from HEAD collecting commits that have no project_revisions
+ * row. Stops at the first commit that does, or at the repo root.
+ * Returns oldest-first so caller can insert in parent → child order.
+ */
+async function collectOrphanCommits(
+  projectDir: string,
+  db: Database.Database,
+  projectId: string,
+  headSha: string,
+  signal?: AbortSignal,
+): Promise<CommitMetadata[]> {
+  const orphans: CommitMetadata[] = [];
+  let cursor: string | null = headSha;
+  while (cursor && !revisionIdForSha(db, projectId, cursor)) {
+    const meta = await readCommitMetadata(projectDir, cursor, signal);
+    orphans.push(meta);
+    cursor = await readParentSha(projectDir, cursor, signal);
+  }
+  return orphans.reverse();
+}
+
+async function readParentSha(
+  projectDir: string,
+  ref: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  const out = await runGit(projectDir, ['rev-parse', `${ref}^`], signal, { softFail128: true });
+  return out.trim() || null;
+}
+
+/**
+ * Restore the "every HEAD-reachable commit has a row" invariant by
+ * walking back from HEAD and inserting each missing commit oldest →
+ * newest in one transaction, attributing to the actual git author
+ * (NOT this retrying run).
  */
 async function repairOrphanHead(
   args: RecordRevisionForRunArgs,
@@ -578,28 +600,36 @@ async function repairOrphanHead(
 ): Promise<void> {
   const { projectId, projectDir, db, signal } = args;
   if (revisionIdForSha(db, projectId, headSha)) {
-    // Row for HEAD exists; only thing that could be wrong is a stale
-    // pointer from a legacy partial-write.
     ensureHeadPointerInvariant(db, projectId, headSha);
     return;
   }
-  const meta = await readCommitMetadata(projectDir, 'HEAD', signal);
-  const parentSha = await readHeadParentSha(projectDir, signal);
-  insertRevisionAndAdvancePointer(db, {
-    id: randomUUID(),
-    projectId,
-    parentId: revisionIdForSha(db, projectId, parentSha),
-    gitSha: headSha,
-    createdAt: meta?.authorDateMs ?? Date.now(),
-    source: 'agent-run',
-    message: meta?.message || DEFAULT_COMMIT_MESSAGE,
-    actorIdentityId: null,
-    actorDisplayName: meta?.authorName || null,
-    runId: null,
-    filesChanged: 0,
-    bytesAdded: 0,
-    bytesRemoved: 0,
-  });
+  const orphans = await collectOrphanCommits(projectDir, db, projectId, headSha, signal);
+  if (orphans.length === 0) return;
+
+  const oldestParentSha = await readParentSha(projectDir, orphans[0]!.sha, signal);
+  const oldestParentId = revisionIdForSha(db, projectId, oldestParentSha);
+  const ids = orphans.map(() => randomUUID());
+
+  db.transaction(() => {
+    orphans.forEach((meta, i) => {
+      insertRevision(db, {
+        id: ids[i]!,
+        projectId,
+        parentId: i === 0 ? oldestParentId : ids[i - 1]!,
+        gitSha: meta.sha,
+        createdAt: meta.authorDateMs,
+        source: 'agent-run',
+        message: meta.message || DEFAULT_COMMIT_MESSAGE,
+        actorIdentityId: null,
+        actorDisplayName: meta.authorName || null,
+        runId: null,
+        filesChanged: 0,
+        bytesAdded: 0,
+        bytesRemoved: 0,
+      });
+    });
+    setCurrentRevision(db, projectId, ids[ids.length - 1]!);
+  })();
 }
 
 /**

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -16,6 +16,7 @@ import type Database from 'better-sqlite3';
 
 import { runGit } from '../git/exec.js';
 import type { Identity } from '../identity/types.js';
+import { withProjectLock } from './project-lock.js';
 
 const DEFAULT_GITIGNORE = `# Open Design auto-generated; commit or edit as needed.
 .DS_Store
@@ -158,6 +159,16 @@ export type InitProjectHistoryResult =
 export async function initProjectHistory(
   args: InitProjectHistoryArgs,
 ): Promise<InitProjectHistoryResult> {
+  // Serialize against any concurrent init/record on the same project.
+  // Two callers racing initProjectHistory could otherwise both pass
+  // the readDotGitState() check and both run `git init`, producing
+  // duplicate migration revisions or corrupt state.
+  return withProjectLock(args.projectId, () => initProjectHistoryLocked(args));
+}
+
+async function initProjectHistoryLocked(
+  args: InitProjectHistoryArgs,
+): Promise<InitProjectHistoryResult> {
   const { projectId, projectDir, repoDir, identity, db, signal } = args;
 
   const state = await readDotGitState(projectDir, repoDir);
@@ -250,6 +261,17 @@ export type RecordRevisionForRunResult =
  * the run (auto-commit is best-effort, not part of the run's contract).
  */
 export async function recordRevisionForRun(
+  args: RecordRevisionForRunArgs,
+): Promise<RecordRevisionForRunResult> {
+  // Serialize against concurrent init/record on the same project. Two
+  // runs finishing close together can otherwise both call `git add -A`,
+  // and one `git commit` absorbs the other's staged changes — the
+  // loser sees a clean tree and no-ops. Lock guarantees the
+  // "one revision per run" contract holds.
+  return withProjectLock(args.projectId, () => recordRevisionForRunLocked(args));
+}
+
+async function recordRevisionForRunLocked(
   args: RecordRevisionForRunArgs,
 ): Promise<RecordRevisionForRunResult> {
   const { projectId, projectDir, repoDir, run, message, db, signal } = args;

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -1,0 +1,340 @@
+// Substrate-aware history module: owns substrate initialization for a
+// project (git init + initial migration commit + corresponding
+// project_revisions row), the existing-`.git` collision check, and the
+// per-run "commit if dirty" path that records a revision when a chat
+// run leaves changes on disk.
+//
+// The substrate is git. The API surface (the names of the functions
+// this module exports and the shape of their arguments / results) is
+// substrate-agnostic by design so a future OD-owned implementation
+// could replace `repo-git.ts` without changing call sites in
+// `ensureProject` / `startChatRun` / route handlers.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type Database from 'better-sqlite3';
+
+import { runGit } from '../git/exec.js';
+import type { Identity } from '../identity/types.js';
+
+const DEFAULT_GITIGNORE = `# Open Design auto-generated; commit or edit as needed.
+.DS_Store
+*.log
+`;
+
+const MIGRATION_COMMIT_MESSAGE = 'chore(init): import existing project tree';
+
+/**
+ * Resolve the on-disk path of the substrate's gitdir for a project.
+ * Lives next to projects/ under OD_DATA_DIR so backups already cover
+ * it. The `.gitdir` suffix avoids the confusing nested `<id>/.git/`
+ * layout that conventional `git init` would produce.
+ */
+export function projectRepoPath(repoRoot: string, projectId: string): string {
+  return path.join(repoRoot, `${projectId}.gitdir`);
+}
+
+/** State of the project tree's `.git` entry — used for substrate init + collision detection. */
+type DotGitState =
+  | { kind: 'absent' }
+  | { kind: 'ours' }
+  | { kind: 'foreign-dir' }
+  | { kind: 'foreign-link'; target: string };
+
+/**
+ * Inspect the project tree's `.git` entry. Returns:
+ * - `absent`     — no .git, ready for first init
+ * - `ours`       — .git is a gitlink file pointing at our `repoDir`
+ * - `foreign-dir`  — .git is a regular directory (someone else's repo, possibly cloned)
+ * - `foreign-link` — .git is a gitlink pointing somewhere else
+ *
+ * The caller decides what to do: continue (absent), no-op (ours), or
+ * refuse with a clear user-facing error (foreign-*).
+ */
+async function readDotGitState(projectDir: string, repoDir: string): Promise<DotGitState> {
+  const dotGit = path.join(projectDir, '.git');
+  let stat;
+  try {
+    stat = await fs.lstat(dotGit);
+  } catch {
+    return { kind: 'absent' };
+  }
+  if (stat.isDirectory()) return { kind: 'foreign-dir' };
+  if (!stat.isFile()) return { kind: 'foreign-dir' };
+  // Gitlink file: contents `gitdir: <absolute path>`
+  const content = await fs.readFile(dotGit, 'utf8');
+  const match = /^gitdir:\s*(.+)\s*$/m.exec(content);
+  const linkRaw = match?.[1];
+  if (!linkRaw) return { kind: 'foreign-dir' };
+  const linkedAbsolute = path.isAbsolute(linkRaw)
+    ? linkRaw
+    : path.resolve(projectDir, linkRaw);
+  // `git init --separate-git-dir` canonicalizes its path via the OS
+  // (resolving symlinks), so on platforms where the storage root is
+  // under a symlink (macOS's /tmp → /private/tmp, common deployment
+  // setups where /var or /home is a symlink) a naive string compare
+  // against our unresolved `repoDir` fails. Resolve both sides where
+  // possible — fall back to lexical compare when realpath errors
+  // (e.g., the linked target no longer exists).
+  if (await sameDirectoryPath(linkedAbsolute, repoDir)) {
+    return { kind: 'ours' };
+  }
+  return { kind: 'foreign-link', target: linkedAbsolute };
+}
+
+async function sameDirectoryPath(a: string, b: string): Promise<boolean> {
+  let aResolved = path.resolve(a);
+  let bResolved = path.resolve(b);
+  try { aResolved = await fs.realpath(aResolved); } catch { /* fall back to lexical */ }
+  try { bResolved = await fs.realpath(bResolved); } catch { /* fall back to lexical */ }
+  return aResolved === bResolved;
+}
+
+/**
+ * Construct a git author email when the resolved Identity didn't carry
+ * one. Single-user / LocalFallbackProvider deployments commonly leave
+ * email unset; this synthesizes a stable, ASCII-safe email derived from
+ * the identity's id so git commit doesn't refuse the author line.
+ */
+function syntheticAuthorEmail(identity: Identity): string {
+  if (identity.email && identity.email.trim().length > 0) return identity.email.trim();
+  const safe = identity.id.replace(/[^a-z0-9.-]/gi, '_');
+  return `${safe}@open-design.local`;
+}
+
+/**
+ * Apply the resolved Identity to git's per-repo `user.name` / `user.email`
+ * config. Per-repo (not --global) so we don't perturb the operator's
+ * own git config, and the commit gets the right author line even when
+ * multiple identities operate against the same daemon.
+ */
+async function applyAuthorConfig(
+  projectDir: string,
+  identity: Identity,
+  signal?: AbortSignal,
+): Promise<void> {
+  await runGit(projectDir, ['config', 'user.email', syntheticAuthorEmail(identity)], signal);
+  await runGit(projectDir, ['config', 'user.name', identity.displayName], signal);
+}
+
+export interface InitProjectHistoryArgs {
+  projectId: string;
+  projectDir: string;
+  repoDir: string;
+  identity: Identity;
+  db: Database.Database;
+  signal?: AbortSignal;
+}
+
+export type InitProjectHistoryResult =
+  /** Substrate freshly initialized; first revision recorded. */
+  | { kind: 'initialized'; revisionId: string }
+  /** Substrate was already initialized for this project; no-op. */
+  | { kind: 'already-initialized' }
+  /**
+   * Project tree already contains a `.git` we don't manage. Refuse to
+   * take ownership; the caller surfaces a project-level error. The
+   * `target` field is set when the foreign entry is a gitlink (the
+   * path it points at), absent when the foreign entry is a regular
+   * `.git/` directory.
+   */
+  | { kind: 'foreign-git-collision'; target?: string };
+
+/**
+ * Initialize the history substrate for a project. Idempotent: if the
+ * substrate is already in place, returns `already-initialized` without
+ * touching anything. Refuses to take ownership of a foreign `.git`.
+ *
+ * On `initialized`, the on-disk state is:
+ *  - .git gitlink file inside projectDir → repoDir
+ *  - repoDir contains a full git object database
+ *  - a default .gitignore exists in projectDir (only written if missing)
+ *  - one commit on `main`: the migration commit capturing the current tree
+ *
+ * And the DB state is:
+ *  - one row inserted in project_revisions with source='migration'
+ *  - projects.current_revision_id advanced to that revision's id (the commit SHA)
+ */
+export async function initProjectHistory(
+  args: InitProjectHistoryArgs,
+): Promise<InitProjectHistoryResult> {
+  const { projectId, projectDir, repoDir, identity, db, signal } = args;
+
+  const state = await readDotGitState(projectDir, repoDir);
+  if (state.kind === 'ours') return { kind: 'already-initialized' };
+  if (state.kind === 'foreign-dir') return { kind: 'foreign-git-collision' };
+  if (state.kind === 'foreign-link') {
+    return { kind: 'foreign-git-collision', target: state.target };
+  }
+
+  await fs.mkdir(path.dirname(repoDir), { recursive: true });
+
+  // `git init --separate-git-dir=<repoDir>` puts the object database
+  // at repoDir and writes a `.git` gitlink file in projectDir. Main
+  // is the canonical branch.
+  await runGit(
+    projectDir,
+    ['init', '--separate-git-dir', repoDir, '--initial-branch', 'main'],
+    signal,
+  );
+
+  const gitignorePath = path.join(projectDir, '.gitignore');
+  try {
+    await fs.access(gitignorePath);
+  } catch {
+    await fs.writeFile(gitignorePath, DEFAULT_GITIGNORE, 'utf8');
+  }
+
+  await applyAuthorConfig(projectDir, identity, signal);
+  await runGit(projectDir, ['add', '-A'], signal);
+
+  // Allow an empty initial commit so brand-new projects (no files yet)
+  // still have a starting SHA we can record on the migration row.
+  await runGit(
+    projectDir,
+    ['commit', '--allow-empty', '-m', MIGRATION_COMMIT_MESSAGE],
+    signal,
+  );
+
+  const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
+
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO project_revisions (
+       id, project_id, parent_id, created_at, source, message,
+       actor_identity_id, actor_display_name, run_id,
+       files_changed_count, bytes_added, bytes_removed
+     ) VALUES (?, ?, NULL, ?, 'migration', ?, ?, ?, NULL, 0, 0, 0)`,
+  ).run(sha, projectId, now, MIGRATION_COMMIT_MESSAGE, identity.id, identity.displayName);
+
+  db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(sha, projectId);
+
+  return { kind: 'initialized', revisionId: sha };
+}
+
+export interface RecordRevisionForRunArgs {
+  projectId: string;
+  projectDir: string;
+  repoDir: string;
+  run: { id: string; identity: Identity };
+  /** Commit message — caller derives from the chatBody (typically first line of the user prompt). */
+  message: string;
+  db: Database.Database;
+  signal?: AbortSignal;
+}
+
+export type RecordRevisionForRunResult =
+  /** Tree was dirty and we recorded a new revision. */
+  | { kind: 'recorded'; revisionId: string; filesChanged: number; bytesAdded: number; bytesRemoved: number }
+  /** Nothing to record — the working tree was clean at run end. */
+  | { kind: 'clean' }
+  /** Substrate isn't initialized for this project; caller should init first. */
+  | { kind: 'not-initialized' };
+
+/**
+ * At chat-run end, if the project's working tree has uncommitted changes,
+ * stage and commit them as a revision authored by the run's resolved
+ * identity. Inserts a `project_revisions` row and advances the project's
+ * `current_revision_id` pointer.
+ *
+ * Returns `clean` (no-op) when the tree is clean — the daemon's chat-run
+ * lifecycle calls this unconditionally at run end; it's expected to
+ * sometimes have nothing to do.
+ *
+ * Returns `not-initialized` if the substrate isn't in place for this
+ * project — the caller (P0.7 lifecycle hook) decides whether to call
+ * `initProjectHistory` first or skip silently.
+ *
+ * Errors from git (timeout, unexpected exit) propagate as thrown
+ * exceptions; the caller wraps in try/catch and logs without failing
+ * the run (auto-commit is best-effort, not part of the run's contract).
+ */
+export async function recordRevisionForRun(
+  args: RecordRevisionForRunArgs,
+): Promise<RecordRevisionForRunResult> {
+  const { projectId, projectDir, repoDir, run, message, db, signal } = args;
+
+  const state = await readDotGitState(projectDir, repoDir);
+  if (state.kind !== 'ours') return { kind: 'not-initialized' };
+
+  const status = await runGit(projectDir, ['status', '--short'], signal);
+  if (status.trim().length === 0) return { kind: 'clean' };
+
+  await applyAuthorConfig(projectDir, run.identity, signal);
+  await runGit(projectDir, ['add', '-A'], signal);
+  await runGit(projectDir, ['commit', '-m', message], signal);
+
+  const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
+  const parent = (await runGit(projectDir, ['rev-parse', 'HEAD^'], signal)).trim() || null;
+  const stats = await parseLastCommitStats(projectDir, signal);
+
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO project_revisions (
+       id, project_id, parent_id, created_at, source, message,
+       actor_identity_id, actor_display_name, run_id,
+       files_changed_count, bytes_added, bytes_removed
+     ) VALUES (?, ?, ?, ?, 'agent-run', ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    sha,
+    projectId,
+    parent,
+    now,
+    message,
+    run.identity.id,
+    run.identity.displayName,
+    run.id,
+    stats.filesChanged,
+    stats.bytesAdded,
+    stats.bytesRemoved,
+  );
+
+  db.prepare(`UPDATE projects SET current_revision_id = ? WHERE id = ?`).run(sha, projectId);
+
+  return {
+    kind: 'recorded',
+    revisionId: sha,
+    filesChanged: stats.filesChanged,
+    bytesAdded: stats.bytesAdded,
+    bytesRemoved: stats.bytesRemoved,
+  };
+}
+
+interface CommitStats {
+  filesChanged: number;
+  bytesAdded: number;
+  bytesRemoved: number;
+}
+
+/**
+ * Parse `git show --shortstat --format= HEAD` output to extract counts
+ * for the most recent commit. Format example:
+ *   ` 3 files changed, 7 insertions(+), 2 deletions(-)`
+ * Missing components default to 0 — `git show` may omit insertions or
+ * deletions if zero, or omit the line entirely for an empty commit.
+ *
+ * Note: insertions/deletions are line counts in git's output, not byte
+ * counts. The column is named `bytes_*` in the schema for forward
+ * compatibility with a future OD-owned substrate that may track actual
+ * bytes; under the git substrate we populate the line-count value
+ * which is a useful proxy for "size of change."
+ */
+async function parseLastCommitStats(
+  projectDir: string,
+  signal?: AbortSignal,
+): Promise<CommitStats> {
+  const out = await runGit(
+    projectDir,
+    ['show', '--shortstat', '--format=', 'HEAD'],
+    signal,
+  );
+  const line = out.split('\n').find((l) => l.includes('changed')) ?? '';
+  const files = /(\d+)\s+files? changed/.exec(line)?.[1];
+  const added = /(\d+)\s+insertions?\(\+\)/.exec(line)?.[1];
+  const removed = /(\d+)\s+deletions?\(-\)/.exec(line)?.[1];
+  return {
+    filesChanged: files ? Number(files) : 0,
+    bytesAdded: added ? Number(added) : 0,
+    bytesRemoved: removed ? Number(removed) : 0,
+  };
+}

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -574,12 +574,12 @@ async function collectOrphanCommits(
   while (cursor && !revisionIdForSha(db, projectId, cursor)) {
     const meta = await readCommitMetadata(projectDir, cursor, signal);
     orphans.push(meta);
-    cursor = await readParentSha(projectDir, cursor, signal);
+    cursor = await readFirstParentSha(projectDir, cursor, signal);
   }
   return orphans.reverse();
 }
 
-async function readParentSha(
+async function readFirstParentSha(
   projectDir: string,
   ref: string,
   signal?: AbortSignal,
@@ -606,7 +606,7 @@ async function repairOrphanHead(
   const orphans = await collectOrphanCommits(projectDir, db, projectId, headSha, signal);
   if (orphans.length === 0) return;
 
-  const oldestParentSha = await readParentSha(projectDir, orphans[0]!.sha, signal);
+  const oldestParentSha = await readFirstParentSha(projectDir, orphans[0]!.sha, signal);
   const oldestParentId = revisionIdForSha(db, projectId, oldestParentSha);
   const ids = orphans.map(() => randomUUID());
   const stats: CommitStats[] = [];

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -297,6 +297,15 @@ export type RecordRevisionForRunResult =
   | { kind: 'recorded'; revisionId: string; filesChanged: number; bytesAdded: number; bytesRemoved: number }
   /** Nothing to record — the working tree was clean at run end. */
   | { kind: 'clean' }
+  /**
+   * A concurrent sibling run on the same project advanced HEAD while
+   * this run waited at the lock; the sibling's commit absorbed any
+   * changes this run wrote. We preserve provenance by recording a row
+   * with `git_sha=NULL` and `parent_id` pointing to the sibling's
+   * revision. `current_revision_id` is NOT advanced (the sibling
+   * already owns the head).
+   */
+  | { kind: 'marker'; revisionId: string; absorbedIntoRevisionId: string | null }
   /** Substrate isn't initialized for this project; caller should init first. */
   | { kind: 'not-initialized' };
 
@@ -321,16 +330,30 @@ export type RecordRevisionForRunResult =
 export async function recordRevisionForRun(
   args: RecordRevisionForRunArgs,
 ): Promise<RecordRevisionForRunResult> {
-  // Serialize against concurrent init/record on the same project. Two
-  // runs finishing close together can otherwise both call `git add -A`,
-  // and one `git commit` absorbs the other's staged changes — the
-  // loser sees a clean tree and no-ops. Lock guarantees the
-  // "one revision per run" contract holds.
-  return withProjectLock(args.projectId, () => recordRevisionForRunLocked(args));
+  // The lock alone is not sufficient to preserve the "one revision per
+  // run" contract: two runs finishing close together both have dirty
+  // workdirs, but the first to acquire the lock `git add -A`s the
+  // *combined* dirty state and commits everything; the second acquires
+  // a clean tree and would otherwise no-op (silent provenance loss).
+  // To preserve provenance we capture HEAD *before* queueing for the
+  // lock; if the locked critical section finds the tree clean AND HEAD
+  // has advanced from what we saw, we know a sibling absorbed our
+  // changes and record a marker row attributed to this run.
+  let headBeforeLock: string | null = null;
+  try {
+    headBeforeLock =
+      (await runGit(args.projectDir, ['rev-parse', 'HEAD'], args.signal, { softFail128: true })).trim() || null;
+  } catch {
+    // HEAD may not resolve if the substrate isn't initialized yet —
+    // recordRevisionForRunLocked handles that case explicitly via the
+    // readDotGitState check at its head.
+  }
+  return withProjectLock(args.projectId, () => recordRevisionForRunLocked(args, headBeforeLock));
 }
 
 async function recordRevisionForRunLocked(
   args: RecordRevisionForRunArgs,
+  headBeforeLock: string | null,
 ): Promise<RecordRevisionForRunResult> {
   const { projectId, projectDir, repoDir, run, message, db, signal } = args;
 
@@ -346,7 +369,58 @@ async function recordRevisionForRunLocked(
   await ensureHistoryManagedExcludes(repoDir);
 
   const status = await runGit(projectDir, ['status', '--short'], signal);
-  if (status.trim().length === 0) return { kind: 'clean' };
+  if (status.trim().length === 0) {
+    // Tree is clean. Two cases to distinguish:
+    //   (a) The run genuinely wrote nothing — pure conversational
+    //       reply, no provenance row is needed. (Step 4 contract.)
+    //   (b) A sibling concurrent run absorbed our changes into its
+    //       commit while we were queued at the lock. Compare HEAD
+    //       now against the snapshot we took before queueing — if it
+    //       has advanced, a sibling moved it, and we need a marker
+    //       row so this run's provenance survives.
+    //
+    // Edge case: if a sibling fires AND this run was purely
+    // conversational, we'll log a false-positive marker. That's a
+    // benign data-quality cost for preserving provenance in (b);
+    // the History UI can filter marker rows whose run wrote no
+    // files via cross-referencing tool-use events. See spec §6.
+    const headNow =
+      (await runGit(projectDir, ['rev-parse', 'HEAD'], signal, { softFail128: true })).trim() || null;
+    const advancedDuringWait =
+      headBeforeLock !== null && headNow !== null && headNow !== headBeforeLock;
+    if (!advancedDuringWait) return { kind: 'clean' };
+
+    // Sibling-absorbed path: record a marker row. git_sha=NULL so
+    // the partial unique index (project_id, git_sha) WHERE git_sha
+    // IS NOT NULL doesn't collide. parent_id points at the
+    // sibling's revision row so History UI consumers can show the
+    // marker under its absorbing commit.
+    const absorbedRow = db
+      .prepare(`SELECT id FROM project_revisions WHERE project_id = ? AND git_sha = ?`)
+      .get(projectId, headNow) as { id: string } | undefined;
+    const absorbedIntoRevisionId = absorbedRow?.id ?? null;
+    const markerRevisionId = randomUUID();
+    const markerNow = Date.now();
+    db.prepare(
+      `INSERT INTO project_revisions (
+         id, project_id, parent_id, git_sha, created_at, source, message,
+         actor_identity_id, actor_display_name, run_id,
+         files_changed_count, bytes_added, bytes_removed
+       ) VALUES (?, ?, ?, NULL, ?, 'agent-run', ?, ?, ?, ?, 0, 0, 0)`,
+    ).run(
+      markerRevisionId,
+      projectId,
+      absorbedIntoRevisionId,
+      markerNow,
+      message,
+      run.identity.id,
+      run.identity.displayName,
+      run.id,
+    );
+    // Do NOT advance projects.current_revision_id — the sibling's
+    // recorded row already owns the head pointer.
+    return { kind: 'marker', revisionId: markerRevisionId, absorbedIntoRevisionId };
+  }
 
   await applyAuthorConfig(projectDir, run.identity, signal);
   await runGit(projectDir, ['add', '-A'], signal);

--- a/apps/daemon/src/history/repo.ts
+++ b/apps/daemon/src/history/repo.ts
@@ -287,7 +287,12 @@ async function recordRevisionForRunLocked(
   await runGit(projectDir, ['commit', '-m', message], signal);
 
   const sha = (await runGit(projectDir, ['rev-parse', 'HEAD'], signal)).trim();
-  const parent = (await runGit(projectDir, ['rev-parse', 'HEAD^'], signal)).trim() || null;
+  // Probe for the parent — exit 128 means HEAD has no parent (initial
+  // commit). Under recordRevisionForRun's normal flow this can't
+  // happen because initProjectHistory's migration commit is always
+  // present, but defending against an orphaned HEAD (corrupted
+  // gitdir, manual history rewrite) keeps the contract clean.
+  const parent = (await runGit(projectDir, ['rev-parse', 'HEAD^'], signal, { softFail128: true })).trim() || null;
   const stats = await parseLastCommitStats(projectDir, signal);
 
   const now = Date.now();

--- a/apps/daemon/src/history/run-hook.ts
+++ b/apps/daemon/src/history/run-hook.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 import type Database from 'better-sqlite3';
 
 import { isHistoryEnabled } from './feature-flag.js';
-import { projectRepoPath, recordRevisionForRun } from './repo.js';
+import { projectRepoPath, readHeadSha, recordRevisionForRun } from './repo.js';
 import { isSafeId } from '../projects.js';
 import type { Identity } from '../identity/types.js';
 
@@ -25,12 +25,31 @@ export interface RunFinishedRun {
   identity: Identity | null;
   message: string | null;
   touchedFiles: boolean;
+  /**
+   * HEAD SHA observed by `installHistoryRunCreatedHook` right after
+   * runs.create(). Null when the substrate isn't initialized yet, the
+   * read failed, or the run was created before the created-hook was
+   * installed. Passed through to recordRevisionForRun as the preferred
+   * baseline for the sibling-absorbed marker check.
+   */
+  headAtCreate: string | null;
+}
+
+/**
+ * The created-hook receives a mutable run reference and may set
+ * `headAtCreate` directly on it.
+ */
+export interface RunCreatedRun {
+  id: string;
+  projectId: string | null;
+  headAtCreate: string | null;
 }
 
 type RunFinishedStatus = 'succeeded' | 'failed' | 'canceled';
 
 export interface RunServiceForHook {
   setRunFinishedHook(hook: ((run: RunFinishedRun, status: RunFinishedStatus) => unknown) | null): void;
+  setRunCreatedHook(hook: ((run: RunCreatedRun) => unknown) | null): void;
 }
 
 export interface InstallHistoryRunFinishedHookArgs {
@@ -44,6 +63,8 @@ export interface InstallHistoryRunFinishedHookArgs {
   /** Env override (mainly for tests). Defaults to process.env. */
   env?: NodeJS.ProcessEnv;
 }
+
+export type InstallHistoryRunCreatedHookArgs = InstallHistoryRunFinishedHookArgs;
 
 /**
  * First non-empty line of the prompt, clamped to a single-line subject
@@ -88,6 +109,7 @@ export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHoo
         message,
         db,
         runTouchedFiles: run.touchedFiles,
+        runHeadAtCreate: run.headAtCreate,
       });
 
       if (result.kind === 'recorded') {
@@ -114,6 +136,30 @@ export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHoo
       // 'clean' is the common no-op case — don't log
     } catch (err) {
       console.warn(`[history] auto-commit failed for run ${run.id}:`, err);
+    }
+  });
+}
+
+/**
+ * Install the post-create hook. Reads HEAD asynchronously and stamps
+ * `run.headAtCreate` so the finish-hook's marker check has a baseline
+ * that pre-dates any sibling's commit-and-release cycle. Best-effort:
+ * any failure (unsafe id, missing substrate, git error) leaves
+ * `headAtCreate` null, and the marker check falls back to the
+ * lock-entry baseline that's been there since round 6.
+ */
+export function installHistoryRunCreatedHook(args: InstallHistoryRunCreatedHookArgs): void {
+  const { projectsRoot, runs, env = process.env } = args;
+
+  runs.setRunCreatedHook(async (run) => {
+    if (!isHistoryEnabled(env)) return;
+    if (!run.projectId) return;
+    if (!isSafeId(run.projectId)) return;
+    const projectDir = path.join(projectsRoot, run.projectId);
+    try {
+      run.headAtCreate = await readHeadSha(projectDir);
+    } catch {
+      run.headAtCreate = null;
     }
   });
 }

--- a/apps/daemon/src/history/run-hook.ts
+++ b/apps/daemon/src/history/run-hook.ts
@@ -1,0 +1,118 @@
+// Glue between the chat-run service's finish() hook and the history
+// substrate's recordRevisionForRun.
+//
+// Fires at the end of every chat run. Records a `project_revisions`
+// row when the working tree is dirty, attributing the commit to the
+// run's resolved Identity. Errors propagate as logged warnings — the
+// auto-commit is best-effort and must not affect the run's reported
+// terminal status.
+
+import path from 'node:path';
+import type Database from 'better-sqlite3';
+
+import { isHistoryEnabled } from './feature-flag.js';
+import { projectRepoPath, recordRevisionForRun } from './repo.js';
+import type { Identity } from '../identity/types.js';
+
+const DEFAULT_COMMIT_MESSAGE = 'Agent run';
+
+/**
+ * Shape the chat-run service hands to the run-finished hook. Defined
+ * here because runs.ts is `@ts-nocheck`; consumers that need the
+ * type import from this module.
+ */
+export interface RunFinishedRun {
+  id: string;
+  projectId: string | null;
+  conversationId: string | null;
+  identity: Identity | null;
+  message: string | null;
+}
+
+type RunFinishedStatus = 'succeeded' | 'failed' | 'canceled';
+
+/**
+ * Service surface the hook needs to register itself. Subset of the
+ * full createChatRunService return shape — typed here for clarity.
+ */
+export interface RunServiceForHook {
+  setRunFinishedHook(hook: ((run: RunFinishedRun, status: RunFinishedStatus) => unknown) | null): void;
+}
+
+export interface InstallHistoryRunFinishedHookArgs {
+  db: Database.Database;
+  /** Absolute path holding per-project working trees (PROJECTS_DIR). */
+  projectsRoot: string;
+  /** Absolute path holding per-project gitdirs (REPOS_DIR). */
+  reposRoot: string;
+  /** Run service whose finish() should fire the auto-commit. */
+  runs: RunServiceForHook;
+  /** Env override (mainly for tests). Defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Build a sensible commit message from the user prompt that triggered
+ * the run. Takes the first non-empty line of the prompt and clamps it
+ * to a single-line subject. Falls back to `DEFAULT_COMMIT_MESSAGE` when
+ * there's no prompt (e.g., orbit runs that came through without a
+ * `message` field).
+ */
+function buildCommitMessage(rawPrompt: string | null | undefined): string {
+  if (!rawPrompt) return DEFAULT_COMMIT_MESSAGE;
+  const firstLine = rawPrompt.split('\n').map((l) => l.trim()).find((l) => l.length > 0);
+  if (!firstLine) return DEFAULT_COMMIT_MESSAGE;
+  // Conventional subject-line clamp; readable in `git log --oneline`
+  // and any History pane that truncates beyond ~72 chars.
+  return firstLine.length > 72 ? `${firstLine.slice(0, 71)}…` : firstLine;
+}
+
+/**
+ * Install the post-finish hook that records a revision when the
+ * working tree has uncommitted changes at run end. No-op when the
+ * feature flag is off. No-op when the run has no projectId (some
+ * runs aren't project-scoped). No-op when the run has no resolved
+ * Identity (defensive — shouldn't happen after P0.2 wired it, but
+ * skipping is safer than committing with a null author).
+ */
+export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHookArgs): void {
+  const { db, projectsRoot, reposRoot, runs, env = process.env } = args;
+
+  runs.setRunFinishedHook(async (run, _status) => {
+    if (!isHistoryEnabled(env)) return;
+    if (!run.projectId) return;
+    if (!run.identity) return;
+
+    const projectDir = path.join(projectsRoot, run.projectId);
+    const repoDir = projectRepoPath(reposRoot, run.projectId);
+    const message = buildCommitMessage(run.message);
+
+    try {
+      const result = await recordRevisionForRun({
+        projectId: run.projectId,
+        projectDir,
+        repoDir,
+        run: { id: run.id, identity: run.identity },
+        message,
+        db,
+      });
+
+      if (result.kind === 'recorded') {
+        // Quiet success path — visible enough in DEBUG logs without
+        // adding noise to normal operation.
+        if (process.env.DEBUG?.includes('history')) {
+          console.log(
+            `[history] recorded revision ${result.revisionId.slice(0, 8)} for run ${run.id} (${result.filesChanged} files, +${result.bytesAdded}/-${result.bytesRemoved} lines)`,
+          );
+        }
+      } else if (result.kind === 'not-initialized') {
+        console.warn(
+          `[history] run ${run.id} finished against project ${run.projectId} but the substrate isn't initialized; skipping commit.`,
+        );
+      }
+      // 'clean' is the common no-op case — don't log
+    } catch (err) {
+      console.warn(`[history] auto-commit failed for run ${run.id}:`, err);
+    }
+  });
+}

--- a/apps/daemon/src/history/run-hook.ts
+++ b/apps/daemon/src/history/run-hook.ts
@@ -27,6 +27,7 @@ export interface RunFinishedRun {
   conversationId: string | null;
   identity: Identity | null;
   message: string | null;
+  touchedFiles: boolean;
 }
 
 type RunFinishedStatus = 'succeeded' | 'failed' | 'canceled';
@@ -95,6 +96,7 @@ export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHoo
         run: { id: run.id, identity: run.identity },
         message,
         db,
+        runTouchedFiles: run.touchedFiles,
       });
 
       if (result.kind === 'recorded') {

--- a/apps/daemon/src/history/run-hook.ts
+++ b/apps/daemon/src/history/run-hook.ts
@@ -1,11 +1,7 @@
-// Glue between the chat-run service's finish() hook and the history
-// substrate's recordRevisionForRun.
-//
-// Fires at the end of every chat run. Records a `project_revisions`
-// row when the working tree is dirty, attributing the commit to the
-// run's resolved Identity. Errors propagate as logged warnings — the
-// auto-commit is best-effort and must not affect the run's reported
-// terminal status.
+// Glue between the chat-run service's finish() hook and
+// recordRevisionForRun. Records a `project_revisions` row when the
+// working tree is dirty at run end. Errors are logged warnings —
+// auto-commit is best-effort and must not affect the run's status.
 
 import path from 'node:path';
 import type Database from 'better-sqlite3';
@@ -32,10 +28,6 @@ export interface RunFinishedRun {
 
 type RunFinishedStatus = 'succeeded' | 'failed' | 'canceled';
 
-/**
- * Service surface the hook needs to register itself. Subset of the
- * full createChatRunService return shape — typed here for clarity.
- */
 export interface RunServiceForHook {
   setRunFinishedHook(hook: ((run: RunFinishedRun, status: RunFinishedStatus) => unknown) | null): void;
 }
@@ -53,28 +45,22 @@ export interface InstallHistoryRunFinishedHookArgs {
 }
 
 /**
- * Build a sensible commit message from the user prompt that triggered
- * the run. Takes the first non-empty line of the prompt and clamps it
- * to a single-line subject. Falls back to `DEFAULT_COMMIT_MESSAGE` when
- * there's no prompt (e.g., orbit runs that came through without a
- * `message` field).
+ * First non-empty line of the prompt, clamped to a single-line subject
+ * readable in `git log --oneline` (~72 chars). Falls back to a default
+ * when there's no prompt (e.g., orbit runs without a `message` field).
  */
 function buildCommitMessage(rawPrompt: string | null | undefined): string {
   if (!rawPrompt) return DEFAULT_COMMIT_MESSAGE;
   const firstLine = rawPrompt.split('\n').map((l) => l.trim()).find((l) => l.length > 0);
   if (!firstLine) return DEFAULT_COMMIT_MESSAGE;
-  // Conventional subject-line clamp; readable in `git log --oneline`
-  // and any History pane that truncates beyond ~72 chars.
   return firstLine.length > 72 ? `${firstLine.slice(0, 71)}…` : firstLine;
 }
 
 /**
- * Install the post-finish hook that records a revision when the
- * working tree has uncommitted changes at run end. No-op when the
- * feature flag is off. No-op when the run has no projectId (some
- * runs aren't project-scoped). No-op when the run has no resolved
- * Identity (defensive — shouldn't happen after P0.2 wired it, but
- * skipping is safer than committing with a null author).
+ * Install the post-finish hook. No-op when: the feature flag is off,
+ * the run has no projectId, or the run has no resolved Identity
+ * (defensive — shouldn't happen after P0.2 wired it, but skipping is
+ * safer than committing with a null author).
  */
 export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHookArgs): void {
   const { db, projectsRoot, reposRoot, runs, env = process.env } = args;
@@ -100,20 +86,15 @@ export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHoo
       });
 
       if (result.kind === 'recorded') {
-        // Quiet success path — visible enough in DEBUG logs without
-        // adding noise to normal operation.
         if (process.env.DEBUG?.includes('history')) {
           console.log(
             `[history] recorded revision ${result.revisionId.slice(0, 8)} for run ${run.id} (${result.filesChanged} files, +${result.bytesAdded}/-${result.bytesRemoved} lines)`,
           );
         }
       } else if (result.kind === 'marker') {
-        // Provenance preserved despite a sibling concurrent run
-        // absorbing our changes. Logged at info level (not debug)
-        // so concurrent-run absorption is observable in normal logs
-        // — it's rare enough not to be noisy and useful to surface
-        // when troubleshooting "why doesn't my run appear in
-        // history with its own commit?"
+        // Info-level (not debug): concurrent-run absorption is rare
+        // and useful to surface when troubleshooting "why doesn't my
+        // run appear in history with its own commit?"
         const absorbedSuffix = result.absorbedIntoRevisionId
           ? ` (absorbed into ${result.absorbedIntoRevisionId.slice(0, 8)})`
           : '';

--- a/apps/daemon/src/history/run-hook.ts
+++ b/apps/daemon/src/history/run-hook.ts
@@ -8,7 +8,8 @@ import type Database from 'better-sqlite3';
 
 import { isHistoryEnabled } from './feature-flag.js';
 import { projectRepoPath, readHeadSha, recordRevisionForRun } from './repo.js';
-import { isSafeId } from '../projects.js';
+import { ensureProject, isSafeId } from '../projects.js';
+import { getProject } from '../db.js';
 import type { Identity } from '../identity/types.js';
 
 const DEFAULT_COMMIT_MESSAGE = 'Agent run';
@@ -18,6 +19,14 @@ const DEFAULT_COMMIT_MESSAGE = 'Agent run';
  * here because runs.ts is `@ts-nocheck`; consumers that need the
  * type import from this module.
  */
+export type HistoryStatus =
+  | 'pending'
+  | 'recorded'
+  | 'marker'
+  | 'clean'
+  | 'not-initialized'
+  | 'failed';
+
 export interface RunFinishedRun {
   id: string;
   projectId: string | null;
@@ -33,6 +42,12 @@ export interface RunFinishedRun {
    * baseline for the sibling-absorbed marker check.
    */
   headAtCreate: string | null;
+  // Mutable: the hook sets these as it runs. Surfaced in statusBody so
+  // a successful run with a failed history write is visible — the hook
+  // fires fire-and-forget AFTER terminal broadcast, so console.warn
+  // alone would be silently swallowed for /api/runs and /wait consumers.
+  historyStatus: HistoryStatus | null;
+  historyError: string | null;
 }
 
 /**
@@ -50,6 +65,9 @@ type RunFinishedStatus = 'succeeded' | 'failed' | 'canceled';
 export interface RunServiceForHook {
   setRunFinishedHook(hook: ((run: RunFinishedRun, status: RunFinishedStatus) => unknown) | null): void;
   setRunCreatedHook(hook: ((run: RunCreatedRun) => unknown) | null): void;
+  /** Emit an arbitrary event into the run's SSE buffer. Used by the hook
+   *  to surface `history-completed` after terminal broadcast. */
+  emit(run: { id: string; events: unknown[]; clients: Set<unknown>; nextEventId: number }, event: string, data: unknown): unknown;
 }
 
 export interface InstallHistoryRunFinishedHookArgs {
@@ -100,6 +118,9 @@ export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHoo
     const repoDir = projectRepoPath(reposRoot, run.projectId);
     const message = buildCommitMessage(run.message);
 
+    run.historyStatus = 'pending';
+    run.historyError = null;
+
     try {
       const result = await recordRevisionForRun({
         projectId: run.projectId,
@@ -112,6 +133,14 @@ export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHoo
         runHeadAtCreate: run.headAtCreate,
       });
 
+      run.historyStatus = result.kind;
+      runs.emit(run as never, 'history-completed', {
+        status: result.kind,
+        revisionId: 'revisionId' in result ? result.revisionId : null,
+        absorbedIntoRevisionId:
+          result.kind === 'marker' ? result.absorbedIntoRevisionId : null,
+      });
+
       if (result.kind === 'recorded') {
         if (process.env.DEBUG?.includes('history')) {
           console.log(
@@ -119,9 +148,6 @@ export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHoo
           );
         }
       } else if (result.kind === 'marker') {
-        // Info-level (not debug): concurrent-run absorption is rare
-        // and useful to surface when troubleshooting "why doesn't my
-        // run appear in history with its own commit?"
         const absorbedSuffix = result.absorbedIntoRevisionId
           ? ` (absorbed into ${result.absorbedIntoRevisionId.slice(0, 8)})`
           : '';
@@ -133,8 +159,11 @@ export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHoo
           `[history] run ${run.id} finished against project ${run.projectId} but the substrate isn't initialized; skipping commit.`,
         );
       }
-      // 'clean' is the common no-op case — don't log
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      run.historyStatus = 'failed';
+      run.historyError = message;
+      runs.emit(run as never, 'history-completed', { status: 'failed', error: message });
       console.warn(`[history] auto-commit failed for run ${run.id}:`, err);
     }
   });
@@ -149,14 +178,28 @@ export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHoo
  * lock-entry baseline that's been there since round 6.
  */
 export function installHistoryRunCreatedHook(args: InstallHistoryRunCreatedHookArgs): void {
-  const { projectsRoot, runs, env = process.env } = args;
+  const { db, projectsRoot, runs, env = process.env } = args;
 
   runs.setRunCreatedHook(async (run) => {
     if (!isHistoryEnabled(env)) return;
     if (!run.projectId) return;
     if (!isSafeId(run.projectId)) return;
-    const projectDir = path.join(projectsRoot, run.projectId);
     try {
+      const projectRow = getProject(db, run.projectId);
+      if (!projectRow) return;
+      const metadata = projectRow.metadata ?? null;
+      // Linked-folder projects: don't init substrate over user's tree.
+      // headAtCreate stays null; marker check falls back to lock-entry
+      // baseline (which is also null in that case — these projects don't
+      // have a daemon-owned gitdir at all).
+      if (metadata && typeof metadata === 'object' && metadata.baseDir) return;
+      // Force substrate init BEFORE reading HEAD so concurrent runs
+      // against a fresh project share the same M0 baseline. Without
+      // this, both runs read null and the marker can't fire for the
+      // sibling-absorbed loser. ensureProject is idempotent — concurrent
+      // calls serialize on withProjectLock inside initProjectHistory.
+      await ensureProject(projectsRoot, run.projectId, metadata);
+      const projectDir = path.join(projectsRoot, run.projectId);
       run.headAtCreate = await readHeadSha(projectDir);
     } catch {
       run.headAtCreate = null;

--- a/apps/daemon/src/history/run-hook.ts
+++ b/apps/daemon/src/history/run-hook.ts
@@ -8,6 +8,7 @@ import type Database from 'better-sqlite3';
 
 import { isHistoryEnabled } from './feature-flag.js';
 import { projectRepoPath, recordRevisionForRun } from './repo.js';
+import { isSafeId } from '../projects.js';
 import type { Identity } from '../identity/types.js';
 
 const DEFAULT_COMMIT_MESSAGE = 'Agent run';
@@ -69,6 +70,10 @@ export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHoo
     if (!isHistoryEnabled(env)) return;
     if (!run.projectId) return;
     if (!run.identity) return;
+    if (!isSafeId(run.projectId)) {
+      console.warn(`[history] skipping hook for unsafe projectId ${JSON.stringify(run.projectId)}`);
+      return;
+    }
 
     const projectDir = path.join(projectsRoot, run.projectId);
     const repoDir = projectRepoPath(reposRoot, run.projectId);

--- a/apps/daemon/src/history/run-hook.ts
+++ b/apps/daemon/src/history/run-hook.ts
@@ -105,6 +105,19 @@ export function installHistoryRunFinishedHook(args: InstallHistoryRunFinishedHoo
             `[history] recorded revision ${result.revisionId.slice(0, 8)} for run ${run.id} (${result.filesChanged} files, +${result.bytesAdded}/-${result.bytesRemoved} lines)`,
           );
         }
+      } else if (result.kind === 'marker') {
+        // Provenance preserved despite a sibling concurrent run
+        // absorbing our changes. Logged at info level (not debug)
+        // so concurrent-run absorption is observable in normal logs
+        // — it's rare enough not to be noisy and useful to surface
+        // when troubleshooting "why doesn't my run appear in
+        // history with its own commit?"
+        const absorbedSuffix = result.absorbedIntoRevisionId
+          ? ` (absorbed into ${result.absorbedIntoRevisionId.slice(0, 8)})`
+          : '';
+        console.log(
+          `[history] recorded marker revision ${result.revisionId.slice(0, 8)} for run ${run.id}${absorbedSuffix}`,
+        );
       } else if (result.kind === 'not-initialized') {
         console.warn(
           `[history] run ${run.id} finished against project ${run.projectId} but the substrate isn't initialized; skipping commit.`,

--- a/apps/daemon/src/identity/attribution.ts
+++ b/apps/daemon/src/identity/attribution.ts
@@ -1,0 +1,63 @@
+// Helper that turns an Identity (plus optional request context) into the
+// flat {actorIdentityId, actorDisplayName, actorSourceIp} shape that
+// `upsertMessage` and the history feature's revision-recording paths
+// consume. Centralized so the actor_source_ip extraction logic (parse
+// X-Forwarded-For first, fall back to req.socket.remoteAddress) lives
+// in one place rather than getting copied at every call site.
+
+import type { Identity } from './types.js';
+
+export interface AttributionFields {
+  actorIdentityId: string | null;
+  actorDisplayName: string | null;
+  actorSourceIp: string | null;
+}
+
+interface RequestLike {
+  // Headers is loosely-typed (string-keyed dict of unknown) so any
+  // Express-style Request structurally satisfies the contract. We
+  // only read `x-forwarded-for` from it, narrowing the value at the
+  // read site.
+  headers?: Record<string, unknown> | undefined;
+  socket?: { remoteAddress?: string | null | undefined } | undefined;
+}
+
+/**
+ * Derive flat attribution fields for storing on `messages` /
+ * `project_revisions` rows. Returns all-null when identity is null or
+ * undefined (background paths that don't have identity in scope).
+ *
+ * When a request is provided, also resolves the source IP:
+ *  1. The first comma-separated entry of `X-Forwarded-For` (the
+ *     original client IP behind a reverse proxy).
+ *  2. Falls back to `req.socket.remoteAddress` (the TCP peer; useful
+ *     for direct-loopback callers like the desktop UI).
+ *  3. Null when neither yields a string.
+ *
+ * For non-HTTP code paths (scheduler-fired routines, background
+ * reconciliation), pass no req; source IP stays null.
+ */
+export function attributionFromIdentity(
+  identity: Identity | null | undefined,
+  req?: RequestLike,
+): AttributionFields {
+  if (!identity) {
+    return { actorIdentityId: null, actorDisplayName: null, actorSourceIp: null };
+  }
+  return {
+    actorIdentityId: identity.id,
+    actorDisplayName: identity.displayName,
+    actorSourceIp: extractSourceIp(req),
+  };
+}
+
+function extractSourceIp(req?: RequestLike): string | null {
+  if (!req) return null;
+  const xff = req.headers?.['x-forwarded-for'];
+  if (typeof xff === 'string') {
+    const first = xff.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  const sock = req.socket?.remoteAddress;
+  return typeof sock === 'string' && sock.length > 0 ? sock : null;
+}

--- a/apps/daemon/src/identity/attribution.ts
+++ b/apps/daemon/src/identity/attribution.ts
@@ -1,9 +1,25 @@
 // Helper that turns an Identity (plus optional request context) into the
 // flat {actorIdentityId, actorDisplayName, actorSourceIp} shape that
 // `upsertMessage` and the history feature's revision-recording paths
-// consume. Centralized so the actor_source_ip extraction logic (parse
-// X-Forwarded-For first, fall back to req.socket.remoteAddress) lives
-// in one place rather than getting copied at every call site.
+// consume. Centralized so the source-IP resolution logic lives in one
+// place rather than getting copied at every call site.
+//
+// SECURITY (P0-fix #15) — actor_source_ip is durable audit data; it
+// MUST be trustworthy. We no longer parse `X-Forwarded-For` directly
+// inside this helper. Instead the helper reads `req.ip`, which is
+// Express's `trust proxy`-aware resolved client IP:
+//   - With `app.set('trust proxy', false)` (the default): req.ip is
+//     `req.socket.remoteAddress`, regardless of any forwarded headers
+//     a direct client might send. Spoofed `X-Forwarded-For` values are
+//     ignored.
+//   - With `app.set('trust proxy', 'loopback' | <IP> | <CIDR> | N)`:
+//     Express resolves req.ip from the rightmost forwarded hop that
+//     comes from a trusted source.
+// The daemon's trust-proxy config is plumbed from `OD_TRUST_PROXY` at
+// startup (`apps/daemon/src/server.ts`); deployments fronted by a
+// reverse proxy (Tailscale Serve, nginx, Cloudflare Tunnel, …) MUST
+// set this env var to the proxy's identity for source IPs to reflect
+// the real client.
 
 import type { Identity } from './types.js';
 
@@ -14,11 +30,19 @@ export interface AttributionFields {
 }
 
 interface RequestLike {
-  // Headers is loosely-typed (string-keyed dict of unknown) so any
-  // Express-style Request structurally satisfies the contract. We
-  // only read `x-forwarded-for` from it, narrowing the value at the
-  // read site.
-  headers?: Record<string, unknown> | undefined;
+  /**
+   * Express's `trust proxy`-aware client IP. With trust-proxy unset,
+   * this is the direct TCP peer (forwarded headers are NOT considered).
+   * With trust-proxy configured, Express walks the forwarded chain
+   * from trusted hops only. We rely entirely on this resolution rather
+   * than parsing forwarded headers ourselves so spoofed headers from
+   * untrusted callers can't reach the audit field.
+   */
+  ip?: string | undefined;
+  /**
+   * Fallback raw socket address — used when `req.ip` is unavailable
+   * (e.g., synthetic/test contexts that don't go through Express).
+   */
   socket?: { remoteAddress?: string | null | undefined } | undefined;
 }
 
@@ -27,12 +51,12 @@ interface RequestLike {
  * `project_revisions` rows. Returns all-null when identity is null or
  * undefined (background paths that don't have identity in scope).
  *
- * When a request is provided, also resolves the source IP:
- *  1. The first comma-separated entry of `X-Forwarded-For` (the
- *     original client IP behind a reverse proxy).
- *  2. Falls back to `req.socket.remoteAddress` (the TCP peer; useful
- *     for direct-loopback callers like the desktop UI).
- *  3. Null when neither yields a string.
+ * When a request is provided, also resolves the source IP via
+ * `req.ip` (Express trust-proxy-aware) with a fallback to
+ * `req.socket.remoteAddress` for non-Express test contexts. Forwarded
+ * headers are NEVER parsed by this helper — the daemon-side
+ * `app.set('trust proxy', …)` config is the only path that lets a
+ * forwarded IP land in `req.ip`.
  *
  * For non-HTTP code paths (scheduler-fired routines, background
  * reconciliation), pass no req; source IP stays null.
@@ -53,11 +77,10 @@ export function attributionFromIdentity(
 
 function extractSourceIp(req?: RequestLike): string | null {
   if (!req) return null;
-  const xff = req.headers?.['x-forwarded-for'];
-  if (typeof xff === 'string') {
-    const first = xff.split(',')[0]?.trim();
-    if (first) return first;
-  }
+  // Express's trust-proxy-resolved client IP is the trusted answer.
+  if (typeof req.ip === 'string' && req.ip.length > 0) return req.ip;
+  // Fallback for synthetic test contexts (and defensive against
+  // Express versions that don't populate req.ip for some reason).
   const sock = req.socket?.remoteAddress;
   return typeof sock === 'string' && sock.length > 0 ? sock : null;
 }

--- a/apps/daemon/src/identity/attribution.ts
+++ b/apps/daemon/src/identity/attribution.ts
@@ -1,25 +1,16 @@
-// Helper that turns an Identity (plus optional request context) into the
-// flat {actorIdentityId, actorDisplayName, actorSourceIp} shape that
-// `upsertMessage` and the history feature's revision-recording paths
-// consume. Centralized so the source-IP resolution logic lives in one
-// place rather than getting copied at every call site.
+// Turns an Identity (plus optional request context) into the flat
+// {actorIdentityId, actorDisplayName, actorSourceIp} shape that
+// upsertMessage and the history feature's revision-recording paths
+// consume. Centralized so source-IP resolution lives in one place.
 //
-// SECURITY (P0-fix #15) — actor_source_ip is durable audit data; it
-// MUST be trustworthy. We no longer parse `X-Forwarded-For` directly
-// inside this helper. Instead the helper reads `req.ip`, which is
-// Express's `trust proxy`-aware resolved client IP:
-//   - With `app.set('trust proxy', false)` (the default): req.ip is
-//     `req.socket.remoteAddress`, regardless of any forwarded headers
-//     a direct client might send. Spoofed `X-Forwarded-For` values are
-//     ignored.
-//   - With `app.set('trust proxy', 'loopback' | <IP> | <CIDR> | N)`:
-//     Express resolves req.ip from the rightmost forwarded hop that
-//     comes from a trusted source.
-// The daemon's trust-proxy config is plumbed from `OD_TRUST_PROXY` at
-// startup (`apps/daemon/src/server.ts`); deployments fronted by a
-// reverse proxy (Tailscale Serve, nginx, Cloudflare Tunnel, …) MUST
-// set this env var to the proxy's identity for source IPs to reflect
-// the real client.
+// SECURITY — actor_source_ip is durable audit data; it MUST be
+// trustworthy. This helper reads `req.ip`, which is Express's
+// `trust proxy`-aware resolved client IP. With trust-proxy unset
+// (the default) req.ip is the raw socket peer and any forwarded
+// headers a direct caller sends are ignored. The daemon's
+// trust-proxy config is plumbed from `OD_TRUST_PROXY` at startup
+// (apps/daemon/src/server.ts); proxy-fronted deployments MUST set
+// it to the proxy's identity for source IPs to reflect the real client.
 
 import type { Identity } from './types.js';
 
@@ -32,34 +23,24 @@ export interface AttributionFields {
 interface RequestLike {
   /**
    * Express's `trust proxy`-aware client IP. With trust-proxy unset,
-   * this is the direct TCP peer (forwarded headers are NOT considered).
-   * With trust-proxy configured, Express walks the forwarded chain
-   * from trusted hops only. We rely entirely on this resolution rather
-   * than parsing forwarded headers ourselves so spoofed headers from
-   * untrusted callers can't reach the audit field.
+   * this is the direct TCP peer (forwarded headers NOT considered);
+   * with trust-proxy configured, Express walks the forwarded chain
+   * from trusted hops only.
    */
   ip?: string | undefined;
-  /**
-   * Fallback raw socket address — used when `req.ip` is unavailable
-   * (e.g., synthetic/test contexts that don't go through Express).
-   */
+  /** Fallback for synthetic/test contexts that bypass Express. */
   socket?: { remoteAddress?: string | null | undefined } | undefined;
 }
 
 /**
  * Derive flat attribution fields for storing on `messages` /
- * `project_revisions` rows. Returns all-null when identity is null or
- * undefined (background paths that don't have identity in scope).
+ * `project_revisions`. Returns all-null when identity is null
+ * (background paths without identity in scope).
  *
- * When a request is provided, also resolves the source IP via
- * `req.ip` (Express trust-proxy-aware) with a fallback to
- * `req.socket.remoteAddress` for non-Express test contexts. Forwarded
- * headers are NEVER parsed by this helper — the daemon-side
- * `app.set('trust proxy', …)` config is the only path that lets a
- * forwarded IP land in `req.ip`.
- *
- * For non-HTTP code paths (scheduler-fired routines, background
- * reconciliation), pass no req; source IP stays null.
+ * When a request is provided, also resolves source IP via `req.ip`
+ * with a fallback to `req.socket.remoteAddress`. Forwarded headers
+ * are NEVER parsed by this helper — `app.set('trust proxy', …)` is
+ * the only path that lets a forwarded IP land in `req.ip`.
  */
 export function attributionFromIdentity(
   identity: Identity | null | undefined,
@@ -77,7 +58,6 @@ export function attributionFromIdentity(
 
 function extractSourceIp(req?: RequestLike): string | null {
   if (!req) return null;
-  // Express's trust-proxy-resolved client IP is the trusted answer.
   if (typeof req.ip === 'string' && req.ip.length > 0) return req.ip;
   // Fallback for synthetic test contexts (and defensive against
   // Express versions that don't populate req.ip for some reason).

--- a/apps/daemon/src/identity/middleware.ts
+++ b/apps/daemon/src/identity/middleware.ts
@@ -1,0 +1,53 @@
+// Express middleware that resolves Identity once per request and attaches
+// it to `req.identity`. Consumers (chat-run lifecycle, message attribution,
+// post-run history commits) read through `req.identity` instead of
+// resolving from scratch.
+//
+// Identity is needed at multiple write boundaries during a single run
+// (message upsert, agent run start, post-run commit). Resolving once at
+// middleware time and propagating via the durable `run` object — which
+// outlives the HTTP request — avoids subtle "identity changed mid-run"
+// bugs and removes the need for AsyncLocalStorage (which the daemon
+// doesn't use anywhere else).
+
+import type { Request, RequestHandler } from 'express';
+import { resolveIdentity, type Identity } from './types.js';
+
+// Augment Express's Request interface so `req.identity` is typed
+// everywhere it's read. This is the daemon's only Request augmentation
+// today; co-locating it with the middleware that sets it keeps the
+// type and the assignment in one file.
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      /**
+       * Resolved Identity for this request. Populated by the identity
+       * middleware (apps/daemon/src/identity/middleware.ts) early in
+       * the middleware chain; undefined only if the middleware hasn't
+       * run yet (e.g., in a handler registered before the middleware
+       * was wired).
+       */
+      identity?: Identity;
+    }
+  }
+}
+
+/**
+ * Create the identity-resolution middleware. Resolves once per request,
+ * attaches the result to `req.identity`, and calls `next()` without
+ * blocking — identity resolution is fast (env-var reads only, today)
+ * and shouldn't fail.
+ *
+ * Pass an explicit env for tests; defaults to process.env in production.
+ * The factory pattern matches the daemon's other middleware-construction
+ * conventions and makes the middleware trivially mockable.
+ */
+export function createIdentityMiddleware(
+  env: NodeJS.ProcessEnv = process.env,
+): RequestHandler {
+  return (req: Request, _res, next) => {
+    req.identity = resolveIdentity(req, env);
+    next();
+  };
+}

--- a/apps/daemon/src/identity/middleware.ts
+++ b/apps/daemon/src/identity/middleware.ts
@@ -1,32 +1,25 @@
-// Express middleware that resolves Identity once per request and attaches
-// it to `req.identity`. Consumers (chat-run lifecycle, message attribution,
-// post-run history commits) read through `req.identity` instead of
-// resolving from scratch.
+// Express middleware that resolves Identity once per request and
+// attaches it to `req.identity`. Consumers (chat-run lifecycle,
+// message attribution, post-run history commits) read through
+// `req.identity` instead of resolving from scratch.
 //
-// Identity is needed at multiple write boundaries during a single run
-// (message upsert, agent run start, post-run commit). Resolving once at
-// middleware time and propagating via the durable `run` object — which
-// outlives the HTTP request — avoids subtle "identity changed mid-run"
-// bugs and removes the need for AsyncLocalStorage (which the daemon
-// doesn't use anywhere else).
+// Resolving once at middleware time and propagating via the durable
+// `run` object (which outlives the HTTP request) avoids subtle
+// "identity changed mid-run" bugs without needing AsyncLocalStorage.
 
 import type { Request, RequestHandler } from 'express';
 import { resolveIdentity, type Identity } from './types.js';
 
 // Augment Express's Request interface so `req.identity` is typed
-// everywhere it's read. This is the daemon's only Request augmentation
-// today; co-locating it with the middleware that sets it keeps the
-// type and the assignment in one file.
+// everywhere it's read. Co-located with the middleware that sets it.
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
     interface Request {
       /**
        * Resolved Identity for this request. Populated by the identity
-       * middleware (apps/daemon/src/identity/middleware.ts) early in
-       * the middleware chain; undefined only if the middleware hasn't
-       * run yet (e.g., in a handler registered before the middleware
-       * was wired).
+       * middleware; undefined only if the middleware hasn't run yet
+       * (e.g., a handler registered before the middleware was wired).
        */
       identity?: Identity;
     }
@@ -34,14 +27,11 @@ declare global {
 }
 
 /**
- * Create the identity-resolution middleware. Resolves once per request,
- * attaches the result to `req.identity`, and calls `next()` without
- * blocking — identity resolution is fast (env-var reads only, today)
- * and shouldn't fail.
+ * Create the identity-resolution middleware. Resolves once per
+ * request and attaches the result to `req.identity`. Identity
+ * resolution is fast (env-var reads only, today) and shouldn't fail.
  *
  * Pass an explicit env for tests; defaults to process.env in production.
- * The factory pattern matches the daemon's other middleware-construction
- * conventions and makes the middleware trivially mockable.
  */
 export function createIdentityMiddleware(
   env: NodeJS.ProcessEnv = process.env,

--- a/apps/daemon/src/identity/types.ts
+++ b/apps/daemon/src/identity/types.ts
@@ -1,25 +1,22 @@
 // Identity seam — minimal types and resolver for attributing chat runs
-// and revision history to "who initiated this." This module deliberately
-// stays small: it defines the contract (Identity, IdentityProvider,
-// resolveIdentity) and ships one default implementation
-// (LocalFallbackProvider) so the history feature gated by
-// OD_GIT_INTEGRATION_ENABLED can land without a separate identity layer.
+// and revision history to "who initiated this." Ships one default
+// implementation (LocalFallbackProvider) so the history feature can
+// land without a separate identity layer.
 //
-// A future multi-user-support feature will register richer providers
-// (OAuth, reverse-proxy header trust, etc.) ahead of the fallback by
-// extending REGISTERED_PROVIDERS or wiring a registerProvider helper.
-// Existing call sites continue to read through resolveIdentity(req)
-// unchanged when that happens.
+// A future multi-user feature will register richer providers (OAuth,
+// reverse-proxy header trust) ahead of the fallback. Existing call
+// sites continue to read through resolveIdentity(req) unchanged.
 
 /**
- * Resolved identity for an incoming request. Consumed by features that
- * need to attribute changes to a user — primarily the history feature
- * (commit author lines, `actor_*` columns on `messages`).
+ * Resolved identity for an incoming request. Consumed by features
+ * that need to attribute changes to a user — primarily the history
+ * feature (commit author lines, `actor_*` columns on `messages`).
  */
 export interface Identity {
   /**
-   * Stable, provider-prefixed (e.g., 'local:default', 'oauth:google:weston@...').
-   * Used as the durable key on `messages.actor_identity_id`.
+   * Stable, provider-prefixed (e.g., 'local:default',
+   * 'oauth:google:weston@…'). Used as the durable key on
+   * `messages.actor_identity_id`.
    */
   id: string;
   /** Human-readable name for UI chips and commit author lines. */
@@ -27,7 +24,7 @@ export interface Identity {
   /**
    * Optional; used for the git author email when present. Single-user
    * deployments often leave this unset and accept the synthetic
-   * `<id>@open-design.local` author email the history feature falls back to.
+   * `<id>@open-design.local` email the history feature falls back to.
    */
   email?: string;
   /**
@@ -38,9 +35,8 @@ export interface Identity {
 }
 
 /**
- * Structural subset of an Express Request we need to resolve identity —
- * kept minimal so providers can be tested without instantiating full
- * Request objects.
+ * Structural subset of an Express Request used by providers. Kept
+ * minimal so providers can be tested without full Request objects.
  */
 export interface RequestWithIdentityHeaders {
   headers?: {
@@ -55,9 +51,9 @@ export interface RequestWithIdentityHeaders {
 }
 
 /**
- * A provider attempts to resolve identity from a request. Returns null
- * if it can't (e.g., a header-trust provider sees no relevant headers),
- * letting the next provider in the registration order try.
+ * A provider attempts to resolve identity from a request. Returns
+ * null when it can't (e.g., header-trust provider sees no relevant
+ * headers), letting the next provider try.
  */
 export interface IdentityProvider {
   resolve(req: RequestWithIdentityHeaders, env?: NodeJS.ProcessEnv): Identity | null;
@@ -65,10 +61,9 @@ export interface IdentityProvider {
 
 /**
  * Last-resort provider — always returns a usable placeholder identity.
- * Single-user deployments (desktop, single-user self-hosted) end up here
- * by default; the OD_LOCAL_IDENTITY and OD_LOCAL_IDENTITY_EMAIL env vars
- * let an operator customize what's recorded for chat-run attribution and
- * commit author lines without needing a multi-user identity layer.
+ * Single-user deployments end up here by default; OD_LOCAL_IDENTITY
+ * and OD_LOCAL_IDENTITY_EMAIL customize what's recorded without
+ * needing a multi-user identity layer.
  */
 export const LocalFallbackProvider: IdentityProvider = {
   resolve(_req, env = process.env) {
@@ -86,9 +81,9 @@ export const LocalFallbackProvider: IdentityProvider = {
 };
 
 /**
- * Provider registration order. First match wins. LocalFallbackProvider
- * must remain the last entry so resolveIdentity always returns a valid
- * Identity. Multi-user features prepend richer providers here.
+ * Provider registration order. First match wins.
+ * LocalFallbackProvider MUST remain the last entry so resolveIdentity
+ * always returns a valid Identity.
  */
 const REGISTERED_PROVIDERS: IdentityProvider[] = [
   LocalFallbackProvider,
@@ -96,10 +91,8 @@ const REGISTERED_PROVIDERS: IdentityProvider[] = [
 
 /**
  * Resolve identity for a request. Tries each registered provider in
- * order; returns the first non-null result. Because LocalFallbackProvider
- * always returns non-null, this function always returns a valid Identity.
- *
- * Pass an explicit env for testing; defaults to process.env in production.
+ * order; returns the first non-null result. Always returns a valid
+ * Identity while LocalFallbackProvider is registered.
  */
 export function resolveIdentity(
   req: RequestWithIdentityHeaders,
@@ -109,7 +102,6 @@ export function resolveIdentity(
     const result = provider.resolve(req, env);
     if (result) return result;
   }
-  // Unreachable while LocalFallbackProvider is registered; the throw is a
-  // belt-and-suspenders guard against future re-orderings of the array.
+  // Belt-and-suspenders guard against future re-orderings.
   throw new Error('resolveIdentity: no provider matched (LocalFallbackProvider missing from registration)');
 }

--- a/apps/daemon/src/identity/types.ts
+++ b/apps/daemon/src/identity/types.ts
@@ -1,0 +1,115 @@
+// Identity seam — minimal types and resolver for attributing chat runs
+// and revision history to "who initiated this." This module deliberately
+// stays small: it defines the contract (Identity, IdentityProvider,
+// resolveIdentity) and ships one default implementation
+// (LocalFallbackProvider) so the history feature gated by
+// OD_GIT_INTEGRATION_ENABLED can land without a separate identity layer.
+//
+// A future multi-user-support feature will register richer providers
+// (OAuth, reverse-proxy header trust, etc.) ahead of the fallback by
+// extending REGISTERED_PROVIDERS or wiring a registerProvider helper.
+// Existing call sites continue to read through resolveIdentity(req)
+// unchanged when that happens.
+
+/**
+ * Resolved identity for an incoming request. Consumed by features that
+ * need to attribute changes to a user — primarily the history feature
+ * (commit author lines, `actor_*` columns on `messages`).
+ */
+export interface Identity {
+  /**
+   * Stable, provider-prefixed (e.g., 'local:default', 'oauth:google:weston@...').
+   * Used as the durable key on `messages.actor_identity_id`.
+   */
+  id: string;
+  /** Human-readable name for UI chips and commit author lines. */
+  displayName: string;
+  /**
+   * Optional; used for the git author email when present. Single-user
+   * deployments often leave this unset and accept the synthetic
+   * `<id>@open-design.local` author email the history feature falls back to.
+   */
+  email?: string;
+  /**
+   * Free-form provider tag for audit / UI badges
+   * (e.g., 'local-fallback', 'header:tailscale', 'oauth:google').
+   */
+  source: string;
+}
+
+/**
+ * Structural subset of an Express Request we need to resolve identity —
+ * kept minimal so providers can be tested without instantiating full
+ * Request objects.
+ */
+export interface RequestWithIdentityHeaders {
+  headers?: {
+    host?: unknown;
+    'x-forwarded-for'?: unknown;
+    'x-forwarded-host'?: unknown;
+    'x-forwarded-proto'?: unknown;
+  };
+  socket?: {
+    remoteAddress?: string | null | undefined;
+  };
+}
+
+/**
+ * A provider attempts to resolve identity from a request. Returns null
+ * if it can't (e.g., a header-trust provider sees no relevant headers),
+ * letting the next provider in the registration order try.
+ */
+export interface IdentityProvider {
+  resolve(req: RequestWithIdentityHeaders, env?: NodeJS.ProcessEnv): Identity | null;
+}
+
+/**
+ * Last-resort provider — always returns a usable placeholder identity.
+ * Single-user deployments (desktop, single-user self-hosted) end up here
+ * by default; the OD_LOCAL_IDENTITY and OD_LOCAL_IDENTITY_EMAIL env vars
+ * let an operator customize what's recorded for chat-run attribution and
+ * commit author lines without needing a multi-user identity layer.
+ */
+export const LocalFallbackProvider: IdentityProvider = {
+  resolve(_req, env = process.env) {
+    const displayName = (env.OD_LOCAL_IDENTITY ?? '').trim() || 'Local User';
+    const emailRaw = (env.OD_LOCAL_IDENTITY_EMAIL ?? '').trim();
+    // Conditional spread keeps `email` absent (not just undefined) when
+    // unset, so the type matches Identity under exactOptionalPropertyTypes.
+    return {
+      id: 'local:default',
+      displayName,
+      source: 'local-fallback',
+      ...(emailRaw.length > 0 ? { email: emailRaw } : {}),
+    };
+  },
+};
+
+/**
+ * Provider registration order. First match wins. LocalFallbackProvider
+ * must remain the last entry so resolveIdentity always returns a valid
+ * Identity. Multi-user features prepend richer providers here.
+ */
+const REGISTERED_PROVIDERS: IdentityProvider[] = [
+  LocalFallbackProvider,
+];
+
+/**
+ * Resolve identity for a request. Tries each registered provider in
+ * order; returns the first non-null result. Because LocalFallbackProvider
+ * always returns non-null, this function always returns a valid Identity.
+ *
+ * Pass an explicit env for testing; defaults to process.env in production.
+ */
+export function resolveIdentity(
+  req: RequestWithIdentityHeaders,
+  env: NodeJS.ProcessEnv = process.env,
+): Identity {
+  for (const provider of REGISTERED_PROVIDERS) {
+    const result = provider.resolve(req, env);
+    if (result) return result;
+  }
+  // Unreachable while LocalFallbackProvider is registered; the throw is a
+  // belt-and-suspenders guard against future re-orderings of the array.
+  throw new Error('resolveIdentity: no provider matched (LocalFallbackProvider missing from registration)');
+}

--- a/apps/daemon/src/identity/types.ts
+++ b/apps/daemon/src/identity/types.ts
@@ -65,12 +65,17 @@ export interface IdentityProvider {
  * and OD_LOCAL_IDENTITY_EMAIL customize what's recorded without
  * needing a multi-user identity layer.
  */
+// Strip control characters so env-supplied values can't smuggle newlines
+// or NULs into git author lines or SQLite text columns.
+function sanitizeIdentityField(raw: string): string {
+  // eslint-disable-next-line no-control-regex
+  return raw.replace(/[\x00-\x1f\x7f]/g, '').trim();
+}
+
 export const LocalFallbackProvider: IdentityProvider = {
   resolve(_req, env = process.env) {
-    const displayName = (env.OD_LOCAL_IDENTITY ?? '').trim() || 'Local User';
-    const emailRaw = (env.OD_LOCAL_IDENTITY_EMAIL ?? '').trim();
-    // Conditional spread keeps `email` absent (not just undefined) when
-    // unset, so the type matches Identity under exactOptionalPropertyTypes.
+    const displayName = sanitizeIdentityField(env.OD_LOCAL_IDENTITY ?? '') || 'Local User';
+    const emailRaw = sanitizeIdentityField(env.OD_LOCAL_IDENTITY_EMAIL ?? '');
     return {
       id: 'local:default',
       displayName,

--- a/apps/daemon/src/live-artifacts/refresh.ts
+++ b/apps/daemon/src/live-artifacts/refresh.ts
@@ -612,14 +612,18 @@ async function executeGitSummary(options: ExecuteLocalDaemonRefreshSourceOptions
   const input = options.source.input as GitSummaryInput;
   const maxCommits = optionalPositiveInteger(input.maxCommits, 'input.maxCommits', 10, 50);
   const dir = projectDir(options.projectsRoot, options.projectId);
-  const insideWorkTree = (await runGit(dir, ['rev-parse', '--is-inside-work-tree'], options.signal)).trim() === 'true';
+  // `git.summary` is a read-only probe — exit 128 carries a meaningful
+  // "no" (e.g., not a repo) and should not throw. Pass softFail128 on
+  // every sub-call so the probe semantics are preserved end-to-end.
+  const probeOpts = { softFail128: true } as const;
+  const insideWorkTree = (await runGit(dir, ['rev-parse', '--is-inside-work-tree'], options.signal, probeOpts)).trim() === 'true';
   if (!insideWorkTree) return asBoundedRefreshOutput({ toolName: 'git.summary', isRepository: false, branch: '', status: [], recentCommits: [], diffStat: [] });
 
   const [branch, status, recentCommits, diffStat] = await Promise.all([
-    runGit(dir, ['branch', '--show-current'], options.signal),
-    runGit(dir, ['status', '--short'], options.signal),
-    runGit(dir, ['log', `--max-count=${maxCommits}`, '--pretty=format:%h %s'], options.signal),
-    runGit(dir, ['diff', '--stat', '--', '.'], options.signal),
+    runGit(dir, ['branch', '--show-current'], options.signal, probeOpts),
+    runGit(dir, ['status', '--short'], options.signal, probeOpts),
+    runGit(dir, ['log', `--max-count=${maxCommits}`, '--pretty=format:%h %s'], options.signal, probeOpts),
+    runGit(dir, ['diff', '--stat', '--', '.'], options.signal, probeOpts),
   ]);
 
   return asBoundedRefreshOutput({

--- a/apps/daemon/src/live-artifacts/refresh.ts
+++ b/apps/daemon/src/live-artifacts/refresh.ts
@@ -1,13 +1,10 @@
-import { execFile } from 'node:child_process';
 import { lstat, readFile, realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
-import { promisify } from 'node:util';
 
+import { runGit } from '../git/exec.js';
 import { listFiles, projectDir, readProjectFile, validateProjectPath } from '../projects.js';
 import type { BoundedJsonObject, BoundedJsonValue, LiveArtifact, LiveArtifactRefreshSourceMetadata, LiveArtifactSource } from './schema.js';
 import { validateBoundedJsonObject } from './schema.js';
-
-const execFileAsync = promisify(execFile);
 
 export const DEFAULT_LIVE_ARTIFACT_SOURCE_TIMEOUT_MS = 30_000;
 export const DEFAULT_LIVE_ARTIFACT_TOTAL_TIMEOUT_MS = 120_000;
@@ -609,17 +606,6 @@ async function executeProjectFilesReadJson(options: ExecuteLocalDaemonRefreshSou
 
 function compactExecOutput(value: string): string[] {
   return value.split('\n').map((line) => line.trimEnd()).filter(Boolean).slice(0, 100);
-}
-
-async function runGit(projectPath: string, args: string[], signal: AbortSignal | undefined): Promise<string> {
-  try {
-    const result = await execFileAsync('git', args, { cwd: projectPath, signal, timeout: 10_000, maxBuffer: 128 * 1024 });
-    return result.stdout.toString();
-  } catch (error) {
-    const maybeError = error as { stdout?: string | Buffer; stderr?: string | Buffer; message?: string; code?: unknown };
-    if (maybeError.code === 128) return '';
-    throw new Error(maybeError.stderr?.toString().trim() || maybeError.message || 'git command failed');
-  }
 }
 
 async function executeGitSummary(options: ExecuteLocalDaemonRefreshSourceOptions): Promise<BoundedJsonObject> {

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -1,4 +1,6 @@
 import type { Express } from 'express';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
 import {
   defaultScenarioPluginIdForProjectMetadata,
   type PluginManifest,
@@ -271,7 +273,10 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       ) {
         const tpl = getTemplate(db, metadata.templateId);
         if (tpl && Array.isArray(tpl.files) && tpl.files.length > 0) {
-          await ensureProject(PROJECTS_DIR, id);
+          // Write seeds BEFORE triggering ensureProject so the
+          // history substrate's migration commit captures them
+          // rather than attributing them to a later agent run.
+          await mkdir(path.join(PROJECTS_DIR, id), { recursive: true });
           for (const f of tpl.files) {
             if (
               !f ||
@@ -286,12 +291,14 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
                 id,
                 f.name,
                 Buffer.from(f.content, 'utf8'),
+                { skipEnsureProject: true },
               );
             } catch {
               // Skip individual file failures — the template snapshot is
               // best-effort; the agent still has the embedded copy.
             }
           }
+          await ensureProject(PROJECTS_DIR, id);
         }
       }
       /** @type {import('@open-design/contracts').CreateProjectResponse} */

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -14,6 +14,7 @@ import {
   resolvePluginSnapshot,
 } from './plugins/index.js';
 import type { RouteDeps } from './server-context.js';
+import { attributionFromIdentity } from './identity/attribution.js';
 import { listSkills } from './skills.js';
 import { auditDesignSystemPackage } from './tools-connectors-cli.js';
 
@@ -534,6 +535,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
     const saved = upsertMessage(db, req.params.cid, {
       ...m,
       id: req.params.mid,
+      ...attributionFromIdentity(req.identity, req),
     });
     // Bump the parent project's updatedAt so the project list re-orders.
     updateProject(db, req.params.id, {});

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -298,7 +298,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
               // best-effort; the agent still has the embedded copy.
             }
           }
-          await ensureProject(PROJECTS_DIR, id);
+          await ensureProject(PROJECTS_DIR, id, projectMetadata);
         }
       }
       /** @type {import('@open-design/contracts').CreateProjectResponse} */

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -52,20 +52,15 @@ export function resolveProjectDir(projectsRoot, projectId, metadata?) {
 }
 
 // Optional post-ensure hook registered once at daemon startup. The
-// history feature (#1241) uses this to run `initProjectHistory` after
-// every ensureProject call without requiring callers (13+ across the
-// codebase) to thread DB / identity / repo paths through their args.
-// The hook is invoked after the directory exists; it must be idempotent
-// (ensureProject is called repeatedly throughout a project's lifetime)
-// and never throw — errors are best-effort logged by the hook itself,
-// not surfaced to the ensureProject caller. Null when no hook is wired.
+// history feature (#1241) uses this to run initProjectHistory after
+// every ensureProject call without threading DB / identity / repo
+// paths through the 13+ ensureProject call sites. Must be idempotent.
 let projectEnsuredHook = null;
 
 /**
  * Register a callback to run after every ensureProject call. Single
  * slot — subsequent calls overwrite. Hook errors propagate to
- * ensureProject's caller; the hook owns its own try/catch for any
- * non-fatal results it wants to swallow.
+ * ensureProject's caller; the hook owns its own try/catch.
  */
 export function setProjectEnsuredHook(hook) {
   projectEnsuredHook = hook;

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -62,9 +62,10 @@ export function resolveProjectDir(projectsRoot, projectId, metadata?) {
 let projectEnsuredHook = null;
 
 /**
- * Register a callback to run after every ensureProject call. Called once
- * at daemon startup by the history feature. Subsequent calls overwrite
- * the previous hook; pass null to detach (mainly for tests).
+ * Register a callback to run after every ensureProject call. Single
+ * slot — subsequent calls overwrite. Hook errors propagate to
+ * ensureProject's caller; the hook owns its own try/catch for any
+ * non-fatal results it wants to swallow.
  */
 export function setProjectEnsuredHook(hook) {
   projectEnsuredHook = hook;
@@ -77,14 +78,7 @@ export async function ensureProject(projectsRoot, projectId, metadata?) {
     await mkdir(dir, { recursive: true });
   }
   if (projectEnsuredHook) {
-    try {
-      await projectEnsuredHook({ projectsRoot, projectId, projectDir: dir, metadata });
-    } catch (err) {
-      // ensureProject's existing contract is "return the directory"; a
-      // hook failure must not break that. The hook is responsible for
-      // its own logging.
-      console.warn(`[projects] ensureProject hook failed for ${projectId}:`, err);
-    }
+    await projectEnsuredHook({ projectsRoot, projectId, projectDir: dir, metadata });
   }
   return dir;
 }

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -639,10 +639,17 @@ export async function writeProjectFile(
   projectId,
   name,
   body,
-  { overwrite = true, artifactManifest = null } = {},
+  { overwrite = true, artifactManifest = null, skipEnsureProject = false } = {},
   metadata?,
 ) {
-  const dir = await ensureProject(projectsRoot, projectId, metadata);
+  // skipEnsureProject lets seed-writing callers (template projects,
+  // plugin-share) write files BEFORE triggering the substrate-init
+  // hook, so the migration commit captures the seeds rather than
+  // attributing them to a later agent run. Caller takes responsibility
+  // for the project directory existing.
+  const dir = skipEnsureProject
+    ? resolveProjectDir(projectsRoot, projectId, metadata)
+    : await ensureProject(projectsRoot, projectId, metadata);
   const safeName = sanitizePath(name);
   const target = await resolveSafeReal(dir, safeName);
   if (!overwrite) {

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -51,11 +51,40 @@ export function resolveProjectDir(projectsRoot, projectId, metadata?) {
   return path.join(projectsRoot, projectId);
 }
 
+// Optional post-ensure hook registered once at daemon startup. The
+// history feature (#1241) uses this to run `initProjectHistory` after
+// every ensureProject call without requiring callers (13+ across the
+// codebase) to thread DB / identity / repo paths through their args.
+// The hook is invoked after the directory exists; it must be idempotent
+// (ensureProject is called repeatedly throughout a project's lifetime)
+// and never throw — errors are best-effort logged by the hook itself,
+// not surfaced to the ensureProject caller. Null when no hook is wired.
+let projectEnsuredHook = null;
+
+/**
+ * Register a callback to run after every ensureProject call. Called once
+ * at daemon startup by the history feature. Subsequent calls overwrite
+ * the previous hook; pass null to detach (mainly for tests).
+ */
+export function setProjectEnsuredHook(hook) {
+  projectEnsuredHook = hook;
+}
+
 export async function ensureProject(projectsRoot, projectId, metadata?) {
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   // Git-linked folders already exist; skip mkdir to avoid side-effects.
   if (typeof metadata?.baseDir !== 'string') {
     await mkdir(dir, { recursive: true });
+  }
+  if (projectEnsuredHook) {
+    try {
+      await projectEnsuredHook({ projectsRoot, projectId, projectDir: dir, metadata });
+    } catch (err) {
+      // ensureProject's existing contract is "return the directory"; a
+      // hook failure must not break that. The hook is responsible for
+      // its own logging.
+      console.warn(`[projects] ensureProject hook failed for ${projectId}:`, err);
+    }
   }
   return dir;
 }

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -140,6 +140,12 @@ export function createChatRunService({
       cancelRequested: false,
       touchedFiles: false,
       headAtCreate: null,
+      // History capture outcome — surfaces in statusBody so a successful
+      // run with a failed history write is visible (the hook fires
+      // fire-and-forget AFTER terminal broadcast, so a thrown error in
+      // recordRevisionForRun would otherwise be silently swallowed).
+      historyStatus: null,
+      historyError: null,
     };
     runs.set(run.id, run);
     if (runCreatedHook) {
@@ -191,6 +197,8 @@ export function createChatRunService({
     signal: run.signal,
     error: run.error ?? null,
     errorCode: run.errorCode ?? null,
+    historyStatus: run.historyStatus ?? null,
+    historyError: run.historyError ?? null,
   });
 
   const finish = (run, status, code: number | null = null, signal: string | null = null) => {

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -3,6 +3,14 @@ import { randomUUID } from 'node:crypto';
 
 export const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
 
+// Agent tool_use names that mutate the worktree. Sets run.touchedFiles
+// so the history hook can distinguish runs that dirtied files from
+// purely conversational runs when deciding whether to record a marker
+// for a sibling-absorbed concurrent run. Bash is excluded — it's
+// commonly used for read-only operations and would produce false
+// positives.
+const FILE_WRITE_TOOL_NAMES = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit']);
+
 function readString(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
@@ -97,6 +105,7 @@ export function createChatRunService({
       error: null,
       errorCode: null,
       cancelRequested: false,
+      touchedFiles: false,
     };
     runs.set(run.id, run);
     return run;
@@ -115,6 +124,9 @@ export function createChatRunService({
       const details = extractErrorDetails(data);
       if (details.error) run.error = details.error;
       if (details.errorCode) run.errorCode = details.errorCode;
+    }
+    if (event === 'tool_use' && data && typeof data.name === 'string' && FILE_WRITE_TOOL_NAMES.has(data.name)) {
+      run.touchedFiles = true;
     }
     const id = run.nextEventId++;
     const record = { id, event, data, timestamp: Date.now() };

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -3,13 +3,23 @@ import { randomUUID } from 'node:crypto';
 
 export const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
 
-// Agent tool_use names that mutate the worktree. Sets run.touchedFiles
-// so the history hook can distinguish runs that dirtied files from
-// purely conversational runs when deciding whether to record a marker
-// for a sibling-absorbed concurrent run. Bash is excluded — it's
-// commonly used for read-only operations and would produce false
-// positives.
-const FILE_WRITE_TOOL_NAMES = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit']);
+// Tool names (case-insensitive) that MAY mutate the worktree. Bash is
+// included because a Bash run that writes via shell (mv/cp/redirect)
+// losing marker provenance is worse than a Bash-reads-only run getting
+// a false-positive marker. Lowercase here because adapters disagree:
+// claude-stream emits "Bash", pi-rpc emits "bash".
+const FILE_WRITE_TOOL_NAMES = new Set(['write', 'edit', 'multiedit', 'notebookedit', 'bash']);
+
+function toolUseNameFromEvent(event: string, data: any): string | null {
+  if (!data) return null;
+  // Direct emit (some test paths and internal call sites):
+  //   emit(run, 'tool_use', { id, name, input })
+  if (event === 'tool_use' && typeof data.name === 'string') return data.name;
+  // Production agent-event wrapper (server.ts send('agent', ev), where
+  // ev is the typed adapter event including { type: 'tool_use', name }):
+  if (event === 'agent' && data.type === 'tool_use' && typeof data.name === 'string') return data.name;
+  return null;
+}
 
 function readString(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
@@ -125,7 +135,8 @@ export function createChatRunService({
       if (details.error) run.error = details.error;
       if (details.errorCode) run.errorCode = details.errorCode;
     }
-    if (event === 'tool_use' && data && typeof data.name === 'string' && FILE_WRITE_TOOL_NAMES.has(data.name)) {
+    const toolName = toolUseNameFromEvent(event, data);
+    if (toolName && FILE_WRITE_TOOL_NAMES.has(toolName.toLowerCase())) {
       run.touchedFiles = true;
     }
     const id = run.nextEventId++;

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -28,10 +28,20 @@ export function createChatRunService({
   // Optional fire-and-forget hook fired when a run reaches a terminal
   // state via finish(). Used by the history feature (#1241) to record
   // a revision when the working tree is dirty at run end. The hook's
-  // Promise is intentionally not awaited — finish()'s contract is
-  // synchronous (closes SSE clients, schedules cleanup) and a slow or
-  // failing hook must not block that path.
+  // Promise is intentionally not awaited from finish() — finish()'s
+  // contract is synchronous (closes SSE clients, schedules cleanup)
+  // and a slow or failing hook must not block that path. BUT the
+  // promise is tracked in `pendingFinishHooks` so shutdownActive() can
+  // await pending hooks before the daemon exits — otherwise a SIGTERM
+  // during a run can race the auto-commit and drop the revision row.
   let runFinishedHook = null;
+
+  /**
+   * Pending finish-hook promises. Each finish() call that fires a
+   * hook adds the promise here and removes it on settle. shutdownActive()
+   * awaits all of them so the process doesn't exit mid-write.
+   */
+  const pendingFinishHooks = new Set();
 
   /**
    * Register a callback to run after every run.finish(). Pass null to
@@ -144,14 +154,19 @@ export function createChatRunService({
     for (const waiter of run.waiters) waiter(statusBody(run));
     run.waiters.clear();
     scheduleCleanup(run);
-    // Fire-and-forget — the history feature uses this to commit any
+    // Fire-but-track — the history feature uses this to commit any
     // dirty working-tree changes the run produced. Errors are logged
     // by the hook itself; finish()'s contract stays synchronous so
     // late callers (cleanup, status polling) aren't blocked on git.
+    // The promise is added to pendingFinishHooks so shutdownActive()
+    // can wait for in-flight hooks before the daemon exits — without
+    // this tracking, a SIGTERM mid-hook drops the revision row.
     if (runFinishedHook) {
-      Promise.resolve(runFinishedHook(run, status)).catch((err) => {
+      const hookPromise = Promise.resolve(runFinishedHook(run, status)).catch((err) => {
         console.warn(`[runs] finished hook failed for run ${run.id}:`, err);
       });
+      pendingFinishHooks.add(hookPromise);
+      hookPromise.finally(() => pendingFinishHooks.delete(hookPromise));
     }
   };
 
@@ -274,6 +289,34 @@ export function createChatRunService({
         await waitForChildExit(run.child, 500);
       }
     }));
+
+    // Wait for any in-flight finish-hooks before returning, so the
+    // daemon doesn't `process.exit()` mid-write. The hooks run
+    // independently of the run's child-process lifecycle (they were
+    // fired synchronously by `finish()` above but execute async — the
+    // history auto-commit does multiple git invocations + a SQLite
+    // write), and without this await the SIGTERM path is racy with
+    // the revision-row insert.
+    //
+    // We cap the wait at 2× graceMs so a stuck hook doesn't hang
+    // shutdown indefinitely. The cap is generous: graceMs is sized
+    // for the slowest child to exit, and the hook is typically
+    // faster (no LLM round-trip, just local fs + sqlite).
+    if (pendingFinishHooks.size > 0) {
+      const inflight = Array.from(pendingFinishHooks);
+      const hookGraceMs = Math.max(graceMs * 2, 1000);
+      let timeoutHandle;
+      const timeoutPromise = new Promise((resolve) => {
+        timeoutHandle = setTimeout(resolve, hookGraceMs);
+      });
+      await Promise.race([Promise.allSettled(inflight), timeoutPromise]);
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      if (pendingFinishHooks.size > 0) {
+        console.warn(
+          `[runs] shutdownActive returning with ${pendingFinishHooks.size} finish-hook(s) still in flight after ${hookGraceMs}ms grace; their writes may be lost.`,
+        );
+      }
+    }
   };
 
   const wait = (run) => {

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -3,20 +3,18 @@ import { randomUUID } from 'node:crypto';
 
 export const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
 
-// Tool names (case-insensitive) that MAY mutate the worktree. Bash is
-// included because a Bash run that writes via shell (mv/cp/redirect)
-// losing marker provenance is worse than a Bash-reads-only run getting
-// a false-positive marker. Lowercase here because adapters disagree:
-// claude-stream emits "Bash", pi-rpc emits "bash".
+// Tool names (lowercase) that MAY mutate the worktree. Bash is
+// included: losing marker provenance for a Bash run that wrote via
+// shell (mv/cp/redirect) is worse than a Bash-reads-only run getting
+// a false marker. Adapters disagree on casing (claude-stream emits
+// "Bash", pi-rpc emits "bash") — caller lowercases before lookup.
 const FILE_WRITE_TOOL_NAMES = new Set(['write', 'edit', 'multiedit', 'notebookedit', 'bash']);
 
 function toolUseNameFromEvent(event: string, data: any): string | null {
   if (!data) return null;
-  // Direct emit (some test paths and internal call sites):
-  //   emit(run, 'tool_use', { id, name, input })
+  // Direct emit shape: emit(run, 'tool_use', { id, name, input }).
   if (event === 'tool_use' && typeof data.name === 'string') return data.name;
-  // Production agent-event wrapper (server.ts send('agent', ev), where
-  // ev is the typed adapter event including { type: 'tool_use', name }):
+  // Production agent-event wrapper: send('agent', { type: 'tool_use', name, ... }).
   if (event === 'agent' && data.type === 'tool_use' && typeof data.name === 'string') return data.name;
   return null;
 }
@@ -44,27 +42,15 @@ export function createChatRunService({
   const runs = new Map();
 
   // Optional fire-and-forget hook fired when a run reaches a terminal
-  // state via finish(). Used by the history feature (#1241) to record
-  // a revision when the working tree is dirty at run end. The hook's
-  // Promise is intentionally not awaited from finish() — finish()'s
-  // contract is synchronous (closes SSE clients, schedules cleanup)
-  // and a slow or failing hook must not block that path. BUT the
-  // promise is tracked in `pendingFinishHooks` so shutdownActive() can
-  // await pending hooks before the daemon exits — otherwise a SIGTERM
-  // during a run can race the auto-commit and drop the revision row.
+  // state. The hook's promise is not awaited from finish() — finish()'s
+  // contract is synchronous (closes SSE clients, schedules cleanup) —
+  // but is tracked in `pendingFinishHooks` so shutdownActive() can wait
+  // for them before exit. Without that wait, a SIGTERM during a run
+  // can race the auto-commit and drop the revision row.
   let runFinishedHook = null;
-
-  /**
-   * Pending finish-hook promises. Each finish() call that fires a
-   * hook adds the promise here and removes it on settle. shutdownActive()
-   * awaits all of them so the process doesn't exit mid-write.
-   */
   const pendingFinishHooks = new Set();
 
-  /**
-   * Register a callback to run after every run.finish(). Pass null to
-   * detach. Single-slot — subsequent calls overwrite.
-   */
+  /** Register a callback to run after every run.finish(). Single-slot. */
   const setRunFinishedHook = (hook) => {
     runFinishedHook = hook;
   };
@@ -89,16 +75,13 @@ export function createChatRunService({
           : null,
       pluginId:
         typeof meta.pluginId === 'string' && meta.pluginId ? meta.pluginId : null,
-      // Resolved Identity for the user/context that initiated this run.
-      // Populated by callers from `req.identity` (set by the identity
-      // middleware). Stored on the run so it remains available across
-      // the async run lifecycle (message upsert, post-run history
-      // commit), which outlives the HTTP request.
+      // Resolved Identity (from req.identity at create time). Stored
+      // on the run so it survives the async lifecycle (message upsert,
+      // post-run history commit) past the HTTP request.
       identity: meta.identity && typeof meta.identity === 'object' ? meta.identity : null,
-      // User prompt that initiated this run. Captured at create time
-      // so the post-run history commit hook can derive a commit
-      // message from it without re-querying the messages table at
-      // commit-time (which would race with concurrent runs on the
+      // User prompt captured at create time so the post-run history
+      // commit hook can derive a commit message without re-querying
+      // the messages table (which would race concurrent runs on the
       // same conversation).
       message: typeof meta.message === 'string' ? meta.message : null,
       status: 'queued',
@@ -177,13 +160,9 @@ export function createChatRunService({
     for (const waiter of run.waiters) waiter(statusBody(run));
     run.waiters.clear();
     scheduleCleanup(run);
-    // Fire-but-track — the history feature uses this to commit any
-    // dirty working-tree changes the run produced. Errors are logged
-    // by the hook itself; finish()'s contract stays synchronous so
-    // late callers (cleanup, status polling) aren't blocked on git.
-    // The promise is added to pendingFinishHooks so shutdownActive()
-    // can wait for in-flight hooks before the daemon exits — without
-    // this tracking, a SIGTERM mid-hook drops the revision row.
+    // Fire-but-track: history auto-commit runs asynchronously without
+    // blocking finish(), but the promise is tracked so shutdownActive
+    // can wait for it before the daemon exits.
     if (runFinishedHook) {
       const hookPromise = Promise.resolve(runFinishedHook(run, status)).catch((err) => {
         console.warn(`[runs] finished hook failed for run ${run.id}:`, err);
@@ -306,16 +285,10 @@ export function createChatRunService({
         }
       }
       killChild(run, 'SIGTERM');
-      // Wait for the child to fully exit BEFORE calling finish() —
-      // finish() fires the runFinishedHook, which (in the history
-      // feature) does `git status / add / commit` against the
-      // worktree. If finish() ran before the child exit completed,
-      // a child handling SIGTERM gracefully (flushing files to
-      // disk) could write its last changes AFTER the hook's
-      // git-status snapshot, leaving those files uncommitted and
-      // dropping the final auto-commit. Reordering ensures the
-      // worktree is in its final, post-child-exit state when the
-      // hook reads it.
+      // Wait for the child to fully exit BEFORE calling finish(). A
+      // child handling SIGTERM gracefully (flushing files to disk)
+      // can write its final changes after the runFinishedHook's
+      // git-status snapshot otherwise, leaving them uncommitted.
       if (run.child && !(await waitForChildExit(run.child, graceMs))) {
         killChild(run, 'SIGKILL');
         await waitForChildExit(run.child, 500);
@@ -323,18 +296,9 @@ export function createChatRunService({
       finish(run, 'canceled', null, 'SIGTERM');
     }));
 
-    // Wait for any in-flight finish-hooks before returning, so the
-    // daemon doesn't `process.exit()` mid-write. The hooks run
-    // independently of the run's child-process lifecycle (they were
-    // fired synchronously by `finish()` above but execute async — the
-    // history auto-commit does multiple git invocations + a SQLite
-    // write), and without this await the SIGTERM path is racy with
-    // the revision-row insert.
-    //
-    // We cap the wait at 2× graceMs so a stuck hook doesn't hang
-    // shutdown indefinitely. The cap is generous: graceMs is sized
-    // for the slowest child to exit, and the hook is typically
-    // faster (no LLM round-trip, just local fs + sqlite).
+    // Wait for in-flight finish-hooks (history auto-commit does git +
+    // sqlite writes) so the daemon doesn't process.exit() mid-write.
+    // Cap at 2× graceMs so a stuck hook doesn't hang shutdown.
     if (pendingFinishHooks.size > 0) {
       const inflight = Array.from(pendingFinishHooks);
       const hookGraceMs = Math.max(graceMs * 2, 1000);

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -3,20 +3,47 @@ import { randomUUID } from 'node:crypto';
 
 export const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
 
-// Tool names (lowercase) that MAY mutate the worktree. Bash is
-// included: losing marker provenance for a Bash run that wrote via
-// shell (mv/cp/redirect) is worse than a Bash-reads-only run getting
-// a false marker. Adapters disagree on casing (claude-stream emits
-// "Bash", pi-rpc emits "bash") — caller lowercases before lookup.
-const FILE_WRITE_TOOL_NAMES = new Set(['write', 'edit', 'multiedit', 'notebookedit', 'bash']);
+// Denylist of tools known to be read-only. Anything else flips
+// touchedFiles. Bias is toward "may have written" — missing a real
+// commit is harder to recover than recording a marker revision.
+const READ_ONLY_TOOL_NAMES = new Set([
+  'read', 'grep', 'glob', 'ls', 'list',
+  'websearch', 'web_search', 'webfetch', 'web_fetch',
+  'todoread', 'todowrite',
+  'askuserquestion',
+]);
+
+// Codex emits file mutations as item.completed events with these types.
+// json-event-stream.ts only translates command_execution → Bash and
+// agent_message → text_delta; everything else flows through as the
+// 'agent' event with the raw item attached.
+const CODEX_WRITE_ITEM_TYPES = new Set([
+  'patch_apply', 'apply_patch', 'file_change', 'file_write', 'write_file', 'edit',
+]);
 
 function toolUseNameFromEvent(event: string, data: any): string | null {
   if (!data) return null;
-  // Direct emit shape: emit(run, 'tool_use', { id, name, input }).
   if (event === 'tool_use' && typeof data.name === 'string') return data.name;
-  // Production agent-event wrapper: send('agent', { type: 'tool_use', name, ... }).
   if (event === 'agent' && data.type === 'tool_use' && typeof data.name === 'string') return data.name;
   return null;
+}
+
+function isFileWriteEvidence(event: string, data: any): boolean {
+  const toolName = toolUseNameFromEvent(event, data);
+  if (toolName) return !READ_ONLY_TOOL_NAMES.has(toolName.toLowerCase());
+
+  if (event === 'agent' && data && typeof data === 'object') {
+    const phase = data.type;
+    if (phase === 'item.started' || phase === 'item.completed') {
+      const itemType = data?.item?.type;
+      if (typeof itemType === 'string') {
+        const lc = itemType.toLowerCase();
+        if (CODEX_WRITE_ITEM_TYPES.has(lc)) return true;
+        if (/patch|apply|file_change|write_file|file_write/.test(lc)) return true;
+      }
+    }
+  }
+  return false;
 }
 
 function readString(value) {
@@ -118,10 +145,7 @@ export function createChatRunService({
       if (details.error) run.error = details.error;
       if (details.errorCode) run.errorCode = details.errorCode;
     }
-    const toolName = toolUseNameFromEvent(event, data);
-    if (toolName && FILE_WRITE_TOOL_NAMES.has(toolName.toLowerCase())) {
-      run.touchedFiles = true;
-    }
+    if (isFileWriteEvidence(event, data)) run.touchedFiles = true;
     const id = run.nextEventId++;
     const record = { id, event, data, timestamp: Date.now() };
     run.events.push(record);

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -45,6 +45,12 @@ export function createChatRunService({
           : null,
       pluginId:
         typeof meta.pluginId === 'string' && meta.pluginId ? meta.pluginId : null,
+      // Resolved Identity for the user/context that initiated this run.
+      // Populated by callers from `req.identity` (set by the identity
+      // middleware). Stored on the run so it remains available across
+      // the async run lifecycle (message upsert, post-run history
+      // commit), which outlives the HTTP request.
+      identity: meta.identity && typeof meta.identity === 'object' ? meta.identity : null,
       status: 'queued',
       createdAt: now,
       updatedAt: now,

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -25,6 +25,22 @@ export function createChatRunService({
 }) {
   const runs = new Map();
 
+  // Optional fire-and-forget hook fired when a run reaches a terminal
+  // state via finish(). Used by the history feature (#1241) to record
+  // a revision when the working tree is dirty at run end. The hook's
+  // Promise is intentionally not awaited — finish()'s contract is
+  // synchronous (closes SSE clients, schedules cleanup) and a slow or
+  // failing hook must not block that path.
+  let runFinishedHook = null;
+
+  /**
+   * Register a callback to run after every run.finish(). Pass null to
+   * detach. Single-slot — subsequent calls overwrite.
+   */
+  const setRunFinishedHook = (hook) => {
+    runFinishedHook = hook;
+  };
+
   const create = (meta = {}) => {
     const now = Date.now();
     const run = {
@@ -51,6 +67,12 @@ export function createChatRunService({
       // the async run lifecycle (message upsert, post-run history
       // commit), which outlives the HTTP request.
       identity: meta.identity && typeof meta.identity === 'object' ? meta.identity : null,
+      // User prompt that initiated this run. Captured at create time
+      // so the post-run history commit hook can derive a commit
+      // message from it without re-querying the messages table at
+      // commit-time (which would race with concurrent runs on the
+      // same conversation).
+      message: typeof meta.message === 'string' ? meta.message : null,
       status: 'queued',
       createdAt: now,
       updatedAt: now,
@@ -122,6 +144,15 @@ export function createChatRunService({
     for (const waiter of run.waiters) waiter(statusBody(run));
     run.waiters.clear();
     scheduleCleanup(run);
+    // Fire-and-forget — the history feature uses this to commit any
+    // dirty working-tree changes the run produced. Errors are logged
+    // by the hook itself; finish()'s contract stays synchronous so
+    // late callers (cleanup, status polling) aren't blocked on git.
+    if (runFinishedHook) {
+      Promise.resolve(runFinishedHook(run, status)).catch((err) => {
+        console.warn(`[runs] finished hook failed for run ${run.id}:`, err);
+      });
+    }
   };
 
   const fail = (run, code, message, init = {}) => {
@@ -263,6 +294,7 @@ export function createChatRunService({
     finish,
     fail,
     statusBody,
+    setRunFinishedHook,
     isTerminal(status) {
       return TERMINAL_RUN_STATUSES.has(status);
     },

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -283,11 +283,21 @@ export function createChatRunService({
         }
       }
       killChild(run, 'SIGTERM');
-      finish(run, 'canceled', null, 'SIGTERM');
+      // Wait for the child to fully exit BEFORE calling finish() —
+      // finish() fires the runFinishedHook, which (in the history
+      // feature) does `git status / add / commit` against the
+      // worktree. If finish() ran before the child exit completed,
+      // a child handling SIGTERM gracefully (flushing files to
+      // disk) could write its last changes AFTER the hook's
+      // git-status snapshot, leaving those files uncommitted and
+      // dropping the final auto-commit. Reordering ensures the
+      // worktree is in its final, post-child-exit state when the
+      // hook reads it.
       if (run.child && !(await waitForChildExit(run.child, graceMs))) {
         killChild(run, 'SIGKILL');
         await waitForChildExit(run.child, 500);
       }
+      finish(run, 'canceled', null, 'SIGTERM');
     }));
 
     // Wait for any in-flight finish-hooks before returning, so the

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -82,6 +82,19 @@ export function createChatRunService({
     runFinishedHook = hook;
   };
 
+  // Symmetric hook fired right after create(). Lets the history feature
+  // stamp `run.headAtCreate` from a synchronous HEAD read so the marker
+  // check has a baseline that pre-dates any sibling's finish-hook
+  // commit. Tracked in `pendingCreateHooks` so shutdownActive() can
+  // await any in-flight baseline reads.
+  let runCreatedHook = null;
+  const pendingCreateHooks = new Set();
+
+  /** Register a callback to run after every runs.create(). Single-slot. */
+  const setRunCreatedHook = (hook) => {
+    runCreatedHook = hook;
+  };
+
   const create = (meta = {}) => {
     const now = Date.now();
     const run = {
@@ -126,8 +139,16 @@ export function createChatRunService({
       errorCode: null,
       cancelRequested: false,
       touchedFiles: false,
+      headAtCreate: null,
     };
     runs.set(run.id, run);
+    if (runCreatedHook) {
+      const hookPromise = Promise.resolve(runCreatedHook(run)).catch((err) => {
+        console.warn(`[runs] created hook failed for run ${run.id}:`, err);
+      });
+      pendingCreateHooks.add(hookPromise);
+      hookPromise.finally(() => pendingCreateHooks.delete(hookPromise));
+    }
     return run;
   };
 
@@ -321,20 +342,26 @@ export function createChatRunService({
     }));
 
     // Wait for in-flight finish-hooks (history auto-commit does git +
-    // sqlite writes) so the daemon doesn't process.exit() mid-write.
-    // Cap at 2× graceMs so a stuck hook doesn't hang shutdown.
-    if (pendingFinishHooks.size > 0) {
-      const inflight = Array.from(pendingFinishHooks);
+    // sqlite writes) and any still-pending create-hooks (HEAD baseline
+    // reads) so the daemon doesn't process.exit() mid-write. Cap at 2×
+    // graceMs so a stuck hook doesn't hang shutdown.
+    const inflightHooks = [
+      ...Array.from(pendingFinishHooks),
+      ...Array.from(pendingCreateHooks),
+    ];
+    if (inflightHooks.length > 0) {
       const hookGraceMs = Math.max(graceMs * 2, 1000);
       let timeoutHandle;
       const timeoutPromise = new Promise((resolve) => {
         timeoutHandle = setTimeout(resolve, hookGraceMs);
       });
-      await Promise.race([Promise.allSettled(inflight), timeoutPromise]);
+      await Promise.race([Promise.allSettled(inflightHooks), timeoutPromise]);
       if (timeoutHandle) clearTimeout(timeoutHandle);
-      if (pendingFinishHooks.size > 0) {
+      const stillFinish = pendingFinishHooks.size;
+      const stillCreate = pendingCreateHooks.size;
+      if (stillFinish > 0 || stillCreate > 0) {
         console.warn(
-          `[runs] shutdownActive returning with ${pendingFinishHooks.size} finish-hook(s) still in flight after ${hookGraceMs}ms grace; their writes may be lost.`,
+          `[runs] shutdownActive returning with ${stillFinish} finish-hook(s) and ${stillCreate} create-hook(s) still in flight after ${hookGraceMs}ms grace; their writes may be lost.`,
         );
       }
     }
@@ -359,6 +386,7 @@ export function createChatRunService({
     fail,
     statusBody,
     setRunFinishedHook,
+    setRunCreatedHook,
     isTerminal(status) {
       return TERMINAL_RUN_STATUSES.has(status);
     },

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -390,6 +390,7 @@ import { configureComposioConfigStore } from './connectors/composio-config.js';
 import { CHAT_TOOL_ENDPOINTS, CHAT_TOOL_OPERATIONS, toolTokenRegistry } from './tool-tokens.js';
 import { createIdentityMiddleware } from './identity/middleware.js';
 import { resolveIdentity } from './identity/types.js';
+import { installHistoryEnsureHook } from './history/ensure-hook.js';
 import {
   aggregateCloudflarePagesStatus,
   buildDeployFileSet,
@@ -1224,6 +1225,10 @@ const ARTIFACTS_DIR = path.join(RUNTIME_DATA_DIR, 'artifacts');
 // read path so project-membership, size, and CSP guards cannot be bypassed.
 const CRITIQUE_ARTIFACTS_DIR = path.join(RUNTIME_DATA_DIR, 'critique-artifacts');
 const PROJECTS_DIR = path.join(RUNTIME_DATA_DIR, 'projects');
+// Per-project gitdirs for the history feature (#1241). Sibling to
+// PROJECTS_DIR so backup stories that already cover OD_DATA_DIR pick
+// it up transparently. Only used when OD_GIT_INTEGRATION_ENABLED is on.
+const REPOS_DIR = path.join(RUNTIME_DATA_DIR, 'repos');
 const USER_SKILLS_DIR = path.join(RUNTIME_DATA_DIR, 'skills');
 const USER_DESIGN_SYSTEMS_DIR = path.join(RUNTIME_DATA_DIR, 'design-systems');
 const PLUGIN_REGISTRY_ROOTS = registryRootsForDataDir(RUNTIME_DATA_DIR);
@@ -3509,6 +3514,11 @@ export async function startServer({
   projectMetadataLookup = (id) => {
     try { return getProject(db, id)?.metadata ?? null; } catch { return null; }
   };
+  // Register the history feature's post-ensure hook. No-op when
+  // OD_GIT_INTEGRATION_ENABLED is unset; otherwise auto-initializes
+  // the substrate (git init + initial migration commit) on first
+  // ensure for each project. Idempotent across subsequent ensures.
+  installHistoryEnsureHook({ db, reposRoot: REPOS_DIR });
   configureConnectorCredentialStore(new FileConnectorCredentialStore(RUNTIME_DATA_DIR));
   configureComposioConfigStore(RUNTIME_DATA_DIR);
   composioConnectorProvider.configureCatalogCache(RUNTIME_DATA_DIR);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -388,6 +388,8 @@ import { configureConnectorCredentialStore, ConnectorServiceError, FileConnector
 import { composioConnectorProvider } from './connectors/composio.js';
 import { configureComposioConfigStore } from './connectors/composio-config.js';
 import { CHAT_TOOL_ENDPOINTS, CHAT_TOOL_OPERATIONS, toolTokenRegistry } from './tool-tokens.js';
+import { createIdentityMiddleware } from './identity/middleware.js';
+import { resolveIdentity } from './identity/types.js';
 import {
   aggregateCloudflarePagesStatus,
   buildDeployFileSet,
@@ -3204,6 +3206,15 @@ export async function startServer({
       return next();
     });
   }
+
+  // Identity middleware — resolves req.identity once per request via
+  // the identity seam in apps/daemon/src/identity/types.ts. Today's
+  // LocalFallbackProvider returns a configurable placeholder; future
+  // multi-user-support work registers richer providers ahead of it.
+  // Consumers (chat-run lifecycle, message attribution) read identity
+  // from req.identity rather than resolving from scratch — see the spec
+  // for #1241 for the durable-on-run propagation rationale.
+  app.use(createIdentityMiddleware());
 
   // Multi-directory scanning shared by every skill / template surface. The
   // helpers delegate to listSkills(roots) which walks roots in priority
@@ -11111,6 +11122,7 @@ export async function startServer({
       assistantMessageId,
       clientRequestId: `orbit-${trigger}-${randomUUID()}`,
       agentId,
+      identity: req.identity,
     });
     upsertMessage(db, conversationId, {
       id: `orbit-user-${run.id}`,
@@ -11269,7 +11281,7 @@ export async function startServer({
         resolvedSnapshot = resolved;
       }
     }
-    const meta = { ...(req.body || {}) };
+    const meta = { ...(req.body || {}), identity: req.identity };
     if (resolvedSnapshot?.ok) {
       meta.appliedPluginSnapshotId = resolvedSnapshot.snapshotId;
       if (!meta.pluginId) meta.pluginId = resolvedSnapshot.snapshot.pluginId;
@@ -11589,7 +11601,7 @@ export async function startServer({
     if (daemonShuttingDown) {
       return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', 'daemon is shutting down');
     }
-    const run = design.runs.create();
+    const run = design.runs.create({ identity: req.identity });
     design.runs.stream(run, req, res);
     design.runs.start(run, () => startChatRun(req.body || {}, run));
   });
@@ -11723,6 +11735,13 @@ export async function startServer({
       assistantMessageId,
       clientRequestId: `routine-${trigger}-${randomUUID()}`,
       agentId,
+      // Routines fire from the scheduler, not from an HTTP request, so
+      // there's no req.identity to forward. Use the env-driven identity
+      // fallback so the run still has an attributable Identity (the
+      // local user under LocalFallbackProvider). When a future
+      // multi-user feature captures the routine creator's identity at
+      // creation time, this site reads from the routine record instead.
+      identity: resolveIdentity({}),
       ...(resolvedRoutineSnapshot?.ok
         ? {
             appliedPluginSnapshotId: resolvedRoutineSnapshot.snapshotId,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9716,18 +9716,19 @@ export async function startServer({
     let cwd = null;
     let existingProjectFiles = [];
     if (typeof projectId === 'string' && projectId) {
-      try {
-        const chatProject = getProject(db, projectId);
-        const chatMeta = chatProject?.metadata;
-        if (chatMeta?.baseDir) {
-          cwd = path.normalize(chatMeta.baseDir);
-          existingProjectFiles = await listFiles(PROJECTS_DIR, projectId, { metadata: chatMeta });
-        } else {
-          cwd = await ensureProject(PROJECTS_DIR, projectId);
-          existingProjectFiles = await listFiles(PROJECTS_DIR, projectId);
-        }
-      } catch {
-        cwd = null;
+      // Errors from ensureProject (incl. history init failures when
+      // OD_GIT_INTEGRATION_ENABLED is on) propagate up — `runs.start`
+      // catches and marks the run failed, surfacing a clear cause.
+      // Pre-#16 a bare catch silently set cwd=null, leaving the run
+      // running in an inherited dir and hiding init breakage.
+      const chatProject = getProject(db, projectId);
+      const chatMeta = chatProject?.metadata;
+      if (chatMeta?.baseDir) {
+        cwd = path.normalize(chatMeta.baseDir);
+        existingProjectFiles = await listFiles(PROJECTS_DIR, projectId, { metadata: chatMeta });
+      } else {
+        cwd = await ensureProject(PROJECTS_DIR, projectId, chatMeta);
+        existingProjectFiles = await listFiles(PROJECTS_DIR, projectId, { metadata: chatMeta });
       }
     }
     if (run.cancelRequested || design.runs.isTerminal(run.status)) return;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3188,6 +3188,30 @@ export async function startServer({
   }
 
   const app = express();
+  // Configure Express's trust-proxy resolution from OD_TRUST_PROXY.
+  // P0-fix #15: actor_source_ip on messages/revisions is durable audit
+  // data, so it must come from a trusted source. With trust-proxy
+  // unset (the default), req.ip is the raw socket peer and forwarded
+  // headers from direct callers are ignored. With trust-proxy set
+  // (e.g., 'loopback' for a same-host Tailscale Serve / nginx proxy,
+  // or a specific CIDR), Express resolves req.ip from the rightmost
+  // forwarded hop coming from a trusted source. Accepted values:
+  //   - 'true' / 'false' → boolean
+  //   - numeric string → hop count
+  //   - 'loopback' | 'linklocal' | 'uniquelocal' → built-in keyword
+  //   - any other string → passed through (Express handles IP/CIDR)
+  const rawTrustProxy = (process.env.OD_TRUST_PROXY ?? '').trim();
+  if (rawTrustProxy.length > 0) {
+    if (rawTrustProxy === 'true') {
+      app.set('trust proxy', true);
+    } else if (rawTrustProxy === 'false') {
+      app.set('trust proxy', false);
+    } else if (/^\d+$/.test(rawTrustProxy)) {
+      app.set('trust proxy', Number.parseInt(rawTrustProxy, 10));
+    } else {
+      app.set('trust proxy', rawTrustProxy);
+    }
+  }
   app.use(express.json({ limit: '4mb' }));
 
   // Plan §3.K1 — bearer-token middleware.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6067,17 +6067,15 @@ export async function startServer({
       const stagedPath = `plugin-source/${sourceSlug}`;
       const prompt = renderPluginSharePrompt({ action, sourcePlugin, stagedPath });
       const metadata = { kind: 'prototype' };
-      // Copy plugin source BEFORE ensureProject so the history
-      // migration commit captures the seed files rather than
-      // attributing them to a later agent run.
+      // Seeds land BEFORE ensureProject so the migration commit captures
+      // them; insertProject lands BEFORE ensureProject so the history
+      // hook's FK target exists when it fires.
       const projectRoot = path.join(PROJECTS_DIR, id);
       await fs.promises.mkdir(projectRoot, { recursive: true });
       await copyPluginFolderForProjectContext(
         sourcePlugin.fsPath,
         path.join(projectRoot, 'plugin-source', sourceSlug),
       );
-      await ensureProject(PROJECTS_DIR, id, metadata);
-
       insertProject(db, {
         id,
         name: `${PLUGIN_SHARE_ACTION_LABELS[action]}: ${sourcePlugin.title || sourcePlugin.id}`,
@@ -6088,6 +6086,7 @@ export async function startServer({
         createdAt: now,
         updatedAt: now,
       });
+      await ensureProject(PROJECTS_DIR, id, metadata);
       insertConversation(db, {
         id: cid,
         projectId: id,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2035,7 +2035,7 @@ function normalizePersistedToolInput(input) {
   return input;
 }
 
-function pinAssistantMessageOnRunCreate(db, run) {
+function pinAssistantMessageOnRunCreate(db, run, req) {
   if (!run.conversationId || !run.assistantMessageId) return;
   const existing = db
     .prepare(`SELECT id FROM messages WHERE id = ?`)
@@ -2053,8 +2053,6 @@ function pinAssistantMessageOnRunCreate(db, run) {
     ).run(run.id, run.status, run.createdAt, run.assistantMessageId);
     return;
   }
-  // No req in scope here → source IP is null. run.identity was
-  // resolved at create time.
   upsertMessage(db, run.conversationId, {
     id: run.assistantMessageId,
     role: 'assistant',
@@ -2064,7 +2062,7 @@ function pinAssistantMessageOnRunCreate(db, run) {
     runId: run.id,
     runStatus: run.status,
     startedAt: run.createdAt,
-    ...attributionFromIdentity(run.identity),
+    ...attributionFromIdentity(run.identity, req),
   });
 }
 
@@ -11349,7 +11347,7 @@ export async function startServer({
     }
     const run = design.runs.create(meta);
     try {
-      pinAssistantMessageOnRunCreate(db, run);
+      pinAssistantMessageOnRunCreate(db, run, req);
     } catch (err) {
       console.warn('[runs] message create pin failed', err);
     }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -392,7 +392,7 @@ import { createIdentityMiddleware } from './identity/middleware.js';
 import { resolveIdentity } from './identity/types.js';
 import { attributionFromIdentity } from './identity/attribution.js';
 import { installHistoryEnsureHook } from './history/ensure-hook.js';
-import { installHistoryRunFinishedHook } from './history/run-hook.js';
+import { installHistoryRunCreatedHook, installHistoryRunFinishedHook } from './history/run-hook.js';
 import {
   aggregateCloudflarePagesStatus,
   buildDeployFileSet,
@@ -4546,6 +4546,15 @@ export async function startServer({
   // History feature's chat-run-finished hook. No-op when
   // OD_GIT_INTEGRATION_ENABLED is unset; otherwise commits dirty
   // working-tree state at run end with the run's identity as author.
+  // The created-hook stamps each run with HEAD-at-create so the
+  // finish-hook's marker check has a baseline that pre-dates any
+  // sibling's commit-and-release cycle (sequential-completion case).
+  installHistoryRunCreatedHook({
+    db,
+    projectsRoot: PROJECTS_DIR,
+    reposRoot: REPOS_DIR,
+    runs: design.runs,
+  });
   installHistoryRunFinishedHook({
     db,
     projectsRoot: PROJECTS_DIR,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6067,11 +6067,16 @@ export async function startServer({
       const stagedPath = `plugin-source/${sourceSlug}`;
       const prompt = renderPluginSharePrompt({ action, sourcePlugin, stagedPath });
       const metadata = { kind: 'prototype' };
-      const projectRoot = await ensureProject(PROJECTS_DIR, id, metadata);
+      // Copy plugin source BEFORE ensureProject so the history
+      // migration commit captures the seed files rather than
+      // attributing them to a later agent run.
+      const projectRoot = path.join(PROJECTS_DIR, id);
+      await fs.promises.mkdir(projectRoot, { recursive: true });
       await copyPluginFolderForProjectContext(
         sourcePlugin.fsPath,
         path.join(projectRoot, 'plugin-source', sourceSlug),
       );
+      await ensureProject(PROJECTS_DIR, id, metadata);
 
       insertProject(db, {
         id,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -391,6 +391,7 @@ import { CHAT_TOOL_ENDPOINTS, CHAT_TOOL_OPERATIONS, toolTokenRegistry } from './
 import { createIdentityMiddleware } from './identity/middleware.js';
 import { resolveIdentity } from './identity/types.js';
 import { installHistoryEnsureHook } from './history/ensure-hook.js';
+import { installHistoryRunFinishedHook } from './history/run-hook.js';
 import {
   aggregateCloudflarePagesStatus,
   buildDeployFileSet,
@@ -4523,6 +4524,16 @@ export async function startServer({
     getAppVersion: () => cachedAppVersion?.version ?? '0.0.0',
     readAnalyticsContext,
   };
+  // Register the history feature's chat-run-finished hook against the
+  // runs service. No-op when OD_GIT_INTEGRATION_ENABLED is unset;
+  // otherwise commits any dirty working-tree state at the end of each
+  // run with the run's resolved identity as author.
+  installHistoryRunFinishedHook({
+    db,
+    projectsRoot: PROJECTS_DIR,
+    reposRoot: REPOS_DIR,
+    runs: design.runs,
+  });
 
   // PostHog runtime config — gated on BOTH a server-side key (POSTHOG_KEY)
   // and the user's opt-in metrics consent (Privacy → "Share usage data").
@@ -11133,6 +11144,7 @@ export async function startServer({
       clientRequestId: `orbit-${trigger}-${randomUUID()}`,
       agentId,
       identity: req.identity,
+      message: prompt,
     });
     upsertMessage(db, conversationId, {
       id: `orbit-user-${run.id}`,
@@ -11611,7 +11623,10 @@ export async function startServer({
     if (daemonShuttingDown) {
       return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', 'daemon is shutting down');
     }
-    const run = design.runs.create({ identity: req.identity });
+    const run = design.runs.create({
+      identity: req.identity,
+      message: typeof req.body?.message === 'string' ? req.body.message : null,
+    });
     design.runs.stream(run, req, res);
     design.runs.start(run, () => startChatRun(req.body || {}, run));
   });
@@ -11752,6 +11767,7 @@ export async function startServer({
       // multi-user feature captures the routine creator's identity at
       // creation time, this site reads from the routine record instead.
       identity: resolveIdentity({}),
+      message: routine.prompt,
       ...(resolvedRoutineSnapshot?.ok
         ? {
             appliedPluginSnapshotId: resolvedRoutineSnapshot.snapshotId,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -390,6 +390,7 @@ import { configureComposioConfigStore } from './connectors/composio-config.js';
 import { CHAT_TOOL_ENDPOINTS, CHAT_TOOL_OPERATIONS, toolTokenRegistry } from './tool-tokens.js';
 import { createIdentityMiddleware } from './identity/middleware.js';
 import { resolveIdentity } from './identity/types.js';
+import { attributionFromIdentity } from './identity/attribution.js';
 import { installHistoryEnsureHook } from './history/ensure-hook.js';
 import { installHistoryRunFinishedHook } from './history/run-hook.js';
 import {
@@ -2052,6 +2053,8 @@ function pinAssistantMessageOnRunCreate(db, run) {
     ).run(run.id, run.status, run.createdAt, run.assistantMessageId);
     return;
   }
+  // run.identity (populated at runs.create time per P0.2) is the
+  // resolved actor for this run; no req in scope here so source IP is null.
   upsertMessage(db, run.conversationId, {
     id: run.assistantMessageId,
     role: 'assistant',
@@ -2061,6 +2064,7 @@ function pinAssistantMessageOnRunCreate(db, run) {
     runId: run.id,
     runStatus: run.status,
     startedAt: run.createdAt,
+    ...attributionFromIdentity(run.identity),
   });
 }
 
@@ -5072,6 +5076,7 @@ export async function startServer({
     const saved = upsertMessage(db, req.params.cid, {
       ...m,
       id: req.params.mid,
+      ...attributionFromIdentity(req.identity, req),
     });
     // Bump the parent project's updatedAt so the project list re-orders.
     updateProject(db, req.params.id, {});
@@ -11146,10 +11151,12 @@ export async function startServer({
       identity: req.identity,
       message: prompt,
     });
+    const orbitAttribution = attributionFromIdentity(req.identity, req);
     upsertMessage(db, conversationId, {
       id: `orbit-user-${run.id}`,
       role: 'user',
       content: prompt,
+      ...orbitAttribution,
     });
     upsertMessage(db, conversationId, {
       id: assistantMessageId,
@@ -11160,6 +11167,7 @@ export async function startServer({
       runId: run.id,
       runStatus: 'queued',
       startedAt: now,
+      ...orbitAttribution,
     });
 
     if (template?.dir) {
@@ -11783,10 +11791,15 @@ export async function startServer({
         // Snapshot linking is best-effort; the in-memory run still carries it.
       }
     }
+    // Routines fire from the scheduler with no req in scope, so no
+    // source IP. The identity is the routine creator's fallback
+    // identity already resolved into run.identity at create time.
+    const routineAttribution = attributionFromIdentity(run.identity);
     upsertMessage(db, conversationId, {
       id: `routine-user-${run.id}`,
       role: 'user',
       content: routine.prompt,
+      ...routineAttribution,
     });
     upsertMessage(db, conversationId, {
       id: assistantMessageId,
@@ -11797,6 +11810,7 @@ export async function startServer({
       runId: run.id,
       runStatus: 'queued',
       startedAt: now,
+      ...routineAttribution,
     });
 
     const modelPrefs = appConfig.agentModels?.[agentId] ?? {};

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1227,9 +1227,9 @@ const ARTIFACTS_DIR = path.join(RUNTIME_DATA_DIR, 'artifacts');
 // read path so project-membership, size, and CSP guards cannot be bypassed.
 const CRITIQUE_ARTIFACTS_DIR = path.join(RUNTIME_DATA_DIR, 'critique-artifacts');
 const PROJECTS_DIR = path.join(RUNTIME_DATA_DIR, 'projects');
-// Per-project gitdirs for the history feature (#1241). Sibling to
-// PROJECTS_DIR so backup stories that already cover OD_DATA_DIR pick
-// it up transparently. Only used when OD_GIT_INTEGRATION_ENABLED is on.
+// Per-project gitdirs for the history feature (#1241), sibling to
+// PROJECTS_DIR so existing OD_DATA_DIR backups pick them up. Only
+// used when OD_GIT_INTEGRATION_ENABLED is on.
 const REPOS_DIR = path.join(RUNTIME_DATA_DIR, 'repos');
 const USER_SKILLS_DIR = path.join(RUNTIME_DATA_DIR, 'skills');
 const USER_DESIGN_SYSTEMS_DIR = path.join(RUNTIME_DATA_DIR, 'design-systems');
@@ -2053,8 +2053,8 @@ function pinAssistantMessageOnRunCreate(db, run) {
     ).run(run.id, run.status, run.createdAt, run.assistantMessageId);
     return;
   }
-  // run.identity (populated at runs.create time per P0.2) is the
-  // resolved actor for this run; no req in scope here so source IP is null.
+  // No req in scope here → source IP is null. run.identity was
+  // resolved at create time.
   upsertMessage(db, run.conversationId, {
     id: run.assistantMessageId,
     role: 'assistant',
@@ -3189,17 +3189,14 @@ export async function startServer({
 
   const app = express();
   // Configure Express's trust-proxy resolution from OD_TRUST_PROXY.
-  // P0-fix #15: actor_source_ip on messages/revisions is durable audit
-  // data, so it must come from a trusted source. With trust-proxy
-  // unset (the default), req.ip is the raw socket peer and forwarded
-  // headers from direct callers are ignored. With trust-proxy set
-  // (e.g., 'loopback' for a same-host Tailscale Serve / nginx proxy,
-  // or a specific CIDR), Express resolves req.ip from the rightmost
-  // forwarded hop coming from a trusted source. Accepted values:
-  //   - 'true' / 'false' → boolean
-  //   - numeric string → hop count
-  //   - 'loopback' | 'linklocal' | 'uniquelocal' → built-in keyword
-  //   - any other string → passed through (Express handles IP/CIDR)
+  // actor_source_ip is durable audit data; req.ip MUST come from a
+  // trusted source. Unset (default) → req.ip is the raw socket peer.
+  // Set → Express resolves req.ip from the rightmost forwarded hop
+  // coming from a trusted source. Accepted values:
+  //   'true' / 'false' → boolean
+  //   numeric string → hop count
+  //   'loopback' | 'linklocal' | 'uniquelocal' → built-in keyword
+  //   any other string → passed through (Express handles IP/CIDR)
   const rawTrustProxy = (process.env.OD_TRUST_PROXY ?? '').trim();
   if (rawTrustProxy.length > 0) {
     if (rawTrustProxy === 'true') {
@@ -3242,12 +3239,9 @@ export async function startServer({
   }
 
   // Identity middleware — resolves req.identity once per request via
-  // the identity seam in apps/daemon/src/identity/types.ts. Today's
-  // LocalFallbackProvider returns a configurable placeholder; future
-  // multi-user-support work registers richer providers ahead of it.
-  // Consumers (chat-run lifecycle, message attribution) read identity
-  // from req.identity rather than resolving from scratch — see the spec
-  // for #1241 for the durable-on-run propagation rationale.
+  // the identity seam. Consumers read req.identity rather than
+  // resolving from scratch; see spec #1241 for the durable-on-run
+  // propagation rationale.
   app.use(createIdentityMiddleware());
 
   // Multi-directory scanning shared by every skill / template surface. The
@@ -3543,10 +3537,9 @@ export async function startServer({
   projectMetadataLookup = (id) => {
     try { return getProject(db, id)?.metadata ?? null; } catch { return null; }
   };
-  // Register the history feature's post-ensure hook. No-op when
+  // History feature's post-ensure hook. No-op when
   // OD_GIT_INTEGRATION_ENABLED is unset; otherwise auto-initializes
-  // the substrate (git init + initial migration commit) on first
-  // ensure for each project. Idempotent across subsequent ensures.
+  // the substrate on first ensure per project. Idempotent.
   installHistoryEnsureHook({ db, reposRoot: REPOS_DIR });
   configureConnectorCredentialStore(new FileConnectorCredentialStore(RUNTIME_DATA_DIR));
   configureComposioConfigStore(RUNTIME_DATA_DIR);
@@ -4552,10 +4545,9 @@ export async function startServer({
     getAppVersion: () => cachedAppVersion?.version ?? '0.0.0',
     readAnalyticsContext,
   };
-  // Register the history feature's chat-run-finished hook against the
-  // runs service. No-op when OD_GIT_INTEGRATION_ENABLED is unset;
-  // otherwise commits any dirty working-tree state at the end of each
-  // run with the run's resolved identity as author.
+  // History feature's chat-run-finished hook. No-op when
+  // OD_GIT_INTEGRATION_ENABLED is unset; otherwise commits dirty
+  // working-tree state at run end with the run's identity as author.
   installHistoryRunFinishedHook({
     db,
     projectsRoot: PROJECTS_DIR,
@@ -9716,11 +9708,10 @@ export async function startServer({
     let cwd = null;
     let existingProjectFiles = [];
     if (typeof projectId === 'string' && projectId) {
-      // Errors from ensureProject (incl. history init failures when
-      // OD_GIT_INTEGRATION_ENABLED is on) propagate up — `runs.start`
-      // catches and marks the run failed, surfacing a clear cause.
-      // Pre-#16 a bare catch silently set cwd=null, leaving the run
-      // running in an inherited dir and hiding init breakage.
+      // Errors from ensureProject (incl. history init failures)
+      // propagate up; runs.start catches and marks the run failed.
+      // A bare catch here would silently leave the run in an inherited
+      // dir and hide init breakage.
       const chatProject = getProject(db, projectId);
       const chatMeta = chatProject?.metadata;
       if (chatMeta?.baseDir) {
@@ -11173,16 +11164,13 @@ export async function startServer({
       assistantMessageId,
       clientRequestId: `orbit-${trigger}-${randomUUID()}`,
       agentId,
-      // Orbit runs are dispatched by orbitService.setRunHandler, which is
-      // invoked from the scheduler/HTTP-trigger plumbing without `req` in
-      // scope. Use the env-driven identity fallback so the run still has
-      // an attributable Identity (LocalFallbackProvider on a single-user
-      // install). Mirrors the routine handler pattern below.
+      // Orbit runs fire from scheduler/HTTP-trigger plumbing without
+      // `req` in scope. Use the env-driven identity fallback so the run
+      // still has an attributable Identity. Mirrors the routine handler.
       identity: resolveIdentity({}),
       message: prompt,
     });
-    // No req here (see comment above); attribute from the resolved
-    // run.identity without a source IP. Matches the routine pattern.
+    // No req in scope → no source IP. Same shape as the routine path.
     const orbitAttribution = attributionFromIdentity(run.identity);
     upsertMessage(db, conversationId, {
       id: `orbit-user-${run.id}`,
@@ -11800,12 +11788,9 @@ export async function startServer({
       assistantMessageId,
       clientRequestId: `routine-${trigger}-${randomUUID()}`,
       agentId,
-      // Routines fire from the scheduler, not from an HTTP request, so
-      // there's no req.identity to forward. Use the env-driven identity
-      // fallback so the run still has an attributable Identity (the
-      // local user under LocalFallbackProvider). When a future
-      // multi-user feature captures the routine creator's identity at
-      // creation time, this site reads from the routine record instead.
+      // Routines fire from the scheduler without `req` in scope. Use
+      // the env-driven identity fallback for now; a future multi-user
+      // feature reads the routine creator's identity off the routine row.
       identity: resolveIdentity({}),
       message: routine.prompt,
       ...(resolvedRoutineSnapshot?.ok
@@ -11823,9 +11808,7 @@ export async function startServer({
         // Snapshot linking is best-effort; the in-memory run still carries it.
       }
     }
-    // Routines fire from the scheduler with no req in scope, so no
-    // source IP. The identity is the routine creator's fallback
-    // identity already resolved into run.identity at create time.
+    // No req in scope → no source IP. Same shape as the orbit path.
     const routineAttribution = attributionFromIdentity(run.identity);
     upsertMessage(db, conversationId, {
       id: `routine-user-${run.id}`,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11148,10 +11148,17 @@ export async function startServer({
       assistantMessageId,
       clientRequestId: `orbit-${trigger}-${randomUUID()}`,
       agentId,
-      identity: req.identity,
+      // Orbit runs are dispatched by orbitService.setRunHandler, which is
+      // invoked from the scheduler/HTTP-trigger plumbing without `req` in
+      // scope. Use the env-driven identity fallback so the run still has
+      // an attributable Identity (LocalFallbackProvider on a single-user
+      // install). Mirrors the routine handler pattern below.
+      identity: resolveIdentity({}),
       message: prompt,
     });
-    const orbitAttribution = attributionFromIdentity(req.identity, req);
+    // No req here (see comment above); attribute from the resolved
+    // run.identity without a source IP. Matches the routine pattern.
+    const orbitAttribution = attributionFromIdentity(run.identity);
     upsertMessage(db, conversationId, {
       id: `orbit-user-${run.id}`,
       role: 'user',

--- a/apps/daemon/tests/git-exec.test.ts
+++ b/apps/daemon/tests/git-exec.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { runGit } from '../src/git/exec.js';
+
+// Integration test against a real git binary in a temp directory. `runGit`
+// is the wrapper around `git`, so the value of the test is in confirming
+// the actual binary's behavior (exit codes, stdout shape, error
+// propagation) — not in mocking child_process.
+
+function tmpRepoRoot(): string {
+  return mkdtempSync(path.join(tmpdir(), 'od-git-exec-'));
+}
+
+function initEmptyDir(): string {
+  return tmpRepoRoot();
+}
+
+function initRepoWithOneCommit(): string {
+  const dir = tmpRepoRoot();
+  // Use init.defaultBranch=main + per-repo user.email/name so the test
+  // doesn't rely on the developer's global git config.
+  execFileSync('git', ['init', '-q', '--initial-branch=main'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+  writeFileSync(path.join(dir, 'README.md'), '# test\n');
+  execFileSync('git', ['add', '-A'], { cwd: dir });
+  execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: dir });
+  return dir;
+}
+
+describe('runGit', () => {
+  const cleanup: string[] = [];
+
+  beforeEach(() => {
+    cleanup.length = 0;
+  });
+
+  afterEach(() => {
+    for (const dir of cleanup) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns stdout for a successful command in a real repo', async () => {
+    const dir = initRepoWithOneCommit();
+    cleanup.push(dir);
+
+    const out = await runGit(dir, ['rev-parse', '--is-inside-work-tree'], undefined);
+    expect(out.trim()).toBe('true');
+  });
+
+  it('returns the current branch via "branch --show-current"', async () => {
+    const dir = initRepoWithOneCommit();
+    cleanup.push(dir);
+
+    const out = await runGit(dir, ['branch', '--show-current'], undefined);
+    expect(out.trim()).toBe('main');
+  });
+
+  it('returns empty string when run in a non-repo directory (exit 128)', async () => {
+    const dir = initEmptyDir();
+    cleanup.push(dir);
+
+    const out = await runGit(dir, ['rev-parse', '--is-inside-work-tree'], undefined);
+    expect(out).toBe('');
+  });
+
+  it('throws with stderr text for non-128 errors (e.g., unknown subcommand)', async () => {
+    const dir = initRepoWithOneCommit();
+    cleanup.push(dir);
+
+    // `git -c <bad>` triggers a non-128 usage error.
+    await expect(runGit(dir, ['--not-a-real-flag'], undefined)).rejects.toThrow();
+  });
+
+  it('honors an abort signal', async () => {
+    const dir = initRepoWithOneCommit();
+    cleanup.push(dir);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(runGit(dir, ['status'], controller.signal)).rejects.toThrow();
+  });
+});

--- a/apps/daemon/tests/git-exec.test.ts
+++ b/apps/daemon/tests/git-exec.test.ts
@@ -60,12 +60,33 @@ describe('runGit', () => {
     expect(out.trim()).toBe('main');
   });
 
-  it('returns empty string when run in a non-repo directory (exit 128)', async () => {
+  it('throws by default when run in a non-repo directory (exit 128 is strict)', async () => {
     const dir = initEmptyDir();
     cleanup.push(dir);
 
-    const out = await runGit(dir, ['rev-parse', '--is-inside-work-tree'], undefined);
+    // Strict default — exit 128 surfaces as a thrown Error. This is
+    // the right behavior for mutating callers; silently mapping 128
+    // to '' would let a status probe against a corrupted gitdir be
+    // misread as "clean tree" and skip a needed commit.
+    await expect(runGit(dir, ['rev-parse', '--is-inside-work-tree'], undefined)).rejects.toThrow();
+  });
+
+  it('returns empty string on exit 128 when softFail128 is passed (probe semantics)', async () => {
+    const dir = initEmptyDir();
+    cleanup.push(dir);
+
+    const out = await runGit(dir, ['rev-parse', '--is-inside-work-tree'], undefined, { softFail128: true });
     expect(out).toBe('');
+  });
+
+  it('softFail128 does not silence non-128 errors', async () => {
+    const dir = initRepoWithOneCommit();
+    cleanup.push(dir);
+
+    // Unknown subcommand returns a different non-zero code; softFail128 must not catch it.
+    await expect(
+      runGit(dir, ['--not-a-real-flag'], undefined, { softFail128: true }),
+    ).rejects.toThrow();
   });
 
   it('throws with stderr text for non-128 errors (e.g., unknown subcommand)', async () => {

--- a/apps/daemon/tests/history-ensure-hook.test.ts
+++ b/apps/daemon/tests/history-ensure-hook.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+import { ensureProject, setProjectEnsuredHook } from '../src/projects.js';
+import { migrateProjectRevisions } from '../src/history/persistence.js';
+import { installHistoryEnsureHook } from '../src/history/ensure-hook.js';
+
+function freshSandbox(): { dataRoot: string; projectsRoot: string; reposRoot: string; db: Database.Database } {
+  const dataRoot = mkdtempSync(path.join(tmpdir(), 'od-ensure-hook-'));
+  const projectsRoot = path.join(dataRoot, 'projects');
+  const reposRoot = path.join(dataRoot, 'repos');
+  mkdirSync(projectsRoot, { recursive: true });
+  mkdirSync(reposRoot, { recursive: true });
+
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT,
+      created_at INTEGER NOT NULL
+    );
+    INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p1', 'p1', 0, 0);
+  `);
+  migrateProjectRevisions(db);
+  return { dataRoot, projectsRoot, reposRoot, db };
+}
+
+describe('installHistoryEnsureHook', () => {
+  let sandbox: ReturnType<typeof freshSandbox>;
+
+  beforeEach(() => {
+    sandbox = freshSandbox();
+  });
+
+  afterEach(() => {
+    setProjectEnsuredHook(null);
+    sandbox.db.close();
+    rmSync(sandbox.dataRoot, { recursive: true, force: true });
+  });
+
+  it('is a no-op when OD_GIT_INTEGRATION_ENABLED is unset', async () => {
+    installHistoryEnsureHook({ db: sandbox.db, reposRoot: sandbox.reposRoot, env: {} });
+
+    const dir = await ensureProject(sandbox.projectsRoot, 'p1');
+
+    expect(existsSync(dir)).toBe(true);                                         // dir was created
+    expect(existsSync(path.join(dir, '.git'))).toBe(false);                     // no substrate init
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions`).get() as { n: number };
+    expect(count.n).toBe(0);
+  });
+
+  it('initializes the substrate when the flag is on and project is fresh', async () => {
+    installHistoryEnsureHook({
+      db: sandbox.db,
+      reposRoot: sandbox.reposRoot,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    const dir = await ensureProject(sandbox.projectsRoot, 'p1');
+
+    expect(existsSync(path.join(dir, '.git'))).toBe(true);                      // gitlink written
+    expect(existsSync(path.join(sandbox.reposRoot, 'p1.gitdir'))).toBe(true);   // gitdir created
+    const row = sandbox.db.prepare(
+      `SELECT source, run_id, actor_identity_id FROM project_revisions WHERE project_id = 'p1'`,
+    ).get() as { source: string; run_id: string | null; actor_identity_id: string };
+    expect(row.source).toBe('migration');
+    expect(row.run_id).toBeNull();
+    expect(row.actor_identity_id).toBe('local:default');
+  });
+
+  it('is idempotent — re-ensuring an initialized project does not duplicate revisions', async () => {
+    installHistoryEnsureHook({
+      db: sandbox.db,
+      reposRoot: sandbox.reposRoot,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    await ensureProject(sandbox.projectsRoot, 'p1');
+    await ensureProject(sandbox.projectsRoot, 'p1');
+    await ensureProject(sandbox.projectsRoot, 'p1');
+
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = 'p1'`).get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  it('skips linked-folder projects (metadata.baseDir set)', async () => {
+    installHistoryEnsureHook({
+      db: sandbox.db,
+      reposRoot: sandbox.reposRoot,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    // Create a "user folder" outside the projects root with its own preexisting content
+    const userFolder = path.join(sandbox.dataRoot, 'my-existing-project');
+    mkdirSync(userFolder, { recursive: true });
+    writeFileSync(path.join(userFolder, 'README.md'), '# user-owned\n');
+
+    await ensureProject(sandbox.projectsRoot, 'p1', { baseDir: userFolder });
+
+    // No substrate init should have run against the user's folder
+    expect(existsSync(path.join(userFolder, '.git'))).toBe(false);
+    expect(existsSync(path.join(sandbox.reposRoot, 'p1.gitdir'))).toBe(false);
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions`).get() as { n: number };
+    expect(count.n).toBe(0);
+  });
+
+  it('does not throw when a foreign .git is present (collision is logged, ensure still returns dir)', async () => {
+    installHistoryEnsureHook({
+      db: sandbox.db,
+      reposRoot: sandbox.reposRoot,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    // Pre-create the project dir with a foreign .git
+    const dir = path.join(sandbox.projectsRoot, 'p1');
+    mkdirSync(path.join(dir, '.git'), { recursive: true });
+
+    const returned = await ensureProject(sandbox.projectsRoot, 'p1');
+
+    expect(returned).toBe(dir);                                                 // contract preserved
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions`).get() as { n: number };
+    expect(count.n).toBe(0);                                                    // no migration row inserted
+  });
+
+  it('an unrelated hook failure does not break ensureProject', async () => {
+    // Install a deliberately-throwing hook directly (bypassing
+    // installHistoryEnsureHook) to verify ensureProject's hook
+    // try/catch wraps the call correctly.
+    setProjectEnsuredHook(async () => {
+      throw new Error('boom');
+    });
+
+    const dir = await ensureProject(sandbox.projectsRoot, 'p1');
+    expect(existsSync(dir)).toBe(true);
+  });
+});

--- a/apps/daemon/tests/history-ensure-hook.test.ts
+++ b/apps/daemon/tests/history-ensure-hook.test.ts
@@ -142,15 +142,31 @@ describe('installHistoryEnsureHook', () => {
     expect(count.n).toBe(0);                                                    // no migration row inserted
   });
 
-  it('an unrelated hook failure does not break ensureProject', async () => {
-    // Install a deliberately-throwing hook directly (bypassing
-    // installHistoryEnsureHook) to verify ensureProject's hook
-    // try/catch wraps the call correctly.
+  it('propagates hook errors instead of swallowing them', async () => {
+    // When OD_GIT_INTEGRATION_ENABLED is on, init failures (git missing,
+    // EACCES on gitdir, SQLite errors) are contract violations — the
+    // user opted into history and expects it to work. ensureProject
+    // must surface those errors rather than returning a silently
+    // broken directory.
     setProjectEnsuredHook(async () => {
       throw new Error('boom');
     });
 
-    const dir = await ensureProject(sandbox.projectsRoot, 'p1');
-    expect(existsSync(dir)).toBe(true);
+    await expect(ensureProject(sandbox.projectsRoot, 'p1')).rejects.toThrow('boom');
+  });
+
+  it('surfaces a real initProjectHistory failure when the substrate cannot be created', async () => {
+    // Forcing initProjectHistory to fail: point reposRoot at a path
+    // that exists as a regular file, so `fs.mkdir(path.dirname(repoDir))`
+    // fails with ENOTDIR. ensureProject must propagate the error.
+    const blockingFile = path.join(sandbox.dataRoot, 'blocked-repos');
+    writeFileSync(blockingFile, 'this-is-a-file-not-a-dir');
+    installHistoryEnsureHook({
+      db: sandbox.db,
+      reposRoot: blockingFile,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    await expect(ensureProject(sandbox.projectsRoot, 'p1')).rejects.toThrow();
   });
 });

--- a/apps/daemon/tests/history-ensure-hook.test.ts
+++ b/apps/daemon/tests/history-ensure-hook.test.ts
@@ -22,6 +22,13 @@ function freshSandbox(): { dataRoot: string; projectsRoot: string; reposRoot: st
     CREATE TABLE projects (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
+      skill_id TEXT,
+      design_system_id TEXT,
+      pending_prompt TEXT,
+      metadata_json TEXT,
+      applied_plugin_snapshot_id TEXT,
+      custom_instructions TEXT,
+      current_revision_id TEXT,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
@@ -168,5 +175,29 @@ describe('installHistoryEnsureHook', () => {
     });
 
     await expect(ensureProject(sandbox.projectsRoot, 'p1')).rejects.toThrow();
+  });
+
+  it('skips a linked-folder project even when the caller omits metadata (DB lookup)', async () => {
+    // Set the project's metadata.baseDir in the DB to mark it linked,
+    // then call ensureProject WITHOUT passing metadata (mirrors the
+    // 8+ call sites that pass only (root, projectId)). The hook must
+    // detect the linked state via getProject() and short-circuit
+    // before initializing substrate at the wrong path.
+    sandbox.db.prepare(
+      `UPDATE projects SET metadata_json = ? WHERE id = 'p1'`,
+    ).run(JSON.stringify({ baseDir: '/tmp/elsewhere' }));
+
+    installHistoryEnsureHook({
+      db: sandbox.db,
+      reposRoot: sandbox.reposRoot,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    const dir = await ensureProject(sandbox.projectsRoot, 'p1');
+    expect(existsSync(dir)).toBe(true);
+    // Substrate was NOT initialized — no gitdir, no migration row
+    expect(existsSync(path.join(sandbox.reposRoot, 'p1.gitdir'))).toBe(false);
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions`).get() as { n: number };
+    expect(count.n).toBe(0);
   });
 });

--- a/apps/daemon/tests/history-persistence.test.ts
+++ b/apps/daemon/tests/history-persistence.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { migrateProjectRevisions } from '../src/history/persistence.js';
+
+type DbRow = Record<string, unknown>;
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  // Stand up just enough of the upstream schema to exercise the
+  // migration: projects + messages exist (so the column-additions can
+  // attach to them) and conversations exists (referenced by messages
+  // via FK if/when production schema declares one).
+  db.exec(`
+    CREATE TABLE projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT,
+      created_at INTEGER NOT NULL
+    );
+    INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p1', 'p1', 0, 0);
+  `);
+  migrateProjectRevisions(db);
+  return db;
+}
+
+function columnsOf(db: Database.Database, table: string): string[] {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as DbRow[];
+  return rows.map((r) => r.name as string);
+}
+
+describe('migrateProjectRevisions', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('is idempotent: running twice does not throw or duplicate', () => {
+    expect(() => {
+      migrateProjectRevisions(db);
+      migrateProjectRevisions(db);
+    }).not.toThrow();
+
+    const tableRow = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='project_revisions'`)
+      .get() as { name: string } | undefined;
+    expect(tableRow?.name).toBe('project_revisions');
+  });
+
+  it('creates project_revisions with the expected columns', () => {
+    const cols = columnsOf(db, 'project_revisions');
+    expect(cols).toEqual(expect.arrayContaining([
+      'id',
+      'project_id',
+      'parent_id',
+      'created_at',
+      'source',
+      'message',
+      'actor_identity_id',
+      'actor_display_name',
+      'run_id',
+      'files_changed_count',
+      'bytes_added',
+      'bytes_removed',
+    ]));
+  });
+
+  it('adds current_revision_id to projects (nullable)', () => {
+    const cols = columnsOf(db, 'projects');
+    expect(cols).toContain('current_revision_id');
+    // Existing rows have NULL for the new column.
+    const row = db.prepare(`SELECT current_revision_id FROM projects WHERE id = 'p1'`).get() as DbRow;
+    expect(row.current_revision_id).toBeNull();
+  });
+
+  it('adds actor_* columns to messages', () => {
+    const cols = columnsOf(db, 'messages');
+    expect(cols).toContain('actor_identity_id');
+    expect(cols).toContain('actor_display_name');
+    expect(cols).toContain('actor_source_ip');
+  });
+
+  it('enforces the source CHECK constraint', () => {
+    const insert = db.prepare(`
+      INSERT INTO project_revisions (id, project_id, parent_id, created_at, source, message)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `);
+    // Valid source values accepted
+    expect(() => insert.run('r1', 'p1', null, 1, 'agent-run', 'first')).not.toThrow();
+    expect(() => insert.run('r2', 'p1', 'r1', 2, 'manual-snapshot', 'tagged')).not.toThrow();
+    expect(() => insert.run('r3', 'p1', 'r2', 3, 'restore', 'reverted')).not.toThrow();
+    expect(() => insert.run('r4', 'p1', null, 4, 'migration', 'import')).not.toThrow();
+
+    // Invalid source rejected by CHECK
+    expect(() =>
+      insert.run('r5', 'p1', null, 5, 'made-up-source', 'nope'),
+    ).toThrow();
+  });
+
+  it('cascades on project delete (FK)', () => {
+    db.prepare(`
+      INSERT INTO project_revisions (id, project_id, parent_id, created_at, source, message)
+      VALUES ('r1', 'p1', NULL, 1, 'migration', 'first')
+    `).run();
+    expect(
+      (db.prepare(`SELECT COUNT(*) AS n FROM project_revisions`).get() as { n: number }).n,
+    ).toBe(1);
+
+    db.prepare(`DELETE FROM projects WHERE id = 'p1'`).run();
+    expect(
+      (db.prepare(`SELECT COUNT(*) AS n FROM project_revisions`).get() as { n: number }).n,
+    ).toBe(0);
+  });
+
+  it('creates the (project_id, created_at DESC) index', () => {
+    const idx = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_project_revisions_project_created'`)
+      .get() as { name: string } | undefined;
+    expect(idx?.name).toBe('idx_project_revisions_project_created');
+  });
+});

--- a/apps/daemon/tests/history-persistence.test.ts
+++ b/apps/daemon/tests/history-persistence.test.ts
@@ -101,6 +101,55 @@ describe('migrateProjectRevisions', () => {
     expect(() => insert.run('uuid-3', 'p1', sharedSha, 3)).toThrow();
   });
 
+  it('migrates a legacy database that already has project_revisions without git_sha', () => {
+    // Simulate a database that ran the pre-fix migration (id=SHA, no
+    // git_sha column). The fixed migration must add the column before
+    // creating the (project_id, git_sha) partial unique index, otherwise
+    // SQLite errors with `no such column: git_sha` and migration aborts
+    // before the backfill can run.
+    const legacyDb = new Database(':memory:');
+    legacyDb.pragma('foreign_keys = ON');
+    legacyDb.exec(`
+      CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+      CREATE TABLE conversations (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+      CREATE TABLE messages (id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT, created_at INTEGER NOT NULL);
+      CREATE TABLE project_revisions (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        parent_id TEXT,
+        created_at INTEGER NOT NULL,
+        source TEXT NOT NULL,
+        message TEXT NOT NULL,
+        actor_identity_id TEXT,
+        actor_display_name TEXT,
+        run_id TEXT,
+        files_changed_count INTEGER NOT NULL DEFAULT 0,
+        bytes_added INTEGER NOT NULL DEFAULT 0,
+        bytes_removed INTEGER NOT NULL DEFAULT 0
+      );
+      INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p1', 'p1', 0, 0);
+      -- A legacy revision row with id=SHA, no git_sha column populated
+      INSERT INTO project_revisions (id, project_id, created_at, source, message)
+      VALUES ('a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2', 'p1', 1, 'migration', 'legacy');
+    `);
+
+    expect(() => migrateProjectRevisions(legacyDb)).not.toThrow();
+
+    // git_sha column now exists; legacy row's value is NULL (expected)
+    const cols = legacyDb.prepare(`PRAGMA table_info(project_revisions)`).all() as DbRow[];
+    expect(cols.map((c) => c.name)).toContain('git_sha');
+    const legacyRow = legacyDb.prepare(`SELECT git_sha FROM project_revisions LIMIT 1`).get() as DbRow;
+    expect(legacyRow.git_sha).toBeNull();
+
+    // The partial unique index exists
+    const idx = legacyDb
+      .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_project_revisions_project_sha'`)
+      .get() as { name: string } | undefined;
+    expect(idx?.name).toBe('idx_project_revisions_project_sha');
+
+    legacyDb.close();
+  });
+
   it('allows multiple NULL git_sha rows (non-git substrates do not violate the unique index)', () => {
     const insert = db.prepare(`
       INSERT INTO project_revisions (id, project_id, parent_id, git_sha, created_at, source, message)

--- a/apps/daemon/tests/history-persistence.test.ts
+++ b/apps/daemon/tests/history-persistence.test.ts
@@ -69,6 +69,7 @@ describe('migrateProjectRevisions', () => {
       'id',
       'project_id',
       'parent_id',
+      'git_sha',
       'created_at',
       'source',
       'message',
@@ -79,6 +80,36 @@ describe('migrateProjectRevisions', () => {
       'bytes_added',
       'bytes_removed',
     ]));
+  });
+
+  it('enforces uniqueness on (project_id, git_sha) — two projects with the same SHA do not collide', () => {
+    // Set up a second project so we can insert two rows under
+    // different project_ids with the same git_sha (the collision
+    // scenario the synthetic-UUID-id fix addresses).
+    db.exec(`INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p2', 'p2', 0, 0)`);
+
+    const sharedSha = 'a'.repeat(40);
+    const insert = db.prepare(`
+      INSERT INTO project_revisions (id, project_id, parent_id, git_sha, created_at, source, message)
+      VALUES (?, ?, NULL, ?, ?, 'migration', 'shared content')
+    `);
+    // Two projects, same SHA, different revision UUIDs — both inserts succeed.
+    expect(() => insert.run('uuid-1', 'p1', sharedSha, 1)).not.toThrow();
+    expect(() => insert.run('uuid-2', 'p2', sharedSha, 2)).not.toThrow();
+
+    // But the same (project_id, git_sha) pair would violate the unique partial index.
+    expect(() => insert.run('uuid-3', 'p1', sharedSha, 3)).toThrow();
+  });
+
+  it('allows multiple NULL git_sha rows (non-git substrates do not violate the unique index)', () => {
+    const insert = db.prepare(`
+      INSERT INTO project_revisions (id, project_id, parent_id, git_sha, created_at, source, message)
+      VALUES (?, 'p1', NULL, NULL, ?, 'migration', 'no sha')
+    `);
+    // Partial index ignores NULL git_sha — many rows without SHAs is fine.
+    expect(() => insert.run('uuid-n1', 1)).not.toThrow();
+    expect(() => insert.run('uuid-n2', 2)).not.toThrow();
+    expect(() => insert.run('uuid-n3', 3)).not.toThrow();
   });
 
   it('adds current_revision_id to projects (nullable)', () => {

--- a/apps/daemon/tests/history-project-lock.test.ts
+++ b/apps/daemon/tests/history-project-lock.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { withProjectLock, __resetProjectLocksForTests } from '../src/history/project-lock.js';
+
+describe('withProjectLock', () => {
+  afterEach(() => {
+    __resetProjectLocksForTests();
+  });
+
+  it('serializes operations on the same project', async () => {
+    const order: string[] = [];
+
+    const a = withProjectLock('p1', async () => {
+      order.push('a-start');
+      await new Promise((r) => setTimeout(r, 20));
+      order.push('a-end');
+      return 'A';
+    });
+    const b = withProjectLock('p1', async () => {
+      order.push('b-start');
+      await new Promise((r) => setTimeout(r, 5));
+      order.push('b-end');
+      return 'B';
+    });
+
+    const [resA, resB] = await Promise.all([a, b]);
+    expect(resA).toBe('A');
+    expect(resB).toBe('B');
+    // b's start must follow a's end — not interleave
+    expect(order).toEqual(['a-start', 'a-end', 'b-start', 'b-end']);
+  });
+
+  it('runs operations on different projects concurrently', async () => {
+    const order: string[] = [];
+
+    const a = withProjectLock('p1', async () => {
+      order.push('a-start');
+      await new Promise((r) => setTimeout(r, 20));
+      order.push('a-end');
+    });
+    const b = withProjectLock('p2', async () => {
+      order.push('b-start');
+      await new Promise((r) => setTimeout(r, 5));
+      order.push('b-end');
+    });
+
+    await Promise.all([a, b]);
+    // p2's faster work finishes before p1's slower work
+    expect(order).toEqual(['a-start', 'b-start', 'b-end', 'a-end']);
+  });
+
+  it('releases the lock when the wrapped fn throws (next caller can proceed)', async () => {
+    const failing = withProjectLock('p1', async () => {
+      throw new Error('boom');
+    });
+    // The failing call's rejection must not poison the queue
+    await expect(failing).rejects.toThrow('boom');
+
+    // A subsequent call on the same project should still work
+    const ok = await withProjectLock('p1', async () => 'ok');
+    expect(ok).toBe('ok');
+  });
+
+  it('does not deadlock when many calls queue on the same project', async () => {
+    const results = await Promise.all(
+      Array.from({ length: 25 }, (_, i) =>
+        withProjectLock('p1', async () => {
+          await new Promise((r) => setTimeout(r, 1));
+          return i;
+        }),
+      ),
+    );
+    expect(results).toEqual(Array.from({ length: 25 }, (_, i) => i));
+  });
+
+  it('propagates the return value from the wrapped fn', async () => {
+    const obj = { ok: true, n: 42 };
+    const result = await withProjectLock('p1', async () => obj);
+    expect(result).toBe(obj); // identity, not just deep-equal
+  });
+});

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -309,4 +309,63 @@ describe('recordRevisionForRun', () => {
 
     expect(result.kind).toBe('not-initialized');
   });
+
+  it('serializes concurrent record calls so each run gets its own revision', async () => {
+    // Two parallel recordRevisionForRun calls against the same project,
+    // each writing a distinct file. Without the per-project lock the
+    // second call sees the tree cleaned by the first call's commit and
+    // returns 'clean' (data loss). With the lock both produce
+    // 'recorded' results because each call observes only its own
+    // changes against a tree the previous call has already committed.
+    writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'a\n');
+    writeFileSync(path.join(sandbox.projectDir, 'b.txt'), 'b\n');
+
+    const [resA, resB] = await Promise.all([
+      recordRevisionForRun({
+        projectId: sandbox.projectId,
+        projectDir: sandbox.projectDir,
+        repoDir: sandbox.repoDir,
+        run: { id: 'run-a', identity: TEST_IDENTITY },
+        message: 'first parallel',
+        db: sandbox.db,
+      }),
+      recordRevisionForRun({
+        projectId: sandbox.projectId,
+        projectDir: sandbox.projectDir,
+        repoDir: sandbox.repoDir,
+        run: { id: 'run-b', identity: TEST_IDENTITY },
+        message: 'second parallel',
+        db: sandbox.db,
+      }),
+    ]);
+
+    // Exactly one of the two ends up with a 'recorded' result — the
+    // other observes a clean tree because the first commit captured
+    // its work too. That's the expected behavior under the lock: the
+    // serialization point is which commit "wins"; the change set is
+    // preserved either way (no silent data loss).
+    const kinds = [resA.kind, resB.kind].sort();
+    expect(kinds).toContain('recorded');
+
+    // Total revisions for this project = 1 migration (from beforeEach)
+    // + at least one agent-run commit. The second call may or may not
+    // have produced its own commit depending on lock ordering; what
+    // matters is that no data is silently dropped.
+    const totalRevisions = (sandbox.db.prepare(
+      `SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = ?`,
+    ).get(sandbox.projectId) as { n: number }).n;
+    expect(totalRevisions).toBeGreaterThanOrEqual(2);
+
+    // Every staged file is now committed somewhere — the working
+    // tree is clean after both calls finish.
+    const cleanProbe = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-probe', identity: TEST_IDENTITY },
+      message: 'probe',
+      db: sandbox.db,
+    });
+    expect(cleanProbe.kind).toBe('clean');
+  });
 });

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -435,13 +435,16 @@ describe('recordRevisionForRun', () => {
     expect(firstRow.parent_id).toMatch(/^[0-9a-f-]{36}$/);
   });
 
-  it('serializes concurrent record calls so each run gets its own revision', async () => {
+  it('preserves provenance for both runs when one absorbs the others changes (marker row)', async () => {
     // Two parallel recordRevisionForRun calls against the same project,
-    // each writing a distinct file. Without the per-project lock the
-    // second call sees the tree cleaned by the first call's commit and
-    // returns 'clean' (data loss). With the lock both produce
-    // 'recorded' results because each call observes only its own
-    // changes against a tree the previous call has already committed.
+    // each contributing a distinct file. The lock serializes the commits
+    // to prevent repo corruption, but in the common timing case the
+    // winning commit absorbs BOTH files into one commit. Without the
+    // marker-row mechanism the loser would observe a clean tree and
+    // return 'clean' with no provenance row — silent loss caught by
+    // the P0 reference-deployment exercise (PR #2619). The fix
+    // captures HEAD before the lock and records a `marker` row when
+    // the locked status check finds a clean tree but HEAD has moved.
     writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'a\n');
     writeFileSync(path.join(sandbox.projectDir, 'b.txt'), 'b\n');
 
@@ -464,25 +467,66 @@ describe('recordRevisionForRun', () => {
       }),
     ]);
 
-    // Exactly one of the two ends up with a 'recorded' result — the
-    // other observes a clean tree because the first commit captured
-    // its work too. That's the expected behavior under the lock: the
-    // serialization point is which commit "wins"; the change set is
-    // preserved either way (no silent data loss).
+    // Exactly one of the two ends up with 'recorded' (the lock winner);
+    // the other ends up with 'marker' (saw clean tree but HEAD moved).
+    // Order is non-deterministic per lock acquisition.
     const kinds = [resA.kind, resB.kind].sort();
-    expect(kinds).toContain('recorded');
+    expect(kinds).toEqual(['marker', 'recorded']);
 
-    // Total revisions for this project = 1 migration (from beforeEach)
-    // + at least one agent-run commit. The second call may or may not
-    // have produced its own commit depending on lock ordering; what
-    // matters is that no data is silently dropped.
-    const totalRevisions = (sandbox.db.prepare(
-      `SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = ?`,
-    ).get(sandbox.projectId) as { n: number }).n;
-    expect(totalRevisions).toBeGreaterThanOrEqual(2);
+    // Total revisions for this project = 1 migration + 1 agent-run + 1 marker = 3.
+    // Provenance preserved: every run has its own row.
+    const rows = sandbox.db
+      .prepare(
+        `SELECT id, source, run_id, git_sha, parent_id
+           FROM project_revisions
+          WHERE project_id = ?
+          ORDER BY created_at`,
+      )
+      .all(sandbox.projectId) as Array<{
+        id: string;
+        source: string;
+        run_id: string | null;
+        git_sha: string | null;
+        parent_id: string | null;
+      }>;
+    expect(rows).toHaveLength(3);
+    // Narrow indexed access for `noUncheckedIndexedAccess` after the length assertion above.
+    const [migrationRow, firstAgentRow, secondAgentRow] = rows as [
+      (typeof rows)[number],
+      (typeof rows)[number],
+      (typeof rows)[number],
+    ];
 
-    // Every staged file is now committed somewhere — the working
-    // tree is clean after both calls finish.
+    // [migration, recorded(run-a or run-b), marker(the other)]
+    expect(migrationRow.source).toBe('migration');
+    expect(firstAgentRow.source).toBe('agent-run');
+    expect(secondAgentRow.source).toBe('agent-run');
+
+    // The two agent-run rows correspond to the two distinct run_ids — no run loses provenance.
+    const agentRunIds = new Set([firstAgentRow.run_id, secondAgentRow.run_id]);
+    expect(agentRunIds).toEqual(new Set(['run-a', 'run-b']));
+
+    // Exactly one agent-run row has a git_sha (the commit); the other is the marker.
+    const agentRunShas = [firstAgentRow.git_sha, secondAgentRow.git_sha];
+    expect(agentRunShas.filter((s) => s !== null)).toHaveLength(1);
+    expect(agentRunShas.filter((s) => s === null)).toHaveLength(1);
+
+    // The marker's parent_id points to the recorded row's id — links
+    // the marker to the commit that absorbed its run's changes so
+    // History UI consumers can render the relationship.
+    const markerRow = rows.find((r) => r.source === 'agent-run' && r.git_sha === null)!;
+    const recordedRow = rows.find((r) => r.source === 'agent-run' && r.git_sha !== null)!;
+    expect(markerRow.parent_id).toBe(recordedRow.id);
+
+    // projects.current_revision_id advances to the recorded row (the
+    // commit that owns HEAD), NOT the marker row.
+    // (We didn't add a `current_revision_id` UPDATE for markers by design.)
+    // The test sandbox doesn't have current_revision_id wired into the
+    // projects table — it's tested separately in the recorded-path test
+    // — so we just assert the recorded row is the latest with a SHA.
+
+    // Subsequent record call against a now-clean tree returns 'clean'
+    // (no HEAD advance during its lock wait → genuine no-op, no marker).
     const cleanProbe = await recordRevisionForRun({
       projectId: sandbox.projectId,
       projectDir: sandbox.projectDir,

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -402,6 +402,7 @@ describe('recordRevisionForRun', () => {
       run: { id: 'run-1', identity: TEST_IDENTITY },
       message: 'Add hero section',
       db: sandbox.db,
+      runTouchedFiles: true,
     });
 
     expect(result.kind).toBe('recorded');
@@ -536,7 +537,8 @@ describe('recordRevisionForRun', () => {
     expect(backfilled.run_id).toBeNull();
     // message reflects the actual commit, not a hardcoded marker
     expect(backfilled.message).toBe('this commit lost its DB write');
-    expect(backfilled.files_changed_count).toBe(0);
+    // Stats come from `git show --shortstat <sha>` per orphan, not 0.
+    expect(backfilled.files_changed_count).toBe(1);
     // created_at reflects the commit's author date, not the repair time
     const commitDateIso = execFileSync('git', [
       `--git-dir=${sandbox.repoDir}`, 'log', '-1', '--format=%aI', orphanSha,
@@ -769,6 +771,7 @@ describe('recordRevisionForRun', () => {
       run: { id: 'run-mixed', identity: TEST_IDENTITY },
       message: 'add hero',
       db: sandbox.db,
+      runTouchedFiles: true,
     });
     if (result.kind !== 'recorded') throw new Error('expected recorded');
 
@@ -837,6 +840,7 @@ describe('recordRevisionForRun', () => {
       run: { id: 'run-chain-1', identity: TEST_IDENTITY },
       message: 'first',
       db: sandbox.db,
+      runTouchedFiles: true,
     });
     if (first.kind !== 'recorded') throw new Error('expected first to record');
 
@@ -849,6 +853,7 @@ describe('recordRevisionForRun', () => {
       run: { id: 'run-chain-2', identity: TEST_IDENTITY },
       message: 'second',
       db: sandbox.db,
+      runTouchedFiles: true,
     });
     if (second.kind !== 'recorded') throw new Error('expected second to record');
 
@@ -993,18 +998,20 @@ describe('recordRevisionForRun', () => {
       }),
     ]);
 
-    // Invariant under test, order-independent: the conversational run
-    // (runTouchedFiles=false) MUST NEVER produce a marker row. It may
-    // end up with a 'recorded' row if it happens to win the lock
-    // against a dirty workdir (separate attribution concern outside
-    // this fix's scope), but a marker (git_sha IS NULL) is durable
-    // false provenance and must never appear for it.
-    const talkerMarker = sandbox.db
-      .prepare(
-        `SELECT id FROM project_revisions
-          WHERE project_id = ? AND run_id = 'talker-b' AND git_sha IS NULL`,
-      )
+    // The conversational run (runTouchedFiles=false) must never produce
+    // ANY row — neither a marker (git_sha IS NULL) nor a recorded row
+    // attributing the sibling's work to it. Both shapes are false
+    // provenance; the dirt belongs to the writer, not the talker.
+    const talkerRow = sandbox.db
+      .prepare(`SELECT id FROM project_revisions WHERE project_id = ? AND run_id = 'talker-b'`)
       .get(sandbox.projectId);
-    expect(talkerMarker).toBeUndefined();
+    expect(talkerRow).toBeUndefined();
+
+    // a.txt did land in history exactly once (the writer's row).
+    const writerRow = sandbox.db
+      .prepare(`SELECT id, git_sha FROM project_revisions WHERE project_id = ? AND run_id = 'writer-a'`)
+      .get(sandbox.projectId) as { id: string; git_sha: string };
+    expect(writerRow).toBeDefined();
+    expect(writerRow.git_sha).toMatch(/^[0-9a-f]{40}$/);
   });
 });

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -693,7 +693,7 @@ describe('recordRevisionForRun', () => {
     expect(proj.current_revision_id).toBe(bRow.id);
   });
 
-  it('fails loudly when commit metadata cannot be read during repair (no fabrication)', async () => {
+  it('fails loudly when the git object DB is corrupt during repair (no fabrication)', async () => {
     writeFileSync(path.join(sandbox.projectDir, 'orphan.txt'), 'x\n');
     execFileSync(
       'git',
@@ -710,8 +710,15 @@ describe('recordRevisionForRun', () => {
       { stdio: 'ignore' },
     );
 
-    // Corrupt the gitdir so git log fails. Removing HEAD is enough.
-    rmSync(path.join(sandbox.repoDir, 'HEAD'), { force: true });
+    const orphanSha = execFileSync(
+      'git',
+      [`--git-dir=${sandbox.repoDir}`, 'rev-parse', 'HEAD'],
+      { encoding: 'utf8' },
+    ).trim();
+    rmSync(
+      path.join(sandbox.repoDir, 'objects', orphanSha.slice(0, 2), orphanSha.slice(2)),
+      { force: true },
+    );
 
     await expect(
       recordRevisionForRun({
@@ -724,7 +731,6 @@ describe('recordRevisionForRun', () => {
       }),
     ).rejects.toThrow();
 
-    // No orphan row was written. Only the original migration row remains.
     const count = sandbox.db.prepare(
       `SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = ?`,
     ).get(sandbox.projectId) as { n: number };

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -219,6 +219,74 @@ describe('initProjectHistory', () => {
     expect(third.kind).toBe('already-initialized');
   });
 
+  it('repairs a half-init with an unborn HEAD (gitdir exists, no initial commit)', async () => {
+    // The narrower half-init case: a crash between `git init` (creates
+    // gitdir + gitlink) and `git commit --allow-empty` (creates the
+    // initial commit). On retry, readDotGitState() returns 'ours' but
+    // HEAD is unborn — the previous repair (P0-fix.10) would call
+    // `git rev-parse HEAD` and throw on exit 128, leaving the project
+    // permanently broken. Fix: probe HEAD with softFail128 and, when
+    // absent, resume the remaining init steps before writing the row.
+    writeFileSync(path.join(sandbox.projectDir, 'README.md'), '# project\n');
+
+    // Manually create the unborn-HEAD half-state without running
+    // initProjectHistory at all. `git init --separate-git-dir` puts
+    // the gitdir at repoDir, writes the gitlink in projectDir, and
+    // creates HEAD pointing at refs/heads/main — but with no
+    // commits yet, so rev-parse HEAD exits 128 ("unknown revision").
+    mkdirSync(path.dirname(sandbox.repoDir), { recursive: true });
+    execFileSync('git', [
+      'init',
+      `--separate-git-dir=${sandbox.repoDir}`,
+      '--initial-branch=main',
+      sandbox.projectDir,
+    ], { stdio: 'ignore' });
+    // Sanity: rev-parse HEAD exits 128 on the unborn branch
+    expect(() => execFileSync('git', [`--git-dir=${sandbox.repoDir}`, 'rev-parse', 'HEAD'])).toThrow();
+
+    // initProjectHistory should detect 'ours' + no migration row + no
+    // HEAD, and resume the init from where the previous attempt died.
+    const result = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+    expect(result.kind).toBe('repaired');
+    if (result.kind !== 'repaired') return;
+
+    // After repair: HEAD exists, the initial commit was created.
+    const headSha = execFileSync('git', [`--git-dir=${sandbox.repoDir}`, 'rev-parse', 'HEAD']).toString().trim();
+    expect(headSha).toMatch(/^[0-9a-f]{40}$/);
+
+    // Migration row exists and matches HEAD
+    const row = sandbox.db.prepare(
+      `SELECT git_sha, source, actor_identity_id FROM project_revisions WHERE id = ?`,
+    ).get(result.revisionId) as { git_sha: string; source: string; actor_identity_id: string };
+    expect(row.source).toBe('migration');
+    expect(row.git_sha).toBe(headSha);
+    expect(row.actor_identity_id).toBe('local:default');
+
+    // info/exclude was populated with the daemon-managed block
+    const excludeBody = readFileSync(path.join(sandbox.repoDir, 'info', 'exclude'), 'utf8');
+    expect(excludeBody).toContain('.od-skills/');
+
+    // projects.current_revision_id was advanced
+    const proj = sandbox.db.prepare(`SELECT current_revision_id FROM projects WHERE id = 'p1'`).get() as { current_revision_id: string };
+    expect(proj.current_revision_id).toBe(result.revisionId);
+
+    // Subsequent call returns the no-op fast path
+    const second = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+    expect(second.kind).toBe('already-initialized');
+  });
+
   it('refuses to take ownership of a foreign .git directory', async () => {
     // Simulate a cloned repo: put a regular .git/ directory in the tree
     mkdirSync(path.join(sandbox.projectDir, '.git'), { recursive: true });

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -300,6 +300,84 @@ describe('recordRevisionForRun', () => {
     expect(count.n).toBe(1);
   });
 
+  it('treats a tree where only .od-skills/ changed as clean (runtime scratch is excluded)', async () => {
+    // The daemon stages active skills into <cwd>/.od-skills/ before
+    // each agent run — that's pure runtime scratch and should never
+    // produce a revision. Substrate init writes the exclude to
+    // <repoDir>/info/exclude; this regression test makes sure the
+    // exclude is in effect.
+    const skillsDir = path.join(sandbox.projectDir, '.od-skills', 'staged-skill');
+    mkdirSync(skillsDir, { recursive: true });
+    writeFileSync(path.join(skillsDir, 'SKILL.md'), '# staged skill\n');
+
+    const result = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-skill-only', identity: TEST_IDENTITY },
+      message: 'should not commit anything',
+      db: sandbox.db,
+    });
+
+    expect(result.kind).toBe('clean');
+    // Still only the migration row exists
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = ?`).get(sandbox.projectId) as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  it('records a user-file change even when .od-skills/ is also dirty (skills do not block real work)', async () => {
+    // Write both a real file AND staged-skill scratch; the commit
+    // should capture only the real file (the scratch stays untracked).
+    const skillsDir = path.join(sandbox.projectDir, '.od-skills', 'staged-skill');
+    mkdirSync(skillsDir, { recursive: true });
+    writeFileSync(path.join(skillsDir, 'SKILL.md'), '# staged skill\n');
+    writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hero</h1>\n');
+
+    const result = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-mixed', identity: TEST_IDENTITY },
+      message: 'add hero',
+      db: sandbox.db,
+    });
+    if (result.kind !== 'recorded') throw new Error('expected recorded');
+
+    // Only hero.html should be in the commit; .od-skills/ stays untracked.
+    expect(result.filesChanged).toBe(1);
+    expect(result.bytesAdded).toBe(1);
+  });
+
+  it('backfills info/exclude on a legacy substrate that pre-dates the fix', async () => {
+    // Simulate a substrate initialized before info/exclude was being
+    // written — clobber the file to nothing and verify recordRevisionForRun
+    // re-asserts our patterns before staging.
+    const excludePath = path.join(sandbox.repoDir, 'info', 'exclude');
+    writeFileSync(excludePath, '# pre-fix content with no daemon-managed marker\n');
+
+    // .od-skills/ scratch only — should be excluded after the backfill.
+    const skillsDir = path.join(sandbox.projectDir, '.od-skills', 'staged-skill');
+    mkdirSync(skillsDir, { recursive: true });
+    writeFileSync(path.join(skillsDir, 'SKILL.md'), '# staged skill\n');
+
+    const result = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-legacy-substrate', identity: TEST_IDENTITY },
+      message: 'should be clean post-backfill',
+      db: sandbox.db,
+    });
+
+    expect(result.kind).toBe('clean');
+    // info/exclude now carries the daemon-managed marker and patterns.
+    const updated = readFileSync(excludePath, 'utf8');
+    expect(updated).toContain('open-design:history-managed');
+    expect(updated).toContain('.od-skills/');
+    // The pre-existing content is preserved (we append, not overwrite).
+    expect(updated).toContain('# pre-fix content with no daemon-managed marker');
+  });
+
   it('returns "not-initialized" if substrate is missing for the project', async () => {
     // Create a fresh sandbox without init
     sandbox.db.close();

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -440,6 +440,116 @@ describe('recordRevisionForRun', () => {
     expect(count.n).toBe(1);
   });
 
+  it('backfills an orphan HEAD revision when a prior call crashed between git commit and the DB INSERT', async () => {
+    // P0-fix #14 — invariant: at the end of recordRevisionForRunLocked,
+    // HEAD's SHA always has a corresponding project_revisions row. If
+    // a prior call's git commit landed but its SQLite INSERT failed
+    // (transient error or process crash), HEAD is one commit ahead of
+    // the table. Without the orphan-backfill check the next call sees
+    // status='' clean, headBeforeLock === headNow, and returns 'clean'
+    // — the orphan stays orphan forever and provenance is permanently
+    // broken for that commit.
+    //
+    // This test simulates the boundary-4 crash directly: create the
+    // orphan commit via git (no row in the table for it), then call
+    // recordRevisionForRun and assert the back-fill row was inserted
+    // with the right linkage.
+
+    // Discover the migration row that was inserted by beforeEach's init
+    const migrationRow = sandbox.db.prepare(
+      `SELECT id, git_sha FROM project_revisions WHERE project_id = ? AND source = 'migration'`,
+    ).get(sandbox.projectId) as { id: string; git_sha: string };
+    expect(migrationRow).toBeDefined();
+
+    // Simulate the boundary-4 state: make an extra commit at HEAD
+    // (the "orphan") that NO project_revisions row references.
+    writeFileSync(path.join(sandbox.projectDir, 'orphan-from-crashed-run.txt'), 'a\n');
+    execFileSync(
+      'git',
+      [`--git-dir=${sandbox.repoDir}`, `--work-tree=${sandbox.projectDir}`, 'add', '-A'],
+      { stdio: 'ignore' },
+    );
+    execFileSync(
+      'git',
+      [`--git-dir=${sandbox.repoDir}`, `--work-tree=${sandbox.projectDir}`,
+       '-c', 'user.email=crashed@test.local', '-c', 'user.name=crashed',
+       'commit', '-m', 'this commit lost its DB write'],
+      { stdio: 'ignore' },
+    );
+    const orphanSha = execFileSync('git', [`--git-dir=${sandbox.repoDir}`, 'rev-parse', 'HEAD']).toString().trim();
+    expect(orphanSha).not.toBe(migrationRow.git_sha);
+    // Confirm the orphan really has no row before we call recordRevisionForRun
+    const preExisting = sandbox.db.prepare(
+      `SELECT id FROM project_revisions WHERE project_id = ? AND git_sha = ?`,
+    ).get(sandbox.projectId, orphanSha) as { id: string } | undefined;
+    expect(preExisting).toBeUndefined();
+
+    // Now call recordRevisionForRun with a CLEAN tree (no new file
+    // changes). The orphan-backfill check should fire before the
+    // status check and insert the missing row.
+    const result = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-after-crash', identity: TEST_IDENTITY },
+      message: 'this run had no file changes',
+      db: sandbox.db,
+    });
+
+    // The tree truly is clean for this call (we already committed the
+    // orphan file above; nothing new to commit now), so the return is
+    // 'clean'. The back-fill happened as a side-effect.
+    expect(result.kind).toBe('clean');
+
+    // The orphan SHA now has a row
+    const backfilled = sandbox.db.prepare(
+      `SELECT id, source, parent_id, git_sha, actor_identity_id, actor_display_name, run_id, files_changed_count, message
+         FROM project_revisions WHERE project_id = ? AND git_sha = ?`,
+    ).get(sandbox.projectId, orphanSha) as {
+      id: string;
+      source: string;
+      parent_id: string | null;
+      git_sha: string;
+      actor_identity_id: string;
+      actor_display_name: string;
+      run_id: string | null;
+      files_changed_count: number;
+      message: string;
+    };
+    expect(backfilled).toBeDefined();
+    expect(backfilled.source).toBe('agent-run');
+    // parent_id points at the previous latest row (the migration row)
+    expect(backfilled.parent_id).toBe(migrationRow.id);
+    expect(backfilled.actor_identity_id).toBe('local:default');
+    // The original run_id from the crashed call is unrecoverable
+    expect(backfilled.run_id).toBeNull();
+    // Marker message indicates recovery
+    expect(backfilled.message).toContain('recovered');
+    expect(backfilled.files_changed_count).toBe(0);
+
+    // projects.current_revision_id now points at the back-filled row
+    const proj = sandbox.db.prepare(`SELECT current_revision_id FROM projects WHERE id = 'p1'`).get() as { current_revision_id: string };
+    expect(proj.current_revision_id).toBe(backfilled.id);
+
+    // Total rows: migration + orphan-backfill
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = 'p1'`).get() as { n: number };
+    expect(count.n).toBe(2);
+
+    // A subsequent recordRevisionForRun on a still-clean tree is a
+    // pure no-op — HEAD now has its row, no orphan to repair.
+    const secondCall = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-after-backfill', identity: TEST_IDENTITY },
+      message: 'still clean',
+      db: sandbox.db,
+    });
+    expect(secondCall.kind).toBe('clean');
+    const finalCount = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = 'p1'`).get() as { n: number };
+    expect(finalCount.n).toBe(2);
+  });
+
   it('treats a tree where only .od-skills/ changed as clean (runtime scratch is excluded)', async () => {
     // The daemon stages active skills into <cwd>/.od-skills/ before
     // each agent run — that's pure runtime scratch and should never

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -638,6 +638,97 @@ describe('recordRevisionForRun', () => {
     expect(after.current_revision_id).toBe(migrationRow.id);
   });
 
+  it('backfills every orphan in a multi-commit chain (oldest → newest), not just HEAD', async () => {
+    const migrationRow = sandbox.db.prepare(
+      `SELECT id, git_sha FROM project_revisions WHERE project_id = ? AND source = 'migration'`,
+    ).get(sandbox.projectId) as { id: string; git_sha: string };
+
+    // Two consecutive crashed runs: each landed a commit but never the
+    // SQLite row. Construct via direct git so the DB has only the
+    // migration row.
+    const gitArgs = (...args: string[]) => execFileSync(
+      'git',
+      [`--git-dir=${sandbox.repoDir}`, `--work-tree=${sandbox.projectDir}`,
+       '-c', 'user.email=ghost@test.local', '-c', 'user.name=Ghost', ...args],
+      { stdio: 'ignore' },
+    );
+    writeFileSync(path.join(sandbox.projectDir, 'orphan-A.txt'), 'A\n');
+    gitArgs('add', '-A');
+    gitArgs('commit', '-m', 'first orphan (A)');
+    const orphanA = execFileSync('git', [`--git-dir=${sandbox.repoDir}`, 'rev-parse', 'HEAD']).toString().trim();
+    writeFileSync(path.join(sandbox.projectDir, 'orphan-B.txt'), 'B\n');
+    gitArgs('add', '-A');
+    gitArgs('commit', '-m', 'second orphan (B)');
+    const orphanB = execFileSync('git', [`--git-dir=${sandbox.repoDir}`, 'rev-parse', 'HEAD']).toString().trim();
+
+    await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'retry-after-two-crashes', identity: TEST_IDENTITY },
+      message: 'unused',
+      db: sandbox.db,
+    });
+
+    const rows = sandbox.db.prepare(
+      `SELECT id, git_sha, parent_id, message FROM project_revisions WHERE project_id = ?`,
+    ).all(sandbox.projectId) as Array<{ id: string; git_sha: string; parent_id: string | null; message: string }>;
+    expect(rows).toHaveLength(3);
+    const bySha = new Map(rows.map((r) => [r.git_sha, r]));
+    const migRow = bySha.get(migrationRow.git_sha)!;
+    const aRow = bySha.get(orphanA)!;
+    const bRow = bySha.get(orphanB)!;
+    expect(migRow).toBeDefined();
+    expect(aRow).toBeDefined();
+    expect(bRow).toBeDefined();
+    expect(migRow.parent_id).toBeNull();
+    expect(aRow.parent_id).toBe(migRow.id);
+    expect(bRow.parent_id).toBe(aRow.id);
+    expect(aRow.message).toBe('first orphan (A)');
+    expect(bRow.message).toBe('second orphan (B)');
+
+    const proj = sandbox.db.prepare(`SELECT current_revision_id FROM projects WHERE id = 'p1'`).get() as { current_revision_id: string };
+    expect(proj.current_revision_id).toBe(bRow.id);
+  });
+
+  it('fails loudly when commit metadata cannot be read during repair (no fabrication)', async () => {
+    writeFileSync(path.join(sandbox.projectDir, 'orphan.txt'), 'x\n');
+    execFileSync(
+      'git',
+      [`--git-dir=${sandbox.repoDir}`, `--work-tree=${sandbox.projectDir}`,
+       '-c', 'user.email=ghost@test.local', '-c', 'user.name=Ghost',
+       'add', '-A'],
+      { stdio: 'ignore' },
+    );
+    execFileSync(
+      'git',
+      [`--git-dir=${sandbox.repoDir}`, `--work-tree=${sandbox.projectDir}`,
+       '-c', 'user.email=ghost@test.local', '-c', 'user.name=Ghost',
+       'commit', '-m', 'about to break'],
+      { stdio: 'ignore' },
+    );
+
+    // Corrupt the gitdir so git log fails. Removing HEAD is enough.
+    rmSync(path.join(sandbox.repoDir, 'HEAD'), { force: true });
+
+    await expect(
+      recordRevisionForRun({
+        projectId: sandbox.projectId,
+        projectDir: sandbox.projectDir,
+        repoDir: sandbox.repoDir,
+        run: { id: 'retry-after-corruption', identity: TEST_IDENTITY },
+        message: 'unused',
+        db: sandbox.db,
+      }),
+    ).rejects.toThrow();
+
+    // No orphan row was written. Only the original migration row remains.
+    const count = sandbox.db.prepare(
+      `SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = ?`,
+    ).get(sandbox.projectId) as { n: number };
+    expect(count.n).toBe(1);
+  });
+
   it('treats a tree where only .od-skills/ changed as clean (runtime scratch is excluded)', async () => {
     // The daemon stages active skills into <cwd>/.od-skills/ before
     // each agent run — that's pure runtime scratch and should never

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { execFileSync } from 'node:child_process';
+
+import { migrateProjectRevisions } from '../src/history/persistence.js';
+import {
+  initProjectHistory,
+  projectRepoPath,
+  recordRevisionForRun,
+} from '../src/history/repo.js';
+import { isHistoryEnabled } from '../src/history/feature-flag.js';
+import type { Identity } from '../src/identity/types.js';
+
+const TEST_IDENTITY: Identity = {
+  id: 'local:default',
+  displayName: 'Test User',
+  email: 'test@example.com',
+  source: 'local-fallback',
+};
+
+function setupSandbox(): { dataRoot: string; projectsRoot: string; reposRoot: string; projectId: string; projectDir: string; repoDir: string; db: Database.Database } {
+  const dataRoot = mkdtempSync(path.join(tmpdir(), 'od-history-'));
+  const projectsRoot = path.join(dataRoot, 'projects');
+  const reposRoot = path.join(dataRoot, 'repos');
+  const projectId = 'p1';
+  const projectDir = path.join(projectsRoot, projectId);
+  const repoDir = projectRepoPath(reposRoot, projectId);
+  mkdirSync(projectDir, { recursive: true });
+
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      title TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT,
+      created_at INTEGER NOT NULL
+    );
+    INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p1', 'p1', 0, 0);
+  `);
+  migrateProjectRevisions(db);
+  return { dataRoot, projectsRoot, reposRoot, projectId, projectDir, repoDir, db };
+}
+
+describe('isHistoryEnabled', () => {
+  it('returns false when the flag is unset', () => {
+    expect(isHistoryEnabled({})).toBe(false);
+  });
+  it.each(['1', 'true', 'yes', 'TRUE', 'Yes'])('returns true for %s', (value) => {
+    expect(isHistoryEnabled({ OD_GIT_INTEGRATION_ENABLED: value })).toBe(true);
+  });
+  it.each(['0', 'false', 'no', '', '  '])('returns false for %s', (value) => {
+    expect(isHistoryEnabled({ OD_GIT_INTEGRATION_ENABLED: value })).toBe(false);
+  });
+});
+
+describe('initProjectHistory', () => {
+  let sandbox: ReturnType<typeof setupSandbox>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox();
+  });
+  afterEach(() => {
+    sandbox.db.close();
+    rmSync(sandbox.dataRoot, { recursive: true, force: true });
+  });
+
+  it('initializes a fresh project tree: creates repo, .gitignore, migration revision', async () => {
+    // Drop one file before init so the migration commit is non-empty
+    writeFileSync(path.join(sandbox.projectDir, 'README.md'), '# project\n');
+
+    const result = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+
+    expect(result.kind).toBe('initialized');
+    if (result.kind !== 'initialized') return; // type guard for the assertions below
+
+    // The gitdir lives at the expected path
+    expect(existsSync(sandbox.repoDir)).toBe(true);
+    // The project tree has a .git gitlink pointing at our repoDir
+    const dotGit = readFileSync(path.join(sandbox.projectDir, '.git'), 'utf8');
+    expect(dotGit).toMatch(/^gitdir:\s*/);
+    expect(dotGit).toContain(sandbox.repoDir);
+    // Default .gitignore was written
+    expect(existsSync(path.join(sandbox.projectDir, '.gitignore'))).toBe(true);
+    // The migration commit's SHA was returned
+    expect(result.revisionId).toMatch(/^[0-9a-f]{40}$/);
+    // project_revisions has a 'migration' row for this SHA
+    const row = sandbox.db.prepare(
+      `SELECT id, source, parent_id, actor_identity_id FROM project_revisions WHERE id = ?`,
+    ).get(result.revisionId) as { id: string; source: string; parent_id: string | null; actor_identity_id: string };
+    expect(row.source).toBe('migration');
+    expect(row.parent_id).toBeNull();
+    expect(row.actor_identity_id).toBe('local:default');
+    // current_revision_id was advanced
+    const proj = sandbox.db.prepare(`SELECT current_revision_id FROM projects WHERE id = 'p1'`).get() as { current_revision_id: string };
+    expect(proj.current_revision_id).toBe(result.revisionId);
+  });
+
+  it('is idempotent — second call returns already-initialized without re-touching', async () => {
+    writeFileSync(path.join(sandbox.projectDir, 'README.md'), '# project\n');
+
+    const first = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+    expect(first.kind).toBe('initialized');
+
+    const second = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+    expect(second.kind).toBe('already-initialized');
+
+    // Still exactly one revision row
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = 'p1'`).get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  it('refuses to take ownership of a foreign .git directory', async () => {
+    // Simulate a cloned repo: put a regular .git/ directory in the tree
+    mkdirSync(path.join(sandbox.projectDir, '.git'), { recursive: true });
+    writeFileSync(path.join(sandbox.projectDir, '.git', 'config'), '[core]\n');
+
+    const result = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+
+    expect(result.kind).toBe('foreign-git-collision');
+    // No revision row was inserted
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions`).get() as { n: number };
+    expect(count.n).toBe(0);
+  });
+
+  it('refuses to take ownership of a foreign .git gitlink (points elsewhere)', async () => {
+    // .git is a gitlink, but to a different gitdir than ours
+    const elsewhere = path.join(sandbox.dataRoot, 'somewhere-else.gitdir');
+    writeFileSync(path.join(sandbox.projectDir, '.git'), `gitdir: ${elsewhere}\n`);
+
+    const result = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+
+    expect(result.kind).toBe('foreign-git-collision');
+    if (result.kind !== 'foreign-git-collision') return;
+    expect(result.target).toBe(elsewhere);
+  });
+
+  it('handles an empty project tree (allow-empty initial commit)', async () => {
+    // Don't drop any files — just init against an empty dir
+    const result = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+    expect(result.kind).toBe('initialized');
+    if (result.kind === 'initialized') {
+      expect(result.revisionId).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+
+  it('synthesizes a git author email when Identity has none', async () => {
+    writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'a\n');
+    const identityWithoutEmail: Identity = {
+      id: 'local:default',
+      displayName: 'No Email User',
+      source: 'local-fallback',
+    };
+    const result = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: identityWithoutEmail,
+      db: sandbox.db,
+    });
+    expect(result.kind).toBe('initialized');
+    if (result.kind !== 'initialized') return;
+    // Inspect the actual commit's author email via git
+    const author = execFileSync('git', ['log', '-1', '--format=%ae', result.revisionId], {
+      cwd: sandbox.projectDir,
+    }).toString().trim();
+    expect(author).toBe('local_default@open-design.local');
+  });
+});
+
+describe('recordRevisionForRun', () => {
+  let sandbox: ReturnType<typeof setupSandbox>;
+
+  beforeEach(async () => {
+    sandbox = setupSandbox();
+    writeFileSync(path.join(sandbox.projectDir, 'README.md'), '# project\n');
+    await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+  });
+  afterEach(() => {
+    sandbox.db.close();
+    rmSync(sandbox.dataRoot, { recursive: true, force: true });
+  });
+
+  it('records a revision when the tree is dirty after a run', async () => {
+    // Simulate the agent writing a new file during the run
+    writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
+
+    const result = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-1', identity: TEST_IDENTITY },
+      message: 'Add hero section',
+      db: sandbox.db,
+    });
+
+    expect(result.kind).toBe('recorded');
+    if (result.kind !== 'recorded') return;
+    expect(result.revisionId).toMatch(/^[0-9a-f]{40}$/);
+    expect(result.filesChanged).toBe(1);
+    expect(result.bytesAdded).toBe(1);
+
+    // Revision row stored with run_id + source='agent-run'
+    const row = sandbox.db.prepare(
+      `SELECT source, run_id, actor_identity_id, parent_id FROM project_revisions WHERE id = ?`,
+    ).get(result.revisionId) as { source: string; run_id: string; actor_identity_id: string; parent_id: string | null };
+    expect(row.source).toBe('agent-run');
+    expect(row.run_id).toBe('run-1');
+    expect(row.actor_identity_id).toBe('local:default');
+    expect(row.parent_id).not.toBeNull(); // we have the migration parent
+
+    // current_revision_id advanced
+    const proj = sandbox.db.prepare(`SELECT current_revision_id FROM projects WHERE id = 'p1'`).get() as { current_revision_id: string };
+    expect(proj.current_revision_id).toBe(result.revisionId);
+  });
+
+  it('returns "clean" with no-op when the tree is unchanged', async () => {
+    const result = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-2', identity: TEST_IDENTITY },
+      message: 'No-op run',
+      db: sandbox.db,
+    });
+
+    expect(result.kind).toBe('clean');
+
+    // Still exactly the original migration row + nothing new
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = 'p1'`).get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  it('returns "not-initialized" if substrate is missing for the project', async () => {
+    // Create a fresh sandbox without init
+    sandbox.db.close();
+    rmSync(sandbox.dataRoot, { recursive: true, force: true });
+    sandbox = setupSandbox();
+    writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'a\n');
+
+    const result = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-3', identity: TEST_IDENTITY },
+      message: 'whatever',
+      db: sandbox.db,
+    });
+
+    expect(result.kind).toBe('not-initialized');
+  });
+});

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -706,6 +706,7 @@ describe('recordRevisionForRun', () => {
         run: { id: 'run-a', identity: TEST_IDENTITY },
         message: 'first parallel',
         db: sandbox.db,
+        runTouchedFiles: true,
       }),
       recordRevisionForRun({
         projectId: sandbox.projectId,
@@ -714,6 +715,7 @@ describe('recordRevisionForRun', () => {
         run: { id: 'run-b', identity: TEST_IDENTITY },
         message: 'second parallel',
         db: sandbox.db,
+        runTouchedFiles: true,
       }),
     ]);
 
@@ -786,5 +788,49 @@ describe('recordRevisionForRun', () => {
       db: sandbox.db,
     });
     expect(cleanProbe.kind).toBe('clean');
+  });
+
+  it('does not create a marker for a purely conversational run when a sibling commits in parallel', async () => {
+    writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'a\n');
+
+    await Promise.all([
+      recordRevisionForRun({
+        projectId: sandbox.projectId,
+        projectDir: sandbox.projectDir,
+        repoDir: sandbox.repoDir,
+        run: { id: 'writer-a', identity: TEST_IDENTITY },
+        message: 'wrote a.txt',
+        db: sandbox.db,
+        runTouchedFiles: true,
+      }),
+      recordRevisionForRun({
+        projectId: sandbox.projectId,
+        projectDir: sandbox.projectDir,
+        repoDir: sandbox.repoDir,
+        run: { id: 'talker-b', identity: TEST_IDENTITY },
+        message: 'just chatted',
+        db: sandbox.db,
+        runTouchedFiles: false,
+      }),
+    ]);
+
+    // Lock order is non-deterministic: either A or B may win and
+    // record the dirty file. The contract under test is narrower:
+    // the conversational run (runTouchedFiles=false) must NEVER
+    // produce a marker row regardless of lock order.
+    const talkerMarker = sandbox.db
+      .prepare(
+        `SELECT id FROM project_revisions
+          WHERE project_id = ? AND run_id = 'talker-b' AND git_sha IS NULL`,
+      )
+      .get(sandbox.projectId);
+    expect(talkerMarker).toBeUndefined();
+
+    // a.txt got committed exactly once (lock winner records it),
+    // so total = migration + 1 recorded = 2 rows.
+    const count = sandbox.db
+      .prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = ?`)
+      .get(sandbox.projectId) as { n: number };
+    expect(count.n).toBe(2);
   });
 });

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -147,6 +147,78 @@ describe('initProjectHistory', () => {
     expect(count.n).toBe(1);
   });
 
+  it('repairs a half-initialized substrate (gitdir present, migration row missing)', async () => {
+    // Setup: do a normal init, then simulate the "post-commit DB write
+    // failed" outcome by deleting the migration row and clearing the
+    // current_revision_id pointer. This is the state the daemon would
+    // be in after a crash (or transient SQLite error) between the git
+    // commit and the INSERT/UPDATE in initProjectHistoryLocked.
+    writeFileSync(path.join(sandbox.projectDir, 'README.md'), '# project\n');
+    const first = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+    expect(first.kind).toBe('initialized');
+
+    // Force the half-init state — gitdir on disk stays, DB state lost.
+    sandbox.db.prepare(`DELETE FROM project_revisions WHERE project_id = ?`).run(sandbox.projectId);
+    sandbox.db.prepare(`UPDATE projects SET current_revision_id = NULL WHERE id = ?`).run(sandbox.projectId);
+    const pre = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = ?`).get(sandbox.projectId) as { n: number };
+    expect(pre.n).toBe(0);
+
+    // Retry init — should detect the half-init state and repair from HEAD,
+    // NOT short-circuit at the readDotGitState() === 'ours' check.
+    const second = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+    expect(second.kind).toBe('repaired');
+    if (second.kind !== 'repaired') return;
+
+    // The reconstructed migration row references HEAD's SHA.
+    const repaired = sandbox.db.prepare(
+      `SELECT id, source, parent_id, git_sha, actor_identity_id, run_id, files_changed_count
+         FROM project_revisions WHERE id = ?`,
+    ).get(second.revisionId) as {
+      id: string;
+      source: string;
+      parent_id: string | null;
+      git_sha: string;
+      actor_identity_id: string;
+      run_id: string | null;
+      files_changed_count: number;
+    };
+    expect(repaired.source).toBe('migration');
+    expect(repaired.parent_id).toBeNull();
+    expect(repaired.git_sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(repaired.actor_identity_id).toBe('local:default');
+    expect(repaired.run_id).toBeNull();
+    expect(repaired.files_changed_count).toBe(0);
+    // Exactly the SHA of the existing HEAD (we didn't make a new commit)
+    const headSha = execFileSync('git', [`--git-dir=${sandbox.repoDir}`, 'rev-parse', 'HEAD']).toString().trim();
+    expect(repaired.git_sha).toBe(headSha);
+
+    // projects.current_revision_id was re-advanced to the repaired revision
+    const proj = sandbox.db.prepare(`SELECT current_revision_id FROM projects WHERE id = 'p1'`).get() as { current_revision_id: string };
+    expect(proj.current_revision_id).toBe(second.revisionId);
+
+    // A third call after repair returns the no-op fast path
+    const third = await initProjectHistory({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      identity: TEST_IDENTITY,
+      db: sandbox.db,
+    });
+    expect(third.kind).toBe('already-initialized');
+  });
+
   it('refuses to take ownership of a foreign .git directory', async () => {
     // Simulate a cloned repo: put a regular .git/ directory in the tree
     mkdirSync(path.join(sandbox.projectDir, '.git'), { recursive: true });

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -106,14 +106,15 @@ describe('initProjectHistory', () => {
     expect(dotGit).toContain(sandbox.repoDir);
     // Default .gitignore was written
     expect(existsSync(path.join(sandbox.projectDir, '.gitignore'))).toBe(true);
-    // The migration commit's SHA was returned
-    expect(result.revisionId).toMatch(/^[0-9a-f]{40}$/);
-    // project_revisions has a 'migration' row for this SHA
+    // revisionId is a substrate-opaque UUID, not the git SHA
+    expect(result.revisionId).toMatch(/^[0-9a-f-]{36}$/);
+    // project_revisions has a 'migration' row; the git SHA lives in git_sha
     const row = sandbox.db.prepare(
-      `SELECT id, source, parent_id, actor_identity_id FROM project_revisions WHERE id = ?`,
-    ).get(result.revisionId) as { id: string; source: string; parent_id: string | null; actor_identity_id: string };
+      `SELECT id, source, parent_id, git_sha, actor_identity_id FROM project_revisions WHERE id = ?`,
+    ).get(result.revisionId) as { id: string; source: string; parent_id: string | null; git_sha: string; actor_identity_id: string };
     expect(row.source).toBe('migration');
     expect(row.parent_id).toBeNull();
+    expect(row.git_sha).toMatch(/^[0-9a-f]{40}$/);
     expect(row.actor_identity_id).toBe('local:default');
     // current_revision_id was advanced
     const proj = sandbox.db.prepare(`SELECT current_revision_id FROM projects WHERE id = 'p1'`).get() as { current_revision_id: string };
@@ -194,7 +195,7 @@ describe('initProjectHistory', () => {
     });
     expect(result.kind).toBe('initialized');
     if (result.kind === 'initialized') {
-      expect(result.revisionId).toMatch(/^[0-9a-f]{40}$/);
+      expect(result.revisionId).toMatch(/^[0-9a-f-]{36}$/);
     }
   });
 
@@ -214,8 +215,12 @@ describe('initProjectHistory', () => {
     });
     expect(result.kind).toBe('initialized');
     if (result.kind !== 'initialized') return;
-    // Inspect the actual commit's author email via git
-    const author = execFileSync('git', ['log', '-1', '--format=%ae', result.revisionId], {
+    // revisionId is the substrate-opaque UUID; resolve the actual
+    // git SHA via the DB row before asking git about the commit.
+    const row = sandbox.db.prepare(
+      `SELECT git_sha FROM project_revisions WHERE id = ?`,
+    ).get(result.revisionId) as { git_sha: string };
+    const author = execFileSync('git', ['log', '-1', '--format=%ae', row.git_sha], {
       cwd: sandbox.projectDir,
     }).toString().trim();
     expect(author).toBe('local_default@open-design.local');
@@ -256,17 +261,21 @@ describe('recordRevisionForRun', () => {
 
     expect(result.kind).toBe('recorded');
     if (result.kind !== 'recorded') return;
-    expect(result.revisionId).toMatch(/^[0-9a-f]{40}$/);
+    // revisionId is now a substrate-opaque UUID; the git SHA lives in
+    // the git_sha column.
+    expect(result.revisionId).toMatch(/^[0-9a-f-]{36}$/);
     expect(result.filesChanged).toBe(1);
     expect(result.bytesAdded).toBe(1);
 
-    // Revision row stored with run_id + source='agent-run'
+    // Revision row stored with run_id + source='agent-run'.
+    // parent_id is the parent's UUID (the migration revision), not its SHA.
     const row = sandbox.db.prepare(
-      `SELECT source, run_id, actor_identity_id, parent_id FROM project_revisions WHERE id = ?`,
-    ).get(result.revisionId) as { source: string; run_id: string; actor_identity_id: string; parent_id: string | null };
+      `SELECT source, run_id, actor_identity_id, parent_id, git_sha FROM project_revisions WHERE id = ?`,
+    ).get(result.revisionId) as { source: string; run_id: string; actor_identity_id: string; parent_id: string | null; git_sha: string };
     expect(row.source).toBe('agent-run');
     expect(row.run_id).toBe('run-1');
     expect(row.actor_identity_id).toBe('local:default');
+    expect(row.git_sha).toMatch(/^[0-9a-f]{40}$/);
     expect(row.parent_id).not.toBeNull(); // we have the migration parent
 
     // current_revision_id advanced
@@ -308,6 +317,44 @@ describe('recordRevisionForRun', () => {
     });
 
     expect(result.kind).toBe('not-initialized');
+  });
+
+  it('parent_id chains revisions by UUID (not git SHA) so cross-repo SHA collisions cannot break the chain', async () => {
+    // Initial state (from beforeEach): one migration revision exists.
+    // Write a file and record a first agent-run revision.
+    writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'a\n');
+    const first = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-chain-1', identity: TEST_IDENTITY },
+      message: 'first',
+      db: sandbox.db,
+    });
+    if (first.kind !== 'recorded') throw new Error('expected first to record');
+
+    // Second run on top — parent should be the first revision's UUID.
+    writeFileSync(path.join(sandbox.projectDir, 'b.txt'), 'b\n');
+    const second = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-chain-2', identity: TEST_IDENTITY },
+      message: 'second',
+      db: sandbox.db,
+    });
+    if (second.kind !== 'recorded') throw new Error('expected second to record');
+
+    const secondRow = sandbox.db.prepare(
+      `SELECT parent_id FROM project_revisions WHERE id = ?`,
+    ).get(second.revisionId) as { parent_id: string };
+    expect(secondRow.parent_id).toBe(first.revisionId);
+
+    // first's parent points at the migration revision (a UUID, not a SHA)
+    const firstRow = sandbox.db.prepare(
+      `SELECT parent_id FROM project_revisions WHERE id = ?`,
+    ).get(first.revisionId) as { parent_id: string };
+    expect(firstRow.parent_id).toMatch(/^[0-9a-f-]{36}$/);
   });
 
   it('serializes concurrent record calls so each run gets its own revision', async () => {

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -980,6 +980,79 @@ describe('recordRevisionForRun', () => {
     expect(cleanProbe.kind).toBe('clean');
   });
 
+  it('records a marker for run B when run A commits entirely before B enters the hook (sequential completion)', async () => {
+    // Sequential variant of the absorption case: A's full hook completes
+    // before B's even starts. Without runHeadAtCreate, B sees A's HEAD
+    // both at recordRevisionForRun entry and inside the lock, so
+    // headBeforeLock === headNow → no advance observed → marker silently
+    // lost. With runHeadAtCreate captured at runs.create() time (before
+    // A committed), the baseline pre-dates A's commit and the marker
+    // fires.
+    const headAtCreate = (sandbox.db
+      .prepare(`SELECT git_sha FROM project_revisions WHERE project_id = ? AND source = 'migration'`)
+      .get(sandbox.projectId) as { git_sha: string }).git_sha;
+
+    writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'from-a\n');
+    const resA = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-a', identity: TEST_IDENTITY },
+      message: 'A finishes first',
+      db: sandbox.db,
+      runTouchedFiles: true,
+    });
+    expect(resA.kind).toBe('recorded');
+
+    const resB = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-b', identity: TEST_IDENTITY },
+      message: 'B absorbed sequentially',
+      db: sandbox.db,
+      runTouchedFiles: true,
+      runHeadAtCreate: headAtCreate,
+    });
+    expect(resB.kind).toBe('marker');
+
+    const markerRow = sandbox.db
+      .prepare(
+        `SELECT run_id, source, git_sha, parent_id, actor_identity_id
+           FROM project_revisions
+          WHERE project_id = ? AND run_id = 'run-b'`,
+      )
+      .get(sandbox.projectId) as {
+        run_id: string;
+        source: string;
+        git_sha: string | null;
+        parent_id: string | null;
+        actor_identity_id: string;
+      };
+    expect(markerRow.source).toBe('agent-run');
+    expect(markerRow.git_sha).toBeNull();
+    expect(markerRow.actor_identity_id).toBe(TEST_IDENTITY.id);
+
+    const aRow = sandbox.db
+      .prepare(`SELECT id FROM project_revisions WHERE project_id = ? AND run_id = 'run-a'`)
+      .get(sandbox.projectId) as { id: string };
+    expect(markerRow.parent_id).toBe(aRow.id);
+
+    // Without runHeadAtCreate, the same finishing-clean-tree call must
+    // NOT produce a marker — proves runHeadAtCreate is what flips the
+    // outcome, not some other side effect.
+    const resC = await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-c', identity: TEST_IDENTITY },
+      message: 'C without runHeadAtCreate',
+      db: sandbox.db,
+      runTouchedFiles: true,
+    });
+    expect(resC.kind).toBe('clean');
+  });
+
   it('does not create a marker for a purely conversational run when a sibling commits in parallel', async () => {
     writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'a\n');
 

--- a/apps/daemon/tests/history-repo.test.ts
+++ b/apps/daemon/tests/history-repo.test.ts
@@ -181,26 +181,31 @@ describe('initProjectHistory', () => {
     expect(second.kind).toBe('repaired');
     if (second.kind !== 'repaired') return;
 
-    // The reconstructed migration row references HEAD's SHA.
+    // Case (a): HEAD already exists from the crashed prior init.
+    // The retry did NOT author this commit — it just reconstructs the
+    // missing row. Attribution comes from the existing commit's git
+    // metadata; we leave actor_identity_id NULL because that resolved
+    // value is unrecoverable from git alone.
     const repaired = sandbox.db.prepare(
-      `SELECT id, source, parent_id, git_sha, actor_identity_id, run_id, files_changed_count
+      `SELECT id, source, parent_id, git_sha, actor_identity_id, actor_display_name, run_id, files_changed_count
          FROM project_revisions WHERE id = ?`,
     ).get(second.revisionId) as {
       id: string;
       source: string;
       parent_id: string | null;
       git_sha: string;
-      actor_identity_id: string;
+      actor_identity_id: string | null;
+      actor_display_name: string | null;
       run_id: string | null;
       files_changed_count: number;
     };
     expect(repaired.source).toBe('migration');
     expect(repaired.parent_id).toBeNull();
     expect(repaired.git_sha).toMatch(/^[0-9a-f]{40}$/);
-    expect(repaired.actor_identity_id).toBe('local:default');
+    expect(repaired.actor_identity_id).toBeNull();
+    expect(repaired.actor_display_name).toBe('Test User');
     expect(repaired.run_id).toBeNull();
     expect(repaired.files_changed_count).toBe(0);
-    // Exactly the SHA of the existing HEAD (we didn't make a new commit)
     const headSha = execFileSync('git', [`--git-dir=${sandbox.repoDir}`, 'rev-parse', 'HEAD']).toString().trim();
     expect(repaired.git_sha).toBe(headSha);
 
@@ -503,29 +508,41 @@ describe('recordRevisionForRun', () => {
 
     // The orphan SHA now has a row
     const backfilled = sandbox.db.prepare(
-      `SELECT id, source, parent_id, git_sha, actor_identity_id, actor_display_name, run_id, files_changed_count, message
+      `SELECT id, source, parent_id, git_sha, actor_identity_id, actor_display_name, run_id, files_changed_count, message, created_at
          FROM project_revisions WHERE project_id = ? AND git_sha = ?`,
     ).get(sandbox.projectId, orphanSha) as {
       id: string;
       source: string;
       parent_id: string | null;
       git_sha: string;
-      actor_identity_id: string;
-      actor_display_name: string;
+      actor_identity_id: string | null;
+      actor_display_name: string | null;
       run_id: string | null;
       files_changed_count: number;
       message: string;
+      created_at: number;
     };
     expect(backfilled).toBeDefined();
     expect(backfilled.source).toBe('agent-run');
-    // parent_id points at the previous latest row (the migration row)
+    // parent_id derived from `git rev-parse HEAD^` resolved via
+    // git_sha — should match the actual git parent (the migration).
     expect(backfilled.parent_id).toBe(migrationRow.id);
-    expect(backfilled.actor_identity_id).toBe('local:default');
-    // The original run_id from the crashed call is unrecoverable
+    // Attribution recovered from git, not the retrying run:
+    //   actor_identity_id is unrecoverable from git alone
+    expect(backfilled.actor_identity_id).toBeNull();
+    //   actor_display_name from `git show -s --format=%an`
+    expect(backfilled.actor_display_name).toBe('crashed');
+    // run_id from the crashed call is unrecoverable
     expect(backfilled.run_id).toBeNull();
-    // Marker message indicates recovery
-    expect(backfilled.message).toContain('recovered');
+    // message reflects the actual commit, not a hardcoded marker
+    expect(backfilled.message).toBe('this commit lost its DB write');
     expect(backfilled.files_changed_count).toBe(0);
+    // created_at reflects the commit's author date, not the repair time
+    const commitDateIso = execFileSync('git', [
+      `--git-dir=${sandbox.repoDir}`, 'log', '-1', '--format=%aI', orphanSha,
+    ]).toString().trim();
+    const commitDateMs = Date.parse(commitDateIso);
+    expect(backfilled.created_at).toBe(commitDateMs);
 
     // projects.current_revision_id now points at the back-filled row
     const proj = sandbox.db.prepare(`SELECT current_revision_id FROM projects WHERE id = 'p1'`).get() as { current_revision_id: string };
@@ -548,6 +565,77 @@ describe('recordRevisionForRun', () => {
     expect(secondCall.kind).toBe('clean');
     const finalCount = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = 'p1'`).get() as { n: number };
     expect(finalCount.n).toBe(2);
+  });
+
+  it('orphan backfill does not leak attribution from the retrying run when identities differ', async () => {
+    // Make an orphan commit authored by identity A (the crashed run).
+    // Then call recordRevisionForRun with identity B (the retry). The
+    // backfilled row must reflect A's git author, not B's identity.
+    writeFileSync(path.join(sandbox.projectDir, 'orphan-from-A.txt'), 'work from A\n');
+    execFileSync(
+      'git',
+      [`--git-dir=${sandbox.repoDir}`, `--work-tree=${sandbox.projectDir}`, 'add', '-A'],
+      { stdio: 'ignore' },
+    );
+    execFileSync(
+      'git',
+      [
+        `--git-dir=${sandbox.repoDir}`,
+        `--work-tree=${sandbox.projectDir}`,
+        '-c', 'user.email=alice@test.local',
+        '-c', 'user.name=Alice',
+        'commit', '-m', 'feature work by Alice',
+      ],
+      { stdio: 'ignore' },
+    );
+    const orphanSha = execFileSync('git', [`--git-dir=${sandbox.repoDir}`, 'rev-parse', 'HEAD']).toString().trim();
+
+    const BOB: Identity = {
+      id: 'oauth:bob@example.com',
+      displayName: 'Bob',
+      email: 'bob@example.com',
+      source: 'oauth',
+    };
+    await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'bob-retry', identity: BOB },
+      message: 'unused by the backfill path',
+      db: sandbox.db,
+    });
+
+    const backfilled = sandbox.db.prepare(
+      `SELECT actor_identity_id, actor_display_name, message FROM project_revisions WHERE git_sha = ?`,
+    ).get(orphanSha) as { actor_identity_id: string | null; actor_display_name: string | null; message: string };
+    expect(backfilled.actor_identity_id).toBeNull();
+    expect(backfilled.actor_display_name).toBe('Alice');
+    expect(backfilled.message).toBe('feature work by Alice');
+  });
+
+  it('repairs stale current_revision_id when the HEAD row exists but the pointer is wrong', async () => {
+    // Simulate the legacy partial-write state: row landed but the
+    // UPDATE projects pointer didn't (pre-transaction-wrap, or
+    // external interference). Invariant: HEAD's row.id == pointer.
+    const migrationRow = sandbox.db.prepare(
+      `SELECT id FROM project_revisions WHERE project_id = ? AND source = 'migration'`,
+    ).get(sandbox.projectId) as { id: string };
+
+    sandbox.db.prepare(`UPDATE projects SET current_revision_id = NULL WHERE id = ?`).run(sandbox.projectId);
+    const before = sandbox.db.prepare(`SELECT current_revision_id FROM projects WHERE id = ?`).get(sandbox.projectId) as { current_revision_id: string | null };
+    expect(before.current_revision_id).toBeNull();
+
+    await recordRevisionForRun({
+      projectId: sandbox.projectId,
+      projectDir: sandbox.projectDir,
+      repoDir: sandbox.repoDir,
+      run: { id: 'run-after-stale-pointer', identity: TEST_IDENTITY },
+      message: 'unrelated',
+      db: sandbox.db,
+    });
+
+    const after = sandbox.db.prepare(`SELECT current_revision_id FROM projects WHERE id = ?`).get(sandbox.projectId) as { current_revision_id: string };
+    expect(after.current_revision_id).toBe(migrationRow.id);
   });
 
   it('treats a tree where only .od-skills/ changed as clean (runtime scratch is excluded)', async () => {
@@ -814,10 +902,12 @@ describe('recordRevisionForRun', () => {
       }),
     ]);
 
-    // Lock order is non-deterministic: either A or B may win and
-    // record the dirty file. The contract under test is narrower:
-    // the conversational run (runTouchedFiles=false) must NEVER
-    // produce a marker row regardless of lock order.
+    // Invariant under test, order-independent: the conversational run
+    // (runTouchedFiles=false) MUST NEVER produce a marker row. It may
+    // end up with a 'recorded' row if it happens to win the lock
+    // against a dirty workdir (separate attribution concern outside
+    // this fix's scope), but a marker (git_sha IS NULL) is durable
+    // false provenance and must never appear for it.
     const talkerMarker = sandbox.db
       .prepare(
         `SELECT id FROM project_revisions
@@ -825,12 +915,5 @@ describe('recordRevisionForRun', () => {
       )
       .get(sandbox.projectId);
     expect(talkerMarker).toBeUndefined();
-
-    // a.txt got committed exactly once (lock winner records it),
-    // so total = migration + 1 recorded = 2 rows.
-    const count = sandbox.db
-      .prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = ?`)
-      .get(sandbox.projectId) as { n: number };
-    expect(count.n).toBe(2);
   });
 });

--- a/apps/daemon/tests/history-run-hook.test.ts
+++ b/apps/daemon/tests/history-run-hook.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+import { migrateProjectRevisions } from '../src/history/persistence.js';
+import { initProjectHistory } from '../src/history/repo.js';
+import { installHistoryRunFinishedHook } from '../src/history/run-hook.js';
+import type { RunFinishedRun, RunServiceForHook } from '../src/history/run-hook.js';
+import type { Identity } from '../src/identity/types.js';
+
+const TEST_IDENTITY: Identity = {
+  id: 'local:default',
+  displayName: 'Test User',
+  email: 'test@example.com',
+  source: 'local-fallback',
+};
+
+/**
+ * Minimal stand-in for design.runs that captures the hook installer.
+ * The real createChatRunService is too heavy to construct just to fire
+ * one callback — directly invoking the registered hook is the unit
+ * test the wiring deserves.
+ */
+function fakeRunService(): RunServiceForHook & { fire: (run: RunFinishedRun, status: 'succeeded' | 'failed' | 'canceled') => Promise<void> } {
+  let hook: ((r: RunFinishedRun, s: 'succeeded' | 'failed' | 'canceled') => unknown) | null = null;
+  return {
+    setRunFinishedHook(h) { hook = h; },
+    async fire(run, status) {
+      if (hook) await hook(run, status);
+    },
+  };
+}
+
+function setupSandbox() {
+  const dataRoot = mkdtempSync(path.join(tmpdir(), 'od-run-hook-'));
+  const projectsRoot = path.join(dataRoot, 'projects');
+  const reposRoot = path.join(dataRoot, 'repos');
+  const projectDir = path.join(projectsRoot, 'p1');
+  mkdirSync(projectDir, { recursive: true });
+  mkdirSync(reposRoot, { recursive: true });
+
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+    CREATE TABLE conversations (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+    CREATE TABLE messages (id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT, created_at INTEGER NOT NULL);
+    INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p1', 'p1', 0, 0);
+  `);
+  migrateProjectRevisions(db);
+
+  return { dataRoot, projectsRoot, reposRoot, projectDir, db };
+}
+
+async function withInitializedSubstrate(sandbox: ReturnType<typeof setupSandbox>): Promise<void> {
+  writeFileSync(path.join(sandbox.projectDir, 'README.md'), '# project\n');
+  await initProjectHistory({
+    projectId: 'p1',
+    projectDir: sandbox.projectDir,
+    repoDir: path.join(sandbox.reposRoot, 'p1.gitdir'),
+    identity: TEST_IDENTITY,
+    db: sandbox.db,
+  });
+}
+
+describe('installHistoryRunFinishedHook', () => {
+  let sandbox: ReturnType<typeof setupSandbox>;
+  let runs: ReturnType<typeof fakeRunService>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox();
+    runs = fakeRunService();
+  });
+
+  afterEach(() => {
+    sandbox.db.close();
+    rmSync(sandbox.dataRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('records a revision when the run leaves a dirty tree (flag on, substrate ready)', async () => {
+    await withInitializedSubstrate(sandbox);
+
+    installHistoryRunFinishedHook({
+      db: sandbox.db,
+      projectsRoot: sandbox.projectsRoot,
+      reposRoot: sandbox.reposRoot,
+      runs,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    // Simulate the agent writing a new file during the run
+    writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
+
+    await runs.fire(
+      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section' },
+      'succeeded',
+    );
+
+    const rows = sandbox.db.prepare(
+      `SELECT source, run_id, message FROM project_revisions WHERE project_id = 'p1' ORDER BY created_at ASC`,
+    ).all() as Array<{ source: string; run_id: string | null; message: string }>;
+    // First row is the migration; second is the auto-commit
+    expect(rows.length).toBe(2);
+    expect(rows[1]!.source).toBe('agent-run');
+    expect(rows[1]!.run_id).toBe('run-1');
+    expect(rows[1]!.message).toBe('Add hero section');
+  });
+
+  it('is a no-op when the feature flag is off', async () => {
+    await withInitializedSubstrate(sandbox);
+
+    installHistoryRunFinishedHook({
+      db: sandbox.db,
+      projectsRoot: sandbox.projectsRoot,
+      reposRoot: sandbox.reposRoot,
+      runs,
+      env: {},
+    });
+
+    writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
+
+    await runs.fire(
+      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section' },
+      'succeeded',
+    );
+
+    // Only the migration row from setup; no auto-commit happened
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = 'p1'`).get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  it('skips when the run has no projectId', async () => {
+    installHistoryRunFinishedHook({
+      db: sandbox.db,
+      projectsRoot: sandbox.projectsRoot,
+      reposRoot: sandbox.reposRoot,
+      runs,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    await runs.fire(
+      { id: 'run-2', projectId: null, conversationId: null, identity: TEST_IDENTITY, message: 'doesnt matter' },
+      'succeeded',
+    );
+
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions`).get() as { n: number };
+    expect(count.n).toBe(0);
+  });
+
+  it('skips when the run has no identity', async () => {
+    await withInitializedSubstrate(sandbox);
+
+    installHistoryRunFinishedHook({
+      db: sandbox.db,
+      projectsRoot: sandbox.projectsRoot,
+      reposRoot: sandbox.reposRoot,
+      runs,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
+
+    await runs.fire(
+      { id: 'run-3', projectId: 'p1', conversationId: 'c1', identity: null, message: 'no identity' },
+      'succeeded',
+    );
+
+    // Still only the migration row
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = 'p1'`).get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  it('is a no-op when the tree is clean', async () => {
+    await withInitializedSubstrate(sandbox);
+
+    installHistoryRunFinishedHook({
+      db: sandbox.db,
+      projectsRoot: sandbox.projectsRoot,
+      reposRoot: sandbox.reposRoot,
+      runs,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    // No file changes — run ends with clean tree
+    await runs.fire(
+      { id: 'run-clean', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'no changes' },
+      'succeeded',
+    );
+
+    const count = sandbox.db.prepare(`SELECT COUNT(*) AS n FROM project_revisions WHERE project_id = 'p1'`).get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  it('commits even when the run failed (preserves partial work)', async () => {
+    await withInitializedSubstrate(sandbox);
+
+    installHistoryRunFinishedHook({
+      db: sandbox.db,
+      projectsRoot: sandbox.projectsRoot,
+      reposRoot: sandbox.reposRoot,
+      runs,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    writeFileSync(path.join(sandbox.projectDir, 'partial.html'), '<h1>WIP</h1>\n');
+
+    await runs.fire(
+      { id: 'run-failed', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Try something' },
+      'failed',
+    );
+
+    const rows = sandbox.db.prepare(
+      `SELECT source, run_id FROM project_revisions WHERE project_id = 'p1' ORDER BY created_at ASC`,
+    ).all() as Array<{ source: string; run_id: string | null }>;
+    expect(rows.length).toBe(2);
+    expect(rows[1]!.source).toBe('agent-run');
+    expect(rows[1]!.run_id).toBe('run-failed');
+  });
+
+  it('builds a sensible commit message from a multi-line prompt (first line)', async () => {
+    await withInitializedSubstrate(sandbox);
+
+    installHistoryRunFinishedHook({
+      db: sandbox.db,
+      projectsRoot: sandbox.projectsRoot,
+      reposRoot: sandbox.reposRoot,
+      runs,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'content\n');
+
+    await runs.fire(
+      { id: 'run-multi', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Refactor the hero\n\nMake it darker and more minimal\nMatch the brand palette' },
+      'succeeded',
+    );
+
+    const row = sandbox.db.prepare(
+      `SELECT message FROM project_revisions WHERE run_id = 'run-multi'`,
+    ).get() as { message: string };
+    expect(row.message).toBe('Refactor the hero');
+  });
+
+  it('falls back to "Agent run" when the prompt is empty / null', async () => {
+    await withInitializedSubstrate(sandbox);
+
+    installHistoryRunFinishedHook({
+      db: sandbox.db,
+      projectsRoot: sandbox.projectsRoot,
+      reposRoot: sandbox.reposRoot,
+      runs,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+
+    writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'content\n');
+
+    await runs.fire(
+      { id: 'run-noprompt', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: null },
+      'succeeded',
+    );
+
+    const row = sandbox.db.prepare(
+      `SELECT message FROM project_revisions WHERE run_id = 'run-noprompt'`,
+    ).get() as { message: string };
+    expect(row.message).toBe('Agent run');
+  });
+});

--- a/apps/daemon/tests/history-run-hook.test.ts
+++ b/apps/daemon/tests/history-run-hook.test.ts
@@ -96,7 +96,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
 
     await runs.fire(
-      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section' },
+      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section', touchedFiles: true },
       'succeeded',
     );
 
@@ -124,7 +124,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
 
     await runs.fire(
-      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section' },
+      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section', touchedFiles: true },
       'succeeded',
     );
 
@@ -143,7 +143,7 @@ describe('installHistoryRunFinishedHook', () => {
     });
 
     await runs.fire(
-      { id: 'run-2', projectId: null, conversationId: null, identity: TEST_IDENTITY, message: 'doesnt matter' },
+      { id: 'run-2', projectId: null, conversationId: null, identity: TEST_IDENTITY, message: 'doesnt matter', touchedFiles: true },
       'succeeded',
     );
 
@@ -165,7 +165,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
 
     await runs.fire(
-      { id: 'run-3', projectId: 'p1', conversationId: 'c1', identity: null, message: 'no identity' },
+      { id: 'run-3', projectId: 'p1', conversationId: 'c1', identity: null, message: 'no identity', touchedFiles: true },
       'succeeded',
     );
 
@@ -187,7 +187,7 @@ describe('installHistoryRunFinishedHook', () => {
 
     // No file changes — run ends with clean tree
     await runs.fire(
-      { id: 'run-clean', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'no changes' },
+      { id: 'run-clean', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'no changes', touchedFiles: true },
       'succeeded',
     );
 
@@ -209,7 +209,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'partial.html'), '<h1>WIP</h1>\n');
 
     await runs.fire(
-      { id: 'run-failed', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Try something' },
+      { id: 'run-failed', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Try something', touchedFiles: true },
       'failed',
     );
 
@@ -235,7 +235,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'content\n');
 
     await runs.fire(
-      { id: 'run-multi', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Refactor the hero\n\nMake it darker and more minimal\nMatch the brand palette' },
+      { id: 'run-multi', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Refactor the hero\n\nMake it darker and more minimal\nMatch the brand palette', touchedFiles: true },
       'succeeded',
     );
 
@@ -259,7 +259,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'content\n');
 
     await runs.fire(
-      { id: 'run-noprompt', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: null },
+      { id: 'run-noprompt', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: null, touchedFiles: true },
       'succeeded',
     );
 

--- a/apps/daemon/tests/history-run-hook.test.ts
+++ b/apps/daemon/tests/history-run-hook.test.ts
@@ -23,12 +23,20 @@ const TEST_IDENTITY: Identity = {
  * one callback — directly invoking the registered hook is the unit
  * test the wiring deserves.
  */
-function fakeRunService(): RunServiceForHook & { fire: (run: RunFinishedRun, status: 'succeeded' | 'failed' | 'canceled') => Promise<void> } {
+function fakeRunService(): RunServiceForHook & {
+  fire: (run: RunFinishedRun, status: 'succeeded' | 'failed' | 'canceled') => Promise<void>;
+  fireCreate: (run: { id: string; projectId: string | null; headAtCreate: string | null }) => Promise<void>;
+} {
   let hook: ((r: RunFinishedRun, s: 'succeeded' | 'failed' | 'canceled') => unknown) | null = null;
+  let createHook: ((r: { id: string; projectId: string | null; headAtCreate: string | null }) => unknown) | null = null;
   return {
     setRunFinishedHook(h) { hook = h; },
+    setRunCreatedHook(h) { createHook = h; },
     async fire(run, status) {
       if (hook) await hook(run, status);
+    },
+    async fireCreate(run) {
+      if (createHook) await createHook(run);
     },
   };
 }
@@ -96,7 +104,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
 
     await runs.fire(
-      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section', touchedFiles: true },
+      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section', touchedFiles: true, headAtCreate: null },
       'succeeded',
     );
 
@@ -124,7 +132,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
 
     await runs.fire(
-      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section', touchedFiles: true },
+      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section', touchedFiles: true, headAtCreate: null },
       'succeeded',
     );
 
@@ -143,7 +151,7 @@ describe('installHistoryRunFinishedHook', () => {
     });
 
     await runs.fire(
-      { id: 'run-2', projectId: null, conversationId: null, identity: TEST_IDENTITY, message: 'doesnt matter', touchedFiles: true },
+      { id: 'run-2', projectId: null, conversationId: null, identity: TEST_IDENTITY, message: 'doesnt matter', touchedFiles: true, headAtCreate: null },
       'succeeded',
     );
 
@@ -165,7 +173,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
 
     await runs.fire(
-      { id: 'run-3', projectId: 'p1', conversationId: 'c1', identity: null, message: 'no identity', touchedFiles: true },
+      { id: 'run-3', projectId: 'p1', conversationId: 'c1', identity: null, message: 'no identity', touchedFiles: true, headAtCreate: null },
       'succeeded',
     );
 
@@ -187,7 +195,7 @@ describe('installHistoryRunFinishedHook', () => {
 
     // No file changes — run ends with clean tree
     await runs.fire(
-      { id: 'run-clean', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'no changes', touchedFiles: true },
+      { id: 'run-clean', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'no changes', touchedFiles: true, headAtCreate: null },
       'succeeded',
     );
 
@@ -209,7 +217,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'partial.html'), '<h1>WIP</h1>\n');
 
     await runs.fire(
-      { id: 'run-failed', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Try something', touchedFiles: true },
+      { id: 'run-failed', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Try something', touchedFiles: true, headAtCreate: null },
       'failed',
     );
 
@@ -235,7 +243,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'content\n');
 
     await runs.fire(
-      { id: 'run-multi', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Refactor the hero\n\nMake it darker and more minimal\nMatch the brand palette', touchedFiles: true },
+      { id: 'run-multi', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Refactor the hero\n\nMake it darker and more minimal\nMatch the brand palette', touchedFiles: true, headAtCreate: null },
       'succeeded',
     );
 
@@ -259,7 +267,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'content\n');
 
     await runs.fire(
-      { id: 'run-noprompt', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: null, touchedFiles: true },
+      { id: 'run-noprompt', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: null, touchedFiles: true, headAtCreate: null },
       'succeeded',
     );
 

--- a/apps/daemon/tests/history-run-hook.test.ts
+++ b/apps/daemon/tests/history-run-hook.test.ts
@@ -6,7 +6,8 @@ import Database from 'better-sqlite3';
 
 import { migrateProjectRevisions } from '../src/history/persistence.js';
 import { initProjectHistory } from '../src/history/repo.js';
-import { installHistoryRunFinishedHook } from '../src/history/run-hook.js';
+import { installHistoryEnsureHook } from '../src/history/ensure-hook.js';
+import { installHistoryRunCreatedHook, installHistoryRunFinishedHook } from '../src/history/run-hook.js';
 import type { RunFinishedRun, RunServiceForHook } from '../src/history/run-hook.js';
 import type { Identity } from '../src/identity/types.js';
 
@@ -23,15 +24,27 @@ const TEST_IDENTITY: Identity = {
  * one callback — directly invoking the registered hook is the unit
  * test the wiring deserves.
  */
+interface EmittedEvent {
+  event: string;
+  data: unknown;
+}
+
 function fakeRunService(): RunServiceForHook & {
   fire: (run: RunFinishedRun, status: 'succeeded' | 'failed' | 'canceled') => Promise<void>;
   fireCreate: (run: { id: string; projectId: string | null; headAtCreate: string | null }) => Promise<void>;
+  emitted: EmittedEvent[];
 } {
   let hook: ((r: RunFinishedRun, s: 'succeeded' | 'failed' | 'canceled') => unknown) | null = null;
   let createHook: ((r: { id: string; projectId: string | null; headAtCreate: string | null }) => unknown) | null = null;
+  const emitted: EmittedEvent[] = [];
   return {
     setRunFinishedHook(h) { hook = h; },
     setRunCreatedHook(h) { createHook = h; },
+    emit(_run, event, data) {
+      emitted.push({ event, data });
+      return { id: emitted.length, event, data };
+    },
+    emitted,
     async fire(run, status) {
       if (hook) await hook(run, status);
     },
@@ -52,8 +65,22 @@ function setupSandbox() {
   const db = new Database(':memory:');
   db.pragma('journal_mode = WAL');
   db.pragma('foreign_keys = ON');
+  // Mirror PROJECT_COLS so getProject(db, projectId) (called by the
+  // created-hook for the linked-folder check + ensureProject baseline)
+  // can read every column the daemon expects.
   db.exec(`
-    CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+    CREATE TABLE projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      skill_id TEXT,
+      design_system_id TEXT,
+      pending_prompt TEXT,
+      metadata_json TEXT,
+      applied_plugin_snapshot_id TEXT,
+      custom_instructions TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
     CREATE TABLE conversations (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
     CREATE TABLE messages (id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT, created_at INTEGER NOT NULL);
     INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p1', 'p1', 0, 0);
@@ -104,7 +131,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
 
     await runs.fire(
-      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section', touchedFiles: true, headAtCreate: null },
+      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section', touchedFiles: true, headAtCreate: null, historyStatus: null, historyError: null },
       'succeeded',
     );
 
@@ -132,7 +159,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
 
     await runs.fire(
-      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section', touchedFiles: true, headAtCreate: null },
+      { id: 'run-1', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Add hero section', touchedFiles: true, headAtCreate: null, historyStatus: null, historyError: null },
       'succeeded',
     );
 
@@ -151,7 +178,7 @@ describe('installHistoryRunFinishedHook', () => {
     });
 
     await runs.fire(
-      { id: 'run-2', projectId: null, conversationId: null, identity: TEST_IDENTITY, message: 'doesnt matter', touchedFiles: true, headAtCreate: null },
+      { id: 'run-2', projectId: null, conversationId: null, identity: TEST_IDENTITY, message: 'doesnt matter', touchedFiles: true, headAtCreate: null, historyStatus: null, historyError: null },
       'succeeded',
     );
 
@@ -173,7 +200,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'hero.html'), '<h1>Hello</h1>\n');
 
     await runs.fire(
-      { id: 'run-3', projectId: 'p1', conversationId: 'c1', identity: null, message: 'no identity', touchedFiles: true, headAtCreate: null },
+      { id: 'run-3', projectId: 'p1', conversationId: 'c1', identity: null, message: 'no identity', touchedFiles: true, headAtCreate: null, historyStatus: null, historyError: null },
       'succeeded',
     );
 
@@ -195,7 +222,7 @@ describe('installHistoryRunFinishedHook', () => {
 
     // No file changes — run ends with clean tree
     await runs.fire(
-      { id: 'run-clean', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'no changes', touchedFiles: true, headAtCreate: null },
+      { id: 'run-clean', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'no changes', touchedFiles: true, headAtCreate: null, historyStatus: null, historyError: null },
       'succeeded',
     );
 
@@ -217,7 +244,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'partial.html'), '<h1>WIP</h1>\n');
 
     await runs.fire(
-      { id: 'run-failed', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Try something', touchedFiles: true, headAtCreate: null },
+      { id: 'run-failed', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Try something', touchedFiles: true, headAtCreate: null, historyStatus: null, historyError: null },
       'failed',
     );
 
@@ -243,7 +270,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'content\n');
 
     await runs.fire(
-      { id: 'run-multi', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Refactor the hero\n\nMake it darker and more minimal\nMatch the brand palette', touchedFiles: true, headAtCreate: null },
+      { id: 'run-multi', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: 'Refactor the hero\n\nMake it darker and more minimal\nMatch the brand palette', touchedFiles: true, headAtCreate: null, historyStatus: null, historyError: null },
       'succeeded',
     );
 
@@ -267,7 +294,7 @@ describe('installHistoryRunFinishedHook', () => {
     writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'content\n');
 
     await runs.fire(
-      { id: 'run-noprompt', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: null, touchedFiles: true, headAtCreate: null },
+      { id: 'run-noprompt', projectId: 'p1', conversationId: 'c1', identity: TEST_IDENTITY, message: null, touchedFiles: true, headAtCreate: null, historyStatus: null, historyError: null },
       'succeeded',
     );
 
@@ -275,5 +302,183 @@ describe('installHistoryRunFinishedHook', () => {
       `SELECT message FROM project_revisions WHERE run_id = 'run-noprompt'`,
     ).get() as { message: string };
     expect(row.message).toBe('Agent run');
+  });
+
+  // Bug A coverage — matrix cells {P1,P2,P3,P4}×E9 (hook throws).
+  // Without observability, recordRevisionForRun failures land in
+  // console.warn after terminal broadcast and the API surface still
+  // reports a clean run. The historyStatus/historyError fields + the
+  // history-completed SSE event give reattaching clients and CLI
+  // consumers a visible signal.
+  describe('history capture observability', () => {
+    it('stamps historyStatus=recorded and emits history-completed when the commit succeeds', async () => {
+      await withInitializedSubstrate(sandbox);
+      installHistoryRunFinishedHook({
+        db: sandbox.db,
+        projectsRoot: sandbox.projectsRoot,
+        reposRoot: sandbox.reposRoot,
+        runs,
+        env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+      });
+      writeFileSync(path.join(sandbox.projectDir, 'a.txt'), 'x\n');
+
+      const run: RunFinishedRun = {
+        id: 'run-ok', projectId: 'p1', conversationId: 'c1',
+        identity: TEST_IDENTITY, message: 'work', touchedFiles: true,
+        headAtCreate: null, historyStatus: null, historyError: null,
+      };
+      await runs.fire(run, 'succeeded');
+
+      expect(run.historyStatus).toBe('recorded');
+      expect(run.historyError).toBeNull();
+      const ev = runs.emitted.find((e) => e.event === 'history-completed');
+      expect(ev).toBeDefined();
+      expect((ev?.data as { status: string }).status).toBe('recorded');
+    });
+
+    it('stamps historyStatus=clean when there is no work to commit', async () => {
+      await withInitializedSubstrate(sandbox);
+      installHistoryRunFinishedHook({
+        db: sandbox.db,
+        projectsRoot: sandbox.projectsRoot,
+        reposRoot: sandbox.reposRoot,
+        runs,
+        env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+      });
+
+      const run: RunFinishedRun = {
+        id: 'run-clean', projectId: 'p1', conversationId: 'c1',
+        identity: TEST_IDENTITY, message: 'noop', touchedFiles: false,
+        headAtCreate: null, historyStatus: null, historyError: null,
+      };
+      await runs.fire(run, 'succeeded');
+
+      expect(run.historyStatus).toBe('clean');
+      expect(run.historyError).toBeNull();
+    });
+
+    it('stamps historyStatus=failed + historyError when recordRevisionForRun throws', async () => {
+      // Don't initialize substrate AND set substrate state up so it's
+      // half-init. Then corrupt the gitdir so the recovery path throws.
+      await withInitializedSubstrate(sandbox);
+      // Wipe the entire gitdir mid-flight — readDotGitState will read
+      // the gitlink in the worktree but git operations against it fail.
+      rmSync(path.join(sandbox.reposRoot, 'p1.gitdir'), { recursive: true, force: true });
+
+      installHistoryRunFinishedHook({
+        db: sandbox.db,
+        projectsRoot: sandbox.projectsRoot,
+        reposRoot: sandbox.reposRoot,
+        runs,
+        env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+      });
+
+      // Mark the tree dirty so the dirty-tree branch tries to commit
+      // and fails on the missing gitdir.
+      writeFileSync(path.join(sandbox.projectDir, 'broken.txt'), 'will not commit\n');
+
+      const run: RunFinishedRun = {
+        id: 'run-broken', projectId: 'p1', conversationId: 'c1',
+        identity: TEST_IDENTITY, message: 'will fail', touchedFiles: true,
+        headAtCreate: null, historyStatus: null, historyError: null,
+      };
+      await runs.fire(run, 'succeeded');
+
+      // The exact failure mode depends on which git op trips first; we
+      // care that the status is observable, not the specific message.
+      expect(['failed', 'not-initialized']).toContain(run.historyStatus);
+      if (run.historyStatus === 'failed') {
+        expect(run.historyError).toBeTruthy();
+        const ev = runs.emitted.find((e) => e.event === 'history-completed');
+        expect((ev?.data as { status: string }).status).toBe('failed');
+      }
+    });
+  });
+});
+
+// Bug B coverage — matrix cells P1×E3 (overlapping write) and P1×E4
+// (sequential write) on fresh projects. Without the created-hook
+// initializing substrate before reading HEAD, both runs against a
+// fresh project end up with headAtCreate=null and the marker can't
+// fire for the sibling-absorbed loser.
+describe('installHistoryRunCreatedHook', () => {
+  let sandbox: ReturnType<typeof setupSandbox>;
+  let runs: ReturnType<typeof fakeRunService>;
+
+  beforeEach(() => {
+    sandbox = setupSandbox();
+    runs = fakeRunService();
+    // Created-hook calls ensureProject which fires the ensure-hook;
+    // both must be installed for the substrate-init chain to work.
+    installHistoryEnsureHook({
+      db: sandbox.db,
+      reposRoot: sandbox.reposRoot,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+    installHistoryRunCreatedHook({
+      db: sandbox.db,
+      projectsRoot: sandbox.projectsRoot,
+      reposRoot: sandbox.reposRoot,
+      runs,
+      env: { OD_GIT_INTEGRATION_ENABLED: '1' },
+    });
+  });
+
+  afterEach(() => {
+    sandbox.db.close();
+    rmSync(sandbox.dataRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('initializes substrate on a fresh project and stamps headAtCreate with the migration SHA', async () => {
+    const run = { id: 'run-fresh', projectId: 'p1', headAtCreate: null as string | null };
+    await runs.fireCreate(run);
+
+    expect(run.headAtCreate).toMatch(/^[0-9a-f]{40}$/);
+    // The substrate should now exist; subsequent reads see the same SHA.
+    const row = sandbox.db.prepare(
+      `SELECT git_sha FROM project_revisions WHERE project_id = 'p1' AND source = 'migration'`,
+    ).get() as { git_sha: string };
+    expect(row.git_sha).toBe(run.headAtCreate);
+  });
+
+  it('stamps both concurrent runs against a fresh project with the same M0 baseline', async () => {
+    const runA = { id: 'run-a', projectId: 'p1', headAtCreate: null as string | null };
+    const runB = { id: 'run-b', projectId: 'p1', headAtCreate: null as string | null };
+    await Promise.all([runs.fireCreate(runA), runs.fireCreate(runB)]);
+
+    expect(runA.headAtCreate).toMatch(/^[0-9a-f]{40}$/);
+    expect(runB.headAtCreate).toBe(runA.headAtCreate);
+  });
+
+  it('skips linked-folder projects (leaves headAtCreate null)', async () => {
+    sandbox.db.prepare(`UPDATE projects SET metadata_json = ? WHERE id = 'p1'`)
+      .run(JSON.stringify({ baseDir: '/tmp/somewhere' }));
+
+    const run = { id: 'run-linked', projectId: 'p1', headAtCreate: null as string | null };
+    await runs.fireCreate(run);
+
+    expect(run.headAtCreate).toBeNull();
+  });
+
+  it('leaves headAtCreate null when the projects row is missing (run referenced an unknown project)', async () => {
+    const run = { id: 'run-ghost', projectId: 'unknown-project', headAtCreate: null as string | null };
+    await runs.fireCreate(run);
+
+    expect(run.headAtCreate).toBeNull();
+  });
+
+  it('is a no-op when the feature flag is unset', async () => {
+    const flagOffRuns = fakeRunService();
+    installHistoryRunCreatedHook({
+      db: sandbox.db,
+      projectsRoot: sandbox.projectsRoot,
+      reposRoot: sandbox.reposRoot,
+      runs: flagOffRuns,
+      env: {},
+    });
+    const run = { id: 'run-x', projectId: 'p1', headAtCreate: null as string | null };
+    await flagOffRuns.fireCreate(run);
+    expect(run.headAtCreate).toBeNull();
   });
 });

--- a/apps/daemon/tests/identity-attribution.test.ts
+++ b/apps/daemon/tests/identity-attribution.test.ts
@@ -33,48 +33,66 @@ describe('attributionFromIdentity', () => {
     });
   });
 
-  it('reads source IP from X-Forwarded-For (first comma-separated entry)', () => {
+  it('reads source IP from req.ip (Express trust-proxy-resolved client IP)', () => {
+    // Express populates req.ip according to the app's `trust proxy`
+    // setting. When trust-proxy is unset, req.ip is the raw socket
+    // peer. When trust-proxy is configured, req.ip is the resolved
+    // forwarded IP from trusted hops. Either way, the helper trusts
+    // req.ip as the right answer.
+    const req = { ip: '100.113.57.7', socket: { remoteAddress: '127.0.0.1' } };
+    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('100.113.57.7');
+  });
+
+  it('falls back to socket.remoteAddress when req.ip is undefined (synthetic test contexts)', () => {
+    // For test contexts that don't go through Express, req.ip won't
+    // be populated. The helper degrades gracefully to socket.remoteAddress
+    // so existing tests / non-Express callers still get a sensible answer.
+    const req = { socket: { remoteAddress: '127.0.0.1' } };
+    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('127.0.0.1');
+  });
+
+  it('SECURITY — never reads X-Forwarded-For header (spoofable when trust-proxy is unset)', () => {
+    // P0-fix #15 — before the fix this helper parsed X-Forwarded-For
+    // directly from req.headers, making `actor_source_ip` trivially
+    // spoofable by direct callers (Express's trust-proxy was never
+    // consulted). After the fix, X-Forwarded-For is invisible to this
+    // helper; only Express's `req.ip` (which honors trust-proxy) is
+    // trusted. This test simulates an attacker sending a spoofed XFF
+    // with no trust-proxy configured — the value MUST be ignored.
     const req = {
-      headers: { 'x-forwarded-for': '100.113.57.7, 10.0.0.1, 172.16.0.1' },
-      socket: { remoteAddress: '::1' },
+      headers: { 'x-forwarded-for': '203.0.113.99' }, // attacker-controlled
+      // req.ip is what Express resolved with trust-proxy unset:
+      // the real socket peer, NOT the spoofed XFF.
+      ip: '127.0.0.1',
+      socket: { remoteAddress: '127.0.0.1' },
+    };
+    // The helper sees only req.ip — the spoofed header is invisible.
+    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('127.0.0.1');
+    // Sanity: the spoofed value DOES NOT appear in any field
+    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).not.toBe('203.0.113.99');
+  });
+
+  it('honors req.ip even when an attacker-spoofed X-Forwarded-For is present (trust-proxy enforced upstream)', () => {
+    // Mirrors the post-fix expectation: when trust-proxy IS configured
+    // (e.g., 'loopback' for a same-host Tailscale Serve), Express
+    // resolves req.ip from the forwarded chain. The helper trusts
+    // that resolution. Tests this by populating req.ip with the
+    // "Express resolved" value and showing the helper uses it.
+    const req = {
+      headers: { 'x-forwarded-for': '203.0.113.99' }, // ignored by us
+      ip: '100.113.57.7', // Express's resolved client IP (post-trust-proxy)
+      socket: { remoteAddress: '127.0.0.1' },
     };
     expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('100.113.57.7');
   });
 
-  it('falls back to socket.remoteAddress when no X-Forwarded-For', () => {
-    const req = {
-      headers: {},
-      socket: { remoteAddress: '127.0.0.1' },
-    };
-    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('127.0.0.1');
-  });
-
-  it('strips whitespace from X-Forwarded-For entries', () => {
-    const req = {
-      headers: { 'x-forwarded-for': '  100.113.57.7  ' },
-      socket: { remoteAddress: '::1' },
-    };
-    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('100.113.57.7');
-  });
-
-  it('treats empty X-Forwarded-For as missing, falls back to socket', () => {
-    const req = {
-      headers: { 'x-forwarded-for': '' },
-      socket: { remoteAddress: '127.0.0.1' },
-    };
-    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('127.0.0.1');
-  });
-
-  it('returns null source IP when neither header nor socket has a usable value', () => {
-    const req = { headers: {}, socket: { remoteAddress: null } };
+  it('returns null source IP when neither req.ip nor socket has a usable value', () => {
+    const req = { socket: { remoteAddress: null } };
     expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBeNull();
   });
 
-  it('ignores non-string X-Forwarded-For (e.g., array from multiple headers)', () => {
-    const req = {
-      headers: { 'x-forwarded-for': ['100.113.57.7', '10.0.0.1'] as unknown as string },
-      socket: { remoteAddress: '127.0.0.1' },
-    };
+  it('treats empty-string req.ip as missing, falls back to socket', () => {
+    const req = { ip: '', socket: { remoteAddress: '127.0.0.1' } };
     expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('127.0.0.1');
   });
 });

--- a/apps/daemon/tests/identity-attribution.test.ts
+++ b/apps/daemon/tests/identity-attribution.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { attributionFromIdentity } from '../src/identity/attribution.js';
+import type { Identity } from '../src/identity/types.js';
+
+const IDENTITY: Identity = {
+  id: 'local:default',
+  displayName: 'Local User',
+  source: 'local-fallback',
+};
+
+describe('attributionFromIdentity', () => {
+  it('returns all-null when identity is null', () => {
+    expect(attributionFromIdentity(null)).toEqual({
+      actorIdentityId: null,
+      actorDisplayName: null,
+      actorSourceIp: null,
+    });
+  });
+
+  it('returns all-null when identity is undefined', () => {
+    expect(attributionFromIdentity(undefined)).toEqual({
+      actorIdentityId: null,
+      actorDisplayName: null,
+      actorSourceIp: null,
+    });
+  });
+
+  it('extracts id and displayName from identity, source IP null without req', () => {
+    expect(attributionFromIdentity(IDENTITY)).toEqual({
+      actorIdentityId: 'local:default',
+      actorDisplayName: 'Local User',
+      actorSourceIp: null,
+    });
+  });
+
+  it('reads source IP from X-Forwarded-For (first comma-separated entry)', () => {
+    const req = {
+      headers: { 'x-forwarded-for': '100.113.57.7, 10.0.0.1, 172.16.0.1' },
+      socket: { remoteAddress: '::1' },
+    };
+    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('100.113.57.7');
+  });
+
+  it('falls back to socket.remoteAddress when no X-Forwarded-For', () => {
+    const req = {
+      headers: {},
+      socket: { remoteAddress: '127.0.0.1' },
+    };
+    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('127.0.0.1');
+  });
+
+  it('strips whitespace from X-Forwarded-For entries', () => {
+    const req = {
+      headers: { 'x-forwarded-for': '  100.113.57.7  ' },
+      socket: { remoteAddress: '::1' },
+    };
+    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('100.113.57.7');
+  });
+
+  it('treats empty X-Forwarded-For as missing, falls back to socket', () => {
+    const req = {
+      headers: { 'x-forwarded-for': '' },
+      socket: { remoteAddress: '127.0.0.1' },
+    };
+    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('127.0.0.1');
+  });
+
+  it('returns null source IP when neither header nor socket has a usable value', () => {
+    const req = { headers: {}, socket: { remoteAddress: null } };
+    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBeNull();
+  });
+
+  it('ignores non-string X-Forwarded-For (e.g., array from multiple headers)', () => {
+    const req = {
+      headers: { 'x-forwarded-for': ['100.113.57.7', '10.0.0.1'] as unknown as string },
+      socket: { remoteAddress: '127.0.0.1' },
+    };
+    expect(attributionFromIdentity(IDENTITY, req).actorSourceIp).toBe('127.0.0.1');
+  });
+});

--- a/apps/daemon/tests/identity-middleware.test.ts
+++ b/apps/daemon/tests/identity-middleware.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { createIdentityMiddleware } from '../src/identity/middleware.js';
+
+function fakeReq(): Request {
+  return { headers: {}, socket: { remoteAddress: '127.0.0.1' } } as unknown as Request;
+}
+
+const fakeRes = {} as Response;
+
+describe('createIdentityMiddleware', () => {
+  it('attaches the resolved identity to req.identity and calls next', () => {
+    const middleware = createIdentityMiddleware({});
+    const req = fakeReq();
+    const next = vi.fn() as unknown as NextFunction;
+
+    middleware(req, fakeRes, next);
+
+    expect(req.identity).toBeDefined();
+    expect(req.identity?.id).toBe('local:default');
+    expect(req.identity?.source).toBe('local-fallback');
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('honors the explicit env passed to the factory', () => {
+    const middleware = createIdentityMiddleware({ OD_LOCAL_IDENTITY: 'Weston' });
+    const req = fakeReq();
+    const next = vi.fn() as unknown as NextFunction;
+
+    middleware(req, fakeRes, next);
+
+    expect(req.identity?.displayName).toBe('Weston');
+  });
+
+  it('produces a fresh Identity per request (does not share references across calls)', () => {
+    const middleware = createIdentityMiddleware({ OD_LOCAL_IDENTITY: 'Tester' });
+    const reqA = fakeReq();
+    const reqB = fakeReq();
+    const next = vi.fn() as unknown as NextFunction;
+
+    middleware(reqA, fakeRes, next);
+    middleware(reqB, fakeRes, next);
+
+    expect(reqA.identity).not.toBe(reqB.identity);
+    // Both should still have the same logical content
+    expect(reqA.identity?.displayName).toBe('Tester');
+    expect(reqB.identity?.displayName).toBe('Tester');
+  });
+
+  it('does not throw when req has no socket or headers', () => {
+    const middleware = createIdentityMiddleware({});
+    const minimalReq = {} as unknown as Request;
+    const next = vi.fn() as unknown as NextFunction;
+
+    expect(() => middleware(minimalReq, fakeRes, next)).not.toThrow();
+    expect(minimalReq.identity).toBeDefined();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/daemon/tests/identity.test.ts
+++ b/apps/daemon/tests/identity.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LocalFallbackProvider,
+  resolveIdentity,
+} from '../src/identity/types.js';
+
+// A minimal request shape that satisfies resolveIdentity's structural
+// type without instantiating a real Express Request.
+const emptyReq = { headers: {}, socket: { remoteAddress: '127.0.0.1' } };
+
+describe('LocalFallbackProvider', () => {
+  it('returns a default placeholder identity when env is empty', () => {
+    // `email` is intentionally absent (not just undefined) under
+    // exactOptionalPropertyTypes — the conditional-spread in the
+    // provider only includes the property when populated.
+    expect(LocalFallbackProvider.resolve(emptyReq, {})).toEqual({
+      id: 'local:default',
+      displayName: 'Local User',
+      source: 'local-fallback',
+    });
+  });
+
+  it('honors OD_LOCAL_IDENTITY for the display name', () => {
+    expect(LocalFallbackProvider.resolve(emptyReq, { OD_LOCAL_IDENTITY: 'Weston' })?.displayName)
+      .toBe('Weston');
+  });
+
+  it('honors OD_LOCAL_IDENTITY_EMAIL when set, leaves email undefined when unset', () => {
+    expect(LocalFallbackProvider.resolve(emptyReq, { OD_LOCAL_IDENTITY_EMAIL: 'weston@example.com' })?.email)
+      .toBe('weston@example.com');
+    expect(LocalFallbackProvider.resolve(emptyReq, {})?.email).toBeUndefined();
+  });
+
+  it('treats whitespace-only env values as unset', () => {
+    const id = LocalFallbackProvider.resolve(emptyReq, {
+      OD_LOCAL_IDENTITY: '   ',
+      OD_LOCAL_IDENTITY_EMAIL: '\t\n ',
+    });
+    expect(id?.displayName).toBe('Local User');
+    expect(id?.email).toBeUndefined();
+  });
+
+  it('preserves the placeholder id regardless of env customization', () => {
+    expect(LocalFallbackProvider.resolve(emptyReq, {
+      OD_LOCAL_IDENTITY: 'Anyone',
+      OD_LOCAL_IDENTITY_EMAIL: 'anyone@example.com',
+    })?.id).toBe('local:default');
+  });
+});
+
+describe('resolveIdentity', () => {
+  it('returns a valid Identity even for a request with no relevant headers', () => {
+    const id = resolveIdentity(emptyReq, {});
+    expect(id.id).toBe('local:default');
+    expect(id.source).toBe('local-fallback');
+  });
+
+  it('uses process.env by default when no env is passed', () => {
+    // We don't assert specific values from the ambient env (that would
+    // make the test environment-dependent); we just verify the function
+    // returns a structurally valid Identity.
+    const id = resolveIdentity(emptyReq);
+    expect(typeof id.id).toBe('string');
+    expect(typeof id.displayName).toBe('string');
+    expect(typeof id.source).toBe('string');
+  });
+
+  it('reflects the OD_LOCAL_IDENTITY env var through the resolver', () => {
+    expect(resolveIdentity(emptyReq, { OD_LOCAL_IDENTITY: 'Test User' }).displayName)
+      .toBe('Test User');
+  });
+});

--- a/apps/daemon/tests/messages-actor-columns.test.ts
+++ b/apps/daemon/tests/messages-actor-columns.test.ts
@@ -66,7 +66,10 @@ describe('upsertMessage stores actor_* columns from attribution', () => {
 
   it('INSERT path populates the actor columns when attribution is provided', () => {
     const req = {
-      headers: { 'x-forwarded-for': '100.113.57.7' },
+      // req.ip is Express's trust-proxy-resolved client IP — what
+      // attributionFromIdentity reads. Forwarded headers are NEVER
+      // parsed by the helper directly (P0-fix #15).
+      ip: '100.113.57.7',
       socket: { remoteAddress: '::1' },
     };
     upsertMessage(db, 'c1', {
@@ -96,7 +99,7 @@ describe('upsertMessage stores actor_* columns from attribution', () => {
       id: 'm-keep',
       role: 'user',
       content: 'first',
-      ...attributionFromIdentity(IDENTITY, { headers: {}, socket: { remoteAddress: '10.0.0.1' } }),
+      ...attributionFromIdentity(IDENTITY, { socket: { remoteAddress: '10.0.0.1' } }),
     });
 
     // Second upsert (e.g., streaming update from the agent) — no identity passed.
@@ -122,7 +125,7 @@ describe('upsertMessage stores actor_* columns from attribution', () => {
       id: 'm-overwrite',
       role: 'user',
       content: 'updated',
-      ...attributionFromIdentity(newerId, { headers: {}, socket: { remoteAddress: '::1' } }),
+      ...attributionFromIdentity(newerId, { socket: { remoteAddress: '::1' } }),
     });
 
     const row = db.prepare(`SELECT actor_identity_id, actor_display_name, actor_source_ip FROM messages WHERE id='m-overwrite'`).get() as MessageRow;

--- a/apps/daemon/tests/messages-actor-columns.test.ts
+++ b/apps/daemon/tests/messages-actor-columns.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { upsertMessage } from '../src/db.js';
+import { attributionFromIdentity } from '../src/identity/attribution.js';
+import { migrateProjectRevisions } from '../src/history/persistence.js';
+import type { Identity } from '../src/identity/types.js';
+
+const IDENTITY: Identity = {
+  id: 'local:default',
+  displayName: 'Local User',
+  source: 'local-fallback',
+};
+
+function freshDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  // Minimal upstream schema for upsertMessage (mirrors what
+  // db.ts:migrate() creates). The actor_* columns come from
+  // migrateProjectRevisions which the daemon runs as part of the
+  // main migrate() chain.
+  db.exec(`
+    CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT NOT NULL, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+    CREATE TABLE conversations (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, title TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL);
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      agent_id TEXT,
+      agent_name TEXT,
+      run_id TEXT,
+      run_status TEXT,
+      last_run_event_id TEXT,
+      events_json TEXT,
+      attachments_json TEXT,
+      comment_attachments_json TEXT,
+      produced_files_json TEXT,
+      feedback_json TEXT,
+      started_at INTEGER,
+      ended_at INTEGER,
+      position INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY(conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+    );
+    INSERT INTO projects (id, name, created_at, updated_at) VALUES ('p1', 'p1', 0, 0);
+    INSERT INTO conversations (id, project_id, title, created_at, updated_at) VALUES ('c1', 'p1', 't', 0, 0);
+  `);
+  migrateProjectRevisions(db);
+  return db;
+}
+
+type MessageRow = {
+  actor_identity_id: string | null;
+  actor_display_name: string | null;
+  actor_source_ip: string | null;
+};
+
+describe('upsertMessage stores actor_* columns from attribution', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('INSERT path populates the actor columns when attribution is provided', () => {
+    const req = {
+      headers: { 'x-forwarded-for': '100.113.57.7' },
+      socket: { remoteAddress: '::1' },
+    };
+    upsertMessage(db, 'c1', {
+      id: 'm1',
+      role: 'user',
+      content: 'Hello',
+      ...attributionFromIdentity(IDENTITY, req),
+    });
+
+    const row = db.prepare(`SELECT actor_identity_id, actor_display_name, actor_source_ip FROM messages WHERE id='m1'`).get() as MessageRow;
+    expect(row.actor_identity_id).toBe('local:default');
+    expect(row.actor_display_name).toBe('Local User');
+    expect(row.actor_source_ip).toBe('100.113.57.7');
+  });
+
+  it('INSERT path leaves actor columns null when no identity is provided', () => {
+    upsertMessage(db, 'c1', { id: 'm-anon', role: 'user', content: 'no identity' });
+
+    const row = db.prepare(`SELECT actor_identity_id, actor_display_name, actor_source_ip FROM messages WHERE id='m-anon'`).get() as MessageRow;
+    expect(row.actor_identity_id).toBeNull();
+    expect(row.actor_display_name).toBeNull();
+    expect(row.actor_source_ip).toBeNull();
+  });
+
+  it('UPDATE path preserves existing actor columns when a later upsert lacks identity', () => {
+    upsertMessage(db, 'c1', {
+      id: 'm-keep',
+      role: 'user',
+      content: 'first',
+      ...attributionFromIdentity(IDENTITY, { headers: {}, socket: { remoteAddress: '10.0.0.1' } }),
+    });
+
+    // Second upsert (e.g., streaming update from the agent) — no identity passed.
+    upsertMessage(db, 'c1', { id: 'm-keep', role: 'user', content: 'updated' });
+
+    const row = db.prepare(`SELECT actor_identity_id, actor_display_name, actor_source_ip FROM messages WHERE id='m-keep'`).get() as MessageRow;
+    expect(row.actor_identity_id).toBe('local:default');
+    expect(row.actor_display_name).toBe('Local User');
+    expect(row.actor_source_ip).toBe('10.0.0.1');
+  });
+
+  it('UPDATE path overwrites actor columns when a later upsert provides identity', () => {
+    const earlyId: Identity = { id: 'local:default', displayName: 'Original', source: 'local-fallback' };
+    upsertMessage(db, 'c1', {
+      id: 'm-overwrite',
+      role: 'user',
+      content: 'first',
+      ...attributionFromIdentity(earlyId),
+    });
+
+    const newerId: Identity = { id: 'oauth:google:newer@example.com', displayName: 'Newer', source: 'oauth' };
+    upsertMessage(db, 'c1', {
+      id: 'm-overwrite',
+      role: 'user',
+      content: 'updated',
+      ...attributionFromIdentity(newerId, { headers: {}, socket: { remoteAddress: '::1' } }),
+    });
+
+    const row = db.prepare(`SELECT actor_identity_id, actor_display_name, actor_source_ip FROM messages WHERE id='m-overwrite'`).get() as MessageRow;
+    expect(row.actor_identity_id).toBe('oauth:google:newer@example.com');
+    expect(row.actor_display_name).toBe('Newer');
+    expect(row.actor_source_ip).toBe('::1');
+  });
+});

--- a/apps/daemon/tests/messages-actor-columns.test.ts
+++ b/apps/daemon/tests/messages-actor-columns.test.ts
@@ -37,6 +37,7 @@ function freshDb(): Database.Database {
       comment_attachments_json TEXT,
       produced_files_json TEXT,
       feedback_json TEXT,
+      pre_turn_file_names_json TEXT,
       started_at INTEGER,
       ended_at INTEGER,
       position INTEGER NOT NULL,

--- a/apps/daemon/tests/runs.test.ts
+++ b/apps/daemon/tests/runs.test.ts
@@ -101,8 +101,8 @@ describe('chat run service touchedFiles tracking', () => {
     expect((run as any).touchedFiles).toBe(false);
   });
 
-  it.each(['Write', 'Edit', 'MultiEdit', 'NotebookEdit'])(
-    'flips to true when a %s tool_use event is emitted',
+  it.each(['Write', 'Edit', 'MultiEdit', 'NotebookEdit', 'Bash', 'bash', 'WRITE'])(
+    'flips to true for direct tool_use event with name %s (case-insensitive)',
     (toolName) => {
       const runs = createRuns();
       const run = runs.create();
@@ -111,28 +111,46 @@ describe('chat run service touchedFiles tracking', () => {
     },
   );
 
-  it.each(['Bash', 'Read', 'Grep', 'Glob', 'WebFetch'])(
-    'stays false for non-write tool_use names (%s — read-only or ambiguous)',
+  it.each(['Write', 'Edit', 'bash'])(
+    'flips to true for production-shape agent-wrapped tool_use with name %s',
     (toolName) => {
+      // Real path: server.ts calls send('agent', ev) where ev wraps the
+      // adapter's typed event { type: 'tool_use', name, ... }. The
+      // direct-shape check used by older tests bypassed this wrapper.
       const runs = createRuns();
       const run = runs.create();
-      runs.emit(run, 'tool_use', { id: 't1', name: toolName, input: {} });
-      expect((run as any).touchedFiles).toBe(false);
+      runs.emit(run, 'agent', { type: 'tool_use', id: 't1', name: toolName, input: {} });
+      expect((run as any).touchedFiles).toBe(true);
     },
   );
 
-  it('stays false for non-tool_use events even with a matching name field', () => {
+  it.each(['Read', 'Grep', 'Glob', 'WebFetch'])(
+    'stays false for read-only tool name %s (both event shapes)',
+    (toolName) => {
+      const runs = createRuns();
+      const direct = runs.create();
+      runs.emit(direct, 'tool_use', { id: 't1', name: toolName, input: {} });
+      expect((direct as any).touchedFiles).toBe(false);
+
+      const wrapped = runs.create();
+      runs.emit(wrapped, 'agent', { type: 'tool_use', id: 't1', name: toolName, input: {} });
+      expect((wrapped as any).touchedFiles).toBe(false);
+    },
+  );
+
+  it('stays false for non-tool_use agent events even with a matching name field', () => {
     const runs = createRuns();
     const run = runs.create();
-    runs.emit(run, 'stdout', { name: 'Write', text: 'red herring' });
+    runs.emit(run, 'agent', { type: 'text_delta', name: 'Write', delta: 'red herring' });
+    runs.emit(run, 'stdout', { name: 'Write', text: 'another red herring' });
     expect((run as any).touchedFiles).toBe(false);
   });
 
   it('stays true once set — does not reset on subsequent non-write events', () => {
     const runs = createRuns();
     const run = runs.create();
-    runs.emit(run, 'tool_use', { id: 't1', name: 'Write', input: {} });
-    runs.emit(run, 'tool_use', { id: 't2', name: 'Read', input: {} });
+    runs.emit(run, 'agent', { type: 'tool_use', id: 't1', name: 'Write', input: {} });
+    runs.emit(run, 'agent', { type: 'tool_use', id: 't2', name: 'Read', input: {} });
     runs.emit(run, 'stdout', { text: 'after' });
     expect((run as any).touchedFiles).toBe(true);
   });

--- a/apps/daemon/tests/runs.test.ts
+++ b/apps/daemon/tests/runs.test.ts
@@ -201,6 +201,54 @@ describe('chat run service stream replay', () => {
     expect(shutdownReturnedAt - shutdownStartedAt).toBeGreaterThanOrEqual(90);
   });
 
+  it('fires runFinishedHook AFTER the child fully exits (no race against graceful SIGTERM writes)', async () => {
+    // Second review pass on PR #2619 (P0-fix.13): the previous fix
+    // tracked pending hook promises but still fired finish() (and
+    // therefore the hook) BEFORE waitForChildExit. A child that
+    // handles SIGTERM gracefully — flushing files to disk before
+    // exiting — could write its final changes AFTER the hook's
+    // `git status` snapshot already ran. Those last writes never
+    // make it into the auto-commit, dropping the final revision.
+    //
+    // This test simulates that pattern: a child that delays its
+    // 'exit' emission by 50ms after SIGTERM, with an onBeforeExit
+    // callback timestamping the latest "child write." The hook
+    // records when IT fires. Assertion: hook fires AFTER child
+    // exit, i.e. after any graceful-flush writes.
+    const runs = createRuns();
+    let childLastWroteAt: number | null = null;
+    let hookFiredAt: number | null = null;
+    let hookSawChildAlive: boolean | null = null;
+    const child = new FakeChildProcess({ closeOn: 'SIGTERM', delayMs: 50 });
+    // Simulate the child writing files right before exit (the
+    // pattern this fix is protecting against).
+    child.onBeforeExit = () => {
+      childLastWroteAt = Date.now();
+    };
+    runs.setRunFinishedHook(async () => {
+      hookFiredAt = Date.now();
+      // The hook can observe the child's exit state — pre-fix this
+      // would be 'alive' (child still running); post-fix it should
+      // be 'exited' because we wait for child exit first.
+      hookSawChildAlive = child.exitEmittedAt === null;
+    });
+
+    const run = runs.create({ projectId: 'project-1', conversationId: 'conv-1' });
+    run.status = 'running';
+    (run as any).child = child;
+
+    await runs.shutdownActive({ graceMs: 500 });
+
+    // Both events happened
+    expect(childLastWroteAt).not.toBeNull();
+    expect(hookFiredAt).not.toBeNull();
+    // The child's final write completed BEFORE the hook fired —
+    // proving the hook reads a post-child-exit worktree
+    expect(hookFiredAt!).toBeGreaterThanOrEqual(childLastWroteAt!);
+    // And the hook saw the child as exited when it fired
+    expect(hookSawChildAlive).toBe(false);
+  });
+
   it('does not hang shutdownActive forever on a stuck runFinishedHook', async () => {
     // Belt-and-suspenders: if a hook gets stuck (e.g. fs lock,
     // hung subprocess), shutdownActive must time out and still
@@ -248,8 +296,23 @@ class FakeChildProcess extends EventEmitter {
   signalCode: string | null = null;
   killed = false;
   signals: string[] = [];
+  /** Set the moment this child actually emits 'exit'. Used by ordering tests. */
+  exitEmittedAt: number | null = null;
+  /** Optional callback fired just before the 'exit' emit — simulates last writes. */
+  onBeforeExit: (() => void) | undefined = undefined;
 
-  constructor(private readonly options: { closeOn: 'SIGTERM' | 'SIGKILL' }) {
+  constructor(
+    private readonly options: {
+      closeOn: 'SIGTERM' | 'SIGKILL';
+      /**
+       * Delay (ms) between receiving the matching signal and emitting
+       * 'exit'/'close'. Simulates a child handling SIGTERM gracefully
+       * (e.g., flushing files to disk) before exiting. Default 0
+       * (queueMicrotask immediate emit).
+       */
+      delayMs?: number;
+    },
+  ) {
     super();
   }
 
@@ -257,11 +320,23 @@ class FakeChildProcess extends EventEmitter {
     this.killed = true;
     this.signals.push(signal);
     if (signal === this.options.closeOn) {
-      this.signalCode = signal;
-      queueMicrotask(() => {
+      const fire = () => {
+        try { this.onBeforeExit?.(); } catch { /* ignore */ }
+        // Mirror real ChildProcess: signalCode is set when the process
+        // actually exits, NOT when kill() is called. Setting it eagerly
+        // would let `waitForChildExit` short-circuit before the delayed
+        // 'exit' emission fires — which is exactly the race this
+        // FakeChildProcess is here to simulate.
+        this.signalCode = signal;
+        this.exitEmittedAt = Date.now();
         this.emit('exit', null, signal);
         this.emit('close', null, signal);
-      });
+      };
+      if (this.options.delayMs && this.options.delayMs > 0) {
+        setTimeout(fire, this.options.delayMs).unref?.();
+      } else {
+        queueMicrotask(fire);
+      }
     }
     return true;
   }

--- a/apps/daemon/tests/runs.test.ts
+++ b/apps/daemon/tests/runs.test.ts
@@ -163,6 +163,71 @@ describe('chat run service stream replay', () => {
       run.events.filter((e: { id: number }) => e.id > cursor).map((e: { id: number }) => e.id),
     );
   });
+
+  it('awaits in-flight runFinishedHook promises during shutdownActive', async () => {
+    // Caught in code review on PR #2619: without tracking pending
+    // hook promises and awaiting them in shutdownActive, a SIGTERM
+    // mid-hook can let process.exit() race the auto-commit write,
+    // dropping the run's project_revisions row. This test exercises
+    // the contract: shutdownActive must not return until in-flight
+    // hooks have settled.
+    const runs = createRuns();
+    let hookCompletedAt: number | null = null;
+    let hookStartedAt: number | null = null;
+    runs.setRunFinishedHook(async () => {
+      hookStartedAt = Date.now();
+      // Simulate the multi-step history auto-commit (HEAD probe,
+      // lock acquisition, git status/add/commit, sqlite INSERT).
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      hookCompletedAt = Date.now();
+    });
+
+    const child = new FakeChildProcess({ closeOn: 'SIGTERM' });
+    const run = runs.create({ projectId: 'project-1', conversationId: 'conv-1' });
+    run.status = 'running';
+    (run as any).child = child;
+
+    const shutdownStartedAt = Date.now();
+    await runs.shutdownActive({ graceMs: 500 });
+    const shutdownReturnedAt = Date.now();
+
+    // The hook ran (started + completed both set)
+    expect(hookStartedAt).not.toBeNull();
+    expect(hookCompletedAt).not.toBeNull();
+    // And it completed BEFORE shutdownActive returned — the
+    // contract we just installed.
+    expect(hookCompletedAt!).toBeLessThanOrEqual(shutdownReturnedAt);
+    // Sanity: shutdownActive waited at least the hook's ~100ms
+    expect(shutdownReturnedAt - shutdownStartedAt).toBeGreaterThanOrEqual(90);
+  });
+
+  it('does not hang shutdownActive forever on a stuck runFinishedHook', async () => {
+    // Belt-and-suspenders: if a hook gets stuck (e.g. fs lock,
+    // hung subprocess), shutdownActive must time out and still
+    // return so the daemon can exit. The bound is 2× graceMs.
+    const runs = createRuns();
+    let hookSettled = false;
+    runs.setRunFinishedHook(() => new Promise(() => {
+      // Intentionally never resolves; would-be data loss is logged
+      // by shutdownActive but doesn't hang the process.
+    }));
+
+    const child = new FakeChildProcess({ closeOn: 'SIGTERM' });
+    const run = runs.create({ projectId: 'project-1', conversationId: 'conv-1' });
+    run.status = 'running';
+    (run as any).child = child;
+
+    const start = Date.now();
+    await runs.shutdownActive({ graceMs: 100 });
+    const elapsed = Date.now() - start;
+
+    // Min wait is 1000ms (the floor in runs.ts: max(graceMs*2, 1000))
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+    // Upper bound — generous margin for test scheduling jitter
+    expect(elapsed).toBeLessThanOrEqual(2500);
+    // The hook itself never resolved
+    expect(hookSettled).toBe(false);
+  });
 });
 
 function createRuns() {

--- a/apps/daemon/tests/runs.test.ts
+++ b/apps/daemon/tests/runs.test.ts
@@ -94,6 +94,50 @@ describe('chat run service shutdown', () => {
   });
 });
 
+describe('chat run service touchedFiles tracking', () => {
+  it('starts false on a new run', () => {
+    const runs = createRuns();
+    const run = runs.create();
+    expect((run as any).touchedFiles).toBe(false);
+  });
+
+  it.each(['Write', 'Edit', 'MultiEdit', 'NotebookEdit'])(
+    'flips to true when a %s tool_use event is emitted',
+    (toolName) => {
+      const runs = createRuns();
+      const run = runs.create();
+      runs.emit(run, 'tool_use', { id: 't1', name: toolName, input: {} });
+      expect((run as any).touchedFiles).toBe(true);
+    },
+  );
+
+  it.each(['Bash', 'Read', 'Grep', 'Glob', 'WebFetch'])(
+    'stays false for non-write tool_use names (%s — read-only or ambiguous)',
+    (toolName) => {
+      const runs = createRuns();
+      const run = runs.create();
+      runs.emit(run, 'tool_use', { id: 't1', name: toolName, input: {} });
+      expect((run as any).touchedFiles).toBe(false);
+    },
+  );
+
+  it('stays false for non-tool_use events even with a matching name field', () => {
+    const runs = createRuns();
+    const run = runs.create();
+    runs.emit(run, 'stdout', { name: 'Write', text: 'red herring' });
+    expect((run as any).touchedFiles).toBe(false);
+  });
+
+  it('stays true once set — does not reset on subsequent non-write events', () => {
+    const runs = createRuns();
+    const run = runs.create();
+    runs.emit(run, 'tool_use', { id: 't1', name: 'Write', input: {} });
+    runs.emit(run, 'tool_use', { id: 't2', name: 'Read', input: {} });
+    runs.emit(run, 'stdout', { text: 'after' });
+    expect((run as any).touchedFiles).toBe(true);
+  });
+});
+
 describe('chat run service stream replay', () => {
   it('always replays the final event when a reattaching client cursor is at the end of a terminal run', () => {
     const sendCalls: Array<{ event: string; data: unknown; id: number }> = [];

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -49,7 +49,6 @@ const residualSkippedDirectories = new Set([
   ".tmp",
   ".vite",
   "dist",
-  "local",
   "node_modules",
   "out",
 ]);
@@ -113,6 +112,8 @@ const residualAllowedPathPrefixes = [
   "design-templates/html-ppt/assets/",
   "test-results/",
   "vendor/",
+  // Untracked local working tree (gitignored at the repo root).
+  "local/",
 ];
 
 const residualAllowedPathPatterns: RegExp[] = [

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -49,6 +49,7 @@ const residualSkippedDirectories = new Set([
   ".tmp",
   ".vite",
   "dist",
+  "local",
   "node_modules",
   "out",
 ]);


### PR DESCRIPTION
Refs #1241

## Why

This is the first phase of the git-integration feature proposed in #1241 — the foundation that subsequent phases (P1 History UI, P2 worktree variants, P3 external remotes, P4 agent-facing read-only history tools) build on. P0 ships the substrate, identity seam, and chat-run lifecycle integration without any user-visible UI surface, so it can land safely behind a feature flag while subsequent phases catch up.

The pain it eventually addresses (covered in the #1241 thread): agent-driven design tools that have no version history overwrite prior good states silently, lose provenance ("who did this"), and force users to clone projects manually for "what if we tried a different direction" exploration. P0 establishes the data model and lifecycle hooks; P1 (now starting) surfaces the data via a History pane.

## What users will see

**Nothing changes by default.** Gated behind `OD_GIT_INTEGRATION_ENABLED` (off unless explicitly set to `1` / `true` / `yes`). With the flag off, no git operations occur, no substrate is initialized, and no `project_revisions` rows are written. The identity middleware (`req.identity`) is always active — that's the "always on" identity seam, independent of the substrate gate — and any new messages get their `messages.actor_*` columns populated from the resolved identity (idle metadata when the substrate is off; meaningful provenance when it's on). Reference: validated end-to-end in the deployment exercise below (Step 7).

With the flag on, the daemon silently records project history at run boundaries:

- Each project gets a git repo initialized at `<OD_DATA_DIR>/repos/<project-id>.gitdir/` with a `.git` gitlink in the working tree.
- Every chat run that leaves the tree dirty produces one commit at run-end, authored by the resolved identity (today: a configurable `OD_LOCAL_IDENTITY` placeholder), with the user prompt as the commit subject.
- A `project_revisions` row mirrors each commit with a substrate-opaque UUID id and the git SHA in a separate column; `projects.current_revision_id` advances; `messages.actor_*` columns populate from the resolved identity.

P1 surfaces this data via a History pane; this PR is purely plumbing.

## Surface area

- [x] **CLI / env var** — adds `OD_GIT_INTEGRATION_ENABLED`, `OD_LOCAL_IDENTITY`, `OD_LOCAL_IDENTITY_EMAIL`
- [x] **API / contract** — adds the identity seam (`apps/daemon/src/identity/types.ts`) with `Express.Request.identity` augmentation. No new HTTP endpoints in P0 (those land in P1)
- [x] **Default behavior change** — adds 1 new table (`project_revisions`) + 4 columns across `projects` and `messages`. Migrations idempotent + ordered so legacy databases upgrade cleanly. Existing data unaffected; off-by-default flag makes the change opt-in
- [ ] UI (none in P0)
- [ ] Keyboard shortcut
- [ ] Extension point
- [ ] i18n keys (none in P0)
- [ ] New top-level dependency (none — uses existing `better-sqlite3`, `git` binary via existing `runGit` helper, `node:crypto.randomUUID`)

## What landed

17 commits: 8 original P0-work commits, then 9 review-correction commits (7 from internal code review, 2 found by the reference-deployment exercise — see "Review corrections" below). Listed in branch order (current SHAs after rebase onto latest main):

| Phase | Commit | Subject |
|---|---|---|
| P0 | `041e67d6` | `feat(daemon): add identity seam for revision attribution` |
| P0 | `25d7b173` | `chore(guard): skip local/ for personal working content` |
| P0 | `c505b92a` | `feat(daemon): wire request-context identity through to chat runs` |
| P0 | `96151b1e` | `refactor(daemon): promote runGit to shared git/exec module` |
| P0 | `7a3cb3fb` | `feat(daemon): add history-feature SQLite schema` |
| P0 | `fff2f8c2` | `feat(daemon): add history substrate adapter (init + record)` |
| P0 | `d4d9efa1` | `feat(daemon): auto-init history substrate via ensureProject hook` |
| P0 | `f169ba79` | `feat(daemon): auto-commit at chat-run end via run-finished hook` |
| fix | `8a9e298a` | `fix(daemon): serialize per-project history operations` |
| fix | `82e6f986` | `fix(daemon): make runGit strict by default; opt-in softFail128 for probes` |
| fix | `804404af` | `fix(daemon): use synthetic UUIDs as revision ids; SHA in its own column` |
| fix | `18f94a34` | `fix(daemon): populate messages.actor_* on every upsert that carries identity` |
| fix | `710c8822` | `fix(daemon): order history migration so git_sha column exists before its index` |
| fix | `fbc073f0` | `fix(daemon): route ensure-hook identity through resolveIdentity, not LocalFallbackProvider directly` |
| fix | `86975312` | `fix(daemon): exclude runtime scratch (.od-skills/) from history substrate` |
| fix | `c55ac8c5` | `fix(daemon): resolve env-driven identity in orbit setRunHandler` |
| fix | `5e83a052` | `fix(daemon): record marker revision when sibling absorbs concurrent run` |

## Architecture

New modules under `apps/daemon/src/`:

```
identity/types.ts              seam: Identity, resolveIdentity, LocalFallbackProvider
identity/middleware.ts         req.identity wiring via Express middleware
identity/attribution.ts        Identity → {actor_*} flattener (X-Forwarded-For parse)
git/exec.ts                    shared runGit, strict by default; opt-in softFail128 for probes
history/persistence.ts         SQLite migration (UUID-keyed revisions, git_sha column, actor_* on messages)
history/feature-flag.ts        OD_GIT_INTEGRATION_ENABLED gate
history/repo.ts                substrate adapter (initProjectHistory, recordRevisionForRun)
history/project-lock.ts        per-project async serialization (Promise tail-chain)
history/ensure-hook.ts         glues init into ensureProject lifecycle
history/run-hook.ts            glues record into runs.finish() lifecycle
```

Existing modules touched (surgical hooks only):

- `db.ts` — wire `migrateProjectRevisions`; extend `upsertMessage` to write `actor_*` columns
- `runs.ts` — store `identity` + `message` on the run object via `meta`; add `setRunFinishedHook` slot; fire from `finish()`
- `projects.ts` — `setProjectEnsuredHook` slot in `ensureProject`, wrapped in try/catch
- `chat-routes.ts` + `server.ts` — pass `req.identity` through to 5 `runs.create()` call sites; `attributionFromIdentity` at 5 `upsertMessage` sites; install both hooks at startup
- `project-routes.ts` — `attributionFromIdentity` at 1 message-PUT route
- `live-artifacts/refresh.ts` — use the promoted `runGit` with `{softFail128: true}` for its 5 probe sub-calls
- `scripts/guard.ts` — add `local` to `residualSkippedDirectories` alongside `.task` / `.claude-sessions` / similar personal-scratch dirs

## Review corrections

After the initial 8 P0 commits landed and the green-check matrix went clean, internal review and the reference-deployment exercise found **9 real bugs** the matrix didn't catch. All fixed on the same branch with regression tests:

1. **Per-project race** — concurrent finishes on the same project both `git add -A` against the shared tree; one commit absorbed both runs' staged changes; loser saw clean tree and no-oped. Fix: async per-project lock around init/record. (See also #9 — the lock alone was necessary but not sufficient.)
2. **`runGit` exit-128 swallowing** — the helper silently mapped exit 128 to `''`. Safe for read-only probes (the original `git.summary` consumer) but unsafe for mutating callers — a corrupted gitdir making `git status` return 128 would be read as "clean tree" and skip the commit. Fix: strict by default; opt-in `{softFail128: true}` for probes.
3. **`project_revisions.id` collision risk** — used the commit SHA as the primary key, but SHA1 commits are only unique within a repo. Two projects with identical empty-tree migration commits at the same second would collide. Fix: synthetic UUIDs + separate `git_sha` column; partial unique index on `(project_id, git_sha)`.
4. **`messages.actor_*` columns added but never populated** — schema work landed; no `upsertMessage` call site wrote to them. Initial completion claim was wrong. Fix: `attributionFromIdentity(identity, req?)` helper at every call site that has identity in scope.
5. **Migration ordering on legacy DBs** — the `(project_id, git_sha)` partial unique index ran inside the same `db.exec()` that created the table, before the compatibility `ALTER TABLE ADD COLUMN git_sha` for legacy DBs. Aborted on databases that ran the pre-fix migration. Fix: split into four ordered steps so the column-add precedes its index.
6. **Ensure-hook bypassed identity seam** — `installHistoryEnsureHook` called `LocalFallbackProvider.resolve` directly, bypassing the registered-provider chain. Contradicts the acceptance criterion that all identity reads go through `resolveIdentity(req)`. Fix: route through `resolveIdentity({}, env)`.
7. **Runtime skill staging committed as history** — daemon stages active skills into `<cwd>/.od-skills/<folder>/` before every agent run; default `.gitignore` didn't cover it; runs that wrote no user files produced a revision capturing the staged skill copies. Fix: daemon-managed exclusion in `<repoDir>/info/exclude` (not the user-visible `.gitignore`), idempotent and backfills on legacy substrates.
8. **Orbit `setRunHandler` referenced an out-of-scope `req`** *(caught by CI)* — when wiring `identity: req.identity` and `attributionFromIdentity(req.identity, req)` across `server.ts` (which is `// @ts-nocheck`, so scope checks were disabled), I missed that `orbitService.setRunHandler(async ({...}) => …)` is invoked by the scheduler-not-Express plumbing and has no `req`. The orbit e2e test caught it with `HTTP 500 /api/orbit/run: {"error":"req is not defined"}`. Fix: mirror the routine handler's pattern — `resolveIdentity({})` + `attributionFromIdentity(run.identity)`.
9. **Provenance loss on concurrent runs** *(caught by the reference-deployment exercise, Step 5)* — fix #1's per-project lock prevented git repo corruption but did **not** preserve provenance. When the lock-winner's commit absorbed both runs' dirty files into one commit, the lock-loser observed a clean tree on lock acquisition and silently no-oped, leaving its `run_id` with no `project_revisions` row. (The original test that purportedly validated #1 actually encoded the bug as expected behavior — its assertion `expect(kinds).toContain('recorded')` allowed one no-op outcome.) Fix: capture HEAD before queueing at the lock; when the locked critical section finds a clean tree AND HEAD has advanced from the pre-lock snapshot, record a `marker` row (`git_sha=NULL`, `parent_id` pointing at the sibling's revision, `run_id` linked). Schema already supported this via the partial unique index designed in fix #3. Test rewritten with strict `expect(kinds).toEqual(['marker', 'recorded'])` — no escape hatch.

The first 7 fixes came from internal review on the static code; fixes #8 and #9 came from live validation (CI on push for #8; the reference-deployment exercise for #9). The pattern is documented in our team's [`green-ci-is-not-correctness`](#) practice note.

## Validation

| Check | Result |
|---|---|
| `pnpm guard` | exit 0 |
| `pnpm typecheck` (workspace) | exit 0 |
| `pnpm --filter @open-design/daemon build` | exit 0 |
| `pnpm --filter @open-design/daemon test` | 3157 pass / 1 skip / 4 todo / 0 fail across 266 test files |
| **Reference-deployment exercise** | ✅ **Complete** — all 7 steps passed against a live deployment with `OD_GIT_INTEGRATION_ENABLED=1` and real agent runs. See "Reference-deployment exercise results" below. |

### Reference-deployment exercise results

Exercised against a TrueNAS-hosted deployment (NAS + Docker + Tailscale Serve) using two real existing projects with accumulated content, including:

1. ✅ Deploy with flag on → daemon serves; schema migrated; env vars wired
2. ✅ Substrate init on first project use → `<id>.gitdir/` created with full git layout; gitlink resolves; `info/exclude` contains `.od-skills/`; migration revision row recorded
3. ✅ Agent run that writes a file → commit recorded with `OD_LOCAL_IDENTITY` as author; both pre-existing PNG and new file absorbed; `project_revisions` row linked to run_id; `projects.current_revision_id` advanced; `messages.actor_*` populated including X-Forwarded-For–parsed source IP
4. ✅ Clean-tree (conversational) run → no new commit, no new revision, but the run still completes; new messages get attribution (the conversational-only path correctly doesn't write history)
5. ✅ Two concurrent browser-tab runs on the same project → both runs' files in the commit; both runs have provenance rows (one `recorded` + one `marker`). Exposed bug #9 above on the pre-fix branch; the marker fix is what closes this step
6. ✅ Daemon restart → migrations idempotent; no re-init; current_revision_id and HEAD unchanged; no errors or warnings in restart logs
7. ✅ Flip `OD_GIT_INTEGRATION_ENABLED=0` + restart → run completes normally, file written, but no new commit / revision / current_revision_id advance. Identity-seam-populated `actor_*` columns still apply to new messages (the seam is independent of the substrate gate — see "What users will see" above)

## Moving on to P1 in parallel

The P1 (History UI) implementation work is now split into two sequenced sub-PRs to keep review surface manageable:

- **#02a P1-server** — history contracts (`packages/contracts/src/api/history.ts`), 6 `/api/projects/:id/history/*` endpoints, `od history` CLI subcommands (per AGENTS.md UI/CLI dual-track), daemon endpoint tests. No UI.
- **#02b P1-ui** — `HistoryPane.tsx`, read-only view-at-revision mode + banner, attribution chip, restore confirmation modal, header integration, i18n in 18 locales, Playwright e2e flow test.

Both ship as PRs against `nexu-io/open-design` after this P0 PR merges. The P1-server PR opens first (P1-ui imports its frozen contract shape); both can develop in parallel.

## Notes for review

**Module boundaries:** all new code lives in `apps/daemon/src/identity/` and `apps/daemon/src/history/` — net-new directories, no edits to existing modules' internals. The hook-registration pattern (`setProjectEnsuredHook`, `setRunFinishedHook`) means existing call sites of `ensureProject` and `runs.finish()` don't need to know about the history feature; the feature opts into their lifecycle from one wiring point each in `server.ts` bootstrap.

**Forward compatibility:** the schema is substrate-agnostic by design — `project_revisions.id` is UUID, with the git SHA in a separate column. A future OD-owned substrate could replace `history/repo.ts` without changing the schema, the contracts shapes, or any consumer code. The identity seam is designed for the multi-user-support feature to plug in OAuth / header-trust providers ahead of `LocalFallbackProvider` without touching call sites.

**Known minor data-quality observations** (non-blocking; would be follow-up polish):

- *Commit subjects sometimes start with `## context warning` or other markdown prefixes* — the web UI prepends context/skill output to the message before sending to `/api/chat`; `buildCommitMessage` takes the first line of what arrives, which can be the prefix rather than the user's intent. A future polish could strip leading markdown headers before taking the subject line.
- *Migration revision rows have `files_changed_count=0`* even when the import-existing-tree commit contained files. The initial commit has no parent to diff against, so the count defaults to 0. Reasonable behavior; could also be the tree size — either interpretation is defensible.

**Happy to split** any of the 17 commits into separate PRs if reviewers prefer smaller-grained landings. The 8 original P0 commits each represent a self-contained change; the 9 fix commits each address one specific defect with its own regression test. Suggested split-axes if helpful: identity seam + middleware as a standalone PR, then schema + persistence module as a second, then the lifecycle hooks as a third.
