### PR TITLE
feat(web): enable Next.js Turbopack for the web dev server

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,7 @@
     "src"
   ],
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbopack",
     "build": "next build",
     "build:sidecar": "tsc -p tsconfig.sidecar.json",
     "typecheck": "tsc -b --noEmit",


### PR DESCRIPTION
## Why

The web dev server runs on Next.js webpack by default. On this monorepo (19 locale files, many components, a sizeable i18n content surface) webpack dev mode pushes the Node heap past the default 4 GB ceiling after a few hot reloads and the process dies with:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

When that happens the desktop window keeps pointing at the now-dead web URL and the only "fix" is to restart the web sidecar (and then the desktop, because the URL/port changes). Anyone leaving a long dev session open hits this.

## What users will see

- `pnpm tools-dev` (and downstream desktop) no longer drifts toward OOM during a long dev session.
- Faster HMR (Turbopack does Rust-side bundling instead of webpack's JavaScript pipeline).
- No behavioural change to the rendered app — Turbopack is now stable for dev on Next.js 16.

## How it works

Single-line change in `apps/web/package.json`:

```diff
-"dev": "next dev",
+"dev": "next dev --turbopack",
```

`apps/web/next.config.ts` already declares `turbopack.root: WORKSPACE_ROOT` (the pnpm workspace anchor it computes from `OD_WORKSPACE_ROOT` / `pnpm-workspace.yaml`), so workspace resolution stays consistent across the webpack and Turbopack code paths. No other config changes were needed.

The build script (`next build`) is unchanged on purpose — this PR is scoped to the dev server, where the OOM repro is. Turbopack for build is its own decision and worth its own PR.

## Surface area

- [x] **Default behaviour change (dev only)** — `pnpm --filter @open-design/web dev` now runs through Turbopack.
- [ ] CLI / contracts / i18n / new deps — none. (`next` already ships Turbopack.)
- [ ] Extension points / new root deps — none.

**UI/CLI dual-track note:** dev tooling only; production runtime (`next build`) is unchanged, so neither the web UI nor the `od` CLI surface area moves.

## Screenshots

No UI change.

## Validation

**Automated**

- `apps/web` typecheck / tests — unaffected (Turbopack is a dev-server bundler choice, not a runtime API).
- `apps/web/next.config.ts` already has `turbopack.root` set, so the dev server picks up the correct workspace root.

**Behavioural**

- Local: ran `pnpm tools-dev run web` on the change, navigated the app for a long enough session that webpack mode would have drifted to OOM; Turbopack stayed stable. Hot reload latency dropped noticeably.

## Related

- The dev OOM is the upstream cause of repeated "desktop window pointing at a dead web URL" reports — restarting web + desktop is the current workaround. This PR removes the root cause for the dev surface.
