### PR TITLE
Keep prototype previews on the current screen after reload

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -948,7 +948,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       }
 
       const file = await readProjectFile(PROJECTS_DIR, projectId, relPath, project?.metadata);
-      if (file.mime.startsWith('text/html')) {
+      if (req.query.preview === '1' && file.mime.startsWith('text/html')) {
         res.type(file.mime).send(injectPrototypeLocationRelay(file.buffer.toString('utf8')));
         return;
       }

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -15,6 +15,7 @@ import {
   resolvePluginSnapshot,
 } from './plugins/index.js';
 import { connectorService } from './connectors/service.js';
+import { injectPrototypeLocationRelay } from './prototype-scroll-relay.js';
 import type { RouteDeps } from './server-context.js';
 import { listSkills } from './skills.js';
 import { auditDesignSystemPackage } from './tools-connectors-cli.js';
@@ -947,6 +948,10 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       }
 
       const file = await readProjectFile(PROJECTS_DIR, projectId, relPath, project?.metadata);
+      if (file.mime.startsWith('text/html')) {
+        res.type(file.mime).send(injectPrototypeLocationRelay(file.buffer.toString('utf8')));
+        return;
+      }
       res.type(file.mime).send(file.buffer);
     } catch (err: any) {
       const status = err && err.code === 'ENOENT' ? 404 : 400;

--- a/apps/daemon/src/prototype-scroll-relay.ts
+++ b/apps/daemon/src/prototype-scroll-relay.ts
@@ -1,0 +1,36 @@
+const RELAY_MARKER = 'data-od-prototype-location-relay';
+
+const LOCATION_RELAY_SCRIPT = `<script ${RELAY_MARKER}>(function(){
+  function reportLoc(){
+    try {
+      (window.parent || window).postMessage({
+        type: 'od:url-load-loc',
+        pathname: location.pathname,
+        search: location.search,
+        hash: location.hash
+      }, '*');
+    } catch (_) {}
+  }
+  reportLoc();
+  window.addEventListener('hashchange', reportLoc);
+  ['pushState', 'replaceState'].forEach(function(method){
+    var original = history[method];
+    if (typeof original !== 'function') return;
+    history[method] = function(){
+      var result = original.apply(this, arguments);
+      reportLoc();
+      return result;
+    };
+  });
+})();</script>`;
+
+export function injectPrototypeLocationRelay(html: string): string {
+  if (html.includes(RELAY_MARKER)) return html;
+  if (/<\/head\s*>/i.test(html)) {
+    return html.replace(/<\/head\s*>/i, `${LOCATION_RELAY_SCRIPT}</head>`);
+  }
+  if (/<\/body\s*>/i.test(html)) {
+    return html.replace(/<\/body\s*>/i, `${LOCATION_RELAY_SCRIPT}</body>`);
+  }
+  return `${html}${LOCATION_RELAY_SCRIPT}`;
+}

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -223,6 +223,15 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('accept-ranges')).toBeNull();
     const text = await res.text();
