### PR TITLE
fix(#2361): patch both causes that present as blank preview

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3723,6 +3723,13 @@ function HtmlViewer({
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const activatedSrcDocTransportHtmlRef = useRef<string | null>(null);
+  // Tracks the iframe DOM node whose dedupe ref was last reset by the
+  // srcDoc onLoad handler. We reset the dedupe exactly once per freshly
+  // mounted iframe (the first load is the shell HTML), and skip every
+  // subsequent load on the same node (those are our own
+  // document.open/write/close inside the shell). See onLoad below for
+  // the infinite-loop story (issue #2361).
+  const srcDocFrameDedupeResetForRef = useRef<HTMLIFrameElement | null>(null);
   const isActivePreviewIframeSource = useCallback((source: MessageEventSource | null) => {
     return !!source && source === iframeRef.current?.contentWindow;
   }, []);
@@ -6437,15 +6444,40 @@ function HtmlViewer({
                       onLoad={() => {
                         const frame = srcDocPreviewIframeRef.current;
                         if (!useUrlLoadPreview) iframeRef.current = frame;
-                        // Any srcDoc iframe load means we are talking to a
-                        // fresh document shell. Clear the activation dedupe so
-                        // switching preview -> source -> preview cannot strand
-                        // the new shell on the blank transport page.
-                        activatedSrcDocTransportHtmlRef.current = null;
-                        // Belt-and-suspenders for the ready handshake: if the
-                        // postMessage racing the parent's listener registration
-                        // ever loses, the load event still tells us the shell
-                        // script ran to completion.
+                        // Reset the activation dedupe exactly ONCE per
+                        // freshly mounted iframe DOM node, never on the
+                        // subsequent load events that the same node
+                        // emits during normal srcDoc rendering.
+                        //
+                        // The iframe's load event fires twice for one
+                        // successful activation: once when the lazy
+                        // transport shell HTML loads, and again when
+                        // our own document.open/write/close inside the
+                        // shell finishes. PR #2699 reset the dedupe on
+                        // every load so that switching
+                        // preview -> source -> preview (which remounts
+                        // this iframe as a fresh DOM node) would
+                        // re-activate the new shell. But resetting on
+                        // every load also re-activated on the SECOND
+                        // load of a non-remounted frame, which
+                        // re-triggered document.open/write/close, which
+                        // re-fired the load event, ad infinitum. The
+                        // dedupe ref oscillated between null and the
+                        // current srcDoc thousands of times per render
+                        // and each iteration restarted every CSS
+                        // animation from its `from` keyframe. Designs
+                        // using `animation-fill-mode: both` with
+                        // `from { opacity: 0 }` stayed at opacity 0
+                        // forever and the preview read as blank.
+                        // That is issue #2361.
+                        //
+                        // Tracking the last frame we reset for lets us
+                        // keep PR #2699's "remount after Source toggle"
+                        // fix while breaking the loop on plain renders.
+                        if (frame && srcDocFrameDedupeResetForRef.current !== frame) {
+                          srcDocFrameDedupeResetForRef.current = frame;
+                          activatedSrcDocTransportHtmlRef.current = null;
+                        }
                         if (useLazySrcDocTransport) setSrcDocShellReady(true);
                         activateSrcDocTransport(frame);
                         dcViewportRestoreAtRef.current = Date.now();

--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -117,7 +117,7 @@ export function parseForceInline(search: string | URLSearchParams | null | undef
  * serves raw HTML untouched, so artifacts that touch sandbox-blocked Web
  * Storage at startup go blank.
  *
- * Scope is narrow on purpose. This helper detects two reliable signals
+ * Scope is narrow on purpose. This helper detects three reliable signals
  * visible in the *document* source and routes those artifacts back through
  * srcDoc by toggling `forceInline`:
  *
@@ -127,18 +127,24 @@ export function parseForceInline(search: string | URLSearchParams | null | undef
  *     Storage from `useState` initializers.
  *   - Direct `localStorage` / `sessionStorage` mentions in the document
  *     source (covers inline scripts and plain HTML that calls them).
+ *   - Any external `<script src="…">` (including `type="module"`): the
+ *     parent string scan can't see the linked subresource's body, and
+ *     agent-emitted artifacts commonly read Web Storage from an external
+ *     `boot.js` / `app.js` at module eval (issue #2361). Conservatively
+ *     route any external script through srcDoc so the shim is in place
+ *     before that read happens. The alternative — fetching every script
+ *     URL ahead of the iframe and scanning it — would duplicate work the
+ *     browser is about to do and add round trips on every preview load,
+ *     so the heuristic favors a few extra srcDoc-mode previews over those
+ *     additional requests.
  *
- * Known limitation: a `<script src="./app.js">` (or
- * `<script type="module" src="./main.js">`) whose **external** file reads
- * Web Storage at module eval is *not* covered — the helper only sees the
- * HTML, not the linked subresource, so URL-load is still chosen and the
- * SecurityError still throws. Catching that case would require fetching
- * and scanning every script reference before deciding the iframe load
- * strategy, which duplicates work the browser is about to do and adds
- * round trips on every preview load. Leaving that path uncovered until
- * there's a reported case that justifies the cost. Workaround for now:
- * users can opt the artifact into srcDoc with `?forceInline=1` or by
- * toggling Tweaks.
+ * Remaining known limitation: dynamically injected scripts
+ * (`document.createElement('script'); s.src = '…'; head.appendChild(s)`)
+ * are still invisible to this scan because the literal `<script src=…>`
+ * tag never appears in the source. Such artifacts will still URL-load and
+ * still throw on Web Storage access at startup. Workaround for now: users
+ * can opt the artifact into srcDoc with `?forceInline=1` or by toggling
+ * Tweaks.
  *
  * Pure string scan — caller passes the same `source` already fetched for
  * preview rendering, so this adds no extra I/O. Heuristic by design: false
@@ -155,5 +161,11 @@ export function htmlNeedsSandboxShim(source: string): boolean {
   // reject hyphenated variants if a real case ever surfaces.
   if (/<script\s[^>]*\btype\s*=\s*["']?text\/babel\b/i.test(source)) return true;
   if (/\b(?:local|session)Storage\b/.test(source)) return true;
+  // External `<script ... src=...>` — see issue #2361. `\s[^>]*?` requires at
+  // least one whitespace after `<script` (so we don't match `<scripts>`-like
+  // text or self-closing-ish edge cases) and stays non-greedy to keep the
+  // search bounded to the tag itself. Lazy match avoids spilling into
+  // unrelated `src=` attributes on later tags in the same document.
+  if (/<script\s[^>]*?\bsrc\s*=/i.test(source)) return true;
   return false;
 }

--- a/apps/web/tests/components/file-viewer-render-mode.test.ts
+++ b/apps/web/tests/components/file-viewer-render-mode.test.ts
@@ -193,12 +193,14 @@ describe('htmlNeedsSandboxShim', () => {
     expect(htmlNeedsSandboxShim('<script type=text/babelish></script>')).toBe(false);
   });
 
-  it('does not match plain <script> tags or unrelated MIME types', () => {
-    expect(htmlNeedsSandboxShim('<script src="app.js"></script>')).toBe(false);
-    expect(htmlNeedsSandboxShim('<script type="module" src="app.js"></script>')).toBe(false);
+  it('does not match unrelated MIME types or inline-only <script> tags', () => {
+    // Inline JSON data island — no executable code, no Web Storage access.
     expect(htmlNeedsSandboxShim('<script type="application/json">{}</script>')).toBe(false);
     // Substring-only matches must not trigger (e.g. text/babel-like custom type).
     expect(htmlNeedsSandboxShim('<script type="text/babelish"></script>')).toBe(false);
+    // A bare inline <script> without src= and without a Web Storage mention
+    // is left alone (URL-load can render it fine without the shim).
+    expect(htmlNeedsSandboxShim('<script>console.log("hi")</script>')).toBe(false);
   });
 
   it('detects direct localStorage / sessionStorage references in the source', () => {
@@ -213,5 +215,41 @@ describe('htmlNeedsSandboxShim', () => {
     expect(htmlNeedsSandboxShim('Storage')).toBe(false);
     expect(htmlNeedsSandboxShim('mylocalStorageWrapper')).toBe(false);
     expect(htmlNeedsSandboxShim('SuperLocalStorage')).toBe(false);
+  });
+
+  // Issue #2361 — Tweaks and animations problems
+  // Agent-emitted artifacts commonly read `localStorage` from an *external*
+  // script (e.g. `<script src="boot.js">` that initializes theme/language).
+  // The parent string scan can't see the script body, so prior to #2361 the
+  // helper returned false, the preview took the URL-load path, and the
+  // sandboxed iframe threw `SecurityError` on first read — leaving the
+  // artifact blank until the user toggled Tweaks (which forces srcDoc and
+  // pulls in `injectSandboxShim`). Conservatively route any external script
+  // through srcDoc so the shim is available from the start.
+  it('flags any external <script src=> as needing the shim (issue #2361)', () => {
+    // Plain external script — the original reporter's repro shape.
+    expect(htmlNeedsSandboxShim('<script src="boot.js"></script>')).toBe(true);
+    // ES module import.
+    expect(htmlNeedsSandboxShim('<script type="module" src="main.js"></script>')).toBe(true);
+    // Attributes between <script and src= (defer / async / nonce / crossorigin).
+    expect(htmlNeedsSandboxShim('<script defer src="./app.js"></script>')).toBe(true);
+    expect(htmlNeedsSandboxShim('<script async src="https://cdn.example.com/lib.js"></script>')).toBe(true);
+    // Single-quoted src.
+    expect(htmlNeedsSandboxShim("<script src='./bundle.js'></script>")).toBe(true);
+    // Whitespace around the equals sign.
+    expect(htmlNeedsSandboxShim('<script src = "./bundle.js"></script>')).toBe(true);
+    // Unquoted src value (HTML5 permits unquoted attrs).
+    expect(htmlNeedsSandboxShim('<script src=boot.js></script>')).toBe(true);
+    // Case-insensitive tag name.
+    expect(htmlNeedsSandboxShim('<SCRIPT SRC="boot.js"></SCRIPT>')).toBe(true);
+  });
+
+  it('does not match incidental "src=" in non-script contexts (issue #2361 regression)', () => {
+    // `<img src=>` is not an executable subresource for our purposes.
+    expect(htmlNeedsSandboxShim('<img src="logo.png">')).toBe(false);
+    // `<link rel="stylesheet" href=>` similarly does not run JavaScript.
+    expect(htmlNeedsSandboxShim('<link rel="stylesheet" href="styles.css">')).toBe(false);
+    // Text content mentioning `script src=` (e.g. a docs page) must not trigger.
+    expect(htmlNeedsSandboxShim('<p>Use <code>&lt;script src=&quot;app.js&quot;&gt;</code></p>')).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #2361

## Why

I'm the contributor who opened #2800 — after running this in a real `next build && next start` production runtime, I realized that PR is the wrong fix to land alone. Two independent code paths produce the same "preview blank until I click Tweaks/Themes" symptom; #2800 only patches one of them. The other was introduced 3 hours after v0.8.0 was cut, so it's not in any stable release yet but is on `main` and 100% reproducible in a production build with no React strict / HMR / dev overlay to mask it.

I cannot retroactively prove which cause @CarrioliDante saw on 2026-05-20. So this PR patches both and asks the reviewer to pull and verify.

## What users will see

- Designs with external `<script src>` (e.g. agent-emitted `boot.js`) no longer blank out because of a sandbox SecurityError.
- Designs with CSS animations using `animation-fill-mode: both` + `from { opacity: 0 }` (typical editorial hero fade-in) no longer stay blank because of an infinite srcDoc re-activation loop.
- Neither case requires the user to click Tweaks/Themes to "wake up" the preview.

## Surface area

- [x] **UI** — preview iframe behavior in `apps/web/src/components/FileViewer.tsx` and `apps/web/src/components/file-viewer-render-mode.ts`
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change

## Screenshots

Recorded in a `next build && next start` production runtime (NODE_ENV=production, no HMR, no React strict double-effect, no dev overlay). Same project artifact, same prod build, only the `FileViewer.tsx` onLoad logic differs between the two videos.

**RED — current `main` (no fix), production build, hero stays blank:**

<!-- RED VIDEO PLACEHOLDER — drag .tmp/2361-screenshots/red-prod.mp4 here in the GitHub PR editor -->

**GREEN — this branch (fix applied), same production build, hero visible immediately:**

<!-- GREEN VIDEO PLACEHOLDER — drag .tmp/2361-screenshots/green-prod.mp4 here in the GitHub PR editor -->

## Bug fix verification

**Cause A — external `<script src>` SecurityError** (long-standing): the URL-load iframe runs in `sandbox="allow-scripts"` (no `allow-same-origin`); external scripts reading `localStorage` throw `SecurityError`; the boot script aborts; preview reads as blank. Clicking Tweaks switches to the srcDoc render path, which has `injectSandboxShim` for Web Storage, so content suddenly appears. Fix: `htmlNeedsSandboxShim` now matches `<script ... src=...>`, routing such designs through srcDoc. The docblock at `apps/web/src/components/file-viewer-render-mode.ts:109-135` already cited issue #2361 as the motivation.

**Cause B — srcDoc onLoad infinite re-activate loop** (regression from PR #2699/#2710, merged into main 2026-05-22 14:51 UTC as commit `ac0a9212`): the iframe `load` event fires twice per successful activation — once when the empty transport shell HTML loads, and again when our own `document.open()/write(realHtml)/close()` inside the shell finishes. PR #2699 added an unconditional reset of the activation dedupe ref on every load to handle a separate problem (toggling Code → Preview remounts the iframe as a fresh DOM node; the dedupe ref had to be cleared so the new shell could re-activate). That same reset also fires on the SECOND load of an unchanged frame, re-triggers activation, re-runs `document.open/write/close`, re-fires load, ad infinitum (~4,763 iterations counted in one local repro before stopping). Each iteration rebuilds the document and restarts every CSS animation from its `from` keyframe — designs using `animation-fill-mode: both` with `from { opacity: 0 }` therefore stay at opacity 0 forever and the preview reads as blank. In a production runtime the loop runs uninterrupted, so the symptom is a stable blank. In a dev runtime with React strict on, the double-effect occasionally lets the animation paint one frame above opacity 0, which is the "flicker, but ok after I click Tweaks" symptom dev users see.

Fix: a new `srcDocFrameDedupeResetForRef` tracks the last iframe DOM node we reset the dedupe for. The reset runs exactly once per freshly mounted iframe (the first load is the shell HTML) and is skipped on every subsequent same-node load. Switching Preview → Code → Preview remounts the iframe as a fresh DOM node, so the reset still happens there and PR #2699's regression test (`reactivates the srcDoc transport after switching source back to preview`) still passes.

**Tests**: 216 files / 2035 tests pass on this branch, including PR #2699's own regression test for the Source → Preview remount case.

**Production verification**: `OD_WEB_OUTPUT_MODE=server NODE_ENV=production pnpm --filter @open-design/web build` then `next start` against the daemon on a sibling port — confirmed RED on the parent commit (Cause B reproduces in prod) and GREEN on this branch (hero visible immediately). Same production build, same project artifact, only the `FileViewer.tsx` onLoad logic differs.

**Honest scope note**: I cannot prove which of these two causes @CarrioliDante actually hit on 2026-05-20. v0.8.0 stable was published 2026-05-22 12:43 UTC — two days after the issue was filed — so the "v0.8.0" version field likely refers to a pre-release / dev build either way. Both causes are real, both reproduce in production, both are user-visible, and conflating them under one PR was my judgment call to avoid closing #2361 while one of the two ships in the next release. Maintainers may prefer two separate PRs — happy to split.

## Validation

- `pnpm guard` — 26/26 unit tests pass (yomoa-ai design system temporarily moved aside; local-only artifact)
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web test` — 216 files / 2035 tests pass
- `next build && next start` production server, daemon on a sibling port — manually verified RED on parent commit and GREEN on this branch with the same project artifact and same prod build (see videos above)
