### PR TITLE
fix(web): keep Vercel static builds writing to out

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -79,7 +79,9 @@ function resolveDistDir(defaultValue: string) {
   return toPosixPath(isAbsolute(configured) ? relative(WEB_ROOT, configured) || '.' : configured);
 }
 
-const DIST_DIR = shouldStaticExport ? null : resolveDistDir('.next');
+const DIST_DIR = shouldStaticExport && process.env.OD_WEB_DIST_DIR == null
+  ? null
+  : resolveDistDir('.next');
 
 function resolveDevTsconfigPath() {
   const configured = process.env.OD_WEB_TSCONFIG_PATH;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -79,7 +79,7 @@ function resolveDistDir(defaultValue: string) {
   return toPosixPath(isAbsolute(configured) ? relative(WEB_ROOT, configured) || '.' : configured);
 }
 
-const DIST_DIR = resolveDistDir(isProd ? (shouldStaticExport ? 'out' : '.next') : '.next');
+const DIST_DIR = shouldStaticExport ? null : resolveDistDir('.next');
 
 function resolveDevTsconfigPath() {
   const configured = process.env.OD_WEB_TSCONFIG_PATH;
@@ -166,9 +166,10 @@ const nextConfig: NextConfig = {
     root: WORKSPACE_ROOT,
   },
   ...(DEV_TSCONFIG_PATH ? { typescript: { tsconfigPath: DEV_TSCONFIG_PATH } } : {}),
-  // Keep the bundle output predictable so the daemon's STATIC_DIR can point
-  // at it without any glob trickery.
-  distDir: DIST_DIR,
+  // Static exports keep Next.js's default `out/` output directory so static
+  // hosts like Vercel can publish the generated site directly. Server runtimes
+  // still keep a predictable traced build directory for sidecar launchers.
+  ...(DIST_DIR ? { distDir: DIST_DIR } : {}),
   ...(shouldStaticExport
     ? {
         output: 'export' as const,

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -79,7 +79,7 @@ function resolveDistDir(defaultValue: string) {
   return toPosixPath(isAbsolute(configured) ? relative(WEB_ROOT, configured) || '.' : configured);
 }
 
-const DIST_DIR = shouldStaticExport && process.env.OD_WEB_DIST_DIR == null
+const DIST_DIR = shouldStaticExport && !process.env.OD_WEB_DIST_DIR
   ? null
   : resolveDistDir('.next');
 

--- a/apps/web/tests/runtime/app-route-export.test.ts
+++ b/apps/web/tests/runtime/app-route-export.test.ts
@@ -1,12 +1,36 @@
-import { describe, expect, it } from 'vitest';
-import nextConfig from '../../next.config';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as spaShellRoute from '../../app/[[...slug]]/page';
 
+const WEB_ROOT = dirname(fileURLToPath(new URL('../../..', import.meta.url)));
+
+async function loadNextConfig() {
+  vi.resetModules();
+  return (await import('../../next.config')).default;
+}
+
+afterEach(() => {
+  delete process.env.OD_WEB_DIST_DIR;
+  vi.resetModules();
+});
+
 describe('SPA shell export route', () => {
-  it('stays compatible with static export builds', () => {
+  it('stays compatible with static export builds', async () => {
+    const nextConfig = await loadNextConfig();
     expect(nextConfig.output).toBe('export');
     expect(nextConfig.distDir).toBeUndefined();
     expect('dynamicParams' in spaShellRoute).toBe(false);
     expect(spaShellRoute.generateStaticParams()).toEqual([{ slug: [] }]);
+  });
+
+  it('keeps an explicit dist dir override even when static export is selected', async () => {
+    const configuredDistDir = resolve(WEB_ROOT, '.tmp', 'vitest-next');
+    process.env.OD_WEB_DIST_DIR = configuredDistDir;
+
+    const nextConfig = await loadNextConfig();
+
+    expect(nextConfig.output).toBe('export');
+    expect(nextConfig.distDir).toContain('vitest-next');
   });
 });

--- a/apps/web/tests/runtime/app-route-export.test.ts
+++ b/apps/web/tests/runtime/app-route-export.test.ts
@@ -5,6 +5,7 @@ import * as spaShellRoute from '../../app/[[...slug]]/page';
 describe('SPA shell export route', () => {
   it('stays compatible with static export builds', () => {
     expect(nextConfig.output).toBe('export');
+    expect(nextConfig.distDir).toBeUndefined();
     expect('dynamicParams' in spaShellRoute).toBe(false);
     expect(spaShellRoute.generateStaticParams()).toEqual([{ slug: [] }]);
   });

--- a/apps/web/tests/runtime/app-route-export.test.ts
+++ b/apps/web/tests/runtime/app-route-export.test.ts
@@ -33,4 +33,13 @@ describe('SPA shell export route', () => {
     expect(nextConfig.output).toBe('export');
     expect(nextConfig.distDir).toContain('vitest-next');
   });
+
+  it('treats an empty dist dir override as unset for static export builds', async () => {
+    process.env.OD_WEB_DIST_DIR = '';
+
+    const nextConfig = await loadNextConfig();
+
+    expect(nextConfig.output).toBe('export');
+    expect(nextConfig.distDir).toBeUndefined();
+  });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "pnpm install && pnpm --filter @open-design/web build",
+  "buildCommand": "OD_WEB_OUTPUT_MODE= pnpm --filter @open-design/web build",
   "installCommand": "pnpm install",
   "outputDirectory": "apps/web/out",
   "framework": null


### PR DESCRIPTION
Closes #1628

## Why

The Vercel deployment path is supposed to publish the static `apps/web/out/` export, but it could still inherit `OD_WEB_OUTPUT_MODE` from the surrounding environment and switch the build into a server runtime that never writes that directory. This left Vercel with a successful build step and no deployable `out/` artifact.

## What users will see

Vercel deployments for the web app complete again instead of failing after the build with `No Output Directory named "out" found after the Build completed.`

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots


## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/runtime/app-route-export.test.ts`
- Did the test go red on `main` and green on this branch? no
- A red spec was not cheap to write because `main` already passes a plain local `next build`; the failure depends on Vercel inheriting a server-oriented `OD_WEB_OUTPUT_MODE`. Verification instead ran the Vercel-style build command with `OD_WEB_OUTPUT_MODE=server` pre-set and confirmed the branch clears that override and produces `apps/web/out/`.

## Validation

- `pnpm --filter @open-design/web test -- tests/runtime/app-route-export.test.ts`
- `rm -rf "apps/web/out" "apps/web/.next" && OD_WEB_OUTPUT_MODE=server sh -c 'OD_WEB_OUTPUT_MODE= pnpm --filter @open-design/web build && test -d apps/web/out'`\n- `pnpm guard`\n- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>