### PR TITLE
Harden packaged updater downloads and install handoff

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@open-design/diagnostics": "workspace:*",
+    "@open-design/download": "workspace:*",
     "@open-design/host": "workspace:*",
     "@open-design/platform": "workspace:*",
     "@open-design/sidecar": "workspace:*",

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1732,7 +1732,10 @@ export function createDesktopUpdater(
   async function installUpdate(): Promise<DesktopUpdateStatusSnapshot> {
     const unsupported = unsupportedStatus();
     if (unsupported != null) return unsupported;
-    if (installFrozen && installResult != null) return snapshot();
+    if (installResult != null) {
+      installFrozen = true;
+      return snapshot();
+    }
     if (activeRelease == null) {
       const restored = await restoreStoreState();
       if (restored == null || activeRelease == null) {

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
-import { createReadStream, createWriteStream } from "node:fs";
+import { createReadStream } from "node:fs";
 import {
   access,
   chmod,
@@ -15,9 +15,15 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
-import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
+import {
+  MANAGED_DOWNLOAD_ERROR_CODES,
+  ManagedDownloadError,
+  downloadCopyAndClear,
+  type ManagedDownloadChecksum,
+  type ManagedDownloadProgress,
+} from "@open-design/download";
 import {
   DESKTOP_UPDATE_CHANNELS,
   DESKTOP_UPDATE_MODES,
@@ -66,6 +72,7 @@ const OWNERSHIP_SENTINEL = ".open-design-updater-root.json";
 const STORE_METADATA_FILE = "metadata.json";
 const RELEASES_DIR = "releases";
 const STAGING_DIR = "staging";
+const DOWNLOADS_DIR = "downloads";
 const BACK_DIR = ".back";
 const HELPERS_DIR = "helpers";
 const UPDATE_ROOT_VERSION = 1;
@@ -469,6 +476,7 @@ function logStoreError(logger: DesktopUpdaterLogger, error: DesktopUpdateErrorSn
 function isAllowedRootEntry(name: string): boolean {
   return name === OWNERSHIP_SENTINEL ||
     name === STORE_METADATA_FILE ||
+    name === DOWNLOADS_DIR ||
     name === RELEASES_DIR ||
     name === STAGING_DIR ||
     name === BACK_DIR ||
@@ -590,7 +598,7 @@ async function ensureOwnedUpdateRoot(
       return { ok: false, error };
     }
 
-    for (const dirName of [RELEASES_DIR, STAGING_DIR, BACK_DIR, HELPERS_DIR]) {
+    for (const dirName of [RELEASES_DIR, STAGING_DIR, DOWNLOADS_DIR, BACK_DIR, HELPERS_DIR]) {
       const path = join(realRoot, dirName);
       let entry;
       try {
@@ -909,36 +917,6 @@ async function hashFile(path: string, algorithm: "sha256" | "sha512"): Promise<s
   return hash.digest("hex");
 }
 
-async function downloadToFile(
-  fetchImpl: typeof globalThis.fetch,
-  url: string,
-  path: string,
-  onProgress: (progress: DesktopUpdateProgressSnapshot) => void,
-): Promise<void> {
-  const response = await fetchImpl(url);
-  if (!response.ok) throw new Error(`artifact request returned HTTP ${response.status}`);
-  if (response.body == null) throw new Error("artifact response did not include a body");
-  await mkdir(dirname(path), { recursive: true });
-  const totalRaw = response.headers.get("content-length");
-  const parsedTotalBytes = totalRaw == null ? undefined : Number(totalRaw);
-  const totalBytes = parsedTotalBytes != null && Number.isFinite(parsedTotalBytes) && parsedTotalBytes > 0
-    ? parsedTotalBytes
-    : undefined;
-  let receivedBytes = 0;
-  const meter = new Transform({
-    transform(chunk: Buffer, _encoding, callback) {
-      receivedBytes += chunk.byteLength;
-      onProgress({ receivedBytes, ...(totalBytes == null ? {} : { totalBytes }) });
-      callback(null, chunk);
-    },
-  });
-  await pipeline(
-    Readable.fromWeb(response.body as never),
-    meter,
-    createWriteStream(path, { flags: "wx" }),
-  );
-}
-
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -949,6 +927,9 @@ function isRetryableArtifactDownloadError(error: unknown): boolean {
 }
 
 function userFacingDownloadErrorMessage(error: unknown): string {
+  if (error instanceof ManagedDownloadError && error.code === MANAGED_DOWNLOAD_ERROR_CODES.NETWORK_EXHAUSTED) {
+    return `The network connection ended while downloading the update. Please try again.`;
+  }
   const message = errorMessage(error);
   if (isRetryableArtifactDownloadError(error)) {
     return `The network connection ended while downloading the update. Please try again.`;
@@ -956,31 +937,29 @@ function userFacingDownloadErrorMessage(error: unknown): string {
   return message;
 }
 
-async function downloadToFileWithRetries(
-  fetchImpl: typeof globalThis.fetch,
-  url: string,
-  path: string,
-  onProgress: (progress: DesktopUpdateProgressSnapshot) => void,
-  logger: DesktopUpdaterLogger,
-): Promise<void> {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= ARTIFACT_DOWNLOAD_MAX_ATTEMPTS; attempt += 1) {
-    if (attempt > 1) await rm(path, { force: true }).catch(() => undefined);
-    try {
-      await downloadToFile(fetchImpl, url, path, onProgress);
-      return;
-    } catch (downloadError) {
-      lastError = downloadError;
-      if (attempt >= ARTIFACT_DOWNLOAD_MAX_ATTEMPTS || !isRetryableArtifactDownloadError(downloadError)) break;
-      logger.warn("[open-design updater] retrying interrupted update download", {
-        attempt,
-        error: errorMessage(downloadError),
-        maxAttempts: ARTIFACT_DOWNLOAD_MAX_ATTEMPTS,
-        url,
-      });
-    }
+function managedChecksum(checksum: DesktopUpdateChecksumSnapshot): ManagedDownloadChecksum {
+  if (checksum.value == null) throw new Error("artifact checksum is missing");
+  return {
+    algorithm: checksum.algorithm,
+    value: checksum.value,
+  };
+}
+
+function updateProgressFromManaged(progress: ManagedDownloadProgress): DesktopUpdateProgressSnapshot {
+  return {
+    receivedBytes: progress.receivedBytes,
+    ...(progress.totalBytes == null ? {} : { totalBytes: progress.totalBytes }),
+  };
+}
+
+function desktopDownloadError(error: unknown): DesktopUpdateErrorSnapshot {
+  if (error instanceof ManagedDownloadError && error.code === MANAGED_DOWNLOAD_ERROR_CODES.CHECKSUM_MISMATCH) {
+    return createError("checksum-mismatch", "downloaded update checksum did not match release metadata", error.details);
   }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  if (error instanceof ManagedDownloadError && error.code === MANAGED_DOWNLOAD_ERROR_CODES.TARGET_LOCKED) {
+    return createError("download-target-locked", "another update download is already using this target");
+  }
+  return createError("download-failed", userFacingDownloadErrorMessage(error));
 }
 
 async function ensureOwnedSubdir(root: string, name: string): Promise<string> {
@@ -1617,6 +1596,7 @@ export function createDesktopUpdater(
     };
     try {
       const stagingRoot = await ensureOwnedSubdir(opened.root.realRoot, STAGING_DIR);
+      const downloadsRoot = await ensureOwnedSubdir(opened.root.realRoot, DOWNLOADS_DIR);
       const releasesRoot = await ensureOwnedSubdir(opened.root.realRoot, RELEASES_DIR);
       stagingDir = join(stagingRoot, cycleId);
       if (!containsPath(opened.root.realRoot, stagingDir)) {
@@ -1628,10 +1608,22 @@ export function createDesktopUpdater(
         return await failDownload(createError("download-path-escaped", "resolved update download path escaped update root"));
       }
       const resolvedChecksum = await resolveChecksum(fetchImpl, nextCandidate.checksum);
-      await downloadToFileWithRetries(fetchImpl, nextCandidate.artifact.url, tmpPath, (nextProgress) => {
-        progress = nextProgress;
-        emit();
-      }, logger);
+      await downloadCopyAndClear({
+        basePath: downloadsRoot,
+        bucket: "package-launcher",
+        fetch: fetchImpl,
+        fileName: outputName,
+        maxAttempts: ARTIFACT_DOWNLOAD_MAX_ATTEMPTS,
+        onProgress: (nextProgress) => {
+          progress = updateProgressFromManaged(nextProgress);
+          emit();
+        },
+        outputPath: tmpPath,
+        payload: {
+          checksum: managedChecksum(resolvedChecksum),
+          url: nextCandidate.artifact.url,
+        },
+      });
       const digest = await hashFile(tmpPath, resolvedChecksum.algorithm);
       if (resolvedChecksum.value == null || digest.toLowerCase() !== resolvedChecksum.value.toLowerCase()) {
         return await failDownload(
@@ -1687,10 +1679,7 @@ export function createDesktopUpdater(
       incomingRelease = null;
       progress = undefined;
       await writeMetadataPatch((current) => ({ ...current, incoming: undefined }));
-      return setState(
-        DESKTOP_UPDATE_STATES.ERROR,
-        createError("download-failed", userFacingDownloadErrorMessage(downloadError)),
-      );
+      return setState(DESKTOP_UPDATE_STATES.ERROR, desktopDownloadError(downloadError));
     }
   }
 

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -436,6 +436,40 @@ describe("desktop updater", () => {
     }
   });
 
+  it("reuses the same install result for repeated installer open requests", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    const launches: Array<{ appPid: number; installerPath: string; root: string; timeoutMs: number }> = [];
+    try {
+      const updater = createDesktopUpdater(
+        {
+          arch: "arm64",
+          downloadRoot: root,
+          env: {
+            ...updaterEnv(fixture.metadataUrl),
+            [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
+          },
+          source: SIDECAR_SOURCES.TOOLS_PACK,
+        },
+        { launchInstallerAfterQuit: async (input) => {
+          launches.push(input);
+          return "";
+        } },
+      );
+
+      const checked = await updater.checkForUpdates();
+      const first = await updater.installUpdate();
+      const second = await updater.installUpdate();
+
+      expect(first.installResult?.path).toBe(checked.downloadPath);
+      expect(second.installResult).toEqual(first.installResult);
+      expect(launches).toHaveLength(1);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("writes and detaches the mac helper script that opens the installer after quit", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture();

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -23,6 +23,7 @@ import {
 import { installerObservationSummaryPath } from "../../src/main/installer-observations.js";
 
 type FixtureServer = {
+  artifactRanges: () => string[];
   artifactRequests: () => number;
   close: () => Promise<void>;
   metadataRequests: () => number;
@@ -98,8 +99,9 @@ async function createUpdaterFixture(options: {
     ? `open-design-${version}-win-x64-setup.exe`
     : `open-design-${version}-mac-arm64.dmg`;
   const artifactPath = `/artifact.${artifactExt}`;
-  const artifactBody = options.artifactBody ?? "open design updater fixture";
+  const artifactBody = Buffer.from(options.artifactBody ?? "open design updater fixture");
   const digest = createHash("sha256").update(artifactBody).digest("hex");
+  const artifactRanges: string[] = [];
   let artifactRequests = 0;
   let metadataRequests = 0;
   const server = createServer((request, response) => {
@@ -118,7 +120,7 @@ async function createUpdaterFixture(options: {
               [artifactKey]: {
                 name: artifactName,
                 sha256Url: `http://${serverAddress(server)}${artifactPath}.sha256`,
-                size: Buffer.byteLength(artifactBody),
+                size: artifactBody.byteLength,
                 url: `http://${serverAddress(server)}${artifactPath}`,
               },
             },
@@ -130,14 +132,26 @@ async function createUpdaterFixture(options: {
     }
     if (url === artifactPath) {
       artifactRequests += 1;
-      response.setHeader("content-length", String(Buffer.byteLength(artifactBody)));
       const failArtifactAttempts = options.failArtifactAttempts ?? (options.failFirstArtifactWithTerminated === true ? 1 : 0);
+      const range = typeof request.headers.range === "string" ? request.headers.range : undefined;
+      if (range != null) artifactRanges.push(range);
+      const match = range == null ? null : /^bytes=(\d+)-$/.exec(range);
+      const start = match?.[1] == null ? 0 : Number(match[1]);
+      const ranged = range != null && Number.isInteger(start) && start >= 0 && start < artifactBody.byteLength;
+      const body = ranged ? artifactBody.subarray(start) : artifactBody;
+      response.setHeader("accept-ranges", "bytes");
+      response.setHeader("content-length", String(body.byteLength));
+      if (ranged) {
+        response.statusCode = 206;
+        response.setHeader("content-range", `bytes ${start}-${artifactBody.byteLength - 1}/${artifactBody.byteLength}`);
+      }
       if (artifactRequests <= failArtifactAttempts) {
-        response.write(artifactBody.slice(0, Math.max(1, Math.floor(artifactBody.length / 2))));
-        response.destroy(new Error("terminated"));
+        const failedChunkLength = Math.max(1, Math.floor(body.byteLength / 2));
+        response.write(body.subarray(0, failedChunkLength));
+        setTimeout(() => response.destroy(new Error("terminated")), 5);
         return;
       }
-      response.end(artifactBody);
+      response.end(body);
       return;
     }
     if (url === `${artifactPath}.sha256`) {
@@ -153,6 +167,7 @@ async function createUpdaterFixture(options: {
   });
   const address = serverAddress(server);
   return {
+    artifactRanges: () => artifactRanges,
     artifactRequests: () => artifactRequests,
     close: async () => {
       await new Promise<void>((resolveClose, rejectClose) => {
@@ -304,7 +319,7 @@ describe("desktop updater", () => {
     }
   });
 
-  it("retries an interrupted artifact download before surfacing an error", async () => {
+  it("resumes an interrupted artifact download before surfacing an error", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture({
       artifactBody: "open design updater fixture with retry",
@@ -328,10 +343,8 @@ describe("desktop updater", () => {
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.error).toBeUndefined();
       expect(fixture.artifactRequests()).toBe(2);
-      expect(logger.warn).toHaveBeenCalledWith(
-        "[open-design updater] retrying interrupted update download",
-        expect.objectContaining({ error: expect.stringMatching(/terminated|fetch failed/i) }),
-      );
+      expect(fixture.artifactRanges()).toEqual([expect.stringMatching(/^bytes=\d+-$/)]);
+      expect(logger.warn).not.toHaveBeenCalled();
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });

--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -19,6 +19,7 @@ import type {
   ExecutionSettingsPopoverClickProps,
   SettingsPopoverClickProps,
   HomeChatComposerClickProps,
+  UpdateIndicatorClickProps,
   NewProjectModalTabClickProps,
   NewProjectModalElementClickProps,
   PluginReplacementModalClickProps,
@@ -85,7 +86,9 @@ import type {
   OnboardingClickProps,
   OnboardingRuntimeScanResultProps,
   OnboardingCompleteResultProps,
-  UpdatePopoverSurfaceViewProps,
+  UpdateIndicatorSurfaceViewProps,
+  UpdatePromptSurfaceViewProps,
+  UpdateInstallResultProps,
 } from '@open-design/contracts/analytics';
 
 type TrackOptions = { requestId?: string; insertId?: string };
@@ -189,6 +192,13 @@ export function trackSettingsPopoverClick(
 export function trackHomeChatComposerClick(
   track: Track,
   props: HomeChatComposerClickProps,
+): void {
+  send(track, 'ui_click', props);
+}
+
+export function trackUpdateIndicatorClick(
+  track: Track,
+  props: UpdateIndicatorClickProps,
 ): void {
   send(track, 'ui_click', props);
 }
@@ -701,11 +711,25 @@ export function trackOnboardingCompleteResult(
   send(track, 'onboarding_complete_result', props);
 }
 
-// ---- Update popover surface_view ----------------------------------------
+// ---- Update indicator / prompt ------------------------------------------
 
-export function trackUpdatePopoverSurfaceView(
+export function trackUpdateIndicatorSurfaceView(
   track: Track,
-  props: UpdatePopoverSurfaceViewProps,
+  props: UpdateIndicatorSurfaceViewProps,
 ): void {
   send(track, 'surface_view', props);
+}
+
+export function trackUpdatePromptSurfaceView(
+  track: Track,
+  props: UpdatePromptSurfaceViewProps,
+): void {
+  send(track, 'surface_view', props);
+}
+
+export function trackUpdateInstallResult(
+  track: Track,
+  props: UpdateInstallResultProps,
+): void {
+  send(track, 'update_install_result', props);
 }

--- a/apps/web/src/components/UpdaterPopup.tsx
+++ b/apps/web/src/components/UpdaterPopup.tsx
@@ -1,11 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { OpenDesignHostUpdaterStatusSnapshot } from '@open-design/host';
 
 import { Icon } from './Icon';
 import {
-  checkForUpdaterUpdate,
   deriveUpdaterModel,
-  downloadUpdaterUpdate,
   openUpdaterInstaller,
   quitAfterUpdaterInstallerOpen,
   readUpdaterStatus,
@@ -15,27 +13,19 @@ import {
 import { useT } from '../i18n';
 import type { Dict } from '../i18n/types';
 import { useAnalytics, useAppVersion } from '../analytics/provider';
-import { trackUpdatePopoverSurfaceView } from '../analytics/events';
+import {
+  trackUpdateIndicatorClick,
+  trackUpdateIndicatorSurfaceView,
+  trackUpdateInstallResult,
+  trackUpdatePromptSurfaceView,
+} from '../analytics/events';
 
-type InstallState = 'idle' | 'opening' | 'opened' | 'quitting';
+type InstallState = 'idle' | 'opening';
 type Translator = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 
 function versionText(t: Translator, model: UpdaterModel): string {
   const version = model.availableVersion;
   return version == null ? t('updater.readyGeneric') : t('updater.readyVersion', { version });
-}
-
-function navLabel(t: Translator, model: UpdaterModel): string {
-  if (model.errorMessage != null) return t('updater.failed');
-  if (model.installerOpened) return t('updater.installerOpened');
-  if (model.status?.state === 'checking') return t('updater.checking');
-  if (model.downloadProgress != null || model.busy) {
-    const percent = model.downloadProgress?.percent;
-    return percent == null ? t('updater.downloading') : t('updater.downloadingPercent', { percent });
-  }
-  if (model.hasDownloadedInstaller) return t('updater.ready');
-  if (model.upToDate || model.status?.state === 'idle') return t('updater.upToDate');
-  return t('updater.available');
 }
 
 function channelLabelFor(channel: string | null | undefined): string | null {
@@ -53,16 +43,24 @@ function channelLabelFor(channel: string | null | undefined): string | null {
   }
 }
 
+function updateVersionProps(model: UpdaterModel, appVersionBefore: string | null) {
+  return {
+    ...(appVersionBefore ? { app_version_before: appVersionBefore } : {}),
+    ...(model.availableVersion ? { app_version_after: model.availableVersion } : {}),
+  };
+}
+
+function updaterErrorCode(model: UpdaterModel): string | undefined {
+  return model.status?.error?.code;
+}
+
 export function UpdaterPopup() {
   const t = useT();
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const actionInFlightRef = useRef(false);
   const [model, setModel] = useState<UpdaterModel>(() => deriveUpdaterModel(null));
-  const [dismissedPromptKey, setDismissedPromptKey] = useState<string | null>(null);
   const [panelOpen, setPanelOpen] = useState(false);
   const [installState, setInstallState] = useState<InstallState>('idle');
-  const [actionError, setActionError] = useState<string | null>(null);
-  const [manualChecking, setManualChecking] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -71,7 +69,7 @@ export function UpdaterPopup() {
       setModel(deriveUpdaterModel(status, { hostAvailable: true }));
     };
     const unsubscribe = subscribeToUpdaterStatus(applyStatus);
-    void readUpdaterStatus({ payload: { source: 'updater-popup:mount' } }).then((result) => {
+    void readUpdaterStatus({ payload: { source: 'updater-indicator:mount' } }).then((result) => {
       if (!mounted) return;
       if (result.ok) {
         setModel(result.model);
@@ -85,50 +83,63 @@ export function UpdaterPopup() {
     };
   }, []);
 
-  const isPanelOpen = useMemo(() => {
-    if (actionError != null) return true;
-    if (panelOpen) return true;
-    if (!model.shouldPrompt || model.promptKey == null) return false;
-    return model.promptKey !== dismissedPromptKey;
-  }, [actionError, dismissedPromptKey, model.promptKey, model.shouldPrompt, panelOpen]);
-
-  // `surface_view page_name=home area=update_popover` — fires once per
-  // panel-open transition so the doc's "升级浮窗曝光" funnel actually
-  // sees data. `app_version_before` is the running daemon version,
-  // `app_version_after` is the available version the updater wants to
-  // install. Both optional so a popup that opens without a complete
-  // model still contributes a row.
+  const ready = model.environment === 'desktop' && model.shouldShowControl;
+  const openingInstaller = installState === 'opening';
+  const controlLabel = t('updater.openInstaller');
+  const channelLabel = channelLabelFor(model.status?.channel);
   const analytics = useAnalytics();
   const appVersionBefore = useAppVersion();
-  const lastReportedKeyRef = useRef<string | null>(null);
+  const versionProps = useMemo(
+    () => updateVersionProps(model, appVersionBefore),
+    [appVersionBefore, model.availableVersion],
+  );
+
+  const indicatorSurfaceKey = `${model.currentVersion ?? 'unknown'}->${model.availableVersion ?? 'unknown'}:${model.status?.downloadPath ?? 'unknown'}`;
+  const lastIndicatorSurfaceKeyRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!isPanelOpen) {
-      lastReportedKeyRef.current = null;
+    if (!ready) {
+      lastIndicatorSurfaceKeyRef.current = null;
       return;
     }
-    const key = `${appVersionBefore}->${model.availableVersion ?? 'unknown'}`;
-    if (lastReportedKeyRef.current === key) return;
-    lastReportedKeyRef.current = key;
-    trackUpdatePopoverSurfaceView(analytics.track, {
+    if (lastIndicatorSurfaceKeyRef.current === indicatorSurfaceKey) return;
+    lastIndicatorSurfaceKeyRef.current = indicatorSurfaceKey;
+    trackUpdateIndicatorSurfaceView(analytics.track, {
       page_name: 'home',
-      area: 'update_popover',
-      ...(appVersionBefore ? { app_version_before: appVersionBefore } : {}),
-      ...(model.availableVersion
-        ? { app_version_after: model.availableVersion }
-        : {}),
+      area: 'update_indicator',
+      ...versionProps,
     });
-  }, [analytics.track, appVersionBefore, isPanelOpen, model.availableVersion]);
+  }, [analytics.track, indicatorSurfaceKey, ready, versionProps]);
+
+  const promptSurfaceKey = panelOpen ? indicatorSurfaceKey : null;
+  const lastPromptSurfaceKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (promptSurfaceKey == null) {
+      lastPromptSurfaceKeyRef.current = null;
+      return;
+    }
+    if (lastPromptSurfaceKeyRef.current === promptSurfaceKey) return;
+    lastPromptSurfaceKeyRef.current = promptSurfaceKey;
+    trackUpdatePromptSurfaceView(analytics.track, {
+      page_name: 'home',
+      area: 'update_prompt',
+      ...versionProps,
+    });
+  }, [analytics.track, promptSurfaceKey, versionProps]);
 
   const close = useCallback(() => {
-    if (installState === 'opening' || installState === 'quitting') return;
-    if (model.promptKey != null) setDismissedPromptKey(model.promptKey);
+    if (openingInstaller) return;
+    trackUpdateIndicatorClick(analytics.track, {
+      page_name: 'home',
+      area: 'update_prompt',
+      element: 'later',
+      action: 'dismiss',
+      ...versionProps,
+    });
     setPanelOpen(false);
-    setInstallState('idle');
-    setActionError(null);
-  }, [installState, model.promptKey]);
+  }, [analytics.track, openingInstaller, versionProps]);
 
   useEffect(() => {
-    if (!isPanelOpen) return;
+    if (!panelOpen) return;
     const onDocClick = (event: MouseEvent) => {
       const target = event.target;
       if (!(target instanceof Node)) return;
@@ -143,270 +154,127 @@ export function UpdaterPopup() {
       document.removeEventListener('mousedown', onDocClick);
       document.removeEventListener('keydown', onKey);
     };
-  }, [close, isPanelOpen]);
-
-  if (model.environment !== 'desktop' || (!model.shouldShowControl && actionError == null)) return null;
-
-  const checkNow = async () => {
-    if (!model.canCheck || manualChecking) return;
-    setPanelOpen(true);
-    setManualChecking(true);
-    setActionError(null);
-    try {
-      const result = await checkForUpdaterUpdate({ payload: { source: 'updater-popup:manual' } });
-      if (result.ok) {
-        setModel(result.model);
-      } else {
-        setActionError(result.reason);
-      }
-    } finally {
-      setManualChecking(false);
-    }
-  };
-
-  const downloadNow = async () => {
-    if (!model.canDownload || manualChecking) return;
-    setManualChecking(true);
-    setActionError(null);
-    try {
-      const result = await downloadUpdaterUpdate({ payload: { source: 'updater-popup:manual-download' } });
-      if (result.ok) {
-        setModel(result.model);
-      } else {
-        setActionError(result.reason);
-      }
-    } finally {
-      setManualChecking(false);
-    }
-  };
-
-  const requestQuitOpenDesign = async () => {
-    setInstallState('quitting');
-    setActionError(null);
-    const result = await quitAfterUpdaterInstallerOpen({ payload: { source: 'updater-popup' } });
-    if (!result.ok) {
-      actionInFlightRef.current = false;
-      setActionError(result.reason);
-      setInstallState('opened');
-    }
-  };
-
-  const quitOpenDesign = async () => {
-    if (actionInFlightRef.current) return;
-    actionInFlightRef.current = true;
-    await requestQuitOpenDesign();
-  };
+  }, [close, panelOpen]);
 
   const installAndQuit = async () => {
-    if (actionInFlightRef.current) return;
+    if (actionInFlightRef.current || !ready) return;
     actionInFlightRef.current = true;
+    setInstallState('opening');
+    trackUpdateIndicatorClick(analytics.track, {
+      page_name: 'home',
+      area: 'update_prompt',
+      element: 'install_update',
+      action: 'install',
+      ...versionProps,
+    });
     try {
-      setInstallState('opening');
-      setActionError(null);
-      const result = await openUpdaterInstaller({ payload: { source: 'updater-popup' } });
+      const result = await openUpdaterInstaller({ payload: { source: 'updater-prompt' } });
       if (!result.ok) {
-        actionInFlightRef.current = false;
-        setActionError(result.reason);
-        setInstallState('idle');
+        trackUpdateInstallResult(analytics.track, {
+          page_name: 'home',
+          area: 'update_prompt',
+          result: 'failed',
+          error_code: result.reason,
+          ...versionProps,
+        });
+        return;
+      }
+      if (result.model.errorMessage != null) {
+        trackUpdateInstallResult(analytics.track, {
+          page_name: 'home',
+          area: 'update_prompt',
+          result: 'failed',
+          ...(updaterErrorCode(result.model) ? { error_code: updaterErrorCode(result.model) } : {}),
+          ...versionProps,
+        });
         return;
       }
       setModel(result.model);
-      if (result.model.errorMessage != null) {
-        actionInFlightRef.current = false;
-        setActionError(result.model.errorMessage);
-        setInstallState('idle');
-        return;
-      }
-      setPanelOpen(true);
-      await requestQuitOpenDesign();
+      trackUpdateInstallResult(analytics.track, {
+        page_name: 'home',
+        area: 'update_prompt',
+        result: 'success',
+        ...versionProps,
+      });
+      setPanelOpen(false);
+      await quitAfterUpdaterInstallerOpen({ payload: { source: 'updater-prompt' } });
     } catch (error) {
+      trackUpdateInstallResult(analytics.track, {
+        page_name: 'home',
+        area: 'update_prompt',
+        result: 'failed',
+        error_code: error instanceof Error ? error.name : 'unknown',
+        ...versionProps,
+      });
+    } finally {
       actionInFlightRef.current = false;
-      setActionError(error instanceof Error ? error.message : String(error));
       setInstallState('idle');
     }
   };
 
-  const openingInstaller = installState === 'opening';
-  const quitting = installState === 'quitting';
-  const actionInFlight = openingInstaller || quitting || manualChecking;
-  const opened = installState === 'opened' || quitting || model.installerOpened;
-  const statusError = model.errorMessage;
-  const failed = actionError != null || statusError != null;
-  const checking = model.status?.state === 'checking' || (manualChecking && !model.hasDownloadedInstaller);
-  const updateAvailable = model.status?.state === 'available';
-  const current = model.upToDate || model.status?.state === 'idle';
-  const title = failed
-    ? opened
-      ? t('updater.quitFailedTitle')
-      : t('updater.failed')
-    : opened
-      ? t('updater.installerOpened')
-      : checking
-        ? t('updater.checking')
-        : current
-          ? t('updater.upToDate')
-          : model.hasDownloadedInstaller
-            ? t('updater.ready')
-            : t('updater.available');
-  const body = failed
-    ? opened
-      ? t('updater.quitFailedBody')
-      : statusError ?? t('updater.openFailedFallback')
-    : opened
-      ? t('updater.installerOpenBody')
-      : checking
-        ? t('updater.checking')
-        : current
-          ? t('updater.upToDate')
-          : model.hasDownloadedInstaller
-            ? versionText(t, model)
-            : t('updater.availableBody', { version: model.availableVersion ?? t('updater.ready') });
-  const progress = model.downloadProgress;
-  const progressStyle = {
-    '--updater-progress': `${progress?.percent ?? 0}%`,
-  } as CSSProperties;
-  const controlDisabled = actionInFlight || (model.busy && !model.hasDownloadedInstaller && !model.installerOpened);
-  const controlLabel = navLabel(t, model);
-  const canOpenInstaller = model.canOpenInstaller && model.hasDownloadedInstaller;
-  const updaterTone = failed
-    ? ' is-error'
-    : opened
-    ? ' is-opened'
-    : progress != null
-    ? ' is-progress'
-    : model.hasDownloadedInstaller
-    ? ' is-ready'
-    : current
-    ? ' is-current'
-    : ' is-available';
-  const channelLabel = channelLabelFor(model.status?.channel);
+  if (!ready) return null;
 
   return (
     <div className="entry-updater-menu" ref={wrapRef}>
       <button
-        aria-disabled={controlDisabled ? 'true' : undefined}
-        aria-expanded={isPanelOpen}
+        aria-disabled={openingInstaller ? 'true' : undefined}
+        aria-expanded={panelOpen}
         aria-label={controlLabel}
-        className={`entry-nav-rail__btn entry-updater-menu__button${updaterTone}${isPanelOpen ? ' is-active' : ''}${controlDisabled ? ' is-disabled' : ''}`}
+        className={`entry-nav-rail__btn entry-updater-menu__button is-ready${panelOpen ? ' is-active' : ''}${openingInstaller ? ' is-disabled' : ''}`}
         data-testid="entry-nav-updater"
         data-tooltip={controlLabel}
         title={controlLabel}
         type="button"
         onClick={() => {
-          if (controlDisabled) return;
-          if (isPanelOpen) {
-            close();
+          if (openingInstaller) return;
+          if (panelOpen) {
+            setPanelOpen(false);
             return;
           }
-          if (!failed && !opened && !updateAvailable && !model.hasDownloadedInstaller && progress == null) {
-            void checkNow();
-            return;
-          }
+          trackUpdateIndicatorClick(analytics.track, {
+            page_name: 'home',
+            area: 'update_indicator',
+            element: 'ready_indicator',
+            action: 'open_prompt',
+            ...versionProps,
+          });
           setPanelOpen(true);
         }}
       >
         <span className="entry-updater-menu__glyph">
-          <Icon
-            name={model.hasDownloadedInstaller || progress != null || updateAvailable ? 'arrow-up' : 'check'}
-            size={18}
-            strokeWidth={2.25}
-          />
+          <Icon name="arrow-up" size={18} strokeWidth={2.25} />
         </span>
-        {progress != null ? (
-          <span
-            aria-label={controlLabel}
-            aria-valuemax={100}
-            aria-valuemin={0}
-            {...(progress.percent == null ? {} : { 'aria-valuenow': progress.percent })}
-            className="entry-updater-menu__progress"
-            data-testid="entry-nav-updater-progress"
-            role="progressbar"
-            style={progressStyle}
-          />
-        ) : null}
       </button>
-      {isPanelOpen ? (
+      {panelOpen ? (
         <section
           aria-labelledby="updater-popup-title"
-          className={`updater-popup${updaterTone}`}
+          className="updater-popup is-ready"
           data-testid="updater-popup"
           role="dialog"
         >
           <div className="updater-popup__icon">
-            <Icon name={opened || current ? 'check' : 'arrow-up'} size={20} strokeWidth={2.2} />
+            <Icon name="arrow-up" size={20} strokeWidth={2.2} />
           </div>
           <div className="updater-popup__body">
-            <h2 id="updater-popup-title">{title}</h2>
-            <p>{body}</p>
-            {channelLabel != null && !failed ? <span className="updater-popup__badge">{channelLabel}</span> : null}
-            {actionError != null && actionError !== body ? <p className="updater-popup__error">{actionError}</p> : null}
+            <h2 id="updater-popup-title">{t('updater.ready')}</h2>
+            <p>{versionText(t, model)}</p>
+            {channelLabel != null ? <span className="updater-popup__badge">{channelLabel}</span> : null}
           </div>
           <div className="updater-popup__actions">
-            {opened ? (
-              quitting ? (
-                <button className="updater-popup__button updater-popup__button--primary" disabled type="button">
-                  {t('updater.quitting')}
-                </button>
-              ) : (
-                <>
-                  <button className="updater-popup__button" type="button" onClick={close}>
-                    {t('updater.done')}
-                  </button>
-                  <button
-                    className="updater-popup__button updater-popup__button--primary"
-                    data-testid="updater-quit-button"
-                    disabled={!model.canQuitAfterInstallerOpen || quitting}
-                    type="button"
-                    onClick={() => {
-                      void quitOpenDesign();
-                    }}
-                  >
-                    {t('updater.quitButton')}
-                  </button>
-                </>
-              )
-            ) : failed || current ? (
-              <button className="updater-popup__button" type="button" onClick={close}>
-                {t('updater.done')}
-              </button>
-            ) : checking ? (
-              <button className="updater-popup__button updater-popup__button--primary" disabled type="button">
-                {t('updater.checking')}
-              </button>
-            ) : updateAvailable && !model.hasDownloadedInstaller ? (
-              <>
-                <button className="updater-popup__button" disabled={actionInFlight} type="button" onClick={close}>
-                  {t('updater.later')}
-                </button>
-                <button
-                  className="updater-popup__button updater-popup__button--primary"
-                  disabled={actionInFlight}
-                  type="button"
-                  onClick={() => {
-                    void downloadNow();
-                  }}
-                >
-                  {t('updater.download')}
-                </button>
-              </>
-            ) : (
-              <>
-                <button className="updater-popup__button" disabled={actionInFlight} type="button" onClick={close}>
-                  {t('updater.later')}
-                </button>
-                <button
-                  className="updater-popup__button updater-popup__button--primary"
-                  data-testid="updater-install-button"
-                  disabled={openingInstaller || !canOpenInstaller}
-                  type="button"
-                  onClick={() => {
-                    void installAndQuit();
-                  }}
-                >
-                  {openingInstaller ? t('updater.opening') : t('updater.openInstaller')}
-                </button>
-              </>
-            )}
+            <button className="updater-popup__button" disabled={openingInstaller} type="button" onClick={close}>
+              {t('updater.later')}
+            </button>
+            <button
+              className="updater-popup__button updater-popup__button--primary"
+              data-testid="updater-install-button"
+              disabled={openingInstaller}
+              type="button"
+              onClick={() => {
+                void installAndQuit();
+              }}
+            >
+              {openingInstaller ? t('updater.opening') : t('updater.openInstaller')}
+            </button>
           </div>
         </section>
       ) : null}

--- a/apps/web/src/components/UpdaterPopup.tsx
+++ b/apps/web/src/components/UpdaterPopup.tsx
@@ -20,7 +20,9 @@ import {
   trackUpdatePromptSurfaceView,
 } from '../analytics/events';
 
-type InstallState = 'idle' | 'opening';
+const INSTALL_HANDOFF_WATCHDOG_MS = 10_000;
+
+type InstallState = 'idle' | 'opening' | 'handoff' | 'recoverable';
 type Translator = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 
 function versionText(t: Translator, model: UpdaterModel): string {
@@ -58,9 +60,32 @@ export function UpdaterPopup() {
   const t = useT();
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const actionInFlightRef = useRef(false);
+  const handoffWatchdogRef = useRef<number | null>(null);
   const [model, setModel] = useState<UpdaterModel>(() => deriveUpdaterModel(null));
   const [panelOpen, setPanelOpen] = useState(false);
   const [installState, setInstallState] = useState<InstallState>('idle');
+
+  const clearHandoffWatchdog = useCallback(() => {
+    if (handoffWatchdogRef.current == null) return;
+    window.clearTimeout(handoffWatchdogRef.current);
+    handoffWatchdogRef.current = null;
+  }, []);
+
+  const recoverFromInstallerHandoff = useCallback(() => {
+    handoffWatchdogRef.current = null;
+    actionInFlightRef.current = false;
+    setInstallState('recoverable');
+    setPanelOpen(true);
+  }, []);
+
+  const startHandoffWatchdog = useCallback(() => {
+    clearHandoffWatchdog();
+    // The quit IPC can resolve before Electron has actually torn down the
+    // renderer. Keep the handoff UI up, but do not leave it stuck forever.
+    handoffWatchdogRef.current = window.setTimeout(recoverFromInstallerHandoff, INSTALL_HANDOFF_WATCHDOG_MS);
+  }, [clearHandoffWatchdog, recoverFromInstallerHandoff]);
+
+  useEffect(() => clearHandoffWatchdog, [clearHandoffWatchdog]);
 
   useEffect(() => {
     let mounted = true;
@@ -84,7 +109,9 @@ export function UpdaterPopup() {
   }, []);
 
   const ready = model.environment === 'desktop' && model.shouldShowControl;
-  const openingInstaller = installState === 'opening';
+  const installBusy = installState === 'opening' || installState === 'handoff';
+  const canStartInstall = ready || installState === 'recoverable';
+  const showControl = ready || installState !== 'idle';
   const controlLabel = t('updater.openInstaller');
   const channelLabel = channelLabelFor(model.status?.channel);
   const analytics = useAnalytics();
@@ -127,7 +154,7 @@ export function UpdaterPopup() {
   }, [analytics.track, promptSurfaceKey, versionProps]);
 
   const close = useCallback(() => {
-    if (openingInstaller) return;
+    if (installBusy) return;
     trackUpdateIndicatorClick(analytics.track, {
       page_name: 'home',
       area: 'update_prompt',
@@ -136,7 +163,7 @@ export function UpdaterPopup() {
       ...versionProps,
     });
     setPanelOpen(false);
-  }, [analytics.track, openingInstaller, versionProps]);
+  }, [analytics.track, installBusy, versionProps]);
 
   useEffect(() => {
     if (!panelOpen) return;
@@ -157,9 +184,11 @@ export function UpdaterPopup() {
   }, [close, panelOpen]);
 
   const installAndQuit = async () => {
-    if (actionInFlightRef.current || !ready) return;
+    if (actionInFlightRef.current || !canStartInstall) return;
     actionInFlightRef.current = true;
+    clearHandoffWatchdog();
     setInstallState('opening');
+    setPanelOpen(true);
     trackUpdateIndicatorClick(analytics.track, {
       page_name: 'home',
       area: 'update_prompt',
@@ -170,6 +199,8 @@ export function UpdaterPopup() {
     try {
       const result = await openUpdaterInstaller({ payload: { source: 'updater-prompt' } });
       if (!result.ok) {
+        actionInFlightRef.current = false;
+        setInstallState('idle');
         trackUpdateInstallResult(analytics.track, {
           page_name: 'home',
           area: 'update_prompt',
@@ -180,6 +211,8 @@ export function UpdaterPopup() {
         return;
       }
       if (result.model.errorMessage != null) {
+        actionInFlightRef.current = false;
+        setInstallState('idle');
         trackUpdateInstallResult(analytics.track, {
           page_name: 'home',
           area: 'update_prompt',
@@ -190,15 +223,25 @@ export function UpdaterPopup() {
         return;
       }
       setModel(result.model);
+      setInstallState('handoff');
+      startHandoffWatchdog();
       trackUpdateInstallResult(analytics.track, {
         page_name: 'home',
         area: 'update_prompt',
         result: 'success',
         ...versionProps,
       });
-      setPanelOpen(false);
-      await quitAfterUpdaterInstallerOpen({ payload: { source: 'updater-prompt' } });
+      const quitResult = await quitAfterUpdaterInstallerOpen({ payload: { source: 'updater-prompt' } });
+      if (!quitResult.ok) {
+        clearHandoffWatchdog();
+        actionInFlightRef.current = false;
+        setInstallState('recoverable');
+        setPanelOpen(true);
+      }
     } catch (error) {
+      clearHandoffWatchdog();
+      actionInFlightRef.current = false;
+      setInstallState('idle');
       trackUpdateInstallResult(analytics.track, {
         page_name: 'home',
         area: 'update_prompt',
@@ -206,27 +249,24 @@ export function UpdaterPopup() {
         error_code: error instanceof Error ? error.name : 'unknown',
         ...versionProps,
       });
-    } finally {
-      actionInFlightRef.current = false;
-      setInstallState('idle');
     }
   };
 
-  if (!ready) return null;
+  if (!showControl) return null;
 
   return (
     <div className="entry-updater-menu" ref={wrapRef}>
       <button
-        aria-disabled={openingInstaller ? 'true' : undefined}
+        aria-disabled={installBusy ? 'true' : undefined}
         aria-expanded={panelOpen}
         aria-label={controlLabel}
-        className={`entry-nav-rail__btn entry-updater-menu__button is-ready${panelOpen ? ' is-active' : ''}${openingInstaller ? ' is-disabled' : ''}`}
+        className={`entry-nav-rail__btn entry-updater-menu__button is-ready${panelOpen ? ' is-active' : ''}${installBusy ? ' is-disabled' : ''}`}
         data-testid="entry-nav-updater"
         data-tooltip={controlLabel}
         title={controlLabel}
         type="button"
         onClick={() => {
-          if (openingInstaller) return;
+          if (installBusy) return;
           if (panelOpen) {
             setPanelOpen(false);
             return;
@@ -261,19 +301,19 @@ export function UpdaterPopup() {
             {channelLabel != null ? <span className="updater-popup__badge">{channelLabel}</span> : null}
           </div>
           <div className="updater-popup__actions">
-            <button className="updater-popup__button" disabled={openingInstaller} type="button" onClick={close}>
+            <button className="updater-popup__button" disabled={installBusy} type="button" onClick={close}>
               {t('updater.later')}
             </button>
             <button
               className="updater-popup__button updater-popup__button--primary"
               data-testid="updater-install-button"
-              disabled={openingInstaller}
+              disabled={installBusy}
               type="button"
               onClick={() => {
                 void installAndQuit();
               }}
             >
-              {openingInstaller ? t('updater.opening') : t('updater.openInstaller')}
+              {installBusy ? t('updater.opening') : t('updater.openInstaller')}
             </button>
           </div>
         </section>

--- a/apps/web/src/lib/updater.ts
+++ b/apps/web/src/lib/updater.ts
@@ -119,11 +119,7 @@ export function deriveUpdaterModel(
           status.downloadPath ?? status.artifactUrl ?? status.artifact?.url ?? 'unknown-artifact',
         ].join(':');
   const canQuitAfterInstallerOpen = hostAvailable && installerOpened;
-  const shouldShowControl = Boolean(
-    hostAvailable &&
-    status?.enabled &&
-    status.supported,
-  );
+  const shouldShowControl = Boolean(canOpenInstaller && hasDownloadedInstaller && !installerOpened);
 
   return {
     availableVersion,

--- a/apps/web/tests/components/UpdaterPopup.test.tsx
+++ b/apps/web/tests/components/UpdaterPopup.test.tsx
@@ -38,13 +38,6 @@ function downloadedStatus(overrides: Partial<OpenDesignHostUpdaterStatusSnapshot
   };
 }
 
-function notAvailableStatus(): OpenDesignHostUpdaterStatusSnapshot {
-  return {
-    ...idleStatus(),
-    state: 'not-available',
-  };
-}
-
 describe('UpdaterPopup', () => {
   let restoreHost: (() => void) | null = null;
 
@@ -54,18 +47,118 @@ describe('UpdaterPopup', () => {
     restoreHost = null;
   });
 
-  it('waits for host status and installs with one click from the popup', async () => {
-    let status = downloadedStatus();
-    const install = vi.fn(async () => {
-      status = downloadedStatus({
-        installResult: {
-          dryRun: true,
-          openedAt: '2026-05-19T00:00:00.000Z',
-          path: status.downloadPath ?? '/tmp/open-design-updater/Open Design Beta.dmg',
+  it('stays hidden for non-installable updater states', async () => {
+    for (const status of [
+      idleStatus(),
+      { ...idleStatus(), state: 'not-available' as const },
+      downloadedStatus({
+        progress: {
+          receivedBytes: 50,
+          totalBytes: 100,
+        },
+        state: 'downloading',
+      }),
+      downloadedStatus({
+        downloadPath: undefined,
+        error: {
+          code: 'update-store-invalid-shape',
+          message: 'update store contains unexpected root entries',
+        },
+        state: 'error',
+      }),
+    ]) {
+      restoreHost = installMockOpenDesignHost({
+        host: {
+          updater: {
+            status: vi.fn(async () => status),
+          },
         },
       });
-      return status;
+
+      const view = render(<UpdaterPopup />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(screen.queryByTestId('entry-nav-updater')).toBeNull();
+      expect(screen.queryByTestId('updater-popup')).toBeNull();
+      view.unmount();
+      restoreHost?.();
+      restoreHost = null;
+    }
+  });
+
+  it('shows only the ready indicator until the user opens the install prompt', async () => {
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
     });
+
+    render(<UpdaterPopup />);
+
+    const button = await screen.findByTestId('entry-nav-updater');
+    expect(button.getAttribute('data-tooltip')).toBe('Install update');
+    expect(screen.queryByTestId('updater-popup')).toBeNull();
+
+    fireEvent.click(button);
+
+    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
+    expect(screen.getByText('Open Design 1.2.3-beta.4 is ready. Open Design will close and open the installer.')).toBeTruthy();
+    expect(screen.getByTestId('updater-install-button').textContent).toBe('Install update');
+  });
+
+  it('uses localized ready prompt copy from the app i18n provider', async () => {
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
+    });
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <UpdaterPopup />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(await screen.findByTestId('entry-nav-updater'));
+
+    expect(await screen.findByRole('dialog', { name: '更新已就绪' })).toBeTruthy();
+    expect(screen.getByTestId('updater-install-button').textContent).toBe('安装更新');
+    expect(screen.getByText('Open Design 1.2.3-beta.4 已就绪。Open Design 会关闭并打开安装器。')).toBeTruthy();
+  });
+
+  it('dismisses the confirmation prompt before installation starts', async () => {
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    fireEvent.click(await screen.findByTestId('entry-nav-updater'));
+    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId('updater-popup')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('entry-nav-updater'));
+    fireEvent.click(screen.getByRole('button', { name: 'Later' }));
+    expect(screen.queryByTestId('updater-popup')).toBeNull();
+  });
+
+  it('installs and quits from the prompt with one disabled in-flight action', async () => {
+    let status = downloadedStatus();
+    let resolveInstall: (status: OpenDesignHostUpdaterStatusSnapshot) => void = () => undefined;
+    const install = vi.fn(() => new Promise<OpenDesignHostUpdaterStatusSnapshot>((resolve) => {
+      resolveInstall = resolve;
+    }));
     const quit = vi.fn(async () => ({ ok: true as const }));
     restoreHost = installMockOpenDesignHost({
       host: {
@@ -79,16 +172,62 @@ describe('UpdaterPopup', () => {
 
     render(<UpdaterPopup />);
 
-    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
-    expect(screen.getByText('Open Design 1.2.3-beta.4 is ready. Open Design will close and open the installer.')).toBeTruthy();
+    fireEvent.click(await screen.findByTestId('entry-nav-updater'));
     fireEvent.click(screen.getByTestId('updater-install-button'));
-    await waitFor(() => expect(install).toHaveBeenCalledWith({ payload: { source: 'updater-popup' } }));
-    await waitFor(() => expect(quit).toHaveBeenCalledWith({ payload: { source: 'updater-popup' } }));
-    expect(await screen.findByRole('dialog', { name: 'Installer opened' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Quitting...' }).getAttribute('disabled')).not.toBeNull();
+    fireEvent.click(screen.getByTestId('updater-install-button'));
+
+    expect(install).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Opening installer...' }).getAttribute('disabled')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Later' }).getAttribute('disabled')).not.toBeNull();
+
+    await act(async () => {
+      status = downloadedStatus({
+        installResult: {
+          dryRun: true,
+          openedAt: '2026-05-19T00:00:00.000Z',
+          path: '/tmp/open-design-updater/Open Design Beta.dmg',
+        },
+      });
+      resolveInstall(status);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(install).toHaveBeenCalledWith({ payload: { source: 'updater-prompt' } }));
+    await waitFor(() => expect(quit).toHaveBeenCalledWith({ payload: { source: 'updater-prompt' } }));
+    expect(screen.queryByTestId('updater-popup')).toBeNull();
+    expect(screen.queryByTestId('entry-nav-updater')).toBeNull();
   });
 
-  it('reacts to updater subscription events without polling-only behavior', async () => {
+  it('keeps install failures internal and leaves the ready prompt usable', async () => {
+    const install = vi.fn(async () => downloadedStatus({
+      error: {
+        code: 'open-installer-failed',
+        message: 'fixture open failed',
+      },
+      state: 'error',
+    }));
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install,
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    fireEvent.click(await screen.findByTestId('entry-nav-updater'));
+    fireEvent.click(screen.getByTestId('updater-install-button'));
+
+    await waitFor(() => expect(install).toHaveBeenCalledWith({ payload: { source: 'updater-prompt' } }));
+    expect(screen.queryByText('fixture open failed')).toBeNull();
+    expect(screen.queryByRole('dialog', { name: 'Update failed' })).toBeNull();
+    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
+    expect(screen.getByTestId('updater-install-button').getAttribute('disabled')).toBeNull();
+  });
+
+  it('reacts to updater subscription events by showing the ready indicator only', async () => {
     const listeners = new Set<OpenDesignHostUpdaterStatusListener>();
     restoreHost = installMockOpenDesignHost({
       host: {
@@ -106,242 +245,13 @@ describe('UpdaterPopup', () => {
     await act(async () => {
       await Promise.resolve();
     });
-    expect(await screen.findByTestId('entry-nav-updater')).toBeTruthy();
-    expect(screen.queryByTestId('updater-popup')).toBeNull();
+    expect(screen.queryByTestId('entry-nav-updater')).toBeNull();
 
     act(() => {
       for (const listener of listeners) listener(downloadedStatus());
     });
-    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
-    expect(screen.getByTestId('entry-nav-updater')).toBeTruthy();
-  });
 
-  it('runs a manual check from the current-version control and shows the zh-CN no-update popup', async () => {
-    const check = vi.fn(async () => notAvailableStatus());
-    restoreHost = installMockOpenDesignHost({
-      host: {
-        updater: {
-          check,
-          status: vi.fn(async () => idleStatus()),
-        },
-      },
-    });
-
-    render(
-      <I18nProvider initial="zh-CN">
-        <UpdaterPopup />
-      </I18nProvider>,
-    );
-
-    const button = await screen.findByTestId('entry-nav-updater');
-    expect(button.className).toContain('is-current');
-    fireEvent.click(button);
-
-    await waitFor(() => expect(check).toHaveBeenCalledWith({ payload: { source: 'updater-popup:manual' } }));
-    expect(await screen.findByRole('dialog', { name: '您已经是最新版本啦' })).toBeTruthy();
-    expect(screen.getAllByText('您已经是最新版本啦').length).toBeGreaterThan(0);
-  });
-
-  it('uses localized updater copy from the app i18n provider', async () => {
-    restoreHost = installMockOpenDesignHost({
-      host: {
-        updater: {
-          status: vi.fn(async () => downloadedStatus()),
-        },
-      },
-    });
-
-    render(
-      <I18nProvider initial="zh-CN">
-        <UpdaterPopup />
-      </I18nProvider>,
-    );
-
-    expect(await screen.findByRole('dialog', { name: '更新已就绪' })).toBeTruthy();
-    expect(screen.getByTestId('updater-install-button').textContent).toBe('安装更新');
-    expect(screen.getByText('Open Design 1.2.3-beta.4 已就绪。Open Design 会关闭并打开安装器。')).toBeTruthy();
-  });
-
-  it('dismisses the popup when clicking outside it', async () => {
-    restoreHost = installMockOpenDesignHost({
-      host: {
-        updater: {
-          status: vi.fn(async () => downloadedStatus()),
-        },
-      },
-    });
-
-    render(<UpdaterPopup />);
-
-    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
-    fireEvent.mouseDown(document.body);
-    expect(screen.queryByTestId('updater-popup')).toBeNull();
-  });
-
-  it('dismisses the auto-opened popup when clicking the updater control again', async () => {
-    restoreHost = installMockOpenDesignHost({
-      host: {
-        updater: {
-          status: vi.fn(async () => downloadedStatus()),
-        },
-      },
-    });
-
-    render(<UpdaterPopup />);
-
-    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
-    fireEvent.click(screen.getByTestId('entry-nav-updater'));
-    expect(screen.queryByTestId('updater-popup')).toBeNull();
-  });
-
-  it('keeps the popup locked open while install and quit is in flight', async () => {
-    let resolveInstall: (status: OpenDesignHostUpdaterStatusSnapshot) => void = () => undefined;
-    const install = vi.fn(() => new Promise<OpenDesignHostUpdaterStatusSnapshot>((resolve) => {
-      resolveInstall = resolve;
-    }));
-    const quit = vi.fn(async () => ({ ok: true as const }));
-    restoreHost = installMockOpenDesignHost({
-      host: {
-        updater: {
-          install,
-          quit,
-          status: vi.fn(async () => downloadedStatus()),
-        },
-      },
-    });
-
-    render(<UpdaterPopup />);
-
-    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
-    fireEvent.click(screen.getByTestId('updater-install-button'));
-    fireEvent.click(screen.getByTestId('updater-install-button'));
-    expect(install).toHaveBeenCalledTimes(1);
-    expect(await screen.findByRole('button', { name: 'Opening installer...' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Later' }).getAttribute('disabled')).not.toBeNull();
-
-    fireEvent.mouseDown(document.body);
-    expect(screen.getByTestId('updater-popup')).toBeTruthy();
-    fireEvent.click(screen.getByTestId('entry-nav-updater'));
-    expect(screen.getByTestId('updater-popup')).toBeTruthy();
-
-    await act(async () => {
-      resolveInstall(downloadedStatus({
-        installResult: {
-          dryRun: true,
-          openedAt: '2026-05-19T00:00:00.000Z',
-          path: '/tmp/open-design-updater/Open Design Beta.dmg',
-        },
-      }));
-      await Promise.resolve();
-    });
-    await waitFor(() => expect(quit).toHaveBeenCalledWith({ payload: { source: 'updater-popup' } }));
-  });
-
-  it('keeps the updater control visible while an update is downloading', async () => {
-    restoreHost = installMockOpenDesignHost({
-      host: {
-        updater: {
-          status: vi.fn(async () => downloadedStatus({
-            progress: {
-              receivedBytes: 50,
-              totalBytes: 100,
-            },
-            state: 'downloading',
-          })),
-        },
-      },
-    });
-
-    render(<UpdaterPopup />);
-
-    await act(async () => {
-      await Promise.resolve();
-    });
     expect(await screen.findByTestId('entry-nav-updater')).toBeTruthy();
     expect(screen.queryByTestId('updater-popup')).toBeNull();
-    expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('50');
-  });
-
-  it('keeps the popup open when opening the installer returns an updater error state', async () => {
-    restoreHost = installMockOpenDesignHost({
-      host: {
-        updater: {
-          install: vi.fn(async () => downloadedStatus({
-            error: {
-              code: 'open-installer-failed',
-              message: 'fixture open failed',
-            },
-            state: 'error',
-          })),
-          status: vi.fn(async () => downloadedStatus()),
-        },
-      },
-    });
-
-    render(<UpdaterPopup />);
-    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
-    fireEvent.click(screen.getByTestId('updater-install-button'));
-    expect(await screen.findByRole('dialog', { name: 'Update failed' })).toBeTruthy();
-    expect(screen.getByText('fixture open failed')).toBeTruthy();
-  });
-
-  it('keeps a retry quit action if Open Design cannot quit after opening the installer', async () => {
-    let status = downloadedStatus();
-    const install = vi.fn(async () => {
-      status = downloadedStatus({
-        installResult: {
-          dryRun: true,
-          openedAt: '2026-05-19T00:00:00.000Z',
-          path: status.downloadPath ?? '/tmp/open-design-updater/Open Design Beta.dmg',
-        },
-      });
-      return status;
-    });
-    const quit = vi.fn(async () => ({ ok: false as const, reason: 'fixture quit failed' }));
-    restoreHost = installMockOpenDesignHost({
-      host: {
-        updater: {
-          install,
-          quit,
-          status: vi.fn(async () => status),
-        },
-      },
-    });
-
-    render(<UpdaterPopup />);
-
-    expect(await screen.findByRole('dialog', { name: 'Update ready' })).toBeTruthy();
-    fireEvent.click(screen.getByTestId('updater-install-button'));
-    expect(await screen.findByRole('dialog', { name: 'Could not quit' })).toBeTruthy();
-    expect(screen.getByText('fixture quit failed')).toBeTruthy();
-    expect(screen.getByTestId('updater-quit-button')).toBeTruthy();
-  });
-
-  it('keeps background update errors behind the updater control until the user opens it', async () => {
-    restoreHost = installMockOpenDesignHost({
-      host: {
-        updater: {
-          status: vi.fn(async () => downloadedStatus({
-            downloadPath: undefined,
-            error: {
-              code: 'update-store-invalid-shape',
-              message: 'update store contains unexpected root entries',
-            },
-            state: 'error',
-          })),
-        },
-      },
-    });
-
-    render(<UpdaterPopup />);
-
-    await act(async () => {
-      await Promise.resolve();
-    });
-    const button = await screen.findByTestId('entry-nav-updater');
-    expect(screen.queryByTestId('updater-popup')).toBeNull();
-    fireEvent.click(button);
-    expect(await screen.findByRole('dialog', { name: 'Update failed' })).toBeTruthy();
-    expect(screen.getByText('update store contains unexpected root entries')).toBeTruthy();
   });
 });

--- a/apps/web/tests/components/UpdaterPopup.test.tsx
+++ b/apps/web/tests/components/UpdaterPopup.test.tsx
@@ -153,7 +153,7 @@ describe('UpdaterPopup', () => {
     expect(screen.queryByTestId('updater-popup')).toBeNull();
   });
 
-  it('installs and quits from the prompt with one disabled in-flight action', async () => {
+  it('keeps the prompt in handoff loading after opening the installer', async () => {
     let status = downloadedStatus();
     let resolveInstall: (status: OpenDesignHostUpdaterStatusSnapshot) => void = () => undefined;
     const install = vi.fn(() => new Promise<OpenDesignHostUpdaterStatusSnapshot>((resolve) => {
@@ -194,8 +194,64 @@ describe('UpdaterPopup', () => {
 
     await waitFor(() => expect(install).toHaveBeenCalledWith({ payload: { source: 'updater-prompt' } }));
     await waitFor(() => expect(quit).toHaveBeenCalledWith({ payload: { source: 'updater-prompt' } }));
-    expect(screen.queryByTestId('updater-popup')).toBeNull();
-    expect(screen.queryByTestId('entry-nav-updater')).toBeNull();
+    expect(screen.getByTestId('entry-nav-updater')).toBeTruthy();
+    expect(screen.getByRole('dialog', { name: 'Update ready' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Opening installer...' }).getAttribute('disabled')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Later' }).getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('recovers the handoff prompt if the app has not closed after the watchdog', async () => {
+    const install = vi.fn(async () => downloadedStatus({
+      installResult: {
+        dryRun: true,
+        openedAt: '2026-05-19T00:00:00.000Z',
+        path: '/tmp/open-design-updater/Open Design Beta.dmg',
+      },
+    }));
+    const quit = vi.fn(async () => ({ ok: true as const }));
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install,
+          quit,
+          status: vi.fn(async () => downloadedStatus()),
+        },
+      },
+    });
+
+    render(<UpdaterPopup />);
+
+    fireEvent.click(await screen.findByTestId('entry-nav-updater'));
+    vi.useFakeTimers();
+    try {
+      fireEvent.click(screen.getByTestId('updater-install-button'));
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(screen.getByRole('button', { name: 'Opening installer...' }).getAttribute('disabled')).not.toBeNull();
+
+      act(() => {
+        vi.advanceTimersByTime(10_000);
+      });
+
+      expect(screen.getByRole('dialog', { name: 'Update ready' })).toBeTruthy();
+      expect(screen.getByTestId('updater-install-button').textContent).toBe('Install update');
+      expect(screen.getByTestId('updater-install-button').getAttribute('disabled')).toBeNull();
+      fireEvent.click(screen.getByTestId('updater-install-button'));
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(install).toHaveBeenCalledTimes(2);
+      expect(quit).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('keeps install failures internal and leaves the ready prompt usable', async () => {

--- a/apps/web/tests/lib/updater.test.ts
+++ b/apps/web/tests/lib/updater.test.ts
@@ -66,7 +66,7 @@ describe('web updater model', () => {
     expect(model.promptKey).toContain('1.2.3-beta.4');
   });
 
-  it('keeps updater control visible while a package update is downloading', () => {
+  it('keeps downloading progress internal without showing the updater control', () => {
     const model = deriveUpdaterModel(
       downloadedStatus({
         progress: {
@@ -78,7 +78,7 @@ describe('web updater model', () => {
       { hostAvailable: true },
     );
     expect(model.busy).toBe(true);
-    expect(model.shouldShowControl).toBe(true);
+    expect(model.shouldShowControl).toBe(false);
     expect(model.downloadProgress).toEqual({
       percent: 25,
       receivedBytes: 25,
@@ -86,7 +86,7 @@ describe('web updater model', () => {
     });
   });
 
-  it('shows a current-version updater control for enabled desktop package launchers', () => {
+  it('keeps current-version package launchers hidden from the updater UI', () => {
     const model = deriveUpdaterModel(
       downloadedStatus({
         availableVersion: undefined,
@@ -97,7 +97,7 @@ describe('web updater model', () => {
     );
 
     expect(model.environment).toBe('desktop');
-    expect(model.shouldShowControl).toBe(true);
+    expect(model.shouldShowControl).toBe(false);
     expect(model.shouldPrompt).toBe(false);
     expect(model.upToDate).toBe(true);
     expect(model.hasDownloadedInstaller).toBe(false);

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -81,14 +81,14 @@ const clickUpdaterRailExpression = `
     return { clicked: true };
   })()
 `;
-const clickUpdaterPrimaryExpression = `
+const startUpdaterDownloadExpression = `
   (() => {
-    const popup = document.querySelector('[data-testid="updater-popup"]');
-    const button = popup?.querySelector('.updater-popup__button--primary');
-    if (!(button instanceof HTMLButtonElement)) return { clicked: false, reason: 'missing-primary-button' };
-    if (button.disabled) return { clicked: false, reason: 'primary-button-disabled' };
-    button.click();
-    return { clicked: true };
+    const updater = window.__od__?.updater;
+    if (updater == null || typeof updater.download !== 'function') {
+      return { started: false, reason: 'missing-host-updater-download' };
+    }
+    void updater.download({ payload: { source: 'packaged-e2e:silent-download' } });
+    return { started: true };
   })()
 `;
 
@@ -328,6 +328,11 @@ type UpdaterClickEvalValue = {
   reason?: string;
 };
 
+type UpdaterStartEvalValue = {
+  reason?: string;
+  started: boolean;
+};
+
 const shouldRunPackagedWinSmoke = process.platform === 'win32' && process.env.OD_PACKAGED_E2E_WIN === '1';
 const winDescribe = shouldRunPackagedWinSmoke ? describe : describe.skip;
 
@@ -444,7 +449,11 @@ winDescribe('packaged windows runtime smoke', () => {
         });
       }
 
-      const popup = await measureSmokeStep(timings, 'wait updater popup', async () => waitForUpdaterPopup());
+      const fixtureInfo = updaterFixture?.info;
+      if (fixtureInfo == null) throw new Error('updater fixture was not initialized');
+      const popup = await measureSmokeStep(timings, 'open ready updater prompt', async () =>
+        openReadyUpdaterPrompt(fixtureInfo.version),
+      );
       expect(popup.visible).toBe(true);
       expect(popup.title).toEqual(expect.any(String));
       expect(popup.title?.trim().length).toBeGreaterThan(0);
@@ -645,10 +654,10 @@ async function runPackagedUpdaterViolentChecks(options: {
   await clearUpdateRoot(options.expectedUpdateRoot);
   const liveLockStart = await options.startDesktop('start live-lock updater pass');
   await waitForHealthyDesktop();
-  await openUpdaterAndWaitAvailable('live-lock updater check', options.fixture.info.version);
+  await checkUpdaterAvailable('live-lock updater check', options.fixture.info.version);
   const liveLockArtifactRequestsBefore = artifactRequests(options.fixture).length;
   await writeManagedDownloadLock(options.expectedUpdateRoot, options.fixture.info.version, liveLockStart.pid);
-  await clickUpdaterPrimaryButton('live-lock updater download');
+  await startUpdaterDownload('live-lock updater silent download');
   const liveLockStatus = await waitForUpdaterStatus(
     (inspect) => inspect.update?.state === 'error',
     'live-lock updater error',
@@ -661,10 +670,10 @@ async function runPackagedUpdaterViolentChecks(options: {
   await clearUpdateRoot(options.expectedUpdateRoot);
   await options.startDesktop('start corrupt-helper updater pass');
   await waitForHealthyDesktop();
-  await openUpdaterAndWaitAvailable('corrupt-helper updater check', options.fixture.info.version);
+  await checkUpdaterAvailable('corrupt-helper updater check', options.fixture.info.version);
   await writeTamperedManagedDownloadState(options.expectedUpdateRoot, options.fixture.info.version);
   const corruptRequestsBefore = artifactRequests(options.fixture).length;
-  await clickUpdaterPrimaryButton('corrupt-helper updater download');
+  await runUpdaterDownload('corrupt-helper updater silent download');
   const corruptHelperStatus = await waitForUpdaterStatus(
     (inspect) => inspect.update?.state === 'downloaded',
     'corrupt-helper updater downloaded',
@@ -678,7 +687,7 @@ async function runPackagedUpdaterViolentChecks(options: {
   await clearUpdateRoot(options.expectedUpdateRoot);
   await options.startDesktop('start updater-root attack seed');
   await waitForHealthyDesktop();
-  await openUpdaterAndWaitAvailable('updater-root attack check', options.fixture.info.version);
+  await checkUpdaterAvailable('updater-root attack check', options.fixture.info.version);
   await writeUnexpectedUpdateRootEntry(options.expectedUpdateRoot);
   await options.stopDesktop('stop after updater-root attack seed');
   await options.startDesktop('start updater-root attack restore');
@@ -700,8 +709,8 @@ async function runPackagedUpdaterViolentChecks(options: {
     await clearUpdateRoot(options.expectedUpdateRoot);
     await options.startDesktop('start checksum-mismatch updater pass');
     await waitForHealthyDesktop();
-    await openUpdaterAndWaitAvailable('checksum-mismatch updater check', badFixture.info.version);
-    await clickUpdaterPrimaryButton('checksum-mismatch updater download');
+    await checkUpdaterAvailable('checksum-mismatch updater check', badFixture.info.version);
+    await runUpdaterDownload('checksum-mismatch updater silent download');
     badChecksumStatus = await waitForUpdaterStatus(
       (inspect) => inspect.update?.state === 'error',
       'checksum-mismatch updater error',
@@ -783,14 +792,13 @@ async function runRealUpdateInstallerAcceptance(options: {
   );
   await options.startDesktop('start real public update installer');
   await waitForHealthyDesktop();
-  await clickUpdaterRailButton('real public update check');
-  const available = await waitForUpdaterStatus(
-    (inspect) => inspect.update?.state === 'available' || inspect.update?.state === 'downloaded',
-    'real public update available',
-    120_000,
-  );
+  const available = await runToolsPackJson<WinInspectResult>('inspect', ['--update-action', 'check']);
+  expect(
+    available.update?.state === 'available' || available.update?.state === 'downloaded',
+    `real public update available: ${formatUnknown(available)}`,
+  ).toBe(true);
   if (available.update?.state !== 'downloaded') {
-    await clickUpdaterPrimaryButton('real public update download');
+    await runUpdaterDownload('real public update silent download');
   }
   const downloaded = await waitForUpdaterStatus(
     (inspect) => inspect.update?.state === 'downloaded',
@@ -829,9 +837,9 @@ async function runInterruptedResumePass(
     startDesktop: (step: string) => Promise<WinStartResult>;
   },
 ): Promise<{ partialBytes: number; range: string | null }> {
-  await openUpdaterAndWaitAvailable(`${label} check`, options.fixture.info.version);
+  await checkUpdaterAvailable(`${label} check`, options.fixture.info.version);
   const requestsBefore = artifactRequests(options.fixture).length;
-  await clickUpdaterPrimaryButton(`${label} start download`);
+  await startUpdaterDownload(`${label} start silent download`);
   const downloading = await waitForUpdaterStatus(
     (inspect) => inspect.update?.state === 'downloading',
     `${label} downloading`,
@@ -850,8 +858,8 @@ async function runInterruptedResumePass(
 
   await options.startDesktop(`${label} restart`);
   await waitForHealthyDesktop();
-  await openUpdaterAndWaitAvailable(`${label} retry check`, options.fixture.info.version);
-  await clickUpdaterPrimaryButton(`${label} retry download`);
+  await checkUpdaterAvailable(`${label} retry check`, options.fixture.info.version);
+  await runUpdaterDownload(`${label} retry silent download`);
   await waitForUpdaterStatus(
     (inspect) => inspect.update?.state === 'downloaded',
     `${label} downloaded after resume`,
@@ -865,26 +873,42 @@ async function runInterruptedResumePass(
 }
 
 async function runUiCheckAndDownloadToReady(label: string, version: string): Promise<WinInspectResult> {
-  await openUpdaterAndWaitAvailable(`${label} check`, version);
-  await clickUpdaterPrimaryButton(`${label} download`);
+  await checkUpdaterAvailable(`${label} check`, version);
+  await runUpdaterDownload(`${label} silent download`);
   const status = await waitForUpdaterStatus(
     (inspect) => inspect.update?.state === 'downloaded',
     `${label} downloaded`,
   );
-  await waitForUpdaterPopup();
   return status;
 }
 
-async function openUpdaterAndWaitAvailable(label: string, version: string): Promise<UpdaterPopupEvalValue> {
-  await clickUpdaterRailButton(label);
-  const status = await waitForUpdaterStatus(
-    (inspect) => inspect.update?.state === 'available',
-    `${label} available`,
-  );
+async function checkUpdaterAvailable(label: string, version: string): Promise<WinInspectResult> {
+  const status = await runToolsPackJson<WinInspectResult>('inspect', ['--update-action', 'check']);
+  expect(status.update?.state, `${label}: expected updater check to find an available update`).toBe('available');
   expect(status.update?.availableVersion).toBe(version);
+  return status;
+}
+
+async function runUpdaterDownload(label: string): Promise<WinInspectResult> {
+  const status = await runToolsPackJson<WinInspectResult>('inspect', ['--update-action', 'download']);
+  expect(
+    status.update?.state === 'downloaded' || status.update?.state === 'error',
+    `${label}: expected updater download to settle`,
+  ).toBe(true);
+  return status;
+}
+
+async function startUpdaterDownload(label: string): Promise<void> {
+  const started = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', startUpdaterDownloadExpression]);
+  const value = assertUpdaterStartEvalValue(started.eval?.value);
+  expect(value.started, `${label}: ${value.reason ?? 'updater download was not started'}`).toBe(true);
+}
+
+async function openReadyUpdaterPrompt(version: string): Promise<UpdaterPopupEvalValue> {
+  await clickUpdaterRailButton('open ready updater prompt');
   return await waitForUpdaterPopupMatching(
-    (popup) => popup.visible && !popup.installButtonVisible && (popup.text ?? '').includes(version),
-    `${label} popup available`,
+    (popup) => popup.visible && popup.installButtonVisible && (popup.text ?? '').includes(version),
+    'ready updater prompt',
   );
 }
 
@@ -892,12 +916,6 @@ async function clickUpdaterRailButton(label: string): Promise<void> {
   const click = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', clickUpdaterRailExpression]);
   const value = assertUpdaterClickEvalValue(click.eval?.value);
   expect(value.clicked, `${label}: ${value.reason ?? 'updater rail not clicked'}`).toBe(true);
-}
-
-async function clickUpdaterPrimaryButton(label: string): Promise<void> {
-  const click = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', clickUpdaterPrimaryExpression]);
-  const value = assertUpdaterClickEvalValue(click.eval?.value);
-  expect(value.clicked, `${label}: ${value.reason ?? 'updater primary not clicked'}`).toBe(true);
 }
 
 async function waitForUpdaterStatus(
@@ -1486,28 +1504,6 @@ async function waitForHealthyDesktop(): Promise<WinInspectResult> {
   throw new Error(`packaged windows runtime did not become healthy: ${formatUnknown(lastResult)}`);
 }
 
-async function waitForUpdaterPopup(): Promise<UpdaterPopupEvalValue> {
-  const timeoutMs = 90_000;
-  const startedAt = Date.now();
-  let lastResult: unknown = null;
-
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      const inspect = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', updaterPopupExpression]);
-      lastResult = inspect;
-      if (inspect.status?.state === 'running' && inspect.eval?.ok === true) {
-        const value = asUpdaterPopupEvalValue(inspect.eval.value);
-        if (value?.visible === true && value.installButtonVisible === true) return value;
-      }
-    } catch (error) {
-      lastResult = error;
-    }
-    await delay(1000);
-  }
-
-  throw new Error(`packaged windows updater popup did not appear: ${formatUnknown(lastResult)}`);
-}
-
 async function waitForUpdaterInstallerOpened(): Promise<WinInspectResult> {
   const timeoutMs = 60_000;
   const startedAt = Date.now();
@@ -1584,6 +1580,14 @@ function assertUpdaterClickEvalValue(value: unknown): UpdaterClickEvalValue {
   return normalized;
 }
 
+function assertUpdaterStartEvalValue(value: unknown): UpdaterStartEvalValue {
+  const normalized = asUpdaterStartEvalValue(value);
+  if (normalized == null) {
+    throw new Error(`unexpected updater start eval value: ${formatUnknown(value)}`);
+  }
+  return normalized;
+}
+
 function asHealthEvalValue(value: unknown): HealthEvalValue | null {
   if (!isRecord(value)) return null;
   if (typeof value.href !== 'string' || typeof value.status !== 'number' || typeof value.title !== 'string') return null;
@@ -1605,6 +1609,13 @@ function asUpdaterClickEvalValue(value: unknown): UpdaterClickEvalValue | null {
   if (typeof value.clicked !== 'boolean') return null;
   if (value.reason != null && typeof value.reason !== 'string') return null;
   return value as UpdaterClickEvalValue;
+}
+
+function asUpdaterStartEvalValue(value: unknown): UpdaterStartEvalValue | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.started !== 'boolean') return null;
+  if (value.reason != null && typeof value.reason !== 'string') return null;
+  return value as UpdaterStartEvalValue;
 }
 
 function expectPathInside(filePath: string, expectedRoot: string): void {

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -1,7 +1,9 @@
 // @vitest-environment node
 
+import { createHash } from 'node:crypto';
 import { execFile, spawn, type ChildProcessByStdio } from 'node:child_process';
-import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import type { Readable } from 'node:stream';
@@ -27,11 +29,15 @@ const toolsPackBin = join(workspaceRoot, 'tools', 'pack', 'bin', 'tools-pack.mjs
 const toolsServeBin = join(workspaceRoot, 'tools', 'serve', 'bin', 'tools-serve.mjs');
 const maxInstallDurationMs = Number.parseInt(process.env.OD_PACKAGED_E2E_WIN_MAX_INSTALL_MS ?? '120000', 10);
 const verifyReinstallWhileRunning = process.env.OD_PACKAGED_E2E_WIN_VERIFY_REINSTALL !== '0';
+const verifyViolentUpdater = process.env.OD_PACKAGED_E2E_WIN_UPDATER_VIOLENT !== '0';
+const verifyRealUpdateInstaller = process.env.OD_PACKAGED_E2E_WIN_REAL_UPDATE_INSTALL === '1';
 const releaseChannel = process.env.OD_PACKAGED_E2E_RELEASE_CHANNEL;
 const releaseVersion = process.env.OD_PACKAGED_E2E_RELEASE_VERSION;
 const updateScenario = resolvePackagedUpdateScenario({ releaseChannel, releaseVersion });
 const installIdentity = resolvePackagedWinInstallIdentity({ namespace, releaseVersion });
 const toolsPackReleaseVersionArgs = releaseAppVersionArgs(releaseVersion);
+const violentArtifactBytes = Number.parseInt(process.env.OD_PACKAGED_E2E_WIN_UPDATER_BYTES ?? `${16 * 1024 * 1024}`, 10);
+const violentChunkDelayMs = Number.parseInt(process.env.OD_PACKAGED_E2E_WIN_UPDATER_CHUNK_DELAY_MS ?? '18', 10);
 
 const outputNamespaceRoot = join(toolsPackDir, 'out', 'win', 'namespaces', namespace);
 const runtimeNamespaceRoot = join(toolsPackDir, 'runtime', 'win', 'namespaces', namespace);
@@ -41,11 +47,16 @@ const updaterPopupExpression = `
   (() => {
     const popup = document.querySelector('[data-testid="updater-popup"]');
     const button = document.querySelector('[data-testid="updater-install-button"]');
+    const primary = popup?.querySelector('.updater-popup__button--primary');
     const onboarding = document.querySelector('.onboarding-view');
+    const rail = document.querySelector('[data-testid="entry-nav-updater"]');
     return {
       href: location.href,
       installButtonVisible: button instanceof HTMLButtonElement && !button.disabled,
       onboardingVisible: onboarding instanceof HTMLElement,
+      primaryDisabled: primary instanceof HTMLButtonElement ? primary.disabled : null,
+      primaryText: primary instanceof HTMLButtonElement ? primary.textContent?.trim() ?? null : null,
+      railTooltip: rail instanceof HTMLElement ? rail.getAttribute('data-tooltip') : null,
       text: popup?.textContent?.trim() ?? null,
       title: popup?.querySelector('h2')?.textContent?.trim() ?? null,
       visible: popup instanceof HTMLElement,
@@ -61,8 +72,28 @@ const clickUpdaterInstallExpression = `
     return { clicked: true };
   })()
 `;
+const clickUpdaterRailExpression = `
+  (() => {
+    const button = document.querySelector('[data-testid="entry-nav-updater"]');
+    if (!(button instanceof HTMLButtonElement)) return { clicked: false, reason: 'missing-updater-rail' };
+    if (button.getAttribute('aria-disabled') === 'true') return { clicked: false, reason: 'updater-rail-disabled' };
+    button.click();
+    return { clicked: true };
+  })()
+`;
+const clickUpdaterPrimaryExpression = `
+  (() => {
+    const popup = document.querySelector('[data-testid="updater-popup"]');
+    const button = popup?.querySelector('.updater-popup__button--primary');
+    if (!(button instanceof HTMLButtonElement)) return { clicked: false, reason: 'missing-primary-button' };
+    if (button.disabled) return { clicked: false, reason: 'primary-button-disabled' };
+    button.click();
+    return { clicked: true };
+  })()
+`;
 
 type DesktopStatus = {
+  pid?: number;
   state?: string;
   title?: string | null;
   url?: string | null;
@@ -124,6 +155,17 @@ type WinUninstallResult = {
   residueObservation?: WinCleanupResult['residueObservation'];
 };
 
+type WinListResult = {
+  current: {
+    registryEntries: Array<{
+      displayName: string | null;
+      displayVersion: string | null;
+      installLocation: string | null;
+      keyPath: string;
+    }>;
+  };
+};
+
 type WinInspectResult = {
   eval?: {
     error?: string;
@@ -135,6 +177,10 @@ type WinInspectResult = {
   };
   status: DesktopStatus | null;
   update?: {
+    active?: {
+      path?: string;
+      version?: string;
+    };
     availableVersion?: string;
     channel?: string;
     currentVersion?: string;
@@ -146,6 +192,10 @@ type WinInspectResult = {
     installResult?: {
       dryRun?: boolean;
       path: string;
+    };
+    progress?: {
+      receivedBytes?: number;
+      totalBytes?: number;
     };
     state: string;
   };
@@ -178,6 +228,42 @@ type SmokeTiming = {
   step: string;
 };
 
+type ViolentUpdaterSummary = {
+  badChecksum: {
+    code: string | undefined;
+    requestCount: number;
+  };
+  cacheClear: {
+    downloadedVersion: string | undefined;
+  };
+  corruptHelperReset: {
+    downloadedVersion: string | undefined;
+    fullArtifactRequestsAfterTamper: number;
+  };
+  firstResume: {
+    partialBytes: number;
+    range: string | null;
+  };
+  liveLock: {
+    code: string | undefined;
+    artifactRequestsAfterLock: number;
+  };
+  rootAttack: {
+    code: string | undefined;
+  };
+  secondResume: {
+    partialBytes: number;
+    range: string | null;
+  };
+};
+
+type RealUpdateInstallerSummary = {
+  downloadedPath: string;
+  displayVersion: string | null;
+  nsisLogTail: string[];
+  registryEntryCount: number;
+};
+
 type DirectInstallerResult = {
   code: number | null;
   nsisLogTail: string[];
@@ -195,15 +281,43 @@ type InstalledAppPackage = {
 type UpdaterFixtureProcess = {
   close: () => Promise<void>;
   info: {
+    artifactUrl?: string;
     metadataUrl: string;
+    sha256?: string;
     version: string;
   };
+};
+
+type ViolentUpdaterRequest = {
+  aborted?: boolean;
+  end?: number;
+  method: string;
+  path: string;
+  range: string | null;
+  sent?: number;
+  start?: number;
+  status: number;
+  total?: number;
+};
+
+type ViolentUpdaterFixtureProcess = UpdaterFixtureProcess & {
+  info: UpdaterFixtureProcess['info'] & {
+    artifactBytes: number;
+    artifactUrl: string;
+    checksumUrl: string;
+    publishedSha256: string;
+    realSha256: string;
+  };
+  requests: ViolentUpdaterRequest[];
 };
 
 type UpdaterPopupEvalValue = {
   href?: string;
   installButtonVisible: boolean;
   onboardingVisible?: boolean;
+  primaryDisabled?: boolean | null;
+  primaryText?: string | null;
+  railTooltip?: string | null;
   text: string | null;
   title: string | null;
   visible: boolean;
@@ -227,6 +341,8 @@ winDescribe('packaged windows runtime smoke', () => {
     let updaterFixture: UpdaterFixtureProcess | null = null;
     let passed = false;
     const timings: SmokeTiming[] = [];
+    let violentUpdater: ViolentUpdaterSummary | { skipped: true } = { skipped: true };
+    let realUpdateInstaller: RealUpdateInstallerSummary | { skipped: true } = { skipped: true };
     try {
       await measureSmokeStep(timings, 'pre-clean uninstall', async () => {
         await runToolsPackJson<WinUninstallResult>('uninstall', ['--remove-product-user-data']).catch(() => null);
@@ -235,6 +351,7 @@ winDescribe('packaged windows runtime smoke', () => {
       const install = await measureSmokeStep(timings, 'install', async () => runToolsPackJson<WinInstallResult>('install'));
       installed = true;
       const expectedUpdateRoot = await resolveExpectedUpdateRoot(install.installDir);
+      await measureSmokeStep(timings, 'clear updater root', async () => clearUpdateRoot(expectedUpdateRoot));
 
       expect(install.namespace).toBe(namespace);
       expectPathInside(install.installerPath, join(outputNamespaceRoot, 'builder'));
@@ -264,12 +381,34 @@ winDescribe('packaged windows runtime smoke', () => {
         );
       }
 
-      updaterFixture = await startUpdaterFixtureProcess(updateScenario);
-      applyPackagedUpdateEnv(process.env, updateScenario, updaterFixture.info.metadataUrl);
+      updaterFixture = verifyViolentUpdater
+        ? await startViolentUpdaterFixtureProcess(updateScenario, {
+            artifactBytes: violentArtifactBytes,
+            chunkDelayMs: violentChunkDelayMs,
+          })
+        : await startUpdaterFixtureProcess(updateScenario);
+      if (verifyViolentUpdater) applyManualPackagedUpdateEnv(process.env, updateScenario, updaterFixture.info.metadataUrl);
+      else applyPackagedUpdateEnv(process.env, updateScenario, updaterFixture.info.metadataUrl);
       await seedPackagedOnboardingComplete(install.installDir);
 
-      let start = await measureSmokeStep(timings, 'start', async () => runToolsPackJson<WinStartResult>('start'));
-      started = true;
+      const startDesktop = async (step: string): Promise<WinStartResult> => {
+        const nextStart = await measureSmokeStep(timings, step, async () => runToolsPackJson<WinStartResult>('start'));
+        started = true;
+        return nextStart;
+      };
+      const stopDesktop = async (step: string): Promise<WinStopResult> => {
+        const stop = await measureSmokeStep(timings, step, async () => runToolsPackJson<WinStopResult>('stop'));
+        started = false;
+        return stop;
+      };
+      const killDesktop = async (step: string, pid: number): Promise<void> => {
+        await measureSmokeStep(timings, step, async () => {
+          await forceKillProcessTree(pid);
+        });
+        started = false;
+      };
+
+      let start = await startDesktop('start');
 
       expect(start.namespace).toBe(namespace);
       expect(start.source).toBe('installed');
@@ -289,6 +428,20 @@ winDescribe('packaged windows runtime smoke', () => {
         expect(value.health.version).toBe(updateScenario.expectedCurrentVersion);
       } else {
         expect(value.health.version).toEqual(expect.any(String));
+      }
+
+      if (verifyViolentUpdater) {
+        violentUpdater = await runPackagedUpdaterViolentChecks({
+          expectedUpdateRoot,
+          fixture: assertViolentUpdaterFixture(updaterFixture),
+          killDesktop,
+          startDesktop: async (step) => {
+            start = await startDesktop(step);
+            return start;
+          },
+          stopDesktop,
+          timings,
+        });
       }
 
       const popup = await measureSmokeStep(timings, 'wait updater popup', async () => waitForUpdaterPopup());
@@ -319,8 +472,21 @@ winDescribe('packaged windows runtime smoke', () => {
       expect(updateInstall.update?.installResult?.dryRun).toBe(true);
       expectPathInside(updateInstall.update?.installResult?.path ?? '', expectedUpdateRoot);
 
+      if (verifyRealUpdateInstaller) {
+        realUpdateInstaller = await measureSmokeStep(timings, 'real public update installer acceptance', async () =>
+          runRealUpdateInstallerAcceptance({
+            installDir: install.installDir,
+            startDesktop: async (step) => {
+              start = await startDesktop(step);
+              return start;
+            },
+            stopDesktop,
+          }),
+        );
+      }
+
       let reinstall: DirectInstallerResult | { skipped: true } = { skipped: true };
-      if (verifyReinstallWhileRunning) {
+      if (verifyReinstallWhileRunning && !verifyRealUpdateInstaller) {
         reinstall = await measureSmokeStep(timings, 'direct reinstall while running', async () =>
           runDirectInstaller(install.installerPath, install.installDir),
         );
@@ -388,6 +554,7 @@ winDescribe('packaged windows runtime smoke', () => {
         expectedUpdateRoot,
         logs: summarizeLogs(logs),
         namespace,
+        realUpdateInstaller,
         reinstall,
         screenshot: report.screenshotRelpath,
         start: {
@@ -404,6 +571,7 @@ winDescribe('packaged windows runtime smoke', () => {
           install: updateInstall.update,
           popup,
           status: updateStatus.update,
+          violent: violentUpdater,
         },
       });
       passed = true;
@@ -434,7 +602,7 @@ winDescribe('packaged windows runtime smoke', () => {
 
       printSmokeTimings(timings);
     }
-  }, 300_000);
+  }, 720_000);
 });
 
 async function measureSmokeStep<T>(timings: SmokeTiming[], step: string, run: () => Promise<T>): Promise<T> {
@@ -455,6 +623,426 @@ function printSmokeTimings(timings: SmokeTiming[]): void {
       `measured total: ${Math.round(totalMs / 100) / 10}s`,
     ].join('\n'),
   );
+}
+
+async function runPackagedUpdaterViolentChecks(options: {
+  expectedUpdateRoot: string;
+  fixture: ViolentUpdaterFixtureProcess;
+  killDesktop: (step: string, pid: number) => Promise<void>;
+  startDesktop: (step: string) => Promise<WinStartResult>;
+  stopDesktop: (step: string) => Promise<WinStopResult>;
+  timings: SmokeTiming[];
+}): Promise<ViolentUpdaterSummary> {
+  const firstResume = await runInterruptedResumePass('first interrupted updater resume', options);
+
+  await options.stopDesktop('stop before cache-clear updater pass');
+  await clearUpdateRoot(options.expectedUpdateRoot);
+  await options.startDesktop('start after cache clear');
+  await waitForHealthyDesktop();
+  const cacheClearStatus = await runUiCheckAndDownloadToReady('cache-clear updater pass', options.fixture.info.version);
+
+  await options.stopDesktop('stop before live-lock updater pass');
+  await clearUpdateRoot(options.expectedUpdateRoot);
+  const liveLockStart = await options.startDesktop('start live-lock updater pass');
+  await waitForHealthyDesktop();
+  await openUpdaterAndWaitAvailable('live-lock updater check', options.fixture.info.version);
+  const liveLockArtifactRequestsBefore = artifactRequests(options.fixture).length;
+  await writeManagedDownloadLock(options.expectedUpdateRoot, options.fixture.info.version, liveLockStart.pid);
+  await clickUpdaterPrimaryButton('live-lock updater download');
+  const liveLockStatus = await waitForUpdaterStatus(
+    (inspect) => inspect.update?.state === 'error',
+    'live-lock updater error',
+  );
+  expect(liveLockStatus.update?.error?.code).toBe('download-target-locked');
+  const liveLockArtifactRequestsAfter = artifactRequests(options.fixture).length - liveLockArtifactRequestsBefore;
+  expect(liveLockArtifactRequestsAfter).toBe(0);
+
+  await options.stopDesktop('stop before corrupt-helper updater pass');
+  await clearUpdateRoot(options.expectedUpdateRoot);
+  await options.startDesktop('start corrupt-helper updater pass');
+  await waitForHealthyDesktop();
+  await openUpdaterAndWaitAvailable('corrupt-helper updater check', options.fixture.info.version);
+  await writeTamperedManagedDownloadState(options.expectedUpdateRoot, options.fixture.info.version);
+  const corruptRequestsBefore = artifactRequests(options.fixture).length;
+  await clickUpdaterPrimaryButton('corrupt-helper updater download');
+  const corruptHelperStatus = await waitForUpdaterStatus(
+    (inspect) => inspect.update?.state === 'downloaded',
+    'corrupt-helper updater downloaded',
+  );
+  const corruptNewRequests = artifactRequests(options.fixture).slice(corruptRequestsBefore);
+  const fullArtifactRequestsAfterTamper = corruptNewRequests.filter((request) => request.range == null && request.status === 200).length;
+  expect(fullArtifactRequestsAfterTamper).toBeGreaterThan(0);
+  await expectManagedDownloadsClear(options.expectedUpdateRoot);
+
+  await options.stopDesktop('stop before updater-root attack');
+  await clearUpdateRoot(options.expectedUpdateRoot);
+  await options.startDesktop('start updater-root attack seed');
+  await waitForHealthyDesktop();
+  await openUpdaterAndWaitAvailable('updater-root attack check', options.fixture.info.version);
+  await writeUnexpectedUpdateRootEntry(options.expectedUpdateRoot);
+  await options.stopDesktop('stop after updater-root attack seed');
+  await options.startDesktop('start updater-root attack restore');
+  const rootAttackStatus = await waitForUpdaterStatus(
+    (inspect) => inspect.update?.state === 'error',
+    'updater-root attack error',
+  );
+  expect(rootAttackStatus.update?.error?.code).toBe('update-store-invalid-shape');
+
+  const badFixture = await startViolentUpdaterFixtureProcess(updateScenario, {
+    artifactBytes: 4 * 1024 * 1024,
+    badChecksum: true,
+    chunkDelayMs: 1,
+  });
+  let badChecksumStatus: WinInspectResult | null = null;
+  try {
+    applyManualPackagedUpdateEnv(process.env, updateScenario, badFixture.info.metadataUrl);
+    await options.stopDesktop('stop before checksum-mismatch updater pass');
+    await clearUpdateRoot(options.expectedUpdateRoot);
+    await options.startDesktop('start checksum-mismatch updater pass');
+    await waitForHealthyDesktop();
+    await openUpdaterAndWaitAvailable('checksum-mismatch updater check', badFixture.info.version);
+    await clickUpdaterPrimaryButton('checksum-mismatch updater download');
+    badChecksumStatus = await waitForUpdaterStatus(
+      (inspect) => inspect.update?.state === 'error',
+      'checksum-mismatch updater error',
+    );
+    expect(badChecksumStatus.update?.error?.code).toBe('checksum-mismatch');
+    await expectManagedDownloadsClear(options.expectedUpdateRoot);
+  } finally {
+    await badFixture.close().catch((error: unknown) => {
+      console.error('failed to close bad checksum updater fixture', error);
+    });
+    applyManualPackagedUpdateEnv(process.env, updateScenario, options.fixture.info.metadataUrl);
+  }
+
+  await options.stopDesktop('stop before second interrupted updater resume');
+  await clearUpdateRoot(options.expectedUpdateRoot);
+  await options.startDesktop('start second interrupted updater resume');
+  await waitForHealthyDesktop();
+  const secondResume = await runInterruptedResumePass('second interrupted updater resume', options);
+  if (badChecksumStatus == null) throw new Error('checksum-mismatch updater pass did not produce a status');
+
+  return {
+    badChecksum: {
+      code: badChecksumStatus.update?.error?.code,
+      requestCount: badFixture.requests.length,
+    },
+    cacheClear: {
+      downloadedVersion: cacheClearStatus.update?.availableVersion,
+    },
+    corruptHelperReset: {
+      downloadedVersion: corruptHelperStatus.update?.availableVersion,
+      fullArtifactRequestsAfterTamper,
+    },
+    firstResume,
+    liveLock: {
+      artifactRequestsAfterLock: liveLockArtifactRequestsAfter,
+      code: liveLockStatus.update?.error?.code,
+    },
+    rootAttack: {
+      code: rootAttackStatus.update?.error?.code,
+    },
+    secondResume,
+  };
+}
+
+function assertViolentUpdaterFixture(value: UpdaterFixtureProcess | null): ViolentUpdaterFixtureProcess {
+  if (!isViolentUpdaterFixture(value)) {
+    throw new Error('expected the violent updater fixture to be active');
+  }
+  return value;
+}
+
+function isViolentUpdaterFixture(value: UpdaterFixtureProcess | null): value is ViolentUpdaterFixtureProcess {
+  return (
+    value != null &&
+    Array.isArray((value as Partial<ViolentUpdaterFixtureProcess>).requests) &&
+    typeof (value as Partial<ViolentUpdaterFixtureProcess>).info?.artifactBytes === 'number' &&
+    typeof (value as Partial<ViolentUpdaterFixtureProcess>).info?.artifactUrl === 'string' &&
+    typeof (value as Partial<ViolentUpdaterFixtureProcess>).info?.checksumUrl === 'string' &&
+    typeof (value as Partial<ViolentUpdaterFixtureProcess>).info?.publishedSha256 === 'string' &&
+    typeof (value as Partial<ViolentUpdaterFixtureProcess>).info?.realSha256 === 'string'
+  );
+}
+
+async function runRealUpdateInstallerAcceptance(options: {
+  installDir: string;
+  startDesktop: (step: string) => Promise<WinStartResult>;
+  stopDesktop: (step: string) => Promise<WinStopResult>;
+}): Promise<RealUpdateInstallerSummary> {
+  if (releaseChannel == null || releaseChannel === '' || releaseVersion == null || releaseVersion === '') {
+    throw new Error('OD_PACKAGED_E2E_WIN_REAL_UPDATE_INSTALL requires OD_PACKAGED_E2E_RELEASE_CHANNEL and OD_PACKAGED_E2E_RELEASE_VERSION');
+  }
+  const expectedUpdateRoot = await resolveExpectedUpdateRoot(options.installDir);
+  await options.stopDesktop('stop before real public update installer');
+  await clearUpdateRoot(expectedUpdateRoot);
+  applyManualPackagedUpdateEnv(
+    process.env,
+    updateScenario,
+    `https://releases.open-design.ai/${updateScenario.channel}/latest/metadata.json`,
+  );
+  await options.startDesktop('start real public update installer');
+  await waitForHealthyDesktop();
+  await clickUpdaterRailButton('real public update check');
+  const available = await waitForUpdaterStatus(
+    (inspect) => inspect.update?.state === 'available' || inspect.update?.state === 'downloaded',
+    'real public update available',
+    120_000,
+  );
+  if (available.update?.state !== 'downloaded') {
+    await clickUpdaterPrimaryButton('real public update download');
+  }
+  const downloaded = await waitForUpdaterStatus(
+    (inspect) => inspect.update?.state === 'downloaded',
+    'real public update downloaded',
+    10 * 60_000,
+  );
+  const downloadedPath = downloaded.update?.downloadPath;
+  if (downloadedPath == null) throw new Error(`real public update did not expose a downloadPath: ${formatUnknown(downloaded)}`);
+  expectPathInside(downloadedPath, expectedUpdateRoot);
+  await options.stopDesktop('stop before installing real public update');
+  const installResult = await runDirectInstaller(downloadedPath, options.installDir);
+  expect(installResult.code).toBe(0);
+  const list = await runToolsPackJson<WinListResult>('list');
+  const matchingEntries = list.current.registryEntries.filter((entry) => entry.displayName === installIdentity.displayName);
+  expect(matchingEntries.length).toBe(1);
+  const entry = matchingEntries[0];
+  if (entry == null) throw new Error(`expected one registry entry for ${installIdentity.displayName}`);
+  expect(entry.keyPath).toContain(`Open Design-${installIdentity.namespaceToken}`);
+  expect(entry.displayVersion).toBe(downloaded.update?.availableVersion);
+  await options.startDesktop('start after real public update install');
+  await waitForHealthyDesktop();
+  return {
+    downloadedPath,
+    displayVersion: entry.displayVersion,
+    nsisLogTail: installResult.nsisLogTail,
+    registryEntryCount: matchingEntries.length,
+  };
+}
+
+async function runInterruptedResumePass(
+  label: string,
+  options: {
+    expectedUpdateRoot: string;
+    fixture: ViolentUpdaterFixtureProcess;
+    killDesktop: (step: string, pid: number) => Promise<void>;
+    startDesktop: (step: string) => Promise<WinStartResult>;
+  },
+): Promise<{ partialBytes: number; range: string | null }> {
+  await openUpdaterAndWaitAvailable(`${label} check`, options.fixture.info.version);
+  const requestsBefore = artifactRequests(options.fixture).length;
+  await clickUpdaterPrimaryButton(`${label} start download`);
+  const downloading = await waitForUpdaterStatus(
+    (inspect) => inspect.update?.state === 'downloading',
+    `${label} downloading`,
+    30_000,
+  );
+  await delay(900);
+  const pid = downloading.status?.pid ?? (await runToolsPackJson<WinInspectResult>('inspect')).status?.pid;
+  if (typeof pid !== 'number' || pid <= 0) throw new Error(`${label}: desktop pid was not available before forced kill`);
+  await options.killDesktop(`${label} forced kill`, pid);
+  await delay(1200);
+
+  const partial = await readManagedDownloadPartial(options.expectedUpdateRoot);
+  expect(partial.bytes).toBeGreaterThan(0);
+  const aborted = artifactRequests(options.fixture).slice(requestsBefore).find((request) => request.aborted === true);
+  expect(aborted, `${label}: expected an aborted artifact request`).toBeTruthy();
+
+  await options.startDesktop(`${label} restart`);
+  await waitForHealthyDesktop();
+  await openUpdaterAndWaitAvailable(`${label} retry check`, options.fixture.info.version);
+  await clickUpdaterPrimaryButton(`${label} retry download`);
+  await waitForUpdaterStatus(
+    (inspect) => inspect.update?.state === 'downloaded',
+    `${label} downloaded after resume`,
+  );
+  const resumed = artifactRequests(options.fixture)
+    .slice(requestsBefore)
+    .find((request) => request.status === 206 && request.range === `bytes=${partial.bytes}-`);
+  expect(resumed, `${label}: expected Range resume from ${partial.bytes}`).toBeTruthy();
+  await expectManagedDownloadsClear(options.expectedUpdateRoot);
+  return { partialBytes: partial.bytes, range: resumed?.range ?? null };
+}
+
+async function runUiCheckAndDownloadToReady(label: string, version: string): Promise<WinInspectResult> {
+  await openUpdaterAndWaitAvailable(`${label} check`, version);
+  await clickUpdaterPrimaryButton(`${label} download`);
+  const status = await waitForUpdaterStatus(
+    (inspect) => inspect.update?.state === 'downloaded',
+    `${label} downloaded`,
+  );
+  await waitForUpdaterPopup();
+  return status;
+}
+
+async function openUpdaterAndWaitAvailable(label: string, version: string): Promise<UpdaterPopupEvalValue> {
+  await clickUpdaterRailButton(label);
+  const status = await waitForUpdaterStatus(
+    (inspect) => inspect.update?.state === 'available',
+    `${label} available`,
+  );
+  expect(status.update?.availableVersion).toBe(version);
+  return await waitForUpdaterPopupMatching(
+    (popup) => popup.visible && !popup.installButtonVisible && (popup.text ?? '').includes(version),
+    `${label} popup available`,
+  );
+}
+
+async function clickUpdaterRailButton(label: string): Promise<void> {
+  const click = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', clickUpdaterRailExpression]);
+  const value = assertUpdaterClickEvalValue(click.eval?.value);
+  expect(value.clicked, `${label}: ${value.reason ?? 'updater rail not clicked'}`).toBe(true);
+}
+
+async function clickUpdaterPrimaryButton(label: string): Promise<void> {
+  const click = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', clickUpdaterPrimaryExpression]);
+  const value = assertUpdaterClickEvalValue(click.eval?.value);
+  expect(value.clicked, `${label}: ${value.reason ?? 'updater primary not clicked'}`).toBe(true);
+}
+
+async function waitForUpdaterStatus(
+  predicate: (inspect: WinInspectResult) => boolean,
+  label: string,
+  timeoutMs = 120_000,
+): Promise<WinInspectResult> {
+  const startedAt = Date.now();
+  let lastResult: unknown = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const inspect = await runToolsPackJson<WinInspectResult>('inspect', ['--update-action', 'status']);
+      lastResult = inspect;
+      if (predicate(inspect)) return inspect;
+    } catch (error) {
+      lastResult = error;
+    }
+    await delay(750);
+  }
+  throw new Error(`${label}: updater status timed out: ${formatUnknown(lastResult)}`);
+}
+
+async function waitForUpdaterPopupMatching(
+  predicate: (value: UpdaterPopupEvalValue) => boolean,
+  label: string,
+  timeoutMs = 90_000,
+): Promise<UpdaterPopupEvalValue> {
+  const startedAt = Date.now();
+  let lastResult: unknown = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const inspect = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', updaterPopupExpression]);
+      lastResult = inspect;
+      if (inspect.status?.state === 'running' && inspect.eval?.ok === true) {
+        const value = asUpdaterPopupEvalValue(inspect.eval.value);
+        if (value != null && predicate(value)) return value;
+      }
+    } catch (error) {
+      lastResult = error;
+    }
+    await delay(750);
+  }
+  throw new Error(`${label}: updater popup timed out: ${formatUnknown(lastResult)}`);
+}
+
+async function forceKillProcessTree(pid: number): Promise<void> {
+  if (process.platform === 'win32') {
+    await execFileAsync('taskkill.exe', ['/PID', String(pid), '/F'], {
+      env: process.env,
+      windowsHide: true,
+    }).catch((error: unknown) => {
+      if (isExecError(error) && /not found|not running|no running instance/i.test(`${error.stdout}\n${error.stderr}`)) return;
+      throw error;
+    });
+    return;
+  }
+  process.kill(pid, 'SIGKILL');
+}
+
+function artifactRequests(fixture: ViolentUpdaterFixtureProcess): ViolentUpdaterRequest[] {
+  return fixture.requests.filter((request) => request.path === new URL(fixture.info.artifactUrl).pathname);
+}
+
+async function clearUpdateRoot(updateRoot: string): Promise<void> {
+  assertSafeUpdateRoot(updateRoot);
+  await rm(updateRoot, { force: true, recursive: true });
+}
+
+function assertSafeUpdateRoot(updateRoot: string): void {
+  const resolved = resolve(updateRoot);
+  if (basename(resolved) !== 'updates' || basename(dirname(resolved)) !== namespace) {
+    throw new Error(`refusing to mutate unexpected update root: ${resolved}`);
+  }
+}
+
+async function readManagedDownloadPartial(updateRoot: string): Promise<{ bytes: number; path: string }> {
+  const partialRoot = join(updateRoot, 'downloads', '.partial');
+  const entries = await readdir(partialRoot).catch(() => []);
+  const partial = entries.find((entry) => entry.endsWith('.partial'));
+  if (partial == null) throw new Error(`expected a managed download partial under ${partialRoot}`);
+  const partialPath = join(partialRoot, partial);
+  return { bytes: (await stat(partialPath)).size, path: partialPath };
+}
+
+async function expectManagedDownloadsClear(updateRoot: string): Promise<void> {
+  const downloadsRoot = join(updateRoot, 'downloads');
+  for (const child of ['.locks', '.partial', '.state']) {
+    const entries = await readdir(join(downloadsRoot, child)).catch(() => []);
+    expect(entries, `${child} should be empty after copy-and-clear/reset`).toEqual([]);
+  }
+}
+
+async function ensureManagedDownloadBase(updateRoot: string): Promise<string> {
+  const downloadsRoot = join(updateRoot, 'downloads');
+  await mkdir(join(downloadsRoot, '.locks'), { recursive: true });
+  await mkdir(join(downloadsRoot, '.partial'), { recursive: true });
+  await mkdir(join(downloadsRoot, '.state'), { recursive: true });
+  await writeFile(
+    join(downloadsRoot, '.open-design-download-root.json'),
+    `${JSON.stringify({
+      createdAt: new Date().toISOString(),
+      kind: 'open-design-managed-download-root',
+      schemaVersion: 1,
+    }, null, 2)}\n`,
+    'utf8',
+  );
+  return downloadsRoot;
+}
+
+async function writeManagedDownloadLock(updateRoot: string, version: string, pid: number): Promise<string> {
+  const downloadsRoot = await ensureManagedDownloadBase(updateRoot);
+  const key = managedDownloadTargetKey(version);
+  const lockPath = join(downloadsRoot, '.locks', `${key}.lock`);
+  await writeFile(lockPath, `${JSON.stringify({ createdAt: new Date().toISOString(), pid })}\n`, 'utf8');
+  return lockPath;
+}
+
+async function writeTamperedManagedDownloadState(updateRoot: string, version: string): Promise<void> {
+  const downloadsRoot = await ensureManagedDownloadBase(updateRoot);
+  const key = managedDownloadTargetKey(version);
+  await writeFile(join(downloadsRoot, '.state', `${key}.json`), `${JSON.stringify({ kind: 'tampered' })}\n`, 'utf8');
+  await writeFile(join(downloadsRoot, '.partial', `${key}.partial`), 'tampered partial', 'utf8');
+}
+
+async function writeUnexpectedUpdateRootEntry(updateRoot: string): Promise<void> {
+  assertSafeUpdateRoot(updateRoot);
+  await writeFile(join(updateRoot, 'unexpected-root-entry.txt'), 'tamper', 'utf8');
+}
+
+function managedDownloadTargetKey(version: string): string {
+  return createHash('sha256').update(`package-launcher\0${updaterOutputFileName(version)}`).digest('hex');
+}
+
+function updaterOutputFileName(version: string): string {
+  return [
+    'open-design',
+    sanitizeUpdaterPathSegment(version),
+    'win',
+    'x64',
+    'installer',
+  ].join('-') + '.exe';
+}
+
+function sanitizeUpdaterPathSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'update';
 }
 
 async function runToolsPackJson<T>(action: string, extraArgs: string[] = []): Promise<T> {
@@ -497,6 +1085,7 @@ async function runToolsPackJson<T>(action: string, extraArgs: string[] = []): Pr
 
 const UPDATE_ENV_KEYS = [
   'OD_UPDATE_AUTO_CHECK',
+  'OD_UPDATE_AUTO_DOWNLOAD',
   'OD_UPDATE_ENABLED',
   'OD_UPDATE_METADATA_URL',
   'OD_UPDATE_CURRENT_VERSION',
@@ -516,6 +1105,16 @@ function restoreUpdateEnv(previous: Partial<Record<(typeof UPDATE_ENV_KEYS)[numb
     if (previous[key] == null) delete process.env[key];
     else process.env[key] = previous[key];
   }
+}
+
+function applyManualPackagedUpdateEnv(
+  env: NodeJS.ProcessEnv,
+  scenario: PackagedUpdateScenario,
+  metadataUrl: string,
+): void {
+  applyPackagedUpdateEnv(env, scenario, metadataUrl);
+  env.OD_UPDATE_AUTO_CHECK = '0';
+  env.OD_UPDATE_AUTO_DOWNLOAD = '0';
 }
 
 async function startUpdaterFixtureProcess(scenario: PackagedUpdateScenario): Promise<UpdaterFixtureProcess> {
@@ -551,6 +1150,260 @@ async function startUpdaterFixtureProcess(scenario: PackagedUpdateScenario): Pro
     },
     info,
   };
+}
+
+async function startViolentUpdaterFixtureProcess(
+  scenario: PackagedUpdateScenario,
+  options: { artifactBytes: number; badChecksum?: boolean; chunkDelayMs: number },
+): Promise<ViolentUpdaterFixtureProcess> {
+  const channel = scenario.channel;
+  const version = scenario.fixtureVersion;
+  const host = '127.0.0.1';
+  const artifactName = `open-design-${version}-win-x64-setup.exe`;
+  const artifact = createDeterministicArtifact(options.artifactBytes);
+  const realSha256 = createHash('sha256').update(artifact).digest('hex');
+  const publishedSha256 =
+    options.badChecksum === true
+      ? `${realSha256.slice(0, -1)}${realSha256.endsWith('0') ? '1' : '0'}`
+      : realSha256;
+  const requests: ViolentUpdaterRequest[] = [];
+  let origin = '';
+
+  const server = createServer((request, response) => {
+    const path = new URL(request.url ?? '/', origin || `http://${host}`).pathname;
+    if (path === `/${channel}/latest/metadata.json`) {
+      const body = JSON.stringify({
+        channel,
+        generatedAt: new Date().toISOString(),
+        ...fixtureChannelMetadata(channel, version),
+        platforms: {
+          win: {
+            arch: 'x64',
+            artifacts: {
+              installer: {
+                contentType: 'application/vnd.microsoft.portable-executable',
+                name: artifactName,
+                sha256Url: `${origin}/${channel}/versions/${version}/${artifactName}.sha256`,
+                size: artifact.byteLength,
+                url: `${origin}/${channel}/versions/${version}/${artifactName}`,
+              },
+            },
+            channel,
+            enabled: true,
+            feed: null,
+            label: 'Windows x64',
+            platform: 'win',
+            platformKey: 'win',
+            signed: false,
+          },
+        },
+        version: 1,
+      });
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      response.setHeader('content-length', String(Buffer.byteLength(body)));
+      response.end(request.method === 'HEAD' ? undefined : body);
+      requests.push({ method: request.method ?? 'GET', path, range: request.headers.range ?? null, status: 200 });
+      return;
+    }
+    if (path === `/${channel}/versions/${version}/${artifactName}.sha256`) {
+      const body = `${publishedSha256}  ${artifactName}\n`;
+      response.setHeader('content-type', 'text/plain; charset=utf-8');
+      response.setHeader('content-length', String(Buffer.byteLength(body)));
+      response.end(request.method === 'HEAD' ? undefined : body);
+      requests.push({ method: request.method ?? 'GET', path, range: request.headers.range ?? null, status: 200 });
+      return;
+    }
+    if (path === `/${channel}/versions/${version}/${artifactName}`) {
+      sendViolentArtifact(request, response, artifact, options.chunkDelayMs, path, requests);
+      return;
+    }
+    response.statusCode = 404;
+    response.end('not found');
+    requests.push({ method: request.method ?? 'GET', path, range: request.headers.range ?? null, status: 404 });
+  });
+
+  await listen(server, 0, host);
+  origin = serverOrigin(server);
+  const artifactUrl = `${origin}/${channel}/versions/${version}/${artifactName}`;
+  return {
+    close: () => closeServer(server),
+    info: {
+      artifactBytes: artifact.byteLength,
+      artifactUrl,
+      checksumUrl: `${artifactUrl}.sha256`,
+      metadataUrl: `${origin}/${channel}/latest/metadata.json`,
+      publishedSha256,
+      realSha256,
+      sha256: publishedSha256,
+      version,
+    },
+    requests,
+  };
+}
+
+function createDeterministicArtifact(bytes: number): Buffer {
+  if (!Number.isInteger(bytes) || bytes <= 0) throw new Error(`artifact bytes must be positive, got ${bytes}`);
+  const artifact = Buffer.allocUnsafe(bytes);
+  for (let index = 0; index < artifact.length; index += 1) {
+    artifact[index] = (index * 31 + (index >>> 3)) & 0xff;
+  }
+  return artifact;
+}
+
+function fixtureChannelMetadata(channel: PackagedUpdateScenario['channel'], version: string): Record<string, unknown> {
+  if (channel === 'stable') {
+    return {
+      baseVersion: version,
+      releaseVersion: version,
+      stableVersion: version,
+    };
+  }
+  const counted = prereleaseCounterParts(version);
+  if (counted == null) throw new Error(`fixture version is not a counted prerelease: ${version}`);
+  if (channel === 'beta') {
+    return {
+      baseVersion: counted.baseVersion,
+      betaNumber: counted.number,
+      betaVersion: version,
+    };
+  }
+  if (channel === 'nightly') {
+    return {
+      baseVersion: counted.baseVersion,
+      nightlyNumber: counted.number,
+      nightlyVersion: version,
+      releaseVersion: version,
+      stableVersion: counted.baseVersion,
+    };
+  }
+  return {
+    baseVersion: counted.baseVersion,
+    previewNumber: counted.number,
+    previewVersion: version,
+    releaseVersion: version,
+  };
+}
+
+function prereleaseCounterParts(version: string): { baseVersion: string; number: number } | null {
+  const hyphen = /^(\d+\.\d+\.\d+)-.+\.(\d+)$/.exec(version);
+  if (hyphen?.[1] != null && hyphen[2] != null) return { baseVersion: hyphen[1], number: Number(hyphen[2]) };
+  const dotted = /^(\d+\.\d+\.\d+)\.[^.]+\.(\d+)$/.exec(version);
+  if (dotted?.[1] != null && dotted[2] != null) return { baseVersion: dotted[1], number: Number(dotted[2]) };
+  return null;
+}
+
+function sendViolentArtifact(
+  request: IncomingMessage,
+  response: ServerResponse,
+  artifact: Buffer,
+  chunkDelayMs: number,
+  path: string,
+  requests: ViolentUpdaterRequest[],
+): void {
+  const rangeHeader = request.headers.range;
+  const range = parseByteRange(rangeHeader, artifact.byteLength);
+  response.setHeader('accept-ranges', 'bytes');
+  response.setHeader('content-type', 'application/vnd.microsoft.portable-executable');
+  if (range === 'invalid' || range === 'unsatisfiable') {
+    response.statusCode = 416;
+    response.setHeader('content-range', `bytes */${artifact.byteLength}`);
+    response.end();
+    requests.push({ method: request.method ?? 'GET', path, range: rangeHeader ?? null, status: 416 });
+    return;
+  }
+
+  const start = range?.start ?? 0;
+  const end = range?.end ?? artifact.byteLength - 1;
+  const total = end - start + 1;
+  if (range != null) {
+    response.statusCode = 206;
+    response.setHeader('content-range', `bytes ${start}-${end}/${artifact.byteLength}`);
+  }
+  response.setHeader('content-length', String(total));
+
+  const entry: ViolentUpdaterRequest = {
+    end,
+    method: request.method ?? 'GET',
+    path,
+    range: rangeHeader ?? null,
+    sent: 0,
+    start,
+    status: response.statusCode,
+    total,
+  };
+  let done = false;
+  response.on('close', () => {
+    if (!done) requests.push({ ...entry, aborted: true });
+  });
+  if (request.method === 'HEAD') {
+    done = true;
+    requests.push({ ...entry, aborted: false, sent: 0 });
+    response.end();
+    return;
+  }
+
+  let cursor = start;
+  const pump = () => {
+    if (cursor > end) {
+      done = true;
+      requests.push({ ...entry, aborted: false });
+      response.end();
+      return;
+    }
+    const next = Math.min(cursor + 64 * 1024, end + 1);
+    const chunk = artifact.subarray(cursor, next);
+    cursor = next;
+    entry.sent = (entry.sent ?? 0) + chunk.byteLength;
+    if (!response.write(chunk)) {
+      response.once('drain', () => setTimeout(pump, chunkDelayMs));
+      return;
+    }
+    setTimeout(pump, chunkDelayMs);
+  };
+  pump();
+}
+
+type ParsedRange = { end: number; start: number } | 'invalid' | 'unsatisfiable' | null;
+
+function parseByteRange(value: string | undefined, size: number): ParsedRange {
+  if (value == null) return null;
+  if (!value.startsWith('bytes=')) return 'invalid';
+  const match = /^bytes=(\d*)-(\d*)$/.exec(value);
+  const rawStart = match?.[1];
+  const rawEnd = match?.[2];
+  if (rawStart == null || rawEnd == null || (rawStart.length === 0 && rawEnd.length === 0)) return 'invalid';
+  if (rawStart.length === 0) {
+    const suffix = Number(rawEnd);
+    if (!Number.isSafeInteger(suffix) || suffix <= 0) return 'invalid';
+    return { start: Math.max(size - suffix, 0), end: size - 1 };
+  }
+  const start = Number(rawStart);
+  const end = rawEnd.length === 0 ? size - 1 : Number(rawEnd);
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start > end) return 'invalid';
+  if (start >= size) return 'unsatisfiable';
+  return { start, end: Math.min(end, size - 1) };
+}
+
+function listen(server: Server, port: number, host: string): Promise<void> {
+  return new Promise<void>((resolveListen, rejectListen) => {
+    server.once('error', rejectListen);
+    server.listen(port, host, () => {
+      server.off('error', rejectListen);
+      resolveListen();
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => (error == null ? resolveClose() : rejectClose(error)));
+  });
+}
+
+function serverOrigin(server: Server): string {
+  const address = server.address();
+  if (address == null || typeof address === 'string') throw new Error('updater fixture did not listen on TCP');
+  return `http://127.0.0.1:${address.port}`;
 }
 
 async function readUpdaterFixtureInfo(child: ChildProcessByStdio<null, Readable, Readable>): Promise<UpdaterFixtureProcess['info']> {
@@ -687,9 +1540,12 @@ function assertLogPathsAndContent(result: LogsResult): void {
   const combined = Object.values(result.logs)
     .flatMap((entry) => entry.lines)
     .join('\n');
+  const unexpectedStandaloneExits = combined
+    .split(/\r?\n/)
+    .filter((line) => /standalone Next\.js server exited/i.test(line) && !/signal=SIGTERM/i.test(line));
   expect(combined).not.toMatch(/ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING/);
   expect(combined).not.toMatch(/packaged runtime failed/i);
-  expect(combined).not.toMatch(/standalone Next\.js server exited/i);
+  expect(unexpectedStandaloneExits).toEqual([]);
 }
 
 function summarizeLogs(result: LogsResult): Record<string, { lineCount: number; logPath: string }> {

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -26,6 +26,7 @@ export type AnalyticsEventName =
   | 'run_created'
   | 'run_finished'
   // Packaged updater lifecycle
+  | 'update_install_result'
   | 'update_apply_observed'
   // File manager
   | 'file_upload_result'
@@ -593,6 +594,15 @@ export interface HomeChatComposerClickProps {
   chip_id?: string;
 }
 
+export interface UpdateIndicatorClickProps {
+  page_name: 'home';
+  area: 'update_indicator' | 'update_prompt';
+  element: 'ready_indicator' | 'later' | 'install_update';
+  action: 'open_prompt' | 'dismiss' | 'install';
+  app_version_before?: string;
+  app_version_after?: string;
+}
+
 export interface NewProjectModalTabClickProps {
   page_name: 'home';
   area: 'new_project_modal';
@@ -1157,6 +1167,7 @@ export type UiClickProps =
   | ExecutionSettingsPopoverClickProps
   | SettingsPopoverClickProps
   | HomeChatComposerClickProps
+  | UpdateIndicatorClickProps
   | NewProjectModalTabClickProps
   | NewProjectModalElementClickProps
   | PluginReplacementModalClickProps
@@ -1244,13 +1255,19 @@ export interface AssistantFeedbackReasonPanelSurfaceViewProps {
   rating: 'positive' | 'negative';
 }
 
-// Home toolbar "Update ready" popover. Fires once per render of the
-// upgrade-available card (see top-right of `EntryShell` /
-// `WorkspaceTabsBar`). `app_version_before` / `app_version_after` ride
-// along so the dashboard can compare adoption rate by version delta.
-export interface UpdatePopoverSurfaceViewProps {
+// Packaged updater UI surfaces. The download pipeline is intentionally
+// silent; these fire only when a verified update is installable and when the
+// user opens the final confirmation prompt.
+export interface UpdateIndicatorSurfaceViewProps {
   page_name: 'home';
-  area: 'update_popover';
+  area: 'update_indicator';
+  app_version_before?: string;
+  app_version_after?: string;
+}
+
+export interface UpdatePromptSurfaceViewProps {
+  page_name: 'home';
+  area: 'update_prompt';
   app_version_before?: string;
   app_version_after?: string;
 }
@@ -1261,7 +1278,8 @@ export type SurfaceViewProps =
   | PluginReplacementModalSurfaceViewProps
   | DesignSystemsTemplatesModalSurfaceViewProps
   | AssistantFeedbackReasonPanelSurfaceViewProps
-  | UpdatePopoverSurfaceViewProps;
+  | UpdateIndicatorSurfaceViewProps
+  | UpdatePromptSurfaceViewProps;
 
 // ---- Result events -------------------------------------------------------
 
@@ -1291,6 +1309,15 @@ export interface PluginReplacementResultProps {
   plugin_before: string;
   plugin_after: string;
   result: TrackingResult;
+  error_code?: string;
+}
+
+export interface UpdateInstallResultProps {
+  page_name: 'home';
+  area: 'update_prompt';
+  result: TrackingResult;
+  app_version_before?: string;
+  app_version_after?: string;
   error_code?: string;
 }
 
@@ -1539,6 +1566,7 @@ export type AnalyticsEventPayload =
   | { event: 'plugin_replacement_result'; props: PluginReplacementResultProps }
   | { event: 'run_created'; props: RunCreatedProps }
   | { event: 'run_finished'; props: RunFinishedProps }
+  | { event: 'update_install_result'; props: UpdateInstallResultProps }
   | { event: 'update_apply_observed'; props: UpdateApplyObservedProps }
   | { event: 'file_upload_result'; props: FileUploadResultProps }
   | { event: 'artifact_export_result'; props: ArtifactExportResultProps }

--- a/packages/download/esbuild.config.mjs
+++ b/packages/download/esbuild.config.mjs
@@ -1,0 +1,11 @@
+import { build } from "esbuild";
+
+await build({
+  bundle: true,
+  entryPoints: ["./src/index.ts"],
+  format: "esm",
+  outfile: "./dist/index.mjs",
+  packages: "external",
+  platform: "node",
+  target: "node24",
+});

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@open-design/download",
+  "version": "0.8.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "node ./esbuild.config.mjs && tsc -p tsconfig.json --emitDeclarationOnly",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
+  },
+  "dependencies": {
+    "@open-design/platform": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "24.12.2",
+    "esbuild": "0.28.0",
+    "typescript": "6.0.3",
+    "vitest": "4.1.6"
+  },
+  "engines": {
+    "node": "~24"
+  }
+}

--- a/packages/download/src/index.ts
+++ b/packages/download/src/index.ts
@@ -1,0 +1,990 @@
+import { createHash } from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
+import {
+  access,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+import { atomicCopyFile, pathContains, removePathBestEffort } from "@open-design/platform";
+
+const STORE_SENTINEL = ".open-design-download-root.json";
+const STATE_DIR = ".state";
+const PARTIAL_DIR = ".partial";
+const LOCK_DIR = ".locks";
+const STORE_SCHEMA_VERSION = 1;
+const MANIFEST_SCHEMA_VERSION = 1;
+const STORE_KIND = "open-design-managed-download-root";
+const MANIFEST_KIND = "open-design-managed-download";
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_PRUNE_OLDER_THAN_MS = 24 * 60 * 60 * 1000;
+
+export type ManagedDownloadChecksum = {
+  algorithm: "sha256" | "sha512";
+  value: string;
+};
+
+export type ManagedDownloadPayload = {
+  checksum: ManagedDownloadChecksum;
+  headers?: Record<string, string>;
+  url: string;
+};
+
+export type ManagedDownloadProgress = {
+  receivedBytes: number;
+  sessionReceivedBytes: number;
+  totalBytes?: number;
+};
+
+export type ManagedDownloadOptions = {
+  basePath: string;
+  bucket: string;
+  fileName: string;
+  fetch?: typeof globalThis.fetch;
+  maxAttempts?: number;
+  onProgress?: (progress: ManagedDownloadProgress) => void;
+  payload: ManagedDownloadPayload;
+  signal?: AbortSignal;
+};
+
+export type ManagedDownloadResult = {
+  bucket: string;
+  bytes: number;
+  checksum: ManagedDownloadChecksum;
+  fileName: string;
+  path: string;
+  reusedComplete: boolean;
+  resumed: boolean;
+  urlDigest: string;
+};
+
+export type DownloadCopyAndClearOptions = ManagedDownloadOptions & {
+  outputPath: string;
+};
+
+export type DownloadCopyAndClearResult = {
+  bytes: number;
+  cleanup: "deferred" | "removed";
+  cleanupWarning?: string;
+  outputPath: string;
+  reusedComplete: boolean;
+  resumed: boolean;
+};
+
+export type ManagedDownloadInspection = {
+  bucket: string;
+  complete: boolean;
+  fileName: string;
+  manifest: "complete" | "missing" | "partial" | "unreadable";
+  path: string;
+};
+
+export type RemoveManagedDownloadOptions = {
+  basePath: string;
+  bucket: string;
+  fileName: string;
+};
+
+export type RemoveManagedDownloadResult = {
+  removed: boolean;
+};
+
+export type PruneManagedDownloadsOptions = {
+  basePath: string;
+  now?: Date;
+  olderThanMs?: number;
+};
+
+export type PruneManagedDownloadsResult = {
+  removed: number;
+  warnings: string[];
+};
+
+export const MANAGED_DOWNLOAD_ERROR_CODES = Object.freeze({
+  ABORTED: "aborted",
+  CHECKSUM_MISMATCH: "checksum-mismatch",
+  INVALID_TARGET: "invalid-target",
+  NETWORK_EXHAUSTED: "network-exhausted",
+  OUTPUT_CONFLICT: "output-conflict",
+  STORE_CORRUPT: "store-corrupt",
+  STORE_NOT_OWNED: "store-not-owned",
+  TARGET_CONFLICT: "target-conflict",
+  TARGET_LOCKED: "target-locked",
+} as const);
+
+export type ManagedDownloadErrorCode =
+  (typeof MANAGED_DOWNLOAD_ERROR_CODES)[keyof typeof MANAGED_DOWNLOAD_ERROR_CODES];
+
+export class ManagedDownloadError extends Error {
+  readonly code: ManagedDownloadErrorCode;
+  readonly details?: unknown;
+
+  constructor(code: ManagedDownloadErrorCode, message: string, details?: unknown) {
+    super(message);
+    this.name = "ManagedDownloadError";
+    this.code = code;
+    if (details !== undefined) this.details = details;
+  }
+}
+
+type StoreSentinel = {
+  createdAt: string;
+  kind: typeof STORE_KIND;
+  schemaVersion: typeof STORE_SCHEMA_VERSION;
+};
+
+type DownloadManifest = {
+  bucket: string;
+  checksum: ManagedDownloadChecksum;
+  createdAt: string;
+  fileName: string;
+  identityDigest: string;
+  kind: typeof MANIFEST_KIND;
+  schemaVersion: typeof MANIFEST_SCHEMA_VERSION;
+  state: "complete" | "partial";
+  targetKey: string;
+  totalBytes?: number;
+  updatedAt: string;
+  urlDigest: string;
+  validators?: {
+    etag?: string;
+    lastModified?: string;
+  };
+};
+
+type NormalizedTarget = {
+  basePath: string;
+  bucket: string;
+  checksum: ManagedDownloadChecksum;
+  fileName: string;
+  finalPath: string;
+  identityDigest: string;
+  lockPath: string;
+  manifestPath: string;
+  partialPath: string;
+  targetKey: string;
+  url: string;
+  urlDigest: string;
+};
+
+type ActiveTask = {
+  listeners: Set<(progress: ManagedDownloadProgress) => void>;
+  promise: Promise<ManagedDownloadResult>;
+  targetKey: string;
+};
+
+type CopyLease = {
+  key: string;
+};
+
+type CopyLeaseState = {
+  clearRequested: boolean;
+  count: number;
+  removeOptions: RemoveManagedDownloadOptions | null;
+};
+
+type AcquiredLock = {
+  path: string;
+};
+
+type DownloadAttemptResult = {
+  resumed: boolean;
+  totalBytes?: number;
+};
+
+type ReusableState = {
+  manifest: DownloadManifest | null;
+  reset?: boolean;
+  result?: ManagedDownloadResult;
+};
+
+const activeTasks = new Map<string, ActiveTask>();
+const activeTargets = new Map<string, string>();
+const copyLeases = new Map<string, CopyLeaseState>();
+
+function errorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error == null || !("code" in error)) return null;
+  const code = (error as { code?: unknown }).code;
+  return code == null ? null : String(code);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function normalizeChecksum(input: ManagedDownloadChecksum): ManagedDownloadChecksum {
+  if (input.algorithm !== "sha256" && input.algorithm !== "sha512") {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.INVALID_TARGET, `unsupported checksum algorithm: ${String(input.algorithm)}`);
+  }
+  const value = input.value.trim().toLowerCase();
+  const expectedLength = input.algorithm === "sha256" ? 64 : 128;
+  if (!new RegExp(`^[0-9a-f]{${expectedLength}}$`).test(value)) {
+    throw new ManagedDownloadError(
+      MANAGED_DOWNLOAD_ERROR_CODES.INVALID_TARGET,
+      `${input.algorithm} checksum must be ${expectedLength} hex characters`,
+    );
+  }
+  return { algorithm: input.algorithm, value };
+}
+
+function normalizeSegment(value: string, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.INVALID_TARGET, `${label} must be a non-empty string`);
+  }
+  if (value === "." || value === ".." || value.includes("\0") || /[\\/]/.test(value) || isAbsolute(value)) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.INVALID_TARGET, `${label} must be a safe single path segment`);
+  }
+  return value;
+}
+
+function normalizeUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error("only http and https URLs are supported");
+    }
+    return url.toString();
+  } catch (error) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.INVALID_TARGET, errorMessage(error));
+  }
+}
+
+function normalizeBasePath(basePath: string): string {
+  if (typeof basePath !== "string" || basePath.length === 0 || basePath.includes("\0")) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.INVALID_TARGET, "basePath must be a non-empty path");
+  }
+  const resolved = resolve(basePath);
+  if (!isAbsolute(resolved)) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.INVALID_TARGET, `basePath must resolve to an absolute path: ${basePath}`);
+  }
+  return resolved;
+}
+
+function targetFromOptions(options: Pick<ManagedDownloadOptions, "basePath" | "bucket" | "fileName" | "payload">): NormalizedTarget {
+  const basePath = normalizeBasePath(options.basePath);
+  const bucket = normalizeSegment(options.bucket, "bucket");
+  const fileName = normalizeSegment(options.fileName, "fileName");
+  const checksum = normalizeChecksum(options.payload.checksum);
+  const url = normalizeUrl(options.payload.url);
+  const urlDigest = digest(url);
+  const identityDigest = digest(`${url}\0${checksum.algorithm}\0${checksum.value}`);
+  const targetKey = digest(`${bucket}\0${fileName}`);
+  const finalPath = resolve(basePath, bucket, fileName);
+  const manifestPath = resolve(basePath, STATE_DIR, `${targetKey}.json`);
+  const partialPath = resolve(basePath, PARTIAL_DIR, `${targetKey}.partial`);
+  const lockPath = resolve(basePath, LOCK_DIR, `${targetKey}.lock`);
+  for (const path of [finalPath, manifestPath, partialPath, lockPath]) {
+    if (!pathContains(basePath, path)) {
+      throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.INVALID_TARGET, "resolved managed download path escaped basePath");
+    }
+  }
+  return { basePath, bucket, checksum, fileName, finalPath, identityDigest, lockPath, manifestPath, partialPath, targetKey, url, urlDigest };
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson<T>(path: string): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function writeJson(path: string, payload: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Date.now().toString(36)}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  await rename(tmp, path);
+}
+
+async function directoryIsEmpty(path: string): Promise<boolean> {
+  const entries = await readdir(path);
+  return entries.length === 0;
+}
+
+function isStoreSentinel(value: unknown): value is StoreSentinel {
+  if (typeof value !== "object" || value == null || Array.isArray(value)) return false;
+  const record = value as Partial<StoreSentinel>;
+  return record.kind === STORE_KIND && record.schemaVersion === STORE_SCHEMA_VERSION && typeof record.createdAt === "string";
+}
+
+async function writeSentinel(basePath: string): Promise<void> {
+  await writeJson(join(basePath, STORE_SENTINEL), {
+    createdAt: new Date().toISOString(),
+    kind: STORE_KIND,
+    schemaVersion: STORE_SCHEMA_VERSION,
+  } satisfies StoreSentinel);
+}
+
+async function resetOwnedBase(basePath: string): Promise<void> {
+  const sentinel = await readJson<unknown>(join(basePath, STORE_SENTINEL));
+  if (!isStoreSentinel(sentinel)) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED, `download base is not owned: ${basePath}`);
+  }
+  const entries = await readdir(basePath).catch(() => []);
+  for (const entry of entries) {
+    await rm(join(basePath, entry), { force: true, recursive: true }).catch(() => undefined);
+  }
+  await writeSentinel(basePath);
+  await ensureStoreDirs(basePath);
+}
+
+async function ensureStoreDirs(basePath: string): Promise<void> {
+  await mkdir(join(basePath, STATE_DIR), { recursive: true });
+  await mkdir(join(basePath, PARTIAL_DIR), { recursive: true });
+  await mkdir(join(basePath, LOCK_DIR), { recursive: true });
+}
+
+async function ensureManagedBase(basePath: string): Promise<void> {
+  await mkdir(basePath, { recursive: true });
+  const entry = await lstat(basePath);
+  if (!entry.isDirectory() || entry.isSymbolicLink()) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED, `download base is not an owned directory: ${basePath}`);
+  }
+  const sentinelPath = join(basePath, STORE_SENTINEL);
+  const sentinel = await readJson<unknown>(sentinelPath);
+  if (sentinel == null) {
+    if (!(await directoryIsEmpty(basePath))) {
+      throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED, `download base is not empty and has no ownership marker: ${basePath}`);
+    }
+    await writeSentinel(basePath);
+  } else if (!isStoreSentinel(sentinel)) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED, `download base has an invalid ownership marker: ${basePath}`);
+  }
+  await ensureStoreDirs(basePath);
+}
+
+function isChecksum(value: unknown): value is ManagedDownloadChecksum {
+  if (typeof value !== "object" || value == null || Array.isArray(value)) return false;
+  const checksum = value as Partial<ManagedDownloadChecksum>;
+  return (
+    (checksum.algorithm === "sha256" || checksum.algorithm === "sha512") &&
+    typeof checksum.value === "string"
+  );
+}
+
+function isManifest(value: unknown): value is DownloadManifest {
+  if (typeof value !== "object" || value == null || Array.isArray(value)) return false;
+  const record = value as Partial<DownloadManifest>;
+  return (
+    record.kind === MANIFEST_KIND &&
+    record.schemaVersion === MANIFEST_SCHEMA_VERSION &&
+    typeof record.bucket === "string" &&
+    typeof record.fileName === "string" &&
+    typeof record.targetKey === "string" &&
+    typeof record.identityDigest === "string" &&
+    typeof record.urlDigest === "string" &&
+    isChecksum(record.checksum) &&
+    (record.state === "complete" || record.state === "partial") &&
+    typeof record.createdAt === "string" &&
+    typeof record.updatedAt === "string"
+  );
+}
+
+async function readManifest(path: string): Promise<DownloadManifest | "invalid" | null> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+    return isManifest(parsed) ? parsed : "invalid";
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return null;
+    return "invalid";
+  }
+}
+
+function manifestMatchesTarget(manifest: DownloadManifest, target: NormalizedTarget): boolean {
+  return (
+    manifest.bucket === target.bucket &&
+    manifest.fileName === target.fileName &&
+    manifest.targetKey === target.targetKey &&
+    manifest.identityDigest === target.identityDigest &&
+    manifest.urlDigest === target.urlDigest &&
+    manifest.checksum.algorithm === target.checksum.algorithm &&
+    manifest.checksum.value.toLowerCase() === target.checksum.value
+  );
+}
+
+function createManifest(
+  target: NormalizedTarget,
+  state: "complete" | "partial",
+  patch: Partial<Pick<DownloadManifest, "totalBytes" | "validators">> = {},
+): DownloadManifest {
+  const now = new Date().toISOString();
+  return {
+    bucket: target.bucket,
+    checksum: target.checksum,
+    createdAt: now,
+    fileName: target.fileName,
+    identityDigest: target.identityDigest,
+    kind: MANIFEST_KIND,
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    state,
+    targetKey: target.targetKey,
+    updatedAt: now,
+    urlDigest: target.urlDigest,
+    ...patch,
+  };
+}
+
+async function hashFile(path: string, algorithm: "sha256" | "sha512"): Promise<string> {
+  const hash = createHash(algorithm);
+  await pipeline(createReadStream(path), hash);
+  return hash.digest("hex");
+}
+
+async function statFileSize(path: string): Promise<number | null> {
+  try {
+    const entry = await stat(path);
+    return entry.isFile() ? entry.size : null;
+  } catch {
+    return null;
+  }
+}
+
+async function emitExistingProgress(path: string, totalBytes: number | undefined, emit: (progress: ManagedDownloadProgress) => void): Promise<void> {
+  const existing = await statFileSize(path);
+  if (existing == null || existing <= 0) return;
+  emit({ receivedBytes: existing, sessionReceivedBytes: 0, ...(totalBytes == null ? {} : { totalBytes }) });
+}
+
+function contentLength(response: Response): number | undefined {
+  const raw = response.headers.get("content-length");
+  if (raw == null) return undefined;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function validatorsFromResponse(response: Response): DownloadManifest["validators"] | undefined {
+  const etag = response.headers.get("etag") ?? undefined;
+  const lastModified = response.headers.get("last-modified") ?? undefined;
+  return etag == null && lastModified == null ? undefined : { ...(etag == null ? {} : { etag }), ...(lastModified == null ? {} : { lastModified }) };
+}
+
+function validatorsConflict(saved: DownloadManifest["validators"] | undefined, response: Response): boolean {
+  if (saved == null) return false;
+  const etag = response.headers.get("etag") ?? undefined;
+  const lastModified = response.headers.get("last-modified") ?? undefined;
+  if (saved.etag != null && etag != null && saved.etag !== etag) return true;
+  if (saved.lastModified != null && lastModified != null && saved.lastModified !== lastModified) return true;
+  return false;
+}
+
+function parseContentRange(value: string | null): { end: number; start: number; totalBytes?: number } | null {
+  if (value == null) return null;
+  const match = /^bytes\s+(\d+)-(\d+)\/(\d+|\*)$/i.exec(value.trim());
+  if (match?.[1] == null || match[2] == null || match[3] == null) return null;
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  const totalBytes = match[3] === "*" ? undefined : Number(match[3]);
+  if (!Number.isInteger(start) || !Number.isInteger(end) || end < start) return null;
+  if (totalBytes != null && (!Number.isInteger(totalBytes) || totalBytes <= end)) return null;
+  return { start, end, ...(totalBytes == null ? {} : { totalBytes }) };
+}
+
+async function writeResponseBodyToPartial(
+  response: Response,
+  target: NormalizedTarget,
+  options: {
+    emit: (progress: ManagedDownloadProgress) => void;
+    startBytes: number;
+    totalBytes?: number;
+  },
+): Promise<void> {
+  if (response.body == null) throw new Error("download response did not include a body");
+  let receivedBytes = options.startBytes;
+  let sessionReceivedBytes = 0;
+  const meter = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      receivedBytes += chunk.byteLength;
+      sessionReceivedBytes += chunk.byteLength;
+      options.emit({
+        receivedBytes,
+        sessionReceivedBytes,
+        ...(options.totalBytes == null ? {} : { totalBytes: options.totalBytes }),
+      });
+      callback(null, chunk);
+    },
+  });
+  await pipeline(
+    Readable.fromWeb(response.body as never),
+    meter,
+    createWriteStream(target.partialPath, { flags: options.startBytes > 0 ? "a" : "w" }),
+  );
+}
+
+async function tryResumeDownload(
+  target: NormalizedTarget,
+  manifest: DownloadManifest,
+  fetchImpl: typeof globalThis.fetch,
+  emit: (progress: ManagedDownloadProgress) => void,
+  requestHeaders: Record<string, string> | undefined,
+): Promise<DownloadAttemptResult | "restart"> {
+  const partialBytes = await statFileSize(target.partialPath);
+  if (partialBytes == null || partialBytes <= 0) return "restart";
+  const response = await fetchImpl(target.url, {
+    headers: {
+      ...(requestHeaders ?? {}),
+      ...(manifest.validators?.etag == null ? {} : { "If-Range": manifest.validators.etag }),
+      Range: `bytes=${partialBytes}-`,
+    },
+  });
+  if (response.status !== 206) return "restart";
+  const range = parseContentRange(response.headers.get("content-range"));
+  if (range == null || range.start !== partialBytes || validatorsConflict(manifest.validators, response)) {
+    return "restart";
+  }
+  const totalBytes = range.totalBytes ?? manifest.totalBytes ?? partialBytes + (contentLength(response) ?? 0);
+  await emitExistingProgress(target.partialPath, totalBytes, emit);
+  await writeJson(target.manifestPath, {
+    ...manifest,
+    state: "partial",
+    totalBytes,
+    updatedAt: new Date().toISOString(),
+    validators: manifest.validators ?? validatorsFromResponse(response),
+  } satisfies DownloadManifest);
+  await writeResponseBodyToPartial(response, target, { emit, startBytes: partialBytes, totalBytes });
+  return { resumed: true, totalBytes };
+}
+
+async function downloadFromZero(
+  target: NormalizedTarget,
+  fetchImpl: typeof globalThis.fetch,
+  emit: (progress: ManagedDownloadProgress) => void,
+  requestHeaders: Record<string, string> | undefined,
+): Promise<DownloadAttemptResult> {
+  await rm(target.partialPath, { force: true }).catch(() => undefined);
+  const response = await fetchImpl(target.url, { headers: requestHeaders });
+  if (!response.ok) throw new Error(`download request returned HTTP ${response.status}`);
+  const totalBytes = contentLength(response);
+  const validators = validatorsFromResponse(response);
+  await writeJson(target.manifestPath, createManifest(target, "partial", { totalBytes, validators }));
+  await writeResponseBodyToPartial(response, target, { emit, startBytes: 0, totalBytes });
+  return { resumed: false, totalBytes };
+}
+
+async function downloadWithRetries(
+  target: NormalizedTarget,
+  manifest: DownloadManifest | null,
+  options: {
+    emit: (progress: ManagedDownloadProgress) => void;
+    fetchImpl: typeof globalThis.fetch;
+    maxAttempts: number;
+    requestHeaders?: Record<string, string>;
+  },
+): Promise<DownloadAttemptResult> {
+  let lastError: unknown;
+  let nextManifest = manifest;
+  let resumed = false;
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
+    try {
+      if (nextManifest?.state === "partial") {
+        const resume = await tryResumeDownload(target, nextManifest, options.fetchImpl, options.emit, options.requestHeaders);
+        if (resume !== "restart") return { ...resume, resumed: true };
+        await rm(target.partialPath, { force: true }).catch(() => undefined);
+        nextManifest = null;
+      }
+      const full = await downloadFromZero(target, options.fetchImpl, options.emit, options.requestHeaders);
+      resumed = resumed || full.resumed;
+      return { ...full, resumed };
+    } catch (error) {
+      lastError = error;
+      const partialBytes = await statFileSize(target.partialPath);
+      if (partialBytes != null && partialBytes > 0) {
+        nextManifest = {
+          ...(nextManifest ?? createManifest(target, "partial")),
+          state: "partial",
+          updatedAt: new Date().toISOString(),
+        };
+        await writeJson(target.manifestPath, nextManifest).catch(() => undefined);
+      }
+    }
+  }
+  throw new ManagedDownloadError(
+    MANAGED_DOWNLOAD_ERROR_CODES.NETWORK_EXHAUSTED,
+    `download failed after ${options.maxAttempts} attempts: ${errorMessage(lastError)}`,
+  );
+}
+
+async function acquireLock(target: NormalizedTarget): Promise<AcquiredLock> {
+  await mkdir(dirname(target.lockPath), { recursive: true });
+  try {
+    await writeFile(target.lockPath, `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`, { flag: "wx" });
+    return { path: target.lockPath };
+  } catch (error) {
+    if (errorCode(error) === "EEXIST") {
+      throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.TARGET_LOCKED, `download target is locked: ${target.bucket}/${target.fileName}`);
+    }
+    throw error;
+  }
+}
+
+async function releaseLock(lock: AcquiredLock | null): Promise<void> {
+  if (lock == null) return;
+  await rm(lock.path, { force: true }).catch(() => undefined);
+}
+
+async function suspiciousReset(target: NormalizedTarget): Promise<ReusableState> {
+  await resetOwnedBase(target.basePath);
+  return { manifest: null, reset: true };
+}
+
+async function loadReusableState(target: NormalizedTarget): Promise<ReusableState> {
+  const manifest = await readManifest(target.manifestPath);
+  const finalExists = await pathExists(target.finalPath);
+  const partialExists = await pathExists(target.partialPath);
+  if (manifest === "invalid") {
+    return await suspiciousReset(target);
+  }
+  if (manifest == null) {
+    if (finalExists || partialExists) return await suspiciousReset(target);
+    return { manifest: null };
+  }
+  if (!manifestMatchesTarget(manifest, target)) {
+    return await suspiciousReset(target);
+  }
+  if (manifest.state === "complete") {
+    if (!finalExists) return await suspiciousReset(target);
+    const actual = await hashFile(target.finalPath, target.checksum.algorithm).catch(() => null);
+    if (actual !== target.checksum.value) return await suspiciousReset(target);
+    const bytes = await statFileSize(target.finalPath);
+    if (bytes == null) return await suspiciousReset(target);
+    return {
+      manifest,
+      result: {
+        bucket: target.bucket,
+        bytes,
+        checksum: target.checksum,
+        fileName: target.fileName,
+        path: target.finalPath,
+        reusedComplete: true,
+        resumed: false,
+        urlDigest: target.urlDigest,
+      },
+    };
+  }
+  if (!partialExists) return await suspiciousReset(target);
+  return { manifest };
+}
+
+async function runManagedDownload(
+  target: NormalizedTarget,
+  options: {
+    emit: (progress: ManagedDownloadProgress) => void;
+    fetchImpl: typeof globalThis.fetch;
+    maxAttempts: number;
+    requestHeaders?: Record<string, string>;
+  },
+): Promise<ManagedDownloadResult> {
+  await ensureManagedBase(target.basePath);
+  await pruneManagedDownloads({ basePath: target.basePath }).catch(() => undefined);
+  let lock: AcquiredLock | null = await acquireLock(target);
+  try {
+    let state = await loadReusableState(target);
+    if (state.result != null) return state.result;
+    if (state.reset === true) {
+      // A reset removes the lock as part of the managed base cleanup, so
+      // reacquire it before writing the fresh target state.
+      await releaseLock(lock);
+      lock = null;
+      await ensureManagedBase(target.basePath);
+      lock = await acquireLock(target);
+      state = await loadReusableState(target);
+      if (state.result != null) return state.result;
+      if (state.reset === true) {
+        throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_CORRUPT, "download state kept resetting after base cleanup");
+      }
+    }
+    const download = await downloadWithRetries(target, state.manifest, options);
+    const actual = await hashFile(target.partialPath, target.checksum.algorithm).catch((error: unknown) => {
+      throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_CORRUPT, `downloaded partial could not be hashed: ${errorMessage(error)}`);
+    });
+    if (actual !== target.checksum.value) {
+      await resetOwnedBase(target.basePath).catch(() => undefined);
+      throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.CHECKSUM_MISMATCH, "downloaded file checksum did not match requested payload", {
+        actual,
+        expected: target.checksum.value,
+      });
+    }
+
+    await mkdir(dirname(target.finalPath), { recursive: true });
+    if (await pathExists(target.finalPath)) {
+      const existing = await hashFile(target.finalPath, target.checksum.algorithm).catch(() => null);
+      if (existing !== target.checksum.value) {
+        await resetOwnedBase(target.basePath).catch(() => undefined);
+        throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_CORRUPT, "existing complete file did not match requested payload");
+      }
+      await rm(target.partialPath, { force: true }).catch(() => undefined);
+    } else {
+      await rename(target.partialPath, target.finalPath);
+    }
+    const bytes = await statFileSize(target.finalPath);
+    if (bytes == null) throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_CORRUPT, "complete file is missing after promotion");
+    await writeJson(target.manifestPath, createManifest(target, "complete", { totalBytes: download.totalBytes }));
+    return {
+      bucket: target.bucket,
+      bytes,
+      checksum: target.checksum,
+      fileName: target.fileName,
+      path: target.finalPath,
+      reusedComplete: false,
+      resumed: download.resumed,
+      urlDigest: target.urlDigest,
+    };
+  } finally {
+    await releaseLock(lock);
+  }
+}
+
+function activeKey(target: NormalizedTarget): string {
+  return `${target.basePath}\0${target.targetKey}\0${target.identityDigest}`;
+}
+
+function targetActiveKey(target: NormalizedTarget): string {
+  return `${target.basePath}\0${target.targetKey}`;
+}
+
+function waitForTask(
+  task: ActiveTask,
+  options: Pick<ManagedDownloadOptions, "onProgress" | "signal">,
+): Promise<ManagedDownloadResult> {
+  return new Promise<ManagedDownloadResult>((resolveWait, rejectWait) => {
+    if (options.signal?.aborted) {
+      rejectWait(new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.ABORTED, "download wait was aborted"));
+      return;
+    }
+    const listener = options.onProgress;
+    if (listener != null) task.listeners.add(listener);
+    const cleanup = () => {
+      if (listener != null) task.listeners.delete(listener);
+      options.signal?.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      rejectWait(new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.ABORTED, "download wait was aborted"));
+    };
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+    task.promise.then(
+      (result) => {
+        cleanup();
+        resolveWait(result);
+      },
+      (error: unknown) => {
+        cleanup();
+        rejectWait(error);
+      },
+    );
+  });
+}
+
+export async function managedDownload(options: ManagedDownloadOptions): Promise<ManagedDownloadResult> {
+  const target = targetFromOptions(options);
+  const key = activeKey(target);
+  const targetKey = targetActiveKey(target);
+  const existingForTarget = activeTargets.get(targetKey);
+  if (existingForTarget != null && existingForTarget !== key) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.TARGET_CONFLICT, `download target is already active with a different identity: ${target.bucket}/${target.fileName}`);
+  }
+  const existing = activeTasks.get(key);
+  if (existing != null) return await waitForTask(existing, options);
+
+  const listeners = new Set<(progress: ManagedDownloadProgress) => void>();
+  const emit = (progress: ManagedDownloadProgress) => {
+    for (const listener of listeners) listener(progress);
+  };
+  const task: ActiveTask = {
+    listeners,
+    targetKey,
+    promise: runManagedDownload(target, {
+      emit,
+      fetchImpl: options.fetch ?? globalThis.fetch,
+      maxAttempts: options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+      requestHeaders: options.payload.headers,
+    }),
+  };
+  activeTasks.set(key, task);
+  activeTargets.set(targetKey, key);
+  task.promise.finally(() => {
+    activeTasks.delete(key);
+    if (activeTargets.get(targetKey) === key) activeTargets.delete(targetKey);
+  }).catch(() => undefined);
+  return await waitForTask(task, options);
+}
+
+function acquireCopyLease(target: NormalizedTarget): CopyLease {
+  const key = targetActiveKey(target);
+  const state = copyLeases.get(key) ?? { clearRequested: false, count: 0, removeOptions: null };
+  state.count += 1;
+  copyLeases.set(key, state);
+  return { key };
+}
+
+async function requestClearAfterCopy(target: NormalizedTarget): Promise<"deferred" | "removed"> {
+  const key = targetActiveKey(target);
+  const state = copyLeases.get(key);
+  if (state != null && state.count > 1) {
+    state.clearRequested = true;
+    state.removeOptions = { basePath: target.basePath, bucket: target.bucket, fileName: target.fileName };
+    return "deferred";
+  }
+  await removeManagedDownload({ basePath: target.basePath, bucket: target.bucket, fileName: target.fileName });
+  return "removed";
+}
+
+async function releaseCopyLease(lease: CopyLease): Promise<void> {
+  const state = copyLeases.get(lease.key);
+  if (state == null) return;
+  state.count -= 1;
+  if (state.count > 0) return;
+  copyLeases.delete(lease.key);
+  if (state.clearRequested && state.removeOptions != null) {
+    await removeManagedDownload(state.removeOptions).catch(() => undefined);
+  }
+}
+
+export async function downloadCopyAndClear(options: DownloadCopyAndClearOptions): Promise<DownloadCopyAndClearResult> {
+  const target = targetFromOptions(options);
+  if (typeof options.outputPath !== "string" || options.outputPath.length === 0 || options.outputPath.includes("\0")) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.INVALID_TARGET, "outputPath must be a non-empty path");
+  }
+  const outputPath = resolve(options.outputPath);
+  if (!isAbsolute(outputPath)) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.INVALID_TARGET, `outputPath must resolve to an absolute path: ${options.outputPath}`);
+  }
+  const lease = acquireCopyLease(target);
+  try {
+    const downloaded = await managedDownload(options);
+    const existingOutput = await statFileSize(outputPath);
+    if (existingOutput != null) {
+      const existingDigest = await hashFile(outputPath, target.checksum.algorithm).catch(() => null);
+      if (existingDigest !== target.checksum.value) {
+        throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.OUTPUT_CONFLICT, `output already exists with different bytes: ${outputPath}`);
+      }
+    } else {
+      await atomicCopyFile(downloaded.path, outputPath);
+      const copiedDigest = await hashFile(outputPath, target.checksum.algorithm);
+      if (copiedDigest !== target.checksum.value) {
+        throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.CHECKSUM_MISMATCH, "copied output checksum did not match requested payload");
+      }
+    }
+    let cleanup: "deferred" | "removed" = "removed";
+    let cleanupWarning: string | undefined;
+    try {
+      cleanup = await requestClearAfterCopy(target);
+    } catch (error) {
+      cleanupWarning = errorMessage(error);
+    }
+    return {
+      bytes: downloaded.bytes,
+      cleanup,
+      ...(cleanupWarning == null ? {} : { cleanupWarning }),
+      outputPath,
+      reusedComplete: downloaded.reusedComplete,
+      resumed: downloaded.resumed,
+    };
+  } finally {
+    await releaseCopyLease(lease);
+  }
+}
+
+export async function inspectManagedDownload(options: RemoveManagedDownloadOptions): Promise<ManagedDownloadInspection> {
+  const target = targetFromOptions({
+    ...options,
+    payload: {
+      checksum: { algorithm: "sha256", value: "0".repeat(64) },
+      url: "https://example.invalid/",
+    },
+  });
+  await ensureManagedBase(target.basePath);
+  const rawManifest = await readManifest(target.manifestPath);
+  const manifest = rawManifest === "invalid" ? "unreadable" : rawManifest?.state ?? "missing";
+  return {
+    bucket: target.bucket,
+    complete: await pathExists(target.finalPath),
+    fileName: target.fileName,
+    manifest,
+    path: target.finalPath,
+  };
+}
+
+export async function removeManagedDownload(options: RemoveManagedDownloadOptions): Promise<RemoveManagedDownloadResult> {
+  const target = targetFromOptions({
+    ...options,
+    payload: {
+      checksum: { algorithm: "sha256", value: "0".repeat(64) },
+      url: "https://example.invalid/",
+    },
+  });
+  if (activeTargets.has(targetActiveKey(target))) {
+    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.TARGET_LOCKED, `download target is active: ${target.bucket}/${target.fileName}`);
+  }
+  await ensureManagedBase(target.basePath);
+  await Promise.all([
+    removePathBestEffort(target.finalPath),
+    removePathBestEffort(target.partialPath, { recursive: false }),
+    removePathBestEffort(target.manifestPath, { recursive: false }),
+    removePathBestEffort(target.lockPath, { recursive: false }),
+  ]);
+  const bucketPath = join(target.basePath, target.bucket);
+  const entries = await readdir(bucketPath).catch(() => null);
+  if (entries != null && entries.length === 0) await rm(bucketPath, { force: true, recursive: true }).catch(() => undefined);
+  return { removed: true };
+}
+
+async function removeEntriesOlderThan(root: string, olderThan: number): Promise<{ removed: number; warnings: string[] }> {
+  const warnings: string[] = [];
+  let removed = 0;
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    const info = await stat(path).catch(() => null);
+    if (info == null || info.mtimeMs > olderThan) continue;
+    const result = await removePathBestEffort(path);
+    if (result.removed) removed += 1;
+    else if (result.error != null) warnings.push(result.error);
+  }
+  return { removed, warnings };
+}
+
+export async function pruneManagedDownloads(options: PruneManagedDownloadsOptions): Promise<PruneManagedDownloadsResult> {
+  const basePath = normalizeBasePath(options.basePath);
+  await ensureManagedBase(basePath);
+  const olderThan = (options.now?.getTime() ?? Date.now()) - (options.olderThanMs ?? DEFAULT_PRUNE_OLDER_THAN_MS);
+  const roots = [join(basePath, STATE_DIR), join(basePath, PARTIAL_DIR), join(basePath, LOCK_DIR)];
+  let removed = 0;
+  const warnings: string[] = [];
+  for (const root of roots) {
+    const result = await removeEntriesOlderThan(root, olderThan);
+    removed += result.removed;
+    warnings.push(...result.warnings);
+  }
+  const bucketEntries = await readdir(basePath, { withFileTypes: true }).catch(() => []);
+  for (const entry of bucketEntries) {
+    if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+    const result = await removeEntriesOlderThan(join(basePath, entry.name), olderThan);
+    removed += result.removed;
+    warnings.push(...result.warnings);
+    const remaining = await readdir(join(basePath, entry.name)).catch(() => null);
+    if (remaining != null && remaining.length === 0) await rm(join(basePath, entry.name), { force: true, recursive: true }).catch(() => undefined);
+  }
+  return { removed, warnings };
+}

--- a/packages/download/src/index.ts
+++ b/packages/download/src/index.ts
@@ -15,7 +15,7 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
-import { atomicCopyFile, pathContains, removePathBestEffort } from "@open-design/platform";
+import { atomicCopyFile, isProcessAlive, pathContains, removePathBestEffort } from "@open-design/platform";
 
 const STORE_SENTINEL = ".open-design-download-root.json";
 const STATE_DIR = ".state";
@@ -194,6 +194,11 @@ type CopyLeaseState = {
 
 type AcquiredLock = {
   path: string;
+};
+
+type DownloadLockFile = {
+  createdAt: string;
+  pid: number;
 };
 
 type DownloadAttemptResult = {
@@ -400,6 +405,15 @@ function isManifest(value: unknown): value is DownloadManifest {
     typeof record.createdAt === "string" &&
     typeof record.updatedAt === "string"
   );
+}
+
+function isDownloadLockFile(value: unknown): value is DownloadLockFile {
+  if (typeof value !== "object" || value == null || Array.isArray(value)) return false;
+  const record = value as Partial<DownloadLockFile>;
+  return typeof record.createdAt === "string" &&
+    typeof record.pid === "number" &&
+    Number.isInteger(record.pid) &&
+    record.pid > 0;
 }
 
 async function readManifest(path: string): Promise<DownloadManifest | "invalid" | null> {
@@ -627,15 +641,31 @@ async function downloadWithRetries(
 
 async function acquireLock(target: NormalizedTarget): Promise<AcquiredLock> {
   await mkdir(dirname(target.lockPath), { recursive: true });
-  try {
-    await writeFile(target.lockPath, `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid })}\n`, { flag: "wx" });
-    return { path: target.lockPath };
-  } catch (error) {
-    if (errorCode(error) === "EEXIST") {
-      throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.TARGET_LOCKED, `download target is locked: ${target.bucket}/${target.fileName}`);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await writeFile(
+        target.lockPath,
+        `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid } satisfies DownloadLockFile)}\n`,
+        { flag: "wx" },
+      );
+      return { path: target.lockPath };
+    } catch (error) {
+      if (errorCode(error) === "EEXIST") {
+        const staleLockCleared = attempt === 0 && await clearStaleLock(target);
+        if (staleLockCleared) continue;
+        throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.TARGET_LOCKED, `download target is locked: ${target.bucket}/${target.fileName}`);
+      }
+      throw error;
     }
-    throw error;
   }
+  throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.TARGET_LOCKED, `download target is locked: ${target.bucket}/${target.fileName}`);
+}
+
+async function clearStaleLock(target: NormalizedTarget): Promise<boolean> {
+  const lock = await readJson<unknown>(target.lockPath);
+  if (!isDownloadLockFile(lock) || isProcessAlive(lock.pid)) return false;
+  await rm(target.lockPath, { force: true }).catch(() => undefined);
+  return true;
 }
 
 async function releaseLock(lock: AcquiredLock | null): Promise<void> {

--- a/packages/download/tests/index.test.ts
+++ b/packages/download/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -43,6 +44,21 @@ function tmpRoot(label: string): string {
 
 function sha256(body: Buffer | string): string {
   return createHash("sha256").update(body).digest("hex");
+}
+
+function targetKey(bucket: string, fileName: string): string {
+  return createHash("sha256").update(`${bucket}\0${fileName}`).digest("hex");
+}
+
+function lockPath(basePath: string, bucket: string, fileName: string): string {
+  return join(basePath, ".locks", `${targetKey(bucket, fileName)}.lock`);
+}
+
+function exitedPid(): number {
+  const child = spawnSync(process.execPath, ["-e", ""], { stdio: "ignore" });
+  if (child.error != null) throw child.error;
+  if (typeof child.pid !== "number") throw new Error("spawnSync did not expose a pid");
+  return child.pid;
 }
 
 function sendBody(response: ServerResponse, body: Buffer, options: { delayMs?: number } = {}): void {
@@ -246,6 +262,59 @@ describe("managed download package", () => {
       const result = await keeper;
       expect(readFileSync(result.path, "utf8")).toBe(body);
       expect(fixture.requests).toHaveLength(1);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("clears a stale pid lock before acquiring the target", async () => {
+    const body = "stale lock payload";
+    const fixture = await startFixture(body);
+    const root = tmpRoot("stale-lock");
+    const basePath = join(root, "downloads");
+    try {
+      await inspectManagedDownload({ basePath, bucket: "updates", fileName: "installer.bin" });
+      writeFileSync(lockPath(basePath, "updates", "installer.bin"), JSON.stringify({
+        createdAt: new Date().toISOString(),
+        pid: exitedPid(),
+      }));
+
+      const result = await managedDownload({
+        basePath,
+        bucket: "updates",
+        fileName: "installer.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+      });
+
+      expect(readFileSync(result.path, "utf8")).toBe(body);
+      expect(existsSync(lockPath(basePath, "updates", "installer.bin"))).toBe(false);
+      expect(fixture.requests).toHaveLength(1);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("quick-fails when the target lock pid is still alive", async () => {
+    const body = "alive lock payload";
+    const fixture = await startFixture(body);
+    const root = tmpRoot("alive-lock");
+    const basePath = join(root, "downloads");
+    try {
+      await inspectManagedDownload({ basePath, bucket: "updates", fileName: "installer.bin" });
+      writeFileSync(lockPath(basePath, "updates", "installer.bin"), JSON.stringify({
+        createdAt: new Date().toISOString(),
+        pid: process.pid,
+      }));
+
+      await expect(
+        managedDownload({
+          basePath,
+          bucket: "updates",
+          fileName: "installer.bin",
+          payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+        }),
+      ).rejects.toMatchObject({ code: MANAGED_DOWNLOAD_ERROR_CODES.TARGET_LOCKED });
+      expect(fixture.requests).toHaveLength(0);
     } finally {
       await fixture.close();
     }

--- a/packages/download/tests/index.test.ts
+++ b/packages/download/tests/index.test.ts
@@ -1,0 +1,346 @@
+import { createHash } from "node:crypto";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  MANAGED_DOWNLOAD_ERROR_CODES,
+  downloadCopyAndClear,
+  inspectManagedDownload,
+  managedDownload,
+  pruneManagedDownloads,
+  removeManagedDownload,
+  type ManagedDownloadProgress,
+} from "../src/index.js";
+
+type FixtureRequest = {
+  range?: string;
+};
+
+type FixtureServer = {
+  close(): Promise<void>;
+  requests: FixtureRequest[];
+  url: string;
+};
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function tmpRoot(label: string): string {
+  const root = mkdtempSync(join(tmpdir(), `od-download-${label}-`));
+  roots.push(root);
+  return root;
+}
+
+function sha256(body: Buffer | string): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+function sendBody(response: ServerResponse, body: Buffer, options: { delayMs?: number } = {}): void {
+  const send = () => {
+    response.end(body);
+  };
+  if (options.delayMs == null) send();
+  else setTimeout(send, options.delayMs);
+}
+
+async function startFixture(
+  body: Buffer | string,
+  options: {
+    delayMs?: number;
+    failFirstBytes?: number;
+    range?: boolean;
+  } = {},
+): Promise<FixtureServer> {
+  const payload = Buffer.isBuffer(body) ? body : Buffer.from(body);
+  const requests: FixtureRequest[] = [];
+  let requestCount = 0;
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    requestCount += 1;
+    const range = typeof request.headers.range === "string" ? request.headers.range : undefined;
+    requests.push({ ...(range == null ? {} : { range }) });
+
+    if (options.failFirstBytes != null && requestCount === 1) {
+      response.writeHead(200, {
+        "content-length": payload.byteLength,
+        "content-type": "application/octet-stream",
+        etag: '"fixture-etag"',
+      });
+      response.write(payload.subarray(0, options.failFirstBytes));
+      setTimeout(() => response.destroy(), 5);
+      return;
+    }
+
+    if (range != null && options.range !== false) {
+      const match = /^bytes=(\d+)-$/.exec(range);
+      const start = match?.[1] == null ? Number.NaN : Number(match[1]);
+      if (Number.isInteger(start) && start >= 0 && start < payload.byteLength) {
+        const chunk = payload.subarray(start);
+        response.writeHead(206, {
+          "content-length": chunk.byteLength,
+          "content-range": `bytes ${start}-${payload.byteLength - 1}/${payload.byteLength}`,
+          "content-type": "application/octet-stream",
+          etag: '"fixture-etag"',
+        });
+        sendBody(response, chunk, { delayMs: options.delayMs });
+        return;
+      }
+    }
+
+    response.writeHead(200, {
+      "content-length": payload.byteLength,
+      "content-type": "application/octet-stream",
+      etag: '"fixture-etag"',
+    });
+    sendBody(response, payload, { delayMs: options.delayMs });
+  });
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", rejectListen);
+      resolveListen();
+    });
+  });
+  const address = server.address();
+  if (address == null || typeof address === "string") throw new Error("fixture did not listen on tcp");
+  return {
+    close: () => new Promise<void>((resolveClose, rejectClose) => server.close((error) => (error == null ? resolveClose() : rejectClose(error)))),
+    requests,
+    url: `http://127.0.0.1:${address.port}/artifact.bin`,
+  };
+}
+
+describe("managed download package", () => {
+  it("downloads, copies to caller output, verifies, and clears managed state", async () => {
+    const body = "copy and clear payload";
+    const fixture = await startFixture(body);
+    const root = tmpRoot("copy-clear");
+    const outputPath = join(root, "out", "artifact.bin");
+    try {
+      const result = await downloadCopyAndClear({
+        basePath: join(root, "downloads"),
+        bucket: "artifacts",
+        fileName: "payload.bin",
+        outputPath,
+        payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+      });
+
+      expect(result.cleanup).toBe("removed");
+      expect(readFileSync(outputPath, "utf8")).toBe(body);
+      const inspected = await inspectManagedDownload({ basePath: join(root, "downloads"), bucket: "artifacts", fileName: "payload.bin" });
+      expect(inspected.complete).toBe(false);
+      expect(inspected.manifest).toBe("missing");
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("resumes a partial download when the server supports Range", async () => {
+    const body = "resumable payload from a flaky connection";
+    const fixture = await startFixture(body, { failFirstBytes: 9, range: true });
+    const root = tmpRoot("resume");
+    try {
+      const result = await managedDownload({
+        basePath: join(root, "downloads"),
+        bucket: "updates",
+        fileName: "installer.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+      });
+
+      expect(result.resumed).toBe(true);
+      expect(readFileSync(result.path, "utf8")).toBe(body);
+      expect(fixture.requests.some((request) => request.range?.startsWith("bytes="))).toBe(true);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("falls back to a full download when Range is not honored", async () => {
+    const body = "fallback payload from a server without range support";
+    const fixture = await startFixture(body, { failFirstBytes: 8, range: false });
+    const root = tmpRoot("range-fallback");
+    try {
+      const result = await managedDownload({
+        basePath: join(root, "downloads"),
+        bucket: "updates",
+        fileName: "installer.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+      });
+
+      expect(result.resumed).toBe(false);
+      expect(readFileSync(result.path, "utf8")).toBe(body);
+      expect(fixture.requests.some((request) => request.range?.startsWith("bytes="))).toBe(true);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("quick-fails a checksum mismatch after resetting owned state", async () => {
+    const fixture = await startFixture("wrong bytes");
+    const root = tmpRoot("checksum-mismatch");
+    await expect(
+      managedDownload({
+        basePath: join(root, "downloads"),
+        bucket: "updates",
+        fileName: "installer.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256("expected bytes") }, url: fixture.url },
+      }),
+    ).rejects.toMatchObject({ code: MANAGED_DOWNLOAD_ERROR_CODES.CHECKSUM_MISMATCH });
+    await fixture.close();
+  });
+
+  it("dedupes same-process callers and fans out progress", async () => {
+    const body = "dedupe payload";
+    const fixture = await startFixture(body, { delayMs: 40 });
+    const root = tmpRoot("dedupe");
+    const firstProgress: ManagedDownloadProgress[] = [];
+    const secondProgress: ManagedDownloadProgress[] = [];
+    try {
+      const input = {
+        basePath: join(root, "downloads"),
+        bucket: "shared",
+        fileName: "payload.bin",
+        payload: { checksum: { algorithm: "sha256" as const, value: sha256(body) }, url: fixture.url },
+      };
+      const [first, second] = await Promise.all([
+        managedDownload({ ...input, onProgress: (progress) => firstProgress.push(progress) }),
+        managedDownload({ ...input, onProgress: (progress) => secondProgress.push(progress) }),
+      ]);
+
+      expect(first.path).toBe(second.path);
+      expect(fixture.requests).toHaveLength(1);
+      expect(firstProgress.length).toBeGreaterThan(0);
+      expect(secondProgress.length).toBeGreaterThan(0);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("aborts only the caller wait while the shared transfer continues", async () => {
+    const body = "abort subscriber payload";
+    const fixture = await startFixture(body, { delayMs: 60 });
+    const root = tmpRoot("abort");
+    const controller = new AbortController();
+    try {
+      const input = {
+        basePath: join(root, "downloads"),
+        bucket: "shared",
+        fileName: "payload.bin",
+        payload: { checksum: { algorithm: "sha256" as const, value: sha256(body) }, url: fixture.url },
+      };
+      const aborted = managedDownload({ ...input, signal: controller.signal });
+      const keeper = managedDownload(input);
+      await sleep(5);
+      controller.abort();
+
+      await expect(aborted).rejects.toMatchObject({ code: MANAGED_DOWNLOAD_ERROR_CODES.ABORTED });
+      const result = await keeper;
+      expect(readFileSync(result.path, "utf8")).toBe(body);
+      expect(fixture.requests).toHaveLength(1);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("refuses to overwrite caller output when bytes differ", async () => {
+    const body = "output conflict payload";
+    const fixture = await startFixture(body);
+    const root = tmpRoot("output-conflict");
+    const outputPath = join(root, "artifact.bin");
+    writeFileSync(outputPath, "existing");
+    try {
+      await expect(
+        downloadCopyAndClear({
+          basePath: join(root, "downloads"),
+          bucket: "updates",
+          fileName: "installer.bin",
+          outputPath,
+          payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+        }),
+      ).rejects.toMatchObject({ code: MANAGED_DOWNLOAD_ERROR_CODES.OUTPUT_CONFLICT });
+      expect(readFileSync(outputPath, "utf8")).toBe("existing");
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("exposes explicit remove for managed targets", async () => {
+    const body = "remove payload";
+    const fixture = await startFixture(body);
+    const root = tmpRoot("remove");
+    const basePath = join(root, "downloads");
+    try {
+      const result = await managedDownload({
+        basePath,
+        bucket: "updates",
+        fileName: "installer.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+      });
+      expect(existsSync(result.path)).toBe(true);
+
+      await removeManagedDownload({ basePath, bucket: "updates", fileName: "installer.bin" });
+      expect((await inspectManagedDownload({ basePath, bucket: "updates", fileName: "installer.bin" })).complete).toBe(false);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("prunes managed data older than the default one-day window", async () => {
+    const body = "old payload";
+    const fixture = await startFixture(body);
+    const root = tmpRoot("prune");
+    const basePath = join(root, "downloads");
+    try {
+      await managedDownload({
+        basePath,
+        bucket: "updates",
+        fileName: "installer.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+      });
+
+      const pruned = await pruneManagedDownloads({ basePath, now: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000) });
+
+      expect(pruned.removed).toBeGreaterThan(0);
+      expect((await inspectManagedDownload({ basePath, bucket: "updates", fileName: "installer.bin" })).complete).toBe(false);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("resets suspicious complete state and redownloads from a clean base", async () => {
+    const body = "fresh payload";
+    const fixture = await startFixture(body);
+    const root = tmpRoot("suspicious-reset");
+    const basePath = join(root, "downloads");
+    try {
+      const first = await managedDownload({
+        basePath,
+        bucket: "updates",
+        fileName: "installer.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+      });
+      writeFileSync(first.path, "tampered bytes");
+
+      const second = await managedDownload({
+        basePath,
+        bucket: "updates",
+        fileName: "installer.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+      });
+
+      expect(readFileSync(second.path, "utf8")).toBe(body);
+      expect(fixture.requests.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      await fixture.close();
+    }
+  });
+});

--- a/packages/download/tsconfig.json
+++ b/packages/download/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "resolveJsonModule": true,
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/download/tsconfig.tests.json
+++ b/packages/download/tsconfig.tests.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -1,8 +1,8 @@
 import { execFile, spawn, type ChildProcess, type StdioOptions } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, rename, rm, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { extname, isAbsolute, join } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 export type CommandInvocation = {
@@ -59,6 +59,24 @@ export type StopProcessesResult = {
 
 export type HttpWaitOptions = {
   timeoutMs?: number;
+};
+
+export type AtomicCopyFileOptions = {
+  overwrite?: boolean;
+};
+
+export type AtomicCopyFileResult = {
+  bytesCopied: number;
+  replaced: boolean;
+};
+
+export type RemovePathBestEffortOptions = {
+  recursive?: boolean;
+};
+
+export type RemovePathBestEffortResult = {
+  error?: string;
+  removed: boolean;
 };
 
 type WindowsProcessRecord = {
@@ -148,6 +166,72 @@ function errorCode(error: unknown): string | null {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+export function pathContains(root: string, target: string): boolean {
+  const resolvedRoot = resolve(root);
+  const resolvedTarget = resolve(target);
+  const rel = relative(resolvedRoot, resolvedTarget);
+  return rel === "" || (rel.length > 0 && !rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function destinationExistsError(destinationPath: string): NodeJS.ErrnoException {
+  const error = new Error(`destination already exists: ${destinationPath}`) as NodeJS.ErrnoException;
+  error.code = "EEXIST";
+  return error;
+}
+
+export async function atomicCopyFile(
+  sourcePath: string,
+  destinationPath: string,
+  options: AtomicCopyFileOptions = {},
+): Promise<AtomicCopyFileResult> {
+  const source = resolve(sourcePath);
+  const destination = resolve(destinationPath);
+  if (source === destination) {
+    const entry = await stat(destination);
+    if (!entry.isFile()) throw new Error(`destination is not a file: ${destination}`);
+    return { bytesCopied: entry.size, replaced: true };
+  }
+
+  const destinationDir = dirname(destination);
+  await mkdir(destinationDir, { recursive: true });
+  const existing = await stat(destination).catch((error: unknown) => {
+    if (errorCode(error) === "ENOENT") return null;
+    throw error;
+  });
+  if (existing != null && options.overwrite !== true) {
+    throw destinationExistsError(destination);
+  }
+
+  const tempPath = join(
+    destinationDir,
+    `.${basename(destination)}.${process.pid}.${Date.now().toString(36)}.${Math.random().toString(36).slice(2)}.tmp`,
+  );
+  try {
+    await copyFile(source, tempPath);
+    if (options.overwrite === true) {
+      await rm(destination, { force: true });
+    }
+    await rename(tempPath, destination);
+    const copied = await stat(destination);
+    return { bytesCopied: copied.size, replaced: existing != null };
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function removePathBestEffort(
+  path: string,
+  options: RemovePathBestEffortOptions = {},
+): Promise<RemovePathBestEffortResult> {
+  try {
+    await rm(path, { force: true, recursive: options.recursive ?? true });
+    return { removed: true };
+  } catch (error) {
+    return { error: errorMessage(error), removed: false };
+  }
 }
 
 // `cmd.exe /s /c "..."` runs percent-expansion on the inner line *regardless*

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -1,15 +1,18 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  atomicCopyFile,
   createCommandInvocation,
   createPackageManagerInvocation,
   createProcessStampArgs,
   matchesStampedProcess,
+  pathContains,
   readProcessStampFromCommand,
+  removePathBestEffort,
   wellKnownUserToolchainBins,
   type ProcessStampContract,
 } from "../src/index.js";
@@ -85,6 +88,64 @@ describe("generic process stamp primitives", () => {
     expect(matchesStampedProcess({ command }, { app: "ui", namespace: stamp.namespace, source: "tool" }, fakeContract)).toBe(true);
     expect(matchesStampedProcess({ command }, { namespace: "stamp-boundary-b" }, fakeContract)).toBe(false);
     expect(matchesStampedProcess({ command }, { source: "pack" }, fakeContract)).toBe(false);
+  });
+});
+
+describe("generic filesystem primitives", () => {
+  it("recognizes paths contained by a resolved root", () => {
+    const root = join(tmpdir(), "platform-path-root");
+
+    expect(pathContains(root, join(root, "child", "file.txt"))).toBe(true);
+    expect(pathContains(root, root)).toBe(true);
+    expect(pathContains(root, join(root, "..", "outside.txt"))).toBe(false);
+  });
+
+  it("copies through a destination-local temporary file", async () => {
+    const root = mkdtempSync(join(tmpdir(), "platform-atomic-copy-"));
+    try {
+      const source = join(root, "source.bin");
+      const destination = join(root, "nested", "destination.bin");
+      writeFileSync(source, "atomic copy payload");
+
+      const result = await atomicCopyFile(source, destination);
+
+      expect(result).toEqual({ bytesCopied: "atomic copy payload".length, replaced: false });
+      expect(readFileSync(destination, "utf8")).toBe("atomic copy payload");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to replace an existing destination unless overwrite is explicit", async () => {
+    const root = mkdtempSync(join(tmpdir(), "platform-atomic-copy-exists-"));
+    try {
+      const source = join(root, "source.bin");
+      const destination = join(root, "destination.bin");
+      writeFileSync(source, "new payload");
+      writeFileSync(destination, "old payload");
+
+      await expect(atomicCopyFile(source, destination)).rejects.toMatchObject({ code: "EEXIST" });
+      expect(readFileSync(destination, "utf8")).toBe("old payload");
+
+      const overwritten = await atomicCopyFile(source, destination, { overwrite: true });
+      expect(overwritten.replaced).toBe(true);
+      expect(readFileSync(destination, "utf8")).toBe("new payload");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("removes paths best-effort without throwing on missing paths", async () => {
+    const root = mkdtempSync(join(tmpdir(), "platform-best-effort-rm-"));
+    const target = join(root, "target");
+    mkdirSync(target);
+    try {
+      expect((await removePathBestEffort(target)).removed).toBe(true);
+      expect(existsSync(target)).toBe(false);
+      expect((await removePathBestEffort(target)).removed).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       '@open-design/diagnostics':
         specifier: workspace:*
         version: link:../../packages/diagnostics
+      '@open-design/download':
+        specifier: workspace:*
+        version: link:../../packages/download
       '@open-design/host':
         specifier: workspace:*
         version: link:../../packages/host
@@ -395,6 +398,25 @@ importers:
       vitest:
         specifier: 4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(jsdom@29.1.1)(vite@7.3.3(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  packages/download:
+    dependencies:
+      '@open-design/platform':
+        specifier: workspace:*
+        version: link:../platform
+    devDependencies:
+      '@types/node':
+        specifier: 24.12.2
+        version: 24.12.2
+      esbuild:
+        specifier: 0.28.0
+        version: 0.28.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/host:
     devDependencies:

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -59,6 +59,7 @@ const residualAllowedExactPaths = new Set([
   "packages/agui-adapter/esbuild.config.mjs",
   "packages/contracts/esbuild.config.mjs",
   "packages/diagnostics/esbuild.config.mjs",
+  "packages/download/esbuild.config.mjs",
   "packages/host/esbuild.config.mjs",
   "packages/platform/esbuild.config.mjs",
   "packages/plugin-runtime/esbuild.config.mjs",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -8,6 +8,7 @@ const repoRoot = resolve(scriptDir, "..");
 
 const buildTargets = [
   "packages/contracts",
+  "packages/platform",
   "packages/download",
   "packages/host",
   "packages/registry-protocol",
@@ -15,7 +16,6 @@ const buildTargets = [
   "packages/plugin-runtime",
   "packages/sidecar-proto",
   "packages/sidecar",
-  "packages/platform",
   "packages/diagnostics",
   "tools/dev",
   "tools/pack",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -8,6 +8,7 @@ const repoRoot = resolve(scriptDir, "..");
 
 const buildTargets = [
   "packages/contracts",
+  "packages/download",
   "packages/host",
   "packages/registry-protocol",
   "packages/agui-adapter",

--- a/tools/serve/src/updater-fixture.ts
+++ b/tools/serve/src/updater-fixture.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { createServer, type Server } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 
 type UpdaterFixtureChannel = "stable" | "beta" | "nightly" | "preview";
 
@@ -60,6 +61,81 @@ function prereleaseCounterParts(version: string): { baseVersion: string; number:
     return { baseVersion: nightly[1], number: Number(nightly[2]) };
   }
   return null;
+}
+
+type ParsedRange = { end: number; start: number } | "invalid" | "unsatisfiable" | null;
+
+function parseNonNegativeInteger(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function parseByteRange(value: string | undefined, size: number): ParsedRange {
+  if (value == null) return null;
+  if (!value.startsWith("bytes=")) return "invalid";
+  const spec = value.slice("bytes=".length).trim();
+  if (spec.length === 0 || spec.includes(",")) return "invalid";
+
+  const match = /^(\d*)-(\d*)$/.exec(spec);
+  if (match == null) return "invalid";
+  const [, startText, endText] = match;
+  if (startText == null || endText == null || (startText.length === 0 && endText.length === 0)) {
+    return "invalid";
+  }
+  if (size <= 0) return "unsatisfiable";
+
+  if (startText.length === 0) {
+    const suffixLength = parseNonNegativeInteger(endText);
+    if (suffixLength == null || suffixLength === 0) return "invalid";
+    return {
+      end: size - 1,
+      start: Math.max(size - suffixLength, 0),
+    };
+  }
+
+  const start = parseNonNegativeInteger(startText);
+  if (start == null) return "invalid";
+  const end = endText.length === 0 ? size - 1 : parseNonNegativeInteger(endText);
+  if (end == null || start > end) return "invalid";
+  if (start >= size) return "unsatisfiable";
+  return {
+    end: Math.min(end, size - 1),
+    start,
+  };
+}
+
+function endWithOptionalBody(request: IncomingMessage, response: ServerResponse, body: Buffer | string): void {
+  response.end(request.method === "HEAD" ? undefined : body);
+}
+
+function sendArtifact(
+  request: IncomingMessage,
+  response: ServerResponse,
+  artifactBody: Buffer,
+  contentType: string,
+): void {
+  response.setHeader("accept-ranges", "bytes");
+  response.setHeader("content-type", contentType);
+  const range = parseByteRange(request.headers.range, artifactBody.byteLength);
+  if (range === "invalid" || range === "unsatisfiable") {
+    response.statusCode = 416;
+    response.setHeader("content-range", `bytes */${artifactBody.byteLength}`);
+    response.end();
+    return;
+  }
+
+  if (range != null) {
+    const body = artifactBody.subarray(range.start, range.end + 1);
+    response.statusCode = 206;
+    response.setHeader("content-length", String(body.byteLength));
+    response.setHeader("content-range", `bytes ${range.start}-${range.end}/${artifactBody.byteLength}`);
+    endWithOptionalBody(request, response, body);
+    return;
+  }
+
+  response.setHeader("content-length", String(artifactBody.byteLength));
+  endWithOptionalBody(request, response, artifactBody);
 }
 
 function normalizeChannel(value: string | undefined): UpdaterFixtureChannel {
@@ -170,9 +246,7 @@ export async function startUpdaterFixtureServer(options: UpdaterFixtureOptions =
       return;
     }
     if (path === `/${channel}/versions/${version}/${artifactName}`) {
-      response.setHeader("content-length", String(artifactBody.byteLength));
-      response.setHeader("content-type", contentType);
-      response.end(artifactBody);
+      sendArtifact(request, response, artifactBody, contentType);
       return;
     }
     if (path === `/${channel}/versions/${version}/${artifactName}.sha256`) {

--- a/tools/serve/tests/updater-fixture.test.ts
+++ b/tools/serve/tests/updater-fixture.test.ts
@@ -69,6 +69,50 @@ describe("updater fixture server", () => {
     }
   });
 
+  it("serves artifact byte ranges for resumable download validation", async () => {
+    const server = await startUpdaterFixtureServer({
+      artifactBody: "fixture artifact",
+      channel: "beta",
+      version: "2.0.0-beta-nightly.1",
+    });
+    try {
+      const rangedArtifact = await fetch(server.info.artifactUrl, {
+        headers: { range: "bytes=8-15" },
+      });
+      expect(rangedArtifact.status).toBe(206);
+      expect(rangedArtifact.headers.get("accept-ranges")).toBe("bytes");
+      expect(rangedArtifact.headers.get("content-range")).toBe("bytes 8-15/16");
+      expect(await rangedArtifact.text()).toBe("artifact");
+
+      const suffixArtifact = await fetch(server.info.artifactUrl, {
+        headers: { range: "bytes=-8" },
+      });
+      expect(suffixArtifact.status).toBe(206);
+      expect(suffixArtifact.headers.get("content-range")).toBe("bytes 8-15/16");
+      expect(await suffixArtifact.text()).toBe("artifact");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects unsatisfiable artifact byte ranges", async () => {
+    const server = await startUpdaterFixtureServer({
+      artifactBody: "fixture artifact",
+      channel: "beta",
+      version: "2.0.0-beta-nightly.1",
+    });
+    try {
+      const artifact = await fetch(server.info.artifactUrl, {
+        headers: { range: "bytes=100-120" },
+      });
+      expect(artifact.status).toBe(416);
+      expect(artifact.headers.get("accept-ranges")).toBe("bytes");
+      expect(artifact.headers.get("content-range")).toBe("bytes */16");
+    } finally {
+      await server.close();
+    }
+  });
+
   it("serves nightly and preview channel-specific release versions", async () => {
     const nightly = await startUpdaterFixtureServer({
       channel: "nightly",


### PR DESCRIPTION
## Why

This PR comes from the packaged updater hardening pass for the release/v0.8.0 line. The immediate use case was validating real nightly Windows updates under interruption, cache damage, and user restarts without exposing download internals in the app UI.

The pain being addressed is that updater delivery previously mixed UI state, download orchestration, and installer handoff too tightly. A network interruption, stale local state, or repeated install click could leave ambiguous behavior for users and weak evidence for release validation.

## What users will see

Packaged desktop users no longer see updater download/check/progress/error states in the left rail. When an update installer has been downloaded and verified, the rail shows a single final "Install update" entry. Clicking it opens a confirmation popover; choosing install keeps the popover in a loading handoff state while Open Design opens the installer and quits.

If the app does not close after the installer handoff, the prompt recovers after a conservative watchdog so the user can retry the idempotent installer handoff instead of seeing a blank gap.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

UI validation is covered by the packaged Windows updater acceptance harness and local manual nightly flow. Screenshot attachment will be added after the post-PR `win.spec.ts` acceptance pass if the PR surface requires a static artifact.

## Bug fix verification

- Test path that reproduces the behavior:
  - `apps/web/tests/components/UpdaterPopup.test.tsx`
  - `apps/web/tests/lib/updater.test.ts`
  - `apps/desktop/tests/main/updater.test.ts`
  - `e2e/specs/win.spec.ts`
- Did the test go red on `main` and green on this branch? no; this is a hardening/behavior convergence PR, not a single reported production bug.
- Additional verification: local packaged Windows nightly `.9 -> .10` manual flow confirmed IPC recovery across repeated user restarts, resumed download completion, active release placement, and ready-only UI.

## Validation

- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/e2e typecheck`
- `pnpm --filter @open-design/web test -- tests/components/UpdaterPopup.test.tsx tests/lib/updater.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/desktop test -- tests/main/updater.test.ts`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm tools-pack win build --dir .tmp\tools-pack-violent --namespace rg --to nsis --json`
- `OD_PACKAGED_E2E_WIN=1 OD_PACKAGED_E2E_NAMESPACE=rg OD_PACKAGED_E2E_TOOLS_PACK_DIR=.tmp/tools-pack-violent OD_PACKAGED_E2E_WIN_VERIFY_REINSTALL=0 pnpm test specs/win.spec.ts`
- `git diff --check`
- `pnpm guard`
- `pnpm typecheck`

Post-PR acceptance on final branch tip:

- `pnpm tools-pack win build --dir .tmp\tools-pack-violent --namespace rg --to nsis --json`
- `OD_PACKAGED_E2E_WIN=1 OD_PACKAGED_E2E_NAMESPACE=rg OD_PACKAGED_E2E_TOOLS_PACK_DIR=.tmp/tools-pack-violent OD_PACKAGED_E2E_WIN_VERIFY_REINSTALL=0 pnpm test specs/win.spec.ts`

Result: passed on 2026-05-22.

Key evidence from `.tmp/e2e-release-report/win/summary.json`:

- First resume used `Range: bytes=3262976-`.
- Second resume used `Range: bytes=3538944-`.
- Live lock quick-failed with `download-target-locked` and `artifactRequestsAfterLock: 0`.
- Root attack quick-failed with `update-store-invalid-shape`.
- Bad checksum path failed with `checksum-mismatch`.
- Ready UI showed `railTooltip: "安装更新"` and `primaryText: "安装更新"`.
- Installer handoff dry-run wrote an `installResult.path` under the managed update release directory.
