### PR TITLE
fix(web): warn BYOK users that API mode has no file-edit tools

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2914,6 +2914,13 @@ export function SettingsDialog({
                   <h3>{API_PROTOCOL_LABELS[apiProtocol]}</h3>
                 </div>
               </div>
+              <p
+                className="settings-test-status warn settings-byok-no-file-tools-notice"
+                role="note"
+                data-testid="settings-byok-no-file-tools-notice"
+              >
+                {t('settings.byokNoFileToolsNotice')}
+              </p>
               {byokPreconditionNotice ? (
                 <p
                   className="settings-test-status error"

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -164,6 +164,8 @@ export const en: Dict = {
   'settings.modeDaemonInstalledMeta': '{count} installed',
   'settings.modeApi': 'API provider',
   'settings.modeApiMeta': 'BYOK',
+  'settings.byokNoFileToolsNotice':
+    "BYOK mode talks to the model directly and can't read, write, or edit files in your project — the agent will reply with text or HTML instead of applying changes. Switch to Local CLI mode (Claude Code, Codex, …) if you want the agent to edit project files.",
   'settings.codeAgent': 'Code agent',
   'settings.codeAgentHint': 'Pick the CLI that runs your prompts.',
   'settings.rescan': '↻ Rescan',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -164,6 +164,8 @@ export const zhCN: Dict = {
   'settings.modeDaemonInstalledMeta': '已安装 {count} 个',
   'settings.modeApi': 'API 提供方',
   'settings.modeApiMeta': 'BYOK',
+  'settings.byokNoFileToolsNotice':
+    'BYOK 模式直接与模型对话，无法读取、写入或修改项目中的文件——代理只会以文本或 HTML 回复，不会真正落盘修改。如果需要让代理修改项目文件，请切换到本机 CLI 模式（Claude Code、Codex 等）。',
   'settings.codeAgent': '代码代理',
   'settings.codeAgentHint': '选择用来运行提示词的 CLI。',
   'settings.rescan': '↻ 重新扫描',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -193,6 +193,7 @@ export interface Dict {
   'settings.modeDaemonInstalledMeta': string;
   'settings.modeApi': string;
   'settings.modeApiMeta': string;
+  'settings.byokNoFileToolsNotice': string;
   'settings.codeAgent': string;
   'settings.codeAgentHint': string;
   'settings.rescan': string;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -389,6 +389,33 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     ).toBe('https://platform.openai.com/api-keys');
   });
 
+  it('warns BYOK users that API mode cannot edit project files (issue #1106)', () => {
+    // Regression cover: switching from Local CLI to BYOK previously gave no
+    // signal that file-editing tools (`Read`/`Write`/`Edit`) are absent on the
+    // API path. Users typed "continue adjusting the design" expecting edits
+    // and got an HTML monologue back. The notice must be visible on every
+    // BYOK protocol tab so the missing tool surface is discoverable before
+    // the user wastes a turn.
+    renderSettingsDialog();
+
+    const notice = screen.getByTestId('settings-byok-no-file-tools-notice');
+    expect(notice.textContent).toContain('BYOK mode');
+    expect(notice.textContent).toContain("can't read, write, or edit files");
+    expect(notice.textContent).toContain('Local CLI mode');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+    expect(screen.getByTestId('settings-byok-no-file-tools-notice')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Google Gemini' }));
+    expect(screen.getByTestId('settings-byok-no-file-tools-notice')).toBeTruthy();
+  });
+
+  it('hides the BYOK no-file-tools notice when Local CLI mode is selected', () => {
+    renderSettingsDialog({ mode: 'daemon' });
+
+    expect(screen.queryByTestId('settings-byok-no-file-tools-notice')).toBeNull();
+  });
+
   it('lets Anthropic and Google users customize the default base URL', () => {
     renderSettingsDialog();
 


### PR DESCRIPTION
Fixes #1106

## Why

- **Use case** — Triaging issue #1106 from @qwertyaya: a user who hit their Claude Code quota switched the agent surface from **Local CLI** to **BYOK** with their own Anthropic API key, then asked the agent to keep adjusting a design. The model "replied" with HTML/CSS in the chat instead of editing any files. The user assumed it was broken, not a missing surface.
- **Pain** — The BYOK chat proxy is a thin pass-through; it does not wire up the agent runtime that exposes `Read` / `Write` / `Edit` to the model. So when a BYOK-routed model "decides" to edit a file, the daemon has nothing to dispatch — the call just becomes more streamed text. As @lefarcen noted in the issue thread, the architectural gap tracked by #313 / #699 / #719 is real, but a full BYOK tool loop is out of scope for a P1 fix. The minimum acceptable bar is a UI warning so users don't waste turns wondering why nothing on disk changed.

## What users will see

When BYOK / API provider mode is selected in **Settings → Execution**, a soft-warning notice now appears at the top of the BYOK panel (right under the protocol heading, above any precondition error). The notice reads:

> BYOK mode talks to the model directly and can't read, write, or edit files in your project — the agent will reply with text or HTML instead of applying changes. Switch to Local CLI mode (Claude Code, Codex, …) if you want the agent to edit project files.

The notice persists across all BYOK protocol tabs (Anthropic / OpenAI / Azure / Google / Ollama / SenseAudio) and disappears the moment users switch back to Local CLI mode.

## Surface area

- [x] **UI** — new informational notice in the BYOK panel of `Settings → Execution` (`apps/web`)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [x] **i18n keys** — `settings.byokNoFileToolsNotice` (English + explicit zh-CN translation; other locales inherit through the existing `...en` spread)
- [ ] **New top-level dependency**
- [ ] **Default behavior change**

## Screenshots

The notice uses the existing `.settings-test-status.warn` styling (amber border / background / text), placed at the top of the BYOK panel between the protocol heading and the precondition notice slot. Visual changes are verified by the new render tests below; manual smoke covered Anthropic, OpenAI, and Google Gemini tabs.

## Bug fix verification

This is a UX / discoverability bug rather than a logic bug — the architectural gap (no BYOK tool loop) was already known. The added regression coverage locks in the new notice instead of a runtime invariant:

- Test path: `apps/web/tests/components/SettingsDialog.execution.test.tsx`
  - `warns BYOK users that API mode cannot edit project files (issue #1106)` — checks the notice is rendered for Anthropic, OpenAI, and Google Gemini tabs
  - `hides the BYOK no-file-tools notice when Local CLI mode is selected` — confirms the notice is gated on `mode === 'api'`
- Both tests fail on `main` (notice does not exist) and pass on this branch.

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm typecheck` (full workspace)
- `pnpm --filter @open-design/web exec vitest run tests/components/SettingsDialog.execution.test.tsx -t "BYOK"` — 24 tests pass, including the two new ones for the notice
- `pnpm --filter @open-design/web test -- --run tests/i18n/locales.test.ts` — i18n tier-1 parity locks remain green (zh-CN declares the new key explicitly)

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>