### PR TITLE
fix(daemon): resolve imported design systems in user catalog

### DIFF
--- a/apps/daemon/src/static-resource-routes.ts
+++ b/apps/daemon/src/static-resource-routes.ts
@@ -582,7 +582,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       }
       const systems = await listAllDesignSystems();
       const designSystemId = path.basename(fs.realpathSync.native(result.dir));
-      const designSystem = systems.find((system) => system.id === designSystemId);
+      const designSystem = findUserDesignSystemInCatalog(systems, designSystemId);
       if (!designSystem) {
         return res.status(500).json({ error: `installed design system was not found in catalog: ${result.dir}` });
       }
@@ -638,10 +638,10 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
         ...(typeof body.name === 'string' ? { name: body.name } : {}),
         ...(importMode ? { importMode } : {}),
         ...(craftApplies ? { craftApplies } : {}),
-        reservedIds: before.map((system) => system.id),
+        reservedIds: designSystemDirIdsFromCatalog(before),
       });
       const systems = await listAllDesignSystems();
-      const designSystem = systems.find((system) => system.id === result.id);
+      const designSystem = findUserDesignSystemInCatalog(systems, result.id);
       if (!designSystem) {
         return sendApiError(
           res,
@@ -681,11 +681,11 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
           ...(typeof body.branch === 'string' ? { branch: body.branch } : {}),
           ...(importMode ? { importMode } : {}),
           ...(craftApplies ? { craftApplies } : {}),
-          reservedIds: before.map((system) => system.id),
+          reservedIds: designSystemDirIdsFromCatalog(before),
         },
       );
       const systems = await listAllDesignSystems();
-      const designSystem = systems.find((system) => system.id === result.id);
+      const designSystem = findUserDesignSystemInCatalog(systems, result.id);
       if (!designSystem) {
         return sendApiError(
           res,
@@ -722,6 +722,24 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
     }
   });
 
