### PR TITLE
fix: synchronously update URL when creating new conversation

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3360,6 +3360,17 @@ export function ProjectView({
       messagesConversationIdRef.current = fresh.id;
       setConversations((curr) => [fresh, ...curr]);
       setActiveConversationId(fresh.id);
+      // Push the new conversation id into the URL synchronously so the
+      // route-sync effect sees a matching route before it can revert.
+      navigate(
+        {
+          kind: 'project',
+          projectId: project.id,
+          conversationId: fresh.id,
+          fileName: openTabsState.active ?? null,
+        },
+        { replace: true },
+      );
       setError(null);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Could not create a conversation for this project.';
@@ -3369,7 +3380,7 @@ export function ProjectView({
       creatingConversationRef.current = false;
       setCreatingConversation(false);
     }
-  }, [project.id, activeConversationId, messages.length]);
+  }, [project.id, activeConversationId, messages.length, navigate, openTabsState.active]);
 
   const handleSelectConversation = useCallback((id: string) => {
     if (id === activeConversationId && failedMessagesConversationId !== id) return;

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProjectView } from '../../src/components/ProjectView';
+import { navigate } from '../../src/router';
 import type {
   AppConfig,
   ChatMessage,
@@ -35,6 +36,7 @@ const patchProject = vi.fn();
 const saveTabs = vi.fn();
 const playSound = vi.fn();
 const showCompletionNotification = vi.fn();
+const mockedNavigate = vi.mocked(navigate);
 
 vi.mock('../../src/i18n', () => ({
   useI18n: () => ({
@@ -463,6 +465,31 @@ describe('ProjectView conversation run isolation', () => {
     });
   });
 
+  it('keeps a routed conversation from snapping back after creating a new conversation', async () => {
+    renderProjectView(config, project, { routeConversationId: 'conv-a' });
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    mockedNavigate.mockClear();
+
+    fireEvent.click(screen.getByTestId('new-conversation'));
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-c'));
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      {
+        kind: 'project',
+        projectId: project.id,
+        conversationId: 'conv-c',
+        fileName: null,
+      },
+      { replace: true },
+    );
+
+    await act(async () => {});
+
+    expect(screen.getByTestId('active-conversation').textContent).toBe('conv-c');
+    expect(screen.getByTestId('active-conversation').textContent).not.toBe('conv-a');
+  });
+
   it('notifies when a detached active run is terminal after returning to its conversation', async () => {
     renderProjectView();
 
@@ -708,11 +735,16 @@ describe('ProjectView conversation run isolation', () => {
   });
 });
 
-function renderProjectView(renderConfig = config, renderProject: Project = project) {
+function renderProjectView(
+  renderConfig = config,
+  renderProject: Project = project,
+  options: { routeConversationId?: string | null } = {},
+) {
   return render(
     <ProjectView
       project={renderProject}
       routeFileName={null}
+      routeConversationId={options.routeConversationId ?? null}
       config={renderConfig}
       agents={[{ id: 'agent-1', name: 'OpenCode', bin: 'opencode', available: true, models: [] }]}
       skills={[]}


### PR DESCRIPTION
Fixes #2930

## Why
Creating a new conversation updated local state before the route changed, which let the route-sync effect snap the active conversation back to the previous URL-backed conversation.

## What users will see
After creating a new conversation, the app stays on the new conversation instead of briefly switching back to the previous one.

## Surface area
- [x] UI
- apps/web/src/components/ProjectView.tsx

## Validation
- Manually verified the create-new-conversation -> switch-to-older-conversation flow described in #2930.
- Existing CI on the PR is passing.
