### PR TITLE
Forward Node proxy env to packaged sidecars

### DIFF
--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -39,10 +39,14 @@ const PACKAGED_CHILD_ENV_ALLOWLIST = [
   "LANG",
   "LC_ALL",
   "LOGNAME",
+  "NODE_USE_ENV_PROXY",
   "NO_PROXY",
   "TMPDIR",
   "USER",
   "VP_HOME",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
 ] as const;
 
 function shouldForwardPackagedChildEnv(key: string, includeProviderSecrets = false): boolean {

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -81,20 +81,28 @@ describe('packaged child Vite+ environment forwarding', () => {
     expect(env.RANDOM_INTERNAL_FLAG).toBeUndefined();
   });
 
-  it('forwards standard proxy variables to packaged sidecars', () => {
+  it('forwards standard Node proxy variables to packaged sidecars', () => {
     const env = resolvePackagedChildBaseEnv({
       HOME: '/Users/tester',
       HTTP_PROXY: 'http://127.0.0.1:7890',
       HTTPS_PROXY: 'http://127.0.0.1:7890',
+      NODE_USE_ENV_PROXY: '1',
       NO_PROXY: 'localhost,127.0.0.1',
       RANDOM_INTERNAL_FLAG: 'drop-me',
+      http_proxy: 'http://127.0.0.1:7891',
+      https_proxy: 'http://127.0.0.1:7891',
+      no_proxy: 'localhost,127.0.0.1,::1',
     });
 
     expect(env).toMatchObject({
       HOME: '/Users/tester',
       HTTP_PROXY: 'http://127.0.0.1:7890',
       HTTPS_PROXY: 'http://127.0.0.1:7890',
+      NODE_USE_ENV_PROXY: '1',
       NO_PROXY: 'localhost,127.0.0.1',
+      http_proxy: 'http://127.0.0.1:7891',
+      https_proxy: 'http://127.0.0.1:7891',
+      no_proxy: 'localhost,127.0.0.1,::1',
     });
     expect(env.RANDOM_INTERNAL_FLAG).toBeUndefined();
   });


### PR DESCRIPTION
## Why

I hit this while using the packaged desktop app behind a local system proxy. The packaged launcher already forwards the uppercase proxy variables, but it drops `NODE_USE_ENV_PROXY` and the lowercase proxy variables that Node's env proxy support also reads. That means packaged daemon/web sidecars can miss a user's working shell proxy configuration, so provider calls such as OpenAI can fail even when the same environment works outside the packaged app.

This is a narrow packaged-runtime bug fix: keep the existing allowlist model, and add only the Node proxy variables needed for the sidecars to inherit the user's proxy configuration.

## What users will see

Users who launch the packaged app with `NODE_USE_ENV_PROXY=1` plus lowercase `http_proxy`, `https_proxy`, or `no_proxy` in the app environment will have those values forwarded to the packaged sidecars. This lets the packaged daemon use the same proxy configuration as the launcher environment.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI changes.

## Bug fix verification

- Test path that reproduces the bug: `apps/packaged/tests/sidecars.test.ts`
- Did the test go red on `main` and green on this branch? No. This extends the existing env forwarding coverage for the missing proxy env names, but I did not run an explicit red/green baseline cycle against `main`.
- Additional verification: confirmed locally in the packaged app that forwarding `NODE_USE_ENV_PROXY`, `http_proxy`, `https_proxy`, and `no_proxy` lets the daemon inherit the proxy env and reach the OpenAI proxy route.

## Validation

- `npm exec --yes pnpm@10.33.2 -- install --filter @open-design/packaged... --ignore-scripts`
- `npm exec --yes pnpm@10.33.2 -- --filter @open-design/sidecar-proto build`
- `npm exec --yes pnpm@10.33.2 -- --filter @open-design/sidecar build`
- `npm exec --yes pnpm@10.33.2 -- --filter @open-design/platform build`
- `npm exec --yes pnpm@10.33.2 -- --filter @open-design/host build`
- `npm exec --yes pnpm@10.33.2 -- --filter @open-design/diagnostics build`
- `npm exec --yes pnpm@10.33.2 -- --filter @open-design/desktop build`
- `npm exec --yes pnpm@10.33.2 -- exec vitest run -c vitest.config.ts tests/sidecars.test.ts` from `apps/packaged` - passed, 16 tests

Notes:
- Commands emitted Node engine warnings because this machine is on Node `v26.0.0` while the repo targets Node `~24`.
- `npm exec --yes pnpm@10.33.2 -- --filter @open-design/packaged test -- sidecars.test.ts` also loaded unrelated packaged desktop suites and failed because Electron was installed with `--ignore-scripts`; the targeted `tests/sidecars.test.ts` run passed.
