### PR TITLE
Make share deploys visibly complete

### DIFF
--- a/apps/daemon/src/deploy-routes.ts
+++ b/apps/daemon/src/deploy-routes.ts
@@ -89,7 +89,7 @@ export function registerDeployRoutes(app: Express, ctx: RegisterDeployRoutesDeps
         PROJECTS_DIR,
         req.params.id,
         fileName,
-        { metadata: deployProject?.metadata },
+        { metadata: deployProject?.metadata, includeProjectFiles: true },
       );
       const project = getProject(db, req.params.id);
       const cloudflarePagesProjectName =
@@ -171,7 +171,7 @@ export function registerDeployRoutes(app: Express, ctx: RegisterDeployRoutesDeps
         PROJECTS_DIR,
         req.params.id,
         fileName,
-        { metadata: preflightProject?.metadata, providerId },
+        { metadata: preflightProject?.metadata, providerId, includeProjectFiles: true },
       );
       res.json(body);
     } catch (err: any) {

--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { hash as blake3Hash } from 'blake3-wasm';
-import { readProjectFile, validateProjectPath } from './projects.js';
+import { listFiles, readProjectFile, validateProjectPath } from './projects.js';
 
 export const VERCEL_PROVIDER_ID = 'vercel-self';
 export const CLOUDFLARE_PAGES_PROVIDER_ID = 'cloudflare-pages';
@@ -29,7 +29,12 @@ type CloudflarePagesConfigHints = {
 };
 type DeployFile = { file: string; data: Buffer | Uint8Array | string; contentType?: string; sourcePath?: string };
 type DeployFilePlan = { entryPath: string; html: string; files: DeployFile[]; missing: string[]; invalid: string[] };
-type DeployOptions = { metadata?: unknown; hookScriptUrl?: string; providerId?: DeployProviderId };
+type DeployOptions = {
+  metadata?: unknown;
+  hookScriptUrl?: string;
+  providerId?: DeployProviderId;
+  includeProjectFiles?: boolean;
+};
 type CloudflarePagesDeploySelection = { zoneId: string; zoneName: string; domainPrefix: string; hostname: string };
 type CloudflareDnsRecord = JsonObject & { id?: string; type?: string; name?: string; content?: string; comment?: string };
 type DeployLinkStatus = 'ready' | 'protected' | 'failed' | 'link-delayed';
@@ -318,6 +323,14 @@ export async function buildDeployFilePlan(projectsRoot: string, projectId: strin
     }
   }
 
+  if (options.includeProjectFiles) {
+    await addVisibleProjectFilesToDeployPlan(files, {
+      projectsRoot,
+      projectId,
+      metadata: options.metadata,
+    });
+  }
+
   return {
     entryPath,
     html,
@@ -339,6 +352,37 @@ export async function buildDeployFileSet(projectsRoot: string, projectId: string
     });
   }
   return plan.files;
