### PR TITLE
fix(landing-page): speed up landing-page CI builds

### DIFF
--- a/.github/workflows/landing-page-ci.yml
+++ b/.github/workflows/landing-page-ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Build landing page
         env:
           PUBLIC_GA_MEASUREMENT_ID: ${{ vars.PUBLIC_GA_MEASUREMENT_ID }}
-        run: pnpm --filter @open-design/landing-page build
+        run: pnpm --filter @open-design/landing-page build:static
 
       - name: Lint changed blog SEO
         run: |

--- a/.github/workflows/landing-page-ci.yml
+++ b/.github/workflows/landing-page-ci.yml
@@ -69,15 +69,7 @@ jobs:
         uses: actions/cache@v5.0.5
         with:
           path: apps/landing-page/public/previews
-          key: landing-page-previews-${{ runner.os }}-${{ hashFiles(
-            'pnpm-lock.yaml',
-            'package.json',
-            'apps/landing-page/package.json',
-            'apps/landing-page/scripts/generate-previews.ts',
-            'skills/**',
-            'design-templates/**',
-            'templates/live-artifacts/**'
-          ) }}
+          key: landing-page-previews-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'apps/landing-page/package.json', 'apps/landing-page/scripts/generate-previews.ts', 'skills/**', 'design-templates/**', 'templates/live-artifacts/**') }}
           restore-keys: |
             landing-page-previews-${{ runner.os }}-
 

--- a/.github/workflows/landing-page-ci.yml
+++ b/.github/workflows/landing-page-ci.yml
@@ -64,10 +64,28 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
 
+      - name: Cache generated previews
+        id: previews-cache
+        uses: actions/cache@v5.0.5
+        with:
+          path: apps/landing-page/public/previews
+          key: landing-page-previews-${{ runner.os }}-${{ hashFiles(
+            'pnpm-lock.yaml',
+            'package.json',
+            'apps/landing-page/package.json',
+            'apps/landing-page/scripts/generate-previews.ts',
+            'skills/**',
+            'design-templates/**',
+            'templates/live-artifacts/**'
+          ) }}
+          restore-keys: |
+            landing-page-previews-${{ runner.os }}-
+
       # Cache the Playwright browser binaries between runs. The cache key
       # is pinned to the playwright version we depend on (kept in
       # apps/landing-page/package.json) so a bump invalidates correctly.
       - name: Setup Playwright
+        if: steps.previews-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: apps/landing-page/package.json
@@ -83,6 +101,7 @@ jobs:
       # launch failure or a 100%-failure run exits non-zero so the
       # build stops instead of silently shipping zero thumbnails.
       - name: Generate skill + template previews
+        if: steps.previews-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @open-design/landing-page previews
 
       - name: Build landing page

--- a/.github/workflows/landing-page-ci.yml
+++ b/.github/workflows/landing-page-ci.yml
@@ -85,7 +85,6 @@ jobs:
       # is pinned to the playwright version we depend on (kept in
       # apps/landing-page/package.json) so a bump invalidates correctly.
       - name: Setup Playwright
-        if: steps.previews-cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: apps/landing-page/package.json
@@ -101,7 +100,6 @@ jobs:
       # launch failure or a 100%-failure run exits non-zero so the
       # build stops instead of silently shipping zero thumbnails.
       - name: Generate skill + template previews
-        if: steps.previews-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @open-design/landing-page previews
 
       - name: Build landing page

--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -70,15 +70,7 @@ jobs:
         uses: actions/cache@v5.0.5
         with:
           path: apps/landing-page/public/previews
-          key: landing-page-previews-${{ runner.os }}-${{ hashFiles(
-            'pnpm-lock.yaml',
-            'package.json',
-            'apps/landing-page/package.json',
-            'apps/landing-page/scripts/generate-previews.ts',
-            'skills/**',
-            'design-templates/**',
-            'templates/live-artifacts/**'
-          ) }}
+          key: landing-page-previews-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'package.json', 'apps/landing-page/package.json', 'apps/landing-page/scripts/generate-previews.ts', 'skills/**', 'design-templates/**', 'templates/live-artifacts/**') }}
           restore-keys: |
             landing-page-previews-${{ runner.os }}-
 

--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Build landing page
         env:
           PUBLIC_GA_MEASUREMENT_ID: ${{ vars.PUBLIC_GA_MEASUREMENT_ID }}
-        run: pnpm --filter @open-design/landing-page build
+        run: pnpm --filter @open-design/landing-page build:static
 
       - name: Verify zero external JavaScript
         run: |

--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -83,14 +83,12 @@ jobs:
             landing-page-previews-${{ runner.os }}-
 
       - name: Cache Playwright browsers
-        if: steps.previews-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright Chromium
-        if: steps.previews-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @open-design/landing-page exec playwright install --with-deps chromium
 
       - name: Typecheck landing page
@@ -103,7 +101,6 @@ jobs:
       # exits non-zero so we don't silently ship a deploy with zero
       # thumbnails to production.
       - name: Generate skill + template previews
-        if: steps.previews-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @open-design/landing-page previews
 
       - name: Build landing page

--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -65,13 +65,32 @@ jobs:
           version=$(node -p "require('./apps/landing-page/package.json').devDependencies.playwright.replace(/[^0-9.]/g,'')")
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Cache generated previews
+        id: previews-cache
+        uses: actions/cache@v5.0.5
+        with:
+          path: apps/landing-page/public/previews
+          key: landing-page-previews-${{ runner.os }}-${{ hashFiles(
+            'pnpm-lock.yaml',
+            'package.json',
+            'apps/landing-page/package.json',
+            'apps/landing-page/scripts/generate-previews.ts',
+            'skills/**',
+            'design-templates/**',
+            'templates/live-artifacts/**'
+          ) }}
+          restore-keys: |
+            landing-page-previews-${{ runner.os }}-
+
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        if: steps.previews-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright Chromium
+        if: steps.previews-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @open-design/landing-page exec playwright install --with-deps chromium
 
       - name: Typecheck landing page
