### PR TITLE
fix(daemon): prevent duplicate routine fires on DST fall-back days

### DIFF
--- a/apps/daemon/src/routines.ts
+++ b/apps/daemon/src/routines.ts
@@ -331,6 +331,56 @@ export function nextRunAtForSchedule(
   return null;
 }
 
+// After a scheduled fire, advance past every UTC instant that maps to the
+// same wall-clock slot on the same calendar day. On DST fall-back days a
+// daily 01:30 can exist twice (EDT then EST); firing the first must not
+// immediately reschedule the second — users expect one run per slot (#2890).
+export function nextRunAtForScheduleAfterScheduledFire(
+  schedule: RoutineSchedule,
+  firedAt: Date,
+): Date | null {
+  if (schedule.kind === 'hourly') {
+    return nextRunAtForSchedule(schedule, firedAt);
+  }
+  if (
+    schedule.kind !== 'daily' &&
+    schedule.kind !== 'weekdays' &&
+    schedule.kind !== 'weekly'
+  ) {
+    return nextRunAtForSchedule(schedule, firedAt);
+  }
+
+  const timeMatch = /^(\d{2}):(\d{2})$/.exec(schedule.time);
+  if (!timeMatch) return nextRunAtForSchedule(schedule, firedAt);
+  const hour = Number(timeMatch[1]);
+  const minute = Number(timeMatch[2]);
+  const firedParts = partsInTimezone(schedule.timezone, firedAt);
+  if (firedParts.hour !== hour || firedParts.minute !== minute) {
+    return nextRunAtForSchedule(schedule, firedAt);
+  }
+  if (schedule.kind === 'weekdays' && (firedParts.weekday < 1 || firedParts.weekday > 5)) {
+    return nextRunAtForSchedule(schedule, firedAt);
+  }
+  if (schedule.kind === 'weekly' && firedParts.weekday !== schedule.weekday) {
+    return nextRunAtForSchedule(schedule, firedAt);
+  }
+
+  const candidates = tzWallToUtcCandidates(
+    schedule.timezone,
+    firedParts.year,
+    firedParts.month,
+    firedParts.day,
+    hour,
+    minute,
+  );
+  if (candidates.length <= 1) {
+    return nextRunAtForSchedule(schedule, firedAt);
+  }
+
+  const lastCandidate = candidates[candidates.length - 1]!;
+  return nextRunAtForSchedule(schedule, new Date(lastCandidate.getTime() + 1_000));
+}
+
 // ---------- validation ----------
 
 export function isValidWallTime(time: string): boolean {
@@ -435,7 +485,7 @@ export class RoutineService {
     }
   }
 
-  rescheduleOne(routineId: string): void {
+  rescheduleOne(routineId: string, afterScheduledFireAt?: Date): void {
     const existing = this.timers.get(routineId);
     if (existing) {
       clearTimeout(existing.timer);
@@ -443,7 +493,7 @@ export class RoutineService {
     }
     if (!this.started) return;
     const routine = this.persistence.list().find((r) => r.id === routineId);
-    if (routine) this.scheduleRoutine(routine);
+    if (routine) this.scheduleRoutine(routine, afterScheduledFireAt);
   }
 
   unschedule(routineId: string): void {
@@ -454,9 +504,11 @@ export class RoutineService {
     }
   }
 
-  private scheduleRoutine(routine: Routine): void {
+  private scheduleRoutine(routine: Routine, afterScheduledFireAt?: Date): void {
     if (!routine.enabled) return;
-    const fireAt = nextRunAtForSchedule(routine.schedule);
+    const fireAt = afterScheduledFireAt
+      ? nextRunAtForScheduleAfterScheduledFire(routine.schedule, afterScheduledFireAt)
+      : nextRunAtForSchedule(routine.schedule);
     if (!fireAt) return;
     // setTimeout can't carry past 2^31 ms (~24.8 days); we cap and use
     // a chained re-schedule. Routines fire within hours/days, but a
@@ -473,7 +525,7 @@ export class RoutineService {
         })
         .finally(() => {
           // Always reschedule so a single fire keeps the cadence alive.
-          this.rescheduleOne(routine.id);
+          this.rescheduleOne(routine.id, fireAt);
         });
     }, delay);
     if (typeof timer.unref === 'function') timer.unref();

--- a/apps/daemon/tests/routines.test.ts
+++ b/apps/daemon/tests/routines.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   nextRunAtForSchedule,
+  nextRunAtForScheduleAfterScheduledFire,
   validateSchedule,
   validateTarget,
 } from '../src/routines.js';
@@ -159,6 +160,38 @@ describe('nextRunAtForSchedule DST handling', () => {
     expect(parts.day).toBe('15');
     expect(parts.hour).toBe('08');
     expect(parts.minute).toBe('30');
+  });
+});
+
+describe('nextRunAtForScheduleAfterScheduledFire', () => {
+  it('does not reschedule the second ambiguous instance on the same fall-back day (#2890)', () => {
+    const schedule = {
+      kind: 'daily' as const,
+      time: '01:30',
+      timezone: 'America/New_York',
+    };
+    const firstFire = new Date('2026-11-01T05:30:00Z');
+    const next = nextRunAtForScheduleAfterScheduledFire(schedule, firstFire);
+    expect(next).not.toBeNull();
+    if (!next) return;
+
+    const parts = partsIn('America/New_York', next);
+    expect(parts.year).toBe('2026');
+    expect(parts.month).toBe('11');
+    expect(parts.day).toBe('02');
+    expect(parts.hour).toBe('01');
+    expect(parts.minute).toBe('30');
+  });
+
+  it('still advances hourly schedules from the fire instant', () => {
+    const firedAt = new Date('2026-05-13T10:15:30Z');
+    const next = nextRunAtForScheduleAfterScheduledFire(
+      { kind: 'hourly', minute: 15 },
+      firedAt,
+    );
+    expect(next).not.toBeNull();
+    if (!next) return;
+    expect(next.toISOString()).toBe('2026-05-13T11:15:00.000Z');
   });
 });
 


### PR DESCRIPTION
Fixes #2890

## Summary
On DST fall-back days a daily wall-clock slot can map to two UTC instants (e.g. 01:30 America/New_York). After the first scheduled fire, `rescheduleOne` reused `nextRunAtForSchedule(now)` which still picked the second ambiguous instance on the same calendar day — causing duplicate runs for one user-visible slot.

## Surface area
- `apps/daemon/src/routines.ts` — `nextRunAtForScheduleAfterScheduledFire()`; scheduled timer reschedule passes the fired instant.
- `apps/daemon/tests/routines.test.ts` — regression coverage for fall-back day + hourly cadence.

## Validation
- `cd apps/daemon && pnpm test tests/routines.test.ts` — 14 passed.

Made with [Cursor](https://cursor.com)