### PR TITLE
fix(web): redact agent executable path from running-status pill

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -41,7 +41,11 @@ import { useT } from "../i18n";
 import { deriveFileOps, type FileOpEntry } from "../runtime/file-ops";
 import { unfinishedTodosFromEvents, type TodoItem } from "../runtime/todos";
 import type { Dict } from "../i18n/types";
-import { agentDisplayName, exactAgentDisplayName } from "../utils/agentLabels";
+import {
+  agentDisplayName,
+  exactAgentDisplayName,
+  friendlyStatusDetail,
+} from "../utils/agentLabels";
 import {
   exactDateTime,
   messageTime,
@@ -1354,7 +1358,9 @@ function latestStatusLabel(
 ): { label: string; detail?: string | undefined } | undefined {
   for (let i = events.length - 1; i >= 0; i--) {
     const ev = events[i]!;
-    if (ev.kind === "status") return { label: ev.label, detail: ev.detail };
+    if (ev.kind === "status") {
+      return { label: ev.label, detail: friendlyStatusDetail(ev.label, ev.detail) };
+    }
   }
   return undefined;
 }

--- a/apps/web/src/utils/agentLabels.ts
+++ b/apps/web/src/utils/agentLabels.ts
@@ -97,3 +97,33 @@ function normalizeKey(raw: string): string {
     .replace(/\s+/g, ' ')
     .toLowerCase();
 }
+
+// Visible-status invariant for the chat waiting pill (issue #2874): the
+// daemon's start-event payload carries `bin` (the resolved agent executable
+// path) which gets persisted as `detail` on the `starting` status event.
+// Packaged-app paths like
+//   /Applications/Open Design Beta.app/Contents/Resources/open-design/bin/vela
+// leak the install root and (on custom installs) the user's home directory.
+// Replace the path with the known agent display name when we can recognize it,
+// otherwise drop the detail and let the localized status label speak.
+//
+// Scoped to the `starting` label on purpose: other labels (error, audit, ...)
+// legitimately carry user-readable detail strings that may themselves
+// reference paths, and over-redacting would hide actionable error context.
+export function friendlyStatusDetail(
+  label: string,
+  detail: string | null | undefined,
+): string | undefined {
+  const trimmed = detail?.trim();
+  if (!trimmed) return undefined;
+  if (label !== 'starting') return trimmed;
+  if (!looksLikeFilesystemPath(trimmed)) return trimmed;
+  return agentDisplayName(trimmed) ?? undefined;
+}
+
+function looksLikeFilesystemPath(value: string): boolean {
+  // POSIX absolute, home-relative, parent-relative, current-relative, or
+  // Windows-drive paths. Any embedded path separator also qualifies — the
+  // intent is "this string is talking about a file on disk, not a label."
+  return /^([/~]|\.\.?[\\/]|[A-Za-z]:[\\/])/.test(value) || value.includes('/') || value.includes('\\');
+}

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -224,3 +224,55 @@ describe('AssistantMessage recovered produced files', () => {
     expect(screen.getByText('iphone-device-reveal.mp4')).toBeTruthy();
   });
 });
