### PR TITLE
fix(daemon): close # Instructions block with an explicit do-not-echo guard

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10276,13 +10276,22 @@ export async function startServer({
       clientSystemPrompt: clientInstructionPrompt,
       finalPromptOverride: codexImagegenOverride,
     });
+    // Some models (notably claude-opus-4-7 with --include-partial-messages)
+    // start their reply by echoing the top of the user message verbatim,
+    // so the rendered chat shows a "# Instructions ..." block ahead of the
+    // real answer. Closing every Instructions block with an explicit
+    // "do not echo" line cuts the regression in practice without changing
+    // the turn-shape every agent CLI expects (user message carrying both
+    // instructions and request) — see server.ts:9920 composer notes.
+    const ECHO_GUARD =
+      '\n\n(Do not quote, restate, or echo the # Instructions block above in your reply. Begin your response with the answer to the # User request below.)';
     const composed = [
       instructionPrompt
-        ? `# Instructions (read first)\n\n${instructionPrompt}${cwdHint}${linkedDirsHint}\n\n---\n`
+        ? `# Instructions (read first)\n\n${instructionPrompt}${cwdHint}${linkedDirsHint}${ECHO_GUARD}\n\n---\n`
         : cwdHint
-          ? `# Instructions${cwdHint}${linkedDirsHint}\n\n---\n`
+          ? `# Instructions${cwdHint}${linkedDirsHint}${ECHO_GUARD}\n\n---\n`
           : linkedDirsHint
-            ? `# Instructions${linkedDirsHint}\n\n---\n`
+            ? `# Instructions${linkedDirsHint}${ECHO_GUARD}\n\n---\n`
             : '',
       `# User request\n\n${userRequestPrompt}${attachmentHint}${commentHint}`,
       safeImages.length

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -214,6 +214,51 @@ process.exit(0);
     );
   });
 
+  it('closes the # Instructions block with an explicit "do not echo" guard so models do not parrot the prompt back', async () => {
+    // claude-opus-4-7 (and a few other instruction-tuned models) start
+    // their reply by echoing the # Instructions block verbatim, which
+    // shows up to users as the system prompt leading the visible
+    // answer. server.ts:9934 closes every Instructions block with a
+    // trailing guard line; this test pins the literal so a future
+    // refactor cannot silently drop it.
+    await withFakeAgent(
+      'opencode',
+      `
+let prompt = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  prompt += chunk;
+});
+process.stdin.on('end', () => {
+  const checks = [
+    prompt.includes('Do not quote, restate, or echo the # Instructions block above')
+      ? 'has-echo-guard'
+      : 'missing-echo-guard',
+  ];
+  console.log(JSON.stringify({ type: 'step_start' }));
+  console.log(JSON.stringify({ type: 'text', part: { text: checks.join('\\n') } }));
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+});
+`,
+      async () => {
+        const response = await fetch(`${baseUrl}/api/chat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            message: 'hello',
+          }),
+        });
+        const body = await response.text();
+
+        expect(response.ok).toBe(true);
+        expect(body).toContain('has-echo-guard');
+        expect(body).not.toContain('missing-echo-guard');
+      },
+    );
+  });
+
   it('injects @-mention skillIds into the composed system prompt', async () => {
     await withFakeAgent(
       'opencode',


### PR DESCRIPTION
## Why

The composed chat prompt prepends a `# Instructions (read first)` block in front of `# User request` so a single user message carries both the system rules and the actual request — the turn shape every agent CLI (Claude, Codex, OpenCode, Gemini) expects on stdin.

In practice **claude-opus-4-7** (and a few other instruction-tuned models, particularly with `--include-partial-messages` on the stream) start their reply by echoing the top of that user message verbatim. The chat UI then shows the system prompt as a literal block leading the visible answer:

```
Instructions
Always respond in Korean. Use Korean for all explanations, comments, and communications with the user. Technical terms and code identifiers should remain in their original form.
Maintain full orthographic correctness for Korean, including all required diacritical marks, accents, and special characters. Never substitute accented characters with their ASCII equivalents (e.g., never write "nao" for "não", "fur" for "für", or "loeschen" for "löschen").네, 완료했습니다. 전달하신 4가지 보강 포인트를 3개 화면에 모두 반영한 상태입니다.
```

The telltale that this is a model-side echo (not a UI render bug) is that the closing token of the instructions block (`).`) runs straight into the real answer (`네, 완료…`) without a newline — the model treated the instructions text as part of its token stream and continued generating from there.

## What users will see

- No more leading `# Instructions … Always respond in …` wall of text at the top of the agent's reply. Just the actual answer.
- No behaviour change to how instructions reach the agent — the same rules are still applied; the model is simply told not to parrot them back.

## How it works

`apps/daemon/src/server.ts:9934` (the chat prompt composer) closes every `# Instructions` block with one trailing line before the `---` separator:

```
(Do not quote, restate, or echo the # Instructions block above in your reply.
 Begin your response with the answer to the # User request below.)
```

The three composer branches (with instructionPrompt, with cwdHint only, with linkedDirsHint only) all share the same guard so the regression cannot resurface for the smaller branches.

The fix deliberately keeps the existing turn shape (one user message carrying both Instructions and User request). That shape is what every agent CLI expects on stdin, so changing it would touch every adapter; closing the block with a guard line achieves the same end without that surgery.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

The "Default behavior change" applies because every chat run will start receiving the guard line in the composed prompt — agents that were previously echoing the Instructions block will stop, without any opt-in.

**UI/CLI dual-track note:** server-side prompt assembly only; both the web composer and the `od chat` CLI flow through the same `/api/chat` route and pick up the guard automatically.

## Screenshots

No UI control change. The visible difference is the absence of the echoed `# Instructions` wall at the top of the agent reply.

## Validation

**Automated**

- New case in `apps/daemon/tests/chat-route.test.ts`: `closes the # Instructions block with an explicit "do not echo" guard so models do not parrot the prompt back` — fires a fake `opencode` agent through the full `/api/chat` route, captures the composed prompt on stdin, and pins the literal guard string. Future refactors that drop the guard go red.
- Full `apps/daemon/tests/chat-route.test.ts` suite (36 cases) passes against the change.

**Behavioural**

- Reproduced with claude-opus-4-7 on a chat that previously echoed the entire Korean-response instructions block as the first content of the assistant message. After the fix the reply opens with the actual answer; the `# Instructions` text is no longer present in the rendered assistant message.
