### PR TITLE
Expose resolved project directory through MCP get_project

### DIFF
--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -31,7 +31,7 @@ interface DesignSystemsPayload { designSystems?: CatalogItem[] }
 interface ResourcePayload { skill?: { body?: string; content?: string }; designSystem?: { body?: string; content?: string }; body?: string; content?: string }
 interface ProjectSummary { id: string; name: string; metadata?: JsonObject }
 interface ProjectsPayload { projects?: ProjectSummary[] }
-interface ProjectPayload { project?: ProjectSummary; id?: string; name?: string; metadata?: JsonObject }
+interface ProjectPayload { project?: ProjectSummary; id?: string; name?: string; metadata?: JsonObject; resolvedDir?: string }
 interface ActiveContext { active?: boolean; projectId?: string; projectName?: string | null; fileName?: string | null; ageMs?: number | null }
 type ResolvedProject = { id: string; name: string; source: 'uuid' | 'id' | 'exact' | 'slug' | 'substring' };
 interface ProjectListCache { baseUrl: string; t: number; list: ProjectSummary[] }
@@ -127,7 +127,7 @@ const TOOL_DEFS = [
   {
     name: 'get_project',
     description:
-      'Single project metadata: name, active skill/design-system ids, entryFile, kind, timestamps.',
+      'Single project metadata: name, active skill/design-system ids, entryFile, kind, timestamps, resolvedDir.',
     inputSchema: {
       type: 'object',
       properties: { project: PROJECT_ARG },
@@ -510,12 +510,14 @@ async function handleMcpToolCall(baseUrl: string, name: unknown, args: McpArgs) 
         const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
         const data = await getJson<ProjectPayload>(`${baseUrl}/api/projects/${encodeURIComponent(id)}`);
         const project = data?.project ?? data;
+        const resolvedDir = typeof data?.resolvedDir === 'string' ? data.resolvedDir : null;
         return ok(
           withActiveEcho(
             {
               ...project,
               entryFile: project?.metadata?.entryFile ?? null,
               kind: project?.metadata?.kind ?? null,
+              resolvedDir,
             },
             active,
             resolved,

--- a/apps/daemon/tests/mcp-get-project.test.ts
+++ b/apps/daemon/tests/mcp-get-project.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { handleMcpToolCall } from '../src/mcp.js';
+
+const originalFetch = globalThis.fetch;
+
+function firstJson<T>(result: { content: Array<{ text: string }> }): T {
+  const item = result.content[0];
+  if (!item) throw new Error('expected MCP text content');
+  return JSON.parse(item.text) as T;
+}
+
+describe('public MCP get_project', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('surfaces the daemon-resolved project directory', async () => {
+    const base = 'http://127.0.0.1:19001';
+    const projectId = '11111111-1111-1111-1111-111111111111';
+    const resolvedDir = '/tmp/open-design/projects/demo';
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe(`${base}/api/projects/${projectId}`);
+      return new Response(
+        JSON.stringify({
+          project: {
+            id: projectId,
+            name: 'Demo',
+            metadata: { entryFile: 'index.html', kind: 'prototype' },
+          },
+          resolvedDir,
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(base, 'get_project', {
+      project: projectId,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(firstJson(result)).toMatchObject({
+      id: projectId,
+      name: 'Demo',
+      entryFile: 'index.html',
+      kind: 'prototype',
+      resolvedDir,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- include the daemon-resolved `resolvedDir` in MCP `get_project` responses
- document `resolvedDir` in the MCP tool description
- add coverage for the public MCP `get_project` payload

## Tests
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/mcp-get-project.test.ts tests/projects-routes.test.ts`
- `pnpm --filter @open-design/daemon typecheck`

Note: local test runs used Node v25.9.0, which emits the existing repo engine warning because the workspace declares Node ~24.