### PR TITLE
Add Codex interactive capability map example

### DIFF
--- a/plugins/_official/examples/codex-interactive-capability-map/SKILL.md
+++ b/plugins/_official/examples/codex-interactive-capability-map/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: codex-interactive-capability-map
+zh_name: "Codex 交互式能力地图"
+en_name: "Codex Interactive Capability Map"
+emoji: "🗺️"
+description: "Turn a long-form article, thread, memo, or product narrative into a compact clickable capability map with a workflow loop, use-case matrix, and responsive detail panel."
+category: prototype
+scenario: knowledge
+aspect_hint: "desktop web prototype, responsive down to tablet"
+featured: 42
+tags: ["codex", "article", "thread", "knowledge", "map", "interactive", "capability", "explainer"]
+example_id: sample-codex-interactive-capability-map
+example_name: "Codex Interactive Capability Map · Operating Model"
+example_format: html
+example_tagline: "Long text → clickable operating model"
+example_desc: "A long post transformed into a concise visual map with linked concepts, use cases, and detail cards."
+od:
+  mode: prototype
+  surface: web
+  platform: desktop
+  scenario: knowledge
+  featured: 42
+  preview:
+    type: html
+    entry: index.html
+  design_system:
+    requires: false
+  example_prompt: "Turn this long-form article or thread into a Codex-style interactive capability map. Extract the core concepts, organize them into a workflow loop and use-case matrix, then build a polished single-file HTML prototype with clickable cards and a detail panel."
+---
+
+# Codex Interactive Capability Map
+
+Transform a long article, social thread, memo, product essay, or launch narrative into a visual explainer that people can scan and click through.
+
+## Use When
+
+- The input is mostly text and the user wants a clearer mental model.
+- The content contains repeated concepts, a process, a framework, capabilities, or operating principles.
+- The desired output is a polished web artifact, not a static summary.
+
+## Workflow
+
+1. Read the source material and extract 6-10 core concepts.
+2. Name the overall model in plain language. Prefer a short noun phrase such as "Operating Model", "Capability Map", or "Workflow Loop".
+3. Build three linked views:
+   - A hero that frames the source and the promise.
+   - A workflow loop that shows the main sequence or system.
+   - A use-case matrix that combines concepts into practical scenarios.
+4. Add a right-side detail panel. Clicking any nav item, loop node, matrix card, or maturity level must update the panel.
+5. Make the clicked element and the detail panel visibly correspond through shared color, motion, icon/mark shape, or gradient.
+6. Keep copy short. The artifact should reduce reading effort, not recreate the article.
+
+## Visual Direction
+
+- Use a Codex-inspired refined product style with soft liquid motion, glassy surfaces, and crisp functional controls.
+- Make the first viewport feel like a finished product surface, not a wireframe.
+- Favor diagrams, loops, matrices, rails, cards, and progressive disclosure over paragraphs.
+- Use meaningful hover and active states. A click should feel consequential.
+- Avoid external image dependencies unless the user explicitly provides assets.
+
+## Interaction Requirements
+
+- All clickable elements must update content or scroll to a meaningful section.
+- The active state must be visually obvious.
+- The detail panel should animate on each change.
+- Long labels must wrap cleanly and never be clipped.
+- The layout must work at 1280px wide and collapse cleanly below 900px.
+
+## Output Contract
+
+Emit one single-file HTML artifact:
+
+```html
+<artifact identifier="codex-interactive-capability-map" type="text/html" title="Codex Interactive Capability Map">
+<!doctype html>
+<html>...</html>
+</artifact>
+```
+
+Include all CSS and JavaScript inline. Do not use lorem ipsum. Do not leave placeholder cards. If the source does not include enough concrete details, infer a small, clearly labeled conceptual model from the source instead of inventing unrelated content.

--- a/plugins/_official/examples/codex-interactive-capability-map/SKILL.md
+++ b/plugins/_official/examples/codex-interactive-capability-map/SKILL.md
@@ -22,7 +22,7 @@ od:
   featured: 42
   preview:
     type: html
-    entry: index.html
+    entry: example.html
   design_system:
     requires: false
   example_prompt: "Turn this long-form article or thread into a Codex-style interactive capability map. Extract the core concepts, organize them into a workflow loop and use-case matrix, then build a polished single-file HTML prototype with clickable cards and a detail panel."

