### PR TITLE
fix(prompt): tighten Comment scope from soft guide to hard constraint

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -805,7 +805,7 @@ export function renderCommentAttachmentHint(commentAttachments) {
     '',
     '',
     '<attached-preview-comments>',
-    'Scope: treat each attachment as the default refinement target. For visual marks, inspect the screenshot and modify the marked region first. Preserve unrelated areas.',
+    "Hard scope: change ONLY the elements identified below by selector / position / pod members. Do NOT modify sibling sub-pages, parent layout, global CSS, design tokens, or unrelated rules even if you notice issues there — surface those as a follow-up note in your reply instead of editing them. If the user's request cannot be satisfied without touching outside this scope, ask the user before proceeding. For visual marks, inspect the screenshot and modify the marked region first.",
   ];
   for (const item of commentAttachments) {
     const targetKind =

--- a/apps/daemon/tests/comment-attachments.test.ts
+++ b/apps/daemon/tests/comment-attachments.test.ts
@@ -171,6 +171,12 @@ describe('preview comment agent payload', () => {
     expect(hint).toContain('file: index.html');
     expect(hint).toContain('selector: [data-od-id="hero-title"]');
     expect(hint).toContain('comment: Make the headline shorter');
+    // The hard-scope sentence IS the behavior change. Assert its key phrases
+    // so a future edit that softens or drops the directive lights the suite
+    // red instead of silently re-opening the over-broad edit bug.
+    expect(hint).toContain('Hard scope: change ONLY');
+    expect(hint).toContain('Do NOT modify sibling sub-pages, parent layout, global CSS, design tokens, or unrelated rules');
+    expect(hint).toContain('ask the user before proceeding');
   });
 
   it('renders pod attachments with grouped member context', () => {

--- a/apps/web/src/comments.ts
+++ b/apps/web/src/comments.ts
@@ -277,7 +277,7 @@ function renderCommentAttachmentContext(commentAttachments: ChatCommentAttachmen
     '',
     '',
     '<attached-preview-comments>',
-    'Scope: apply the user request to the attached preview target by default. For visual marks, inspect the screenshot and modify the marked region first. Preserve unrelated elements.',
+    "Hard scope: change ONLY the elements identified below by selector / position / pod members. Do NOT modify sibling sub-pages, parent layout, global CSS, design tokens, or unrelated rules even if you notice issues there — surface those as a follow-up note in your reply instead of editing them. If the user's request cannot be satisfied without touching outside this scope, ask the user before proceeding. For visual marks, inspect the screenshot and modify the marked region first.",
   ];
   commentAttachments.forEach((item) => {
     const position = normalizePosition(item.pagePosition);

--- a/apps/web/tests/comments.test.ts
+++ b/apps/web/tests/comments.test.ts
@@ -242,6 +242,12 @@ describe('preview comment attachment helpers', () => {
     expect(content).toContain('<attached-preview-comments>');
     expect(content).toContain('selector: [data-od-id="hero-title"]');
     expect(content).toContain('comment: Only shorten this title');
+    // The hard-scope sentence IS the behavior change. Assert its key phrases
+    // so a future edit that softens or drops the directive lights the suite
+    // red instead of silently re-opening the over-broad edit bug.
+    expect(content).toContain('Hard scope: change ONLY');
+    expect(content).toContain('Do NOT modify sibling sub-pages, parent layout, global CSS, design tokens, or unrelated rules');
+    expect(content).toContain('ask the user before proceeding');
   });
 
   it('adds hidden comment context only to the current user message sent to API providers', () => {


### PR DESCRIPTION
## Why

When users attach a preview Comment, the agent already receives the target's `file`, `selector`, `position`, and (for visual marks) a screenshot — so the *technical* scope is fully described. What's loose is the natural-language framing.

The block currently opens with:

> Scope: apply the user request to the attached preview target by default. ... Preserve unrelated elements.

That reads as a preference, not a constraint. In practice agents still refactor sibling sub-pages, parent layout, design tokens, or global CSS when the user only meant the one attached element — the comment was "tighten this card's spacing" and the diff comes back touching three files of unrelated tokens. The repro is easy on multi-page prototypes where the user is commenting on page B and the agent reflows page A's layout to "match."

## What users will see

No UI change. The behaviour change is that an agent receiving a Comment attachment will:

- Modify only the element identified by selector / position / pod members.
- Leave sibling sub-pages, parent layout, design tokens, and global CSS alone even if it spots issues there.
- Surface those adjacent observations as a follow-up note in its reply instead of silently editing.
- Ask the user when the request genuinely cannot be satisfied without touching outside scope.

For visual-mark comments, the directive still anchors on the marked region first (existing behaviour preserved).

## How it works

One-line copy change in both renderers that build `<attached-preview-comments>`:

- `apps/web/src/comments.ts` — the web composer attachment context (used by `ChatPane` when sending).
- `apps/daemon/src/server.ts` — the daemon-side attachment renderer (used by attachment hints in routes that compose prompts server-side).

Kept symmetric so the web composer and daemon hint paths can't drift.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

The "Default behavior change" applies because the directive the agent sees in `<attached-preview-comments>` is part of the runtime prompt — anyone attaching a Comment to a chat will start receiving the harder-scoped behaviour without an opt-in.

**UI/CLI dual-track note:** Comment attachments are surfaced into the same prompt regardless of whether the user sent via the web composer or via `od chat … --comment …`, because both rendered prompts go through `<attached-preview-comments>`. The new directive applies to both surfaces; no per-track work.

## Screenshots

No UI change. The block is internal to the prompt sent to the agent.

## Validation

**Automated**

- `apps/web/tests/comments.test.ts` and `apps/daemon/tests/comment-attachments.test.ts` exercise the `<attached-preview-comments>` block; both still pass against the updated wording.

**Behavioural**

- Comment attached to a single card on page B of a multi-page prototype with the prompt "tighten the spacing." Before: agent's diff also touched a shared token file used by page A. After: diff is scoped to the attached card; an inline note in the reply mentions the token file as a possible follow-up.


## Bug fix verification

**Red → green seam:** The directive text in the `<attached-preview-comments>` block is the bug surface — agents reading a soft "include enough surrounding context" guide were free to edit sibling sub-pages or shared tokens, which manifested as over-broad diffs on Comment-attached requests.

- **Red on `main`:** before this PR, `apps/web/tests/comments.test.ts:241-249` and `apps/daemon/tests/comment-attachments.test.ts:170-179` did not assert the hard-scope phrasing. A future edit that softens or drops the directive sentence would keep both suites green while silently re-opening the over-broad edit bug.
- **Green on this branch:** `commentsToAttachments` / `renderCommentAttachmentHint` now emit `"Hard scope: change ONLY ... Do NOT modify sibling sub-pages, parent layout, global CSS, design tokens, or unrelated rules ... ask the user before proceeding"`, and both test files now explicitly `expect(...).toContain(...)` those phrases, so any future weakening of the directive lights the suite red.

Behavioural verification stays as documented in `## Validation` above: a Comment attached to one card no longer pulls a shared-token edit into the diff.
