### PR TITLE
fix(web): preserve streamed output when a run ends canceled

### DIFF
--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -592,7 +592,16 @@ async function consumeDaemonRun({
       }
     }
 
-    if (endStatus === 'canceled') return;
+    if (endStatus === 'canceled') {
+      // OpenCode and other agents can emit useful output before the daemon
+      // SIGTERM's the child (shutdown, user cancel, long-run timeout). The
+      // run status is still `canceled`, but abandoning `acc` here drops the
+      // assistant text and skips the onDone file-diff path in ProjectView.
+      if (acc.trim()) {
+        handlers.onDone(acc);
+      }
+      return;
+    }
 
     // Trust the server's authoritative success declaration. When the server
     // explicitly sets `status: 'succeeded'` (either in the SSE end payload

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -481,6 +481,69 @@ describe('streamViaDaemon', () => {
     expect(handlers.onDone).not.toHaveBeenCalled();
   });
 
+  it('preserves streamed output when a run ends as canceled', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: stdout',
+              'data: {"chunk":"partial output"}',
+              '',
+              'event: end',
+              'data: {"code":null,"signal":"SIGTERM","status":"canceled"}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onDone).toHaveBeenCalledWith('partial output');
+    expect(handlers.onError).not.toHaveBeenCalled();
+  });
+
+  it('does not call onDone when a canceled run produced no output', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: end',
+              'data: {"code":null,"signal":"SIGTERM","status":"canceled"}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onDone).not.toHaveBeenCalled();
+    expect(handlers.onError).not.toHaveBeenCalled();
+  });
+
   it('keeps the daemon run alive when the browser-side stream aborts', async () => {
     const handlers = createDaemonHandlers();
     const controller = new AbortController();


### PR DESCRIPTION
## Summary

- When a run ends with `status: 'canceled'`, call `handlers.onDone(acc)` if stdout/agent text was already streamed
- Keeps the assistant turn and triggers the existing ProjectView `onDone` path (text flush + linked-repo file diff) instead of silently dropping accumulated output after SIGTERM

## Root cause

`consumeDaemonRun` returned early on `endStatus === 'canceled'` before `onDone`, so OpenCode runs that produced useful output before the daemon sent SIGTERM looked empty in the UI.

## Surface area

- [ ] API
- [x] UI (chat run consumption in `apps/web/src/providers/daemon.ts`)
- [ ] CLI
- [ ] Docs

## Validation

- [x] `pnpm test tests/providers/sse.test.ts` (37 passed)
- [ ] Manual: start an OpenCode linked-repo run, cancel after output appears, confirm assistant text + file changes remain visible

Fixes #2760

Made with [Cursor](https://cursor.com)