### PR TITLE
fix: restore Atelier Zero deck plugin prompt

### DIFF
--- a/plugins/_official/examples/open-design-landing-deck/open-design.json
+++ b/plugins/_official/examples/open-design-landing-deck/open-design.json
@@ -45,8 +45,8 @@
     },
     "useCase": {
       "query": {
-        "en": "Produce a single-file slide deck in the Atelier Zero visual language (warm-paper background, italic-serif emphasis spans, coral terminating dots, surreal collage plates) — Open Design's brand deck recipe. The deck uses **horizontal magazine-style swipe pagination** (←/→, wheel, swipe), a per-slide chrome strip with bra",
-        "zh-CN": "使用这个插件完成以下任务：Produce a single-file slide deck in the Atelier Zero visual language (warm-paper background, italic-serif emphasis spans, coral terminating dots, surreal collage plates) — Open Design's brand deck recipe. The deck uses **horizontal magazine-style swipe pagination** (←/→, wheel, swipe), a per-slide chrome strip with bra"
+        "en": "Build me an 11-slide pitch deck for \"Lumen Field\", a focus-soundscape studio. Cover with hero plate, two section dividers, two product content slides with bullets, a stats slide showing 12 soundscapes / 4 presets / 1 daily ritual, a customer quote, a closing CTA, and an end card. Reuse the open-design-landing image library.",
+        "zh-CN": "使用这个插件完成以下任务：Build me an 11-slide pitch deck for \"Lumen Field\", a focus-soundscape studio. Cover with hero plate, two section dividers, two product content slides with bullets, a stats slide showing 12 soundscapes / 4 presets / 1 daily ritual, a customer quote, a closing CTA, and an end card. Reuse the open-design-landing image library."
       },
       "exampleOutputs": [
         {

--- a/scripts/migrate-to-plugins/example.test.ts
+++ b/scripts/migrate-to-plugins/example.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { derivePrompt } from './example.ts';
+
+test('example plugin manifests prefer top-level skill example_prompt', () => {
+  const prompt = derivePrompt({
+    description: 'A long description that should not become the plugin use-case query.',
+    example_prompt: 'Build a polished deck from the authored example prompt.',
+  });
+
+  assert.equal(prompt, 'Build a polished deck from the authored example prompt.');
+});
+
+test('example plugin manifests fall back to od.example_prompt before description snippets', () => {
+  const prompt = derivePrompt({
+    description: 'A long description that should not become the plugin use-case query.',
+    od: {
+      example_prompt: 'Create a focused artifact from od metadata.',
+    },
+  });
+
+  assert.equal(prompt, 'Create a focused artifact from od metadata.');
+});

--- a/scripts/migrate-to-plugins/example.ts
+++ b/scripts/migrate-to-plugins/example.ts
@@ -32,6 +32,7 @@ interface SkillFrontmatter {
   zh_name?: string;
   en_name?: string;
   description?: string;
+  example_prompt?: string;
   triggers?: unknown[];
   tags?: unknown[];
   od?: {
@@ -169,8 +170,8 @@ function inferSurface(mode: string): string {
   return 'web';
 }
 
-function derivePrompt(fm: SkillFrontmatter): string {
-  const explicit = fm.od?.example_prompt;
+export function derivePrompt(fm: SkillFrontmatter): string {
+  const explicit = fm.example_prompt ?? fm.od?.example_prompt;
   if (typeof explicit === 'string' && explicit.trim()) return explicit.trim();
   const desc = typeof fm.description === 'string' ? fm.description.trim() : '';
   if (!desc) return 'Produce the artifact described in this skill, following its workflow exactly.';


### PR DESCRIPTION
﻿Fixes #2808

## Changes
- restore the Atelier Zero landing deck plugin's default use-case prompt so it no longer ends mid-sentence at with bra
- teach the example-plugin migration script to prefer top-level example_prompt from SKILL.md frontmatter before falling back to a description snippet
- add a focused regression test for that migration path

## Verification
- node --import file:///F:/work/bounty-work/nexu-open-design/node_modules/tsx/dist/loader.mjs --test scripts/migrate-to-plugins/example.test.ts
- JSON.parse check for plugins/_official/examples/open-design-landing-deck/open-design.json
- git diff --check

Note: I also tried tsc -p scripts/tsconfig.json --noEmit from this clean worktree, but this worktree does not have its own node_modules, so TypeScript could not resolve @types/node. The targeted node test above was run through the already-installed sibling checkout's tsx loader.