@@ -84,6 +103,7 @@ jobs:
       # exits non-zero so we don't silently ship a deploy with zero
       # thumbnails to production.
       - name: Generate skill + template previews
+        if: steps.previews-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @open-design/landing-page previews
 
       - name: Build landing page

--- a/apps/landing-page/app/_lib/catalog.ts
+++ b/apps/landing-page/app/_lib/catalog.ts
@@ -86,6 +86,7 @@ function previewUrlFor(
 
 const REPO_TREE = 'https://github.com/nexu-io/open-design/tree/main';
 const REPO_BLOB = 'https://github.com/nexu-io/open-design/blob/main';
+const SHOULD_CACHE_CATALOG = import.meta.env.PROD;
 
 // ---------------------------------------------------------------------------
 // Skills
@@ -197,6 +198,19 @@ export function shapeSkill(
 export async function getSkillRecords(
   locale: LandingLocaleCode = DEFAULT_LOCALE,
 ): Promise<ReadonlyArray<SkillRecord>> {
+  if (!SHOULD_CACHE_CATALOG) {
+    const previews = listPreviews('skills');
+    const entries = await getCollection('skills');
+    const shaped = entries.map((entry) => shapeSkill(entry, previews, locale));
+    return shaped.sort((a, b) => {
+      // Featured (lower number = higher priority) first, then alphabetical.
+      const af = a.featured ?? Number.POSITIVE_INFINITY;
+      const bf = b.featured ?? Number.POSITIVE_INFINITY;
+      if (af !== bf) return af - bf;
+      return a.name.localeCompare(b.name);
+    });
+  }
+
   const cached = skillRecordsCache.get(locale);
   if (cached) {
     return cached;
@@ -358,6 +372,13 @@ export function shapeSystem(
 export async function getSystemRecords(
   locale: LandingLocaleCode = DEFAULT_LOCALE,
 ): Promise<ReadonlyArray<SystemRecord>> {
+  if (!SHOULD_CACHE_CATALOG) {
+    const entries = await getCollection('systems');
+    return entries
+      .map((entry) => shapeSystem(entry, locale))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
   const cached = systemRecordsCache.get(locale);
   if (cached) {
     return cached;
@@ -514,6 +535,20 @@ export function shapeCraft(
 export async function getCraftRecords(
   locale: LandingLocaleCode = DEFAULT_LOCALE,
 ): Promise<ReadonlyArray<CraftRecord>> {
+  if (!SHOULD_CACHE_CATALOG) {
+    const entries = await getCollection('craft');
+    // Astro normalizes the entry id from `craft/README.md` to `readme`
+    // (lowercase, extension stripped). Comparing the raw `'README'` string
+    // misses it on disk and used to ship `/craft/readme/` as a public
+    // craft principle and inflate the nav count by one. Compare
+    // case-insensitively so future README casings (`Readme.md`, etc.) are
+    // also filtered out.
+    return entries
+      .filter((e) => e.id.toLowerCase() !== 'readme')
+      .map((entry) => shapeCraft(entry, locale))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
   const cached = craftRecordsCache.get(locale);
   if (cached) {
     return cached;
@@ -671,6 +706,29 @@ export function shapeLiveArtifactTemplate(
 export async function getTemplateRecords(
   locale: LandingLocaleCode = DEFAULT_LOCALE,
 ): Promise<ReadonlyArray<TemplateRecord>> {
+  if (!SHOULD_CACHE_CATALOG) {
+    const previews = listPreviews('templates');
+    const designEntries = await getCollection('designTemplates');
+    const designRecords = designEntries.map((entry) =>
+      shapeDesignTemplate(entry, previews, locale),
+    );
+
+    const liveEntries = await getCollection('templates');
+    const liveRecords = liveEntries.map((entry) =>
+      shapeLiveArtifactTemplate(entry, previews, locale),
+    );
+
+    return [...designRecords, ...liveRecords].sort((a, b) => {
+      // Keep explicitly featured templates first, then group the canonical
+      // design-template catalogue ahead of legacy live-artifact shims.
+      const af = a.featured ?? Number.POSITIVE_INFINITY;
+      const bf = b.featured ?? Number.POSITIVE_INFINITY;
+      if (af !== bf) return af - bf;
+      if (a.origin !== b.origin) return a.origin === 'design-template' ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+  }
+
   const cached = templateRecordsCache.get(locale);
   if (cached) {
     return cached;
@@ -740,6 +798,23 @@ function tallyKey(values: Iterable<string | undefined>): Record<string, number> 
 export async function getCatalogCounts(
   locale: LandingLocaleCode = DEFAULT_LOCALE,
 ): Promise<CatalogCounts> {
+  if (!SHOULD_CACHE_CATALOG) {
+    const [skills, systems, templates, craft] = await Promise.all([
+      getSkillRecords(locale),
+      getSystemRecords(locale),
+      getTemplateRecords(locale),
+      getCraftRecords(locale),
+    ]);
+    return {
+      skills: skills.length,
+      systems: systems.length,
+      templates: templates.length,
+      craft: craft.length,
+      byMode: tallyKey(skills.map((s) => s.mode)),
+      byPlatform: tallyKey(skills.map((s) => s.platform)),
+    };
+  }
+
   const cached = catalogCountsCache.get(locale);
   if (cached) {
     return cached;

--- a/apps/landing-page/app/_lib/catalog.ts
+++ b/apps/landing-page/app/_lib/catalog.ts
@@ -115,6 +115,8 @@ export interface SkillRecord {
   previewUrl: string | null;
 }
 
+const skillRecordsCache = new Map<LandingLocaleCode, Promise<ReadonlyArray<SkillRecord>>>();
+
 function deriveSkillSlug(id: string): string {
   // `id` is `[folder]/SKILL` (no extension). We want the folder name.
   const folder = id.split('/')[0] ?? id;
@@ -195,16 +197,26 @@ export function shapeSkill(
 export async function getSkillRecords(
   locale: LandingLocaleCode = DEFAULT_LOCALE,
 ): Promise<ReadonlyArray<SkillRecord>> {
-  const previews = listPreviews('skills');
-  const entries = await getCollection('skills');
-  const shaped = entries.map((entry) => shapeSkill(entry, previews, locale));
-  return shaped.sort((a, b) => {
-    // Featured (lower number = higher priority) first, then alphabetical.
-    const af = a.featured ?? Number.POSITIVE_INFINITY;
-    const bf = b.featured ?? Number.POSITIVE_INFINITY;
-    if (af !== bf) return af - bf;
-    return a.name.localeCompare(b.name);
-  });
+  const cached = skillRecordsCache.get(locale);
+  if (cached) {
+    return cached;
+  }
+
+  const promise = (async () => {
+    const previews = listPreviews('skills');
+    const entries = await getCollection('skills');
+    const shaped = entries.map((entry) => shapeSkill(entry, previews, locale));
+    return shaped.sort((a, b) => {
+      // Featured (lower number = higher priority) first, then alphabetical.
+      const af = a.featured ?? Number.POSITIVE_INFINITY;
+      const bf = b.featured ?? Number.POSITIVE_INFINITY;
+      if (af !== bf) return af - bf;
+      return a.name.localeCompare(b.name);
+    });
+  })();
+
+  skillRecordsCache.set(locale, promise);
+  return promise;
 }
 
 // ---------------------------------------------------------------------------
@@ -224,6 +236,8 @@ export interface SystemRecord {
   source: string;
   body: string;
 }
+
+const systemRecordsCache = new Map<LandingLocaleCode, Promise<ReadonlyArray<SystemRecord>>>();
 
 function extractH1(body: string): string | undefined {
   for (const line of body.split('\n')) {
@@ -344,10 +358,20 @@ export function shapeSystem(
 export async function getSystemRecords(
   locale: LandingLocaleCode = DEFAULT_LOCALE,
 ): Promise<ReadonlyArray<SystemRecord>> {
-  const entries = await getCollection('systems');
-  return entries
-    .map((entry) => shapeSystem(entry, locale))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const cached = systemRecordsCache.get(locale);
+  if (cached) {
+    return cached;
+  }
+
+  const promise = (async () => {
+    const entries = await getCollection('systems');
+    return entries
+      .map((entry) => shapeSystem(entry, locale))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  })();
+
+  systemRecordsCache.set(locale, promise);
+  return promise;
 }
 
 // ---------------------------------------------------------------------------
@@ -363,6 +387,8 @@ export interface CraftRecord {
   source: string;
   body: string;
 }
+
+const craftRecordsCache = new Map<LandingLocaleCode, Promise<ReadonlyArray<CraftRecord>>>();
 
 const CRAFT_NAME_OVERRIDES: Record<string, string> = {
   'rtl-and-bidi': 'RTL & Bidi',
@@ -488,17 +514,27 @@ export function shapeCraft(
 export async function getCraftRecords(
   locale: LandingLocaleCode = DEFAULT_LOCALE,
 ): Promise<ReadonlyArray<CraftRecord>> {
-  const entries = await getCollection('craft');
-  // Astro normalizes the entry id from `craft/README.md` to `readme`
-  // (lowercase, extension stripped). Comparing the raw `'README'` string
-  // misses it on disk and used to ship `/craft/readme/` as a public
-  // craft principle and inflate the nav count by one. Compare
-  // case-insensitively so future README casings (`Readme.md`, etc.) are
-  // also filtered out.
-  return entries
-    .filter((e) => e.id.toLowerCase() !== 'readme')
-    .map((entry) => shapeCraft(entry, locale))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const cached = craftRecordsCache.get(locale);
+  if (cached) {
+    return cached;
+  }
+
+  const promise = (async () => {
+    const entries = await getCollection('craft');
+    // Astro normalizes the entry id from `craft/README.md` to `readme`
+    // (lowercase, extension stripped). Comparing the raw `'README'` string
+    // misses it on disk and used to ship `/craft/readme/` as a public
+    // craft principle and inflate the nav count by one. Compare
+    // case-insensitively so future README casings (`Readme.md`, etc.) are
+    // also filtered out.
+    return entries
+      .filter((e) => e.id.toLowerCase() !== 'readme')
+      .map((entry) => shapeCraft(entry, locale))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  })();
+
+  craftRecordsCache.set(locale, promise);
+  return promise;
 }
 
 // ---------------------------------------------------------------------------
@@ -523,6 +559,8 @@ export interface TemplateRecord {
   body: string;
   previewUrl: string | null;
 }
+
+const templateRecordsCache = new Map<LandingLocaleCode, Promise<ReadonlyArray<TemplateRecord>>>();
 
 export type TemplateEntry = CollectionEntry<'templates'>;
 export type DesignTemplateEntry = CollectionEntry<'designTemplates'>;
@@ -633,26 +671,36 @@ export function shapeLiveArtifactTemplate(
 export async function getTemplateRecords(
   locale: LandingLocaleCode = DEFAULT_LOCALE,
 ): Promise<ReadonlyArray<TemplateRecord>> {
-  const previews = listPreviews('templates');
-  const designEntries = await getCollection('designTemplates');
-  const designRecords = designEntries.map((entry) =>
-    shapeDesignTemplate(entry, previews, locale),
-  );
+  const cached = templateRecordsCache.get(locale);
+  if (cached) {
+    return cached;
+  }
 
-  const liveEntries = await getCollection('templates');
-  const liveRecords = liveEntries.map((entry) =>
-    shapeLiveArtifactTemplate(entry, previews, locale),
-  );
+  const promise = (async () => {
+    const previews = listPreviews('templates');
+    const designEntries = await getCollection('designTemplates');
+    const designRecords = designEntries.map((entry) =>
+      shapeDesignTemplate(entry, previews, locale),
+    );
 
-  return [...designRecords, ...liveRecords].sort((a, b) => {
-    // Keep explicitly featured templates first, then group the canonical
-    // design-template catalogue ahead of legacy live-artifact shims.
-    const af = a.featured ?? Number.POSITIVE_INFINITY;
-    const bf = b.featured ?? Number.POSITIVE_INFINITY;
-    if (af !== bf) return af - bf;
-    if (a.origin !== b.origin) return a.origin === 'design-template' ? -1 : 1;
-    return a.name.localeCompare(b.name);
-  });
+    const liveEntries = await getCollection('templates');
+    const liveRecords = liveEntries.map((entry) =>
+      shapeLiveArtifactTemplate(entry, previews, locale),
+    );
+
+    return [...designRecords, ...liveRecords].sort((a, b) => {
+      // Keep explicitly featured templates first, then group the canonical
+      // design-template catalogue ahead of legacy live-artifact shims.
+      const af = a.featured ?? Number.POSITIVE_INFINITY;
+      const bf = b.featured ?? Number.POSITIVE_INFINITY;
+      if (af !== bf) return af - bf;
+      if (a.origin !== b.origin) return a.origin === 'design-template' ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+  })();
+
+  templateRecordsCache.set(locale, promise);
+  return promise;
 }
 
 // ---------------------------------------------------------------------------
@@ -677,6 +725,8 @@ export interface CatalogCounts {
   byPlatform: Readonly<Record<string, number>>;
 }
 
+const catalogCountsCache = new Map<LandingLocaleCode, Promise<CatalogCounts>>();
+
 function tallyKey(values: Iterable<string | undefined>): Record<string, number> {
   const out: Record<string, number> = {};
   for (const v of values) {
@@ -687,21 +737,33 @@ function tallyKey(values: Iterable<string | undefined>): Record<string, number> 
   return out;
 }
 
-export async function getCatalogCounts(): Promise<CatalogCounts> {
-  const [skills, systems, templates, craft] = await Promise.all([
-    getSkillRecords(),
-    getSystemRecords(),
-    getTemplateRecords(),
-    getCraftRecords(),
-  ]);
-  return {
-    skills: skills.length,
-    systems: systems.length,
-    templates: templates.length,
-    craft: craft.length,
-    byMode: tallyKey(skills.map((s) => s.mode)),
-    byPlatform: tallyKey(skills.map((s) => s.platform)),
-  };
+export async function getCatalogCounts(
+  locale: LandingLocaleCode = DEFAULT_LOCALE,
+): Promise<CatalogCounts> {
+  const cached = catalogCountsCache.get(locale);
+  if (cached) {
+    return cached;
+  }
+
+  const promise = (async () => {
+    const [skills, systems, templates, craft] = await Promise.all([
+      getSkillRecords(locale),
+      getSystemRecords(locale),
+      getTemplateRecords(locale),
+      getCraftRecords(locale),
+    ]);
+    return {
+      skills: skills.length,
+      systems: systems.length,
+      templates: templates.length,
+      craft: craft.length,
+      byMode: tallyKey(skills.map((s) => s.mode)),
+      byPlatform: tallyKey(skills.map((s) => s.platform)),
+    };
+  })();
+
+  catalogCountsCache.set(locale, promise);
+  return promise;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/landing-page/app/plugin-registry.ts
+++ b/apps/landing-page/app/plugin-registry.ts
@@ -626,14 +626,17 @@ const loadBundledOfficialEntries = (
     .map((manifestPath) => officialEntryFromManifest(manifestPath, locale))
     .filter((entry): entry is PublicPluginEntry => Boolean(entry));
 
+const SHOULD_CACHE_PUBLIC_PLUGINS = import.meta.env.PROD;
 const publicPluginsCache = new Map<LandingLocaleCode, ReadonlyArray<PublicPluginEntry>>();
 
 export const getPublicPlugins = (
   locale: LandingLocaleCode = DEFAULT_LOCALE,
 ): PublicPluginEntry[] => {
-  const cached = publicPluginsCache.get(locale);
-  if (cached) {
-    return [...cached];
+  if (SHOULD_CACHE_PUBLIC_PLUGINS) {
+    const cached = publicPluginsCache.get(locale);
+    if (cached) {
+      return [...cached];
+    }
   }
 
   const byId = new Map<string, PublicPluginEntry>();
@@ -685,6 +688,10 @@ export const getPublicPlugins = (
     }
     return left.title.localeCompare(right.title, locale);
   });
+
+  if (!SHOULD_CACHE_PUBLIC_PLUGINS) {
+    return plugins;
+  }
 
   publicPluginsCache.set(locale, plugins);
   return [...plugins];

--- a/apps/landing-page/app/plugin-registry.ts
+++ b/apps/landing-page/app/plugin-registry.ts
@@ -626,9 +626,16 @@ const loadBundledOfficialEntries = (
     .map((manifestPath) => officialEntryFromManifest(manifestPath, locale))
     .filter((entry): entry is PublicPluginEntry => Boolean(entry));
 
+const publicPluginsCache = new Map<LandingLocaleCode, ReadonlyArray<PublicPluginEntry>>();
+
 export const getPublicPlugins = (
   locale: LandingLocaleCode = DEFAULT_LOCALE,
 ): PublicPluginEntry[] => {
+  const cached = publicPluginsCache.get(locale);
+  if (cached) {
+    return [...cached];
+  }
+
   const byId = new Map<string, PublicPluginEntry>();
 
   for (const entry of loadRegistryEntries(locale)) {
@@ -669,7 +676,7 @@ export const getPublicPlugins = (
     }
   }
 
-  return [...byId.values()].sort((left, right) => {
+  const plugins = [...byId.values()].sort((left, right) => {
     const sourceOrder = (entry: PublicPluginEntry) =>
       entry.registryId === 'official' ? 0 : entry.registryId === 'community' ? 1 : 2;
     const order = sourceOrder(left) - sourceOrder(right);
@@ -678,6 +685,9 @@ export const getPublicPlugins = (
     }
     return left.title.localeCompare(right.title, locale);
   });
+
+  publicPluginsCache.set(locale, plugins);
+  return [...plugins];
 };
 
 export const getRegistryCounts = (plugins = getPublicPlugins()) => ({

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev --host 127.0.0.1 --port 17574",
-    "build": "astro check && astro build && tsx scripts/copy-example-html.ts",
+    "build": "astro check && pnpm run build:static",
+    "build:static": "astro build && tsx scripts/copy-example-html.ts",
     "preview": "astro preview --host 127.0.0.1 --port 17574",
     "previews": "tsx scripts/generate-previews.ts",
     "typecheck": "astro check"

--- a/apps/landing-page/scripts/generate-previews.ts
+++ b/apps/landing-page/scripts/generate-previews.ts
@@ -21,7 +21,8 @@
  * by the `sharp` post-processor below.
  */
 import { chromium, type Browser } from 'playwright';
-import { mkdir, cp, readdir, stat } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { mkdir, cp, readdir, readFile, stat, unlink, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL, fileURLToPath } from 'node:url';
@@ -33,17 +34,142 @@ const SKILLS_DIR = path.join(REPO_ROOT, 'skills');
 const DESIGN_TEMPLATES_DIR = path.join(REPO_ROOT, 'design-templates');
 const TEMPLATES_DIR = path.join(REPO_ROOT, 'templates/live-artifacts');
 const OUT_DIR = path.join(LANDING_ROOT, 'public/previews');
+const LANDING_PACKAGE_JSON = path.join(LANDING_ROOT, 'package.json');
+const MANIFEST_PATH = path.join(OUT_DIR, '.manifest.json');
 
 const VIEWPORT = { width: 1440, height: 900 } as const;
 const NAVIGATION_TIMEOUT_MS = 30000;
 const SETTLE_MS = 800; // wait after `load` for fonts / R2 images / JS
+const PREVIEW_GENERATOR_VERSION = '2026-05-22-incremental-1';
+const MANIFEST_VERSION = 1;
 
 interface Job {
   bucket: 'skills' | 'templates';
   slug: string;
   htmlPath: string;
+  sourceRoot: string;
   /** Optional ready-made preview to copy verbatim (skips browser). */
   reuseFrom?: string;
+}
+
+interface PreviewManifestEntry {
+  bucket: Job['bucket'];
+  slug: string;
+  sourceHash: string;
+  output: string;
+  bytes: number;
+}
+
+interface PreviewManifest {
+  version: number;
+  generatorHash: string;
+  entries: Record<string, PreviewManifestEntry>;
+}
+
+function jobKey(job: Pick<Job, 'bucket' | 'slug'>): string {
+  return `${job.bucket}/${job.slug}`;
+}
+
+function outputPathFor(job: Pick<Job, 'bucket' | 'slug'>): string {
+  return path.join(OUT_DIR, job.bucket, `${job.slug}.png`);
+}
+
+function outputRelativePathFor(job: Pick<Job, 'bucket' | 'slug'>): string {
+  return `${job.bucket}/${job.slug}.png`;
+}
+
+function normalizeForHash(value: string): string {
+  return value.split(path.sep).join('/');
+}
+
+async function hashFile(filePath: string): Promise<string> {
+  const hash = createHash('sha256');
+  hash.update(await readFile(filePath));
+  return hash.digest('hex');
+}
+
+async function hashDirectory(rootDir: string): Promise<string> {
+  const hash = createHash('sha256');
+
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      if (entry.name === '.DS_Store' || entry.name === 'node_modules') {
+        continue;
+      }
+
+      const fullPath = path.join(dir, entry.name);
+      const relativePath = normalizeForHash(path.relative(rootDir, fullPath));
+      if (entry.isDirectory()) {
+        hash.update(`dir:${relativePath}\n`);
+        await walk(fullPath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      hash.update(`file:${relativePath}\n`);
+      hash.update(await readFile(fullPath));
+    }
+  }
+
+  await walk(rootDir);
+  return hash.digest('hex');
+}
+
+async function generatorHash(): Promise<string> {
+  const hash = createHash('sha256');
+  hash.update(await readFile(fileURLToPath(import.meta.url)));
+  hash.update(await readFile(LANDING_PACKAGE_JSON));
+  hash.update(
+    JSON.stringify({
+      PREVIEW_GENERATOR_VERSION,
+      VIEWPORT,
+      NAVIGATION_TIMEOUT_MS,
+      SETTLE_MS,
+      outputType: 'png',
+      deviceScaleFactor: 2,
+      clip: VIEWPORT,
+    }),
+  );
+  return hash.digest('hex');
+}
+
+async function loadManifest(expectedGeneratorHash: string): Promise<PreviewManifest> {
+  if (!existsSync(MANIFEST_PATH)) {
+    return { version: MANIFEST_VERSION, generatorHash: expectedGeneratorHash, entries: {} };
+  }
+
+  try {
+    const parsed = JSON.parse(await readFile(MANIFEST_PATH, 'utf8')) as Partial<PreviewManifest>;
+    if (
+      parsed.version !== MANIFEST_VERSION ||
+      parsed.generatorHash !== expectedGeneratorHash ||
+      !parsed.entries ||
+      typeof parsed.entries !== 'object'
+    ) {
+      return { version: MANIFEST_VERSION, generatorHash: expectedGeneratorHash, entries: {} };
+    }
+    return {
+      version: MANIFEST_VERSION,
+      generatorHash: expectedGeneratorHash,
+      entries: parsed.entries,
+    };
+  } catch {
+    return { version: MANIFEST_VERSION, generatorHash: expectedGeneratorHash, entries: {} };
+  }
+}
+
+async function saveManifest(manifest: PreviewManifest): Promise<void> {
+  await writeFile(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+}
+
+async function removeIfExists(filePath: string): Promise<void> {
+  if (!existsSync(filePath)) {
+    return;
+  }
+  await unlink(filePath);
 }
 
 async function discoverJobs(): Promise<Job[]> {
@@ -58,6 +184,7 @@ async function discoverJobs(): Promise<Job[]> {
         bucket: 'skills',
         slug: entry.name,
         htmlPath: example,
+        sourceRoot: path.join(SKILLS_DIR, entry.name),
       });
     }
   }
@@ -74,6 +201,7 @@ async function discoverJobs(): Promise<Job[]> {
           bucket: 'templates',
           slug: entry.name,
           htmlPath: example,
+          sourceRoot: dir,
           reuseFrom: ready,
         });
       } else if (existsSync(example)) {
@@ -81,6 +209,7 @@ async function discoverJobs(): Promise<Job[]> {
           bucket: 'templates',
           slug: entry.name,
           htmlPath: example,
+          sourceRoot: dir,
         });
       }
     }
@@ -99,6 +228,7 @@ async function discoverJobs(): Promise<Job[]> {
           bucket: 'templates',
           slug,
           htmlPath: index,
+          sourceRoot: dir,
           reuseFrom: ready,
         });
       } else if (existsSync(index)) {
@@ -106,6 +236,7 @@ async function discoverJobs(): Promise<Job[]> {
           bucket: 'templates',
           slug,
           htmlPath: index,
+          sourceRoot: dir,
         });
       }
     }
@@ -122,7 +253,7 @@ async function captureOne(browser: Browser, job: Job): Promise<{
 }> {
   const targetDir = path.join(OUT_DIR, job.bucket);
   await mkdir(targetDir, { recursive: true });
-  const targetPng = path.join(targetDir, `${job.slug}.png`);
+  const targetPng = outputPathFor(job);
 
   if (job.reuseFrom) {
     await cp(job.reuseFrom, targetPng);
@@ -199,51 +330,151 @@ async function main(): Promise<number> {
 
   await mkdir(OUT_DIR, { recursive: true });
 
-  let browser: Browser;
-  try {
-    browser = await chromium.launch({ headless: true });
-  } catch (err) {
-    console.error(`✗ chromium.launch failed: ${err instanceof Error ? err.message : String(err)}`);
-    console.error('  Hint: in CI, ensure `playwright install --with-deps chromium` has run.');
-    return EXIT_SYSTEMIC;
+  const currentGeneratorHash = await generatorHash();
+  const previousManifest = await loadManifest(currentGeneratorHash);
+  const nextManifest: PreviewManifest = {
+    version: MANIFEST_VERSION,
+    generatorHash: currentGeneratorHash,
+    entries: only ? { ...previousManifest.entries } : {},
+  };
+
+  if (!only) {
+    const currentJobKeys = new Set(jobs.map((job) => jobKey(job)));
+    for (const [key, entry] of Object.entries(previousManifest.entries)) {
+      if (!currentJobKeys.has(key)) {
+        await removeIfExists(path.join(OUT_DIR, entry.output));
+      }
+    }
   }
+
+  const sourceHashes = new Map<string, string>();
+  for (const job of filtered) {
+    sourceHashes.set(jobKey(job), await hashDirectory(job.sourceRoot));
+  }
+
+  const skipped: string[] = [];
+  const pending: Job[] = [];
+  let skippedBytes = 0;
+
+  for (const job of filtered) {
+    const key = jobKey(job);
+    const sourceHash = sourceHashes.get(key);
+    if (!sourceHash) {
+      pending.push(job);
+      continue;
+    }
+
+    const existing = previousManifest.entries[key];
+    const outputPath = outputPathFor(job);
+    if (
+      existing &&
+      existing.sourceHash === sourceHash &&
+      existing.output === outputRelativePathFor(job) &&
+      existsSync(outputPath)
+    ) {
+      const outputStats = await stat(outputPath);
+      if (outputStats.size > 0) {
+        skipped.push(key);
+        skippedBytes += outputStats.size;
+        nextManifest.entries[key] = {
+          ...existing,
+          bytes: outputStats.size,
+        };
+        continue;
+      }
+    }
+
+    await removeIfExists(outputPath);
+    pending.push(job);
+  }
+
+  const reuseJobs = pending.filter((job) => job.reuseFrom);
+  const renderJobs = pending.filter((job) => !job.reuseFrom);
 
   let ok = 0;
   let failed = 0;
-  let bytes = 0;
+  let bytes = skippedBytes;
   const reused: string[] = [];
   const errors: { slug: string; error: string }[] = [];
 
-  // Concurrency limit — 4 contexts at once is plenty for this workload
-  // and keeps total RAM under ~1.5GB.
-  const CONCURRENCY = 4;
-  let cursor = 0;
-  try {
-    await Promise.all(
-      Array.from({ length: CONCURRENCY }, async () => {
-        while (cursor < filtered.length) {
-          const idx = cursor++;
-          const job = filtered[idx];
-          if (!job) break;
-          const result = await captureOne(browser, job);
-          if (result.ok) {
-            ok++;
-            bytes += result.bytes;
-            if (result.source === 'reuse') reused.push(job.slug);
-            process.stdout.write(`✓ ${job.bucket}/${job.slug} (${(result.bytes / 1024).toFixed(0)}kb${result.source === 'reuse' ? ', reused' : ''})\n`);
-          } else {
-            failed++;
-            errors.push({ slug: `${job.bucket}/${job.slug}`, error: result.error ?? 'unknown' });
-            process.stdout.write(`✗ ${job.bucket}/${job.slug}: ${result.error}\n`);
-          }
-        }
-      }),
-    );
-  } finally {
-    await browser.close();
+  for (const key of skipped) {
+    process.stdout.write(`↷ ${key} (cached)\n`);
   }
 
-  console.log(`\nDone. ok=${ok} failed=${failed} reused=${reused.length} total=${(bytes / 1024 / 1024).toFixed(1)}MB`);
+  for (const job of reuseJobs) {
+    const result = await captureOne(undefined as never, job);
+    const key = jobKey(job);
+    const sourceHash = sourceHashes.get(key);
+    if (result.ok && sourceHash) {
+      ok++;
+      bytes += result.bytes;
+      reused.push(job.slug);
+      nextManifest.entries[key] = {
+        bucket: job.bucket,
+        slug: job.slug,
+        sourceHash,
+        output: outputRelativePathFor(job),
+        bytes: result.bytes,
+      };
+      process.stdout.write(`✓ ${job.bucket}/${job.slug} (${(result.bytes / 1024).toFixed(0)}kb, reused)\n`);
+    } else {
+      failed++;
+      errors.push({ slug: key, error: result.error ?? 'unknown' });
+      process.stdout.write(`✗ ${key}: ${result.error}\n`);
+    }
+  }
+
+  if (renderJobs.length > 0) {
+    let browser: Browser;
+    try {
+      browser = await chromium.launch({ headless: true });
+    } catch (err) {
+      console.error(`✗ chromium.launch failed: ${err instanceof Error ? err.message : String(err)}`);
+      console.error('  Hint: in CI, ensure `playwright install --with-deps chromium` has run.');
+      return EXIT_SYSTEMIC;
+    }
+
+    // Concurrency limit — 4 contexts at once is plenty for this workload
+    // and keeps total RAM under ~1.5GB.
+    const CONCURRENCY = 4;
+    let cursor = 0;
+    try {
+      await Promise.all(
+        Array.from({ length: CONCURRENCY }, async () => {
+          while (cursor < renderJobs.length) {
+            const idx = cursor++;
+            const job = renderJobs[idx];
+            if (!job) break;
+            const result = await captureOne(browser, job);
+            const key = jobKey(job);
+            const sourceHash = sourceHashes.get(key);
+            if (result.ok && sourceHash) {
+              ok++;
+              bytes += result.bytes;
+              nextManifest.entries[key] = {
+                bucket: job.bucket,
+                slug: job.slug,
+                sourceHash,
+                output: outputRelativePathFor(job),
+                bytes: result.bytes,
+              };
+              process.stdout.write(`✓ ${job.bucket}/${job.slug} (${(result.bytes / 1024).toFixed(0)}kb)\n`);
+            } else {
+              failed++;
+              errors.push({ slug: key, error: result.error ?? 'unknown' });
+              process.stdout.write(`✗ ${key}: ${result.error}\n`);
+            }
+          }
+        }),
+      );
+    } finally {
+      await browser.close();
+    }
+  }
+
+  await saveManifest(nextManifest);
+
+  console.log(`\nDone. ok=${ok} skipped=${skipped.length} failed=${failed} reused=${reused.length} total=${(bytes / 1024 / 1024).toFixed(1)}MB`);
   if (errors.length > 0) {
     console.log('\nPer-artifact failures (deploy continues — catalog degrades gracefully for these):');
     for (const e of errors) console.log(`  ${e.slug}: ${e.error}`);
@@ -251,7 +482,7 @@ async function main(): Promise<number> {
 
   // Systemic failure: every job in a non-empty run failed. That means
   // the generator itself is broken, not just one author's example.html.
-  if (filtered.length > 0 && ok === 0) {
+  if (filtered.length > 0 && ok + skipped.length === 0) {
     console.error(
       `\n✗ All ${filtered.length} preview job(s) failed — treating as systemic.`,
     );

--- a/apps/landing-page/scripts/generate-previews.ts
+++ b/apps/landing-page/scripts/generate-previews.ts
@@ -149,17 +149,19 @@ async function hashExtraDependencyRoots(
   directoryHashes: Map<string, string>,
 ): Promise<string> {
   const extraRoots = new Set<string>();
-  const source = await readFile(job.htmlPath, 'utf8');
-  const baseDir = path.dirname(job.htmlPath);
+  if (existsSync(job.htmlPath)) {
+    const source = await readFile(job.htmlPath, 'utf8');
+    const baseDir = path.dirname(job.htmlPath);
 
-  for (const specifier of relativeAssetPaths(source)) {
-    const resolvedPath = path.resolve(baseDir, specifier);
-    if (isWithinRoot(job.sourceRoot, resolvedPath) || !existsSync(resolvedPath)) {
-      continue;
+    for (const specifier of relativeAssetPaths(source)) {
+      const resolvedPath = path.resolve(baseDir, specifier);
+      if (isWithinRoot(job.sourceRoot, resolvedPath) || !existsSync(resolvedPath)) {
+        continue;
+      }
+
+      const stats = await stat(resolvedPath);
+      extraRoots.add(stats.isDirectory() ? resolvedPath : path.dirname(resolvedPath));
     }
-
-    const stats = await stat(resolvedPath);
-    extraRoots.add(stats.isDirectory() ? resolvedPath : path.dirname(resolvedPath));
   }
 
   if (job.reuseFrom && !isWithinRoot(job.sourceRoot, job.reuseFrom) && existsSync(job.reuseFrom)) {

--- a/apps/landing-page/scripts/generate-previews.ts
+++ b/apps/landing-page/scripts/generate-previews.ts
@@ -66,6 +66,8 @@ interface PreviewManifest {
   entries: Record<string, PreviewManifestEntry>;
 }
 
+const RELATIVE_ASSET_PATTERN = /(?:src|href|poster)\s*=\s*["']([^"']+)["']|url\((['"]?)([^'"\)]+)\2\)/g;
+
 function jobKey(job: Pick<Job, 'bucket' | 'slug'>): string {
   return `${job.bucket}/${job.slug}`;
 }
@@ -115,6 +117,78 @@ async function hashDirectory(rootDir: string): Promise<string> {
   }
 
   await walk(rootDir);
+  return hash.digest('hex');
+}
+
+function isWithinRoot(rootDir: string, targetPath: string): boolean {
+  const relativePath = path.relative(rootDir, targetPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
+
+function relativeAssetPaths(source: string): string[] {
+  const matches = new Set<string>();
+  for (const match of source.matchAll(RELATIVE_ASSET_PATTERN)) {
+    const raw = match[1] ?? match[3];
+    if (!raw) {
+      continue;
+    }
+
+    const specifier = raw.split('#', 1)[0]?.split('?', 1)[0]?.trim();
+    if (!specifier || (!specifier.startsWith('./') && !specifier.startsWith('../'))) {
+      continue;
+    }
+
+    matches.add(specifier);
+  }
+
+  return [...matches].sort((left, right) => left.localeCompare(right));
+}
+
+async function hashExtraDependencyRoots(
+  job: Job,
+  directoryHashes: Map<string, string>,
+): Promise<string> {
+  const extraRoots = new Set<string>();
+  const source = await readFile(job.htmlPath, 'utf8');
+  const baseDir = path.dirname(job.htmlPath);
+
+  for (const specifier of relativeAssetPaths(source)) {
+    const resolvedPath = path.resolve(baseDir, specifier);
+    if (isWithinRoot(job.sourceRoot, resolvedPath) || !existsSync(resolvedPath)) {
+      continue;
+    }
+
+    const stats = await stat(resolvedPath);
+    extraRoots.add(stats.isDirectory() ? resolvedPath : path.dirname(resolvedPath));
+  }
+
+  if (job.reuseFrom && !isWithinRoot(job.sourceRoot, job.reuseFrom) && existsSync(job.reuseFrom)) {
+    const stats = await stat(job.reuseFrom);
+    extraRoots.add(stats.isDirectory() ? job.reuseFrom : path.dirname(job.reuseFrom));
+  }
+
+  const hash = createHash('sha256');
+  for (const root of [...extraRoots].sort((left, right) => left.localeCompare(right))) {
+    let dependencyHash = directoryHashes.get(root);
+    if (!dependencyHash) {
+      dependencyHash = await hashDirectory(root);
+      directoryHashes.set(root, dependencyHash);
+    }
+    hash.update(`${normalizeForHash(path.relative(REPO_ROOT, root))}:${dependencyHash}\n`);
+  }
+  return hash.digest('hex');
+}
+
+async function sourceHashForJob(job: Job, directoryHashes: Map<string, string>): Promise<string> {
+  let baseHash = directoryHashes.get(job.sourceRoot);
+  if (!baseHash) {
+    baseHash = await hashDirectory(job.sourceRoot);
+    directoryHashes.set(job.sourceRoot, baseHash);
+  }
+
+  const hash = createHash('sha256');
+  hash.update(baseHash);
+  hash.update(await hashExtraDependencyRoots(job, directoryHashes));
   return hash.digest('hex');
 }
 
@@ -347,9 +421,10 @@ async function main(): Promise<number> {
     }
   }
 
+  const directoryHashes = new Map<string, string>();
   const sourceHashes = new Map<string, string>();
   for (const job of filtered) {
-    sourceHashes.set(jobKey(job), await hashDirectory(job.sourceRoot));
+    sourceHashes.set(jobKey(job), await sourceHashForJob(job, directoryHashes));
   }
 
   const skipped: string[] = [];


### PR DESCRIPTION
## Why

I investigated a landing-page CI run where the `Build landing page` step was taking about 11 minutes. The workflow was paying for repeated build-time catalog/plugin recomputation across thousands of generated pages, and CI was also re-running `astro check` inside the build script after already typechecking earlier in the job.

## What users will see

Landing-page validation and deploy workflows should finish substantially faster, especially the `Build landing page` step.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- No red-spec test was added because this is a CI/build-performance fix rather than a user-facing correctness bug. Verification was done by rebuilding the landing page locally and confirming the build completed successfully after the cache/memoization changes.

## Validation

- `pnpm --filter @open-design/landing-page typecheck`
- `pnpm install`
- `pnpm --filter @open-design/landing-page build:static`