### PR TITLE
feat: add "Use system fonts" dismiss to the missing-fonts banner

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -47,6 +47,7 @@ import type { PluginFolderAgentAction } from './design-files/pluginFolderActions
 import { FileViewer, LiveArtifactViewer } from './FileViewer';
 import { Icon } from './Icon';
 import { LiveArtifactBadges } from './LiveArtifactBadges';
+import { MissingBrandFontsBanner } from './MissingBrandFontsBanner';
 import { PasteTextDialog } from './PasteTextDialog';
 import { QuickSwitcher } from './QuickSwitcher';
 import { SketchEditor } from './SketchEditor';
@@ -1534,17 +1535,7 @@ function DesignSystemProjectPanel({
         ) : null}
 
         {fontFiles.length === 0 ? (
-          <div className="ds-project-warning-card">
-            <Icon name="help-circle" size={16} />
-            <span>
-              <strong>Missing brand fonts</strong>
-              <small>Open Design is rendering typography with substitute web fonts.</small>
-            </span>
-            <button type="button" className="ghost compact" onClick={onUploadAssets}>
-              <Icon name="upload" size={13} />
-              Upload fonts
-            </button>
-          </div>
+          <MissingBrandFontsBanner projectId={projectId} onUploadAssets={onUploadAssets} />
         ) : null}
 
         <div className="ds-project-sections">

--- a/apps/web/src/components/MissingBrandFontsBanner.tsx
+++ b/apps/web/src/components/MissingBrandFontsBanner.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Icon } from './Icon';
 
