### PR TITLE
feat(comments): add comment attachment API

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -115,6 +115,7 @@ function migrate(db: SqliteDb): void {
       text TEXT NOT NULL,
       position_json TEXT NOT NULL,
       html_hint TEXT NOT NULL,
+      style_json TEXT,
       note TEXT NOT NULL,
       status TEXT NOT NULL,
       created_at INTEGER NOT NULL,
@@ -242,6 +243,9 @@ function migrate(db: SqliteDb): void {
   }
   if (!previewCommentCols.some((c: DbRow) => c.name === 'pod_members_json')) {
     db.exec(`ALTER TABLE preview_comments ADD COLUMN pod_members_json TEXT`);
+  }
+  if (!previewCommentCols.some((c: DbRow) => c.name === 'style_json')) {
+    db.exec(`ALTER TABLE preview_comments ADD COLUMN style_json TEXT`);
   }
   const deploymentCols = db.prepare(`PRAGMA table_info(deployments)`).all() as DbRow[];
   if (!deploymentCols.some((c: DbRow) => c.name === 'status')) {
@@ -1042,7 +1046,7 @@ export function listPreviewComments(db: SqliteDb, projectId: string, conversatio
               file_path AS filePath, element_id AS elementId, selector, label,
               text, position_json AS positionJson, html_hint AS htmlHint,
               selection_kind AS selectionKind, member_count AS memberCount,
-              pod_members_json AS podMembersJson,
+              pod_members_json AS podMembersJson, style_json AS styleJson,
               note, status, created_at AS createdAt, updated_at AS updatedAt
          FROM preview_comments
         WHERE project_id = ? AND conversation_id = ?
@@ -1065,6 +1069,7 @@ export function upsertPreviewComment(db: SqliteDb, projectId: string, conversati
   const position = normalizePosition(target.position);
   const selectionKind = target.selectionKind === 'pod' ? 'pod' : 'element';
   const podMembers = selectionKind === 'pod' ? normalizePodMembers(target.podMembers) : [];
+  const style = normalizeAnnotationStyle(target.style);
   const memberCount = selectionKind === 'pod'
     ? (podMembers.length > 0
         ? podMembers.length
@@ -1086,8 +1091,8 @@ export function upsertPreviewComment(db: SqliteDb, projectId: string, conversati
     `INSERT INTO preview_comments
        (id, project_id, conversation_id, file_path, element_id, selector, label,
         text, position_json, html_hint, selection_kind, member_count, pod_members_json,
-        note, status, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        style_json, note, status, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(project_id, conversation_id, file_path, element_id) DO UPDATE SET
        selector = excluded.selector,
        label = excluded.label,
@@ -1097,6 +1102,7 @@ export function upsertPreviewComment(db: SqliteDb, projectId: string, conversati
        selection_kind = excluded.selection_kind,
        member_count = excluded.member_count,
        pod_members_json = excluded.pod_members_json,
+       style_json = excluded.style_json,
        note = excluded.note,
        status = 'open',
        updated_at = excluded.updated_at`,
@@ -1114,6 +1120,7 @@ export function upsertPreviewComment(db: SqliteDb, projectId: string, conversati
     selectionKind,
     selectionKind === 'pod' ? memberCount : null,
     selectionKind === 'pod' ? JSON.stringify(podMembers) : null,
+    style ? JSON.stringify(style) : null,
     note,
     'open',
     createdAt,
@@ -1150,7 +1157,7 @@ function getPreviewComment(db: SqliteDb, projectId: string, conversationId: stri
               file_path AS filePath, element_id AS elementId, selector, label,
               text, position_json AS positionJson, html_hint AS htmlHint,
               selection_kind AS selectionKind, member_count AS memberCount,
-              pod_members_json AS podMembersJson,
+              pod_members_json AS podMembersJson, style_json AS styleJson,
               note, status, created_at AS createdAt, updated_at AS updatedAt
          FROM preview_comments
         WHERE id = ? AND project_id = ? AND conversation_id = ?`,
@@ -1173,6 +1180,7 @@ function normalizePreviewComment(row: DbRow) {
     text: row.text,
     position: parseJsonOrUndef(row.positionJson) ?? { x: 0, y: 0, width: 0, height: 0 },
     htmlHint: row.htmlHint,
+    style: normalizeAnnotationStyle(parseJsonOrUndef(row.styleJson)),
     selectionKind: row.selectionKind === 'pod' ? 'pod' : 'element',
     memberCount:
       normalizedPodMembers && normalizedPodMembers.length > 0
@@ -1214,10 +1222,39 @@ function normalizePodMembers(input: unknown) {
           typeof member.htmlHint === 'string'
             ? compactWhitespace(member.htmlHint).slice(0, 180)
             : '',
+        style: normalizeAnnotationStyle(member.style),
       };
     })
     .filter(Boolean);
 }
+
+function normalizeAnnotationStyle(input: unknown) {
+  if (!input || typeof input !== 'object') return undefined;
+  const raw = input as DbRow;
+  const style: DbRow = {};
+  for (const key of ANNOTATION_STYLE_KEYS) {
+    const value = raw[key];
+    if (typeof value !== 'string') continue;
+    const trimmed = compactWhitespace(value);
+    if (trimmed) style[key] = trimmed.slice(0, 120);
+  }
+  return Object.keys(style).length > 0 ? style : undefined;
+}
+
+const ANNOTATION_STYLE_KEYS = [
+  'color',
+  'backgroundColor',
+  'fontSize',
+  'fontWeight',
+  'lineHeight',
+  'textAlign',
+  'fontFamily',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'borderRadius',
+] as const;
 
 function compactWhitespace(value: string): string {
   return value.replace(/\s+/g, ' ').trim();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -774,6 +774,7 @@ export function normalizeCommentAttachments(input) {
         currentText: compactString(raw.currentText, 160),
         pagePosition: normalizeAttachmentPosition(raw.pagePosition),
         htmlHint: compactString(raw.htmlHint, 180),
+        style: normalizeAnnotationStyle(raw.style),
         selectionKind,
         memberCount,
         podMembers,
@@ -809,6 +810,7 @@ export function renderCommentAttachmentHint(commentAttachments) {
       `position: ${formatAttachmentPosition(item.pagePosition)}`,
       `currentText: ${item.currentText || '(empty)'}`,
       `htmlHint: ${item.htmlHint || '(none)'}`,
+      `computedStyle: ${formatAnnotationStyle(item.style) || '(none)'}`,
       `comment: ${item.comment}`,
     );
     if (targetKind === 'visual') {
@@ -827,6 +829,8 @@ export function renderCommentAttachmentHint(commentAttachments) {
         lines.push(
           `member.${memberIndex + 1}: ${member.elementId} | ${member.label || '(unlabeled)'} | ${member.selector}`,
         );
+        const memberStyle = formatAnnotationStyle(member.style);
+        if (memberStyle) lines.push(`member.${memberIndex + 1}.computedStyle: ${memberStyle}`);
       });
     }
   }
@@ -885,10 +889,49 @@ function normalizeAttachmentPodMembers(input) {
         text: compactString(member.text, 160),
         position: normalizeAttachmentPosition(member.position),
         htmlHint: compactString(member.htmlHint, 180),
+        style: normalizeAnnotationStyle(member.style),
       };
     })
     .filter(Boolean);
 }
+
+function normalizeAnnotationStyle(input) {
+  if (!input || typeof input !== 'object') return undefined;
+  const style = {};
+  for (const key of ANNOTATION_STYLE_KEYS) {
+    const value = input[key];
+    if (typeof value !== 'string') continue;
+    const trimmed = value.replace(/\s+/g, ' ').trim();
+    if (trimmed) style[key] = trimmed.slice(0, 120);
+  }
+  return Object.keys(style).length > 0 ? style : undefined;
+}
+
+function formatAnnotationStyle(style) {
+  if (!style || typeof style !== 'object') return '';
+  return ANNOTATION_STYLE_KEYS
+    .map((key) => {
+      const value = style[key];
+      return value ? `${key}: ${value}` : null;
+    })
+    .filter(Boolean)
+    .join('; ');
+}
+
+const ANNOTATION_STYLE_KEYS = [
+  'color',
+  'backgroundColor',
+  'fontSize',
+  'fontWeight',
+  'lineHeight',
+  'textAlign',
+  'fontFamily',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'borderRadius',
+];
 
 function finiteAttachmentNumber(value) {
   return Number.isFinite(value) ? Math.round(value) : 0;

--- a/apps/web/src/comments.ts
+++ b/apps/web/src/comments.ts
@@ -2,6 +2,7 @@ import type {
   ChatCommentAttachment,
   ChatCommentSelectionKind,
   ChatMessage,
+  PreviewAnnotationStyle,
   PreviewCommentMember,
   PreviewComment,
   PreviewCommentSelectionKind,
@@ -16,7 +17,9 @@ export interface PreviewCommentSnapshot {
   label: string;
   text: string;
   position: { x: number; y: number; width: number; height: number };
+  hoverPoint?: { x: number; y: number };
   htmlHint: string;
+  style?: PreviewAnnotationStyle;
   selectionKind?: PreviewCommentSelectionKind;
   memberCount?: number;
   podMembers?: PreviewCommentMember[];
@@ -37,6 +40,7 @@ export interface VisualAnnotationTarget {
   text?: string;
   position?: { x: number; y: number; width: number; height: number };
   htmlHint?: string;
+  style?: PreviewAnnotationStyle;
 }
 
 export interface VisualAnnotationAttachmentInput {
@@ -59,6 +63,7 @@ export function targetFromSnapshot(snapshot: PreviewCommentSnapshot): PreviewCom
     text: trimContextText(snapshot.text),
     position: normalizePosition(snapshot.position),
     htmlHint: trimHtmlHint(snapshot.htmlHint),
+    style: normalizeStyle(snapshot.style),
     selectionKind: snapshot.selectionKind === 'pod' ? 'pod' : 'element',
     memberCount:
       snapshot.selectionKind === 'pod'
@@ -101,6 +106,7 @@ export function liveSnapshotForComment(
     text: trimContextText(comment.text),
     position: normalizePosition(comment.position),
     htmlHint: trimHtmlHint(comment.htmlHint),
+    style: normalizeStyle(comment.style),
     selectionKind: comment.selectionKind === 'pod' ? 'pod' : 'element',
     memberCount: comment.memberCount,
     podMembers: normalizeMembers(comment.podMembers),
@@ -123,6 +129,7 @@ export function commentToAttachment(
     currentText: trimContextText(comment.text),
     pagePosition: normalizePosition(comment.position),
     htmlHint: trimHtmlHint(comment.htmlHint),
+    style: normalizeStyle(comment.style),
     selectionKind: comment.selectionKind === 'pod' ? 'pod' : 'element',
     memberCount:
       comment.selectionKind === 'pod'
@@ -169,6 +176,7 @@ export function buildBoardCommentAttachments(input: {
       currentText: trimContextText(input.target.text),
       pagePosition: normalizePosition(input.target.position),
       htmlHint: trimHtmlHint(input.target.htmlHint),
+      style: normalizeStyle(input.target.style),
       selectionKind,
       memberCount,
       podMembers: podMembers.length > 0 ? podMembers : undefined,
@@ -194,6 +202,7 @@ export function buildVisualAnnotationAttachment(input: VisualAnnotationAttachmen
     currentText: trimContextText(target?.text || ''),
     pagePosition: normalizePosition(target?.position ?? input.bounds),
     htmlHint: trimHtmlHint(target?.htmlHint || ''),
+    style: normalizeStyle(target?.style),
     selectionKind: 'visual',
     screenshotPath: input.screenshotPath,
     markKind: input.markKind,
@@ -292,6 +301,7 @@ function renderCommentAttachmentContext(commentAttachments: ChatCommentAttachmen
       `position: x${position.x} y${position.y} ${position.width}x${position.height}`,
       `currentText: ${trimContextText(item.currentText || '') || '(empty)'}`,
       `htmlHint: ${trimHtmlHint(item.htmlHint || '') || '(none)'}`,
+      `computedStyle: ${formatAnnotationStyle(item.style) || '(none)'}`,
       `comment: ${item.comment}`,
     );
     if (selectionKind === 'visual') {
@@ -310,6 +320,8 @@ function renderCommentAttachmentContext(commentAttachments: ChatCommentAttachmen
         lines.push(
           `member.${memberIndex + 1}: ${member.elementId} | ${member.label || '(unlabeled)'} | ${member.selector}`,
         );
+        const memberStyle = formatAnnotationStyle(member.style);
+        if (memberStyle) lines.push(`member.${memberIndex + 1}.computedStyle: ${memberStyle}`);
       });
     }
   });
@@ -350,6 +362,46 @@ function normalizeMembers(input: PreviewCommentMember[] | undefined): PreviewCom
       text: trimContextText(String(member.text || '')),
       position: normalizePosition(member.position),
       htmlHint: trimHtmlHint(String(member.htmlHint || '')),
+      style: normalizeStyle(member.style),
     }))
     .filter((member) => member.elementId && member.selector);
 }
+
+function normalizeStyle(input: unknown): PreviewAnnotationStyle | undefined {
+  if (!input || typeof input !== 'object') return undefined;
+  const raw = input as Record<string, unknown>;
+  const style: PreviewAnnotationStyle = {};
+  for (const key of ANNOTATION_STYLE_KEYS) {
+    const value = raw[key];
+    if (typeof value !== 'string') continue;
+    const trimmed = value.replace(/\s+/g, ' ').trim();
+    if (trimmed) style[key] = trimmed.slice(0, 120);
+  }
+  return Object.keys(style).length > 0 ? style : undefined;
+}
+
+function formatAnnotationStyle(style: PreviewAnnotationStyle | undefined): string {
+  if (!style) return '';
+  return ANNOTATION_STYLE_KEYS
+    .map((key) => {
+      const value = style[key];
+      return value ? `${key}: ${value}` : null;
+    })
+    .filter((item): item is string => Boolean(item))
+    .join('; ');
+}
+
+const ANNOTATION_STYLE_KEYS = [
+  'color',
+  'backgroundColor',
+  'fontSize',
+  'fontWeight',
+  'lineHeight',
+  'textAlign',
+  'fontFamily',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'borderRadius',
+] as const;

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1560,17 +1560,39 @@ export async function writeProjectTextFile(
   content: string,
   options?: { artifactManifest?: ArtifactManifest },
 ): Promise<ProjectFile | null> {
+  const result = await writeProjectTextFileDetailed(projectId, name, content, options);
+  return result.ok ? result.file : null;
+}
+
+export type WriteProjectTextFileResult =
+  | { ok: true; file: ProjectFile }
+  | { ok: false; status?: number; code?: string; message: string };
+
+export async function writeProjectTextFileDetailed(
+  projectId: string,
+  name: string,
+  content: string,
+  options?: { artifactManifest?: ArtifactManifest },
+): Promise<WriteProjectTextFileResult> {
   try {
     const resp = await fetch(`/api/projects/${encodeURIComponent(projectId)}/files`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, content, artifactManifest: options?.artifactManifest }),
     });
-    if (!resp.ok) return null;
+    if (!resp.ok) {
+      const body = await readApiErrorBody(resp);
+      return {
+        ok: false,
+        status: resp.status,
+        code: body.code,
+        message: body.message || resp.statusText || 'Save failed',
+      };
+    }
     const json = (await resp.json()) as { file: ProjectFile };
-    return json.file;
+    return { ok: true, file: json.file };
   } catch {
-    return null;
+    return { ok: false, message: 'Network error while saving the file' };
   }
 }
 

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -52,6 +52,7 @@ import type {
   Project,
   ProjectPlatform,
   PreviewCommentMember,
+  PreviewAnnotationStyle,
   PreviewCommentSelectionKind,
   PreviewComment,
   PreviewCommentStatus,
@@ -86,6 +87,7 @@ export type {
   OrbitRunSummary,
   OrbitStatusResponse,
   PreviewCommentMember,
+  PreviewAnnotationStyle,
   PreviewCommentSelectionKind,
   PreviewVisualMarkKind,
 } from '@open-design/contracts';

--- a/apps/web/tests/comments.test.ts
+++ b/apps/web/tests/comments.test.ts
@@ -23,11 +23,21 @@ describe('preview comment attachment helpers', () => {
       text: `  ${'Title '.repeat(80)}  `,
       htmlHint: `<h1 class="hero-title" data-od-id="hero-title">${'x'.repeat(240)}</h1>`,
       position: { x: 10.4, y: 20.5, width: 300.2, height: 88.8 },
+      style: {
+        color: 'rgb(26, 25, 22)',
+        fontSize: '13.5px',
+        fontFamily: 'Inter, sans-serif',
+      },
     });
 
     expect(target.text.length).toBeLessThanOrEqual(160);
     expect(target.htmlHint.length).toBeLessThanOrEqual(180);
     expect(target.position).toEqual({ x: 10, y: 21, width: 300, height: 89 });
+    expect(target.style).toMatchObject({
+      color: 'rgb(26, 25, 22)',
+      fontSize: '13.5px',
+      fontFamily: 'Inter, sans-serif',
+    });
   });
 
   it('creates ordered compact send payloads from attached comments', () => {
@@ -233,7 +243,18 @@ describe('preview comment attachment helpers', () => {
 
   it('serializes selected comments into API-mode prompt context without visible input', () => {
     const attachments = commentsToAttachments([
-      comment({ id: 'c1', elementId: 'hero-title', note: 'Only shorten this title' }),
+      comment({
+        id: 'c1',
+        elementId: 'hero-title',
+        note: 'Only shorten this title',
+        style: {
+          color: 'rgb(26, 25, 22)',
+          backgroundColor: 'rgba(255, 255, 255, 0)',
+          fontSize: '13.5px',
+          fontWeight: '500',
+          fontFamily: 'Inter, sans-serif',
+        },
+      }),
     ]);
 
     const content = messageContentWithCommentAttachments('', attachments);
@@ -241,6 +262,8 @@ describe('preview comment attachment helpers', () => {
     expect(content).toContain('(No extra typed instruction.)');
     expect(content).toContain('<attached-preview-comments>');
     expect(content).toContain('selector: [data-od-id="hero-title"]');
+    expect(content).toContain('computedStyle: color: rgb(26, 25, 22)');
+    expect(content).toContain('fontSize: 13.5px');
     expect(content).toContain('comment: Only shorten this title');
   });
 

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -18,6 +18,7 @@ import {
   isDeployProviderId,
   updateDeployConfig,
   uploadProjectFiles,
+  writeProjectTextFileDetailed,
 } from '../../src/providers/registry';
 
 describe('fetchAppVersionInfo', () => {
@@ -50,6 +51,29 @@ describe('fetchAppVersionInfo', () => {
     );
 
     await expect(fetchAppVersionInfo()).resolves.toBeNull();
+  });
+});
+
+describe('writeProjectTextFileDetailed', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('surfaces daemon save errors instead of collapsing them to null', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({
+        error: { code: 'ARTIFACT_REGRESSION', message: 'new artifact is smaller than the prior version' },
+      }), { status: 422, headers: { 'Content-Type': 'application/json' } })),
+    );
+
+    await expect(writeProjectTextFileDetailed('project-1', 'preview.html', '<html></html>')).resolves.toEqual({
+      ok: false,
+      status: 422,
+      code: 'ARTIFACT_REGRESSION',
+      message: 'new artifact is smaller than the prior version',
+    });
   });
 });
 

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -3,6 +3,7 @@ import type {
   PreviewCommentMember,
   PreviewCommentPosition,
   PreviewCommentSelectionKind,
+  PreviewAnnotationStyle,
   PreviewVisualMarkKind,
 } from './comments';
 import type { ResearchOptions } from './research';
@@ -121,6 +122,7 @@ export interface ChatCommentAttachment {
   currentText: string;
   pagePosition: PreviewCommentPosition;
   htmlHint: string;
+  style?: PreviewAnnotationStyle;
   selectionKind?: ChatCommentSelectionKind;
   memberCount?: number;
   podMembers?: PreviewCommentMember[];

--- a/packages/contracts/src/api/comments.ts
+++ b/packages/contracts/src/api/comments.ts
@@ -15,6 +15,21 @@ export interface PreviewCommentPosition {
   height: number;
 }
 
+export interface PreviewAnnotationStyle {
+  color?: string;
+  backgroundColor?: string;
+  fontSize?: string;
+  fontWeight?: string;
+  lineHeight?: string;
+  textAlign?: string;
+  fontFamily?: string;
+  paddingTop?: string;
+  paddingRight?: string;
+  paddingBottom?: string;
+  paddingLeft?: string;
+  borderRadius?: string;
+}
+
 export type PreviewCommentSelectionKind = 'element' | 'pod';
 export type PreviewVisualMarkKind = 'click' | 'stroke' | 'click+stroke';
 
@@ -25,6 +40,7 @@ export interface PreviewCommentMember {
   text: string;
   position: PreviewCommentPosition;
   htmlHint: string;
+  style?: PreviewAnnotationStyle;
 }
 
 export interface PreviewCommentTarget {
@@ -35,6 +51,7 @@ export interface PreviewCommentTarget {
   text: string;
   position: PreviewCommentPosition;
   htmlHint: string;
+  style?: PreviewAnnotationStyle;
   selectionKind?: PreviewCommentSelectionKind;
   memberCount?: number;
   podMembers?: PreviewCommentMember[];
@@ -51,6 +68,7 @@ export interface PreviewComment {
   text: string;
   position: PreviewCommentPosition;
   htmlHint: string;
+  style?: PreviewAnnotationStyle;
   selectionKind?: PreviewCommentSelectionKind;
   memberCount?: number;
   podMembers?: PreviewCommentMember[];

--- a/scripts/approve-fork-pr-workflows.ts
+++ b/scripts/approve-fork-pr-workflows.ts
@@ -1,0 +1,434 @@
+import { fileURLToPath } from "node:url";
+
+type PullRequest = {
+  number: number;
+  state: string;
+  draft?: boolean;
+  changed_files: number;
+  head: {
+    ref: string;
+    sha: string;
+    repo: { full_name: string } | null;
+  };
+  base: {
+    ref: string;
+    sha: string;
+    repo: { full_name: string };
+  };
+};
+
+type PullRequestFile = {
+  filename: string;
+  previous_filename?: string;
+  status: string;
+};
+
+type WorkflowRun = {
+  id: number;
+  name: string | null;
+  event: string;
+  head_branch?: string | null;
+  head_repository?: { full_name: string } | null;
+  status: string | null;
+  conclusion: string | null;
+  head_sha: string;
+  path: string;
+  pull_requests: Array<{
+    number: number;
+    head: { sha: string; repo: { full_name: string } | null };
+    base: { ref: string; sha: string; repo: { full_name: string } };
+  }>;
+};
+
+type WorkflowRunsResponse = {
+  workflow_runs: WorkflowRun[];
+};
+
+type ListPendingApprovalRunsDeps = {
+  loadWorkflowRunsResponsePage?: (path: string) => Promise<WorkflowRunsResponse>;
+  loadPullRequestsForHeadSha?: (repo: string, headSha: string) => Promise<PullRequest[]>;
+  loadPullRequestsForHeadRef?: (repo: string, headOwnerAndRef: string) => Promise<PullRequest[]>;
+};
+
+const dryRun = process.env.DRY_RUN === "true";
+const defaultPendingRunPollIntervalMs = 3_000;
+const defaultPendingRunFirstAppearanceTimeoutMs = 4 * 60_000;
+const defaultPendingRunSettlingWindowMs = 30_000;
+
+type PendingRunPollingConfig = {
+  pollIntervalMs?: number;
+  firstAppearanceTimeoutMs?: number;
+  settlingWindowMs?: number;
+};
+
+function pendingRunSetSignature(runs: WorkflowRun[]): string {
+  return runs
+    .map((run) => `${run.id}:${run.head_sha}:${normalizeWorkflowPath(run.path)}`)
+    .sort()
+    .join(",");
+}
+
+// Workflow allowlisting is the security boundary: fork PRs may touch broader
+// source paths, but this script only approves low-privilege pull_request
+// workflows. Keep privileged workflow_run / release / deploy workflows out of
+// this set.
+const allowedWorkflowPaths = new Set([
+  ".github/workflows/ci.yml",
+  ".github/workflows/visual-pr-capture.yml",
+  ".github/workflows/visual-pr-verify.yml",
+]);
+
+export function normalizeWorkflowPath(path: string): string {
+  const suffixIndex = path.indexOf("@");
+  return suffixIndex >= 0 ? path.slice(0, suffixIndex) : path;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function getRepo(): string {
+  return requireEnv("GITHUB_REPOSITORY");
+}
+
+function getToken(): string {
+  return requireEnv("GITHUB_TOKEN");
+}
+
+function getPrNumber(): number {
+  return Number(requireEnv("PR_NUMBER"));
+}
+
+function isAllowedSourceOrTestPath(path: string): boolean {
+  return /^(apps|packages)\/[^/]+\/(src|tests)\//.test(path);
+}
+
+export function isAllowedChangedPath(path: string): boolean {
+  if (isDeniedChangedPath(path)) return false;
+  return (
+    isDocsPath(path) ||
+    path.startsWith("apps/web/") ||
+    isAllowedSourceOrTestPath(path)
+  );
+}
+
+export function isDeniedChangedPath(path: string): boolean {
+  return (
+    path.startsWith(".github/") ||
+    path.startsWith("scripts/") ||
+    path.startsWith("e2e/scripts/") ||
+    path.startsWith("nix/") ||
+    path.startsWith("tools/pack/") ||
+    path === "package.json" ||
+    path.endsWith("/package.json") ||
+    path === "pnpm-lock.yaml" ||
+    path === "pnpm-workspace.yaml" ||
+    path === "flake.nix" ||
+    path === "flake.lock" ||
+    /(^|\/)tsconfig(\.[^.]+)*\.json$/.test(path) ||
+    /(^|\/)(next|vite|vitest|playwright|astro|postcss|tailwind|eslint|prettier|wrangler|electron-builder)(\.config)?\.[^.]+$/.test(
+      path,
+    ) ||
+    path.endsWith("esbuild.config.mjs") ||
+    path.endsWith("esbuild.config.ts")
+  );
+}
+
+function isDocsPath(path: string): boolean {
+  return (
+    path === "README.md" ||
+    path === "README.zh-CN.md" ||
+    path === "CONTRIBUTING.md" ||
+    path === "CONTRIBUTING.zh-CN.md" ||
+    path === "QUICKSTART.md" ||
+    path.startsWith("docs/")
+  );
+}
+
+function changedPathSet(file: PullRequestFile): string[] {
+  return [file.filename, file.previous_filename].filter((path): path is string => Boolean(path));
+}
+
+export function isPendingApprovalRun(run: WorkflowRun, pull: PullRequest): boolean {
+  return (
+    run.head_sha === pull.head.sha &&
+    run.event === "pull_request" &&
+    (run.status === "action_required" || run.conclusion === "action_required") &&
+    allowedWorkflowPaths.has(normalizeWorkflowPath(run.path))
+  );
+}
+
+export function hasPullApprovalStateDrift(initialPull: PullRequest, latestPull: PullRequest): boolean {
+  return (
+    latestPull.state !== "open" ||
+    Boolean(latestPull.draft) ||
+    latestPull.head.sha !== initialPull.head.sha ||
+    latestPull.base.ref !== initialPull.base.ref ||
+    latestPull.head.repo?.full_name !== initialPull.head.repo?.full_name
+  );
+}
+
+function isSamePullRequest(candidate: WorkflowRun["pull_requests"][number] | PullRequest, pull: PullRequest): boolean {
+  return (
+    candidate.number === pull.number &&
+    candidate.head.sha === pull.head.sha &&
+    candidate.head.repo?.full_name === pull.head.repo?.full_name &&
+    candidate.base.ref === pull.base.ref &&
+    candidate.base.repo.full_name === pull.base.repo.full_name
+  );
+}
+
+function hasMatchingHeadIdentity(run: WorkflowRun, pull: PullRequest): boolean {
+  return (
+    run.head_sha === pull.head.sha &&
+    typeof run.head_branch === "string" &&
+    run.head_branch === pull.head.ref &&
+    run.head_repository?.full_name === pull.head.repo?.full_name
+  );
+}
+
+export function runTargetsPullRequest(
+  run: WorkflowRun,
+  pull: PullRequest,
+  associatedPullsForHeadSha: PullRequest[],
+  associatedPullsForHeadRef: PullRequest[],
+): boolean {
+  if (run.pull_requests.length > 0) {
+    if (run.pull_requests.length !== 1) return false;
+    const [associatedPull] = run.pull_requests;
+    if (!associatedPull) return false;
+    return isSamePullRequest(associatedPull, pull);
+  }
+
+  if (associatedPullsForHeadSha.length === 0) {
+    if (!hasMatchingHeadIdentity(run, pull) || associatedPullsForHeadRef.length !== 1) return false;
+    const [associatedPull] = associatedPullsForHeadRef;
+    if (!associatedPull) return false;
+    return isSamePullRequest(associatedPull, pull);
+  }
+
+  if (associatedPullsForHeadSha.length !== 1) return false;
+  const [associatedPull] = associatedPullsForHeadSha;
+  if (!associatedPull) return false;
+  return isSamePullRequest(associatedPull, pull);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitForPendingApprovalRuns(
+  loadRuns: () => Promise<WorkflowRun[]>,
+  sleep: (ms: number) => Promise<void> = delay,
+  now: () => number = Date.now,
+  config: PendingRunPollingConfig = {},
+): Promise<WorkflowRun[]> {
+  const pollIntervalMs = config.pollIntervalMs ?? defaultPendingRunPollIntervalMs;
+  const firstAppearanceTimeoutMs = config.firstAppearanceTimeoutMs ?? defaultPendingRunFirstAppearanceTimeoutMs;
+  const settlingWindowMs = config.settlingWindowMs ?? defaultPendingRunSettlingWindowMs;
+  const firstAppearanceDeadline = now() + firstAppearanceTimeoutMs;
+  let pendingRuns: WorkflowRun[] = [];
+
+  const collectRuns = async (): Promise<void> => {
+    pendingRuns = await loadRuns();
+  };
+
+  await collectRuns();
+
+  while (pendingRuns.length === 0 && now() < firstAppearanceDeadline) {
+    await sleep(pollIntervalMs);
+    await collectRuns();
+  }
+
+  let settlingDeadline = pendingRuns.length > 0 ? now() + settlingWindowMs : null;
+  let lastPendingRunSetSignature = pendingRunSetSignature(pendingRuns);
+
+  while (pendingRuns.length > 0 && settlingDeadline !== null && now() < settlingDeadline) {
+
+    await sleep(pollIntervalMs);
+    const previousPendingRunSetSignature = lastPendingRunSetSignature;
+    await collectRuns();
+
+    lastPendingRunSetSignature = pendingRunSetSignature(pendingRuns);
+    if (lastPendingRunSetSignature !== previousPendingRunSetSignature) {
+      settlingDeadline = now() + settlingWindowMs;
+    }
+  }
+
+  return pendingRuns;
+}
+
+async function github<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${getToken()}`,
+      "User-Agent": "open-design-fork-pr-workflow-approver",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...init.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API ${init.method ?? "GET"} ${path} failed with ${response.status}: ${body}`);
+  }
+
+  if (response.status === 204) return undefined as T;
+  return (await response.json()) as T;
+}
+
+async function githubPaginated<T>(path: string): Promise<T[]> {
+  const results: T[] = [];
+  for (let page = 1; ; page += 1) {
+    const separator = path.includes("?") ? "&" : "?";
+    const items = await github<T[]>(`${path}${separator}per_page=100&page=${page}`);
+    results.push(...items);
+    if (items.length < 100) return results;
+  }
+}
+
+async function approveRun(run: WorkflowRun): Promise<void> {
+  const repo = getRepo();
+
+  if (dryRun) {
+    console.log(`[dry-run] would approve workflow run ${run.id} (${run.name ?? run.path})`);
+    return;
+  }
+
+  await github<void>(`/repos/${repo}/actions/runs/${run.id}/approve`, { method: "POST" });
+  console.log(`Approved workflow run ${run.id} (${run.name ?? run.path})`);
+}
+
+async function listPullRequestsForHeadSha(repo: string, headSha: string): Promise<PullRequest[]> {
+  return githubPaginated<PullRequest>(`/repos/${repo}/commits/${headSha}/pulls`);
+}
+
+async function listPullRequestsForHeadRef(repo: string, headOwnerAndRef: string): Promise<PullRequest[]> {
+  return githubPaginated<PullRequest>(`/repos/${repo}/pulls?state=open&head=${encodeURIComponent(headOwnerAndRef)}`);
+}
+
+async function listWorkflowRunsForHeadSha(
+  repo: string,
+  headSha: string,
+  loadWorkflowRunsResponsePage: (path: string) => Promise<WorkflowRunsResponse>,
+): Promise<WorkflowRun[]> {
+  const workflowRuns: WorkflowRun[] = [];
+
+  for (let page = 1; ; page += 1) {
+    const response = await loadWorkflowRunsResponsePage(
+      `/repos/${repo}/actions/runs?event=pull_request&head_sha=${headSha}&per_page=100&page=${page}`,
+    );
+    workflowRuns.push(...response.workflow_runs);
+    if (response.workflow_runs.length < 100) return workflowRuns;
+  }
+}
+
+export async function listPendingApprovalRuns(
+  repo: string,
+  pull: PullRequest,
+  deps: ListPendingApprovalRunsDeps = {},
+): Promise<WorkflowRun[]> {
+  const loadWorkflowRunsResponsePage = deps.loadWorkflowRunsResponsePage ?? ((path: string) => github<WorkflowRunsResponse>(path));
+  const loadPullRequestsForHeadSha =
+    deps.loadPullRequestsForHeadSha ?? ((currentRepo: string, headSha: string) => listPullRequestsForHeadSha(currentRepo, headSha));
+  const loadPullRequestsForHeadRef =
+    deps.loadPullRequestsForHeadRef ?? ((currentRepo: string, headOwnerAndRef: string) => listPullRequestsForHeadRef(currentRepo, headOwnerAndRef));
+
+  const workflowRuns = await listWorkflowRunsForHeadSha(repo, pull.head.sha, loadWorkflowRunsResponsePage);
+
+  const associatedPullsForHeadSha = (await loadPullRequestsForHeadSha(repo, pull.head.sha)).filter(
+    (candidate) => candidate.state === "open",
+  );
+  const associatedPullsForHeadRef =
+    associatedPullsForHeadSha.length === 0
+      ? await (async () => {
+          const headOwner = pull.head.repo?.full_name.split("/")[0];
+          const headOwnerAndRef = headOwner ? `${headOwner}:${pull.head.ref}` : null;
+          if (!headOwnerAndRef) return [];
+          return (await loadPullRequestsForHeadRef(repo, headOwnerAndRef)).filter(
+            (candidate) =>
+              candidate.state === "open" &&
+              candidate.head.sha === pull.head.sha &&
+              candidate.head.repo?.full_name === pull.head.repo?.full_name,
+          );
+        })()
+      : [];
+
+  return workflowRuns.filter(
+    (run) =>
+      isPendingApprovalRun(run, pull) &&
+      runTargetsPullRequest(run, pull, associatedPullsForHeadSha, associatedPullsForHeadRef),
+  );
+}
+
+async function main(): Promise<void> {
+  const repo = getRepo();
+  const prNumber = getPrNumber();
+
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    throw new Error(`Invalid PR_NUMBER: ${process.env.PR_NUMBER ?? ""}`);
+  }
+
+  const pull = await github<PullRequest>(`/repos/${repo}/pulls/${prNumber}`);
+  if (pull.state !== "open") {
+    console.log(`Skipping PR #${prNumber}: state is ${pull.state}.`);
+    return;
+  }
+  if (pull.draft) {
+    console.log(`Skipping PR #${prNumber}: draft PR.`);
+    return;
+  }
+  if (!pull.head.repo) {
+    console.log(`Skipping PR #${prNumber}: head repository is unavailable.`);
+    return;
+  }
+  if (pull.head.repo.full_name === pull.base.repo.full_name) {
+    console.log(`Skipping PR #${prNumber}: not a fork PR.`);
+    return;
+  }
+
+  const files = await githubPaginated<PullRequestFile>(`/repos/${repo}/pulls/${prNumber}/files`);
+  if (files.length !== pull.changed_files) {
+    console.log(
+      `Skipping PR #${prNumber}: GitHub returned ${files.length} changed files, but PR reports ${pull.changed_files}.`,
+    );
+    return;
+  }
+
+  const latestPull = await github<PullRequest>(`/repos/${repo}/pulls/${prNumber}`);
+  if (hasPullApprovalStateDrift(pull, latestPull)) {
+    console.log(`Skipping PR #${prNumber}: PR head/base changed while evaluating workflow approval.`);
+    return;
+  }
+
+  const blockedPaths = files.flatMap((file) => changedPathSet(file).filter((path) => !isAllowedChangedPath(path)));
+
+  if (blockedPaths.length > 0) {
+    console.log(`Skipping PR #${prNumber}: changed paths are outside the auto-approval allowlist.`);
+    for (const path of blockedPaths) console.log(`- ${path}`);
+    return;
+  }
+
+  const pendingRuns = await waitForPendingApprovalRuns(() => listPendingApprovalRuns(repo, pull));
+
+  if (pendingRuns.length === 0) {
+    console.log(`No action_required pull_request workflow runs found for PR #${prNumber} at ${pull.head.sha}.`);
+    return;
+  }
+
+  const approvalPull = await github<PullRequest>(`/repos/${repo}/pulls/${prNumber}`);
+  if (hasPullApprovalStateDrift(pull, approvalPull)) {
+    console.log(`Skipping PR #${prNumber}: PR changed while waiting for approvable workflow runs.`);
+    return;
+  }
+
+  for (const run of pendingRuns) await approveRun(run);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}


### PR DESCRIPTION
## Why
Split from #2655 so the comment attachment data model and web/daemon API can be reviewed independently. This unblocks later preview comment UI and queued-send PRs without mixing UI changes into the contract/API review.

## What users will see
No direct UI change in this PR. It adds the persisted/API plumbing needed for preview comments to be attached to chat messages.

## Validation
- pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/comments.test.ts tests/providers/registry.test.ts
- pnpm --filter @open-design/contracts typecheck
- pnpm --filter @open-design/daemon typecheck
- pnpm --filter @open-design/web typecheck
- pnpm guard