### PR TITLE
fix(web): align draw note enter action

### DIFF
--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState, type CSSProperties, type Poin
 import { Icon } from './Icon';
 import type { PreviewVisualMarkKind } from '../types';
 import { requestPreviewSnapshot } from '../runtime/exports';
+import { isImeComposing } from '../utils/imeComposing';
 
 export type PreviewDrawMode = 'click' | 'draw';
 
@@ -62,6 +63,7 @@ export function PreviewDrawOverlay({
   const [note, setNote] = useState('');
   const strokesRef = useRef<Stroke[]>([]);
   const drawingRef = useRef<Stroke | null>(null);
+  const composingRef = useRef(false);
   const [hasInk, setHasInk] = useState(false);
   const [pendingAction, setPendingAction] = useState<'queue' | 'send' | null>(null);
   const sending = pendingAction !== null;
@@ -460,7 +462,16 @@ export function PreviewDrawOverlay({
               fontSize: 13,
               transition: 'background 120ms ease, border-color 120ms ease, box-shadow 120ms ease',
             }}
-            onKeyDown={(e) => { if (e.key === 'Enter') void send('queue'); }}
+            onCompositionStart={() => {
+              composingRef.current = true;
+            }}
+            onCompositionEnd={() => {
+              composingRef.current = false;
+            }}
+            onKeyDown={(e) => {
+              if (isImeComposing(e, composingRef.current)) return;
+              if (e.key === 'Enter') void send('send');
+            }}
           />
           <button
             type="button"

--- a/apps/web/src/utils/imeComposing.ts
+++ b/apps/web/src/utils/imeComposing.ts
@@ -2,7 +2,7 @@ import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
 /** True while an IME composition is active or this key is part of confirming it. */
 export function isImeComposing(
-  event: ReactKeyboardEvent<HTMLTextAreaElement>,
+  event: ReactKeyboardEvent<HTMLInputElement | HTMLTextAreaElement>,
   composing: boolean,
 ): boolean {
   const nativeEvent = event.nativeEvent as KeyboardEvent & { keyCode?: number };

--- a/apps/web/tests/components/PreviewDrawOverlay.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.test.tsx
@@ -6,6 +6,57 @@ import { describe, expect, it, vi } from 'vitest';
 import { PreviewDrawOverlay } from '../../src/components/PreviewDrawOverlay';
 
 describe('PreviewDrawOverlay', () => {
+  it('uses the visible primary send action when Enter submits a note', async () => {
+    const annotation = vi.fn();
+    window.addEventListener('opendesign:annotation', annotation);
+
+    try {
+      const { container } = render(
+        <PreviewDrawOverlay active>
+          <div style={{ width: 320, height: 200 }} />
+        </PreviewDrawOverlay>,
+      );
+
+      const input = container.querySelector<HTMLInputElement>('.preview-draw-note-input');
+      expect(input).toBeTruthy();
+
+      fireEvent.change(input!, { target: { value: 'Please inspect this panel.' } });
+      fireEvent.keyDown(input!, { key: 'Enter' });
+
+      await waitFor(() => expect(annotation).toHaveBeenCalledTimes(1));
+      expect(annotation.mock.calls[0]?.[0].detail).toMatchObject({
+        action: 'send',
+        note: 'Please inspect this panel.',
+      });
+    } finally {
+      window.removeEventListener('opendesign:annotation', annotation);
+    }
+  });
+
+  it('does not submit a note when Enter confirms IME composition', () => {
+    const annotation = vi.fn();
+    window.addEventListener('opendesign:annotation', annotation);
+
+    try {
+      const { container } = render(
+        <PreviewDrawOverlay active>
+          <div style={{ width: 320, height: 200 }} />
+        </PreviewDrawOverlay>,
+      );
+
+      const input = container.querySelector<HTMLInputElement>('.preview-draw-note-input');
+      expect(input).toBeTruthy();
+
+      fireEvent.change(input!, { target: { value: '检查这个面板' } });
+      fireEvent.compositionStart(input!);
+      fireEvent.keyDown(input!, { key: 'Enter', keyCode: 229 });
+
+      expect(annotation).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('opendesign:annotation', annotation);
+    }
+  });
+
   it('clears transient ink when draw mode exits', async () => {
     const { container, rerender } = render(
       <PreviewDrawOverlay active>


### PR DESCRIPTION
Fixes #2968.

## Summary
- make the draw overlay note input submit with the visible primary Send action on Enter
- preserve IME composition Enter handling for CJK input
- add focused regressions for Enter-to-send and IME confirmation

## Validation
- pnpm --dir apps/web test -- PreviewDrawOverlay.test.tsx
- pnpm --dir apps/web typecheck
- pnpm guard
- git diff --check