### PR TITLE
fix: prevent tab overlap in edit mode by removing default focus outline

### DIFF
--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -1060,12 +1060,18 @@
   font: inherit;
   font-size: 12px;
   font-weight: 650;
+  outline: none;
 }
 
 .manual-edit-tabs button.selected {
   border-color: var(--accent);
   color: var(--text);
   background: var(--accent-soft);
+}
+
+.manual-edit-tabs button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .manual-edit-tab-body {


### PR DESCRIPTION
## Problem

When selecting the Style tab in edit mode, the browser's default focus outline would extend beyond the tab's bounds and visually overlap adjacent tabs, making the tab bar look broken and reducing readability.

Fixes #2904

## Root Cause

Clicking a tab button triggers the browser's default focus outline, which renders outside the element's border box. Combined with the 6px gap between tabs, the outline from the selected tab would overlap neighboring tab labels.

## Solution

1. Remove the default focus outline with `outline: none` to prevent visual overlap during normal interaction
2. Add a custom `:focus-visible` style with `outline-offset: 2px` to maintain keyboard navigation accessibility without causing overlap

```css
.manual-edit-tabs button {
  /* ... existing styles ... */
  outline: none;
}

.manual-edit-tabs button:focus-visible {
  outline: 2px solid var(--accent);
  outline-offset: 2px;
}
```

This ensures tabs remain visually distinct and properly aligned while preserving accessible focus indicators for keyboard users.

## Surface area

- [x] UI — Edit mode tab bar styling
- [ ] API
- [ ] CLI
- [ ] Docs

## Testing

**Manual testing steps:**

1. Open a file in edit mode
2. Select an element to show the right-side editing panel
3. Click through the tabs: Content, Style, Attributes, HTML
4. Verify that selected tabs do not overlap or obscure adjacent tabs
5. Test keyboard navigation (Tab key) to verify focus-visible outline appears correctly

**Expected behavior:**
- All tabs remain fully readable and properly aligned
- No visual overlap between selected tab and neighbors
- Keyboard focus indicator (outline) appears with proper offset when navigating via Tab key

**Accessibility:**
- `:focus-visible` ensures keyboard users still get a clear focus indicator
- Mouse clicks don't show the outline (better visual experience)
- Maintains WCAG 2.1 focus indicator requirements