### PR TITLE
Split bug report template logs and screenshots into separate fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -64,13 +64,15 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Logs / screenshots (optional)
-      description: |
-        If relevant, paste any error output, console logs, or screenshots.
-        For daemon logs, run `pnpm tools-dev logs --json`.
+      label: Logs (optional)
+      description: Paste any error output or console logs. For daemon logs, run `pnpm tools-dev logs --json`.
       render: shell
-    validations:
-      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots (optional)
+      description: Drag and drop or paste images here to show the visual bug.
 
   - type: textarea
     id: context


### PR DESCRIPTION
Fixes #2606

## Why

The bug report template grouped logs and screenshots into a single field, making issue reports less structured and harder to review.

This change improves the issue reporting experience by separating technical diagnostic information (logs) from visual evidence (screenshots), making bug reports easier to fill out and easier for maintainers to triage.

## What users will see

When opening a bug report, users will now see two separate optional fields:

- "Logs (optional)" for console output and daemon logs
- "Screenshots (optional)" for visual bug evidence

This creates a clearer reporting flow and improves issue organization.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Opened the bug report template and verified that logs and screenshots now appear as separate optional fields
- Confirmed the logs section retains shell rendering support
- Confirmed screenshots now support image drag-and-drop or paste workflow
- Manual validation only (template/configuration change)

## Validation

- Verified GitHub issue template YAML structure
- Confirmed template renders correctly with separated input areas
- Manual review of generated issue form behavior