### PR TITLE
fix(web): scale recent-project HTML thumbnails to a desktop design width

### DIFF
--- a/apps/web/src/styles/home/recent-projects.css
+++ b/apps/web/src/styles/home/recent-projects.css
@@ -89,6 +89,11 @@
   justify-content: center;
   position: relative;
   overflow: hidden;
+  /* Container for the HTML preview iframe's responsive scale (below): the
+   * iframe renders at a fixed desktop design width and is scaled by the
+   * card's own width so the page reads as a faithful thumbnail instead of
+   * collapsing at the narrow card width. */
+  container-type: inline-size;
 }
 .recent-projects__card-thumb-html,
 .recent-projects__card-thumb-image,
@@ -116,6 +121,17 @@
 .recent-projects__thumb-iframe {
   pointer-events: none;
   background: #fff;
+  /* Render the page at a desktop design width, then scale it down to the
+   * card width via a container query so non-responsive galleries don't
+   * collapse at the narrow card size. 1280x720 keeps the 16/9 thumb ratio,
+   * so the scaled iframe fills the thumb exactly. */
+  inset: auto;
+  top: 0;
+  left: 0;
+  width: 1280px;
+  height: 720px;
+  transform-origin: 0 0;
+  transform: scale(calc(100cqw / 1280px));
 }
 .recent-projects__deck-frame,
 .recent-projects__deck-iframe,


### PR DESCRIPTION
## Why

On the Home view, each Recent projects card renders a live HTML preview in an
iframe. The iframe was sized `width:100%; height:100%`, so it rendered the page
at the **card's own narrow width** — the grid cell goes as small as `180px`
(`repeat(auto-fill, minmax(180px, 1fr))`). A gallery designed for desktop then
collapses at that width: its sticky top bar overlaps and the title text clips,
so the thumbnail looks broken.

The plugin-home HTML tiles already avoid this (`plugins-home__html-iframe`
renders at a fixed design size and scales down with `transform`). Recent
projects didn't, so the two HTML-preview surfaces were inconsistent.

## What users will see

Recent project cards whose preview is an HTML page now show a faithful,
shrunk-down desktop thumbnail instead of a collapsed/garbled narrow render.
Non-HTML covers (image/video/logo/glyph) are unchanged.

## Surface area

- [x] **UI / CSS only** — `apps/web/src/styles/home/recent-projects.css`.
- [ ] No component, API, i18n, CLI, or config changes.

## How

- Make `.recent-projects__card-thumb` a query container (`container-type: inline-size`).
- Render `.recent-projects__thumb-iframe` at `1280x720` (matching the 16/9 thumb)
  and scale it with `transform: scale(calc(100cqw / 1280px))`, origin `0 0`, so it
  shrinks to the card's actual width regardless of the responsive grid cell size.

## Verification

`pnpm guard` passes. Verified in the running app: a desktop-width gallery
preview that previously collapsed at the narrow card width now renders as a
clean scaled thumbnail; image/video/glyph covers unaffected.
