### PR TITLE
fix(web): load skill files after create/save expands the row

### DIFF
--- a/apps/web/src/components/SkillsSection.tsx
+++ b/apps/web/src/components/SkillsSection.tsx
@@ -198,20 +198,23 @@ export function SkillsSection({ cfg, setCfg }: Props) {
     [filesById],
   );
 
+  // Prefetch body + file tree whenever a row is expanded — including after
+  // create/save, which sets expandedId directly without a header click (#2974).
+  useEffect(() => {
+    if (!expandedId) return;
+    void ensureBody(expandedId);
+    void ensureFiles(expandedId);
+  }, [expandedId, ensureBody, ensureFiles]);
+
   const toggleExpanded = useCallback(
     (id: string) => {
-      setExpandedId((cur) => {
-        if (cur === id) return null;
-        void ensureBody(id);
-        void ensureFiles(id);
-        return id;
-      });
+      setExpandedId((cur) => (cur === id ? null : id));
       // Switching rows aborts any in-flight edit on the previous row.
       setEditingId((cur) => (cur === id ? cur : null));
       setConfirmDeleteId(null);
       setConfirmBuiltInEditId(null);
     },
-    [ensureBody, ensureFiles],
+    [],
   );
 
   const startCreate = useCallback(() => {

--- a/apps/web/tests/components/SkillsSection.test.tsx
+++ b/apps/web/tests/components/SkillsSection.test.tsx
@@ -155,4 +155,66 @@ describe('SkillsSection', () => {
     expect(within(row).queryByTestId('skills-edit-builtin-warning')).toBeNull();
     expect(await within(row).findByTestId('skills-edit-form')).toBeTruthy();
   });
+
+  it('loads the skill file tree after creating a new skill (#2974)', async () => {
+    const created = makeSkill({
+      id: 'my-skill',
+      name: 'My skill',
+      source: 'user',
+    });
+    const setCfg = vi.fn();
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/skills' && (!init || init.method === undefined)) {
+        return new Response(JSON.stringify({ skills: [created] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/skills/import' && init?.method === 'POST') {
+        return new Response(JSON.stringify({ skill: created }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/skills/my-skill/files') {
+        return new Response(
+          JSON.stringify({
+            files: [{ path: 'SKILL.md', kind: 'file', size: 128 }],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/skills/my-skill') {
+        return new Response(
+          JSON.stringify({ skill: created, body: '# My skill\n\nSteps.' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as typeof fetch;
+
+    render(
+      <SkillsSection
+        cfg={TEST_CONFIG}
+        setCfg={setCfg}
+      />,
+    );
+
+    fireEvent.click(await screen.findByTestId('skills-new'));
+    const form = await screen.findByTestId('skills-create-form');
+    fireEvent.change(within(form).getByPlaceholderText('my-skill'), {
+      target: { value: 'My skill' },
+    });
+    fireEvent.change(within(form).getByPlaceholderText(/Explain the workflow/), {
+      target: { value: '# My skill\n\nSteps.' },
+    });
+    fireEvent.click(within(form).getByTestId('skills-save'));
+
+    const row = await screen.findByTestId('skill-row-my-skill');
+    await waitFor(() => {
+      expect(within(row).queryByText('No files in this skill folder.')).toBeNull();
+      expect(within(row).getAllByText('SKILL.md').length).toBeGreaterThanOrEqual(1);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #2974

## Summary
After creating or saving a custom skill, Settings expands the new row programmatically but never fetched `/api/skills/:id/files`, so the file tree showed the empty-state copy even though `SKILL.md` was written on disk.

## Surface area
- `apps/web/src/components/SkillsSection.tsx` — prefetch body + files whenever `expandedId` changes.
- `apps/web/tests/components/SkillsSection.test.tsx` — regression test for post-create file listing.

## Validation
- `cd apps/web && pnpm test tests/components/SkillsSection.test.tsx` — 5 passed.

Note: this fixes the stale empty file tree after save. Adding arbitrary extra file uploads beyond `SKILL.md` is still out of scope for the current UI.

Made with [Cursor](https://cursor.com)