+    expect(text).toBe('<html/>');
+    expect(text).not.toContain('data-od-prototype-location-relay');
+  });
+
+  it('injects the prototype location relay only for preview HTML requests', async () => {
+    const res = await fetch(`${rawUrl('page.html')}?preview=1`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('accept-ranges')).toBeNull();
+    const text = await res.text();
     expect(text).toContain('<html');
     expect(text).toContain('data-od-prototype-location-relay');
     expect(text).toContain('od:url-load-loc');

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -223,7 +223,9 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('accept-ranges')).toBeNull();
     const text = await res.text();
-    expect(text).toBe('<html/>');
+    expect(text).toContain('<html');
+    expect(text).toContain('data-od-prototype-location-relay');
+    expect(text).toContain('od:url-load-loc');
   });
 
   it('returns 404 for a missing file', async () => {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4093,6 +4093,16 @@ function HtmlViewer({
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
   const [urlLoadSubPath, setUrlLoadSubPath] = useState<string | null>(null);
   const [urlLoadHash, setUrlLoadHash] = useState('');
+  // Tracked URL-load location is per-artifact: it only makes sense for the
+  // file whose iframe last reported it. When the user switches to a
+  // different file (or project), we must clear the tracked location before
+  // the new iframe reports its own, otherwise the new file's src would be
+  // built from the previous file's sub-page/hash and the viewer would
+  // continue showing the old navigated page.
+  useEffect(() => {
+    setUrlLoadSubPath(null);
+    setUrlLoadHash('');
+  }, [projectId, file.name]);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -67,7 +67,12 @@ import {
 } from '../runtime/exports';
 import { buildReactComponentSrcdoc } from '../runtime/react-component';
 import { findHtmlEntriesReferencing } from '../runtime/jsx-module-refs';
-import { buildLazySrcdocTransport, buildSrcdoc, canActivateSrcDocTransport } from '../runtime/srcdoc';
+import {
+  buildLazySrcdocTransport,
+  buildSrcdoc,
+  buildUrlLoadRefreshSrc,
+  canActivateSrcDocTransport,
+} from '../runtime/srcdoc';
 import {
   hasUrlModeBridge,
   htmlNeedsFocusGuard,
@@ -4062,6 +4067,8 @@ function HtmlViewer({
   const [manualEditViewportWidth, setManualEditViewportWidth] = useState<number | null>(null);
   const [commentPortalHost, setCommentPortalHost] = useState<HTMLElement | null>(null);
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
+  const [urlLoadSubPath, setUrlLoadSubPath] = useState<string | null>(null);
+  const [urlLoadHash, setUrlLoadHash] = useState('');
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -4538,7 +4545,15 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
 
   useEffect(() => {
     if (filesRefreshKey === 0) return;
-    const nextSrc = `${basePreviewSrcUrl}&fr=${filesRefreshKey}`;
+    const nextSrc = buildUrlLoadRefreshSrc({
+      entrySrcUrl: basePreviewSrcUrl,
+      filesRefreshKey,
+      urlLoadSubPath,
+      fileName: file.name,
+      urlLoadHash,
+      rawFileUrl: (filePath) =>
+        `${projectRawUrl(projectId, filePath)}?v=${Math.round(file.mtime)}&r=${reloadKey}`,
+    });
     const timeout = window.setTimeout(() => {
       if (useUrlLoadPreview && urlPreviewIframeRef.current?.contentWindow) {
         urlPreviewIframeRef.current.contentWindow.location.replace(nextSrc);
@@ -4547,7 +4562,17 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
       }
     }, 180);
     return () => window.clearTimeout(timeout);
-  }, [basePreviewSrcUrl, filesRefreshKey, useUrlLoadPreview]);
+  }, [
+    basePreviewSrcUrl,
+    file.mtime,
+    file.name,
+    filesRefreshKey,
+    projectId,
+    reloadKey,
+    urlLoadHash,
+    urlLoadSubPath,
+    useUrlLoadPreview,
+  ]);
 
   useEffect(() => {
     setInlinedSource(null);
@@ -4774,15 +4799,44 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         }, '*');
       }
     }
+    function onUrlLoadLoc(ev: MessageEvent) {
+      if (!ev.source || ev.source !== urlPreviewIframeRef.current?.contentWindow) return;
+      const data = ev.data as { type?: string; pathname?: string; hash?: string } | null;
+      if (!data || data.type !== 'od:url-load-loc') return;
+      setUrlLoadHash(typeof data.hash === 'string' ? data.hash : '');
+      const rawPrefix = projectRawUrl(projectId, '');
+      const pathname = typeof data.pathname === 'string' ? data.pathname : '';
+      const idx = pathname.indexOf(rawPrefix);
+      const relative = idx >= 0
+        ? pathname
+            .slice(idx + rawPrefix.length)
+            .split('/')
+            .map((segment) => {
+              try {
+                return decodeURIComponent(segment);
+              } catch {
+                return segment;
+              }
+            })
+            .join('/')
+        : '';
+      if (!relative || relative === file.name || !/\.html?$/i.test(relative)) {
+        setUrlLoadSubPath(null);
+        return;
+      }
+      setUrlLoadSubPath(relative);
+    }
     window.addEventListener('message', onMessage);
     window.addEventListener('message', onRestoreRequest);
     window.addEventListener('message', onDcViewportMessage);
+    window.addEventListener('message', onUrlLoadLoc);
     return () => {
       window.removeEventListener('message', onMessage);
       window.removeEventListener('message', onRestoreRequest);
       window.removeEventListener('message', onDcViewportMessage);
+      window.removeEventListener('message', onUrlLoadLoc);
     };
-  }, [isActivePreviewIframeSource, isOurPreviewIframeSource]);
+  }, [isActivePreviewIframeSource, isOurPreviewIframeSource, projectId, file.name]);
 
   useEffect(() => {
     if (!effectiveDeck) {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -541,6 +541,29 @@ export function previewOverlayTransform(
   };
 }
 
+export function htmlPreviewUrlForLocation(
+  projectId: string,
+  fileName: string,
+  mtime: number,
+  reloadKey: number,
+  options: {
+    urlLoadSubPath?: string | null;
+    urlLoadHash?: string;
+    filesRefreshKey?: number;
+  } = {},
+): string {
+  const path = options.urlLoadSubPath && /\.html?$/i.test(options.urlLoadSubPath)
+    ? options.urlLoadSubPath
+    : fileName;
+  const query = new URLSearchParams({
+    v: String(Math.round(mtime)),
+    r: String(reloadKey),
+  });
+  if (options.filesRefreshKey !== undefined) query.set('fr', String(options.filesRefreshKey));
+  const hash = options.urlLoadHash?.startsWith('#') ? options.urlLoadHash : '';
+  return `${projectRawUrl(projectId, path)}?${query.toString()}${hash}`;
+}
+
 function previewScaleShellStyle(
   viewport: PreviewViewportId,
   previewScale: number,
@@ -4526,16 +4549,26 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     needsFocusGuard,
   });
   const basePreviewSrcUrl = useMemo(
-    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}`,
+    () => htmlPreviewUrlForLocation(projectId, file.name, file.mtime, reloadKey),
     [projectId, file.name, file.mtime, reloadKey],
   );
   const [previewSrcUrl, setPreviewSrcUrl] = useState(basePreviewSrcUrl);
-  const activePreviewSrcUrl = (
+  const trackedPreviewSrcUrl = useMemo(
+    () => htmlPreviewUrlForLocation(projectId, file.name, file.mtime, reloadKey, {
+      urlLoadSubPath,
+      urlLoadHash,
+    }),
+    [projectId, file.name, file.mtime, reloadKey, urlLoadSubPath, urlLoadHash],
+  );
+  const hasTrackedPreviewLocation = Boolean(urlLoadSubPath || urlLoadHash);
+  const previewSrcMatchesBase =
     previewSrcUrl === basePreviewSrcUrl ||
-    previewSrcUrl.startsWith(`${basePreviewSrcUrl}&`)
-  )
-    ? previewSrcUrl
-    : basePreviewSrcUrl;
+    previewSrcUrl.startsWith(`${basePreviewSrcUrl}&`);
+  const activePreviewSrcUrl = hasTrackedPreviewLocation
+    ? trackedPreviewSrcUrl
+    : previewSrcMatchesBase
+      ? previewSrcUrl
+      : basePreviewSrcUrl;
   useEffect(() => {
     setPreviewSrcUrl(basePreviewSrcUrl);
   }, [basePreviewSrcUrl]);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -38,6 +38,7 @@ import {
   uploadProjectFiles,
   liveArtifactPreviewUrl,
   projectFileUrl,
+  projectPreviewUrl,
   projectRawUrl,
   LiveArtifactRefreshError,
   refreshLiveArtifact,
@@ -561,7 +562,7 @@ export function htmlPreviewUrlForLocation(
   });
   if (options.filesRefreshKey !== undefined) query.set('fr', String(options.filesRefreshKey));
   const hash = options.urlLoadHash?.startsWith('#') ? options.urlLoadHash : '';
-  return `${projectRawUrl(projectId, path)}?${query.toString()}${hash}`;
+  return `${projectPreviewUrl(projectId, path)}&${query.toString()}${hash}`;
 }
 
 function previewScaleShellStyle(
@@ -4585,7 +4586,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
       fileName: file.name,
       urlLoadHash,
       rawFileUrl: (filePath) =>
-        `${projectRawUrl(projectId, filePath)}?v=${Math.round(file.mtime)}&r=${reloadKey}`,
+        `${projectPreviewUrl(projectId, filePath)}&v=${Math.round(file.mtime)}&r=${reloadKey}`,
     });
     const timeout = window.setTimeout(() => {
       if (useUrlLoadPreview && urlPreviewIframeRef.current?.contentWindow) {

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1740,6 +1740,10 @@ export function projectRawUrl(projectId: string, filePath: string): string {
   return `/api/projects/${encodeURIComponent(projectId)}/raw/${safePath}`;
 }
 
+export function projectPreviewUrl(projectId: string, filePath: string): string {
+  return `${projectRawUrl(projectId, filePath)}?preview=1`;
+}
+
 function looksLikeImage(name: string): boolean {
   return /\.(png|jpe?g|gif|webp|svg|avif|bmp)$/i.test(name);
 }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -34,6 +34,28 @@ export type SrcdocOptions = {
   previewFocusGuard?: boolean;
 };
 
+export interface UrlLoadRefreshSrcInputs {
+  entrySrcUrl: string;
+  filesRefreshKey: number;
+  urlLoadSubPath: string | null;
+  fileName: string;
+  urlLoadHash: string;
+  rawFileUrl: (filePath: string) => string;
+}
+
+export function buildUrlLoadRefreshSrc(inputs: UrlLoadRefreshSrcInputs): string {
+  const refreshQuery = `fr=${encodeURIComponent(String(inputs.filesRefreshKey))}`;
+  const hash = normalizeLocationHash(inputs.urlLoadHash);
+  const onSubPage =
+    !!inputs.urlLoadSubPath &&
+    inputs.urlLoadSubPath !== inputs.fileName &&
+    /\.html?$/i.test(inputs.urlLoadSubPath);
+  const base = onSubPage
+    ? inputs.rawFileUrl(inputs.urlLoadSubPath!)
+    : inputs.entrySrcUrl;
+  return `${appendQueryParam(base, refreshQuery)}${hash}`;
+}
+
 export function buildSrcdoc(
   html: string,
   options: SrcdocOptions = {}
@@ -80,6 +102,19 @@ export function buildSrcdoc(
   // visible flash) every time the host toggle flips.
   const withTweaks = injectTweaksBridge(withEdit);
   return injectSrcdocTransportActivationBridge(injectSnapshotBridge(withTweaks));
+}
+
+function appendQueryParam(url: string, query: string): string {
+  const hashIndex = url.indexOf('#');
+  const beforeHash = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+  const hash = hashIndex >= 0 ? url.slice(hashIndex) : '';
+  const joiner = beforeHash.includes('?') ? '&' : '?';
+  return `${beforeHash}${joiner}${query}${hash}`;
+}
+
+function normalizeLocationHash(hash: string): string {
+  if (!hash) return '';
+  return hash.startsWith('#') ? hash : `#${hash}`;
 }
 
 /**

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -148,14 +148,14 @@ describe('FileViewer HTML preview location URLs', () => {
       urlLoadSubPath: 'screens/parent/parent-app.html',
       urlLoadHash: '#report',
       filesRefreshKey: 7,
-    })).toBe('/api/projects/project-1/raw/screens/parent/parent-app.html?v=1710000000&r=2&fr=7#report');
+    })).toBe('/api/projects/project-1/raw/screens/parent/parent-app.html?preview=1&v=1710000000&r=2&fr=7#report');
   });
 
   it('preserves same-file hash routes without treating them as a sub-page', () => {
     expect(htmlPreviewUrlForLocation('project-1', 'screens/admin/admin-console.html', 1710000000, 0, {
       urlLoadSubPath: null,
       urlLoadHash: '#AD11',
-    })).toBe('/api/projects/project-1/raw/screens/admin/admin-console.html?v=1710000000&r=0#AD11');
+    })).toBe('/api/projects/project-1/raw/screens/admin/admin-console.html?preview=1&v=1710000000&r=0#AD11');
   });
 });
 
@@ -614,7 +614,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).toContain('data-od-render-mode="url-load"');
     expect(markup).toContain('data-od-render-mode="url-load" data-od-active="true"');
     expect(markup).toContain('data-od-render-mode="srcdoc" data-od-active="false"');
-    expect(markup).toContain('src="/api/projects/project-1/raw/page.html?v=1710000000&amp;r=0"');
+    expect(markup).toContain('src="/api/projects/project-1/raw/page.html?preview=1&amp;v=1710000000&amp;r=0"');
     expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
   });
 
@@ -792,7 +792,8 @@ describe('FileViewer SVG artifacts', () => {
 
     const { container } = render(<Switcher />);
     const getFrame = () => container.querySelector<HTMLIFrameElement>('[data-testid="artifact-preview-frame"]');
-    expect(getFrame()?.getAttribute('src')).toBe('/api/projects/project-1/raw/first.html?v=1710000000&r=0');
+    const initialFrame = getFrame();
+    expect(initialFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/first.html?preview=1&v=1710000000&r=0');
 
     const observationsBeforeSwitch = observedCommittedSrcs.length;
     fireEvent.click(screen.getByRole('button', { name: 'Switch file' }));
@@ -800,9 +801,9 @@ describe('FileViewer SVG artifacts', () => {
     const nextFrame = getFrame();
     expect(nextFrame).toBeTruthy();
     expect(observedCommittedSrcs[observationsBeforeSwitch]).toBe(
-      '/api/projects/project-1/raw/second.html?v=1710000000&r=0',
+      '/api/projects/project-1/raw/second.html?preview=1&v=1710000000&r=0',
     );
-    expect(nextFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/second.html?v=1710000000&r=0');
+    expect(nextFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/second.html?preview=1&v=1710000000&r=0');
   });
 
   it('allows downloads in the in-tab HTML presentation iframe', async () => {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -459,7 +459,7 @@ describe('FileViewer SVG artifacts', () => {
     const { container } = render(<Shell />);
 
     const firstFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-    expect(firstFrame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=0');
+    expect(firstFrame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?preview=1&v=1710000000&r=0');
 
     fireEvent.click(screen.getByRole('button', { name: 'Leave project' }));
 
@@ -467,7 +467,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.getByTestId('home-view')).toBeTruthy();
     const parkedFrame = container.querySelector<HTMLIFrameElement>('.iframe-keep-alive-pool iframe');
     expect(parkedFrame).toBe(firstFrame);
-    expect(parkedFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=0');
+    expect(parkedFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?preview=1&v=1710000000&r=0');
 
     fireEvent.click(screen.getByRole('button', { name: 'Return project' }));
 
@@ -587,7 +587,7 @@ describe('FileViewer SVG artifacts', () => {
 
     const secondFrame = screen.getByTestId('pooled-frame');
     expect(secondFrame).not.toBe(firstFrame);
-    expect(secondFrame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1&r=0');
+    expect(secondFrame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?preview=1&v=1&r=0');
   });
 
   it('URL-loads a plain HTML preview iframe instead of inlining via srcDoc', () => {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -30,6 +30,7 @@ import {
   SvgViewer,
   applyInspectOverridesToSource,
   effectivePreviewScale,
+  htmlPreviewUrlForLocation,
   parseInspectOverridesFromSource,
   previewOverlayTransform,
   serializeInspectOverrides,
@@ -138,6 +139,23 @@ describe('FileViewer preview scale', () => {
     expect(tablet.scale).toBeCloseTo(752 / 1180, 5);
     expect(tablet.offsetX).toBeCloseTo(24 + (1152 - 820 * (752 / 1180)) / 2, 5);
     expect(tablet.offsetY).toBe(24);
+  });
+});
+
+describe('FileViewer HTML preview location URLs', () => {
+  it('targets the tracked sub-page and hash when refreshing a navigated url-load preview', () => {
+    expect(htmlPreviewUrlForLocation('project-1', 'index-v1.html', 1710000000.4, 2, {
+      urlLoadSubPath: 'screens/parent/parent-app.html',
+      urlLoadHash: '#report',
+      filesRefreshKey: 7,
+    })).toBe('/api/projects/project-1/raw/screens/parent/parent-app.html?v=1710000000&r=2&fr=7#report');
+  });
+
+  it('preserves same-file hash routes without treating them as a sub-page', () => {
+    expect(htmlPreviewUrlForLocation('project-1', 'screens/admin/admin-console.html', 1710000000, 0, {
+      urlLoadSubPath: null,
+      urlLoadHash: '#AD11',
+    })).toBe('/api/projects/project-1/raw/screens/admin/admin-console.html?v=1710000000&r=0#AD11');
   });
 });
 

--- a/apps/web/tests/runtime/srcdoc-transport.test.ts
+++ b/apps/web/tests/runtime/srcdoc-transport.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildLazySrcdocTransport,
+  buildUrlLoadRefreshSrc,
   canActivateSrcDocTransport,
   type SrcDocActivationInputs,
 } from '../../src/runtime/srcdoc';
@@ -195,5 +196,47 @@ describe('canActivateSrcDocTransport (#2253)', () => {
         activatedHtml: '<html>previous</html>',
       }),
     ).toBe(true);
+  });
+});
+describe('buildUrlLoadRefreshSrc (file-change preview reload)', () => {
+  const rawFileUrl = (filePath: string) => `/api/projects/p/raw/${filePath}?v=10&r=0`;
+
+  it('preserves the current hash when reloading the entry file', () => {
+    expect(
+      buildUrlLoadRefreshSrc({
+        entrySrcUrl: '/api/projects/p/raw/index.html?v=10&r=0',
+        filesRefreshKey: 7,
+        urlLoadSubPath: null,
+        fileName: 'index.html',
+        urlLoadHash: '#detail-3',
+        rawFileUrl,
+      }),
+    ).toBe('/api/projects/p/raw/index.html?v=10&r=0&fr=7#detail-3');
+  });
+
+  it('reloads the current sub-page instead of snapping back to the entry file', () => {
+    expect(
+      buildUrlLoadRefreshSrc({
+        entrySrcUrl: '/api/projects/p/raw/index.html?v=10&r=0',
+        filesRefreshKey: 8,
+        urlLoadSubPath: 'screens/parent/detail.html',
+        fileName: 'index.html',
+        urlLoadHash: '#child-a',
+        rawFileUrl,
+      }),
+    ).toBe('/api/projects/p/raw/screens/parent/detail.html?v=10&r=0&fr=8#child-a');
+  });
+
+  it('does not treat the entry file as a sub-page', () => {
+    expect(
+      buildUrlLoadRefreshSrc({
+        entrySrcUrl: '/api/projects/p/raw/index.html?v=10&r=0',
+        filesRefreshKey: 9,
+        urlLoadSubPath: 'index.html',
+        fileName: 'index.html',
+        urlLoadHash: '',
+        rawFileUrl,
+      }),
+    ).toBe('/api/projects/p/raw/index.html?v=10&r=0&fr=9');
   });
 });


### PR DESCRIPTION
## Why
Chat-driven edits reload the preview iframe after file changes. When the user is on a detail screen, that reload can snap the prototype back to its entry screen because the host was rebuilding from the entry artifact URL.

## What users will see
When editing a prototype from chat, the preview keeps the currently reported hash or HTML sub-page instead of returning to the first screen.

## Implementation
- Inject a small location relay into raw HTML preview responses.
- Track `od:url-load-loc` reports in `FileViewer`.
- Build file-change refresh URLs from the current sub-page/hash when available.
- Add regression coverage for refresh URL composition and raw HTML relay injection.

## Validation
- `pnpm --filter @open-design/web test tests/runtime/srcdoc-transport.test.ts`
- `pnpm --filter @open-design/daemon test tests/project-file-range.test.ts`
- `pnpm guard`

## Known gap
- `pnpm --filter @open-design/web typecheck` currently fails on `origin/main` with unrelated `osLocale` type errors in `src/i18n/index.tsx` and `tests/i18n/detect-initial-locale.test.ts`.

## Surface area
- [x] Web UI
- [x] Daemon/API
- [x] Tests
