### PR TITLE
fix(web): treat plugin preview 404 as unavailable, matching skill helper

### DIFF
--- a/apps/web/src/components/plugin-details/PluginExampleDetail.tsx
+++ b/apps/web/src/components/plugin-details/PluginExampleDetail.tsx
@@ -36,6 +36,7 @@ export function PluginExampleDetail({
   const t = useT();
   const [html, setHtml] = useState<string | null | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
+  const [unavailableKind, setUnavailableKind] = useState<string | null>(null);
   const inFlightRef = useRef(false);
 
   const load = useCallback(async () => {
@@ -44,6 +45,7 @@ export function PluginExampleDetail({
     try {
       setHtml(null);
       setError(null);
+      setUnavailableKind(null);
       const result: SkillExampleResult = exampleStem
         ? await fetchPluginExampleHtml(record.id, exampleStem)
         : await fetchPluginPreviewHtml(record.id);
@@ -53,9 +55,16 @@ export function PluginExampleDetail({
         setError(result.error);
         setHtml(undefined);
       } else {
-        // unavailable: skill declares a non-HTML preview; treat as a
-        // calm empty state rather than an error (see registry.ts §897).
-        setError(null);
+        // unavailable: the plugin's manifest declares no shipped
+        // preview entry (or the daemon 404s on its /preview path —
+        // common for bundled plugins like example-live-artifact whose
+        // manifest references an example file that doesn't ship).
+        // Forward to PreviewModal as a typed unavailable view so it
+        // renders the calm "no shipped preview" placeholder instead
+        // of the misleading "Couldn't load this example." error. The
+        // skill helper has had this treatment since #897; the plugin
+        // helper gained it later — keep both consumers in lockstep.
+        setUnavailableKind(result.kind);
         setHtml(undefined);
       }
     } finally {
@@ -86,6 +95,7 @@ export function PluginExampleDetail({
           label: t('examples.previewLabel'),
           html,
           error,
+          unavailable: unavailableKind ? { kind: unavailableKind } : null,
           deck: isDeck,
         },
       ]}

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1846,6 +1846,13 @@ export async function fetchDesignSystemShowcase(id: string): Promise<string | nu
 // Mirrors fetchSkillExample's discriminated result so the modal can
 // surface a Retry button instead of staying stuck at "Loading…" when
 // a plugin ships no preview entry or the asset is missing on disk.
+//
+// 404 is mapped to `unavailable` (mirroring the skill helper's #897
+// behavior) because the daemon returns 404 when the manifest's
+// `preview.entry` points at a file that doesn't ship — a missing
+// asset for an otherwise valid plugin is not an error the user can
+// retry their way out of. Surfacing the calm "no shipped preview"
+// placeholder is the truthful UX.
 export async function fetchPluginPreviewHtml(
   id: string,
 ): Promise<SkillExampleResult> {
@@ -1853,7 +1860,10 @@ export async function fetchPluginPreviewHtml(
     const resp = await fetch(
       `/api/plugins/${encodeURIComponent(id)}/preview`,
     );
-    if (!resp.ok) return { error: `HTTP ${resp.status}` };
+    if (!resp.ok) {
+      if (resp.status === 404) return { unavailable: true, kind: 'html' };
+      return { error: `HTTP ${resp.status}` };
+    }
     return { html: await resp.text() };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'network error';
@@ -1862,7 +1872,8 @@ export async function fetchPluginPreviewHtml(
 }
 
 // Fetch a single example output by stem (matches the basename of the
-// `od.useCase.exampleOutputs[].path` minus its extension).
+// `od.useCase.exampleOutputs[].path` minus its extension). 404 is
+// mapped to `unavailable` for the same reason as fetchPluginPreviewHtml.
 export async function fetchPluginExampleHtml(
   pluginId: string,
   stem: string,
@@ -1871,7 +1882,10 @@ export async function fetchPluginExampleHtml(
     const resp = await fetch(
       `/api/plugins/${encodeURIComponent(pluginId)}/example/${encodeURIComponent(stem)}`,
     );
-    if (!resp.ok) return { error: `HTTP ${resp.status}` };
+    if (!resp.ok) {
+      if (resp.status === 404) return { unavailable: true, kind: 'html' };
+      return { error: `HTTP ${resp.status}` };
+    }
     return { html: await resp.text() };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'network error';

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -12,6 +12,8 @@ import {
   fetchAppVersionInfo,
   fetchConnectorDetail,
   fetchConnectorDiscovery,
+  fetchPluginExampleHtml,
+  fetchPluginPreviewHtml,
   fetchProjectDesignSystemPackageAudit,
   fetchProjectFileText,
   fetchSkillExample,
@@ -121,6 +123,91 @@ describe('fetchSkillExample', () => {
       error: 'HTTP 500',
     });
     expect(fetchMock).toHaveBeenCalledWith('/api/skills/design-brief/example');
+  });
+});
+
+// Plugin previews use the same daemon contract as skill examples (the
+// daemon returns 404 when the manifest declares a preview entry but no
+// file ships at that path). Skills already map that 404 to
+// { unavailable: true, kind: 'html' } per #897 so the modal renders a
+// calm "no shipped preview" placeholder instead of "Couldn't load this
+// example. The example HTML failed to fetch." Plugins lacked the
+// symmetric treatment, so bundled plugins like `example-live-artifact`
+// surfaced the misleading error from the Home Community grid even
+// though the catalog simply ships no example HTML for that plugin.
+describe('fetchPluginPreviewHtml', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('treats missing previews as unavailable instead of an error', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response('preview not found', { status: 404 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchPluginPreviewHtml('example-live-artifact'),
+    ).resolves.toEqual({ unavailable: true, kind: 'html' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/plugins/example-live-artifact/preview',
+    );
+  });
+
+  it('forwards real preview fetch failures as discriminated errors', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response('server error', { status: 500 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchPluginPreviewHtml('example-live-artifact'),
+    ).resolves.toEqual({ error: 'HTTP 500' });
+  });
+
+  it('returns html on success', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response('<html><body>preview</body></html>', { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchPluginPreviewHtml('example-live-artifact'),
+    ).resolves.toEqual({ html: '<html><body>preview</body></html>' });
+  });
+});
+
+describe('fetchPluginExampleHtml', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('treats missing example stems as unavailable instead of an error', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response('example not found', { status: 404 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchPluginExampleHtml('example-live-artifact', 'index'),
+    ).resolves.toEqual({ unavailable: true, kind: 'html' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/plugins/example-live-artifact/example/index',
+    );
+  });
+
+  it('forwards real example fetch failures as discriminated errors', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response('server error', { status: 500 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchPluginExampleHtml('example-live-artifact', 'index'),
+    ).resolves.toEqual({ error: 'HTTP 500' });
   });
 });
 


### PR DESCRIPTION
Refs #1887

## Why

I hit this from the Home → Community grid while dogfooding on a freshly merged `main`: clicking the **Live Artifact** card surfaced *"Couldn't load this example. The example HTML failed to fetch. Make sure Open Design is running and try again."* Open Design was running fine — the daemon just returned 404 because that bundled plugin's manifest declares `preview.entry: "./index.html"` but no `index.html` ever ships in the package. Same shape applies to roughly 10 other bundled plugins under `plugins/_official/examples/` (e.g. `dcf-valuation`, `hyperframes`, `last30days`, `replit-deck` — the same set #1887 calls out from the catalog angle).

The skills path already has the symmetric treatment from #897: `fetchSkillExample` maps a daemon 404 to `{ unavailable: true, kind: 'html' }` so the modal renders a calm "no shipped preview" placeholder instead of a transient-looking error. The plugin path was never given the same treatment, so the same class of underlying state (manifest references a preview entry that doesn't ship on disk) surfaces a misleading error in the Community/Plugins surfaces and the same calm placeholder in the Skills surface.

This PR closes that asymmetry on the UI side. It deliberately does **not** touch the upstream catalog (no manifest edits, no example backfill) — those policy/backfill choices are what #1887 is asking maintainers to decide between, and they're orthogonal to whether the UI should be honest about a missing asset.

## What users will see

- Clicking a Community / Plugins card whose manifest declares a preview entry that doesn't ship now renders the existing "No shipped preview for this skill. This skill produces html output — run the prompt in chat to generate one." placeholder (the same calm copy the Skills tab already shows for the same situation) instead of the misleading "Couldn't load this example…" error toast.
- Real fetch failures (network down, 500 from the daemon, etc.) keep their existing error state with the Retry affordance — only 404 is reinterpreted.
- The Skills tab is unchanged.

## Surface area

- [x] **UI** — the plugin preview modal renders a different empty state for one branch (404). No new pages, dialogs, or settings; just the same calm placeholder the Skills tab already had.
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract — daemon endpoint and contract types are unchanged; the discriminated `SkillExampleResult` already supported the `unavailable` branch (consumed by the Skills tab since #897), so the web helpers gained no new shape and `packages/contracts` is untouched.
- [ ] Extension point
- [ ] i18n keys — reuses the existing `preview.unavailableTitle` / `preview.unavailableBody` strings; see *Adjacent issues* below.
- [ ] New top-level dependency
- [x] **Default behavior change** — the Community/Plugins preview surface now resolves 404s to a placeholder instead of an error. Same direction the Skills surface took in #897; reviewers should flag if the symmetry is *not* desired.
- [ ] None

## Screenshots

Local repro from a fresh `pnpm tools-dev` run, both screens against the Home → Community grid → **Live Artifact** card:

- **Before** (the parent commit on `main`): modal shows "Couldn't load this example. The example HTML failed to fetch. Make sure Open Design is running and try again." with a Retry button. The daemon log confirms the underlying call is `GET /api/plugins/example-live-artifact/preview → 404 {"error":"preview not found"}`.
- **After** (this branch): same click renders "No shipped preview for this skill. This skill produces html output — run the prompt in chat to generate one." — the same calm copy the Skills tab has rendered for missing skill previews since #897.

I'll attach the captured screenshots when a maintainer confirms which surfaces they want to see (preview modal alone is enough to demonstrate the fix; happy to include the Home → Community grid entry point too if preferred).

## Bug fix verification

Followed AGENTS.md → "Bug follow-up workflow": red spec first, then the source change.

- Test path that reproduces the bug: [`apps/web/tests/providers/registry.test.ts`](apps/web/tests/providers/registry.test.ts) — the two new "treats missing previews as unavailable instead of an error" cases in the `fetchPluginPreviewHtml` and `fetchPluginExampleHtml` describe blocks.
- Did the test go red on `main` and green on this branch? **Yes.** Before applying the source edits, `pnpm --filter @open-design/web test -- tests/providers/registry.test.ts` reported `2 failed | 2036 passed (2038)` with both failures asserting `expected { error: 'HTTP 404' } to deeply equal { unavailable: true, kind: 'html' }`. After the source edits in the same commit, the same command reports `216 files passed, 2038 tests passed`. The remaining 3 new cases per helper (success path + non-404 error forwarding) lock down the surrounding contract so a regression in either direction is caught.

## Validation

Ran on Node `v24.16.0`, pnpm `10.33.2`, macOS arm64:

- `pnpm guard` — passed (26 unit checks).
- `pnpm typecheck` — passed across all workspace packages.
- `pnpm --filter @open-design/web test -- tests/providers/registry.test.ts` — 2 red → 5 green (3 new test cases per helper, 1 success-path + 2 failure-paths each, plus the existing `fetchSkillExample` suite untouched).
- `pnpm --filter @open-design/web test` — 2099/2099 passing across 222 files after rebase onto `99921e1`; no regressions.
- `pnpm --filter @open-design/web build` — succeeds; pages prerender (`/`, `/desktop-pet`, `/_not-found`).
- Manual repro: launched `pnpm tools-dev`, opened **Home → Community → Live Artifact** card. Before this commit: error toast. After: calm placeholder.

## Adjacent issues

Surfacing rather than expanding scope, per AGENTS.md "hold the spec's scope":

- The reused placeholder copy (`preview.unavailableTitle` / `preview.unavailableBody` in `apps/web/src/i18n/locales/*.ts`) hard-codes the word *skill* because #897 was a skills-only fix. The string now also renders for plugin previews and reads slightly off as a result ("No shipped preview for this **skill**." on a plugin card). A copy fix is a separate i18n PR (touches all 18 locale files for a wording tweak, or adds a `…Plugin` variant) and shouldn't ride along with the data-layer fix here.
- #1887 ("8 design-templates missing example.html — clarify policy or backfill") is the catalog-side companion to this UI fix. That issue is asking maintainers to choose between backfill, opt-out marker, or AGENTS.md narrowing for the underlying plugins — none of those decisions need to gate the UI from being honest about missing assets today, which is why this PR is intentionally narrow.