### PR TITLE
fix(analytics): fill missing DS event fields + submit_revision + studio apply

### DIFF
--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -500,7 +500,8 @@ export function DesignSystemCreationFlow({
     function emitCreateResult(
       result: 'success' | 'failed' | 'cancelled',
       designSystemId: string | undefined,
-      errorCode?: string,
+      errorCode: string | undefined,
+      projectId: string | undefined,
     ) {
       trackDesignSystemCreateResult(analytics.track, {
         page_name: 'design_systems',
@@ -508,6 +509,7 @@ export function DesignSystemCreationFlow({
         entry_from: createEntryFrom,
         result,
         design_system_id: designSystemId,
+        project_id: projectId,
         design_system_source: designSystemOrigin,
         source_count: snapshot.sourceCount,
         created_as_project: result === 'success',
@@ -533,7 +535,7 @@ export function DesignSystemCreationFlow({
       if (!created) {
         setError('Could not generate this design system.');
         setStep('setup');
-        emitCreateResult('failed', undefined, 'DS_DRAFT_CREATE_FAILED');
+        emitCreateResult('failed', undefined, 'DS_DRAFT_CREATE_FAILED', undefined);
         onGenerateSettled?.(snapshot, {
           result: 'failed',
           errorCode: 'DS_DRAFT_CREATE_FAILED',
@@ -544,7 +546,7 @@ export function DesignSystemCreationFlow({
       if (!workspace) {
         setError('Could not open the design system workspace.');
         setStep('setup');
-        emitCreateResult('failed', created.id, 'DS_WORKSPACE_OPEN_FAILED');
+        emitCreateResult('failed', created.id, 'DS_WORKSPACE_OPEN_FAILED', undefined);
         onGenerateSettled?.(snapshot, {
           result: 'failed',
           errorCode: 'DS_WORKSPACE_OPEN_FAILED',
@@ -555,7 +557,7 @@ export function DesignSystemCreationFlow({
       const setupState = state;
       const connector = githubConnector;
       onCreated(project.id, project);
-      emitCreateResult('success', created.id);
+      emitCreateResult('success', created.id, undefined, project.id);
       onGenerateSettled?.(snapshot, { result: 'success' });
       scheduleAfterProjectHandoff(() => {
         void prepareCreatedDesignSystemProject({
@@ -576,7 +578,7 @@ export function DesignSystemCreationFlow({
       const errorCode = err instanceof Error
         ? `DS_GENERATE_THREW:${err.message.slice(0, 80)}`
         : 'DS_GENERATE_THREW';
-      emitCreateResult('failed', undefined, errorCode);
+      emitCreateResult('failed', undefined, errorCode, undefined);
       onGenerateSettled?.(snapshot, { result: 'failed', errorCode });
     } finally {
       setGenerationStarting(false);
@@ -1072,6 +1074,7 @@ export function DesignSystemDetailView({
         view_type: 'page',
         entry_from: entryFrom,
         design_system_id: system.id,
+        project_id: workspaceProjectId ?? undefined,
         // Origin is the DS's provenance-style source. We don't yet
         // have a precise mapping from `system.source` / provenance
         // metadata to the v2 enum, so we report `unknown` rather
@@ -1099,11 +1102,12 @@ export function DesignSystemDetailView({
         view_type: 'page',
         entry_from: entryFrom,
         design_system_id: system.id,
+        project_id: workspaceProjectId ?? undefined,
         design_system_source: 'unknown',
         design_system_status: designSystemStatus,
       });
     }
-  }, [analytics.track, system?.id, generationActive, designSystemStatus, system]);
+  }, [analytics.track, system?.id, generationActive, designSystemStatus, system, workspaceProjectId]);
   const introChatMessages = useMemo(
     () => buildDesignSystemChatMessages({
       system,
@@ -1303,6 +1307,32 @@ export function DesignSystemDetailView({
       setChatError(null);
       setStatusLine(null);
       setChatSeed(null);
+      // `design_system_review_result` with `submit_revision` fires
+      // once per send that originates from a Needs-work section seed.
+      // The earlier Looks good / Needs work click emitted
+      // `result: submitted` with `review_action: looks_good|needs_work`
+      // — this is the second leg (`action=submit_revision`), recording
+      // the moment the user actually dispatched a fix request with
+      // text. Without it the funnel can't separate "user picked Needs
+      // work but never sent" from "user picked Needs work and sent a
+      // revision request".
+      if (feedbackSection && system) {
+        const slug = designSystemModuleSlug(feedbackSection);
+        trackDesignSystemReviewResult(analytics.track, {
+          page_name: 'design_system_project',
+          area: 'design_system_preview',
+          review_action: 'submit_revision',
+          result: 'submitted',
+          design_system_id: system.id,
+          project_id: projectId,
+          module_id: slug,
+          module_type: designSystemModuleType(slug),
+          module_index: 0,
+          feedback_length_bucket: designSystemLengthBucket(rawText),
+          has_custom_feedback: rawText.length > 0,
+          duration_ms: 0,
+        });
+      }
       setFeedbackSection(null);
       const startedAt = Date.now();
       const userMsg: ChatMessage = {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -46,8 +46,16 @@ import {
   type ResearchOptions,
 } from '@open-design/contracts';
 import { projectKindToTracking } from '@open-design/contracts/analytics';
+import type {
+  TrackingDesignSystemApplyTargetKind,
+  TrackingDesignSystemOrigin,
+  TrackingDesignSystemStatusValue,
+} from '@open-design/contracts/analytics';
 import { useAnalytics } from '../analytics/provider';
-import { trackPageView } from '../analytics/events';
+import {
+  trackDesignSystemApplyResult,
+  trackPageView,
+} from '../analytics/events';
 import {
   clearOnboardingSessionId,
   peekOnboardingSessionId,
@@ -3294,6 +3302,63 @@ export function ProjectView({
   const handleChangeDesignSystemId = useCallback(
     (nextId: string | null) => {
       if ((project.designSystemId ?? null) === nextId) return;
+      // `design_system_apply_result` studio variant. The existing
+      // NewProjectPanel picker fires the same event under
+      // `page_name=home`; this in-project header picker fires under
+      // `page_name=studio` so the funnel sees applies from both
+      // surfaces. `target_project_kind` derives from
+      // `project.metadata.kind`.
+      const target =
+        (projectKindToTracking(project.metadata?.kind ?? null) ?? 'unknown') as TrackingDesignSystemApplyTargetKind;
+      const picked = nextId
+        ? designSystems.find((d) => d.id === nextId)
+        : null;
+      const origin: TrackingDesignSystemOrigin | undefined = picked
+        ? picked.source === 'user'
+          ? 'manual_create'
+          : picked.source === 'built-in'
+            ? 'official_preset'
+            : picked.source === 'installed'
+              ? 'template'
+              : 'unknown'
+        : undefined;
+      const status: TrackingDesignSystemStatusValue | undefined = picked
+        ? picked.status === 'draft' || picked.status === 'published'
+          ? picked.status
+          : 'unknown'
+        : undefined;
+      if (nextId === null) {
+        trackDesignSystemApplyResult(analytics.track, {
+          page_name: 'studio',
+          area: 'design_system_picker',
+          action: 'clear_selection',
+          result: 'success',
+          target_project_kind: target,
+          design_system_applied: false,
+          design_system_selection_mode: 'none',
+          is_default: false,
+          is_auto_selected: false,
+          available_design_system_count: designSystems.length,
+          duration_ms: 0,
+        });
+      } else {
+        trackDesignSystemApplyResult(analytics.track, {
+          page_name: 'studio',
+          area: 'design_system_picker',
+          action: 'select_design_system',
+          result: 'success',
+          target_project_kind: target,
+          design_system_id: nextId,
+          design_system_source: origin,
+          design_system_status: status,
+          design_system_applied: true,
+          design_system_selection_mode: 'manual',
+          is_default: false,
+          is_auto_selected: false,
+          available_design_system_count: designSystems.length,
+          duration_ms: 0,
+        });
+      }
       const updated: Project = {
         ...project,
         designSystemId: nextId,
@@ -3302,7 +3367,7 @@ export function ProjectView({
       onProjectChange(updated);
       void patchProject(project.id, { designSystemId: nextId });
     },
-    [project, onProjectChange],
+    [project, onProjectChange, designSystems, analytics.track],
   );
 
   const handleSaveInstructions = useCallback(async () => {


### PR DESCRIPTION
## Why

Four follow-up gaps surfaced from comparing the v2 spec field lists against live PostHog data on a DS-create + DS-detail walkthrough. Spec rows the dashboard expects, but never arrived because the emit site either omitted an optional field that's filled in scope, or never emitted at all on a code path the spec covers.

## What users will see

Nothing visible. Four additional / enriched analytics rows:

1. **New `design_system_apply_result` row on `page_name=studio`** when the user switches the DS via the in-project header picker. The home-side picker variant (PR #2706) keeps firing; this completes the apply-funnel from both surfaces.

2. **`design_system_create_result.project_id` is now populated** on the success branch (was always missing).

3. **New `design_system_review_result` row with `review_action=submit_revision`** when the user clicks Needs work → types feedback → sends. Without it, the dashboard couldn't separate "picked Needs work but never sent" from "picked Needs work and dispatched a revision request".

4. **`page_view{page_name=design_system_project}` now carries `project_id`** on both the generation-active and the preview variants.

## How

- **ProjectView.tsx**: `handleChangeDesignSystemId` emits `design_system_apply_result` with `page_name=studio`, `area=design_system_picker`, `action=select_design_system|clear_selection`. Selection mode is always `manual`; `target_project_kind` derives from `project.metadata.kind` via `projectKindToTracking`. The DS's origin (manual_create / official_preset / template / unknown) and status are mapped from `DesignSystemSummary.source` / `.status`.
- **DesignSystemFlow.tsx**:
  - `emitCreateResult` signature widens to take `projectId`. Success branch passes `project.id` (in scope from `workspace.project` after `ensureDesignSystemWorkspace`); both failure branches pass `undefined`.
  - `sendProjectChatMessage` emits `design_system_review_result{review_action: submit_revision, result: submitted}` when `feedbackSection` is set on send. Carries the section slug + length bucket of the typed feedback.
  - The two `trackPageView{page_name: design_system_project}` calls now pass `project_id: workspaceProjectId`. `workspaceProjectId` added to the useEffect deps so a delayed-mount ensure re-emits with the now-known id.

`regenerate` review action stays out of scope — the current UI has no explicit regenerate button; the Generate path always creates a fresh DS.

## Validation

- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm --filter @open-design/web test` — 1844/1844 passing

## Surface area

- [x] `apps/web/**`
- [ ] `apps/daemon/**`
- [ ] `packages/contracts/**` (no contract change needed — these fields were already optional on existing Props)
- [ ] CLI / env vars / i18n keys / new deps

Stacks on top of #2706 (DS family events) which is merged on `release/v0.8.0`. Pure analytics emission change — no daemon wire-format change, no breaking change to existing events.