### PR TITLE
fix(daemon): recover truncated tool input so bulk Edits stop showing "(unnamed)"

### DIFF
--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -36,6 +36,12 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
   // Claude Code still repeats them in the final assistant wrapper, often with
   // empty `{}` inputs, so we suppress that duplicate emission.
   const streamedToolUseIds = new Set<string>();
+  // Best-effort partial inputs recovered from streamed `input_json_delta`
+  // bytes that did NOT parse cleanly at content_block_stop (e.g. Windows
+  // stdout dropped a fragment mid-tool-call — see #1914). Keyed by tool_use
+  // id, consumed by the assistant-wrapper merge below so we surface
+  // `file_path` instead of an empty `{}` that renders as "(unnamed)".
+  const recoveredToolUseInputs = new Map<string, Record<string, unknown>>();
   // Most recent assistant message id so content_block_* events without an id
   // can be attributed correctly.
   let currentMessageId: string | null = null;
@@ -131,11 +137,24 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
             streamedToolUseIds.delete(block.id);
             continue;
           }
+          let input: unknown = block.input ?? null;
+          if (typeof block.id === 'string') {
+            const recovered = recoveredToolUseInputs.get(block.id);
+            if (recovered) {
+              recoveredToolUseInputs.delete(block.id);
+              // Wrapper values are authoritative when present; recovered
+              // fragments backfill missing keys (typically `file_path`)
+              // so the UI no longer renders the card as "(unnamed)".
+              input = isRecord(input)
+                ? { ...recovered, ...input }
+                : recovered;
+            }
+          }
           onEvent({
             type: 'tool_use',
             id: block.id,
             name: block.name,
-            input: block.input ?? null,
+            input,
           });
         } else if (
           !alreadyStreamed &&
@@ -246,8 +265,15 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
           });
           streamedToolUseIds.add(state.id);
         } catch {
-          // Fall through to the final assistant wrapper's input if the
-          // streamed JSON is malformed or incomplete.
+          // Streamed JSON did not parse cleanly — most often because a stdout
+          // fragment was dropped mid-tool-call on Windows (#1914). Try to
+          // recover whatever values made it through and stash them; the
+          // assistant wrapper merge above will surface them as the tool
+          // input so the UI shows real file paths instead of "(unnamed)".
+          const recovered = bestEffortParsePartialJson(state.input);
+          if (recovered) {
+            recoveredToolUseInputs.set(state.id, recovered);
+          }
         }
       }
       blocks.delete(key);
@@ -266,4 +292,107 @@ function stringifyToolResult(content: unknown): string {
       .join('\n');
   }
   return JSON.stringify(content);
+}
+
+/**
+ * Recovers as much of a streamed tool input object as possible from a JSON
+ * fragment that failed to parse. Truncation typically lands inside a string
+ * value or at a dangling separator: we close any open string, balance the
+ * bracket stack, and progressively strip dangling key/colon/comma tails
+ * until a prefix parses. Returns `null` if nothing useful can be salvaged.
+ *
+ * Scoped to top-level objects because every Claude tool input is an object;
+ * arrays/scalars never appear as the outermost shape.
+ */
+export function bestEffortParsePartialJson(input: string): Record<string, unknown> | null {
+  const trimmed = input.trim();
+  if (!trimmed || !trimmed.startsWith('{')) return null;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    // Fall through to repair.
+  }
+
+  let body = trimmed;
+  for (let attempt = 0; attempt < 64; attempt++) {
+    const { stack, inString, escape } = scanJsonState(body);
+
+    let working = body;
+    if (escape) working = working.slice(0, -1);
+    if (inString) working += '"';
+
+    // Strip dangling separators / orphan key fragments so the closers attach
+    // to a balanced position. Repeat until stable — stripping `"key":` can
+    // expose a trailing `,` that needs its own pass.
+    let prev: string;
+    do {
+      prev = working;
+      working = working.replace(/\s+$/, '');
+      working = working.replace(/,$/, '');
+      working = working.replace(/("(?:[^"\\]|\\.)*"\s*:\s*)$/, '');
+      working = working.replace(/,\s*"(?:[^"\\]|\\.)*"\s*$/, '');
+    } while (working !== prev);
+
+    let closers = '';
+    for (let i = stack.length - 1; i >= 0; i--) closers += stack[i] === '{' ? '}' : ']';
+
+    try {
+      const parsed = JSON.parse(working + closers);
+      return isRecord(parsed) ? parsed : null;
+    } catch {
+      const next = stripTrailingPartialEntry(body);
+      if (next === body || next.length === 0) return null;
+      body = next;
+    }
+  }
+  return null;
+}
+
+function scanJsonState(s: string): { stack: Array<'{' | '['>; inString: boolean; escape: boolean } {
+  const stack: Array<'{' | '['> = [];
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]!;
+    if (escape) { escape = false; continue; }
+    if (inString) {
+      if (ch === '\\') escape = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{') stack.push('{');
+    else if (ch === '[') stack.push('[');
+    else if (ch === '}' || ch === ']') stack.pop();
+  }
+  return { stack, inString, escape };
+}
+
+function stripTrailingPartialEntry(body: string): string {
+  // Walk the body, tracking per-container "last safe cut" — either the
+  // position just after the container's opening bracket or the position of
+  // its most recent top-level comma. When we hit a parse failure, cutting
+  // back to the innermost container's last safe point drops the half-written
+  // entry without disturbing the rest of the object.
+  let inString = false;
+  let escape = false;
+  const stack: Array<{ lastSep: number }> = [];
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i]!;
+    if (escape) { escape = false; continue; }
+    if (inString) {
+      if (ch === '\\') escape = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{' || ch === '[') stack.push({ lastSep: i + 1 });
+    else if (ch === '}' || ch === ']') stack.pop();
+    else if (ch === ',' && stack.length > 0) stack[stack.length - 1]!.lastSep = i;
+  }
+  if (stack.length === 0) return '';
+  const top = stack[stack.length - 1]!;
+  return body.slice(0, top.lastSep).replace(/[,\s]+$/, '');
 }

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -119,6 +119,98 @@ describe('structured agent stream fixtures', () => {
     });
   });
 
