### PR TITLE
fix(daemon): detect CodeWhale as DeepSeek TUI fallback binary

### DIFF
--- a/apps/daemon/src/runtimes/defs/deepseek.ts
+++ b/apps/daemon/src/runtimes/defs/deepseek.ts
@@ -5,15 +5,13 @@ export const deepseekAgentDef = {
     id: 'deepseek',
     name: 'DeepSeek TUI',
     // The `deepseek` dispatcher owns the `exec` / `--auto` subcommands and
-    // delegates to a sibling `deepseek-tui` runtime binary at exec time.
-    // Upstream documents both binaries as required (npm and cargo paths
-    // install them together), so a host with only `deepseek-tui` on PATH
-    // isn't a supported install — and `deepseek-tui` itself doesn't accept
-    // the argv shape `buildArgs` produces (`exec --auto <prompt>`). We only
-    // probe the dispatcher; advertising availability via a `deepseek-tui`
-    // fallback would surface the agent as runnable but make `/api/chat`
-    // exit immediately on the first prompt.
+    // delegates to a sibling TUI runtime binary at exec time. Upstream also
+    // ships the same dispatcher as `codewhale` after the CodeWhale rename
+    // (issue #2983). The companion `deepseek-tui` / `codewhale-tui` runtime
+    // is not probed here — it does not accept the argv shape `buildArgs`
+    // produces (`exec --auto <prompt>`).
     bin: 'deepseek',
+    fallbackBins: ['codewhale'],
     versionArgs: ['--version'],
     // No `models` subcommand that prints a clean id-per-line list; the
     // canonical model ids for DeepSeek V4 are documented in the README,

--- a/apps/daemon/src/runtimes/metadata.ts
+++ b/apps/daemon/src/runtimes/metadata.ts
@@ -68,8 +68,8 @@ const AGENT_INSTALL_LINKS: Record<
     docsUrl: 'https://github.com/mistralai/vibe-acp',
   },
   deepseek: {
-    installUrl: 'https://github.com/deepseek-ai/DeepSeek-TUI',
-    docsUrl: 'https://github.com/deepseek-ai/DeepSeek-TUI/blob/main/README.md',
+    installUrl: 'https://github.com/Hmbown/CodeWhale',
+    docsUrl: 'https://github.com/Hmbown/CodeWhale/blob/main/README.md',
   },
 };
 

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -194,7 +194,7 @@ test('detectAgents includes sanitized install and docs metadata from split runti
       assert.ok(deepseek);
       assert.equal(
         deepseek.docsUrl,
-        'https://github.com/deepseek-ai/DeepSeek-TUI/blob/main/README.md',
+        'https://github.com/Hmbown/CodeWhale/blob/main/README.md',
       );
     });
   } finally {

--- a/apps/daemon/tests/runtimes/executables.test.ts
+++ b/apps/daemon/tests/runtimes/executables.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import {
-  assert, chmodSync, claude, gemini, join, minimalAgentDef, mkdirSync, mkdtempSync, resolveAgentExecutable, rmSync, tmpdir, withPlatform, writeFileSync,
+  assert, chmodSync, claude, deepseek, gemini, join, minimalAgentDef, mkdirSync, mkdtempSync, resolveAgentExecutable, rmSync, tmpdir, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
 
 const fsTest = process.platform === 'win32' ? test.skip : test;
@@ -21,6 +21,17 @@ test('claude entry declares openclaude as a fallback bin (issue #235)', () => {
   assert.ok(
     claude.fallbackBins.includes('openclaude'),
     `claude.fallbackBins must include 'openclaude'; got ${JSON.stringify(claude.fallbackBins)}`,
+  );
+});
+
+test('deepseek entry declares codewhale as a fallback bin (issue #2983)', () => {
+  assert.ok(
+    Array.isArray(deepseek.fallbackBins),
+    'deepseek.fallbackBins must be an array',
+  );
+  assert.ok(
+    deepseek.fallbackBins.includes('codewhale'),
+    `deepseek.fallbackBins must include 'codewhale'; got ${JSON.stringify(deepseek.fallbackBins)}`,
   );
 });
 

--- a/apps/daemon/tests/runtimes/prompt-budget.test.ts
+++ b/apps/daemon/tests/runtimes/prompt-budget.test.ts
@@ -426,19 +426,16 @@ test('cmd-shim and direct-exe guards are mutually exclusive on a single resoluti
   assert.ok(checkWindowsDirectExeCommandLineBudget(deepseek, exePath, args));
 });
 
-test('deepseek entry does not advertise deepseek-tui as a fallback bin', () => {
-  // `deepseek` is the dispatcher that owns `exec` / `--auto`; `deepseek-tui`
-  // is the runtime companion the dispatcher invokes. Upstream installs both
-  // together (npm and cargo). A `deepseek-tui`-only host is not a supported
-  // install, and `deepseek-tui` itself doesn't accept `exec --auto <prompt>`
-  // — surfacing it via fallbackBins would advertise availability but make
-  // the first /api/chat run fail. Pin the absence so the fallback can't
-  // drift back without an accompanying buildArgs branch + test.
-  assert.equal(
-    Array.isArray((deepseek as TestAgentDef & { fallbackBins?: string[] }).fallbackBins)
-      && ((deepseek as TestAgentDef & { fallbackBins?: string[] }).fallbackBins?.length ?? 0) > 0,
-    false,
-    `deepseek must not declare fallbackBins until the deepseek-tui-only invocation is implemented and tested; got ${JSON.stringify((deepseek as TestAgentDef & { fallbackBins?: string[] }).fallbackBins)}`,
+test('deepseek entry declares codewhale as a fallback bin but not deepseek-tui (issue #2983)', () => {
+  const fallbackBins = (deepseek as TestAgentDef & { fallbackBins?: string[] }).fallbackBins;
+  assert.ok(Array.isArray(fallbackBins), 'deepseek.fallbackBins must be an array');
+  assert.ok(
+    fallbackBins.includes('codewhale'),
+    `deepseek.fallbackBins must include 'codewhale'; got ${JSON.stringify(fallbackBins)}`,
+  );
+  assert.ok(
+    !fallbackBins.includes('deepseek-tui'),
+    'deepseek-tui is the runtime companion and must not be advertised as a dispatcher fallback',
   );
 });
 


### PR DESCRIPTION
## Summary

- Add `codewhale` to the DeepSeek TUI agent `fallbackBins` so renamed CodeWhale installs are auto-detected when `deepseek` is missing from PATH
- Keep excluding `deepseek-tui` / runtime companions from fallback probing (they do not accept `exec --auto <prompt>`)
- Point DeepSeek install metadata at the current CodeWhale upstream repo

## Root cause

CodeWhale renamed the dispatcher binary from `deepseek` to `codewhale`. Open Design only probed `deepseek`, so users with CodeWhale-only installs saw the agent as unavailable unless they manually set `DEEPSEEK_BIN`.

## Surface area

- [x] API (agent detection / executable resolution)
- [x] UI (Settings agent list visibility)
- [ ] CLI
- [ ] Docs

## Validation

- [x] `npx vitest run -c vitest.config.ts tests/runtimes/executables.test.ts tests/runtimes/prompt-budget.test.ts`
- [ ] Manual: install `codewhale` without `deepseek` on PATH and confirm Settings detects DeepSeek TUI

Fixes #2983

Made with [Cursor](https://cursor.com)