### PR TITLE
fix: ignore generated project dirs before watching

### DIFF
--- a/apps/daemon/src/project-ignored-dirs.ts
+++ b/apps/daemon/src/project-ignored-dirs.ts
@@ -1,0 +1,40 @@
+// Directory names that should not be listed or watched for folder-backed
+// projects. These are generated, installed, or cache trees that add file
+// descriptor pressure without adding useful design context.
+export const IGNORED_PROJECT_DIR_NAMES = new Set([
+  '.git',
+  'node_modules',
+  'vendor',
+  '.od',
+  'debug',
+  'dist',
+  'build',
+  '.build',
+  'deriveddata',
+  'target',
+  '.next',
+  '.nuxt',
+  '.turbo',
+  '.cache',
+  '.output',
+  'out',
+  'coverage',
+  '.gradle',
+  '.swiftpm',
+  '.tmp',
+  '.venv',
+  'venv',
+  '__pycache__',
+  '.mypy_cache',
+  '.pytest_cache',
+  '.tox',
+  '.ruff_cache',
+].map((name) => name.toLowerCase()));
+
+export function isIgnoredProjectDirName(name: unknown): boolean {
+  const normalized = String(name).toLowerCase();
+  return (
+    IGNORED_PROJECT_DIR_NAMES.has(normalized) ||
+    normalized.startsWith('deriveddata-')
+  );
+}

--- a/apps/daemon/src/project-watchers.ts
+++ b/apps/daemon/src/project-watchers.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import chokidar, { type FSWatcher } from 'chokidar';
 
