### PR TITLE
fix(design-systems): align mission control status tokens

### DIFF
--- a/design-systems/mission-control/components.html
+++ b/design-systems/mission-control/components.html
@@ -20,9 +20,9 @@
         --accent-on: #06101d;
         --accent-hover: color-mix(in oklab, var(--accent), black 8%);
         --accent-active: color-mix(in oklab, var(--accent), black 14%);
-        --success: #22c55e;
-        --warn: #fbbf24;
-        --danger: #fb7185;
+        --success: #26DE81;
+        --warn: #FF9F43;
+        --danger: #FF4757;
         --font-display: Inter, system-ui, sans-serif;
         --font-body: Inter, system-ui, sans-serif;
         --font-mono: "SF Mono", ui-monospace, Menlo, monospace;

--- a/design-systems/mission-control/tokens.css
+++ b/design-systems/mission-control/tokens.css
@@ -17,9 +17,9 @@
   --accent-on: #06101d;
   --accent-hover: color-mix(in oklab, var(--accent), black 8%);
   --accent-active: color-mix(in oklab, var(--accent), black 14%);
-  --success: #22c55e;
-  --warn: #fbbf24;
-  --danger: #fb7185;
+  --success: #26DE81;
+  --warn: #FF9F43;
+  --danger: #FF4757;
   --font-display: Inter, system-ui, sans-serif;
   --font-body: Inter, system-ui, sans-serif;
   --font-mono: "SF Mono", ui-monospace, Menlo, monospace;


### PR DESCRIPTION
Fixes #2961

## Summary
- align Mission Control `tokens.css` status colors with the canonical `DESIGN.md` telemetry palette
- update `components.html` to keep the fixture root tokens in sync with `tokens.css`

## Surface area
- [ ] User-facing behavior
- [ ] API or schema
- [ ] Build, CI, or tooling
- [ ] Documentation
- [x] None - internal design-token/fixture alignment only

## Bug-fix verification
Before this fix, Mission Control status tokens were partially out of sync with `design-systems/mission-control/DESIGN.md`: `--success`, `--warn`, and `--danger` did not all match the canonical telemetry palette. After the update, both `tokens.css` and the `components.html` fixture root use the DESIGN.md values for all three status tokens: `#26DE81`, `#FF9F43`, and `#FF4757`.

## Validation
- `pnpm guard`
- `git diff --check`