### PR TITLE
fix(host): accept folder imports without entry files

### DIFF
--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -31,7 +31,7 @@ export type OpenDesignHostProjectImportInit = {
 
 export type OpenDesignHostProjectImportSuccess = {
   conversationId: string;
-  entryFile: string;
+  entryFile: string | null;
   ok: true;
   projectId: string;
 };
@@ -310,8 +310,11 @@ export function normalizeOpenDesignHostProjectImportResult(input: unknown): Open
   const rawProjectId = isRecord(project) ? project.id : null;
   const projectId = typeof rawProjectId === "string" ? rawProjectId : null;
   const conversationId = typeof response.conversationId === "string" ? response.conversationId : null;
-  const entryFile = typeof response.entryFile === "string" ? response.entryFile : null;
-  if (projectId == null || conversationId == null || entryFile == null) {
+  const entryFile =
+    typeof response.entryFile === "string" || response.entryFile === null
+      ? response.entryFile
+      : undefined;
+  if (projectId == null || conversationId == null || entryFile === undefined) {
     return failure("daemon import response did not include host project identifiers", response);
   }
 

--- a/packages/host/tests/index.test.ts
+++ b/packages/host/tests/index.test.ts
@@ -129,6 +129,29 @@ describe("open-design host contract", () => {
     expect(JSON.stringify(result)).not.toContain("resolvedDir");
   });
 
+  it("accepts imported folders with no detected entry file", () => {
+    const result = normalizeOpenDesignHostProjectImportResult({
+      ok: true,
+      response: {
+        project: {
+          id: "project-1",
+          name: "Imported source repo",
+          resolvedDir: "/private/path/that-must-not-cross",
+        },
+        conversationId: "conversation-1",
+        entryFile: null,
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      projectId: "project-1",
+      conversationId: "conversation-1",
+      entryFile: null,
+    });
+    expect(JSON.stringify(result)).not.toContain("resolvedDir");
+  });
+
   it("preserves canceled and structured failure project-import results", () => {
     expect(normalizeOpenDesignHostProjectImportResult({ canceled: true, ok: false })).toEqual({
       canceled: true,


### PR DESCRIPTION
Closes #1856

## Why

Issue #1856 reports that choosing a folder from the desktop app does not leave Open Design recognizing the selected code repository. I found the desktop host bridge rejecting successful folder-import daemon responses whenever the daemon could not detect a root HTML entry file. That is normal for many source repositories, where `entryFile` is intentionally `null` and the project should open to the file panel.

This PR fixes that host-side mismatch so source folders without an obvious HTML entry point still import and open as projects.

## What users will see

Desktop users can select a local code folder even when it has no root `index.html` or other detected HTML file. Open Design will open the imported project instead of showing a failed folder import.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `packages/host/tests/index.test.ts` (`accepts imported folders with no detected entry file`)
- Did the test go red on `main` and green on this branch? No; I did not switch this worktree back to `main`, but the previous host normalizer required `entryFile` to be a string, so the added `entryFile: null` case is the narrowed failing condition.

## Validation

- `pnpm --filter @open-design/host test`
- `pnpm --filter @open-design/host typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>