### PR TITLE
fix(ci): broaden fork PR workflow auto-approval

### DIFF
--- a/scripts/approve-fork-pr-workflows.test.ts
+++ b/scripts/approve-fork-pr-workflows.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   hasPullApprovalStateDrift,
+  isAllowedChangedPath,
   isDeniedChangedPath,
   isPendingApprovalRun,
   listPendingApprovalRuns,
@@ -440,7 +441,19 @@ test("isDeniedChangedPath blocks common tool config files under allowlisted sour
   assert.equal(isDeniedChangedPath("apps/web/tsconfig.sidecar.json"), true);
   assert.equal(isDeniedChangedPath("apps/daemon/tsconfig.tests.json"), true);
   assert.equal(isDeniedChangedPath("packages/contracts/tsconfig.tests.json"), true);
+  assert.equal(isDeniedChangedPath("apps/packaged/tsconfig.json"), true);
+  assert.equal(isDeniedChangedPath("apps/packaged/vitest.config.ts"), true);
   assert.equal(isDeniedChangedPath("apps/web/src/app/page.tsx"), false);
+});
+
+test("isAllowedChangedPath allows ordinary app and package source/test paths while keeping denied surfaces blocked", () => {
+  assert.equal(isAllowedChangedPath("apps/packaged/src/main.ts"), true);
+  assert.equal(isAllowedChangedPath("apps/packaged/tests/main.test.ts"), true);
+  assert.equal(isAllowedChangedPath("apps/desktop/src/main.ts"), true);
+  assert.equal(isAllowedChangedPath("packages/sidecar/src/index.ts"), true);
+  assert.equal(isAllowedChangedPath("tools/pack/src/index.ts"), false);
+  assert.equal(isAllowedChangedPath("apps/packaged/tsconfig.json"), false);
+  assert.equal(isAllowedChangedPath("apps/packaged/vitest.config.ts"), false);
 });
 
 test("waitForPendingApprovalRuns retries until action_required runs appear and keeps polling through the retry window", async () => {

--- a/scripts/approve-fork-pr-workflows.ts
+++ b/scripts/approve-fork-pr-workflows.ts
@@ -97,15 +97,16 @@ function getPrNumber(): number {
   return Number(requireEnv("PR_NUMBER"));
 }
 
-function isAllowedChangedPath(path: string): boolean {
+function isAllowedSourceOrTestPath(path: string): boolean {
+  return /^(apps|packages)\/[^/]+\/(src|tests)\//.test(path);
+}
+
+export function isAllowedChangedPath(path: string): boolean {
   if (isDeniedChangedPath(path)) return false;
   return (
     isDocsPath(path) ||
     path.startsWith("apps/web/") ||
-    path.startsWith("apps/daemon/src/") ||
-    path.startsWith("apps/daemon/tests/") ||
-    path.startsWith("packages/contracts/src/") ||
-    path.startsWith("packages/contracts/tests/")
+    isAllowedSourceOrTestPath(path)
   );
 }
 
@@ -116,7 +117,6 @@ export function isDeniedChangedPath(path: string): boolean {
     path.startsWith("e2e/scripts/") ||
     path.startsWith("nix/") ||
     path.startsWith("tools/pack/") ||
-    path.startsWith("apps/packaged/") ||
     path === "package.json" ||
     path.endsWith("/package.json") ||
     path === "pnpm-lock.yaml" ||


### PR DESCRIPTION
## Why

The current fork PR auto-approval policy was optimized for caution, but it leaves maintainers manually approving many ordinary source and test changes that already run only in low-privilege `pull_request` workflows. This broadens the safe path allowlist so open-source contributions can reach CI faster without weakening the existing protections around workflow, dependency, config, packaging, and release-control surfaces.

## What users will see

Fork PRs that only touch ordinary app/package `src/**` and `tests/**` files will start their existing CI workflows automatically more often instead of waiting for a maintainer to approve them by hand.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the policy gap: `scripts/approve-fork-pr-workflows.test.ts`
- Did the test go red on `main` and green on this branch? No — this is a policy expansion, so I added coverage for the newly allowed app/package `src/**` and `tests/**` paths and for the denylisted config/tooling surfaces that must stay blocked.

## Validation

- `node --test scripts/approve-fork-pr-workflows.test.ts`
- `pnpm guard`
- `pnpm typecheck`