### PR TITLE
Fix Design Files workspace loading

### DIFF
--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -21,6 +21,7 @@ import {
 } from '../providers/registry';
 import {
   createConversation,
+  getProject,
   listConversations,
   listMessages,
   loadTabs,
@@ -722,6 +723,12 @@ export function DesignSystemDetailView({
       if (cancelled) return;
       if (!workspace) {
         if (fallbackProjectId) {
+          const fallbackProject = await getProject(fallbackProjectId);
+          if (cancelled) return;
+          if (!fallbackProject) {
+            setWorkspaceLoadError('Could not open the design system workspace.');
+            return;
+          }
           const files = await fetchProjectFiles(fallbackProjectId);
           if (cancelled) return;
           setWorkspaceProjectId(fallbackProjectId);

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -96,6 +96,11 @@ interface DetailProps {
 type SetupStep = 'setup' | 'confirm';
 type ReviewTab = 'system' | 'files';
 
+interface ResolvedDesignSystemWorkspaceProject {
+  projectId: string;
+  files: ProjectFile[];
+}
+
 interface SetupState {
   company: string;
   githubUrl: string;
@@ -183,6 +188,26 @@ function readRememberedGenerationJob(designSystemId: string): string | null {
   } catch {
     return null;
   }
+}
+
+async function resolveDesignSystemWorkspaceProject(
+  system: Pick<DesignSystemDetail, 'id' | 'projectId'>,
+): Promise<ResolvedDesignSystemWorkspaceProject | null> {
+  const workspace = await ensureDesignSystemWorkspace(system.id);
+  if (workspace) {
+    return {
+      projectId: workspace.project.id,
+      files: workspace.files,
+    };
+  }
+  if (!system.projectId) return null;
+  const fallbackProject = await getProject(system.projectId);
+  if (!fallbackProject) return null;
+  const files = await fetchProjectFiles(system.projectId);
+  return {
+    projectId: system.projectId,
+    files,
+  };
 }
 
 function clearRememberedGenerationJob(designSystemId: string): void {
@@ -714,38 +739,19 @@ export function DesignSystemDetailView({
 
   useEffect(() => {
     if (!system) return undefined;
-    const designSystemId = system.id;
-    const fallbackProjectId = system.projectId;
+    const currentSystem = system;
     let cancelled = false;
     async function syncWorkspaceProject() {
       setWorkspaceLoadError(null);
-      const workspace = await ensureDesignSystemWorkspace(designSystemId);
+      const resolved = await resolveDesignSystemWorkspaceProject(currentSystem);
       if (cancelled) return;
-      if (!workspace) {
-        if (fallbackProjectId) {
-          const fallbackProject = await getProject(fallbackProjectId);
-          if (cancelled) return;
-          if (!fallbackProject) {
-            setWorkspaceLoadError('Could not open the design system workspace.');
-            return;
-          }
-          const files = await fetchProjectFiles(fallbackProjectId);
-          if (cancelled) return;
-          setWorkspaceProjectId(fallbackProjectId);
-          setWorkspaceProjectFiles(files);
-          if (onOpenProject && openedProjectRef.current !== fallbackProjectId) {
-            openedProjectRef.current = fallbackProjectId;
-            await onProjectsRefresh?.();
-            if (!cancelled) onOpenProject(fallbackProjectId);
-          }
-          return;
-        }
+      if (!resolved) {
         setWorkspaceLoadError('Could not open the design system workspace.');
         return;
       }
-      const projectId = workspace.project.id;
+      const projectId = resolved.projectId;
       setWorkspaceProjectId(projectId);
-      setWorkspaceProjectFiles(workspace.files);
+      setWorkspaceProjectFiles(resolved.files);
       if (onOpenProject && openedProjectRef.current !== projectId) {
         openedProjectRef.current = projectId;
         await onProjectsRefresh?.();
@@ -1022,11 +1028,11 @@ export function DesignSystemDetailView({
   async function ensureWorkspaceProject() {
     if (!system) return workspaceProjectId;
     if (workspaceProjectId) return workspaceProjectId;
-    const workspace = await ensureDesignSystemWorkspace(system.id);
-    if (!workspace) return null;
-    setWorkspaceProjectId(workspace.project.id);
-    setWorkspaceProjectFiles(workspace.files);
-    return workspace.project.id;
+    const resolved = await resolveDesignSystemWorkspaceProject(system);
+    if (!resolved) return null;
+    setWorkspaceProjectId(resolved.projectId);
+    setWorkspaceProjectFiles(resolved.files);
+    return resolved.projectId;
   }
 
   const refreshWorkspaceProjectFiles = useCallback(async (projectId: string) => {

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -663,6 +663,7 @@ export function DesignSystemDetailView({
   const [chatSeed, setChatSeed] = useState<{ id: string; text: string } | null>(null);
   const [workspaceProjectId, setWorkspaceProjectId] = useState<string | null>(null);
   const [workspaceProjectFiles, setWorkspaceProjectFiles] = useState<ProjectFile[]>([]);
+  const [workspaceLoadError, setWorkspaceLoadError] = useState<string | null>(null);
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
   const [projectChatMessages, setProjectChatMessages] = useState<ChatMessage[]>([]);
@@ -685,6 +686,7 @@ export function DesignSystemDetailView({
     setRevisions([]);
     setWorkspaceProjectId(null);
     setWorkspaceProjectFiles([]);
+    setWorkspaceLoadError(null);
     setConversations([]);
     setActiveConversationId(null);
     setProjectChatMessages([]);
@@ -710,18 +712,37 @@ export function DesignSystemDetailView({
   }, [id]);
 
   useEffect(() => {
-    if (!system || system.source !== 'user') return undefined;
+    if (!system) return undefined;
     const designSystemId = system.id;
+    const fallbackProjectId = system.projectId;
     let cancelled = false;
     async function syncWorkspaceProject() {
+      setWorkspaceLoadError(null);
       const workspace = await ensureDesignSystemWorkspace(designSystemId);
-      if (cancelled || !workspace) return;
-      setWorkspaceProjectId(workspace.project.id);
+      if (cancelled) return;
+      if (!workspace) {
+        if (fallbackProjectId) {
+          const files = await fetchProjectFiles(fallbackProjectId);
+          if (cancelled) return;
+          setWorkspaceProjectId(fallbackProjectId);
+          setWorkspaceProjectFiles(files);
+          if (onOpenProject && openedProjectRef.current !== fallbackProjectId) {
+            openedProjectRef.current = fallbackProjectId;
+            await onProjectsRefresh?.();
+            if (!cancelled) onOpenProject(fallbackProjectId);
+          }
+          return;
+        }
+        setWorkspaceLoadError('Could not open the design system workspace.');
+        return;
+      }
+      const projectId = workspace.project.id;
+      setWorkspaceProjectId(projectId);
       setWorkspaceProjectFiles(workspace.files);
-      if (onOpenProject && openedProjectRef.current !== workspace.project.id) {
-        openedProjectRef.current = workspace.project.id;
+      if (onOpenProject && openedProjectRef.current !== projectId) {
+        openedProjectRef.current = projectId;
         await onProjectsRefresh?.();
-        if (!cancelled) onOpenProject(workspace.project.id);
+        if (!cancelled) onOpenProject(projectId);
       }
     }
     void syncWorkspaceProject();
@@ -1576,6 +1597,8 @@ export function DesignSystemDetailView({
                 tabsState={workspaceTabsState}
                 onTabsStateChange={persistWorkspaceTabsState}
               />
+            ) : workspaceLoadError ? (
+              <div className="viewer-empty">{workspaceLoadError}</div>
             ) : (
               <div className="viewer-empty">Opening the design system workspace...</div>
             )}

--- a/apps/web/tests/components/DesignSystemFlow.test.tsx
+++ b/apps/web/tests/components/DesignSystemFlow.test.tsx
@@ -12,7 +12,7 @@ import {
   DesignSystemCreationFlow,
   DesignSystemDetailView,
 } from '../../src/components/DesignSystemFlow';
-import type { AppConfig, DesignSystemDetail, Project } from '../../src/types';
+import type { AppConfig, DesignSystemDetail, Project, ProjectFile } from '../../src/types';
 import { I18nProvider } from '../../src/i18n';
 
 const mocks = vi.hoisted(() => ({
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   fetchDesignSystemRevisions: vi.fn(),
   fetchProjectDesignSystemPackageAudit: vi.fn(),
   fetchProjectFiles: vi.fn(),
+  getProject: vi.fn(),
   openFolderDialog: vi.fn(),
   patchProject: vi.fn(),
   createConversation: vi.fn(),
@@ -91,6 +92,7 @@ vi.mock('../../src/state/projects', async () => {
   return {
     ...actual,
     createConversation: mocks.createConversation,
+    getProject: mocks.getProject,
     listConversations: mocks.listConversations,
     listMessages: mocks.listMessages,
     loadTabs: mocks.loadTabs,
@@ -114,6 +116,7 @@ beforeEach(() => {
   mocks.fetchDesignSystemRevisions.mockResolvedValue([]);
   mocks.fetchProjectDesignSystemPackageAudit.mockResolvedValue(null);
   mocks.fetchProjectFiles.mockResolvedValue([]);
+  mocks.getProject.mockResolvedValue(null);
   mocks.fetchConnectorStatuses.mockResolvedValue({});
   mocks.createConversation.mockResolvedValue(null);
   mocks.listConversations.mockResolvedValue([]);
@@ -1827,6 +1830,135 @@ describe('DesignSystemDetailView', () => {
     await waitFor(() => expect(mocks.ensureDesignSystemWorkspace).toHaveBeenCalledWith(system.id));
     await waitFor(() => expect(screen.getByTestId('design-system-files')).toBeTruthy());
     expect(screen.queryByText('Opening the design system workspace...')).toBeNull();
+  });
+
+  it('opens the existing project fallback when workspace creation returns null', async () => {
+    const system: DesignSystemDetail = {
+      id: 'user:acme-design-system',
+      title: 'Acme Design System',
+      category: 'Custom',
+      summary: 'Acme product workspace.',
+      swatches: [],
+      surface: 'web',
+      body: '# Acme Design System\n',
+      source: 'user',
+      status: 'draft',
+      isEditable: true,
+      projectId: 'ds-acme-design-system',
+    };
+    const project: Project = {
+      id: 'ds-acme-design-system',
+      name: 'Acme Design System',
+      skillId: null,
+      designSystemId: system.id,
+      createdAt: 1,
+      updatedAt: 1,
+      metadata: {
+        kind: 'other',
+        importedFrom: 'design-system',
+        entryFile: 'DESIGN.md',
+        sourceFileName: system.id,
+      },
+    };
+    const files: ProjectFile[] = [
+      { name: 'DESIGN.md', size: 42, mtime: 1, kind: 'text', mime: 'text/markdown' },
+    ];
+    const config: AppConfig = {
+      mode: 'daemon',
+      apiKey: '',
+      baseUrl: '',
+      model: '',
+      agentId: 'agent-1',
+      agentModels: {},
+      skillId: null,
+      designSystemId: null,
+    };
+    const onOpenProject = vi.fn();
+    const onProjectsRefresh = vi.fn();
+
+    mocks.fetchDesignSystem.mockResolvedValue(system);
+    mocks.ensureDesignSystemWorkspace.mockResolvedValue(null);
+    mocks.getProject.mockResolvedValue(project);
+    mocks.fetchProjectFiles.mockResolvedValue(files);
+    mocks.listConversations.mockResolvedValue([
+      { id: 'conv-design-system', projectId: project.id, title: 'Design system', createdAt: 1, updatedAt: 1 },
+    ]);
+
+    render(
+      <DesignSystemDetailView
+        id={system.id}
+        selectedId={system.id}
+        config={config}
+        agents={[{ id: 'agent-1', name: 'OpenCode', bin: 'opencode', available: true, models: [] }]}
+        onBack={() => {}}
+        onSetDefault={() => {}}
+        onOpenProject={onOpenProject}
+        onProjectsRefresh={onProjectsRefresh}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Design Files' }));
+
+    await waitFor(() => expect(mocks.ensureDesignSystemWorkspace).toHaveBeenCalledWith(system.id));
+    await waitFor(() => expect(mocks.getProject).toHaveBeenCalledWith(project.id));
+    expect(mocks.fetchProjectFiles).toHaveBeenCalledWith(project.id);
+    await waitFor(() => expect(screen.getByTestId('design-system-files')).toBeTruthy());
+    expect(onProjectsRefresh).toHaveBeenCalledTimes(1);
+    expect(onOpenProject).toHaveBeenCalledWith(project.id);
+    expect(screen.queryByText('Could not open the design system workspace.')).toBeNull();
+  });
+
+  it('shows a terminal error when workspace creation and project fallback both fail', async () => {
+    const system: DesignSystemDetail = {
+      id: 'user:acme-design-system',
+      title: 'Acme Design System',
+      category: 'Custom',
+      summary: 'Acme product workspace.',
+      swatches: [],
+      surface: 'web',
+      body: '# Acme Design System\n',
+      source: 'user',
+      status: 'draft',
+      isEditable: true,
+      projectId: 'ds-acme-design-system',
+    };
+    const config: AppConfig = {
+      mode: 'daemon',
+      apiKey: '',
+      baseUrl: '',
+      model: '',
+      agentId: 'agent-1',
+      agentModels: {},
+      skillId: null,
+      designSystemId: null,
+    };
+    const onOpenProject = vi.fn();
+
+    mocks.fetchDesignSystem.mockResolvedValue(system);
+    mocks.ensureDesignSystemWorkspace.mockResolvedValue(null);
+    mocks.getProject.mockResolvedValue(null);
+
+    render(
+      <DesignSystemDetailView
+        id={system.id}
+        selectedId={system.id}
+        config={config}
+        agents={[{ id: 'agent-1', name: 'OpenCode', bin: 'opencode', available: true, models: [] }]}
+        onBack={() => {}}
+        onSetDefault={() => {}}
+        onOpenProject={onOpenProject}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Design Files' }));
+
+    await waitFor(() => expect(mocks.ensureDesignSystemWorkspace).toHaveBeenCalledWith(system.id));
+    await waitFor(() => expect(mocks.getProject).toHaveBeenCalledWith(system.projectId));
+    expect(mocks.fetchProjectFiles).not.toHaveBeenCalled();
+    expect(onOpenProject).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByText('Could not open the design system workspace.')).toBeTruthy());
+    expect(screen.queryByText('Opening the design system workspace...')).toBeNull();
+    expect(screen.queryByTestId('design-system-files')).toBeNull();
   });
 
   it('passes the current UI locale to daemon workspace chat runs', async () => {

--- a/apps/web/tests/components/DesignSystemFlow.test.tsx
+++ b/apps/web/tests/components/DesignSystemFlow.test.tsx
@@ -1961,6 +1961,92 @@ describe('DesignSystemDetailView', () => {
     expect(screen.queryByTestId('design-system-files')).toBeNull();
   });
 
+  it('sends chat through an existing project fallback when workspace creation returns null', async () => {
+    const system: DesignSystemDetail = {
+      id: 'user:acme-design-system',
+      title: 'Acme Design System',
+      category: 'Custom',
+      summary: 'Acme product workspace.',
+      swatches: [],
+      surface: 'web',
+      body: '# Acme Design System\n',
+      source: 'user',
+      status: 'draft',
+      isEditable: true,
+      projectId: 'ds-acme-design-system',
+    };
+    const project: Project = {
+      id: 'ds-acme-design-system',
+      name: 'Acme Design System',
+      skillId: null,
+      designSystemId: system.id,
+      createdAt: 1,
+      updatedAt: 1,
+      metadata: {
+        kind: 'other',
+        importedFrom: 'design-system',
+        entryFile: 'DESIGN.md',
+        sourceFileName: system.id,
+      },
+    };
+    const files: ProjectFile[] = [
+      { name: 'DESIGN.md', size: 42, mtime: 1, kind: 'text', mime: 'text/markdown' },
+    ];
+    const config: AppConfig = {
+      mode: 'daemon',
+      apiKey: '',
+      baseUrl: '',
+      model: '',
+      agentId: 'agent-1',
+      agentModels: {},
+      skillId: null,
+      designSystemId: null,
+    };
+    const conversation = {
+      id: 'conv-design-system',
+      projectId: project.id,
+      title: 'Design system',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    mocks.fetchDesignSystem.mockResolvedValue(system);
+    mocks.ensureDesignSystemWorkspace
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValue(null);
+    mocks.getProject.mockResolvedValue(project);
+    mocks.fetchProjectFiles.mockResolvedValue(files);
+    mocks.createConversation.mockResolvedValue(conversation);
+
+    render(
+      <DesignSystemDetailView
+        id={system.id}
+        selectedId={system.id}
+        config={config}
+        agents={[{ id: 'agent-1', name: 'OpenCode', bin: 'opencode', available: true, models: [] }]}
+        onBack={() => {}}
+        onSetDefault={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(mocks.ensureDesignSystemWorkspace).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByTestId('design-system-chat-send'));
+
+    await waitFor(() => expect(mocks.ensureDesignSystemWorkspace).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mocks.streamViaDaemon).toHaveBeenCalledTimes(1));
+    expect(mocks.getProject).toHaveBeenCalledWith(project.id);
+    expect(mocks.fetchProjectFiles).toHaveBeenCalledWith(project.id);
+    expect(mocks.createConversation).toHaveBeenCalledWith(project.id, 'Design system');
+    expect(mocks.streamViaDaemon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: project.id,
+        conversationId: conversation.id,
+        designSystemId: system.id,
+      }),
+    );
+    expect(screen.queryByText('Could not open the design system workspace.')).toBeNull();
+  });
+
   it('passes the current UI locale to daemon workspace chat runs', async () => {
     const system: DesignSystemDetail = {
       id: 'user:acme-design-system',

--- a/apps/web/tests/components/DesignSystemFlow.test.tsx
+++ b/apps/web/tests/components/DesignSystemFlow.test.tsx
@@ -1767,6 +1767,68 @@ describe('DesignSystemCreationFlow', () => {
 });
 
 describe('DesignSystemDetailView', () => {
+  it('opens the Design Files workspace when the detail payload omits the optional source field', async () => {
+    const system = {
+      id: 'user:acme-design-system',
+      title: 'Acme Design System',
+      category: 'Custom',
+      summary: 'Acme product workspace.',
+      swatches: [],
+      surface: 'web',
+      body: '# Acme Design System\n',
+      status: 'draft',
+      isEditable: true,
+      projectId: 'ds-acme-design-system',
+    } satisfies Omit<DesignSystemDetail, 'source'>;
+    const project: Project = {
+      id: 'ds-acme-design-system',
+      name: 'Acme Design System',
+      skillId: null,
+      designSystemId: system.id,
+      createdAt: 1,
+      updatedAt: 1,
+      metadata: {
+        kind: 'other',
+        importedFrom: 'design-system',
+        entryFile: 'DESIGN.md',
+        sourceFileName: system.id,
+      },
+    };
+    const config: AppConfig = {
+      mode: 'daemon',
+      apiKey: '',
+      baseUrl: '',
+      model: '',
+      agentId: 'agent-1',
+      agentModels: {},
+      skillId: null,
+      designSystemId: null,
+    };
+
+    mocks.fetchDesignSystem.mockResolvedValue(system);
+    mocks.ensureDesignSystemWorkspace.mockResolvedValue({ project, files: [] });
+    mocks.listConversations.mockResolvedValue([
+      { id: 'conv-design-system', projectId: project.id, title: 'Design system', createdAt: 1, updatedAt: 1 },
+    ]);
+
+    render(
+      <DesignSystemDetailView
+        id={system.id}
+        selectedId={system.id}
+        config={config}
+        agents={[{ id: 'agent-1', name: 'OpenCode', bin: 'opencode', available: true, models: [] }]}
+        onBack={() => {}}
+        onSetDefault={() => {}}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Design Files' }));
+
+    await waitFor(() => expect(mocks.ensureDesignSystemWorkspace).toHaveBeenCalledWith(system.id));
+    await waitFor(() => expect(screen.getByTestId('design-system-files')).toBeTruthy());
+    expect(screen.queryByText('Opening the design system workspace...')).toBeNull();
+  });
+
   it('passes the current UI locale to daemon workspace chat runs', async () => {
     const system: DesignSystemDetail = {
       id: 'user:acme-design-system',


### PR DESCRIPTION
Closes #2405

## Why

Users reported that the Design Files tab could remain stuck on `Opening the design system workspace...` after creating or opening a design system in the packaged macOS app. I wrote this to close that bug and restore access to generated design system files.

The failure path was that the web detail view treated `source` as required even though the design-system contract marks it optional. When the detail payload omitted `source`, the workspace open effect never ran, so the tab had no way to leave the loading state.

## What users will see

Opening the Design Files tab for a project-backed design system now finishes loading and shows the workspace files. If the workspace cannot be opened and no project fallback exists, the tab shows a terminal error instead of spinning forever.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not captured; this is a loading-state bug fix covered by the component regression test.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/DesignSystemFlow.test.tsx`
- Did the test go red on `main` and green on this branch? Not run on `main`; the test models the pre-fix condition where the optional `source` field is omitted and would have left the tab on the loading message.

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/DesignSystemFlow.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm typecheck`

Note: `pnpm --filter @open-design/web test -- DesignSystemFlow.test.tsx` unexpectedly selected the whole web suite and hit an unrelated existing failure in `tests/components/HomeView.media-options.test.tsx` (`home-hero-footer-option-audioType` not found). The targeted DesignSystemFlow test command above passed.
