### PR TITLE
fix: preview close button hover

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10944,7 +10944,22 @@ button.connector-action.is-loading {
   align-items: center;
   justify-content: center;
   box-shadow: var(--shadow-xs);
+  transition: opacity 120ms ease, background 120ms ease, border-color 120ms ease, color 120ms ease;
 }
+
+@media (hover: hover) and (pointer: fine) {
+  .df-preview-close {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .df-preview:hover .df-preview-close,
+  .df-preview-close:focus-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 .df-preview-close:hover {
   background: var(--bg-subtle);
   border-color: var(--border-strong);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10960,6 +10960,13 @@ button.connector-action.is-loading {
   }
 }
 
+@media (any-pointer: coarse) {
+  .df-preview-close {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 .df-preview-close:hover {
   background: var(--bg-subtle);
   border-color: var(--border-strong);


### PR DESCRIPTION
Fixes #2662 

## Why

This PR addresses a usability issue in the preview panel where the close button overlap fix unintentionally made the dismiss action inaccessible on touch/coarse-pointer devices.

The previous change hid the close button by default and only revealed it on hover. While that improves visual clarity on desktop devices, touch devices do not support hover interactions, leaving no reliable way to close the preview from the panel itself.

This update preserves the cleaner hover-reveal behavior for hover-capable devices while keeping the close button visible and tappable on touch devices.

## What users will see

- On desktop/hover-capable devices, the preview close button stays hidden until the user hovers over the preview area.
- On touch devices, the close button remains visible and accessible at all times.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

N/A — behavior-only CSS change.

## Bug fix verification

- Verified that the close button remains visible and clickable on non-hover/touch devices through media-query-based behavior separation.
- Hover-reveal behavior remains unchanged for hover-capable devices.

## Validation

- Verified CSS behavior and selector scoping locally.