### PR TITLE
fix(web): preserve automation ingest select chevron

### DIFF
--- a/apps/web/src/styles/home/tasks.css
+++ b/apps/web/src/styles/home/tasks.css
@@ -567,6 +567,139 @@
   cursor: progress;
 }
 
+/* ---------- Source ingestion ---------- */
+
+.automations-ingest {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.automation-ingest-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-xs);
+}
+
+.automation-ingest-controls,
+.automation-ingest-fields {
+  display: grid;
+  gap: 10px;
+}
+
+.automation-ingest-controls {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.automation-ingest-fields {
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+}
+
+.automation-ingest-field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 5px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.automation-ingest-field input,
+.automation-ingest-field select,
+.automation-ingest-field textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background-color: var(--bg-subtle);
+  color: var(--text);
+  font: 12.5px/1.4 var(--font, system-ui);
+}
+
+.automation-ingest-field input,
+.automation-ingest-field select {
+  height: 34px;
+  padding: 0 10px;
+}
+
+.automation-ingest-field textarea {
+  min-height: 116px;
+  padding: 10px;
+  resize: vertical;
+}
+
+.automation-ingest-field input:focus,
+.automation-ingest-field select:focus,
+.automation-ingest-field textarea:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent, #79a8ff) 44%, var(--border));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #79a8ff) 14%, transparent);
+}
+
+.automation-ingest-field--body {
+  text-transform: none;
+}
+
+.automation-ingest-field--body > span {
+  text-transform: uppercase;
+}
+
+.automation-ingest-footer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: end;
+}
+
+.automation-ingest-recent {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.automation-ingest-recent li {
+  display: flex;
+  max-width: 260px;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+  padding: 7px 9px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-subtle) 72%, transparent);
+}
+
+.automation-ingest-recent span,
+.automation-ingest-recent small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.automation-ingest-recent span {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.automation-ingest-recent small,
+.automation-ingest-empty {
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+
 /* ---------- Template gallery ---------- */
 
 .automations-templates {

--- a/apps/web/tests/styles/automation-ingest-select.test.ts
+++ b/apps/web/tests/styles/automation-ingest-select.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+
+import postcss, { type Declaration, type Root, type Rule } from 'postcss';
+import { describe, expect, it } from 'vitest';
+
+const indexCss = readFileSync(new URL('../../src/index.css', import.meta.url), 'utf8');
+const tasksCss = readFileSync(
+  new URL('../../src/styles/home/tasks.css', import.meta.url),
+  'utf8',
+);
+
+const indexRoot = postcss.parse(indexCss, { from: 'src/index.css' });
+const tasksRoot = postcss.parse(tasksCss, { from: 'src/styles/home/tasks.css' });
+
+function ruleFor(root: Root, selector: string): Rule {
+  let found: Rule | null = null;
+
+  root.walkRules((rule) => {
+    const selectors = rule.selector.split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) found ??= rule;
+  });
+
+  if (!found) throw new Error(`Missing CSS block for ${selector}`);
+  return found;
+}
+
+function declaration(rule: Rule, property: string): Declaration | null {
+  const declarations: Declaration[] = [];
+
+  rule.walkDecls(property, (decl) => {
+    declarations.push(decl);
+  });
+
+  return declarations.at(-1) ?? null;
+}
+
+function value(rule: Rule, property: string): string {
+  const decl = declaration(rule, property);
+  if (!decl) throw new Error(`Missing CSS property ${property}`);
+  return decl.value;
+}
+
+describe('automation ingest select styles', () => {
+  it('preserves custom select chevrons while tinting ingest fields', () => {
+    const ingestSelect = ruleFor(tasksRoot, '.automation-ingest-field select');
+
+    expect(value(ingestSelect, 'background-color')).toBe('var(--bg-subtle)');
+    expect(declaration(ingestSelect, 'background')).toBeNull();
+
+    for (const selector of ["[data-theme='dark'] select", 'html:not([data-theme]) select']) {
+      const select = ruleFor(indexRoot, selector);
+
+      expect(value(select, 'background-repeat')).toBe('no-repeat');
+      expect(value(select, 'background-position')).toBe('right 10px center');
+      expect(value(select, 'background-size')).toBe('12px 12px');
+    }
+  });
+});


### PR DESCRIPTION
Fixes #2694

## Summary
- keep the automation ingest field tint on `background-color` so the shared select chevron `background-image` is not overwritten
- repeat the dark-theme select chevron sizing/positioning declarations when the dark SVG is swapped in
- add a CSS invariant test covering both the automation ingest select rule and dark select chevron rule

## Surface area
- [x] UI
- [ ] API
- [ ] Database
- [ ] Runtime behavior
- [ ] Developer tooling

## Bug verification
- Confirmed the new test fails when these CSS changes are temporarily reversed: `Missing CSS property background-color`

## Validation
- `pnpm --filter @open-design/web test -- tests/styles/automation-ingest-select.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`