### PR TITLE
fix: synchronously update URL when creating new conversation to prevent route-sync conflict

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3356,6 +3356,20 @@ export function ProjectView({
       messagesConversationIdRef.current = fresh.id;
       setConversations((curr) => [fresh, ...curr]);
       setActiveConversationId(fresh.id);
+      // Push the new conversation id into the URL synchronously so the
+      // route-sync effect sees a matching `routeConversationId` before
+      // it can revert `activeConversationId`. Without this, the route-sync
+      // effect can fight the conversation switch, preventing users from
+      // switching back to older conversations after creating a new one.
+      navigate(
+        {
+          kind: 'project',
+          projectId: project.id,
+          conversationId: fresh.id,
+          fileName: openTabsState.active ?? null,
+        },
+        { replace: true },
+      );
       setError(null);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Could not create a conversation for this project.';
@@ -3365,7 +3379,7 @@ export function ProjectView({
       creatingConversationRef.current = false;
       setCreatingConversation(false);
     }
-  }, [project.id, activeConversationId, messages.length]);
+  }, [project.id, activeConversationId, messages.length, navigate, openTabsState.active]);
 
   const handleSelectConversation = useCallback((id: string) => {
     if (id === activeConversationId && failedMessagesConversationId !== id) return;


### PR DESCRIPTION
## Problem

After creating a new conversation, users are unable to switch back to older conversations. The conversation list appears to be unresponsive to clicks.

Fixes #2930

## Root Cause

When creating a new conversation, `handleNewConversation` sets `activeConversationId` to the new conversation ID but does not synchronously update the URL. This creates a timing window where:

1. `handleNewConversation` sets `activeConversationId = fresh.id`
2. The URL-sync effect (L1336) eventually updates the URL asynchronously
3. The route-sync effect (L800-819) may execute before the URL updates
4. It sees the stale `routeConversationId` (pointing to the old conversation)
5. It pulls `activeConversationId` back to the old conversation
6. This creates a conflict that prevents subsequent conversation switches

This is the same class of bug that PR #1710 fixed for `handleSelectConversation`, but `handleNewConversation` was not updated at that time.

## Solution

Mirror the approach from `handleSelectConversation`: synchronously call `navigate()` immediately after setting `activeConversationId` in `handleNewConversation`. This ensures the route-sync effect sees a matching `routeConversationId` before it can revert the conversation switch.

```typescript
setActiveConversationId(fresh.id);
// Push the new conversation id into the URL synchronously
navigate(
  {
    kind: 'project',
    projectId: project.id,
    conversationId: fresh.id,
    fileName: openTabsState.active ?? null,
  },
  { replace: true },
);
```

Also updated the dependency array to include `navigate` and `openTabsState.active`.

## Surface area

- [x] UI — Conversation switching after creating new conversations
- [ ] API
- [ ] CLI
- [ ] Docs

## Testing

**Manual testing steps:**

1. Open a project with existing conversations
2. Create a new conversation (click the + button)
3. Try to switch back to an older conversation by clicking it in the history list
4. Verify that the conversation switches successfully

**Expected behavior:**
- After creating a new conversation, clicking on older conversations should switch to them immediately
- No unresponsive behavior or stuck state

**Regression coverage:**
- Verify that creating multiple new conversations in sequence still works
- Verify that switching between conversations (without creating new ones) still works
- Verify that the URL updates correctly and deep-linking to conversations still works