### PR TITLE
fix(web): align manual edit canvas on device viewports

### DIFF
--- a/apps/web/src/styles/viewer/core.css
+++ b/apps/web/src/styles/viewer/core.css
@@ -998,7 +998,8 @@
   will-change: transform;
 }
 .preview-viewport:not(.preview-viewport-desktop) .preview-frame-clip,
-.preview-viewport:not(.preview-viewport-desktop) .comment-frame-clip {
+.preview-viewport:not(.preview-viewport-desktop) .comment-frame-clip,
+.preview-viewport:not(.preview-viewport-desktop).manual-edit-workspace .manual-edit-canvas {
   position: relative;
   inset: auto;
 }

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -91,6 +91,17 @@ describe('FileViewer preview scale', () => {
     expect(css).toContain('.viewer-action');
   });
 
+  it('keeps manual edit canvas layout aligned with comment preview on device viewports (#2960)', () => {
+    const css = readExpandedIndexCss();
+
+    expect(css).toContain(
+      '.preview-viewport:not(.preview-viewport-desktop).manual-edit-workspace .manual-edit-canvas',
+    );
+    expect(css).toMatch(
+      /\.preview-viewport:not\(\.preview-viewport-desktop\) \.preview-frame-clip,\s*\n\.preview-viewport:not\(\.preview-viewport-desktop\) \.comment-frame-clip,\s*\n\.preview-viewport:not\(\.preview-viewport-desktop\)\.manual-edit-workspace \.manual-edit-canvas \{\s*\n\s*position: relative;/,
+    );
+  });
+
   it('keeps the manual edit titlebar from overlapping the close button', () => {
     const css = readExpandedIndexCss();
 


### PR DESCRIPTION
Fixes #2960

## Summary
On mobile/tablet preview viewports, manual edit mode kept `.manual-edit-canvas` absolutely positioned (`inset: 0`) while comment preview uses a centered, device-sized clip. That full-bleed layer misaligned the scaled iframe with visible content, so element clicks/CSS edits could no-op unless the preview was expanded (e.g. presentation/fullscreen).

## Surface area
- `apps/web/src/styles/viewer/core.css` — apply the same `position: relative; inset: auto` device-viewport rule to `.manual-edit-canvas`.
- `apps/web/tests/components/FileViewer.test.tsx` — CSS regression test for the shared layout rule.

## Validation
- `cd apps/web && pnpm test tests/components/FileViewer.test.tsx -t "manual edit canvas layout"` — passed.

Made with [Cursor](https://cursor.com)