### PR TITLE
fix: re-activate srcDoc transport when exiting Edit mode to prevent blank preview

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4283,6 +4283,23 @@ function HtmlViewer({
     wasUrlLoadPreviewRef.current = false;
     activateSrcDocTransport();
   }, [activateSrcDocTransport, useUrlLoadPreview]);
+  
+  // Re-activate srcDoc transport when exiting manual edit mode to ensure
+  // the preview renders correctly when switching from Edit to Draw mode.
+  // Without this, the preview can remain blank because the frozen source
+  // is cleared but the iframe content is not refreshed.
+  const prevManualEditModeRef = useRef(manualEditMode);
+  useEffect(() => {
+    const wasInEditMode = prevManualEditModeRef.current;
+    const isNowInEditMode = manualEditMode;
+    prevManualEditModeRef.current = isNowInEditMode;
+    
+    // When exiting edit mode (was true, now false), re-activate the transport
+    if (wasInEditMode && !isNowInEditMode && !useUrlLoadPreview) {
+      activateSrcDocTransport();
+    }
+  }, [manualEditMode, useUrlLoadPreview, activateSrcDocTransport]);
+  
   useEffect(() => {
     restorePreviewScrollPosition();
   }, [boardMode, manualEditMode, srcDoc, restorePreviewScrollPosition]);


### PR DESCRIPTION
## Problem

When switching from Edit to Draw mode, the HTML preview can go blank instead of continuing to render the document.

Fixes #2912

## Root Cause

When exiting Edit mode to enter Draw mode, the following sequence occurs:

1. `exitManualEditModeAfterFlush()` is called, which sets `manualEditMode = false`
2. This triggers `setManualEditFrozenSource(null)` in the `setManualEditMode` callback
3. `previewSource` switches from `manualEditFrozenSource` back to `livePreviewSource`
4. `srcDoc` is recalculated with the new `previewSource` and `editBridge: false`

However, `activateSrcDocTransport()` was only triggered when `useUrlLoadPreview` changed. When switching from Edit to Draw mode, `useUrlLoadPreview` typically doesn't change, so the iframe content is not refreshed with the new `srcDoc`, leaving the preview blank.

## Solution

Add a `useEffect` that detects when `manualEditMode` transitions from `true` to `false`, and explicitly calls `activateSrcDocTransport()` to ensure the iframe content is refreshed with the updated `srcDoc`.

This ensures that when the user switches from Edit to Draw mode, the preview iframe is properly refreshed and continues to display the document.

## Surface area

- [x] UI — Preview rendering during mode transitions
- [ ] API
- [ ] CLI
- [ ] Docs

## Testing

**Manual testing steps:**

1. Open an HTML artifact that renders correctly in preview
2. Click **Edit** to enter edit mode
3. Click **Draw** to switch to draw mode
4. Verify that the preview area continues to show the document (not blank)

**Expected behavior:**
- The preview should remain visible throughout the Edit → Draw transition
- No blank white screen should appear