### PR TITLE
Fix viewport deck artifact preview alignment

### DIFF
--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1478,11 +1478,26 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   }
   function canSetActive(list){
     if (findActiveByClass(list) >= 0) return true;
-    if (viewportTransformTrack(list)) return true;
     for (var i=0; i<list.length; i++) {
       if (list[i].style.display === 'none') return true;
       if (list[i].style.visibility === 'hidden') return true;
       if (list[i].hasAttribute('hidden')) return true;
+    }
+    return false;
+  }
+  function tryAuthoredNavigation(target, list){
+    var track = viewportTransformTrack(list);
+    if (!track) return false;
+    var before = activeIndex(list);
+    var clamped = Math.max(0, Math.min(list.length - 1, target));
+    var diff = clamped - before;
+    if (!diff) { report(); return true; }
+    var key = diff > 0 ? 'ArrowRight' : 'ArrowLeft';
+    var n = Math.abs(diff);
+    for (var k = 0; k < n; k++) dispatchKey(key);
+    if (activeIndex(list) === clamped) {
+      setTimeout(report, 280);
+      return true;
     }
     return false;
   }
@@ -1552,6 +1567,8 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
       scrollGo(target);
       return;
     }
+    if (tryAuthoredNavigation(target, list)) return;
+    if (viewportTransformTrack(list) && setActive(target)) return;
     if (canSetActive(list) && setActive(target)) return;
     if (action === 'next') dispatchKey('ArrowRight');
     else if (action === 'prev') dispatchKey('ArrowLeft');
@@ -1564,6 +1581,8 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     if (!list.length) return;
     var target = Math.max(0, Math.min(list.length - 1, i));
     if (isScrollDeck()) { scrollGo(target); return; }
+    if (tryAuthoredNavigation(target, list)) return;
+    if (viewportTransformTrack(list) && setActive(target)) return;
     if (canSetActive(list) && setActive(target)) return;
     var current = activeIndex(list);
     var diff = target - current;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1386,7 +1386,45 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     if (document.body && document.body.scrollWidth > document.body.clientWidth + 1) return document.body;
     return document.scrollingElement || document.documentElement;
   }
+  function viewportTransformTrack(list){
+    if (!list || !list.length) return null;
+    var parent = list[0].parentElement;
+    if (!parent || parent === document.body) return null;
+    for (var i=1; i<list.length; i++) {
+      if (list[i].parentElement !== parent) return null;
+    }
+    try {
+      var parentStyle = window.getComputedStyle(parent);
+      var firstStyle = window.getComputedStyle(list[0]);
+      var parentClasses = parent.classList;
+      var hasTrackName = parent.id === 'deck' ||
+        (parentClasses && (
+          parentClasses.contains('deck') ||
+          parentClasses.contains('deck-track') ||
+          parentClasses.contains('slides')
+        ));
+      var fixedFlexTrack = parentStyle.position === 'fixed' && parentStyle.display.indexOf('flex') >= 0;
+      var computedTrackWidth = parseFloat(parentStyle.width || '0');
+      var viewportSized = (parent.style.width || '').indexOf('vw') >= 0 ||
+        (list[0].style.width || '').indexOf('vw') >= 0 ||
+        (list[0].style.flex || '').indexOf('vw') >= 0 ||
+        (firstStyle.width || '').indexOf('vw') >= 0 ||
+        (firstStyle.flexBasis || '').indexOf('vw') >= 0 ||
+        (Number.isFinite(computedTrackWidth) && computedTrackWidth > window.innerWidth + 1);
+      return hasTrackName && fixedFlexTrack && viewportSized ? parent : null;
+    } catch (_) {
+      return null;
+    }
+  }
+  function syncViewportTransformTrack(i, list){
+    var track = viewportTransformTrack(list);
+    if (!track) return false;
+    if (!track.style.width) track.style.width = (list.length * 100) + 'vw';
+    track.style.transform = 'translateX(' + (-i * 100) + 'vw)';
+    return true;
+  }
   function isScrollDeck(){
+    if (viewportTransformTrack(slides())) return false;
     var sc = scroller();
     return !!(sc && sc.scrollWidth > sc.clientWidth + 1);
   }
