### PR TITLE
fix(web): polish shared chrome controls

### DIFF
--- a/apps/web/src/components/AppChromeHeader.tsx
+++ b/apps/web/src/components/AppChromeHeader.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { useT } from '../i18n';
-import { Icon } from './Icon';
+import { RemixIcon } from './RemixIcon';
 
 interface Props {
   actions?: ReactNode;
@@ -33,7 +33,7 @@ export function AppChromeHeader({
           title={resolvedBackLabel}
           aria-label={resolvedBackLabel}
         >
-          <Icon name="arrow-left" size={15} />
+          <RemixIcon name="arrow-left-line" size={16} />
         </button>
       ) : null}
       {children ? <div className="app-chrome-content">{children}</div> : null}
@@ -61,7 +61,7 @@ export function SettingsIconButton({
       title={title}
       aria-label={ariaLabel}
     >
-      <Icon name="settings" size={17} />
+      <RemixIcon name="settings-line" size={18} />
     </button>
   );
 }

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useT } from '../i18n';
 import { AgentIcon } from './AgentIcon';
-import { Icon } from './Icon';
+import { RemixIcon } from './RemixIcon';
 import { renderModelOptions } from './modelOptions';
 import type { AgentInfo, AppConfig, ExecMode } from '../types';
 import { apiProtocolLabel } from '../utils/apiProtocol';
