### PR TITLE
fix(web): clip inline model switcher labels

### DIFF
--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -708,6 +708,7 @@
   transition: background-color 120ms ease, border-color 120ms ease,
     color 120ms ease;
   max-width: 360px;
+  overflow: hidden;
 }
 .inline-switcher__chip:hover {
   background: var(--bg-subtle);
@@ -747,6 +748,10 @@
   white-space: nowrap;
 }
 .inline-switcher__chip-mode {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-weight: 600;
   color: var(--text-strong);
 }
@@ -754,9 +759,14 @@
   color: var(--text-faint);
 }
 .inline-switcher__chip-primary {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--text);
 }
 .inline-switcher__chip-model {
+  min-width: 0;
   color: var(--text-muted);
   max-width: 160px;
   overflow: hidden;

--- a/apps/web/tests/styles/inline-model-switcher.test.ts
+++ b/apps/web/tests/styles/inline-model-switcher.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const entryLayoutCss = readFileSync(new URL('../../src/styles/home/entry-layout.css', import.meta.url), 'utf8');
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(entryLayoutCss)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g'))];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('InlineModelSwitcher styles', () => {
+  it('clips long model labels inside the compact chip', () => {
+    const chip = cssDeclarations('.inline-switcher__chip');
+    expect(ruleValue(chip, 'overflow')).toBe('hidden');
+
+    for (const selector of [
+      '.inline-switcher__chip-mode',
+      '.inline-switcher__chip-primary',
+      '.inline-switcher__chip-model',
+    ]) {
+      const block = cssDeclarations(selector);
+      expect(ruleValue(block, 'min-width'), selector).toBe('0');
+      expect(ruleValue(block, 'overflow'), selector).toBe('hidden');
+      expect(ruleValue(block, 'text-overflow'), selector).toBe('ellipsis');
+      expect(ruleValue(block, 'white-space'), selector).toBe('nowrap');
+    }
+  });
+});


### PR DESCRIPTION
Fixes #2718

## Why

I picked this up after claiming the issue because the compact runtime/model selector can render long model names outside the chip boundary. The source trace in the issue pointed to `InlineModelSwitcher` and `entry-layout.css`, and the current styles had truncation on the model span but not enough flex-item constraints to keep the whole chip bounded.

The pain being addressed is a broken-looking top-bar selector when model/provider labels are long. The selected value should degrade with ellipsis instead of bleeding out of the pill.

## What users will see

Long runtime/model selector labels stay clipped inside the top-bar chip. The chip keeps its fixed visual boundary, and the mode/provider/model text segments truncate with ellipsis when there is not enough room.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; the issue screenshot shows the visual symptom, and this PR adds a focused CSS invariant test for the overflow/truncation rules.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/inline-model-switcher.test.ts`
- Did the test go red on `main` and green on this branch? yes. With the CSS file temporarily reverted, the new test failed on the missing `overflow` rule; restored branch code passes.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web test -- tests/styles/inline-model-switcher.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`