### PR TITLE
test(web): mock useI18n in ProjectView reattach-restore suite

### DIFF
--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -30,6 +30,13 @@ const patchProject = vi.fn();
 const saveTabs = vi.fn();
 
 vi.mock('../../src/i18n', () => ({
+  // ProjectView calls useI18n() (for locale/t); mock it like the other
+  // ProjectView suites so the render does not throw on a missing export.
+  useI18n: () => ({
+    locale: 'en',
+    setLocale: () => undefined,
+    t: (value: string) => value,
+  }),
   useT: () => ((value: string) => value),
 }));
 


### PR DESCRIPTION
## Why

`ProjectView.reattach-restore.test.tsx` is red on `main`: every render throws
`No "useI18n" export is defined on the "../../src/i18n" mock`, failing 5 of its
10 cases. `ProjectView` calls `useI18n()` (for `locale` / `t`), but this suite's
i18n mock only returned `useT`, so the mocked module is missing the export the
component needs at render time.

## What users will see

No user-facing change — test-only fix.

## Surface area

- [x] Tests only — adds the missing `useI18n` export to one suite's i18n mock.
- [ ] No source, API, i18n-key, CLI, or config changes.

## Verification

`pnpm --filter @open-design/web test -- ProjectView.reattach-restore` → 10/10
pass (was 5 failed / 5 passed). The mock now matches the shape the other
ProjectView suites already use (`useI18n` returning `{ locale, setLocale, t }`
plus `useT`).