@@ -41,6 +41,7 @@ export function AvatarMenu({
   const t = useT();
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -49,7 +50,10 @@ export function AvatarMenu({
       if (!wrapRef.current.contains(e.target as Node)) setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
+      if (e.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
     };
     document.addEventListener('mousedown', onClick);
     document.addEventListener('keydown', onKey);
@@ -82,18 +86,25 @@ export function AvatarMenu({
   return (
     <div className="avatar-menu" ref={wrapRef}>
       <button
+        ref={triggerRef}
         type="button"
-        className="settings-icon-btn"
+        className="avatar-agent-trigger"
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="menu"
         aria-expanded={open}
+        data-tooltip={t('avatar.title')}
         title={t('avatar.title')}
         aria-label={t('avatar.title')}
       >
-        <Icon name="settings" size={17} />
+        {currentAgent ? (
+          <AgentIcon id={currentAgent.id} size={18} />
+        ) : (
+          <RemixIcon name="link" size={18} />
+        )}
+        <RemixIcon name="arrow-down-s-line" size={13} />
       </button>
       {open ? (
-        <div className="avatar-popover" role="menu">
+        <div className="avatar-popover" role="dialog" aria-label={t('avatar.title')}>
           <div className="avatar-popover-head">
             <span className="who">
               {config.mode === 'daemon'
@@ -111,8 +122,16 @@ export function AvatarMenu({
 
           <button
             type="button"
-            className="avatar-item"
+            className={`avatar-item${config.mode === 'daemon' ? ' active' : ''}`}
+            aria-current={config.mode === 'daemon' ? 'true' : undefined}
             onClick={() => {
+              if (config.mode === 'daemon') {
+                setOpen(false);
+                if (!daemonLive) {
+                  onOpenSettings();
+                }
+                return;
+              }
               onModeChange('daemon');
               if (!daemonLive) {
                 // No daemon — let user know via settings page rather than
@@ -124,7 +143,7 @@ export function AvatarMenu({
             disabled={!daemonLive && config.mode !== 'daemon'}
           >
             <span className="avatar-item-icon" aria-hidden>
-              <Icon name="file-code" size={14} />
+              <RemixIcon name="file-code-line" size={15} />
             </span>
             <span>{t('avatar.useLocal')}</span>
             {config.mode === 'daemon' ? (
@@ -132,46 +151,60 @@ export function AvatarMenu({
             ) : !daemonLive ? (
               <span className="avatar-item-meta">{t('avatar.metaOffline')}</span>
             ) : null}
+            {config.mode === 'daemon' ? (
+              <RemixIcon name="check-line" size={14} className="avatar-item-check" />
+            ) : null}
           </button>
           <button
             type="button"
-            className="avatar-item"
+            className={`avatar-item${config.mode === 'api' ? ' active' : ''}`}
+            aria-current={config.mode === 'api' ? 'true' : undefined}
             onClick={() => onModeChange('api')}
           >
             <span className="avatar-item-icon" aria-hidden>
-              <Icon name="link" size={14} />
+              <RemixIcon name="link" size={15} />
             </span>
             <span>{t('avatar.useApi')}</span>
             {config.mode === 'api' ? (
               <span className="avatar-item-meta">{t('avatar.metaActive')}</span>
+            ) : null}
+            {config.mode === 'api' ? (
+              <RemixIcon name="check-line" size={14} className="avatar-item-check" />
             ) : null}
           </button>
 
           {config.mode === 'daemon' && installedAgents.length > 0 ? (
             <>
               <div className="avatar-section-label">{t('avatar.codeAgent')}</div>
-              {installedAgents.map((a) => (
-                <button
-                  type="button"
-                  key={a.id}
-                  className="avatar-item"
-                  onClick={() => {
-                    onAgentChange(a.id);
-                    // Keep the popover open so the user can immediately
-                    // pick a model for the agent they just chose.
-                  }}
-                >
-                  <AgentIcon id={a.id} size={18} />
-                  <span>{a.name}</span>
-                  {config.agentId === a.id ? (
-                    <span className="avatar-item-meta">
-                      {t('avatar.metaSelected')}
-                    </span>
-                  ) : a.version ? (
-                    <span className="avatar-item-meta">{a.version}</span>
-                  ) : null}
-                </button>
-              ))}
+              {installedAgents.map((a) => {
+                const selected = config.agentId === a.id;
+                return (
+                  <button
+                    type="button"
+                    key={a.id}
+                    className={`avatar-item${selected ? ' active' : ''}`}
+                    aria-current={selected ? 'true' : undefined}
+                    onClick={() => {
+                      onAgentChange(a.id);
+                      // Keep the popover open so the user can immediately
+                      // pick a model for the agent they just chose.
+                    }}
+                  >
+                    <AgentIcon id={a.id} size={18} />
+                    <span>{a.name}</span>
+                    {selected ? (
+                      <span className="avatar-item-meta">
+                        {t('avatar.metaSelected')}
+                      </span>
+                    ) : a.version ? (
+                      <span className="avatar-item-meta">{a.version}</span>
+                    ) : null}
+                    {selected ? (
+                      <RemixIcon name="check-line" size={14} className="avatar-item-check" />
+                    ) : null}
+                  </button>
+                );
+              })}
               {currentAgent &&
               currentAgent.available &&
               ((currentAgent.models && currentAgent.models.length > 0) ||
@@ -245,7 +278,7 @@ export function AvatarMenu({
                 }}
               >
                 <span className="avatar-item-icon" aria-hidden>
-                  <Icon name="reload" size={14} />
+                  <RemixIcon name="refresh-line" size={15} />
                 </span>
                 <span>{t('avatar.rescan')}</span>
               </button>
@@ -263,7 +296,7 @@ export function AvatarMenu({
             }}
           >
             <span className="avatar-item-icon" aria-hidden>
-              <Icon name="settings" size={14} />
+              <RemixIcon name="settings-line" size={15} />
             </span>
             <span>{t('avatar.settings')}</span>
             <span className="avatar-item-meta">{isMacPlatform() ? '⌘,' : 'Ctrl+,'}</span>
@@ -278,7 +311,7 @@ export function AvatarMenu({
               }}
             >
               <span className="avatar-item-icon" aria-hidden>
-                <Icon name="arrow-left" size={14} />
+                <RemixIcon name="arrow-left-line" size={15} />
               </span>
               <span>{t('avatar.backToProjects')}</span>
             </button>


### PR DESCRIPTION
## Why
Split from #2655 so shared chrome/avatar/menu visual polish can be reviewed independently from preview editing and queue behavior.

## What users will see
Header and avatar-menu controls use the updated icon-only treatment and matching shared CSS polish.

## Validation
- pnpm --filter @open-design/web typecheck
- pnpm guard