+
+// Issue #2874: the running-state waiting pill rendered `latestStatus.detail`
+// verbatim, so the daemon's start-event `bin` field (the resolved agent
+// executable path) leaked into the visible chat status. That value is shaped
+// like `/Applications/Open Design Beta.app/Contents/Resources/open-design/bin/vela`
+// — it reveals the install root and on custom installs the user's home dir.
+describe('AssistantMessage waiting-pill executable-path leak (#2874)', () => {
+  const LEAKY_PATH =
+    '/Applications/Open Design Beta.app/Contents/Resources/open-design/bin/vela';
+
+  it('does not surface a raw absolute executable path while waiting for first output', () => {
+    const { container } = render(
+      <AssistantMessage
+        message={baseMessage({
+          content: '',
+          runStatus: 'running',
+          endedAt: undefined,
+          events: [
+            { kind: 'status', label: 'starting', detail: LEAKY_PATH } as ChatMessage['events'][number],
+          ],
+        })}
+        streaming
+        projectId="proj-1"
+      />,
+    );
+
+    expect(container.innerHTML).not.toContain(LEAKY_PATH);
+    expect(container.innerHTML).not.toContain('/bin/vela');
+    expect(container.innerHTML).not.toContain('Open Design Beta.app');
+  });
+
+  it('still surfaces a recognized agent name extracted from the binary path', () => {
+    const claudePath =
+      '/Applications/Open Design Beta.app/Contents/Resources/open-design/bin/claude';
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          content: '',
+          runStatus: 'running',
+          endedAt: undefined,
+          events: [
+            { kind: 'status', label: 'starting', detail: claudePath } as ChatMessage['events'][number],
+          ],
+        })}
+        streaming
+        projectId="proj-1"
+      />,
+    );
+
+    expect(screen.getAllByText('Claude').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/tests/utils/agentLabels.test.ts
+++ b/apps/web/tests/utils/agentLabels.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { friendlyStatusDetail } from '../../src/utils/agentLabels';
+
+describe('friendlyStatusDetail', () => {
+  // Locks the invariant from issue #2874: the daemon's chat `start` SSE event
+  // carries the resolved agent binary as `detail`, and the visible status pill
+  // must not surface that absolute filesystem path. Packaged-app paths leak
+  // both the install root and (on custom homebrew installs) the user's home
+  // directory, so a missing transform shows up as a privacy/UX regression in
+  // the running-status surface.
+  const PACKAGED_VELA =
+    '/Applications/Open Design Beta.app/Contents/Resources/open-design/bin/vela';
+  const PACKAGED_CLAUDE =
+    '/Applications/Open Design Beta.app/Contents/Resources/open-design/bin/claude';
+
+  it('replaces a starting-status absolute path with the known agent display name', () => {
+    expect(friendlyStatusDetail('starting', PACKAGED_CLAUDE)).toBe('Claude');
+  });
+
+  it('drops a starting-status absolute path when the basename is not a known agent', () => {
+    expect(friendlyStatusDetail('starting', PACKAGED_VELA)).toBeUndefined();
+  });
+
+  it('drops Windows-style absolute paths under starting status', () => {
+    expect(
+      friendlyStatusDetail(
+        'starting',
+        'C:\\Program Files\\Open Design\\resources\\open-design\\bin\\unknown.exe',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('preserves non-path details verbatim', () => {
+    expect(friendlyStatusDetail('starting', 'Claude')).toBe('Claude');
+    expect(friendlyStatusDetail('starting', 'claude-opus-4-7')).toBe('claude-opus-4-7');
+  });
+
+  it('preserves details on other status labels (errors and friends can mention paths)', () => {
+    expect(
+      friendlyStatusDetail('error', `ENOENT: ${PACKAGED_VELA}`),
+    ).toBe(`ENOENT: ${PACKAGED_VELA}`);
+  });
+
+  it('returns undefined when detail is undefined or empty', () => {
+    expect(friendlyStatusDetail('starting', undefined)).toBeUndefined();
+    expect(friendlyStatusDetail('starting', '')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #2874

## Why

Hit this while reading the Live Artifact status surface — the running-state pill rendered a raw packaged-app executable path (`/Applications/Open Design Beta.app/Contents/Resources/open-design/bin/vela`) right inside the user-facing chat bubble. That reads as internal debug output leaking through, and on custom installs it also exposes the user's home directory. The reporter (@AmyShang-alt) attached a clear screenshot in #2874 showing the same shape.

## What users will see

While an agent is starting and no first output has arrived yet, the waiting pill now shows a clean localized status (e.g. "Starting…") with a recognized agent name when we can derive one (e.g. "Claude"), instead of the raw on-disk binary path. Absolute paths whose basename isn't a known agent simply drop the detail and let the localized label speak.

Error/audit/other status details keep flowing through verbatim — error messages that legitimately reference paths still surface.

## Surface area

- [x] **UI** — chat running-status pill in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Before (from the linked issue, by @AmyShang-alt): the absolute `/Applications/Open Design Beta.app/Contents/Resources/open-design/bin/vela` path appears inside the message bubble.

After: locked by component test `AssistantMessage waiting-pill executable-path leak (#2874)` — the `latestStatus.detail` rendered by `WaitingPill` never contains the raw path. I did not stand up a packaged install locally to capture a live "after" screenshot; the symptom-level test renders the same component with the same leaky `start`-event payload and asserts the markup is path-free, so behavior is covered without depending on a packaged-app side channel.

## Bug fix verification

- Test paths:
  - `apps/web/tests/utils/agentLabels.test.ts` — 6 cases lock the invariant on the new `friendlyStatusDetail` helper (recognized agents → display name; unknown basename → drop; Windows-style absolute → drop; non-path details preserved; other labels pass through).
  - `apps/web/tests/components/AssistantMessage.test.tsx` — the new `AssistantMessage waiting-pill executable-path leak (#2874)` describe block reproduces the symptom at the rendering boundary.
- Both went red on `main` (7 failures from the missing helper + the symptom assertion) and green on this branch (16/16).

## Validation

- `pnpm --filter @open-design/web test` → 226 files / 2123 tests pass
- `pnpm typecheck` → clean
- `pnpm guard` → 29/29 pass

## Implementation note

The fix lives at the rendering boundary in the web layer (`latestStatusLabel` → new `friendlyStatusDetail` helper), not at the persistence boundary in the daemon. Reasons:

- Previously persisted history (older runs with raw `bin` in the `starting` status `detail`) is sanitized on replay without a data migration.
- The SSE `start` event still carries `bin` for developer/debug consumers; only the user-facing pill is redacted.
- The helper is scoped to the `starting` label so future labels that legitimately mention paths (errors, etc.) remain actionable.