+import { isIgnoredProjectDirName } from './project-ignored-dirs.js';
 import { projectDir, resolveProjectDir } from './projects.js';
 
 /**
@@ -16,24 +17,7 @@ import { projectDir, resolveProjectDir } from './projects.js';
 // against the path *relative to the watch root* so that ancestor directories
 // (e.g. the daemon's own `.od/` runtime dir, which contains every project) do
 // not accidentally match and silence every event in the tree.
-const IGNORE_NAMES = new Set([
-  '.git',
-  'node_modules',
-  '.od',
-  'debug',
-  '.DS_Store',
-  // Python virtual environments and caches — can contain tens of thousands of
-  // files, exhausting the process fd table and breaking child-process spawning.
-  // These names are safe to match at any path depth: a directory named `.venv`
-  // or `__pycache__` is never legitimate authored source in a project tree.
-  '.venv',
-  'venv',
-  '__pycache__',
-  '.mypy_cache',
-  '.pytest_cache',
-  '.tox',
-  '.ruff_cache',
-]);
+const WATCHER_ONLY_IGNORE_NAMES = new Set(['.ds_store']);
 export type ProjectWatchKind = 'add' | 'change' | 'unlink';
 export interface ProjectWatchEvent { type: 'file-changed'; path: string; kind: ProjectWatchKind }
 export type ProjectWatchCallback = (evt: ProjectWatchEvent) => void;
@@ -56,7 +40,10 @@ export function makeIgnored(rootDir: string): (absPath: string) => boolean {
   return (absPath: string): boolean => {
     const rel = path.relative(rootDir, absPath);
     if (!rel || rel === '' || rel.startsWith('..')) return false; // never ignore root itself
-    return rel.split(/[\\/]/).some((seg) => IGNORE_NAMES.has(seg));
+    return rel.split(/[\\/]/).some((seg) => {
+      const normalized = seg.toLowerCase();
+      return WATCHER_ONLY_IGNORE_NAMES.has(normalized) || isIgnoredProjectDirName(normalized);
+    });
   };
 }
 

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -25,6 +25,7 @@ import {
   assertArtifactPublicationAllowed,
   isPublicationGuardedArtifactKind,
 } from './artifact-publication-guard.js';
+import { isIgnoredProjectDirName } from './project-ignored-dirs.js';
 
 const FORBIDDEN_SEGMENT = /^$|^\.\.?$/;
 const RESERVED_PROJECT_FILE_SEGMENTS = new Set(['.live-artifacts']);
@@ -66,7 +67,7 @@ export async function listFiles(projectsRoot, projectId, opts = {}) {
   const out = [];
   // Skip build/install dirs for linked folders so node_modules doesn't stall
   // the walk on large repos.
-  const skipDirs = metadata?.baseDir ? SKIP_DIRS : undefined;
+  const skipDirs = metadata?.baseDir ? isIgnoredProjectDirName : undefined;
   await collectFiles(dir, '', out, skipDirs, dir);
   // Newest first — matches the visual order users expect after generating.
   out.sort((a, b) => b.mtime - a.mtime);
@@ -76,16 +77,6 @@ export async function listFiles(projectsRoot, projectId, opts = {}) {
   }
   return out;
 }
-
-// Build/install dirs that should be hidden from the file panel when a
-// project is rooted at metadata.baseDir (the user's own folder). Without
-// this, the listing would be dominated by node_modules, lockfiles, and
-// build output that have no design value.
-const SKIP_DIRS = new Set([
-  'node_modules', '.git', 'dist', 'build', '.next', '.nuxt', '.turbo',
-  '.cache', '.output', 'out', 'coverage', '__pycache__', '.venv',
-  'vendor', 'target', '.od', '.tmp',
-]);
 
 // Best-effort entry-file detector — looks for index.html at the root,
 // then any *.html file. Returns null if nothing obvious is found, in
@@ -104,7 +95,7 @@ export async function detectEntryFile(dir: string): Promise<string | null> {
   return null;
 }
 
-async function collectFiles(dir, relDir, out, skipDirs?: Set<string>, projectRoot = dir) {
+async function collectFiles(dir, relDir, out, shouldSkipDir?: (name: string) => boolean, projectRoot = dir) {
   let entries = [];
   try {
     entries = await readdir(dir, { withFileTypes: true });
@@ -117,8 +108,8 @@ async function collectFiles(dir, relDir, out, skipDirs?: Set<string>, projectRoo
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
     if (e.isDirectory()) {
-      if (skipDirs && skipDirs.has(e.name)) continue;
-      await collectFiles(full, rel, out, skipDirs, projectRoot);
+      if (shouldSkipDir?.(e.name)) continue;
+      await collectFiles(full, rel, out, shouldSkipDir, projectRoot);
       continue;
     }
     if (!e.isFile()) continue;

--- a/apps/daemon/tests/folder-import-projects.test.ts
+++ b/apps/daemon/tests/folder-import-projects.test.ts
@@ -105,6 +105,12 @@ describe('listFiles with metadata.baseDir', () => {
     await writeFile(path.join(baseDir, '.git', 'HEAD'), 'ref: refs/heads/main');
     await mkdir(path.join(baseDir, 'dist'));
     await writeFile(path.join(baseDir, 'dist', 'bundle.js'), '/*compiled*/');
+    await mkdir(path.join(baseDir, 'Build', 'DerivedData-KeeTests'), { recursive: true });
+    await writeFile(path.join(baseDir, 'Build', 'DerivedData-KeeTests', 'index-store'), '');
+    await mkdir(path.join(baseDir, 'vendor', 'package'), { recursive: true });
+    await writeFile(path.join(baseDir, 'vendor', 'package', 'generated.js'), '');
+    await mkdir(path.join(baseDir, 'Rust', 'KeePassCore', 'target', 'release'), { recursive: true });
+    await writeFile(path.join(baseDir, 'Rust', 'KeePassCore', 'target', 'release', 'libkeepass.a'), '');
     await mkdir(path.join(baseDir, 'src'));
     await writeFile(path.join(baseDir, 'src', 'app.ts'), 'export {}');
   });
