### PR TITLE
fix: add confirmation dialog before deleting extraction history items

### DIFF
--- a/apps/web/src/components/MemorySection.tsx
+++ b/apps/web/src/components/MemorySection.tsx
@@ -1364,6 +1364,7 @@ export function MemorySection({
   }, [indexDraft, fireFlash]);
 
   const onDeleteExtraction = useCallback(async (id: string) => {
+    if (!window.confirm(t('settings.memoryExtractionDeleteConfirm'))) return;
     // Optimistic removal: drop the row immediately so the click feels
     // instant. The SSE 'deleted' event will arrive moments later and is
     // a no-op against an already-removed id; if the request fails we
@@ -1373,7 +1374,7 @@ export function MemorySection({
     if (!ok) {
       void reloadExtractions();
     }
-  }, [reloadExtractions]);
+  }, [reloadExtractions, t]);
 
   const onClearExtractions = useCallback(async () => {
     if (!window.confirm(t('settings.memoryExtractionsClearConfirm'))) return;

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1645,6 +1645,7 @@ export const ar: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'تثبيت',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1583,6 +1583,7 @@ export const de: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'Installieren',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -2409,6 +2409,7 @@ export const en: Dict = {
   'settings.memoryExtractionWritten': 'written',
   'settings.memoryExtractionDuration': 'in',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.memoryExtractionsClearConfirm':

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1534,6 +1534,7 @@ export const esES: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'Instalar',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1688,6 +1688,7 @@ export const fa: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'نصب',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -2307,6 +2307,7 @@ export const fr: Dict = {
   'settings.memoryExtractionWritten': 'écrite',
   'settings.memoryExtractionDuration': 'en',
   'settings.memoryExtractionDelete': 'Supprimer',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Effacer',
   'settings.memoryExtractionsClearTitle': 'Effacer tout l’historique d’extraction',
   'settings.memoryExtractionsClearConfirm': 'Effacer tout l’historique des extractions ? Cette action est irréversible.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1655,6 +1655,7 @@ export const hu: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'Telepítés',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1763,6 +1763,7 @@ export const id: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'Instal',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1519,6 +1519,7 @@ export const it: Dict = {
   'settings.memoryNoProviderBannerBody': 'Nessuna chiave API trovata per l\'estrattore di memoria. Aggiungi una chiave OpenAI sotto Provider di media, o imposta ANTHROPIC_API_KEY / OPENAI_API_KEY nell\'ambiente, per abilitare l\'estrazione guidata da LLM. L\'estrazione euristica regex è ancora attiva.',
   'settings.memoryExtractionProviderOverride': 'impostazioni memoria',
   'settings.memoryExtractionDelete': 'Elimina',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Cancella',
   'settings.memoryExtractionsClearTitle': 'Cancella tutta la cronologia di estrazione',
   'settings.libraryInstall': 'Installa',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1582,6 +1582,7 @@ export const ja: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'インストール',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1695,6 +1695,7 @@ export const ko: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': '설치',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1645,6 +1645,7 @@ export const pl: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'Zainstaluj',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1686,6 +1686,7 @@ export const ptBR: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'Instalar',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1686,6 +1686,7 @@ export const ru: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'Установить',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1632,6 +1632,7 @@ export const tr: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'Yükle',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1687,6 +1687,7 @@ export const uk: Dict = {
   'settings.memoryNoProviderBannerBody': 'No API key found for the memory extractor. Add an OpenAI key under Media providers, or set ANTHROPIC_API_KEY / OPENAI_API_KEY in the environment, to enable LLM-driven extraction. Heuristic regex extraction is still active.',
   'settings.memoryExtractionProviderOverride': 'memory settings',
   'settings.memoryExtractionDelete': 'Delete',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': 'Clear',
   'settings.memoryExtractionsClearTitle': 'Clear all extraction history',
   'settings.libraryInstall': 'Встановити',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -2374,7 +2374,7 @@ export const zhCN: Dict = {
   'settings.memoryExtractionWritten': '写入',
   'settings.memoryExtractionDuration': '耗时',
   'settings.memoryExtractionDelete': '删除',
-  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
+  'settings.memoryExtractionDeleteConfirm': '确定要删除这条抽取历史吗？此操作无法撤销。',
   'settings.memoryExtractionsClear': '清空',
   'settings.memoryExtractionsClearTitle': '清空整个抽取历史',
   'settings.memoryExtractionsClearConfirm': '确定要清空整个抽取历史吗？此操作无法撤销。',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -2374,6 +2374,7 @@ export const zhCN: Dict = {
   'settings.memoryExtractionWritten': '写入',
   'settings.memoryExtractionDuration': '耗时',
   'settings.memoryExtractionDelete': '删除',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': '清空',
   'settings.memoryExtractionsClearTitle': '清空整个抽取历史',
   'settings.memoryExtractionsClearConfirm': '确定要清空整个抽取历史吗？此操作无法撤销。',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1925,6 +1925,7 @@ export const zhTW: Dict = {
   'settings.memoryNoProviderBannerBody': '未找到可用的 API key，LLM 抽取已跳過。可以在媒體提供者裡填入 OpenAI key，或設定環境變數 ANTHROPIC_API_KEY / OPENAI_API_KEY 來啟用。啟發式抽取仍在執行。',
   'settings.memoryExtractionProviderOverride': '記憶設定',
   'settings.memoryExtractionDelete': '刪除',
+  'settings.memoryExtractionDeleteConfirm': 'Delete this extraction history item? This cannot be undone.',
   'settings.memoryExtractionsClear': '清空',
   'settings.memoryExtractionsClearTitle': '清空整個抽取歷史',
   'settings.libraryInstall': '安裝',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -627,6 +627,7 @@ export interface Dict {
   'settings.memoryExtractionWritten': string;
   'settings.memoryExtractionDuration': string;
   'settings.memoryExtractionDelete': string;
+  'settings.memoryExtractionDeleteConfirm': string;
   'settings.memoryExtractionsClear': string;
   'settings.memoryExtractionsClearTitle': string;
   'settings.memoryExtractionsClearConfirm': string;


### PR DESCRIPTION
## Summary

Fixes #2975

Adds a confirmation dialog before deleting individual extraction history items to prevent accidental data loss.

## Problem

Previously, extraction history items could be deleted with a single click, with no way to undo the action. This created unnecessary risk for accidental deletions.

## Solution

Added a window.confirm check in the onRemoveExtraction callback, following the exact same pattern as the existing onClearExtractions function.

## Changes

- **File**: apps/web/src/components/MemorySection.tsx
  - Added confirmation check before deletion
  - Updated useCallback dependency array to include t
  
- **i18n**: Added settings.memoryExtractionDeleteConfirm key to all 20 locale files
  - English: "Delete this extraction history item? This cannot be undone."
  - Other locales: Same English text as placeholder (ready for translation)

## Surface area

- [x] **UI** — Settings Memory page extraction history deletion flow
- [x] **i18n keys** — Added settings.memoryExtractionDeleteConfirm to all locales

## Testing

Manual testing needed:
1. Open Settings → Memory
2. Navigate to extraction history
3. Click delete on any extraction item
4. Verify confirmation dialog appears
5. Test both "Cancel" (no deletion) and "OK" (deletion proceeds)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Follows existing patterns in the codebase

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are minimal and focused
- [x] Follows the same pattern as onClearExtractions
- [x] All locale files updated consistently

## Related PRs

Supersedes #2497 (closed in favor of this PR)