### PR TITLE
fix: clear skill selected state in @mention picker when skill is removed (issue #2650)

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1351,7 +1351,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                 mcpServers={filteredMcpServers}
                 connectors={filteredConnectors}
                 query={mention.q}
-                currentSkillId={currentSkillId}
+                stagedSkillIds={stagedSkillIds}
                 onPickFile={insertMention}
                 onPickPlugin={(record) => void insertPluginMention(record)}
                 onPickSkill={(skill) => void insertSkillMention(skill)}
@@ -2372,7 +2372,7 @@ function MentionPopover({
   skills,
   mcpServers,
   query,
-  currentSkillId,
+  stagedSkillIds,
   onPickFile,
   onPickPlugin,
   onPickSkill,
@@ -2385,7 +2385,7 @@ function MentionPopover({
   skills: SkillSummary[];
   mcpServers: McpServerConfig[];
   query: string;
-  currentSkillId: string | null;
+  stagedSkillIds: Set<string>;
   onPickFile: (path: string) => void;
   onPickPlugin: (record: InstalledPluginRecord) => void;
   onPickSkill: (skill: SkillSummary) => void;
@@ -2471,7 +2471,7 @@ function MentionPopover({
           <>
             <div className="mention-section-label">Skills</div>
             {skills.map((skill) => {
-              const active = skill.id === currentSkillId;
+              const active = stagedSkillIds.has(skill.id);
               return (
                 <button
                   key={`skill-${skill.id}`}


### PR DESCRIPTION
## Summary

**Issue:** After deleting a referenced skill from the conversation input (e.g. manually removing `@skill-name` from the draft textarea), the skill's selected state was NOT cleared in the @mention popover picker — it still showed a checkmark.

**Root cause:** The `MentionPopover` component checked if a skill was 'active' using `skill.id === currentSkillId`, where `currentSkillId` is the project's *persistent* skill (set globally via `@apply`). This is incorrect for per-turn @-mentioned skills. The active state should reflect whether the skill is currently staged for this turn (i.e. present in the draft), not whether it's the project's persistent skill.

**Fix:** Replaced `currentSkillId` prop with `stagedSkillIds` (a `Set<string>` of per-turn staged skill ids). The active check now correctly uses `stagedSkillIds.has(skill.id)`, so when a skill is removed from the draft (and the chip disappears), the picker immediately clears its selected state.

## Changes

**File modified:** `apps/web/src/components/ChatComposer.tsx`

- `MentionPopover` prop `currentSkillId: string | null` → `stagedSkillIds: Set<string>`
- `active` check changed from `skill.id === currentSkillId` to `stagedSkillIds.has(skill.id)`
- Call site updated to pass `stagedSkillIds` instead of `currentSkillId`

Fixes #2650