### PR TITLE
Let chat know the visible preview page

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -948,7 +948,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       }
 
       const file = await readProjectFile(PROJECTS_DIR, projectId, relPath, project?.metadata);
-      if (file.mime.startsWith('text/html')) {
+      if (req.query.preview === '1' && file.mime.startsWith('text/html')) {
         res.type(file.mime).send(injectPrototypeLocationRelay(file.buffer.toString('utf8')));
         return;
       }

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -15,6 +15,7 @@ import {
   resolvePluginSnapshot,
 } from './plugins/index.js';
 import { connectorService } from './connectors/service.js';
+import { injectPrototypeLocationRelay } from './prototype-scroll-relay.js';
 import type { RouteDeps } from './server-context.js';
 import { listSkills } from './skills.js';
 import { auditDesignSystemPackage } from './tools-connectors-cli.js';
@@ -947,6 +948,10 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       }
 
       const file = await readProjectFile(PROJECTS_DIR, projectId, relPath, project?.metadata);
+      if (file.mime.startsWith('text/html')) {
+        res.type(file.mime).send(injectPrototypeLocationRelay(file.buffer.toString('utf8')));
+        return;
+      }
       res.type(file.mime).send(file.buffer);
     } catch (err: any) {
       const status = err && err.code === 'ENOENT' ? 404 : 400;

--- a/apps/daemon/src/prototype-scroll-relay.ts
+++ b/apps/daemon/src/prototype-scroll-relay.ts
@@ -22,6 +22,25 @@ const LOCATION_RELAY_SCRIPT = `<script ${RELAY_MARKER}>(function(){
       return result;
     };
   });
+  // Plain <a href> click triggers a full navigation; relative URLs drop the
+  // base's ?preview=1, so the destination raw response goes through the
+  // byte-accurate branch with no relay injected and the host stops receiving
+  // od:url-load-loc. Re-stamp preview=1 on same-origin navigations so the
+  // next page keeps the relay.
+  document.addEventListener('click', function(e){
+    var link = e.target && e.target.closest && e.target.closest('a[href]');
+    if (!link) return;
+    if (e.defaultPrevented) return;
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    if (link.target && link.target !== '' && link.target !== '_self') return;
+    var url;
+    try { url = new URL(link.href, location.href); } catch (_) { return; }
+    if (url.origin !== location.origin) return;
+    if (url.searchParams.get('preview') === '1') return;
+    e.preventDefault();
+    url.searchParams.set('preview', '1');
+    try { location.assign(url.toString()); } catch (_) {}
+  }, true);
 })();</script>`;
 
 export function injectPrototypeLocationRelay(html: string): string {

--- a/apps/daemon/src/prototype-scroll-relay.ts
+++ b/apps/daemon/src/prototype-scroll-relay.ts
@@ -1,0 +1,36 @@
+const RELAY_MARKER = 'data-od-prototype-location-relay';
+
+const LOCATION_RELAY_SCRIPT = `<script ${RELAY_MARKER}>(function(){
+  function reportLoc(){
+    try {
+      (window.parent || window).postMessage({
+        type: 'od:url-load-loc',
+        pathname: location.pathname,
+        search: location.search,
+        hash: location.hash
+      }, '*');
+    } catch (_) {}
+  }
+  reportLoc();
+  window.addEventListener('hashchange', reportLoc);
+  ['pushState', 'replaceState'].forEach(function(method){
+    var original = history[method];
+    if (typeof original !== 'function') return;
+    history[method] = function(){
+      var result = original.apply(this, arguments);
+      reportLoc();
+      return result;
+    };
+  });
+})();</script>`;
+
+export function injectPrototypeLocationRelay(html: string): string {
+  if (html.includes(RELAY_MARKER)) return html;
+  if (/<\/head\s*>/i.test(html)) {
+    return html.replace(/<\/head\s*>/i, `${LOCATION_RELAY_SCRIPT}</head>`);
+  }
+  if (/<\/body\s*>/i.test(html)) {
+    return html.replace(/<\/body\s*>/i, `${LOCATION_RELAY_SCRIPT}</body>`);
+  }
+  return `${html}${LOCATION_RELAY_SCRIPT}`;
+}

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -223,6 +223,15 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('accept-ranges')).toBeNull();
     const text = await res.text();
+    expect(text).toBe('<html/>');
+    expect(text).not.toContain('data-od-prototype-location-relay');
+  });
+
+  it('injects the prototype location relay only for preview HTML requests', async () => {
+    const res = await fetch(`${rawUrl('page.html')}?preview=1`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('accept-ranges')).toBeNull();
+    const text = await res.text();
     expect(text).toContain('<html');
     expect(text).toContain('data-od-prototype-location-relay');
     expect(text).toContain('od:url-load-loc');

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -235,6 +235,12 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(text).toContain('<html');
     expect(text).toContain('data-od-prototype-location-relay');
     expect(text).toContain('od:url-load-loc');
+    // Anchor click must re-stamp preview=1 so the destination raw response
+    // keeps the relay (RFC 3986 relative-URL resolution drops the base
+    // query). Without this, multi-file prototypes that navigate via plain
+    // <a href> snap back to the entry page on the next file refresh because
+    // the host never receives od:url-load-loc from the new page.
+    expect(text).toContain("searchParams.set('preview', '1')");
   });
 
   it('returns 404 for a missing file', async () => {

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -223,7 +223,9 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('accept-ranges')).toBeNull();
     const text = await res.text();
-    expect(text).toBe('<html/>');
+    expect(text).toContain('<html');
+    expect(text).toContain('data-od-prototype-location-relay');
+    expect(text).toContain('od:url-load-loc');
   });
 
   it('returns 404 for a missing file', async () => {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -67,7 +67,12 @@ import {
 } from '../runtime/exports';
 import { buildReactComponentSrcdoc } from '../runtime/react-component';
 import { findHtmlEntriesReferencing } from '../runtime/jsx-module-refs';
-import { buildLazySrcdocTransport, buildSrcdoc, canActivateSrcDocTransport } from '../runtime/srcdoc';
+import {
+  buildLazySrcdocTransport,
+  buildSrcdoc,
+  buildUrlLoadRefreshSrc,
+  canActivateSrcDocTransport,
+} from '../runtime/srcdoc';
 import {
   hasUrlModeBridge,
   htmlNeedsFocusGuard,
@@ -4062,6 +4067,8 @@ function HtmlViewer({
   const [manualEditViewportWidth, setManualEditViewportWidth] = useState<number | null>(null);
   const [commentPortalHost, setCommentPortalHost] = useState<HTMLElement | null>(null);
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
+  const [urlLoadSubPath, setUrlLoadSubPath] = useState<string | null>(null);
+  const [urlLoadHash, setUrlLoadHash] = useState('');
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -4538,7 +4545,15 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
 
   useEffect(() => {
     if (filesRefreshKey === 0) return;
-    const nextSrc = `${basePreviewSrcUrl}&fr=${filesRefreshKey}`;
+    const nextSrc = buildUrlLoadRefreshSrc({
+      entrySrcUrl: basePreviewSrcUrl,
+      filesRefreshKey,
+      urlLoadSubPath,
+      fileName: file.name,
+      urlLoadHash,
+      rawFileUrl: (filePath) =>
+        `${projectRawUrl(projectId, filePath)}?v=${Math.round(file.mtime)}&r=${reloadKey}`,
+    });
     const timeout = window.setTimeout(() => {
       if (useUrlLoadPreview && urlPreviewIframeRef.current?.contentWindow) {
         urlPreviewIframeRef.current.contentWindow.location.replace(nextSrc);
@@ -4547,7 +4562,17 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
       }
     }, 180);
     return () => window.clearTimeout(timeout);
-  }, [basePreviewSrcUrl, filesRefreshKey, useUrlLoadPreview]);
+  }, [
+    basePreviewSrcUrl,
+    file.mtime,
+    file.name,
+    filesRefreshKey,
+    projectId,
+    reloadKey,
+    urlLoadHash,
+    urlLoadSubPath,
+    useUrlLoadPreview,
+  ]);
 
   useEffect(() => {
     setInlinedSource(null);
@@ -4774,15 +4799,44 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         }, '*');
       }
     }
+    function onUrlLoadLoc(ev: MessageEvent) {
+      if (!ev.source || ev.source !== urlPreviewIframeRef.current?.contentWindow) return;
+      const data = ev.data as { type?: string; pathname?: string; hash?: string } | null;
+      if (!data || data.type !== 'od:url-load-loc') return;
+      setUrlLoadHash(typeof data.hash === 'string' ? data.hash : '');
+      const rawPrefix = projectRawUrl(projectId, '');
+      const pathname = typeof data.pathname === 'string' ? data.pathname : '';
+      const idx = pathname.indexOf(rawPrefix);
+      const relative = idx >= 0
+        ? pathname
+            .slice(idx + rawPrefix.length)
+            .split('/')
+            .map((segment) => {
+              try {
+                return decodeURIComponent(segment);
+              } catch {
+                return segment;
+              }
+            })
+            .join('/')
+        : '';
+      if (!relative || relative === file.name || !/\.html?$/i.test(relative)) {
+        setUrlLoadSubPath(null);
+        return;
+      }
+      setUrlLoadSubPath(relative);
+    }
     window.addEventListener('message', onMessage);
     window.addEventListener('message', onRestoreRequest);
     window.addEventListener('message', onDcViewportMessage);
+    window.addEventListener('message', onUrlLoadLoc);
     return () => {
       window.removeEventListener('message', onMessage);
       window.removeEventListener('message', onRestoreRequest);
       window.removeEventListener('message', onDcViewportMessage);
+      window.removeEventListener('message', onUrlLoadLoc);
     };
-  }, [isActivePreviewIframeSource, isOurPreviewIframeSource]);
+  }, [isActivePreviewIframeSource, isOurPreviewIframeSource, projectId, file.name]);
 
   useEffect(() => {
     if (!effectiveDeck) {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -541,6 +541,29 @@ export function previewOverlayTransform(
   };
 }
 
+export function htmlPreviewUrlForLocation(
+  projectId: string,
+  fileName: string,
+  mtime: number,
+  reloadKey: number,
+  options: {
+    urlLoadSubPath?: string | null;
+    urlLoadHash?: string;
+    filesRefreshKey?: number;
+  } = {},
+): string {
+  const path = options.urlLoadSubPath && /\.html?$/i.test(options.urlLoadSubPath)
+    ? options.urlLoadSubPath
+    : fileName;
+  const query = new URLSearchParams({
+    v: String(Math.round(mtime)),
+    r: String(reloadKey),
+  });
+  if (options.filesRefreshKey !== undefined) query.set('fr', String(options.filesRefreshKey));
+  const hash = options.urlLoadHash?.startsWith('#') ? options.urlLoadHash : '';
+  return `${projectRawUrl(projectId, path)}?${query.toString()}${hash}`;
+}
+
 function previewScaleShellStyle(
   viewport: PreviewViewportId,
   previewScale: number,
@@ -4526,16 +4549,26 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     needsFocusGuard,
   });
   const basePreviewSrcUrl = useMemo(
-    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}`,
+    () => htmlPreviewUrlForLocation(projectId, file.name, file.mtime, reloadKey),
     [projectId, file.name, file.mtime, reloadKey],
   );
   const [previewSrcUrl, setPreviewSrcUrl] = useState(basePreviewSrcUrl);
-  const activePreviewSrcUrl = (
+  const trackedPreviewSrcUrl = useMemo(
+    () => htmlPreviewUrlForLocation(projectId, file.name, file.mtime, reloadKey, {
+      urlLoadSubPath,
+      urlLoadHash,
+    }),
+    [projectId, file.name, file.mtime, reloadKey, urlLoadSubPath, urlLoadHash],
+  );
+  const hasTrackedPreviewLocation = Boolean(urlLoadSubPath || urlLoadHash);
+  const previewSrcMatchesBase =
     previewSrcUrl === basePreviewSrcUrl ||
-    previewSrcUrl.startsWith(`${basePreviewSrcUrl}&`)
-  )
-    ? previewSrcUrl
-    : basePreviewSrcUrl;
+    previewSrcUrl.startsWith(`${basePreviewSrcUrl}&`);
+  const activePreviewSrcUrl = hasTrackedPreviewLocation
+    ? trackedPreviewSrcUrl
+    : previewSrcMatchesBase
+      ? previewSrcUrl
+      : basePreviewSrcUrl;
   useEffect(() => {
     setPreviewSrcUrl(basePreviewSrcUrl);
   }, [basePreviewSrcUrl]);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -38,6 +38,7 @@ import {
   uploadProjectFiles,
   liveArtifactPreviewUrl,
   projectFileUrl,
+  projectPreviewUrl,
   projectRawUrl,
   LiveArtifactRefreshError,
   refreshLiveArtifact,
@@ -561,7 +562,7 @@ export function htmlPreviewUrlForLocation(
   });
   if (options.filesRefreshKey !== undefined) query.set('fr', String(options.filesRefreshKey));
   const hash = options.urlLoadHash?.startsWith('#') ? options.urlLoadHash : '';
-  return `${projectRawUrl(projectId, path)}?${query.toString()}${hash}`;
+  return `${projectPreviewUrl(projectId, path)}&${query.toString()}${hash}`;
 }
 
 function previewScaleShellStyle(
@@ -4585,7 +4586,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
       fileName: file.name,
       urlLoadHash,
       rawFileUrl: (filePath) =>
-        `${projectRawUrl(projectId, filePath)}?v=${Math.round(file.mtime)}&r=${reloadKey}`,
+        `${projectPreviewUrl(projectId, filePath)}&v=${Math.round(file.mtime)}&r=${reloadKey}`,
     });
     const timeout = window.setTimeout(() => {
       if (useUrlLoadPreview && urlPreviewIframeRef.current?.contentWindow) {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -117,6 +117,7 @@ import type {
   PreviewCommentMember,
   PreviewCommentTarget,
 } from '../types';
+import type { PreviewChatContext } from '../preview-chat-context';
 import { ManualEditPanel, emptyManualEditDraft, type ManualEditDraft } from './ManualEditPanel';
 import {
   applyManualEditPatch,
@@ -717,6 +718,7 @@ interface Props {
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
   onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
+  onPreviewLocationChange?: (context: PreviewChatContext | null) => void;
   onFileSaved?: () => Promise<void> | void;
   // Open `openName` as a tab (focusing it) and close `closeName` in one
   // atomic tab-state update. The React module pointer uses this to jump to the
@@ -739,6 +741,7 @@ export function FileViewer({
   onSavePreviewComment,
   onRemovePreviewComment,
   onSendBoardCommentAttachments,
+  onPreviewLocationChange,
   onFileSaved,
   onOpenFileReplacing,
   commentPortalId,
@@ -763,6 +766,10 @@ export function FileViewer({
       page_name: 'artifact',
     });
   }, [projectId, projectKind, file.name, file.kind, rendererMatch?.renderer.id, analytics.track]);
+  useEffect(() => {
+    if (rendererMatch?.renderer.id === 'html' || rendererMatch?.renderer.id === 'deck-html') return;
+    onPreviewLocationChange?.(null);
+  }, [onPreviewLocationChange, rendererMatch?.renderer.id]);
 
   if (rendererMatch?.renderer.id === 'html' || rendererMatch?.renderer.id === 'deck-html') {
     return (
@@ -779,6 +786,7 @@ export function FileViewer({
         onSavePreviewComment={onSavePreviewComment}
         onRemovePreviewComment={onRemovePreviewComment}
         onSendBoardCommentAttachments={onSendBoardCommentAttachments}
+        onPreviewLocationChange={onPreviewLocationChange}
         onFileSaved={onFileSaved}
         commentPortalId={commentPortalId}
         onCommentModeChange={onCommentModeChange}
@@ -3874,6 +3882,7 @@ function HtmlViewer({
   onSavePreviewComment,
   onRemovePreviewComment,
   onSendBoardCommentAttachments,
+  onPreviewLocationChange,
   onFileSaved,
   commentPortalId,
   onCommentModeChange,
@@ -3890,6 +3899,7 @@ function HtmlViewer({
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
   onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
+  onPreviewLocationChange?: (context: PreviewChatContext | null) => void;
   onFileSaved?: () => Promise<void> | void;
   commentPortalId?: string;
   onCommentModeChange?: (active: boolean) => void;
@@ -4093,6 +4103,13 @@ function HtmlViewer({
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
   const [urlLoadSubPath, setUrlLoadSubPath] = useState<string | null>(null);
   const [urlLoadHash, setUrlLoadHash] = useState('');
+  useEffect(() => {
+    onPreviewLocationChange?.({
+      activeFilePath: file.name,
+      visibleFilePath: urlLoadSubPath || file.name,
+      hash: urlLoadHash || undefined,
+    });
+  }, [file.name, onPreviewLocationChange, urlLoadHash, urlLoadSubPath]);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -42,6 +42,7 @@ import {
   type ProjectMetadata,
   type ProjectFile,
 } from '../types';
+import type { PreviewChatContext } from '../preview-chat-context';
 import { DesignFilesPanel } from './DesignFilesPanel';
 import type { PluginFolderAgentAction } from './design-files/pluginFolderActions';
 import { designSystemGithubEvidenceState, repoConnectCopy } from './design-system-github-evidence';
@@ -80,6 +81,7 @@ interface Props {
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
   onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
+  onPreviewLocationChange?: (context: PreviewChatContext | null) => void;
   onPluginFolderAgentAction?: (
     relativePath: string,
     action: PluginFolderAgentAction,
@@ -209,6 +211,7 @@ export function FileWorkspace({
   onSavePreviewComment,
   onRemovePreviewComment,
   onSendBoardCommentAttachments,
+  onPreviewLocationChange,
   onPluginFolderAgentAction,
   activePluginActionPaths,
   hiddenPluginActionPaths,
@@ -781,6 +784,10 @@ export function FileWorkspace({
     }
     return null;
   }, [activeTab, visibleFiles, sketches]);
+  useEffect(() => {
+    if (activeFile) return;
+    onPreviewLocationChange?.(null);
+  }, [activeFile, onPreviewLocationChange]);
 
   const activeLiveArtifact = useMemo<LiveArtifactWorkspaceEntry | null>(() => {
     if (activeTab === DESIGN_FILES_TAB || activeTab === DESIGN_SYSTEM_TAB) return null;
@@ -1067,6 +1074,7 @@ export function FileWorkspace({
             onSavePreviewComment={onSavePreviewComment}
             onRemovePreviewComment={onRemovePreviewComment}
             onSendBoardCommentAttachments={onSendBoardCommentAttachments}
+            onPreviewLocationChange={onPreviewLocationChange}
             onFileSaved={onRefreshFiles}
             onOpenFileReplacing={openFileReplacing}
             commentPortalId={commentPortalId}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -136,6 +136,11 @@ import {
   mergeAttachedComments,
   removeAttachedComment,
 } from '../comments';
+import {
+  historyWithPreviewContext,
+  samePreviewChatContext,
+  type PreviewChatContext,
+} from '../preview-chat-context';
 import { buildPptxExportPrompt } from '../lib/build-pptx-export-prompt';
 import { AppChromeHeader } from './AppChromeHeader';
 import { AvatarMenu } from './AvatarMenu';
@@ -571,6 +576,7 @@ export function ProjectView({
   const [messagesInitialized, setMessagesInitialized] = useState(false);
   const [previewComments, setPreviewComments] = useState<PreviewComment[]>([]);
   const [attachedComments, setAttachedComments] = useState<PreviewComment[]>([]);
+  const [previewChatContext, setPreviewChatContext] = useState<PreviewChatContext | null>(null);
   const [streaming, setStreaming] = useState(false);
   const [streamingConversationId, setStreamingConversationId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -2745,9 +2751,10 @@ export function ProjectView({
               },
             }
           : undefined;
+        const daemonHistory = historyWithPreviewContext(nextHistory, userMsg.id, previewChatContext);
         void streamViaDaemon({
           agentId: config.agentId,
-          history: nextHistory,
+          history: daemonHistory,
           signal: controller.signal,
           cancelSignal: cancelController.signal,
           handlers,
@@ -2855,7 +2862,11 @@ export function ProjectView({
         }
         const systemPrompt = await composedSystemPrompt();
         const apiHistory = await historyWithApiAttachmentContext(
-          historyWithCommentAttachmentContext(nextHistory, userMsg.id),
+          historyWithPreviewContext(
+            historyWithCommentAttachmentContext(nextHistory, userMsg.id),
+            userMsg.id,
+            previewChatContext,
+          ),
           userMsg.id,
           project.id,
           projectFiles,
@@ -2908,6 +2919,7 @@ export function ProjectView({
       agentsById,
       composedSystemPrompt,
       onTouchProject,
+      previewChatContext,
       project.id,
       project.name,
       projectFiles,
@@ -2965,6 +2977,10 @@ export function ProjectView({
     handleSend,
     removeQueuedChatSend,
   ]);
+
+  const handlePreviewLocationChange = useCallback((next: PreviewChatContext | null) => {
+    setPreviewChatContext((prev) => (samePreviewChatContext(prev, next) ? prev : next));
+  }, []);
 
   const handleRetry = useCallback(
     (assistantMessage: ChatMessage) => {
@@ -4561,6 +4577,7 @@ export function ProjectView({
           onSavePreviewComment={savePreviewComment}
           onRemovePreviewComment={removePreviewComment}
           onSendBoardCommentAttachments={handleSendBoardCommentAttachments}
+          onPreviewLocationChange={handlePreviewLocationChange}
           onPluginFolderAgentAction={handlePluginFolderAgentAction}
           activePluginActionPaths={activePluginActionPaths}
           focusMode={workspaceFocused}

--- a/apps/web/src/preview-chat-context.ts
+++ b/apps/web/src/preview-chat-context.ts
@@ -1,0 +1,54 @@
+import type { ChatMessage } from './types';
+
+export interface PreviewChatContext {
+  activeFilePath: string;
+  visibleFilePath: string;
+  hash?: string;
+}
+
+export function messageContentWithPreviewContext(
+  content: string,
+  context: PreviewChatContext | null,
+): string {
+  if (!context) return content;
+  const visibleContent = content.trim() || '(No extra typed instruction.)';
+  const lines = [
+    '',
+    '',
+    '<current-preview-context>',
+    'The user is asking from the live preview. Treat visibleFile as the page currently shown in the preview iframe.',
+    `activeFile: ${context.activeFilePath}`,
+    `visibleFile: ${context.visibleFilePath}`,
+  ];
+  if (context.hash) lines.push(`hash: ${context.hash}`);
+  lines.push('</current-preview-context>');
+  return `${visibleContent}${lines.join('\n')}`;
+}
+
+export function historyWithPreviewContext(
+  history: ChatMessage[],
+  messageId: string,
+  context: PreviewChatContext | null,
+): ChatMessage[] {
+  if (!context) return history;
+  return history.map((message) => {
+    if (message.id !== messageId || message.role !== 'user') return message;
+    return {
+      ...message,
+      content: messageContentWithPreviewContext(message.content, context),
+    };
+  });
+}
+
+export function samePreviewChatContext(
+  left: PreviewChatContext | null,
+  right: PreviewChatContext | null,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return (
+    left.activeFilePath === right.activeFilePath &&
+    left.visibleFilePath === right.visibleFilePath &&
+    (left.hash ?? '') === (right.hash ?? '')
+  );
+}

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1740,6 +1740,10 @@ export function projectRawUrl(projectId: string, filePath: string): string {
   return `/api/projects/${encodeURIComponent(projectId)}/raw/${safePath}`;
 }
 
+export function projectPreviewUrl(projectId: string, filePath: string): string {
+  return `${projectRawUrl(projectId, filePath)}?preview=1`;
+}
+
 function looksLikeImage(name: string): boolean {
   return /\.(png|jpe?g|gif|webp|svg|avif|bmp)$/i.test(name);
 }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -34,6 +34,28 @@ export type SrcdocOptions = {
   previewFocusGuard?: boolean;
 };
 
+export interface UrlLoadRefreshSrcInputs {
+  entrySrcUrl: string;
+  filesRefreshKey: number;
+  urlLoadSubPath: string | null;
+  fileName: string;
+  urlLoadHash: string;
+  rawFileUrl: (filePath: string) => string;
+}
+
+export function buildUrlLoadRefreshSrc(inputs: UrlLoadRefreshSrcInputs): string {
+  const refreshQuery = `fr=${encodeURIComponent(String(inputs.filesRefreshKey))}`;
+  const hash = normalizeLocationHash(inputs.urlLoadHash);
+  const onSubPage =
+    !!inputs.urlLoadSubPath &&
+    inputs.urlLoadSubPath !== inputs.fileName &&
+    /\.html?$/i.test(inputs.urlLoadSubPath);
+  const base = onSubPage
+    ? inputs.rawFileUrl(inputs.urlLoadSubPath!)
+    : inputs.entrySrcUrl;
+  return `${appendQueryParam(base, refreshQuery)}${hash}`;
+}
+
 export function buildSrcdoc(
   html: string,
   options: SrcdocOptions = {}
@@ -80,6 +102,19 @@ export function buildSrcdoc(
   // visible flash) every time the host toggle flips.
   const withTweaks = injectTweaksBridge(withEdit);
   return injectSrcdocTransportActivationBridge(injectSnapshotBridge(withTweaks));
+}
+
+function appendQueryParam(url: string, query: string): string {
+  const hashIndex = url.indexOf('#');
+  const beforeHash = hashIndex >= 0 ? url.slice(0, hashIndex) : url;
+  const hash = hashIndex >= 0 ? url.slice(hashIndex) : '';
+  const joiner = beforeHash.includes('?') ? '&' : '?';
+  return `${beforeHash}${joiner}${query}${hash}`;
+}
+
+function normalizeLocationHash(hash: string): string {
+  if (!hash) return '';
+  return hash.startsWith('#') ? hash : `#${hash}`;
 }
 
 /**

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -148,14 +148,14 @@ describe('FileViewer HTML preview location URLs', () => {
       urlLoadSubPath: 'screens/parent/parent-app.html',
       urlLoadHash: '#report',
       filesRefreshKey: 7,
-    })).toBe('/api/projects/project-1/raw/screens/parent/parent-app.html?v=1710000000&r=2&fr=7#report');
+    })).toBe('/api/projects/project-1/raw/screens/parent/parent-app.html?preview=1&v=1710000000&r=2&fr=7#report');
   });
 
   it('preserves same-file hash routes without treating them as a sub-page', () => {
     expect(htmlPreviewUrlForLocation('project-1', 'screens/admin/admin-console.html', 1710000000, 0, {
       urlLoadSubPath: null,
       urlLoadHash: '#AD11',
-    })).toBe('/api/projects/project-1/raw/screens/admin/admin-console.html?v=1710000000&r=0#AD11');
+    })).toBe('/api/projects/project-1/raw/screens/admin/admin-console.html?preview=1&v=1710000000&r=0#AD11');
   });
 });
 
@@ -614,7 +614,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).toContain('data-od-render-mode="url-load"');
     expect(markup).toContain('data-od-render-mode="url-load" data-od-active="true"');
     expect(markup).toContain('data-od-render-mode="srcdoc" data-od-active="false"');
-    expect(markup).toContain('src="/api/projects/project-1/raw/page.html?v=1710000000&amp;r=0"');
+    expect(markup).toContain('src="/api/projects/project-1/raw/page.html?preview=1&amp;v=1710000000&amp;r=0"');
     expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
   });
 
@@ -792,7 +792,8 @@ describe('FileViewer SVG artifacts', () => {
 
     const { container } = render(<Switcher />);
     const getFrame = () => container.querySelector<HTMLIFrameElement>('[data-testid="artifact-preview-frame"]');
-    expect(getFrame()?.getAttribute('src')).toBe('/api/projects/project-1/raw/first.html?v=1710000000&r=0');
+    const initialFrame = getFrame();
+    expect(initialFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/first.html?preview=1&v=1710000000&r=0');
 
     const observationsBeforeSwitch = observedCommittedSrcs.length;
     fireEvent.click(screen.getByRole('button', { name: 'Switch file' }));
@@ -800,9 +801,9 @@ describe('FileViewer SVG artifacts', () => {
     const nextFrame = getFrame();
     expect(nextFrame).toBeTruthy();
     expect(observedCommittedSrcs[observationsBeforeSwitch]).toBe(
-      '/api/projects/project-1/raw/second.html?v=1710000000&r=0',
+      '/api/projects/project-1/raw/second.html?preview=1&v=1710000000&r=0',
     );
-    expect(nextFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/second.html?v=1710000000&r=0');
+    expect(nextFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/second.html?preview=1&v=1710000000&r=0');
   });
 
   it('allows downloads in the in-tab HTML presentation iframe', async () => {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -30,6 +30,7 @@ import {
   SvgViewer,
   applyInspectOverridesToSource,
   effectivePreviewScale,
+  htmlPreviewUrlForLocation,
   parseInspectOverridesFromSource,
   previewOverlayTransform,
   serializeInspectOverrides,
@@ -138,6 +139,23 @@ describe('FileViewer preview scale', () => {
     expect(tablet.scale).toBeCloseTo(752 / 1180, 5);
     expect(tablet.offsetX).toBeCloseTo(24 + (1152 - 820 * (752 / 1180)) / 2, 5);
     expect(tablet.offsetY).toBe(24);
+  });
+});
+
+describe('FileViewer HTML preview location URLs', () => {
+  it('targets the tracked sub-page and hash when refreshing a navigated url-load preview', () => {
+    expect(htmlPreviewUrlForLocation('project-1', 'index-v1.html', 1710000000.4, 2, {
+      urlLoadSubPath: 'screens/parent/parent-app.html',
+      urlLoadHash: '#report',
+      filesRefreshKey: 7,
+    })).toBe('/api/projects/project-1/raw/screens/parent/parent-app.html?v=1710000000&r=2&fr=7#report');
+  });
+
+  it('preserves same-file hash routes without treating them as a sub-page', () => {
+    expect(htmlPreviewUrlForLocation('project-1', 'screens/admin/admin-console.html', 1710000000, 0, {
+      urlLoadSubPath: null,
+      urlLoadHash: '#AD11',
+    })).toBe('/api/projects/project-1/raw/screens/admin/admin-console.html?v=1710000000&r=0#AD11');
   });
 });
 

--- a/apps/web/tests/preview-chat-context.test.ts
+++ b/apps/web/tests/preview-chat-context.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  historyWithPreviewContext,
+  messageContentWithPreviewContext,
+  samePreviewChatContext,
+} from '../src/preview-chat-context';
+import type { ChatMessage } from '../src/types';
+
+describe('preview chat context', () => {
+  it('adds the current visible preview page to a user message', () => {
+    const content = messageContentWithPreviewContext('현재 보이는 페이지가 뭐야?', {
+      activeFilePath: 'index.html',
+      visibleFilePath: 'screens/kiosk/k1-waiting.html',
+      hash: '#step-2',
+    });
+
+    expect(content).toContain('<current-preview-context>');
+    expect(content).toContain('activeFile: index.html');
+    expect(content).toContain('visibleFile: screens/kiosk/k1-waiting.html');
+    expect(content).toContain('hash: #step-2');
+  });
+
+  it('injects preview context only into the current user turn sent to the model', () => {
+    const history: ChatMessage[] = [
+      { id: 'old', role: 'user', content: 'old' },
+      { id: 'assistant', role: 'assistant', content: 'reply' },
+      { id: 'new', role: 'user', content: 'new' },
+    ];
+
+    const next = historyWithPreviewContext(history, 'new', {
+      activeFilePath: 'index-v1.html',
+      visibleFilePath: 'index-v1.html',
+    });
+
+    expect(next[0]?.content).toBe('old');
+    expect(next[1]?.content).toBe('reply');
+    expect(next[2]?.content).toContain('visibleFile: index-v1.html');
+  });
+
+  it('compares preview contexts by value', () => {
+    expect(samePreviewChatContext(
+      { activeFilePath: 'index.html', visibleFilePath: 'a.html' },
+      { activeFilePath: 'index.html', visibleFilePath: 'a.html', hash: '' },
+    )).toBe(true);
+    expect(samePreviewChatContext(
+      { activeFilePath: 'index.html', visibleFilePath: 'a.html' },
+      { activeFilePath: 'index.html', visibleFilePath: 'b.html' },
+    )).toBe(false);
+  });
+});

--- a/apps/web/tests/runtime/srcdoc-transport.test.ts
+++ b/apps/web/tests/runtime/srcdoc-transport.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildLazySrcdocTransport,
+  buildUrlLoadRefreshSrc,
   canActivateSrcDocTransport,
   type SrcDocActivationInputs,
 } from '../../src/runtime/srcdoc';
@@ -195,5 +196,47 @@ describe('canActivateSrcDocTransport (#2253)', () => {
         activatedHtml: '<html>previous</html>',
       }),
     ).toBe(true);
+  });
+});
+describe('buildUrlLoadRefreshSrc (file-change preview reload)', () => {
+  const rawFileUrl = (filePath: string) => `/api/projects/p/raw/${filePath}?v=10&r=0`;
+
+  it('preserves the current hash when reloading the entry file', () => {
+    expect(
+      buildUrlLoadRefreshSrc({
+        entrySrcUrl: '/api/projects/p/raw/index.html?v=10&r=0',
+        filesRefreshKey: 7,
+        urlLoadSubPath: null,
+        fileName: 'index.html',
+        urlLoadHash: '#detail-3',
+        rawFileUrl,
+      }),
+    ).toBe('/api/projects/p/raw/index.html?v=10&r=0&fr=7#detail-3');
+  });
+
+  it('reloads the current sub-page instead of snapping back to the entry file', () => {
+    expect(
+      buildUrlLoadRefreshSrc({
+        entrySrcUrl: '/api/projects/p/raw/index.html?v=10&r=0',
+        filesRefreshKey: 8,
+        urlLoadSubPath: 'screens/parent/detail.html',
+        fileName: 'index.html',
+        urlLoadHash: '#child-a',
+        rawFileUrl,
+      }),
+    ).toBe('/api/projects/p/raw/screens/parent/detail.html?v=10&r=0&fr=8#child-a');
+  });
+
+  it('does not treat the entry file as a sub-page', () => {
+    expect(
+      buildUrlLoadRefreshSrc({
+        entrySrcUrl: '/api/projects/p/raw/index.html?v=10&r=0',
+        filesRefreshKey: 9,
+        urlLoadSubPath: 'index.html',
+        fileName: 'index.html',
+        urlLoadHash: '',
+        rawFileUrl,
+      }),
+    ).toBe('/api/projects/p/raw/index.html?v=10&r=0&fr=9');
   });
 });


### PR DESCRIPTION
## Why

This is a follow-up stacked on #2836. While working in the preview, ordinary chat turns do not carry the currently visible iframe location, so the agent can identify a page from a Comment attachment but has to guess when the user asks “what page is currently visible?” in plain chat.

The pain is user-facing: users expect the chat panel to understand the visible preview page without needing to place a comment marker first.

## What users will see

When they ask from a project with an HTML preview open, the next chat turn carries lightweight current-preview context to the agent: active file, visible preview file, and hash when present. The persisted chat message stays unchanged; the extra context is only added to the model-bound history.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visible UI change. This only changes the context sent with a chat turn.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/preview-chat-context.test.ts`
- Did the test go red on `main` and green on this branch? no; this is stacked on #2836, because the preview location source does not exist on `main` yet.
- Additional verification: `FileViewer` regression tests confirm the preview component still renders after adding the location callback wiring.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web test tests/preview-chat-context.test.ts`
- `pnpm --filter @open-design/web test tests/components/FileViewer.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`

Related: #2836
