### PR TITLE
fix(packaged): forward Windows session env so Codex CLI test stops timing out

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1291,13 +1291,39 @@ async function testAgentConnectionInternal(
     kind: 'timeout' | 'aborted',
   ): ConnectionTestResponse => {
     const latencyMs = Date.now() - start;
-    console.warn(`[test:agent] ${def.name} → ${kind} in ${(latencyMs / 1000).toFixed(1)}s`);
+    // Build a redacted tail of whatever the child managed to print before
+    // the cancellation fired. Without this, a Windows packaged Codex run
+    // that stalls on TLS/proxy initialization shows up in the UI as a
+    // bare "timeout in 45.0s" with nothing to diagnose against (#2197).
+    // The sink keeps the last 400 chars of each stream and the running
+    // assistant-text buffer, which is what we have to work with — we
+    // truncate further when joining so the SettingsDialog status line
+    // doesn't grow unbounded for long stderr dumps.
+    const stderrTail = sink.getStderrTail().trim();
+    const rawStdoutTail = sink.getRawStdoutTail().trim();
+    const bufferedText = sink.getText().trim();
+    const detailParts = [
+      kind === 'timeout'
+        ? `Timed out after ${(latencyMs / 1000).toFixed(1)}s waiting for ${def.name}.`
+        : `Cancelled after ${(latencyMs / 1000).toFixed(1)}s waiting for ${def.name}.`,
+      stderrTail ? `stderr: ${stderrTail.slice(-200)}` : null,
+      rawStdoutTail || bufferedText
+        ? `stdout: ${(rawStdoutTail || bufferedText).slice(-200)}`
+        : null,
+    ].filter(Boolean);
+    const detail = redactSecrets(detailParts.join(' · '));
+    console.warn(
+      `[test:agent] ${def.name} → ${kind} in ${(latencyMs / 1000).toFixed(1)}s${
+        detail ? ` (${detail})` : ''
+      }`,
+    );
     return {
       ok: false,
       kind: 'timeout',
       latencyMs,
       model,
       agentName: def.name,
+      ...(detail ? { detail } : {}),
     };
   };
 

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2399,6 +2399,40 @@ console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_messag
     );
   });
 
