### PR TITLE
fix(web): anchor avatar-popover to left in RTL so it doesn't clip off-screen

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1449,6 +1449,10 @@ code {
   flex-direction: column;
   gap: 2px;
 }
+[dir="rtl"] .avatar-popover {
+  right: auto;
+  left: 0;
+}
 .avatar-popover-head {
   padding: 10px 10px 8px;
   display: flex;


### PR DESCRIPTION
Fixes #2719

## Why

The settings popover (`.avatar-popover`) clips off-screen when switching to an RTL locale like Arabic or Farsi. The settings cog renders on the left side after the flex layout reverses, but the popover still anchors `right: 0`, pushing its 280px width off-screen to the left and making the Settings menu unusable in RTL languages.

## What users will see

Arabic / Farsi / any RTL locale: the settings popover now opens correctly below the cog instead of disappearing off-screen to the left.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

### Before

<img width="2672" height="1552" alt="image" src="https://github.com/user-attachments/assets/35722add-b67c-43a8-84f5-a73e3e415086" />

### After

<img width="2416" height="1408" alt="image" src="https://github.com/user-attachments/assets/313eb9a2-38ef-4707-85cd-7ce96c1b0d1d" />

## Validation

`pnpm guard` + `pnpm typecheck` + browser inspection in both LTR and RTL (ar/fa) locales.