### PR TITLE
[codex] Fix release updater smoke recovery

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -198,6 +198,8 @@ type LoadedRelease = {
   ref: UpdateReleaseRef;
 };
 
+type ResolvedChecksumSnapshot = DesktopUpdateChecksumSnapshot & { value: string };
+
 type OwnedRoot =
   | { metadataPath: string; ok: true; realRoot: string }
   | { error: DesktopUpdateErrorSnapshot; ok: false };
@@ -509,6 +511,10 @@ function isChecksumSnapshot(value: unknown): value is DesktopUpdateChecksumSnaps
   if (value.value != null && typeof value.value !== "string") return false;
   if (value.url != null && typeof value.url !== "string") return false;
   return true;
+}
+
+function isResolvedChecksumSnapshot(value: unknown): value is ResolvedChecksumSnapshot {
+  return isChecksumSnapshot(value) && typeof value.value === "string" && value.value.length > 0;
 }
 
 function isUpdateReleaseRef(value: unknown): value is UpdateReleaseRef {
@@ -1343,6 +1349,60 @@ async function loadActiveRelease(
   return { ok: true, active: { path: artifactPath, ref: active } };
 }
 
+function checksumMatchesCandidate(checksum: ResolvedChecksumSnapshot, candidate: UpdateCandidate): boolean {
+  if (checksum.algorithm !== candidate.checksum.algorithm) return false;
+  if (candidate.checksum.url != null && checksum.url !== candidate.checksum.url) return false;
+  if (candidate.checksum.value != null && checksum.value.toLowerCase() !== candidate.checksum.value.toLowerCase()) return false;
+  return true;
+}
+
+async function loadVerifiedReleaseForCandidate(
+  root: OwnedRoot & { ok: true },
+  candidate: UpdateCandidate,
+): Promise<LoadedRelease | null> {
+  const releasesRoot = resolve(root.realRoot, RELEASES_DIR);
+  const entries = await readdir(releasesRoot, { withFileTypes: true }).catch(() => []);
+  const outputName = artifactFileName(candidate);
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const releaseDir = resolve(releasesRoot, entry.name);
+    if (!containsPath(root.realRoot, releaseDir)) continue;
+
+    const checksum = await readJson<unknown>(join(releaseDir, "checksum.json"));
+    if (!isResolvedChecksumSnapshot(checksum) || !checksumMatchesCandidate(checksum, candidate)) continue;
+    if (entry.name !== releaseKey(candidate, checksum)) continue;
+
+    const metadata = await readJson<unknown>(join(releaseDir, "metadata.json"));
+    if (!isRecord(metadata)) continue;
+
+    const artifactPath = resolve(releaseDir, outputName);
+    if (!containsPath(root.realRoot, artifactPath)) continue;
+    const artifactStat = await stat(artifactPath).catch(() => null);
+    if (artifactStat == null || !artifactStat.isFile()) continue;
+    const digest = await hashFile(artifactPath, checksum.algorithm).catch(() => null);
+    if (digest?.toLowerCase() !== checksum.value.toLowerCase()) continue;
+
+    const ref: UpdateReleaseRef = {
+      arch: candidate.arch,
+      artifact: candidate.artifact,
+      artifactPath: relative(root.realRoot, artifactPath),
+      checksum,
+      checksumPath: relative(root.realRoot, join(releaseDir, "checksum.json")),
+      channel: candidate.channel,
+      downloadedAt: artifactStat.mtime.toISOString(),
+      key: entry.name,
+      metadata,
+      metadataPath: relative(root.realRoot, join(releaseDir, "metadata.json")),
+      platformKey: candidate.platformKey,
+      version: candidate.version,
+    };
+    return { path: artifactPath, ref };
+  }
+
+  return null;
+}
+
 export function createDesktopUpdater(
   configInput: DesktopUpdaterConfigInput,
   deps: DesktopUpdaterDeps = {},
@@ -1534,6 +1594,29 @@ export function createDesktopUpdater(
         candidate = selected.candidate;
         metadata = selected.candidate.metadata;
         return setState(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      }
+      const openedForAdoption = await openStore();
+      if (openedForAdoption.ok) {
+        const adoptedRelease = await loadVerifiedReleaseForCandidate(openedForAdoption.root, selected.candidate);
+        if (adoptedRelease != null) {
+          candidate = selected.candidate;
+          activeRelease = adoptedRelease;
+          metadata = adoptedRelease.ref.metadata;
+          installFrozen = false;
+          installResult = undefined;
+          incomingRelease = null;
+          progress = undefined;
+          await writeStoreMetadata(openedForAdoption.root, {
+            ...openedForAdoption.metadata,
+            active: adoptedRelease.ref,
+            incoming: undefined,
+            installFrozen: false,
+            installResult: undefined,
+            lastCheckedAt,
+            version: STORE_METADATA_VERSION,
+          });
+          return setState(DESKTOP_UPDATE_STATES.DOWNLOADED);
+        }
       }
       candidate = selected.candidate;
       const available = activeRelease == null

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -628,6 +628,47 @@ describe("desktop updater", () => {
     }
   });
 
+  it("adopts a verified release directory when active metadata is missing", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const first = await updater.checkForUpdates();
+      expect(first.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(first.downloadPath).toEqual(expect.any(String));
+      expect(fixture.artifactRequests()).toBe(1);
+
+      await writeFile(join(root, "metadata.json"), JSON.stringify({
+        lastCheckedAt: first.lastCheckedAt,
+        version: 1,
+      }), "utf8");
+
+      const restarted = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+      const restored = await restarted.checkForUpdates();
+      const metadata = JSON.parse(await readFile(join(root, "metadata.json"), "utf8")) as Record<string, unknown>;
+
+      expect(restored.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(restored.downloadPath).toBe(first.downloadPath);
+      expect(restored.active?.path).toBe(first.downloadPath);
+      expect(metadata.active).toEqual(expect.any(Object));
+      expect(fixture.artifactRequests()).toBe(1);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("reports old flat updater stores as protocol errors without repairing them", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture();

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -64,6 +64,15 @@ const clickUpdaterInstallExpression = `
     return { clicked: true };
   })()
 `;
+const clickUpdaterRailExpression = `
+  (() => {
+    const button = document.querySelector('[data-testid="entry-nav-updater"]');
+    if (!(button instanceof HTMLButtonElement)) return { clicked: false, reason: 'missing-updater-rail' };
+    if (button.getAttribute('aria-disabled') === 'true') return { clicked: false, reason: 'updater-rail-disabled' };
+    button.click();
+    return { clicked: true };
+  })()
+`;
 
 type DesktopStatus = {
   state?: string;
@@ -224,9 +233,10 @@ macDescribe('packaged mac runtime smoke', () => {
         expect(value.health.version).toEqual(expect.any(String));
       }
 
-      const popup = await waitForUpdaterPopup();
+      const popup = await openReadyUpdaterPrompt(updaterFixture.info.version);
       expect(popup.visible).toBe(true);
-      expect(popup.title).toBe('Update ready');
+      expect(popup.title).toEqual(expect.any(String));
+      expect(popup.title?.trim().length).toBeGreaterThan(0);
       expect(popup.installButtonVisible).toBe(true);
       expect(popup.text ?? '').toContain(updaterFixture.info.version);
 
@@ -1662,8 +1672,25 @@ async function waitForHealthyDesktop(): Promise<MacInspectResult> {
   throw new Error(`packaged mac runtime did not become healthy: ${formatUnknown(lastResult)}`);
 }
 
-async function waitForUpdaterPopup(): Promise<UpdaterPopupEvalValue> {
-  const timeoutMs = 90_000;
+async function openReadyUpdaterPrompt(version: string): Promise<UpdaterPopupEvalValue> {
+  await clickUpdaterRailButton('open ready updater prompt');
+  return await waitForUpdaterPopupMatching(
+    (popup) => popup.visible && popup.installButtonVisible && (popup.text ?? '').includes(version),
+    'ready updater prompt',
+  );
+}
+
+async function clickUpdaterRailButton(label: string): Promise<void> {
+  const click = await runToolsPackJson<MacInspectResult>('inspect', ['--expr', clickUpdaterRailExpression]);
+  const value = assertUpdaterClickEvalValue(click.eval?.value);
+  expect(value.clicked, `${label}: ${value.reason ?? 'updater rail not clicked'}`).toBe(true);
+}
+
+async function waitForUpdaterPopupMatching(
+  predicate: (value: UpdaterPopupEvalValue) => boolean,
+  label: string,
+  timeoutMs = 90_000,
+): Promise<UpdaterPopupEvalValue> {
   const startedAt = Date.now();
   let lastResult: unknown = null;
 
@@ -1673,7 +1700,7 @@ async function waitForUpdaterPopup(): Promise<UpdaterPopupEvalValue> {
       lastResult = inspect;
       if (inspect.status?.state === 'running' && inspect.eval?.ok === true) {
         const value = asUpdaterPopupEvalValue(inspect.eval.value);
-        if (value?.visible === true && value.installButtonVisible === true) return value;
+        if (value != null && predicate(value)) return value;
       }
     } catch (error) {
       lastResult = error;
@@ -1681,7 +1708,7 @@ async function waitForUpdaterPopup(): Promise<UpdaterPopupEvalValue> {
     await delay(1000);
   }
 
-  throw new Error(`packaged mac updater popup did not appear: ${formatUnknown(lastResult)}`);
+  throw new Error(`${label}: updater popup timed out: ${formatUnknown(lastResult)}`);
 }
 
 async function waitForUpdaterInstallerOpened(): Promise<MacInspectResult> {


### PR DESCRIPTION
## Why

The `release-stable` nightly run on `release/v0.8.0` failed in `Build release mac arm64` after PR #2677 landed. The packaged updater reached `state=downloaded`, but the mac smoke still expected the updater prompt to appear automatically.

This PR fixes the release smoke expectation for the ready-only updater UI and addresses the adjacent restart recovery gap found during manual nightly validation: a verified package could remain in `updates/releases/*` while `metadata.json.active` was missing, causing the updater to start a fresh partial download instead of adopting the already verified artifact.

## What users will see

Users should see fewer redundant update downloads after interrupted/restarted updater sessions. Release validation should also pass the mac arm64 updater smoke by opening the ready prompt through the updater rail before clicking install.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no user-facing UI surface changes. The e2e smoke now drives the existing updater rail before asserting the existing ready prompt.

## Bug fix verification

- Test path that reproduces the bug:
  - `e2e/specs/mac.spec.ts` covers the failed release smoke path.
  - `apps/desktop/tests/main/updater.test.ts` covers adopting a verified release directory when active metadata is missing.
- Did the test go red on `main` and green on this branch? No. The mac smoke failure was observed directly in `release-stable` run `26275286256`, job `77338347628`; the orphaned release adoption issue was reproduced through manual nightly IPC/file probing, then encoded as a focused unit regression on this branch.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/desktop test -- updater.test.ts`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm -C e2e typecheck`
- `pnpm -C e2e test specs/mac.spec.ts` (skipped as expected without packaged env)
- `git diff --check`
- `pnpm guard`
- `pnpm typecheck` (existing Astro/Zod deprecation hints only)
