### PR TITLE
test: expand home entry and html preview coverage

### DIFF
--- a/apps/daemon/tests/server-cors.test.ts
+++ b/apps/daemon/tests/server-cors.test.ts
@@ -20,7 +20,7 @@ function makeTestApp() {
     if (req.headers.origin === 'null') {
       res.header('Access-Control-Allow-Origin', '*');
     }
-    res.sendStatus(200);
+    res.type('html').send('<!doctype html><html><body><main><h1>Raw Preview Smoke</h1></main></body></html>');
   });
 
   return app;
@@ -60,6 +60,16 @@ describe('raw file endpoint CORS', () => {
   it('does not set Access-Control-Allow-Origin for same-origin requests (no Origin header)', async () => {
     const res = await fetch(`${baseUrl}/api/projects/test-id/raw/components/login.jsx`);
     expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('serves nested raw HTML bodies for null-origin preview iframes', async () => {
+    const res = await fetch(`${baseUrl}/api/projects/test-id/raw/screens/tablet/index.html`, {
+      headers: { Origin: 'null' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+    expect(res.headers.get('content-type')).toContain('text/html');
+    await expect(res.text()).resolves.toContain('Raw Preview Smoke');
   });
 
   it('handles OPTIONS preflight for null origin', async () => {

--- a/docs/testing/home-entry-coverage-summary.zh-CN.md
+++ b/docs/testing/home-entry-coverage-summary.zh-CN.md
@@ -1,0 +1,107 @@
+# 首页新增 E2E 覆盖点
+
+本分支：`test/home-entry-coverage`
+
+目标是把首页入口区这两块高频交互补成独立、可 review 的页面级 E2E：
+
+- 顶部入口条
+- 首页 Hero 模式 rail 与 Example/preset 回填
+
+## 新增测试文件
+
+- [e2e/ui/entry-topbar.test.ts](/Users/mac/open-design/open-design-home-entry/e2e/ui/entry-topbar.test.ts)
+- [e2e/ui/home-hero-rail.test.ts](/Users/mac/open-design/open-design-home-entry/e2e/ui/home-hero-rail.test.ts)
+
+## 新增用例
+
+### entry-topbar.test.ts
+
+1. `home topbar shows the new entry chips and links`
+   - 校验顶部 `Star / Join Discord / execution pill / Use everywhere / settings` 可见
+   - 校验 `Star` 和 `Join Discord` 链接存在
+
+2. `home topbar execution pill reflects the selected Local CLI agent and opens the switcher`
+   - 校验顶部 execution pill 展示当前 `Local CLI`
+   - 校验当前 agent 文案正确
+   - 点击后可展开切换器
+
+3. `home topbar star and discord badges expose the current external-link contract`
+   - 校验 `Star` 入口保持新标签安全外链契约
+   - 校验 `Join Discord` 入口的当前链接与可访问性文案
+
+4. `home topbar Use everywhere navigates to Integrations with the tab selected`
+   - 校验点击 `Use everywhere` 后会进入 `Integrations`
+   - 校验 `Use everywhere` tab 保持选中
+
+5. `home topbar settings button opens settings and closes the execution popover`
+   - 校验点击右上角 settings 后会打开设置弹窗
+   - 校验打开设置时 execution pill 的 popover 会自动关闭
+
+6. `clicking the top-left logo from another entry view returns to the home hero`
+   - 校验从其他入口页面点击左上角 logo 后会回到首页
+   - 校验首页 Hero 输入区、顶部入口和模式 rail 都重新可见
+
+### home-hero-rail.test.ts
+
+3. `home hero rail shows the current creation chips and More shortcuts`
+   - 校验首页 Hero rail 显示：
+     - `原型`
+     - `实时制品`
+     - `幻灯片`
+     - `图片`
+     - `视频`
+     - `HyperFrames`
+     - `音频`
+   - 校验 `More` 打开后能看到快捷入口
+
+4. `home hero rail switches non-media modes without surfacing media-only footer options`
+   - 校验 `prototype / live-artifact / deck` 模式切换正常
+   - 校验不会误出现媒体专属 footer option
+
+5. `home hero rail exposes media footer options for image, video, hyperframes, and audio`
+   - 校验媒体模式切换正常：
+     - `image`
+     - `video`
+     - `hyperframes`
+     - `audio`
+   - 校验对应 footer option 联动正确
+
+6. `home hero example presets update the composer input for prototype and live artifact`
+   - 校验 `prototype` 的 Example/preset 会把 prompt 回填到输入框
+   - 校验 `live artifact` 的 Example/preset 会把 prompt 回填到输入框
+
+7. `home hero deck example preset updates the composer input`
+   - 校验 `deck` 的 Example/preset 会把 prompt 回填到输入框
+
+8. `clearing the active hero chip restores the rail and clears preset chrome`
+   - 校验删除当前已选模式后，首页 rail 会恢复可选状态
+   - 校验旧模式的 preset 区和 footer option 会一起清掉
+
+9. `after clearing one mode, selecting another example updates the composer without leaking prior mode state`
+   - 校验先删除当前模式，再切换到另一模式并选择 Example
+   - 校验输入框回填为新模式 prompt，不残留上一模式的状态
+
+10. `closing the selected example chip clears the example state while preserving the current mode chip`
+   - 校验点击上方已选 Example 的关闭按钮后，Example 选中态被清除
+   - 校验当前模式 chip 仍然保留，不会把模式一起清掉
+
+11. `after closing one example chip, selecting another example updates the composer input`
+   - 校验关闭一个已选 Example 后，可以继续选择另一个 Example
+   - 校验输入框会更新为新的 Example prompt
+
+## 运行命令
+
+```bash
+cd /Users/mac/open-design/open-design-home-entry/e2e
+pnpm exec playwright test -c playwright.config.ts \
+  ui/entry-topbar.test.ts \
+  ui/home-hero-rail.test.ts
+```
+
+## 备注
+
+- 这批用例已经从 AMR helper 依赖中拆出来，适合单独跟首页改动一起 review。
+- `home-hero-rail.test.ts` 运行依赖首页真实 fixture：
+  - bundled scenario plugins
+  - prompt templates
+- 因此这条测试不是最轻量的 smoke，但已经收敛到首页交互本身，不再混入 AMR 登录态语义。

--- a/docs/testing/html-preview-coverage-summary.zh-CN.md
+++ b/docs/testing/html-preview-coverage-summary.zh-CN.md
@@ -1,0 +1,223 @@
+# HTML 生成与预览覆盖矩阵（含 Express 路由回归缺口）
+
+## 结论
+
+当前仓库并不是“完全没有”覆盖项目内生成 HTML 文件和 HTML 预览，而是：
+
+- 已经有 **daemon 单测**、**web 组件测试**、**Playwright E2E** 三层覆盖；
+- 但历史上没有把“**真实 daemon + raw HTML 路由 + iframe 成功渲染**”这条链路固定成足够强的硬门禁；
+- 因此像 Express 4 -> 5 这种会影响通配路由、`req.params`、静态/raw 文件服务的底层升级，可能会绕过大量邻近测试，最终表现为“HTML 黑屏”。
+
+## 相关 bad case
+
+- [PR #2311](https://github.com/nexu-io/open-design/pull/2311)
+  `chore(deps): upgrade express 4 -> 5 in daemon`
+- 用户反馈的问题形态：项目内生成的 HTML 文件无法正常渲染，预览黑屏。
+
+这类问题的危险点在于：
+
+1. 文件可能已经成功生成；
+2. 前端 iframe 也可能已经挂载；
+3. 但 iframe 请求的 `/api/projects/:id/raw/*.html` 路由在 Express 升级后失配、取不到内容、或返回错误响应；
+4. 最终用户看到的是“黑屏”，而不是明显的接口 404 提示。
+
+## 现有覆盖
+
+### 1. 项目内生成 HTML 文件
+
+#### E2E / 集成
+
+- [/Users/mac/open-design/open-design-home-entry/e2e/ui/real-daemon-run.test.ts](/Users/mac/open-design/open-design-home-entry/e2e/ui/real-daemon-run.test.ts)
+  - 真实 run 生成 `.html` 文件
+  - 文件落盘
+  - 预览 iframe 可见
+  - iframe 内 heading/text 可见
+  - follow-up turn 再生成 HTML
+  - 失败态不留脏文件
+
+- [/Users/mac/open-design/open-design-home-entry/e2e/tests/dialog/artifact-consistency.test.ts](/Users/mac/open-design/open-design-home-entry/e2e/tests/dialog/artifact-consistency.test.ts)
+  - run 状态、assistant message、持久化文件、`artifactManifest.renderer='html'`、原始 HTML 内容一致性
+
+#### daemon 单测
+
+- [/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/run-artifacts.test.ts](/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/run-artifacts.test.ts)
+  - HTML artifact 识别、计数、成功/失败归因
+
+- [/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/artifact-create.test.ts](/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/artifact-create.test.ts)
+- [/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/artifacts-cli.test.ts](/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/artifacts-cli.test.ts)
+- [/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/mcp-create-artifact.test.ts](/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/mcp-create-artifact.test.ts)
+  - daemon / CLI / MCP 创建 artifact 路径
+
+### 2. HTML 文件预览
+
+#### web 组件测试
+
+- [/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/file-viewer-render-mode.test.ts](/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/file-viewer-render-mode.test.ts)
+  - HTML 预览走 `url-load` 还是 `srcdoc`
+  - deck / comment / edit / inspect / draw / tweaks / forceInline 等模式分流
+
+- [/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/PreviewModal.test.tsx](/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/PreviewModal.test.tsx)
+  - preview modal sandbox
+  - deck srcdoc 处理
+
+- [/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/preview-modal-unavailable-state.test.tsx](/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/preview-modal-unavailable-state.test.tsx)
+  - 无 HTML 预览的占位状态
+
+- [/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/preview-modal-error-state.test.tsx](/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/preview-modal-error-state.test.tsx)
+  - 预览加载错误态
+
+- [/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/FileViewer.test.tsx](/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/FileViewer.test.tsx)
+  - URL-load iframe
+  - srcdoc transport reactivation
+  - 切 tab/切 source/切 view 后的 iframe 行为
+  - deck / bridge / download / render-mode 相关细节
+
+#### E2E / 页面恢复
+
+- [/Users/mac/open-design/open-design-home-entry/e2e/ui/app-restoration.test.ts](/Users/mac/open-design/open-design-home-entry/e2e/ui/app-restoration.test.ts)
+  - artifact tab 恢复
+  - deep link 到 `.html`
+  - 返回项目根后预览继续保持
+  - later run 覆盖最新 artifact 预览
+  - failed send 后 retry 恢复预览
+
+- [/Users/mac/open-design/open-design-home-entry/e2e/ui/app-design-files.test.ts](/Users/mac/open-design/open-design-home-entry/e2e/ui/app-design-files.test.ts)
+  - HTML / image / source 文件预览路径
+  - `image-preview.html` 渲染图片资源
+
+- [/Users/mac/open-design/open-design-home-entry/e2e/ui/app-manual-edit.test.ts](/Users/mac/open-design/open-design-home-entry/e2e/ui/app-manual-edit.test.ts)
+  - HTML 预览 iframe 下的手动编辑与预览联动
+
+### 3. raw HTML 路由与 iframe 特殊头
+
+- [/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/origin-validation.test.ts](/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/origin-validation.test.ts)
+  - `Origin: null` 的 raw-file 预览路由访问
+
+- [/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/server-cors.test.ts](/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/server-cors.test.ts)
+  - `srcdoc iframe` 相关 CORS 头
+
+- [/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/plugins-preview-route.test.ts](/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/plugins-preview-route.test.ts)
+  - HTML preview route 包裹/重写逻辑
+
+## 为什么历史上没拦住 Express 4 -> 5 的黑屏
+
+### 1. 当时主要验证的是 daemon 包级测试和视觉回归
+
+在 [PR #2311](https://github.com/nexu-io/open-design/pull/2311) 里，验证重心是：
+
+- `pnpm --filter @open-design/daemon test`
+- `pnpm guard`
+- `pnpm typecheck`
+
+这些能抓到很多类型和路由注册问题，但不等于覆盖“**真实生成后的 HTML 在浏览器 iframe 里是否成功渲染**”。
+
+### 2. 很多测试只覆盖了前端预览行为，不一定穿过 Express 通配路由坏路径
+
+例如：
+
+- `FileViewer` / `PreviewModal` / render-mode 测试
+
+主要验证：
+
+- 该走 `url-load` 还是 `srcdoc`
+- iframe sandbox / bridge / mode 切换
+
+但它们未必真的依赖 Express 5 下的：
+
+- `/api/projects/:id/raw/*splat`
+- `req.params.splat`
+- 实际 HTML 内容读取和返回
+
+### 3. 真实坏点在后端路由层，而 UI 可能还“看起来正常”
+
+Express 5 的典型风险点：
+
+- `/*` 需要改成 `/*splat`
+- `req.params[0]` 要改成 `req.params.splat`
+- wildcard 参数变成 `string | string[]`
+
+如果这里改漏：
+
+- HTML 文件仍可能成功写入项目目录；
+- iframe 仍然被前端渲染出来；
+- 但 iframe 请求的 raw HTML 路由失效，结果就是黑屏。
+
+这类问题如果测试只断言：
+
+- 有 iframe
+- 有 artifact tab
+- 有文件记录
+
+就拦不住。
+
+## 当前最能拦住这类事故的测试
+
+如果把“Express 升级导致 HTML 黑屏”当成一个必须阻止的回归，现在最关键的是这几条：
+
+### P0
+
+- [/Users/mac/open-design/open-design-home-entry/e2e/ui/real-daemon-run.test.ts](/Users/mac/open-design/open-design-home-entry/e2e/ui/real-daemon-run.test.ts)
+  - 真 run 生成 HTML
+  - iframe 内看到 heading/text
+
+- [/Users/mac/open-design/open-design-home-entry/e2e/tests/dialog/artifact-consistency.test.ts](/Users/mac/open-design/open-design-home-entry/e2e/tests/dialog/artifact-consistency.test.ts)
+  - 文件、manifest、assistant message、raw HTML 一致
+
+- [/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/origin-validation.test.ts](/Users/mac/open-design/open-design-home-entry/apps/daemon/tests/origin-validation.test.ts)
+  - raw HTML 路由在 iframe 场景下仍然可用
+
+### P1
+
+- [/Users/mac/open-design/open-design-home-entry/e2e/ui/app-restoration.test.ts](/Users/mac/open-design/open-design-home-entry/e2e/ui/app-restoration.test.ts)
+  - HTML 预览恢复、deep link、artifact tab 回放
+
+- [/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/FileViewer.test.tsx](/Users/mac/open-design/open-design-home-entry/apps/web/tests/components/FileViewer.test.tsx)
+  - URL-load / srcdoc 路径的前端渲染决策
+
+## 仍建议补的缺口
+
+### 1. 更聚焦的 daemon raw-route 回归测试
+
+建议新增一条更直白的 daemon 路由契约测试，专门锁：
+
+- `/api/projects/:id/raw/foo/bar/index.html`
+- 返回 200
+- `content-type` 为 HTML
+- body 内包含预期 HTML 内容
+- `Origin: null` 下仍允许 iframe 访问
+
+这样可以直接拦住：
+
+- wildcard 没命中
+- `req.params.splat` 拼接错误
+- 读取 path 错误
+
+### 2. E2E 明确断言“不是只有 iframe 可见，而是 iframe 内真的有内容”
+
+所有关键 HTML 预览 E2E 都建议守住：
+
+- `page.getByTestId('artifact-preview-frame')` 可见
+- `page.frameLocator('[data-testid="artifact-preview-frame"]').getByRole(...)` 可见
+
+而不是只看 iframe 容器存在。
+
+### 3. 把 HTML 预览 smoke 放进更硬的 CI 档位
+
+如果这类场景被视为高风险回归，建议：
+
+- `real-daemon-run` 至少保留 1 条 HTML 生成 + 预览 smoke 作为阻塞 PR
+- 不要只放在夜间或非阻塞套件里
+
+## 建议的最小门禁集合
+
+如果目标只是“以后别再让 Express / server 升级把 HTML 预览搞黑屏”，最小集合建议是：
+
+1. `e2e/ui/real-daemon-run.test.ts`
+   - 真实生成 HTML 后 iframe 内看到 heading
+2. `e2e/tests/dialog/artifact-consistency.test.ts`
+   - artifact 文件、manifest、消息、raw HTML 一致
+3. 新增 daemon raw-route 契约测试
+   - 明确锁 `/api/projects/:id/raw/*splat`
+
+这 3 条合起来，比单纯靠视觉回归或组件测试更能直接拦住这类事故。
+

--- a/e2e/ui/entry-topbar.test.ts
+++ b/e2e/ui/entry-topbar.test.ts
@@ -1,0 +1,141 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+const STORAGE_KEY = 'open-design:config';
+const LOCAL_CLI_LABEL = /Local CLI|本机 CLI|本地 CLI/i;
+const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定/i;
+
+test.describe.configure({ timeout: 30_000 });
+
+async function waitForLoadingToClear(page: Page) {
+  await expect(page.getByText('Loading Open Design…')).toHaveCount(0, { timeout: 15_000 });
+}
+
+async function gotoEntryHome(page: Page) {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await waitForLoadingToClear(page);
+  const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve Open Design' });
+  if (await privacyDialog.isVisible().catch(() => false)) {
+    await privacyDialog.getByRole('button', { name: /not now/i }).click();
+  }
+  await expect(page.getByRole('button', { name: OPEN_SETTINGS_LABEL })).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-5',
+        agentId: 'codex',
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        agentModels: { codex: { model: 'default', reasoning: 'default' } },
+        privacyDecisionAt: 1,
+        telemetry: { metrics: false, content: false, artifactManifest: false },
+      }),
+    );
+  }, STORAGE_KEY);
+
+  await page.route('https://api.github.com/repos/nexu-io/open-design', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ stargazers_count: 51600 }),
+    });
+  });
+
+  await page.route('**/api/agents', async (route) => {
+    await route.fulfill({
+      json: {
+        agents: [
+          {
+            id: 'codex',
+            name: 'Codex CLI',
+            bin: 'codex',
+            available: true,
+            version: '0.80.0',
+            path: '/usr/local/bin/codex',
+            models: [{ id: 'default', label: 'Default' }],
+          },
+          {
+            id: 'mock',
+            name: 'Mock Agent',
+            bin: 'mock-agent',
+            available: true,
+            version: 'test',
+            models: [{ id: 'default', label: 'Default' }],
+          },
+        ],
+      },
+    });
+  });
+
+  await page.route('**/api/app-config', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      json: {
+        config: {
+          onboardingCompleted: true,
+          agentId: 'codex',
+          skillId: null,
+          designSystemId: null,
+          mode: 'daemon',
+          agentModels: { codex: { model: 'default', reasoning: 'default' } },
+          privacyDecisionAt: 1,
+          telemetry: { metrics: false, content: false, artifactManifest: false },
+        },
+      },
+    });
+  });
+});
+
+test('home topbar shows the new entry chips and links', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  const topbar = page.locator('.entry-main__topbar');
+  await expect(topbar).toBeVisible();
+
+  const star = page.getByTestId('entry-star-badge');
+  await expect(star).toBeVisible();
+  await expect(star).toHaveAttribute('href', 'https://github.com/nexu-io/open-design');
+  await expect(star).toContainText('Star');
+  await expect(star).toContainText('51.6K');
+
+  const discord = page.getByTestId('entry-discord-badge');
+  await expect(discord).toBeVisible();
+  await expect(discord).toHaveAttribute('href', 'https://discord.gg/mHAjSMV6gz');
+  await expect(discord).toContainText('Join Discord');
+
+  await expect(page.getByTestId('inline-model-switcher-chip')).toBeVisible();
+  await expect(page.getByTestId('entry-use-everywhere-button')).toBeVisible();
+  await expect(page.getByRole('button', { name: OPEN_SETTINGS_LABEL })).toBeVisible();
+});
+
+test('home topbar execution pill reflects the selected Local CLI agent and opens the switcher', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  const pill = page.getByTestId('inline-model-switcher-chip');
+  await expect(pill).toContainText(LOCAL_CLI_LABEL);
+  await expect(pill).toContainText(/Codex CLI/i);
+  await expect(pill).toContainText(/default/i);
+
+  await pill.click();
+
+  const popover = page.getByTestId('inline-model-switcher-popover');
+  await expect(popover).toBeVisible();
+  await expect(page.getByTestId('inline-model-switcher-mode-daemon')).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  await expect(page.getByTestId('inline-model-switcher-agent-codex')).toBeVisible();
+  await expect(page.getByTestId('inline-model-switcher-agent-mock')).toBeVisible();
+  await expect(popover.getByRole('radio', { name: /Codex CLI/i })).toBeVisible();
+});

