### PR TITLE
fix: keep raw HTML source out of artifact chat prose

### DIFF
--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -859,6 +859,9 @@ function renderMetadataBlock(
     lines.push(
       '- **interaction-fidelity rule**: when the requested screen includes user input, generation, copying, validation, login, checkout, filtering, or any action verb, build real interactive controls for that screen. Do not substitute static text rows, prefilled-only mockups, screenshot-like device frames, or decorative state cards for editable inputs and working actions.',
     );
+    lines.push(
+      '- **artifact-output rule**: when you generate an HTML artifact, keep conversational prose concise and product-facing. Do not dump the full raw HTML source back into chat; the artifact/file is the source of truth and the assistant message should only summarize the result.',
+    );
   }
   if (metadata.includeLandingPage) {
     lines.push(

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -248,6 +248,15 @@ describe('composeSystemPrompt', () => {
     expect(prompt).not.toContain('**platformTargets**');
   });
 
+  it('tells artifact generation to summarize instead of dumping raw HTML source into chat', () => {
+    const prompt = composeSystemPrompt({
+      metadata: { kind: 'prototype', fidelity: 'production' } as any,
+    });
+
+    expect(prompt).toContain('Do not dump the full raw HTML source back into chat');
+    expect(prompt).toContain('the assistant message should only summarize the result');
+  });
+
   it('uses the primary skill surface when composed skill modes conflict', () => {
     const prompt = composeSystemPrompt({
       skillMode: 'image',


### PR DESCRIPTION
Fixes #2913

## Why

HTML artifact generation could leak the full raw HTML source back into the chat response. That made the conversation noisy and exposed implementation detail that belongs in the generated artifact/file instead of the assistant prose.

## What users will see

When an HTML artifact is generated, the assistant should give a concise product-facing summary in chat instead of dumping the raw HTML source. The artifact remains the source of truth for the actual implementation.

## Surface area

- `apps/daemon` prompt behavior
- Adds an `artifact-output rule` beside the existing prototype/template prompt rules in `renderMetadataBlock`.
- Adds prompt coverage in `apps/daemon/tests/prompts/system.test.ts` so the guidance cannot drift silently.

## Validation

- Added a daemon prompt unit test that verifies the composed system prompt includes both: `Do not dump the full raw HTML source back into chat` and `the assistant message should only summarize the result`.
- GitHub CI is green for the PR, including daemon workspace tests and workspace validation.
