### PR TITLE
feat(analytics): replace regenerate_from_review with is_regenerate + generation_attempt

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11850,6 +11850,12 @@ export async function startServer({
       const hintProjectKind = typeof analyticsHints.projectKind === 'string'
         ? analyticsHints.projectKind
         : null;
+      const hintIsRegenerate = typeof analyticsHints.isRegenerate === 'boolean'
+        ? analyticsHints.isRegenerate
+        : undefined;
+      const hintGenerationAttempt = typeof analyticsHints.generationAttempt === 'number'
+        ? analyticsHints.generationAttempt
+        : undefined;
       const dsRunContext =
         analyticsHints.designSystemRunContext
           && typeof analyticsHints.designSystemRunContext === 'object'
@@ -11858,8 +11864,7 @@ export async function startServer({
       const isDesignSystemRun =
         hintProjectKind === 'design_system'
         || hintEntryFrom === 'design_system_create'
-        || hintEntryFrom === 'onboarding_design_system'
-        || hintEntryFrom === 'regenerate_from_review';
+        || hintEntryFrom === 'onboarding_design_system';
       // Only fields the current `/api/runs` create payload actually
       // sends. The v2 schema documents extended context props
       // (entry_from / project_kind / target_platforms / fidelity /
@@ -11898,6 +11903,8 @@ export async function startServer({
             ? 'unknown'
             : 'not_applicable',
         ...(isDesignSystemRun ? {
+          is_regenerate: hintIsRegenerate ?? false,
+          generation_attempt: hintGenerationAttempt ?? 1,
           ds_source_origin: typeof dsRunContext.origin === 'string'
             ? dsRunContext.origin
             : undefined,

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -1494,14 +1494,15 @@ export function DesignSystemDetailView({
 
       // DS workspace chat = the run that generates / regenerates the
       // DESIGN.md and preview modules. Every send from this surface
-      // is a DS-variant run, so we always populate analyticsHints. The
-      // `regenerate_from_review` entry_from is reserved for revisions
-      // triggered by the Looks good / Needs work loop (which today
-      // also flows through this composer); a future split can detect
-      // a pending revision and switch entry_from accordingly.
+      // is a DS-variant run, so we always populate analyticsHints.
+      // Regeneration is tracked via `isRegenerate` + `generationAttempt`
+      // so entry_from always reflects the original entry source.
       const wasOnboardingHandoff =
         Boolean(peekOnboardingSessionId())
         || sessionStorage.getItem(`od:auto-send-first:${projectId}`) === '1';
+      const isRegenerate = previousMessages.length > 0;
+      const generationAttempt =
+        previousMessages.filter((m) => m.role === 'assistant').length + 1;
       void streamViaDaemon({
         agentId: config.agentId,
         history: agentHistory,
@@ -1521,10 +1522,10 @@ export function DesignSystemDetailView({
         analyticsHints: {
           entryFrom: wasOnboardingHandoff
             ? 'onboarding_design_system'
-            : feedbackSection
-              ? 'regenerate_from_review'
-              : 'design_system_create',
+            : 'design_system_create',
           projectKind: 'design_system',
+          isRegenerate,
+          generationAttempt,
           designSystemRunContext: {
             origin: 'manual_create',
           },

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2661,23 +2661,23 @@ export function ProjectView({
         // analyticsHints so the daemon emits run_created /
         // run_finished under `page_name=design_system_project`,
         // `area=design_system_generation`, `project_kind=design_system`.
-        // The first-ever message into a DS workspace is the auto-sent
-        // generation kickoff (entry_from=`onboarding_design_system` is
-        // the doc's name for "DS create flow handed off to the agent");
-        // subsequent messages are review-driven regenerations
-        // (`regenerate_from_review`). Use `messages.length === 0` —
-        // truer than autoSendFirstMessageRef which races StrictMode
-        // remounts + sessionStorage clears.
+        // The first message is the initial generation; subsequent ones
+        // are regenerations triggered by review feedback. We track this
+        // via `isRegenerate` + `generationAttempt` rather than changing
+        // entry_from, so the original entry source is preserved.
         const isDesignSystemWorkspaceProject =
           project.metadata?.importedFrom === 'design-system';
-        const dsEntryFrom: 'onboarding_design_system' | 'regenerate_from_review' =
-          messages.length === 0
+        const isFirstGeneration = messages.length === 0;
+        const dsEntryFrom: 'onboarding_design_system' | 'design_system_create' =
+          isFirstGeneration
             ? 'onboarding_design_system'
-            : 'regenerate_from_review';
+            : 'design_system_create';
         const dsAnalyticsHints = isDesignSystemWorkspaceProject
           ? {
               entryFrom: dsEntryFrom,
               projectKind: 'design_system' as const,
+              isRegenerate: !isFirstGeneration,
+              generationAttempt: messages.filter((m) => m.role === 'assistant').length + 1,
               designSystemRunContext: {
                 origin: 'manual_create' as const,
               },

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -692,11 +692,12 @@ export type TrackingDesignSystemApplyTargetKind =
 
 // Entry from for the run_created / run_finished DS variant. Distinct
 // from the chat-panel entry_from enum because DS runs don't originate
-// from new_project / chat_composer at all.
+// from new_project / chat_composer at all. `regenerate_from_review` was
+// removed — regeneration is tracked via `is_regenerate` +
+// `generation_attempt` so the original entry source is preserved.
 export type TrackingDesignSystemRunEntryFrom =
   | 'design_system_create'
   | 'onboarding_design_system'
-  | 'regenerate_from_review'
   | 'unknown';
 
 // ---- Design-system lifecycle result props --------------------------------
@@ -1643,6 +1644,12 @@ export interface RunCreatedProps {
   design_system_id?: string;
   design_system_source: TrackingDesignSystemSource;
   design_system_version?: string;
+  // DS regeneration tracking. When `is_regenerate` is true, this run
+  // was triggered by a review-feedback regeneration — `entry_from`
+  // still records the *original* entry surface (onboarding vs
+  // design_system_create) so funnel analysis stays unbroken.
+  is_regenerate?: boolean;
+  generation_attempt?: number;
   // DS-variant context. `ds_source_origin` mirrors the
   // `TrackingDesignSystemOrigin` set used on DS page_views (where
   // the DS came from), separate from the runtime-selection

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -53,8 +53,7 @@ export type ChatAnalyticsEntryFrom =
   | 'new_project'
   | 'chat_composer'
   | 'design_system_create'
-  | 'onboarding_design_system'
-  | 'regenerate_from_review';
+  | 'onboarding_design_system';
 
 export type ChatAnalyticsLengthBucket =
   | '0'
@@ -99,6 +98,8 @@ export interface ChatAnalyticsHints {
     | 'audio'
     | 'design_system'
     | 'other';
+  isRegenerate?: boolean;
+  generationAttempt?: number;
   designSystemRunContext?: ChatAnalyticsDesignSystemRunContext;
 }
 


### PR DESCRIPTION
## Why

The `regenerate_from_review` value in `entry_from` was masking the original entry source when a user regenerated their design system after review feedback. This made it impossible to analyze the full generation funnel per entry path (onboarding vs design_systems_page), because regeneration events lost their origin context.

This change was identified during DS 2.0 tracking doc review and aligns with the updated spec (row 92-93 of the tracking document, updated 2026-05-26).

## What users will see

No user-facing change. This is an analytics schema change — PostHog events will now carry `is_regenerate` (boolean) and `generation_attempt` (number) instead of overwriting `entry_from` with `regenerate_from_review`.

## Surface area

- [x] **API / contract** — changed shape in `packages/contracts` (analytics event types and chat API hints)
- [x] **None** — internal analytics refactor only

## Validation

- `pnpm guard` — passes (pre-existing `.DS_Store` violations only)
- `pnpm typecheck` on contracts — passes (pre-existing unrelated `handoff` module error only)
- Daemon and web typecheck — no new errors introduced by this change