### PR TITLE
[codex] Fix Vela companion packaging

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -8,6 +8,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-KoQXeryzkgkNLsaZS20W2MBWf7KIV7QT2CyiuWmEs3A=";
-  webHash = "sha256-20p4vKaFLRPBnY7Id+qsiDa87mRbBeZmkXoMI13MCsQ=";
+  daemonHash = "sha256-BAs/v7AXyYchClBo+smuP0fSsblnW6Uh7LFywfJkIZY=";
+  webHash = "sha256-nzaScs0187VBcyp3NT+zXQuqORwj0C8DOu0cXy8ZxAQ=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,8 +601,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.1-test.2
-        version: 0.0.1-test.2
+        specifier: 0.0.1
+        version: 0.0.1
 
   tools/serve:
     dependencies:
@@ -1642,13 +1642,13 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.1-test.2':
-    resolution: {integrity: sha512-R1zHuM5YZaJU55siutsXWQc4tex8swUZkhuOHT72TKiyJiPH34EG23Z10GuOJoujvXUNp7cMZPNrsyzzIToDXw==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.1':
+    resolution: {integrity: sha512-DBUWX3siQPm6BYa+CbTVtHuDJu0MKFHVQHIEM9ESbfuHGbBP0rOmASTQqcmPWhUYOyEZcVzpDYcX4exjxh2P7g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli@0.0.1-test.2':
-    resolution: {integrity: sha512-L8dTJl03d5D0oGvpRFXyZz9bPI3diQAnEaDFi7iuVIiRbctoUgpKp7E3cZc8vGJ63/pYQSRWIUCWnjkCm2QRFA==}
+  '@powerformer/vela-cli@0.0.1':
+    resolution: {integrity: sha512-C82uWQWf6uTIy5UXiyqK7+i+5oknS4VKjueWuQoZ+B8UUczRvQsHuguVDD4i9OnBrFXCxh8PltkVOhsKlOLw/A==}
     hasBin: true
 
   '@rollup/pluginutils@5.3.0':
@@ -6043,12 +6043,12 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.1-test.2':
+  '@powerformer/vela-cli-darwin-arm64@0.0.1':
     optional: true
 
-  '@powerformer/vela-cli@0.0.1-test.2':
+  '@powerformer/vela-cli@0.0.1':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.1-test.2
+      '@powerformer/vela-cli-darwin-arm64': 0.0.1
     optional: true
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -22,7 +22,7 @@
     "electron-builder": "26.8.1"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.1-test.2"
+    "@powerformer/vela-cli": "0.0.1"
   },
   "devDependencies": {
     "@types/node": "24.12.2",

--- a/tools/pack/src/vela-cli.ts
+++ b/tools/pack/src/vela-cli.ts
@@ -2,6 +2,7 @@ import { chmod, cp, mkdir, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 export const VELA_CLI_BIN_ENV = "OPEN_DESIGN_VELA_CLI_BIN";
+const OPEN_CODE_COMPANION_RELATIVE_PATH = ["libexec", "opencode"] as const;
 
 type VelaCliPlatform = "linux" | "mac" | "win";
 type VelaCliResolveResult =
@@ -47,42 +48,53 @@ export async function copyOptionalVelaCliBinary({
   const target = join(resourceRoot, "bin", targetBinaryName(platform));
   await mkdir(dirname(target), { recursive: true });
   await cp(source, target);
-  await copyAdjacentSupportTree({ source, target, supportTreeName: "libexec" });
+  await copyBundledOpenCodeTree({ requireBundled, resourceRoot, source });
   if (platform !== "win") {
     await chmod(target, 0o755);
   }
   return { source, target };
 }
 
-async function copyAdjacentSupportTree({
-  source,
-  target,
-  supportTreeName,
-}: {
-  source: string;
-  target: string;
-  supportTreeName: string;
-}): Promise<void> {
-  const sourceSupportTree = join(dirname(source), supportTreeName);
-  const targetSupportTree = join(dirname(target), supportTreeName);
-
-  try {
-    const sourceSupportTreeStat = await stat(sourceSupportTree);
-    if (!sourceSupportTreeStat.isDirectory()) return;
-  } catch (error) {
-    if (isNotFoundError(error)) return;
-    throw error;
-  }
-
-  await cp(sourceSupportTree, targetSupportTree, { recursive: true });
+export function resolveVelaCliOpenCodeCompanionTree(source: string): string {
+  return join(dirname(source), ...OPEN_CODE_COMPANION_RELATIVE_PATH);
 }
 
-function isNotFoundError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    "code" in error &&
-    (error as NodeJS.ErrnoException).code === "ENOENT"
-  );
+export async function resolveOptionalVelaCliOpenCodeCompanionTree(
+  source: string,
+): Promise<string | null> {
+  const sourceTree = resolveVelaCliOpenCodeCompanionTree(source);
+  return (await isDirectory(sourceTree)) ? sourceTree : null;
+}
+
+async function copyBundledOpenCodeTree({
+  requireBundled,
+  resourceRoot,
+  source,
+}: {
+  requireBundled: boolean;
+  resourceRoot: string;
+  source: string;
+}): Promise<void> {
+  const sourceTree = resolveVelaCliOpenCodeCompanionTree(source);
+  const targetTree = join(resourceRoot, "bin", ...OPEN_CODE_COMPANION_RELATIVE_PATH);
+  if (!(await isDirectory(sourceTree))) {
+    if (requireBundled) {
+      throw strictResolutionError(
+        `unable to resolve bundled Vela CLI: OpenCode companion directory is missing at ${sourceTree}`,
+      );
+    }
+    return;
+  }
+  await cp(sourceTree, targetTree, { force: true, recursive: true });
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
 }
 
 export async function resolveOptionalVelaCliBinary({

--- a/tools/pack/src/win/resources.ts
+++ b/tools/pack/src/win/resources.ts
@@ -4,15 +4,23 @@ import { dirname, join } from "node:path";
 import { hashJson, hashPath, ToolPackCache } from "../cache.js";
 import type { ToolPackConfig } from "../config.js";
 import { copyBundledResourceTrees, winResources } from "../resources.js";
-import { copyOptionalVelaCliBinary, resolveOptionalVelaCliBinary } from "../vela-cli.js";
+import {
+  copyOptionalVelaCliBinary,
+  resolveOptionalVelaCliBinary,
+  resolveOptionalVelaCliOpenCodeCompanionTree,
+} from "../vela-cli.js";
 import type { WinPaths, ResourceTreeCacheMetadata } from "./types.js";
 
-const RESOURCE_TREE_CACHE_SCHEMA_VERSION = 3;
+const RESOURCE_TREE_CACHE_SCHEMA_VERSION = 4;
 
 async function createResourceTreeCacheKey(config: ToolPackConfig): Promise<string> {
   const velaCliBin = await resolveOptionalVelaCliBinary({
     requireBundled: config.requireVelaCli,
   });
+  const velaOpenCodeCompanion =
+    velaCliBin == null
+      ? null
+      : await resolveOptionalVelaCliOpenCodeCompanionTree(velaCliBin);
   return hashJson({
     assetsCommunityPets: await hashPath(join(config.workspaceRoot, "assets", "community-pets")),
     assetsFrames: await hashPath(join(config.workspaceRoot, "assets", "frames")),
@@ -27,6 +35,9 @@ async function createResourceTreeCacheKey(config: ToolPackConfig): Promise<strin
     skills: await hashPath(join(config.workspaceRoot, "skills")),
     requireVelaCli: config.requireVelaCli,
     velaCliBin: velaCliBin ? await hashPath(velaCliBin) : null,
+    velaOpenCodeCompanion: velaOpenCodeCompanion
+      ? await hashPath(velaOpenCodeCompanion)
+      : null,
   });
 }
 

--- a/tools/pack/tests/resources.test.ts
+++ b/tools/pack/tests/resources.test.ts
@@ -1,10 +1,31 @@
 import { describe, expect, it } from "vitest";
-import { access, constants, mkdtemp, readFile, rm, writeFile, mkdir, stat } from "node:fs/promises";
+import {
+  access,
+  chmod,
+  constants,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { copyBundledResourceTrees } from "../src/resources.js";
 import { copyOptionalVelaCliBinary, resolveOptionalVelaCliBinary } from "../src/vela-cli.js";
+
+async function writeFakeOpenCodeCompanion(
+  source: string,
+  content = "#!/bin/sh\nexit 0\n",
+): Promise<string> {
+  const companion = join(dirname(source), "libexec", "opencode", "opencode");
+  await mkdir(dirname(companion), { recursive: true });
+  await writeFile(companion, content, "utf8");
+  await chmod(companion, 0o755);
+  return companion;
+}
 
 describe("copyBundledResourceTrees", () => {
   it("includes daemon resource trees", async () => {
@@ -127,13 +148,8 @@ describe("copyOptionalVelaCliBinary", () => {
 
     try {
       await mkdir(join(root, "source"), { recursive: true });
-      await mkdir(join(root, "source", "libexec", "opencode"), { recursive: true });
       await writeFile(source, "#!/bin/sh\nexit 0\n", "utf8");
-      await writeFile(
-        join(root, "source", "libexec", "opencode", "opencode"),
-        "#!/bin/sh\nexit 0\n",
-        "utf8",
-      );
+      await writeFakeOpenCodeCompanion(source, "#!/bin/sh\necho opencode\n");
 
       const copied = await copyOptionalVelaCliBinary({
         env: { OPEN_DESIGN_VELA_CLI_BIN: source },
@@ -143,13 +159,38 @@ describe("copyOptionalVelaCliBinary", () => {
       });
 
       const target = join(resourceRoot, "bin", "vela");
+      const companionTarget = join(resourceRoot, "bin", "libexec", "opencode", "opencode");
       await expect(readFile(target, "utf8")).resolves.toBe("#!/bin/sh\nexit 0\n");
-      await expect(
-        readFile(join(resourceRoot, "bin", "libexec", "opencode", "opencode"), "utf8"),
-      ).resolves.toBe("#!/bin/sh\nexit 0\n");
+      await expect(readFile(companionTarget, "utf8")).resolves.toBe(
+        "#!/bin/sh\necho opencode\n",
+      );
       await expect(access(target, constants.X_OK)).resolves.toBeUndefined();
+      await expect(access(companionTarget, constants.X_OK)).resolves.toBeUndefined();
       expect(copied).toEqual({ source, target });
       expect((await stat(target)).mode & 0o111).not.toBe(0);
+      expect((await stat(companionTarget)).mode & 0o111).not.toBe(0);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("fails strict mode when the OpenCode companion tree is missing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-vela-strict-"));
+    const source = join(root, "source", "vela");
+    const resourceRoot = join(root, "resources", "open-design");
+
+    try {
+      await mkdir(join(root, "source"), { recursive: true });
+      await writeFile(source, "#!/bin/sh\nexit 0\n", "utf8");
+
+      await expect(
+        copyOptionalVelaCliBinary({
+          env: { OPEN_DESIGN_VELA_CLI_BIN: source },
+          platform: "mac",
+          requireBundled: true,
+          resourceRoot,
+        }),
+      ).rejects.toThrow(/OpenCode companion directory is missing.*OPEN_DESIGN_VELA_CLI_BIN/);
     } finally {
       await rm(root, { force: true, recursive: true });
     }
@@ -162,13 +203,8 @@ describe("copyOptionalVelaCliBinary", () => {
 
     try {
       await mkdir(join(root, "source"), { recursive: true });
-      await mkdir(join(root, "source", "libexec", "opencode"), { recursive: true });
       await writeFile(source, "fake exe\n", "utf8");
-      await writeFile(
-        join(root, "source", "libexec", "opencode", "opencode.exe"),
-        "fake opencode exe\n",
-        "utf8",
-      );
+      await writeFakeOpenCodeCompanion(source, "fake opencode\n");
 
       const copied = await copyOptionalVelaCliBinary({
         env: { OPEN_DESIGN_VELA_CLI_BIN: source },
@@ -177,10 +213,9 @@ describe("copyOptionalVelaCliBinary", () => {
       });
 
       const target = join(resourceRoot, "bin", "vela.exe");
+      const companionTarget = join(resourceRoot, "bin", "libexec", "opencode", "opencode");
       await expect(readFile(target, "utf8")).resolves.toBe("fake exe\n");
-      await expect(
-        readFile(join(resourceRoot, "bin", "libexec", "opencode", "opencode.exe"), "utf8"),
-      ).resolves.toBe("fake opencode exe\n");
+      await expect(readFile(companionTarget, "utf8")).resolves.toBe("fake opencode\n");
       expect(copied).toEqual({ source, target });
     } finally {
       await rm(root, { force: true, recursive: true });
@@ -194,13 +229,8 @@ describe("copyOptionalVelaCliBinary", () => {
 
     try {
       await mkdir(join(root, "source"), { recursive: true });
-      await mkdir(join(root, "source", "libexec", "opencode"), { recursive: true });
       await writeFile(source, "#!/bin/sh\nexit 0\n", "utf8");
-      await writeFile(
-        join(root, "source", "libexec", "opencode", "opencode"),
-        "#!/bin/sh\necho opencode\n",
-        "utf8",
-      );
+      await writeFakeOpenCodeCompanion(source, "#!/bin/sh\necho opencode\n");
 
       const copied = await copyOptionalVelaCliBinary({
         env: {},
@@ -213,10 +243,11 @@ describe("copyOptionalVelaCliBinary", () => {
       });
 
       const target = join(resourceRoot, "bin", "vela");
+      const companionTarget = join(resourceRoot, "bin", "libexec", "opencode", "opencode");
       await expect(readFile(target, "utf8")).resolves.toBe("#!/bin/sh\nexit 0\n");
-      await expect(
-        readFile(join(resourceRoot, "bin", "libexec", "opencode", "opencode"), "utf8"),
-      ).resolves.toBe("#!/bin/sh\necho opencode\n");
+      await expect(readFile(companionTarget, "utf8")).resolves.toBe(
+        "#!/bin/sh\necho opencode\n",
+      );
       await expect(access(target, constants.X_OK)).resolves.toBeUndefined();
       expect(copied).toEqual({ source, target });
     } finally {

--- a/tools/pack/tests/win-resources.test.ts
+++ b/tools/pack/tests/win-resources.test.ts
@@ -1,6 +1,6 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -8,6 +8,17 @@ import { ToolPackCache } from "../src/cache.js";
 import type { ToolPackConfig } from "../src/config.js";
 import { prepareResourceTree } from "../src/win/resources.js";
 import type { WinPaths } from "../src/win/types.js";
+
+async function writeFakeOpenCodeCompanion(
+  source: string,
+  content = "#!/bin/sh\nexit 0\n",
+): Promise<string> {
+  const companion = join(dirname(source), "libexec", "opencode", "opencode");
+  await mkdir(dirname(companion), { recursive: true });
+  await writeFile(companion, content, "utf8");
+  await chmod(companion, 0o755);
+  return companion;
+}
 
 async function createWorkspaceFixture(workspaceRoot: string): Promise<void> {
   await mkdir(join(workspaceRoot, "skills", "sample"), { recursive: true });
@@ -106,13 +117,8 @@ describe("prepareResourceTree", () => {
     try {
       await createWorkspaceFixture(workspaceRoot);
       await mkdir(join(root, "source"), { recursive: true });
-      await mkdir(join(root, "source", "libexec", "opencode"), { recursive: true });
       await writeFile(source, "fake vela exe\n", "utf8");
-      await writeFile(
-        join(root, "source", "libexec", "opencode", "opencode.exe"),
-        "fake opencode exe\n",
-        "utf8",
-      );
+      await writeFakeOpenCodeCompanion(source, "fake opencode\n");
       process.env.OPEN_DESIGN_VELA_CLI_BIN = source;
 
       await prepareResourceTree(config, paths, cache, { materialize: true });
@@ -121,8 +127,8 @@ describe("prepareResourceTree", () => {
         "fake vela exe\n",
       );
       await expect(
-        readFile(join(resourceRoot, "bin", "libexec", "opencode", "opencode.exe"), "utf8"),
-      ).resolves.toBe("fake opencode exe\n");
+        readFile(join(resourceRoot, "bin", "libexec", "opencode", "opencode"), "utf8"),
+      ).resolves.toBe("fake opencode\n");
     } finally {
       if (originalVelaBin == null) delete process.env.OPEN_DESIGN_VELA_CLI_BIN;
       else process.env.OPEN_DESIGN_VELA_CLI_BIN = originalVelaBin;
@@ -148,6 +154,53 @@ describe("prepareResourceTree", () => {
       await expect(
         prepareResourceTree(config, paths, cache, { materialize: true }),
       ).rejects.toThrow();
+    } finally {
+      if (originalVelaBin == null) delete process.env.OPEN_DESIGN_VELA_CLI_BIN;
+      else process.env.OPEN_DESIGN_VELA_CLI_BIN = originalVelaBin;
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("invalidates the Windows resource tree cache when the Vela companion changes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-vela-companion-"));
+    const workspaceRoot = join(root, "workspace");
+    const resourceRoot = join(root, "materialized", "open-design");
+    const source = join(root, "source", "vela.exe");
+    const cache = new ToolPackCache(join(root, "cache"));
+    const config = { workspaceRoot } as ToolPackConfig;
+    const paths = { resourceRoot } as WinPaths;
+    const originalVelaBin = process.env.OPEN_DESIGN_VELA_CLI_BIN;
+    const materializedCompanion = join(
+      resourceRoot,
+      "bin",
+      "libexec",
+      "opencode",
+      "opencode",
+    );
+
+    try {
+      await createWorkspaceFixture(workspaceRoot);
+      await mkdir(join(root, "source"), { recursive: true });
+      await writeFile(source, "fake vela exe\n", "utf8");
+      const sourceCompanion = await writeFakeOpenCodeCompanion(source, "companion one\n");
+      process.env.OPEN_DESIGN_VELA_CLI_BIN = source;
+
+      await prepareResourceTree(config, paths, cache, { materialize: true });
+      await expect(readFile(materializedCompanion, "utf8")).resolves.toBe(
+        "companion one\n",
+      );
+
+      await writeFile(sourceCompanion, "companion two\n", "utf8");
+
+      await prepareResourceTree(config, paths, cache, { materialize: true });
+
+      await expect(readFile(materializedCompanion, "utf8")).resolves.toBe(
+        "companion two\n",
+      );
+      expect(cache.report().entries.map((entry) => entry.status)).toEqual([
+        "miss",
+        "miss",
+      ]);
     } finally {
       if (originalVelaBin == null) delete process.env.OPEN_DESIGN_VELA_CLI_BIN;
       else process.env.OPEN_DESIGN_VELA_CLI_BIN = originalVelaBin;


### PR DESCRIPTION
## Why

Vela packaging needs to carry the OpenCode companion tree beside the bundled Vela executable. The production Vela CLI resolves `libexec/opencode/opencode` relative to the packaged `vela` binary, so copying only `bin/vela` leaves `vela agent run` unable to start its companion runtime.

This also moves the Open Design tools-pack dependency from the test package to the published `@powerformer/vela-cli@0.0.1` package.

## What users will see

Packaged AMR builds that include Vela now include the companion OpenCode runtime under `resources/open-design/bin/libexec/opencode`, so Vela agent execution can work from the packaged app without requiring a global `opencode` install.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is packaging behavior.

## Bug fix verification

- Test path that reproduces the bug: `tools/pack/tests/resources.test.ts` and `tools/pack/tests/win-resources.test.ts`
- Did the test go red on `main` and green on this branch? No; this targets the AMR packaging branch and adds focused regression coverage for the companion tree contract.
- Additional verification: strict mac packaging smoke passed before rebasing this work onto latest `origin/feat/amr-runtime-acp`, with packaged `vela --version` returning `0.0.1` and packaged `opencode --version` returning `1.15.10`.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --dir tools/pack exec vitest run tests/resources.test.ts tests/win-resources.test.ts`
- `git diff --check`
