### PR TITLE
fix: add 'Use system fonts' dismiss button to missing fonts banner

### DIFF
--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -852,6 +852,7 @@ export function DesignSystemDetailView({
   const [feedbackSection, setFeedbackSection] = useState<string | null>(null);
   const [chatSeed, setChatSeed] = useState<{ id: string; text: string } | null>(null);
   const [workspaceProjectId, setWorkspaceProjectId] = useState<string | null>(null);
+  const [workspaceProject, setWorkspaceProject] = useState<Project | null>(null);
   const [workspaceProjectFiles, setWorkspaceProjectFiles] = useState<ProjectFile[]>([]);
   const [workspaceLoadError, setWorkspaceLoadError] = useState<string | null>(null);
   const [conversations, setConversations] = useState<Conversation[]>([]);
@@ -876,6 +877,7 @@ export function DesignSystemDetailView({
     setSystem(null);
     setRevisions([]);
     setWorkspaceProjectId(null);
+    setWorkspaceProject(null);
     setWorkspaceProjectFiles([]);
     setWorkspaceLoadError(null);
     setConversations([]);
@@ -918,6 +920,10 @@ export function DesignSystemDetailView({
       const projectId = resolved.projectId;
       setWorkspaceProjectId(projectId);
       setWorkspaceProjectFiles(resolved.files);
+      const project = await getProject(projectId);
+      if (!cancelled && project) {
+        setWorkspaceProject(project);
+      }
       if (onOpenProject && openedProjectRef.current !== projectId) {
         openedProjectRef.current = projectId;
         await onProjectsRefresh?.();
@@ -1688,6 +1694,22 @@ export function DesignSystemDetailView({
     }
   }
 
+  async function handleDismissMissingFontsWarning() {
+    if (!workspaceProject) return;
+    const baseMetadata: ProjectMetadata = {
+      kind: workspaceProject.metadata?.kind ?? 'other',
+      ...workspaceProject.metadata,
+    };
+    const metadata: ProjectMetadata = {
+      ...baseMetadata,
+      dismissedMissingFontsWarning: true,
+    };
+    const updated = await patchProject(workspaceProject.id, { metadata });
+    if (updated) {
+      setWorkspaceProject(updated);
+    }
+  }
+
   if (!system) {
     return (
       <div className="ds-setup-shell ds-setup-shell--center">
@@ -1808,17 +1830,23 @@ export function DesignSystemDetailView({
               ) : null}
             </div>
             <DesignSystemPackageCard system={system} />
-            <div className="ds-warning-card">
-              <Icon name="help-circle" />
-              <span>
-                <strong>Missing brand fonts</strong>
-                Open Design is rendering typography with substitute web fonts.
-              </span>
-              <button type="button" className="ghost compact">
-                <Icon name="upload" />
-                Upload fonts
-              </button>
-            </div>
+            {!workspaceProject?.metadata?.dismissedMissingFontsWarning ? (
+              <div className="ds-warning-card">
+                <Icon name="help-circle" />
+                <span>
+                  <strong>Missing brand fonts</strong>
+                  Open Design is rendering typography with substitute web fonts.
+                </span>
+                <button type="button" className="ghost compact">
+                  <Icon name="upload" />
+                  Upload fonts
+                </button>
+                <button type="button" className="ghost compact" onClick={handleDismissMissingFontsWarning}>
+                  <Icon name="check" />
+                  Use system fonts
+                </button>
+              </div>
+            ) : null}
             {statusLine ? <div className="ds-status-line">{statusLine}</div> : null}
             <WorkspaceActivityCard message={workspaceActivityMessage} active={chatStreaming} />
             {pendingRevision ? (

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -102,6 +102,8 @@ interface Props {
     details?: DesignSystemReviewDetails,
   ) => void;
   onUseDesignSystem?: (id: string, title: string) => void;
+  projectMetadata?: ProjectMetadata;
+  onDismissMissingFontsWarning?: () => void;
 }
 
 interface SketchState {
@@ -216,6 +218,8 @@ export function FileWorkspace({
   designSystemReview,
   onDesignSystemReviewDecision,
   onUseDesignSystem,
+  projectMetadata,
+  onDismissMissingFontsWarning,
 }: Props) {
   const t = useT();
   const analytics = useAnalytics();
@@ -959,6 +963,8 @@ export function FileWorkspace({
             designSystemReview={designSystemReview}
             onReviewDecision={onDesignSystemReviewDecision}
             onUseDesignSystem={onUseDesignSystem}
+            projectMetadata={projectMetadata}
+            onDismissMissingFontsWarning={onDismissMissingFontsWarning}
           />
         ) : activeTab === DESIGN_FILES_TAB ? (
           <DesignFilesPanel
@@ -1126,6 +1132,8 @@ function DesignSystemProjectPanel({
   designSystemReview,
   onReviewDecision,
   onUseDesignSystem,
+  projectMetadata,
+  onDismissMissingFontsWarning,
 }: {
   projectId: string;
   system: DesignSystemSummary;
@@ -1149,6 +1157,8 @@ function DesignSystemProjectPanel({
     details?: DesignSystemReviewDetails,
   ) => void;
   onUseDesignSystem?: (id: string, title: string) => void;
+  projectMetadata?: ProjectMetadata;
+  onDismissMissingFontsWarning?: () => void;
 }) {
   const [reviewDecisions, setReviewDecisions] = useState<Record<string, DesignSystemReviewDecision>>({});
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({});
@@ -1533,7 +1543,7 @@ function DesignSystemProjectPanel({
           </div>
         ) : null}
 
-        {fontFiles.length === 0 ? (
+        {fontFiles.length === 0 && !projectMetadata?.dismissedMissingFontsWarning ? (
           <div className="ds-project-warning-card">
             <Icon name="help-circle" size={16} />
             <span>
@@ -1543,6 +1553,10 @@ function DesignSystemProjectPanel({
             <button type="button" className="ghost compact" onClick={onUploadAssets}>
               <Icon name="upload" size={13} />
               Upload fonts
+            </button>
+            <button type="button" className="ghost compact" onClick={onDismissMissingFontsWarning}>
+              <Icon name="check" size={13} />
+              Use system fonts
             </button>
           </div>
         ) : null}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3134,6 +3134,20 @@ export function ProjectView({
     if (details?.agentTask) entry.agentTask = details.agentTask;
     persistDesignSystemReviewEntry(sectionTitle, entry);
   }, [persistDesignSystemReviewEntry]);
+
+  const handleDismissMissingFontsWarning = useCallback(() => {
+    const baseMetadata: ProjectMetadata = {
+      kind: project.metadata?.kind ?? 'other',
+      ...project.metadata,
+    };
+    const metadata: ProjectMetadata = {
+      ...baseMetadata,
+      dismissedMissingFontsWarning: true,
+    };
+    onProjectChange({ ...project, metadata });
+    void patchProject(project.id, { metadata });
+  }, [onProjectChange, project]);
+
   useEffect(() => {
     if (!activeConversationId || !messagesInitialized || currentConversationActionDisabled) return;
     const queued = Object.entries(project.metadata?.designSystemReview ?? {}).find(
@@ -4186,6 +4200,8 @@ export function ProjectView({
           onDesignSystemNeedsWork={sendDesignSystemFeedback}
           designSystemReview={project.metadata?.designSystemReview}
           onDesignSystemReviewDecision={persistDesignSystemReviewDecision}
+          projectMetadata={project.metadata}
+          onDismissMissingFontsWarning={handleDismissMissingFontsWarning}
         />
       </div>
       {projectActionsToast ? (

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -159,6 +159,8 @@ export interface ProjectMetadata {
   // Stored on design-system projects so the review overview can remember
   // which generated sections were accepted or sent back for another pass.
   designSystemReview?: Record<string, DesignSystemReviewEntry>;
+  // User preference to hide the missing brand fonts warning banner.
+  dismissedMissingFontsWarning?: boolean;
 }
 
 export interface Project {


### PR DESCRIPTION
## Summary

Adds a **Use system fonts** button to the "Missing brand fonts" banner, allowing users to dismiss the warning when they're comfortable with the fallback fonts.

## Changes

- Added `dismissedMissingFontsWarning` flag to `ProjectMetadata` interface
- Added "Use system fonts" button alongside "Upload fonts" in both banner locations:
  - `FileWorkspace.tsx` (design system project panel, ~line 1540)
  - `DesignSystemFlow.tsx` (design system detail view, ~line 1814)
- Implemented per-project dismissal persistence via `patchProject`
- Banner is hidden after dismissal and persists across page reloads
- This iteration is acknowledge-only; does not change actual rendering behavior

## Testing

- [x] TypeScript compilation passes
- [ ] Manual testing: dismiss banner in both locations
- [ ] Manual testing: verify dismissal persists after page reload
- [ ] Manual testing: verify dismissal is per-project (other projects still show banner)

## Notes

- The banner code was duplicated in two locations; this PR maintains that structure for minimal risk
- Future enhancement could extract a shared component to reduce duplication
- Future enhancement could actually switch previews to system font stack when dismissed

Fixes #2814