### PR TITLE
test(web): cover duplicate example card deduplication

### DIFF
--- a/apps/web/tests/components/ExamplesTab.test.tsx
+++ b/apps/web/tests/components/ExamplesTab.test.tsx
@@ -148,6 +148,43 @@ describe('ExamplesTab', () => {
     expect(screen.getByText('No skills available. Is the daemon running?')).toBeTruthy();
   });
 
+  it('deduplicates duplicate skill ids so each example card renders once (#2889)', () => {
+    const onUsePrompt = vi.fn();
+    render(
+      <ExamplesTab
+        skills={[
+          skill({
+            id: 'xhs-white-editorial',
+            name: 'XHS editorial',
+            examplePrompt: 'First prompt',
+          }),
+          skill({
+            id: 'xhs-white-editorial',
+            name: 'Duplicate XHS editorial',
+            examplePrompt: 'Duplicate prompt',
+          }),
+          skill({
+            id: 'open-design-landing',
+            name: 'Open Design landing',
+            examplePrompt: 'Unique prompt',
+          }),
+        ]}
+        onUsePrompt={onUsePrompt}
+      />,
+    );
+
+    expect(screen.getAllByTestId('example-card-xhs-white-editorial')).toHaveLength(1);
+    expect(screen.getByTestId('example-card-open-design-landing')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('example-use-prompt-xhs-white-editorial'));
+    expect(onUsePrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'xhs-white-editorial',
+        examplePrompt: 'First prompt',
+      }),
+    );
+  });
+
   it('filters examples by free-text search and shows an empty match state', () => {
     renderExamples();
 


### PR DESCRIPTION
## Summary

- Add a regression test ensuring `ExamplesTab` renders one card per `skill.id` even when the catalog contains duplicate entries
- Assert the first occurrence wins for the "Use this prompt" callback

The deduplication logic already landed on `main` in `ExamplesTab`; this PR pins the #2889 behavior with test coverage.

## Surface area

- [x] UI (Examples tab regression test)
- [ ] API
- [ ] CLI
- [ ] Docs

## Validation

- [x] `pnpm test tests/components/ExamplesTab.test.tsx`

Closes #2889

Made with [Cursor](https://cursor.com)