+  // Issue #2197: when a packaged Codex CLI on Windows hangs talking to
+  // the OpenAI API (typical cause: a corporate proxy or DLL/loader issue
+  // in the sanitized packaged-child env), the daemon only ever logged
+  // "[test:agent] Codex CLI → timeout in 45.0s" with no clue what went
+  // wrong. The cancellation result now also carries whatever the child
+  // printed to stderr / stdout before the timeout fired, so Settings can
+  // surface a real diagnostic instead of a bare timeout latency.
+  it('surfaces child stderr in the timeout detail so failures are not silent', async () => {
+    await withFakeCodex(
+      `
+process.stderr.write('Error: connect ECONNREFUSED 127.0.0.1:7890');
+setInterval(() => {}, 1000);
+`,
+      async () => {
+        const controller = new AbortController();
+        const pending = testAgentConnection({
+          agentId: 'codex',
+          signal: controller.signal,
+        });
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        controller.abort();
+        const result = await pending;
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'timeout',
+          agentName: 'Codex CLI',
+        });
+        expect(typeof result.detail).toBe('string');
+        expect(result.detail).toContain('stderr');
+        expect(result.detail).toContain('ECONNREFUSED');
+      },
+    );
+  }, 10_000);
+
   it('hard-cancels aborted agent probes before cleaning up', async () => {
     const markerDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-marker-'));
     const pidFile = path.join(markerDir, 'pid');

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -49,12 +49,73 @@ const PACKAGED_CHILD_ENV_ALLOWLIST = [
   "no_proxy",
 ] as const;
 
-function shouldForwardPackagedChildEnv(key: string, includeProviderSecrets = false): boolean {
-  return (
+// Windows-only env keys the packaged daemon must inherit so spawned CLI
+// children (codex.exe, claude.cmd, opencode.cmd, ...) match the user's
+// interactive shell. Stripping these is what made the Codex CLI test in
+// issue #2197 hang for 45 s on a packaged Windows install while running
+// codex manually from PowerShell with the same CODEX_HOME / CODEX_BIN
+// returned "ok" in seconds. Codex's Rust HTTPS stack (reqwest +
+// schannel) opens temp files under TEMP/TMP, expands `~` from
+// USERPROFILE, and relies on the Win32 loader walking SYSTEMROOT for
+// its TLS DLLs; cmd.exe-mediated `.cmd` shim spawns additionally need
+// PATHEXT and COMSPEC to resolve the right command. Forwarding these is
+// safe — they describe the user, not secrets — and they cannot collide
+// with the secret-key allowlist because they are not credential names.
+const WINDOWS_SYSTEM_ENV_KEYS = [
+  "APPDATA",
+  "COMPUTERNAME",
+  "COMSPEC",
+  "ComSpec",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "LOCALAPPDATA",
+  "OS",
+  "PATHEXT",
+  "PROCESSOR_ARCHITECTURE",
+  "PROCESSOR_ARCHITEW6432",
+  "PROCESSOR_IDENTIFIER",
+  "PROGRAMDATA",
+  "PROGRAMFILES",
+  "PROGRAMFILES(X86)",
+  "PROGRAMW6432",
+  "PUBLIC",
+  "SESSIONNAME",
+  "SYSTEMDRIVE",
+  "SYSTEMROOT",
+  "TEMP",
+  "TMP",
+  "USERDOMAIN",
+  "USERDOMAIN_ROAMINGPROFILE",
+  "USERNAME",
+  "USERPROFILE",
+  "windir",
+] as const;
+
+const WINDOWS_SYSTEM_ENV_KEY_SET = new Set<string>(
+  WINDOWS_SYSTEM_ENV_KEYS.map((key) => key.toUpperCase()),
+);
+
+function isWindowsSystemEnvKey(key: string): boolean {
+  return WINDOWS_SYSTEM_ENV_KEY_SET.has(key.toUpperCase());
+}
+
+function shouldForwardPackagedChildEnv(
+  key: string,
+  includeProviderSecrets = false,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (
     PACKAGED_CHILD_ENV_ALLOWLIST.includes(
       key as (typeof PACKAGED_CHILD_ENV_ALLOWLIST)[number],
-    ) ||
-    (includeProviderSecrets && (key.endsWith("_API_KEY") || key.endsWith("_TOKEN")))
+    )
+  ) {
+    return true;
+  }
+  if (platform === "win32" && isWindowsSystemEnvKey(key)) {
+    return true;
+  }
+  return (
+    includeProviderSecrets && (key.endsWith("_API_KEY") || key.endsWith("_TOKEN"))
   );
 }
 
@@ -211,10 +272,15 @@ export function resolvePackagedPathEnv(basePath = process.env.PATH ?? ""): strin
 export function resolvePackagedChildBaseEnv(
   env: NodeJS.ProcessEnv = process.env,
   includeProviderSecrets = false,
+  platform: NodeJS.Platform = process.platform,
 ): NodeJS.ProcessEnv {
   const baseEnv: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(env)) {
-    if (value != null && value.length > 0 && shouldForwardPackagedChildEnv(key, includeProviderSecrets)) {
+    if (
+      value != null &&
+      value.length > 0 &&
+      shouldForwardPackagedChildEnv(key, includeProviderSecrets, platform)
+    ) {
       baseEnv[key] = value;
     }
   }

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -122,6 +122,86 @@ describe('packaged child Vite+ environment forwarding', () => {
       rmSync(vpHome, { recursive: true, force: true });
     }
   });
+
+  // Issue #2197: a packaged Windows install had Codex CLI test always
+  // time out at 45 s even though running codex manually with the same
+  // CODEX_HOME / CODEX_BIN succeeded in seconds. Root cause was that
+  // the packaged daemon's child-env allowlist stripped USERPROFILE,
+  // APPDATA, LOCALAPPDATA, TEMP, SYSTEMROOT, PATHEXT, COMSPEC and the
+  // rest of the Windows session env, so the spawned codex.exe couldn't
+  // resolve its TLS temp paths / system DLL search and stalled on
+  // network init. These keys must flow through on win32 (without
+  // re-introducing them on POSIX where they would be cruft) so the
+  // packaged daemon mirrors what an interactive PowerShell child sees.
+  it('forwards core Windows session env vars to packaged sidecars on win32', () => {
+    const env = resolvePackagedChildBaseEnv(
+      {
+        APPDATA: 'C:\\Users\\tester\\AppData\\Roaming',
+        COMSPEC: 'C:\\Windows\\system32\\cmd.exe',
+        ComSpec: 'C:\\Windows\\system32\\cmd.exe',
+        HOMEDRIVE: 'C:',
+        HOMEPATH: '\\Users\\tester',
+        LOCALAPPDATA: 'C:\\Users\\tester\\AppData\\Local',
+        PATHEXT: '.COM;.EXE;.BAT;.CMD',
+        PROCESSOR_ARCHITECTURE: 'AMD64',
+        PROGRAMDATA: 'C:\\ProgramData',
+        PROGRAMFILES: 'C:\\Program Files',
+        'PROGRAMFILES(X86)': 'C:\\Program Files (x86)',
+        PROGRAMW6432: 'C:\\Program Files',
+        SYSTEMDRIVE: 'C:',
+        SYSTEMROOT: 'C:\\Windows',
+        TEMP: 'C:\\Users\\tester\\AppData\\Local\\Temp',
+        TMP: 'C:\\Users\\tester\\AppData\\Local\\Temp',
+        USERDOMAIN: 'TESTER-PC',
+        USERNAME: 'tester',
+        USERPROFILE: 'C:\\Users\\tester',
+        windir: 'C:\\Windows',
+        OD_INTERNAL_FLAG: 'drop-me',
+      },
+      false,
+      'win32',
+    );
+
+    expect(env).toMatchObject({
+      APPDATA: 'C:\\Users\\tester\\AppData\\Roaming',
+      COMSPEC: 'C:\\Windows\\system32\\cmd.exe',
+      ComSpec: 'C:\\Windows\\system32\\cmd.exe',
+      HOMEDRIVE: 'C:',
+      HOMEPATH: '\\Users\\tester',
+      LOCALAPPDATA: 'C:\\Users\\tester\\AppData\\Local',
+      PATHEXT: '.COM;.EXE;.BAT;.CMD',
+      PROCESSOR_ARCHITECTURE: 'AMD64',
+      PROGRAMDATA: 'C:\\ProgramData',
+      PROGRAMFILES: 'C:\\Program Files',
+      'PROGRAMFILES(X86)': 'C:\\Program Files (x86)',
+      PROGRAMW6432: 'C:\\Program Files',
+      SYSTEMDRIVE: 'C:',
+      SYSTEMROOT: 'C:\\Windows',
+      TEMP: 'C:\\Users\\tester\\AppData\\Local\\Temp',
+      TMP: 'C:\\Users\\tester\\AppData\\Local\\Temp',
+      USERDOMAIN: 'TESTER-PC',
+      USERNAME: 'tester',
+      USERPROFILE: 'C:\\Users\\tester',
+      windir: 'C:\\Windows',
+    });
+    expect(env.OD_INTERNAL_FLAG).toBeUndefined();
+  });
+
+  it('does not forward Windows-only env vars on POSIX hosts', () => {
+    const env = resolvePackagedChildBaseEnv(
+      {
+        HOME: '/Users/tester',
+        // POSIX has no business inheriting these in the packaged child.
+        APPDATA: '/Users/tester/AppData/Roaming',
+        SYSTEMROOT: '/Users/tester/Windows',
+        USERPROFILE: '/Users/tester',
+      },
+      false,
+      'darwin',
+    );
+
+    expect(env).toEqual({ HOME: '/Users/tester' });
+  });
 });
 
 /**

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -2096,8 +2096,13 @@ function renderOnboardingProviderTestMessage(
       return t('settings.testRateLimited');
     case 'upstream_unavailable':
       return t('settings.testUpstream', { status: result.status ?? 0 });
-    case 'timeout':
-      return t('settings.testTimeout', { ms });
+    case 'timeout': {
+      // Issue #2197: surface the redacted child stderr/stdout tail the
+      // daemon now attaches to timeout responses, instead of dropping
+      // it on the floor.
+      const baseMessage = t('settings.testTimeout', { ms });
+      return result.detail ? `${baseMessage} ${result.detail}` : baseMessage;
+    }
     default:
       return t('settings.testUnknown', { detail: result.detail ?? '' });
   }

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1458,8 +1458,15 @@ export function SettingsDialog({
         return t('settings.testRateLimited');
       case 'upstream_unavailable':
         return t('settings.testUpstream', { status: result.status ?? 0 });
-      case 'timeout':
-        return t('settings.testTimeout', { ms });
+      case 'timeout': {
+        // Issue #2197: when a packaged Windows Codex CLI test stalls,
+        // the daemon now carries the child's stderr/stdout tail in
+        // `detail`. Append it so the Settings status line surfaces
+        // the real failure (e.g. ECONNREFUSED through the corporate
+        // proxy) instead of a bare "Test timed out after 45036 ms."
+        const baseMessage = t('settings.testTimeout', { ms });
+        return result.detail ? `${baseMessage} ${result.detail}` : baseMessage;
+      }
       case 'agent_not_installed':
         return t('settings.testAgentMissing', { agentName });
       case 'agent_auth_required':


### PR DESCRIPTION
Fixes #2197

## Why

A packaged Open Design install on Windows reported that the Settings → Codex CLI **Test** button always times out at ~45 s, even though running `codex.cmd exec ...` manually from PowerShell with the same `CODEX_HOME` / `CODEX_BIN` returns `ok` in seconds. The daemon log only ever showed `[test:agent] Codex CLI → timeout in 45.0s`, so the user had no way to tell what actually failed.

Root cause: `apps/packaged/src/sidecars.ts` runs a strict allowlist on `process.env` before spawning the daemon (and web) sidecars. That allowlist covers POSIX session vars (`HOME`, `USER`, proxies, …) but strips every Windows-only session variable — `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `TEMP`, `TMP`, `SYSTEMROOT`, `PATHEXT`, `COMSPEC`, `PROGRAMFILES`, etc. Codex CLI's Rust HTTPS stack opens scratch files under `TEMP`, expands `~` from `USERPROFILE`, and depends on the Win32 loader walking `SYSTEMROOT` for its schannel TLS DLLs; the `.cmd` shim launch also needs `PATHEXT` and `COMSPEC`. With those gone, the child stalls on TLS / proxy initialization and the connection test hits the 45 s budget.

## What users will see

- On packaged Windows, the **Codex CLI → Test** (and any other Local CLI test) now sees the same Windows session env as an interactive PowerShell child, so it no longer hangs on TLS/proxy init.
- When a connection test does time out for any other reason, the Settings status line now also shows the child's stderr/stdout tail (e.g. `Test timed out after 45036 ms. stderr: Error: connect ECONNREFUSED 127.0.0.1:7890`) instead of just the bare latency. The same diagnostic flows into the daemon log line.
- POSIX hosts are unchanged — the Windows-only keys are gated on `platform === 'win32'`.

## Surface area

- [x] **UI** — Settings / onboarding status line now appends `result.detail` after the localized timeout copy
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract — uses the existing optional `detail` field on `ConnectionTestResponse`
- [ ] Extension point
- [ ] i18n keys — no new keys; existing `settings.testTimeout` is reused for the base string
- [ ] New top-level dependency
- [ ] Default behavior change
- [x] **Other** — packaged daemon child-env allowlist (Windows-only addition)

## Screenshots

N/A — fix is observable only on a real Windows packaged install. The UI change is purely additive (a trailing detail clause after the existing localized timeout string).

## Bug fix verification

Two red specs encode the bug, both go green on this branch:

- `apps/packaged/tests/sidecars.test.ts` — *"forwards core Windows session env vars to packaged sidecars on win32"* and *"does not forward Windows-only env vars on POSIX hosts"*. The first one fails on `main` because the allowlist drops every Windows session key; the second guards against accidental POSIX regressions.
- `apps/daemon/tests/connection-test.test.ts` — *"surfaces child stderr in the timeout detail so failures are not silent"*. Fails on `main` because the cancellation result only carries `latencyMs`.

The Windows-specific runtime fix itself can't be exercised from POSIX CI, but the env-forwarding seam is now pinned in both directions and the daemon diagnostic now carries enough context for a packaged Windows user to see the actual stall reason rather than just a 45 s latency.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon exec vitest run tests/connection-test.test.ts` → 90 passed
- `pnpm --filter @open-design/packaged exec vitest run tests/sidecars.test.ts` → 18 passed
- `pnpm --filter @open-design/web test` → 2141 passed
- `pnpm --filter @open-design/daemon build` and `pnpm --filter @open-design/packaged build` both clean