### PR TITLE
Surface GitHub repo connect/import CTA in design system projects

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -1001,19 +1001,20 @@ export function ChatPane({
                       </span>
                       <span className="chat-connect-repo-body">
                         <span className="chat-connect-repo-title">
-                          {repoConnectCopy(Boolean(githubConnected)).cardTitle}
+                          {repoConnectCopy(githubConnected).cardTitle}
                         </span>
                         <span className="chat-connect-repo-text">
-                          {repoConnectCopy(Boolean(githubConnected)).cardBody}
+                          {repoConnectCopy(githubConnected).cardBody}
                         </span>
                       </span>
                       <button
                         type="button"
                         className="primary-ghost"
+                        disabled={githubConnected === undefined}
                         onClick={() => onConnectRepo?.()}
                       >
                         <Icon name="github" size={13} />
-                        {repoConnectCopy(Boolean(githubConnected)).buttonLabel}
+                        {repoConnectCopy(githubConnected).buttonLabel}
                       </button>
                     </div>
                   ) : null}

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -26,6 +26,8 @@ import {
 } from './ChatComposer';
 import type { PluginFolderAgentAction } from './design-files/pluginFolderActions';
 import { Icon } from './Icon';
+import { repoConnectCopy } from './design-system-github-evidence';
+import type { SettingsSection } from './SettingsDialog';
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 
@@ -270,10 +272,24 @@ interface Props {
   onRenameConversation?: (id: string, title: string) => void;
   // Composer settings/CLI button forwards to here. The dialog lives in App
   // (it owns the AppConfig lifecycle) so we just pass the open trigger.
-  onOpenSettings?: () => void;
+  onOpenSettings?: (section?: SettingsSection) => void;
   // Same dialog, but landing on the External MCP tab. Forwarded to the
   // composer's `/mcp` slash and MCP picker button.
   onOpenMcpSettings?: () => void;
+  // True when this project is a GitHub-backed design system whose repository
+  // evidence has not fully landed. Surfaces a "Connect your repo" CTA in the
+  // empty chat state alongside the starter examples.
+  connectRepoNeeded?: boolean;
+  // Live GitHub connector status, used only to pick the connect-repo CTA copy
+  // (connect vs re-import). Undefined until the status fetch resolves.
+  githubConnected?: boolean;
+  // Fires when the connect-repo CTA button is clicked. The parent decides what
+  // it does based on connector status (open Connectors, or prefill the composer
+  // with the import instruction).
+  onConnectRepo?: () => void;
+  // Bumped by the parent to push a draft into the composer (used by the
+  // "Import repo" CTA). The nonce lets the same text fire more than once.
+  composerDraftSignal?: { text: string; nonce: number };
   // Optional pet wiring forwarded straight through to ChatComposer's
   // /pet button. When omitted the composer hides the button entirely.
   petConfig?: AppConfig['pet'];
@@ -341,6 +357,10 @@ export function ChatPane({
   onRenameConversation,
   onOpenSettings,
   onOpenMcpSettings,
+  connectRepoNeeded,
+  githubConnected,
+  onConnectRepo,
+  composerDraftSignal,
   petConfig,
   onAdoptPet,
   onTogglePet,
@@ -429,6 +449,17 @@ export function ChatPane({
       composerRef.current?.setDraft('');
     }
   }, [initialDraft]);
+
+  // Parent-driven composer prefill (the "Import repo" CTA). Reuse the same
+  // imperative setDraft the starter cards use; the nonce guards against
+  // re-applying the same signal on unrelated re-renders.
+  const lastDraftSignalNonceRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!composerDraftSignal) return;
+    if (lastDraftSignalNonceRef.current === composerDraftSignal.nonce) return;
+    lastDraftSignalNonceRef.current = composerDraftSignal.nonce;
+    composerRef.current?.setDraft(composerDraftSignal.text);
+  }, [composerDraftSignal]);
 
   useEffect(() => {
     const el = logRef.current;
@@ -963,6 +994,29 @@ export function ChatPane({
                       </button>
                     ))}
                   </div>
+                  {connectRepoNeeded ? (
+                    <div className="chat-connect-repo" role="note">
+                      <span className="chat-connect-repo-icon" aria-hidden>
+                        <Icon name="github" size={18} />
+                      </span>
+                      <span className="chat-connect-repo-body">
+                        <span className="chat-connect-repo-title">
+                          {repoConnectCopy(Boolean(githubConnected)).cardTitle}
+                        </span>
+                        <span className="chat-connect-repo-text">
+                          {repoConnectCopy(Boolean(githubConnected)).cardBody}
+                        </span>
+                      </span>
+                      <button
+                        type="button"
+                        className="primary-ghost"
+                        onClick={() => onConnectRepo?.()}
+                      >
+                        <Icon name="github" size={13} />
+                        {repoConnectCopy(Boolean(githubConnected)).buttonLabel}
+                      </button>
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
               {messages.map((m, i) => {

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -44,6 +44,7 @@ import {
 } from '../types';
 import { DesignFilesPanel } from './DesignFilesPanel';
 import type { PluginFolderAgentAction } from './design-files/pluginFolderActions';
+import { designSystemGithubEvidenceState, repoConnectCopy } from './design-system-github-evidence';
 import { FileViewer, LiveArtifactViewer } from './FileViewer';
 import { Icon } from './Icon';
 import { LiveArtifactBadges } from './LiveArtifactBadges';
@@ -102,6 +103,8 @@ interface Props {
     details?: DesignSystemReviewDetails,
   ) => void;
   onUseDesignSystem?: (id: string, title: string) => void;
+  onConnectRepo?: () => void;
+  githubConnected?: boolean;
 }
 
 interface SketchState {
@@ -216,6 +219,8 @@ export function FileWorkspace({
   designSystemReview,
   onDesignSystemReviewDecision,
   onUseDesignSystem,
+  onConnectRepo,
+  githubConnected,
 }: Props) {
   const t = useT();
   const analytics = useAnalytics();
@@ -959,6 +964,8 @@ export function FileWorkspace({
             designSystemReview={designSystemReview}
             onReviewDecision={onDesignSystemReviewDecision}
             onUseDesignSystem={onUseDesignSystem}
+            onConnectRepo={onConnectRepo}
+            githubConnected={githubConnected}
           />
         ) : activeTab === DESIGN_FILES_TAB ? (
           <DesignFilesPanel
@@ -1126,6 +1133,8 @@ function DesignSystemProjectPanel({
   designSystemReview,
   onReviewDecision,
   onUseDesignSystem,
+  onConnectRepo,
+  githubConnected,
 }: {
   projectId: string;
   system: DesignSystemSummary;
@@ -1149,6 +1158,8 @@ function DesignSystemProjectPanel({
     details?: DesignSystemReviewDetails,
   ) => void;
   onUseDesignSystem?: (id: string, title: string) => void;
+  onConnectRepo?: () => void;
+  githubConnected?: boolean;
 }) {
   const [reviewDecisions, setReviewDecisions] = useState<Record<string, DesignSystemReviewDecision>>({});
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({});
@@ -1515,16 +1526,17 @@ function DesignSystemProjectPanel({
 
         {!githubEvidence.ready ? (
           <div className="ds-project-warning-card">
-            <Icon name="help-circle" size={16} />
+            <Icon name="github" size={16} />
             <span>
-              <strong>Waiting for GitHub connector evidence</strong>
-              <small>
-                {githubEvidence.noteCount === 0
-                  ? 'Run connector intake before publishing. Drafts cannot be used by other projects until repository evidence is captured.'
-                  : 'Connector evidence notes exist; waiting for repository file snapshots before publishing.'}
-              </small>
+              <strong>{repoConnectCopy(Boolean(githubConnected)).bannerTitle}</strong>
+              <small>{repoConnectCopy(Boolean(githubConnected)).bannerBody}</small>
             </span>
-            {githubEvidence.hasSourceManifest ? (
+            {onConnectRepo ? (
+              <button type="button" className="ghost compact" onClick={onConnectRepo}>
+                <Icon name="github" size={13} />
+                {repoConnectCopy(Boolean(githubConnected)).buttonLabel}
+              </button>
+            ) : githubEvidence.hasSourceManifest ? (
               <button type="button" className="ghost compact" onClick={() => onOpenFile('context/source-context.md')}>
                 <Icon name="file" size={13} />
                 Open source context
@@ -1589,39 +1601,6 @@ function designSystemHasSourceContext(system: DesignSystemSummary): boolean {
     provenance.notes?.trim() ||
     provenance.sourceNotes?.trim(),
   );
-}
-
-function designSystemGithubEvidenceState(
-  system: DesignSystemSummary,
-  names: string[],
-): {
-  required: boolean;
-  ready: boolean;
-  noteCount: number;
-  snapshotCount: number;
-  hasSourceManifest: boolean;
-} {
-  const expectedRepos = system.provenance?.githubUrls?.length ?? 0;
-  const required = expectedRepos > 0;
-  if (!required) {
-    return {
-      required: false,
-      ready: true,
-      noteCount: 0,
-      snapshotCount: 0,
-      hasSourceManifest: names.some((name) => normalizeDesignSystemPath(name) === 'context/source-context.md'),
-    };
-  }
-  const normalized = names.map(normalizeDesignSystemPath);
-  const noteCount = normalized.filter((name) => /^context\/github\/[^/]+\.md$/u.test(name)).length;
-  const snapshotCount = normalized.filter((name) => /^context\/github\/[^/]+\/files\//u.test(name)).length;
-  return {
-    required: true,
-    ready: noteCount >= expectedRepos && snapshotCount > 0,
-    noteCount,
-    snapshotCount,
-    hasSourceManifest: normalized.includes('context/source-context.md'),
-  };
 }
 
 function slugForTestId(value: string): string {

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -1528,13 +1528,18 @@ function DesignSystemProjectPanel({
           <div className="ds-project-warning-card">
             <Icon name="github" size={16} />
             <span>
-              <strong>{repoConnectCopy(Boolean(githubConnected)).bannerTitle}</strong>
-              <small>{repoConnectCopy(Boolean(githubConnected)).bannerBody}</small>
+              <strong>{repoConnectCopy(githubConnected).bannerTitle}</strong>
+              <small>{repoConnectCopy(githubConnected).bannerBody}</small>
             </span>
             {onConnectRepo ? (
-              <button type="button" className="ghost compact" onClick={onConnectRepo}>
+              <button
+                type="button"
+                className="ghost compact"
+                disabled={githubConnected === undefined}
+                onClick={onConnectRepo}
+              >
                 <Icon name="github" size={13} />
-                {repoConnectCopy(Boolean(githubConnected)).buttonLabel}
+                {repoConnectCopy(githubConnected).buttonLabel}
               </button>
             ) : githubEvidence.hasSourceManifest ? (
               <button type="button" className="ghost compact" onClick={() => onOpenFile('context/source-context.md')}>

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3470,11 +3470,13 @@ export function ProjectView({
     [designSystemProject, projectFiles],
   );
   // Only the connect-repo CTA copy depends on this (connect vs re-import), so
-  // resolve it lazily and only while the CTA is actually showing.
-  const [githubConnected, setGithubConnected] = useState(false);
+  // resolve it lazily and only while the CTA is actually showing. Tri-state:
+  // `undefined` means the status fetch has not resolved yet, which keeps the
+  // CTA neutral and disabled so a fast click can't fire the wrong action.
+  const [githubConnected, setGithubConnected] = useState<boolean | undefined>(undefined);
   useEffect(() => {
     if (!connectRepoNeeded) {
-      setGithubConnected(false);
+      setGithubConnected(undefined);
       return;
     }
     let aborted = false;
@@ -3505,6 +3507,9 @@ export function ProjectView({
   // not connected it opens Connectors; once connected it prefills the composer
   // with the import instruction so the user can review and send it.
   const handleConnectRepo = useCallback(() => {
+    // Status not resolved yet; the CTA is disabled in this window, but guard
+    // anyway so a stray call can't route a connected account to Connectors.
+    if (githubConnected === undefined) return;
     if (githubConnected) {
       setComposerDraftSignal({
         text: buildRepoImportPrompt(designSystemProject, projectFiles.map((file) => file.name)),

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -26,6 +26,7 @@ import { fetchElevenLabsVoiceOptions } from '../providers/elevenlabs-voices';
 import { normalizeCustomReason } from '@open-design/contracts/analytics';
 import {
   deletePreviewComment,
+  fetchConnectorStatuses,
   fetchPreviewComments,
   fetchDesignSystem,
   fetchDesignTemplate,
@@ -145,6 +146,7 @@ import {
   useCritiqueTheaterEnabled,
 } from './Theater';
 import { decideAutoOpenAfterWrite } from './auto-open-file';
+import { designSystemNeedsRepoConnect, REPO_IMPORT_PROMPT } from './design-system-github-evidence';
 import { collectReferencedJsxNames } from '../runtime/jsx-module-refs';
 import { FileWorkspace } from './FileWorkspace';
 import { Icon } from './Icon';
@@ -152,6 +154,7 @@ import {
   type PluginFolderAgentAction,
 } from './design-files/pluginFolderActions';
 import { CenteredLoader } from './Loading';
+import type { SettingsSection } from './SettingsDialog';
 import { Toast } from './Toast';
 import { useDesignMdState } from '../hooks/useDesignMdState';
 import { useFinalizeProject } from '../hooks/useFinalizeProject';
@@ -203,7 +206,7 @@ interface Props {
     choice: { model?: string; reasoning?: string },
   ) => void;
   onRefreshAgents: () => void;
-  onOpenSettings: () => void;
+  onOpenSettings: (section?: SettingsSection) => void;
   onOpenMcpSettings?: () => void;
   // Pet wiring forwarded to the chat composer so users can adopt /
   // wake / tuck a pet without leaving the project view.
@@ -3462,6 +3465,52 @@ export function ProjectView({
     () => designSystemProject ? latestDesignSystemActivityEvents(messages) : [],
     [designSystemProject, messages],
   );
+  const connectRepoNeeded = useMemo(
+    () => designSystemNeedsRepoConnect(designSystemProject, projectFiles.map((file) => file.name)),
+    [designSystemProject, projectFiles],
+  );
+  // Only the connect-repo CTA copy depends on this (connect vs re-import), so
+  // resolve it lazily and only while the CTA is actually showing.
+  const [githubConnected, setGithubConnected] = useState(false);
+  useEffect(() => {
+    if (!connectRepoNeeded) {
+      setGithubConnected(false);
+      return;
+    }
+    let aborted = false;
+    const controller = new AbortController();
+    const refresh = () => {
+      void fetchConnectorStatuses({ signal: controller.signal }).then((statuses) => {
+        if (!aborted) setGithubConnected(statuses.github?.status === 'connected');
+      });
+    };
+    refresh();
+    // Connecting GitHub happens in the Connectors dialog or an external OAuth
+    // window, neither of which changes connectRepoNeeded. Re-check on focus so
+    // the CTA flips from "Connect GitHub" to "Import repo" when the user returns.
+    const onFocus = () => refresh();
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onFocus);
+    return () => {
+      aborted = true;
+      controller.abort();
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onFocus);
+    };
+  }, [connectRepoNeeded]);
+
+  // Signal that pushes a draft into the chat composer (the "Import repo" CTA).
+  const [composerDraftSignal, setComposerDraftSignal] = useState<{ text: string; nonce: number }>();
+  // One handler for both the review banner and the chat CTA. When GitHub is
+  // not connected it opens Connectors; once connected it prefills the composer
+  // with the import instruction so the user can review and send it.
+  const handleConnectRepo = useCallback(() => {
+    if (githubConnected) {
+      setComposerDraftSignal({ text: REPO_IMPORT_PROMPT, nonce: Date.now() });
+    } else {
+      onOpenSettings('composio');
+    }
+  }, [githubConnected, onOpenSettings]);
 
   const isDeck = useMemo(
     () =>
@@ -4116,6 +4165,10 @@ export function ProjectView({
               onRenameConversation={handleRenameConversation}
               onOpenSettings={onOpenSettings}
               onOpenMcpSettings={onOpenMcpSettings}
+              connectRepoNeeded={connectRepoNeeded}
+              githubConnected={githubConnected}
+              onConnectRepo={handleConnectRepo}
+              composerDraftSignal={composerDraftSignal}
               petConfig={config.pet}
               onAdoptPet={onAdoptPetInline}
               onTogglePet={onTogglePet}
@@ -4186,6 +4239,8 @@ export function ProjectView({
           onDesignSystemNeedsWork={sendDesignSystemFeedback}
           designSystemReview={project.metadata?.designSystemReview}
           onDesignSystemReviewDecision={persistDesignSystemReviewDecision}
+          onConnectRepo={handleConnectRepo}
+          githubConnected={githubConnected}
         />
       </div>
       {projectActionsToast ? (

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -146,7 +146,7 @@ import {
   useCritiqueTheaterEnabled,
 } from './Theater';
 import { decideAutoOpenAfterWrite } from './auto-open-file';
-import { designSystemNeedsRepoConnect, REPO_IMPORT_PROMPT } from './design-system-github-evidence';
+import { buildRepoImportPrompt, designSystemNeedsRepoConnect } from './design-system-github-evidence';
 import { collectReferencedJsxNames } from '../runtime/jsx-module-refs';
 import { FileWorkspace } from './FileWorkspace';
 import { Icon } from './Icon';
@@ -3506,11 +3506,14 @@ export function ProjectView({
   // with the import instruction so the user can review and send it.
   const handleConnectRepo = useCallback(() => {
     if (githubConnected) {
-      setComposerDraftSignal({ text: REPO_IMPORT_PROMPT, nonce: Date.now() });
+      setComposerDraftSignal({
+        text: buildRepoImportPrompt(designSystemProject, projectFiles.map((file) => file.name)),
+        nonce: Date.now(),
+      });
     } else {
       onOpenSettings('composio');
     }
-  }, [githubConnected, onOpenSettings]);
+  }, [githubConnected, onOpenSettings, designSystemProject, projectFiles]);
 
   const isDeck = useMemo(
     () =>

--- a/apps/web/src/components/design-system-github-evidence.ts
+++ b/apps/web/src/components/design-system-github-evidence.ts
@@ -65,13 +65,30 @@ export function designSystemNeedsRepoConnect(
 
 /**
  * Instruction dropped into the chat composer when GitHub is connected and the
- * user clicks "Import repo". The design-system project agent already has the
- * bounded `od tools connectors github-design-context` command in
- * `context/source-context.md`; this prompt tells it to run that intake so the
- * evidence notes and file snapshots get captured, which is what clears the CTA.
+ * user clicks "Import repo". Built from the design system's linked repo URLs so
+ * it runs even before `context/source-context.md` exists. The CTA shows for any
+ * incomplete GitHub-backed system, and that manifest may not be written yet, so
+ * keying the prompt to the manifest would dead-start the recovery on a missing
+ * file. When the manifest is present the agent is told to follow the exact
+ * bounded commands it lists.
  */
-export const REPO_IMPORT_PROMPT =
-  'Pull the linked GitHub repository into this design system. Read `context/source-context.md`, then run the bounded `github-design-context` intake command it lists for each linked repo so the evidence notes and file snapshots under `context/github/<repo>/files/` are captured. After the snapshots land, update DESIGN.md, the token files, and the preview cards from that evidence.';
+export function buildRepoImportPrompt(
+  system: DesignSystemSummary | null | undefined,
+  names: string[],
+): string {
+  const githubUrls = system?.provenance?.githubUrls ?? [];
+  const repoList = githubUrls.length ? ` for ${githubUrls.join(', ')}` : '';
+  const hasManifest = names.some(
+    (name) => normalizeDesignSystemPath(name) === 'context/source-context.md',
+  );
+  const manifestClause = hasManifest
+    ? ' If `context/source-context.md` is present, follow the exact bounded commands it lists.'
+    : '';
+  return (
+    `Pull the linked GitHub repository into this design system. Run the bounded \`github-design-context\` intake${repoList} so the evidence notes and file snapshots under \`context/github/<repo>/files/\` are captured.${manifestClause}` +
+    ' After the snapshots land, update DESIGN.md, the token files, and the preview cards from that evidence.'
+  );
+}
 
 export interface RepoConnectCopy {
   /** Heading used by the review banner. */

--- a/apps/web/src/components/design-system-github-evidence.ts
+++ b/apps/web/src/components/design-system-github-evidence.ts
@@ -105,12 +105,23 @@ export interface RepoConnectCopy {
 
 /**
  * Copy for the "Connect your repo" CTA, split by live GitHub connector status.
- * When GitHub is already connected the copy stops asking the user to connect
- * and instead points at the re-import step that actually pulls repo files.
- * Both the review banner and the chat empty-state card share this so the two
- * surfaces never drift.
+ * `undefined` means the status fetch has not resolved yet: show a neutral,
+ * pending label so a fast click can't fire the wrong action (connect vs import)
+ * before we know whether GitHub is connected. Once known, connected copy points
+ * at the re-import step and not-connected copy asks the user to connect. Both
+ * the review banner and the chat empty-state card share this so they never
+ * drift.
  */
-export function repoConnectCopy(githubConnected: boolean): RepoConnectCopy {
+export function repoConnectCopy(githubConnected: boolean | undefined): RepoConnectCopy {
+  if (githubConnected === undefined) {
+    return {
+      bannerTitle: 'Connect your repo to pull aspects of your design system',
+      cardTitle: 'Connect your repo',
+      bannerBody: 'Checking your GitHub connection...',
+      cardBody: 'Checking your GitHub connection...',
+      buttonLabel: 'Checking GitHub...',
+    };
+  }
   if (githubConnected) {
     return {
       bannerTitle: 'GitHub is connected',

--- a/apps/web/src/components/design-system-github-evidence.ts
+++ b/apps/web/src/components/design-system-github-evidence.ts
@@ -1,0 +1,114 @@
+import type { DesignSystemSummary } from '../types';
+
+export interface DesignSystemGithubEvidence {
+  /** The design system references at least one GitHub repo in its provenance. */
+  required: boolean;
+  /** Connector notes and file snapshots have both been captured. */
+  ready: boolean;
+  /** Count of `context/github/<repo>.md` connector notes present. */
+  noteCount: number;
+  /** Count of `context/github/<repo>/files/...` snapshot files present. */
+  snapshotCount: number;
+  hasSourceManifest: boolean;
+}
+
+function normalizeDesignSystemPath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^\.?\//, '').toLowerCase();
+}
+
+/**
+ * Inspect the captured files for a design system to decide how far GitHub
+ * intake has progressed. When the system declares no GitHub repos this returns
+ * `ready: true` so non-GitHub systems never see repo prompts.
+ */
+export function designSystemGithubEvidenceState(
+  system: DesignSystemSummary,
+  names: string[],
+): DesignSystemGithubEvidence {
+  const expectedRepos = system.provenance?.githubUrls?.length ?? 0;
+  const required = expectedRepos > 0;
+  if (!required) {
+    return {
+      required: false,
+      ready: true,
+      noteCount: 0,
+      snapshotCount: 0,
+      hasSourceManifest: names.some(
+        (name) => normalizeDesignSystemPath(name) === 'context/source-context.md',
+      ),
+    };
+  }
+  const normalized = names.map(normalizeDesignSystemPath);
+  const noteCount = normalized.filter((name) => /^context\/github\/[^/]+\.md$/u.test(name)).length;
+  const snapshotCount = normalized.filter((name) => /^context\/github\/[^/]+\/files\//u.test(name)).length;
+  return {
+    required: true,
+    ready: noteCount >= expectedRepos && snapshotCount > 0,
+    noteCount,
+    snapshotCount,
+    hasSourceManifest: normalized.includes('context/source-context.md'),
+  };
+}
+
+/**
+ * True when a design system points at GitHub repos but the repository evidence
+ * is not fully captured yet. This is the single signal that gates the
+ * "Connect your repo" CTA in the review banner and the chat empty state.
+ */
+export function designSystemNeedsRepoConnect(
+  system: DesignSystemSummary | null | undefined,
+  names: string[],
+): boolean {
+  if (!system) return false;
+  return !designSystemGithubEvidenceState(system, names).ready;
+}
+
+/**
+ * Instruction dropped into the chat composer when GitHub is connected and the
+ * user clicks "Import repo". The design-system project agent already has the
+ * bounded `od tools connectors github-design-context` command in
+ * `context/source-context.md`; this prompt tells it to run that intake so the
+ * evidence notes and file snapshots get captured, which is what clears the CTA.
+ */
+export const REPO_IMPORT_PROMPT =
+  'Pull the linked GitHub repository into this design system. Read `context/source-context.md`, then run the bounded `github-design-context` intake command it lists for each linked repo so the evidence notes and file snapshots under `context/github/<repo>/files/` are captured. After the snapshots land, update DESIGN.md, the token files, and the preview cards from that evidence.';
+
+export interface RepoConnectCopy {
+  /** Heading used by the review banner. */
+  bannerTitle: string;
+  /** Short title used by the chat empty-state card. */
+  cardTitle: string;
+  /** Supporting sentence for the review banner. */
+  bannerBody: string;
+  /** Supporting sentence for the chat empty-state card. */
+  cardBody: string;
+  /** Action button label. */
+  buttonLabel: string;
+}
+
+/**
+ * Copy for the "Connect your repo" CTA, split by live GitHub connector status.
+ * When GitHub is already connected the copy stops asking the user to connect
+ * and instead points at the re-import step that actually pulls repo files.
+ * Both the review banner and the chat empty-state card share this so the two
+ * surfaces never drift.
+ */
+export function repoConnectCopy(githubConnected: boolean): RepoConnectCopy {
+  if (githubConnected) {
+    return {
+      bannerTitle: 'GitHub is connected',
+      cardTitle: 'GitHub is connected',
+      bannerBody: 'Re-import this repo to pull its files into your design system.',
+      cardBody: 'Re-import this repo to pull its files into your design system.',
+      buttonLabel: 'Import repo',
+    };
+  }
+  return {
+    bannerTitle: 'Connect your repo to pull aspects of your design system',
+    cardTitle: 'Connect your repo',
+    bannerBody:
+      'Connect GitHub so Open Design can read your repository and pull colors, type, and components into this design system.',
+    cardBody: 'Pull colors, type, and components from your repository into this design system.',
+    buttonLabel: 'Connect GitHub',
+  };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -13346,6 +13346,59 @@ button.ghost.mcp-copy-btn:hover:not(:disabled) {
   }
 }
 
+/* Connect-your-repo CTA in the empty chat state. Shares the example cards'
+   sizing and accent system but stands apart with a tinted fill so it reads as
+   guidance rather than another starter prompt. */
+.chat-connect-repo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  max-width: 520px;
+  padding: 14px 16px;
+  background: var(--accent-tint);
+  border: 1px solid var(--accent-soft);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-xs);
+  opacity: 0;
+  animation: chat-example-in 380ms cubic-bezier(0.22, 1, 0.36, 1) 220ms forwards;
+}
+.chat-connect-repo-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: #fff;
+}
+.chat-connect-repo-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+  flex: 1;
+}
+.chat-connect-repo-title {
+  font-weight: 600;
+  color: var(--text-strong);
+  font-size: 13.5px;
+}
+.chat-connect-repo-text {
+  color: var(--text-muted);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.chat-connect-repo button {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
 .assistant-header {
   display: flex;
   align-items: center;
@@ -26745,6 +26798,27 @@ body.desktop-pet-shell .pet-task-item {
 .app .chat-example-cta {
   width: 22px;
   height: 22px;
+}
+.app .chat-connect-repo {
+  max-width: none;
+  padding: 10px 12px;
+  gap: 10px;
+  border-radius: 10px;
+  box-shadow: none;
+  animation: none;
+  opacity: 1;
+}
+.app .chat-connect-repo-icon {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+}
+.app .chat-connect-repo-title {
+  font-size: 12.8px;
+}
+.app .chat-connect-repo-text {
+  font-size: 12px;
+  line-height: 1.35;
 }
 
 .app .composer {

--- a/apps/web/tests/components/ChatPane.connect-repo.test.tsx
+++ b/apps/web/tests/components/ChatPane.connect-repo.test.tsx
@@ -57,13 +57,26 @@ function renderPane(extra: Partial<React.ComponentProps<typeof ChatPane>>) {
 describe('ChatPane connect-repo CTA', () => {
   it('fires onConnectRepo with the Connect GitHub label when the repo evidence is incomplete', () => {
     const onConnectRepo = vi.fn();
-    const { container } = renderPane({ connectRepoNeeded: true, onConnectRepo });
+    const { container } = renderPane({ connectRepoNeeded: true, githubConnected: false, onConnectRepo });
 
     expect(container.querySelector('.chat-connect-repo')).not.toBeNull();
     const connectButton = screen.getByRole('button', { name: /Connect GitHub/ });
     fireEvent.click(connectButton);
 
     expect(onConnectRepo).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a disabled pending button until the connector status resolves', () => {
+    const onConnectRepo = vi.fn();
+    // githubConnected omitted -> undefined -> status still loading.
+    renderPane({ connectRepoNeeded: true, onConnectRepo });
+
+    const pendingButton = screen.getByRole('button', { name: /Checking GitHub/ });
+    expect((pendingButton as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(pendingButton);
+    expect(onConnectRepo).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /Connect GitHub/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Import repo/ })).toBeNull();
   });
 
   it('switches to an Import repo action when GitHub is already connected', () => {

--- a/apps/web/tests/components/ChatPane.connect-repo.test.tsx
+++ b/apps/web/tests/components/ChatPane.connect-repo.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { forwardRef, useImperativeHandle } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatPane } from '../../src/components/ChatPane';
+import type { Conversation, ProjectMetadata } from '../../src/types';
+
+const composerMocks = vi.hoisted(() => ({ setDraft: vi.fn() }));
+
+vi.mock('../../src/i18n', () => ({
+  useI18n: () => ({ locale: 'en', setLocale: () => undefined, t: (key: string) => key }),
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('../../src/components/ChatComposer', () => ({
+  ChatComposer: forwardRef((_props, ref) => {
+    useImperativeHandle(ref, () => ({ setDraft: composerMocks.setDraft }));
+    return <output data-testid="composer" />;
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const conversations: Conversation[] = [
+  { id: 'conv-1', projectId: 'project-1', title: 'Conversation 1', createdAt: 1, updatedAt: 1 },
+];
+
+const projectMetadata: ProjectMetadata = { kind: 'prototype' };
+
+function renderPane(extra: Partial<React.ComponentProps<typeof ChatPane>>) {
+  return render(
+    <ChatPane
+      projectKindForTracking="prototype"
+      messages={[]}
+      streaming={false}
+      error={null}
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      conversations={conversations}
+      activeConversationId="conv-1"
+      onSelectConversation={vi.fn()}
+      onDeleteConversation={vi.fn()}
+      projectMetadata={projectMetadata}
+      {...extra}
+    />,
+  );
+}
+
+describe('ChatPane connect-repo CTA', () => {
+  it('fires onConnectRepo with the Connect GitHub label when the repo evidence is incomplete', () => {
+    const onConnectRepo = vi.fn();
+    const { container } = renderPane({ connectRepoNeeded: true, onConnectRepo });
+
+    expect(container.querySelector('.chat-connect-repo')).not.toBeNull();
+    const connectButton = screen.getByRole('button', { name: /Connect GitHub/ });
+    fireEvent.click(connectButton);
+
+    expect(onConnectRepo).toHaveBeenCalledTimes(1);
+  });
+
+  it('switches to an Import repo action when GitHub is already connected', () => {
+    const onConnectRepo = vi.fn();
+    const { container } = renderPane({ connectRepoNeeded: true, githubConnected: true, onConnectRepo });
+
+    expect(container.querySelector('.chat-connect-repo')).not.toBeNull();
+    expect(screen.getByText('GitHub is connected')).toBeTruthy();
+    const importButton = screen.getByRole('button', { name: /Import repo/ });
+    fireEvent.click(importButton);
+
+    expect(onConnectRepo).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('button', { name: /Connect GitHub/ })).toBeNull();
+  });
+
+  it('prefills the composer when the parent pushes a draft signal', () => {
+    renderPane({
+      connectRepoNeeded: true,
+      githubConnected: true,
+      onConnectRepo: vi.fn(),
+      composerDraftSignal: { text: 'Pull the linked repo', nonce: 1 },
+    });
+
+    expect(composerMocks.setDraft).toHaveBeenCalledWith('Pull the linked repo');
+  });
+
+  it('hides the CTA when the project does not need a repo connection', () => {
+    const { container } = renderPane({ connectRepoNeeded: false, onOpenSettings: vi.fn() });
+    expect(container.querySelector('.chat-connect-repo')).toBeNull();
+  });
+
+  it('hides the CTA once the conversation has messages', () => {
+    const { container } = renderPane({
+      connectRepoNeeded: true,
+      onOpenSettings: vi.fn(),
+      messages: [{ id: 'user-1', role: 'user', content: 'hi', createdAt: 1 }],
+    });
+    expect(container.querySelector('.chat-connect-repo')).toBeNull();
+  });
+});

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -304,6 +304,7 @@ describe('FileWorkspace design-system project surface', () => {
           },
         })}
         onConnectRepo={onConnectRepo}
+        githubConnected={false}
       />,
     );
 
@@ -342,6 +343,7 @@ describe('FileWorkspace design-system project surface', () => {
           },
         })}
         onConnectRepo={vi.fn()}
+        githubConnected={false}
       />,
     );
 

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -274,7 +274,7 @@ describe('FileWorkspace design-system project surface', () => {
       '.ds-project-publish-card input[type="checkbox"]',
     );
 
-    expect(container.textContent).toContain('Waiting for GitHub connector evidence');
+    expect(container.textContent).toContain('Connect your repo to pull aspects of your design system');
     expect(publishToggle?.disabled).toBe(true);
 
     await act(async () => {
@@ -283,5 +283,106 @@ describe('FileWorkspace design-system project surface', () => {
     });
 
     expect(registryMocks.updateDesignSystemDraft).not.toHaveBeenCalled();
+  });
+
+  it('offers a Connect GitHub action that routes to Connectors when repo evidence is missing', async () => {
+    const onConnectRepo = vi.fn();
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[workspaceFile('DESIGN.md'), workspaceFile('preview/colors.html')]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem({
+          provenance: {
+            companyBlurb: 'Acme analytics workspace',
+            githubUrls: ['https://github.com/acme/product'],
+          },
+        })}
+        onConnectRepo={onConnectRepo}
+      />,
+    );
+
+    const connectButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Connect GitHub'),
+    );
+    expect(connectButton).toBeTruthy();
+
+    await act(async () => {
+      connectButton?.click();
+      await Promise.resolve();
+    });
+
+    expect(onConnectRepo).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the Connect GitHub action when evidence notes exist but file snapshots are still missing', () => {
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[
+          workspaceFile('DESIGN.md'),
+          workspaceFile('context/github/acme-product.md'),
+          workspaceFile('preview/colors.html'),
+        ]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem({
+          provenance: {
+            companyBlurb: 'Acme analytics workspace',
+            githubUrls: ['https://github.com/acme/product'],
+          },
+        })}
+        onConnectRepo={vi.fn()}
+      />,
+    );
+
+    expect(container.textContent).toContain('Connect your repo to pull aspects of your design system');
+    const connectButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Connect GitHub'),
+    );
+    expect(connectButton).toBeTruthy();
+  });
+
+  it('shows re-import guidance instead of Connect when GitHub is already connected', () => {
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[
+          workspaceFile('DESIGN.md'),
+          workspaceFile('context/github/acme-product.md'),
+          workspaceFile('preview/colors.html'),
+        ]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem({
+          provenance: {
+            companyBlurb: 'Acme analytics workspace',
+            githubUrls: ['https://github.com/acme/product'],
+          },
+        })}
+        onConnectRepo={vi.fn()}
+        githubConnected
+      />,
+    );
+
+    expect(container.textContent).toContain('GitHub is connected');
+    expect(container.textContent).not.toContain('Connect your repo to pull aspects of your design system');
+    const importButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Import repo'),
+    );
+    expect(importButton).toBeTruthy();
   });
 });

--- a/apps/web/tests/components/design-system-github-evidence.test.ts
+++ b/apps/web/tests/components/design-system-github-evidence.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  designSystemGithubEvidenceState,
+  designSystemNeedsRepoConnect,
+  repoConnectCopy,
+  REPO_IMPORT_PROMPT,
+} from '../../src/components/design-system-github-evidence';
+import type { DesignSystemSummary } from '../../src/types';
+
+function designSystem(overrides: Partial<DesignSystemSummary> = {}): DesignSystemSummary {
+  return {
+    id: 'user:acme',
+    title: 'Acme Design System',
+    category: 'Custom',
+    summary: 'Context project for Acme.',
+    swatches: [],
+    surface: 'web',
+    source: 'user',
+    status: 'draft',
+    isEditable: true,
+    ...overrides,
+  };
+}
+
+const githubBacked = designSystem({
+  provenance: { githubUrls: ['https://github.com/acme/product'] },
+});
+
+describe('designSystemGithubEvidenceState', () => {
+  it('treats systems without GitHub repos as ready and never required', () => {
+    const state = designSystemGithubEvidenceState(designSystem(), ['DESIGN.md', 'preview/colors.html']);
+    expect(state.required).toBe(false);
+    expect(state.ready).toBe(true);
+  });
+
+  it('detects the source manifest for non-GitHub systems', () => {
+    const state = designSystemGithubEvidenceState(designSystem(), ['context/source-context.md']);
+    expect(state.hasSourceManifest).toBe(true);
+  });
+
+  it('is not ready when a GitHub repo is declared but no evidence has landed', () => {
+    const state = designSystemGithubEvidenceState(githubBacked, ['DESIGN.md']);
+    expect(state.required).toBe(true);
+    expect(state.noteCount).toBe(0);
+    expect(state.snapshotCount).toBe(0);
+    expect(state.ready).toBe(false);
+  });
+
+  it('stays not-ready when notes exist but file snapshots are still missing', () => {
+    const state = designSystemGithubEvidenceState(githubBacked, [
+      'DESIGN.md',
+      'context/github/acme-product.md',
+    ]);
+    expect(state.noteCount).toBe(1);
+    expect(state.snapshotCount).toBe(0);
+    expect(state.ready).toBe(false);
+  });
+
+  it('becomes ready once notes cover every repo and at least one snapshot exists', () => {
+    const state = designSystemGithubEvidenceState(githubBacked, [
+      'context/github/acme-product.md',
+      'context/github/acme-product/files/App.tsx',
+    ]);
+    expect(state.noteCount).toBe(1);
+    expect(state.snapshotCount).toBe(1);
+    expect(state.ready).toBe(true);
+  });
+
+  it('normalizes leading ./ and backslash paths case-insensitively', () => {
+    const state = designSystemGithubEvidenceState(githubBacked, [
+      './context\\github\\Acme-Product.md',
+      'context\\github\\Acme-Product\\files\\Button.tsx',
+    ]);
+    expect(state.noteCount).toBe(1);
+    expect(state.snapshotCount).toBe(1);
+    expect(state.ready).toBe(true);
+  });
+});
+
+describe('designSystemNeedsRepoConnect', () => {
+  it('returns false for a missing system', () => {
+    expect(designSystemNeedsRepoConnect(null, ['DESIGN.md'])).toBe(false);
+    expect(designSystemNeedsRepoConnect(undefined, ['DESIGN.md'])).toBe(false);
+  });
+
+  it('returns false for systems without GitHub repos', () => {
+    expect(designSystemNeedsRepoConnect(designSystem(), ['DESIGN.md'])).toBe(false);
+  });
+
+  it('returns true while a GitHub-backed system is missing evidence', () => {
+    expect(designSystemNeedsRepoConnect(githubBacked, ['context/github/acme-product.md'])).toBe(true);
+  });
+
+  it('returns false once evidence is fully captured', () => {
+    expect(
+      designSystemNeedsRepoConnect(githubBacked, [
+        'context/github/acme-product.md',
+        'context/github/acme-product/files/App.tsx',
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe('repoConnectCopy', () => {
+  it('asks the user to connect when GitHub is not connected', () => {
+    const copy = repoConnectCopy(false);
+    expect(copy.buttonLabel).toBe('Connect GitHub');
+    expect(copy.bannerTitle).toBe('Connect your repo to pull aspects of your design system');
+    expect(copy.cardTitle).toBe('Connect your repo');
+  });
+
+  it('switches to re-import guidance when GitHub is already connected', () => {
+    const copy = repoConnectCopy(true);
+    expect(copy.buttonLabel).toBe('Import repo');
+    expect(copy.bannerTitle).toBe('GitHub is connected');
+    expect(copy.cardTitle).toBe('GitHub is connected');
+    expect(copy.bannerBody).toContain('Re-import');
+    expect(copy.cardBody).toContain('Re-import');
+  });
+});
+
+describe('REPO_IMPORT_PROMPT', () => {
+  it('tells the agent to run the bounded github-design-context intake', () => {
+    expect(REPO_IMPORT_PROMPT).toContain('context/source-context.md');
+    expect(REPO_IMPORT_PROMPT).toContain('github-design-context');
+    expect(REPO_IMPORT_PROMPT).toContain('context/github/');
+  });
+});

--- a/apps/web/tests/components/design-system-github-evidence.test.ts
+++ b/apps/web/tests/components/design-system-github-evidence.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildRepoImportPrompt,
   designSystemGithubEvidenceState,
   designSystemNeedsRepoConnect,
   repoConnectCopy,
-  REPO_IMPORT_PROMPT,
 } from '../../src/components/design-system-github-evidence';
 import type { DesignSystemSummary } from '../../src/types';
 
@@ -120,10 +120,21 @@ describe('repoConnectCopy', () => {
   });
 });
 
-describe('REPO_IMPORT_PROMPT', () => {
-  it('tells the agent to run the bounded github-design-context intake', () => {
-    expect(REPO_IMPORT_PROMPT).toContain('context/source-context.md');
-    expect(REPO_IMPORT_PROMPT).toContain('github-design-context');
-    expect(REPO_IMPORT_PROMPT).toContain('context/github/');
+describe('buildRepoImportPrompt', () => {
+  it('runs the bounded intake from the linked repo URLs', () => {
+    const prompt = buildRepoImportPrompt(githubBacked, ['DESIGN.md']);
+    expect(prompt).toContain('github-design-context');
+    expect(prompt).toContain('context/github/');
+    expect(prompt).toContain('https://github.com/acme/product');
+  });
+
+  it('does not require source-context.md when the manifest is absent', () => {
+    const prompt = buildRepoImportPrompt(githubBacked, ['DESIGN.md']);
+    expect(prompt).not.toContain('context/source-context.md');
+  });
+
+  it('points at source-context.md only once the manifest exists', () => {
+    const prompt = buildRepoImportPrompt(githubBacked, ['DESIGN.md', 'context/source-context.md']);
+    expect(prompt).toContain('context/source-context.md');
   });
 });

--- a/apps/web/tests/components/design-system-github-evidence.test.ts
+++ b/apps/web/tests/components/design-system-github-evidence.test.ts
@@ -118,6 +118,16 @@ describe('repoConnectCopy', () => {
     expect(copy.bannerBody).toContain('Re-import');
     expect(copy.cardBody).toContain('Re-import');
   });
+
+  it('shows a neutral pending label while the status is still loading', () => {
+    const copy = repoConnectCopy(undefined);
+    expect(copy.buttonLabel).toBe('Checking GitHub...');
+    expect(copy.bannerBody).toContain('Checking');
+    expect(copy.cardBody).toContain('Checking');
+    // Never advertise connect or import before the status is known.
+    expect(copy.buttonLabel).not.toBe('Connect GitHub');
+    expect(copy.buttonLabel).not.toBe('Import repo');
+  });
 });
 
 describe('buildRepoImportPrompt', () => {


### PR DESCRIPTION
Fixes #2815

## Why

I hit this on my own StackMe design system. It was built from a GitHub repo, but the repo files never got pulled in, so the Design System review tab just showed a banner that said "Waiting for GitHub connector evidence." It told me nothing I could act on, it blocked publishing, and there was no way to recover short of recreating the project. When I went looking for how to actually pull the repo, the answer was "ask the agent in chat," which is not discoverable at all.

So this turns that dead-end into guidance, and it does it in the Start-a-conversation empty state too, because someone who misses the banner in the Design System tab should still get caught on their next new chat.

## What users will see

For a design system whose repo evidence is incomplete, two surfaces now show a small card: the Design System review banner, and the project's Start-a-conversation empty state (its own style, sitting below the starter prompts).

- **GitHub not connected:** the card reads "Connect your repo to pull aspects of your design system" with a **Connect GitHub** button that opens Settings -> Connectors.
- **GitHub connected:** the card reads "GitHub is connected" with an **Import repo** button. Clicking it drops a ready-to-send instruction into the chat composer that tells the agent to run the bounded `github-design-context` intake for the linked repo. You review it and hit Send; the agent pulls the repo, the snapshots land, and the card clears on its own.

The connected/not-connected split is the same on both surfaces, and the connector status refreshes when you return to the window, so after you connect GitHub in the OAuth flow the copy flips from "Connect GitHub" to "Import repo" without a reload.

## Surface area

- [x] **UI** — new connect/import card in the Design System review banner and the Start-a-conversation empty state
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract** — no new endpoint; reads the existing `GET /api/connectors/status` and the existing `DesignSystemSummary` shape
- [ ] **Extension point**
- [ ] **i18n keys** — none; this surface (the design-system review banner) uses hardcoded English already, and the new strings match that
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the banner copy for existing GitHub-backed design systems changes from the old "Waiting for GitHub connector evidence" text to the connect/import CTA, and viewing such a project now fires one `GET /api/connectors/status` while the CTA is showing
- [ ] **None**

## Screenshots

<img width="762" height="778" alt="CleanShot 2026-05-24 at 01 55 42@2x" src="https://github.com/user-attachments/assets/2513b14b-7958-4bc4-8690-81268c241469" />

<img width="1674" height="684" alt="Laravel 2026-05-24 01 53 39" src="https://github.com/user-attachments/assets/114f4e8d-806e-4798-a675-c956148fe8ad" />




## Bug fix verification

Not a regression bug with a red spec; it's a UX fix for a feature request. The behavior is covered by new unit tests (listed under Validation), including the connect-vs-import copy split and the composer prefill.

Note on scope: the re-pull runs through the existing agent intake (`od tools connectors github-design-context`, prefilled into the composer) rather than a new daemon endpoint that re-triggers the pull automatically. Auto-pull-after-connect would be a follow-up; this PR is the surfacing and the one-click hand-off the issue asks for.

## Validation

- `pnpm guard` — clean
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm --filter @open-design/web test` — 2054 pass, including the three files touched here:
  - `design-system-github-evidence.test.ts` — evidence state, the connect-vs-import copy, and the import prompt content
  - `ChatPane.connect-repo.test.tsx` — CTA shows in the empty state, connect vs import labels, fires the handler, hides once messages exist, and the composer prefill
  - `FileWorkspace.design-system.test.tsx` — banner copy and button per connector state, publishing still gated until evidence lands
