### PR TITLE
fix: show scroll arrows when project type tabs overflow

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5996,7 +5996,7 @@ a.avatar-item:visited {
   opacity: 1;
 }
 .newproj-tabs-arrow {
-  display: none;
+  display: flex;
   position: absolute;
   top: 50%;
   z-index: 2;


### PR DESCRIPTION
## Summary

Fixes the issue where the Media tab (and other tabs) were hidden when the New Project panel width was insufficient, with no visual indication that more tabs existed.

## Problem

The scroll arrow implementation was already complete in the code:
- Left/right arrow buttons (NewProjectPanel.tsx lines 775-816)
- Scroll state tracking (`tabScroll`)
- Overflow detection (`updateTabScrollState`)
- Smooth scrolling (`scrollTabs`)

However, the arrows were never visible because of a CSS issue:
- `.newproj-tabs-arrow` had `display: none` (line 5999 in index.css)
- The `.hidden` class controlled visibility via `opacity: 0` and `pointer-events: none`
- But the base `display: none` prevented the arrows from ever appearing

## Solution

Changed `.newproj-tabs-arrow` from `display: none` to `display: flex`:
- Arrows now appear when tabs overflow
- The existing `.hidden` class still works correctly to hide arrows when not needed
- No JavaScript changes required

## Testing

- ✅ TypeScript typecheck passes
- ✅ One-line CSS change, minimal risk
- ✅ Existing scroll logic and state management unchanged

## Before/After

**Before:** Tabs overflow with no visual indication  
**After:** Left/right scroll arrows appear when tabs don't fit

Fixes #1679