### PR TITLE
feat(preview): url-load bridges — scroll restore, Cmd/Ctrl-wheel zoom, Comment/Inspect sub-page keep

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -15,6 +15,7 @@ import {
   resolvePluginSnapshot,
 } from './plugins/index.js';
 import { connectorService } from './connectors/service.js';
+import { injectScrollRelay } from './prototype-scroll-relay.js';
 import type { RouteDeps } from './server-context.js';
 import { listSkills } from './skills.js';
 import { auditDesignSystemPackage } from './tools-connectors-cli.js';
@@ -947,6 +948,13 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       }
 
       const file = await readProjectFile(PROJECTS_DIR, projectId, relPath, project?.metadata);
+      // url-load HTML is served raw; inject the scroll-position relay so
+      // multi-page prototypes keep their place on back-navigation without any
+      // per-project code. Non-HTML files are sent byte-for-byte.
+      if (file.mime.startsWith('text/html')) {
+        res.type(file.mime).send(injectScrollRelay(file.buffer.toString('utf8')));
+        return;
+      }
       res.type(file.mime).send(file.buffer);
     } catch (err: any) {
       const status = err && err.code === 'ENOENT' ? 404 : 400;

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -948,10 +948,13 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       }
 
       const file = await readProjectFile(PROJECTS_DIR, projectId, relPath, project?.metadata);
