### PR TITLE
Capture native (Swift) source in the GitHub design import

### DIFF
--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -21,6 +21,7 @@ import {
 
 import { parseFrontmatter } from './frontmatter.js';
 import type { FrontmatterObject, FrontmatterValue } from './frontmatter.js';
+import { extractSwiftColors } from './swift-colors.js';
 
 export type DesignSystemSurface = 'web' | 'image' | 'video' | 'audio';
 export type DesignSystemSource = 'built-in' | 'installed' | 'user';
@@ -2840,6 +2841,11 @@ function extractSwatches(raw: string): string[] {
     );
     push(nameCell ?? '', hex);
   }
+  // Form D: SwiftUI Color(...) declarations (HSB / RGB / white), converted to
+  // hex. Swift repos define palette tokens in source rather than CSS, so a
+  // captured ColorSystem.swift or a DESIGN.md that quotes it would otherwise
+  // yield no swatches. Inline hex forms above still win in pickSwatchRow.
+  for (const token of extractSwiftColors(raw)) push(token.name, token.hex);
   if (colors.length === 0) return [];
   return pickSwatchRow(colors).values;
 }

--- a/apps/daemon/src/swift-colors.ts
+++ b/apps/daemon/src/swift-colors.ts
@@ -1,0 +1,122 @@
+// Parse SwiftUI Color(...) declarations into named hex swatches.
+//
+// SwiftUI repos express palette tokens in source rather than CSS, e.g.
+//   static let grey50 = Color(hue: 220 / 360, saturation: 0.02, brightness: 0.99)
+//   static let appShellLight = Color(red: 0xF4 / 255, green: 0xF4 / 255, blue: 0xF4 / 255)
+// so the design-system swatch extraction needs to read these forms and convert
+// them to hex. Component values can be plain decimals (0.99), hex bytes (0xF4),
+// or simple divisions (0xF4 / 255, 220 / 360).
+//
+// Note: Color(hue:saturation:brightness:) is HSB (brightness/value), not HSL,
+// so the conversion uses the HSV math.
+
+export interface SwiftColorToken {
+  name: string;
+  hex: string;
+}
+
+/**
+ * Evaluate a single SwiftUI color component expression: a hex byte (`0xF4`), a
+ * decimal (`0.99`), an integer (`255`), or a single division of those
+ * (`0xF4 / 255`, `220 / 360`). Returns null when the expression is anything
+ * more complex so callers can skip it rather than guess.
+ */
+export function evalSwiftNumber(expr: string): number | null {
+  const parts = expr.split('/');
+  if (parts.length > 2) return null;
+  const values = parts.map((part) => {
+    const token = part.trim();
+    if (/^0x[0-9a-f]+$/i.test(token)) return Number.parseInt(token, 16);
+    if (/^[+-]?(?:\d+\.?\d*|\.\d+)$/.test(token)) return Number.parseFloat(token);
+    return Number.NaN;
+  });
+  if (values.some((value) => Number.isNaN(value))) return null;
+  if (values.length === 1) return values[0]!;
+  if (values[1] === 0) return null;
+  return values[0]! / values[1]!;
+}
+
+function clampUnit(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function byteHex(unit: number): string {
+  return Math.round(clampUnit(unit) * 255)
+    .toString(16)
+    .padStart(2, '0');
+}
+
+/** Build #rrggbb from red/green/blue unit floats (0..1). */
+export function rgbUnitToHex(red: number, green: number, blue: number): string {
+  return `#${byteHex(red)}${byteHex(green)}${byteHex(blue)}`;
+}
+
+/** Convert HSB/HSV unit floats (0..1) to #rrggbb. */
+export function hsbToHex(hue: number, saturation: number, brightness: number): string {
+  const h = ((hue % 1) + 1) % 1;
+  const s = clampUnit(saturation);
+  const v = clampUnit(brightness);
+  const i = Math.floor(h * 6);
+  const f = h * 6 - i;
+  const p = v * (1 - s);
+  const q = v * (1 - f * s);
+  const t = v * (1 - (1 - f) * s);
+  let red = 0;
+  let green = 0;
+  let blue = 0;
+  switch (i % 6) {
+    case 0: red = v; green = t; blue = p; break;
+    case 1: red = q; green = v; blue = p; break;
+    case 2: red = p; green = v; blue = t; break;
+    case 3: red = p; green = q; blue = v; break;
+    case 4: red = t; green = p; blue = v; break;
+    default: red = v; green = p; blue = q; break;
+  }
+  return rgbUnitToHex(red, green, blue);
+}
+
+function namedArg(args: string, key: string): number | null {
+  const match = args.match(new RegExp(`\\b${key}\\s*:\\s*([^,)]+)`, 'u'));
+  if (!match) return null;
+  return evalSwiftNumber(match[1]!.trim());
+}
+
+function swiftColorArgsToHex(args: string): string | null {
+  const red = namedArg(args, 'red');
+  const green = namedArg(args, 'green');
+  const blue = namedArg(args, 'blue');
+  if (red !== null && green !== null && blue !== null) return rgbUnitToHex(red, green, blue);
+
+  const hue = namedArg(args, 'hue');
+  const saturation = namedArg(args, 'saturation');
+  const brightness = namedArg(args, 'brightness');
+  if (hue !== null && saturation !== null && brightness !== null) {
+    return hsbToHex(hue, saturation, brightness);
+  }
+
+  // Color(white:) is grayscale.
+  const white = namedArg(args, 'white');
+  if (white !== null) return rgbUnitToHex(white, white, white);
+
+  return null;
+}
+
+/**
+ * Find SwiftUI `Color(...)` declarations in source/markdown and return them as
+ * named hex swatches. Handles the `red:green:blue:`, `hue:saturation:brightness:`,
+ * and `white:` initializers (a trailing `opacity:`/`alpha:` arg is ignored for
+ * the swatch hex). A leading `let name =` / `var name =` / `static let name =`
+ * names the swatch; named asset colors like `Color("Accent")` carry no value
+ * and are skipped.
+ */
+export function extractSwiftColors(raw: string): SwiftColorToken[] {
+  const tokens: SwiftColorToken[] = [];
+  const declRe = /(?:(?:static\s+|public\s+|private\s+|internal\s+)*(?:let|var)\s+([A-Za-z_]\w*)\s*(?::[^=\n]+)?=\s*)?\bColor\s*\(([^)]*)\)/gu;
+  let match: RegExpExecArray | null;
+  while ((match = declRe.exec(raw)) !== null) {
+    const name = match[1] ?? '';
+    const hex = swiftColorArgsToHex(match[2] ?? '');
+    if (hex) tokens.push({ name, hex });
+  }
+  return tokens;
+}

