### PR TITLE
feat: show success feedback after HTML edits in manual editor

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3848,6 +3848,7 @@ function HtmlViewer({
   const [manualEditHistory, setManualEditHistory] = useState<ManualEditHistoryEntry[]>([]);
   const [manualEditUndone, setManualEditUndone] = useState<ManualEditHistoryEntry[]>([]);
   const [manualEditError, setManualEditError] = useState<string | null>(null);
+  const [manualEditSuccess, setManualEditSuccess] = useState<string | null>(null);
   const [manualEditSaving, setManualEditSaving] = useState(false);
   const manualEditSavingRef = useRef(false);
   const manualEditPendingStyleRef = useRef<ManualEditPendingStyleSave | null>(null);
@@ -4958,6 +4959,7 @@ function HtmlViewer({
     manualEditSavingRef.current = true;
     setManualEditSaving(true);
     setManualEditError(null);
+    setManualEditSuccess(null);
     try {
       const baseSource = sourceRef.current;
       const result = applyManualEditPatch(baseSource, patch);
@@ -4997,6 +4999,10 @@ function HtmlViewer({
         reconcileManualEditStyleSave(patch.id, patch.styles, result.source);
       }
       await onFileSaved?.();
+      // Show success feedback
+      setManualEditSuccess(label);
+      // Clear success message after 2 seconds
+      setTimeout(() => setManualEditSuccess(null), 2000);
       return true;
     } finally {
       manualEditSavingRef.current = false;
@@ -6359,6 +6365,7 @@ function HtmlViewer({
                 draft={manualEditDraft}
                 history={manualEditHistory}
                 error={manualEditError}
+                success={manualEditSuccess}
                 canUndo={manualEditHistory.length > 0}
                 canRedo={manualEditUndone.length > 0}
                 busy={manualEditSaving}

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -25,8 +25,13 @@ export function ManualEditPanel({
   targets,
   selectedTarget,
   draft,
+  history,
   error,
+  success,
   canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
   onSelectTarget,
   onDraftChange,
   onStyleChange,
@@ -43,6 +48,7 @@ export function ManualEditPanel({
   draft: ManualEditDraft;
   history: ManualEditHistoryEntry[];
   error: string | null;
+  success?: string | null;
   canUndo: boolean;
   canRedo: boolean;
   busy?: boolean;
@@ -326,6 +332,7 @@ export function ManualEditPanel({
         ) : null}
 
         {error ? <div className="manual-edit-error">{error}</div> : null}
+        {success ? <div className="manual-edit-success">{success}</div> : null}
         </section>
       </aside>
     </>

--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -1109,6 +1109,16 @@
   font-size: 12px;
 }
 
+.manual-edit-success {
+  margin: 0 12px 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--green-border);
+  border-radius: 6px;
+  color: var(--green);
+  background: var(--green-bg);
+  font-size: 12px;
+}
+
 .manual-edit-changes {
   flex: 1;
   min-height: 0;


### PR DESCRIPTION
## Problem

After editing HTML successfully in the manual editor, there is no clear confirmation that the change was applied. Users may wonder whether the update succeeded or retry unnecessarily.

Fixes #2905

## Solution

- Add `manualEditSuccess` state to track successful edit operations
- Display success message with the edit label (e.g., "HTML: Button", "Content: Heading")
- Auto-clear success message after 2 seconds
- Add green success banner styled consistently with the existing error banner
- Clear success state when starting a new edit to avoid stale messages

**Implementation:**
- `FileViewer.tsx`: Added success state and set it after successful `applyManualEdit`
- `ManualEditPanel.tsx`: Added `success` prop and display success banner
- `memory.css`: Added `.manual-edit-success` styles matching error banner pattern

## Surface area

- [x] UI (Success feedback banner)
- [ ] API
- [ ] CLI
- [ ] Docs

## Testing

**Manual testing steps:**
1. Open a file in edit mode
2. Select an element
3. Open the HTML tab in the right-side editor panel
4. Modify the selected element HTML
5. Click "Apply HTML"
6. Verify a green success banner appears showing "HTML: [element label]"
7. Verify the banner disappears after 2 seconds
8. Try other edit actions (Content, Style, Attributes) and verify they also show success feedback

**Expected behavior:**
- Success banner appears immediately after successful edit
- Banner shows the edit type and element label
- Banner auto-dismisses after 2 seconds
- Banner uses green color scheme consistent with success states
- No stale success messages when starting a new edit