### PR TITLE
fix(daemon): surface Copilot trusted-folder and rate-limit failures

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -32,6 +32,7 @@ import { attachAcpSession } from './acp.js';
 import { attachPiRpcSession } from './pi-rpc.js';
 import { createClaudeStreamHandler } from './claude-stream.js';
 import { diagnoseClaudeCliFailure } from './claude-diagnostics.js';
+import { diagnoseCopilotCliFailure } from './copilot-diagnostics.js';
 import { createCopilotStreamHandler } from './copilot-stream.js';
 import { createJsonEventStreamHandler } from './json-event-stream.js';
 import { agentCliEnvForAgent, validateAgentCliEnv } from './app-config.js';
@@ -1556,9 +1557,18 @@ async function testAgentConnectionInternal(
         stdoutTail: rawStdoutTail || buffered,
         env,
       });
-      if (claudeDiagnostic) {
+      const copilotDiagnostic = diagnoseCopilotCliFailure({
+        agentId: input.agentId,
+        exitCode: winner.code,
+        signal: winner.signal,
+        stderrTail,
+        stdoutTail: rawStdoutTail || buffered,
+        env,
+      });
+      const agentDiagnostic = claudeDiagnostic ?? copilotDiagnostic;
+      if (agentDiagnostic) {
         console.warn(
-          `[test:agent] ${def.name} → claude_diagnostic: ${claudeDiagnostic.detail}`,
+          `[test:agent] ${def.name} → agent_diagnostic: ${agentDiagnostic.detail}`,
         );
         return {
           ok: false,
@@ -1566,7 +1576,7 @@ async function testAgentConnectionInternal(
           latencyMs,
           model,
           agentName: def.name,
-          detail: claudeDiagnostic.detail,
+          detail: agentDiagnostic.detail,
           diagnostics: buildDiagnostics({
             phase: 'spawn',
             exitCode: winner.code,

--- a/apps/daemon/src/copilot-diagnostics.ts
+++ b/apps/daemon/src/copilot-diagnostics.ts
@@ -1,0 +1,117 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { redactSecrets } from './redact.js';
+
+export interface CopilotCliDiagnosticInput {
+  agentId: string;
+  exitCode?: number | null;
+  signal?: string | null;
+  stderrTail?: string | null;
+  stdoutTail?: string | null;
+  env?: Record<string, unknown> | null;
+}
+
+export interface CopilotCliDiagnostic {
+  message: string;
+  detail: string;
+  retryable: boolean;
+}
+
+function body(input: CopilotCliDiagnosticInput): string {
+  return [input.stderrTail, input.stdoutTail]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    .join('\n');
+}
+
+function copilotTrustedFolderExample(): string {
+  const home = os.homedir();
+  if (process.platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'Open Design', '**');
+  }
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    return path.join(appData, 'Open Design', '**');
+  }
+  return path.join(home, '.local', 'share', 'Open Design', '**');
+}
+
+function withContext(
+  message: string,
+  detail: string,
+  input: CopilotCliDiagnosticInput,
+): CopilotCliDiagnostic {
+  const diagnosticTail = redactSecrets(body(input)).replace(/\s+/g, ' ').trim().slice(-240);
+  const context: string[] = [message, detail];
+  if (diagnosticTail) context.push(`Copilot output: ${diagnosticTail}`);
+  return {
+    message: redactSecrets(message),
+    detail: redactSecrets(context.filter(Boolean).join(' ')),
+    retryable: true,
+  };
+}
+
+export function diagnoseCopilotCliFailure(
+  input: CopilotCliDiagnosticInput,
+): CopilotCliDiagnostic | null {
+  if (input.agentId !== 'copilot') return null;
+  if (input.exitCode === 0 && !input.signal) return null;
+
+  const text = body(input);
+  const normalized = text.toLowerCase();
+
+  const rateLimited =
+    /user_weekly_rate_limited/i.test(text) ||
+    /rate[_ -]?limit/i.test(text) ||
+    /\b429\b/.test(text);
+  if (rateLimited) {
+    return withContext(
+      'GitHub Copilot CLI hit a provider rate limit for the selected model.',
+      'Try model `auto` in Settings, switch to another Copilot model, or retry after your quota resets. Open Design previously surfaced this as a generic exit code 1.',
+      input,
+    );
+  }
+
+  const trustedFolderFailure =
+    /trustedfolder/i.test(text) ||
+    /trusted folder/i.test(text) ||
+    /folder trust/i.test(text) ||
+    /directory is not trusted/i.test(text) ||
+    /not trusted/i.test(text) ||
+    (/tool\.execution_complete/i.test(text) &&
+      /"success"\s*:\s*false/i.test(text) &&
+      /(trust|permission|access denied|not allowed|outside workspace)/i.test(text));
+  if (trustedFolderFailure) {
+    const trustedPath = copilotTrustedFolderExample();
+    return withContext(
+      'GitHub Copilot CLI could not access the Open Design project directory.',
+      `Add the Open Design application data directory to trustedFolders in ~/.copilot/config.json, for example: "${trustedPath}". Copilot requires this before tool calls can read or write project files launched by Open Design.`,
+      input,
+    );
+  }
+
+  if (!text.trim() && input.exitCode === 1) {
+    const trustedPath = copilotTrustedFolderExample();
+    return withContext(
+      'GitHub Copilot CLI exited before producing diagnostics.',
+      `If tool calls failed to read or write project files, add "${trustedPath}" to trustedFolders in ~/.copilot/config.json. Otherwise retry with model \`auto\` or check \`copilot --help\` in your terminal.`,
+      input,
+    );
+  }
+
+  if (
+    normalized.includes('tool') &&
+    (normalized.includes('permission') ||
+      normalized.includes('access denied') ||
+      normalized.includes('not allowed'))
+  ) {
+    const trustedPath = copilotTrustedFolderExample();
+    return withContext(
+      'GitHub Copilot CLI rejected a tool call against the Open Design project directory.',
+      `If file tools fail, add "${trustedPath}" to trustedFolders in ~/.copilot/config.json and retry.`,
+      input,
+    );
+  }
+
+  return null;
+}

--- a/apps/daemon/src/runtimes/defs/copilot.ts
+++ b/apps/daemon/src/runtimes/defs/copilot.ts
@@ -47,6 +47,7 @@ export const copilotAgentDef = {
     // Settings.
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
+      { id: 'auto', label: 'Auto (Copilot CLI)' },
       { id: 'claude-sonnet-4.6', label: 'Claude Sonnet 4.6' },
       { id: 'gpt-5.2', label: 'GPT-5.2' },
     ],

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -168,6 +168,7 @@ import {
 import { ingestRoutineConnectorEvolution } from './automation-routine-evolution.js';
 import { createClaudeStreamHandler } from './claude-stream.js';
 import { diagnoseClaudeCliFailure } from './claude-diagnostics.js';
+import { diagnoseCopilotCliFailure } from './copilot-diagnostics.js';
 import { loadCritiqueConfigFromEnv } from './critique/config.js';
 import { reconcileStaleRuns } from './critique/persistence.js';
 import { runOrchestrator } from './critique/orchestrator.js';
@@ -11389,14 +11390,23 @@ export async function startServer({
         artifactQuietShutdownRequested,
       });
       if (status === 'failed') {
-        const diagnostic = diagnoseClaudeCliFailure({
-          agentId: def.id,
-          exitCode: code,
-          signal,
-          stderrTail: agentStderrTail,
-          stdoutTail: agentStdoutTail,
-          env: spawnedAgentEnv,
-        });
+        const diagnostic =
+          diagnoseClaudeCliFailure({
+            agentId: def.id,
+            exitCode: code,
+            signal,
+            stderrTail: agentStderrTail,
+            stdoutTail: agentStdoutTail,
+            env: spawnedAgentEnv,
+          }) ??
+          diagnoseCopilotCliFailure({
+            agentId: def.id,
+            exitCode: code,
+            signal,
+            stderrTail: agentStderrTail,
+            stdoutTail: agentStdoutTail,
+            env: spawnedAgentEnv,
+          });
         if (diagnostic) {
           send('error', createSseErrorPayload(
             'AGENT_EXECUTION_FAILED',

--- a/apps/daemon/tests/copilot-diagnostics.test.ts
+++ b/apps/daemon/tests/copilot-diagnostics.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { diagnoseCopilotCliFailure } from '../src/copilot-diagnostics.js';
+
+describe('diagnoseCopilotCliFailure', () => {
+  it('returns null for non-copilot agents', () => {
+    expect(
+      diagnoseCopilotCliFailure({
+        agentId: 'claude',
+        exitCode: 1,
+        stderrTail: 'user_weekly_rate_limited',
+      }),
+    ).toBeNull();
+  });
+
+  it('maps Copilot rate-limit output to actionable guidance', () => {
+    const diagnostic = diagnoseCopilotCliFailure({
+      agentId: 'copilot',
+      exitCode: 1,
+      stdoutTail: '{"type":"result","success":false,"error":"user_weekly_rate_limited"}',
+    });
+
+    expect(diagnostic?.message).toContain('rate limit');
+    expect(diagnostic?.detail).toContain('auto');
+  });
+
+  it('maps trusted-folder failures to config guidance', () => {
+    const diagnostic = diagnoseCopilotCliFailure({
+      agentId: 'copilot',
+      exitCode: 1,
+      stderrTail: 'Directory is not trusted by Copilot CLI',
+    });
+
+    expect(diagnostic?.message).toContain('project directory');
+    expect(diagnostic?.detail).toContain('trustedFolders');
+    expect(diagnostic?.detail).toContain('Open Design');
+  });
+
+  it('maps silent exit code 1 to trusted-folder troubleshooting', () => {
+    const diagnostic = diagnoseCopilotCliFailure({
+      agentId: 'copilot',
+      exitCode: 1,
+    });
+
+    expect(diagnostic?.message).toContain('exited before producing diagnostics');
+    expect(diagnostic?.detail).toContain('trustedFolders');
+  });
+
+  it('maps tool permission failures in JSON output to trusted-folder guidance', () => {
+    const diagnostic = diagnoseCopilotCliFailure({
+      agentId: 'copilot',
+      exitCode: 1,
+      stdoutTail:
+        '{"type":"tool.execution_complete","data":{"success":false,"result":{"content":"access denied outside trusted folder"}}}',
+    });
+
+    expect(diagnostic?.message).toContain('project directory');
+    expect(diagnostic?.detail).toContain('trustedFolders');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `diagnoseCopilotCliFailure()` to translate common Copilot CLI failures into actionable chat errors instead of a generic `agent exited with code 1`
- Detect provider rate limits (`user_weekly_rate_limited`, 429) and suggest model `auto` / quota retry
- Detect trusted-folder / tool permission failures and point users at the required `trustedFolders` entry for the Open Design application data directory
- Expose `auto` in the Copilot fallback model picker list

## Root cause

Copilot runs against packaged Open Design project directories under the application-support namespace. When Copilot lacks folder trust or hits account rate limits, the daemon only surfaced a non-zero exit code, hiding the upstream reason reported in the JSON stream / stderr tail.

## Surface area

- [x] API (daemon chat run close diagnostics + connection test)
- [x] UI (chat error banner via SSE `error` events)
- [ ] CLI
- [ ] Docs

## Validation

- [x] `npx vitest run -c vitest.config.ts tests/copilot-diagnostics.test.ts`
- [ ] Manual: run Copilot without trusted folder and confirm the chat shows trustedFolders guidance

Fixes #2835

Made with [Cursor](https://cursor.com)