### PR TITLE
feat: localize Scheduled Routine error messages for Chinese

### DIFF
--- a/apps/web/src/components/TasksView.tsx
+++ b/apps/web/src/components/TasksView.tsx
@@ -24,6 +24,7 @@ import { navigate } from '../router';
 import type { SkillSummary } from '../types';
 import { useAnalytics } from '../analytics/provider';
 import { trackAutomationsClick, trackPageView } from '../analytics/events';
+import { useI18n } from '../i18n';
 import {
   NewAutomationModal,
   describeScheduleSummary,
@@ -387,7 +388,21 @@ function proposalActionLabel(action: AutomationEvolutionProposal['action']): str
 }
 
 export function TasksView({ skills = [], designTemplates = [], connectors = [] }: Props) {
+  const { t } = useI18n();
   const analytics = useAnalytics();
+  
+  // Localize error messages from backend
+  const localizeError = useCallback((error: string): string => {
+    // Match common error patterns and return localized versions
+    if (error.includes('Agent completed without producing any output')) {
+      return t('routines.errorAgentNoOutput');
+    }
+    if (error.includes('Paste source content before ingesting it')) {
+      return t('routines.errorPasteSource');
+    }
+    // Return original error if no match
+    return error;
+  }, [t]);
   // P2 page_view page_name=automations. Ref-keyed so re-renders don't
   // double-fire while the user is on the page.
   const pageViewFiredRef = useState<{ fired: boolean }>(() => ({ fired: false }))[0];
@@ -510,7 +525,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
 
   const submitSourceIngestion = async () => {
     if (!sourceForm.bodyMarkdown.trim()) {
-      setError('Paste source content before ingesting it.');
+      setError(t('routines.errorPasteSource'));
       return;
     }
     setIngestingSource(true);
@@ -1202,7 +1217,7 @@ function AutomationRunHistory({
             </div>
             {run.summary || run.error ? (
               <div className={`automation-history__message${run.error ? ' is-error' : ''}`}>
-                {run.error ?? run.summary}
+                {run.error ? localizeError(run.error) : run.summary}
               </div>
             ) : null}
             <div className="automation-history__actions">

--- a/apps/web/src/components/TasksView.tsx
+++ b/apps/web/src/components/TasksView.tsx
@@ -843,6 +843,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                       refreshKey={historyTick}
                       crystallizingRunId={crystallizingRunId}
                       onCrystallizeRun={crystallizeRun}
+                      localizeError={localizeError}
                     />
                   ) : null}
                 </li>
@@ -1161,11 +1162,13 @@ function AutomationRunHistory({
   refreshKey,
   crystallizingRunId,
   onCrystallizeRun,
+  localizeError,
 }: {
   routineId: string;
   refreshKey: number;
   crystallizingRunId: string | null;
   onCrystallizeRun: (routineId: string, runId: string) => void;
+  localizeError: (error: string) => string;
 }) {
   const [runs, setRuns] = useState<RoutineRun[] | null>(null);
 

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1674,4 +1674,7 @@ export const ar: Dict = {
   'diagnostics.exporting': 'جارٍ التصدير…',
   'diagnostics.exportSuccess': 'تم حفظ التشخيص في {path}',
   'diagnostics.exportFailed': 'تعذّر تصدير التشخيص: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1611,4 +1611,7 @@ export const de: Dict = {
   'diagnostics.exporting': 'Exportiere…',
   'diagnostics.exportSuccess': 'Diagnose gespeichert: {path}',
   'diagnostics.exportFailed': 'Diagnose-Export fehlgeschlagen: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -894,7 +894,10 @@ export const en: Dict = {
   'routines.confirmDelete':
     'Delete this automation? Past runs and their projects are kept.',
   'routines.errorPickProject':
-    'Pick a project to reuse, or switch to “Create new each run”',
+    'Pick a project to reuse, or switch to "Create new each run"',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
   'entry.helpAria': 'Help',
   'entry.helpMenuAria': 'Help menu',
   'entry.helpGetHelp': 'Get help on GitHub',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1562,4 +1562,7 @@ export const esES: Dict = {
   'diagnostics.exporting': 'Exportando…',
   'diagnostics.exportSuccess': 'Diagnósticos guardados en {path}',
   'diagnostics.exportFailed': 'No se pudieron exportar los diagnósticos: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1716,4 +1716,7 @@ export const fa: Dict = {
   'diagnostics.exporting': 'در حال صادر کردن…',
   'diagnostics.exportSuccess': 'تشخیص در {path} ذخیره شد',
   'diagnostics.exportFailed': 'صادر کردن تشخیص ناموفق بود: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1899,4 +1899,7 @@ export const fr: Dict = {
   'diagnostics.exporting': 'Exportation…',
   'diagnostics.exportSuccess': 'Diagnostic enregistré dans {path}',
   'diagnostics.exportFailed': 'Impossible d\'exporter le diagnostic: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1683,4 +1683,7 @@ export const hu: Dict = {
   'diagnostics.exporting': 'Exportálás…',
   'diagnostics.exportSuccess': 'Diagnosztika mentve: {path}',
   'diagnostics.exportFailed': 'Diagnosztika exportálása sikertelen: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1716,4 +1716,7 @@ export const id: Dict = {
   'diagnostics.exporting': 'Mengekspor…',
   'diagnostics.exportSuccess': 'Diagnostik disimpan di {path}',
   'diagnostics.exportFailed': 'Gagal mengekspor diagnostik: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1540,4 +1540,7 @@ export const it: Dict = {
   'liveArtifact.viewer.code.loading': 'Caricamento codice…',
   'liveArtifact.viewer.code.unavailable': 'Il codice non è ancora disponibile.',
   'liveArtifact.viewer.code.empty': 'Questo file di codice è vuoto.',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1610,4 +1610,7 @@ export const ja: Dict = {
   'diagnostics.exporting': 'エクスポート中…',
   'diagnostics.exportSuccess': '診断情報を {path} に保存しました',
   'diagnostics.exportFailed': '診断情報のエクスポートに失敗しました: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1723,4 +1723,7 @@ export const ko: Dict = {
   'diagnostics.exporting': '내보내는 중…',
   'diagnostics.exportSuccess': '진단 정보를 {path}에 저장했습니다',
   'diagnostics.exportFailed': '진단 정보 내보내기 실패: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1673,4 +1673,7 @@ export const pl: Dict = {
   'diagnostics.exporting': 'Eksportowanie…',
   'diagnostics.exportSuccess': 'Diagnostyka zapisana w {path}',
   'diagnostics.exportFailed': 'Nie udało się wyeksportować diagnostyki: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1714,4 +1714,7 @@ export const ptBR: Dict = {
   'diagnostics.exporting': 'Exportando…',
   'diagnostics.exportSuccess': 'Diagnósticos salvos em {path}',
   'diagnostics.exportFailed': 'Falha ao exportar diagnósticos: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1714,4 +1714,7 @@ export const ru: Dict = {
   'diagnostics.exporting': 'Экспортирование…',
   'diagnostics.exportSuccess': 'Диагностика сохранена: {path}',
   'diagnostics.exportFailed': 'Не удалось экспортировать диагностику: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1506,4 +1506,7 @@ export const th: Dict = {
   'settings.designSystemsCategory': 'หมวดหมู่',
   'settings.designSystemsAllCategories': 'ทุกหมวดหมู่',
   'settings.designSystemsShowInHomeGallery': 'แสดงในแกลเลอรีหน้าแรก',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1660,4 +1660,7 @@ export const tr: Dict = {
   'diagnostics.exporting': 'Dışa aktarılıyor…',
   'diagnostics.exportSuccess': 'Tanılama {path} konumuna kaydedildi',
   'diagnostics.exportFailed': 'Tanılama dışa aktarılamadı: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1716,4 +1716,7 @@ export const uk: Dict = {
   'diagnostics.exporting': 'Експортування…',
   'diagnostics.exportSuccess': 'Діагностику збережено: {path}',
   'diagnostics.exportFailed': 'Не вдалося експортувати діагностику: {message}',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -891,7 +891,10 @@ export const zhCN: Dict = {
   'routines.status.failed': '失败',
   'routines.status.canceled': '已取消',
   'routines.confirmDelete': '删除此自动化？过往运行记录及其项目将予以保留。',
-  'routines.errorPickProject': '请选择要复用的项目，或切换为“每次运行新建项目”。',
+  'routines.errorPickProject': '请选择要复用的项目，或切换为"每次运行新建项目"。',
+  'routines.errorAgentNoOutput':
+    '智能体完成运行但未产生任何输出。模型或提供商可能返回了空响应 — 请检查智能体日志以查看上游错误。',
+  'routines.errorPasteSource': '请先粘贴来源内容再进行导入。',
   'entry.helpAria': '帮助',
   'entry.helpMenuAria': '帮助菜单',
   'entry.helpGetHelp': '在 GitHub 上获取帮助',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1965,4 +1965,7 @@ export const zhTW: Dict = {
   'pluginCard.publishTitle': '將外掛發布為 GitHub 儲存庫',
   'pluginCard.contributeAria': '將 {title} 貢獻至 Open Design',
   'pluginCard.contributeTitle': '透過 pull request 將外掛貢獻至 Open Design',
+  'routines.errorAgentNoOutput':
+    'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
+  'routines.errorPasteSource': 'Paste source content before ingesting it.',
 };

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1206,6 +1206,8 @@ export interface Dict {
   'routines.status.canceled': string;
   'routines.confirmDelete': string;
   'routines.errorPickProject': string;
+  'routines.errorAgentNoOutput': string;
+  'routines.errorPasteSource': string;
   // Bottom-of-rail help menu
   'entry.helpAria': string;
   'entry.helpMenuAria': string;


### PR DESCRIPTION
## Problem

When the system language is set to Chinese, Scheduled Routine error messages still appear in English, creating an inconsistent user experience.

Fixes #2902

## Solution

- Add `localizeError` helper function in TasksView to match and translate common error messages from backend
- Add translation keys for common error patterns:
  - `routines.errorAgentNoOutput`: "Agent completed without producing any output..."
  - `routines.errorPasteSource`: "Paste source content before ingesting it."
- Apply localization to `run.error` display in automation history
- Replace hardcoded error string with translation key

**Implementation approach:**
Since error messages originate from the backend (daemon), we use pattern matching on the frontend to detect known error messages and replace them with localized versions. This allows us to localize user-facing errors without modifying backend code.

## Surface area

- [x] UI (Error message localization)
- [ ] API
- [ ] CLI
- [ ] Docs

## Testing

**Manual testing steps:**
1. Set system language to Chinese
2. Create a Scheduled Routine that will fail (e.g., with an invalid configuration)
3. Trigger the routine to run and fail
4. Check the error message in the automation history
5. Verify the error message is displayed in Chinese
6. Switch back to English and verify the error displays in English

**Expected behavior:**
- When system language is Chinese, error messages like "Agent completed without producing any output" display in Chinese: "智能体完成运行但未产生任何输出..."
- When system language is English, error messages display in English
- Unknown error messages fall back to the original text

**Error messages localized:**
- Agent no output error (most common failure case)
- Paste source content error (validation error)