### PR TITLE
[codex] Fix mac updater smoke rail readiness

### DIFF
--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -233,7 +233,17 @@ macDescribe('packaged mac runtime smoke', () => {
         expect(value.health.version).toEqual(expect.any(String));
       }
 
-      const popup = await openReadyUpdaterPrompt(updaterFixture.info.version);
+      const updaterVersion = updaterFixture.info.version;
+      const readyUpdate = await waitForUpdaterStatus(
+        (status) =>
+          status.update?.state === 'downloaded' &&
+          status.update.availableVersion === updaterVersion &&
+          typeof status.update.downloadPath === 'string',
+        'ready updater prompt update downloaded',
+      );
+      expect(readyUpdate.update?.downloadPath).toEqual(expect.any(String));
+
+      const popup = await openReadyUpdaterPrompt(updaterVersion);
       expect(popup.visible).toBe(true);
       expect(popup.title).toEqual(expect.any(String));
       expect(popup.title?.trim().length).toBeGreaterThan(0);
@@ -1672,6 +1682,26 @@ async function waitForHealthyDesktop(): Promise<MacInspectResult> {
   throw new Error(`packaged mac runtime did not become healthy: ${formatUnknown(lastResult)}`);
 }
 
+async function waitForUpdaterStatus(
+  predicate: (inspect: MacInspectResult) => boolean,
+  label: string,
+  timeoutMs = 120_000,
+): Promise<MacInspectResult> {
+  const startedAt = Date.now();
+  let lastResult: unknown = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const inspect = await runToolsPackJson<MacInspectResult>('inspect', ['--update-action', 'status']);
+      lastResult = inspect;
+      if (predicate(inspect)) return inspect;
+    } catch (error) {
+      lastResult = error;
+    }
+    await delay(750);
+  }
+  throw new Error(`${label}: updater status timed out: ${formatUnknown(lastResult)}`);
+}
+
 async function openReadyUpdaterPrompt(version: string): Promise<UpdaterPopupEvalValue> {
   await clickUpdaterRailButton('open ready updater prompt');
   return await waitForUpdaterPopupMatching(
@@ -1680,10 +1710,21 @@ async function openReadyUpdaterPrompt(version: string): Promise<UpdaterPopupEval
   );
 }
 
-async function clickUpdaterRailButton(label: string): Promise<void> {
-  const click = await runToolsPackJson<MacInspectResult>('inspect', ['--expr', clickUpdaterRailExpression]);
-  const value = assertUpdaterClickEvalValue(click.eval?.value);
-  expect(value.clicked, `${label}: ${value.reason ?? 'updater rail not clicked'}`).toBe(true);
+async function clickUpdaterRailButton(label: string, timeoutMs = 90_000): Promise<void> {
+  const startedAt = Date.now();
+  let lastResult: unknown = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const click = await runToolsPackJson<MacInspectResult>('inspect', ['--expr', clickUpdaterRailExpression]);
+      const value = assertUpdaterClickEvalValue(click.eval?.value);
+      lastResult = value;
+      if (value.clicked) return;
+    } catch (error) {
+      lastResult = error;
+    }
+    await delay(750);
+  }
+  throw new Error(`${label}: updater rail did not become clickable: ${formatUnknown(lastResult)}`);
 }
 
 async function waitForUpdaterPopupMatching(


### PR DESCRIPTION
## Why

The `release-stable` mac arm64 job failed again after #2687 merged. This time the packaged mac smoke reached a healthy desktop/web/daemon runtime, then immediately failed with `missing-updater-rail` while trying to open the ready updater prompt.

The pain being addressed is release gating noise: the smoke was clicking the updater rail before the updater had reached the downloaded state and before the renderer had necessarily rendered the ready indicator. The app runtime was healthy; the test sequencing was too eager.

## What users will see

Nothing changes for end users. This only makes the packaged mac release smoke wait for the updater to be ready before opening the existing updater prompt.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This is a packaged smoke sequencing fix only.

## Bug fix verification

- Test path that reproduces the bug: `e2e/specs/mac.spec.ts`
- Did the test go red on `main` and green on this branch? Not on `main`; this targets `release/v0.8.0`. It went red locally on the release branch with `missing-updater-rail` and green after this change.
- Red command:
  `OD_PACKAGED_E2E_MAC=1 OD_PACKAGED_E2E_TOOLS_PACK_DIR=.tmp/tools-pack-mac-redgreen-stable OD_PACKAGED_E2E_NAMESPACE=rg-mac pnpm -C e2e test specs/mac.spec.ts`
- Green command:
  `OD_PACKAGED_E2E_MAC=1 OD_PACKAGED_E2E_TOOLS_PACK_DIR=.tmp/tools-pack-mac-redgreen-green OD_PACKAGED_E2E_NAMESPACE=rg-mac pnpm -C e2e test specs/mac.spec.ts`

## Validation

- `pnpm tools-pack mac build --dir .tmp/tools-pack-mac-redgreen-stable --namespace rg-mac --portable --app-version 0.8.0 --mac-compression normal --to all --json`
- Red local packaged smoke reproduced `missing-updater-rail`.
- Fresh-runtime green local packaged smoke passed: `1 passed | 15 skipped`, duration `33.90s`.
- `pnpm -C e2e typecheck`
- `git diff --check origin/release/v0.8.0...HEAD`