+}
+
+async function addVisibleProjectFilesToDeployPlan(
+  files: Map<string, DeployFile>,
+  input: { projectsRoot: string; projectId: string; metadata?: unknown },
+) {
+  if (isLinkedFolderProject(input.metadata)) return;
+  const projectFiles = await listFiles(input.projectsRoot, input.projectId, { metadata: input.metadata });
+  for (const item of projectFiles) {
+    if (!item?.name || files.has(item.name)) continue;
+    const safePath = validateProjectPath(item.name);
+    // The selected entry is already mapped to provider-root index.html. Keep
+    // the original root index reserved so choosing index-v1.html does not get
+    // overwritten by the old launcher at the same deploy path.
+    if (safePath === 'index.html') continue;
+    const projectFile = await readProjectFile(input.projectsRoot, input.projectId, safePath, input.metadata);
+    files.set(safePath, {
+      file: safePath,
+      data: projectFile.buffer,
+      contentType: projectFile.mime,
+      sourcePath: safePath,
+    });
+  }
+}
+
+function isLinkedFolderProject(metadata: unknown) {
+  return Boolean(
+    metadata
+      && typeof metadata === 'object'
+      && typeof (metadata as { baseDir?: unknown }).baseDir === 'string',
+  );
 }
 
 export async function deployToVercel({ config, files, projectId }: { config: DeployConfig; files: DeployFile[]; projectId: string }) {

--- a/apps/daemon/tests/deploy-routes.test.ts
+++ b/apps/daemon/tests/deploy-routes.test.ts
@@ -1,5 +1,5 @@
 import type http from 'node:http';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -677,6 +677,9 @@ describe('deploy provider routes', () => {
     const projectId = `vercel-payload-${Date.now()}`;
     const dir = await ensureProject(path.join(dataDir, 'projects'), projectId);
     await writeFile(path.join(dir, 'index.html'), '<!doctype html><h1>Hello</h1>');
+    await writeFile(path.join(dir, 'index-v1.html'), '<!doctype html><h1>V1</h1>');
+    await mkdir(path.join(dir, 'screens'), { recursive: true });
+    await writeFile(path.join(dir, 'screens', 'k1-waiting.html'), '<!doctype html><h1>K1</h1>');
     try {
       const createProjectResp = await fetch(`${baseUrl}/api/projects`, {
         method: 'POST',
@@ -714,6 +717,11 @@ describe('deploy provider routes', () => {
           const body = JSON.parse(String(init?.body ?? '{}'));
           expect(body).not.toHaveProperty('cloudflarePages');
           expect(JSON.stringify(body)).not.toContain('example.com');
+          expect(body.files.map((item: { file: string }) => item.file).sort()).toEqual([
+            'index-v1.html',
+            'index.html',
+            'screens/k1-waiting.html',
+          ]);
           return new Response(JSON.stringify({
             id: 'vercel-dep-1',
             readyState: 'READY',

--- a/apps/daemon/tests/deploy.test.ts
+++ b/apps/daemon/tests/deploy.test.ts
@@ -235,6 +235,51 @@ describe('deploy file set', () => {
     expect(files.map((f) => f.file)).toEqual(['index.html']);
   });
 
+  it('can include all visible project files while keeping the selected entry at index.html', async () => {
+    const { projectsRoot, projectId, dir } = await setupProject();
+    await mkdir(path.join(dir, 'screens'), { recursive: true });
+    await writeFile(path.join(dir, 'index.html'), '<!doctype html><h1>Launcher</h1>');
+    await writeFile(path.join(dir, 'index-v1.html'), '<!doctype html><h1>V1</h1>');
+    await writeFile(path.join(dir, 'screens', 'k1-waiting.html'), '<!doctype html><h1>K1</h1>');
+    await writeFile(path.join(dir, 'index-v1.html.artifact.json'), '{}');
+
+    const files = await buildDeployFileSet(projectsRoot, projectId, 'index-v1.html', {
+      includeProjectFiles: true,
+    });
+    const index = files.find((item) => item.file === 'index.html');
+
+    expect(files.map((f) => f.file).sort()).toEqual([
+      'index-v1.html',
+      'index.html',
+      'screens/k1-waiting.html',
+    ]);
+    expect(index?.sourcePath).toBe('index-v1.html');
+    expect(index?.data.toString('utf8')).toContain('V1');
+  });
+
+  it('does not publish unreferenced files from linked-folder projects', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'od-deploy-linked-test-'));
+    const projectsRoot = path.join(root, 'projects');
+    const linkedDir = path.join(root, 'linked');
+    const projectId = 'linked-p1';
+    const metadata = { baseDir: linkedDir };
+    await mkdir(path.join(linkedDir, 'src'), { recursive: true });
+    await writeFile(path.join(linkedDir, 'index.html'), '<!doctype html><link rel="stylesheet" href="style.css"><h1>Linked</h1>');
+    await writeFile(path.join(linkedDir, 'style.css'), 'body { color: black; }');
+    await writeFile(path.join(linkedDir, 'README.md'), '# Private notes');
+    await writeFile(path.join(linkedDir, 'src', 'app.ts'), 'export const secret = true;');
+
+    const files = await buildDeployFileSet(projectsRoot, projectId, 'index.html', {
+      metadata,
+      includeProjectFiles: true,
+    });
+
+    expect(files.map((f) => f.file).sort()).toEqual([
+      'index.html',
+      'style.css',
+    ]);
+  });
+
   it('injects a closeable deploy hook script from cdn when configured', async () => {
     const { projectsRoot, projectId, dir } = await setupProject();
     await writeFile(path.join(dir, 'page.html'), '<!doctype html><body><h1>Hello</h1></body>');

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3896,6 +3896,7 @@ function HtmlViewer({
   const [sendingBoardBatch, setSendingBoardBatch] = useState(false);
   const [commentSavedToast, setCommentSavedToast] = useState<string | null>(null);
   const [templateSavedToast, setTemplateSavedToast] = useState<string | null>(null);
+  const [deploySavedToast, setDeploySavedToast] = useState<{ message: string; details: string } | null>(null);
   const [selectedSideCommentIds, setSelectedSideCommentIds] = useState<Set<string>>(() => new Set());
   const [commentSidePanelCollapsed, setCommentSidePanelCollapsed] = useState(false);
   const [strokePoints, setStrokePoints] = useState<StrokePoint[]>([]);
@@ -5484,6 +5485,15 @@ function HtmlViewer({
       }));
       setDeployment(next);
       setDeployResult(next);
+      if (deployResultState(next.status) !== 'failed') {
+        setDeploySavedToast({
+          message: t('fileViewer.deploySuccessToast'),
+          details: t('fileViewer.deploySuccessToastDetails', {
+            provider: deployProviderLabel,
+            url: next.url,
+          }),
+        });
+      }
     } catch (err) {
       const option = getDeployProviderOption(deployProviderId);
       setDeployError(
@@ -5728,7 +5738,7 @@ function HtmlViewer({
       ? t('fileViewer.deployingToProvider', { provider: deployProviderLabel })
       : deployPhase === 'preparing-link'
         ? t('fileViewer.preparingPublicLink')
-        : t('fileViewer.deployToProvider', { provider: deployProviderLabel });
+        : deployActionLabelFor(deployProviderId);
   const copyDeployLabel = (url: string) =>
     copiedDeployLink === url.trim()
       ? t('fileViewer.copied')
@@ -6967,6 +6977,11 @@ function HtmlViewer({
               )}
               <p className="hint">{t(deployProvider.previewHintKey)}</p>
               {deployError ? <p className="deploy-error">{deployError}</p> : null}
+              {!deployError && deployPhase === 'idle' && deployResultCards.length > 0 ? (
+                <p className="hint" role="status">
+                  {t('fileViewer.deployLinkReady')} · {t('fileViewer.deployResultLabel')}
+                </p>
+              ) : null}
               {deployResultCards.length > 0 ? (
                 <div className={`deploy-result-block ${deployResultState(activeDeployment?.status)}`}>
                   <div className="deploy-result-summary">
@@ -7068,6 +7083,16 @@ function HtmlViewer({
             </div>
           </div>
         </div>
+      ) : null}
+      {deploySavedToast ? (
+        <Toast
+          message={deploySavedToast.message}
+          details={deploySavedToast.details}
+          tone="success"
+          placement="top"
+          ttlMs={3600}
+          onDismiss={() => setDeploySavedToast(null)}
+        />
       ) : null}
     </div>
   );

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -6977,7 +6977,10 @@ function HtmlViewer({
               )}
               <p className="hint">{t(deployProvider.previewHintKey)}</p>
               {deployError ? <p className="deploy-error">{deployError}</p> : null}
-              {!deployError && deployPhase === 'idle' && deployResultCards.length > 0 ? (
+              {!deployError
+                && deployPhase === 'idle'
+                && deployResultCards.length > 0
+                && deployResultState(activeDeployment?.status) === 'ready' ? (
                 <p className="hint" role="status">
                   {t('fileViewer.deployLinkReady')} · {t('fileViewer.deployResultLabel')}
                 </p>

--- a/apps/web/src/components/Toast.tsx
+++ b/apps/web/src/components/Toast.tsx
@@ -27,11 +27,13 @@ export interface ToastProps {
   /** ARIA role. Use "alert" for error messages (announced immediately),
    *  "status" (default) for non-urgent confirmations. */
   role?: 'status' | 'alert';
+  tone?: 'default' | 'success';
+  placement?: 'bottom' | 'top';
 }
 
 const DEFAULT_TTL = 4000;
 
-export function Toast({ message, details, code, ttlMs = DEFAULT_TTL, onDismiss, role = 'status' }: ToastProps) {
+export function Toast({ message, details, code, ttlMs = DEFAULT_TTL, onDismiss, role = 'status', tone = 'default', placement = 'bottom' }: ToastProps) {
   // When code is present the toast is a manual-action surface; never
   // auto-dismiss it out from under the user mid-copy.
   const effectiveTtl = code ? 0 : ttlMs;
@@ -45,7 +47,11 @@ export function Toast({ message, details, code, ttlMs = DEFAULT_TTL, onDismiss, 
   }, [message, details, code, effectiveTtl, onDismiss]);
 
   return (
-    <div className="od-toast" role={role} aria-live={role === 'alert' ? 'assertive' : 'polite'}>
+    <div
+      className={`od-toast tone-${tone} placement-${placement}`}
+      role={role}
+      aria-live={role === 'alert' ? 'assertive' : 'polite'}
+    >
       <div className="od-toast-message">{message}</div>
       {details ? <div className="od-toast-details">{details}</div> : null}
       {code ? (

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1121,6 +1121,8 @@ export const ar: Dict = {
   'fileViewer.deployProviderFailed': 'فشل النشر إلى {provider}. تحقق من الإعدادات وحاول مرة أخرى.',
   'fileViewer.deployResultLabel': 'رابط النشر',
   'fileViewer.deployLinkReady': 'جاهز',
+  'fileViewer.deploySuccessToast': 'تم رفع النشر بنجاح',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'الرابط العام معلق',
   'fileViewer.deployLinkDelayed': 'تم نشر الموقع، لكن الرابط العام ما زال قيد التحضير.',
   'fileViewer.deployLinkFailed': 'فشل النطاق المخصص',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1009,6 +1009,8 @@ export const de: Dict = {
   'fileViewer.deployProviderFailed': '{provider}-Deployment fehlgeschlagen. Prüfe die Einstellungen und versuche es erneut.',
   'fileViewer.deployResultLabel': 'Deployment-URL',
   'fileViewer.deployLinkReady': 'Bereit',
+  'fileViewer.deploySuccessToast': 'Deployment erfolgreich hochgeladen',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Öffentlicher Link ausstehend',
   'fileViewer.deployLinkDelayed': 'Die Seite wurde deployt. Der Anbieter bereitet den öffentlichen Link noch vor.',
   'fileViewer.deployLinkFailed': 'Benutzerdefinierte Domain fehlgeschlagen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1795,6 +1795,8 @@ export const en: Dict = {
   'fileViewer.deployProviderFailed': '{provider} deploy failed. Check settings and try again.',
   'fileViewer.deployResultLabel': 'Deployed URL',
   'fileViewer.deployLinkReady': 'Ready',
+  'fileViewer.deploySuccessToast': 'Deployment uploaded successfully',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Public link pending',
   'fileViewer.deployLinkDelayed': 'Your site is deployed. The public link is still being prepared.',
   'fileViewer.deployLinkFailed': 'Custom domain failed',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1010,6 +1010,8 @@ export const esES: Dict = {
   'fileViewer.deployProviderFailed': 'El despliegue en {provider} falló. Revisa la configuración e inténtalo de nuevo.',
   'fileViewer.deployResultLabel': 'URL desplegada',
   'fileViewer.deployLinkReady': 'Listo',
+  'fileViewer.deploySuccessToast': 'Despliegue subido correctamente',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Enlace público pendiente',
   'fileViewer.deployLinkDelayed': 'El sitio se ha desplegado. El proveedor aún está preparando el enlace público.',
   'fileViewer.deployLinkFailed': 'Falló el dominio personalizado',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1281,6 +1281,8 @@ export const fa: Dict = {
   'fileViewer.deployProviderFailed': 'استقرار روی {provider} ناموفق بود. تنظیمات را بررسی و دوباره تلاش کنید.',
   'fileViewer.deployResultLabel': 'URL مستقرشده',
   'fileViewer.deployLinkReady': 'آماده',
+  'fileViewer.deploySuccessToast': 'استقرار با موفقیت آپلود شد',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'لینک عمومی در انتظار است',
   'fileViewer.deployLinkDelayed': 'سایت مستقر شده است. ارائه‌دهنده هنوز لینک عمومی را آماده می‌کند.',
   'fileViewer.deployLinkFailed': 'دامنه سفارشی ناموفق بود',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1137,6 +1137,8 @@ export const fr: Dict = {
   'fileViewer.deployProviderFailed': 'Échec du déploiement {provider}. Vérifiez les réglages et réessayez.',
   'fileViewer.deployResultLabel': 'URL déployée',
   'fileViewer.deployLinkReady': 'Prêt',
+  'fileViewer.deploySuccessToast': 'Déploiement téléversé avec succès',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Lien public en attente',
   'fileViewer.deployLinkDelayed': 'Le site est déployé. Le fournisseur prépare encore le lien public.',
   'fileViewer.deployLinkFailed': 'Le domaine personnalisé a échoué',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1121,6 +1121,8 @@ export const hu: Dict = {
   'fileViewer.deployProviderFailed': 'A {provider} telepítés sikertelen. Ellenőrizd a beállításokat, és próbáld újra.',
   'fileViewer.deployResultLabel': 'Telepített URL',
   'fileViewer.deployLinkReady': 'Kész',
+  'fileViewer.deploySuccessToast': 'A telepítés sikeresen feltöltve',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Nyilvános link várólistán',
   'fileViewer.deployLinkDelayed': 'A webhely telepítve van. A szolgáltató még készíti a nyilvános linket.',
   'fileViewer.deployLinkFailed': 'Az egyéni domain sikertelen',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1271,6 +1271,8 @@ export const id: Dict = {
   'fileViewer.deployFailed': 'Deploy gagal.',
   'fileViewer.deployResultLabel': 'Hasil deploy',
   'fileViewer.deployLinkReady': 'Siap',
+  'fileViewer.deploySuccessToast': 'Deploy berhasil diunggah',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Link deploy sedang disiapkan',
   'fileViewer.deployLinkDelayed': 'Link publik belum siap. Coba lagi sebentar lagi.',
   'fileViewer.deployLinkFailed': 'Domain kustom gagal',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1027,6 +1027,8 @@ export const it: Dict = {
   'fileViewer.deployProviderFailed': 'Distribuzione {provider} fallita. Controlla le impostazioni e riprova.',
   'fileViewer.deployResultLabel': 'URL distribuito',
   'fileViewer.deployLinkReady': 'Pronto',
+  'fileViewer.deploySuccessToast': 'Distribuzione caricata correttamente',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Link pubblico in attesa',
   'fileViewer.deployLinkDelayed': 'Il sito è distribuito. Il provider sta ancora preparando il link pubblico.',
   'fileViewer.deployLinkFailed': 'Il dominio personalizzato è fallito',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1008,6 +1008,8 @@ export const ja: Dict = {
   'fileViewer.deployProviderFailed': '{provider} のデプロイに失敗しました。設定を確認して再試行してください。',
   'fileViewer.deployResultLabel': 'デプロイ URL',
   'fileViewer.deployLinkReady': '準備完了',
+  'fileViewer.deploySuccessToast': 'デプロイを正常にアップロードしました',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': '公開リンク準備中',
   'fileViewer.deployLinkDelayed': 'サイトはデプロイされました。プロバイダーが公開リンクを準備中です。',
   'fileViewer.deployLinkFailed': 'カスタムドメインに失敗しました',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1121,6 +1121,8 @@ export const ko: Dict = {
   'fileViewer.deployProviderFailed': '{provider} 배포에 실패했습니다. 설정을 확인하고 다시 시도해 주세요.',
   'fileViewer.deployResultLabel': '배포된 URL',
   'fileViewer.deployLinkReady': '준비됨',
+  'fileViewer.deploySuccessToast': '배포가 정상적으로 업로드되었습니다',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': '공개 링크 보류 중',
   'fileViewer.deployLinkDelayed': '사이트가 배포되었습니다. 플랫폼에서 공개 링크를 아직 준비 중입니다.',
   'fileViewer.deployLinkFailed': '사용자 지정 도메인 실패',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1121,6 +1121,8 @@ export const pl: Dict = {
   'fileViewer.deployProviderFailed': 'Wdrożenie na {provider} nie powiodło się. Sprawdź ustawienia i spróbuj ponownie.',
   'fileViewer.deployResultLabel': 'Wdrożony URL',
   'fileViewer.deployLinkReady': 'Gotowe',
+  'fileViewer.deploySuccessToast': 'Wdrożenie przesłane pomyślnie',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Oczekiwanie na link publiczny',
   'fileViewer.deployLinkDelayed': 'Strona została wdrożona. Dostawca wciąż przygotowuje publiczny link.',
   'fileViewer.deployLinkFailed': 'Domena niestandardowa nie powiodła się',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1162,6 +1162,8 @@ export const ptBR: Dict = {
   'fileViewer.deployProviderFailed': 'A implantação em {provider} falhou. Verifique as configurações e tente novamente.',
   'fileViewer.deployResultLabel': 'URL implantada',
   'fileViewer.deployLinkReady': 'Pronto',
+  'fileViewer.deploySuccessToast': 'Implantação enviada com sucesso',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Link público pendente',
   'fileViewer.deployLinkDelayed': 'Seu site foi implantado. O provedor ainda está preparando o link público.',
   'fileViewer.deployLinkFailed': 'Falha no domínio personalizado',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1162,6 +1162,8 @@ export const ru: Dict = {
   'fileViewer.deployProviderFailed': 'Развёртывание на {provider} не удалось. Проверьте настройки и попробуйте снова.',
   'fileViewer.deployResultLabel': 'URL развёрнутого сайта',
   'fileViewer.deployLinkReady': 'Готово',
+  'fileViewer.deploySuccessToast': 'Развёртывание успешно загружено',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Публичная ссылка готовится',
   'fileViewer.deployLinkDelayed': 'Сайт развёрнут. Провайдер всё ещё готовит публичную ссылку.',
   'fileViewer.deployLinkFailed': 'Пользовательский домен не настроен',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1085,6 +1085,8 @@ export const th: Dict = {
   'fileViewer.deployProviderFailed': 'โฮสต์ไม่ติดสำหรับตัวผู้ดำเนินการ {provider} เช็คการควบคุมดูอีกรอบก่อนเถอะ',
   'fileViewer.deployResultLabel': 'ที่อยู่แบบ URL ซึ่งอัพลง',
   'fileViewer.deployLinkReady': 'ลุยได้ทันที',
+  'fileViewer.deploySuccessToast': 'อัปโหลดการ Deploy สำเร็จแล้ว',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'เตรียมออกสู่หน้าผู้คนข้างนอก',
   'fileViewer.deployLinkDelayed': 'ตัวเว็บนั้นเข้าใช้งานได้แต่ความพร้อมยังถูกแช่ไว้บ้างอยู่',
   'fileViewer.deployLinkFailed': 'โดเมนส่วนตัวที่พยายามมีอยู่ดันไม่เชื่อมกัน',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1108,6 +1108,8 @@ export const tr: Dict = {
   'fileViewer.deployProviderFailed': '{provider} yayını başarısız oldu. Ayarları kontrol edip yeniden deneyin.',
   'fileViewer.deployResultLabel': 'Yayınlanmış URL',
   'fileViewer.deployLinkReady': 'Hazır',
+  'fileViewer.deploySuccessToast': 'Yayın başarıyla yüklendi',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Herkese açık link bekleniyor',
   'fileViewer.deployLinkDelayed': 'Site yayınlandı. Sağlayıcı herkese açık bağlantıyı hâlâ hazırlıyor.',
   'fileViewer.deployLinkFailed': 'Özel alan adı başarısız',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1163,6 +1163,8 @@ export const uk: Dict = {
   'fileViewer.deployProviderFailed': 'Розгортання на {provider} не вдалося. Перевірте налаштування й спробуйте ще раз.',
   'fileViewer.deployResultLabel': 'URL розгортання',
   'fileViewer.deployLinkReady': 'Готово',
+  'fileViewer.deploySuccessToast': 'Розгортання успішно завантажено',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': 'Публічне посилання очікує',
   'fileViewer.deployLinkDelayed': 'Сайт розгорнуто. Провайдер ще готує публічне посилання.',
   'fileViewer.deployLinkFailed': 'Не вдалося налаштувати власний домен',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1762,6 +1762,8 @@ export const zhCN: Dict = {
   'fileViewer.deployProviderFailed': '{provider} 部署失败。请检查设置后重试。',
   'fileViewer.deployResultLabel': '部署链接',
   'fileViewer.deployLinkReady': '已就绪',
+  'fileViewer.deploySuccessToast': '部署已成功上传',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': '公开链接准备中',
   'fileViewer.deployLinkDelayed': '站点已经部署，平台仍在准备公开链接。',
   'fileViewer.deployLinkFailed': '自定义域名失败',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1328,6 +1328,8 @@ export const zhTW: Dict = {
   'fileViewer.deployProviderFailed': '{provider} 部署失敗。請檢查設定後重試。',
   'fileViewer.deployResultLabel': '部署連結',
   'fileViewer.deployLinkReady': '已就緒',
+  'fileViewer.deploySuccessToast': '部署已成功上傳',
+  'fileViewer.deploySuccessToastDetails': '{provider} · {url}',
   'fileViewer.deployLinkPreparingLabel': '公開連結準備中',
   'fileViewer.deployLinkDelayed': '站點已部署，平台仍在準備公開連結。',
   'fileViewer.deployLinkFailed': '自訂網域失敗',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2101,6 +2101,8 @@ export interface Dict {
   'fileViewer.deployProviderFailed': string;
   'fileViewer.deployResultLabel': string;
   'fileViewer.deployLinkReady': string;
+  'fileViewer.deploySuccessToast': string;
+  'fileViewer.deploySuccessToastDetails': string;
   'fileViewer.deployLinkPreparingLabel': string;
   'fileViewer.deployLinkDelayed': string;
   'fileViewer.deployLinkFailed': string;

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -117,6 +117,18 @@
   z-index: 1000;
   pointer-events: auto;
 }
+.od-toast.placement-top {
+  top: 24px;
+  bottom: auto;
+}
+.od-toast.tone-success {
+  border: 1px solid color-mix(in srgb, var(--success, #2da44e) 42%, var(--border));
+  background: color-mix(in srgb, var(--success, #2da44e) 14%, var(--bg));
+  color: var(--text);
+  box-shadow:
+    0 4px 14px rgba(0, 0, 0, 0.14),
+    0 0 0 1px color-mix(in srgb, var(--success, #2da44e) 12%, transparent);
+}
 .od-toast-message {
   font-weight: 500;
 }

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1195,6 +1195,12 @@ describe('FileViewer SVG artifacts', () => {
     expect(pagesDevLabel.closest('.deploy-result-block')).toBe(customDomainLabel.closest('.deploy-result-block'));
     expect(screen.getByText('https://demo-pages.pages.dev')).toBeTruthy();
     expect(screen.getByText('https://demo.example.com')).toBeTruthy();
+    const deployToast = document.querySelector('.od-toast');
+    expect(deployToast?.className).toContain('tone-success');
+    expect(deployToast?.className).toContain('placement-top');
+    expect(deployToast?.textContent).toContain('Deployment uploaded successfully');
+    expect(deployToast?.textContent).toContain('Cloudflare Pages');
+    expect(deployToast?.textContent).toContain('https://demo-pages.pages.dev');
     expect(deployBody).toMatchObject({
       fileName: 'index.html',
       providerId: 'cloudflare-pages',


### PR DESCRIPTION
## Why

Share deploys were confusing in two ways:

- Multi-page HTML projects could deploy the selected entry but miss sibling files, so routes like `/screens/kiosk/k1-waiting.html` could resolve to the provider fallback instead of the intended screen.
- A successful deploy/redeploy only updated the result link inside the deploy dialog. The primary button disabled during upload, then returned to idle without a clear success confirmation.

This PR makes Share deployment behave like a full project upload and gives users an explicit localized success confirmation.

## What users will see

When users deploy from Share to Vercel or Cloudflare Pages, OD now uploads the selected root entry plus the visible project files, so sub-pages remain directly reachable after deployment. After a successful upload, a top-center green success toast says the deployment uploaded successfully and shows the provider plus URL.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No screenshot attached. The UI change is a transient toast after the deploy request succeeds; it is covered by the FileViewer component test.

## Bug fix verification

- Test path that reproduces the deploy payload bug: `apps/daemon/tests/deploy.test.ts`
- Route payload coverage: `apps/daemon/tests/deploy-routes.test.ts`
- UI success feedback coverage: `apps/web/tests/components/FileViewer.test.tsx`
- Did the test go red on `main` and green on this branch? The new tests encode the missing behavior and pass on this branch.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/daemon test tests/deploy.test.ts tests/deploy-routes.test.ts`
- `pnpm --filter @open-design/web test tests/components/FileViewer.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
