### PR TITLE
fix(web): remove duplicate useI18n in ProjectView reattach-restore mock

### DIFF
--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -38,10 +38,6 @@ vi.mock('../../src/i18n', () => ({
     t: (value: string) => value,
   }),
   useT: () => ((value: string) => value),
-  useI18n: () => ({
-    locale: 'en',
-    t: (value: string) => value,
-  }),
 }));
 
 vi.mock('../../src/providers/anthropic', () => ({


### PR DESCRIPTION
## Why

PR #2724 (`dbc86777`) restored the runtime fix for `ProjectView.reattach-restore.test.tsx` — adding the missing `useI18n` mock — but the merge ended up with **two** `useI18n` keys in the same object literal:

```typescript
vi.mock('../../src/i18n', () => ({
  useI18n: () => ({ locale: 'en', setLocale: () => undefined, t: ... }),  // ← #2724's intended addition
  useT: () => ((value: string) => value),
  useI18n: () => ({ locale: 'en', t: ... }),                              // ← duplicate
}));
```

`main` is now red on `Preflight`:

```
apps/web typecheck: tests/components/ProjectView.reattach-restore.test.tsx(41,3):
  error TS1117: An object literal cannot have multiple properties with the same name.
```

PR #2724's web tests passed because at runtime only the *last* duplicate key matters (objects collapse to the latter value), but TypeScript strict mode rejects the duplicate.

## What users will see

No user-facing change — test-only fix.

## Surface area

- [x] Tests only — drops the duplicate `useI18n` entry from one suite's i18n mock.
- [ ] No source, API, i18n-key, CLI, or config changes.

## Which copy to keep

The first `useI18n` (added intentionally by #2724) matches the pattern used by the **9 sibling** ProjectView test files in `apps/web/tests/components/` — `useI18n: () => ({ locale, setLocale, t })` — and is more complete than the second (which lacks `setLocale`). Drop the second.

## Verification

- `pnpm --filter @open-design/web typecheck` → exit 0
- `pnpm --filter @open-design/web test ProjectView.reattach-restore` → **10 passed (10)**

## Notes for review

I hit this when CI on my own PR (#2619) inherited the broken-main state via GitHub's synthetic merge. Filing as a fast follow-up to #2724; happy to defer to the original author / reviewer if they prefer to roll their own correction.