@@ -150,6 +156,9 @@ describe('listFiles with metadata.baseDir', () => {
     expect(paths.some((p) => p.startsWith('node_modules/'))).toBe(false);
     expect(paths.some((p) => p.startsWith('.git/'))).toBe(false);
     expect(paths.some((p) => p.startsWith('dist/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('Build/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('vendor/'))).toBe(false);
+    expect(paths.some((p) => p.includes('/target/'))).toBe(false);
   });
 
   it('does not skip those dirs for non-baseDir projects (back-compat)', async () => {

--- a/apps/daemon/tests/project-watchers.test.ts
+++ b/apps/daemon/tests/project-watchers.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   _activeWatcherCount,
   _resetForTests,
+  makeIgnored,
   subscribe,
   type ProjectWatchEvent,
   type ProjectWatcherOptions,
@@ -125,6 +126,20 @@ describe('project-watchers (refcounting)', () => {
 });
 
 describe('project-watchers (real chokidar)', () => {
+  it('ignores generated build trees case-insensitively before chokidar descends', async () => {
+    const { root, projectId } = await makeProjectsRoot();
+    const projectRoot = path.join(root, projectId);
+    const ignored = makeIgnored(projectRoot);
+
+    expect(ignored(path.join(projectRoot, 'Build', 'DerivedData-KeeTests', 'index-store'))).toBe(true);
+    expect(ignored(path.join(projectRoot, 'Rust', 'KeePassCore', 'target', 'release', 'lib.a'))).toBe(true);
+    expect(ignored(path.join(projectRoot, 'vendor', 'package', 'generated.js'))).toBe(true);
+    expect(ignored(path.join(projectRoot, '.build', 'debug', 'Module.o'))).toBe(true);
+    expect(ignored(path.join(projectRoot, 'src', 'App.swift'))).toBe(false);
+
+    await rm(root, { recursive: true, force: true });
+  });
+
   it('emits file-changed events on add / change / unlink', async () => {
     const { root, projectId } = await makeProjectsRoot();
     const events: ProjectWatchEvent[] = [];


### PR DESCRIPTION
## Why

I hit a local OpenDesign + Claude Code failure where opening a folder-backed project with large generated build trees eventually made the Claude Code connection/run path fail with `spawn EBADF`.

The concrete reproducer was a Swift/Rust project with generated paths like `Build/DerivedData-*`, `.build/`, and `target/`. Those directories are not source/design context, but OpenDesign still listed and watched them for folder-backed projects. The same descriptor-pressure risk applies to vendored dependency trees such as `vendor/`. These trees can produce thousands of extra watched files and file descriptors before the daemon spawns the CLI agent.

## What users will see

Folder-backed projects no longer include common generated build/install/vendor/cache directories in the project file list or project watcher. Existing projects with generated trees should show fewer irrelevant generated files and should put less pressure on the daemon's file descriptors while Claude Code or another CLI agent is running.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [x] **Default behavior change** — generated build/cache/install/vendor dirs are now excluded from folder-backed project file listing and watching by default
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not a UI change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/project-watchers.test.ts` now asserts generated build and `vendor/` trees are ignored case-insensitively before chokidar descends; `apps/daemon/tests/folder-import-projects.test.ts` now asserts folder-backed file listing excludes `Build/DerivedData-*`, nested `target/`, and `vendor/` content.
- The shared ignored-directory predicate now lives in `apps/daemon/src/project-ignored-dirs.ts` and is used by both `listFiles` and `makeIgnored`, so listing and watcher behavior do not drift.
- Did the test go red on `main` and green on this branch? The new assertions cover paths that were previously not ignored by `makeIgnored` / `listFiles`; focused tests are green on this branch.
- Additional smoke: built and ran a containerized OpenDesign daemon + web UI with Claude Code 2.1.150 installed, mounted the existing `kee-ios` project at its real configured path, and confirmed the Settings → CLI test returned `Claude Code replied ... 'ok'` instead of `spawn EBADF`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/project-watchers.test.ts tests/folder-import-projects.test.ts --reporter=verbose` — 2 files / 25 tests passed
- `pnpm --filter @open-design/daemon typecheck`

Note: local validation ran under Node v26.0.0, so pnpm emitted the repo's existing `node ~24` engine warning.
