### PR TITLE
fix: pin custom design systems to top and extract swatches from table tokens

### DIFF
--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -2823,6 +2823,22 @@ function extractSwatches(raw: string): string[] {
   // Form B: "**Stripe Purple** (`#533afd`)"
   const reB = /\*\*([A-Za-z][A-Za-z0-9 /&()+_-]{1,40}?)\*\*\s*\(?\s*`?(#[0-9a-fA-F]{3,8})/g;
   while ((m = reB.exec(raw)) !== null) push(m[1] ?? '', m[2] ?? '');
+  // Form C: Markdown table format
+  // Extract tokens from table rows: first text cell = name, first #hex in row = value
+  const tableRowRegex = /^\s*\|([^|\n]+)\|([^|\n]+(?:\|[^|\n]+)*)\|\s*$/gm;
+  while ((m = tableRowRegex.exec(raw)) !== null) {
+    const firstCell = m[1]?.trim() ?? '';
+    const restOfRow = m[2] ?? '';
+    // Skip header separator rows (e.g., |---|---|)
+    if (/^[\s-:|]+$/.test(firstCell) || /^[\s-:|]+$/.test(restOfRow)) continue;
+    // Skip if first cell looks like a header (common table headers)
+    if (/^(name|token|color|variable|key|property)$/i.test(firstCell)) continue;
+    // Extract first hex color from the rest of the row
+    const hexMatch = /#[0-9a-fA-F]{3,8}/.exec(restOfRow);
+    if (hexMatch && firstCell.length > 0 && /[A-Za-z]/.test(firstCell)) {
+      push(firstCell, hexMatch[0]);
+    }
+  }
   if (colors.length === 0) return [];
   return pickSwatchRow(colors).values;
 }

--- a/apps/daemon/tests/design-systems-frontmatter.test.ts
+++ b/apps/daemon/tests/design-systems-frontmatter.test.ts
@@ -230,4 +230,116 @@ describe('listDesignSystems frontmatter parsing (issue #1857)', () => {
     const [ds] = await listDesignSystems(root);
     expect(ds?.body).toBe(raw);
   });
+
+  it('extracts swatches from markdown table format (issue #2813)', async () => {
+    const root = fresh();
+    writeDesignMd(
+      root,
+      'table-tokens',
+      [
+        '# Design System with Table Tokens',
+        '',
+        '> Category: Productivity',
+        '',
+        'A system using table format for color tokens.',
+        '',
+        '## Color Tokens',
+        '',
+        '| Token Name | Value | Usage |',
+        '|------------|-------|-------|',
+        '| Background | #fafafa | Page background |',
+        '| Text | #111111 | Primary text |',
+        '| Accent | #00b96b | Brand color |',
+        '| Border | #dddddd | Dividers |',
+      ].join('\n'),
+    );
+
+    const [ds] = await listDesignSystems(root);
+    expect(ds?.swatches).toEqual(['#fafafa', '#dddddd', '#111111', '#00b96b']);
+  });
+
+  it('extracts swatches from table format with backticks around hex values', async () => {
+    const root = fresh();
+    writeDesignMd(
+      root,
+      'table-backticks',
+      [
+        '# Table with Backticks',
+        '',
+        '> Category: Custom',
+        '',
+        'Table tokens with code formatting.',
+        '',
+        '| Name | Color |',
+        '|------|-------|',
+        '| Primary | `#ff3366` |',
+        '| Secondary | `#3366ff` |',
+        '| Background | `#ffffff` |',
+        '| Foreground | `#222222` |',
+      ].join('\n'),
+    );
+
+    const [ds] = await listDesignSystems(root);
+    expect(ds?.swatches).toEqual(['#ffffff', '#3366ff', '#222222', '#ff3366']);
+  });
+
+  it('skips table header rows and extracts only data rows', async () => {
+    const root = fresh();
+    writeDesignMd(
+      root,
+      'table-headers',
+      [
+        '# Table with Headers',
+        '',
+        '> Category: Custom',
+        '',
+        'Table with proper headers.',
+        '',
+        '| Name | Value |',
+        '|------|-------|',
+        '| Background | #ffffff |',
+        '| Foreground | #111111 |',
+        '| Accent | #00b96b |',
+        '| Border | #dddddd |',
+      ].join('\n'),
+    );
+
+    const [ds] = await listDesignSystems(root);
+    // pickSwatchRow returns [bg, support, fg, accent]
+    expect(ds?.swatches).toEqual(['#ffffff', '#dddddd', '#111111', '#00b96b']);
+  });
+
+  it('combines table format with inline format tokens (issue #2813)', async () => {
+    const root = fresh();
+    writeDesignMd(
+      root,
+      'mixed-formats',
+      [
+        '# Mixed Format Tokens',
+        '',
+        '> Category: Custom',
+        '',
+        'System with both inline and table tokens.',
+        '',
+        '## Primary Colors',
+        '',
+        '- **Brand Primary:** `#00b96b`',
+        '- **Brand Secondary:** `#0066cc`',
+        '',
+        '## Semantic Colors',
+        '',
+        '| Token | Value |',
+        '|-------|-------|',
+        '| Background | #fafafa |',
+        '| Foreground | #111111 |',
+        '| Border | #dddddd |',
+      ].join('\n'),
+    );
+
+    const [ds] = await listDesignSystems(root);
+    // Should extract from both formats without duplicates
+    expect(ds?.swatches).toHaveLength(4);
+    expect(ds?.swatches).toContain('#00b96b');
+    expect(ds?.swatches).toContain('#fafafa');
+  });
 });

