### PR TITLE
fix(daemon): reject unsafe plugin manifest names

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1731,6 +1731,11 @@ async function readProjectPluginManifest(folder) {
   const name = typeof manifest.name === 'string' && manifest.name.trim()
     ? manifest.name.trim()
     : path.basename(folder);
+  if (/[/\\]/.test(name) || /^\.+$/.test(name)) {
+    throw new Error(
+      `open-design.json in ${folder}: name "${name}" must not contain path separators or consist only of dots`,
+    );
+  }
   return {
     name,
     title: typeof manifest.title === 'string' ? manifest.title : name,
@@ -1738,6 +1743,8 @@ async function readProjectPluginManifest(folder) {
     manifest,
   };
 }
+
+export const __forTestReadProjectPluginManifest = readProjectPluginManifest;
 
 function githubRepoNameFromPluginName(name) {
   const slug = String(name)

--- a/apps/daemon/tests/project-plugin-manifest.test.ts
+++ b/apps/daemon/tests/project-plugin-manifest.test.ts
@@ -1,0 +1,33 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { __forTestReadProjectPluginManifest } from '../src/server.js';
+
+describe('readProjectPluginManifest', () => {
+  async function withManifest(name: string, fn: (folder: string) => Promise<void>) {
+    const folder = await mkdtemp(path.join(tmpdir(), 'od-plugin-manifest-'));
+    try {
+      await writeFile(path.join(folder, 'open-design.json'), JSON.stringify({ name }), 'utf8');
+      await fn(folder);
+    } finally {
+      await rm(folder, { recursive: true, force: true });
+    }
+  }
+
+  it.each(['../evil', '..\\\\evil', '.', '..'])('rejects unsafe manifest name %s', async (name) => {
+    await withManifest(name, async (folder) => {
+      await expect(__forTestReadProjectPluginManifest(folder)).rejects.toThrow(
+        /must not contain path separators or consist only of dots/,
+      );
+    });
+  });
+
+  it('allows ordinary plugin names with dots', async () => {
+    await withManifest('my-plugin.v2', async (folder) => {
+      await expect(__forTestReadProjectPluginManifest(folder)).resolves.toMatchObject({
+        name: 'my-plugin.v2',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Validate project plugin manifest names before they enter the GitHub publish flow.
- Reject names containing path separators or names that consist only of dots.
- Add coverage for unsafe names and allow ordinary dotted names like `my-plugin.v2`.

Closes #2752

## Surface area
- [x] Default behavior change: unsafe manifest names that previously passed through now throw during manifest read.
- [x] Daemon publish/contribution metadata path only.
- [ ] SDK/API surface change.
- [ ] Database/storage migration.
- [ ] UI behavior change.

## Validation
- Manually traced the issue example `../../evil`: the new guard rejects it before `githubRepoNameFromPluginName(meta.name)` and before the commit/PR body can include raw manifest metadata.
- Confirmed ordinary dotted names such as `my-plugin.v2` are covered by the new regression test and are not rejected by the guard.
- CI should pick up `apps/daemon/tests/project-plugin-manifest.test.ts` through the existing daemon Vitest config.

## Tests
- `git diff --cached --check`
- `corepack pnpm --filter @open-design/daemon test -- project-plugin-manifest.test.ts` (not run: sparse clone has no `node_modules`; repo also requires Node `~24`, current local Node is `v22.22.2`)

Prepared with local automation assistance and reviewed before submission.