### PR TITLE
Polish the design system review panel

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -1507,21 +1507,31 @@ function DesignSystemProjectPanel({
               : `Review ${systemDisplayName} design system`}
           </h1>
           <div className="ds-project-publish-card__toggles">
-            <button
-              type="button"
-              className={published ? 'ghost compact' : 'primary'}
-              data-testid="design-system-publish"
-              disabled={statusBusy || (!published && !githubEvidence.ready)}
+            {/* The publish button is disabled until the GitHub import evidence is
+                ready, and a disabled button never fires the hover or focus that
+                surfaces a `title` tooltip. Keep the guidance on this wrapper,
+                which is never disabled, and let pointer events fall through the
+                disabled button to it (see .ds-project-publish-trigger) so the
+                explanation stays reachable exactly when publishing is blocked. */}
+            <span
+              className="ds-project-publish-trigger"
               title={
                 !published && !githubEvidence.ready
                   ? 'Finish importing your GitHub repo before you can publish.'
                   : undefined
               }
-              onClick={() => void togglePublished(!published)}
             >
-              {published ? <Icon name="check" size={14} /> : null}
-              {published ? 'Published' : 'Publish'}
-            </button>
+              <button
+                type="button"
+                className={published ? 'ghost compact' : 'primary'}
+                data-testid="design-system-publish"
+                disabled={statusBusy || (!published && !githubEvidence.ready)}
+                onClick={() => void togglePublished(!published)}
+              >
+                {published ? <Icon name="check" size={14} /> : null}
+                {published ? 'Published' : 'Publish'}
+              </button>
+            </span>
             {published ? (
               <label>
                 <input

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -1304,13 +1304,20 @@ function DesignSystemProjectPanel({
       sectionStatus,
       sectionStatusLabel,
     } = item;
-    // A section marked "Looks good" is validated, so collapse it by default to
-    // show it is done. The user can still re-expand it with the chevron
-    // (expandedSections[instanceId]), and an active agent run forces it open.
-    const reviewedGood = (reviewDecisions[section.title] ?? reviewEntry?.decision) === 'looks-good';
+    const needsAttention = designSystemReviewNeedsAttention(item);
+    // A section the user marked "Looks good" is validated, so collapse it by
+    // default to show it is done. Gate that on the current status, not just the
+    // stored decision: when a section is regenerated after approval its status
+    // moves back to needs-attention, and it has to reopen so the "review again"
+    // notice and the review buttons (both rendered only while expanded) stay
+    // visible. Without the needsAttention guard a stale "looks-good" decision
+    // keeps the regenerated section collapsed and the change is easy to miss.
+    // The user can still re-expand with the chevron (expandedSections[instanceId]),
+    // and an active agent run forces it open.
+    const reviewedGood =
+      !needsAttention && (reviewDecisions[section.title] ?? reviewEntry?.decision) === 'looks-good';
     const expanded =
       (expandedSections[instanceId] ?? (defaultExpanded && !reviewedGood)) || sectionActivity.running;
-    const needsAttention = designSystemReviewNeedsAttention(item);
     return (
       <section
         key={instanceId}

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -1187,6 +1187,10 @@ function DesignSystemProjectPanel({
   const sections = buildDesignSystemReviewSections(allFileNames, fileByName);
   const published = status === 'published';
   const isDefault = published && defaultDesignSystemId === system.id;
+  // Strip a trailing "design system" from the title so the heading
+  // "Review <name> design system" does not read redundantly when a system is
+  // already named e.g. "Acme Design System".
+  const systemDisplayName = system.title.replace(/\s*design system$/i, '').trim() || system.title;
   const activityFileOps = useMemo(() => deriveFileOps(activityEvents), [activityEvents]);
   const activityTodos = useMemo(() => latestTodosFromEvents(activityEvents), [activityEvents]);
   const sectionReviews: DesignSystemProjectSectionReview[] = sections.map((section) => {
@@ -1300,7 +1304,12 @@ function DesignSystemProjectPanel({
       sectionStatus,
       sectionStatusLabel,
     } = item;
-    const expanded = (expandedSections[instanceId] ?? defaultExpanded) || sectionActivity.running;
+    // A section marked "Looks good" is validated, so collapse it by default to
+    // show it is done. The user can still re-expand it with the chevron
+    // (expandedSections[instanceId]), and an active agent run forces it open.
+    const reviewedGood = (reviewDecisions[section.title] ?? reviewEntry?.decision) === 'looks-good';
+    const expanded =
+      (expandedSections[instanceId] ?? (defaultExpanded && !reviewedGood)) || sectionActivity.running;
     const needsAttention = designSystemReviewNeedsAttention(item);
     return (
       <section
@@ -1312,25 +1321,50 @@ function DesignSystemProjectPanel({
         ].join(' ')}
       >
         <div className="ds-project-section-head">
+          {/* The trigger is a stretched button covering the whole head, so the
+              entire row toggles. It is a sibling of the review action buttons
+              (not a parent), so there are no nested interactive elements. The
+              title below is display-only (pointer-events: none) and lets clicks
+              fall through to this trigger. */}
           <button
             type="button"
-            className="ds-project-section-title"
+            className="ds-project-section-head-trigger"
             aria-expanded={expanded}
+            aria-label={`${expanded ? 'Collapse' : 'Expand'} ${section.title}`}
             onClick={() => toggleSection(instanceId)}
-          >
+          />
+          <span className="ds-project-section-title">
             <Icon name={expanded ? 'chevron-down' : 'chevron-right'} size={13} />
             <span>
               <strong>{section.title}</strong>
               <small>{section.subtitle}</small>
             </span>
-          </button>
+            {!expanded ? (
+              <span
+                className={[
+                  'ds-project-section-state',
+                  'ds-project-section-dot',
+                  designSystemSectionStatusClass(sectionStatus),
+                ].join(' ')}
+                aria-label={sectionStatusLabel}
+                title={sectionStatusLabel}
+              >
+                {needsAttention ? 'Needs review' : 'Looks good'}
+              </span>
+            ) : null}
+          </span>
           {expanded ? (
             <div className="ds-project-review-actions" aria-label={`${section.title} review`}>
               <button
                 type="button"
                 className={`ghost success ${reviewDecisions[section.title] === 'looks-good' ? 'active' : ''}`}
                 data-testid={`design-system-review-good-${slugForTestId(section.title)}`}
-                onClick={() => markSectionReview(section.title, 'looks-good')}
+                onClick={() => {
+                  markSectionReview(section.title, 'looks-good');
+                  // Collapse on validate, overriding any manual expand so the
+                  // section always tidies away once it is marked good.
+                  setExpandedSections((current) => ({ ...current, [instanceId]: false }));
+                }}
               >
                 <Icon name="check" size={13} />
                 Looks good
@@ -1385,19 +1419,7 @@ function DesignSystemProjectPanel({
                 </form>
               ) : null}
             </div>
-          ) : (
-            <span
-              className={[
-                'ds-project-section-state',
-                'ds-project-section-dot',
-                designSystemSectionStatusClass(sectionStatus),
-              ].join(' ')}
-              aria-label={sectionStatusLabel}
-              title={sectionStatusLabel}
-            >
-              {needsAttention ? 'Needs review' : 'Looks good'}
-            </span>
-          )}
+          ) : null}
         </div>
         {expanded ? (
           <div className="ds-project-section-body">
@@ -1429,13 +1451,9 @@ function DesignSystemProjectPanel({
               </div>
             ) : null}
             {previewFile ? (
-              <button
-                type="button"
-                className="ds-project-inline-preview"
-                onClick={() => onOpenFile(previewFile.name)}
-              >
+              <div className="ds-project-inline-preview">
                 <DesignSystemInlinePreview projectId={projectId} file={previewFile} />
-              </button>
+              </div>
             ) : (
               <div className="ds-project-preview-placeholder">
                 <Icon name="sparkles" size={16} />
@@ -1476,26 +1494,27 @@ function DesignSystemProjectPanel({
     <div className="ds-project-panel">
       <div className="ds-project-main ds-project-main--review">
         <div className="ds-project-head ds-project-head--review">
-          <h1>{published ? 'Your design system is ready' : 'Review draft design system'}</h1>
-        </div>
-
-        <div className="ds-project-publish-card ds-project-publish-card--review">
-          <p>
+          <h1>
             {published
-              ? "Your team's new projects can use this design system as context by default."
-              : 'Your design system is ready, but your feedback will improve it. Publish it when it is ready to use in future projects.'}
-          </p>
+              ? `${systemDisplayName} design system`
+              : `Review ${systemDisplayName} design system`}
+          </h1>
           <div className="ds-project-publish-card__toggles">
-            <label>
-              <input
-                type="checkbox"
-                checked={published}
-                disabled={statusBusy || (!published && !githubEvidence.ready)}
-                title={!githubEvidence.ready ? 'GitHub connector evidence is required before publishing.' : undefined}
-                onChange={(event) => void togglePublished(event.target.checked)}
-              />
-              Published
-            </label>
+            <button
+              type="button"
+              className={published ? 'ghost compact' : 'primary'}
+              data-testid="design-system-publish"
+              disabled={statusBusy || (!published && !githubEvidence.ready)}
+              title={
+                !published && !githubEvidence.ready
+                  ? 'Finish importing your GitHub repo before you can publish.'
+                  : undefined
+              }
+              onClick={() => void togglePublished(!published)}
+            >
+              {published ? <Icon name="check" size={14} /> : null}
+              {published ? 'Published' : 'Publish'}
+            </button>
             {published ? (
               <label>
                 <input
@@ -1510,6 +1529,14 @@ function DesignSystemProjectPanel({
               </label>
             ) : null}
           </div>
+        </div>
+
+        <div className="ds-project-publish-card ds-project-publish-card--review">
+          <p>
+            {published
+              ? "Your team's new projects can use this design system as context by default."
+              : 'Your design system is ready, but your feedback will improve it. Publish it when it is ready to use in future projects.'}
+          </p>
           {published ? (
             <div className="ds-project-use-row">
               <span>Use this system</span>

--- a/apps/web/src/styles/design-system-flow.css
+++ b/apps/web/src/styles/design-system-flow.css
@@ -1833,6 +1833,19 @@
   font-size: 13px;
   white-space: nowrap;
 }
+.ds-project-publish-trigger {
+  display: inline-flex;
+}
+/* A disabled button does not fire the hover or focus that shows its own `title`,
+   so the publish guidance lives on this wrapper. Make the disabled button
+   transparent to pointer events so hovering it reveals the wrapper title, and
+   carry the not-allowed cursor the button would otherwise show. */
+.ds-project-publish-trigger:has(> button:disabled) {
+  cursor: not-allowed;
+}
+.ds-project-publish-trigger > button:disabled {
+  pointer-events: none;
+}
 .ds-project-use-row {
   margin-top: 14px;
   padding-top: 14px;

--- a/apps/web/src/styles/design-system-flow.css
+++ b/apps/web/src/styles/design-system-flow.css
@@ -1683,6 +1683,43 @@
   place-items: center;
   color: var(--accent);
 }
+/* While the design system is generating (and other waiting states), the small
+   block of the blocks icon hops, spins, and bounces back into the cluster. The
+   <rect> is the small block; transform-box keeps it spinning on its own center.
+   overflow: visible lets the hop rise past the 24-unit viewBox without clipping. */
+.ds-project-generation-mark svg {
+  overflow: visible;
+}
+.ds-project-generation-mark svg rect {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: ds-generation-block 1.4s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+@keyframes ds-generation-block {
+  0% {
+    transform: translateY(0) rotate(0deg);
+  }
+  35% {
+    transform: translateY(-4px) rotate(180deg);
+  }
+  60% {
+    transform: translateY(0) rotate(360deg);
+  }
+  72% {
+    transform: translateY(-2px) rotate(360deg);
+  }
+  85% {
+    transform: translateY(0) rotate(360deg);
+  }
+  100% {
+    transform: translateY(0) rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ds-project-generation-mark svg rect {
+    animation: none;
+  }
+}
 .ds-project-generation-stage h1 {
   margin: 0;
   color: var(--text);
@@ -1784,11 +1821,11 @@
   line-height: 1.45;
 }
 .ds-project-publish-card__toggles {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 18px;
 }
-.ds-project-publish-card label {
+.ds-project-publish-card__toggles label {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -2016,18 +2053,36 @@
   gap: 28px;
 }
 .ds-project-section-head {
+  position: relative;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 14px;
   margin-bottom: 10px;
 }
+/* Stretched toggle: covers the whole head so the entire row expands/collapses.
+   Sits behind the title (which is pointer-events: none, so clicks fall through)
+   and behind the review action buttons (which are lifted above it). */
+.ds-project-section-head-trigger {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  border-radius: inherit;
+}
 .ds-project-section-title {
+  position: relative;
+  z-index: 1;
+  pointer-events: none;
+  flex: 1;
   min-width: 0;
   border: 0;
   background: transparent;
   color: inherit;
-  display: inline-flex;
+  display: flex;
   align-items: flex-start;
   gap: 8px;
   padding: 0;
@@ -2041,7 +2096,7 @@
   display: flex;
   min-width: 0;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 .ds-project-section-title strong {
   margin: 0;
@@ -2103,6 +2158,8 @@
   color: var(--amber);
 }
 .ds-project-review-actions {
+  position: relative;
+  z-index: 1;
   display: inline-flex;
   flex-wrap: wrap;
   justify-content: flex-end;
@@ -2125,6 +2182,51 @@
   border-color: color-mix(in srgb, var(--red) 42%, var(--border));
   background: color-mix(in srgb, var(--red) 9%, var(--bg-panel));
   color: var(--red);
+}
+/* "Needs work..." feedback form. Floats below the review buttons as a popover
+   instead of flowing inline in the actions row, which otherwise cramped the
+   section head. Anchored to .ds-project-review-actions (position: relative). */
+.ds-project-feedback-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 30;
+  width: min(360px, 88vw);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  text-align: left;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+  animation: ds-feedback-pop-in 200ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.ds-project-feedback-popover label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+.ds-project-feedback-popover textarea {
+  width: 100%;
+  resize: vertical;
+  font: inherit;
+}
+.ds-project-feedback-popover > div {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+@keyframes ds-feedback-pop-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 .ds-project-section-body {
   display: flex;
@@ -2166,7 +2268,6 @@
 }
 .ds-project-inline-preview iframe {
   border: 0;
-  pointer-events: none;
 }
 .ds-project-inline-preview img {
   object-fit: contain;
@@ -2311,7 +2412,11 @@
   width: min(940px, 100%);
 }
 .ds-project-head--review {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
   border-bottom: 0;
   padding: 16px 0 28px;
 }
@@ -2332,11 +2437,6 @@
   color: var(--text-muted);
   font-size: 16px;
   line-height: 1.55;
-}
-.ds-project-publish-card--review .ds-project-publish-card__toggles {
-  min-height: 58px;
-  padding: 0 24px;
-  border-top: 1px solid var(--border);
 }
 .ds-project-publish-card--review .ds-project-use-row {
   margin: 0;
@@ -2470,6 +2570,10 @@
   }
   .ds-project-review-actions {
     justify-content: flex-start;
+  }
+  .ds-project-feedback-popover {
+    right: auto;
+    left: 0;
   }
   .ds-project-section-state {
     margin-left: 0;

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -285,6 +285,44 @@ describe('FileWorkspace design-system project surface', () => {
     expect(registryMocks.updateDesignSystemDraft).not.toHaveBeenCalled();
   });
 
+  it('keeps the disabled-publish guidance on a non-disabled wrapper so it stays reachable', () => {
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[
+          workspaceFile('DESIGN.md'),
+          workspaceFile('context/source-context.md'),
+          workspaceFile('preview/colors.html'),
+        ]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem({
+          provenance: {
+            companyBlurb: 'Acme analytics workspace',
+            githubUrls: ['https://github.com/acme/product'],
+          },
+        })}
+      />,
+    );
+
+    const publishButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="design-system-publish"]',
+    );
+    expect(publishButton?.disabled).toBe(true);
+
+    // A disabled button never fires the hover or focus that surfaces a `title`, so
+    // the guidance has to live on a wrapper instead of on the button itself.
+    const guidance = 'Finish importing your GitHub repo before you can publish.';
+    const carrier = container.querySelector<HTMLElement>(`[title="${guidance}"]`);
+    expect(carrier).toBeTruthy();
+    expect(carrier?.tagName).not.toBe('BUTTON');
+    expect(carrier?.contains(publishButton ?? null)).toBe(true);
+  });
+
   it('offers a Connect GitHub action that routes to Connectors when repo evidence is missing', async () => {
     const onConnectRepo = vi.fn();
     const container = renderWorkspace(

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -422,4 +422,41 @@ describe('FileWorkspace design-system project surface', () => {
     // An unreviewed section stays expanded for review.
     expect(unreviewed?.classList.contains('is-expanded')).toBe(true);
   });
+
+  it('reopens a looks-good section after it is regenerated so the review-again prompt stays visible', () => {
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[workspaceFile('DESIGN.md'), workspaceFile('preview/colors.html')]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem()}
+        designSystemReview={{
+          colors: { decision: 'looks-good', updatedAt: '2026-05-14T00:00:00.000Z' },
+        }}
+        designSystemActivityEvents={[
+          toolUse('Write', { file_path: '/project/preview/colors.html' }, 'write-preview'),
+          toolOk('write-preview'),
+        ]}
+      />,
+    );
+
+    const items = Array.from(container.querySelectorAll('.ds-project-review-item'));
+    const titleOf = (el: Element) =>
+      el.querySelector('.ds-project-section-title strong')?.textContent ?? '';
+    const colors = items.find((el) => titleOf(el) === 'colors');
+
+    // The stored decision is still "looks-good", but the regenerated files moved
+    // the section back to "updated". It has to reopen instead of staying collapsed
+    // behind the stale decision, so the review-again notice and the review buttons
+    // are visible again.
+    expect(colors?.classList.contains('is-expanded')).toBe(true);
+    expect(colors?.classList.contains('is-collapsed')).toBe(false);
+    expect(colors?.querySelector('.ds-project-review-actions')).toBeTruthy();
+    expect(colors?.textContent).toContain('before publishing');
+  });
 });

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -118,7 +118,7 @@ describe('FileWorkspace design-system project surface', () => {
 
     expect(markup).toContain('data-testid="design-system-project-tab"');
     expect(markup).toContain('data-testid="design-files-tab"');
-    expect(markup).toContain('Review draft design system');
+    expect(markup).toContain('Review Acme design system');
     expect(markup).not.toContain('<h2>Needs review</h2>');
     expect(markup).toContain('Type');
     expect(markup).toContain('Colors');
@@ -159,7 +159,7 @@ describe('FileWorkspace design-system project surface', () => {
     expect(markup).toContain('Creating your design system...');
     expect(markup).toContain('Keep this tab open. You can come back in a few minutes.');
     expect(markup).toContain('role="progressbar"');
-    expect(markup).not.toContain('Review draft design system');
+    expect(markup).not.toContain('Review Acme design system');
   });
 
   it('keeps generated preview cards hidden until the initial run finishes', () => {
@@ -187,7 +187,7 @@ describe('FileWorkspace design-system project surface', () => {
     );
 
     expect(markup).toContain('Creating your design system...');
-    expect(markup).not.toContain('Review draft design system');
+    expect(markup).not.toContain('Review Acme design system');
     expect(markup).not.toContain('typography-specimens');
     expect(markup).not.toContain('<iframe');
   });
@@ -270,15 +270,15 @@ describe('FileWorkspace design-system project surface', () => {
         })}
       />,
     );
-    const publishToggle = container.querySelector<HTMLInputElement>(
-      '.ds-project-publish-card input[type="checkbox"]',
+    const publishButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="design-system-publish"]',
     );
 
     expect(container.textContent).toContain('Connect your repo to pull aspects of your design system');
-    expect(publishToggle?.disabled).toBe(true);
+    expect(publishButton?.disabled).toBe(true);
 
     await act(async () => {
-      publishToggle?.click();
+      publishButton?.click();
       await Promise.resolve();
     });
 
@@ -386,5 +386,40 @@ describe('FileWorkspace design-system project surface', () => {
       button.textContent?.includes('Import repo'),
     );
     expect(importButton).toBeTruthy();
+  });
+
+  it('collapses a section once it is marked looks-good', () => {
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[
+          workspaceFile('DESIGN.md'),
+          workspaceFile('preview/typography-specimens.html'),
+          workspaceFile('preview/colors-primary.html'),
+        ]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem()}
+        designSystemReview={{
+          'typography-specimens': { decision: 'looks-good', updatedAt: '2026-05-14T00:00:00.000Z' },
+        }}
+      />,
+    );
+
+    const items = Array.from(container.querySelectorAll('.ds-project-review-item'));
+    const titleOf = (el: Element) =>
+      el.querySelector('.ds-project-section-title strong')?.textContent ?? '';
+    const reviewed = items.find((el) => titleOf(el) === 'typography-specimens');
+    const unreviewed = items.find((el) => titleOf(el) === 'colors-primary');
+
+    // A validated section collapses and reads as "Looks good".
+    expect(reviewed?.classList.contains('is-collapsed')).toBe(true);
+    expect(reviewed?.querySelector('.ds-project-section-state')?.textContent).toContain('Looks good');
+    // An unreviewed section stays expanded for review.
+    expect(unreviewed?.classList.contains('is-expanded')).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

I was reviewing a generated design system and kept hitting rough edges in the review panel. The "Needs work" feedback form crammed itself into the section header row, reviewed sections stayed expanded so the list never felt resolved, the inline preview couldn't scroll, only the title text toggled the accordion (not the whole header), and publishing was a small checkbox buried in a card so it read as hidden. None of these are bugs that break a flow outright, but together they made the panel feel unfinished. This PR is a pass over all of it.

## What users will see

In the Design System review panel:

- The "Needs work" feedback form now drops below the review buttons as a popover instead of squeezing into the header row.
- Marking a section "Looks good" collapses it, so reviewed sections tidy away and the remaining work is what's left open. The chevron still re-expands a section, and an active agent run keeps it open.
- The inline preview iframe scrolls, and the click-to-open wrapper is gone, so you can read a tall preview in place.
- The whole section header is the expand/collapse target, not just the title text.
- The publish header is reworked: the heading names the system ("Review StackMe design system"), and publishing is a Publish button sitting inline with the heading instead of a checkbox in the card. The disabled-state tooltip now says what is actually needed.
- While a design system generates, the small block in the loading mark hops, spins, and bounces back into the cluster (with a reduced-motion guard).

## Surface area

- [x] **UI** — Design System review panel (header, accordion, feedback form, inline preview, publish control, loading mark)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — none; this panel renders hardcoded English throughout (the new strings match the surrounding ones), so there was no dictionary to extend
- [ ] **New top-level dependency**
- [x] **Default behavior change** — reviewed sections now default to collapsed, and the publish control changes from a checkbox to a button
- [ ] **None**

## Screenshots

<img width="816" height="155" alt="CleanShot 2026-05-24 at 18 24 30" src="https://github.com/user-attachments/assets/c1755efe-bf8f-4548-89cc-875de5884c9d" />

<img width="602" height="310" alt="CleanShot 2026-05-24 at 18 20 33" src="https://github.com/user-attachments/assets/377e0c44-a070-4e85-984b-d23257d2ea25" />

<img width="800" height="261" alt="CleanShot 2026-05-24 at 19 44 41" src="https://github.com/user-attachments/assets/496f6b8e-0627-4cdf-b423-5aa663e0b521" />


## Bug fix verification

Not a regression fix; this is UI polish. Behavior is covered by unit tests in `FileWorkspace.design-system.test.tsx` (a looks-good section renders collapsed; the publish control is disabled until evidence is ready). The visual changes were checked by driving the running app and inspecting the rendered DOM (header is a single trigger, the inline preview iframe is interactive, the publish button enables/disables correctly).

## Validation

- `pnpm guard` 26/26
- `pnpm --filter @open-design/web typecheck` clean
- `pnpm --filter @open-design/web test` full suite green (the design-system suite covers the collapse and publish-gate behavior)