-      // url-load HTML is served raw; inject the scroll-position relay so
-      // multi-page prototypes keep their place on back-navigation without any
-      // per-project code. Non-HTML files are sent byte-for-byte.
-      if (file.mime.startsWith('text/html')) {
+      // url-load HTML preview opts into the scroll-position relay via `?preview=1`
+      // so multi-page prototypes keep their place on back-navigation. The default
+      // raw response stays byte-accurate so non-preview consumers (HtmlViewer's
+      // fetchProjectFileText path for manual-edit / Inspect save, deploy/export
+      // staging, MCP file reads) never see injected markup baked into saved files.
+      const wantsPreview = req.query?.preview === '1';
+      if (wantsPreview && file.mime.startsWith('text/html')) {
         res.type(file.mime).send(injectScrollRelay(file.buffer.toString('utf8')));
         return;
       }

--- a/apps/daemon/src/prototype-scroll-relay.ts
+++ b/apps/daemon/src/prototype-scroll-relay.ts
@@ -50,6 +50,15 @@ const SCROLL_RELAY_SCRIPT = `<script ${SCROLL_RELAY_MARKER}>(function(){
   function reportLoc(){ try { (window.parent || window).postMessage({ type: 'od:url-load-loc', pathname: location.pathname, search: location.search, hash: location.hash }, '*'); } catch (e) {} }
   reportLoc();
   window.addEventListener('hashchange', reportLoc);
+  // In-page SPAs (e.g. an admin console) switch view with
+  // history.replaceState('#panel') instead of assigning location.hash, which
+  // does NOT fire hashchange — wrap the history API so those view changes are
+  // still reported, otherwise a stale hash gets restored on srcDoc rebuild.
+  ['pushState', 'replaceState'].forEach(function (m) {
+    var orig = history[m];
+    if (typeof orig !== 'function') return;
+    history[m] = function () { var r = orig.apply(this, arguments); reportLoc(); return r; };
+  });
   // Cmd/Ctrl + wheel forwards to the host to zoom the preview; the sandboxed
   // iframe otherwise swallows the gesture so the host never sees it.
   document.addEventListener('wheel', function(e){

--- a/apps/daemon/src/prototype-scroll-relay.ts
+++ b/apps/daemon/src/prototype-scroll-relay.ts
@@ -1,0 +1,58 @@
+/**
+ * Scroll-position relay injected into HTML served on the url-load preview path
+ * (`GET /api/projects/:id/raw/*`).
+ *
+ * Multi-page prototypes navigate between separate files (e.g. an entry gallery
+ * that links out to `screens/*.html` and back). Each "back to list" is a full
+ * page load, so the list snaps to 0,0 and the user loses their place. The
+ * srcDoc preview path already augments served HTML (see
+ * `apps/web/src/runtime/srcdoc.ts`); url-load served raw HTML untouched, so
+ * generated prototypes had to hand-roll their own position keeping.
+ *
+ * This injects a tiny per-pathname scroll memory so it works with zero markup
+ * and zero per-project code. It relays through `window.name` because the
+ * preview iframe is sandboxed `allow-scripts` without `allow-same-origin`,
+ * where `localStorage`/`sessionStorage` reset on every reload while
+ * `window.name` survives same-context navigation.
+ *
+ * Coexistence guard: the relay only reads/writes `window.name` when it is
+ * empty or already holds our `ODSCROLL:` map. If a project uses `window.name`
+ * for its own purpose, the relay yields entirely and never clobbers it.
+ */
+
+export const SCROLL_RELAY_MARKER = 'data-od-scroll-relay';
+
+const SCROLL_RELAY_SCRIPT = `<script ${SCROLL_RELAY_MARKER}>(function(){
+  if (window.__odScrollRelay) return; window.__odScrollRelay = 1;
+  var K = 'ODSCROLL:';
+  function nm(){ try { return String(window.name || ''); } catch (e) { return ''; } }
+  function ours(){ var n = nm(); return n === '' || n.indexOf(K) === 0; }
+  function load(){ if (!ours()) return null; var n = nm(); if (n.indexOf(K) !== 0) return {}; try { return JSON.parse(n.slice(K.length)) || {}; } catch (e) { return {}; } }
+  function store(m){ if (!ours()) return; try { window.name = K + JSON.stringify(m); } catch (e) {} }
+  var path = location.pathname;
+  var map = load();
+  if (map && Object.prototype.hasOwnProperty.call(map, path)) {
+    var y = map[path] | 0;
+    var apply = function(){ window.scrollTo(0, y); };
+    apply();
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', apply);
+    requestAnimationFrame(apply);
+  }
+  function remember(){ var m = load(); if (!m) return; m[path] = Math.round(window.scrollY); store(m); }
+  window.addEventListener('pagehide', remember);
+  document.addEventListener('visibilitychange', function(){ if (document.visibilityState === 'hidden') remember(); });
+  document.addEventListener('click', function(e){ var a = e.target && e.target.closest && e.target.closest('a[href]'); if (a) remember(); }, true);
+})();</script>`;
+
+/**
+ * Inject the scroll relay into an HTML document string. Idempotent (a document
+ * already carrying the marker is returned unchanged). Prefers to land just
+ * before `</body>`, then `</head>`, then appends as a last resort so even
+ * fragment-like HTML still gets it.
+ */
+export function injectScrollRelay(html: string): string {
+  if (html.includes(SCROLL_RELAY_MARKER)) return html;
+  if (/<\/body\s*>/i.test(html)) return html.replace(/<\/body\s*>/i, (m) => `${SCROLL_RELAY_SCRIPT}${m}`);
+  if (/<\/head\s*>/i.test(html)) return html.replace(/<\/head\s*>/i, (m) => `${SCROLL_RELAY_SCRIPT}${m}`);
+  return html + SCROLL_RELAY_SCRIPT;
+}

--- a/apps/daemon/src/prototype-scroll-relay.ts
+++ b/apps/daemon/src/prototype-scroll-relay.ts
@@ -61,10 +61,13 @@ const SCROLL_RELAY_SCRIPT = `<script ${SCROLL_RELAY_MARKER}>(function(){
   });
   // Cmd/Ctrl + wheel forwards to the host to zoom the preview; the sandboxed
   // iframe otherwise swallows the gesture so the host never sees it.
+  // Forward deltaMode too — classic mouse wheels on Firefox / some Windows
+  // setups report DOM_DELTA_LINE (=1, ±3 per notch) instead of pixels, so the
+  // host needs the mode to compensate or zoom feels inert.
   document.addEventListener('wheel', function(e){
     if (!(e.metaKey || e.ctrlKey)) return;
     e.preventDefault();
-    try { (window.parent || window).postMessage({ type: 'od:zoom-wheel', deltaY: e.deltaY }, '*'); } catch (_) {}
+    try { (window.parent || window).postMessage({ type: 'od:zoom-wheel', deltaY: e.deltaY, deltaMode: e.deltaMode }, '*'); } catch (_) {}
   }, { passive: false });
 })();</script>`;
 

--- a/apps/daemon/src/prototype-scroll-relay.ts
+++ b/apps/daemon/src/prototype-scroll-relay.ts
@@ -42,6 +42,14 @@ const SCROLL_RELAY_SCRIPT = `<script ${SCROLL_RELAY_MARKER}>(function(){
   window.addEventListener('pagehide', remember);
   document.addEventListener('visibilitychange', function(){ if (document.visibilityState === 'hidden') remember(); });
   document.addEventListener('click', function(e){ var a = e.target && e.target.closest && e.target.closest('a[href]'); if (a) remember(); }, true);
+  // Report the page the url-load preview iframe is currently showing. The host
+  // cannot read location across the sandboxed (no allow-same-origin) frame, so
+  // it needs this to know which sub-page a multi-page prototype navigated to
+  // (e.g. to render that page, not the entry file, when a srcDoc-only bridge
+  // like Comment/Inspect mode is toggled).
+  function reportLoc(){ try { (window.parent || window).postMessage({ type: 'od:url-load-loc', pathname: location.pathname, search: location.search, hash: location.hash }, '*'); } catch (e) {} }
+  reportLoc();
+  window.addEventListener('hashchange', reportLoc);
 })();</script>`;
 
 /**

--- a/apps/daemon/src/prototype-scroll-relay.ts
+++ b/apps/daemon/src/prototype-scroll-relay.ts
@@ -50,6 +50,13 @@ const SCROLL_RELAY_SCRIPT = `<script ${SCROLL_RELAY_MARKER}>(function(){
   function reportLoc(){ try { (window.parent || window).postMessage({ type: 'od:url-load-loc', pathname: location.pathname, search: location.search, hash: location.hash }, '*'); } catch (e) {} }
   reportLoc();
   window.addEventListener('hashchange', reportLoc);
+  // Cmd/Ctrl + wheel forwards to the host to zoom the preview; the sandboxed
+  // iframe otherwise swallows the gesture so the host never sees it.
+  document.addEventListener('wheel', function(e){
+    if (!(e.metaKey || e.ctrlKey)) return;
+    e.preventDefault();
+    try { (window.parent || window).postMessage({ type: 'od:zoom-wheel', deltaY: e.deltaY }, '*'); } catch (_) {}
+  }, { passive: false });
 })();</script>`;
 
 /**

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -223,7 +223,11 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('accept-ranges')).toBeNull();
     const text = await res.text();
-    expect(text).toBe('<html/>');
+    // The raw route injects the url-load scroll-position relay into served
+    // text/html, so the body is the full file plus the relay script (not a
+    // byte range). Assert the original document is delivered intact.
+    expect(text.startsWith('<html/>')).toBe(true);
+    expect(text).toContain('data-od-scroll-relay');
   });
 
   it('returns 404 for a missing file', async () => {

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -223,9 +223,20 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('accept-ranges')).toBeNull();
     const text = await res.text();
-    // The raw route injects the url-load scroll-position relay into served
-    // text/html, so the body is the full file plus the relay script (not a
-    // byte range). Assert the original document is delivered intact.
+    // The default raw response is byte-accurate: non-preview consumers
+    // (HtmlViewer's fetchProjectFileText path for manual-edit / Inspect
+    // save, deploy/export staging, MCP file reads) must not see the
+    // injected preview shim baked into the file body.
+    expect(text).toBe('<html/>');
+    expect(text).not.toContain('data-od-scroll-relay');
+  });
+
+  it('injects the preview shim only when ?preview=1 opts in', async () => {
+    const res = await fetch(`${rawUrl('page.html')}?preview=1`);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    // The url-load preview iframe opts in via ?preview=1, so the body is
+    // the full file plus the relay script.
     expect(text.startsWith('<html/>')).toBe(true);
     expect(text).toContain('data-od-scroll-relay');
   });

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -38,6 +38,7 @@ import {
   uploadProjectFiles,
   liveArtifactPreviewUrl,
   projectFileUrl,
+  projectPreviewUrl,
   projectRawUrl,
   LiveArtifactRefreshError,
   refreshLiveArtifact,
@@ -4002,8 +4003,13 @@ function HtmlViewer({
   // Cmd/Ctrl + wheel zoom: the preview is a sandboxed iframe that swallows
   // wheel events, so the injected preview bridge forwards the gesture to the
   // host as an `od:zoom-wheel` message; this clamps it to the % control range.
-  const applyZoomWheel = useCallback((deltaY: number) => {
-    setZoom((z) => Math.max(25, Math.min(200, Math.round(z - deltaY * 0.25))));
+  // WheelEvent.deltaY is only in pixels when deltaMode === DOM_DELTA_PIXEL (0).
+  // Classic mouse wheels on Firefox / some Windows setups report DOM_DELTA_LINE
+  // (1, ~16px per line) — without that conversion the ±3 per notch only shifts
+  // zoom by 0–1% and the gesture feels inert.
+  const applyZoomWheel = useCallback((deltaY: number, deltaMode: number = 0) => {
+    const px = deltaMode === 1 ? deltaY * 16 : deltaMode === 2 ? deltaY * 100 : deltaY;
+    setZoom((z) => Math.max(25, Math.min(200, Math.round(z - px * 0.25))));
   }, []);
   const fileViewportKey = previewViewportStateKey(projectId, file);
   const [previewViewport, setPreviewViewportState] = useState<PreviewViewportId>(
@@ -4533,8 +4539,13 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     forceInline: forceInline || needsSandboxShim,
     needsFocusGuard,
   });
+  // The url-load preview iframe opts into the daemon's HTML shim (scroll
+  // relay, sub-page reporting, zoom forwarder) via projectPreviewUrl. Other
+  // raw-route consumers (fetchProjectFileText for manual-edit / Inspect save,
+  // deploy/export, MCP file reads) continue to use projectRawUrl so saved
+  // files never have the injected script baked into them.
   const basePreviewSrcUrl = useMemo(
-    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}`,
+    () => `${projectPreviewUrl(projectId, file.name)}&v=${Math.round(file.mtime)}&r=${reloadKey}`,
     [projectId, file.name, file.mtime, reloadKey],
   );
   const [previewSrcUrl, setPreviewSrcUrl] = useState(basePreviewSrcUrl);
@@ -4857,9 +4868,9 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     }
     function onZoomWheel(ev: MessageEvent) {
       if (!isActivePreviewIframeSource(ev.source)) return;
-      const data = ev.data as { type?: string; deltaY?: number } | null;
+      const data = ev.data as { type?: string; deltaY?: number; deltaMode?: number } | null;
       if (!data || data.type !== 'od:zoom-wheel' || typeof data.deltaY !== 'number') return;
-      applyZoomWheel(data.deltaY);
+      applyZoomWheel(data.deltaY, typeof data.deltaMode === 'number' ? data.deltaMode : 0);
     }
     window.addEventListener('message', onMessage);
     window.addEventListener('message', onRestoreRequest);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3999,6 +3999,12 @@ function HtmlViewer({
   const [source, setSource] = useState<string | null>(liveHtml ?? null);
   const [inlinedSource, setInlinedSource] = useState<string | null>(null);
   const [zoom, setZoom] = useState(100);
+  // Cmd/Ctrl + wheel zoom: the preview is a sandboxed iframe that swallows
+  // wheel events, so the injected preview bridge forwards the gesture to the
+  // host as an `od:zoom-wheel` message; this clamps it to the % control range.
+  const applyZoomWheel = useCallback((deltaY: number) => {
+    setZoom((z) => Math.max(25, Math.min(200, Math.round(z - deltaY * 0.25))));
+  }, []);
   const fileViewportKey = previewViewportStateKey(projectId, file);
   const [previewViewport, setPreviewViewportState] = useState<PreviewViewportId>(
     () => htmlPreviewViewportState.get(fileViewportKey) ?? 'desktop',
@@ -4831,17 +4837,25 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
       }
       setUrlLoadSubPath(relative);
     }
+    function onZoomWheel(ev: MessageEvent) {
+      if (!isActivePreviewIframeSource(ev.source)) return;
+      const data = ev.data as { type?: string; deltaY?: number } | null;
+      if (!data || data.type !== 'od:zoom-wheel' || typeof data.deltaY !== 'number') return;
+      applyZoomWheel(data.deltaY);
+    }
     window.addEventListener('message', onMessage);
     window.addEventListener('message', onRestoreRequest);
     window.addEventListener('message', onDcViewportMessage);
     window.addEventListener('message', onUrlLoadLoc);
+    window.addEventListener('message', onZoomWheel);
     return () => {
       window.removeEventListener('message', onMessage);
       window.removeEventListener('message', onRestoreRequest);
       window.removeEventListener('message', onDcViewportMessage);
       window.removeEventListener('message', onUrlLoadLoc);
+      window.removeEventListener('message', onZoomWheel);
     };
-  }, [isActivePreviewIframeSource, isOurPreviewIframeSource, projectId, file.name]);
+  }, [isActivePreviewIframeSource, isOurPreviewIframeSource, projectId, file.name, applyZoomWheel]);
 
   useEffect(() => {
     if (!effectiveDeck) {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4816,8 +4816,13 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
       }
     }
     function onUrlLoadLoc(ev: MessageEvent) {
-      if (!isOurPreviewIframeSource(ev.source)) return;
-      if (!isActivePreviewIframeSource(ev.source)) return;
+      // Accept location reports from the url-load iframe even when it is no
+      // longer the active preview. A large/slow sub-page (e.g. a 100KB admin
+      // console) may only report its location AFTER Comment/Inspect has already
+      // switched the active iframe to srcDoc; gating on the active iframe would
+      // drop that report and the srcDoc would snap back to the entry/list page.
+      // Only the url-load relay emits od:url-load-loc, so this stays unambiguous.
+      if (!ev.source || ev.source !== urlPreviewIframeRef.current?.contentWindow) return;
       const data = ev.data as { type?: string; pathname?: string; hash?: string } | null;
       if (!data || data.type !== 'od:url-load-loc') return;
       // Always track the current hash — a hash-routed SPA changes view within

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -67,7 +67,7 @@ import {
 } from '../runtime/exports';
 import { buildReactComponentSrcdoc } from '../runtime/react-component';
 import { findHtmlEntriesReferencing } from '../runtime/jsx-module-refs';
-import { buildLazySrcdocTransport, buildSrcdoc, canActivateSrcDocTransport } from '../runtime/srcdoc';
+import { buildLazySrcdocTransport, buildSrcdoc, canActivateSrcDocTransport, selectSrcDocSource } from '../runtime/srcdoc';
 import {
   hasUrlModeBridge,
   htmlNeedsFocusGuard,
@@ -4599,9 +4599,14 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     };
   }, [useUrlLoadPreview, urlLoadSubPath, file.name, projectId, reloadKey]);
 
-  const usingSubPageSrcDoc = !useUrlLoadPreview && subPageSource != null && !!urlLoadSubPath && urlLoadSubPath !== file.name;
-  const srcDocSource = usingSubPageSrcDoc ? subPageSource : previewSource;
-  const srcDocBaseDir = usingSubPageSrcDoc ? baseDirFor(urlLoadSubPath) : baseDirFor(file.name);
+  const { source: srcDocSource, usingSubPage: usingSubPageSrcDoc } = selectSrcDocSource({
+    useUrlLoadPreview,
+    urlLoadSubPath,
+    fileName: file.name,
+    subPageSource,
+    previewSource,
+  });
+  const srcDocBaseDir = baseDirFor(usingSubPageSrcDoc && urlLoadSubPath ? urlLoadSubPath : file.name);
   const srcDoc = useMemo(
     () => (srcDocSource ? buildSrcdoc(srcDocSource, {
       deck: effectiveDeck,

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4074,6 +4074,9 @@ function HtmlViewer({
   // instead of snapping back to the entry/list page.
   const [urlLoadSubPath, setUrlLoadSubPath] = useState<string | null>(null);
   const [subPageSource, setSubPageSource] = useState<string | null>(null);
+  // Latest location.hash the url-load preview reported, so a srcDoc rebuild
+  // (forced by Comment/Inspect) can restore a hash-routed SPA's current view.
+  const [urlLoadHash, setUrlLoadHash] = useState('');
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -4574,9 +4577,10 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     };
   }, [source, effectiveDeck, projectId, file.name, useUrlLoadPreview]);
 
-  // Reset the tracked sub-page whenever the previewed entry file changes.
+  // Reset the tracked sub-page/hash whenever the previewed entry file changes.
   useEffect(() => {
     setUrlLoadSubPath(null);
+    setUrlLoadHash('');
   }, [file.name]);
   // When a comment/inspect toggle forces the preview off the url-load path
   // while the iframe was on a sub-page, fetch that sub-page's HTML so the
@@ -4603,12 +4607,13 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
       deck: effectiveDeck,
       baseHref: projectRawUrl(projectId, srcDocBaseDir),
       initialSlideIndex: htmlPreviewSlideState.get(previewStateKey)?.active ?? 0,
+      initialHash: urlLoadHash || undefined,
       selectionBridge: true,
       editBridge: manualEditMode,
       paletteBridge: false,
       previewFocusGuard: true,
     }) : ''),
-    [srcDocSource, srcDocBaseDir, effectiveDeck, projectId, previewStateKey, manualEditMode],
+    [srcDocSource, srcDocBaseDir, effectiveDeck, projectId, previewStateKey, manualEditMode, urlLoadHash],
   );
   const lazySrcDocTransport = useMemo(() => buildLazySrcdocTransport(), []);
   const [srcDocTransportResetKey, setSrcDocTransportResetKey] = useState(0);
@@ -4813,8 +4818,11 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     function onUrlLoadLoc(ev: MessageEvent) {
       if (!isOurPreviewIframeSource(ev.source)) return;
       if (!isActivePreviewIframeSource(ev.source)) return;
-      const data = ev.data as { type?: string; pathname?: string } | null;
+      const data = ev.data as { type?: string; pathname?: string; hash?: string } | null;
       if (!data || data.type !== 'od:url-load-loc') return;
+      // Always track the current hash — a hash-routed SPA changes view within
+      // the same file, so restore it even when the path matches the entry file.
+      setUrlLoadHash(typeof data.hash === 'string' ? data.hash : '');
       const rawPrefix = projectRawUrl(projectId, '');
       const pathname = typeof data.pathname === 'string' ? data.pathname : '';
       const idx = pathname.indexOf(rawPrefix);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4062,6 +4062,12 @@ function HtmlViewer({
   const [manualEditViewportWidth, setManualEditViewportWidth] = useState<number | null>(null);
   const [commentPortalHost, setCommentPortalHost] = useState<HTMLElement | null>(null);
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
+  // Project-relative path of the sub-page the url-load iframe has navigated to
+  // (e.g. `screens/teacher/teacher-console.html`), or null when on the entry
+  // file. Lets a comment/inspect toggle that forces srcDoc keep the sub-page
+  // instead of snapping back to the entry/list page.
+  const [urlLoadSubPath, setUrlLoadSubPath] = useState<string | null>(null);
+  const [subPageSource, setSubPageSource] = useState<string | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -4562,17 +4568,41 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     };
   }, [source, effectiveDeck, projectId, file.name, useUrlLoadPreview]);
 
+  // Reset the tracked sub-page whenever the previewed entry file changes.
+  useEffect(() => {
+    setUrlLoadSubPath(null);
+  }, [file.name]);
+  // When a comment/inspect toggle forces the preview off the url-load path
+  // while the iframe was on a sub-page, fetch that sub-page's HTML so the
+  // srcDoc renders the page the user was actually looking at.
+  useEffect(() => {
+    if (useUrlLoadPreview || !urlLoadSubPath || urlLoadSubPath === file.name) {
+      setSubPageSource(null);
+      return;
+    }
+    let ignore = false;
+    void fetchProjectFileText(projectId, urlLoadSubPath, { cacheBustKey: reloadKey }).then((text) => {
+      if (!ignore) setSubPageSource(text);
+    });
+    return () => {
+      ignore = true;
+    };
+  }, [useUrlLoadPreview, urlLoadSubPath, file.name, projectId, reloadKey]);
+
+  const usingSubPageSrcDoc = !useUrlLoadPreview && subPageSource != null && !!urlLoadSubPath && urlLoadSubPath !== file.name;
+  const srcDocSource = usingSubPageSrcDoc ? subPageSource : previewSource;
+  const srcDocBaseDir = usingSubPageSrcDoc ? baseDirFor(urlLoadSubPath) : baseDirFor(file.name);
   const srcDoc = useMemo(
-    () => (previewSource ? buildSrcdoc(previewSource, {
+    () => (srcDocSource ? buildSrcdoc(srcDocSource, {
       deck: effectiveDeck,
-      baseHref: projectRawUrl(projectId, baseDirFor(file.name)),
+      baseHref: projectRawUrl(projectId, srcDocBaseDir),
       initialSlideIndex: htmlPreviewSlideState.get(previewStateKey)?.active ?? 0,
       selectionBridge: true,
       editBridge: manualEditMode,
       paletteBridge: false,
       previewFocusGuard: true,
     }) : ''),
-    [previewSource, effectiveDeck, projectId, file.name, previewStateKey, manualEditMode],
+    [srcDocSource, srcDocBaseDir, effectiveDeck, projectId, previewStateKey, manualEditMode],
   );
   const lazySrcDocTransport = useMemo(() => buildLazySrcdocTransport(), []);
   const [srcDocTransportResetKey, setSrcDocTransportResetKey] = useState(0);
@@ -4774,15 +4804,44 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         }, '*');
       }
     }
+    function onUrlLoadLoc(ev: MessageEvent) {
+      if (!isOurPreviewIframeSource(ev.source)) return;
+      if (!isActivePreviewIframeSource(ev.source)) return;
+      const data = ev.data as { type?: string; pathname?: string } | null;
+      if (!data || data.type !== 'od:url-load-loc') return;
+      const rawPrefix = projectRawUrl(projectId, '');
+      const pathname = typeof data.pathname === 'string' ? data.pathname : '';
+      const idx = pathname.indexOf(rawPrefix);
+      const relative = idx >= 0
+        ? pathname
+            .slice(idx + rawPrefix.length)
+            .split('/')
+            .map((segment) => {
+              try {
+                return decodeURIComponent(segment);
+              } catch {
+                return segment;
+              }
+            })
+            .join('/')
+        : '';
+      if (!relative || relative === file.name || !/\.html?$/i.test(relative)) {
+        setUrlLoadSubPath(null);
+        return;
+      }
+      setUrlLoadSubPath(relative);
+    }
     window.addEventListener('message', onMessage);
     window.addEventListener('message', onRestoreRequest);
     window.addEventListener('message', onDcViewportMessage);
+    window.addEventListener('message', onUrlLoadLoc);
     return () => {
       window.removeEventListener('message', onMessage);
       window.removeEventListener('message', onRestoreRequest);
       window.removeEventListener('message', onDcViewportMessage);
+      window.removeEventListener('message', onUrlLoadLoc);
     };
-  }, [isActivePreviewIframeSource, isOurPreviewIframeSource]);
+  }, [isActivePreviewIframeSource, isOurPreviewIframeSource, projectId, file.name]);
 
   useEffect(() => {
     if (!effectiveDeck) {

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1740,6 +1740,15 @@ export function projectRawUrl(projectId: string, filePath: string): string {
   return `/api/projects/${encodeURIComponent(projectId)}/raw/${safePath}`;
 }
 
+// Preview-mode variant of projectRawUrl: same path, but opts into the
+// daemon's HTML preview shim (scroll-position relay, sub-page reporting,
+// Cmd/Ctrl+wheel zoom forwarder). Only the live url-load preview iframe
+// should use this; manual-edit/Inspect-save fetches and deploy/export
+// staging must keep calling projectRawUrl so saved files stay byte-accurate.
+export function projectPreviewUrl(projectId: string, filePath: string): string {
+  return `${projectRawUrl(projectId, filePath)}?preview=1`;
+}
+
 function looksLikeImage(name: string): boolean {
   return /\.(png|jpe?g|gif|webp|svg|avif|bmp)$/i.test(name);
 }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -711,6 +711,13 @@ function injectSandboxShim(doc: string): string {
       safe && window.open(href, '_blank', 'noopener,noreferrer');
     }
   });
+  // Cmd/Ctrl + wheel forwards to the host to zoom the preview; the sandboxed
+  // iframe otherwise swallows the gesture so the host never sees it.
+  document.addEventListener('wheel', function(e){
+    if (!(e.metaKey || e.ctrlKey)) return;
+    e.preventDefault();
+    try { (window.parent || window).postMessage({ type: 'od:zoom-wheel', deltaY: e.deltaY }, '*'); } catch (_) {}
+  }, { passive: false });
 })();</script>`;
   if (/<head[^>]*>/i.test(doc))
     return doc.replace(/<head[^>]*>/i, (m) => `${m}${shim}`);

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -159,6 +159,52 @@ export function canActivateSrcDocTransport(state: SrcDocActivationInputs): boole
   return true;
 }
 
+export interface SrcDocSourceInputs {
+  /** Host is currently showing the URL-loaded iframe (no srcDoc needed). */
+  useUrlLoadPreview: boolean;
+  /** The sub-page the url-load iframe had navigated to, relative to the entry. */
+  urlLoadSubPath: string | null;
+  /** The entry file backing this preview (e.g. the gallery index.html). */
+  fileName: string;
+  /** Lazily-fetched HTML of `urlLoadSubPath`, or null while the fetch is in flight. */
+  subPageSource: string | null;
+  /** The entry file's own HTML. */
+  previewSource: string | null;
+}
+
+export interface SrcDocSourceDecision {
+  /** HTML the srcDoc should render, or null to keep the shell blank for now. */
+  source: string | null;
+  /** True when the resolved source is the navigated sub-page, not the entry. */
+  usingSubPage: boolean;
+  /** True when a sub-page is expected but its HTML has not arrived yet. */
+  pending: boolean;
+}
+
+/**
+ * Pure decision for which HTML the srcDoc preview should render once Comment /
+ * Inspect forces the host off the url-load path.
+ *
+ * The `pending` branch is the fix for the Comment-mode "first-page flash": a
+ * large sub-page (e.g. a 100KB admin console) reports its location and is then
+ * fetched only AFTER the active iframe has already swapped to srcDoc. During
+ * that gap `subPageSource` is still null. Falling back to `previewSource` (the
+ * entry/gallery file) would render it for those frames before snapping to the
+ * real sub-page. Returning a null source instead keeps the srcDoc shell blank
+ * (canActivateSrcDocTransport bails on empty html), so the user sees blank ->
+ * correct page rather than gallery -> correct page.
+ */
+export function selectSrcDocSource(inputs: SrcDocSourceInputs): SrcDocSourceDecision {
+  const hasSubPage =
+    !inputs.useUrlLoadPreview &&
+    !!inputs.urlLoadSubPath &&
+    inputs.urlLoadSubPath !== inputs.fileName;
+  const usingSubPage = hasSubPage && inputs.subPageSource != null;
+  const pending = hasSubPage && inputs.subPageSource == null;
+  const source = usingSubPage ? inputs.subPageSource : pending ? null : inputs.previewSource;
+  return { source, usingSubPage, pending };
+}
+
 function injectSrcdocTransportActivationBridge(doc: string): string {
   const script = `<script data-od-srcdoc-transport-activation>(function(){
   window.addEventListener('message', function(ev){

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -782,10 +782,13 @@ function injectSandboxShim(doc: string): string {
   });
   // Cmd/Ctrl + wheel forwards to the host to zoom the preview; the sandboxed
   // iframe otherwise swallows the gesture so the host never sees it.
+  // Forward deltaMode too — classic mouse wheels on Firefox / some Windows
+  // setups report DOM_DELTA_LINE (=1, ±3 per notch) instead of pixels, so the
+  // host needs the mode to compensate or zoom feels inert.
   document.addEventListener('wheel', function(e){
     if (!(e.metaKey || e.ctrlKey)) return;
     e.preventDefault();
-    try { (window.parent || window).postMessage({ type: 'od:zoom-wheel', deltaY: e.deltaY }, '*'); } catch (_) {}
+    try { (window.parent || window).postMessage({ type: 'od:zoom-wheel', deltaY: e.deltaY, deltaMode: e.deltaMode }, '*'); } catch (_) {}
   }, { passive: false });
 })();</script>`;
   if (/<head[^>]*>/i.test(doc))

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -32,6 +32,11 @@ export type SrcdocOptions = {
   paletteBridge?: boolean;
   initialPalette?: string | null;
   previewFocusGuard?: boolean;
+  // Hash to restore before user scripts run, so a hash-routed in-page SPA
+  // (e.g. js/spaflow.js using location.hash) shows the view the url-load
+  // preview was on instead of resetting to its default when a srcDoc-only
+  // bridge (Comment / Inspect) forces a srcDoc rebuild.
+  initialHash?: string;
 };
 
 export function buildSrcdoc(
@@ -53,7 +58,8 @@ export function buildSrcdoc(
   const withOdIds = annotateMissingOdIds(wrapped);
   const withSourcePaths = options.editBridge ? annotateManualEditSourcePaths(withOdIds) : withOdIds;
   const withBase = options.baseHref ? injectBaseHref(withSourcePaths, options.baseHref) : withSourcePaths;
-  const withShim = injectSandboxShim(withBase);
+  const withHash = options.initialHash ? injectInitialHash(withBase, options.initialHash) : withBase;
+  const withShim = injectSandboxShim(withHash);
   const withFocusGuard = options.previewFocusGuard ? injectPreviewFocusGuard(withShim) : withShim;
   const withDeck = options.deck ? injectDeckBridge(withFocusGuard, options.initialSlideIndex) : withFocusGuard;
   // Comment + Inspect share an element-selection bridge: both pick a
@@ -624,6 +630,23 @@ function injectBeforeBodyEnd(doc: string, payload: string): string {
 function injectBaseHref(doc: string, baseHref: string): string {
   const safeHref = escapeAttr(baseHref);
   const tag = `<base href="${safeHref}">`;
+  if (/<head[^>]*>/i.test(doc)) {
+    return doc.replace(/<head[^>]*>/i, (m) => `${m}${tag}`);
+  }
+  if (/<html[^>]*>/i.test(doc)) {
+    return doc.replace(/<html[^>]*>/i, (m) => `${m}<head>${tag}</head>`);
+  }
+  return tag + doc;
+}
+
+// Restore a URL hash before user scripts run so a hash-routed in-page SPA
+// resolves to the view the url-load preview was on (not its default) after a
+// srcDoc rebuild. Runs synchronously in <head> and re-applies on
+// DOMContentLoaded; setting location.hash also fires hashchange for routers
+// that listen for it.
+function injectInitialHash(doc: string, hash: string): string {
+  const safeHash = JSON.stringify(hash);
+  const tag = `<script>(function(){try{var h=${safeHash};if(!h)return;function set(){try{if(location.hash!==h)location.hash=h;}catch(e){}}set();document.addEventListener('DOMContentLoaded',set);}catch(e){}})();</script>`;
   if (/<head[^>]*>/i.test(doc)) {
     return doc.replace(/<head[^>]*>/i, (m) => `${m}${tag}`);
   }

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -596,7 +596,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).toContain('data-od-render-mode="url-load"');
     expect(markup).toContain('data-od-render-mode="url-load" data-od-active="true"');
     expect(markup).toContain('data-od-render-mode="srcdoc" data-od-active="false"');
-    expect(markup).toContain('src="/api/projects/project-1/raw/page.html?v=1710000000&amp;r=0"');
+    expect(markup).toContain('src="/api/projects/project-1/raw/page.html?preview=1&amp;v=1710000000&amp;r=0"');
     expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
   });
 
@@ -774,7 +774,8 @@ describe('FileViewer SVG artifacts', () => {
 
     const { container } = render(<Switcher />);
     const getFrame = () => container.querySelector<HTMLIFrameElement>('[data-testid="artifact-preview-frame"]');
-    expect(getFrame()?.getAttribute('src')).toBe('/api/projects/project-1/raw/first.html?v=1710000000&r=0');
+    const initialFrame = getFrame();
+    expect(initialFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/first.html?preview=1&v=1710000000&r=0');
 
     const observationsBeforeSwitch = observedCommittedSrcs.length;
     fireEvent.click(screen.getByRole('button', { name: 'Switch file' }));
@@ -782,9 +783,9 @@ describe('FileViewer SVG artifacts', () => {
     const nextFrame = getFrame();
     expect(nextFrame).toBeTruthy();
     expect(observedCommittedSrcs[observationsBeforeSwitch]).toBe(
-      '/api/projects/project-1/raw/second.html?v=1710000000&r=0',
+      '/api/projects/project-1/raw/second.html?preview=1&v=1710000000&r=0',
     );
-    expect(nextFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/second.html?v=1710000000&r=0');
+    expect(nextFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/second.html?preview=1&v=1710000000&r=0');
   });
 
   it('allows downloads in the in-tab HTML presentation iframe', async () => {

--- a/apps/web/tests/runtime/srcdoc-transport.test.ts
+++ b/apps/web/tests/runtime/srcdoc-transport.test.ts
@@ -5,7 +5,9 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildLazySrcdocTransport,
   canActivateSrcDocTransport,
+  selectSrcDocSource,
   type SrcDocActivationInputs,
+  type SrcDocSourceInputs,
 } from '../../src/runtime/srcdoc';
 
 function extractShellScript(shellHtml: string): string {
@@ -195,5 +197,58 @@ describe('canActivateSrcDocTransport (#2253)', () => {
         activatedHtml: '<html>previous</html>',
       }),
     ).toBe(true);
+  });
+});
+
+describe('selectSrcDocSource (Comment-mode first-page flash)', () => {
+  const ENTRY = '<html>gallery index</html>';
+  const SUB = '<html>admin console AD11</html>';
+  const SOURCE_BASE: SrcDocSourceInputs = {
+    useUrlLoadPreview: false,
+    urlLoadSubPath: 'screens/admin/admin-console.html',
+    fileName: 'index.html',
+    subPageSource: SUB,
+    previewSource: ENTRY,
+  };
+
+  it('renders the entry file when url-load is still active', () => {
+    const r = selectSrcDocSource({ ...SOURCE_BASE, useUrlLoadPreview: true });
+    expect(r.source).toBe(ENTRY);
+    expect(r.usingSubPage).toBe(false);
+    expect(r.pending).toBe(false);
+  });
+
+  it('renders the sub-page once its HTML has been fetched', () => {
+    const r = selectSrcDocSource(SOURCE_BASE);
+    expect(r.source).toBe(SUB);
+    expect(r.usingSubPage).toBe(true);
+    expect(r.pending).toBe(false);
+  });
+
+  it('holds a null source (NOT the entry file) while the sub-page is still loading', () => {
+    // This is the flash fix: a slow sub-page reports its location and is fetched
+    // only after the active iframe has swapped to srcDoc. Returning previewSource
+    // here would flash the gallery/first page; null keeps the shell blank.
+    const r = selectSrcDocSource({ ...SOURCE_BASE, subPageSource: null });
+    expect(r.source).toBeNull();
+    expect(r.source).not.toBe(ENTRY);
+    expect(r.usingSubPage).toBe(false);
+    expect(r.pending).toBe(true);
+  });
+
+  it('renders the entry file when no sub-page navigation happened', () => {
+    const r = selectSrcDocSource({ ...SOURCE_BASE, urlLoadSubPath: null });
+    expect(r.source).toBe(ENTRY);
+    expect(r.pending).toBe(false);
+  });
+
+  it('treats the entry file as itself, never as a pending sub-page', () => {
+    const r = selectSrcDocSource({
+      ...SOURCE_BASE,
+      urlLoadSubPath: 'index.html',
+      subPageSource: null,
+    });
+    expect(r.source).toBe(ENTRY);
+    expect(r.pending).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

The default preview-iframe behaviour is too noisy for multi-page prototypes:

- **Sub-page on Comment/Inspect.** Comment and Inspect are srcDoc-only bridges (selection-postMessage needs same-origin). Toggling either while the url-load iframe is showing `screens/3.html` rebuilds the srcDoc from the *entry* `index.html`, dropping the user on the wrong page. The "flash" symptom in #2143 / #2344 / #2616 is the same root cause.
- **Scroll snaps to 0,0.** Each link to a sibling sub-page is a full reload; the sandboxed iframe loses scroll state and the user keeps re-scrolling to find their place.
- **Cmd-wheel zoom is swallowed.** The sandbox eats wheel events before the host listener gets them.

## What users will see

- Switching to Comment or Inspect mid-navigation keeps the visible page; the entry gallery no longer kicks in.
- The transition is flash-free — the srcDoc shell stays blank until its source matches the destination page.
- Scroll position is preserved per sub-page across back-navigation, with no per-project markup.
- Cmd/Ctrl + wheel inside the preview zooms the host (100% ↔ 25–200% clamp).

## How it works

- `injectScrollRelay(html)` in `apps/daemon/src/prototype-scroll-relay.ts` ships a tiny `<script data-od-scroll-relay>` only for HTML responses opted in via `?preview=1`. The script (a) remembers `window.scrollY` per `location.pathname` in `window.name` under an `ODSCROLL:` map, (b) reports the current pathname to the host on load / `hashchange` / `pushState` / `replaceState`, and (c) forwards Cmd/Ctrl + wheel as an `od:zoom-wheel` postMessage carrying `deltaY` and `deltaMode`.
- The web `projectPreviewUrl` helper is the only caller that opts in. `fetchProjectFileText`, deploy/export staging, and MCP file reads keep calling `projectRawUrl` so the served body stays byte-for-byte.
- `selectSrcDocSource()` in `apps/web/src/runtime/srcdoc.ts` returns `null` while a Comment/Inspect sub-page resolve is in flight, so the iframe holds blank instead of flashing the entry file.
- `applyZoomWheel(deltaY, deltaMode)` converts LINE (1) and PAGE (2) units to pixels before scaling, so classic mouse wheels on Firefox / Windows aren't stuck at 0–1% per notch.

## Surface area

- [x] **API / contract** — `GET /api/projects/:id/raw/*` now opts into HTML injection only on `?preview=1`; the default raw body is byte-accurate again. The injected bridge carries `window.name` `ODSCROLL` scroll memory, `od:url-load-loc` location reports on load/hashchange/`pushState`/`replaceState`, and an `od:zoom-wheel` postMessage including `deltaY` and `deltaMode`.
- [x] **Default behavior change** — preview scroll-restore, Cmd-wheel zoom, Comment/Inspect sub-page keep, flash-free transition, and hash preservation; all no opt-in for the user.
- [ ] CLI flags / env vars / i18n keys / new root deps — none.
- [ ] Extension points (`skills/`, `design-systems/`, `design-templates/`, `craft/`) — none.

**UI/CLI dual-track note:** these are preview-rendering behaviours inside the sandboxed web preview iframe. They have no `od` CLI analogue — the CLI does not render the preview iframe — so the dual-track requirement does not apply.

## Screenshots

No new UI control or entry point — the change is to how the existing preview, Comment, and Inspect surfaces behave. Behaviour is verified below; a before/after of the flash is sub-frame and not meaningfully screenshot-able.

## Validation

**Automated**

- `pnpm guard` — passes.
- `apps/daemon` typecheck + `tests/project-file-range.test.ts` — passes. The test is split into "default raw is byte-accurate" (body equals `<html/>`, no relay marker) and "?preview=1 injects the shim" so the new contract is explicit.
- `apps/web` typecheck + tests — passes. `apps/web/tests/runtime/srcdoc-transport.test.ts` covers the pure `selectSrcDocSource()` decision (the pending branch must return a null source and never fall back to the entry file). `apps/web/tests/components/FileViewer.test.tsx` asserts the url-load iframe `src` carries `?preview=1`.

**Behavioural (sandboxed iframe over the real daemon route)**

- **Byte-accuracy of `/raw/*`**: `fetch('/api/projects/<id>/raw/<file.html>')` returns the original document untouched; opening the same file in HtmlViewer and saving via the manual-edit / Inspect flow does not introduce any injected markup.
- **Scroll restore**: scrolled a list, opened a screen, returned via a back link → restored to the prior offset at load with no 0,0 flash. Stored per-pathname in `window.name` (`ODSCROLL:{…}`); the coexistence guard yields entirely if a project uses `window.name` itself.
- **Zoom**: Cmd + wheel inside the preview iframe drove the host zoom 100% → 130% (wheel-up) → 25% floor (wheel-down). `deltaMode` is forwarded so LINE-unit wheels (Firefox / classic Windows mice) are converted to pixels and respond at the same feel.
- **Comment/Inspect sub-page keep**: navigated the url-load iframe to a range of sub-pages and pressed Comment → each stayed on its own page rather than snapping to the entry gallery.
- **Flash removal**: with the `selectSrcDocSource` null branch, the iframe shell stays blank during the sub-page resolve instead of briefly painting the entry document.

## Related

- #2143 (active reset-on-Comment/Inspect issue), #2344, #2616 — same preview-reset family, addressed by the Comment/Inspect sub-page keep + flash removal here.
