### PR TITLE
[codex] Surface AMR account failures

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -142,7 +142,13 @@ function validateTelemetry(raw: unknown): TelemetryPrefs | undefined {
 }
 
 const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
-  ['amr', new Set(['VELA_BIN', 'VELA_LINK_URL', 'VELA_RUNTIME_KEY', 'VELA_OPENCODE_BIN'])],
+  ['amr', new Set([
+    'VELA_BIN',
+    'VELA_LINK_URL',
+    'VELA_RUNTIME_KEY',
+    'VELA_OPENCODE_BIN',
+    'OPEN_DESIGN_AMR_PROFILE',
+  ])],
   ['aider', new Set(['AIDER_BIN'])],
   ['claude', new Set(['CLAUDE_CONFIG_DIR', 'CLAUDE_BIN', 'ANTHROPIC_BASE_URL', 'ANTHROPIC_API_KEY'])],
   ['codex', new Set(['CODEX_HOME', 'CODEX_BIN', 'OPENAI_BASE_URL', 'CODEX_API_KEY', 'OPENAI_API_KEY'])],

--- a/apps/daemon/src/integrations/vela-errors.ts
+++ b/apps/daemon/src/integrations/vela-errors.ts
@@ -1,0 +1,88 @@
+export type AmrAccountErrorCode = 'AMR_AUTH_REQUIRED' | 'AMR_INSUFFICIENT_BALANCE';
+
+export interface AmrAccountFailure {
+  code: AmrAccountErrorCode;
+  message: string;
+  action: 'relogin' | 'recharge';
+  actionUrl?: string;
+}
+
+export const DEFAULT_AMR_RECHARGE_URL = 'https://open-design.ai/amr/wallet';
+
+const AMR_AUTH_REQUIRED_MESSAGE =
+  'AMR sign-in is required. Sign in to AMR Cloud again, then retry this run.';
+
+const AMR_INSUFFICIENT_BALANCE_MESSAGE =
+  'AMR Cloud reported insufficient balance for this model. Recharge your AMR wallet, then retry this run.';
+
+function normalizeFailureText(text: string): string {
+  return String(text || '').toLowerCase();
+}
+
+function containsInsufficientBalanceSignal(value: string): boolean {
+  if (
+    value.includes('insufficient_balance') ||
+    value.includes('insufficient balance') ||
+    value.includes('insufficient wallet balance') ||
+    value.includes('insufficient credits') ||
+    value.includes('insufficient credit') ||
+    value.includes('insufficient funds') ||
+    value.includes('not enough balance') ||
+    value.includes('not enough credits') ||
+    value.includes('wallet balance') ||
+    value.includes('balance is empty') ||
+    value.includes('balance too low') ||
+    value.includes('billing balance')
+  ) {
+    return true;
+  }
+  return value.includes('quota') && /\b(wallet|balance|credit|billing|funds?)\b/.test(value);
+}
+
+export function classifyAmrAccountFailure(text: string): AmrAccountFailure | null {
+  const value = normalizeFailureText(text);
+  if (!value.trim()) return null;
+
+  if (containsInsufficientBalanceSignal(value)) {
+    return {
+      code: 'AMR_INSUFFICIENT_BALANCE',
+      message: AMR_INSUFFICIENT_BALANCE_MESSAGE,
+      action: 'recharge',
+      actionUrl: DEFAULT_AMR_RECHARGE_URL,
+    };
+  }
+
+  if (
+    value.includes('auth_required') ||
+    value.includes('authentication required') ||
+    value.includes('not authenticated') ||
+    value.includes('unauthenticated') ||
+    value.includes('not logged in') ||
+    value.includes('login missing') ||
+    value.includes('sign in again') ||
+    value.includes('sign-in required') ||
+    value.includes('signin required') ||
+    value.includes('token has expired') ||
+    value.includes('expired token') ||
+    value.includes('invalid session') ||
+    value.includes('session expired') ||
+    value.includes('invalid api key') ||
+    value.includes('forbidden_api_key')
+  ) {
+    return {
+      code: 'AMR_AUTH_REQUIRED',
+      message: AMR_AUTH_REQUIRED_MESSAGE,
+      action: 'relogin',
+    };
+  }
+
+  return null;
+}
+
+export function amrAccountFailureDetails(failure: AmrAccountFailure) {
+  return {
+    kind: 'amr_account',
+    action: failure.action,
+    ...(failure.actionUrl ? { actionUrl: failure.actionUrl } : {}),
+  };
+}

