### PR TITLE
feat: add gradient indicator for scrollable edit tabs

### DIFF
--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -64,10 +64,33 @@ export function ManualEditPanel({
   const [uploadingImage, setUploadingImage] = useState(false);
   const selectedTargetRef = useRef<ManualEditTarget | null>(selectedTarget);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const tabsRef = useRef<HTMLDivElement | null>(null);
   const targetForInspector = selectedTarget;
   useEffect(() => {
     selectedTargetRef.current = selectedTarget;
   }, [selectedTarget]);
+  
+  // Detect if tabs are scrollable and update data attribute
+  useEffect(() => {
+    const tabsEl = tabsRef.current;
+    if (!tabsEl) return;
+    
+    const updateScrollable = () => {
+      const isScrollable = tabsEl.scrollWidth > tabsEl.clientWidth;
+      const isAtEnd = tabsEl.scrollLeft + tabsEl.clientWidth >= tabsEl.scrollWidth - 1;
+      tabsEl.setAttribute('data-scrollable', String(isScrollable && !isAtEnd));
+    };
+    
+    updateScrollable();
+    tabsEl.addEventListener('scroll', updateScrollable);
+    window.addEventListener('resize', updateScrollable);
+    
+    return () => {
+      tabsEl.removeEventListener('scroll', updateScrollable);
+      window.removeEventListener('resize', updateScrollable);
+    };
+  }, [targetForInspector, activeTab]);
+  
   const [activeTab, setActiveTab] = useState<ManualEditTab>('style');
   const tab = targetForInspector
     ? (activeTab === 'page' ? 'style' : activeTab)
@@ -143,7 +166,7 @@ export function ManualEditPanel({
       </section>
       <aside className="manual-edit-right">
         <section className="manual-edit-modal cc-panel">
-          <div className="manual-edit-tabs" role="tablist" aria-label="Manual edit tabs">
+          <div ref={tabsRef} className="manual-edit-tabs" role="tablist" aria-label="Manual edit tabs">
             {(targetForInspector ? ELEMENT_TABS : PAGE_TABS).map((item) => (
               <button
                 key={item.id}

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -66,6 +66,8 @@ export function ManualEditPanel({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const tabsRef = useRef<HTMLDivElement | null>(null);
   const targetForInspector = selectedTarget;
+  const [activeTab, setActiveTab] = useState<ManualEditTab>('style');
+  
   useEffect(() => {
     selectedTargetRef.current = selectedTarget;
   }, [selectedTarget]);
@@ -91,7 +93,6 @@ export function ManualEditPanel({
     };
   }, [targetForInspector, activeTab]);
   
-  const [activeTab, setActiveTab] = useState<ManualEditTab>('style');
   const tab = targetForInspector
     ? (activeTab === 'page' ? 'style' : activeTab)
     : (activeTab === 'source' ? 'source' : 'page');

--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -1011,6 +1011,33 @@
   padding: 10px 12px;
   border-bottom: 1px solid var(--border);
   overflow-x: auto;
+  position: relative;
+  /* Hide scrollbar for cleaner look */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.manual-edit-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+/* Gradient indicator when content overflows to the right */
+.manual-edit-tabs::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 40px;
+  background: linear-gradient(to right, transparent, var(--bg-panel));
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+/* Show gradient when scrollable (not at the end) */
+.manual-edit-tabs[data-scrollable="true"]::after {
+  opacity: 1;
 }
 
 .manual-edit-tabs button {


### PR DESCRIPTION
## Problem

In edit mode, when the tab/action row contains more items than can fit in the visible width, some tabs are pushed off-screen. The UI does not clearly indicate that the row can scroll horizontally, so users may not realize there are additional tabs available.

Fixes #2907

## Solution

Add a visual gradient indicator on the right edge of the tab row to signal that more content exists off-screen:

- **Fade gradient**: 40px gradient from transparent to panel background color on the right edge
- **Dynamic detection**: JavaScript detects when tabs overflow and updates `data-scrollable` attribute
- **Smart hiding**: Gradient disappears when scrolled to the end (no more content to the right)
- **Clean scrollbar**: Hide native scrollbar while maintaining scroll functionality
- **Responsive**: Updates on window resize and tab changes

**Implementation:**
- `ManualEditPanel.tsx`: Added `tabsRef` and scroll detection logic with `useEffect`
- `memory.css`: Added gradient pseudo-element with `::after` and scrollbar hiding

## Surface area

- [x] UI (Gradient indicator)
- [ ] API
- [ ] CLI
- [ ] Docs

## Testing

**Manual testing steps:**
1. Open a file in edit mode
2. Select an element to show the right-side editing panel
3. Resize the window to make the tab row narrower than its content
4. Verify a fade gradient appears on the right edge
5. Scroll the tab row to the right
6. Verify the gradient disappears when reaching the end
7. Scroll back left and verify the gradient reappears
8. Resize the window wider and verify the gradient disappears when all tabs fit

**Expected behavior:**
- Gradient is visible only when tabs overflow and not scrolled to the end
- Gradient smoothly fades from transparent to panel background
- No scrollbar visible (cleaner appearance)
- Tabs remain fully scrollable with mouse/trackpad
- Gradient updates immediately on resize or tab changes