### PR TITLE
fix(web): live-update preview during Comment mode

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4062,11 +4062,23 @@ function HtmlViewer({
       sourceRef.current = null;
     }
     let cancelled = false;
-    void fetchProjectFileText(projectId, file.name).then((text) => {
-      if (!cancelled) {
-        setSource(text);
-        sourceRef.current = text;
-      }
+    // Cache-bust the fetch on every mtime / reload / files-refresh bump.
+    // Without this, an agent edit during Comment mode (srcDoc path) gets
+    // stale HTML from the browser HTTP cache — the source state ends up
+    // identical to the previous value, srcDoc is byte-equal to the last
+    // activated HTML, canActivateSrcDocTransport bails on the dedupe
+    // check, and the preview only refreshes when Comment closes and the
+    // url-load iframe takes over with its own ?v=mtime cache-bust.
+    void fetchProjectFileText(projectId, file.name, {
+      cacheBustKey: `${file.mtime}-${reloadKey}-${filesRefreshKey}`,
+    }).then((text) => {
+      if (cancelled) return;
+      // Chokidar emits agent rewrites as unlink+add+change bursts; a
+      // transient null mid-burst would blank source → srcDoc empty →
+      // shell stays on prior frame. Keep the last good text instead.
+      if (text == null) return;
+      setSource(text);
+      sourceRef.current = text;
     });
     return () => {
       cancelled = true;
@@ -4265,12 +4277,30 @@ function HtmlViewer({
       shellReady: srcDocShellReady,
       activatedHtml: activatedSrcDocTransportHtmlRef.current,
     })) return false;
+    // A SECOND activation while Comment mode is on would document.open +
+    // write over the iframe's existing document. The window-level message
+    // listener survives, but iframe.onLoad does NOT refire for
+    // document.write, so host-side re-init (slide nav sync, scroll
+    // restore, bridge replay) is silently skipped — the visible page can
+    // drift out of sync with the host's tracked state (e.g. the page
+    // indicator shows 3 while the iframe rendered page 4 of the freshly
+    // edited deck). Force a fresh shell mount under Comment so onLoad
+    // fires and the full re-init pipeline runs against the new HTML.
+    //
+    // Skip the remount path in Manual Edit, where the postMessage
+    // activate carries the patched HTML and host-side scroll/slide
+    // state intentionally stays put across the patch.
+    if (boardMode && activatedSrcDocTransportHtmlRef.current !== null) {
+      activatedSrcDocTransportHtmlRef.current = null;
+      setSrcDocTransportResetKey((key) => key + 1);
+      return true;
+    }
     const win = target?.contentWindow;
     if (!win) return false;
     win.postMessage({ type: 'od:srcdoc-transport-activate', html: srcDoc }, '*');
     activatedSrcDocTransportHtmlRef.current = srcDoc;
     return true;
-  }, [srcDoc, useLazySrcDocTransport, useUrlLoadPreview, srcDocShellReady]);
+  }, [srcDoc, useLazySrcDocTransport, useUrlLoadPreview, srcDocShellReady, boardMode]);
   useEffect(() => {
     if (useUrlLoadPreview) {
       activatedSrcDocTransportHtmlRef.current = null;

--- a/apps/web/tests/components/FileViewer.manual-edit.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit.test.tsx
@@ -114,7 +114,12 @@ describe('FileViewer manual edit regressions', () => {
       const second = { ...htmlPreviewFile(), name: 'second.html', path: 'second.html' };
       const { rerender } = render(<FileViewer projectId="project-1" projectKind="prototype" file={first} />);
 
-      await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/projects/project-1/raw/preview.html', {}));
+      // The raw fetch is cache-busted on every mtime / reload / files-refresh
+      // bump so srcDoc-mode previews see fresh HTML after agent edits.
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/api\/projects\/project-1\/raw\/preview\.html(\?|$)/),
+        {},
+      ));
       fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
       const baseSizeInput = await waitFor(() => {
         const input = Array.from(document.querySelectorAll('.cc-row'))


### PR DESCRIPTION
## Why

While Comment mode is on, asking the agent to change preview text appears to do nothing visually — the preview only updates once Comment is toggled off. On multi-page decks the same flow can leave the iframe visibly on a different page than the bottom page indicator claims (e.g. indicator says `3` but the iframe is showing page 4 of the freshly edited deck).

The cause is three small interactions in `FileViewer`:

1. The raw HTML fetch for the preview source uses no cache-bust hint, so an agent rewrite returns stale bytes from the browser HTTP cache.
2. With stale bytes, the new `srcDoc` ends up byte-equal to the last activated HTML, so `canActivateSrcDocTransport` bails on its dedupe check.
3. Even when `srcDoc` does change, the second activation document.opens / writes over the iframe in place; `iframe.onLoad` does not refire for `document.write`, so the host-side re-init pipeline (slide nav sync, scroll restore, bridge replay) is silently skipped and the visible page drifts out of sync with the host's tracked state.

When the user toggles Comment off, the url-load iframe takes over with its own `?v=mtime` cache-bust and remounts cleanly, which is why the preview only "catches up" at that moment.

## What users will see

In Comment mode, an agent edit now reflects in the preview immediately — no need to toggle Comment off to see the change. On multi-page deck-style prototypes, the bottom page indicator stays in sync with the iframe's actual rendered page after agent edits.

## How it works

- Cache-bust the raw fetch on every `file.mtime` / `reloadKey` / `filesRefreshKey` bump (`fetchProjectFileText` already supports `cacheBustKey`).
- Ignore a null fetch response — chokidar emits agent rewrites as an unlink+add+change burst, and the transient null mid-burst would otherwise blank source → empty srcDoc → blank shell. Keep the last good frame until valid HTML arrives.
- On the second activation while Comment mode is on, force a fresh shell mount (bump `srcDocTransportResetKey`) instead of postMessage document.write, so `iframe.onLoad` fires and the full re-init pipeline runs against the new HTML. Manual Edit keeps the existing postMessage activate path (its patched HTML must not lose host-side scroll/slide state across each patch).

## Surface area

- [x] Web UI (`apps/web/src/components/FileViewer.tsx`)
- [x] Tests (`apps/web/tests/components/FileViewer.manual-edit.test.tsx` — adjusted the existing raw-URL assertion to match the new `?cacheBust=…` suffix)

No CLI, no daemon, no contract, no i18n, no new deps.

## Validation

```
pnpm --filter @open-design/web exec vitest run tests/components/FileViewer
# Test Files  3 passed (3)
# Tests  101 passed (101)
```

Manually verified end-to-end in the local dev runtime: opened a multi-page prototype, navigated to a sub-page, toggled Comment on, asked the agent to change a heading. Before: preview did not update until Comment was toggled off, and on deck-style multi-page it visibly skipped to a different page than the bottom indicator. After: preview updates immediately on the same page, indicator stays in sync.