### PR TITLE
fix(daemon): run Trae CLI ACP with yolo

### DIFF
--- a/apps/daemon/src/runtimes/defs/trae-cli.ts
+++ b/apps/daemon/src/runtimes/defs/trae-cli.ts
@@ -16,7 +16,7 @@ export const traeCliAgentDef = {
         defaultModelOption: DEFAULT_MODEL_OPTION,
       }),
     fallbackModels: [DEFAULT_MODEL_OPTION],
-    buildArgs: () => ['acp', 'serve'],
+    buildArgs: () => ['acp', 'serve', '--yolo'],
     streamFormat: 'acp-json-rpc',
     mcpDiscovery: 'mature-acp',
     externalMcpInjection: 'acp-merge',

--- a/apps/daemon/tests/runtimes/trae-cli.test.ts
+++ b/apps/daemon/tests/runtimes/trae-cli.test.ts
@@ -37,8 +37,17 @@ describe('Trae CLI runtime adapter', () => {
     expect(runtimeDef.fallbackBins).toBeUndefined();
     expect(traeCliAgentDef.versionArgs).toEqual(['--version']);
     expect(traeCliAgentDef.versionProbeTimeoutMs).toBeGreaterThan(3000);
-    expect(runtimeDef.buildArgs('', [], [], {})).toEqual(['acp', 'serve']);
     expect(traeCliAgentDef.streamFormat).toBe('acp-json-rpc');
+  });
+
+  it('launches the ACP server with yolo mode for headless runs', () => {
+    const runtimeDef = traeCliAgentDef as RuntimeAgentDef;
+
+    expect(runtimeDef.buildArgs('', [], [], {})).toEqual([
+      'acp',
+      'serve',
+      '--yolo',
+    ]);
   });
 
   it('fetches live models from traecli acp serve', async () => {

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -214,10 +214,11 @@ The adapter declares which strategy to use via `capabilities().nativeSkillLoadin
 
 ### 5.10 Trae CLI
 
-- Invocation: `traecli acp serve`, using the daemon's shared ACP JSON-RPC transport. The adapter follows Trae CLI's public ACP entrypoint documented at https://www.volcengine.com/docs/86677/2227861?lang=zh.
+- Invocation: `traecli acp serve --yolo`, using the daemon's shared ACP JSON-RPC transport. The adapter follows Trae CLI's public ACP entrypoint documented at https://www.volcengine.com/docs/86677/2227861?lang=zh.
 - Streaming: `acp-json-rpc`; the daemon uses the same ACP event path as the other ACP-backed adapters.
 - Models: dynamic via the ACP handshake. If model discovery fails, the picker falls back to the CLI's default configuration rather than requiring CI or startup detection to log in to Trae CLI.
 - Skills: prompt injection only in v1. External MCP servers can be forwarded through the ACP launch descriptor with the existing `acp-merge` path.
+- Permission: `--yolo` avoids headless approval prompts in the web UI. This follows the adapter catalog's existing non-interactive permission posture for CLIs such as Devin, Copilot, Qoder, and DeepSeek: the daemon runs agent CLIs without a TTY, so it must not rely on an interactive tool-approval prompt to make progress.
 - **Gotcha:** Detection only proves `traecli --version` and model discovery can run in the current environment. Trae CLI owns login, account scope, and model entitlement; the daemon does not run login flows or edit Trae CLI configuration.
 
 ### 5.11 Pi


### PR DESCRIPTION
## Why

Follow-up to #2729. That PR added the public Trae CLI ACP adapter, but it launched Trae with `traecli acp serve` only. In Open Design the daemon runs agent CLIs without a TTY, so a runtime adapter should not depend on an interactive tool-approval prompt to make progress.

Trae CLI exposes `--yolo` for this exact posture: `traecli acp serve --help` describes it as bypassing tool permission checks. This also matches the existing `docs/agent-adapters.md` pattern for other non-interactive adapters: Devin, Copilot, Qoder, and DeepSeek already document adapter-specific flags that avoid headless approval prompts.

## What users will see

Users who select Trae CLI as their local agent runtime still see the same Trae CLI adapter, but Open Design now launches it with yolo mode enabled so tool calls do not hang waiting for an approval prompt that the web UI cannot answer.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — Trae CLI launches with `--yolo` by default in the existing ACP adapter
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI code changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/trae-cli.test.ts`
- Did the test go red on `main` and green on this branch? yes
- Red result on `main`: `buildArgs` returned `['acp', 'serve']`; the new test expected `['acp', 'serve', '--yolo']`.

## Validation

- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm install --frozen-lockfile`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm --dir apps/daemon exec vitest run tests/runtimes/trae-cli.test.ts tests/runtimes/probe-ghost-cli.test.ts -c vitest.config.ts`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm --filter @open-design/daemon build`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm --filter @open-design/daemon test`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm typecheck`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm guard`
- `git diff --check`
