### PR TITLE
chore: patch qs advisory

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -8,6 +8,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-X64KXAuSKE9ARcKHkgilAj7Nlej/MyAF/tiKsX4AEgg=";
+  daemonHash = "sha256-enohbA0Ha41vTime/L7oa8S7wX6P2+aQAc2MpvtYLcE=";
   webHash = "sha256-74loUCL+WcaZO4AAMnSpNeBhDz1Y9TMgFRPbyaOfPAk=";
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
       "ip-address": "10.2.0",
       "postcss": "8.5.15",
       "protobufjs": "8.4.0",
+      "qs": "6.15.2",
       "yaml": "2.9.0"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   ip-address: 10.2.0
   postcss: 8.5.15
   protobufjs: 8.4.0
+  qs: 6.15.2
   yaml: 2.9.0
 
 importers:
@@ -4088,12 +4089,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
-
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   query-selector-shadow-dom@1.0.1:
@@ -6963,7 +6960,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -6978,7 +6975,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -7620,7 +7617,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -7655,7 +7652,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -9045,11 +9042,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.2:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,10 +10,16 @@ overrides:
   fast-uri: 3.1.2
   hono: 4.12.19
   ip-address: 10.2.0
-  postcss: 8.5.14
+  postcss: 8.5.15
+  protobufjs: 8.4.0
+  qs: 6.15.2
   yaml: 2.9.0
 
 onlyBuiltDependencies:
   - better-sqlite3
+  - core-js
   - electron
+  - electron-winstaller
   - esbuild
+  - protobufjs
+  - sharp


### PR DESCRIPTION
## Summary
- force qs to 6.15.2 to clear CVE-2026-8723 / GHSA-q8mj-m7cp-5q26 through express/body-parser paths
- align pnpm-workspace.yaml overrides with the effective root pnpm override policy
- align the workspace onlyBuiltDependencies list with package.json so the allowed lifecycle-script set is explicit in the active pnpm workspace config
- refresh the daemon Nix pnpm dependency hash for the updated lockfile

## Surface area
- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [x] **Dependency / package config** — root pnpm override, workspace install policy, Nix pnpm deps hash, and lockfile refresh only; no new package is added
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Verification
- pnpm install --lockfile-only --ignore-scripts
- pnpm audit --json: 0 advisories
- pnpm audit --prod --json: 0 advisories
- nix --extra-experimental-features 'nix-command flakes' flake check: advanced past the prior daemon pnpm-deps hash mismatch with the refreshed hash

Note: local pnpm verification was run with Node v26.0.0, so pnpm emitted the existing engine warning for the repo's Node ~24 requirement. The lockfile refresh used --ignore-scripts.
