### PR TITLE
[codex] Bump beta base version to 0.8.1

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/download",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/host",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "description": "Open Design renderer host bridge protocol.",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

This PR bumps the beta release base version after the `release-beta` workflow rejected `0.8.0` because the latest stable is already `0.8.0`.

The pain being addressed is release blocking: the beta packaging workflow requires the packaged base version to be strictly greater than the latest stable version, so `feat/amr-runtime-acp` needs a `0.8.1` base before it can produce a distributable beta package.

## What users will see

Users receiving the beta package built from this branch will see a `0.8.1-beta.1` beta version instead of the workflow failing before artifact creation.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is a package version metadata change only.

## Bug fix verification

Not applicable; this PR unblocks beta packaging and does not fix a runtime bug.

## Validation

- `git diff --check`
- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH pnpm guard`
- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH OPEN_DESIGN_BETA_METADATA_URL=https://releases.open-design.ai/beta/latest/metadata.json node --experimental-strip-types ./scripts/release-beta.ts`
