### PR TITLE
[codex] Polish design system source flows

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -774,7 +774,7 @@ export function App() {
   );
 
   const handleChangeDefaultDesignSystem = useCallback(
-    (designSystemId: string) => {
+    (designSystemId: string | null) => {
       const next = { ...config, designSystemId };
       saveConfig(next);
       void syncConfigToDaemon(next);
@@ -1374,6 +1374,8 @@ export function App() {
         onTouchProject={handleTouchProject}
         onProjectChange={handleProjectChange}
         onProjectsRefresh={refreshProjects}
+        onChangeDefaultDesignSystem={handleChangeDefaultDesignSystem}
+        onDesignSystemsRefresh={refreshDesignSystems}
       />
     );
   } else {

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
 import type { ConnectorConnectResponse, ConnectorDetail, ConnectorStatusResponse } from '@open-design/contracts';
 import { streamViaDaemon } from '../providers/daemon';
 import {
@@ -64,6 +64,7 @@ import { decideAutoOpenAfterWrite } from './auto-open-file';
 import { ChatPane } from './ChatPane';
 import { FileWorkspace } from './FileWorkspace';
 import { Icon, type IconName } from './Icon';
+import { Spinner } from './Loading';
 import { useAnalytics } from '../analytics/provider';
 import {
   trackDesignSystemCreateResult,
@@ -140,6 +141,13 @@ interface CreationProps {
     outcome: { result: 'success' } | { result: 'failed'; errorCode: string },
   ) => void;
 }
+
+const SOURCE_PROCESSING_MIN_VISIBLE_MS = 900;
+const SOURCE_PROCESSING_LOADING_FILE_COUNT = 24;
+const SOURCE_PROCESSING_LOADING_BYTES = 4 * 1024 * 1024;
+const SOURCE_FILE_DIALOG_FOCUS_DELAY_MS = 120;
+const SOURCE_FILE_DIALOG_WARMUP_MS = 450;
+const SOURCE_FILE_DIALOG_STALE_MS = 30_000;
 
 interface DetailProps {
   id: string;
@@ -293,6 +301,7 @@ export function DesignSystemCreationFlow({
   const [state, setState] = useState<SetupState>(EMPTY_SETUP);
   const [error, setError] = useState<string | null>(null);
   const [generationStarting, setGenerationStarting] = useState(false);
+  const [sourceProcessingCount, setSourceProcessingCount] = useState(0);
   const composioConfigured = isComposioConfigured(config?.composio);
   const [githubConnector, setGithubConnector] = useState<ConnectorDetail | null>(null);
   const [githubConnectorLoading, setGithubConnectorLoading] = useState(false);
@@ -474,6 +483,16 @@ export function DesignSystemCreationFlow({
     }));
   }
 
+  function beginSourceProcessing() {
+    setSourceProcessingCount((count) => count + 1);
+    let ended = false;
+    return () => {
+      if (ended) return;
+      ended = true;
+      setSourceProcessingCount((count) => Math.max(0, count - 1));
+    };
+  }
+
   async function handlePickCodeFolder() {
     const selected = await openFolderDialog();
     if (!selected) return;
@@ -488,6 +507,14 @@ export function DesignSystemCreationFlow({
       ...curr,
       codeFolders: curr.codeFolders.filter((item) => item !== folder),
       ...(curr.codeFolders.includes(folder) ? {} : { codeFiles: [], codeFileObjects: [] }),
+    }));
+  }
+
+  function handleRemoveAssetFile(name: string) {
+    setState((curr) => ({
+      ...curr,
+      assetFiles: curr.assetFiles.filter((item) => item !== name),
+      assetFileObjects: curr.assetFileObjects.filter((file) => resourceRelativePath(file) !== name),
     }));
   }
 
@@ -645,6 +672,19 @@ export function DesignSystemCreationFlow({
 
   return (
     <div className={`ds-setup-shell${embedded ? ' ds-setup-shell--embedded' : ''}`}>
+      {sourceProcessingCount > 0 ? (
+        <div
+          className="ds-source-upload-loading"
+          role="status"
+          aria-live="polite"
+          data-testid="ds-source-upload-loading"
+        >
+          <div className="ds-source-upload-loading__card">
+            <Spinner size={18} />
+            <span>Adding source material...</span>
+          </div>
+        </div>
+      ) : null}
       {embedded ? null : (
         <header className="ds-setup-topbar">
           <button type="button" className="ghost" onClick={onBack}>
@@ -747,6 +787,7 @@ export function DesignSystemCreationFlow({
               onBrowseFolder={() => void handlePickCodeFolder()}
               onRemoveName={handleRemoveCodeFolder}
               onError={setError}
+              onProcessingStart={beginSourceProcessing}
               onFiles={(_names, files) => {
                 const stagedFiles = selectLocalCodeFiles(files);
                 const stagedNames = stagedFiles.map((file) => localCodeRelativePath(file));
@@ -765,6 +806,7 @@ export function DesignSystemCreationFlow({
               accept=".fig"
               names={state.figFiles}
               onError={setError}
+              onProcessingStart={beginSourceProcessing}
               onFiles={(_names, files) => {
                 const stagedFiles = selectFigmaFiles(files);
                 const stagedNames = stagedFiles.map((file) => resourceRelativePath(file));
@@ -780,7 +822,9 @@ export function DesignSystemCreationFlow({
               label="Add assets"
               prompt="Drag files here or browse"
               names={state.assetFiles}
+              onRemoveName={handleRemoveAssetFile}
               onError={setError}
+              onProcessingStart={beginSourceProcessing}
               onFiles={(_names, files) => {
                 const stagedFiles = selectAssetFiles(files);
                 const stagedNames = stagedFiles.map((file) => resourceRelativePath(file));
@@ -2383,6 +2427,7 @@ interface DropZoneProps {
   onBrowseFolder?: () => void;
   onRemoveName?: (name: string) => void;
   onError?: (message: string | null) => void;
+  onProcessingStart?: () => () => void;
   onFiles: (names: string[], files: File[]) => void;
 }
 interface WebkitFileSystemEntry {
@@ -2536,21 +2581,127 @@ function DropZone({
   onBrowseFolder,
   onRemoveName,
   onError,
+  onProcessingStart,
   onFiles,
 }: DropZoneProps) {
-  function readFiles(files: FileList | File[] | null) {
-    const nextFiles = Array.from(files ?? []);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const fileDialogPendingRef = useRef(false);
+  const fileDialogCanShowLoadingRef = useRef(false);
+  const fileDialogLoadingFinishRef = useRef<(() => void) | undefined>();
+  const fileDialogFocusDelayRef = useRef<number | undefined>();
+  const fileDialogWarmupRef = useRef<number | undefined>();
+  const fileDialogStaleRef = useRef<number | undefined>();
+
+  useEffect(() => {
+    if (!directory || !onProcessingStart) return undefined;
+    const input = inputRef.current;
+    const handleFocus = () => {
+      beginFileDialogReturnLoading();
+    };
+    const handleCancel = () => {
+      const finish = completeFileDialogTracking();
+      finishProcessingLater(finish);
+    };
+    window.addEventListener('focus', handleFocus);
+    input?.addEventListener('cancel', handleCancel);
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+      input?.removeEventListener('cancel', handleCancel);
+    };
+  });
+
+  function clearFileDialogTimer(ref: { current: number | undefined }) {
+    if (ref.current === undefined) return;
+    window.clearTimeout(ref.current);
+    ref.current = undefined;
+  }
+
+  function prepareFileDialogTracking() {
+    if (!directory || !onProcessingStart) return;
+    const previousFinish = completeFileDialogTracking();
+    previousFinish?.();
+    fileDialogPendingRef.current = true;
+    fileDialogCanShowLoadingRef.current = false;
+    fileDialogFocusDelayRef.current = window.setTimeout(() => {
+      fileDialogCanShowLoadingRef.current = true;
+      fileDialogFocusDelayRef.current = undefined;
+    }, SOURCE_FILE_DIALOG_FOCUS_DELAY_MS);
+    fileDialogWarmupRef.current = window.setTimeout(() => {
+      fileDialogCanShowLoadingRef.current = true;
+      fileDialogWarmupRef.current = undefined;
+      beginFileDialogReturnLoading();
+    }, SOURCE_FILE_DIALOG_WARMUP_MS);
+  }
+
+  function beginFileDialogReturnLoading() {
+    if (!fileDialogPendingRef.current) return;
+    if (!fileDialogCanShowLoadingRef.current) return;
+    if (!onProcessingStart) return;
+    if (fileDialogLoadingFinishRef.current) return;
+    fileDialogLoadingFinishRef.current = onProcessingStart();
+    fileDialogStaleRef.current = window.setTimeout(() => {
+      const finish = completeFileDialogTracking();
+      finishProcessingLater(finish);
+    }, SOURCE_FILE_DIALOG_STALE_MS);
+  }
+
+  function completeFileDialogTracking() {
+    clearFileDialogTimer(fileDialogFocusDelayRef);
+    clearFileDialogTimer(fileDialogWarmupRef);
+    clearFileDialogTimer(fileDialogStaleRef);
+    fileDialogPendingRef.current = false;
+    fileDialogCanShowLoadingRef.current = false;
+    const finish = fileDialogLoadingFinishRef.current;
+    fileDialogLoadingFinishRef.current = undefined;
+    return finish;
+  }
+
+  function finishProcessingLater(finish: (() => void) | undefined) {
+    if (!finish) return;
+    window.setTimeout(finish, SOURCE_PROCESSING_MIN_VISIBLE_MS);
+  }
+  function shouldShowProcessing(files: File[]) {
+    if (files.length >= SOURCE_PROCESSING_LOADING_FILE_COUNT) return true;
+    const totalBytes = files.reduce((sum, file) => sum + file.size, 0);
+    return totalBytes >= SOURCE_PROCESSING_LOADING_BYTES;
+  }
+  function stageFiles(nextFiles: File[]) {
     const nextNames = nextFiles.map((file) => localCodeRelativePath(file));
     if (nextNames.length > 0) {
       onError?.(null);
       onFiles(nextNames, nextFiles);
     }
   }
+  function processSelectedFiles(nextFiles: File[], activeFinish?: () => void) {
+    if (nextFiles.length === 0) {
+      finishProcessingLater(activeFinish);
+      return;
+    }
+    if (!shouldShowProcessing(nextFiles) || !onProcessingStart) {
+      stageFiles(nextFiles);
+      finishProcessingLater(activeFinish);
+      return;
+    }
+    const finish = activeFinish ?? onProcessingStart();
+    runAfterNextPaint(() => {
+      try {
+        stageFiles(nextFiles);
+      } finally {
+        finishProcessingLater(finish);
+      }
+    });
+  }
+  function readFiles(event: ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(event.currentTarget.files ?? []);
+    event.currentTarget.value = '';
+    const finish = completeFileDialogTracking();
+    processSelectedFiles(files, finish);
+  }
   async function readDrop(dataTransfer: DataTransfer) {
     onError?.(null);
     try {
       const nextFiles = await filesFromDataTransfer(dataTransfer);
-      readFiles(nextFiles);
+      processSelectedFiles(nextFiles);
     } catch (error) {
       if (!isFileSystemReadError(error)) throw error;
       onError?.(FILE_SYSTEM_READ_ERROR_MESSAGE);
@@ -2571,11 +2722,13 @@ function DropZone({
           }}
         >
           <input
+            ref={inputRef}
             className="ds-hidden-input"
             type="file"
             multiple
             accept={accept}
-            onChange={(event) => readFiles(event.target.files)}
+            onClick={prepareFileDialogTracking}
+            onChange={readFiles}
             {...directoryProps}
           />
           <span>{names.length > 0 && !onRemoveName ? names.join(', ') : prompt}</span>
@@ -2601,6 +2754,14 @@ function DropZone({
       {helper ? <p>{helper}</p> : null}
     </div>
   );
+}
+
+function runAfterNextPaint(callback: () => void) {
+  if (typeof window.requestAnimationFrame === 'function') {
+    window.requestAnimationFrame(() => window.setTimeout(callback, 0));
+    return;
+  }
+  window.setTimeout(callback, 0);
 }
 
 async function filesFromDataTransfer(dataTransfer: DataTransfer): Promise<File[]> {

--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -50,6 +50,9 @@ const CATEGORY_ORDER = [
 
 type SurfaceFilter = 'all' | Surface;
 type UserListFilter = 'all' | 'published' | 'draft';
+type PrimaryCollection = 'design-system' | 'template';
+type DesignSystemCollection = 'mine' | 'official' | 'enterprise';
+type TemplateCollection = 'mine' | 'enterprise';
 
 const SURFACE_PILLS: { value: SurfaceFilter; labelKey: 'examples.modeAll' | 'ds.surfaceWeb' | 'ds.surfaceImage' | 'ds.surfaceVideo' | 'ds.surfaceAudio' }[] = [
   { value: 'all', labelKey: 'examples.modeAll' },
@@ -85,10 +88,10 @@ function mapStatusToTracking(
   }
 }
 
-function formatShortDate(value: string | undefined): string {
+function formatShortDate(value: number | string | undefined): string {
   if (!value) return 'just now';
-  const time = Date.parse(value);
-  if (!Number.isFinite(time)) return value;
+  const time = typeof value === 'number' ? value : Date.parse(value);
+  if (!Number.isFinite(time)) return String(value);
   return new Intl.DateTimeFormat(undefined, {
     month: 'short',
     day: 'numeric',
@@ -105,6 +108,7 @@ export function DesignSystemsTab({
   onCreate,
   onOpenSystem,
   onSystemsRefresh,
+  templates = [],
 }: Props) {
   const { locale, t } = useI18n();
   const analytics = useAnalytics();
@@ -130,6 +134,9 @@ export function DesignSystemsTab({
   const [filter, setFilter] = useState('');
   const [userFilter, setUserFilter] = useState<UserListFilter>('all');
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [primaryCollection, setPrimaryCollection] = useState<PrimaryCollection>('design-system');
+  const [designSystemCollection, setDesignSystemCollection] = useState<DesignSystemCollection>('mine');
+  const [templateCollection, setTemplateCollection] = useState<TemplateCollection>('mine');
   const [surfaceFilter, setSurfaceFilter] = useState<SurfaceFilter>('all');
   const [category, setCategory] = useState<string>('All');
   // Cache fetched showcase HTML across re-renders so cards never re-flicker
@@ -370,7 +377,88 @@ export function DesignSystemsTab({
 
   return (
     <div className="tab-panel design-systems-manager" data-testid="design-systems-tab">
-      <section className="ds-settings-card" aria-label="Design Systems">
+      <div className="ds-manager-tabs">
+        <div className="subtab-pill" role="tablist" aria-label="Design systems area">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={primaryCollection === 'design-system'}
+            className={primaryCollection === 'design-system' ? 'active' : ''}
+            onClick={() => setPrimaryCollection('design-system')}
+          >
+            Design system
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={primaryCollection === 'template'}
+            className={primaryCollection === 'template' ? 'active' : ''}
+            onClick={() => setPrimaryCollection('template')}
+          >
+            Template
+          </button>
+        </div>
+      </div>
+
+      {primaryCollection === 'design-system' ? (
+        <div className="ds-manager-subtabs">
+          <div className="ds-tag-tabs" role="tablist" aria-label="Design system source">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={designSystemCollection === 'mine'}
+              className={designSystemCollection === 'mine' ? 'active' : ''}
+              onClick={() => setDesignSystemCollection('mine')}
+            >
+              Your systems
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={designSystemCollection === 'official'}
+              className={designSystemCollection === 'official' ? 'active' : ''}
+              onClick={() => setDesignSystemCollection('official')}
+            >
+              Official presets
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={designSystemCollection === 'enterprise'}
+              className={designSystemCollection === 'enterprise' ? 'active' : ''}
+              onClick={() => setDesignSystemCollection('enterprise')}
+            >
+              Enterprise
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="ds-manager-subtabs">
+          <div className="ds-tag-tabs" role="tablist" aria-label="Template source">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={templateCollection === 'mine'}
+              className={templateCollection === 'mine' ? 'active' : ''}
+              onClick={() => setTemplateCollection('mine')}
+            >
+              Your templates
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={templateCollection === 'enterprise'}
+              className={templateCollection === 'enterprise' ? 'active' : ''}
+              onClick={() => setTemplateCollection('enterprise')}
+            >
+              Enterprise
+            </button>
+          </div>
+        </div>
+      )}
+
+      {primaryCollection === 'design-system' && designSystemCollection === 'mine' ? (
+        <section className="ds-settings-card" aria-label="Your design systems">
         <div className="ds-settings-card__head">
           <div>
             <span className="ds-manager-eyebrow">Design Systems</span>
@@ -479,27 +567,15 @@ export function DesignSystemsTab({
             })}
           </div>
         )}
-      </section>
+        </section>
+      ) : null}
 
-      <section className="ds-settings-card ds-templates-card" aria-label="Templates">
-        <div className="ds-settings-card__head">
-          <div>
-            <span className="ds-manager-eyebrow">Templates</span>
-            <h2>Templates</h2>
-          </div>
-        </div>
-        <div className="ds-user-empty">
-          No templates yet. Create one from any generated project via Share once template publishing is enabled.
-        </div>
-      </section>
-
-      <p className="ds-private-note">Only you can view these settings.</p>
-
-      <section className="ds-settings-card" aria-label="Built-in design systems">
+      {primaryCollection === 'design-system' && designSystemCollection === 'official' ? (
+        <section className="ds-settings-card" aria-label="Official design system presets">
         <div className="ds-settings-card__head">
           <div>
             <span className="ds-manager-eyebrow">Library</span>
-            <h2>Built-in library</h2>
+            <h2>Official presets</h2>
           </div>
         </div>
         <div className="tab-panel-toolbar ds-manager-toolbar">
@@ -609,8 +685,76 @@ export function DesignSystemsTab({
             ))}
           </div>
         )}
-      </section>
+        </section>
+      ) : null}
+
+      {primaryCollection === 'design-system' && designSystemCollection === 'enterprise' ? (
+        <ComingSoonPanel
+          eyebrow="Design Systems"
+          title="Enterprise design systems"
+          body="Shared team design systems and governed brand libraries are coming soon."
+        />
+      ) : null}
+
+      {primaryCollection === 'template' && templateCollection === 'mine' ? (
+        <section className="ds-settings-card ds-templates-card" aria-label="Your templates">
+          <div className="ds-settings-card__head">
+            <div>
+              <span className="ds-manager-eyebrow">Templates</span>
+              <h2>Your templates</h2>
+            </div>
+          </div>
+          {templates.length === 0 ? (
+            <div className="ds-user-empty">
+              No templates yet. Create one from any generated project via Share once template publishing is enabled.
+            </div>
+          ) : (
+            <div className="ds-template-list">
+              {templates.map((template) => (
+                <div className="ds-template-row" key={template.id}>
+                  <div>
+                    <strong>{template.name}</strong>
+                    <span>{template.description?.trim() || 'Created from a project'}</span>
+                  </div>
+                  <small>{formatShortDate(template.createdAt)}</small>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      ) : null}
+
+      {primaryCollection === 'template' && templateCollection === 'enterprise' ? (
+        <ComingSoonPanel
+          eyebrow="Templates"
+          title="Enterprise templates"
+          body="Team-approved templates and organization-wide publishing are coming soon."
+        />
+      ) : null}
     </div>
+  );
+}
+
+function ComingSoonPanel({
+  eyebrow,
+  title,
+  body,
+}: {
+  eyebrow: string;
+  title: string;
+  body: string;
+}) {
+  return (
+    <section className="ds-settings-card ds-coming-soon-card" aria-label={title}>
+      <div className="ds-settings-card__head">
+        <div>
+          <span className="ds-manager-eyebrow">{eyebrow}</span>
+          <h2>{title}</h2>
+        </div>
+        <span className="ds-coming-soon-badge">Coming soon</span>
+      </div>
+      <div className="ds-user-empty">{body}</div>
+    </section>
   );
 }
 

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -90,7 +90,7 @@ interface Props {
   onFocusModeChange?: (next: boolean) => void;
   designSystemProject?: DesignSystemSummary | null;
   defaultDesignSystemId?: string | null;
-  onSetDefaultDesignSystem?: (id: string) => void;
+  onSetDefaultDesignSystem?: (id: string | null) => void;
   onDesignSystemsRefresh?: () => Promise<void> | void;
   onDesignSystemNeedsWork?: (
     sectionTitle: string,
@@ -1145,7 +1145,7 @@ function DesignSystemProjectPanel({
   onOpenFile: (name: string) => void;
   onUploadAssets: () => void;
   defaultDesignSystemId?: string | null;
-  onSetDefaultDesignSystem?: (id: string) => void;
+  onSetDefaultDesignSystem?: (id: string | null) => void;
   onDesignSystemsRefresh?: () => Promise<void> | void;
   onNeedsWork?: (
     sectionTitle: string,
@@ -1539,7 +1539,7 @@ function DesignSystemProjectPanel({
                   checked={isDefault}
                   disabled={statusBusy}
                   onChange={(event) => {
-                    if (event.target.checked) onSetDefaultDesignSystem?.(system.id);
+                    onSetDefaultDesignSystem?.(event.target.checked ? system.id : null);
                   }}
                 />
                 Default

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -1614,15 +1614,19 @@ function designSystemOptionsForHome(
       if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
       return a.title.localeCompare(b.title);
     });
+  const autoOption: HomeDesignSystemOption = {
+    id: AUTO_DESIGN_SYSTEM_OPTION_ID,
+    title: t('homeHero.footer.autoDesignSystem'),
+    isDefault: false,
+    auto: true,
+    summary: t('homeHero.footer.autoDesignSystemSummary'),
+  };
+  const defaultOption = systemOptions.find((option) => option.isDefault);
+  if (!defaultOption) return [autoOption, ...systemOptions];
   return [
-    {
-      id: AUTO_DESIGN_SYSTEM_OPTION_ID,
-      title: t('homeHero.footer.autoDesignSystem'),
-      isDefault: false,
-      auto: true,
-      summary: t('homeHero.footer.autoDesignSystemSummary'),
-    },
-    ...systemOptions,
+    defaultOption,
+    autoOption,
+    ...systemOptions.filter((option) => option.id !== defaultOption.id),
   ];
 }
 

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -218,6 +218,8 @@ interface Props {
   onTouchProject: () => void;
   onProjectChange: (next: Project) => void;
   onProjectsRefresh: () => void;
+  onChangeDefaultDesignSystem?: (designSystemId: string | null) => void;
+  onDesignSystemsRefresh?: () => Promise<void> | void;
 }
 
 let liveArtifactEventSequence = 0;
@@ -486,6 +488,8 @@ export function ProjectView({
   onTouchProject,
   onProjectChange,
   onProjectsRefresh,
+  onChangeDefaultDesignSystem,
+  onDesignSystemsRefresh,
 }: Props) {
   const { locale, t } = useI18n();
   const analytics = useAnalytics();
@@ -4244,6 +4248,9 @@ export function ProjectView({
           focusMode={workspaceFocused}
           onFocusModeChange={setWorkspaceFocused}
           designSystemProject={designSystemProject}
+          defaultDesignSystemId={config.designSystemId}
+          onSetDefaultDesignSystem={onChangeDefaultDesignSystem}
+          onDesignSystemsRefresh={onDesignSystemsRefresh}
           onDesignSystemNeedsWork={sendDesignSystemFeedback}
           designSystemReview={project.metadata?.designSystemReview}
           onDesignSystemReviewDecision={persistDesignSystemReviewDecision}

--- a/apps/web/src/styles/design-system-flow.css
+++ b/apps/web/src/styles/design-system-flow.css
@@ -13,6 +13,7 @@
   overflow-y: auto;
   background: var(--bg);
   color: var(--text);
+  position: relative;
 }
 .ds-setup-shell--embedded {
   height: auto;
@@ -422,6 +423,31 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.ds-source-upload-loading {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: color-mix(in srgb, var(--bg) 68%, transparent);
+  backdrop-filter: blur(2px);
+}
+.ds-source-upload-loading__card {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 42px;
+  padding: 0 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-panel);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.14);
 }
 .ds-hidden-input {
   display: none;
@@ -1304,7 +1330,52 @@
   min-height: 320px;
 }
 .design-systems-manager {
-  gap: 20px;
+  gap: 14px;
+}
+.ds-manager-tabs,
+.ds-manager-subtabs {
+  display: flex;
+  align-items: center;
+}
+.ds-manager-tabs {
+  margin-bottom: 2px;
+}
+.ds-manager-subtabs {
+  margin-top: -4px;
+  margin-bottom: 6px;
+}
+.ds-tag-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.ds-tag-tabs::-webkit-scrollbar {
+  display: none;
+}
+.ds-tag-tabs button {
+  min-height: 30px;
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-panel);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  box-shadow: var(--shadow-xs);
+}
+.ds-tag-tabs button:hover:not(.active) {
+  border-color: var(--border-strong);
+  color: var(--text);
+  background: var(--bg-elevated);
+}
+.ds-tag-tabs button.active {
+  border-color: var(--accent);
+  background: var(--accent-tint);
+  color: var(--accent);
 }
 .ds-settings-page {
   gap: 16px;
@@ -1334,7 +1405,7 @@
   min-height: 34px;
 }
 .ds-templates-card {
-  margin-top: -4px;
+  margin-top: 0;
 }
 .ds-private-note {
   margin: -4px 2px 0;
@@ -1418,6 +1489,60 @@
   color: var(--text-muted);
   font-size: 13px;
   line-height: 1.5;
+}
+.ds-coming-soon-card .ds-user-empty {
+  min-height: 108px;
+  display: flex;
+  align-items: center;
+}
+.ds-coming-soon-badge {
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  padding: 5px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.ds-template-list {
+  display: flex;
+  flex-direction: column;
+}
+.ds-template-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--border);
+}
+.ds-template-row:first-child {
+  border-top: 0;
+}
+.ds-template-row > div {
+  min-width: 0;
+  display: grid;
+  gap: 5px;
+}
+.ds-template-row strong {
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
+}
+.ds-template-row span,
+.ds-template-row small {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.ds-template-row span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ds-template-row small {
+  flex: 0 0 auto;
 }
 .ds-user-list {
   display: flex;
@@ -1835,6 +1960,21 @@
 }
 .ds-project-publish-trigger {
   display: inline-flex;
+  align-items: center;
+}
+.ds-project-publish-trigger > button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-height: 28px;
+  padding: 4px 10px;
+  line-height: 1;
+}
+.ds-project-publish-trigger > button svg {
+  width: 13px;
+  height: 13px;
+  flex: none;
 }
 /* A disabled button does not fire the hover or focus that shows its own `title`,
    so the publish guidance lives on this wrapper. Make the disabled button

--- a/apps/web/tests/components/DesignSystemFlow.test.tsx
+++ b/apps/web/tests/components/DesignSystemFlow.test.tsx
@@ -887,6 +887,7 @@ describe('DesignSystemCreationFlow', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Browse folder' }));
 
     await waitFor(() => expect(screen.getByText('/Users/qingyu/work/comfyui')).toBeTruthy());
+    expect(screen.queryByTestId('ds-source-upload-loading')).toBeNull();
 
     continueToGeneration();
     continueToGeneration();
@@ -972,6 +973,7 @@ describe('DesignSystemCreationFlow', () => {
     });
     fireEvent.change(localCodeInput!, { target: { files: [tokenFile] } });
     expect(screen.getByText('1 local code files selected')).toBeTruthy();
+    expect(screen.queryByTestId('ds-source-upload-loading')).toBeNull();
 
     continueToGeneration();
     continueToGeneration();
@@ -995,6 +997,89 @@ describe('DesignSystemCreationFlow', () => {
     );
     expect(window.sessionStorage.getItem(`od:auto-send-first:${project.id}`)).toBe('1');
     expect(onCreated).toHaveBeenCalledWith(project.id, project);
+  });
+
+  it('shows global loading as soon as a large file-picker selection returns', async () => {
+    const { container } = render(
+      <DesignSystemCreationFlow
+        onBack={() => {}}
+        onCreated={() => {}}
+      />,
+    );
+    const localCodeInput = container.querySelector('input[webkitdirectory]') as HTMLInputElement | null;
+    const tokenFiles = Array.from({ length: 25 }, (_, index) => {
+      const file = new File([`:root { --brand-${index}: #d86a4a; }`], `tokens-${index}.css`, {
+        type: 'text/css',
+      });
+      Object.defineProperty(file, 'webkitRelativePath', { value: `comfyui/src/tokens-${index}.css` });
+      return file;
+    });
+
+    fireEvent.change(localCodeInput!, { target: { files: tokenFiles } });
+
+    expect(screen.getByTestId('ds-source-upload-loading').textContent).toContain('Adding source material...');
+    expect(screen.queryByText('25 local code files selected')).toBeNull();
+    await waitFor(() => expect(screen.getByText('25 local code files selected')).toBeTruthy(), { timeout: 2000 });
+    await waitFor(() => expect(screen.queryByTestId('ds-source-upload-loading')).toBeNull(), { timeout: 2500 });
+  });
+
+  it('shows global loading when the folder picker returns before files are enumerated', async () => {
+    const { container } = render(
+      <DesignSystemCreationFlow
+        onBack={() => {}}
+        onCreated={() => {}}
+      />,
+    );
+    const localCodeInput = container.querySelector('input[webkitdirectory]') as HTMLInputElement | null;
+    const tokenFiles = Array.from({ length: 25 }, (_, index) => {
+      const file = new File([`:root { --brand-${index}: #d86a4a; }`], `tokens-${index}.css`, {
+        type: 'text/css',
+      });
+      Object.defineProperty(file, 'webkitRelativePath', { value: `comfyui/src/tokens-${index}.css` });
+      return file;
+    });
+
+    fireEvent.click(localCodeInput!);
+    await new Promise((resolve) => window.setTimeout(resolve, 150));
+    fireEvent(window, new Event('focus'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ds-source-upload-loading').textContent).toContain('Adding source material...');
+    });
+    expect(screen.queryByText('25 local code files selected')).toBeNull();
+
+    fireEvent.change(localCodeInput!, { target: { files: tokenFiles } });
+
+    await waitFor(() => expect(screen.getByText('25 local code files selected')).toBeTruthy(), { timeout: 2000 });
+    await waitFor(() => expect(screen.queryByTestId('ds-source-upload-loading')).toBeNull(), { timeout: 2500 });
+  });
+
+  it('primes global loading while the folder picker is still open', async () => {
+    const { container } = render(
+      <DesignSystemCreationFlow
+        onBack={() => {}}
+        onCreated={() => {}}
+      />,
+    );
+    const localCodeInput = container.querySelector('input[webkitdirectory]') as HTMLInputElement | null;
+    const tokenFiles = Array.from({ length: 25 }, (_, index) => {
+      const file = new File([`:root { --brand-${index}: #d86a4a; }`], `tokens-${index}.css`, {
+        type: 'text/css',
+      });
+      Object.defineProperty(file, 'webkitRelativePath', { value: `comfyui/src/tokens-${index}.css` });
+      return file;
+    });
+
+    fireEvent.click(localCodeInput!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ds-source-upload-loading').textContent).toContain('Adding source material...');
+    }, { timeout: 1000 });
+
+    fireEvent.change(localCodeInput!, { target: { files: tokenFiles } });
+
+    await waitFor(() => expect(screen.getByText('25 local code files selected')).toBeTruthy(), { timeout: 2000 });
+    await waitFor(() => expect(screen.queryByTestId('ds-source-upload-loading')).toBeNull(), { timeout: 2500 });
   });
 
   it('shows a recoverable error when a dragged local code entry cannot be read', async () => {
@@ -1028,6 +1113,50 @@ describe('DesignSystemCreationFlow', () => {
       expect(screen.getByText(/Could not read one or more dropped files or folders/)).toBeTruthy();
     });
     expect(screen.queryByText(/local code files selected/)).toBeNull();
+  });
+
+  it('shows a global loading state while local source files are being read', async () => {
+    const { container } = render(
+      <DesignSystemCreationFlow
+        onBack={() => {}}
+        onCreated={() => {}}
+      />,
+    );
+    const dropZone = container.querySelector('input[webkitdirectory]')?.closest('.ds-drop-zone') as HTMLElement | null;
+    const tokenFiles = Array.from({ length: 25 }, (_, index) => (
+      new File([`:root { --brand-${index}: #d86a4a; }`], `tokens-${index}.css`, { type: 'text/css' })
+    ));
+    let resolveRead!: () => void;
+    const readReady = new Promise<void>((resolve) => {
+      resolveRead = resolve;
+    });
+
+    fireEvent.drop(dropZone!, {
+      dataTransfer: {
+        files: [],
+        items: [
+          ...tokenFiles.map((tokenFile) => ({
+            webkitGetAsEntry: () => ({
+              isFile: true,
+              isDirectory: false,
+              name: tokenFile.name,
+              file: (done: (file: File) => void) => {
+                void readReady.then(() => done(tokenFile));
+              },
+            }),
+          })),
+        ],
+      },
+    });
+
+    expect(screen.queryByTestId('ds-source-upload-loading')).toBeNull();
+    resolveRead();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ds-source-upload-loading').textContent).toContain('Adding source material...');
+    });
+    await waitFor(() => expect(screen.getByText('25 local code files selected')).toBeTruthy());
+    await waitFor(() => expect(screen.queryByTestId('ds-source-upload-loading')).toBeNull());
   });
 
   it('recursively reads a dragged local code folder into the design-system project context', async () => {
@@ -1271,7 +1400,10 @@ describe('DesignSystemCreationFlow', () => {
       target: { value: 'Assets: product brand with custom logo and font' },
     });
     fireEvent.change(assetInput!, { target: { files: [logoFile, fontFile] } });
-    expect(screen.getByText('logo.svg, brand.woff2')).toBeTruthy();
+    expect(screen.getByText('Drag files here or browse')).toBeTruthy();
+    expect(screen.getByText('logo.svg')).toBeTruthy();
+    expect(screen.getByText('brand.woff2')).toBeTruthy();
+    expect(screen.queryByTestId('ds-source-upload-loading')).toBeNull();
 
     continueToGeneration();
     continueToGeneration();

--- a/apps/web/tests/components/DesignSystemsTab.test.tsx
+++ b/apps/web/tests/components/DesignSystemsTab.test.tsx
@@ -79,6 +79,9 @@ describe('DesignSystemsTab', () => {
 
     expect(screen.getByText('Create')).toBeTruthy();
     expect(screen.getByText('Acme Design System')).toBeTruthy();
+    expect(screen.queryByText('Linear')).toBeNull();
+
+    openOfficialPresets();
     expect(screen.getByText('Linear')).toBeTruthy();
   });
 
@@ -119,6 +122,7 @@ describe('DesignSystemsTab', () => {
 
     expect(screen.queryByRole('button', { name: 'Open' })).toBeNull();
 
+    openOfficialPresets();
     fireEvent.click(screen.getByTestId('design-system-preview-linear'));
 
     expect(onPreview).toHaveBeenCalledWith('linear');
@@ -163,6 +167,10 @@ function renderTab(items: DesignSystemSummary[] = librarySystems) {
   );
 }
 
+function openOfficialPresets() {
+  fireEvent.click(screen.getByRole('tab', { name: 'Official presets' }));
+}
+
 // The surface pill renders its label and a `.filter-pill-count` span; read
 // the count back by the visible label so assertions describe the UI.
 function surfacePillCount(label: string): string | null {
@@ -187,6 +195,7 @@ describe('DesignSystemsTab surface filtering', () => {
     // describe the filtered result set, otherwise "All 149 / Web 149" is a
     // lie about what the user is looking at.
     renderTab();
+    openOfficialPresets();
 
     expect(surfacePillCount('All')).toBe('5');
     expect(surfacePillCount('Web')).toBe('3');
@@ -205,6 +214,7 @@ describe('DesignSystemsTab surface filtering', () => {
     // refining inside it. The category survives when it still has matches
     // for the chosen surface.
     renderTab();
+    openOfficialPresets();
     selectCategory('Retro');
 
     fireEvent.click(screen.getByRole('tab', { name: /^Web/ }));
@@ -228,6 +238,7 @@ describe('DesignSystemsTab surface filtering', () => {
       ds({ id: 'retro-img-1', title: 'Retro Image One', category: 'Retro', surface: 'image' }),
     ];
     renderTab(webOnlyCategory);
+    openOfficialPresets();
     expect(screen.queryByRole('tab', { name: /^Image/ })).not.toBeNull();
 
     selectCategory('Tools');
@@ -243,6 +254,7 @@ describe('DesignSystemsTab surface filtering', () => {
     // only web systems match — the Image chip must stay, and stay selected,
     // so the active filter is visible instead of an empty grid with no chip.
     renderTab();
+    openOfficialPresets();
     fireEvent.click(screen.getByRole('tab', { name: /^Image/ }));
 
     fireEvent.change(screen.getByTestId('design-systems-search'), {

--- a/apps/web/tests/components/FileWorkspace.design-system.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.design-system.test.tsx
@@ -323,6 +323,52 @@ describe('FileWorkspace design-system project surface', () => {
     expect(carrier?.contains(publishButton ?? null)).toBe(true);
   });
 
+  it('publishes project-backed design systems and refreshes the registry state', async () => {
+    registryMocks.updateDesignSystemDraft.mockResolvedValue(
+      designSystem({ status: 'published' }),
+    );
+    const onRefresh = vi.fn();
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[
+          workspaceFile('DESIGN.md'),
+          workspaceFile('context/source-context.md'),
+          workspaceFile('context/github/acme-product.md'),
+          workspaceFile('context/github/acme-product/files/src/components/Button.tsx'),
+          workspaceFile('preview/colors.html'),
+        ]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem({
+          provenance: {
+            companyBlurb: 'Acme analytics workspace',
+            githubUrls: ['https://github.com/acme/product'],
+          },
+        })}
+        onDesignSystemsRefresh={onRefresh}
+      />,
+    );
+    const publishButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="design-system-publish"]',
+    );
+
+    await act(async () => {
+      publishButton?.click();
+      await Promise.resolve();
+    });
+
+    expect(registryMocks.updateDesignSystemDraft).toHaveBeenCalledWith('user:acme', {
+      status: 'published',
+    });
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(container.textContent).toContain('Acme design system');
+  });
+
   it('offers a Connect GitHub action that routes to Connectors when repo evidence is missing', async () => {
     const onConnectRepo = vi.fn();
     const container = renderWorkspace(
@@ -496,5 +542,65 @@ describe('FileWorkspace design-system project surface', () => {
     expect(colors?.classList.contains('is-collapsed')).toBe(false);
     expect(colors?.querySelector('.ds-project-review-actions')).toBeTruthy();
     expect(colors?.textContent).toContain('before publishing');
+  });
+
+  it('routes the default checkbox to the selected design system id', async () => {
+    const onSetDefault = vi.fn();
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[workspaceFile('DESIGN.md'), workspaceFile('preview/colors.html')]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem({ status: 'published' })}
+        defaultDesignSystemId="default"
+        onSetDefaultDesignSystem={onSetDefault}
+      />,
+    );
+    const defaultToggle = container.querySelector<HTMLInputElement>(
+      '.ds-project-publish-card__toggles input[type="checkbox"]',
+    );
+
+    await act(async () => {
+      defaultToggle?.click();
+      await Promise.resolve();
+    });
+
+    expect(onSetDefault).toHaveBeenCalledWith('user:acme');
+  });
+
+  it('clears the default design system when the selected default checkbox is unchecked', async () => {
+    const onSetDefault = vi.fn();
+    const container = renderWorkspace(
+      <FileWorkspace
+        projectId="ds-acme"
+        projectKind="prototype"
+        files={[workspaceFile('DESIGN.md'), workspaceFile('preview/colors.html')]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        designSystemProject={designSystem({ status: 'published' })}
+        defaultDesignSystemId="user:acme"
+        onSetDefaultDesignSystem={onSetDefault}
+      />,
+    );
+    const defaultToggle = container.querySelector<HTMLInputElement>(
+      '.ds-project-publish-card__toggles input[type="checkbox"]',
+    );
+
+    expect(defaultToggle?.checked).toBe(true);
+
+    await act(async () => {
+      defaultToggle?.click();
+      await Promise.resolve();
+    });
+
+    expect(onSetDefault).toHaveBeenCalledWith(null);
   });
 });

--- a/apps/web/tests/components/HomeView.prefill.test.tsx
+++ b/apps/web/tests/components/HomeView.prefill.test.tsx
@@ -660,7 +660,7 @@ describe('HomeView prompt handoff', () => {
     ))).toBe(false);
     expect(
       screen.getByTestId('home-hero-footer-option-designSystem').textContent,
-    ).toContain('Auto');
+    ).toContain('Refly Design System');
     expect(screen.getByTestId('home-hero-footer-option-fidelity')).toBeTruthy();
     expect(screen.getByTestId('home-hero-footer-option-designSystem')).toBeTruthy();
     expect((screen.getByTestId('home-hero-input') as HTMLTextAreaElement).value).toBe('');
@@ -752,7 +752,7 @@ describe('HomeView prompt handoff', () => {
     expect(screen.getByTestId('home-hero-active-type-chip').textContent).toContain('Prototype');
     expect(
       screen.getByTestId('home-hero-footer-option-designSystem').textContent,
-    ).toContain('Auto');
+    ).toContain('Refly Design System');
     expect(screen.getByTestId('home-hero-footer-option-fidelity').textContent).toContain('High fidelity');
     expect(screen.queryByTestId('plugin-inputs-form')).toBeNull();
     expect(screen.queryByTestId('home-hero-prompt-slot-fidelity')).toBeNull();

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -183,6 +183,7 @@ test('design systems page is reachable from entry nav and supports search, previ
   await expect(page.getByTestId('entry-nav-design-systems')).toHaveAttribute('aria-current', 'page');
   await expect(page.getByRole('heading', { name: 'Design systems' })).toBeVisible();
   await expect(page.getByTestId('design-systems-tab')).toBeVisible();
+  await page.getByRole('tab', { name: 'Official presets' }).click();
   await expect(page.getByTestId('design-system-card-agentic')).toBeVisible();
   await expect(page.getByTestId('design-system-card-agentic')).toContainText(/default/i);
   await expect(page.getByTestId('design-system-card-airbnb')).toBeVisible();

--- a/e2e/ui/visual-home.test.ts
+++ b/e2e/ui/visual-home.test.ts
@@ -111,6 +111,7 @@ test('captures the design systems page surface', async ({ page }) => {
   await page.getByTestId('entry-nav-design-systems').click();
   await expect(page).toHaveURL(/\/design-systems$/);
   await expect(page.getByTestId('design-systems-tab')).toBeVisible();
+  await page.getByRole('tab', { name: 'Official presets' }).click();
   await expect(page.getByTestId('design-system-card-agentic')).toBeVisible();
   await expect(page.getByTestId('design-system-card-airbnb')).toBeVisible();
   await waitForVisualFonts(page);


### PR DESCRIPTION
## Why

This PR polishes the design-system creation and selection flow after testing the new source-material UX locally. The main pain was that design-system organization, default-system behavior, and local source uploads felt inconsistent: users could not clearly distinguish personal systems, official presets, templates, and coming-soon enterprise sections, and large local-folder selection could appear frozen while the browser enumerated files.

It also fixes the publish/default controls in generated design-system projects so the visible status matches the registry state users expect.

## What users will see

Design systems now use the same primary tab style as Projects: `Design system` and `Template`. Design-system content is grouped into small tag-style subtabs for `Your systems`, `Official presets`, and `Enterprise`; templates are grouped into `Your templates` and `Enterprise`, with enterprise sections shown as coming soon.

When a user marks a design system as default, the Home style picker now preselects that design system instead of staying on `Auto`. The design-system project header also lets users publish/unpublish and set/unset default state with aligned compact controls.

On `/design-systems/create`, local source uploads now show a global `Adding source material...` loading state for large folder/file selections, including the gap before the browser has finished enumerating a selected folder. Local code and uploaded assets render as removable tags below the dropzones.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Verified in the local web preview at `/design-systems`, `/design-systems/create`, the design-system project review header, and Home style picker. The large-folder picker path was also checked with Playwright by clicking the visible dropzone and confirming the global loading overlay appears while the file chooser is still open.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/DesignSystemFlow.test.tsx`
- Did the test go red on `main` and green on this branch? no; this was covered as a regression spec while iterating the UI fix rather than first run against `main`.
- Added coverage for file-picker return before file enumeration, folder-picker warmup loading, local-code project context copying, asset tag rendering, publish/default controls, and design-system tab grouping.

## Validation

- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/DesignSystemFlow.test.tsx`
- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/DesignSystemsTab.test.tsx tests/components/FileWorkspace.design-system.test.tsx`
- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/HomeView.prefill.test.tsx tests/components/HomeView.media-options.test.tsx`
- `pnpm -C e2e exec playwright test -c playwright.config.ts ui/entry-chrome-flows.test.ts -g "design systems page"`
- `pnpm -C e2e exec playwright test -c playwright.visual.config.ts ui/visual-home.test.ts -g "design systems page"`
- `pnpm -C e2e typecheck`
- Browser smoke check: clicking the visible local-code folder dropzone shows `Adding source material...` before files are returned.
