### PR TITLE
fix: auto-flip onboarding dropdown when viewport space is insufficient

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1788,11 +1788,12 @@ function OnboardingDropdown(props: OnboardingDropdownProps) {
     placeholder,
     value,
     options,
-    placement = 'bottom',
+    placement: propPlacement = 'bottom',
     multiple = false,
   } = props;
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const [computedPlacement, setComputedPlacement] = useState<'bottom' | 'top'>(propPlacement);
   const selectedValues = Array.isArray(value) ? value : value ? [value] : [];
   const selectedOptions = options.filter((option) => selectedValues.includes(option.value));
   const selectedOption = selectedOptions[0];
@@ -1800,6 +1801,27 @@ function OnboardingDropdown(props: OnboardingDropdownProps) {
   const selectedLabel = multiple
     ? selectedOptions.map((option) => option.label).join(', ')
     : selectedOption?.label;
+
+  // Detect available space and adjust placement when dropdown opens
+  useEffect(() => {
+    if (!open || !rootRef.current) return;
+
+    const trigger = rootRef.current.querySelector('.onboarding-view__select-trigger');
+    if (!trigger) return;
+
+    const triggerRect = trigger.getBoundingClientRect();
+    const viewportHeight = window.innerHeight;
+    const menuMaxHeight = 240 + 12 + 6; // max-height + padding + gap
+    const spaceBelow = viewportHeight - triggerRect.bottom;
+    const spaceAbove = triggerRect.top;
+
+    // If not enough space below and more space above, flip to top
+    if (spaceBelow < menuMaxHeight && spaceAbove > spaceBelow) {
+      setComputedPlacement('top');
+    } else {
+      setComputedPlacement(propPlacement);
+    }
+  }, [open, propPlacement]);
 
   useEffect(() => {
     if (!open) return;
@@ -1825,7 +1847,7 @@ function OnboardingDropdown(props: OnboardingDropdownProps) {
   }, [open]);
 
   return (
-    <div className="onboarding-view__select-field" data-placement={placement} ref={rootRef}>
+    <div className="onboarding-view__select-field" data-placement={computedPlacement} ref={rootRef}>
       <span className="onboarding-view__select-label">{label}</span>
       <button
         type="button"


### PR DESCRIPTION
Fixes #2643

## Problem

On the Onboarding page, when the model selection dropdown is opened near the bottom of the viewport, the menu extends downward and the last option sits too close to the bottom edge, making the full dropdown hard to see and interact with.

## Root Cause

The `OnboardingDropdown` component always uses the prop-provided placement (default: `'bottom'`) without checking available viewport space. When there is insufficient space below the trigger, the menu still renders downward and gets clipped or cramped against the window boundary.

## Solution

Add viewport collision detection that runs when the dropdown opens:

1. Measure space below and above the trigger button
2. If space below < menu max-height (240px + padding) AND space above > space below, flip placement to `'top'`
3. Otherwise, use the prop-provided placement

The CSS already supports both placements via `data-placement` attribute:
- `[data-placement='bottom']`: `top: calc(100% + 6px)`
- `[data-placement='top']`: `bottom: calc(100% + 6px)`

## Changes

- Added `computedPlacement` state to track dynamic placement
- Added `useEffect` to detect viewport space when dropdown opens
- Updated JSX to use `computedPlacement` instead of static `placement` prop

## Testing

**Manual test:**
1. Open Onboarding page
2. Scroll so model dropdown trigger is near bottom of viewport
3. Open dropdown
4. Verify menu flips upward when insufficient space below
5. Verify menu renders downward when sufficient space below

## Size

**S** — ~20 lines added (viewport detection logic + state)