+  it('recovers tool input when streamed JSON is truncated and the assistant wrapper is empty', () => {
+    // Regression for #1914: when Claude Code emits `--include-partial-messages`
+    // input_json_delta fragments that fail to parse at content_block_stop
+    // (e.g. truncation, dropped fragment), it still sends the final assistant
+    // wrapper with `input: {}`. The handler must not emit `input: {}` to the
+    // web — that produces `(unnamed)` cards with no diagnostic value. It
+    // should instead surface a best-effort parse of the partial JSON so the
+    // UI can show the real `file_path`.
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+
+    handler.feed(`${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'message_start', message: { id: 'msg-edit' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'toolu-edit', name: 'Edit' },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        // Truncated mid-string: the closing `"`, `,` and closing `}` are missing.
+        delta: { type: 'input_json_delta', partial_json: '{"file_path":"src/canvas2-nodes.jsx","old_string":"foo' },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_stop', index: 0 },
+    })}\n${JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg-edit',
+        content: [{ type: 'tool_use', id: 'toolu-edit', name: 'Edit', input: {} }],
+      },
+    })}\n`);
+    handler.flush();
+
+    const toolUses = events.filter(
+      (event): event is { type: string; id: string; name: string; input: unknown } =>
+        typeof event === 'object' &&
+        event !== null &&
+        (event as { type?: string }).type === 'tool_use',
+    );
+
+    expect(toolUses).toHaveLength(1);
+    const use = toolUses[0]!;
+    expect(use.id).toBe('toolu-edit');
+    expect(use.name).toBe('Edit');
+    const input = use.input as Record<string, unknown> | null | undefined;
+    // The file path was fully present in the streamed bytes before the stream
+    // got cut off. We must recover it instead of dropping to `{}`.
+    expect(input).not.toBeNull();
+    expect((input as Record<string, unknown>).file_path).toBe('src/canvas2-nodes.jsx');
+  });
+
+  it('does not strip a valid Edit input when the assistant wrapper carries it but no stream deltas arrived', () => {
+    // Mirror image of the regression: older Claude Code builds (or any build
+    // that skips `--include-partial-messages`) deliver tool input ONLY via
+    // the final assistant wrapper. The handler must still emit it.
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+
+    handler.feed(`${JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg-edit-2',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu-edit-2',
+            name: 'Edit',
+            input: { file_path: 'src/canvas2-nodes.jsx', old_string: 'a', new_string: 'b' },
+          },
+        ],
+      },
+    })}\n`);
+    handler.flush();
+
+    const toolUses = events.filter(
+      (event): event is { type: string; input: unknown } =>
+        typeof event === 'object' &&
+        event !== null &&
+        (event as { type?: string }).type === 'tool_use',
+    );
+    expect(toolUses).toHaveLength(1);
+    expect((toolUses[0]!.input as Record<string, unknown>).file_path).toBe('src/canvas2-nodes.jsx');
+  });
+
   it('emits TodoWrite tool_use from GitHub Copilot CLI JSON stream', () => {
     const events: unknown[] = [];
     const handler = createCopilotStreamHandler((event: unknown) => events.push(event));


### PR DESCRIPTION
Closes #1914

## Why

- Use case: running bulk Edits on Win11 with Claude Code CLI + Opus 4.7 produced 10/11 cards labeled **错误 (unnamed)** — no file paths, no diagnostic, no way to retry. The reporter could not tell which files failed or why.
- Root cause: when Claude Code streams `input_json_delta` fragments and the stream is truncated mid-tool-call (the failure mode in #1914), the daemon's per-block `JSON.parse` at `content_block_stop` throws. The handler then falls back to the assistant-wrapper `tool_use`, whose `input` is `{}` in that situation. The empty object reaches the chat UI, which renders it as "(unnamed)".

## What users will see

- Bulk Edit cards that previously rendered as "(unnamed)" with no `file_path` now surface the partially-streamed input. As long as the streamed bytes contained the `file_path` key (the common case — it's the first arg), the card shows the real file path instead of "(unnamed)".
- Happy path is unchanged: when the wrapper carries the full input, those values stay authoritative and recovered fragments only backfill missing keys.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only (daemon-internal stream parser bug fix; no protocol or surface change)

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/structured-streams.test.ts` — "recovers tool input when streamed JSON is truncated and the assistant wrapper is empty"
- Confirmed red on `main` and green on this branch.
- A companion test ("does not strip a valid Edit input when the assistant wrapper carries it but no stream deltas arrived") locks in the happy-path branch so the recovery code can't regress the non-truncated case.

## Validation

- `pnpm --filter @open-design/daemon test` — 270 files / 3198 tests pass (1 skipped, 4 todo, pre-existing).
- `pnpm guard` — pass.
- `pnpm typecheck` — pass across all workspaces (0 errors).

## Implementation notes

- Added `bestEffortParsePartialJson` in `apps/daemon/src/claude-stream.ts`: closes any open string, balances `{}` / `[]` brackets, strips dangling separators and orphan `"key":` fragments, and progressively drops the trailing half-written entry until a prefix parses.
- Recovered keys are stashed by `tool_use` id and merged into the assistant-wrapper emission. Wrapper values win on conflicts; recovered keys only backfill missing ones (typically `file_path`).
- Bounded retry loop (64 attempts) to keep recovery O(n) and avoid pathological inputs blocking the event handler.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>