### PR TITLE
Fix Gemini BYOK model URL normalization

### DIFF
--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -12,6 +12,7 @@ import {
 import { isSafeId as isSafeProjectId } from './projects.js';
 import { projectKindToTracking } from '@open-design/contracts/analytics';
 import { validateBaseUrlResolved } from './connectionTest.js';
+import { googleStreamGenerateContentUrl } from './google-models.js';
 
 export interface RegisterChatRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'chat' | 'agents' | 'critique' | 'validation' | 'lifecycle' | 'paths'> {}
 
@@ -866,8 +867,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       );
     }
 
-    const clean = effectiveBaseUrl.replace(/\/+$/, '');
-    const url = `${clean}/v1beta/models/${encodeURIComponent(model)}:streamGenerateContent?alt=sse`;
+    const url = googleStreamGenerateContentUrl(effectiveBaseUrl, model);
     console.log(
       `[proxy:google] ${req.method} ${validated.parsed!.hostname} model=${model}`,
     );

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -54,6 +54,7 @@ import {
   type ParsedBaseUrl,
   type ProviderTestRequest,
 } from '@open-design/contracts/api/connectionTest';
+import { googleGenerateContentUrl } from './google-models.js';
 
 export { validateBaseUrl } from '@open-design/contracts/api/connectionTest';
 
