### PR TITLE
fix(download): handle pid reuse in stale locks

### DIFF
--- a/packages/download/src/index.ts
+++ b/packages/download/src/index.ts
@@ -27,6 +27,8 @@ const STORE_KIND = "open-design-managed-download-root";
 const MANIFEST_KIND = "open-design-managed-download";
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_PRUNE_OLDER_THAN_MS = 24 * 60 * 60 * 1000;
+const PID_REUSE_GRACE_MS = 1000;
+const PROCESS_STARTED_AT_MS = Date.now() - process.uptime() * 1000;
 
 export type ManagedDownloadChecksum = {
   algorithm: "sha256" | "sha512";
@@ -199,6 +201,7 @@ type AcquiredLock = {
 type DownloadLockFile = {
   createdAt: string;
   pid: number;
+  processStartedAt?: string;
 };
 
 type DownloadAttemptResult = {
@@ -413,7 +416,31 @@ function isDownloadLockFile(value: unknown): value is DownloadLockFile {
   return typeof record.createdAt === "string" &&
     typeof record.pid === "number" &&
     Number.isInteger(record.pid) &&
-    record.pid > 0;
+    record.pid > 0 &&
+    (record.processStartedAt == null || typeof record.processStartedAt === "string");
+}
+
+function parseTimeMs(value: string | undefined): number | null {
+  if (value == null) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function lockBelongsToCurrentProcess(lock: DownloadLockFile): boolean {
+  if (lock.pid !== process.pid) return false;
+  const ownerStartedAtMs = parseTimeMs(lock.processStartedAt);
+  if (ownerStartedAtMs != null) return ownerStartedAtMs >= PROCESS_STARTED_AT_MS - PID_REUSE_GRACE_MS;
+
+  // Older locks only carried a pid. If Windows reuses that pid for this
+  // process, a lock that predates this process start is definitely stale.
+  const lockCreatedAtMs = parseTimeMs(lock.createdAt);
+  return lockCreatedAtMs == null || lockCreatedAtMs >= PROCESS_STARTED_AT_MS - PID_REUSE_GRACE_MS;
+}
+
+function isLockProcessAlive(lock: DownloadLockFile): boolean {
+  if (!isProcessAlive(lock.pid)) return false;
+  if (lock.pid === process.pid) return lockBelongsToCurrentProcess(lock);
+  return true;
 }
 
 async function readManifest(path: string): Promise<DownloadManifest | "invalid" | null> {
@@ -645,7 +672,11 @@ async function acquireLock(target: NormalizedTarget): Promise<AcquiredLock> {
     try {
       await writeFile(
         target.lockPath,
-        `${JSON.stringify({ createdAt: new Date().toISOString(), pid: process.pid } satisfies DownloadLockFile)}\n`,
+        `${JSON.stringify({
+          createdAt: new Date().toISOString(),
+          pid: process.pid,
+          processStartedAt: new Date(PROCESS_STARTED_AT_MS).toISOString(),
+        } satisfies DownloadLockFile)}\n`,
         { flag: "wx" },
       );
       return { path: target.lockPath };
@@ -663,7 +694,7 @@ async function acquireLock(target: NormalizedTarget): Promise<AcquiredLock> {
 
 async function clearStaleLock(target: NormalizedTarget): Promise<boolean> {
   const lock = await readJson<unknown>(target.lockPath);
-  if (!isDownloadLockFile(lock) || isProcessAlive(lock.pid)) return false;
+  if (!isDownloadLockFile(lock) || isLockProcessAlive(lock)) return false;
   await rm(target.lockPath, { force: true }).catch(() => undefined);
   return true;
 }

--- a/packages/download/tests/index.test.ts
+++ b/packages/download/tests/index.test.ts
@@ -294,6 +294,33 @@ describe("managed download package", () => {
     }
   });
 
+  it("clears a stale lock when Windows reuses the old owner pid for this process", async () => {
+    const body = "pid reuse lock payload";
+    const fixture = await startFixture(body);
+    const root = tmpRoot("pid-reuse-lock");
+    const basePath = join(root, "downloads");
+    try {
+      await inspectManagedDownload({ basePath, bucket: "updates", fileName: "installer.bin" });
+      writeFileSync(lockPath(basePath, "updates", "installer.bin"), JSON.stringify({
+        createdAt: new Date(Date.now() - (process.uptime() + 60) * 1000).toISOString(),
+        pid: process.pid,
+      }));
+
+      const result = await managedDownload({
+        basePath,
+        bucket: "updates",
+        fileName: "installer.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+      });
+
+      expect(readFileSync(result.path, "utf8")).toBe(body);
+      expect(existsSync(lockPath(basePath, "updates", "installer.bin"))).toBe(false);
+      expect(fixture.requests).toHaveLength(1);
+    } finally {
+      await fixture.close();
+    }
+  });
+
   it("quick-fails when the target lock pid is still alive", async () => {
     const body = "alive lock payload";
     const fixture = await startFixture(body);


### PR DESCRIPTION
## Why

While manually stress-testing the packaged Windows updater with repeated close/restart cycles, we hit a real PID reuse edge: a stale download lock from the interrupted updater carried pid `5788`, and Windows reused `5788` for the restarted Nightly main process. The download helper only checked whether the pid was alive, so it treated the stale lock as active and left the updater in `download-target-locked` instead of resuming.

This PR tightens the managed download lock invariant so interrupted updater downloads can recover even when the OS quickly reuses the old owner pid.

## What users will see

Users who close or restart the app during an update download should continue to recover on the next launch. In the PID reuse case, the updater resumes the partial download instead of silently landing in an internal locked state.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A. No UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `packages/download/tests/index.test.ts` (`clears a stale lock when Windows reuses the old owner pid for this process`)
- Did the test go red on `main` and green on this branch? Not run as a separate red step; the live packaged Nightly validation produced the failing `download-target-locked` state with a reused pid, then the new package test went green on this branch.

## Validation

- `pnpm --filter @open-design/download test`
- `pnpm --filter @open-design/download typecheck`
- `pnpm --filter @open-design/download build`
- `pnpm guard`
- `pnpm install --frozen-lockfile`
- `pnpm typecheck`