### PR TITLE
fix(web): constrain connector drawer in settings

### DIFF
--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -348,6 +348,44 @@
   }
 }
 
+
+/* Keep the connector details drawer inside the embedded connectors panel.
+   The shared drawer remains full-viewport elsewhere, but embedded usage
+   needs an in-panel overlay so it does not stack above the settings modal. */
+.connectors-panel-embedded:has(.connector-drawer-backdrop) {
+  min-height: clamp(500px, 62vh, 700px);
+  overflow: hidden;
+  border-radius: var(--radius);
+}
+.connectors-panel-embedded .connector-drawer-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 6;
+  align-items: stretch;
+  padding: 12px;
+  background: color-mix(in srgb, var(--bg) 24%, transparent);
+  border-radius: inherit;
+}
+.connectors-panel-embedded .connector-drawer {
+  width: min(440px, 58%);
+  height: 100%;
+  max-height: none;
+  border-radius: var(--radius);
+  box-shadow: 0 20px 48px -28px rgba(15, 23, 42, 0.55);
+}
+@media (max-width: 720px) {
+  .connectors-panel-embedded:has(.connector-drawer-backdrop) {
+    min-height: clamp(520px, 70vh, 640px);
+  }
+  .connectors-panel-embedded .connector-drawer-backdrop {
+    padding: 0;
+  }
+  .connectors-panel-embedded .connector-drawer {
+    width: 100%;
+    border-radius: var(--radius);
+  }
+}
+
 /* Recent / Your designs segmented pill */
 .subtab-pill {
   display: inline-flex;


### PR DESCRIPTION
Fixes #2735

## Summary
- Keep the connector detail drawer constrained to the embedded connectors panel instead of using the shared full-viewport overlay inside Settings.
- Preserve the full-viewport drawer behavior for non-embedded connector surfaces.
- Add a responsive embedded-panel override so narrow Settings layouts still use the full panel width.

## Validation
- `git diff --check` passed.
- Local `tools-dev` web runtime started for namespace `od2735`; `curl -I http://127.0.0.1:17583/` returned `HTTP/1.1 200 OK`.
- Subagent review found no blocking issues with the scoped drawer CSS.

## Notes
- `pnpm --filter @open-design/web typecheck` was attempted in a recreated worktree using symlinked dependencies from another local worktree, but failed on pre-existing workspace contract/type mismatches unrelated to this CSS-only change (analytics/contracts, design-system fixtures, host/testing imports).
- Browser screenshot capture was attempted, but the local Playwright CLI is missing its Chromium browser binary and `playwright install` would require network access.
