### PR TITLE
Align preview note Enter action with selected submit action

### DIFF
--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -369,7 +369,8 @@ export function PreviewDrawOverlay({
   const overlayPointer = mode === 'draw' ? 'auto' : 'none';
   const showCanvas = active || mode === 'draw' || hasInk;
   const canSubmit = hasInk || Boolean(captureTarget) || Boolean(note.trim());
-  const canSend = canSubmit;
+  const canSend = canSubmit && !sendDisabled;
+  const submitAction: 'queue' | 'send' = canSend ? 'send' : 'queue';
 
   return (
     <div
@@ -460,14 +461,19 @@ export function PreviewDrawOverlay({
               fontSize: 13,
               transition: 'background 120ms ease, border-color 120ms ease, box-shadow 120ms ease',
             }}
-            onKeyDown={(e) => { if (e.key === 'Enter') void send('queue'); }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                void send(submitAction);
+              }
+            }}
           />
           <button
             type="button"
             onClick={() => void send('queue')}
             disabled={sending || !canSubmit}
             style={{
-              ...ghostStyle,
+              ...(submitAction === 'queue' ? pillStyle(true) : ghostStyle),
               opacity: canSubmit ? 1 : 0.4,
               cursor: sending ? 'wait' : (canSubmit ? 'pointer' : 'not-allowed'),
             }}
@@ -487,7 +493,7 @@ export function PreviewDrawOverlay({
             disabled={sending || !canSend}
             title={sendDisabled ? sendDisabledReason : undefined}
             style={{
-              ...pillStyle(true),
+              ...pillStyle(submitAction === 'send'),
               opacity: canSend ? 1 : 0.4,
               cursor: sending ? 'wait' : (canSend ? 'pointer' : 'not-allowed'),
             }}

--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -369,7 +369,7 @@ export function PreviewDrawOverlay({
   const overlayPointer = mode === 'draw' ? 'auto' : 'none';
   const showCanvas = active || mode === 'draw' || hasInk;
   const canSubmit = hasInk || Boolean(captureTarget) || Boolean(note.trim());
-  const canSend = canSubmit && !sendDisabled;
+  const canSend = canSubmit;
   const submitAction: 'queue' | 'send' = canSend ? 'send' : 'queue';
 
   return (

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1564,6 +1564,37 @@ describe('FileViewer tweaks toolbar', () => {
     window.removeEventListener(ANNOTATION_EVENT, annotationSpy);
   });
 
+  it('lets Draw Enter use the selected Send action while a task is running', async () => {
+    const annotationSpy = vi.fn();
+    window.addEventListener(ANNOTATION_EVENT, annotationSpy);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+        streaming
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('draw-overlay-toggle'));
+    const note = screen.getByPlaceholderText('Type anywhere to add a note');
+    fireEvent.change(note, { target: { value: 'mark this with enter' } });
+
+    const send = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
+    expect(send.disabled).toBe(false);
+
+    fireEvent.keyDown(note, { key: 'Enter' });
+
+    await waitFor(() => expect(annotationSpy).toHaveBeenCalledTimes(1));
+    expect(annotationSpy.mock.calls[0]?.[0]).toMatchObject({
+      detail: {
+        action: 'send',
+        note: 'mark this with enter',
+        filePath: 'preview.html',
+      },
+    });
+    window.removeEventListener(ANNOTATION_EVENT, annotationSpy);
+  });
+
   it('hides non-open saved comments from preview markers when the side panel is empty', () => {
     const resolvedComment: PreviewComment = {
       id: 'comment-applying',


### PR DESCRIPTION
## Summary

- Make the preview draw note input submit via the currently selected action when Enter is pressed
- Keep the highlighted action button in sync with the action Enter will trigger
- Preserve the deferred Send path while a run is already streaming
- Add regression coverage for pressing Enter in the Draw note input during streaming

Fixes #2968.

## Surface area

This touches the preview note keyboard/UI interaction in `PreviewDrawOverlay`, plus FileViewer component coverage for the Draw overlay annotation flow.

## Bug fix verification

Before: the Draw note input could show Send as the primary visible action while Enter still dispatched `queue`.

After: Enter dispatches the selected Send action when the note can be submitted, including while streaming so ChatComposer can stage the annotation for deferred send.

## Testing

- `git diff --check`
- Added: `lets Draw Enter use the selected Send action while a task is running`
- Not run locally: full Vitest/typecheck suite because this local environment does not currently have an accessible Node/pnpm toolchain for the repository's Node 24 + pnpm 10 setup.