### PR TITLE
perf(landing): preconnect api.github.com + rAF-throttle scroll listener

### DIFF
--- a/apps/landing-page/app/_components/header-enhancer.astro
+++ b/apps/landing-page/app/_components/header-enhancer.astro
@@ -24,18 +24,28 @@
 
     const chrome = document.querySelector('[data-chrome-headroom]');
     if (chrome) {
+      // Wrap the scroll listener in requestAnimationFrame so a burst of
+      // scroll events (trackpads fire >60Hz) collapses to one DOM
+      // mutation per frame. PSI attributed ~700ms of "forced reflow" to
+      // the un-throttled version.
       let lastY = window.scrollY;
+      let ticking = false;
       const showTopThreshold = 100;
       const scrollDelta = 6;
       window.addEventListener(
         'scroll',
         () => {
-          const y = window.scrollY;
-          const delta = y - lastY;
-          if (y <= showTopThreshold) chrome.classList.remove('is-hidden');
-          else if (delta > scrollDelta) chrome.classList.add('is-hidden');
-          else if (delta < -scrollDelta) chrome.classList.remove('is-hidden');
-          lastY = y;
+          if (ticking) return;
+          ticking = true;
+          requestAnimationFrame(() => {
+            const y = window.scrollY;
+            const delta = y - lastY;
+            if (y <= showTopThreshold) chrome.classList.remove('is-hidden');
+            else if (delta > scrollDelta) chrome.classList.add('is-hidden');
+            else if (delta < -scrollDelta) chrome.classList.remove('is-hidden');
+            lastY = y;
+            ticking = false;
+          });
         },
         { passive: true },
       );

--- a/apps/landing-page/app/_components/home-enhancer.astro
+++ b/apps/landing-page/app/_components/home-enhancer.astro
@@ -62,18 +62,28 @@
     const enhanceHeader = () => {
       const nav = document.querySelector('[data-nav-headroom]');
       if (nav) {
+        // Wrap the scroll listener in requestAnimationFrame so a burst of
+        // scroll events (trackpads fire >60Hz) collapses to one DOM
+        // mutation per frame. PSI attributed ~700ms of "forced reflow" to
+        // the un-throttled version on the previous build.
         let lastY = window.scrollY;
+        let ticking = false;
         const showTopThreshold = 100;
         const scrollDelta = 6;
         window.addEventListener(
           'scroll',
           () => {
-            const y = window.scrollY;
-            const delta = y - lastY;
-            if (y <= showTopThreshold) nav.classList.remove('is-hidden');
-            else if (delta > scrollDelta) nav.classList.add('is-hidden');
-            else if (delta < -scrollDelta) nav.classList.remove('is-hidden');
-            lastY = y;
+            if (ticking) return;
+            ticking = true;
+            requestAnimationFrame(() => {
+              const y = window.scrollY;
+              const delta = y - lastY;
+              if (y <= showTopThreshold) nav.classList.remove('is-hidden');
+              else if (delta > scrollDelta) nav.classList.add('is-hidden');
+              else if (delta < -scrollDelta) nav.classList.remove('is-hidden');
+              lastY = y;
+              ticking = false;
+            });
           },
           { passive: true },
         );

--- a/apps/landing-page/app/_components/resource-hints.astro
+++ b/apps/landing-page/app/_components/resource-hints.astro
@@ -1,0 +1,21 @@
+---
+/*
+ * Resource hints — preconnect to third-party origins the page is about
+ * to talk to, so the TLS handshake completes before the first fetch().
+ *
+ * Why preconnect instead of dns-prefetch:
+ *   preconnect performs DNS + TCP + TLS warmup; dns-prefetch only the
+ *   DNS lookup. For api.github.com we issue 2-3 fetch() calls from
+ *   the inline enhancer scripts almost immediately on page load
+ *   (stars / latest release / contributors), so the full TLS warmup
+ *   saves ~150-300ms per fetch on first visit. After that all calls
+ *   share the same warmed connection via HTTP/2 multiplexing.
+ *
+ * Why `crossorigin`:
+ *   GitHub API responds with CORS. Without the crossorigin attribute
+ *   the browser opens a separate (non-CORS) connection, then opens
+ *   another (CORS) one when fetch() runs, and the preconnect is wasted.
+ */
+---
+
+<link rel='preconnect' href='https://api.github.com' crossorigin />

--- a/apps/landing-page/app/_components/seo-head.astro
+++ b/apps/landing-page/app/_components/seo-head.astro
@@ -24,6 +24,7 @@ import {
   stripLocaleFromPath,
 } from '../i18n';
 import FaviconLinks from './favicon-links.astro';
+import ResourceHints from './resource-hints.astro';
 
 export interface SeoHeadProps {
   /** 'website' for landing/list pages, 'article' for blog posts. */
@@ -155,6 +156,7 @@ const blogJsonLd =
 <link rel='alternate' hreflang='x-default' href={xDefaultHref} />
 <link rel='alternate' type='application/rss+xml' title='Open Design Blog' href={rssUrl} />
 <FaviconLinks />
+<ResourceHints />
 
 {props.googleSiteVerification && (
   <meta name='google-site-verification' content={props.googleSiteVerification} />

--- a/apps/landing-page/app/_components/sub-page-layout.astro
+++ b/apps/landing-page/app/_components/sub-page-layout.astro
@@ -19,6 +19,7 @@ import '../sub-pages.css';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import FaviconLinks from './favicon-links.astro';
+import ResourceHints from './resource-hints.astro';
 import HeaderEnhancer from './header-enhancer.astro';
 import { Header, type HeaderProps } from './header';
 import LocaleSwitcherScript from './locale-switcher-script.astro';
@@ -76,6 +77,7 @@ const ldArray = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
     <link rel="alternate" hreflang="x-default" href={xDefaultHref} />
 
     <FaviconLinks />
+    <ResourceHints />
 
 
     <meta property="og:type" content="website" />

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -4,6 +4,7 @@ import '../globals.css';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import FaviconLinks from '../_components/favicon-links.astro';
+import ResourceHints from '../_components/resource-hints.astro';
 import LocaleSwitcherScript from '../_components/locale-switcher-script.astro';
 import PreciseLazyload from '../_components/precise-lazyload.astro';
 import { heroImage, heroImageSrcset } from '../image-assets';
@@ -143,6 +144,7 @@ const pageHtml = renderToStaticMarkup(
     <link rel="alternate" hreflang="x-default" href={xDefaultHref} />
 
     <FaviconLinks />
+    <ResourceHints />
 
 
     {/*
@@ -225,18 +227,31 @@ const pageHtml = renderToStaticMarkup(
         const enhanceHeader = () => {
           const chrome = document.querySelector('[data-chrome-headroom]');
           if (chrome) {
+            // Wrap the scroll listener's read + classList write in
+            // requestAnimationFrame. Trackpads and high-rate wheels fire
+            // scroll faster than the display refresh, and every callback
+            // that hits classList triggers a layout recalc. rAF collapses
+            // each burst to one DOM mutation per frame — PSI was
+            // attributing ~700ms of "forced reflow" to the un-throttled
+            // version on the previous build.
             let lastY = window.scrollY;
+            let ticking = false;
             const showTopThreshold = 100;
             const scrollDelta = 6;
             window.addEventListener(
               'scroll',
               () => {
-                const y = window.scrollY;
-                const delta = y - lastY;
-                if (y <= showTopThreshold) chrome.classList.remove('is-hidden');
-                else if (delta > scrollDelta) chrome.classList.add('is-hidden');
-                else if (delta < -scrollDelta) chrome.classList.remove('is-hidden');
-                lastY = y;
+                if (ticking) return;
+                ticking = true;
+                requestAnimationFrame(() => {
+                  const y = window.scrollY;
+                  const delta = y - lastY;
+                  if (y <= showTopThreshold) chrome.classList.remove('is-hidden');
+                  else if (delta > scrollDelta) chrome.classList.add('is-hidden');
+                  else if (delta < -scrollDelta) chrome.classList.remove('is-hidden');
+                  lastY = y;
+                  ticking = false;
+                });
               },
               { passive: true },
             );

--- a/apps/landing-page/app/pages/plugins/[...slug].astro
+++ b/apps/landing-page/app/pages/plugins/[...slug].astro
@@ -3,6 +3,7 @@ import '../../globals.css';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import FaviconLinks from '../../_components/favicon-links.astro';
+import ResourceHints from '../../_components/resource-hints.astro';
 import GoogleAnalytics from '../../_components/google-analytics.astro';
 import { Header } from '../../_components/header';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
@@ -165,6 +166,7 @@ const breadcrumbJsonLd = {
     ))}
     <link rel='alternate' hreflang='x-default' href={xDefaultHref} />
     <FaviconLinks />
+    <ResourceHints />
     <meta property='og:type' content='article' />
     <meta property='og:site_name' content='Open Design' />
     <meta property='og:title' content={title} />

--- a/apps/landing-page/app/pages/plugins/index.astro
+++ b/apps/landing-page/app/pages/plugins/index.astro
@@ -3,6 +3,7 @@ import '../../globals.css';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import FaviconLinks from '../../_components/favicon-links.astro';
+import ResourceHints from '../../_components/resource-hints.astro';
 import GoogleAnalytics from '../../_components/google-analytics.astro';
 import { Header } from '../../_components/header';
 import HeaderEnhancer from '../../_components/header-enhancer.astro';
@@ -120,6 +121,7 @@ const trustLabel = (plugin: (typeof plugins)[number]) =>
     ))}
     <link rel='alternate' hreflang='x-default' href={xDefaultHref} />
     <FaviconLinks />
+    <ResourceHints />
     <meta property='og:type' content='website' />
     <meta property='og:site_name' content='Open Design' />
     <meta property='og:title' content={title} />


### PR DESCRIPTION
## Why

Follow-up to #2599 (self-host fonts + critical CSS inline). That PR was merged before this commit could be force-pushed onto its branch, so the two diagnostics PageSpeed Insights was still reporting are split out here.

PSI on `/` (mobile) immediately after #2599 deployed:
- **"Preconnect to required origins"** — `api.github.com` recommended, not declared
- **"Avoid large layout shifts" / forced reflow** — ~700ms attributed to the inline scroll listener

## What users will see

- Page header hide/show on scroll feels smoother (no perceptible jitter on trackpad-rate scroll).
- GitHub-derived UI (stars badge, version chip, contributor wire) appears 150-300ms sooner on first visit because the api.github.com TLS handshake completes in parallel with HTML parse.

No visual changes, no API contract changes.

## Surface area

- [ ] **UI** — no visual changes
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — every page's `<head>` gains a preconnect to api.github.com; scroll listeners now use rAF gating. No user-facing behavioral change.
- [ ] **None**

## Changes

1. **New component `resource-hints.astro`** — emits `<link rel="preconnect" href="https://api.github.com" crossorigin>`. Mounted next to `<FaviconLinks />` in all 5 head fragments (`sub-page-layout.astro`, `seo-head.astro`, `pages/index.astro`, `pages/plugins/index.astro`, `pages/plugins/[...slug].astro`).
2. **rAF scroll throttle** — `pages/index.astro` inline script, `header-enhancer.astro`, `home-enhancer.astro` all gate the scroll handler with a `ticking` flag + `requestAnimationFrame`. `passive: true` preserved.

## Validation

- `pnpm --filter @open-design/landing-page typecheck` — ✓ 0 errors
- Local check: `out/index.html` contains both \`<link rel='preconnect' href='https://api.github.com' crossorigin>\` and `requestAnimationFrame` (verifying inline script picks up the rAF wrapper)
- Spot-check: 5 head fragments emit ResourceHints, scroll listener still uses `{ passive: true }`

## Expected PSI delta

- "Preconnect to required origins" hint: cleared
- "Forced reflow" diagnostic 700ms → near zero
- LCP: small bonus from earlier GH fetch warm-up (~100-300ms)