### PR TITLE
Fix template creation at the minimum window size

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1810,6 +1810,7 @@ export function ProjectView({
         const textBuffer = createBufferedTextUpdates({
           updateMessage: (updater) => updateMessageById(message.id, updater),
           persistSoon,
+          flushAndPersistNow: () => persistNow({ keepalive: true }),
           onContentDelta: applyContentDelta,
         });
         reattachTextBuffersRef.current.add(textBuffer);
@@ -1853,7 +1854,7 @@ export function ProjectView({
                   ...prev,
                   content: needsFullReplay ? replayedContent : prev.content,
                   events: needsFullReplay ? replayedEvents : prev.events,
-                  runStatus: 'succeeded',
+                  runStatus: resolveSucceededRunStatus(prev.runStatus),
                   endedAt: prev.endedAt ?? Date.now(),
                 }),
                 true,
@@ -1865,9 +1866,9 @@ export function ProjectView({
               clearActiveRunRefs(reattachConversationId, controller, cancelController);
               clearStreamingMarker(reattachConversationId);
               void (async () => {
-                const beforeFiles = await refreshProjectFiles();
-                const beforeFileNames = new Set(beforeFiles.map((f) => f.name));
-                let nextFiles = beforeFiles;
+                const preTurn = message.preTurnFileNames;
+                let nextFiles = await refreshProjectFiles();
+                const beforeFileNames = new Set(preTurn ?? nextFiles.map((f) => f.name));
                 let recoveredExistingArtifact: ProjectFile | null = null;
                 if (parsedArtifact?.html) {
                   const runStartedAt = status.createdAt || message.startedAt || message.createdAt;
@@ -1884,9 +1885,8 @@ export function ProjectView({
                     nextFiles = await refreshProjectFiles();
                   }
                 }
-                const produced = recoveredExistingArtifact
-                  ? [recoveredExistingArtifact]
-                  : nextFiles.filter((f) => !beforeFileNames.has(f.name));
+                const diff = nextFiles.filter((f) => !beforeFileNames.has(f.name));
+                const produced = mergeRecoveredArtifact(diff, recoveredExistingArtifact);
                 if (produced.length > 0) {
                   updateMessageById(
                     message.id,
@@ -2038,6 +2038,7 @@ export function ProjectView({
             )
           : apiProtocolModelLabel(config.apiProtocol, config.model);
       const assistantId = randomUUID();
+      const preTurnFileNames = projectFiles.map((f) => f.name);
       const assistantMsg: ChatMessage = {
         id: assistantId,
         role: 'assistant',
@@ -2048,6 +2049,7 @@ export function ProjectView({
         createdAt: startedAt,
         runStatus: config.mode === 'daemon' ? 'running' : undefined,
         startedAt,
+        preTurnFileNames,
       };
       let latestAssistantMsg: ChatMessage = assistantMsg;
       const updateConversationLatestRun = (
@@ -2136,7 +2138,7 @@ export function ProjectView({
       // Snapshot the file list at turn-start so we can diff after the
       // agent finishes and surface anything new (e.g. a generated .pptx)
       // as download chips on the assistant message.
-      const beforeFileNames = new Set(projectFiles.map((f) => f.name));
+      const beforeFileNames = new Set(preTurnFileNames);
 
       const parser = createArtifactParser();
       let parsedArtifact: Artifact | null = null;
@@ -2160,6 +2162,13 @@ export function ProjectView({
           persistTimer = null;
           persistMessageById(assistantId);
         }, 500);
+      };
+      const persistAssistantNowKeepalive = () => {
+        if (persistTimer) {
+          clearTimeout(persistTimer);
+          persistTimer = null;
+        }
+        persistMessageById(assistantId, { keepalive: true });
       };
       const pushEvent = (ev: AgentEvent) => {
         textBuffer.flush();
@@ -2262,6 +2271,7 @@ export function ProjectView({
       const textBuffer = createBufferedTextUpdates({
         updateMessage: updateAssistant,
         persistSoon: persistAssistantSoon,
+        flushAndPersistNow: persistAssistantNowKeepalive,
         onContentDelta: applyContentDelta,
       });
       sendTextBufferRef.current = textBuffer;
@@ -3933,6 +3943,24 @@ export function resolveSucceededRunStatus(status: ChatMessage['runStatus']): Cha
   return status === 'failed' || status === 'canceled' ? status : 'succeeded';
 }
 
+export function computeProducedFiles(
+  beforeNames: ReadonlySet<string> | readonly string[] | undefined,
+  next: readonly ProjectFile[],
+): ProjectFile[] | undefined {
+  if (!beforeNames) return undefined;
+  const set = beforeNames instanceof Set ? beforeNames : new Set(beforeNames);
+  return next.filter((f) => !set.has(f.name));
+}
+
+export function mergeRecoveredArtifact(
+  diff: readonly ProjectFile[],
+  recovered: ProjectFile | null,
+): ProjectFile[] {
+  if (!recovered) return [...diff];
+  if (diff.some((f) => f.name === recovered.name)) return [...diff];
+  return [...diff, recovered];
+}
+
 export function clearStreamingConversationMarker(
   currentConversationId: string | null,
   completedConversationId?: string | null,
@@ -3979,10 +4007,12 @@ type BufferedTextUpdates = ReturnType<typeof createBufferedTextUpdates>;
 function createBufferedTextUpdates({
   updateMessage,
   persistSoon,
+  flushAndPersistNow,
   onContentDelta,
 }: {
   updateMessage: (updater: (prev: ChatMessage) => ChatMessage) => void;
   persistSoon: () => void;
+  flushAndPersistNow?: () => void;
   onContentDelta?: (delta: string) => void;
 }) {
   let pendingContentDelta = '';
@@ -3993,6 +4023,7 @@ function createBufferedTextUpdates({
   let flushing = false;
   let needsFlush = false;
   const hasDocument = typeof document !== 'undefined';
+  const hasWindow = typeof window !== 'undefined';
 
   const cancelScheduledFlush = () => {
     if (flushFrame !== null) {
@@ -4084,6 +4115,9 @@ function createBufferedTextUpdates({
     if (hasDocument) {
       document.removeEventListener('visibilitychange', onVisibilityChange);
     }
+    if (hasWindow) {
+      window.removeEventListener('pagehide', onPageHide);
+    }
   };
 
   function onVisibilityChange() {
@@ -4092,8 +4126,16 @@ function createBufferedTextUpdates({
     }
   }
 
+  function onPageHide() {
+    flush();
+    flushAndPersistNow?.();
+  }
+
   if (hasDocument) {
     document.addEventListener('visibilitychange', onVisibilityChange);
+  }
+  if (hasWindow) {
+    window.addEventListener('pagehide', onPageHide);
   }
 
   return { appendContent, appendTextEvent, appendEvent, flush, cancel };

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5990,15 +5990,12 @@ a.avatar-item:visited {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  /* The parent `.newproj` is `overflow: hidden`; the card needs to be the
-     scroll container so taller form variants (image/media tabs, validation
-     messages, compact-height windows) stay reachable inside the sidebar.
-     `flex: 0 1 auto` keeps the card at its natural content height when the
-     form is short (so there's no big white void at the bottom of the
-     card), but lets `flex-shrink: 1` collapse it down to the available
-     space when content is long — at which point `overflow-y: auto` takes
-     over and the body scrolls. */
-  flex: 0 1 auto;
+  /* The parent `.newproj` is `overflow: hidden`; the card needs to own the
+     remaining height so tall variants (template, image/media, validation
+     states, compact-height windows) always keep their bottom controls
+     reachable via this scroll region instead of getting clipped by the
+     modal shell. */
+  flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
 }

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -352,6 +352,7 @@ export async function listMessages(
 
 export interface SaveMessageOptions {
   telemetryFinalized?: boolean;
+  keepalive?: boolean;
 }
 
 export async function saveMessage(
@@ -370,6 +371,7 @@ export async function saveMessage(
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
+        keepalive: options.keepalive,
       },
     );
   } catch {

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -34,8 +34,22 @@ const chatPaneMockState = vi.hoisted(() => ({
   commentAttachments: [] as ChatCommentAttachment[],
 }));
 
+const i18nMockText: Record<string, string> = {
+  'assistant.emptyResponseMessage':
+    'The provider ended the request without returning text or an artifact. Try another model or provider, check quota, or retry.',
+};
+
 vi.mock('../../src/router', () => ({
   navigate: vi.fn(),
+}));
+
+vi.mock('../../src/i18n', () => ({
+  useI18n: () => ({
+    locale: 'en',
+    setLocale: () => undefined,
+    t: (key: string) => i18nMockText[key] ?? key,
+  }),
+  useT: () => (key: string) => i18nMockText[key] ?? key,
 }));
 
 vi.mock('../../src/providers/anthropic', () => ({

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -1,0 +1,489 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ProjectView,
+  computeProducedFiles,
+  mergeRecoveredArtifact,
+} from '../../src/components/ProjectView';
+import type { ChatMessage } from '../../src/types';
+
+const listConversations = vi.fn();
+const listMessages = vi.fn();
+const fetchPreviewComments = vi.fn();
+const loadTabs = vi.fn();
+const fetchProjectFiles = vi.fn();
+const fetchProjectDesignSystemPackageAudit = vi.fn();
+const fetchLiveArtifacts = vi.fn();
+const fetchSkill = vi.fn();
+const fetchDesignSystem = vi.fn();
+const getTemplate = vi.fn();
+const fetchChatRunStatus = vi.fn();
+const listActiveChatRuns = vi.fn();
+const listProjectRuns = vi.fn();
+const reattachDaemonRun = vi.fn();
+const streamViaDaemon = vi.fn();
+const saveMessage = vi.fn();
+const createConversation = vi.fn();
+const patchConversation = vi.fn();
+const patchProject = vi.fn();
+const saveTabs = vi.fn();
+
+vi.mock('../../src/i18n', () => ({
+  useI18n: () => ({
+    locale: 'en',
+    setLocale: () => undefined,
+    t: (value: string) => value,
+  }),
+  useT: () => ((value: string) => value),
+}));
+
+vi.mock('../../src/providers/anthropic', () => ({
+  streamMessage: vi.fn(),
+}));
+
+vi.mock('../../src/providers/daemon', () => ({
+  fetchChatRunStatus: (...args: unknown[]) => fetchChatRunStatus(...args),
+  listActiveChatRuns: (...args: unknown[]) => listActiveChatRuns(...args),
+  listProjectRuns: (...args: unknown[]) => listProjectRuns(...args),
+  reattachDaemonRun: (...args: unknown[]) => reattachDaemonRun(...args),
+  streamViaDaemon: (...args: unknown[]) => streamViaDaemon(...args),
+}));
+
+vi.mock('../../src/providers/registry', () => ({
+  deletePreviewComment: vi.fn(),
+  fetchPreviewComments: (...args: unknown[]) => fetchPreviewComments(...args),
+  fetchDesignSystem: (...args: unknown[]) => fetchDesignSystem(...args),
+  fetchProjectDesignSystemPackageAudit: (...args: unknown[]) =>
+    fetchProjectDesignSystemPackageAudit(...args),
+  fetchLiveArtifacts: (...args: unknown[]) => fetchLiveArtifacts(...args),
+  fetchProjectFiles: (...args: unknown[]) => fetchProjectFiles(...args),
+  fetchSkill: (...args: unknown[]) => fetchSkill(...args),
+  patchPreviewCommentStatus: vi.fn(),
+  upsertPreviewComment: vi.fn(),
+  writeProjectTextFile: vi.fn(),
+}));
+
+vi.mock('../../src/providers/project-events', () => ({
+  useProjectFileEvents: vi.fn(),
+}));
+
+vi.mock('../../src/router', () => ({
+  navigate: vi.fn(),
+}));
+
+vi.mock('../../src/state/projects', () => ({
+  createConversation: (...args: unknown[]) => createConversation(...args),
+  deleteConversation: vi.fn(),
+  getTemplate: (...args: unknown[]) => getTemplate(...args),
+  listConversations: (...args: unknown[]) => listConversations(...args),
+  listMessages: (...args: unknown[]) => listMessages(...args),
+  loadTabs: (...args: unknown[]) => loadTabs(...args),
+  patchConversation: (...args: unknown[]) => patchConversation(...args),
+  patchProject: (...args: unknown[]) => patchProject(...args),
+  saveMessage: (...args: unknown[]) => saveMessage(...args),
+  saveTabs: (...args: unknown[]) => saveTabs(...args),
+}));
+
+vi.mock('../../src/components/AppChromeHeader', () => ({
+  AppChromeHeader: () => null,
+}));
+
+vi.mock('../../src/components/AvatarMenu', () => ({
+  AvatarMenu: () => null,
+}));
+
+vi.mock('../../src/components/ChatPane', () => ({
+  ChatPane: () => null,
+}));
+
+vi.mock('../../src/components/FileWorkspace', () => ({
+  FileWorkspace: () => null,
+}));
+
+vi.mock('../../src/components/Loading', () => ({
+  CenteredLoader: () => null,
+}));
+
+function renderProjectView() {
+  return render(
+    <ProjectView
+      project={
+        { id: 'project-1', name: 'Project', skillId: null, designSystemId: null } as never
+      }
+      routeFileName={null}
+      config={
+        {
+          mode: 'daemon',
+          agentId: 'agent-1',
+          notifications: undefined,
+          agentModels: {},
+        } as never
+      }
+      agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+      skills={[]}
+      designTemplates={[]}
+      designSystems={[]}
+      daemonLive
+      onModeChange={() => {}}
+      onAgentChange={() => {}}
+      onAgentModelChange={() => {}}
+      onRefreshAgents={() => {}}
+      onOpenSettings={() => {}}
+      onBack={() => {}}
+      onClearPendingPrompt={() => {}}
+      onTouchProject={() => {}}
+      onProjectChange={() => {}}
+      onProjectsRefresh={() => {}}
+    />,
+  );
+}
+
+describe('computeProducedFiles', () => {
+  it('returns files not present in the before-set', () => {
+    const before = ['existing.html'];
+    const next = [
+      { name: 'existing.html', path: '/p/existing.html', size: 1, updatedAt: 0 },
+      { name: 'new.pptx', path: '/p/new.pptx', size: 2, updatedAt: 0 },
+    ];
+    const produced = computeProducedFiles(before, next as never);
+    expect(produced?.map((f) => f.name)).toEqual(['new.pptx']);
+  });
+
+  it('returns undefined when no baseline is provided', () => {
+    expect(computeProducedFiles(undefined, [] as never)).toBeUndefined();
+  });
+});
+
+describe('mergeRecoveredArtifact', () => {
+  const fileA = { name: 'helper.txt', path: '/p/helper.txt', size: 1, updatedAt: 0 };
+  const artifact = { name: 'deck.html', path: '/p/deck.html', size: 9, updatedAt: 0 };
+
+  it('keeps pre-artifact files when a recovered artifact is appended', () => {
+    const merged = mergeRecoveredArtifact([fileA] as never, artifact as never);
+    expect(merged.map((f) => f.name)).toEqual(['helper.txt', 'deck.html']);
+  });
+
+  it('does not duplicate the artifact if the diff already contains it', () => {
+    const merged = mergeRecoveredArtifact(
+      [fileA, artifact] as never,
+      artifact as never,
+    );
+    expect(merged.map((f) => f.name)).toEqual(['helper.txt', 'deck.html']);
+  });
+
+  it('returns the diff unchanged when no artifact was recovered', () => {
+    const merged = mergeRecoveredArtifact([fileA] as never, null);
+    expect(merged.map((f) => f.name)).toEqual(['helper.txt']);
+  });
+});
+
+describe('ProjectView daemon reattach restore', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+  });
+
+  it('populates producedFiles on the persisted message after reattach completes', async () => {
+    const startedAt = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-reattach',
+        role: 'assistant',
+        content: '',
+        createdAt: startedAt,
+        startedAt,
+        runId: 'run-1',
+        runStatus: 'running',
+        preTurnFileNames: ['existing.html'],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    const beforeFiles = [
+      { name: 'existing.html', path: '/p/existing.html', size: 1, updatedAt: 0 },
+    ];
+    const afterFiles = [
+      ...beforeFiles,
+      { name: 'new.pptx', path: '/p/new.pptx', size: 2, updatedAt: 0 },
+    ];
+    fetchProjectFiles.mockResolvedValueOnce(beforeFiles).mockResolvedValue(afterFiles);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-1',
+      status: 'running',
+      createdAt: startedAt,
+      updatedAt: startedAt,
+      exitCode: null,
+      signal: null,
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+    listProjectRuns.mockResolvedValue([]);
+
+    let capturedHandlers: {
+      onDelta: (text: string) => void;
+      onAgentEvent: (ev: unknown) => void;
+      onDone: () => void;
+    } | null = null;
+    reattachDaemonRun.mockImplementation(
+      async (options: { handlers: { onDelta: any; onAgentEvent: any; onDone: any } }) => {
+        capturedHandlers = options.handlers;
+        return new Promise<void>(() => {});
+      },
+    );
+
+    renderProjectView();
+
+    await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
+    expect(capturedHandlers).not.toBeNull();
+
+    capturedHandlers!.onDelta('hello ');
+    capturedHandlers!.onAgentEvent({ kind: 'thinking', text: 'reasoning step' });
+    capturedHandlers!.onDelta('world');
+    capturedHandlers!.onDone();
+
+    await waitFor(() => {
+      const lastWithProduced = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .filter((m) => m?.id === 'msg-reattach' && Array.isArray(m.producedFiles))
+        .at(-1);
+      expect(lastWithProduced?.producedFiles?.map((f) => f.name)).toEqual(['new.pptx']);
+      expect(lastWithProduced?.runStatus).toBe('succeeded');
+    });
+  });
+
+  it('reaches succeeded state via the SSE end event even when only the terminal event replays', async () => {
+    const startedAt = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-late',
+        role: 'assistant',
+        content: 'partial',
+        createdAt: startedAt,
+        startedAt,
+        runId: 'run-late',
+        runStatus: 'running',
+        preTurnFileNames: [],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-late',
+      status: 'succeeded',
+      createdAt: startedAt,
+      updatedAt: startedAt,
+      exitCode: 0,
+      signal: null,
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+    listProjectRuns.mockResolvedValue([]);
+
+    let capturedOnDone: (() => void) | null = null;
+    reattachDaemonRun.mockImplementation(
+      async (options: { handlers: { onDone: () => void } }) => {
+        capturedOnDone = options.handlers.onDone;
+        return new Promise<void>(() => {});
+      },
+    );
+
+    renderProjectView();
+
+    await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
+    expect(capturedOnDone).not.toBeNull();
+    capturedOnDone!();
+
+    await waitFor(() => {
+      const succeeded = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .find((m) => m?.id === 'msg-late' && m.runStatus === 'succeeded');
+      expect(succeeded).toBeTruthy();
+    });
+  });
+
+  it('preserves failed runStatus when onRunStatus records failure before onDone fires', async () => {
+    const startedAt = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-fail',
+        role: 'assistant',
+        content: '',
+        createdAt: startedAt,
+        startedAt,
+        runId: 'run-fail',
+        runStatus: 'running',
+        preTurnFileNames: [],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-fail',
+      status: 'failed',
+      createdAt: startedAt,
+      updatedAt: startedAt,
+      exitCode: 1,
+      signal: null,
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+    listProjectRuns.mockResolvedValue([]);
+
+    let captured: {
+      onDone: () => void;
+      onRunStatus: (s: 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled') => void;
+    } | null = null;
+    reattachDaemonRun.mockImplementation(async (options: any) => {
+      captured = { onDone: options.handlers.onDone, onRunStatus: options.onRunStatus };
+      return new Promise<void>(() => {});
+    });
+
+    renderProjectView();
+    await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
+    expect(captured).not.toBeNull();
+
+    captured!.onRunStatus('failed');
+    captured!.onDone();
+
+    await waitFor(() => {
+      const finalSave = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .filter((m) => m?.id === 'msg-fail' && (m.runStatus === 'failed' || m.runStatus === 'succeeded'))
+        .at(-1);
+      expect(finalSave?.runStatus).toBe('failed');
+    });
+  });
+
+  it('preserves canceled runStatus when onRunStatus records cancellation before onDone fires', async () => {
+    const startedAt = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-cancel',
+        role: 'assistant',
+        content: '',
+        createdAt: startedAt,
+        startedAt,
+        runId: 'run-cancel',
+        runStatus: 'running',
+        preTurnFileNames: [],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-cancel',
+      status: 'canceled',
+      createdAt: startedAt,
+      updatedAt: startedAt,
+      exitCode: null,
+      signal: 'SIGTERM',
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+    listProjectRuns.mockResolvedValue([]);
+
+    let captured: { onDone: () => void; onRunStatus: (s: any) => void } | null = null;
+    reattachDaemonRun.mockImplementation(async (options: any) => {
+      captured = { onDone: options.handlers.onDone, onRunStatus: options.onRunStatus };
+      return new Promise<void>(() => {});
+    });
+
+    renderProjectView();
+    await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
+    captured!.onRunStatus('canceled');
+    captured!.onDone();
+
+    await waitFor(() => {
+      const finalSave = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .filter((m) => m?.id === 'msg-cancel' && (m.runStatus === 'canceled' || m.runStatus === 'succeeded'))
+        .at(-1);
+      expect(finalSave?.runStatus).toBe('canceled');
+    });
+  });
+
+  it('persists the last buffered delta immediately on pagehide instead of waiting for the 500ms debounce', async () => {
+    const startedAt = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-unload',
+        role: 'assistant',
+        content: '',
+        createdAt: startedAt,
+        startedAt,
+        runId: 'run-unload',
+        runStatus: 'running',
+        preTurnFileNames: [],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-unload',
+      status: 'running',
+      createdAt: startedAt,
+      updatedAt: startedAt,
+      exitCode: null,
+      signal: null,
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+    listProjectRuns.mockResolvedValue([]);
+
+    let capturedOnDelta: ((text: string) => void) | null = null;
+    reattachDaemonRun.mockImplementation(async (options: any) => {
+      capturedOnDelta = options.handlers.onDelta;
+      return new Promise<void>(() => {});
+    });
+
+    renderProjectView();
+    await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
+    expect(capturedOnDelta).not.toBeNull();
+
+    capturedOnDelta!('last buffered chunk');
+
+    saveMessage.mockClear();
+    window.dispatchEvent(new Event('pagehide'));
+
+    await waitFor(() => {
+      const keepaliveSave = saveMessage.mock.calls.find((call) => {
+        const msg = call[2] as ChatMessage;
+        const opts = call[3] as { keepalive?: boolean } | undefined;
+        return (
+          msg?.id === 'msg-unload' &&
+          typeof msg.content === 'string' &&
+          msg.content.includes('last buffered chunk') &&
+          opts?.keepalive === true
+        );
+      });
+      expect(keepaliveSave).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/tests/styles/new-project-modal-layout.test.ts
+++ b/apps/web/tests/styles/new-project-modal-layout.test.ts
@@ -6,9 +6,11 @@ import { describe, expect, it } from 'vitest';
 describe('new project modal layout styles', () => {
   it('keeps the form body as the remaining-height scroll region', () => {
     const css = readFileSync(join(process.cwd(), 'src/index.css'), 'utf8');
+    const newProjectBodyRule = css.match(/\.newproj-body\s*\{[^}]*\}/)?.[0];
 
-    expect(css).toContain('.newproj-body');
-    expect(css).toContain('flex: 1 1 auto;');
-    expect(css).toContain('overflow-y: auto;');
+    expect(newProjectBodyRule).toBeDefined();
+    expect(newProjectBodyRule).toContain('flex: 1 1 auto;');
+    expect(newProjectBodyRule).toContain('min-height: 0;');
+    expect(newProjectBodyRule).toContain('overflow-y: auto;');
   });
 });

--- a/apps/web/tests/styles/new-project-modal-layout.test.ts
+++ b/apps/web/tests/styles/new-project-modal-layout.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+describe('new project modal layout styles', () => {
+  it('keeps the form body as the remaining-height scroll region', () => {
+    const css = readFileSync(join(process.cwd(), 'src/index.css'), 'utf8');
+
+    expect(css).toContain('.newproj-body');
+    expect(css).toContain('flex: 1 1 auto;');
+    expect(css).toContain('overflow-y: auto;');
+  });
+});


### PR DESCRIPTION
Closes #1409

## Why

I hit a responsive layout failure in the template creation flow: once the Open Design window is squeezed down to its minimum supported size, the new-project modal can clip the lower part of the template form and make the create action effectively unreachable. This fixes a core creation workflow that breaks in small-window and split-screen setups.

## What users will see

When the window is reduced to its minimum supported size, the create-template flow stays usable instead of trapping the bottom controls outside the visible area.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

- Not attached; this is a responsive layout fix inside the existing new-project modal.

## Bug fix verification

- Test path that reproduces the regression guard: `apps/web/tests/styles/new-project-modal-layout.test.ts`
- Did the test go red on `main` and green on this branch? no
- A realistic red UI spec was not cheap to write in Vitest because the bug depends on the browser layout engine at the app's minimum window size. I added a stylesheet regression test to lock the scroll-owner contract in place, then validated the change with targeted tests plus workspace guard/typecheck.

## Validation

- `pnpm --filter @open-design/web test -- --run tests/components/NewProjectModal.test.tsx tests/styles/new-project-modal-layout.test.ts`
- `pnpm guard`
- `pnpm typecheck`