--- a/apps/web/src/components/DesignSystemsSection.tsx
+++ b/apps/web/src/components/DesignSystemsSection.tsx
@@ -85,6 +85,14 @@ export function DesignSystemsSection({ cfg, setCfg }: Props) {
       list.push(d);
       groups.set(d.category, list);
     }
+    // Sort each category: user-created systems first, then others
+    for (const [category, items] of groups.entries()) {
+      items.sort((a, b) => {
+        if (a.source === 'user' && b.source !== 'user') return -1;
+        if (a.source !== 'user' && b.source === 'user') return 1;
+        return a.title.localeCompare(b.title);
+      });
+    }
     return groups;
   }, [filtered]);
 


### PR DESCRIPTION
## Summary

Implements two improvements to the Design Systems section in Settings:

1. **Pin custom systems to top**: User-created design systems now always appear first in their category
2. **Extract swatches from table tokens**: Support markdown table format for color token definitions

## Changes

### Feature 1: Custom Systems Sorting
- Modified `DesignSystemsSection.tsx` to sort user-created systems (`source: 'user'`) before built-in systems
- Within each category: custom systems first, then alphabetically by title
- Built-in systems remain read-only and unaffected

### Feature 2: Table Format Swatch Extraction
- Extended `extractSwatches` function in `apps/daemon/src/design-systems.ts`
- Now supports three formats:
  - **Form A** (existing): `- **Background:** #FAFAFA`
  - **Form B** (existing): `**Stripe Purple** (#533afd)`
  - **Form C** (new): Markdown table format
- Table parsing rules:
  - First text cell = token name
  - First #hex in row = color value
  - Automatically skips table headers and separator rows
- Fully backward compatible with existing formats
- Can mix all three formats in the same DESIGN.md

## Testing

- ✅ All 12 tests pass in `design-systems-frontmatter.test.ts`
- ✅ Added 4 new test cases:
  - Basic table format extraction
  - Table with backticks around hex values
  - Header row skipping
  - Mixed format compatibility
- ✅ TypeScript typecheck passes for both web and daemon
- ✅ No regression in existing swatch extraction

## Example Table Format

```markdown
| Token Name | Value | Usage |
|------------|-------|-------|
| Background | #fafafa | Page background |
| Text | #111111 | Primary text |
| Accent | #00b96b | Brand color |
```

Fixes #2813