### PR TITLE
Refine Local CLI settings flow

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1945,6 +1945,169 @@ export function SettingsDialog({
   const activeHeader = sectionHeader[activeSection];
   const installedAgents = agents.filter((a) => a.available);
   const unavailableAgents = agents.filter((a) => !a.available);
+  const agentModelOptionLabel = (
+    model: ProviderModelOption | undefined,
+    fallback: string,
+  ) => {
+    if (!model) return fallback;
+    if (model.label && model.label !== model.id) {
+      return `${model.label} (${model.id})`;
+    }
+    return model.label || model.id;
+  };
+  const agentModelSummary = (agent: AgentInfo) => {
+    if (!Array.isArray(agent.models) || agent.models.length === 0) return null;
+    const choice = cfg.agentModels?.[agent.id] ?? {};
+    const modelValue = choice.model ?? agent.models[0]?.id ?? '';
+    if (!modelValue) return t('settings.modelCustom');
+    return agentModelOptionLabel(
+      agent.models.find((m) => m.id === modelValue),
+      modelValue,
+    );
+  };
+  const renderAgentModelConfig = (selected: AgentInfo) => {
+    const hasModels =
+      Array.isArray(selected.models) && selected.models.length > 0;
+    const hasReasoning =
+      Array.isArray(selected.reasoningOptions) &&
+      selected.reasoningOptions.length > 0;
+    if (!hasModels && !hasReasoning) return null;
+    const choice = cfg.agentModels?.[selected.id] ?? {};
+    const setChoice = (
+      next: { model?: string; reasoning?: string },
+    ) => {
+      setCfg((c) => {
+        const prev = c.agentModels?.[selected.id] ?? {};
+        return {
+          ...c,
+          agentModels: {
+            ...(c.agentModels ?? {}),
+            [selected.id]: { ...prev, ...next },
+          },
+        };
+      });
+    };
+    const modelValue =
+      choice.model ?? selected.models?.[0]?.id ?? '';
+    const reasoningValue =
+      choice.reasoning ??
+      selected.reasoningOptions?.[0]?.id ?? '';
+    const customActive =
+      hasModels &&
+      shouldShowCustomModelInput(
+        modelValue,
+        selected.models!.map((m) => m.id),
+        agentCustomModelIds.has(selected.id),
+      );
+    const selectValue = customActive
+      ? CUSTOM_MODEL_SENTINEL
+      : modelValue;
+    const modelSource = selected.modelsSource ?? 'fallback';
+    const modelSourceLabel =
+      modelSource === 'live'
+        ? t('settings.modelSourceLive')
+        : t('settings.modelSourceFallback');
+    const modelSourceHint =
+      modelSource === 'live'
+        ? t('settings.modelPickerLiveHint')
+        : t('settings.modelPickerFallbackHint');
+    return (
+      <div className="agent-card-config">
+        {hasModels ? (
+          <>
+            <label className="field">
+              <span className="field-label">
+                {t('settings.modelPicker')}
+                <span
+                  className={`agent-model-source-badge ${modelSource}`}
+                  aria-hidden="true"
+                >
+                  {modelSourceLabel}
+                </span>
+              </span>
+              <div className="agent-model-select-wrap">
+                <select
+                  value={selectValue}
+                  onChange={(e) => {
+                    if (e.target.value === CUSTOM_MODEL_SENTINEL) {
+                      setAgentCustomModelIds((prev) => {
+                        const next = new Set(prev);
+                        next.add(selected.id);
+                        return next;
+                      });
+                      setChoice({ model: '' });
+                    } else {
+                      setAgentCustomModelIds((prev) => {
+                        if (!prev.has(selected.id)) return prev;
+                        const next = new Set(prev);
+                        next.delete(selected.id);
+                        return next;
+                      });
+                      setChoice({ model: e.target.value });
+                    }
+                  }}
+                >
+                  {renderModelOptions(selected.models!)}
+                  <option value={CUSTOM_MODEL_SENTINEL}>
+                    {t('settings.modelCustom')}
+                  </option>
+                </select>
+                <Icon
+                  name="chevron-down"
+                  size={12}
+                  className="agent-model-select-chevron"
+                />
+              </div>
+            </label>
+            <p className="hint agent-model-row-hint">
+              {modelSourceHint}
+            </p>
+          </>
+        ) : null}
+        {customActive ? (
+          <label className="field">
+            <span className="field-label">
+              {t('settings.modelCustomLabel')}
+            </span>
+            <input
+              type="text"
+              value={modelValue}
+              placeholder={t('settings.modelCustomPlaceholder')}
+              onChange={(e) =>
+                setChoice({ model: e.target.value.trim() })
+              }
+            />
+          </label>
+        ) : null}
+        {hasReasoning ? (
+          <label className="field">
+            <span className="field-label">
+              {t('settings.reasoningPicker')}
+            </span>
+            <div className="agent-model-select-wrap">
+              <select
+                value={reasoningValue}
+                onChange={(e) =>
+                  setChoice({ reasoning: e.target.value })
+                }
+              >
+                {selected.reasoningOptions!.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.label}
+                  </option>
+                ))}
+              </select>
+              <Icon
+                name="chevron-down"
+                size={12}
+                className="agent-model-select-chevron"
+              />
+            </div>
+          </label>
+        ) : null}
+      </div>
+    );
+  };
 
   return (
     <div className="modal-backdrop" onClick={onClose}>
@@ -2352,6 +2515,7 @@ export function SettingsDialog({
                             active && agentTestState.status === 'running';
                           const description = AGENT_SHORT_DESCRIPTIONS[a.id];
                           const agentName = displayAgentName(a);
+                          const modelSummary = agentModelSummary(a);
                           const versionLabel = cleanAgentVersionLabel(
                             a.name,
                             a.version,
@@ -2364,91 +2528,100 @@ export function SettingsDialog({
                                 (active ? ' active' : '')
                               }
                             >
-                              <button
-                                type="button"
-                                className="agent-card-select"
-                                onClick={() => {
-                                  trackSettingsLocalCliClick(analytics.track, {
-                                    page_name: 'settings',
-                                    area: 'configure_execution_mode_local_cli',
-                                    element: 'cli_provider',
-                                    cli_provider_id: agentIdToTracking(a.id),
-                                    install_status: 'installed',
-                                  });
-                                  setCfg((c) => ({ ...c, agentId: a.id }));
-                                }}
-                                aria-pressed={active}
-                              >
-                                <AgentIcon id={a.id} size={32} />
-                                <div className="agent-card-body">
-                                  <div className="agent-card-name">
-                                    <span>{agentName}</span>
-                                    {description ? (
-                                      <>
-                                        <span
-                                          className="agent-card-name-divider"
-                                          aria-hidden="true"
-                                        >
-                                          ·
-                                        </span>
-                                        <span className="agent-card-tagline">
-                                          {description}
-                                        </span>
-                                      </>
-                                    ) : null}
-                                  </div>
-                                  <div className="agent-card-meta">
-                                    {a.authStatus === 'missing' ? (
-                                      <span title={a.authMessage ?? a.path ?? ''}>
-                                        {t('settings.agentAuthRequired')}
-                                      </span>
-                                    ) : a.authStatus === 'unknown' ? (
-                                      <span title={a.authMessage ?? a.path ?? ''}>
-                                        {t('settings.agentAuthUnknown')}
-                                      </span>
-                                    ) : versionLabel ? (
-                                      <span title={a.path ?? ''}>
-                                        {versionLabel}
-                                      </span>
-                                    ) : (
-                                      <span title={a.path ?? ''}>
-                                        {t('common.installed')}
-                                      </span>
-                                    )}
-                                  </div>
-                                </div>
-                              </button>
-                              {a.id === 'amr' ? (
-                                <AmrLoginPill
-                                  className="amr-account-control"
-                                  hideSignedOutStatus
-                                />
-                              ) : null}
-                              {active ? (
+                              <div className="agent-card-main">
                                 <button
                                   type="button"
-                                  className={
-                                    'ghost icon-btn settings-test-btn agent-card-test-btn' +
-                                    (running ? ' loading' : '')
-                                  }
-                                  onClick={() => void handleTestAgent()}
-                                  disabled={running}
-                                  title={t('settings.testTitle')}
+                                  className="agent-card-select"
+                                  onClick={() => {
+                                    trackSettingsLocalCliClick(analytics.track, {
+                                      page_name: 'settings',
+                                      area: 'configure_execution_mode_local_cli',
+                                      element: 'cli_provider',
+                                      cli_provider_id: agentIdToTracking(a.id),
+                                      install_status: 'installed',
+                                    });
+                                    setCfg((c) => ({ ...c, agentId: a.id }));
+                                  }}
+                                  aria-pressed={active}
                                 >
-                                  {running ? (
-                                    <>
-                                      <Icon
-                                        name="spinner"
-                                        size={13}
-                                        className="icon-spin"
-                                      />
-                                      <span>{t('settings.test')}</span>
-                                    </>
-                                  ) : (
-                                    t('settings.test')
-                                  )}
+                                  <AgentIcon id={a.id} size={32} />
+                                  <div className="agent-card-body">
+                                    <div className="agent-card-name">
+                                      <span>{agentName}</span>
+                                      {description ? (
+                                        <>
+                                          <span
+                                            className="agent-card-name-divider"
+                                            aria-hidden="true"
+                                          >
+                                            ·
+                                          </span>
+                                          <span className="agent-card-tagline">
+                                            {description}
+                                          </span>
+                                        </>
+                                      ) : null}
+                                    </div>
+                                    <div className="agent-card-meta">
+                                      {a.authStatus === 'missing' ? (
+                                        <span title={a.authMessage ?? a.path ?? ''}>
+                                          {t('settings.agentAuthRequired')}
+                                        </span>
+                                      ) : a.authStatus === 'unknown' ? (
+                                        <span title={a.authMessage ?? a.path ?? ''}>
+                                          {t('settings.agentAuthUnknown')}
+                                        </span>
+                                      ) : versionLabel ? (
+                                        <span title={a.path ?? ''}>
+                                          {versionLabel}
+                                        </span>
+                                      ) : (
+                                        <span title={a.path ?? ''}>
+                                          {t('common.installed')}
+                                        </span>
+                                      )}
+                                    </div>
+                                    {!active && modelSummary ? (
+                                      <div className="agent-card-model-summary">
+                                        <span>{t('settings.modelPicker')}</span>
+                                        <strong>{modelSummary}</strong>
+                                      </div>
+                                    ) : null}
+                                  </div>
                                 </button>
-                              ) : null}
+                                {a.id === 'amr' ? (
+                                  <AmrLoginPill
+                                    className="amr-account-control"
+                                    hideSignedOutStatus
+                                  />
+                                ) : null}
+                                {active ? (
+                                  <button
+                                    type="button"
+                                    className={
+                                      'ghost icon-btn settings-test-btn agent-card-test-btn' +
+                                      (running ? ' loading' : '')
+                                    }
+                                    onClick={() => void handleTestAgent()}
+                                    disabled={running}
+                                    title={t('settings.testTitle')}
+                                  >
+                                    {running ? (
+                                      <>
+                                        <Icon
+                                          name="spinner"
+                                          size={13}
+                                          className="icon-spin"
+                                        />
+                                        <span>{t('settings.test')}</span>
+                                      </>
+                                    ) : (
+                                      t('settings.test')
+                                    )}
+                                  </button>
+                                ) : null}
+                              </div>
+                              {active ? renderAgentModelConfig(a) : null}
                             </div>
                           );
                           if (active && agentTestState.status !== 'idle') {
@@ -2548,156 +2721,6 @@ export function SettingsDialog({
                       </div>
                     )}
                   </div>
-              {(() => {
-                const selected = agents.find(
-                  (a) => a.id === cfg.agentId && a.available,
-                );
-                if (!selected) return null;
-                const hasModels =
-                  Array.isArray(selected.models) && selected.models.length > 0;
-                const hasReasoning =
-                  Array.isArray(selected.reasoningOptions) &&
-                  selected.reasoningOptions.length > 0;
-                if (!hasModels && !hasReasoning) return null;
-                const choice = cfg.agentModels?.[selected.id] ?? {};
-                const setChoice = (
-                  next: { model?: string; reasoning?: string },
-                ) => {
-                  setCfg((c) => {
-                    const prev = c.agentModels?.[selected.id] ?? {};
-                    return {
-                      ...c,
-                      agentModels: {
-                        ...(c.agentModels ?? {}),
-                        [selected.id]: { ...prev, ...next },
-                      },
-                    };
-                  });
-                };
-                const modelValue =
-                  choice.model ?? selected.models?.[0]?.id ?? '';
-                const reasoningValue =
-                  choice.reasoning ??
-                  selected.reasoningOptions?.[0]?.id ?? '';
-                const customActive =
-                  hasModels &&
-                  shouldShowCustomModelInput(
-                    modelValue,
-                    selected.models!.map((m) => m.id),
-                    agentCustomModelIds.has(selected.id),
-                  );
-                const selectValue = customActive
-                  ? CUSTOM_MODEL_SENTINEL
-                  : modelValue;
-                const modelSource = selected.modelsSource ?? 'fallback';
-                const modelSourceLabel =
-                  modelSource === 'live'
-                    ? t('settings.modelSourceLive')
-                    : t('settings.modelSourceFallback');
-                const modelSourceHint =
-                  modelSource === 'live'
-                    ? t('settings.modelPickerLiveHint')
-                    : t('settings.modelPickerFallbackHint');
-                return (
-                  <div className="agent-model-row">
-                    <div className="agent-model-row-head">
-                      {t('settings.agentModelHead')}{' '}
-                      <strong>{displayAgentName(selected)}</strong>
-                    </div>
-                    {hasModels ? (
-                      <>
-                        <label className="field">
-                          <span className="field-label">
-                            {t('settings.modelPicker')}
-                            <span
-                              className={`agent-model-source-badge ${modelSource}`}
-                            >
-                              {modelSourceLabel}
-                            </span>
-                          </span>
-                          <div className="agent-model-select-wrap">
-                            <select
-                              value={selectValue}
-                              onChange={(e) => {
-                                if (e.target.value === CUSTOM_MODEL_SENTINEL) {
-                                  setAgentCustomModelIds((prev) => {
-                                    const next = new Set(prev);
-                                    next.add(selected.id);
-                                    return next;
-                                  });
-                                  setChoice({ model: '' });
-                                } else {
-                                  setAgentCustomModelIds((prev) => {
-                                    if (!prev.has(selected.id)) return prev;
-                                    const next = new Set(prev);
-                                    next.delete(selected.id);
-                                    return next;
-                                  });
-                                  setChoice({ model: e.target.value });
-                                }
-                              }}
-                            >
-                              {renderModelOptions(selected.models!)}
-                              <option value={CUSTOM_MODEL_SENTINEL}>
-                                {t('settings.modelCustom')}
-                              </option>
-                            </select>
-                            <Icon
-                              name="chevron-down"
-                              size={12}
-                              className="agent-model-select-chevron"
-                            />
-                          </div>
-                        </label>
-                        <p className="hint agent-model-row-hint">
-                          {modelSourceHint}
-                        </p>
-                      </>
-                    ) : null}
-                    {customActive ? (
-                      <label className="field">
-                        <span className="field-label">
-                          {t('settings.modelCustomLabel')}
-                        </span>
-                        <input
-                          type="text"
-                          value={modelValue}
-                          placeholder={t('settings.modelCustomPlaceholder')}
-                          onChange={(e) =>
-                            setChoice({ model: e.target.value.trim() })
-                          }
-                        />
-                      </label>
-                    ) : null}
-                    {hasReasoning ? (
-                      <label className="field">
-                        <span className="field-label">
-                          {t('settings.reasoningPicker')}
-                        </span>
-                        <div className="agent-model-select-wrap">
-                          <select
-                            value={reasoningValue}
-                            onChange={(e) =>
-                              setChoice({ reasoning: e.target.value })
-                            }
-                          >
-                            {selected.reasoningOptions!.map((r) => (
-                              <option key={r.id} value={r.id}>
-                                {r.label}
-                              </option>
-                            ))}
-                          </select>
-                          <Icon
-                            name="chevron-down"
-                            size={12}
-                            className="agent-model-select-chevron"
-                          />
-                        </div>
-                      </label>
-                    ) : null}
-                  </div>
-                );
-              })()}
                   {unavailableAgents.length > 0 ? (
                     <details
                       className="agent-install-collapse"

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -290,7 +290,7 @@ export const en: Dict = {
   'settings.modelPickerHint':
     'Default uses the CLI’s own config. Custom… lets you type any model id.',
   'settings.modelPickerLiveHint':
-    'Models were refreshed from the installed CLI. Default still uses the CLI’s own config.',
+    "Model list comes from this CLI. Default uses the CLI's own config.",
   'settings.modelPickerFallbackHint':
     'Showing built-in defaults. Click Rescan to pull live models from the CLI.',
   'settings.cliEnvTitle': 'Advanced: proxy & custom paths',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -290,7 +290,7 @@ export const zhCN: Dict = {
   'settings.modelPickerHint':
     '当 CLI 提供 `models` 命令时会自动拉取。选择「默认」则沿用 CLI 自身的配置；选择「自定义」可手动输入任何 CLI 支持的模型 id。',
   'settings.modelPickerLiveHint':
-    '已从已安装的 CLI 刷新模型。“默认”仍使用 CLI 自身配置。',
+    '模型列表来自这个 CLI；选“默认”会沿用 CLI 自己的设置。',
   'settings.modelPickerFallbackHint':
     '正在显示内置默认值。点击“重新扫描”可从 CLI 拉取实时模型。',
   'settings.cliEnvTitle': 'CLI 配置位置',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -281,7 +281,7 @@ export const zhTW: Dict = {
   'settings.modelPickerHint':
     '當 CLI 提供 `models` 命令時會自動拉取。選擇「預設」則沿用 CLI 自身的設定；選擇「自訂」可手動輸入任何 CLI 支援的模型 id。',
   'settings.modelPickerLiveHint':
-    '已從已安裝的 CLI 重新整理模型。「預設」仍使用 CLI 自身設定。',
+    '模型列表來自這個 CLI；選「預設」會沿用 CLI 自己的設定。',
   'settings.modelPickerFallbackHint':
     '正在顯示內建預設值。點擊「重新掃描」可從 CLI 拉取即時模型。',
   'settings.cliEnvTitle': 'CLI 設定位置',

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -776,9 +776,15 @@
   transition: border-color 120ms ease, box-shadow 120ms ease, background 120ms ease;
 }
 .agent-card-installed {
+  display: block;
   padding: 0;
   min-height: 72px;
   overflow: hidden;
+}
+.agent-card-main {
+  display: flex;
+  align-items: stretch;
+  min-width: 0;
 }
 .agent-card-select {
   flex: 1;
@@ -815,16 +821,43 @@
   border-color: var(--border-strong);
 }
 .agent-card.active {
-  border-color: var(--border);
-  background: color-mix(in srgb, var(--accent-tint) 54%, var(--bg-panel));
-  box-shadow: none;
+  border-color: color-mix(in srgb, var(--accent) 36%, var(--border));
+  background: var(--bg-panel);
+  box-shadow:
+    0 1px 0 color-mix(in srgb, var(--bg-panel) 88%, transparent) inset,
+    0 10px 28px color-mix(in srgb, var(--text) 9%, transparent);
 }
 .agent-card.active::before {
   content: '';
   position: absolute;
-  inset: 0 auto 0 0;
-  width: 3px;
-  background: var(--accent);
+  inset: 12px auto 12px 0;
+  width: 4px;
+  border-radius: 0 999px 999px 0;
+  background: linear-gradient(180deg, var(--accent), color-mix(in srgb, var(--accent) 56%, var(--selected)));
+}
+.agent-card-installed.active .agent-card-main {
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--accent-tint) 32%, var(--bg-panel)),
+      color-mix(in srgb, var(--accent-tint) 10%, var(--bg-panel))
+    );
+}
+.agent-card-installed.active .agent-card-select {
+  min-height: 78px;
+  padding: 14px 18px 12px 22px;
+}
+.agent-card-installed.active .agent-icon {
+  border-radius: 11px;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--accent) 16%, var(--border-soft)),
+    0 8px 18px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+.agent-card-installed.active .agent-card-name {
+  font-size: 13px;
+}
+.agent-card-installed.active .agent-card-meta {
+  margin-top: 1px;
 }
 .agent-card.disabled {
   cursor: not-allowed;
@@ -949,6 +982,29 @@
   line-height: 1.35;
 }
 .agent-card-meta .muted { color: var(--text-soft); font-style: italic; }
+.agent-card-model-summary {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-top: 4px;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.agent-card-model-summary span {
+  flex: 0 0 auto;
+}
+.agent-card-model-summary strong {
+  min-width: 0;
+  color: var(--text);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .agent-model-row-head {
   font-size: 12px;
   color: var(--text);
@@ -965,6 +1021,20 @@
   border-radius: var(--radius-sm);
   background: var(--bg-panel);
 }
+.agent-card-config {
+  display: grid;
+  gap: 9px;
+  padding: 16px 24px 18px;
+  border-top: 1px solid color-mix(in srgb, var(--accent) 14%, var(--border-soft));
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--bg-subtle) 52%, var(--bg-panel)),
+      color-mix(in srgb, var(--bg-panel) 92%, var(--bg-subtle))
+    );
+}
+.agent-card-config select,
+.agent-card-config input,
 .agent-model-row select,
 .agent-model-row input,
 .agent-cli-env select,
@@ -986,7 +1056,9 @@
   border-radius: var(--radius-sm);
   background: var(--bg-panel);
 }
+.agent-card-config .field,
 .agent-model-row .field { gap: 4px; }
+.agent-card-config .field-label,
 .agent-model-row .field-label {
   display: inline-flex;
   align-items: center;
@@ -996,6 +1068,11 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--text-muted);
+}
+.agent-card-config .field-label {
+  margin-bottom: 2px;
+  font-size: 11px;
+  letter-spacing: 0.06em;
 }
 .agent-model-source-badge {
   display: inline-flex;
@@ -1032,7 +1109,12 @@
   margin-right: 6px;
   color: var(--text-muted);
 }
+.agent-card-config .hint,
 .agent-model-row .hint { margin: 0; font-size: 11.5px; }
+.agent-card-config .hint {
+  color: var(--text-muted);
+  line-height: 1.35;
+}
 .agent-model-select-wrap {
   position: relative;
 }
@@ -1042,6 +1124,14 @@
   background-image: none;
   padding-right: 28px;
   width: 100%;
+}
+.agent-card-config .agent-model-select-wrap select {
+  min-height: 36px;
+  border-color: color-mix(in srgb, var(--border) 78%, transparent);
+  background: color-mix(in srgb, var(--bg-subtle) 82%, var(--bg-panel));
+}
+.agent-card-config .agent-model-select-wrap select:hover {
+  border-color: var(--border-strong);
 }
 .agent-model-select-chevron {
   position: absolute;
@@ -2176,4 +2266,3 @@
   font-weight: 500;
   color: var(--accent);
 }
-

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1057,9 +1057,14 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(screen.getByText(en['settings.agentInstall.pathHint'])).toBeTruthy();
 
     fireEvent.click(codexCard);
-    const modelHead = screen.getByText(/Model for:/);
+    const selectedCard = codexCard.closest('.agent-card') as HTMLElement;
     expect(
-      modelHead.compareDocumentPosition(installGroupSummary) &
+      within(selectedCard).getByRole('combobox', {
+        name: en['settings.modelPicker'],
+      }),
+    ).toBeTruthy();
+    expect(
+      selectedCard.compareDocumentPosition(installGroupSummary) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     await waitForPersist(
@@ -1092,7 +1097,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     fireEvent.click(screen.getByRole('tab', { name: /Local CLI/i }));
     expect(screen.getByText('Live from CLI')).toBeTruthy();
     expect(
-      screen.getByText(/Models were refreshed from the installed CLI/i),
+      screen.getByText(/Model list comes from this CLI/i),
     ).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary
- Move per-CLI model and reasoning controls into the selected Local CLI card so choosing a CLI and configuring it reads as one continuous flow.
- Add compact model summaries for unselected installed CLIs while keeping the selected card free of duplicate model text.
- Refresh the selected-card styling, spacing, source badge accessibility, and live-model helper copy across English, Simplified Chinese, and Traditional Chinese.
- Update the SettingsDialog execution tests for the inline configuration layout.

## Surface area
- [x] **UI** — Settings → Execution Local CLI card flow and inline model controls in `apps/web`
- [ ] **Keyboard shortcut** — no changes
- [ ] **CLI / env var** — no changes
- [ ] **API / contract** — no changes
- [ ] **Extension point** — no changes
- [ ] **i18n keys** — no new keys; existing helper copy updated
- [ ] **New top-level dependency** — no changes
- [ ] **Default behavior change** — no runtime default changes

## Test Plan
- `pnpm i18n:check`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx`
- `git diff --check origin/feat/amr-runtime-acp..HEAD`