### PR TITLE
fix(web): handle dropped file read failures

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -5,6 +5,11 @@ import { useT } from '../i18n';
 import type { Dict } from '../i18n/types';
 import { projectFileUrl } from '../providers/registry';
 import type { LiveArtifactWorkspaceEntry, ProjectFile, ProjectFileKind } from '../types';
+import {
+  createFileSystemReadError,
+  FILE_SYSTEM_READ_ERROR_MESSAGE,
+  isFileSystemReadError,
+} from '../utils/fileSystemErrors';
 import type { PluginFolderAgentAction } from './design-files/pluginFolderActions';
 import { getPluginFolderCandidates } from './design-files/pluginFolders';
 import { Icon } from './Icon';
@@ -133,6 +138,7 @@ export function DesignFilesPanel({
   const analytics = useAnalytics();
   const [refreshing, setRefreshing] = useState(false);
   const [draggingFiles, setDraggingFiles] = useState(false);
+  const [dropReadError, setDropReadError] = useState<string | null>(null);
   const dragDepthRef = useRef(0);
   const [hover, setHover] = useState<string | null>(null);
   const [menuPos, setMenuPos] = useState<{ name: string; top: number; left: number } | null>(null);
@@ -816,8 +822,14 @@ export function DesignFilesPanel({
     ev.preventDefault();
     dragDepthRef.current = 0;
     setDraggingFiles(false);
-    const dropped = await filesFromDataTransfer(ev.dataTransfer);
-    if (dropped.length > 0) onUploadFiles(dropped);
+    setDropReadError(null);
+    try {
+      const dropped = await filesFromDataTransfer(ev.dataTransfer);
+      if (dropped.length > 0) onUploadFiles(dropped);
+    } catch (error) {
+      if (!isFileSystemReadError(error)) throw error;
+      setDropReadError(FILE_SYSTEM_READ_ERROR_MESSAGE);
+    }
   }
 
   async function handlePluginFolderAgentAction(
@@ -1018,18 +1030,23 @@ export function DesignFilesPanel({
       </div>
     ) : null;
 
+  const visibleUploadError = uploadError ?? dropReadError;
+
   return (
     <div className={`df-panel ${preview ? '' : 'no-preview'}`}>
       <div className="df-main">
         <div className="df-body">
-          {uploadError && !preview ? (
+          {visibleUploadError && !preview ? (
             <div className="df-upload-banner" data-testid="upload-error-banner">
-              <span>{uploadError}</span>
-              {onClearUploadError ? (
+              <span>{visibleUploadError}</span>
+              {onClearUploadError || dropReadError ? (
                 <button
                   type="button"
                   data-testid="upload-error-dismiss"
-                  onClick={onClearUploadError}
+                  onClick={() => {
+                    setDropReadError(null);
+                    onClearUploadError?.();
+                  }}
                 >
                   Dismiss
                 </button>
@@ -1594,11 +1611,17 @@ function dateDaysBefore(date: Date, days: number): Date {
 
 async function filesFromDataTransfer(dataTransfer: DataTransfer): Promise<File[]> {
   const items = Array.from(dataTransfer.items ?? []);
-  if (items.length === 0) return Array.from(dataTransfer.files ?? []);
+  const fallbackFiles = Array.from(dataTransfer.files ?? []);
+  if (items.length === 0) return fallbackFiles;
 
-  const files = await Promise.all(items.map(filesFromDataTransferItem));
-  const flattened = files.flat();
-  return flattened.length > 0 ? flattened : Array.from(dataTransfer.files ?? []);
+  const results = await Promise.allSettled(items.map(filesFromDataTransferItem));
+  const rejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+  if (rejected) {
+    if (fallbackFiles.length > 0) return fallbackFiles;
+    throw rejected.reason;
+  }
+  const files = results.flatMap((result) => (result.status === 'fulfilled' ? result.value : []));
+  return files.length > 0 ? files : fallbackFiles;
 }
 
 async function filesFromDataTransferItem(item: DataTransferItem): Promise<File[]> {
@@ -1628,11 +1651,19 @@ async function filesFromFileSystemEntry(entry: FileSystemEntry): Promise<File[]>
 }
 
 function fileFromEntry(entry: FileSystemFileEntryWithFile): Promise<File> {
-  return new Promise((resolve, reject) => entry.file(resolve, reject));
+  return new Promise((resolve, reject) => {
+    entry.file(resolve, (error) => {
+      reject(createFileSystemReadError('Could not read dropped file', error));
+    });
+  });
 }
 
 function readEntryBatch(reader: FileSystemDirectoryReader): Promise<FileSystemEntry[]> {
-  return new Promise((resolve, reject) => reader.readEntries(resolve, reject));
+  return new Promise((resolve, reject) => {
+    reader.readEntries(resolve, (error) => {
+      reject(createFileSystemReadError('Could not read dropped folder', error));
+    });
+  });
 }
 
 function kindGlyph(kind: ProjectFileKind): string {

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -37,6 +37,11 @@ import {
 } from '../runtime/design-system-package-audit';
 import { deriveFileOps } from '../runtime/file-ops';
 import { latestTodosFromEvents } from '../runtime/todos';
+import {
+  createFileSystemReadError,
+  FILE_SYSTEM_READ_ERROR_MESSAGE,
+  isFileSystemReadError,
+} from '../utils/fileSystemErrors';
 import { randomUUID } from '../utils/uuid';
 import type {
   AgentEvent,
@@ -741,6 +746,7 @@ export function DesignSystemCreationFlow({
               directory
               onBrowseFolder={() => void handlePickCodeFolder()}
               onRemoveName={handleRemoveCodeFolder}
+              onError={setError}
               onFiles={(_names, files) => {
                 const stagedFiles = selectLocalCodeFiles(files);
                 const stagedNames = stagedFiles.map((file) => localCodeRelativePath(file));
@@ -758,6 +764,7 @@ export function DesignSystemCreationFlow({
               prompt="Drop .fig here or browse"
               accept=".fig"
               names={state.figFiles}
+              onError={setError}
               onFiles={(_names, files) => {
                 const stagedFiles = selectFigmaFiles(files);
                 const stagedNames = stagedFiles.map((file) => resourceRelativePath(file));
@@ -773,6 +780,7 @@ export function DesignSystemCreationFlow({
               label="Add assets"
               prompt="Drag files here or browse"
               names={state.assetFiles}
+              onError={setError}
               onFiles={(_names, files) => {
                 const stagedFiles = selectAssetFiles(files);
                 const stagedNames = stagedFiles.map((file) => resourceRelativePath(file));
@@ -2374,6 +2382,7 @@ interface DropZoneProps {
   directory?: boolean;
   onBrowseFolder?: () => void;
   onRemoveName?: (name: string) => void;
+  onError?: (message: string | null) => void;
   onFiles: (names: string[], files: File[]) => void;
 }
 interface WebkitFileSystemEntry {
@@ -2526,16 +2535,26 @@ function DropZone({
   directory,
   onBrowseFolder,
   onRemoveName,
+  onError,
   onFiles,
 }: DropZoneProps) {
   function readFiles(files: FileList | File[] | null) {
     const nextFiles = Array.from(files ?? []);
     const nextNames = nextFiles.map((file) => localCodeRelativePath(file));
-    if (nextNames.length > 0) onFiles(nextNames, nextFiles);
+    if (nextNames.length > 0) {
+      onError?.(null);
+      onFiles(nextNames, nextFiles);
+    }
   }
   async function readDrop(dataTransfer: DataTransfer) {
-    const nextFiles = await filesFromDataTransfer(dataTransfer);
-    readFiles(nextFiles);
+    onError?.(null);
+    try {
+      const nextFiles = await filesFromDataTransfer(dataTransfer);
+      readFiles(nextFiles);
+    } catch (error) {
+      if (!isFileSystemReadError(error)) throw error;
+      onError?.(FILE_SYSTEM_READ_ERROR_MESSAGE);
+    }
   }
   const directoryProps = directory ? ({ webkitdirectory: '', directory: '' } as Record<string, string>) : {};
 
@@ -2585,17 +2604,24 @@ function DropZone({
 }
 
 async function filesFromDataTransfer(dataTransfer: DataTransfer): Promise<File[]> {
+  const fallbackFiles = Array.from(dataTransfer.files ?? []);
   const items = Array.from(dataTransfer.items ?? []);
+  if (items.length === 0) return fallbackFiles;
   const entries = items
     .map((item) => {
       const getter = (item as { webkitGetAsEntry?: () => unknown }).webkitGetAsEntry;
       return getter?.call(item) ?? null;
     })
     .filter(isWebkitFileSystemEntry);
-  if (entries.length === 0) return Array.from(dataTransfer.files ?? []);
-  const droppedFiles = await Promise.all(entries.map((entry) => filesFromEntry(entry, entry.name)));
-  const flattened = droppedFiles.flat();
-  return flattened.length > 0 ? flattened : Array.from(dataTransfer.files ?? []);
+  if (entries.length === 0) return fallbackFiles;
+  const results = await Promise.allSettled(entries.map((entry) => filesFromEntry(entry, entry.name)));
+  const rejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+  if (rejected) {
+    if (fallbackFiles.length > 0) return fallbackFiles;
+    throw rejected.reason;
+  }
+  const droppedFiles = results.flatMap((result) => (result.status === 'fulfilled' ? result.value : []));
+  return droppedFiles.length > 0 ? droppedFiles : fallbackFiles;
 }
 
 function isWebkitFileSystemEntry(entry: unknown): entry is WebkitFileSystemEntry {
@@ -2623,7 +2649,9 @@ async function filesFromEntry(entry: WebkitFileSystemEntry, relativePath: string
 
 function fileFromEntry(entry: WebkitFileSystemFileEntry): Promise<File> {
   return new Promise((resolve, reject) => {
-    entry.file(resolve, reject);
+    entry.file(resolve, (error) => {
+      reject(createFileSystemReadError('Could not read dropped file', error));
+    });
   });
 }
 
@@ -2639,7 +2667,9 @@ function readAllDirectoryEntries(entry: WebkitFileSystemDirectoryEntry): Promise
         }
         entries.push(...batch);
         readNextBatch();
-      }, reject);
+      }, (error) => {
+        reject(createFileSystemReadError('Could not read dropped folder', error));
+      });
     }
     readNextBatch();
   });

--- a/apps/web/src/utils/fileSystemErrors.ts
+++ b/apps/web/src/utils/fileSystemErrors.ts
@@ -1,0 +1,26 @@
+function errorSummary(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name || 'Error'}: ${error.message || String(error)}`;
+  }
+  if (error && typeof error === 'object') {
+    const candidate = error as { name?: unknown; message?: unknown };
+    const name = typeof candidate.name === 'string' ? candidate.name : 'Error';
+    const message =
+      typeof candidate.message === 'string' ? candidate.message : String(error);
+    return `${name}: ${message}`;
+  }
+  return String(error);
+}
+
+export const FILE_SYSTEM_READ_ERROR_MESSAGE =
+  'Could not read one or more dropped files or folders. Make sure they still exist and try again.';
+
+export function createFileSystemReadError(action: string, error: unknown): Error {
+  const wrapped = new Error(`${action}: ${errorSummary(error)}`, { cause: error });
+  wrapped.name = 'FileSystemReadError';
+  return wrapped;
+}
+
+export function isFileSystemReadError(error: unknown): error is Error {
+  return error instanceof Error && error.name === 'FileSystemReadError';
+}

--- a/apps/web/tests/components/DesignSystemFlow.test.tsx
+++ b/apps/web/tests/components/DesignSystemFlow.test.tsx
@@ -997,6 +997,39 @@ describe('DesignSystemCreationFlow', () => {
     expect(onCreated).toHaveBeenCalledWith(project.id, project);
   });
 
+  it('shows a recoverable error when a dragged local code entry cannot be read', async () => {
+    const { container } = render(
+      <DesignSystemCreationFlow
+        onBack={() => {}}
+        onCreated={() => {}}
+      />,
+    );
+    const dropZone = container.querySelector('input[webkitdirectory]')?.closest('.ds-drop-zone') as HTMLElement | null;
+
+    fireEvent.drop(dropZone!, {
+      dataTransfer: {
+        files: [],
+        items: [
+          {
+            webkitGetAsEntry: () => ({
+              isFile: true,
+              isDirectory: false,
+              name: 'stale-token.css',
+              file: (_done: (file: File) => void, fail?: (error: DOMException) => void) => {
+                fail?.(new DOMException('missing', 'NotFoundError'));
+              },
+            }),
+          },
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not read one or more dropped files or folders/)).toBeTruthy();
+    });
+    expect(screen.queryByText(/local code files selected/)).toBeNull();
+  });
+
   it('recursively reads a dragged local code folder into the design-system project context', async () => {
     const system: DesignSystemDetail = {
       id: 'user:dragged-folder-design-system',

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -151,6 +151,44 @@ function changeInputValue(input: HTMLInputElement, value: string) {
   input.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
+function renderDesignFilesPanel(overrides: Partial<React.ComponentProps<typeof DesignFilesPanel>> = {}) {
+  const props: React.ComponentProps<typeof DesignFilesPanel> = {
+    projectId: 'project-1',
+    files: [],
+    liveArtifacts: [],
+    onRefreshFiles: vi.fn(),
+    onOpenFile: vi.fn(),
+    onOpenLiveArtifact: vi.fn(),
+    onRenameFile: vi.fn(),
+    onDeleteFile: vi.fn(),
+    onDeleteFiles: vi.fn(),
+    onUpload: vi.fn(),
+    onUploadFiles: vi.fn(),
+    onPaste: vi.fn(),
+    onNewSketch: vi.fn(),
+    ...overrides,
+  };
+  return render(<DesignFilesPanel {...props} />);
+}
+
+function unreadableDropDataTransfer(fallbackFiles: File[] = []) {
+  return {
+    files: fallbackFiles,
+    items: [
+      {
+        webkitGetAsEntry: () => ({
+          isFile: true,
+          isDirectory: false,
+          name: 'stale.png',
+          file: (_done: (file: File) => void, fail?: (error: DOMException) => void) => {
+            fail?.(new DOMException('missing', 'NotFoundError'));
+          },
+        }),
+      },
+    ],
+  };
+}
+
 describe('FileWorkspace upload input', () => {
   it('keeps the Design Files picker aligned with drag-and-drop file support', () => {
     const markup = renderToStaticMarkup(
@@ -258,6 +296,35 @@ describe('FileWorkspace upload input', () => {
         'Uploaded 1 file(s), but 1 failed (permission denied).',
       );
     });
+  });
+
+  it('falls back to the browser file list when a dragged entry cannot be read', async () => {
+    const fallbackFile = new File(['mock'], 'fallback.png', { type: 'image/png' });
+    const onUploadFiles = vi.fn();
+    const { container } = renderDesignFilesPanel({ onUploadFiles });
+
+    fireEvent.drop(container.querySelector('.df-drop')!, {
+      dataTransfer: unreadableDropDataTransfer([fallbackFile]),
+    });
+
+    await waitFor(() => expect(onUploadFiles).toHaveBeenCalledWith([fallbackFile]));
+    expect(screen.queryByTestId('upload-error-banner')).toBeNull();
+  });
+
+  it('shows a recoverable read error when a dragged entry disappears before import', async () => {
+    const onUploadFiles = vi.fn();
+    const { container } = renderDesignFilesPanel({ onUploadFiles });
+
+    fireEvent.drop(container.querySelector('.df-drop')!, {
+      dataTransfer: unreadableDropDataTransfer(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upload-error-banner').textContent).toContain(
+        'Could not read one or more dropped files or folders',
+      );
+    });
+    expect(onUploadFiles).not.toHaveBeenCalled();
   });
 
   it('hides the workspace focus control while the chat pane is open', () => {

--- a/apps/web/tests/utils/fileSystemErrors.test.ts
+++ b/apps/web/tests/utils/fileSystemErrors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FILE_SYSTEM_READ_ERROR_MESSAGE,
+  createFileSystemReadError,
+  isFileSystemReadError,
+} from '../../src/utils/fileSystemErrors';
+
+describe('createFileSystemReadError', () => {
+  it('wraps DOMException-like file system failures in a stack-bearing Error', () => {
+    const cause = new DOMException(
+      'A requested file or directory could not be found at the time an operation was processed.',
+      'NotFoundError',
+    );
+
+    const error = createFileSystemReadError('Could not read dropped file', cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('FileSystemReadError');
+    expect(error.message).toContain('Could not read dropped file');
+    expect(error.message).toContain('NotFoundError');
+    expect(error.cause).toBe(cause);
+    expect(error.stack).toEqual(expect.any(String));
+    expect(isFileSystemReadError(error)).toBe(true);
+    expect(FILE_SYSTEM_READ_ERROR_MESSAGE).toContain('try again');
+  });
+});


### PR DESCRIPTION
## Why

I hit PostHog `$exception` events for browser file-system `NotFoundError` failures from file/folder imports. The root cause is in the browser drag/drop read path: `webkitGetAsEntry()` can hand us a file-system entry that later rejects with a bare `DOMException`, commonly when the dragged file or folder moved, disappeared, is a cloud placeholder that is not local yet, or is otherwise no longer readable by the browser at read time.

That made two things bad: imports could fail before reaching our upload path, and PostHog had no stack because the browser error was not a stack-bearing `Error`.

## What users will see

Dragging files/folders into Design Files or the design-system setup now tries the browser `FileList` fallback when the entry API fails. If the browser truly cannot read the dropped item, the app shows a recoverable “make sure they still exist and try again” message instead of surfacing a global unhandled exception.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A. This is a transient drag/drop browser file-system failure path; the visible behavior is covered by focused jsdom tests rather than a stable screenshot fixture.

## Bug fix verification

- Test paths that reproduce the bug boundary:
  - `apps/web/tests/components/FileWorkspace.test.tsx` covers entry read failure fallback and recoverable Design Files UI error.
  - `apps/web/tests/components/DesignSystemFlow.test.tsx` covers recoverable design-system local-code drop errors.
  - `apps/web/tests/utils/fileSystemErrors.test.ts` covers stack-bearing wrapper behavior for browser `DOMException` failures.
- Did the test go red on `main` and green on this branch? Not re-run on `main` in this worktree. The new tests encode the failing browser boundary and pass on this branch.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/utils/fileSystemErrors.test.ts tests/components/DesignSystemFlow.test.tsx tests/components/FileWorkspace.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

Note: commands were run on Node `v22.22.0` in this shell, so pnpm printed the repo engine warning for required Node `~24`; the listed commands completed successfully.
