### PR TITLE
fix(web): Enter to send in project chat composer

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -39,6 +39,7 @@ import {
   inlineMentionToken,
   type InlineMentionEntity,
 } from '../utils/inlineMentions';
+import { isImeComposing } from '../utils/imeComposing';
 import { ANNOTATION_EVENT, type AnnotationEventDetail } from "./PreviewDrawOverlay";
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
@@ -262,6 +263,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     const [toolsTab, setToolsTab] = useState<ToolsTab>('plugins');
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+    const composingRef = useRef(false);
     const toolsMenuRef = useRef<HTMLDivElement | null>(null);
     const toolsTriggerRef = useRef<HTMLButtonElement | null>(null);
     const petEnabled = Boolean(onAdoptPet && onTogglePet);
@@ -1306,7 +1308,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                 onScroll={(event) => {
                   setComposerScrollTop(event.currentTarget.scrollTop);
                 }}
+                onCompositionStart={() => {
+                  composingRef.current = true;
+                }}
+                onCompositionEnd={() => {
+                  composingRef.current = false;
+                }}
                 onKeyDown={(e) => {
+                  if (isImeComposing(e, composingRef.current)) return;
                   if (slash && filteredSlash.length > 0) {
                     if (e.key === 'ArrowDown') {
                       e.preventDefault();
@@ -1336,7 +1345,12 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                     setMention(null);
                     return;
                   }
-                  if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  if (
+                    e.key === 'Enter' &&
+                    !e.shiftKey &&
+                    !e.altKey &&
+                    (e.metaKey || e.ctrlKey || !mention)
+                  ) {
                     e.preventDefault();
                     void submit();
                   }

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -31,6 +31,7 @@ import type {
   McpServerConfig,
 } from '@open-design/contracts';
 import type { SkillSummary } from '../types';
+import { isImeComposing } from '../utils/imeComposing';
 import { Icon, type IconName } from './Icon';
 import { PluginInputsForm } from './PluginInputsForm';
 import {
@@ -2254,11 +2255,6 @@ function replaceMentionTokenWithText(
   const before = value.slice(0, mention.start).trimEnd();
   const after = value.slice(mention.end).trimStart();
   return [before, replacement.trim(), after].filter(Boolean).join(' ').trim();
-}
-
-function isImeComposing(event: ReactKeyboardEvent<HTMLTextAreaElement>, composing: boolean): boolean {
-  const nativeEvent = event.nativeEvent as KeyboardEvent & { keyCode?: number };
-  return composing || nativeEvent.isComposing || nativeEvent.keyCode === 229;
 }
 
 function pluginMatchesQuery(plugin: InstalledPluginRecord, query: string): boolean {

--- a/apps/web/src/utils/imeComposing.ts
+++ b/apps/web/src/utils/imeComposing.ts
@@ -1,0 +1,10 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+
+/** True while an IME composition is active or this key is part of confirming it. */
+export function isImeComposing(
+  event: ReactKeyboardEvent<HTMLTextAreaElement>,
+  composing: boolean,
+): boolean {
+  const nativeEvent = event.nativeEvent as KeyboardEvent & { keyCode?: number };
+  return composing || nativeEvent.isComposing || nativeEvent.keyCode === 229;
+}

--- a/apps/web/tests/components/ChatComposer.search.test.tsx
+++ b/apps/web/tests/components/ChatComposer.search.test.tsx
@@ -488,6 +488,28 @@ describe('ChatComposer /search command', () => {
     expect(meta).toBeUndefined();
   });
 
+  it('submits the draft on plain Enter (same as Home hero)', async () => {
+    const onSend = vi.fn();
+
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={onSend}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'hello world' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(onSend).toHaveBeenCalledWith('hello world', [], [], undefined);
+  });
+
   it('keeps keyboard submits blocked when sending is disabled', () => {
     const onSend = vi.fn();
 
@@ -507,6 +529,7 @@ describe('ChatComposer /search command', () => {
     const input = screen.getByTestId('chat-composer-input');
     fireEvent.change(input, { target: { value: 'keep this draft' } });
     fireEvent.keyDown(input, { key: 'Enter', metaKey: true });
+    fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(onSend).not.toHaveBeenCalled();
     expect((input as HTMLTextAreaElement).value).toBe('keep this draft');


### PR DESCRIPTION
## Summary
- Project chat composer now submits on Enter, matching Home.
- Shift+Enter still inserts a newline.
- IME composition and open @-mention popover are handled like Home.

Fixes #2640

## Test plan
- [x] `pnpm --filter @open-design/web test --run tests/components/ChatComposer.search.test.tsx tests/components/HomeHero.plugin-picker.test.tsx`
- [ ] Open a project, focus the chat input, press Enter to send; Shift+Enter for newline
- [ ] With @ mention popover open, Enter picks/behaves as before; Cmd/Ctrl+Enter still sends