### PR TITLE
fix(web): preserve chat composer drafts across refreshes

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -97,6 +97,7 @@ interface Props {
   streaming: boolean;
   sendDisabled?: boolean;
   initialDraft?: string;
+  draftStorageKey?: string;
   // Lazy ensure — the composer calls this before its first upload, so the
   // project folder exists on disk before files land in it. Returns the
   // project id when ready.
@@ -190,6 +191,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       streaming,
       sendDisabled = false,
       initialDraft,
+      draftStorageKey,
       onEnsureProject,
       commentAttachments = [],
       onRemoveCommentAttachment,
@@ -216,7 +218,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
   ) {
     const t = useT();
     const analytics = useAnalytics();
-    const [draft, setDraft] = useState(initialDraft ?? "");
+    const [draft, setDraft] = useState(() => initialDraft ?? loadComposerDraft(draftStorageKey) ?? "");
 
     // chat_panel page_view fires from ProjectView (which outlives
     // conversation switches) so the event measures real chat-panel
@@ -294,6 +296,10 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         seededRef.current = true;
       }
     }, [initialDraft, draft]);
+
+    useEffect(() => {
+      saveComposerDraft(draftStorageKey, draft);
+    }, [draftStorageKey, draft]);
 
     useEffect(() => {
       if (!toolsOpen) return;
@@ -2677,6 +2683,28 @@ function MentionPopover({
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function loadComposerDraft(key?: string): string | null {
+  if (!key || typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function saveComposerDraft(key: string | undefined, draft: string) {
+  if (!key || typeof window === 'undefined') return;
+  try {
+    if (draft) {
+      window.localStorage.setItem(key, draft);
+    } else {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    // Storage can be unavailable in privacy modes; the composer should still work.
+  }
 }
 
 function looksLikeImage(name: string): boolean {

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -415,6 +415,9 @@ export function ChatPane({
     (m) => m.role === 'assistant' && isActiveRunStatus(m.runStatus),
   );
   const retryAssistant = retryableAssistantMessage(messages, lastAssistantId, streaming);
+  const composerDraftStorageKey = projectId && activeConversationId
+    ? `od:chat-composer:draft:${projectId}:${activeConversationId}`
+    : undefined;
   // Only the first user message gets the active-plugin chip — the
   // plugin is project-scoped so re-stamping it on every reply would be
   // noise. Subsequent messages still run under the same snapshot.
@@ -1165,6 +1168,7 @@ export function ChatPane({
             streaming={streaming}
             sendDisabled={sendDisabled}
             initialDraft={initialDraft}
+            draftStorageKey={composerDraftStorageKey}
             onEnsureProject={onEnsureProject}
             commentAttachments={commentsToAttachments(attachedComments)}
             onRemoveCommentAttachment={onDetachComment}

--- a/apps/web/tests/components/ChatComposer.infinite-render.test.tsx
+++ b/apps/web/tests/components/ChatComposer.infinite-render.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -50,6 +50,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  window.localStorage.clear();
   cleanup();
 });
 
@@ -76,6 +77,37 @@ describe('ChatComposer infinite re-render regression (#2097)', () => {
 
     expect(onStop).not.toHaveBeenCalled();
     expect(onSend).toHaveBeenCalledWith('change the font', [], [], undefined);
+  });
+
+  it('restores a saved draft for the active conversation', () => {
+    window.localStorage.setItem('od:chat-composer:draft:project-1:conv-1', 'draft before refresh');
+
+    renderComposer({
+      draftStorageKey: 'od:chat-composer:draft:project-1:conv-1',
+    });
+
+    expect((screen.getByTestId('chat-composer-input') as HTMLTextAreaElement).value).toBe(
+      'draft before refresh',
+    );
+  });
+
+  it('clears the saved draft after submitting it', async () => {
+    const key = 'od:chat-composer:draft:project-1:conv-1';
+    const onSend = vi.fn();
+    renderComposer({
+      draftStorageKey: key,
+      onSend,
+    });
+    const textarea = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement;
+    fireEvent.change(textarea, {
+      target: { value: 'send then clear', selectionStart: 15, selectionEnd: 15 },
+    });
+
+    await waitFor(() => expect(window.localStorage.getItem(key)).toBe('send then clear'));
+    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(window.localStorage.getItem(key)).toBeNull());
   });
 
   it('does not re-sync the composer scroll offset on every plain-text keystroke', () => {


### PR DESCRIPTION
## Why

While editing a prompt in an existing project conversation, refreshing or reloading the app drops the unsent composer text. This is easy to hit when the preview reloads or the desktop shell refreshes, and it forces users to rewrite the prompt even though they are still in the same conversation.

This PR keeps unsent composer text scoped to the project + conversation so reloads restore the draft without writing it into chat history.

## What users will see

If a user types into the chat composer and refreshes the app, the text returns when the same conversation opens again. Sending the prompt clears the saved draft. Drafts stay separated between conversations.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual UI change.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ChatComposer.infinite-render.test.tsx`
- Did the test go red on `main` and green on this branch? no — added as focused regression coverage during the fix

## Validation

- `pnpm --filter @open-design/web test tests/components/ChatComposer.infinite-render.test.tsx`
- `pnpm --filter @open-design/web typecheck` fails on current `main` with pre-existing `osLocale` host-client type errors in `src/i18n/index.tsx` and `tests/i18n/detect-initial-locale.test.ts`
