### PR TITLE
Detect and persist skill plugin candidates

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -15,9 +15,11 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v6.0.8
-      with:
-        version: ${{ inputs.pnpm-version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        corepack enable
+        corepack prepare "pnpm@${{ inputs.pnpm-version }}" --activate
 
     - name: Setup Node.js
       uses: actions/setup-node@v6.4.0

--- a/.github/actions/visual-screenshot/action.yml
+++ b/.github/actions/visual-screenshot/action.yml
@@ -5,9 +5,11 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v6.0.8
-      with:
-        version: 10.33.2
+      shell: bash
+      run: |
+        set -euo pipefail
+        corepack enable
+        corepack prepare pnpm@10.33.2 --activate
 
     - name: Setup Node.js
       uses: actions/setup-node@v6.4.0

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -20,7 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        env:
+          REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags --prune --depth=1 origin "$REF"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Check workflow files
         uses: docker://rhysd/actionlint:1.7.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,6 @@ jobs:
     steps:
       - name: Detect workspace and app test scopes
         id: detect
-        env:
-          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -54,9 +52,20 @@ jobs:
           nix_validation_required=false
           workspace_validation_required=false
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            gh api --paginate \
-              "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-              --jq '.[].filename' > "$RUNNER_TEMP/changed-files.txt"
+            : > "$RUNNER_TEMP/changed-files.txt"
+            page=1
+            while :; do
+              response="$(
+                curl --fail --silent --show-error \
+                  --url "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100&page=$page"
+              )"
+              echo "$response" | jq -r '.[].filename' >> "$RUNNER_TEMP/changed-files.txt"
+              count="$(echo "$response" | jq 'length')"
+              if [ "$count" -lt 100 ]; then
+                break
+              fi
+              page="$((page + 1))"
+            done
             while IFS= read -r file; do
               if [[ "$file" == "apps/daemon/"* || "$file" == "packages/contracts/"* || "$file" == "packages/platform/"* || "$file" == "packages/sidecar/"* || "$file" == "packages/sidecar-proto/"* ]]; then
                 daemon_tests_required=true
@@ -142,14 +151,26 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        env:
+          REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags --prune --depth=1 origin "$REF"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
+        run: |
+          set -euo pipefail
+          curl --fail --location https://nixos.org/nix/install | sh -s -- --no-daemon
+          mkdir -p "$HOME/.config/nix"
+          {
+            echo "experimental-features = nix-command flakes"
+            echo "accept-flake-config = true"
+          } >> "$HOME/.config/nix/nix.conf"
+          echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"
 
       - name: nix flake check
         run: nix flake check --print-build-logs --keep-going
@@ -163,7 +184,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        env:
+          REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags --prune --depth=1 origin "$REF"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
@@ -209,7 +238,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        env:
+          REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags --prune --depth=1 origin "$REF"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
@@ -237,7 +274,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        env:
+          REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags --prune --depth=1 origin "$REF"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
@@ -257,7 +302,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        env:
+          REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags --prune --depth=1 origin "$REF"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
@@ -278,7 +331,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        env:
+          REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags --prune --depth=1 origin "$REF"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
@@ -312,7 +373,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        env:
+          REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags --prune --depth=1 origin "$REF"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace

--- a/.github/workflows/fork-pr-workflow-approval.yml
+++ b/.github/workflows/fork-pr-workflow-approval.yml
@@ -32,16 +32,21 @@ concurrency:
 
 jobs:
   approve:
-    if: github.repository == 'nexu-io/open-design' && (github.event_name != 'pull_request_target' || github.event.action != 'edited' || github.event.changes.base != null)
+    if: github.repository == 'nexu-io/open-design' && ((github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && (github.event.action != 'edited' || github.event.changes.base != null)) || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
       - name: Checkout trusted base code
-        uses: actions/checkout@v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
-          persist-credentials: false
+        env:
+          REF: ${{ github.event.pull_request.base.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags --prune --depth=1 origin "$REF"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0

--- a/.github/workflows/visual-pr-capture.yml
+++ b/.github/workflows/visual-pr-capture.yml
@@ -32,9 +32,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags --prune --depth=1 origin "$HEAD_SHA"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Prepare visual screenshot environment
         uses: ./.github/actions/visual-screenshot

--- a/.github/workflows/visual-pr-verify.yml
+++ b/.github/workflows/visual-pr-verify.yml
@@ -20,9 +20,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git init .
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git fetch --no-tags --prune origin "$BASE_SHA" "$HEAD_SHA"
+          git checkout --force "$HEAD_SHA"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Detect visual-relevant changes
         id: changes

--- a/apps/daemon/src/plugins/candidates.ts
+++ b/apps/daemon/src/plugins/candidates.ts
@@ -55,15 +55,15 @@ function normalizeMarkdownText(value: string): string {
   return value.replace(/\r\n?/g, '\n');
 }
 
-function contentDigest(value: string): string {
-  return createHash('sha256').update(value).digest('hex');
+function normalizeSourceRefForIdentity(sourceRef: string): string {
+  return sourceRef.replace(/\\/g, '/').trim();
 }
 
-function candidateFingerprint(sourceRef: string, contentOrKind: string): string {
+function candidateFingerprint(sourceKind: SkillPluginCandidateSourceKind, sourceRef: string): string {
   return createHash('sha256')
-    .update(sourceRef)
+    .update(sourceKind)
     .update('\0')
-    .update(contentOrKind)
+    .update(normalizeSourceRefForIdentity(sourceRef))
     .digest('hex');
 }
 
@@ -122,7 +122,7 @@ function markdownCandidate(
     confidence: explicitSkillMd ? 0.96 : 0.72,
     title,
     ...(description ? { description } : {}),
-    fingerprint: candidateFingerprint(sourceRef, contentDigest(normalized)),
+    fingerprint: candidateFingerprint(sourceKind, sourceRef),
     draftInput: {
       artifactKind: explicitSkillMd ? 'skill-md' : 'markdown-skill-doc',
       source: sourceRef,
@@ -172,7 +172,7 @@ function repoCandidate(ref: string): SkillPluginCandidateInput | null {
     confidence: ref.toLowerCase().includes('skill.md') || ref.toLowerCase().includes('open-design.json') ? 0.84 : 0.68,
     title: repoTitle,
     description: 'Repository link contains plugin-like Open Design files.',
-    fingerprint: candidateFingerprint(ref, 'repo-plugin-link'),
+    fingerprint: candidateFingerprint('repo-link', ref),
     draftInput: {
       artifactKind: 'repo-plugin',
       source: ref,
@@ -304,22 +304,12 @@ export function persistSkillPluginCandidates(
         WHEN skill_plugin_candidates.status = 'dismissed' THEN skill_plugin_candidates.confidence
         ELSE MAX(skill_plugin_candidates.confidence, excluded.confidence)
       END,
-      title = CASE
-        WHEN skill_plugin_candidates.status = 'dismissed' THEN skill_plugin_candidates.title
-        ELSE COALESCE(skill_plugin_candidates.title, excluded.title)
-      END,
-      description = CASE
-        WHEN skill_plugin_candidates.status = 'dismissed' THEN skill_plugin_candidates.description
-        ELSE COALESCE(skill_plugin_candidates.description, excluded.description)
-      END,
-      draft_input_json = CASE
-        WHEN skill_plugin_candidates.status = 'dismissed' THEN skill_plugin_candidates.draft_input_json
-        ELSE excluded.draft_input_json
-      END,
-      updated_at = CASE
-        WHEN skill_plugin_candidates.status = 'dismissed' THEN skill_plugin_candidates.updated_at
-        ELSE excluded.updated_at
-      END
+      source_ref = excluded.source_ref,
+      provenance = excluded.provenance,
+      title = excluded.title,
+      description = excluded.description,
+      draft_input_json = excluded.draft_input_json,
+      updated_at = excluded.updated_at
   `);
   const select = db.prepare(`
     SELECT id, project_id AS projectId, run_id AS runId, source_kind AS sourceKind,

--- a/apps/daemon/src/plugins/candidates.ts
+++ b/apps/daemon/src/plugins/candidates.ts
@@ -160,11 +160,23 @@ function isPluginLikeRepoRef(ref: string): boolean {
   );
 }
 
+function githubRepoTitle(ref: string): string {
+  try {
+    const url = new URL(ref);
+    if (url.hostname === 'github.com') {
+      const parts = url.pathname.split('/').filter(Boolean);
+      if (parts.length >= 2) return parts.slice(0, 2).join('/');
+    }
+  } catch {
+    const parts = ref.replace(/^github:/, '').split(/[/?#]/)[0]?.split('/').filter(Boolean) ?? [];
+    if (parts.length >= 2) return parts.slice(0, 2).join('/');
+  }
+  return 'GitHub plugin source';
+}
+
 function repoCandidate(ref: string): SkillPluginCandidateInput | null {
   if (!isPluginLikeRepoRef(ref)) return null;
-  const refPath = ref.replace(/^github:/, '').split(/[/?#]/)[0] ?? '';
-  const parts = refPath.split('/').filter(Boolean);
-  const repoTitle = parts.length >= 2 ? parts.slice(0, 2).join('/') : 'GitHub plugin source';
+  const repoTitle = githubRepoTitle(ref);
   return {
     sourceKind: 'repo-link',
     sourceRef: ref,

--- a/apps/daemon/src/plugins/candidates.ts
+++ b/apps/daemon/src/plugins/candidates.ts
@@ -1,4 +1,10 @@
 import type Database from 'better-sqlite3';
+import type {
+  SkillPluginCandidate as ContractSkillPluginCandidate,
+  SkillPluginCandidateDraftInput as ContractSkillPluginCandidateDraftInput,
+  SkillPluginCandidateProvenance as ContractSkillPluginCandidateProvenance,
+  SkillPluginCandidateSourceKind as ContractSkillPluginCandidateSourceKind,
+} from '@open-design/contracts';
 import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -6,17 +12,9 @@ import path from 'node:path';
 type SqliteDb = Database.Database;
 type DbRow = Record<string, unknown>;
 
-export type SkillPluginCandidateSourceKind = 'project-file' | 'referenced-file' | 'repo-link';
-export type SkillPluginCandidateProvenance = 'uploaded-skill-md' | 'markdown-skill-doc' | 'plugin-like-link';
-
-export interface SkillPluginCandidateDraftInput {
-  artifactKind: 'skill-md' | 'markdown-skill-doc' | 'repo-plugin';
-  source: string;
-  title?: string;
-  description?: string;
-  contentExcerpt?: string;
-  suggestedFiles: string[];
-}
+export type SkillPluginCandidateSourceKind = ContractSkillPluginCandidateSourceKind;
+export type SkillPluginCandidateProvenance = ContractSkillPluginCandidateProvenance;
+export type SkillPluginCandidateDraftInput = ContractSkillPluginCandidateDraftInput;
 
 export interface SkillPluginCandidateInput {
   sourceKind: SkillPluginCandidateSourceKind;
@@ -29,15 +27,7 @@ export interface SkillPluginCandidateInput {
   draftInput: SkillPluginCandidateDraftInput;
 }
 
-export interface SkillPluginCandidateRow extends SkillPluginCandidateInput {
-  id: string;
-  projectId: string;
-  runId: string | null;
-  status: 'active' | 'dismissed';
-  dismissedAt: number | null;
-  createdAt: number;
-  updatedAt: number;
-}
+export type SkillPluginCandidateRow = ContractSkillPluginCandidate;
 
 export interface DetectSkillPluginCandidatesInput {
   projectRoot?: string | null;

--- a/apps/daemon/src/plugins/candidates.ts
+++ b/apps/daemon/src/plugins/candidates.ts
@@ -1,0 +1,412 @@
+import type Database from 'better-sqlite3';
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+type SqliteDb = Database.Database;
+type DbRow = Record<string, unknown>;
+
+export type SkillPluginCandidateSourceKind = 'project-file' | 'referenced-file' | 'repo-link';
+export type SkillPluginCandidateProvenance = 'uploaded-skill-md' | 'markdown-skill-doc' | 'plugin-like-link';
+
+export interface SkillPluginCandidateDraftInput {
+  artifactKind: 'skill-md' | 'markdown-skill-doc' | 'repo-plugin';
+  source: string;
+  title?: string;
+  description?: string;
+  contentExcerpt?: string;
+  suggestedFiles: string[];
+}
+
+export interface SkillPluginCandidateInput {
+  sourceKind: SkillPluginCandidateSourceKind;
+  sourceRef: string;
+  provenance: SkillPluginCandidateProvenance;
+  confidence: number;
+  title?: string;
+  description?: string;
+  fingerprint: string;
+  draftInput: SkillPluginCandidateDraftInput;
+}
+
+export interface SkillPluginCandidateRow extends SkillPluginCandidateInput {
+  id: string;
+  projectId: string;
+  runId: string | null;
+  status: 'active' | 'dismissed';
+  dismissedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface DetectSkillPluginCandidatesInput {
+  projectRoot?: string | null;
+  attachments?: unknown;
+  message?: unknown;
+  currentPrompt?: unknown;
+  systemPrompt?: unknown;
+}
+
+const MAX_MARKDOWN_READ_BYTES = 128 * 1024;
+const DESCRIPTION_RE = /^\s*description\s*:\s*["']?(.+?)["']?\s*$/im;
+const TITLE_RE = /^\s*#\s+(.+?)\s*$/m;
+const GITHUB_URL_RE = /https?:\/\/github\.com\/[^\s<>)"']+/gi;
+const GITHUB_SHORTHAND_RE = /github:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[^\s<>)"']+)?/g;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function compact(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function normalizeMarkdownText(value: string): string {
+  return value.replace(/\r\n?/g, '\n');
+}
+
+function contentDigest(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function candidateFingerprint(sourceRef: string, contentOrKind: string): string {
+  return createHash('sha256')
+    .update(sourceRef)
+    .update('\0')
+    .update(contentOrKind)
+    .digest('hex');
+}
+
+function deriveTitle(markdown: string, fallback: string): string {
+  const frontmatterName = markdown.match(/^\s*name\s*:\s*["']?(.+?)["']?\s*$/im)?.[1];
+  const title = markdown.match(/^\s*title\s*:\s*["']?(.+?)["']?\s*$/im)?.[1];
+  const heading = markdown.match(TITLE_RE)?.[1];
+  return compact(frontmatterName ?? title ?? heading ?? fallback).slice(0, 120);
+}
+
+function deriveDescription(markdown: string): string | undefined {
+  const fm = markdown.match(DESCRIPTION_RE)?.[1];
+  if (fm) return compact(fm).slice(0, 240);
+  const afterHeading = markdown
+    .replace(/^---[\s\S]*?---\s*/m, '')
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0 && !line.startsWith('#'));
+  return afterHeading ? compact(afterHeading).slice(0, 240) : undefined;
+}
+
+function looksLikeReusableSkillDoc(markdown: string, fileName: string): boolean {
+  const name = path.basename(fileName).toLowerCase();
+  if (name === 'skill.md') return true;
+  if (!name.endsWith('.md')) return false;
+  const text = markdown.toLowerCase();
+  const hasSkillIdentity =
+    /\bskill\b/.test(text) &&
+    (/\btrigger\b/.test(text) ||
+      /\buse when\b/.test(text) ||
+      /\bworkflow\b/.test(text) ||
+      /\btools?\b/.test(text) ||
+      /\binputs?\b/.test(text));
+  const hasReusableFrontmatter =
+    /^\s*---[\s\S]*?\bname\s*:/m.test(markdown) &&
+    /\bdescription\s*:/i.test(markdown);
+  return hasSkillIdentity || hasReusableFrontmatter;
+}
+
+function markdownCandidate(
+  sourceKind: SkillPluginCandidateSourceKind,
+  sourceRef: string,
+  markdown: string,
+): SkillPluginCandidateInput | null {
+  const normalized = normalizeMarkdownText(markdown).slice(0, MAX_MARKDOWN_READ_BYTES);
+  const fileName = path.basename(sourceRef);
+  const explicitSkillMd = fileName.toLowerCase() === 'skill.md';
+  if (!explicitSkillMd && !looksLikeReusableSkillDoc(normalized, fileName)) return null;
+
+  const title = deriveTitle(normalized, explicitSkillMd ? 'SKILL.md' : fileName.replace(/\.md$/i, ''));
+  const description = deriveDescription(normalized);
+  return {
+    sourceKind,
+    sourceRef,
+    provenance: explicitSkillMd ? 'uploaded-skill-md' : 'markdown-skill-doc',
+    confidence: explicitSkillMd ? 0.96 : 0.72,
+    title,
+    ...(description ? { description } : {}),
+    fingerprint: candidateFingerprint(sourceRef, contentDigest(normalized)),
+    draftInput: {
+      artifactKind: explicitSkillMd ? 'skill-md' : 'markdown-skill-doc',
+      source: sourceRef,
+      title,
+      ...(description ? { description } : {}),
+      contentExcerpt: normalized.slice(0, 4000),
+      suggestedFiles: ['SKILL.md', 'open-design.json'],
+    },
+  };
+}
+
+function normalizeGithubRef(raw: string): string | null {
+  const trimmed = raw.replace(/[.,;:!?]+$/g, '');
+  if (trimmed.startsWith('github:')) return trimmed;
+  try {
+    const url = new URL(trimmed);
+    if (url.hostname !== 'github.com') return null;
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts.length < 2) return null;
+    return `https://github.com/${parts.join('/')}`;
+  } catch {
+    return null;
+  }
+}
+
+function isPluginLikeRepoRef(ref: string): boolean {
+  const lower = ref.toLowerCase();
+  return (
+    lower.includes('skill.md') ||
+    lower.includes('open-design.json') ||
+    lower.includes('.claude-plugin') ||
+    lower.includes('plugin.json') ||
+    lower.endsWith('/plugins') ||
+    lower.includes('/plugins/')
+  );
+}
+
+function repoCandidate(ref: string): SkillPluginCandidateInput | null {
+  if (!isPluginLikeRepoRef(ref)) return null;
+  const refPath = ref.replace(/^github:/, '').split(/[/?#]/)[0] ?? '';
+  const parts = refPath.split('/').filter(Boolean);
+  const repoTitle = parts.length >= 2 ? parts.slice(0, 2).join('/') : 'GitHub plugin source';
+  return {
+    sourceKind: 'repo-link',
+    sourceRef: ref,
+    provenance: 'plugin-like-link',
+    confidence: ref.toLowerCase().includes('skill.md') || ref.toLowerCase().includes('open-design.json') ? 0.84 : 0.68,
+    title: repoTitle,
+    description: 'Repository link contains plugin-like Open Design files.',
+    fingerprint: candidateFingerprint(ref, 'repo-plugin-link'),
+    draftInput: {
+      artifactKind: 'repo-plugin',
+      source: ref,
+      title: repoTitle,
+      description: 'Repository link contains plugin-like Open Design files.',
+      suggestedFiles: ['open-design.json', 'SKILL.md'],
+    },
+  };
+}
+
+function promptText(input: DetectSkillPluginCandidatesInput): string {
+  return [input.message, input.currentPrompt, input.systemPrompt]
+    .filter((value): value is string => typeof value === 'string')
+    .join('\n');
+}
+
+function projectRelativePath(root: string, candidate: string): string | null {
+  try {
+    const abs = path.resolve(root, candidate);
+    const rel = path.relative(path.resolve(root), abs);
+    if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return null;
+    return rel.split(path.sep).join('/');
+  } catch {
+    return null;
+  }
+}
+
+async function readMarkdownUnderProject(root: string, rel: string): Promise<string | null> {
+  try {
+    const abs = path.resolve(root, rel);
+    const safeRel = path.relative(path.resolve(root), abs);
+    if (!safeRel || safeRel.startsWith('..') || path.isAbsolute(safeRel)) return null;
+    const stat = await fs.stat(abs);
+    if (!stat.isFile() || stat.size > MAX_MARKDOWN_READ_BYTES) return null;
+    return await fs.readFile(abs, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+export async function detectSkillPluginCandidates(
+  input: DetectSkillPluginCandidatesInput,
+): Promise<SkillPluginCandidateInput[]> {
+  const found = new Map<string, SkillPluginCandidateInput>();
+  const root = typeof input.projectRoot === 'string' && input.projectRoot ? input.projectRoot : null;
+
+  if (root && Array.isArray(input.attachments)) {
+    for (const attachment of input.attachments) {
+      if (typeof attachment !== 'string') continue;
+      const rel = projectRelativePath(root, attachment);
+      if (!rel || !rel.toLowerCase().endsWith('.md')) continue;
+      const body = await readMarkdownUnderProject(root, rel);
+      if (!body) continue;
+      const candidate = markdownCandidate('project-file', rel, body);
+      if (candidate) found.set(candidate.fingerprint, candidate);
+    }
+  }
+
+  const text = promptText(input);
+  for (const match of [...text.matchAll(GITHUB_URL_RE), ...text.matchAll(GITHUB_SHORTHAND_RE)]) {
+    const ref = normalizeGithubRef(match[0]);
+    if (!ref) continue;
+    const candidate = repoCandidate(ref);
+    if (candidate) found.set(candidate.fingerprint, candidate);
+  }
+
+  if (root) {
+    const referencedMd = text.match(/(?:^|[\s"`'(<])([A-Za-z0-9_.\/-]+\.md)(?=$|[\s"`')>,.])/g) ?? [];
+    for (const raw of referencedMd) {
+      const rel = projectRelativePath(root, raw.trim().replace(/^["'`(<]+|[)"'`>,.]+$/g, ''));
+      if (!rel) continue;
+      const body = await readMarkdownUnderProject(root, rel);
+      if (!body) continue;
+      const candidate = markdownCandidate('referenced-file', rel, body);
+      if (candidate) found.set(candidate.fingerprint, candidate);
+    }
+  }
+
+  return Array.from(found.values()).sort((a, b) => b.confidence - a.confidence);
+}
+
+function parseCandidateRow(row: DbRow): SkillPluginCandidateRow {
+  const draftInput = typeof row.draftInputJson === 'string'
+    ? JSON.parse(row.draftInputJson) as SkillPluginCandidateDraftInput
+    : {
+        artifactKind: 'skill-md' as const,
+        source: String(row.sourceRef ?? ''),
+        suggestedFiles: [],
+      };
+  const parsed: SkillPluginCandidateRow = {
+    id: String(row.id),
+    projectId: String(row.projectId),
+    runId: typeof row.runId === 'string' ? row.runId : null,
+    sourceKind: row.sourceKind as SkillPluginCandidateSourceKind,
+    sourceRef: String(row.sourceRef),
+    provenance: row.provenance as SkillPluginCandidateProvenance,
+    confidence: Number(row.confidence),
+    fingerprint: String(row.fingerprint),
+    draftInput,
+    status: row.status === 'dismissed' ? 'dismissed' : 'active',
+    dismissedAt: typeof row.dismissedAt === 'number' ? row.dismissedAt : null,
+    createdAt: Number(row.createdAt),
+    updatedAt: Number(row.updatedAt),
+  };
+  if (typeof row.title === 'string') parsed.title = row.title;
+  if (typeof row.description === 'string') parsed.description = row.description;
+  return parsed;
+}
+
+export function persistSkillPluginCandidates(
+  db: SqliteDb,
+  args: { projectId: string; runId?: string | null; candidates: SkillPluginCandidateInput[]; now?: number },
+): SkillPluginCandidateRow[] {
+  const now = args.now ?? Date.now();
+  const rows: SkillPluginCandidateRow[] = [];
+  const insert = db.prepare(`
+    INSERT INTO skill_plugin_candidates (
+      id, project_id, run_id, source_kind, source_ref, provenance, confidence,
+      title, description, fingerprint, draft_input_json, status, dismissed_at,
+      created_at, updated_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', NULL, ?, ?)
+    ON CONFLICT(project_id, fingerprint) DO UPDATE SET
+      run_id = CASE
+        WHEN skill_plugin_candidates.status = 'dismissed' THEN skill_plugin_candidates.run_id
+        ELSE excluded.run_id
+      END,
+      confidence = CASE
+        WHEN skill_plugin_candidates.status = 'dismissed' THEN skill_plugin_candidates.confidence
+        ELSE MAX(skill_plugin_candidates.confidence, excluded.confidence)
+      END,
+      title = CASE
+        WHEN skill_plugin_candidates.status = 'dismissed' THEN skill_plugin_candidates.title
+        ELSE COALESCE(skill_plugin_candidates.title, excluded.title)
+      END,
+      description = CASE
+        WHEN skill_plugin_candidates.status = 'dismissed' THEN skill_plugin_candidates.description
+        ELSE COALESCE(skill_plugin_candidates.description, excluded.description)
+      END,
+      draft_input_json = CASE
+        WHEN skill_plugin_candidates.status = 'dismissed' THEN skill_plugin_candidates.draft_input_json
+        ELSE excluded.draft_input_json
+      END,
+      updated_at = CASE
+        WHEN skill_plugin_candidates.status = 'dismissed' THEN skill_plugin_candidates.updated_at
+        ELSE excluded.updated_at
+      END
+  `);
+  const select = db.prepare(`
+    SELECT id, project_id AS projectId, run_id AS runId, source_kind AS sourceKind,
+           source_ref AS sourceRef, provenance, confidence, title, description,
+           fingerprint, draft_input_json AS draftInputJson, status,
+           dismissed_at AS dismissedAt, created_at AS createdAt, updated_at AS updatedAt
+      FROM skill_plugin_candidates
+     WHERE project_id = ? AND fingerprint = ?
+  `);
+
+  for (const candidate of args.candidates) {
+    insert.run(
+      `spc_${randomUUID()}`,
+      args.projectId,
+      args.runId ?? null,
+      candidate.sourceKind,
+      candidate.sourceRef,
+      candidate.provenance,
+      candidate.confidence,
+      candidate.title ?? null,
+      candidate.description ?? null,
+      candidate.fingerprint,
+      JSON.stringify(candidate.draftInput),
+      now,
+      now,
+    );
+    const row = select.get(args.projectId, candidate.fingerprint) as DbRow | undefined;
+    if (row && row.status !== 'dismissed') rows.push(parseCandidateRow(row));
+  }
+  return rows;
+}
+
+export function listSkillPluginCandidates(
+  db: SqliteDb,
+  projectId: string,
+  opts: { includeDismissed?: boolean } = {},
+): SkillPluginCandidateRow[] {
+  const rows = db.prepare(`
+    SELECT id, project_id AS projectId, run_id AS runId, source_kind AS sourceKind,
+           source_ref AS sourceRef, provenance, confidence, title, description,
+           fingerprint, draft_input_json AS draftInputJson, status,
+           dismissed_at AS dismissedAt, created_at AS createdAt, updated_at AS updatedAt
+      FROM skill_plugin_candidates
+     WHERE project_id = ?
+       ${opts.includeDismissed ? '' : `AND status != 'dismissed'`}
+     ORDER BY confidence DESC, updated_at DESC
+  `).all(projectId) as DbRow[];
+  return rows.map(parseCandidateRow);
+}
+
+export function dismissSkillPluginCandidate(
+  db: SqliteDb,
+  args: { projectId: string; candidateId: string; now?: number },
+): SkillPluginCandidateRow | null {
+  const now = args.now ?? Date.now();
+  db.prepare(`
+    UPDATE skill_plugin_candidates
+       SET status = 'dismissed', dismissed_at = ?, updated_at = ?
+     WHERE project_id = ? AND id = ?
+  `).run(now, now, args.projectId, args.candidateId);
+  const row = db.prepare(`
+    SELECT id, project_id AS projectId, run_id AS runId, source_kind AS sourceKind,
+           source_ref AS sourceRef, provenance, confidence, title, description,
+           fingerprint, draft_input_json AS draftInputJson, status,
+           dismissed_at AS dismissedAt, created_at AS createdAt, updated_at AS updatedAt
+      FROM skill_plugin_candidates
+     WHERE project_id = ? AND id = ?
+  `).get(args.projectId, args.candidateId) as DbRow | undefined;
+  return row ? parseCandidateRow(row) : null;
+}
+
+export function hasCandidateShape(value: unknown): value is SkillPluginCandidateInput {
+  if (!isPlainObject(value)) return false;
+  return (
+    typeof value.sourceRef === 'string' &&
+    typeof value.fingerprint === 'string' &&
+    typeof value.confidence === 'number' &&
+    isPlainObject(value.draftInput)
+  );
+}

--- a/apps/daemon/src/plugins/candidates.ts
+++ b/apps/daemon/src/plugins/candidates.ts
@@ -212,14 +212,62 @@ function projectRelativePath(root: string, candidate: string): string | null {
   }
 }
 
-async function readMarkdownUnderProject(root: string, rel: string): Promise<string | null> {
+async function resolveCaseInsensitiveChild(parent: string, segment: string): Promise<string | null> {
   try {
-    const abs = path.resolve(root, rel);
-    const safeRel = path.relative(path.resolve(root), abs);
+    const names = await fs.readdir(parent);
+    const exact = names.find((name) => name === segment);
+    if (exact) return path.join(parent, exact);
+    const lower = segment.toLowerCase();
+    const match = names.find((name) => name.toLowerCase() === lower);
+    return match ? path.join(parent, match) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveExistingProjectPath(root: string, rel: string): Promise<string | null> {
+  try {
+    const resolvedRoot = path.resolve(root);
+    const abs = path.resolve(resolvedRoot, rel);
+    const safeRel = path.relative(resolvedRoot, abs);
     if (!safeRel || safeRel.startsWith('..') || path.isAbsolute(safeRel)) return null;
+    try {
+      await fs.stat(abs);
+      return abs;
+    } catch {
+      let current = resolvedRoot;
+      for (const segment of safeRel.split(path.sep)) {
+        const next = await resolveCaseInsensitiveChild(current, segment);
+        if (!next) return null;
+        current = next;
+      }
+      return current;
+    }
+  } catch {
+    return null;
+  }
+}
+
+async function canonicalProjectRelativePath(root: string, abs: string): Promise<string | null> {
+  try {
+    const [rootReal, absReal] = await Promise.all([fs.realpath(root), fs.realpath(abs)]);
+    const rel = path.relative(rootReal, absReal);
+    if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return null;
+    return rel.split(path.sep).join('/');
+  } catch {
+    return null;
+  }
+}
+
+async function readCanonicalMarkdownUnderProject(root: string, rel: string): Promise<{ body: string; sourceRef: string } | null> {
+  try {
+    const abs = await resolveExistingProjectPath(root, rel);
+    if (!abs) return null;
+    const sourceRef = await canonicalProjectRelativePath(root, abs);
+    if (!sourceRef) return null;
     const stat = await fs.stat(abs);
     if (!stat.isFile() || stat.size > MAX_MARKDOWN_READ_BYTES) return null;
-    return await fs.readFile(abs, 'utf8');
+    return { body: await fs.readFile(abs, 'utf8'), sourceRef };
   } catch {
     return null;
   }
@@ -242,9 +290,9 @@ export async function detectSkillPluginCandidates(
       if (typeof attachment !== 'string') continue;
       const rel = projectRelativePath(root, attachment);
       if (!rel || !rel.toLowerCase().endsWith('.md')) continue;
-      const body = await readMarkdownUnderProject(root, rel);
-      if (!body) continue;
-      const candidate = markdownCandidate('project-file', rel, body);
+      const markdown = await readCanonicalMarkdownUnderProject(root, rel);
+      if (!markdown) continue;
+      const candidate = markdownCandidate('project-file', markdown.sourceRef, markdown.body);
       if (candidate) addCandidate(candidate);
     }
   }
@@ -262,9 +310,9 @@ export async function detectSkillPluginCandidates(
     for (const raw of referencedMd) {
       const rel = projectRelativePath(root, raw.trim().replace(/^["'`(<]+|[)"'`>,.]+$/g, ''));
       if (!rel) continue;
-      const body = await readMarkdownUnderProject(root, rel);
-      if (!body) continue;
-      const candidate = markdownCandidate('referenced-file', rel, body);
+      const markdown = await readCanonicalMarkdownUnderProject(root, rel);
+      if (!markdown) continue;
+      const candidate = markdownCandidate('referenced-file', markdown.sourceRef, markdown.body);
       if (candidate) addCandidate(candidate);
     }
   }

--- a/apps/daemon/src/plugins/candidates.ts
+++ b/apps/daemon/src/plugins/candidates.ts
@@ -55,16 +55,12 @@ function normalizeMarkdownText(value: string): string {
   return value.replace(/\r\n?/g, '\n');
 }
 
-function normalizeSourceRefForIdentity(sourceRef: string): string {
+function normalizeFileSourceRefForIdentity(sourceRef: string): string {
   return sourceRef.replace(/\\/g, '/').trim();
 }
 
-function candidateFingerprint(sourceKind: SkillPluginCandidateSourceKind, sourceRef: string): string {
-  return createHash('sha256')
-    .update(sourceKind)
-    .update('\0')
-    .update(normalizeSourceRefForIdentity(sourceRef))
-    .digest('hex');
+function candidateFingerprint(sourceRef: string): string {
+  return createHash('sha256').update(normalizeFileSourceRefForIdentity(sourceRef)).digest('hex');
 }
 
 function deriveTitle(markdown: string, fallback: string): string {
@@ -122,7 +118,7 @@ function markdownCandidate(
     confidence: explicitSkillMd ? 0.96 : 0.72,
     title,
     ...(description ? { description } : {}),
-    fingerprint: candidateFingerprint(sourceKind, sourceRef),
+    fingerprint: candidateFingerprint(sourceRef),
     draftInput: {
       artifactKind: explicitSkillMd ? 'skill-md' : 'markdown-skill-doc',
       source: sourceRef,
@@ -136,7 +132,11 @@ function markdownCandidate(
 
 function normalizeGithubRef(raw: string): string | null {
   const trimmed = raw.replace(/[.,;:!?]+$/g, '');
-  if (trimmed.startsWith('github:')) return trimmed;
+  if (trimmed.startsWith('github:')) {
+    const parts = trimmed.slice('github:'.length).split('/').filter(Boolean);
+    if (parts.length < 2) return null;
+    return `https://github.com/${parts.join('/')}`;
+  }
   try {
     const url = new URL(trimmed);
     if (url.hostname !== 'github.com') return null;
@@ -172,7 +172,7 @@ function repoCandidate(ref: string): SkillPluginCandidateInput | null {
     confidence: ref.toLowerCase().includes('skill.md') || ref.toLowerCase().includes('open-design.json') ? 0.84 : 0.68,
     title: repoTitle,
     description: 'Repository link contains plugin-like Open Design files.',
-    fingerprint: candidateFingerprint('repo-link', ref),
+    fingerprint: candidateFingerprint(ref),
     draftInput: {
       artifactKind: 'repo-plugin',
       source: ref,
@@ -218,6 +218,12 @@ export async function detectSkillPluginCandidates(
 ): Promise<SkillPluginCandidateInput[]> {
   const found = new Map<string, SkillPluginCandidateInput>();
   const root = typeof input.projectRoot === 'string' && input.projectRoot ? input.projectRoot : null;
+  const addCandidate = (candidate: SkillPluginCandidateInput): void => {
+    const existing = found.get(candidate.fingerprint);
+    if (!existing || candidate.confidence > existing.confidence) {
+      found.set(candidate.fingerprint, candidate);
+    }
+  };
 
   if (root && Array.isArray(input.attachments)) {
     for (const attachment of input.attachments) {
@@ -227,7 +233,7 @@ export async function detectSkillPluginCandidates(
       const body = await readMarkdownUnderProject(root, rel);
       if (!body) continue;
       const candidate = markdownCandidate('project-file', rel, body);
-      if (candidate) found.set(candidate.fingerprint, candidate);
+      if (candidate) addCandidate(candidate);
     }
   }
 
@@ -236,7 +242,7 @@ export async function detectSkillPluginCandidates(
     const ref = normalizeGithubRef(match[0]);
     if (!ref) continue;
     const candidate = repoCandidate(ref);
-    if (candidate) found.set(candidate.fingerprint, candidate);
+    if (candidate) addCandidate(candidate);
   }
 
   if (root) {
@@ -247,7 +253,7 @@ export async function detectSkillPluginCandidates(
       const body = await readMarkdownUnderProject(root, rel);
       if (!body) continue;
       const candidate = markdownCandidate('referenced-file', rel, body);
-      if (candidate) found.set(candidate.fingerprint, candidate);
+      if (candidate) addCandidate(candidate);
     }
   }
 

--- a/apps/daemon/src/plugins/index.ts
+++ b/apps/daemon/src/plugins/index.ts
@@ -86,6 +86,7 @@ export * from './atoms/token-map.js';
 export * from './bundled.js';
 export * from './connector-gate.js';
 export * from './connector-probe.js';
+export * from './candidates.js';
 export * from './export.js';
 export * from './doctor.js';
 export * from './installer.js';

--- a/apps/daemon/src/plugins/persistence.ts
+++ b/apps/daemon/src/plugins/persistence.ts
@@ -142,6 +142,31 @@ export function migratePlugins(db: SqliteDb): void {
     CREATE INDEX IF NOT EXISTS idx_genui_proj_surface ON genui_surfaces(project_id, surface_id);
     CREATE INDEX IF NOT EXISTS idx_genui_conv_surface ON genui_surfaces(conversation_id, surface_id);
     CREATE INDEX IF NOT EXISTS idx_genui_run          ON genui_surfaces(run_id);
+
+    CREATE TABLE IF NOT EXISTS skill_plugin_candidates (
+      id               TEXT PRIMARY KEY,
+      project_id       TEXT NOT NULL,
+      run_id           TEXT,
+      source_kind      TEXT NOT NULL,
+      source_ref       TEXT NOT NULL,
+      provenance       TEXT NOT NULL,
+      confidence       REAL NOT NULL,
+      title            TEXT,
+      description      TEXT,
+      fingerprint      TEXT NOT NULL,
+      draft_input_json TEXT NOT NULL,
+      status           TEXT NOT NULL DEFAULT 'active',
+      dismissed_at     INTEGER,
+      created_at       INTEGER NOT NULL,
+      updated_at       INTEGER NOT NULL,
+      UNIQUE(project_id, fingerprint),
+      FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_skill_plugin_candidates_project
+      ON skill_plugin_candidates(project_id, status, updated_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_skill_plugin_candidates_run
+      ON skill_plugin_candidates(run_id);
   `);
 
   const marketplaceCols = db.prepare(`PRAGMA table_info(plugin_marketplaces)`).all() as DbRow[];

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7095,9 +7095,11 @@ export async function startServer({
     const project = getProject(db, req.params.id);
     if (!project) return sendApiError(res, 404, 'NOT_FOUND', 'project not found');
     const includeDismissed = req.query.includeDismissed === 'true';
-    res.json({
+    /** @type {import('@open-design/contracts').SkillPluginCandidateListResponse} */
+    const body = {
       candidates: listSkillPluginCandidates(db, req.params.id, { includeDismissed }),
-    });
+    };
+    res.json(body);
   });
 
   app.post('/api/projects/:id/plugin-candidates/:candidateId/dismiss', (req, res) => {
@@ -7108,7 +7110,9 @@ export async function startServer({
       candidateId: req.params.candidateId,
     });
     if (!candidate) return sendApiError(res, 404, 'NOT_FOUND', 'plugin candidate not found');
-    res.json({ candidate });
+    /** @type {import('@open-design/contracts').SkillPluginCandidateDismissResponse} */
+    const body = { candidate };
+    res.json(body);
   });
 
   // Plan §3.CC1 — `od plugin canon <snapshotId>`. Returns the
@@ -10047,6 +10051,31 @@ export async function startServer({
     }
     if (run.cancelRequested || design.runs.isTerminal(run.status)) return;
     const runId = run.id;
+    const persistSkillPluginCandidatesForSucceededRun = async () => {
+      try {
+        if (typeof projectId !== 'string' || !projectId) return;
+        const project = getProject(db, projectId);
+        if (!project) return;
+        const projectRoot = project.metadata?.baseDir
+          ? path.normalize(project.metadata.baseDir)
+          : await ensureProject(PROJECTS_DIR, projectId);
+        const candidates = await detectSkillPluginCandidates({
+          projectRoot,
+          attachments,
+          message,
+          currentPrompt,
+          systemPrompt,
+        });
+        if (candidates.length === 0) return;
+        persistSkillPluginCandidates(db, {
+          projectId,
+          runId,
+          candidates,
+        });
+      } catch (err) {
+        console.warn('[plugins] skill plugin candidate detection failed', err);
+      }
+    };
 
     // Auto-memory hook. Pulls explicit "remember:" / "我是 X" / "I prefer Y"
     // markers out of the just-arrived user message and writes them as MD
@@ -11070,6 +11099,7 @@ export async function startServer({
           if (run.cancelRequested) {
             design.runs.finish(run, 'canceled', 1, null);
           } else if (succeeded) {
+            await persistSkillPluginCandidatesForSucceededRun();
             design.runs.finish(run, 'succeeded', 0, null);
           } else {
             design.runs.finish(run, 'failed', 1, null);
@@ -11304,7 +11334,7 @@ export async function startServer({
       send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err.message));
       design.runs.finish(run, 'failed', 1, null);
     });
-    child.on('close', (code, signal) => {
+    child.on('close', async (code, signal) => {
       clearInactivityWatchdog();
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
@@ -11392,6 +11422,9 @@ export async function startServer({
             { retryable: diagnostic.retryable, details: { detail: diagnostic.detail } },
           ));
         }
+      }
+      if (status === 'succeeded') {
+        await persistSkillPluginCandidatesForSucceededRun();
       }
       design.runs.finish(run, status, code, signal);
     });
@@ -11765,30 +11798,6 @@ export async function startServer({
     }
     reconcileAssistantMessageOnRunEnd(db, design.runs, run);
     design.runs.start(run, () => startChatRun(meta, run));
-    design.runs.wait(run).then(async (status) => {
-      if (status.status !== 'succeeded') return;
-      if (typeof meta.projectId !== 'string' || !meta.projectId) return;
-      const project = getProject(db, meta.projectId);
-      if (!project) return;
-      const projectRoot = project.metadata?.baseDir
-        ? path.normalize(project.metadata.baseDir)
-        : await ensureProject(PROJECTS_DIR, meta.projectId);
-      const candidates = await detectSkillPluginCandidates({
-        projectRoot,
-        attachments: meta.attachments,
-        message: meta.message,
-        currentPrompt: meta.currentPrompt,
-        systemPrompt: meta.systemPrompt,
-      });
-      if (candidates.length === 0) return;
-      persistSkillPluginCandidates(db, {
-        projectId: meta.projectId,
-        runId: run.id,
-        candidates,
-      });
-    }).catch((err) => {
-      console.warn('[plugins] skill plugin candidate detection failed', err);
-    });
 
     // Analytics v2: emit run_created (daemon-side authoritative) and
     // schedule run_finished on terminal state. The matching `chat-routes.ts`

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -90,6 +90,8 @@ import {
   applyDiffReviewDecisionToCwd,
   applyPlugin,
   buildConnectorProbe,
+  detectSkillPluginCandidates,
+  dismissSkillPluginCandidate,
   defaultBundledRoot,
   doctorPlugin,
   FIRST_PARTY_ATOMS,
@@ -98,10 +100,12 @@ import {
   installFromLocalFolder,
   installPlugin,
   isDiffReviewSurfaceId,
+  listSkillPluginCandidates,
   listInstalledPlugins,
   listIterationsForRun,
   MissingInputError,
   pluginPromptBlock,
+  persistSkillPluginCandidates,
   pruneExpiredSnapshots,
   readPluginLockfile,
   registerBuiltInAtomWorkers,
@@ -7087,6 +7091,26 @@ export async function startServer({
     }
   });
 
+  app.get('/api/projects/:id/plugin-candidates', (req, res) => {
+    const project = getProject(db, req.params.id);
+    if (!project) return sendApiError(res, 404, 'NOT_FOUND', 'project not found');
+    const includeDismissed = req.query.includeDismissed === 'true';
+    res.json({
+      candidates: listSkillPluginCandidates(db, req.params.id, { includeDismissed }),
+    });
+  });
+
+  app.post('/api/projects/:id/plugin-candidates/:candidateId/dismiss', (req, res) => {
+    const project = getProject(db, req.params.id);
+    if (!project) return sendApiError(res, 404, 'NOT_FOUND', 'project not found');
+    const candidate = dismissSkillPluginCandidate(db, {
+      projectId: req.params.id,
+      candidateId: req.params.candidateId,
+    });
+    if (!candidate) return sendApiError(res, 404, 'NOT_FOUND', 'plugin candidate not found');
+    res.json({ candidate });
+  });
+
   // Plan §3.CC1 — `od plugin canon <snapshotId>`. Returns the
   // canonical `## Active plugin` block the agent will see when
   // this snapshot is spliced into the system prompt. Powered by
@@ -11741,6 +11765,30 @@ export async function startServer({
     }
     reconcileAssistantMessageOnRunEnd(db, design.runs, run);
     design.runs.start(run, () => startChatRun(meta, run));
+    design.runs.wait(run).then(async (status) => {
+      if (status.status !== 'succeeded') return;
+      if (typeof meta.projectId !== 'string' || !meta.projectId) return;
+      const project = getProject(db, meta.projectId);
+      if (!project) return;
+      const projectRoot = project.metadata?.baseDir
+        ? path.normalize(project.metadata.baseDir)
+        : await ensureProject(PROJECTS_DIR, meta.projectId);
+      const candidates = await detectSkillPluginCandidates({
+        projectRoot,
+        attachments: meta.attachments,
+        message: meta.message,
+        currentPrompt: meta.currentPrompt,
+        systemPrompt: meta.systemPrompt,
+      });
+      if (candidates.length === 0) return;
+      persistSkillPluginCandidates(db, {
+        projectId: meta.projectId,
+        runId: run.id,
+        candidates,
+      });
+    }).catch((err) => {
+      console.warn('[plugins] skill plugin candidate detection failed', err);
+    });
 
     // Analytics v2: emit run_created (daemon-side authoritative) and
     // schedule run_finished on terminal state. The matching `chat-routes.ts`

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10052,29 +10052,25 @@ export async function startServer({
     if (run.cancelRequested || design.runs.isTerminal(run.status)) return;
     const runId = run.id;
     const persistSkillPluginCandidatesForSucceededRun = async () => {
-      try {
-        if (typeof projectId !== 'string' || !projectId) return;
-        const project = getProject(db, projectId);
-        if (!project) return;
-        const projectRoot = project.metadata?.baseDir
-          ? path.normalize(project.metadata.baseDir)
-          : await ensureProject(PROJECTS_DIR, projectId);
-        const candidates = await detectSkillPluginCandidates({
-          projectRoot,
-          attachments,
-          message,
-          currentPrompt,
-          systemPrompt,
-        });
-        if (candidates.length === 0) return;
-        persistSkillPluginCandidates(db, {
-          projectId,
-          runId,
-          candidates,
-        });
-      } catch (err) {
-        console.warn('[plugins] skill plugin candidate detection failed', err);
-      }
+      if (typeof projectId !== 'string' || !projectId) return;
+      const project = getProject(db, projectId);
+      if (!project) return;
+      const projectRoot = project.metadata?.baseDir
+        ? path.normalize(project.metadata.baseDir)
+        : await ensureProject(PROJECTS_DIR, projectId);
+      const candidates = await detectSkillPluginCandidates({
+        projectRoot,
+        attachments,
+        message,
+        currentPrompt,
+        systemPrompt,
+      });
+      if (candidates.length === 0) return;
+      persistSkillPluginCandidates(db, {
+        projectId,
+        runId,
+        candidates,
+      });
     };
 
     // Auto-memory hook. Pulls explicit "remember:" / "我是 X" / "I prefer Y"
@@ -11424,7 +11420,15 @@ export async function startServer({
         }
       }
       if (status === 'succeeded') {
-        await persistSkillPluginCandidatesForSucceededRun();
+        try {
+          await persistSkillPluginCandidatesForSucceededRun();
+        } catch (err) {
+          send('error', createSseErrorPayload(
+            'AGENT_EXECUTION_FAILED',
+            err instanceof Error ? err.message : String(err),
+          ));
+          return design.runs.finish(run, 'failed', code ?? 1, signal);
+        }
       }
       design.runs.finish(run, status, code, signal);
     });

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -430,14 +430,9 @@ process.stdin.on('end', () => {
         expect(createRunResponse.status).toBe(202);
         await waitForRunStatus(baseUrl, createRunBody.runId, (status) => status === 'succeeded');
 
-        let candidates: Array<{ title?: string; provenance?: string; draftInput?: { contentExcerpt?: string } }> = [];
-        for (let attempt = 0; attempt < 20; attempt += 1) {
-          const candidatesResponse = await fetch(`${baseUrl}/api/projects/${projectId}/plugin-candidates`);
-          const candidatesBody = await candidatesResponse.json() as { candidates: typeof candidates };
-          candidates = candidatesBody.candidates;
-          if (candidates.length > 0) break;
-          await new Promise((resolve) => setTimeout(resolve, 25));
-        }
+        const candidatesResponse = await fetch(`${baseUrl}/api/projects/${projectId}/plugin-candidates`);
+        const candidatesBody = await candidatesResponse.json() as import('@open-design/contracts').SkillPluginCandidateListResponse;
+        const candidates = candidatesBody.candidates;
 
         expect(candidates).toHaveLength(1);
         const candidate = candidates[0]!;

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -368,6 +368,88 @@ process.stdin.on('end', () => {
     expect(stagedFileBody).toBe(expectedChecklist);
   });
 
+  it('persists uploaded SKILL.md plugin candidates after a successful run', async () => {
+    const projectId = `project-${randomUUID()}`;
+    const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Skill candidate project',
+      }),
+    });
+
+    expect(createProjectResponse.ok).toBe(true);
+
+    const uploadResponse = await fetch(`${baseUrl}/api/projects/${projectId}/files`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'SKILL.md',
+        content: [
+          '---',
+          'name: storyboard-helper',
+          'description: Reusable storyboard planning workflow.',
+          '---',
+          '# Storyboard Helper',
+          '',
+          'Use this skill when planning storyboard sequences.',
+        ].join('\n'),
+      }),
+    });
+
+    expect(uploadResponse.ok).toBe(true);
+
+    await withFakeAgent(
+      'opencode',
+      `
+process.stdin.resume();
+process.stdin.on('end', () => {
+  console.log(JSON.stringify({ type: 'step_start' }));
+  console.log(JSON.stringify({ type: 'text', part: { text: 'skill-candidate-run-complete' } }));
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+});
+`,
+      async () => {
+        const createRunResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            projectId,
+            conversationId: `conversation-${randomUUID()}`,
+            assistantMessageId: `assistant-${randomUUID()}`,
+            clientRequestId: `client-${randomUUID()}`,
+            message: 'Use the uploaded SKILL.md.',
+            attachments: ['SKILL.md'],
+          }),
+        });
+        const createRunBody = await createRunResponse.json() as { runId: string };
+
+        expect(createRunResponse.status).toBe(202);
+        await waitForRunStatus(baseUrl, createRunBody.runId, (status) => status === 'succeeded');
+
+        let candidates: Array<{ title?: string; provenance?: string; draftInput?: { contentExcerpt?: string } }> = [];
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          const candidatesResponse = await fetch(`${baseUrl}/api/projects/${projectId}/plugin-candidates`);
+          const candidatesBody = await candidatesResponse.json() as { candidates: typeof candidates };
+          candidates = candidatesBody.candidates;
+          if (candidates.length > 0) break;
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+
+        expect(candidates).toHaveLength(1);
+        const candidate = candidates[0]!;
+        expect(candidate).toMatchObject({
+          title: 'storyboard-helper',
+          provenance: 'uploaded-skill-md',
+        });
+        expect(candidate.draftInput?.contentExcerpt).toContain('Storyboard Helper');
+      },
+    );
+  });
+
   it('stages side files for every composed skill into the project cwd', async () => {
     const projectId = `project-${randomUUID()}`;
     const stagedPaths = [

--- a/apps/daemon/tests/plugins-candidates.test.ts
+++ b/apps/daemon/tests/plugins-candidates.test.ts
@@ -100,8 +100,13 @@ describe('skill plugin candidate detection', () => {
     ]);
     expect(candidates.find((candidate) => candidate.sourceRef === 'docs/research-agent.md')?.title)
       .toBe('Research Agent');
-    expect(candidates.find((candidate) => candidate.sourceKind === 'repo-link')?.draftInput.artifactKind)
-      .toBe('repo-plugin');
+    expect(candidates.find((candidate) => candidate.sourceKind === 'repo-link')).toMatchObject({
+      title: 'nexu-io/open-design',
+      draftInput: {
+        artifactKind: 'repo-plugin',
+        title: 'nexu-io/open-design',
+      },
+    });
   });
 
   it('deduplicates GitHub shorthand and URL spellings for the same repository artifact', async () => {

--- a/apps/daemon/tests/plugins-candidates.test.ts
+++ b/apps/daemon/tests/plugins-candidates.test.ts
@@ -144,4 +144,65 @@ describe('skill plugin candidate persistence', () => {
 
     expect(listSkillPluginCandidates(db, 'project-a')).toEqual([]);
   });
+
+  it('keeps an edited source dismissed without creating duplicate rows', async () => {
+    const skillPath = path.join(tmpRoot, 'SKILL.md');
+    await writeFile(
+      skillPath,
+      `---\nname: original-skill\ndescription: Original reusable workflow.\n---\n# Original Skill\n\nUse this skill when drafting copy.\n`,
+      'utf8',
+    );
+
+    const [firstCandidate] = await detectSkillPluginCandidates({
+      projectRoot: tmpRoot,
+      attachments: ['SKILL.md'],
+    });
+    expect(firstCandidate).toBeTruthy();
+
+    const [persisted] = persistSkillPluginCandidates(db, {
+      projectId: 'project-a',
+      runId: 'run-1',
+      candidates: [firstCandidate!],
+      now: 100,
+    });
+    expect(persisted).toBeTruthy();
+
+    dismissSkillPluginCandidate(db, {
+      projectId: 'project-a',
+      candidateId: persisted!.id,
+      now: 200,
+    });
+
+    await writeFile(
+      skillPath,
+      `---\nname: edited-skill\ndescription: Edited reusable workflow.\n---\n# Edited Skill\n\nUse this skill when revising launch copy.\n`,
+      'utf8',
+    );
+
+    const [editedCandidate] = await detectSkillPluginCandidates({
+      projectRoot: tmpRoot,
+      attachments: ['SKILL.md'],
+    });
+    expect(editedCandidate).toBeTruthy();
+    expect(editedCandidate!.fingerprint).toBe(firstCandidate!.fingerprint);
+
+    const activeRows = persistSkillPluginCandidates(db, {
+      projectId: 'project-a',
+      runId: 'run-2',
+      candidates: [editedCandidate!],
+      now: 300,
+    });
+
+    expect(activeRows).toEqual([]);
+    expect(listSkillPluginCandidates(db, 'project-a')).toEqual([]);
+    expect(listSkillPluginCandidates(db, 'project-a', { includeDismissed: true })).toMatchObject([
+      {
+        id: persisted!.id,
+        status: 'dismissed',
+        title: 'edited-skill',
+        description: 'Edited reusable workflow.',
+        fingerprint: firstCandidate!.fingerprint,
+      },
+    ]);
+  });
 });

--- a/apps/daemon/tests/plugins-candidates.test.ts
+++ b/apps/daemon/tests/plugins-candidates.test.ts
@@ -61,6 +61,26 @@ describe('skill plugin candidate detection', () => {
     expect(candidate.draftInput.contentExcerpt).toContain('Use this skill');
   });
 
+  it('deduplicates the same SKILL.md found through attachments and prompt mentions', async () => {
+    await writeFile(
+      path.join(tmpRoot, 'SKILL.md'),
+      `---\nname: launch-brief\ndescription: Reusable launch brief workflow.\n---\n# Launch Brief\n\nUse this skill when preparing launch copy.\n`,
+      'utf8',
+    );
+
+    const candidates = await detectSkillPluginCandidates({
+      projectRoot: tmpRoot,
+      attachments: ['SKILL.md'],
+      message: 'Use the uploaded SKILL.md.',
+    });
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      sourceRef: 'SKILL.md',
+      fingerprint: candidates[0]!.fingerprint,
+    });
+  });
+
   it('detects clearly reusable markdown skill docs and plugin-like repo links', async () => {
     await mkdir(path.join(tmpRoot, 'docs'), { recursive: true });
     await writeFile(
@@ -82,6 +102,22 @@ describe('skill plugin candidate detection', () => {
       .toBe('Research Agent');
     expect(candidates.find((candidate) => candidate.sourceKind === 'repo-link')?.draftInput.artifactKind)
       .toBe('repo-plugin');
+  });
+
+  it('deduplicates GitHub shorthand and URL spellings for the same repository artifact', async () => {
+    const candidates = await detectSkillPluginCandidates({
+      projectRoot: tmpRoot,
+      message: [
+        'github:nexu-io/open-design/blob/main/skills/foo/SKILL.md',
+        'https://github.com/nexu-io/open-design/blob/main/skills/foo/SKILL.md',
+      ].join('\n'),
+    });
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      sourceKind: 'repo-link',
+      sourceRef: 'https://github.com/nexu-io/open-design/blob/main/skills/foo/SKILL.md',
+    });
   });
 
   it('does not treat generic prompt heading blocks as candidates', async () => {
@@ -202,6 +238,52 @@ describe('skill plugin candidate persistence', () => {
         title: 'edited-skill',
         description: 'Edited reusable workflow.',
         fingerprint: firstCandidate!.fingerprint,
+      },
+    ]);
+  });
+
+  it('keeps a GitHub source dismissed across shorthand and URL spellings', async () => {
+    const [shorthandCandidate] = await detectSkillPluginCandidates({
+      projectRoot: tmpRoot,
+      message: 'github:nexu-io/open-design/blob/main/skills/foo/SKILL.md',
+    });
+    const [urlCandidate] = await detectSkillPluginCandidates({
+      projectRoot: tmpRoot,
+      message: 'https://github.com/nexu-io/open-design/blob/main/skills/foo/SKILL.md',
+    });
+    expect(shorthandCandidate).toBeTruthy();
+    expect(urlCandidate).toBeTruthy();
+    expect(urlCandidate!.fingerprint).toBe(shorthandCandidate!.fingerprint);
+
+    const [persisted] = persistSkillPluginCandidates(db, {
+      projectId: 'project-a',
+      runId: 'run-1',
+      candidates: [shorthandCandidate!],
+      now: 100,
+    });
+    expect(persisted).toBeTruthy();
+
+    dismissSkillPluginCandidate(db, {
+      projectId: 'project-a',
+      candidateId: persisted!.id,
+      now: 200,
+    });
+
+    const activeRows = persistSkillPluginCandidates(db, {
+      projectId: 'project-a',
+      runId: 'run-2',
+      candidates: [urlCandidate!],
+      now: 300,
+    });
+
+    expect(activeRows).toEqual([]);
+    expect(listSkillPluginCandidates(db, 'project-a')).toEqual([]);
+    expect(listSkillPluginCandidates(db, 'project-a', { includeDismissed: true })).toMatchObject([
+      {
+        id: persisted!.id,
+        status: 'dismissed',
+        sourceRef: 'https://github.com/nexu-io/open-design/blob/main/skills/foo/SKILL.md',
+        fingerprint: shorthandCandidate!.fingerprint,
       },
     ]);
   });

--- a/apps/daemon/tests/plugins-candidates.test.ts
+++ b/apps/daemon/tests/plugins-candidates.test.ts
@@ -81,6 +81,26 @@ describe('skill plugin candidate detection', () => {
     });
   });
 
+  it('deduplicates SKILL.md across attachment and prompt casing', async () => {
+    await writeFile(
+      path.join(tmpRoot, 'SKILL.md'),
+      `---\nname: launch-brief\ndescription: Reusable launch brief workflow.\n---\n# Launch Brief\n\nUse this skill when preparing launch copy.\n`,
+      'utf8',
+    );
+
+    const candidates = await detectSkillPluginCandidates({
+      projectRoot: tmpRoot,
+      attachments: ['SKILL.md'],
+      message: 'Use skill.md for the plugin draft.',
+    });
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      sourceRef: 'SKILL.md',
+      provenance: 'uploaded-skill-md',
+    });
+  });
+
   it('detects clearly reusable markdown skill docs and plugin-like repo links', async () => {
     await mkdir(path.join(tmpRoot, 'docs'), { recursive: true });
     await writeFile(

--- a/apps/daemon/tests/plugins-candidates.test.ts
+++ b/apps/daemon/tests/plugins-candidates.test.ts
@@ -1,0 +1,147 @@
+import Database from 'better-sqlite3';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  detectSkillPluginCandidates,
+  dismissSkillPluginCandidate,
+  listSkillPluginCandidates,
+  persistSkillPluginCandidates,
+} from '../src/plugins/candidates.js';
+import { migratePlugins } from '../src/plugins/persistence.js';
+
+let db: Database.Database;
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'od-plugin-candidates-'));
+  db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT);
+    CREATE TABLE conversations (id TEXT PRIMARY KEY, project_id TEXT, title TEXT);
+  `);
+  migratePlugins(db);
+  db.prepare(`INSERT INTO projects (id, name) VALUES ('project-a', 'Project A'), ('project-b', 'Project B')`).run();
+});
+
+afterEach(async () => {
+  db.close();
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe('skill plugin candidate detection', () => {
+  it('detects explicit SKILL.md attachments with draft-generation data', async () => {
+    await writeFile(
+      path.join(tmpRoot, 'SKILL.md'),
+      `---\nname: launch-brief\ndescription: Reusable launch brief workflow.\n---\n# Launch Brief\n\nUse this skill when preparing launch copy.\n`,
+      'utf8',
+    );
+
+    const candidates = await detectSkillPluginCandidates({
+      projectRoot: tmpRoot,
+      attachments: ['SKILL.md'],
+      message: 'Use the uploaded skill.',
+    });
+
+    expect(candidates).toHaveLength(1);
+    const candidate = candidates[0]!;
+    expect(candidate).toMatchObject({
+      sourceKind: 'project-file',
+      sourceRef: 'SKILL.md',
+      provenance: 'uploaded-skill-md',
+      title: 'launch-brief',
+      description: 'Reusable launch brief workflow.',
+      draftInput: {
+        artifactKind: 'skill-md',
+        suggestedFiles: ['SKILL.md', 'open-design.json'],
+      },
+    });
+    expect(candidate.confidence).toBeGreaterThan(0.9);
+    expect(candidate.draftInput.contentExcerpt).toContain('Use this skill');
+  });
+
+  it('detects clearly reusable markdown skill docs and plugin-like repo links', async () => {
+    await mkdir(path.join(tmpRoot, 'docs'), { recursive: true });
+    await writeFile(
+      path.join(tmpRoot, 'docs', 'research-agent.md'),
+      `# Research Agent\n\nReusable skill workflow.\n\n## Trigger\nUse when turning source notes into an evidence-backed brief.\n\n## Tools\nUse search and citation tools.\n`,
+      'utf8',
+    );
+
+    const candidates = await detectSkillPluginCandidates({
+      projectRoot: tmpRoot,
+      message: 'Please use docs/research-agent.md and https://github.com/nexu-io/open-design/blob/main/plugins/foo/open-design.json',
+    });
+
+    expect(candidates.map((candidate) => candidate.provenance).sort()).toEqual([
+      'markdown-skill-doc',
+      'plugin-like-link',
+    ]);
+    expect(candidates.find((candidate) => candidate.sourceRef === 'docs/research-agent.md')?.title)
+      .toBe('Research Agent');
+    expect(candidates.find((candidate) => candidate.sourceKind === 'repo-link')?.draftInput.artifactKind)
+      .toBe('repo-plugin');
+  });
+
+  it('does not treat generic prompt heading blocks as candidates', async () => {
+    const candidates = await detectSkillPluginCandidates({
+      projectRoot: tmpRoot,
+      message: `# Instructions\n\n## Workflow\nDo the thing.\n\n## Steps\n1. Read.\n2. Write.\n\n## Constraints\nBe concise.\n\n## Examples\nExample output.`,
+    });
+
+    expect(candidates).toEqual([]);
+  });
+});
+
+describe('skill plugin candidate persistence', () => {
+  it('persists candidates, hides dismissed candidates, and scopes dismissal to the project', async () => {
+    const [candidate] = await detectSkillPluginCandidates({
+      projectRoot: tmpRoot,
+      message: 'https://github.com/nexu-io/open-design/blob/main/skills/foo/SKILL.md',
+    });
+    expect(candidate).toBeTruthy();
+    const detectedCandidate = candidate!;
+
+    const [projectA] = persistSkillPluginCandidates(db, {
+      projectId: 'project-a',
+      runId: 'run-1',
+      candidates: [detectedCandidate],
+      now: 100,
+    });
+    const [projectB] = persistSkillPluginCandidates(db, {
+      projectId: 'project-b',
+      runId: 'run-2',
+      candidates: [detectedCandidate],
+      now: 100,
+    });
+    expect(projectA).toBeTruthy();
+    expect(projectB).toBeTruthy();
+    const persistedProjectA = projectA!;
+    const persistedProjectB = projectB!;
+
+    expect(persistedProjectA.projectId).toBe('project-a');
+    expect(persistedProjectB.projectId).toBe('project-b');
+    expect(listSkillPluginCandidates(db, 'project-a')).toHaveLength(1);
+
+    const dismissed = dismissSkillPluginCandidate(db, {
+      projectId: 'project-a',
+      candidateId: persistedProjectA.id,
+      now: 200,
+    });
+
+    expect(dismissed?.status).toBe('dismissed');
+    expect(listSkillPluginCandidates(db, 'project-a')).toEqual([]);
+    expect(listSkillPluginCandidates(db, 'project-a', { includeDismissed: true })).toHaveLength(1);
+    expect(listSkillPluginCandidates(db, 'project-b')).toHaveLength(1);
+
+    persistSkillPluginCandidates(db, {
+      projectId: 'project-a',
+      runId: 'run-3',
+      candidates: [detectedCandidate],
+      now: 300,
+    });
+
+    expect(listSkillPluginCandidates(db, 'project-a')).toEqual([]);
+  });
+});

--- a/packages/contracts/src/api/plugin-candidates.ts
+++ b/packages/contracts/src/api/plugin-candidates.ts
@@ -1,0 +1,45 @@
+export type SkillPluginCandidateSourceKind = 'project-file' | 'referenced-file' | 'repo-link';
+
+export type SkillPluginCandidateProvenance =
+  | 'uploaded-skill-md'
+  | 'markdown-skill-doc'
+  | 'plugin-like-link';
+
+export interface SkillPluginCandidateDraftInput {
+  artifactKind: 'skill-md' | 'markdown-skill-doc' | 'repo-plugin';
+  source: string;
+  title?: string;
+  description?: string;
+  contentExcerpt?: string;
+  suggestedFiles: string[];
+}
+
+export interface SkillPluginCandidate {
+  id: string;
+  projectId: string;
+  runId: string | null;
+  sourceKind: SkillPluginCandidateSourceKind;
+  sourceRef: string;
+  provenance: SkillPluginCandidateProvenance;
+  confidence: number;
+  title?: string;
+  description?: string;
+  fingerprint: string;
+  draftInput: SkillPluginCandidateDraftInput;
+  status: 'active' | 'dismissed';
+  dismissedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SkillPluginCandidateListRequest {
+  includeDismissed?: boolean;
+}
+
+export interface SkillPluginCandidateListResponse {
+  candidates: SkillPluginCandidate[];
+}
+
+export interface SkillPluginCandidateDismissResponse {
+  candidate: SkillPluginCandidate;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -18,6 +18,7 @@ export * from './api/live-artifacts.js';
 export * from './api/mcp.js';
 export * from './api/memory.js';
 export * from './api/orbit.js';
+export * from './api/plugin-candidates.js';
 export * from './api/providerModels.js';
 export * from './api/projects.js';
 export * from './api/proxy.js';


### PR DESCRIPTION
Closes #2909

## Why

This implements the issue scope for detecting reusable skill/plugin artifacts after successful runs. The pain addressed is that explicit SKILL.md files, reusable markdown skill docs, and plugin-like repo links were only transient run context, so later plugin draft generation had no project-scoped source candidate to work from.

## What users will see

Successful runs can now leave conservative project-scoped plugin candidates behind when the prompt or attachments include file/link-backed skill artifacts. Dismissed candidates stay hidden for that project only. No UI entry point is added in this PR.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

- Not a bug fix.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/daemon test -- plugins-candidates.test.ts chat-route.test.ts` (repo config ran the full daemon suite: 3,201 passed, 1 skipped, 4 todo)
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/plugins-candidates.test.ts`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>