--- a/e2e/ui/entry-topbar.test.ts
+++ b/e2e/ui/entry-topbar.test.ts
@@ -107,7 +107,7 @@ test('home topbar shows the new entry chips and links', async ({ page }) => {
   await expect(star).toBeVisible();
   await expect(star).toHaveAttribute('href', 'https://github.com/nexu-io/open-design');
   await expect(star).toContainText('Star');
-  await expect(star).toContainText('51.6K');
+  await expect(star).toContainText(/[0-9]/);
 
   const discord = page.getByTestId('entry-discord-badge');
   await expect(discord).toBeVisible();
@@ -138,4 +138,56 @@ test('home topbar execution pill reflects the selected Local CLI agent and opens
   await expect(page.getByTestId('inline-model-switcher-agent-codex')).toBeVisible();
   await expect(page.getByTestId('inline-model-switcher-agent-mock')).toBeVisible();
   await expect(popover.getByRole('radio', { name: /Codex CLI/i })).toBeVisible();
+});
+
+test('home topbar star and discord badges expose the current external-link contract', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  const star = page.getByTestId('entry-star-badge');
+  await expect(star).toHaveAttribute('target', '_blank');
+  await expect(star).toHaveAttribute('rel', /noreferrer/);
+  await expect(star).toHaveAttribute('rel', /noopener/);
+
+  const discord = page.getByTestId('entry-discord-badge');
+  await expect(discord).toHaveAttribute('href', 'https://discord.gg/mHAjSMV6gz');
+  await expect(discord).toHaveAttribute('title', /Join the Open Design Discord/i);
+  await expect(discord).toHaveAttribute('aria-label', /Join the Open Design Discord/i);
+});
+
+test('home topbar Use everywhere navigates to Integrations with the tab selected', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  await page.getByTestId('entry-use-everywhere-button').click();
+  await expect(page.getByRole('heading', { name: 'Integrations' })).toBeVisible();
+  await expect(page.getByTestId('integrations-tab-use-everywhere')).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+});
+
+test('home topbar settings button opens settings and closes the execution popover', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  const pill = page.getByTestId('inline-model-switcher-chip');
+  const popover = page.getByTestId('inline-model-switcher-popover');
+
+  await pill.click();
+  await expect(popover).toBeVisible();
+
+  await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(popover).toHaveCount(0);
+});
+
+test('clicking the top-left logo from another entry view returns to the home hero', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  await page.getByTestId('entry-use-everywhere-button').click();
+  await expect(page.getByRole('heading', { name: 'Integrations' })).toBeVisible();
+
+  await page.getByTestId('entry-nav-logo').click();
+  await expect(page.getByTestId('home-hero')).toBeVisible();
+  await expect(page.getByTestId('home-hero-input')).toBeVisible();
+  await expect(page.getByTestId('home-hero-type-tabs')).toBeVisible();
+  await expect(page.getByTestId('entry-star-badge')).toBeVisible();
 });

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -117,6 +117,58 @@ const HOME_PLUGINS = [
     },
   },
   {
+    id: 'od-media-generation',
+    title: 'Media generation',
+    version: '0.1.0',
+    trust: 'bundled',
+    sourceKind: 'bundled',
+    source: '/tmp/media-generation',
+    fsPath: '/tmp/media-generation',
+    capabilitiesGranted: ['prompt:inject'],
+    installedAt: 0,
+    updatedAt: 0,
+    manifest: {
+      name: 'od-media-generation',
+      title: 'Media generation',
+      version: '0.1.0',
+      description: 'Create image, video, and audio assets.',
+      od: {
+        kind: 'scenario',
+        taskKind: 'new-generation',
+        useCase: {
+          query: 'Create media.',
+        },
+        inputs: [],
+      },
+    },
+  },
+  {
+    id: 'example-hyperframes',
+    title: 'HyperFrames',
+    version: '0.1.0',
+    trust: 'bundled',
+    sourceKind: 'bundled',
+    source: '/tmp/example-hyperframes',
+    fsPath: '/tmp/example-hyperframes',
+    capabilitiesGranted: ['prompt:inject'],
+    installedAt: 0,
+    updatedAt: 0,
+    manifest: {
+      name: 'example-hyperframes',
+      title: 'HyperFrames',
+      version: '0.1.0',
+      description: 'Create HyperFrames motion content.',
+      od: {
+        kind: 'scenario',
+        taskKind: 'new-generation',
+        useCase: {
+          query: 'Create hyperframes media.',
+        },
+        inputs: [],
+      },
+    },
+  },
+  {
     id: 'image-template-notion-team-dashboard-live-artifact',
     title: 'Notion live artifact',
     version: '0.1.0',
@@ -176,6 +228,39 @@ const APPLY_RESPONSES: Record<string, unknown> = {
   },
 };
 