--- a/apps/daemon/src/integrations/vela-errors.ts
+++ b/apps/daemon/src/integrations/vela-errors.ts
@@ -29,7 +29,6 @@ function containsInsufficientBalanceSignal(value: string): boolean {
     value.includes('insufficient funds') ||
     value.includes('not enough balance') ||
     value.includes('not enough credits') ||
-    value.includes('wallet balance') ||
     value.includes('balance is empty') ||
     value.includes('balance too low') ||
     value.includes('billing balance')

--- a/apps/daemon/src/integrations/vela.ts
+++ b/apps/daemon/src/integrations/vela.ts
@@ -69,8 +69,8 @@ export function readVelaLoginStatus(
   const profile = resolveAmrProfile(env);
   const configPath = velaConfigPath();
   const loginInFlight = isVelaLoginInFlight();
-  const configuredRuntimeKey = configuredEnv.VELA_RUNTIME_KEY?.trim() ?? '';
-  const configuredLinkUrl = configuredEnv.VELA_LINK_URL?.trim() ?? '';
+  const configuredRuntimeKey = (configuredEnv.VELA_RUNTIME_KEY ?? env.VELA_RUNTIME_KEY)?.trim() ?? '';
+  const configuredLinkUrl = (configuredEnv.VELA_LINK_URL ?? env.VELA_LINK_URL)?.trim() ?? '';
   if (configuredRuntimeKey && configuredLinkUrl) {
     return { loggedIn: true, loginInFlight, profile, user: null, configPath };
   }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -46,6 +46,10 @@ import {
   readVelaLoginStatus,
   spawnVelaLogin,
 } from './integrations/vela.js';
+import {
+  amrAccountFailureDetails,
+  classifyAmrAccountFailure,
+} from './integrations/vela-errors.js';
 import { migrateLegacyDataDirSync } from './legacy-data-migrator.js';
 import {
   consumedImportNonces,
@@ -10642,6 +10646,16 @@ export async function startServer({
       persistRunEventToAssistantMessage(db, run, event, data);
       design.runs.emit(run, event, data);
     };
+    const sendAmrAccountFailure = (failure) => {
+      send('error', createSseErrorPayload(
+        failure.code,
+        failure.message,
+        {
+          retryable: true,
+          details: amrAccountFailureDetails(failure),
+        },
+      ));
+    };
     const inactivityTimeoutMs = resolveChatRunInactivityTimeoutMs();
     const artifactQuietPeriodMs = resolveChatRunArtifactQuietPeriodMs();
     const inactivityKillGraceMs = 3_000;
@@ -10793,6 +10807,27 @@ export async function startServer({
       ));
       return design.runs.finish(run, 'failed', 1, null);
     }
+    const agentSpawnEnv = spawnEnvForAgent(
+      def.id,
+      {
+        ...createAgentRuntimeEnv(process.env, daemonUrl, toolTokenGrant),
+        ...(def.env || {}),
+      },
+      configuredAgentEnv,
+    );
+    if (def.id === 'amr') {
+      const loginStatus = readVelaLoginStatus(agentSpawnEnv, configuredAgentEnv);
+      if (!loginStatus.loggedIn) {
+        revokeToolToken('child_exit');
+        unregisterChatAgentEventSink();
+        sendAmrAccountFailure({
+          code: 'AMR_AUTH_REQUIRED',
+          message: 'AMR sign-in is required. Sign in to AMR Cloud again, then retry this run.',
+          action: 'relogin',
+        });
+        return design.runs.finish(run, 'failed', 1, null);
+      }
+    }
     const odMediaEnv = {
       OD_BIN,
       OD_NODE_BIN,
@@ -10839,14 +10874,7 @@ export async function startServer({
           ? 'pipe'
           : 'ignore';
       const env = applyAgentLaunchEnv({
-        ...spawnEnvForAgent(
-          def.id,
-          {
-            ...createAgentRuntimeEnv(process.env, daemonUrl, toolTokenGrant),
-            ...(def.env || {}),
-          },
-          configuredAgentEnv,
-        ),
+        ...agentSpawnEnv,
         ...odMediaEnv,
         // OpenCode external-MCP injection (issue #2142). Layered AFTER
         // spawnEnvForAgent / odMediaEnv / configuredAgentEnv so the
@@ -11304,6 +11332,21 @@ export async function startServer({
         mcpServers,
         send: (event, data) => {
           noteAgentActivity();
+          if (def.id === 'amr' && event === 'error') {
+            const failure = classifyAmrAccountFailure(
+              [
+                typeof data?.message === 'string' ? data.message : '',
+                typeof data?.error?.message === 'string' ? data.error.message : '',
+                typeof data?.error?.code === 'string' ? data.error.code : '',
+                agentStdoutTail,
+                agentStderrTail,
+              ].join('\n'),
+            );
+            if (failure) {
+              sendAmrAccountFailure(failure);
+              return;
+            }
+          }
           send(event, data);
         },
         ...(acpStageTimeoutMs !== undefined ? { stageTimeoutMs: acpStageTimeoutMs } : {}),
@@ -11357,6 +11400,15 @@ export async function startServer({
         code !== 0 &&
         !run.cancelRequested
       ) {
+        if (def.id === 'amr') {
+          const amrFailure = classifyAmrAccountFailure(
+            `${agentStderrTail}\n${agentStdoutTail}`,
+          );
+          if (amrFailure) {
+            sendAmrAccountFailure(amrFailure);
+            return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
+          }
+        }
         const authFailure = classifyAgentAuthFailure(
           agentId,
           `${agentStderrTail}\n${agentStdoutTail}`,

--- a/apps/daemon/tests/app-config.test.ts
+++ b/apps/daemon/tests/app-config.test.ts
@@ -317,6 +317,11 @@ describe('app-config', () => {
             CODEX_BIN: '~/bin/codex-next',
             OPENAI_API_KEY: '  sk-proxy-openai  ',
           },
+          amr: {
+            VELA_BIN: '~/bin/vela',
+            OPEN_DESIGN_AMR_PROFILE: '  local  ',
+            HOME: 'should-not-persist',
+          },
           'trae-cli': {
             TRAE_CLI_BIN: '  ~/bin/traecli-public  ',
           },
@@ -334,6 +339,7 @@ describe('app-config', () => {
       expect(cfg.agentCliEnv).toEqual({
         claude: { CLAUDE_CONFIG_DIR: '~/.claude-2', ANTHROPIC_API_KEY: 'sk-proxy-anthropic' },
         codex: { CODEX_HOME: '~/.codex-alt', CODEX_BIN: '~/bin/codex-next', OPENAI_API_KEY: 'sk-proxy-openai' },
+        amr: { VELA_BIN: '~/bin/vela', OPEN_DESIGN_AMR_PROFILE: 'local' },
         'trae-cli': { TRAE_CLI_BIN: '~/bin/traecli-public' },
       });
     });

--- a/apps/daemon/tests/integrations/vela-errors.test.ts
+++ b/apps/daemon/tests/integrations/vela-errors.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_AMR_RECHARGE_URL,
+  amrAccountFailureDetails,
+  classifyAmrAccountFailure,
+} from '../../src/integrations/vela-errors.js';
+
+describe('AMR account failure classification', () => {
+  it('classifies insufficient_balance JSON-RPC failures as rechargeable AMR balance errors', () => {
+    const failure = classifyAmrAccountFailure(
+      'JSON-RPC error -32000: {"code":"insufficient_balance","message":"insufficient balance"}',
+    );
+
+    expect(failure).toMatchObject({
+      code: 'AMR_INSUFFICIENT_BALANCE',
+      action: 'recharge',
+      actionUrl: DEFAULT_AMR_RECHARGE_URL,
+    });
+    expect(amrAccountFailureDetails(failure!)).toEqual({
+      kind: 'amr_account',
+      action: 'recharge',
+      actionUrl: DEFAULT_AMR_RECHARGE_URL,
+    });
+  });
+
+  it('classifies 429 wallet balance payloads as AMR balance errors', () => {
+    const failure = classifyAmrAccountFailure(
+      'HTTP 429 Too Many Requests: quota exceeded because wallet balance is empty',
+    );
+
+    expect(failure).toMatchObject({
+      code: 'AMR_INSUFFICIENT_BALANCE',
+      action: 'recharge',
+    });
+  });
+
+  it('does not classify non-billing throttling as AMR balance errors', () => {
+    expect(classifyAmrAccountFailure('HTTP 429 rate limit reached')).toBeNull();
+    expect(classifyAmrAccountFailure('quota exceeded')).toBeNull();
+  });
+
+  it('classifies expired token, invalid session, and missing login text as AMR auth errors', () => {
+    for (const text of [
+      'Your token has expired. Please sign in again.',
+      'invalid session for AMR profile',
+      'login missing for runtime account',
+      'authentication required',
+    ]) {
+      expect(classifyAmrAccountFailure(text)).toMatchObject({
+        code: 'AMR_AUTH_REQUIRED',
+        action: 'relogin',
+      });
+    }
+  });
+
+  it('does not classify unrelated ACP failures as AMR account failures', () => {
+    expect(classifyAmrAccountFailure('session/prompt failed: model returned malformed output')).toBeNull();
+  });
+});

--- a/apps/daemon/tests/integrations/vela-errors.test.ts
+++ b/apps/daemon/tests/integrations/vela-errors.test.ts
@@ -38,6 +38,7 @@ describe('AMR account failure classification', () => {
   it('does not classify non-billing throttling as AMR balance errors', () => {
     expect(classifyAmrAccountFailure('HTTP 429 rate limit reached')).toBeNull();
     expect(classifyAmrAccountFailure('quota exceeded')).toBeNull();
+    expect(classifyAmrAccountFailure('temporary wallet balance lookup outage')).toBeNull();
   });
 
   it('classifies expired token, invalid session, and missing login text as AMR auth errors', () => {

--- a/apps/daemon/tests/integrations/vela.test.ts
+++ b/apps/daemon/tests/integrations/vela.test.ts
@@ -105,6 +105,18 @@ describe('readVelaLoginStatus', () => {
     expect(JSON.stringify(status)).not.toContain('rt-env-secret');
   });
 
+  it('treats AMR runtime credentials on the effective env as logged in', () => {
+    const status = readVelaLoginStatus({
+      OPEN_DESIGN_AMR_PROFILE: 'local',
+      VELA_RUNTIME_KEY: 'rt-env-secret',
+      VELA_LINK_URL: 'https://openrouter.example/v1',
+    });
+    expect(status.loggedIn).toBe(true);
+    expect(status.user).toBeNull();
+    expect(status.profile).toBe('local');
+    expect(JSON.stringify(status)).not.toContain('rt-env-secret');
+  });
+
   it('requires both env runtime key and link URL before reporting env-only login', () => {
     expect(
       readVelaLoginStatus(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -165,6 +165,8 @@ import { buildClipboardPrompt } from '../lib/build-clipboard-prompt';
 import { copyToClipboard } from '../lib/copy-to-clipboard';
 import { effectiveMaxTokens } from '../state/maxTokens';
 
+const DEFAULT_AMR_RECHARGE_URL = 'https://open-design.ai/amr/wallet';
+
 type ProjectChatSendMeta = ChatSendMeta & {
   retryOfAssistantId?: string;
 };
@@ -2588,17 +2590,21 @@ export function ProjectView({
         },
         onError: (err: Error) => {
           const endedAt = Date.now();
+          const amrFailureText = amrAccountFailureText(err);
           textBuffer.flush();
           textBuffer.cancel();
           cancelSendTextBuffer();
-          setError(err.message);
-          appendAssistantErrorEvent(assistantId, err.message);
+          setError(amrFailureText ?? err.message);
+          appendAssistantErrorEvent(assistantId, amrFailureText ?? err.message);
           updateAssistant((prev) => ({
             ...prev,
             endedAt,
             runStatus: config.mode === 'api' || prev.runId || isActiveRunStatus(prev.runStatus)
               ? 'failed'
               : prev.runStatus,
+            events: amrFailureText
+              ? appendAmrFailureTextEvent(prev.events ?? [], amrFailureText)
+              : prev.events,
           }));
           if (runCommentAttachments.length > 0) {
             void patchAttachedStatuses(runCommentAttachments, 'failed');
@@ -4464,6 +4470,30 @@ function assistantAgentDisplayName(
 
 function isTerminalRunStatus(status: ChatMessage['runStatus']): boolean {
   return status === 'succeeded' || status === 'failed' || status === 'canceled';
+}
+
+function amrAccountFailureText(error: Error): string | null {
+  const coded = error as Error & { code?: string; details?: unknown };
+  if (coded.code === 'AMR_INSUFFICIENT_BALANCE') {
+    const details = coded.details && typeof coded.details === 'object'
+      ? coded.details as { actionUrl?: unknown }
+      : null;
+    const walletUrl =
+      typeof details?.actionUrl === 'string' && details.actionUrl.trim()
+        ? details.actionUrl.trim()
+        : DEFAULT_AMR_RECHARGE_URL;
+    return `${error.message}\n\n[Recharge AMR wallet](${walletUrl})`;
+  }
+  if (coded.code === 'AMR_AUTH_REQUIRED') {
+    return `${error.message}\n\nUse the AMR sign-in control in the model switcher or Settings, then retry this run.`;
+  }
+  return null;
+}
+
+function appendAmrFailureTextEvent(events: AgentEvent[], text: string): AgentEvent[] {
+  const last = events[events.length - 1];
+  if (last?.kind === 'text' && last.text === text) return events;
+  return [...events, { kind: 'text', text }];
 }
 
 function isActiveRunStatus(status: ChatMessage['runStatus']): boolean {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2038,14 +2038,22 @@ export function ProjectView({
               onProjectsRefresh();
             },
             onError: (err) => {
+              const amrFailureText = amrAccountFailureText(err);
               textBuffer.flush();
               textBuffer.cancel();
               unregisterTextBuffer();
-              setError(err.message);
-              appendAssistantErrorEvent(message.id, err.message);
+              setError(amrFailureText ?? err.message);
+              appendAssistantErrorEvent(message.id, amrFailureText ?? err.message);
               updateMessageById(
                 message.id,
-                (prev) => ({ ...prev, runStatus: 'failed', endedAt: prev.endedAt ?? Date.now() }),
+                (prev) => ({
+                  ...prev,
+                  runStatus: 'failed',
+                  endedAt: prev.endedAt ?? Date.now(),
+                  events: amrFailureText
+                    ? appendAmrFailureTextEvent(prev.events ?? [], amrFailureText)
+                    : prev.events,
+                }),
                 true,
               );
               completedReattachRunsRef.current.add(runId);

--- a/apps/web/src/components/amrLoginPolling.ts
+++ b/apps/web/src/components/amrLoginPolling.ts
@@ -1,7 +1,7 @@
 import type { VelaLoginStatus } from '../providers/daemon';
 
 export const AMR_LOGIN_POLL_INTERVAL_MS = 2000;
-export const AMR_LOGIN_TIMEOUT_MS = 60 * 1000;
+export const AMR_LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
 export const AMR_LOGIN_STARTUP_SETTLE_MS = 3000;
 export const AMR_LOGIN_STATUS_EVENT = 'od:amr-login-status-change';
 

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -225,6 +225,16 @@ function daemonSseErrorMessage(data: SseErrorPayload): string {
   return `${message}\n${detail}`;
 }
 
+function daemonSseError(data: SseErrorPayload): Error {
+  const error = new Error(daemonSseErrorMessage(data)) as Error & {
+    code?: string;
+    details?: unknown;
+  };
+  if (data.error?.code) error.code = data.error.code;
+  if (data.error?.details !== undefined) error.details = data.error.details;
+  return error;
+}
+
 export async function streamViaDaemon({
   agentId,
   history,
@@ -632,7 +642,7 @@ async function consumeDaemonRun({
           if (event.event === 'error') {
             onRunStatus?.('failed');
             const data = event.data as SseErrorPayload;
-            handlers.onError(new Error(daemonSseErrorMessage(data)));
+            handlers.onError(daemonSseError(data));
             return;
           }
 

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -363,6 +363,66 @@ describe('ProjectView daemon reattach restore', () => {
     });
   });
 
+  it('renders AMR recharge guidance when a reattached run reports insufficient balance', async () => {
+    const startedAt = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-amr-balance',
+        role: 'assistant',
+        content: '',
+        createdAt: startedAt,
+        startedAt,
+        runId: 'run-amr-balance',
+        runStatus: 'running',
+        preTurnFileNames: [],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-amr-balance',
+      status: 'running',
+      createdAt: startedAt,
+      updatedAt: startedAt,
+      exitCode: null,
+      signal: null,
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+
+    reattachDaemonRun.mockImplementation(async (options: any) => {
+      const error = new Error(
+        'AMR Cloud reported insufficient balance for this model. Recharge your AMR wallet, then retry this run.',
+      ) as Error & { code: string; details: unknown };
+      error.code = 'AMR_INSUFFICIENT_BALANCE';
+      error.details = {
+        kind: 'amr_account',
+        action: 'recharge',
+        actionUrl: 'https://open-design.ai/amr/wallet',
+      };
+      options.handlers.onError(error);
+    });
+
+    renderProjectView();
+
+    await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      const finalSave = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .filter((m) => m?.id === 'msg-amr-balance' && m.runStatus === 'failed')
+        .at(-1);
+      expect(finalSave?.events?.some(
+        (event) => event.kind === 'text'
+          && event.text.includes('[Recharge AMR wallet](https://open-design.ai/amr/wallet)'),
+      )).toBe(true);
+    });
+  });
+
   it('preserves canceled runStatus when onRunStatus records cancellation before onDone fires', async () => {
     const startedAt = Date.now();
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -138,6 +138,7 @@ vi.mock('../../src/components/ChatPane', () => ({
       queuedItems,
       previewComments,
       attachedComments,
+      messages,
       onAttachComment,
       onSelectConversation,
       onSend,
@@ -152,6 +153,7 @@ vi.mock('../../src/components/ChatPane', () => ({
       queuedItems?: Array<{ id: string; prompt: string }>;
       previewComments?: PreviewComment[];
       attachedComments?: PreviewComment[];
+      messages?: ChatMessage[];
       error: string | null;
       onAttachComment?: (comment: PreviewComment) => void;
       onSelectConversation: (id: string) => void;
@@ -165,6 +167,18 @@ vi.mock('../../src/components/ChatPane', () => ({
         <output data-testid="active-conversation">{activeConversationId}</output>
         <output data-testid="streaming-state">{streaming ? 'streaming' : 'idle'}</output>
         <output data-testid="chat-error">{error}</output>
+        <output data-testid="assistant-events">
+          {(messages ?? [])
+            .filter((message) => message.role === 'assistant')
+            .flatMap((message) => message.events ?? [])
+            .map((event) => {
+              if (event.kind === 'text') return event.text;
+              if (event.kind === 'status') return event.detail ?? event.label;
+              return '';
+            })
+            .filter(Boolean)
+            .join('\n')}
+        </output>
         <output data-testid="attached-comment-count">{attached.length}</output>
         {queuedItems?.map((item, index) => (
           <button
@@ -741,6 +755,85 @@ describe('ProjectView conversation run isolation', () => {
     fireEvent.click(screen.getByTestId('send-message'));
 
     await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
+  });
+
+  it('renders recharge guidance for structured AMR insufficient-balance errors', async () => {
+    conversationAMessages = [];
+    fetchChatRunStatus.mockResolvedValue(null);
+    streamViaDaemon.mockImplementation(
+      async (options: {
+        onRunCreated?: (runId: string) => void;
+        handlers: { onError: (error: Error) => void };
+      }) => {
+        options.onRunCreated?.('run-amr-balance');
+        const error = new Error(
+          'AMR Cloud reported insufficient balance for this model. Recharge your AMR wallet, then retry this run.',
+        ) as Error & { code: string; details: unknown };
+        error.code = 'AMR_INSUFFICIENT_BALANCE';
+        error.details = {
+          kind: 'amr_account',
+          action: 'recharge',
+          actionUrl: 'https://open-design.ai/amr/wallet',
+        };
+        options.handlers.onError(error);
+      },
+    );
+
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false));
+
+    fireEvent.click(screen.getByTestId('send-message'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-error').textContent).toContain('Recharge AMR wallet'),
+    );
+    expect(screen.getByTestId('assistant-events').textContent).toContain(
+      '[Recharge AMR wallet](https://open-design.ai/amr/wallet)',
+    );
+    expect(screen.getByTestId('streaming-state').textContent).toBe('idle');
+  });
+
+  it('renders re-login guidance for structured AMR auth-required errors', async () => {
+    conversationAMessages = [];
+    fetchChatRunStatus.mockResolvedValue(null);
+    streamViaDaemon.mockImplementation(
+      async (options: {
+        onRunCreated?: (runId: string) => void;
+        handlers: { onError: (error: Error) => void };
+      }) => {
+        options.onRunCreated?.('run-amr-auth');
+        const error = new Error(
+          'AMR sign-in is required. Sign in to AMR Cloud again, then retry this run.',
+        ) as Error & { code: string; details: unknown };
+        error.code = 'AMR_AUTH_REQUIRED';
+        error.details = {
+          kind: 'amr_account',
+          action: 'relogin',
+        };
+        options.handlers.onError(error);
+      },
+    );
+
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false));
+
+    fireEvent.click(screen.getByTestId('send-message'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-error').textContent).toContain(
+        'Use the AMR sign-in control in the model switcher or Settings',
+      ),
+    );
+    expect(screen.getByTestId('assistant-events').textContent).toContain(
+      'Use the AMR sign-in control in the model switcher or Settings',
+    );
+    expect(screen.getByTestId('streaming-state').textContent).toBe('idle');
   });
 });
 

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -336,7 +336,12 @@ describe('streamViaDaemon', () => {
       handlers,
     });
 
-    expect(handlers.onError).toHaveBeenCalledWith(new Error('typed message'));
+    expect(handlers.onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'typed message',
+        code: 'AGENT_UNAVAILABLE',
+      }),
+    );
     expect(handlers.onDone).not.toHaveBeenCalled();
   });
 
@@ -369,6 +374,46 @@ describe('streamViaDaemon', () => {
     expect(handlers.onError).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining('Set CLAUDE_CONFIG_DIR in Settings'),
+      }),
+    );
+    expect(handlers.onDone).not.toHaveBeenCalled();
+  });
+
+  it('preserves structured AMR SSE error codes and action details', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: error',
+              'data: {"message":"AMR balance unavailable","error":{"code":"AMR_INSUFFICIENT_BALANCE","message":"AMR balance unavailable","details":{"kind":"amr_account","action":"recharge","actionUrl":"https://open-design.ai/amr/wallet"}}}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'amr',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'AMR balance unavailable',
+        code: 'AMR_INSUFFICIENT_BALANCE',
+        details: {
+          kind: 'amr_account',
+          action: 'recharge',
+          actionUrl: 'https://open-design.ai/amr/wallet',
+        },
       }),
     );
     expect(handlers.onDone).not.toHaveBeenCalled();

--- a/e2e/lib/amr.ts
+++ b/e2e/lib/amr.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 export type FakeVelaOptions = {
   assistantText?: string;
   failAuthAtPrompt?: boolean;
+  failBalanceAtPrompt?: boolean;
   requireLoginConfig?: boolean;
 };
 
@@ -70,6 +71,7 @@ import { argv, stdin, stdout, stderr, env, exit } from 'node:process';
 const ASSISTANT_TEXT = ${JSON.stringify(options.assistantText ?? DEFAULT_ASSISTANT_TEXT)};
 const SESSION_ID = env.FAKE_VELA_SESSION_ID || 'fake-amr-session-1';
 const AUTH_FAIL = ${options.failAuthAtPrompt === true ? 'true' : 'false'};
+const BALANCE_FAIL = ${options.failBalanceAtPrompt === true ? 'true' : 'false'};
 const REQUIRE_LOGIN = ${options.requireLoginConfig === false ? 'false' : 'true'};
 
 function writeMessage(obj) {
@@ -179,6 +181,17 @@ function handle(msg) {
     }
     if (AUTH_FAIL) {
       writeError(id, 'Your authentication token has expired. Please sign in again.');
+      return;
+    }
+    if (BALANCE_FAIL) {
+      writeMessage({
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: -32000,
+          message: 'HTTP 429: {"code":"insufficient_balance","message":"insufficient balance"}',
+        },
+      });
       return;
     }
     writeNotification('session/update', {

--- a/e2e/tests/amr/insufficient-balance.test.ts
+++ b/e2e/tests/amr/insufficient-balance.test.ts
@@ -10,13 +10,13 @@ import { listMessages } from '@/vitest/messages';
 import { readRunEvents, startRun, waitForRunTerminal } from '@/vitest/runs';
 import { createSmokeSuite } from '@/vitest/smoke-suite';
 
-describe('AMR auth error convergence', () => {
-  test('marks the run and assistant message as failed when fake vela returns an auth error during prompt', { timeout: 180_000 }, async () => {
-    const suite = await createSmokeSuite('amr-auth-error-convergence');
+describe('AMR insufficient balance run failures', () => {
+  test('fails the run with a recharge-facing AMR error when fake vela reports insufficient balance', { timeout: 180_000 }, async () => {
+    const suite = await createSmokeSuite('amr-insufficient-balance');
 
     await suite.with.toolsDev(async ({ webUrl }) => {
-      const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-auth-error'), {
-        failAuthAtPrompt: true,
+      const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-balance'), {
+        failBalanceAtPrompt: true,
         requireLoginConfig: false,
       });
 
@@ -31,16 +31,15 @@ describe('AMR auth error convergence', () => {
         },
       });
 
-      const project = await createAmrProject(webUrl, 'AMR auth error convergence');
+      const project = await createAmrProject(webUrl, 'AMR insufficient balance');
       const assistantMessageId = `assistant-${Date.now()}`;
-
       const run = await startRun(webUrl, {
         agentId: 'amr',
         assistantMessageId,
         clientRequestId: `req-${Date.now()}`,
         conversationId: project.conversationId,
         designSystemId: null,
-        message: 'Simulate an AMR auth expiry during session/prompt.',
+        message: 'This should surface a recharge link.',
         model: 'default',
         projectId: project.project.id,
         reasoning: 'default',
@@ -50,10 +49,13 @@ describe('AMR auth error convergence', () => {
       const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
       expect(terminal.status).toBe('failed');
 
+      const events = await readRunEvents(webUrl, run.runId);
+      expect(events).toContain('AMR_INSUFFICIENT_BALANCE');
+      expect(events).toContain('https://open-design.ai/amr/wallet');
+
       const messages = await listMessages(webUrl, project.project.id, project.conversationId);
       const assistant = messages.find((message) => message.id === assistantMessageId);
       expect(assistant?.runStatus).toBe('failed');
-      await expect(readRunEvents(webUrl, run.runId)).resolves.toMatch(/AMR_AUTH_REQUIRED/);
     });
   });
 });

--- a/e2e/tests/amr/logout-state-persistence.test.ts
+++ b/e2e/tests/amr/logout-state-persistence.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
-import { seedVelaLoginConfig, writeFakeVelaBin } from '@/amr';
+import { writeFakeVelaBin } from '@/amr';
 import { createAmrProject, putAmrAppConfig } from '@/vitest/amr';
 import { requestJson } from '@/vitest/http';
 import { readRunEvents, startRun, waitForRunStatus, waitForRunTerminal } from '@/vitest/runs';
@@ -13,72 +13,85 @@ import { createSmokeSuite } from '@/vitest/smoke-suite';
 describe('AMR logout state persistence', () => {
   test('a previously working AMR session stops working after local logout and requires re-login', { timeout: 180_000 }, async () => {
     const suite = await createSmokeSuite('amr-logout-state-persistence');
+    const previousProfile = process.env.OPEN_DESIGN_AMR_PROFILE;
+    const previousHome = process.env.HOME;
+    const homeDir = join(suite.scratchDir, 'home-logout-state');
+    process.env.OPEN_DESIGN_AMR_PROFILE = 'local';
+    process.env.HOME = homeDir;
 
-    await suite.with.toolsDev(async ({ webUrl }) => {
-      const homeDir = join(suite.scratchDir, 'home');
-      const successVelaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-logout-success'), {
-        assistantText: 'AMR logout persistence success',
-        requireLoginConfig: false,
-      });
-      const strictVelaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-logout-strict'), {
-        assistantText: 'AMR logout persistence strict',
-      });
-      await seedVelaLoginConfig(homeDir, { email: 'logout-state@example.com', profile: 'local' });
+    try {
+      await suite.with.toolsDev(async ({ webUrl }) => {
+        const successVelaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-logout-success'), {
+          assistantText: 'AMR logout persistence success',
+          requireLoginConfig: false,
+        });
+        const strictVelaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-logout-strict'), {
+          assistantText: 'AMR logout persistence strict',
+        });
 
-      await putAmrAppConfig(webUrl, {
-        agentId: 'amr',
-        agentCliEnv: {
-          amr: {
-            VELA_BIN: successVelaBin,
+        await putAmrAppConfig(webUrl, {
+          agentId: 'amr',
+          agentCliEnv: {
+            amr: {
+              VELA_BIN: successVelaBin,
+              OPEN_DESIGN_AMR_PROFILE: 'local',
+              VELA_LINK_URL: 'http://localhost:18081',
+              VELA_RUNTIME_KEY: 'fake-runtime-key',
+            },
           },
-        },
-      });
+        });
 
-      const project = await createAmrProject(webUrl, 'AMR logout state persistence');
+        const project = await createAmrProject(webUrl, 'AMR logout state persistence');
 
-      const firstRun = await startRun(webUrl, {
-        agentId: 'amr',
-        assistantMessageId: `assistant-success-${Date.now()}`,
-        clientRequestId: `req-success-${Date.now()}`,
-        conversationId: project.conversationId,
-        designSystemId: null,
-        message: 'First AMR run should succeed before logout.',
-        model: 'default',
-        projectId: project.project.id,
-        reasoning: 'default',
-        skillId: null,
-      });
-      await waitForRunStatus(webUrl, firstRun.runId, 'succeeded', { timeoutMs: 20_000 });
+        const firstRun = await startRun(webUrl, {
+          agentId: 'amr',
+          assistantMessageId: `assistant-success-${Date.now()}`,
+          clientRequestId: `req-success-${Date.now()}`,
+          conversationId: project.conversationId,
+          designSystemId: null,
+          message: 'First AMR run should succeed before logout.',
+          model: 'default',
+          projectId: project.project.id,
+          reasoning: 'default',
+          skillId: null,
+        });
+        await waitForRunStatus(webUrl, firstRun.runId, 'succeeded', { timeoutMs: 20_000 });
 
-      await requestJson(webUrl, '/api/integrations/vela/logout', { body: {}, method: 'POST' });
-      const status = await requestJson<{ loggedIn: boolean }>(webUrl, '/api/integrations/vela/status');
-      expect(status.loggedIn).toBe(false);
-
-      await putAmrAppConfig(webUrl, {
-        agentId: 'amr',
-        agentCliEnv: {
-          amr: {
-            VELA_BIN: strictVelaBin,
+        await putAmrAppConfig(webUrl, {
+          agentId: 'amr',
+          agentCliEnv: {
+            amr: {
+              VELA_BIN: strictVelaBin,
+              OPEN_DESIGN_AMR_PROFILE: 'local',
+            },
           },
-        },
-      });
+        });
+        await requestJson(webUrl, '/api/integrations/vela/logout', { body: {}, method: 'POST' });
+        const status = await requestJson<{ loggedIn: boolean }>(webUrl, '/api/integrations/vela/status');
+        expect(status.loggedIn).toBe(false);
 
-      const secondRun = await startRun(webUrl, {
-        agentId: 'amr',
-        assistantMessageId: `assistant-fail-${Date.now()}`,
-        clientRequestId: `req-fail-${Date.now()}`,
-        conversationId: project.conversationId,
-        designSystemId: null,
-        message: 'Second AMR run should require login again.',
-        model: 'default',
-        projectId: project.project.id,
-        reasoning: 'default',
-        skillId: null,
-      });
-      const terminal = await waitForRunTerminal(webUrl, secondRun.runId, { timeoutMs: 20_000 });
-      expect(terminal.status).toBe('failed');
+        const secondRun = await startRun(webUrl, {
+          agentId: 'amr',
+          assistantMessageId: `assistant-fail-${Date.now()}`,
+          clientRequestId: `req-fail-${Date.now()}`,
+          conversationId: project.conversationId,
+          designSystemId: null,
+          message: 'Second AMR run should require login again.',
+          model: 'default',
+          projectId: project.project.id,
+          reasoning: 'default',
+          skillId: null,
+        });
+        const terminal = await waitForRunTerminal(webUrl, secondRun.runId, { timeoutMs: 20_000 });
+        expect(terminal.status).toBe('failed');
 
-      await expect(readRunEvents(webUrl, secondRun.runId)).resolves.toMatch(/sign in again|login missing|expired/i);
-    });
+        await expect(readRunEvents(webUrl, secondRun.runId)).resolves.toMatch(/AMR_AUTH_REQUIRED/);
+      });
+    } finally {
+      if (previousProfile === undefined) delete process.env.OPEN_DESIGN_AMR_PROFILE;
+      else process.env.OPEN_DESIGN_AMR_PROFILE = previousProfile;
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
   });
 });

--- a/e2e/tests/amr/relogin-required.test.ts
+++ b/e2e/tests/amr/relogin-required.test.ts
@@ -4,46 +4,162 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
-import { writeFakeVelaBin } from '@/amr';
+import { seedVelaLoginConfig, writeFakeVelaBin } from '@/amr';
 import { createAmrProject, putAmrAppConfig } from '@/vitest/amr';
-import { readRunEvents, startRun, waitForRunTerminal } from '@/vitest/runs';
+import { readRunEvents, startRun, waitForRunStatus, waitForRunTerminal } from '@/vitest/runs';
 import { createSmokeSuite } from '@/vitest/smoke-suite';
 
 describe('AMR relogin-required run failures', () => {
   test('fails a new /api/runs request when the local AMR login config is missing', { timeout: 180_000 }, async () => {
     const suite = await createSmokeSuite('amr-relogin-required');
+    const previousProfile = process.env.OPEN_DESIGN_AMR_PROFILE;
+    const previousHome = process.env.HOME;
+    const homeDir = join(suite.scratchDir, 'home-missing-login');
+    process.env.OPEN_DESIGN_AMR_PROFILE = 'local';
+    process.env.HOME = homeDir;
 
-    await suite.with.toolsDev(async ({ webUrl }) => {
-      const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-missing-login'));
+    try {
+      await suite.with.toolsDev(async ({ webUrl }) => {
+        const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-missing-login'));
 
-      await putAmrAppConfig(webUrl, {
-        agentId: 'amr',
-        agentCliEnv: {
-          amr: {
-            VELA_BIN: velaBin,
+        await putAmrAppConfig(webUrl, {
+          agentId: 'amr',
+          agentCliEnv: {
+            amr: {
+              VELA_BIN: velaBin,
+              OPEN_DESIGN_AMR_PROFILE: 'local',
+            },
           },
-        },
+        });
+
+        const project = await createAmrProject(webUrl, 'AMR relogin required');
+
+        const assistantMessageId = `assistant-${Date.now()}`;
+        const run = await startRun(webUrl, {
+          agentId: 'amr',
+          assistantMessageId,
+          clientRequestId: `req-${Date.now()}`,
+          conversationId: project.conversationId,
+          designSystemId: null,
+          message: 'This should require a fresh AMR login.',
+          model: 'default',
+          projectId: project.project.id,
+          reasoning: 'default',
+          skillId: null,
+        });
+        const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
+        expect(terminal.status).toBe('failed');
+
+        await expect(readRunEvents(webUrl, run.runId)).resolves.toMatch(/AMR_AUTH_REQUIRED/);
       });
+    } finally {
+      if (previousProfile === undefined) delete process.env.OPEN_DESIGN_AMR_PROFILE;
+      else process.env.OPEN_DESIGN_AMR_PROFILE = previousProfile;
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
+  });
 
-      const project = await createAmrProject(webUrl, 'AMR relogin required');
+  test('uses configured AMR profile env for pre-run login status', { timeout: 180_000 }, async () => {
+    const suite = await createSmokeSuite('amr-configured-profile-preflight');
+    const previousProfile = process.env.OPEN_DESIGN_AMR_PROFILE;
+    const previousHome = process.env.HOME;
+    const homeDir = join(suite.scratchDir, 'home-configured-profile');
+    process.env.OPEN_DESIGN_AMR_PROFILE = 'prod';
+    process.env.HOME = homeDir;
 
-      const assistantMessageId = `assistant-${Date.now()}`;
-      const run = await startRun(webUrl, {
-        agentId: 'amr',
-        assistantMessageId,
-        clientRequestId: `req-${Date.now()}`,
-        conversationId: project.conversationId,
-        designSystemId: null,
-        message: 'This should require a fresh AMR login.',
-        model: 'default',
-        projectId: project.project.id,
-        reasoning: 'default',
-        skillId: null,
+    try {
+      await seedVelaLoginConfig(homeDir, { profile: 'local' });
+      await suite.with.toolsDev(async ({ webUrl }) => {
+        const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-configured-profile'));
+
+        await putAmrAppConfig(webUrl, {
+          agentId: 'amr',
+          agentCliEnv: {
+            amr: {
+              VELA_BIN: velaBin,
+              OPEN_DESIGN_AMR_PROFILE: 'local',
+            },
+          },
+        });
+
+        const project = await createAmrProject(webUrl, 'AMR configured profile preflight');
+        const run = await startRun(webUrl, {
+          agentId: 'amr',
+          assistantMessageId: `assistant-configured-profile-${Date.now()}`,
+          clientRequestId: `req-configured-profile-${Date.now()}`,
+          conversationId: project.conversationId,
+          designSystemId: null,
+          message: 'This should use the configured AMR profile.',
+          model: 'default',
+          projectId: project.project.id,
+          reasoning: 'default',
+          skillId: null,
+        });
+
+        await waitForRunStatus(webUrl, run.runId, 'succeeded', { timeoutMs: 20_000 });
       });
-      const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
-      expect(terminal.status).toBe('failed');
+    } finally {
+      if (previousProfile === undefined) delete process.env.OPEN_DESIGN_AMR_PROFILE;
+      else process.env.OPEN_DESIGN_AMR_PROFILE = previousProfile;
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+    }
+  });
 
-      await expect(readRunEvents(webUrl, run.runId)).resolves.toMatch(/sign in again|login missing|expired/i);
-    });
+  test('uses daemon AMR runtime credentials for pre-run login status', { timeout: 180_000 }, async () => {
+    const suite = await createSmokeSuite('amr-daemon-env-credentials-preflight');
+    const previousProfile = process.env.OPEN_DESIGN_AMR_PROFILE;
+    const previousHome = process.env.HOME;
+    const previousRuntimeKey = process.env.VELA_RUNTIME_KEY;
+    const previousLinkUrl = process.env.VELA_LINK_URL;
+    const homeDir = join(suite.scratchDir, 'home-daemon-env-credentials');
+    process.env.OPEN_DESIGN_AMR_PROFILE = 'local';
+    process.env.HOME = homeDir;
+    process.env.VELA_RUNTIME_KEY = 'fake-runtime-key-from-daemon-env';
+    process.env.VELA_LINK_URL = 'http://localhost:18081';
+
+    try {
+      await suite.with.toolsDev(async ({ webUrl }) => {
+        const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela-daemon-env-credentials'), {
+          requireLoginConfig: false,
+        });
+
+        await putAmrAppConfig(webUrl, {
+          agentId: 'amr',
+          agentCliEnv: {
+            amr: {
+              VELA_BIN: velaBin,
+              OPEN_DESIGN_AMR_PROFILE: 'local',
+            },
+          },
+        });
+
+        const project = await createAmrProject(webUrl, 'AMR daemon env credentials preflight');
+        const run = await startRun(webUrl, {
+          agentId: 'amr',
+          assistantMessageId: `assistant-daemon-env-credentials-${Date.now()}`,
+          clientRequestId: `req-daemon-env-credentials-${Date.now()}`,
+          conversationId: project.conversationId,
+          designSystemId: null,
+          message: 'This should use daemon AMR runtime credentials.',
+          model: 'default',
+          projectId: project.project.id,
+          reasoning: 'default',
+          skillId: null,
+        });
+
+        await waitForRunStatus(webUrl, run.runId, 'succeeded', { timeoutMs: 20_000 });
+      });
+    } finally {
+      if (previousProfile === undefined) delete process.env.OPEN_DESIGN_AMR_PROFILE;
+      else process.env.OPEN_DESIGN_AMR_PROFILE = previousProfile;
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousRuntimeKey === undefined) delete process.env.VELA_RUNTIME_KEY;
+      else process.env.VELA_RUNTIME_KEY = previousRuntimeKey;
+      if (previousLinkUrl === undefined) delete process.env.VELA_LINK_URL;
+      else process.env.VELA_LINK_URL = previousLinkUrl;
+    }
   });
 });

--- a/e2e/tests/amr/turn.test.ts
+++ b/e2e/tests/amr/turn.test.ts
@@ -208,14 +208,15 @@ describe('AMR chat-run end-to-end', () => {
       );
 
       // Persist agentCliEnv so the daemon's runtime resolver picks up the
-      // fake binary AND knows which vela profile to read. HOME is set on
-      // the per-agent env block so the spawned child sees the pre-seeded
-      // ~/.vela/config.json without touching the developer's real one.
+      // fake binary and the pre-run AMR status guard sees configured runtime
+      // credentials without touching the developer's real ~/.vela config.
       await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
         body: {
           agentCliEnv: {
             amr: {
               VELA_BIN: velaBin,
+              VELA_LINK_URL: 'http://localhost:18081',
+              VELA_RUNTIME_KEY: 'fake-runtime-key',
             },
           },
           agentId: 'amr',

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -14,6 +14,8 @@ export const API_ERROR_CODES = [
   'AGENT_AUTH_REQUIRED',
   'AGENT_EXECUTION_FAILED',
   'AGENT_PROMPT_TOO_LARGE',
+  'AMR_AUTH_REQUIRED',
+  'AMR_INSUFFICIENT_BALANCE',
   'PROJECT_NOT_FOUND',
   // Handoff (`POST /api/projects/:id/handoff`): the requested conversation
   // is not in the project, or has no messages to synthesize a handoff from.


### PR DESCRIPTION
## Why

This fixes the AMR paid-model failure path where a Vela insufficient-balance response could leave the OpenDesign task looking like it was still loading instead of giving the user a clear terminal failure.

The pain addressed is user-facing: when the active AMR account has no balance, users need an immediate explanation and a direct recharge action rather than a generic ACP failure or an empty/stuck assistant turn.

## What users will see

When AMR reports insufficient balance, the assistant turn fails terminally and includes a `Recharge AMR wallet` link pointing to `https://open-design.ai/amr/wallet`.

When AMR auth is stale or missing, the assistant turn fails terminally with re-login guidance instead of a generic execution failure.

Onboarding AMR login polling now waits up to five minutes while keeping the existing two-second polling cadence.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a chat-run failure-state change covered by component and E2E assertions rather than a new persistent UI entry point.

## Bug fix verification

- Test path that reproduces the bug: `e2e/tests/amr/insufficient-balance.test.ts`
- Did the test go red on `main` and green on this branch? Not run on `main`; the regression is encoded against fake Vela and passes on this branch.
- Additional focused coverage: daemon AMR classifier tests, web run-consumer tests, and logout-state persistence E2E coverage for the new pre-run AMR auth guard.

## Validation

- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH ./node_modules/.bin/vitest run -c vitest.config.ts tests/integrations/vela-errors.test.ts tests/amr-acp-integration.test.ts tests/integrations/vela.routes.test.ts` from `apps/daemon`
- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH ./node_modules/.bin/vitest run -c vitest.config.ts tests/providers/sse.test.ts tests/components/ProjectView.run-isolation.test.tsx tests/components/EntryShell.onboarding.test.tsx` from `apps/web`
- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH pnpm test tests/amr/turn.test.ts tests/amr/relogin-required.test.ts tests/amr/auth-error-convergence.test.ts tests/amr/insufficient-balance.test.ts tests/amr/logout-state-persistence.test.ts` from `e2e`
- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH pnpm --filter @open-design/web typecheck`
- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH pnpm --filter @open-design/daemon typecheck`
- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH pnpm --filter @open-design/e2e typecheck`
- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH pnpm guard`
- `git diff --check`
- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH pnpm -C e2e exec tsx scripts/playwright.ts clean && PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH pnpm -C e2e exec playwright test -c playwright.config.ts ui/critical-smoke.test.ts ui/entry-chrome-flows.test.ts`