@@ -38,6 +38,14 @@ export function MissingBrandFontsBanner({
   onUploadAssets,
 }: MissingBrandFontsBannerProps) {
   const [dismissed, setDismissed] = useState(() => isFontBannerDismissed(projectId));
+  // FileWorkspace renders this banner without a per-project key, so the same
+  // instance is reused across projects. useState only reads projectId once, so
+  // re-read the dismissal whenever projectId changes. Without this, dismissing
+  // project A would keep the banner hidden for project B even though only A was
+  // written to localStorage.
+  useEffect(() => {
+    setDismissed(isFontBannerDismissed(projectId));
+  }, [projectId]);
   if (dismissed) return null;
 
   function useSystemFonts(): void {

--- a/apps/web/src/components/MissingBrandFontsBanner.tsx
+++ b/apps/web/src/components/MissingBrandFontsBanner.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+
+import { Icon } from './Icon';
+
+// Per-project dismissal of the "Missing brand fonts" banner (issue #2814).
+// Stored in localStorage keyed by project id, mirroring the per-project
+// preference pattern already used in ProjectView. This is acknowledge-only:
+// it hides the banner for users who are fine with the fallback and does NOT
+// change how typography renders (previews keep using the substitute web
+// fonts). A future enhancement could actually switch previews to the OS
+// system font stack.
+
+function fontBannerDismissKey(projectId: string): string {
+  return `od:font-banner-dismissed:${projectId}`;
+}
+
+/** True when the user has dismissed the banner for this project. */
+export function isFontBannerDismissed(projectId: string): boolean {
+  if (!projectId || typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(fontBannerDismissKey(projectId)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+interface MissingBrandFontsBannerProps {
+  projectId: string;
+  /** Wrapper class so callers can match their surrounding card styling. */
+  className?: string;
+  /** When provided, renders an "Upload fonts" action that invokes it. */
+  onUploadAssets?: () => void;
+}
+
+export function MissingBrandFontsBanner({
+  projectId,
+  className = 'ds-project-warning-card',
+  onUploadAssets,
+}: MissingBrandFontsBannerProps) {
+  const [dismissed, setDismissed] = useState(() => isFontBannerDismissed(projectId));
+  if (dismissed) return null;
+
+  function useSystemFonts(): void {
+    if (projectId && typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(fontBannerDismissKey(projectId), '1');
+      } catch {
+        // Storage unavailable (private mode, quota). Still hide for this
+        // session so the click does something useful.
+      }
+    }
+    setDismissed(true);
+  }
+
+  return (
+    <div className={className}>
+      <Icon name="help-circle" size={16} />
+      <span>
+        <strong>Missing brand fonts</strong>
+        <small>Open Design is rendering typography with substitute web fonts.</small>
+      </span>
+      <div className="ds-warning-card-actions">
+        {onUploadAssets ? (
+          <button type="button" className="ghost compact" onClick={onUploadAssets}>
+            <Icon name="upload" size={13} />
+            Upload fonts
+          </button>
+        ) : null}
+        <button type="button" className="ghost compact" onClick={useSystemFonts}>
+          Use system fonts
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/styles/design-system-flow.css
+++ b/apps/web/src/styles/design-system-flow.css
@@ -1936,7 +1936,7 @@
   font-size: 13px;
 }
 .ds-project-warning-card {
-  margin: 14px 0 0;
+  margin: 14px 0 18px;
   display: grid;
   grid-template-columns: 22px minmax(0, 1fr) auto;
   align-items: center;
@@ -1969,6 +1969,13 @@
   align-items: center;
   gap: 7px;
   white-space: nowrap;
+}
+/* Holds the Upload fonts + Use system fonts actions in the card's last cell.
+   Issue #2814. */
+.ds-warning-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .ds-context-strip {
   margin: 22px 0 30px;

--- a/apps/web/tests/components/MissingBrandFontsBanner.test.tsx
+++ b/apps/web/tests/components/MissingBrandFontsBanner.test.tsx
@@ -43,6 +43,23 @@ describe('MissingBrandFontsBanner (issue #2814)', () => {
     expect(screen.getByText('Missing brand fonts')).toBeTruthy();
   });
 
+  it('resyncs dismissal when the same instance switches projects', () => {
+    // FileWorkspace renders the banner without a per-project key, so one
+    // instance is reused as the user moves between projects.
+    const { rerender, container } = render(<MissingBrandFontsBanner projectId="p1" />);
+    fireEvent.click(screen.getByRole('button', { name: /use system fonts/i }));
+    expect(container.querySelector('.ds-project-warning-card')).toBeNull();
+    expect(window.localStorage.getItem('od:font-banner-dismissed:p1')).toBe('1');
+
+    // Switching to a project that was never dismissed shows the banner again.
+    rerender(<MissingBrandFontsBanner projectId="p2" />);
+    expect(screen.getByText('Missing brand fonts')).toBeTruthy();
+
+    // Switching back to the dismissed project hides it again.
+    rerender(<MissingBrandFontsBanner projectId="p1" />);
+    expect(container.querySelector('.ds-project-warning-card')).toBeNull();
+  });
+
   it('invokes onUploadAssets when Upload fonts is clicked', () => {
     const onUploadAssets = vi.fn();
     render(<MissingBrandFontsBanner projectId="p1" onUploadAssets={onUploadAssets} />);

--- a/apps/web/tests/components/MissingBrandFontsBanner.test.tsx
+++ b/apps/web/tests/components/MissingBrandFontsBanner.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MissingBrandFontsBanner } from '../../src/components/MissingBrandFontsBanner';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+describe('MissingBrandFontsBanner (issue #2814)', () => {
+  it('shows Upload fonts + Use system fonts when not dismissed', () => {
+    render(<MissingBrandFontsBanner projectId="p1" onUploadAssets={() => {}} />);
+    expect(screen.getByText('Missing brand fonts')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /upload fonts/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /use system fonts/i })).toBeTruthy();
+  });
+
+  it('dismisses the banner for the project when Use system fonts is clicked', () => {
+    const { container } = render(
+      <MissingBrandFontsBanner projectId="p1" onUploadAssets={() => {}} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /use system fonts/i }));
+    expect(container.querySelector('.ds-project-warning-card')).toBeNull();
+    expect(window.localStorage.getItem('od:font-banner-dismissed:p1')).toBe('1');
+  });
+
+  it('renders nothing when already dismissed for that project', () => {
+    window.localStorage.setItem('od:font-banner-dismissed:p1', '1');
+    const { container } = render(<MissingBrandFontsBanner projectId="p1" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('keeps the dismissal scoped per project', () => {
+    window.localStorage.setItem('od:font-banner-dismissed:p1', '1');
+    render(<MissingBrandFontsBanner projectId="p2" />);
+    // p2 was not dismissed, so the banner still shows.
+    expect(screen.getByText('Missing brand fonts')).toBeTruthy();
+  });
+
+  it('invokes onUploadAssets when Upload fonts is clicked', () => {
+    const onUploadAssets = vi.fn();
+    render(<MissingBrandFontsBanner projectId="p1" onUploadAssets={onUploadAssets} />);
+    fireEvent.click(screen.getByRole('button', { name: /upload fonts/i }));
+    expect(onUploadAssets).toHaveBeenCalledOnce();
+  });
+
+  it('omits Upload fonts when no handler is provided', () => {
+    render(<MissingBrandFontsBanner projectId="p3" />);
+    expect(screen.queryByRole('button', { name: /upload fonts/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /use system fonts/i })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #2814

## Why

I built a design system from a repo that doesn't ship font files, so every time I opened it I got the "Missing brand fonts" banner. My only option was Upload fonts, which I didn't want. I'm fine with the fallback, but there was no way to tell the banner that and make it go away.

## What users will see

The banner has a second button now: "Use system fonts". Click it and the banner disappears for that project, and it stays gone (the choice is saved in localStorage). It doesn't touch rendering. Previews keep using the same fallback fonts they always did. It's purely a "yes, I know, stop reminding me" button.

While I was in there I pulled the banner into a shared `MissingBrandFontsBanner` component and gave the warning card the bottom margin it was missing. It used to sit flush against the section below it.

## Surface area

- [x] UI: new "Use system fonts" button on the missing-fonts banner
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys (the banner copy stays hardcoded, like the original)
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

## Screenshots

Banner with the new button and the added bottom margin (attached).

## Validation

- `pnpm guard`: pass (26/26)
- `pnpm typecheck`: pass
- `pnpm --filter @open-design/web test`: pass, with 6 new tests covering the dismissal, per-project scoping, and the upload handler

## One thing I left alone

There's an older copy of this banner in `DesignSystemFlow` that's always shown and whose "Upload fonts" button does nothing (no handler wired up). I didn't touch it here so this stays focused. The shared component makes unifying them an easy follow-up.