@@ -1440,6 +1478,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   }
   function canSetActive(list){
     if (findActiveByClass(list) >= 0) return true;
+    if (viewportTransformTrack(list)) return true;
     for (var i=0; i<list.length; i++) {
       if (list[i].style.display === 'none') return true;
       if (list[i].style.visibility === 'hidden') return true;
@@ -1486,6 +1525,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
         list[k].style.visibility = k === target ? '' : 'hidden';
       }
     }
+    syncViewportTransformTrack(target, list);
     updateDeckChrome(target, list.length);
     report();
     return true;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1492,9 +1492,12 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     var clamped = Math.max(0, Math.min(list.length - 1, target));
     var diff = clamped - before;
     if (!diff) { report(); return true; }
-    var key = diff > 0 ? 'ArrowRight' : 'ArrowLeft';
-    var n = Math.abs(diff);
-    for (var k = 0; k < n; k++) dispatchKey(key);
+    var key = null;
+    if (Math.abs(diff) === 1) key = diff > 0 ? 'ArrowRight' : 'ArrowLeft';
+    else if (clamped === 0) key = 'Home';
+    else if (clamped === list.length - 1) key = 'End';
+    if (!key) return false;
+    dispatchKey(key);
     if (activeIndex(list) === clamped) {
       setTimeout(report, 280);
       return true;

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-viewport-track.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-viewport-track.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { buildSrcdoc } from '../../src/runtime/srcdoc';
+
+function extractDeckBridgeScript(srcdoc: string): string {
+  const match = srcdoc.match(/<script data-od-deck-bridge>([\s\S]*?)<\/script>/);
+  if (!match || !match[1]) {
+    throw new Error('deck bridge script not found in srcdoc');
+  }
+  return match[1];
+}
+
+function setupViewportTrackDeck() {
+  const bodyHtml = `
+    <div id="deck" style="position: fixed; inset: 0; display: flex; width: 300vw; transform: translateX(0);">
+      <section class="slide active" style="width: 100vw; height: 100vh; flex: 0 0 100vw;">One</section>
+      <section class="slide" style="width: 100vw; height: 100vh; flex: 0 0 100vw;">Two</section>
+      <section class="slide" style="width: 100vw; height: 100vh; flex: 0 0 100vw;">Three</section>
+    </div>`;
+  const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    deck: true,
+  });
+  const script = extractDeckBridgeScript(srcdoc);
+  const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    runScripts: 'outside-only',
+    pretendToBeVisual: true,
+  });
+  const win = dom.window;
+  const parentPostMessage = vi.fn();
+  const scrollTo = vi.fn();
+
+  Object.defineProperty(win, 'innerWidth', { configurable: true, value: 1000 });
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage: parentPostMessage },
+  });
+  Object.defineProperty(win.document.body, 'clientWidth', { configurable: true, value: 1000 });
+  Object.defineProperty(win.document.body, 'scrollWidth', { configurable: true, value: 3000 });
+  Object.defineProperty(win.document.body, 'scrollLeft', { configurable: true, value: 0 });
+  Object.defineProperty(win.document.body, 'scrollTo', { configurable: true, value: scrollTo });
+
+  const evaluate = new win.Function(script);
+  evaluate.call(win);
+
+  return { win, scrollTo };
+}
+
+describe('deck bridge — fixed viewport transform tracks (#1531)', () => {
+  it('drives 100vw fixed tracks with translateX instead of document scrolling', () => {
+    const { win, scrollTo } = setupViewportTrackDeck();
+    const deck = win.document.getElementById('deck') as HTMLElement;
+    const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'next' },
+    }));
+
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(deck.style.transform).toBe('translateX(-100vw)');
+    expect(slides.map((slide) => slide.classList.contains('active'))).toEqual([false, true, false]);
+  });
+});

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-viewport-track.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-viewport-track.test.ts
@@ -18,7 +18,13 @@ function setupViewportTrackDeck() {
       <section class="slide active" style="width: 100vw; height: 100vh; flex: 0 0 100vw;">One</section>
       <section class="slide" style="width: 100vw; height: 100vh; flex: 0 0 100vw;">Two</section>
       <section class="slide" style="width: 100vw; height: 100vh; flex: 0 0 100vw;">Three</section>
-    </div>`;
+    </div>
+    <nav>
+      <button class="dot active" type="button">1</button>
+      <button class="dot" type="button">2</button>
+      <button class="dot" type="button">3</button>
+    </nav>
+    <div class="deck-progress"><span class="bar" style="width: 33.3333%;"></span></div>`;
   const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
     deck: true,
   });
