### PR TITLE
fix(analytics): capture About-you survey across rapid-finish flow

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -792,6 +792,18 @@ function OnboardingView({
     useCase: [] as string[],
     source: '',
   });
+  // Live mirror of `profile` so closures that fire faster than React
+  // commits (rapid dropdown picks, the Finish-setup click after the
+  // last onChange) read the latest selection instead of the value the
+  // closure captured at render-time. Multi-select use_case in
+  // particular needed this: two quick adds within one commit cycle
+  // both read `previous = new Set(profile.useCase = stale [])` and
+  // emitted on both — fine — but reading any cumulative summary off
+  // `profile` directly missed the second pick until the next commit.
+  const profileRef = useRef(profile);
+  useEffect(() => {
+    profileRef.current = profile;
+  }, [profile]);
   const agentRevealTimersRef = useRef<Array<ReturnType<typeof setTimeout>>>([]);
   const cliScanTokenRef = useRef(0);
   const apiProtocol = config.apiProtocol ?? 'anthropic';
@@ -977,6 +989,17 @@ function OnboardingView({
       ? snapshot.sourceCount > 0 || snapshot.hasBrandDescription
       : Boolean(designSource);
     const sourceCount = snapshot ? snapshot.sourceCount : 0;
+    // Read from `profileRef` for the same reason `emitAboutYouSubmit`
+    // does: a Finish-setup click may fire before React commits the
+    // latest dropdown pick, leaving `profile` (closure-captured at
+    // render time) one tick behind.
+    const liveProfile = profileRef.current;
+    const hasAboutYou = Boolean(
+      liveProfile.role
+        || liveProfile.orgSize
+        || liveProfile.useCase.length > 0
+        || liveProfile.source,
+    );
     trackOnboardingCompleteResult(analytics.track, {
       page_name: 'onboarding',
       area: 'onboarding',
@@ -984,14 +1007,23 @@ function OnboardingView({
       exit_step_name: info.stepName,
       completion_type: completionType,
       runtime_type: currentRuntimeType(),
-      has_about_you: Boolean(
-        profile.role || profile.orgSize || profile.useCase.length > 0 || profile.source,
-      ),
+      has_about_you: hasAboutYou,
       has_design_system_request: hasRequest,
       source_count: sourceCount,
       ...(extra.errorCode ? { error_code: extra.errorCode } : {}),
       duration_ms: Math.max(0, Date.now() - onboardingStartedAtRef.current),
       onboarding_session_id: onboardingSessionId,
+      // Survey-snapshot mirror of `about_you_submit` so the funnel has
+      // a second carrier for the user's picks. Only attached when the
+      // user actually touched the About-you step.
+      ...(hasAboutYou ? {
+        role: liveProfile.role || 'unknown',
+        organization_size: liveProfile.orgSize || 'unknown',
+        use_cases: liveProfile.useCase.length > 0
+          ? liveProfile.useCase
+          : ['unknown'],
+        discovery_source: liveProfile.source || 'unknown',
+      } : {}),
     });
   }
 
@@ -1196,6 +1228,17 @@ function OnboardingView({
   }
   function handlePrimaryAction() {
     if (isLastStep) {
+      // Emit the About-you survey snapshot FIRST, before the
+      // continue/complete pair. This is the bombproof carrier for the
+      // user's role / org size / use case / discovery source picks:
+      // per-dropdown clicks are racy on a fast Finish-setup (the user
+      // can pick all four dropdowns and click Finish inside one ~3s
+      // window, and PostHog's posthog-js client may not flush the
+      // individual rows before the route change unmounts the analytics
+      // provider). The snapshot click + the survey fields on
+      // `onboarding_complete_result` give the funnel two independent
+      // paths for the same data.
+      emitAboutYouSubmit();
       emitOnboardingClick('continue', 'continue');
       // Last-step Continue without a DS generation = "completed
       // without design system". The Generate path inside the
@@ -1208,6 +1251,22 @@ function OnboardingView({
     }
     emitOnboardingClick('continue', 'continue');
     setStep((current) => current + 1);
+  }
+
+  // Survey snapshot. Reads `profileRef.current` rather than `profile`
+  // because Finish-setup may fire within the same render commit as the
+  // user's last dropdown pick, before React has rebound the closure to
+  // the latest state. `'unknown'` covers an untouched field on the
+  // About-you step (the spec keeps the wire type open-string so a new
+  // role / use-case option doesn't force a contract bump).
+  function emitAboutYouSubmit(): void {
+    const snapshot = profileRef.current;
+    emitOnboardingClick('about_you_submit', 'continue', {
+      role: snapshot.role || 'unknown',
+      organization_size: snapshot.orgSize || 'unknown',
+      use_cases: snapshot.useCase.length > 0 ? snapshot.useCase : ['unknown'],
+      discovery_source: snapshot.source || 'unknown',
+    });
   }
 
   async function scanCliAgents() {
@@ -1491,7 +1550,14 @@ function OnboardingView({
                   placeholder={t('settings.onboardingSelectPlaceholder')}
                   value={profile.role}
                   options={roleOptions}
-                  onChange={(value) => setProfile((current) => ({ ...current, role: value }))}
+                  onChange={(value) => {
+                    if (typeof value === 'string' && value) {
+                      emitOnboardingClick('role', 'select_option', {
+                        role: value,
+                      });
+                    }
+                    setProfile((current) => ({ ...current, role: value }));
+                  }}
                 />
                 <OnboardingDropdown
                   label={t('settings.onboardingOrgSizeLabel')}
@@ -1518,10 +1584,15 @@ function OnboardingView({
                     // Multi-select: emit one click per newly added
                     // value (delta), not per render of the whole
                     // selection. The dashboard then sees one row per
-                    // use_case chosen.
-                    const previous = new Set(profile.useCase);
+                    // use_case chosen. Compare against `profileRef`
+                    // not `profile` — rapid picks can fire onChange
+                    // before React commits the previous pick, so a
+                    // closure-captured `profile.useCase` is one tick
+                    // behind and re-emits the prior pick on every
+                    // subsequent change.
+                    const previousSet = new Set(profileRef.current.useCase);
                     for (const v of value) {
-                      if (!previous.has(v)) {
+                      if (!previousSet.has(v)) {
                         emitOnboardingClick('use_case', 'select_option', { use_case: v });
                       }
                     }

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -332,6 +332,13 @@ export type TrackingOnboardingScanResult = 'success' | 'failed' | 'timeout';
 export type TrackingOnboardingOrganizationSize = string;
 export type TrackingOnboardingUseCase = string;
 export type TrackingOnboardingDiscoverySource = string;
+// User's self-identified role. Same wire shape and rationale as the
+// other About-you survey strings — `pm`, `designer`, `engineer`,
+// `marketing`, `growth`, `ops`, `founder`, `student`, `other` are the
+// current options from `apps/web/src/components/EntryShell.tsx`
+// (`roleOptions`); the type stays open so adding a future role doesn't
+// force a contract bump.
+export type TrackingOnboardingRole = string;
 
 export interface OnboardingPageViewProps {
   page_name: 'onboarding';
@@ -359,9 +366,15 @@ export type TrackingOnboardingClickElement =
   | 'skip'
   | 'generate'
   // About you fields
+  | 'role'
   | 'organization_size'
   | 'use_case'
   | 'hear_about_us'
+  // Fires once on Finish-setup, carrying the full survey snapshot
+  // (role + organization_size + use_case + discovery_source) so the
+  // funnel always has the user's final picks even when individual
+  // dropdown clicks were dropped on a fast navigate.
+  | 'about_you_submit'
   // Design system source options
   | 'github_repo'
   | 'local_code'
@@ -381,12 +394,12 @@ export type TrackingOnboardingClickAction =
   | 'show_access_methods';
 
 // All optional except the discriminators (area/element/action/step/
-// session id). `organization_size`/`use_case`/`discovery_source` only
-// ride along on About-you clicks. `source_type`/`has_brand_description`/
-// `source_count` only on Design-system source clicks. `runtime_type`/
-// `is_recommended` only on Connect clicks. Doc explicitly forbids
-// brand text, GitHub URL, file name, or path values — all enum + bool
-// + count, no free-text.
+// session id). `role`/`organization_size`/`use_case`/`discovery_source`
+// ride along on About-you clicks AND on the `about_you_submit` snapshot
+// click. `source_type`/`has_brand_description`/`source_count` only on
+// Design-system source clicks. `runtime_type`/`is_recommended` only on
+// Connect clicks. Doc explicitly forbids brand text, GitHub URL, file
+// name, or path values — all enum + bool + count, no free-text.
 export interface OnboardingClickProps {
   page_name: 'onboarding';
   area: TrackingOnboardingArea;
@@ -397,8 +410,14 @@ export interface OnboardingClickProps {
   onboarding_session_id: string;
   runtime_type?: TrackingOnboardingRuntimeType;
   is_recommended?: boolean;
+  role?: TrackingOnboardingRole;
   organization_size?: TrackingOnboardingOrganizationSize;
   use_case?: TrackingOnboardingUseCase;
+  // Multi-pick variant of `use_case` for the survey-snapshot
+  // `about_you_submit` click. Individual `use_case` picks still go
+  // through the scalar field one row per option. The list captures
+  // the final selection at Finish-setup time without firing N rows.
+  use_cases?: TrackingOnboardingUseCase[];
   discovery_source?: TrackingOnboardingDiscoverySource;
   source_type?: TrackingOnboardingSourceType;
   has_brand_description?: boolean;
@@ -433,6 +452,16 @@ export interface OnboardingCompleteResultProps {
   error_code?: string;
   duration_ms: number;
   onboarding_session_id: string;
+  // Survey-snapshot fields. Mirror the values from
+  // `about_you_submit` ui_click so dashboards can read the user's
+  // picks even if the individual dropdown clicks were dropped on
+  // navigate. `'unknown'` is the wire value for a field the user
+  // never touched on the About-you step; missing field means the user
+  // skipped the entire step.
+  role?: TrackingOnboardingRole;
+  organization_size?: TrackingOnboardingOrganizationSize;
+  use_cases?: TrackingOnboardingUseCase[];
+  discovery_source?: TrackingOnboardingDiscoverySource;
 }
 
 // --- Design systems page_view (multi-surface) ---


### PR DESCRIPTION
## Why

PR #2590 wired About-you dropdown selections to fire one `onboarding/ui_click` per pick (`organization_size` / `use_case` / `hear_about_us`) with the chosen value attached. Live PostHog data on nightly.11 showed a real session where every survey value was missing: the user filled all four dropdowns and clicked Finish setup inside a ~3-second window, the route navigated away before posthog-js could flush the per-dropdown rows, and the resulting `onboarding_complete_result` only said `has_about_you: True` without surfacing what the user picked.

Two specific gaps surfaced:

1. **`role` was never tracked at all.** The role `OnboardingDropdown` had no `emitOnboardingClick` call; `OnboardingClickProps` had no `role` field; `TrackingOnboardingClickElement` had no `'role'` element. Even on a slow-path session the dashboard could not see what role the user identified as.

2. **The other three fields** (`organization_size` / `use_case` / `discovery_source`) fired the right click events but were one round-trip away from a route change. With per-dropdown rows as the only carrier, a Finish-setup within a ~3-second batch lost them all to navigation-side flush failure.

## What users will see

Nothing visible. Two new analytics emissions ride on the existing About-you step:

- A new `ui_click` row with `element=role`, `action=select_option`, `role=<picked-value>` fires when the user picks their role (parity with the other three About-you dropdowns).
- A new `ui_click` row with `element=about_you_submit`, `action=continue` fires on Finish setup carrying the full survey snapshot in a single row: `role`, `organization_size`, `use_cases`, `discovery_source`.
- `onboarding_complete_result` itself now carries the same four survey fields when `has_about_you` is true. The dashboard now has two independent carriers for the survey data — losing either path still leaves the funnel a complete picture.

The user does not see the survey results anywhere new in product. This is purely about making the existing About-you step actually populate the analytics it claimed to.

## How

### Contract (`packages/contracts/src/analytics/events.ts`)

- New open-string type `TrackingOnboardingRole`. Same rationale as the other About-you survey strings — kept open so a future role option doesn't force a contract bump.
- New element `'role'` on `TrackingOnboardingClickElement`.
- New element `'about_you_submit'` on the same union for the snapshot click.
- New optional fields on `OnboardingClickProps`: `role` (scalar) and `use_cases` (array, the multi-pick variant for the snapshot click).
- New optional fields on `OnboardingCompleteResultProps`: `role`, `organization_size`, `use_cases`, `discovery_source`.

Open-string is intentional and consistent with the existing `TrackingOnboardingOrganizationSize` / `TrackingOnboardingUseCase` / `TrackingOnboardingDiscoverySource` types. `'unknown'` is the documented wire value for a field the user never touched on the About-you step.

### Emission (`apps/web/src/components/EntryShell.tsx`)

- **Role dropdown** now emits `role/select_option` with `role=<value>` on change, parity with the other three About-you dropdowns.
- **`profileRef`** introduced: live mirror of the `profile` state via a `useEffect`. Closures that fire faster than React commits (rapid multi-pick on `use_case`, the Finish-setup click after the last `onChange`) read the latest selection instead of stale render-time state.
- **`use_case` multi-select delta** now reads from `profileRef.current.useCase` instead of `profile.useCase`. The two-picks-in-one-commit case (which the live data confirmed happens) computes the delta correctly.
- **Finish setup** now fires three rows in sequence:
  1. `about_you_submit/continue` with the full survey snapshot — fires first so the highest-value row is queued before navigation begins.
  2. `continue/continue` (existing behavior preserved).
  3. `onboarding_complete_result` now also carries `role` / `organization_size` / `use_cases` / `discovery_source` when `has_about_you` is true.

`emitOnboardingComplete` also reads from `profileRef` for the same staleness reason — without that, Finish setup that fires within the same commit as the last `onChange` would see `has_about_you=false` despite a real selection.

## Validation

Against the live PostHog stream on namespace `onboarding-survey` (dev build, fresh install via wipe + restart). The post-fix session shows:

```
09:51:13  role/select_option              role=pm
09:51:15  organization_size/select_option organization_size=solo
09:51:16  use_case/select_option          use_case=product
09:51:18  hear_about_us/select_option     discovery_source=github
09:51:20  about_you_submit/continue       role=pm
                                          + organization_size=solo
                                          + use_cases=['product']
                                          + discovery_source=github
09:51:20  continue/continue
09:51:20  onboarding_complete_result      has_about_you=True
                                          + role=pm
                                          + organization_size=solo
                                          + use_cases=['product']
                                          + discovery_source=github
```

An earlier pre-fix session on the same window (same user, no reload between code change and run) shows the original bug: four `use_case` rows, no `role`, no `about_you_submit`, and no survey fields on complete despite `has_about_you: True` — verifying that the bug reproduces against the pre-fix build.

- `pnpm --filter @open-design/contracts build` — clean
- `pnpm --filter @open-design/contracts test` — 111/111 passing
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm --filter @open-design/web test` — 1843/1843 passing

## Surface area

- [x] `apps/web/**`
- [x] `packages/contracts/**`
- [ ] `apps/daemon/**`
- [ ] `apps/desktop/**`
- [ ] `apps/packaged/**`
- [ ] `tools/**`
- [ ] `e2e/**`
- [ ] `skills/**`, `design-systems/**`, `design-templates/**`, `craft/**`
- [ ] CLI flags / env vars / i18n keys / new root deps

Pure analytics emission change. No daemon wire-format change, no user-facing UI change, no breaking change to existing events (new fields are all optional).