@@ -608,9 +609,8 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
       };
     }
     case 'google': {
-      const trimmedBase = baseUrl.replace(/\/+$/, '');
       return {
-        url: `${trimmedBase}/v1beta/models/${encodeURIComponent(model)}:generateContent`,
+        url: googleGenerateContentUrl(baseUrl, model),
         headers: {
           'content-type': 'application/json',
           'x-goog-api-key': apiKey,

--- a/apps/daemon/src/finalize-design.ts
+++ b/apps/daemon/src/finalize-design.ts
@@ -41,6 +41,7 @@ import {
   validateProjectPath,
 } from './projects.js';
 import { exportProjectTranscript } from './transcript-export.js';
+import { googleGenerateContentUrl } from './google-models.js';
 
 // Re-export the request/response types so existing daemon-internal
 // imports (and the route handler) keep their referenced names. The
@@ -595,9 +596,8 @@ function buildFinalizeProviderRequest(params: FinalizeProviderCallParams): Final
   }
 
   if (params.protocol === 'google') {
-    const clean = params.baseUrl.replace(/\/+$/, '');
     return {
-      url: `${clean}/v1beta/models/${encodeURIComponent(params.model)}:generateContent`,
+      url: googleGenerateContentUrl(params.baseUrl, params.model),
       headers: {
         'content-type': 'application/json',
         'x-goog-api-key': params.apiKey,

--- a/apps/daemon/src/google-models.ts
+++ b/apps/daemon/src/google-models.ts
@@ -1,0 +1,33 @@
+export function googleGenerativeLanguageBaseUrl(baseUrl: string): string {
+  const url = new URL(baseUrl);
+  url.search = '';
+  url.hash = '';
+  const pathname = url.pathname
+    .replace(/\/+$/, '')
+    .replace(/\/v\d+(?:beta)?$/i, '');
+  url.pathname = pathname || '/';
+  return url.toString().replace(/\/+$/, '');
+}
+
+export function normalizeGoogleModelId(model: string): string {
+  const trimmed = model.trim();
+  return trimmed.startsWith('models/') ? trimmed.slice('models/'.length) : trimmed;
+}
+
+export function googleModelPathSegment(model: string): string {
+  return encodeURIComponent(normalizeGoogleModelId(model));
+}
+
+export function googleGenerateContentUrl(baseUrl: string, model: string): string {
+  return `${googleGenerativeLanguageBaseUrl(baseUrl)}/v1beta/models/${googleModelPathSegment(model)}:generateContent`;
+}
+
+export function googleStreamGenerateContentUrl(baseUrl: string, model: string): string {
+  return `${googleGenerativeLanguageBaseUrl(baseUrl)}/v1beta/models/${googleModelPathSegment(model)}:streamGenerateContent?alt=sse`;
+}
+
+export function googleProviderModelsUrl(baseUrl: string, apiKey: string): string {
+  const url = new URL(`${googleGenerativeLanguageBaseUrl(baseUrl)}/v1beta/models`);
+  url.searchParams.set('key', apiKey);
+  return url.toString();
+}

--- a/apps/daemon/src/providerModels.ts
+++ b/apps/daemon/src/providerModels.ts
@@ -9,6 +9,7 @@ import type {
 } from '@open-design/contracts/api/providerModels';
 import { isLoopbackApiHost } from '@open-design/contracts/api/connectionTest';
 import { redactSecrets, validateBaseUrlResolved } from './connectionTest.js';
+import { googleProviderModelsUrl, normalizeGoogleModelId } from './google-models.js';
 
 type ProviderModelsInput = ProviderModelsRequest & { signal?: AbortSignal };
 
@@ -114,11 +115,10 @@ function extractAnthropicModels(data: unknown): ProviderModelOption[] {
 
 function googleModelId(rawName: unknown, rawBaseModelId: unknown): string {
   if (typeof rawBaseModelId === 'string' && rawBaseModelId.trim()) {
-    return rawBaseModelId.trim();
+    return normalizeGoogleModelId(rawBaseModelId);
   }
   if (typeof rawName !== 'string') return '';
-  const name = rawName.trim();
-  return name.startsWith('models/') ? name.slice('models/'.length) : name;
+  return normalizeGoogleModelId(rawName);
 }
 
 function supportsGoogleGenerateContent(item: unknown): boolean {
@@ -158,9 +158,7 @@ function providerModelsUrl(protocol: ConnectionTestProtocol, baseUrl: string, ap
     return url.toString();
   }
   if (protocol === 'google') {
-    const url = new URL(`${baseUrl.replace(/\/+$/, '')}/v1beta/models`);
-    url.searchParams.set('key', apiKey);
-    return url.toString();
+    return googleProviderModelsUrl(baseUrl, apiKey);
   }
   throw new Error(`Unsupported protocol: ${protocol}`);
 }

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -271,6 +271,39 @@ describe('POST /api/provider/models', () => {
     });
   });
 
+  it('does not double-append v1beta when listing Gemini models', async () => {
+    const fetchMock = passThroughOrUpstream((url) => {
+      expect(url).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/models?key=goog-key',
+      );
+      return jsonResponse({
+        models: [
+          {
+            name: 'models/gemini-2.0-flash',
+            displayName: 'Gemini 2.0 Flash',
+            supportedGenerationMethods: ['generateContent'],
+          },
+        ],
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/provider/models`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        protocol: 'google',
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+        apiKey: 'goog-key',
+      }),
+    });
+
+    await expect(res.json()).resolves.toMatchObject({
+      ok: true,
+      models: [{ id: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash' }],
+    });
+  });
+
   it('lets unsupported contract protocols return a classified provider-models result', async () => {
     const fetchMock = passThroughOrUpstream(() => jsonResponse({}));
     vi.stubGlobal('fetch', fetchMock);
@@ -1091,6 +1124,38 @@ describe('POST /api/test/connection provider mode', () => {
         baseUrl: 'https://generativelanguage.googleapis.com',
         apiKey: 'goog-key',
         model: 'gemini-2.0-flash',
+      }),
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.sample).toBe('ok');
+    const upstream = fetchMock.mock.calls.find(
+      ([input]) => !String(input).startsWith(baseUrl),
+    );
+    expect(String(upstream![0])).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent',
+    );
+  });
+
+  it('normalizes Gemini model ids and base URLs in the provider smoke test', async () => {
+    const fetchMock = passThroughOrUpstream(() =>
+      jsonResponse({
+        candidates: [
+          { content: { parts: [{ text: 'ok' }] } },
+        ],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'google',
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+        apiKey: 'goog-key',
+        model: 'models/gemini-2.0-flash',
       }),
     });
     const body = (await res.json()) as Record<string, unknown>;

--- a/apps/daemon/tests/proxy-routes.test.ts
+++ b/apps/daemon/tests/proxy-routes.test.ts
@@ -488,6 +488,32 @@ describe('API proxy routes', () => {
     });
   });
 
+  it('normalizes Gemini model ids and base URLs in the streaming proxy', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      return Promise.resolve(sseResponse('data: {"candidates":[{"content":{"parts":[{"text":"ok"}]}}]}\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await realFetch(`${baseUrl}/api/proxy/google/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+        apiKey: 'google-key',
+        model: 'models/gemini-2.0-flash',
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    const [upstreamUrl, upstreamInit] = fetchMock.mock.calls[0]!;
+    expect(String(upstreamUrl)).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse',
+    );
+    expect(upstreamInit?.redirect).toBe('error');
+  });
+
   // Regression for PR #1176: the Ollama proxy fetch must also set
   // `redirect: 'error'`. Without it, a validated public host could
   // 3xx the daemon to a private/internal URL and slip past the


### PR DESCRIPTION
Fixes #1847

## Why

Gemini BYOK could fetch models successfully but still fail the Settings **Test** button and main chat path with a 404-ish upstream/base-url error. The issue thread narrowed this past user configuration: the Google provider tab, base URL, chat model, and memory model were aligned, but runtime requests still failed.

The likely pain was inconsistent Google request construction between model discovery and runtime/test paths.

## What users will see

Users configuring Google Gemini BYOK should see the same model/base-url behavior across **Fetch models**, **Test**, chat proxy requests, and finalize requests. Existing Gemini configs that use a base URL ending in `/v1beta`, or model IDs returned/entered as `models/<id>`, should no longer produce malformed request URLs.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No screenshot attached. This is a daemon-side URL/model normalization fix for the existing BYOK settings/chat flows; the user-facing surface is unchanged except that valid Gemini configurations should stop failing with malformed upstream URLs.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/connection-test.test.ts` and `apps/daemon/tests/proxy-routes.test.ts` now cover Google base URLs that already include `/v1beta` and model IDs shaped as `models/<id>`.
- Did the test go red on `main` and green on this branch? Not run as a separate red/green pass; the new assertions encode the malformed URL cases described in #1847.
- If a red spec wasn't cheap to write, explain why and what verification you did instead: the public issue did not include a real API key/repro environment, so the tests verify deterministic URL construction without calling Google.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts tests/proxy-routes.test.ts`
  - Result: 2 files passed, 138 tests passed.
- `pnpm --filter @open-design/daemon typecheck`
  - Result: passed.

AI-assisted contribution prepared by an ATXP Earn / Clowdbot operator and checked with deterministic tests.
