### PR TITLE
fix(web): fallback broken community card media

### DIFF
--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -6,7 +6,7 @@
 // home view. Until then the poster image is the only thing the
 // browser fetches — keeps a 50-tile gallery cheap.
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { MediaPreviewSpec } from '../preview';
 import { Icon } from '../../Icon';
 
@@ -18,9 +18,16 @@ interface Props {
 
 export function MediaSurface({ preview, pluginTitle, inView }: Props) {
   const [hovering, setHovering] = useState(false);
+  const [posterFailed, setPosterFailed] = useState(false);
   const showVideo =
     inView && hovering && preview.mediaType === 'video' && Boolean(preview.videoUrl);
-  const hasPoster = Boolean(preview.poster);
+  const poster = preview.poster;
+  const hasPoster = Boolean(poster);
+  const showFallback = !hasPoster || posterFailed;
+
+  useEffect(() => {
+    setPosterFailed(false);
+  }, [poster]);
 
   return (
     <div
@@ -28,16 +35,17 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}
     >
-      {inView && preview.poster ? (
+      {inView && poster && !posterFailed ? (
         <img
           className="plugins-home__media-img"
-          src={preview.poster}
+          src={poster}
           alt={`${pluginTitle} preview`}
           loading="lazy"
           decoding="async"
           referrerPolicy="no-referrer"
+          onError={() => setPosterFailed(true)}
         />
-      ) : !hasPoster ? (
+      ) : showFallback ? (
         <MediaFallback pluginTitle={pluginTitle} mediaType={preview.mediaType} />
       ) : (
         <div

--- a/apps/web/tests/components/plugins-home-section.test.tsx
+++ b/apps/web/tests/components/plugins-home-section.test.tsx
@@ -27,6 +27,13 @@ function makePlugin(overrides: {
   featured?: boolean;
   mode?: string;
   kind?: 'scenario' | 'atom';
+  preview?: {
+    type?: string;
+    poster?: string;
+    video?: string;
+    gif?: string;
+    audio?: string;
+  };
 }): InstalledPluginRecord {
   return {
     id: overrides.id,
@@ -48,6 +55,7 @@ function makePlugin(overrides: {
         kind: overrides.kind ?? 'scenario',
         ...(overrides.mode ? { mode: overrides.mode } : {}),
         ...(overrides.featured ? { featured: true } : {}),
+        ...(overrides.preview ? { preview: overrides.preview } : {}),
       },
     },
     fsPath: '/tmp',
@@ -240,6 +248,27 @@ describe('PluginsHomeSection (category bar)', () => {
 
     fireEvent.click(screen.getByTestId('plugins-home-save-localized-deck'));
     expect(screen.getByRole('status').textContent).toContain('Saved 瑞士国际主义 Deck.');
+  });
+
+  it('falls back when a community card poster image fails to load', async () => {
+    const { container } = renderSection([
+      makePlugin({
+        id: 'official-image-template',
+        title: 'Official Image Template',
+        mode: 'image',
+        preview: {
+          type: 'image',
+          poster: 'https://example.invalid/missing-preview.png',
+        },
+      }),
+    ], { preferDefaultFacet: false });
+
+    const img = await screen.findByRole('img', { name: 'Official Image Template preview' });
+    fireEvent.error(img);
+
+    expect(container.querySelector('.plugins-home__media-img')).toBeNull();
+    expect(container.querySelector('.plugins-home__media-fallback')).toBeTruthy();
+    expect(container.querySelector('.plugins-home__media-fallback-glyph')?.textContent).toBe('O');
   });
 
   it('shows the normal empty-filter state for planned empty buckets', () => {


### PR DESCRIPTION
Fixes #2955.

## Summary
- render the existing media fallback when a community card poster image fails to load
- reset the failed-poster state when the card receives a new poster URL
- add a regression for the broken-poster fallback path

## Surface area
- [x] User-facing behavior
- [ ] API or schema
- [ ] Build, CI, or tooling
- [ ] Documentation
- [ ] None

## Bug fix verification
Before this fix, a Community card with an unreachable poster URL kept the broken image surface instead of falling back to the existing media placeholder. After the update, the poster `error` path switches to the fallback UI, and the added `plugins-home-section.test.tsx` regression covers that broken-poster case.

## Validation
- `pnpm --dir apps/web test -- plugins-home-section.test.tsx`
- `pnpm --dir apps/web typecheck`
- `pnpm guard`
- `git diff --check`