### PR TITLE
fix(pack): restore cp import in mac/app.ts (regression from #2160)

### DIFF
--- a/tools/pack/src/mac/app.ts
+++ b/tools/pack/src/mac/app.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { cp, mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 
 import { rebuild, type RebuildOptions } from "@electron/rebuild";


### PR DESCRIPTION
## Why

Author use case: running CI on a separate PR (#2619, P0 history substrate) at 03:51 UTC and every job failed at workspace install with `TS2304: Cannot find name 'cp'` in `tools/pack/src/mac/app.ts`. Tracked it back to #2160 ("Fix mac tools-pack Node fallback") which merged at 03:46 UTC — that change rewrote the `node:fs/promises` import line and dropped `cp`, but left the `await cp(...)` call at line 269 untouched.

Pain: main HEAD's `ci` workflow on `650f7a5d` is failing on the same error (run `26322737524`). Every open PR fails the same way at ~43–48s because the entire workspace install fails at the `tools-pack` postinstall build, before any PR-specific tests can run. That gates the entire PR queue.

## What users will see

No user-visible change. This unbreaks `pnpm install` on `main` and unblocks CI for all in-flight PRs.

## Surface area

- [x] **None** — internal fix to a workspace postinstall build error

## Bug fix verification

Not a "bug" in the falsifiable-test sense; this is a TypeScript compile error caught by the same `tsc` that every CI job runs implicitly via `tools-pack` postinstall. Reproduce:

```bash
git checkout 650f7a5d  # or main HEAD
pnpm --filter @open-design/tools-pack typecheck
# → src/mac/app.ts(269,9): error TS2304: Cannot find name 'cp'.
```

After this PR:

```bash
pnpm --filter @open-design/tools-pack typecheck  # clean exit
```

## Validation

- `pnpm --filter @open-design/tools-pack typecheck` — clean
- Diff is one line: re-add `cp` to the `node:fs/promises` import. The `await cp(...)` call at line 269 (copying `apps/desktop/dist/main/preload.cjs` into the assembled app root) was left intact by #2160; it just lost its import.
- Did not re-add `chmod` — #2160 correctly removed the `chmod` call along with the import.
- `stat` import added by #2160 is correct — used at line 196.

