### PR TITLE
fix(web): keep plugin use menu text readable

### DIFF
--- a/apps/web/src/styles/home/plugins-home.css
+++ b/apps/web/src/styles/home/plugins-home.css
@@ -954,9 +954,10 @@
   font-size: 12px;
   cursor: pointer;
 }
-.plugins-home__use-menu-item:hover,
-.plugins-home__use-menu-item:focus-visible {
-  background: rgba(17, 17, 17, 0.08);
+button.plugins-home__use-menu-item:hover:not(:disabled),
+button.plugins-home__use-menu-item:focus-visible {
+  background: #f3f3f3;
+  color: #111;
   outline: none;
 }
 .plugins-home__action--primary {

--- a/apps/web/tests/styles/plugin-use-menu.test.ts
+++ b/apps/web/tests/styles/plugin-use-menu.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const indexCss = readFileSync(new URL('../../src/index.css', import.meta.url), 'utf8');
+const pluginsHomeCss = readFileSync(
+  new URL('../../src/styles/home/plugins-home.css', import.meta.url),
+  'utf8',
+);
+
+type Specificity = [ids: number, classes: number, types: number];
+
+function cssDeclarations(css: string, selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(css)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g'))];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+function specificity(selector: string): Specificity {
+  const ids = selector.match(/#[\w-]+/g)?.length ?? 0;
+  const classes =
+    (selector.match(/\.[\w-]+/g)?.length ?? 0) +
+    (selector.match(/\[[^\]]+\]/g)?.length ?? 0) +
+    (selector.match(/:(?!:)[\w-]+(?:\([^)]*\))?/g)?.length ?? 0);
+  const withoutPseudos = selector.replace(/:(?!:)[\w-]+(?:\([^)]*\))?/g, '');
+  const types = withoutPseudos
+    .split(/[#.:[\]\s>+~]+/)
+    .filter((part) => /^[a-z][\w-]*$/i.test(part)).length;
+
+  return [ids, classes, types];
+}
+
+function compareSpecificity(left: Specificity, right: Specificity): number {
+  for (let index = 0; index < left.length; index += 1) {
+    const diff = left[index]! - right[index]!;
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const normalized = hex.trim().replace(/^#/, '');
+  if (!/^(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(normalized)) {
+    throw new Error(`Expected #rgb or #rrggbb, got ${hex}`);
+  }
+  const expanded = normalized.length === 3
+    ? [...normalized].map((char) => `${char}${char}`).join('')
+    : normalized;
+  return [
+    Number.parseInt(expanded.slice(0, 2), 16),
+    Number.parseInt(expanded.slice(2, 4), 16),
+    Number.parseInt(expanded.slice(4, 6), 16),
+  ];
+}
+
+function luminance([r, g, b]: [number, number, number]): number {
+  const channel = (value: number) => {
+    const normalized = value / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const first = luminance(hexToRgb(foreground));
+  const second = luminance(hexToRgb(background));
+  const lighter = Math.max(first, second);
+  const darker = Math.min(first, second);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe('plugin use menu contrast', () => {
+  it('keeps option text readable on hover and keyboard focus', () => {
+    const globalHoverSelector = 'button:hover:not(:disabled)';
+    const hoverSelector = 'button.plugins-home__use-menu-item:hover:not(:disabled)';
+    const focusSelector = 'button.plugins-home__use-menu-item:focus-visible';
+    const globalHover = cssDeclarations(indexCss, globalHoverSelector);
+    const hover = cssDeclarations(pluginsHomeCss, hoverSelector);
+    const focus = cssDeclarations(pluginsHomeCss, focusSelector);
+
+    expect(ruleValue(globalHover, 'background')).toBe('var(--bg-subtle)');
+    expect(compareSpecificity(specificity(hoverSelector), specificity(globalHoverSelector))).toBeGreaterThan(0);
+
+    for (const block of [hover, focus]) {
+      const background = ruleValue(block, 'background');
+      const color = ruleValue(block, 'color');
+
+      expect(contrastRatio(color, background)).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #2738

## Why

The plugin card split-button menu can become hard to read in dark mode. The open issue shows the `Use` option in the dropdown losing contrast while hovered, which makes the primary plugin action feel broken even though the menu is otherwise available.

This PR fixes that small hover/focus state directly and adds a regression test around the cascade risk that caused the issue: the global `button:hover:not(:disabled)` rule must not override the plugin menu option state.

## What users will see

In dark mode, hovering or keyboard-focusing the plugin card `Use` dropdown keeps the option text readable on the light menu surface.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before state is captured in #2738. This PR changes only the dropdown option hover/focus colors and covers the state with a CSS regression test that checks both cascade specificity against the global button hover rule and WCAG contrast for the resolved foreground/background pair.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/plugin-use-menu.test.ts`
- Did the test go red on `main` and green on this branch? Not run as a separate red-on-main checkout; the new test asserts the missing invariant from `main` by requiring the plugin menu hover selector to outrank the global button hover rule and to keep at least 4.5:1 contrast.
- Additional review: a read-only subagent review first caught the global-button cascade risk in the initial patch. The final patch was reviewed again with no blocking findings.

## Validation

- `pnpm --filter @open-design/web test tests/styles/plugin-use-menu.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`
