### PR TITLE
Clear manual edit selection after deleting elements

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4992,7 +4992,19 @@ function HtmlViewer({
       }
       setManualEditHistory((current) => [entry, ...current]);
       setManualEditUndone([]);
-      setManualEditDraft((current) => ({ ...current, fullSource: result.source }));
+      if (patch.kind === 'remove-element') {
+        if (manualEditPendingStyleRef.current?.id === patch.id) {
+          manualEditPendingStyleRef.current = null;
+          clearManualEditStyleTimer();
+        }
+        selectedManualEditTargetIdRef.current = null;
+        setSelectedManualEditTarget(null);
+        setManualEditTargets((current) => current.filter((target) => target.id !== patch.id));
+        setManualEditDraft(emptyManualEditDraft(result.source));
+        postSelectedManualEditTargetToIframe(null);
+      } else {
+        setManualEditDraft((current) => ({ ...current, fullSource: result.source }));
+      }
       if (patch.kind === 'set-style') {
         reconcileManualEditStyleSave(patch.id, patch.styles, result.source);
       }

--- a/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
@@ -3,6 +3,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ComponentProps } from 'react';
+import { emptyManualEditStyles, type ManualEditTarget } from '../../src/edit-mode/types';
 import type { ProjectFile } from '../../src/types';
 
 const panelState = vi.hoisted(() => ({
@@ -215,6 +216,79 @@ describe('FileViewer manual edit history regressions', () => {
       );
     });
   });
+
+  it('clears the selected target after deleting an element', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero">Hero</h1><p data-od-id="body">Body</p></body></html>';
+    let persistedSource = initialSource;
+    const savedSources: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.includes('/api/projects/project-1/deployments')) {
+        return new Response(JSON.stringify({ deployments: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/projects/project-1/files') && init?.method === 'POST') {
+        const payload = JSON.parse(String(init.body)) as { content: string };
+        persistedSource = payload.content;
+        savedSources.push(payload.content);
+        return new Response(JSON.stringify({ file: htmlPreviewFile() }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/projects/project-1/raw/preview.html')) {
+        return new Response(persistedSource, { status: 200 });
+      }
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+    await waitFor(() => expect(panelState.props).not.toBeNull());
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const postMessageSpy = vi.spyOn(frame.contentWindow!, 'postMessage');
+
+    await act(async () => {
+      await panelState.props?.onSelectTarget(heroTarget());
+    });
+    await waitFor(() => expect(panelState.props?.selectedTarget?.id).toBe('hero'));
+    expect(panelState.props?.draft.text).toBe('Hero');
+
+    act(() => {
+      panelState.props?.onApplyPatch(
+        { id: 'hero', kind: 'remove-element' },
+        'Delete element',
+      );
+    });
+
+    await waitFor(() => expect(savedSources).toHaveLength(1));
+    expect(savedSources[0]).not.toContain('data-od-id="hero"');
+    expect(savedSources[0]).toContain('data-od-id="body"');
+    await waitFor(() => expect(panelState.props?.selectedTarget).toBeNull());
+    expect(panelState.props?.draft.text).toBe('');
+    expect(panelState.props?.draft.fullSource).not.toContain('data-od-id="hero"');
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'od-edit-selected-target', id: null }),
+      '*',
+    );
+    await waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'od:srcdoc-transport-activate',
+          html: expect.not.stringContaining('data-od-id="hero"'),
+        }),
+        '*',
+      );
+    });
+  });
 });
 
 function htmlPreviewFile(): ProjectFile {
@@ -234,5 +308,22 @@ function htmlPreviewFile(): ProjectFile {
       renderer: 'html',
       exports: ['html'],
     },
+  };
+}
+
+function heroTarget(): ManualEditTarget {
+  return {
+    id: 'hero',
+    kind: 'text',
+    label: 'Hero',
+    tagName: 'h1',
+    className: '',
+    text: 'Hero',
+    rect: { x: 0, y: 0, width: 120, height: 40 },
+    fields: { text: 'Hero' },
+    attributes: { 'data-od-id': 'hero' },
+    styles: emptyManualEditStyles(),
+    isLayoutContainer: false,
+    outerHtml: '<h1 data-od-id="hero">Hero</h1>',
   };
 }


### PR DESCRIPTION
Fixes #2853

## Why

Deleting an element from the manual editor saved the source change, but the side panel could keep showing the removed target while the preview canvas was reloading. I picked this up from the open community issue and kept the fix scoped to the delete path.

## What users will see

After confirming Delete element in manual edit mode, the deleted element is removed from the saved source, the inspector selection is cleared, and the preview is refreshed from the updated source instead of keeping stale target state.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — this is a stale-state bug fix covered by a regression test.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.manual-edit-history.test.tsx`
- Did the test go red on `main` and green on this branch? No; I added the regression test on this branch and verified it passes with the source fix.

## Validation

- `PATH=/tmp/od-corepack-shims:$PATH pnpm guard`
- `PATH=/tmp/od-corepack-shims:$PATH pnpm typecheck`
- `PATH=/tmp/od-corepack-shims:$PATH pnpm --filter @open-design/web build`
- `corepack pnpm --filter @open-design/web test -- tests/components/FileViewer.manual-edit-history.test.tsx` (224 files / 2103 tests passed)

Note: local environment was Node v22.22.1, so pnpm emitted the repo's Node `~24` engine warning while the checks ran successfully.