### PR TITLE
[codex] fix Windows folder import from project modal

### DIFF
--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -107,8 +107,11 @@ function normalizeProjectImportResult(input: unknown): OpenDesignHostProjectImpo
   const rawProjectId = isRecord(project) ? project.id : null;
   const projectId = typeof rawProjectId === 'string' ? rawProjectId : null;
   const conversationId = typeof response.conversationId === 'string' ? response.conversationId : null;
-  const entryFile = typeof response.entryFile === 'string' ? response.entryFile : null;
-  if (projectId == null || conversationId == null || entryFile == null) {
+  const entryFile =
+    typeof response.entryFile === 'string' || response.entryFile === null
+      ? response.entryFile
+      : undefined;
+  if (projectId == null || conversationId == null || entryFile === undefined) {
     return failure('daemon import response did not include host project identifiers', response);
   }
 

--- a/apps/desktop/tests/main/preload-host-boundary.test.ts
+++ b/apps/desktop/tests/main/preload-host-boundary.test.ts
@@ -33,4 +33,12 @@ describe("desktop preload host boundary", () => {
     expect(source).not.toContain('exposeInMainWorld("__odDesktop"');
     expect(source).not.toContain("exposeInMainWorld('__odDesktop'");
   });
+
+  it("mirrors the host import contract by accepting a null entryFile", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(join(here, "../../src/main/preload.cts"), "utf8");
+
+    expect(source).toContain("response.entryFile === null");
+    expect(source).toContain("entryFile === undefined");
+  });
 });

--- a/apps/web/src/components/NewProjectModal.tsx
+++ b/apps/web/src/components/NewProjectModal.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import type { ConnectorDetail } from '@open-design/contracts';
+import type { OpenDesignHostProjectImportSuccess } from '@open-design/host';
 import type {
   DesignSystemSummary,
   MediaProviderCredentials,
@@ -35,6 +36,7 @@ interface Props {
   onCreate: (input: CreateInput & { requestId?: string }) => Promise<boolean> | boolean | void;
   onImportClaudeDesign?: (file: File) => Promise<void> | void;
   onImportFolder?: (baseDir: string) => Promise<void> | void;
+  onImportFolderResponse?: (response: OpenDesignHostProjectImportSuccess) => Promise<void> | void;
   onOpenConnectorsTab?: () => void;
   onClose: () => void;
   initialTab?: CreateTab;
@@ -55,6 +57,7 @@ export function NewProjectModal({
   onCreate,
   onImportClaudeDesign,
   onImportFolder,
+  onImportFolderResponse,
   onOpenConnectorsTab,
   onClose,
   initialTab,
@@ -151,6 +154,7 @@ export function NewProjectModal({
             }}
             {...(onImportClaudeDesign ? { onImportClaudeDesign } : {})}
             {...(onImportFolder ? { onImportFolder } : {})}
+            {...(onImportFolderResponse ? { onImportFolderResponse } : {})}
             {...(onOpenConnectorsTab ? { onOpenConnectorsTab } : {})}
             {...(initialTab ? { initialTab } : {})}
           />

--- a/apps/web/tests/components/NewProjectModal.test.tsx
+++ b/apps/web/tests/components/NewProjectModal.test.tsx
@@ -3,6 +3,12 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@open-design/host', () => ({
+  isOpenDesignHostAvailable: () => true,
+  pickAndImportHostProject: vi.fn(),
+}));
+
+import { pickAndImportHostProject } from '@open-design/host';
 import { NewProjectModal } from '../../src/components/NewProjectModal';
 import type {
   DesignSystemSummary,
@@ -56,6 +62,7 @@ class ResizeObserverMock {
 beforeEach(() => {
   globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
   Element.prototype.scrollIntoView = vi.fn();
+  vi.mocked(pickAndImportHostProject).mockReset();
 });
 
 describe('NewProjectModal layout', () => {
@@ -114,6 +121,40 @@ describe('NewProjectModal layout', () => {
 
     await waitFor(() => {
       expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('forwards the desktop folder import response handler to the inner panel', async () => {
+    const importResult = {
+      conversationId: 'conversation-host',
+      entryFile: 'src/App.tsx',
+      ok: true,
+      projectId: 'project-host',
+    } as const;
+    vi.mocked(pickAndImportHostProject).mockResolvedValue(importResult);
+    const onImportFolderResponse = vi.fn();
+
+    render(
+      <NewProjectModal
+        open
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId={null}
+        templates={[]}
+        promptTemplates={[]}
+        onCreate={() => {}}
+        onImportFolderResponse={onImportFolderResponse}
+        onClose={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open folder' }));
+
+    await waitFor(() => {
+      expect(pickAndImportHostProject).toHaveBeenCalledWith({ skillId: 'prototype-skill' });
+    });
+    await waitFor(() => {
+      expect(onImportFolderResponse).toHaveBeenCalledWith(importResult);
     });
   });
 });


### PR DESCRIPTION
Fixes #2850

## Why

I hit the Windows Desktop new-project flow from issue #2850: the New Project modal in packaged Desktop did not expose the folder import entry point, so local projects could not be opened from that path.

While validating the restored entry point with a Windows `win-unpacked` build, folder import exposed a second contract mismatch: daemon folder import may legitimately return `entryFile: null` when the selected directory has no detected entry file, but the Desktop preload bridge treated that as a malformed host response.

## What users will see

Windows Desktop users will see `Open folder` in the New Project modal again. Selecting a local folder imports the project through the Desktop host picker flow; folders without a detected entry file no longer fail with `daemon import response did not include host project identifiers`.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Windows `win-unpacked` validation showing the restored `Open folder` entry point in the New Project modal:

<img width="1264" height="835" alt="fix_open_folder" src="https://github.com/user-attachments/assets/08b04dcb-2e66-4f28-b884-e87ddc45683d" />

## Bug fix verification

- Test path that reproduces the missing modal bridge: `apps/web/tests/components/NewProjectModal.test.tsx`
- Test path that reproduces the Desktop preload `entryFile: null` contract mismatch: `apps/desktop/tests/main/preload-host-boundary.test.ts`
- Did the tests go red on `main` and green on this branch? yes. The modal test failed before `NewProjectModal` forwarded `onImportFolderResponse`; the preload boundary test failed before the Desktop preload accepted `entryFile: null`.

## Validation

- `pnpm --dir apps/desktop exec vitest run -c vitest.config.ts tests/main/preload-host-boundary.test.ts`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/NewProjectModal.test.tsx`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/web typecheck`
- `git diff --check`
- `pnpm guard` (passed outside the sandbox after the sandbox denied tsx IPC pipe creation with `listen EPERM`)
- `ASTRO_TELEMETRY_DISABLED=1 pnpm typecheck` (plain `pnpm typecheck` hit Astro telemetry trying to create `/root/.config/astro`; disabling telemetry made the full workspace typecheck pass)
- `pnpm tools-pack win build --namespace fix2850 --to dir --portable --json`
- Windows manual verification using the generated `win-unpacked` build: passed; `Open folder` appears and imports the selected local folder without the host identifier error.