--- a/apps/daemon/src/tools-connectors-cli.ts
+++ b/apps/daemon/src/tools-connectors-cli.ts
@@ -590,10 +590,18 @@ function extractDirectoryEntries(value: unknown): GithubDirectoryEntry[] {
   return [...entries.values()].sort((left, right) => left.path.localeCompare(right.path));
 }
 
-function scoreDesignFile(repoPath: string): number {
+export function scoreDesignFile(repoPath: string): number {
   const normalized = repoPath.toLowerCase();
   if (shouldSkipRepoPath(normalized)) return -1;
   let score = 0;
+  // Native / non-web design-token source. Without this, a SwiftUI, Kotlin, or
+  // other non-JS repo has every source file score 0, so config dotfiles (which
+  // hit the generic text bonus below) win the ranking and the real source is
+  // never snapshotted. Design-token files (ColorSystem.swift, Typography.kt,
+  // Spacing.swift, ...) get the high boost; other native source gets a solid
+  // floor so it outranks config noise.
+  if (/(^|\/)(color|colors|colour|colours|theme|themes|palette|palettes|typography|type|fonts?|spacing|sizing|metrics|dimens|tokens?|designsystem|design-?system|design|styles?|styling|appearance|brand|branding)[a-z0-9_]*\.(swift|kt|kts|java|dart|scala|cs|m|mm)$/u.test(normalized)) score += 95;
+  if (/\.(swift|kt|kts|java|scala|go|rs|rb|py|php|cs|dart|vue|svelte|astro|ex|exs|elm|c|cc|cpp|cxx|h|hpp|hh|m|mm)$/u.test(normalized)) score += 40;
   if (/(^|\/)readme\.(md|mdx|txt|rst)$/u.test(normalized)) score += 100;
   if (/(^|\/)package\.json$/u.test(normalized)) score += 95;
   if (/(^|\/)(tailwind|theme|themes?|themeprovider|antdprovider|tokens?|colors?|typography|design-system|design|constant|constants|env|style|styles)\.(config\.)?(ts|tsx|js|jsx|json|css|scss|less|md)$/u.test(normalized)) score += 95;
@@ -640,8 +648,13 @@ function scoreDesignDirectory(repoPath: string): number {
   return score;
 }
 
-function shouldSkipRepoPath(normalizedPath: string): boolean {
+export function shouldSkipRepoPath(normalizedPath: string): boolean {
   if (isDesignAssetDirectory(normalizedPath) || isDesignAssetPath(normalizedPath)) return false;
+  // Editor / CI / agent-tooling directories are never design evidence, but
+  // their .md / .json files otherwise score on the generic text bonus and crowd
+  // out real source (this is what filled a SwiftUI import with .zenflow, .zed,
+  // and .vscode files instead of the Swift token source).
+  if (/(^|\/)\.(vscode|zed|idea|fleet|zenflow|github|husky|gradle|vs|turbo|cache|devcontainer)\//u.test(normalizedPath)) return true;
   return /(^|\/)(node_modules|vendor|dist|build|coverage|\.next|\.nuxt|\.git|out|target|storybook-static)\//u.test(normalizedPath)
     || /(^|\/)(package-lock\.json|pnpm-lock\.ya?ml|yarn\.lock|bun\.lockb)$/u.test(normalizedPath)
     || /(^|\/)(__tests__|__snapshots__|test|tests)\//u.test(normalizedPath)
@@ -664,8 +677,8 @@ function isBinaryDesignAssetPath(normalizedPath: string): boolean {
   return /\.(png|jpe?g|webp|ico|ttf|otf|woff2?)$/u.test(normalizedPath);
 }
 
-function isTextSnapshotPath(normalizedPath: string): boolean {
-  return /\.(css|scss|less|tsx|ts|jsx|js|md|mdx|json|svg|txt|rst)$/u.test(normalizedPath);
+export function isTextSnapshotPath(normalizedPath: string): boolean {
+  return /\.(css|scss|less|tsx|ts|jsx|js|mjs|cjs|md|mdx|json|jsonc|svg|txt|rst|yaml|yml|toml|xml|swift|kt|kts|java|scala|go|rs|rb|py|php|cs|dart|vue|svelte|astro|ex|exs|elm|c|cc|cpp|cxx|h|hpp|hh|m|mm)$/u.test(normalizedPath);
 }
 
 function selectDesignFiles(paths: string[], maxFiles: number): string[] {

--- a/apps/daemon/tests/design-file-score.test.ts
+++ b/apps/daemon/tests/design-file-score.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isTextSnapshotPath,
+  scoreDesignFile,
+  shouldSkipRepoPath,
+} from '../src/tools-connectors-cli.js';
+
+describe('shouldSkipRepoPath', () => {
+  it('skips editor / CI / agent-tooling directories', () => {
+    expect(shouldSkipRepoPath('.vscode/settings.json')).toBe(true);
+    expect(shouldSkipRepoPath('.zed/tasks.json')).toBe(true);
+    expect(shouldSkipRepoPath('.zenflow/tasks/cleanup/spec.md')).toBe(true);
+    expect(shouldSkipRepoPath('.idea/workspace.xml')).toBe(true);
+    expect(shouldSkipRepoPath('.github/workflows/ci.yml')).toBe(true);
+  });
+
+  it('keeps real source directories', () => {
+    expect(shouldSkipRepoPath('sources/stackme/theme/colorsystem.swift')).toBe(false);
+    expect(shouldSkipRepoPath('stackme/views/projectlist.swift')).toBe(false);
+  });
+});
+
+describe('scoreDesignFile (non-web source)', () => {
+  it('ranks Swift token source far above tooling config files', () => {
+    const colorSystem = scoreDesignFile('Sources/StackMe/Theme/ColorSystem.swift');
+    const typography = scoreDesignFile('Sources/StackMe/Theme/Typography.swift');
+    const view = scoreDesignFile('Sources/StackMe/Views/ProjectList.swift');
+    const tooling = scoreDesignFile('.zenflow/tasks/cleanup/spec.md');
+
+    // Tooling dirs are skipped outright.
+    expect(tooling).toBe(-1);
+    // Token source is high-signal; plain source still beats the skipped config.
+    expect(colorSystem).toBeGreaterThan(view);
+    expect(typography).toBeGreaterThan(view);
+    expect(view).toBeGreaterThan(0);
+    expect(view).toBeGreaterThan(tooling);
+  });
+});
+
+describe('isTextSnapshotPath', () => {
+  it('writes native source snapshots, not just web files', () => {
+    // Without this a selected Swift file was dropped at write time, so the
+    // import produced zero snapshots and publishing stayed blocked.
+    expect(isTextSnapshotPath('utilities/colorsystem.swift')).toBe(true);
+    expect(isTextSnapshotPath('app/main.kt')).toBe(true);
+    expect(isTextSnapshotPath('src/theme.css')).toBe(true);
+    expect(isTextSnapshotPath('assets/logo.png')).toBe(false);
+  });
+});

--- a/apps/daemon/tests/design-systems-frontmatter.test.ts
+++ b/apps/daemon/tests/design-systems-frontmatter.test.ts
@@ -254,4 +254,28 @@ describe('listDesignSystems frontmatter parsing (issue #1857)', () => {
     const [ds] = await listDesignSystems(root);
     expect(ds?.body).toBe(raw);
   });
+
+  it('extracts SwiftUI Color tokens as swatches when the palette is Swift source', async () => {
+    const root = fresh();
+    writeDesignMd(
+      root,
+      'swift-brand',
+      [
+        '# Swift Brand',
+        '',
+        '> Category: Custom',
+        '',
+        'Palette from ColorSystem.swift:',
+        '',
+        '- appShellLight: `Color(red: 0xF4 / 255, green: 0xF4 / 255, blue: 0xF4 / 255)`',
+        '- ink: `Color(red: 0x11 / 255, green: 0x11 / 255, blue: 0x11 / 255)`',
+        '- grey50: `Color(hue: 220 / 360, saturation: 0.02, brightness: 0.99)`',
+        '- accent: `Color(hue: 220 / 360, saturation: 0.82, brightness: 0.9)`',
+      ].join('\n'),
+    );
+
+    const [ds] = await listDesignSystems(root);
+    expect(ds?.swatches.length).toBeGreaterThan(0);
+    expect(ds?.swatches).toContain('#f4f4f4');
+  });
 });

--- a/apps/daemon/tests/swift-colors.test.ts
+++ b/apps/daemon/tests/swift-colors.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evalSwiftNumber,
+  extractSwiftColors,
+  hsbToHex,
+  rgbUnitToHex,
+} from '../src/swift-colors.js';
+
+describe('evalSwiftNumber', () => {
+  it('reads decimals, ints, hex bytes, and single divisions', () => {
+    expect(evalSwiftNumber('0.99')).toBeCloseTo(0.99, 5);
+    expect(evalSwiftNumber('255')).toBe(255);
+    expect(evalSwiftNumber('0xF4')).toBe(244);
+    expect(evalSwiftNumber('0xF4 / 255')).toBeCloseTo(244 / 255, 5);
+    expect(evalSwiftNumber('220 / 360')).toBeCloseTo(220 / 360, 5);
+  });
+
+  it('returns null for anything it cannot evaluate safely', () => {
+    expect(evalSwiftNumber('someVar')).toBeNull();
+    expect(evalSwiftNumber('1 / 0')).toBeNull();
+    expect(evalSwiftNumber('1 + 2 + 3')).toBeNull();
+  });
+});
+
+describe('hsbToHex / rgbUnitToHex', () => {
+  it('converts the SwiftUI HSB grey50 token to hex', () => {
+    // static let grey50 = Color(hue: 220 / 360, saturation: 0.02, brightness: 0.99)
+    expect(hsbToHex(220 / 360, 0.02, 0.99)).toBe('#f7f9fc');
+  });
+
+  it('converts unit RGB to hex', () => {
+    expect(rgbUnitToHex(0xf4 / 255, 0xf4 / 255, 0xf4 / 255)).toBe('#f4f4f4');
+    expect(rgbUnitToHex(0, 0, 0)).toBe('#000000');
+    expect(rgbUnitToHex(1, 1, 1)).toBe('#ffffff');
+  });
+});
+
+describe('extractSwiftColors', () => {
+  it('parses HSB and RGB Color declarations with names', () => {
+    const src = [
+      'enum ColorSystem {',
+      '  static let grey50 = Color(hue: 220 / 360, saturation: 0.02, brightness: 0.99)',
+      '  static let appShellLight = Color(red: 0xF4 / 255, green: 0xF4 / 255, blue: 0xF4 / 255)',
+      '  static let scrim = Color(white: 0.0, opacity: 0.4)',
+      '}',
+    ].join('\n');
+    expect(extractSwiftColors(src)).toEqual([
+      { name: 'grey50', hex: '#f7f9fc' },
+      { name: 'appShellLight', hex: '#f4f4f4' },
+      { name: 'scrim', hex: '#000000' },
+    ]);
+  });
+
+  it('skips named asset colors that carry no component values', () => {
+    expect(extractSwiftColors('let accent = Color("AccentColor")')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

I tried to import a SwiftUI app (my StackMe repo) as a design system and could never publish it. The intake ran four times and each run produced the same thing: a design system built from system-derived default colors, with the publish action stuck disabled.

The cause is that the GitHub design import is built for web repos. Its file scorer only credits the React/Tailwind world, so in a native repo every `.swift` file scores 0. The repo's config dotfiles (`.zenflow`, `.vscode`, `.zed`) score on the generic text bonus instead and win the top-N selection, so the "evidence" the agent gets is editor config, not the real `ColorSystem.swift`. On top of that, even when a source file was selected, the snapshot writer's text-file allowlist didn't include `.swift`, so it got dropped at write time. The project files API hides dotfiles, so the publish gate (which requires captured repo file snapshots) saw zero and blocked publishing no matter how many times the intake ran.

## What users will see

Importing a design system from a native-source repo (Swift, and the same applies to Kotlin, Go, Rust, and friends) now pulls the real source. For my StackMe repo the intake captured `ColorSystem.swift`, `TypographySystem.swift`, `SpacingSystem.swift`, the shared styles, and the views and models, instead of `.zenflow` task notes and `.vscode/settings.json`. Because real source snapshots now exist, the design system satisfies the publish gate and the Publish action enables. SwiftUI color literals are also read into the design-system swatches.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — no new flag; this improves the existing `od tools connectors github-design-context` intake
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the import's file selection now includes native source and skips editor/CI tooling directories, so the snapshots captured for a native-source repo change (and a previously un-publishable native design system can become publishable)
- [ ] **None**

## Screenshots

n/a (daemon import behavior, no UI surface)

## Bug fix verification

Not a UI bug, so no Playwright. The regression is encoded as unit tests plus an end-to-end check:

- `tests/design-file-score.test.ts`: `scoreDesignFile` ranks Swift token source above tooling config, `shouldSkipRepoPath` skips `.vscode` / `.zed` / `.zenflow` / `.idea` / `.github`, and `isTextSnapshotPath` accepts native source. Each assertion fails on `main`.
- `tests/swift-colors.test.ts`: `Color(hue:saturation:brightness:)` and `Color(red:green:blue:)` conversions, including `0xF4 / 255` and `220 / 360` component expressions.
- `tests/design-systems-frontmatter.test.ts`: a palette written as SwiftUI `Color(...)` yields swatches through `listDesignSystems`.
- End to end: re-ran the bounded intake against the real StackMe repo. Before, it wrote 24 config dotfiles and `snapshotCount` was 0. After, it wrote 47 Swift files (the token source plus views/models), the files API reports `snapshotCount` 47, and the publish gate flips to enabled.

## Validation

- `pnpm --filter @open-design/daemon build` clean
- `pnpm guard` 26/26
- Suites that exercise the changed code pass: `tools-connectors-cli`, `design-systems`, `design-system-github-import`, `design-system-import`, `design-system-source-context`, `design-system-assets` (78), plus the three new/updated test files
- Full daemon suite: 3178 pass; the only failures are the 4 pre-existing Claude-auth cases (`chat-route`, `connection-test`), unchanged from `main`
