### PR TITLE
fix(pack): bundle download and host packages in Linux AppImage assembly

### DIFF
--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -45,12 +45,14 @@ const CONTAINER_PNPM_HOME = "/tmp/pnpm-home";
 const CONTAINER_NODE_VERSION = "24.14.1";
 const CONTAINER_TOOLS_PACK_CLI_PATH = "tools/pack/bin/tools-pack.mjs";
 
-const INTERNAL_PACKAGES = [
+export const INTERNAL_PACKAGES = [
   { directory: "packages/contracts", name: "@open-design/contracts" },
   { directory: "packages/registry-protocol", name: "@open-design/registry-protocol" },
   { directory: "packages/sidecar-proto", name: "@open-design/sidecar-proto" },
   { directory: "packages/sidecar", name: "@open-design/sidecar" },
   { directory: "packages/platform", name: "@open-design/platform" },
+  { directory: "packages/download", name: "@open-design/download" },
+  { directory: "packages/host", name: "@open-design/host" },
   { directory: "packages/agui-adapter", name: "@open-design/agui-adapter" },
   { directory: "packages/plugin-runtime", name: "@open-design/plugin-runtime" },
   { directory: "packages/diagnostics", name: "@open-design/diagnostics" },
@@ -371,6 +373,8 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
   await runPnpm(config, ["--filter", "@open-design/sidecar-proto", "build"]);
   await runPnpm(config, ["--filter", "@open-design/sidecar", "build"]);
   await runPnpm(config, ["--filter", "@open-design/platform", "build"]);
+  await runPnpm(config, ["--filter", "@open-design/host", "build"]);
+  await runPnpm(config, ["--filter", "@open-design/download", "build"]);
   await runPnpm(config, ["--filter", "@open-design/agui-adapter", "build"]);
   await runPnpm(config, ["--filter", "@open-design/plugin-runtime", "build"]);
   await runPnpm(config, ["--filter", "@open-design/diagnostics", "build"]);

--- a/tools/pack/tests/internal-packages-closure.test.ts
+++ b/tools/pack/tests/internal-packages-closure.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { INTERNAL_PACKAGES as LINUX_INTERNAL_PACKAGES } from "../src/linux.js";
+import { INTERNAL_PACKAGES as MAC_INTERNAL_PACKAGES } from "../src/mac/constants.js";
+import { shouldInstallInternalPackageForMacPrebundle } from "../src/mac-prebundle.js";
+import { INTERNAL_PACKAGES as WIN_INTERNAL_PACKAGES } from "../src/win/constants.js";
+import { shouldInstallInternalPackageForWinPrebundle } from "../src/win-prebundle.js";
+
+const workspaceRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+type PackageEntry = { readonly directory: string; readonly name: string };
+
+function runtimeWorkspaceDeps(directory: string): string[] {
+  const manifest = JSON.parse(
+    readFileSync(join(workspaceRoot, directory, "package.json"), "utf8"),
+  ) as { dependencies?: Record<string, string> };
+  return Object.keys(manifest.dependencies ?? {}).filter((dep) => dep.startsWith("@open-design/"));
+}
+
+// Each pack lane assembles its packaged app by `pnpm pack`-ing a subset of
+// INTERNAL_PACKAGES into tarballs, wiring them as `file:` dependencies, and
+// running an npm/pnpm install in the isolated app directory. `pnpm pack`
+// rewrites every `workspace:*` ref to a concrete version, so the install
+// resolves each tarball's runtime `@open-design/*` dependencies. Any such
+// dependency that is NOT also installed as a local tarball is fetched from the
+// public npm registry and 404s — these packages are workspace-only and never
+// published.
+//
+// The invariant: the set a lane actually installs must be closed under its
+// runtime `@open-design/*` dependencies.
+//
+// The lanes diverge by web output mode:
+//   - linux ships "server" mode and tarball-installs every INTERNAL_PACKAGES
+//     entry, including @open-design/desktop and @open-design/web — so it must
+//     also install their runtime deps (@open-design/download, @open-design/host).
+//   - mac/win default to "standalone", where desktop/web/packaged/daemon are
+//     prebundled with esbuild and excluded from the tarball install. The
+//     packages they do install have no download/host dependency, so those
+//     lanes correctly omit them. Adding download/host there would be dead
+//     weight and would drag in the shared workspace-build cache.
+const LANES: { name: string; packages: readonly PackageEntry[]; isInstalled: (pkg: PackageEntry) => boolean }[] = [
+  {
+    name: "linux",
+    packages: LINUX_INTERNAL_PACKAGES,
+    isInstalled: () => true,
+  },
+  {
+    name: "mac",
+    packages: MAC_INTERNAL_PACKAGES,
+    isInstalled: (pkg) =>
+      shouldInstallInternalPackageForMacPrebundle({ packageName: pkg.name, webOutputMode: "standalone" }),
+  },
+  {
+    name: "win",
+    packages: WIN_INTERNAL_PACKAGES,
+    isInstalled: (pkg) =>
+      shouldInstallInternalPackageForWinPrebundle({ packageName: pkg.name, webOutputMode: "standalone" }),
+  },
+];
+
+describe("pack lane INTERNAL_PACKAGES dependency closure", () => {
+  for (const lane of LANES) {
+    it(`${lane.name}: every installed package's runtime @open-design deps are installed`, () => {
+      const installed = lane.packages.filter((pkg) => lane.isInstalled(pkg));
+      const installedNames = new Set(installed.map((pkg) => pkg.name));
+      const missing: { dependency: string; dependent: string }[] = [];
+
+      for (const pkg of installed) {
+        for (const dependency of runtimeWorkspaceDeps(pkg.directory)) {
+          if (!installedNames.has(dependency)) {
+            missing.push({ dependency, dependent: pkg.name });
+          }
+        }
+      }
+
+      expect(missing).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
Fixes #728

## Why

`pnpm exec tools-pack linux build --to appimage` fails on `main` with a 404 from the public npm registry, so a Linux desktop AppImage cannot be produced from source. #728 (`help wanted`) explicitly asks contributors to run exactly this command on latest `main` and report whether the AppImage builds — this is the next blocker after #2276.

**Root cause.** The Linux path assembles `INTERNAL_PACKAGES` as `file:` tarballs and runs `npm install --omit=dev` in an isolated app directory. `pnpm pack` rewrites each tarball's `workspace:*` refs to a concrete version, so the install resolves each package's runtime `@open-design/*` deps. Any such dep not itself in `INTERNAL_PACKAGES` is fetched from the registry and 404s (these packages are workspace-only).

Linux ships `webOutputMode: "server"` and tarball-installs **every** `INTERNAL_PACKAGES` entry, including `@open-design/desktop` and `@open-design/web`. `@open-design/host` (dep of web + desktop, added in #2246) and `@open-design/download` (dep of desktop, added in #2677) landed after the Linux list was written and were never added:

```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@open-design%2fdownload
```

**Why this is Linux-only (scope rationale).** mac/win default to `webOutputMode: "standalone"`, where `desktop`/`web`/`packaged`/`daemon` are prebundled with esbuild and **excluded** from the tarball install (`shouldInstallInternalPackageFor{Mac,Win}Prebundle` → `MAC/WIN_STANDALONE_PREBUNDLE_EXCLUDED_INTERNAL_PACKAGES`). The packages mac/win *do* tarball-install (`contracts`, `registry-protocol`, `agui-adapter`, `plugin-runtime`, `diagnostics`) have **no** `download`/`host` dependency, so those lanes correctly omit them. This fix therefore stays scoped to `linux.ts` and touches **no** mac/win constants and **no** `workspace-build.ts` cache.

## What users will see

`pnpm exec tools-pack linux build --to appimage` completes and produces a working `Open Design-<namespace>.AppImage` from source on Linux. No change to packaged app behavior.

## Surface area

- [x] **None** — internal build tooling (`tools/pack`) + a regression test. No UI, API/contract, CLI flag, dependency, or default-behavior change.

## Screenshots

N/A — no UI change.

## Bug fix verification

- **Test:** `tools/pack/tests/internal-packages-closure.test.ts` — for each pack lane it derives the set the lane *actually installs* (honoring the standalone prebundle exclusion on mac/win) and asserts that set is **closed under its runtime `@open-design/*` dependencies**.
- **Red on `main`, green on branch?** **yes — and lane-precise.** Reverting the two `INTERNAL_PACKAGES` additions makes only the **linux** case fail, naming the missing edges, while **mac and win still pass**:
  ```
  × linux: every installed package's runtime @open-design deps are installed
    [ { dependency: '@open-design/host',     dependent: '@open-design/web' },
      { dependency: '@open-design/download', dependent: '@open-design/desktop' },
      { dependency: '@open-design/host',     dependent: '@open-design/desktop' } ]
  ✓ mac:  ...
  ✓ win:  ...
  ```
  This encodes *why* only Linux needs these packages and guards every lane against the next workspace dependency silently breaking its assembly.

## Validation

Native (non-containerized) build, Ubuntu / Node 24.15.0 / pnpm 10.33.2:

- `pnpm exec tools-pack linux build --to appimage` → produces `Open Design-default.AppImage` (~277 MB); assembled `node_modules/@open-design/` contains all 14 packages incl. `download` + `host`.
- Runtime smoke (headless, no display server): `tools-pack linux install --headless` + `start --headless` → packaged daemon + web boot, `GET /` and `GET /api/health` return **200**, `stop --headless` clean.
- Extracted AppImage contains the Electron binary, `resources/app`, and all `extraResources` + `open-design-config.json`.
- `pnpm --filter @open-design/tools-pack test` → **132 passed** (incl. the new closure test, all 3 lanes).
- `pnpm --filter @open-design/tools-pack typecheck` → clean. `pnpm guard` → pass.