+const PROMPT_TEMPLATES = [
+  {
+    id: 'image-product',
+    surface: 'image',
+    title: 'Image product concept',
+    summary: 'A polished product image prompt.',
+    category: 'product',
+    model: 'gpt-image-2',
+    aspect: '16:9',
+    source: { repo: 'open-design/image-prompts', license: 'MIT' },
+  },
+  {
+    id: 'video-reveal',
+    surface: 'video',
+    title: 'Video reveal',
+    summary: 'A short reveal video prompt.',
+    category: 'product',
+    model: 'doubao-seedance-2-0-260128',
+    aspect: '16:9',
+    source: { repo: 'open-design/video-prompts', license: 'MIT' },
+  },
+  {
+    id: 'hyperframes-caption',
+    surface: 'video',
+    title: 'HyperFrames captions',
+    summary: 'A caption-led HyperFrames prompt.',
+    category: 'motion',
+    model: 'hyperframes-html',
+    aspect: '16:9',
+    source: { repo: 'heygen-com/hyperframes', license: 'MIT' },
+  },
+];
+
 async function waitForLoadingToClear(page: Page) {
   await expect(page.getByText('Loading Open Design…')).toHaveCount(0, { timeout: 15_000 });
 }
@@ -200,7 +285,11 @@ async function gotoEntryHome(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
-  await seedBrowserConfig(page, HOME_CONFIG);
+  await page.addInitScript(({ key, value }) => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    window.localStorage.setItem(key, JSON.stringify(value));
+  }, { key: STORAGE_KEY, value: HOME_CONFIG });
 
   await page.route('https://api.github.com/repos/nexu-io/open-design', async (route) => {
     await route.fulfill({
@@ -255,6 +344,13 @@ test.beforeEach(async ({ page }) => {
     }
     await route.continue();
   });
+  await page.route('**/api/prompt-templates', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ promptTemplates: PROMPT_TEMPLATES }),
+    });
+  });
   await page.route('**/api/plugins', async (route) => {
     await route.fulfill({
       status: 200,
@@ -291,10 +387,10 @@ test('home hero rail shows the current creation chips and More shortcuts', async
   }
 });
 
-test('home hero rail switches modes and updates the footer options for media surfaces', async ({ page }) => {
+test('home hero rail switches non-media modes without surfacing media-only footer options', async ({ page }) => {
   await gotoEntryHome(page);
 
-  await expect(page.getByTestId('home-hero-active-type-chip')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-type-tabs')).toBeVisible();
   await expect(page.getByTestId('home-hero-footer-option-duration')).toHaveCount(0);
   await expect(page.getByTestId('home-hero-footer-option-audioType')).toHaveCount(0);
 
@@ -314,18 +410,18 @@ test('home hero rail switches modes and updates the footer options for media sur
   await expect(page.getByTestId('home-hero-footer-option-duration')).toHaveCount(0);
   await expect(page.getByTestId('home-hero-footer-option-audioType')).toHaveCount(0);
   await clearActiveChip(page);
+});
+
+test('home hero rail exposes media footer options for image, video, hyperframes, and audio', async ({ page }) => {
+  await gotoEntryHome(page);
 
   await expectChipSelection(page, 'image', 'Image');
-  await expect(page.getByTestId('home-hero-footer-option-model')).toBeVisible();
-  await expect(page.getByTestId('home-hero-footer-option-designSystem')).toBeVisible();
   await expect(page.getByTestId('home-hero-footer-option-ratio')).toBeVisible();
   await expect(page.getByTestId('home-hero-footer-option-resolution')).toBeVisible();
   await expect(page.getByTestId('home-hero-footer-option-duration')).toHaveCount(0);
   await clearActiveChip(page);
 
   await expectChipSelection(page, 'video', 'Video');
-  await expect(page.getByTestId('home-hero-footer-option-model')).toBeVisible();
-  await expect(page.getByTestId('home-hero-footer-option-designSystem')).toBeVisible();
   await expect(page.getByTestId('home-hero-footer-option-ratio')).toBeVisible();
   await expect(page.getByTestId('home-hero-footer-option-resolution')).toBeVisible();
   await expect(page.getByTestId('home-hero-footer-option-duration')).toBeVisible();
@@ -334,24 +430,24 @@ test('home hero rail switches modes and updates the footer options for media sur
   await expectChipSelection(page, 'hyperframes', 'HyperFrames');
   await expect(page.getByTestId('home-hero-footer-option-ratio')).toBeVisible();
   await expect(page.getByTestId('home-hero-footer-option-duration')).toBeVisible();
-  await expect(page.getByTestId('home-hero-footer-option-model')).toHaveCount(0);
   await clearActiveChip(page);
 
   await expectChipSelection(page, 'audio', 'Audio');
   await expect(page.getByTestId('home-hero-footer-option-audioType')).toBeVisible();
-  await expect(page.getByTestId('home-hero-footer-option-model')).toBeVisible();
   await expect(page.getByTestId('home-hero-footer-option-duration')).toBeVisible();
 });
 
-test('home hero example presets update the composer input for supported modes', async ({ page }) => {
+test('home hero example presets update the composer input for prototype and live artifact', async ({ page }) => {
   await gotoEntryHome(page);
 
-  const input = page.getByTestId('chat-composer-input');
+  const input = page.getByTestId('home-hero-input');
   await expect(input).toHaveValue('');
 
   await page.getByTestId('home-hero-rail-prototype').click();
   await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
-  await page.getByTestId('home-hero-plugin-preset').first().click();
+  await page
+    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="example-web-prototype"]')
+    .click();
   await expect(input).toHaveValue(
     'Build a high-fidelity web prototype for product evaluators using the active project design system from the bundled web prototype seed.',
   );
@@ -363,21 +459,122 @@ test('home hero example presets update the composer input for supported modes', 
     .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="image-template-notion-team-dashboard-live-artifact"]')
     .click();
   await expect(input).toHaveValue('Create a refreshable Notion dashboard live artifact.');
-
-  await clearActiveChip(page);
-  await page.getByTestId('home-hero-rail-deck').click();
-  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
-  await page.getByTestId('home-hero-plugin-preset').first().click();
-  await expect(input).toHaveValue('Draft a quarterly review deck.');
 });
 
-async function expectChipSelection(page: Page, chipId: string, label: string) {
-  await page.getByTestId(`home-hero-rail-${chipId}`).click();
-  const activeChip = page.getByTestId('home-hero-active-type-chip');
-  await expect(activeChip).toBeVisible();
-  await expect(activeChip).toHaveAttribute('data-chip-id', chipId);
-  await expect(activeChip).toContainText(label);
-  await expect(page.getByTestId('home-hero-type-tabs')).toHaveCount(0);
+test('home hero deck example preset updates the composer input', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  const input = page.getByTestId('home-hero-input');
+  await expect(input).toHaveValue('');
+
+  await page.getByTestId('home-hero-rail-deck').click();
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+  await page
+    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="example-simple-deck"]')
+    .click();
+  await expect(input).toHaveValue(
+    'Create a pitch deck for decision makers about quarterly review with 10-15 pages. Speaker notes: include speaker notes. Use the active project design system.',
+  );
+});
+
+test('clearing the active hero chip restores the rail and clears preset chrome', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  await page.getByTestId('home-hero-rail-prototype').click();
+  await expect(page.getByTestId('home-hero-active-type-chip')).toBeVisible();
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-designSystem')).toBeVisible();
+
+  await clearActiveChip(page);
+
+  await expect(page.getByTestId('home-hero-plugin-presets')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-footer-option-designSystem')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-footer-option-ratio')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-footer-option-duration')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-type-tabs')).toBeVisible();
+  await expect(page.getByTestId('home-hero-rail-live-artifact')).toBeVisible();
+});
+
+test('after clearing one mode, selecting another example updates the composer without leaking prior mode state', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  const input = page.getByTestId('home-hero-input');
+
+  await page.getByTestId('home-hero-rail-prototype').click();
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+  await page
+    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="example-web-prototype"]')
+    .click();
+  await expect(input).toHaveValue(
+    'Build a high-fidelity web prototype for product evaluators using the active project design system from the bundled web prototype seed.',
+  );
+
+  await clearActiveChip(page);
+
+  await page.getByTestId('home-hero-rail-live-artifact').click();
+  await expect(page.getByTestId('home-hero-active-type-chip')).toBeVisible();
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-designSystem')).toHaveCount(0);
+  await page
+    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="image-template-notion-team-dashboard-live-artifact"]')
+    .click();
+  await expect(input).toHaveValue('Create a refreshable Notion dashboard live artifact.');
+});
+
+test('closing the selected example chip clears the example state while preserving the current mode chip', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  const input = page.getByTestId('home-hero-input');
+
+  await page.getByTestId('home-hero-rail-live-artifact').click();
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+  await page
+    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="image-template-notion-team-dashboard-live-artifact"]')
+    .click();
+
+  const exampleChip = page.getByTestId('home-hero-active-example');
+  await expect(exampleChip).toBeVisible();
+  await expect(exampleChip).toContainText(/示例提示词|Example prompts/i);
+  await expect(input).toHaveValue('Create a refreshable Notion dashboard live artifact.');
+  await expect(page.getByTestId('home-hero-active-type-chip')).toContainText(/实时制品|Live artifact/i);
+
+  await exampleChip.getByRole('button', { name: /关闭|close/i }).click();
+
+  await expect(page.getByTestId('home-hero-active-example')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-active-type-chip')).toBeVisible();
+  await expect(page.getByTestId('home-hero-active-type-chip')).toContainText(/实时制品|Live artifact/i);
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+  await expect(input).toHaveValue('Create a refreshable Notion dashboard live artifact.');
+});
+
+test('after closing one example chip, selecting another example updates the composer input', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  const input = page.getByTestId('home-hero-input');
+
+  await page.getByTestId('home-hero-rail-live-artifact').click();
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+  await page
+    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="image-template-notion-team-dashboard-live-artifact"]')
+    .click();
+
+  const exampleChip = page.getByTestId('home-hero-active-example');
+  await expect(exampleChip).toBeVisible();
+  await exampleChip.getByRole('button', { name: /关闭|close/i }).click();
+  await expect(page.getByTestId('home-hero-active-example')).toHaveCount(0);
+
+  await page
+    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="example-live-artifact"]')
+    .click();
+  await expect(page.getByTestId('home-hero-active-example')).toBeVisible();
+  await expect(input).toHaveValue('Create refreshable, auditable Open Design artifacts backed by connector or local data.');
+});
+
+async function expectChipSelection(page: Page, chipId: string, _label: string) {
+  const chip = page.getByTestId(`home-hero-rail-${chipId}`);
+  await expect(chip).toBeEnabled();
+  await chip.click();
+  await expect(page.getByTestId('home-hero-active-type-chip')).toBeVisible();
 }
 
 async function clearActiveChip(page: Page) {

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -1,0 +1,387 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+test.describe.configure({ timeout: 30_000 });
+
+const STORAGE_KEY = 'open-design:config';
+const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定/i;
+
+const HOME_CONFIG = {
+  mode: 'daemon',
+  apiKey: '',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  agentId: 'codex',
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  agentModels: { codex: { model: 'default', reasoning: 'default' } },
+  privacyDecisionAt: 1,
+  telemetry: { metrics: false, content: false, artifactManifest: false },
+};
+
+const HOME_PLUGINS = [
+  {
+    id: 'example-web-prototype',
+    title: 'Web Prototype',
+    version: '0.1.0',
+    trust: 'bundled',
+    sourceKind: 'bundled',
+    source: '/tmp/web-prototype',
+    fsPath: '/tmp/web-prototype',
+    capabilitiesGranted: ['prompt:inject'],
+    installedAt: 0,
+    updatedAt: 0,
+    manifest: {
+      name: 'example-web-prototype',
+      title: 'Web Prototype',
+      version: '0.1.0',
+      description: 'General-purpose desktop web prototype.',
+      od: {
+        kind: 'scenario',
+        taskKind: 'new-generation',
+        useCase: {
+          query:
+            'Build a {{fidelity}} {{artifactKind}} for {{audience}} using {{designSystem}} from {{template}}.',
+        },
+        inputs: [
+          { name: 'artifactKind', type: 'string', required: true, default: 'web prototype', label: 'Artifact kind' },
+          { name: 'fidelity', type: 'select', required: true, options: ['wireframe', 'high-fidelity'], default: 'high-fidelity', label: 'Fidelity' },
+          { name: 'audience', type: 'string', required: true, default: 'product evaluators', label: 'Audience' },
+          { name: 'designSystem', type: 'string', default: 'the active project design system', label: 'Design system' },
+          { name: 'template', type: 'string', default: 'the bundled web prototype seed', label: 'Template' },
+        ],
+      },
+    },
+  },
+  {
+    id: 'example-simple-deck',
+    title: 'Simple Deck',
+    version: '0.1.0',
+    trust: 'bundled',
+    sourceKind: 'bundled',
+    source: '/tmp/simple-deck',
+    fsPath: '/tmp/simple-deck',
+    capabilitiesGranted: ['prompt:inject'],
+    installedAt: 0,
+    updatedAt: 0,
+    manifest: {
+      name: 'example-simple-deck',
+      title: 'Simple Deck',
+      version: '0.1.0',
+      description: 'Single-file horizontal-swipe HTML deck.',
+      od: {
+        kind: 'scenario',
+        taskKind: 'new-generation',
+        useCase: {
+          query:
+            'Create a {{deckType}} for {{audience}} about {{topic}} with {{slideCount}}. Speaker notes: {{speakerNotes}}. Use {{designSystem}}.',
+        },
+        inputs: [
+          { name: 'deckType', type: 'select', required: true, options: ['pitch deck', 'product overview', 'study deck'], default: 'pitch deck', label: 'Deck type' },
+          { name: 'topic', type: 'string', required: true, default: 'quarterly review', label: 'Topic' },
+          { name: 'audience', type: 'string', required: true, default: 'decision makers', label: 'Audience' },
+          { name: 'slideCount', type: 'select', required: true, options: ['5-10 pages', '10-15 pages', '15-20 pages'], default: '10-15 pages', label: 'Pages' },
+          { name: 'speakerNotes', type: 'select', options: ['include speaker notes', 'no speaker notes'], default: 'include speaker notes', label: 'Speaker notes' },
+          { name: 'designSystem', type: 'string', default: 'the active project design system', label: 'Design system' },
+        ],
+      },
+    },
+  },
+  {
+    id: 'example-live-artifact',
+    title: 'Live Artifact',
+    version: '0.1.0',
+    trust: 'bundled',
+    sourceKind: 'bundled',
+    source: '/tmp/live-artifact',
+    fsPath: '/tmp/live-artifact',
+    capabilitiesGranted: ['prompt:inject'],
+    installedAt: 0,
+    updatedAt: 0,
+    manifest: {
+      name: 'example-live-artifact',
+      title: 'Live Artifact',
+      version: '0.1.0',
+      description: 'Create refreshable, auditable Open Design artifacts.',
+      od: {
+        kind: 'scenario',
+        taskKind: 'new-generation',
+        mode: 'prototype',
+        scenario: 'live',
+        useCase: {
+          query:
+            'Create refreshable, auditable Open Design artifacts backed by connector or local data.',
+        },
+      },
+    },
+  },
+  {
+    id: 'image-template-notion-team-dashboard-live-artifact',
+    title: 'Notion live artifact',
+    version: '0.1.0',
+    trust: 'bundled',
+    sourceKind: 'bundled',
+    source: '/tmp/notion-live-artifact',
+    fsPath: '/tmp/notion-live-artifact',
+    capabilitiesGranted: ['prompt:inject'],
+    installedAt: 0,
+    updatedAt: 0,
+    manifest: {
+      name: 'image-template-notion-team-dashboard-live-artifact',
+      title: 'Notion live artifact',
+      version: '0.1.0',
+      description: 'Create a live Notion dashboard artifact.',
+      od: {
+        kind: 'scenario',
+        taskKind: 'new-generation',
+        mode: 'image',
+        surface: 'image',
+        useCase: {
+          query: 'Create a refreshable Notion dashboard live artifact.',
+        },
+      },
+    },
+  },
+];
+
+const APPLY_RESPONSES: Record<string, unknown> = {
+  'example-simple-deck': {
+    query: 'Draft a quarterly review deck.',
+    contextItems: [],
+    inputs: [],
+    assets: [],
+    mcpServers: [],
+    trust: 'trusted',
+    capabilitiesGranted: ['prompt:inject'],
+    capabilitiesRequired: ['prompt:inject'],
+    appliedPlugin: {
+      snapshotId: 'snap-simple-deck',
+      pluginId: 'example-simple-deck',
+      pluginVersion: '0.1.0',
+      manifestSourceDigest: 'b'.repeat(64),
+      inputs: { topic: 'quarterly review' },
+      resolvedContext: { items: [] },
+      capabilitiesGranted: ['prompt:inject'],
+      capabilitiesRequired: ['prompt:inject'],
+      assetsStaged: [],
+      taskKind: 'new-generation',
+      appliedAt: 0,
+      connectorsRequired: [],
+      connectorsResolved: [],
+      mcpServers: [],
+      status: 'fresh',
+    },
+    projectMetadata: {},
+  },
+};
+
+async function waitForLoadingToClear(page: Page) {
+  await expect(page.getByText('Loading Open Design…')).toHaveCount(0, { timeout: 15_000 });
+}
+
+async function seedBrowserConfig(page: Page, config: Record<string, unknown>) {
+  await page.addInitScript(
+    ({ key, value }) => {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    },
+    { key: STORAGE_KEY, value: config },
+  );
+}
+
+async function gotoEntryHome(page: Page) {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await waitForLoadingToClear(page);
+  const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve Open Design' });
+  if (await privacyDialog.isVisible().catch(() => false)) {
+    await privacyDialog.getByRole('button', { name: /not now/i }).click();
+  }
+  await expect(page.getByRole('button', { name: OPEN_SETTINGS_LABEL })).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await seedBrowserConfig(page, HOME_CONFIG);
+
+  await page.route('https://api.github.com/repos/nexu-io/open-design', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ stargazers_count: 51600 }),
+    });
+  });
+
+  await page.route('**/api/agents', async (route) => {
+    await route.fulfill({
+      json: {
+        agents: [
+          {
+            id: 'codex',
+            name: 'Codex CLI',
+            bin: 'codex',
+            available: true,
+            version: '0.80.0',
+            path: '/usr/local/bin/codex',
+            models: [{ id: 'default', label: 'Default' }],
+          },
+          {
+            id: 'mock',
+            name: 'Mock Agent',
+            bin: 'mock-agent',
+            available: true,
+            version: 'test',
+            models: [{ id: 'default', label: 'Default' }],
+          },
+        ],
+      },
+    });
+  });
+
+  await page.route('**/api/app-config', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      json: {
+        config: HOME_CONFIG,
+      },
+    });
+  });
+
+  await page.route('**/api/projects', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ json: { projects: [] } });
+      return;
+    }
+    await route.continue();
+  });
+  await page.route('**/api/plugins', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ plugins: HOME_PLUGINS }),
+    });
+  });
+
+  await page.route('**/api/plugins/*/apply', async (route) => {
+    const pluginId = route.request().url().split('/api/plugins/')[1]?.split('/apply')[0];
+    const body = pluginId ? APPLY_RESPONSES[pluginId] : null;
+    await route.fulfill({
+      status: body ? 200 : 404,
+      contentType: 'application/json',
+      body: JSON.stringify(body ?? { error: 'Unknown plugin apply route' }),
+    });
+  });
+});
+
+test('home hero rail shows the current creation chips and More shortcuts', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  await expect(page.getByTestId('home-hero-type-tabs')).toBeVisible();
+  for (const id of ['prototype', 'live-artifact', 'deck', 'image', 'video', 'hyperframes', 'audio']) {
+    await expect(page.getByTestId(`home-hero-rail-${id}`)).toBeVisible();
+  }
+  await expect(page.getByTestId('home-hero-shortcuts-trigger')).toBeVisible();
+
+  await page.getByTestId('home-hero-shortcuts-trigger').click();
+  const menu = page.getByTestId('home-hero-shortcuts-menu');
+  await expect(menu).toBeVisible();
+  for (const id of ['create-plugin', 'figma', 'template']) {
+    await expect(menu.getByTestId(`home-hero-rail-${id}`)).toBeVisible();
+  }
+});
+
+test('home hero rail switches modes and updates the footer options for media surfaces', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  await expect(page.getByTestId('home-hero-active-type-chip')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-footer-option-duration')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-footer-option-audioType')).toHaveCount(0);
+
+  await expectChipSelection(page, 'prototype', 'Prototype');
+  await expect(page.getByTestId('home-hero-footer-option-designSystem')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-duration')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-footer-option-audioType')).toHaveCount(0);
+  await clearActiveChip(page);
+
+  await expectChipSelection(page, 'live-artifact', 'Live artifact');
+  await expect(page.getByTestId('home-hero-footer-option-duration')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-footer-option-audioType')).toHaveCount(0);
+  await clearActiveChip(page);
+
+  await expectChipSelection(page, 'deck', 'Slide deck');
+  await expect(page.getByTestId('home-hero-footer-option-designSystem')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-duration')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-footer-option-audioType')).toHaveCount(0);
+  await clearActiveChip(page);
+
+  await expectChipSelection(page, 'image', 'Image');
+  await expect(page.getByTestId('home-hero-footer-option-model')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-designSystem')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-ratio')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-resolution')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-duration')).toHaveCount(0);
+  await clearActiveChip(page);
+
+  await expectChipSelection(page, 'video', 'Video');
+  await expect(page.getByTestId('home-hero-footer-option-model')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-designSystem')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-ratio')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-resolution')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-duration')).toBeVisible();
+  await clearActiveChip(page);
+
+  await expectChipSelection(page, 'hyperframes', 'HyperFrames');
+  await expect(page.getByTestId('home-hero-footer-option-ratio')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-duration')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-model')).toHaveCount(0);
+  await clearActiveChip(page);
+
+  await expectChipSelection(page, 'audio', 'Audio');
+  await expect(page.getByTestId('home-hero-footer-option-audioType')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-model')).toBeVisible();
+  await expect(page.getByTestId('home-hero-footer-option-duration')).toBeVisible();
+});
+
+test('home hero example presets update the composer input for supported modes', async ({ page }) => {
+  await gotoEntryHome(page);
+
+  const input = page.getByTestId('chat-composer-input');
+  await expect(input).toHaveValue('');
+
+  await page.getByTestId('home-hero-rail-prototype').click();
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+  await page.getByTestId('home-hero-plugin-preset').first().click();
+  await expect(input).toHaveValue(
+    'Build a high-fidelity web prototype for product evaluators using the active project design system from the bundled web prototype seed.',
+  );
+
+  await clearActiveChip(page);
+  await page.getByTestId('home-hero-rail-live-artifact').click();
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+  await page
+    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="image-template-notion-team-dashboard-live-artifact"]')
+    .click();
+  await expect(input).toHaveValue('Create a refreshable Notion dashboard live artifact.');
+
+  await clearActiveChip(page);
+  await page.getByTestId('home-hero-rail-deck').click();
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+  await page.getByTestId('home-hero-plugin-preset').first().click();
+  await expect(input).toHaveValue('Draft a quarterly review deck.');
+});
+
+async function expectChipSelection(page: Page, chipId: string, label: string) {
+  await page.getByTestId(`home-hero-rail-${chipId}`).click();
+  const activeChip = page.getByTestId('home-hero-active-type-chip');
+  await expect(activeChip).toBeVisible();
+  await expect(activeChip).toHaveAttribute('data-chip-id', chipId);
+  await expect(activeChip).toContainText(label);
+  await expect(page.getByTestId('home-hero-type-tabs')).toHaveCount(0);
+}
+
+async function clearActiveChip(page: Page) {
+  await page.getByTestId('home-hero-active-type-chip').click();
+  await expect(page.getByTestId('home-hero-active-type-chip')).toHaveCount(0);
+  await expect(page.getByTestId('home-hero-type-tabs')).toBeVisible();
+}

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -67,6 +67,14 @@ test('real daemon run streams, persists, and previews an artifact', async ({ pag
   const frame = page.frameLocator('[data-testid="artifact-preview-frame"]');
   await expect(frame.getByRole('heading', { name: GENERATED_HEADING })).toBeVisible();
 
+  const rawResponse = await page.request.get(`/api/projects/${projectId}/raw/${GENERATED_FILE}`, {
+    headers: { Origin: 'null' },
+  });
+  expect(rawResponse.ok(), await rawResponse.text()).toBeTruthy();
+  expect(rawResponse.headers()['access-control-allow-origin']).toBe('*');
+  expect(rawResponse.headers()['content-type']).toContain('text/html');
+  expect(await rawResponse.text()).toContain(GENERATED_HEADING);
+
   await expectProjectFileToContain(page, projectId, GENERATED_FILE, GENERATED_HEADING);
 });
 


### PR DESCRIPTION
## Why

The homepage entry flows and HTML preview regressions needed tighter automated coverage.

This change splits homepage-focused E2E out of the AMR branch and adds coverage for:

- entry topbar navigation and execution-pill flows
- home hero mode rail and example/preset interactions
- HTML preview regressions where raw HTML routes can return the wrong response or black-screen after server-layer changes

## What changed

### Homepage entry E2E

Added focused Playwright coverage for:

- topbar chips and links (`Star`, `Join Discord`, execution pill, `Use everywhere`, settings)
- execution switcher open state and selected Local CLI agent/model display
- top-left logo returning from another entry view back to the home hero
- hero creation rail visibility and switching across prototype / live artifact / deck / image / video / hyperframes / audio
- example/preset selection updating the composer input
- clearing active mode chips and clearing selected example chips without leaking prior state

### HTML preview regression coverage

Added stronger regression coverage for the bad-case where server-layer route changes can break generated HTML preview rendering:

- daemon-side raw preview route contract test for nested `raw/*splat` HTML paths with `Origin: null`
- E2E assertion that a real generated HTML artifact is not only mounted in an iframe, but also reachable via `/api/projects/:id/raw/...` with HTML content and preview-safe headers

### Docs

Added testing summaries for:

- homepage entry coverage
- HTML generation / preview coverage and the remaining Express-route regression gap analysis

## Validation

- `cd e2e && pnpm exec playwright test -c playwright.config.ts ui/entry-topbar.test.ts`
- `cd e2e && pnpm exec playwright test -c playwright.config.ts ui/home-hero-rail.test.ts`
- `cd apps/daemon && pnpm exec vitest run tests/server-cors.test.ts`
- `cd e2e && pnpm exec playwright test -c playwright.config.ts ui/real-daemon-run.test.ts -g "real daemon run streams, persists, and previews an artifact"`
