### PR TITLE
fix(ci): run merge queue checks on merge groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 
 on:
   pull_request:
+  merge_group:
   # Release validation is owned by the release workflows rather than this CI
   # workflow: `release-stable` has a verify job before publishing, and
   # `release-beta` builds from its selected release commit. Keep this trigger


### PR DESCRIPTION
## Why

We enabled merge queue on the default branch, but `ci.yml` only listened to `pull_request` and `push`. That lets the queue enqueue PRs without producing the required `Validate workspace` signal for the merge-group commit, so entries sit waiting instead of proving the post-merge result.

## What users will see

Maintainers can re-enable merge queue and queued PRs will run the normal CI workflow against GitHub's temporary merge-group ref before landing on `main`.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] Default behavior change

## Verification

- `pnpm guard`
- Confirmed `.github/workflows/ci.yml` now triggers on `merge_group` in addition to `pull_request` and `push`.