+}
+
+function userDesignSystemCatalogId(dirId: string): string {
+  return `user:${dirId}`;
+}
+
+function findUserDesignSystemInCatalog<T extends { id: string }>(
+  systems: T[],
+  dirId: string,
+): T | undefined {
+  const catalogId = userDesignSystemCatalogId(dirId);
+  return systems.find((system) => system.id === catalogId || system.id === dirId);
+}
+
+function designSystemDirIdsFromCatalog(systems: Array<{ id: string }>): string[] {
+  return systems.map((system) =>
+    system.id.startsWith('user:') ? system.id.slice('user:'.length) : system.id,
+  );
 }
 
 function normalizeDesignSystemImportMode(value: unknown): 'normalized' | 'hybrid' | 'verbatim' | undefined {

--- a/apps/daemon/tests/static-resource-routes.test.ts
+++ b/apps/daemon/tests/static-resource-routes.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { isLocalSameOrigin } from '../src/origin-validation.js';
+import { listDesignSystems } from '../src/design-systems.js';
 import { registerStaticResourceRoutes } from '../src/static-resource-routes.js';
 
 describe('static resource mutation routes', () => {
@@ -130,5 +131,117 @@ describe('static resource mutation routes', () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({ code: 'BAD_REQUEST' });
     expect(catalogReadCount).toBe(0);
+  });
+});
+
+describe('design system import catalog lookup', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let tempRoot: string;
+  let sourceRoot: string;
+  let userDesignSystemsDir: string;
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve) => {
+        tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'od-static-import-'));
+        sourceRoot = path.join(tempRoot, 'source-app');
+        userDesignSystemsDir = path.join(tempRoot, 'user-design-systems');
+        fs.mkdirSync(path.join(sourceRoot, 'src', 'styles'), { recursive: true });
+        fs.writeFileSync(
+          path.join(sourceRoot, 'package.json'),
+          JSON.stringify({ name: 'demo-app', description: 'Demo import source.' }),
+        );
+        fs.writeFileSync(
+          path.join(sourceRoot, 'README.md'),
+          '# Demo App\n\nA simple import fixture.\n',
+        );
+        fs.writeFileSync(
+          path.join(sourceRoot, 'src', 'styles', 'tokens.css'),
+          ':root { --color-primary: #3366ff; }',
+        );
+
+        const app = express();
+        app.use(express.json({ limit: '4mb' }));
+        registerStaticResourceRoutes(app, {
+          http: {
+            createSseResponse: () => undefined,
+            isLocalSameOrigin,
+            requireLocalDaemonRequest: (_req: unknown, _res: unknown, next: () => void) => next(),
+            resolvedPortRef: {
+              get current() {
+                const address = server.address();
+                return typeof address === 'object' && address ? address.port : 0;
+              },
+            },
+            sendApiError: (res: express.Response, status: number, code: string, message: string) =>
+              res.status(status).json({ error: message, code }),
+            sendLiveArtifactRouteError: () => undefined,
+            sendMulterError: () => undefined,
+          },
+          paths: {
+            ARTIFACTS_DIR: path.join(tempRoot, 'artifacts'),
+            BUNDLED_PETS_DIR: path.join(tempRoot, 'pets'),
+            DESIGN_SYSTEMS_DIR: path.join(tempRoot, 'design-systems'),
+            DESIGN_TEMPLATES_DIR: path.join(tempRoot, 'design-templates'),
+            OD_BIN: path.join(tempRoot, 'od'),
+            PROJECT_ROOT: tempRoot,
+            PROJECTS_DIR: path.join(tempRoot, 'projects'),
+            PROMPT_TEMPLATES_DIR: path.join(tempRoot, 'prompt-templates'),
+            RUNTIME_DATA_DIR: path.join(tempRoot, 'data'),
+            RUNTIME_DATA_DIR_CANONICAL: path.join(tempRoot, 'data'),
+            SKILLS_DIR: path.join(tempRoot, 'skills'),
+            USER_DESIGN_SYSTEMS_DIR: userDesignSystemsDir,
+            USER_DESIGN_TEMPLATES_DIR: path.join(tempRoot, 'user-design-templates'),
+            USER_SKILLS_DIR: path.join(tempRoot, 'user-skills'),
+          },
+          resources: {
+            listAllDesignSystems: async () =>
+              listDesignSystems(userDesignSystemsDir, {
+                idPrefix: 'user:',
+                source: 'user',
+                isEditable: true,
+                defaultStatus: 'draft',
+              }),
+            listAllSkills: async () => [],
+            listAllDesignTemplates: async () => [],
+            listAllSkillLikeEntries: async () => [],
+            mimeFor: () => 'application/octet-stream',
+          },
+        });
+
+        server = app.listen(0, '127.0.0.1', () => {
+          const addr = server.address() as { port: number };
+          baseUrl = `http://127.0.0.1:${addr.port}`;
+          resolve();
+        });
+      }),
+  );
+
+  afterAll(
+    () =>
+      new Promise<void>((resolve) => {
+        server.close(() => {
+          fs.rmSync(tempRoot, { recursive: true, force: true });
+          resolve();
+        });
+      }),
+  );
+
+  it('returns the imported user design system with its user: catalog id', async () => {
+    const res = await fetch(`${baseUrl}/api/design-systems/import/local`, {
+      method: 'POST',
+      headers: {
+        Origin: baseUrl,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ baseDir: sourceRoot }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { designSystem: { id: string; title: string } };
+    expect(body.designSystem.id).toBe('user:demo-app');
+    expect(body.designSystem.title).toBe('demo app');
+    expect(fs.existsSync(path.join(userDesignSystemsDir, 'demo-app', 'DESIGN.md'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Fix false `500` responses from `POST /api/design-systems/import/local` and `POST /api/design-systems/import/github` after a successful import
- Fix the same catalog lookup bug in `POST /api/design-systems/install`
- Normalize reserved slug ids during import so retries cannot allocate `-2`, `-3`, … duplicates when a prior import already wrote the base slug

## Root cause

User design systems are listed with `user:`-prefixed catalog ids (for example `user:demo-app`), but import/install routes looked up the freshly written directory slug (`demo-app`). The import succeeded on disk, the route returned `imported design system was not found in catalog`, and UI retries created duplicate entries.

## Surface area

- [x] API (daemon import/install routes in `static-resource-routes.ts`)
- [x] UI (Settings → Design Systems local/GitHub import feedback)
- [ ] CLI
- [ ] Docs

## Validation

- [x] `npx vitest run -c vitest.config.ts tests/static-resource-routes.test.ts`
- [ ] Manual: import a local project in Settings → Design Systems and confirm success (no duplicate after retry)

Fixes #2489