@@ -44,6 +50,28 @@ function setupViewportTrackDeck() {
   const evaluate = new win.Function(script);
   evaluate.call(win);
 
+  let activeIndex = 0;
+  function applySlide(index: number) {
+    activeIndex = Math.max(0, Math.min(2, index));
+    const deck = win.document.getElementById('deck') as HTMLElement;
+    const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+    const dots = Array.from(win.document.querySelectorAll<HTMLElement>('.dot'));
+    const progress = win.document.querySelector<HTMLElement>('.deck-progress .bar');
+
+    deck.style.transform = `translateX(${-activeIndex * 100}vw)`;
+    slides.forEach((slide, slideIndex) => {
+      slide.classList.toggle('active', slideIndex === activeIndex);
+    });
+    dots.forEach((dot, dotIndex) => {
+      dot.classList.toggle('active', dotIndex === activeIndex);
+    });
+    if (progress) progress.style.width = `${((activeIndex + 1) / slides.length) * 100}%`;
+  }
+  win.document.addEventListener('keydown', (event) => {
+    if (event.key === 'ArrowRight') applySlide(activeIndex + 1);
+    if (event.key === 'ArrowLeft') applySlide(activeIndex - 1);
+  });
+
   return { win, scrollTo };
 }
 
@@ -52,6 +80,8 @@ describe('deck bridge — fixed viewport transform tracks (#1531)', () => {
     const { win, scrollTo } = setupViewportTrackDeck();
     const deck = win.document.getElementById('deck') as HTMLElement;
     const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+    const dots = Array.from(win.document.querySelectorAll<HTMLElement>('.dot'));
+    const progress = win.document.querySelector<HTMLElement>('.deck-progress .bar');
 
     win.dispatchEvent(new win.MessageEvent('message', {
       data: { type: 'od:slide', action: 'next' },
@@ -60,5 +90,7 @@ describe('deck bridge — fixed viewport transform tracks (#1531)', () => {
     expect(scrollTo).not.toHaveBeenCalled();
     expect(deck.style.transform).toBe('translateX(-100vw)');
     expect(slides.map((slide) => slide.classList.contains('active'))).toEqual([false, true, false]);
+    expect(dots.map((dot) => dot.classList.contains('active'))).toEqual([false, true, false]);
+    expect(progress?.style.width).toBe('66.66666666666666%');
   });
 });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-viewport-track.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-viewport-track.test.ts
@@ -75,6 +75,73 @@ function setupViewportTrackDeck() {
   return { win, scrollTo };
 }
 
+function setupLockedViewportTrackDeck() {
+  const bodyHtml = `
+    <div id="deck" style="position: fixed; inset: 0; display: flex; width: 300vw; transform: translateX(0);">
+      <section class="slide active dark" data-theme="dark" style="width: 100vw; height: 100vh; flex: 0 0 100vw;">One</section>
+      <section class="slide light" data-theme="light" style="width: 100vw; height: 100vh; flex: 0 0 100vw;">Two</section>
+      <section class="slide dark" data-theme="dark" style="width: 100vw; height: 100vh; flex: 0 0 100vw;">Three</section>
+    </div>
+    <nav>
+      <button class="dot active" type="button">1</button>
+      <button class="dot" type="button">2</button>
+      <button class="dot" type="button">3</button>
+    </nav>`;
+  const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    deck: true,
+  });
+  const script = extractDeckBridgeScript(srcdoc);
+  const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    runScripts: 'outside-only',
+    pretendToBeVisual: true,
+  });
+  const win = dom.window;
+  const parentPostMessage = vi.fn();
+  const scrollTo = vi.fn();
+
+  Object.defineProperty(win, 'innerWidth', { configurable: true, value: 1000 });
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage: parentPostMessage },
+  });
+  Object.defineProperty(win.document.body, 'clientWidth', { configurable: true, value: 1000 });
+  Object.defineProperty(win.document.body, 'scrollWidth', { configurable: true, value: 3000 });
+  Object.defineProperty(win.document.body, 'scrollLeft', { configurable: true, value: 0 });
+  Object.defineProperty(win.document.body, 'scrollTo', { configurable: true, value: scrollTo });
+
+  const evaluate = new win.Function(script);
+  evaluate.call(win);
+
+  let activeIndex = 0;
+  let locked = false;
+  function applySlide(index: number) {
+    if (locked) return;
+    activeIndex = Math.max(0, Math.min(2, index));
+    const deck = win.document.getElementById('deck') as HTMLElement;
+    const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+    const dots = Array.from(win.document.querySelectorAll<HTMLElement>('.dot'));
+
+    deck.style.transform = `translateX(${-activeIndex * 100}vw)`;
+    slides.forEach((slide, slideIndex) => {
+      slide.classList.toggle('active', slideIndex === activeIndex);
+    });
+    dots.forEach((dot, dotIndex) => {
+      dot.classList.toggle('active', dotIndex === activeIndex);
+    });
+    const theme = slides[activeIndex]?.dataset.theme ?? 'dark';
+    win.document.body.classList.toggle('light-bg', theme === 'light');
+    locked = true;
+  }
+  win.document.addEventListener('keydown', (event) => {
+    if (event.key === 'ArrowRight') applySlide(activeIndex + 1);
+    if (event.key === 'ArrowLeft') applySlide(activeIndex - 1);
+    if (event.key === 'Home') applySlide(0);
+    if (event.key === 'End') applySlide(2);
+  });
+
+  return { win, scrollTo };
+}
+
 describe('deck bridge — fixed viewport transform tracks (#1531)', () => {
   it('drives 100vw fixed tracks with translateX instead of document scrolling', () => {
     const { win, scrollTo } = setupViewportTrackDeck();
@@ -92,5 +159,22 @@ describe('deck bridge — fixed viewport transform tracks (#1531)', () => {
     expect(slides.map((slide) => slide.classList.contains('active'))).toEqual([false, true, false]);
     expect(dots.map((dot) => dot.classList.contains('active'))).toEqual([false, true, false]);
     expect(progress?.style.width).toBe('66.66666666666666%');
+  });
+
+  it('uses authored endpoint navigation instead of repeated arrows for locked track jumps', () => {
+    const { win, scrollTo } = setupLockedViewportTrackDeck();
+    const deck = win.document.getElementById('deck') as HTMLElement;
+    const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+    const dots = Array.from(win.document.querySelectorAll<HTMLElement>('.dot'));
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 2 },
+    }));
+
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(deck.style.transform).toBe('translateX(-200vw)');
+    expect(slides.map((slide) => slide.classList.contains('active'))).toEqual([false, false, true]);
+    expect(dots.map((dot) => dot.classList.contains('active'))).toEqual([false, false, true]);
+    expect(win.document.body.classList.contains('light-bg')).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #1531

## Why

This PR implements the fix for issue #1531. The `open-design-landing-deck` template uses a fixed full-viewport horizontal track with `100vw` slides and `translateX(...)` navigation, but the host srcdoc bridge could classify that shape as a scroll deck when the wide fixed track contributed to document overflow.

That sent host-driven navigation through document scrolling instead of moving the deck track, which can leave the artifact preview cropped with a gutter on the right.

## What users will see

Full-viewport horizontal deck artifacts like `open-design-landing-deck` stay aligned in the artifact preview when the host drives slide navigation. The first slide remains fully visible and next/previous controls keep the translated track aligned with the preview viewport.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The changed path is the injected sandbox bridge behavior for existing artifact previews; regression coverage exercises the full-viewport deck shape and host navigation contract directly.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/runtime/srcdoc-deck-bridge-viewport-track.test.ts`
- Did the test go red on `main` and green on this branch? yes. Before the fix it called `body.scrollTo({ left: 1000 })` for a fixed `100vw` transform track; after the fix it updates `translateX(-100vw)` and active slide state instead.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/runtime/srcdoc-deck-bridge-viewport-track.test.ts tests/runtime/srcdoc-deck-bridge-framework-deck.test.ts tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts tests/runtime/srcdoc.test.ts` from `apps/web`
- `pnpm guard`
- `pnpm typecheck`
