### PR TITLE
test(i18n): lock zh-CN to tier-1 explicit translation parity (#1894)

### DIFF
--- a/apps/web/tests/i18n/locales.test.ts
+++ b/apps/web/tests/i18n/locales.test.ts
@@ -196,4 +196,39 @@ describe('i18n locales', () => {
 
     expect(source).not.toMatch(/en\['(?:connectors\.category\.|liveArtifact\.viewer\.)/);
   });
+
+  // Tier-1 locale parity lock (issue #1894):
+  //
+  // Most locale modules use `...en` spread so missing translations silently
+  // fall back to English at runtime — that satisfies the dictionary-shape
+  // test above (`Object.keys(dict)` is complete) but hides drift between
+  // English and the rendered locale. `zh-CN` is the one locale today that
+  // declares every key explicitly with no `...en` spread, so a new English
+  // key without a matching `zh-CN` entry is a *real* hole, not a benign
+  // fallback. The two cases below lock that property in place: any future
+  // PR that lets `zh-CN` drift, or reintroduces an implicit spread, fails
+  // CI loudly instead of regressing translation coverage in silence.
+  it('keeps zh-CN explicitly translated for every English key (tier-1 parity lock)', () => {
+    const englishKeys = Object.keys(en).sort();
+    const explicit = explicitLocaleKeys('zh-CN').sort();
+
+    expect(
+      explicit,
+      'zh-CN must explicitly declare every English key (no implicit `...en` spread fallback). ' +
+        'Add the missing translations to `apps/web/src/i18n/locales/zh-CN.ts` rather than re-introducing the spread.',
+    ).toEqual(englishKeys);
+  });
+
+  it('keeps the zh-CN locale source free of the `...en` spread fallback', () => {
+    const source = readFileSync(
+      new URL('../../src/i18n/locales/zh-CN.ts', import.meta.url),
+      'utf8',
+    );
+
+    expect(
+      source,
+      'zh-CN.ts must not use `...en` spread — every key must be explicitly translated. ' +
+        'If you need to add new keys, declare them with their Chinese values directly.',
+    ).not.toMatch(/\.\.\.en\b/);
+  });
 });


### PR DESCRIPTION
## Summary

Refs #1894 (claimed in [this comment](https://github.com/nexu-io/open-design/issues/1894#issuecomment-4533554617) with a deliberately narrow scope).

Adds **two vitest cases** to `apps/web/tests/i18n/locales.test.ts` that pin `zh-CN` to its current tier-1 state — every English key explicitly translated, no `...en` spread fallback. No locale content is touched; no other locale is touched.

## The drift problem (recap from #1894)

The existing shape test

```ts
expect(Object.keys(dict).sort()).toEqual(englishKeys);
```

passes for every locale today, but **most modules satisfy it via `...en` spread**. So an English key added without a matching translation:

1. falls back to English at runtime,
2. lets the shape test pass,
3. and the gap widens in silence.

[`pnpm i18n:coverage`](https://github.com/nexu-io/open-design/pull/1896) from #1896 makes that drift visible, but does not block it.

## Tier-1 today is exactly one locale

| Locale | Module shape | Explicit keys vs `en` (2302) | Notes |
|---|---|---|---|
| **`zh-CN`** | **no `...en` spread, fully explicit** | **2302 / 2302** | Tier-1 — what this PR pins |
| `id` | `export const id: Dict = { ...en, … }` | 1637 / 2302 | Falls back via spread |
| `es-ES` | `export const esES: Dict = { ...en, … }` | 1492 / 2302 | Falls back via spread |
| `de`, `ja`, `pt-BR`, `ru`, `fa`, `ar`, `ko`, `pl`, `hu`, `fr`, `uk`, `tr`, `th`, `it`, `zh-TW` | `...en` spread | 1459 – 1881 / 2302 | Falls back via spread |

(Verified locally against `main` at branch-cut time. The wider policy question — should the rest of these locales also lose their spread? — is intentionally left open in #1894.)

## What this PR adds

Both cases appended to the existing `describe('i18n locales', …)` block:

1. **`keeps zh-CN explicitly translated for every English key (tier-1 parity lock)`** — uses the existing `explicitLocaleKeys('zh-CN')` helper (already defined in the file at lines 33–36) to check that the `'key':` literals in the source match the full English key set. A future PR that adds an English key without updating `zh-CN.ts` fails this case with a pointed error message naming the locale.

2. **`keeps the zh-CN locale source free of the `\`...en\` spread fallback`** — paired source-grep so a refactor cannot silently reintroduce `...en` in `zh-CN.ts`. Same pattern as the existing `avoids brittle per-key English lookups in the Indonesian locale source` case for `id.ts`.

Diff is +35 / -0, single file (`apps/web/tests/i18n/locales.test.ts`).

## Net effect

- **No CI break today.** `zh-CN` already satisfies both cases (2302 explicit keys, no `...en` literal in the source).
- **Future drift is loud.** A PR that adds an English key without a `zh-CN` companion entry, or a refactor that swaps `zh-CN.ts` to `...en` spread, fails CI with a message that names the locale and points at the file.
- **Other locales unaffected.** Their existing `...en` spread continues to work; the shape test continues to pass for them.

## Out of scope

- Choosing the wider policy in #1894 (enforce all / tier-1 subset / report-only). This PR demonstrates one concrete tier-1 implementation against the locale that already satisfies it; it does not commit the project to extending the rule.
- Touching `id.ts` or any other locale module.
- Duplicating or replacing `pnpm i18n:coverage` from #1896.
- Adding or removing translations.

## Test plan

- [x] `git diff main --stat` → `apps/web/tests/i18n/locales.test.ts | 35 +++++++++++++++++++++++++++++++++++`. One file, additions only.
- [x] Logic dry-run against `main` HEAD:
  - English value-bearing keys: **2302**.
  - `zh-CN.ts` `'key':` literal matches: **2302** (no diff vs the English set).
  - `\.\.\.en\b` matches in `zh-CN.ts`: **0**.
- [ ] CI: `pnpm --filter @open-design/web test apps/web/tests/i18n/locales.test.ts` — relying on maintainer CI to confirm. Both new cases should pass without any locale-content changes.

## Related

- #1894 — issue claimed for this narrow slice.
- #1896 — informational `pnpm i18n:coverage` report (already merged; complementary, not replaced).
- #2242 — previous PR that brought `zh-CN`'s untranslated-value count down on the Manual editor / Cloudflare deploy surfaces; this PR locks that ground.

Happy to widen scope (extend the lock to other locales, or fold it into a more general "tier" config) if maintainers prefer that shape during review.