--- a/plugins/_official/examples/codex-interactive-capability-map/example.html
+++ b/plugins/_official/examples/codex-interactive-capability-map/example.html
@@ -1,0 +1,672 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Codex Interactive Capability Map</title>
+  <style>
+    :root {
+      --ink: #070914;
+      --muted: rgba(7, 9, 20, .58);
+      --panel: rgba(255, 255, 255, .72);
+      --panel-strong: rgba(255, 255, 255, .88);
+      --line: rgba(25, 36, 94, .12);
+      --blue: #4d6bff;
+      --blue-2: #87b7ff;
+      --violet: #8f8cff;
+      --lavender: #c8b8ff;
+      --pink: #e7c8ff;
+      --radius: 22px;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: var(--ink);
+      background: #a9c3ff;
+      overflow-x: hidden;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: -24%;
+      z-index: -3;
+      background:
+        radial-gradient(circle at 18% 24%, rgba(216, 232, 255, .95) 0 18%, transparent 34%),
+        radial-gradient(circle at 72% 18%, rgba(77, 99, 255, .70) 0 20%, transparent 42%),
+        radial-gradient(circle at 88% 54%, rgba(114, 97, 255, .55) 0 18%, transparent 38%),
+        radial-gradient(circle at 46% 76%, rgba(208, 195, 255, .80) 0 18%, transparent 39%),
+        linear-gradient(135deg, #9fbdff 0%, #b4c8ff 34%, #6d7cff 67%, #c8b8ff 100%);
+      filter: blur(10px) saturate(118%);
+      animation: codexFlow 13s ease-in-out infinite alternate;
+    }
+
+    body::after {
+      content: "";
+      position: fixed;
+      inset: 0;
+      z-index: -2;
+      background:
+        radial-gradient(circle at 24% 12%, rgba(255,255,255,.36), transparent 28%),
+        linear-gradient(120deg, rgba(255,255,255,.15), transparent 44%, rgba(255,255,255,.16));
+      backdrop-filter: blur(18px);
+      pointer-events: none;
+    }
+
+    .flow-field {
+      position: fixed;
+      inset: 0;
+      z-index: -1;
+      overflow: hidden;
+      pointer-events: none;
+      mix-blend-mode: soft-light;
+    }
+    .flow-field span {
+      position: absolute;
+      width: 58vw;
+      aspect-ratio: 1;
+      border-radius: 42% 58% 60% 40% / 44% 35% 65% 56%;
+      opacity: .48;
+      filter: blur(48px);
+      animation: liquid 15s ease-in-out infinite alternate;
+    }
+    .flow-field span:nth-child(1) { left: -18vw; top: 4vh; background: #ffffff; }
+    .flow-field span:nth-child(2) { right: -20vw; top: 8vh; background: #344dff; animation-delay: -5s; }
+    .flow-field span:nth-child(3) { left: 34vw; bottom: -30vh; background: #e4d7ff; animation-delay: -9s; }
+
+    @keyframes codexFlow {
+      0% { transform: translate3d(-3%, -2%, 0) scale(1) rotate(0deg); }
+      50% { transform: translate3d(3%, 2%, 0) scale(1.07) rotate(3deg); }
+      100% { transform: translate3d(1%, -3%, 0) scale(1.04) rotate(-3deg); }
+    }
+    @keyframes liquid {
+      from { transform: translate3d(-5%, 2%, 0) rotate(0deg) scale(1); border-radius: 42% 58% 60% 40% / 44% 35% 65% 56%; }
+      to { transform: translate3d(8%, -7%, 0) rotate(24deg) scale(1.18); border-radius: 60% 40% 42% 58% / 52% 62% 38% 48%; }
+    }
+
+    button { font: inherit; color: inherit; }
+    .mono {
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      font-size: 12px;
+      letter-spacing: 0;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .page {
+      width: min(1440px, 100%);
+      margin: 0 auto;
+      padding: 26px;
+    }
+
+    .hero {
+      min-height: 72vh;
+      display: grid;
+      place-items: center;
+      text-align: center;
+      padding: 52px 0 34px;
+    }
+
+    .logo-card {
+      width: 118px;
+      height: 118px;
+      border-radius: 30px;
+      margin: 0 auto 24px;
+      display: grid;
+      place-items: center;
+      background:
+        radial-gradient(circle at 34% 30%, rgba(255,255,255,.94), transparent 30%),
+        linear-gradient(145deg, rgba(255,255,255,.88), rgba(235,239,255,.72));
+      box-shadow: 0 24px 70px rgba(35, 54, 140, .18), inset 0 1px 0 rgba(255,255,255,.85);
+    }
+    .logo-mark {
+      width: 72px;
+      height: 58px;
+      border-radius: 24px 26px 22px 24px;
+      display: grid;
+      place-items: center;
+      background:
+        radial-gradient(circle at 36% 20%, rgba(255,255,255,.62), transparent 34%),
+        linear-gradient(145deg, #9db8ff, #4d6bff 58%, #334dff);
+      color: white;
+      font-family: "SFMono-Regular", Consolas, monospace;
+      font-size: 34px;
+      font-weight: 800;
+      letter-spacing: 0;
+      filter: drop-shadow(0 22px 42px rgba(51, 72, 215, .24));
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(76px, 12vw, 168px);
+      line-height: .86;
+      letter-spacing: 0;
+      color: #070914;
+    }
+    .hero p {
+      margin: 28px auto 0;
+      max-width: 780px;
+      font-size: clamp(20px, 2.3vw, 32px);
+      line-height: 1.24;
+      color: rgba(7, 9, 20, .78);
+    }
+    .byline {
+      margin: 18px auto 0;
+      width: max-content;
+      max-width: 100%;
+      border: 1px solid rgba(25,36,94,.12);
+      border-radius: 999px;
+      background: rgba(255,255,255,.36);
+      padding: 9px 14px;
+      color: rgba(7,9,20,.62);
+    }
+    .hero-actions {
+      margin-top: 32px;
+      display: flex;
+      justify-content: center;
+      gap: 14px;
+      flex-wrap: wrap;
+    }
+    .cta {
+      border: 0;
+      border-radius: 999px;
+      padding: 14px 24px;
+      cursor: pointer;
+      background: rgba(255, 255, 255, .34);
+      color: rgba(7, 9, 20, .82);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.42);
+    }
+    .cta.primary {
+      background: #05060b;
+      color: white;
+      box-shadow: 0 18px 44px rgba(21, 30, 80, .22);
+    }
+
+    .workspace {
+      margin: -8vh auto 0;
+      width: min(1120px, calc(100vw - 52px));
+      max-width: 1120px;
+      min-height: 560px;
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      background: var(--panel);
+      backdrop-filter: blur(26px) saturate(138%);
+      box-shadow: 0 34px 110px rgba(31, 46, 128, .22);
+      overflow: hidden;
+    }
+    .window-bar {
+      height: 54px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 18px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(255,255,255,.52);
+    }
+    .traffic { display: flex; gap: 8px; }
+    .traffic span { width: 12px; height: 12px; border-radius: 50%; display: block; }
+    .traffic span:nth-child(1) { background: #ff6b5f; }
+    .traffic span:nth-child(2) { background: #ffcb49; }
+    .traffic span:nth-child(3) { background: #35c75a; }
+    .window-title {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      color: rgba(7,9,20,.72);
+      font-weight: 600;
+      min-width: 0;
+    }
+    .window-title span:first-child {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .window-actions { display: flex; gap: 8px; }
+    .small-btn {
+      border: 1px solid var(--line);
+      background: rgba(255,255,255,.54);
+      border-radius: 999px;
+      padding: 8px 12px;
+      cursor: pointer;
+    }
+
+    .canvas {
+      display: grid;
+      grid-template-columns: 220px minmax(0, 1fr) 270px;
+      min-height: 506px;
+    }
+    .rail {
+      border-right: 1px solid var(--line);
+      padding: 18px;
+      background: rgba(255,255,255,.22);
+    }
+    .rail button {
+      width: 100%;
+      min-height: 44px;
+      border: 0;
+      background: transparent;
+      border-radius: 12px;
+      padding: 10px 12px;
+      text-align: left;
+      cursor: pointer;
+      color: rgba(7,9,20,.70);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      border: 1px solid transparent;
+      transition: transform .18s ease, background .18s ease, box-shadow .18s ease, border-color .18s ease;
+    }
+    .rail button:hover, .rail button.active {
+      background:
+        linear-gradient(90deg, rgba(var(--accent-rgb), .18), rgba(255,255,255,.54));
+      color: var(--ink);
+      border-color: rgba(var(--accent-rgb), .25);
+      box-shadow: 0 10px 28px rgba(var(--accent-rgb), .13);
+      transform: translateX(3px);
+    }
+
+    .diagram {
+      padding: 24px;
+      display: grid;
+      align-content: center;
+      gap: 18px;
+      min-width: 0;
+    }
+    .loop {
+      display: grid;
+      grid-template-columns: repeat(7, minmax(62px, 1fr));
+      gap: 7px;
+      align-items: center;
+    }
+    .node {
+      min-height: 76px;
+      border: 1px solid rgba(25,36,94,.14);
+      background: rgba(255,255,255,.42);
+      border-radius: 18px;
+      padding: 10px 8px;
+      cursor: pointer;
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+      transition: transform .18s ease, background .18s ease, box-shadow .18s ease, border-color .18s ease;
+    }
+    .node::before,
+    .cell::before,
+    .level::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background:
+        radial-gradient(circle at 18% 18%, rgba(255,255,255,.76), transparent 22%),
+        linear-gradient(135deg, rgba(var(--accent-rgb), .18), transparent 58%);
+      opacity: 0;
+      transition: opacity .18s ease;
+      pointer-events: none;
+    }
+    .node:not(:last-child)::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      right: -10px;
+      width: 12px;
+      height: 2px;
+      background: rgba(7,9,20,.28);
+    }
+    .node:hover, .node.active {
+      transform: translateY(-3px);
+      background: rgba(255,255,255,.78);
+      border-color: rgba(var(--accent-rgb), .38);
+      box-shadow: 0 18px 40px rgba(var(--accent-rgb), .18);
+    }
+    .node:hover::before,
+    .node.active::before,
+    .cell:hover::before,
+    .cell.active::before,
+    .level:hover::before,
+    .level.active::before {
+      opacity: 1;
+    }
+    .node.active::after,
+    .cell.active::after,
+    .level.active::after {
+      content: "";
+      position: absolute;
+      inset: -45%;
+      background: conic-gradient(from 120deg, transparent, rgba(var(--accent-rgb), .24), transparent 38%);
+      animation: pulseWash .82s ease-out;
+      pointer-events: none;
+    }
+    @keyframes pulseWash {
+      from { transform: scale(.6); opacity: .9; }
+      to { transform: scale(1.45); opacity: 0; }
+    }
+    .node b { display: block; font-size: 13px; }
+    .node span { display: block; margin-top: 5px; font-size: 11px; color: var(--muted); }
+
+    .matrix {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 8px;
+    }
+    .cell {
+      min-height: 68px;
+      border: 1px solid rgba(25,36,94,.12);
+      background: rgba(255,255,255,.32);
+      border-radius: 16px;
+      padding: 12px;
+      text-align: left;
+      cursor: pointer;
+      color: rgba(7,9,20,.76);
+      position: relative;
+      overflow: hidden;
+      transition: transform .18s ease, background .18s ease, box-shadow .18s ease, border-color .18s ease;
+    }
+    .cell .cell-title {
+      position: relative;
+      z-index: 1;
+      display: block;
+      font-weight: 650;
+    }
+    .cell .cell-code {
+      position: relative;
+      z-index: 1;
+      display: block;
+      margin-top: 8px;
+      color: rgba(7,9,20,.48);
+    }
+    .cell:hover, .cell.active {
+      background: rgba(255,255,255,.74);
+      color: var(--ink);
+      transform: translateY(-4px) scale(1.015);
+      border-color: rgba(var(--accent-rgb), .38);
+      box-shadow: 0 18px 42px rgba(var(--accent-rgb), .18);
+    }
+
+    .detail {
+      border-left: 1px solid var(--line);
+      padding: 18px;
+      background: rgba(255,255,255,.28);
+      display: grid;
+      align-content: center;
+      gap: 18px;
+      min-width: 0;
+    }
+    .detail-card {
+      border: 1px solid rgba(var(--detail-rgb), .28);
+      border-radius: 20px;
+      padding: 18px 16px;
+      background:
+        radial-gradient(circle at var(--detail-x, 86%) 12%, rgba(var(--detail-rgb), .34), transparent 34%),
+        linear-gradient(145deg, rgba(255,255,255,.82), rgba(255,255,255,.46));
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.72);
+      position: relative;
+      overflow: hidden;
+      transition: transform .22s ease, opacity .22s ease, box-shadow .22s ease, border-color .22s ease;
+    }
+    .detail-card::before {
+      content: "";
+      position: absolute;
+      right: 16px;
+      top: 16px;
+      width: 54px;
+      height: 54px;
+      border-radius: var(--detail-mark-radius, 18px);
+      background:
+        linear-gradient(135deg, rgba(var(--detail-rgb), .94), rgba(255,255,255,.42));
+      box-shadow: 0 16px 32px rgba(var(--detail-rgb), .22);
+    }
+    .detail-card::after {
+      content: "";
+      position: absolute;
+      right: 34px;
+      top: 34px;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: rgba(255,255,255,.82);
+    }
+    .detail-card.flash {
+      transform: translateX(-9px) scale(1.02);
+      box-shadow: 0 22px 48px rgba(var(--detail-rgb), .22);
+    }
+    .detail-card > * { position: relative; z-index: 1; }
+    .detail-card h2 {
+      margin: 8px 0 10px;
+      padding-right: 58px;
+      font-size: clamp(22px, 2.1vw, 28px);
+      line-height: 1.05;
+      overflow-wrap: anywhere;
+    }
+    .detail-card p { margin: 0; color: rgba(7,9,20,.67); line-height: 1.42; }
+    .prompt {
+      border-radius: 16px;
+      background:
+        linear-gradient(135deg, rgba(7,9,20,.92), rgba(var(--detail-rgb), .74));
+      color: #eef2ff;
+      padding: 14px;
+      line-height: 1.4;
+      font-size: 14px;
+      overflow-wrap: anywhere;
+      box-shadow: 0 18px 34px rgba(var(--detail-rgb), .20);
+      transition: transform .22s ease, opacity .22s ease, box-shadow .22s ease;
+    }
+    .prompt.flash {
+      transform: translateX(-9px);
+      box-shadow: 0 24px 44px rgba(var(--detail-rgb), .30);
+    }
+
+    .mini-ladder {
+      margin-top: 22px;
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 8px;
+    }
+    .level {
+      border: 0;
+      border-radius: 999px;
+      padding: 10px;
+      background: rgba(255,255,255,.35);
+      cursor: pointer;
+      color: rgba(7,9,20,.68);
+      position: relative;
+      overflow: hidden;
+      transition: transform .18s ease, background .18s ease, box-shadow .18s ease;
+    }
+    .level.active, .level:hover {
+      background: rgba(255,255,255,.80);
+      color: var(--ink);
+      transform: translateY(-2px);
+      box-shadow: 0 14px 32px rgba(var(--accent-rgb), .14);
+    }
+
+    footer {
+      max-width: 1080px;
+      margin: 24px auto 0;
+      color: rgba(7,9,20,.46);
+      text-align: center;
+      padding-bottom: 20px;
+    }
+
+    @media (max-width: 980px) {
+      .workspace { margin-top: 20px; }
+      .canvas { grid-template-columns: 1fr; }
+      .rail, .detail { border: 0; }
+      .loop, .matrix, .mini-ladder { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 1180px) {
+      .workspace { width: min(1040px, calc(100vw - 32px)); }
+      .canvas { grid-template-columns: 200px minmax(0, 1fr) 240px; }
+      .window-actions { display: none; }
+      .rail button { font-size: 14px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="flow-field" aria-hidden="true"><span></span><span></span><span></span></div>
+  <main class="page">
+    <section class="hero">
+      <div>
+        <div class="logo-card"><div class="logo-mark">&gt;_</div></div>
+        <h1>Codex</h1>
+        <p>Build a working loop: context, tools, artifacts, review, automation, and memory.</p>
+        <div class="byline">Article by Jason Liu · visual operating model by Codex</div>
+        <div class="hero-actions">
+          <button class="cta primary" data-focus="loop">Explore the loop</button>
+          <button class="cta" data-focus="matrix">Open operating model</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="workspace" id="workspace">
+      <div class="window-bar">
+        <div class="traffic"><span></span><span></span><span></span></div>
+        <div class="window-title"><span>Getting the most out of Codex</span> <span class="mono">Jason Liu / @jxnlco</span></div>
+        <div class="window-actions"><button class="small-btn">Open</button><button class="small-btn">Commit</button></div>
+      </div>
+      <div class="canvas">
+        <aside class="rail" id="rail"></aside>
+        <section class="diagram">
+          <div>
+            <div class="mono">Instruction to durable memory</div>
+            <div class="loop" id="loop"></div>
+          </div>
+          <div>
+            <div class="mono">Use-case matrix</div>
+            <div class="matrix" id="matrix"></div>
+          </div>
+          <div class="mini-ladder" id="ladder"></div>
+        </section>
+        <aside class="detail">
+          <div class="detail-card">
+            <div class="mono" id="detailType">Selected capability</div>
+            <h2 id="detailTitle">Durable Thread</h2>
+            <p id="detailCopy">A persistent workspace that can be revisited, steered, queued, automated, and connected to memory.</p>
+          </div>
+          <div class="prompt" id="detailPrompt">Keep this thread alive as the working context for the launch review.</div>
+        </aside>
+      </div>
+    </section>
+
+    <footer class="mono">Long-form ideas converted into a visual, clickable operating map.</footer>
+  </main>
+
+  <script>
+    const themes = [
+      { rgb: "77,107,255", mark: "18px", x: "86%" },
+      { rgb: "62,142,255", mark: "999px", x: "78%" },
+      { rgb: "127,100,255", mark: "12px 28px 12px 28px", x: "92%" },
+      { rgb: "73,116,204", mark: "10px", x: "72%" },
+      { rgb: "102,92,235", mark: "50% 35% 50% 35%", x: "82%" },
+      { rgb: "68,139,218", mark: "16px", x: "88%" },
+      { rgb: "112,123,255", mark: "999px 999px 10px 10px", x: "74%" },
+      { rgb: "89,82,220", mark: "22px 8px 22px 8px", x: "90%" },
+      { rgb: "80,121,238", mark: "999px", x: "80%" }
+    ];
+
+    const capabilities = [
+      ["Durable Thread", "Context", "A persistent workspace that can be revisited, steered, queued, automated, and connected to memory.", "Keep this thread alive as the working context for the launch review."],
+      ["Voice", "Input", "Capture rough thought before it becomes a thin written prompt.", "I think someone mentioned this in Slack. Go look and report back."],
+      ["Steering", "Control", "Interrupt the current direction before the task finishes.", "Stop. Make the structure more visual and reduce the copy."],
+      ["Queuing", "Next", "Add the next action without disturbing current work.", "After this finishes, send the preview link to the reviewer."],
+      ["Tools", "Reach", "Act across browser, Chrome, desktop GUI, MCP, and connectors.", "Open the page, inspect the issue, then patch the file."],
+      ["Side Panel", "Artifact", "Keep output next to the conversation that created it.", "Open the artifact, mark layout issues, and repair them."],
+      ["Automation", "Cadence", "Wake the thread on a schedule to keep work moving.", "Every hour, check for PR comments and draft replies."],
+      ["Goals", "Verifier", "Push toward a finish line with a measurable condition.", "Stop only when the tests pass and the bug no longer reproduces."],
+      ["Memory", "Persistence", "Write durable context outside the chat transcript.", "Update the vault only if decisions or blockers changed."]
+    ];
+
+    const loop = ["Input", "Thread", "Tools", "Artifact", "Review", "Goal", "Memory"];
+    const matrix = ["Thread + Browser", "Goal + Tests", "Automation + Slack", "Artifact + Review", "Memory + Vault", "Mobile + Approval", "Queue + Handoff", "Voice + Search"];
+    const levels = ["Code", "Environment", "Context", "Continuity", "System"];
+
+    const rail = document.getElementById("rail");
+    const loopEl = document.getElementById("loop");
+    const matrixEl = document.getElementById("matrix");
+    const ladderEl = document.getElementById("ladder");
+
+    function applyTheme(themeIndex) {
+      const theme = themes[themeIndex % themes.length];
+      const detail = document.querySelector(".detail");
+      detail.style.setProperty("--detail-rgb", theme.rgb);
+      detail.style.setProperty("--detail-mark-radius", theme.mark);
+      detail.style.setProperty("--detail-x", theme.x);
+    }
+
+    function setAccent(button, themeIndex) {
+      button.style.setProperty("--accent-rgb", themes[themeIndex % themes.length].rgb);
+    }
+
+    function setDetail(item, activeLabel, themeIndex = 0) {
+      applyTheme(themeIndex);
+      document.getElementById("detailTitle").textContent = item[0];
+      document.getElementById("detailType").textContent = item[1];
+      document.getElementById("detailCopy").textContent = item[2];
+      document.getElementById("detailPrompt").textContent = item[3];
+      document.querySelectorAll("button[data-key]").forEach(button => button.classList.toggle("active", button.dataset.key === activeLabel));
+      const card = document.querySelector(".detail-card");
+      const prompt = document.querySelector(".prompt");
+      card.classList.remove("flash");
+      prompt.classList.remove("flash");
+      void card.offsetWidth;
+      card.classList.add("flash");
+      prompt.classList.add("flash");
+      setTimeout(() => {
+        card.classList.remove("flash");
+        prompt.classList.remove("flash");
+      }, 260);
+    }
+
+    capabilities.forEach((item, index) => {
+      const button = document.createElement("button");
+      button.dataset.key = `cap-${index}`;
+      setAccent(button, index);
+      button.innerHTML = `<span>${item[0]}</span><span class="mono">${item[1]}</span>`;
+      button.addEventListener("click", () => setDetail(item, `cap-${index}`, index));
+      rail.appendChild(button);
+    });
+
+    loop.forEach((name, index) => {
+      const button = document.createElement("button");
+      const item = capabilities[index] || capabilities[0];
+      button.className = "node";
+      button.dataset.key = `loop-${index}`;
+      setAccent(button, index);
+      button.innerHTML = `<b>${name}</b><span>${item[1]}</span>`;
+      button.addEventListener("click", () => setDetail(item, `loop-${index}`, index));
+      loopEl.appendChild(button);
+    });
+
+    matrix.forEach((name, index) => {
+      const button = document.createElement("button");
+      const item = capabilities[(index + 1) % capabilities.length];
+      button.className = "cell";
+      button.dataset.key = `matrix-${index}`;
+      const themeIndex = (index + 1) % themes.length;
+      setAccent(button, themeIndex);
+      button.innerHTML = `<span class="cell-title">${name}</span><span class="cell-code mono">${item[1]}</span>`;
+      button.addEventListener("click", () => setDetail([name, item[1], item[2], item[3]], `matrix-${index}`, themeIndex));
+      matrixEl.appendChild(button);
+    });
+
+    levels.forEach((name, index) => {
+      const button = document.createElement("button");
+      button.className = "level";
+      button.dataset.key = `level-${index}`;
+      const themeIndex = (index + 4) % themes.length;
+      setAccent(button, themeIndex);
+      button.textContent = name;
+      button.addEventListener("click", () => setDetail([name, "Maturity", `Level ${index + 1}: ${name} describes how deeply Codex is embedded into the work loop.`, "Move from isolated prompts toward durable, verifiable workflows."], `level-${index}`, themeIndex));
+      ladderEl.appendChild(button);
+    });
+
+    document.querySelectorAll("[data-focus]").forEach(button => {
+      button.addEventListener("click", () => document.getElementById("workspace").scrollIntoView({ behavior: "smooth", block: "start" }));
+    });
+
+    setDetail(capabilities[0], "cap-0", 0);
+  </script>
+</body>
+</html>

--- a/plugins/_official/examples/codex-interactive-capability-map/open-design.json
+++ b/plugins/_official/examples/codex-interactive-capability-map/open-design.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "example-codex-interactive-capability-map",
+  "title": "Codex Interactive Capability Map",
+  "version": "0.1.0",
+  "description": "Turn a long-form article, thread, memo, or product narrative into a Codex-style clickable capability map with a workflow loop, use-case matrix, and responsive detail panel.",
+  "license": "MIT",
+  "author": {
+    "name": "Open Design",
+    "url": "https://github.com/nexu-io"
+  },
+  "homepage": "https://github.com/nexu-io/open-design/tree/main/plugins/_official/examples/codex-interactive-capability-map",
+  "tags": [
+    "example",
+    "first-party",
+    "prototype",
+    "knowledge",
+    "web",
+    "desktop",
+    "codex",
+    "article",
+    "thread",
+    "knowledge-map",
+    "interactive",
+    "capability-map",
+    "explainer"
+  ],
+  "compat": {
+    "agentSkills": [
+      {
+        "path": "./SKILL.md"
+      }
+    ]
+  },
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "prototype",
+    "platform": "desktop",
+    "scenario": "knowledge",
+    "surface": "web",
+    "preview": {
+      "type": "html",
+      "entry": "./example.html"
+    },
+    "useCase": {
+      "query": {
+        "en": "Turn this long-form article or thread into a Codex-style interactive capability map. Extract the core concepts, organize them into a workflow loop and use-case matrix, then build a polished single-file HTML prototype with clickable cards and a detail panel.",
+        "zh-CN": "把这篇长文、帖子或产品说明转成一个 Codex 风格的交互式能力地图：提炼核心概念，组织成流程环和用例矩阵，并生成一个带点击卡片与详情面板的单文件 HTML 原型。"
+      },
+      "exampleOutputs": [
+        {
+          "path": "./example.html",
+          "title": "Codex Interactive Capability Map"
+        }
+      ]
+    },
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ],
+      "assets": [
+        "./example.html"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -6535,6 +6535,40 @@
       "taskKind": "new-generation"
     },
     {
+      "name": "open-design/example-codex-interactive-capability-map",
+      "title": "Codex Interactive Capability Map",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/_official/examples/codex-interactive-capability-map",
+      "publisher": {
+        "id": "open-design",
+        "url": "https://open-design.ai"
+      },
+      "capabilitiesSummary": [
+        "prompt:inject",
+        "fs:write"
+      ],
+      "description": "Turn a long-form article, thread, memo, or product narrative into a Codex-style clickable capability map with a workflow loop, use-case matrix, and responsive detail panel.",
+      "tags": [
+        "example",
+        "first-party",
+        "prototype",
+        "knowledge",
+        "web",
+        "desktop",
+        "codex",
+        "article",
+        "thread",
+        "knowledge-map",
+        "interactive",
+        "capability-map",
+        "explainer"
+      ],
+      "homepage": "https://github.com/nexu-io/open-design/tree/main/plugins/_official/examples/codex-interactive-capability-map",
+      "license": "MIT",
+      "mode": "prototype",
+      "taskKind": "new-generation"
+    },
+    {
       "name": "open-design/example-invoice",
       "title": "Invoice",
       "version": "0.1.0",


### PR DESCRIPTION
## Why

I wanted a reusable way to turn long-form posts, articles, and product narratives into compact interactive explainers. This example came from converting a text-heavy Codex post into a clickable capability map that is easier to scan, explore, and share.

## What users will see

Open Design gets a new `Codex Interactive Capability Map` example. Users can give it a long article or thread and ask for a Codex-style interactive map with a hero, workflow loop, use-case matrix, and linked detail panel.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A. This adds an example/template artifact; the preview is included as `plugins/_official/examples/codex-interactive-capability-map/example.html`.

## Bug fix verification

-

## Validation

- `PATH=\"/opt/homebrew/opt/node@24/bin:$PATH\" pnpm guard`
- `PATH=\"/opt/homebrew/opt/node@24/bin:$PATH\" pnpm --filter @open-design/plugin-runtime test`
- `PATH=\"/opt/homebrew/opt/node@24/bin:$PATH\" pnpm typecheck` currently fails in `apps/web` on existing `locale` type errors in `ProjectView.tsx` and `daemon.ts`; this PR only adds template/example files and registry metadata.