### PR TITLE
fix(host): accept folder imports without entry files

### DIFF
--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -85,8 +85,11 @@ function normalizeProjectImportResult(input: unknown): OpenDesignHostProjectImpo
   const rawProjectId = isRecord(project) ? project.id : null;
   const projectId = typeof rawProjectId === 'string' ? rawProjectId : null;
   const conversationId = typeof response.conversationId === 'string' ? response.conversationId : null;
-  const entryFile = typeof response.entryFile === 'string' ? response.entryFile : null;
-  if (projectId == null || conversationId == null || entryFile == null) {
+  const entryFile =
+    typeof response.entryFile === 'string' || response.entryFile === null
+      ? response.entryFile
+      : undefined;
+  if (projectId == null || conversationId == null || entryFile === undefined) {
     return failure('daemon import response did not include host project identifiers', response);
   }
 

--- a/apps/desktop/tests/main/preload-host-boundary.test.ts
+++ b/apps/desktop/tests/main/preload-host-boundary.test.ts
@@ -18,6 +18,7 @@ describe("desktop preload host boundary", () => {
     expect(source).toContain("OPEN_DESIGN_HOST_GLOBAL");
     expect(source).toContain("exportDiagnostics");
     expect(source).toContain("satisfies OpenDesignHostBridge");
+    expect(source).toContain("response.entryFile === null");
     expect(source).toContain("updater");
     expect(source).toContain("invokeUpdater('install'");
     expect(source).toContain("od:update:quit");

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -31,7 +31,7 @@ export type OpenDesignHostProjectImportInit = {
 
 export type OpenDesignHostProjectImportSuccess = {
   conversationId: string;
-  entryFile: string;
+  entryFile: string | null;
   ok: true;
   projectId: string;
 };
@@ -310,8 +310,11 @@ export function normalizeOpenDesignHostProjectImportResult(input: unknown): Open
   const rawProjectId = isRecord(project) ? project.id : null;
   const projectId = typeof rawProjectId === "string" ? rawProjectId : null;
   const conversationId = typeof response.conversationId === "string" ? response.conversationId : null;
-  const entryFile = typeof response.entryFile === "string" ? response.entryFile : null;
-  if (projectId == null || conversationId == null || entryFile == null) {
+  const entryFile =
+    typeof response.entryFile === "string" || response.entryFile === null
+      ? response.entryFile
+      : undefined;
+  if (projectId == null || conversationId == null || entryFile === undefined) {
     return failure("daemon import response did not include host project identifiers", response);
   }
 

--- a/packages/host/tests/index.test.ts
+++ b/packages/host/tests/index.test.ts
@@ -129,6 +129,29 @@ describe("open-design host contract", () => {
     expect(JSON.stringify(result)).not.toContain("resolvedDir");
   });
 
+  it("accepts imported folders with no detected entry file", () => {
+    const result = normalizeOpenDesignHostProjectImportResult({
+      ok: true,
+      response: {
+        project: {
+          id: "project-1",
+          name: "Imported source repo",
+          resolvedDir: "/private/path/that-must-not-cross",
+        },
+        conversationId: "conversation-1",
+        entryFile: null,
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      projectId: "project-1",
+      conversationId: "conversation-1",
+      entryFile: null,
+    });
+    expect(JSON.stringify(result)).not.toContain("resolvedDir");
+  });
+
   it("preserves canceled and structured failure project-import results", () => {
     expect(normalizeOpenDesignHostProjectImportResult({ canceled: true, ok: false })).toEqual({
       canceled: true,


### PR DESCRIPTION
Closes #1856

## Why

Issue #1856 reports that the packaged Desktop app could not choose a folder and then did not recognize a manually provided code repository path. The folder import daemon API already supports source repositories without a detected HTML entry by returning `entryFile: null`, but the desktop host import boundary treated that successful response as malformed.

That meant ordinary code repos without a root HTML entry could be imported by the daemon and then rejected before the web app received the project identifiers.

## What users will see

Desktop users can select a local code folder even when it has no root `index.html` or other detected HTML file. Open Design opens the imported project instead of failing the host-side folder import normalization.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — existing folder imports without detected entry files now succeed through the desktop host boundary
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

- Added regression coverage in `packages/host/tests/index.test.ts` for a successful folder import with `entryFile: null`.
- Added desktop preload boundary coverage to keep the packaged bridge accepting the same nullable entry-file shape.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/host test`
- `pnpm --filter @open-design/host typecheck`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/desktop test`
- `pnpm guard`
- `pnpm typecheck`
