### PR TITLE
fix(web): treat external <script src> as needing the sandbox shim (#2361)

### DIFF
--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -117,7 +117,7 @@ export function parseForceInline(search: string | URLSearchParams | null | undef
  * serves raw HTML untouched, so artifacts that touch sandbox-blocked Web
  * Storage at startup go blank.
  *
- * Scope is narrow on purpose. This helper detects two reliable signals
+ * Scope is narrow on purpose. This helper detects three reliable signals
  * visible in the *document* source and routes those artifacts back through
  * srcDoc by toggling `forceInline`:
  *
@@ -127,18 +127,24 @@ export function parseForceInline(search: string | URLSearchParams | null | undef
  *     Storage from `useState` initializers.
  *   - Direct `localStorage` / `sessionStorage` mentions in the document
  *     source (covers inline scripts and plain HTML that calls them).
+ *   - Any external `<script src="…">` (including `type="module"`): the
+ *     parent string scan can't see the linked subresource's body, and
+ *     agent-emitted artifacts commonly read Web Storage from an external
+ *     `boot.js` / `app.js` at module eval (issue #2361). Conservatively
+ *     route any external script through srcDoc so the shim is in place
+ *     before that read happens. The alternative — fetching every script
+ *     URL ahead of the iframe and scanning it — would duplicate work the
+ *     browser is about to do and add round trips on every preview load,
+ *     so the heuristic favors a few extra srcDoc-mode previews over those
+ *     additional requests.
  *
- * Known limitation: a `<script src="./app.js">` (or
- * `<script type="module" src="./main.js">`) whose **external** file reads
- * Web Storage at module eval is *not* covered — the helper only sees the
- * HTML, not the linked subresource, so URL-load is still chosen and the
- * SecurityError still throws. Catching that case would require fetching
- * and scanning every script reference before deciding the iframe load
- * strategy, which duplicates work the browser is about to do and adds
- * round trips on every preview load. Leaving that path uncovered until
- * there's a reported case that justifies the cost. Workaround for now:
- * users can opt the artifact into srcDoc with `?forceInline=1` or by
- * toggling Tweaks.
+ * Remaining known limitation: dynamically injected scripts
+ * (`document.createElement('script'); s.src = '…'; head.appendChild(s)`)
+ * are still invisible to this scan because the literal `<script src=…>`
+ * tag never appears in the source. Such artifacts will still URL-load and
+ * still throw on Web Storage access at startup. Workaround for now: users
+ * can opt the artifact into srcDoc with `?forceInline=1` or by toggling
+ * Tweaks.
  *
  * Pure string scan — caller passes the same `source` already fetched for
  * preview rendering, so this adds no extra I/O. Heuristic by design: false
@@ -155,5 +161,11 @@ export function htmlNeedsSandboxShim(source: string): boolean {
   // reject hyphenated variants if a real case ever surfaces.
   if (/<script\s[^>]*\btype\s*=\s*["']?text\/babel\b/i.test(source)) return true;
   if (/\b(?:local|session)Storage\b/.test(source)) return true;
+  // External `<script ... src=...>` — see issue #2361. `\s[^>]*?` requires at
+  // least one whitespace after `<script` (so we don't match `<scripts>`-like
+  // text or self-closing-ish edge cases) and stays non-greedy to keep the
+  // search bounded to the tag itself. Lazy match avoids spilling into
+  // unrelated `src=` attributes on later tags in the same document.
+  if (/<script\s[^>]*?\bsrc\s*=/i.test(source)) return true;
   return false;
 }

--- a/apps/web/tests/components/file-viewer-render-mode.test.ts
+++ b/apps/web/tests/components/file-viewer-render-mode.test.ts
@@ -193,12 +193,14 @@ describe('htmlNeedsSandboxShim', () => {
     expect(htmlNeedsSandboxShim('<script type=text/babelish></script>')).toBe(false);
   });
 
-  it('does not match plain <script> tags or unrelated MIME types', () => {
-    expect(htmlNeedsSandboxShim('<script src="app.js"></script>')).toBe(false);
-    expect(htmlNeedsSandboxShim('<script type="module" src="app.js"></script>')).toBe(false);
+  it('does not match unrelated MIME types or inline-only <script> tags', () => {
+    // Inline JSON data island — no executable code, no Web Storage access.
     expect(htmlNeedsSandboxShim('<script type="application/json">{}</script>')).toBe(false);
     // Substring-only matches must not trigger (e.g. text/babel-like custom type).
     expect(htmlNeedsSandboxShim('<script type="text/babelish"></script>')).toBe(false);
+    // A bare inline <script> without src= and without a Web Storage mention
+    // is left alone (URL-load can render it fine without the shim).
+    expect(htmlNeedsSandboxShim('<script>console.log("hi")</script>')).toBe(false);
   });
 
   it('detects direct localStorage / sessionStorage references in the source', () => {
@@ -213,5 +215,41 @@ describe('htmlNeedsSandboxShim', () => {
     expect(htmlNeedsSandboxShim('Storage')).toBe(false);
     expect(htmlNeedsSandboxShim('mylocalStorageWrapper')).toBe(false);
     expect(htmlNeedsSandboxShim('SuperLocalStorage')).toBe(false);
+  });
+
+  // Issue #2361 — Tweaks and animations problems
+  // Agent-emitted artifacts commonly read `localStorage` from an *external*
+  // script (e.g. `<script src="boot.js">` that initializes theme/language).
+  // The parent string scan can't see the script body, so prior to #2361 the
+  // helper returned false, the preview took the URL-load path, and the
+  // sandboxed iframe threw `SecurityError` on first read — leaving the
+  // artifact blank until the user toggled Tweaks (which forces srcDoc and
+  // pulls in `injectSandboxShim`). Conservatively route any external script
+  // through srcDoc so the shim is available from the start.
+  it('flags any external <script src=> as needing the shim (issue #2361)', () => {
+    // Plain external script — the original reporter's repro shape.
+    expect(htmlNeedsSandboxShim('<script src="boot.js"></script>')).toBe(true);
+    // ES module import.
+    expect(htmlNeedsSandboxShim('<script type="module" src="main.js"></script>')).toBe(true);
+    // Attributes between <script and src= (defer / async / nonce / crossorigin).
+    expect(htmlNeedsSandboxShim('<script defer src="./app.js"></script>')).toBe(true);
+    expect(htmlNeedsSandboxShim('<script async src="https://cdn.example.com/lib.js"></script>')).toBe(true);
+    // Single-quoted src.
+    expect(htmlNeedsSandboxShim("<script src='./bundle.js'></script>")).toBe(true);
+    // Whitespace around the equals sign.
+    expect(htmlNeedsSandboxShim('<script src = "./bundle.js"></script>')).toBe(true);
+    // Unquoted src value (HTML5 permits unquoted attrs).
+    expect(htmlNeedsSandboxShim('<script src=boot.js></script>')).toBe(true);
+    // Case-insensitive tag name.
+    expect(htmlNeedsSandboxShim('<SCRIPT SRC="boot.js"></SCRIPT>')).toBe(true);
+  });
+
+  it('does not match incidental "src=" in non-script contexts (issue #2361 regression)', () => {
+    // `<img src=>` is not an executable subresource for our purposes.
+    expect(htmlNeedsSandboxShim('<img src="logo.png">')).toBe(false);
+    // `<link rel="stylesheet" href=>` similarly does not run JavaScript.
+    expect(htmlNeedsSandboxShim('<link rel="stylesheet" href="styles.css">')).toBe(false);
+    // Text content mentioning `script src=` (e.g. a docs page) must not trigger.
+    expect(htmlNeedsSandboxShim('<p>Use <code>&lt;script src=&quot;app.js&quot;&gt;</code></p>')).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #2361

## Why

- **Use case** — Triaging the open issue board for tractable contributions; #2361 stood out because the existing `htmlNeedsSandboxShim` docstring explicitly called out the reporter's scenario as a "Known limitation" waiting for a justifying case.
- **Pain** — Agent-emitted HTML artifacts that read `localStorage` from an external `boot.js` / `app.js` go blank in the preview pane on first load. The recovery (toggle Tweaks) is non-obvious; the underlying `SecurityError` is silent unless DevTools is open. Reporter @CarrioliDante hit this on v0.8.0 / macOS.

## What users will see

Animated / interactive HTML artifacts that initialize from `localStorage` via an external script now render correctly the first time the preview pane opens — no need to toggle Tweaks to recover them. Same iframe, same chrome, same Tweaks button; only the default render path changes for HTML artifacts that load external scripts.

## Surface area

- [ ] **UI** / **Keyboard shortcut** / **CLI / env var** / **API / contract** / **Extension point** / **i18n keys** / **New top-level dependency**
- [x] **Default behavior change** — HTML artifacts containing `<script src=…>` now render via the srcDoc path (with `injectSandboxShim`) instead of URL-load. For those artifacts, DevTools loses source-map / real-filename advantages and the initial document is slightly larger. Pure-static HTML and inline `<script>` without `src=` continue to take the URL-load path unchanged.
- [ ] **None**

## Screenshots

UI surface unchanged. No screenshots — the user-visible diff is "preview now renders" vs "preview is blank until you click Tweaks", which is more legibly shown via the reproduction below.

## Bug fix verification

- **Red spec** — `apps/web/tests/components/file-viewer-render-mode.test.ts` → `htmlNeedsSandboxShim > flags any external <script src=> as needing the shim (issue #2361)` and the immediately-following regression block (`does not match incidental "src=" in non-script contexts`).
- **Red on `main`, green on this branch** — yes. Verified by stashing the source change and re-running just the test file: new spec block fails on baseline, passes after the one-line regex addition.
- **Baseline diff for full suite** — `pnpm --filter @open-design/web test` shows 62 pre-existing failures on `main` (mostly `useCritiqueTheaterEnabled` with `TypeError: window.localStorage.clear is not a function`, unrelated to this code path). Same 62 failures on this branch, plus 2 added passes from the new spec block. Net new failures: 0.

## Reproduction (matches reporter's 3 steps)

1. Drop into a project an `index.html` that ships `<script src="boot.js"></script>`, where `boot.js` reads `localStorage` at module evaluation and then mounts UI into `document.body` (wrap in `DOMContentLoaded` so `document.body` is defined when the shim runs).
2. **Before this PR** — preview is blank. DevTools console shows:
   > `Uncaught SecurityError: Failed to read the 'localStorage' property from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag.` — originating in `boot.js`.
3. **Click Tweaks** — content appears. (Side effect: `paletteActive=true` forces the srcDoc render path, which carries `injectSandboxShim`.)
4. **After this PR** — step 2 already shows content, because `htmlNeedsSandboxShim` now flags any external script and routes the preview through srcDoc from the start.

## Root cause

Decision flow: `FileViewer` → `shouldUrlLoadHtmlPreview` → `htmlNeedsSandboxShim` (`apps/web/src/components/file-viewer-render-mode.ts`).

Prior to this PR, `htmlNeedsSandboxShim` was a pure string scan over the HTML source and matched only two signals: `<script type="text/babel">` and direct `localStorage`/`sessionStorage` mentions. The docstring at lines 108-123 (pre-edit) explicitly called external scripts a "Known limitation":

> Catching that case would require fetching and scanning every script reference before deciding the iframe load strategy, which duplicates work the browser is about to do and adds round trips on every preview load. **Leaving that path uncovered until there's a reported case that justifies the cost.** Workaround for now: users can opt the artifact into srcDoc with `?forceInline=1` or by toggling Tweaks.

\#2361 is that reported case. The fix is a single conservative regex (`/<script\s[^>]*?\bsrc\s*=/i`) that routes any external script through srcDoc; the docstring is updated to record what's now covered and what limitation remains (dynamically `appendChild`-injected scripts whose literal `<script src=…>` tag never appears in the source).

## Trade-off

Artifacts with external scripts lose URL-load's per-asset HTTP caching and source-map / real-filename DX in DevTools, and the iframe receives a slightly larger initial document. The alternative — fetching each `src=` URL ahead of the iframe and scanning the body for storage access — was already rejected in the existing docstring on cost-vs-benefit grounds. Inline `<script>` without `src=` and pure-static HTML continue to take the URL-load path unchanged, so the practical impact is bounded to multi-file React-prototype-style artifacts that ship `<script src>` references.

## Note on the earlier triage in this issue

The earlier suggested fix (`injectTweaksBridge` default-hidden, `data-od-tweaks-hidden` attribute, `od:tweaks-panel-visible` postMessage, edits to `srcdoc.ts` + `syncBridgeModes` in `FileViewer.tsx`) doesn't apply cleanly on `main` — none of those symbols exist (`rg` finds zero hits in the repo). The actual mechanism in play is `htmlNeedsSandboxShim` choosing URL-load + `paletteActive` forcing srcDoc on Tweaks toggle, which matches the docstring's "Known limitation" exactly.

## Claim note

My `/claim` on this issue was auto-rejected by the bot, which attributed the claim to @xxiaoxiong even though they unclaimed 9 seconds after their original `/claim` on 2026-05-20 and @lefarcen explicitly reopened the issue for community help later that morning. Full timeline + reasoning in [this comment](https://github.com/nexu-io/open-design/issues/2361#issuecomment-4525323875). Bringing the PR for review rather than blocking on the claim mechanism; happy to defer if a maintainer prefers to keep it un-claimed for another contributor.

## Validation

- `pnpm guard` — pass.
- `pnpm typecheck` — pass.
- `pnpm --filter @open-design/web test` — 1973 passes / 62 failures, baseline-identical to `main` (verified via stash → re-run); this PR contributes 0 new failures and 2 new passes (the #2361 spec block).

Made with [Cursor](https://cursor.com)