### PR TITLE
fix: strip all artifact blocks to prevent HTML leak in chat

### DIFF
--- a/apps/web/src/artifacts/strip.ts
+++ b/apps/web/src/artifacts/strip.ts
@@ -33,7 +33,7 @@ function findRealOpen(content: string, fromIndex: number, ranges: ReadonlyArray<
 }
 
 /**
- * Remove the first real `<artifact …>…</artifact>` block from `content`.
+ * Remove all real `<artifact …>…</artifact>` blocks from `content`.
  *
  * "Real" excludes any `<artifact` substring that the chat Markdown renderer
  * would render as inline code or part of a fenced code block — those are
@@ -44,22 +44,37 @@ function findRealOpen(content: string, fromIndex: number, ranges: ReadonlyArray<
  * open exists but no matching real close is found, the content is also
  * returned unchanged (refusing to strip is safer than truncating to
  * end-of-string when a tag is malformed or still streaming).
+ *
+ * Strips all artifact blocks iteratively to prevent raw HTML source from
+ * leaking into the conversation when multiple artifacts are present.
  */
 export function stripArtifact(content: string): string {
-  const { ranges: baseRanges, unclosedFenceStart } = computeSkipRanges(content);
-  // For complete (non-streaming) content, an unclosed fence is rendered by
-  // the chat Markdown renderer as a code block extending to end of input
-  // (see runtime/markdown.tsx:49 — the close-loop runs until lines exhaust).
-  // The stripper has to mirror that, otherwise a literal `<artifact …>`
-  // tucked into a code example at the bottom of a chat reply (no trailing
-  // newline) gets treated as a real protocol tag and eaten.
-  const ranges: Range[] =
-    unclosedFenceStart !== null ? [...baseRanges, [unclosedFenceStart, content.length]] : baseRanges;
-  const open = findRealOpen(content, 0, ranges);
-  if (open === -1) return content;
-  const closeTag = content.indexOf('>', open);
-  if (closeTag === -1) return content;
-  const end = findUnskipped(content, CLOSE, closeTag, ranges);
-  if (end === -1) return content;
-  return (content.slice(0, open) + content.slice(end + CLOSE.length)).trim();
+  let result = content;
+  let iteration = 0;
+  const maxIterations = 100; // Safety limit to prevent infinite loops
+  
+  while (iteration < maxIterations) {
+    // Recompute skip ranges for the current result string
+    const { ranges: baseRanges, unclosedFenceStart } = computeSkipRanges(result);
+    // For complete (non-streaming) content, an unclosed fence is rendered by
+    // the chat Markdown renderer as a code block extending to end of input
+    // (see runtime/markdown.tsx:49 — the close-loop runs until lines exhaust).
+    // The stripper has to mirror that, otherwise a literal `<artifact …>`
+    // tucked into a code example at the bottom of a chat reply (no trailing
+    // newline) gets treated as a real protocol tag and eaten.
+    const ranges: Range[] =
+      unclosedFenceStart !== null ? [...baseRanges, [unclosedFenceStart, result.length]] : baseRanges;
+    
+    const open = findRealOpen(result, 0, ranges);
+    if (open === -1) break;
+    const closeTag = result.indexOf('>', open);
+    if (closeTag === -1) break;
+    const end = findUnskipped(result, CLOSE, closeTag, ranges);
+    if (end === -1) break;
+    
+    result = (result.slice(0, open) + result.slice(end + CLOSE.length)).trim();
+    iteration++;
+  }
+  
+  return result;
 }

--- a/apps/web/tests/artifacts/strip.test.ts
+++ b/apps/web/tests/artifacts/strip.test.ts
@@ -128,4 +128,52 @@ describe('stripArtifact', () => {
     ].join('\n');
     expect(stripArtifact(input)).toBe(input);
   });
+
+  it('strips multiple artifact blocks from the same message', () => {
+    // When a message contains multiple artifacts, all should be stripped
+    // to prevent raw HTML source from leaking into the conversation.
+    const input = [
+      'Here is the first artifact:',
+      '<artifact identifier="a" type="text/html" title="A">',
+      '<h1>First</h1>',
+      '</artifact>',
+      'And here is the second:',
+      '<artifact identifier="b" type="text/html" title="B">',
+      '<h1>Second</h1>',
+      '</artifact>',
+      'Done.',
+    ].join('\n');
+    const out = stripArtifact(input);
+    expect(out).not.toContain('<artifact');
+    expect(out).not.toContain('</artifact>');
+    expect(out).not.toContain('<h1>First</h1>');
+    expect(out).not.toContain('<h1>Second</h1>');
+    expect(out).toContain('Here is the first artifact:');
+    expect(out).toContain('And here is the second:');
+    expect(out).toContain('Done.');
+  });
+
+  it('strips multiple artifacts while preserving fenced code blocks', () => {
+    // Multiple artifacts with fenced code blocks between them
+    const input = [
+      '<artifact identifier="a" type="text/html" title="A">',
+      '<h1>First</h1>',
+      '</artifact>',
+      'Example code:',
+      '```html',
+      '<artifact identifier="example">This is just an example</artifact>',
+      '```',
+      '<artifact identifier="b" type="text/html" title="B">',
+      '<h1>Second</h1>',
+      '</artifact>',
+    ].join('\n');
+    const out = stripArtifact(input);
+    // Real artifacts should be stripped
+    expect(out).not.toContain('<h1>First</h1>');
+    expect(out).not.toContain('<h1>Second</h1>');
+    // But the example in the code block should remain
+    expect(out).toContain('```html');
+    expect(out).toContain('<artifact identifier="example">This is just an example</artifact>');
+    expect(out).toContain('Example code:');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2913 

This PR modifies the  function to iteratively remove **all** artifact blocks from chat messages, preventing raw HTML source from leaking into the conversation when multiple artifacts are present.

## Changes

- **Modified  logic**: Changed from single-pass to iterative removal
- **Added safety limit**: 100 iterations max to prevent infinite loops
- **Updated documentation**: Function comments now reflect multi-artifact handling
- **Added regression tests**: 
  - Multiple artifacts in same message
  - Multiple artifacts with fenced code blocks between them

## Testing

All existing tests pass, plus 2 new regression tests:
- ✅ Strips multiple artifact blocks from the same message
- ✅ Strips multiple artifacts while preserving fenced code blocks

```bash
pnpm --filter @open-design/web test strip.test.ts
# Test Files  2 passed (2)
# Tests  16 passed (16)
```

## Implementation Notes

The fix recomputes skip ranges on each iteration to correctly handle multiple artifacts. This ensures that after removing one artifact block, the function continues searching for additional blocks in the updated string.