### PR TITLE
style(web): show preview close button on hover or focus only

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10944,6 +10944,14 @@ button.connector-action.is-loading {
   align-items: center;
   justify-content: center;
   box-shadow: var(--shadow-xs);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease, background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+.df-preview:hover .df-preview-close,
+.df-preview-close:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
 }
 .df-preview-close:hover {
   background: var(--bg-subtle);


### PR DESCRIPTION
Currently, the close button permanently overlaps the top-right corner of the file preview/thumbnail. This obscures details at the edge of the previewed image or HTML page. This change hides the close button by default and shows it smoothly using a CSS hover-reveal transition on hover or keyboard focus, preserving accessibility.