### PR TITLE
fix: clear pendingPrompt when navigating back to Home

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -557,8 +557,17 @@ export function App() {
   }, [route]);
 
   const handleBack = useCallback(() => {
+    const projectId = route.kind === 'project' ? route.projectId : null;
+    if (projectId) {
+      setProjects((curr) =>
+        curr.map((p) =>
+          p.id === projectId ? { ...p, pendingPrompt: undefined } : p,
+        ),
+      );
+      void patchProject(projectId, { pendingPrompt: undefined });
+    }
     navigate({ kind: 'home' });
-  }, []);
+  }, [route]);
 
   const handleClearPendingPrompt = useCallback(() => {
     const projectId = route.kind === 'project' ? route.projectId : null;


### PR DESCRIPTION
Fixes #2878

## Problem
When navigating back to Home from a project and then creating a new session, the new session would inherit the `pendingPrompt` from the previous session. This caused stale prompt content to appear in the composer, breaking session isolation.

## Root Cause
The `handleBack` function only navigated to Home without clearing the current project's `pendingPrompt`. When a new project was created, it could inherit this stale state.

## Solution
Modified `handleBack` to clear `pendingPrompt` before navigating to Home:
1. Extract the current `projectId` from the route
2. Clear `pendingPrompt` from the project state
3. Persist the change via `patchProject` API
4. Then navigate to Home

This follows the same pattern as `handleClearPendingPrompt` for consistency.

## Testing
- Verified the code change in `apps/web/src/App.tsx`
- The fix ensures proper session boundary isolation
- New sessions will start with a clean state

## Related
- Similar to fixes in #1148 (stale pendingPrompt clearing for templates)
- Related to #1271 (conversation run isolation)