### PR TITLE
fix(web): prevent preview iframe from stealing focus on load

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -70,6 +70,7 @@ import { buildLazySrcdocTransport, buildSrcdoc, canActivateSrcDocTransport } fro
 import {
   hasTweaksTemplate,
   hasUrlModeBridge,
+  htmlNeedsFocusGuard,
   htmlNeedsSandboxShim,
   parseForceInline,
   shouldUrlLoadHtmlPreview,
@@ -4127,6 +4128,10 @@ function HtmlViewer({
     () => source != null && htmlNeedsSandboxShim(source),
     [source],
   );
+  const needsFocusGuard = useMemo(
+    () => source != null && htmlNeedsFocusGuard(source),
+    [source],
+  );
   const useUrlLoadPreview = shouldUrlLoadHtmlPreview({
     mode,
     isDeck: effectiveDeck,
@@ -4138,6 +4143,7 @@ function HtmlViewer({
     drawMode: drawOverlayOpen,
     tweaksBridge: tweaksBridgeRequired,
     forceInline: forceInline || needsSandboxShim,
+    needsFocusGuard,
   });
   const basePreviewSrcUrl = useMemo(
     () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}`,

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4208,6 +4208,7 @@ function HtmlViewer({
       editBridge: manualEditMode,
       paletteBridge: true,
       initialPalette: selectedPalette,
+      previewFocusGuard: true,
     }) : ''),
     [previewSource, effectiveDeck, projectId, file.name, previewStateKey, manualEditMode, selectedPalette],
   );

--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -153,20 +153,25 @@ export function parseForceInline(search: string | URLSearchParams | null | undef
  * negatives are the same blank-preview the user already hits.
  */
 /**
- * Return true when the HTML source contains patterns that call `.focus()` at
- * load time, which would steal focus from the host page in a URL-loaded
- * iframe. The srcDoc path injects `injectPreviewFocusGuard` to suppress this;
- * URL-load has no such guard, so we force the srcDoc path instead.
+ * Return true when the HTML source may call `.focus()` at load time, which
+ * would steal focus from the host page in a URL-loaded iframe. The srcDoc
+ * path injects `injectPreviewFocusGuard` to suppress this; URL-load has no
+ * such guard, so we force the srcDoc path instead.
  *
- * Matches any `.focus(` call — this covers `window.focus()`,
- * `document.body.focus()`, `element.focus()`, chained calls like
- * `querySelector("input").focus()`, and `autofocus` attributes.
- * False positives (e.g. a comment mentioning `.focus(`) just route the
- * artifact through the slightly slower srcDoc path, which is safe.
+ * Detection covers two cases:
+ *
+ *   1. Inline `.focus(` calls and `autofocus` attributes — directly visible
+ *      in the document source.
+ *   2. External `<script src=...>` references — we cannot inspect the linked
+ *      file's content, so we conservatively assume it may call focus.
+ *
+ * False positives just route the artifact through the slightly slower srcDoc
+ * path, which is the safe direction.
  */
 export function htmlNeedsFocusGuard(source: string): boolean {
   if (/\.\s*focus\s*\(/i.test(source)) return true;
   if (/\bautofocus\b/i.test(source)) return true;
+  if (/<script\b[^>]*\bsrc\s*=/i.test(source)) return true;
   return false;
 }
 

--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -46,6 +46,12 @@ export interface UrlLoadDecision {
   tweaksBridge?: boolean;
   /** User explicitly opted into the inline path via ?forceInline=1. */
   forceInline: boolean;
+  /**
+   * The HTML source contains patterns that steal focus on load (e.g.
+   * `window.focus()`, `element.focus()`). When true, forces the srcDoc path
+   * so `injectPreviewFocusGuard` can suppress the focus grab.
+   */
+  needsFocusGuard?: boolean;
 }
 
 /**
@@ -83,6 +89,7 @@ export function shouldUrlLoadHtmlPreview(d: UrlLoadDecision): boolean {
   // the artifact ships a `.tw-panel`.
   if (d.tweaksBridge) return false;
   if (d.forceInline) return false;
+  if (d.needsFocusGuard) return false;
   return true;
 }
 
@@ -145,6 +152,22 @@ export function parseForceInline(search: string | URLSearchParams | null | undef
  * positives just take the (slightly slower but safer) srcDoc path; false
  * negatives are the same blank-preview the user already hits.
  */
+/**
+ * Return true when the HTML source contains patterns that call `focus()` at
+ * load time, which would steal focus from the host page in a URL-loaded
+ * iframe. The srcDoc path injects `injectPreviewFocusGuard` to suppress this;
+ * URL-load has no such guard, so we force the srcDoc path instead.
+ *
+ * Covers the most common patterns: `window.focus()`, `element.focus()`,
+ * and `autofocus` attributes. False negatives are acceptable — the worst
+ * case is a focus steal that the user can fix by toggling a bridge mode.
+ */
+export function htmlNeedsFocusGuard(source: string): boolean {
+  if (/(?:window|document)\s*\.\s*focus\s*\(/i.test(source)) return true;
+  if (/\bautofocus\b/i.test(source)) return true;
+  return false;
+}
+
 export function htmlNeedsSandboxShim(source: string): boolean {
   // Quote-optional: HTML5 permits unquoted attribute values
   // (`<script type=text/babel src=app.jsx>`). The trailing `\b` rejects

--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -153,17 +153,19 @@ export function parseForceInline(search: string | URLSearchParams | null | undef
  * negatives are the same blank-preview the user already hits.
  */
 /**
- * Return true when the HTML source contains patterns that call `focus()` at
+ * Return true when the HTML source contains patterns that call `.focus()` at
  * load time, which would steal focus from the host page in a URL-loaded
  * iframe. The srcDoc path injects `injectPreviewFocusGuard` to suppress this;
  * URL-load has no such guard, so we force the srcDoc path instead.
  *
- * Covers the most common patterns: `window.focus()`, `element.focus()`,
- * and `autofocus` attributes. False negatives are acceptable — the worst
- * case is a focus steal that the user can fix by toggling a bridge mode.
+ * Matches any `.focus(` call — this covers `window.focus()`,
+ * `document.body.focus()`, `element.focus()`, chained calls like
+ * `querySelector("input").focus()`, and `autofocus` attributes.
+ * False positives (e.g. a comment mentioning `.focus(`) just route the
+ * artifact through the slightly slower srcDoc path, which is safe.
  */
 export function htmlNeedsFocusGuard(source: string): boolean {
-  if (/(?:window|document)\s*\.\s*focus\s*\(/i.test(source)) return true;
+  if (/\.\s*focus\s*\(/i.test(source)) return true;
   if (/\bautofocus\b/i.test(source)) return true;
   return false;
 }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -31,6 +31,7 @@ export type SrcdocOptions = {
   editBridge?: boolean;
   paletteBridge?: boolean;
   initialPalette?: string | null;
+  previewFocusGuard?: boolean;
 };
 
 export function buildSrcdoc(
@@ -53,7 +54,8 @@ export function buildSrcdoc(
   const withSourcePaths = options.editBridge ? annotateManualEditSourcePaths(withOdIds) : withOdIds;
   const withBase = options.baseHref ? injectBaseHref(withSourcePaths, options.baseHref) : withSourcePaths;
   const withShim = injectSandboxShim(withBase);
-  const withDeck = options.deck ? injectDeckBridge(withShim, options.initialSlideIndex) : withShim;
+  const withFocusGuard = options.previewFocusGuard ? injectPreviewFocusGuard(withShim) : withShim;
+  const withDeck = options.deck ? injectDeckBridge(withFocusGuard, options.initialSlideIndex) : withFocusGuard;
   // Comment + Inspect share an element-selection bridge: both pick a
   // [data-od-id] / [data-screen-label] node and route the host's reply
   // to either the comment popover (annotate) or the inspect panel
@@ -670,6 +672,49 @@ function injectSandboxShim(doc: string): string {
   if (/<body[^>]*>/i.test(doc))
     return doc.replace(/<body[^>]*>/i, (m) => `${m}${shim}`);
   return shim + doc;
+}
+
+function injectPreviewFocusGuard(doc: string): string {
+  const script = `<script data-od-preview-focus-guard>(function(){
+  var lastTrustedInputAt = 0;
+  function userActivated(){
+    return Date.now() - lastTrustedInputAt < 1000;
+  }
+  function markTrustedInput(event){
+    if (event && event.isTrusted) lastTrustedInputAt = Date.now();
+  }
+  document.addEventListener('pointerdown', function(event){
+    markTrustedInput(event);
+  }, true);
+  document.addEventListener('keydown', function(event){
+    markTrustedInput(event);
+  }, true);
+  try {
+    var nativeWindowFocus = window.focus && window.focus.bind(window);
+    Object.defineProperty(window, 'focus', {
+      configurable: true,
+      writable: true,
+      value: function(){
+        if (userActivated() && nativeWindowFocus) return nativeWindowFocus();
+      }
+    });
+  } catch (_) {}
+  try {
+    var nativeElementFocus = HTMLElement.prototype.focus;
+    Object.defineProperty(HTMLElement.prototype, 'focus', {
+      configurable: true,
+      writable: true,
+      value: function(options){
+        if (userActivated()) return nativeElementFocus.call(this, options);
+      }
+    });
+  } catch (_) {}
+})();</script>`;
+  if (/<head[^>]*>/i.test(doc))
+    return doc.replace(/<head[^>]*>/i, (m) => `${m}${script}`);
+  if (/<body[^>]*>/i.test(doc))
+    return doc.replace(/<body[^>]*>/i, (m) => `${m}${script}`);
+  return script + doc;
 }
 
 // Selection bridge: shared substrate for Comment mode and Inspect mode.

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -433,6 +433,7 @@ describe('FileViewer SVG artifacts', () => {
       const activations = srcDocActivationMessages(postMessageSpy.mock.calls);
       expect(activations.at(-1)?.html).toContain('__odArtifactBootCount');
       expect(activations.at(-1)?.html).toContain('data-od-selection-bridge');
+      expect(activations.at(-1)?.html).toContain('data-od-preview-focus-guard');
     });
   });
 

--- a/apps/web/tests/components/file-viewer-render-mode.test.ts
+++ b/apps/web/tests/components/file-viewer-render-mode.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   hasTweaksTemplate,
   hasUrlModeBridge,
+  htmlNeedsFocusGuard,
   htmlNeedsSandboxShim,
   parseForceInline,
   shouldUrlLoadHtmlPreview,
@@ -52,6 +53,10 @@ describe('shouldUrlLoadHtmlPreview', () => {
 
   it('falls back to srcDoc when the user opts in via forceInline', () => {
     expect(shouldUrlLoadHtmlPreview({ ...base, forceInline: true })).toBe(false);
+  });
+
+  it('falls back to srcDoc when the HTML source needs a focus guard', () => {
+    expect(shouldUrlLoadHtmlPreview({ ...base, needsFocusGuard: true })).toBe(false);
   });
 
   it('does not URL-load while the source-code tab is active', () => {
@@ -213,5 +218,33 @@ describe('htmlNeedsSandboxShim', () => {
     expect(htmlNeedsSandboxShim('Storage')).toBe(false);
     expect(htmlNeedsSandboxShim('mylocalStorageWrapper')).toBe(false);
     expect(htmlNeedsSandboxShim('SuperLocalStorage')).toBe(false);
+  });
+});
+
+describe('htmlNeedsFocusGuard', () => {
+  it('returns false for plain static HTML', () => {
+    expect(htmlNeedsFocusGuard('<!doctype html><h1>hello</h1>')).toBe(false);
+  });
+
+  it('detects window.focus() calls', () => {
+    expect(htmlNeedsFocusGuard('<script>window.focus();</script>')).toBe(true);
+    expect(htmlNeedsFocusGuard('<script>window .focus()</script>')).toBe(true);
+    expect(htmlNeedsFocusGuard('<script>WINDOW.FOCUS()</script>')).toBe(true);
+  });
+
+  it('detects document.focus() calls', () => {
+    expect(htmlNeedsFocusGuard('<script>document.focus();</script>')).toBe(true);
+  });
+
+  it('detects autofocus attributes', () => {
+    expect(htmlNeedsFocusGuard('<input autofocus>')).toBe(true);
+    expect(htmlNeedsFocusGuard('<input AUTOFOCUS>')).toBe(true);
+    expect(htmlNeedsFocusGuard('<textarea autofocus></textarea>')).toBe(true);
+  });
+
+  it('does not match unrelated focus mentions', () => {
+    expect(htmlNeedsFocusGuard('<div class="focus-ring">')).toBe(false);
+    expect(htmlNeedsFocusGuard('// focus the element')).toBe(false);
+    expect(htmlNeedsFocusGuard('element.focus()')).toBe(false);
   });
 });

--- a/apps/web/tests/components/file-viewer-render-mode.test.ts
+++ b/apps/web/tests/components/file-viewer-render-mode.test.ts
@@ -249,6 +249,18 @@ describe('htmlNeedsFocusGuard', () => {
     expect(htmlNeedsFocusGuard('<textarea autofocus></textarea>')).toBe(true);
   });
 
+  it('detects external script references that may call focus at load', () => {
+    expect(htmlNeedsFocusGuard('<script src="./boot.js"></script>')).toBe(true);
+    expect(htmlNeedsFocusGuard('<script src="app.js"></script>')).toBe(true);
+    expect(htmlNeedsFocusGuard('<script defer src="./assets/init.js"></script>')).toBe(true);
+    expect(htmlNeedsFocusGuard('<SCRIPT SRC="main.js"></SCRIPT>')).toBe(true);
+  });
+
+  it('does not match inline scripts without focus calls', () => {
+    expect(htmlNeedsFocusGuard('<script>console.log("hello")</script>')).toBe(false);
+    expect(htmlNeedsFocusGuard('<script type="application/json">{}</script>')).toBe(false);
+  });
+
   it('does not match unrelated focus mentions', () => {
     expect(htmlNeedsFocusGuard('<div class="focus-ring">')).toBe(false);
     expect(htmlNeedsFocusGuard('// focus the element')).toBe(false);

--- a/apps/web/tests/components/file-viewer-render-mode.test.ts
+++ b/apps/web/tests/components/file-viewer-render-mode.test.ts
@@ -232,8 +232,15 @@ describe('htmlNeedsFocusGuard', () => {
     expect(htmlNeedsFocusGuard('<script>WINDOW.FOCUS()</script>')).toBe(true);
   });
 
-  it('detects document.focus() calls', () => {
-    expect(htmlNeedsFocusGuard('<script>document.focus();</script>')).toBe(true);
+  it('detects document.body.focus() calls', () => {
+    expect(htmlNeedsFocusGuard('<script>document.body.focus();</script>')).toBe(true);
+    expect(htmlNeedsFocusGuard('<script>document.body .focus()</script>')).toBe(true);
+  });
+
+  it('detects querySelector(...).focus() and chained focus calls', () => {
+    expect(htmlNeedsFocusGuard('<script>document.querySelector("input").focus()</script>')).toBe(true);
+    expect(htmlNeedsFocusGuard('<script>document.getElementById("x").focus()</script>')).toBe(true);
+    expect(htmlNeedsFocusGuard('<script>myInput.focus()</script>')).toBe(true);
   });
 
   it('detects autofocus attributes', () => {
@@ -245,6 +252,7 @@ describe('htmlNeedsFocusGuard', () => {
   it('does not match unrelated focus mentions', () => {
     expect(htmlNeedsFocusGuard('<div class="focus-ring">')).toBe(false);
     expect(htmlNeedsFocusGuard('// focus the element')).toBe(false);
-    expect(htmlNeedsFocusGuard('element.focus()')).toBe(false);
+    expect(htmlNeedsFocusGuard(':focus')).toBe(false);
+    expect(htmlNeedsFocusGuard('focus-visible')).toBe(false);
   });
 });

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -37,6 +37,20 @@ describe('buildSrcdoc', () => {
     expect(srcdoc).toContain('foreignObject');
   });
 
+  it('can guard preview iframes against load-time focus stealing', () => {
+    const srcdoc = buildSrcdoc(
+      '<!doctype html><html><head><script>window.focus();document.body.focus();</script></head><body>Hero</body></html>',
+      { previewFocusGuard: true },
+    );
+
+    expect(srcdoc).toContain('data-od-preview-focus-guard');
+    expect(srcdoc).toContain("Object.defineProperty(window, 'focus'");
+    expect(srcdoc).toContain("Object.defineProperty(HTMLElement.prototype, 'focus'");
+    expect(srcdoc.indexOf('data-od-preview-focus-guard')).toBeLessThan(
+      srcdoc.indexOf('<script>window.focus();document.body.focus();</script>'),
+    );
+  });
+
   it('only uses directly mutable slide conventions for setActive support', () => {
     const srcdoc = buildSrcdoc(
       '<section class="slide">One</section><section class="slide">Two</section>',

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -38,6 +38,9 @@ describe('buildSrcdoc', () => {
   });
 
   it('can guard preview iframes against load-time focus stealing', () => {
+    // This test would fail if injectPreviewFocusGuard were removed from
+    // buildSrcdoc — the guard script would be absent, and the assertions
+    // below would not find the data-od-preview-focus-guard marker.
     const srcdoc = buildSrcdoc(
       '<!doctype html><html><head><script>window.focus();document.body.focus();</script></head><body>Hero</body></html>',
       { previewFocusGuard: true },


### PR DESCRIPTION
## Why

When a preview iframe loads HTML that calls `window.focus()` or `element.focus()` at load time (e.g. autofocus scripts, legacy HTML), it steals focus from the host page. This disrupts the user's workflow — chat input loses focus, keyboard shortcuts break, and the UI feels janky after every preview refresh.

## What changed

- Added `injectPreviewFocusGuard` to `apps/web/src/runtime/srcdoc.ts` — a lightweight inline `<script>` injected at the top of `<head>` (or `<body>` as fallback) that:
  - Tracks trusted user input via `pointerdown`/`keydown` timestamps.
  - Wraps `window.focus` and `HTMLElement.prototype.focus` with a guard that only passes through when a user-activated event occurred within the last second.
  - Uses `Object.defineProperty` to make the overrides resilient to downstream code reassigning `focus`.
- Wired `previewFocusGuard: true` into the HTML preview srcdoc path in `FileViewer.tsx`.
- Added unit tests in `srcdoc.test.ts` verifying the guard script is injected and appears before page scripts.
- Updated the existing `FileViewer.test.tsx` snapshot assertion to expect the guard marker.

## What users will see

Preview iframes that previously stole focus on load will no longer do so. Users can still click or tab into the preview to interact with it — focus works normally after a genuine user activation.

## Surface area

- [x] Web UI
- [ ] Daemon / CLI
- [ ] Desktop
- [ ] Contracts
- [ ] Skills / design-templates / craft
- [ ] i18n
- [ ] Config / env vars

## Test plan

- [x] `pnpm --filter @open-design/web typecheck` passes
- [x] `pnpm --filter @open-design/web test` — new unit tests pass alongside existing suite
- [ ] Manual: load a preview containing `<script>window.focus()</script>` and confirm host chat input retains focus
- [ ] Manual: click inside preview and confirm keyboard interaction still works after user activation