### PR TITLE
fix(web): expose manual edit undo/redo and save confirmation

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3893,6 +3893,7 @@ function HtmlViewer({
       if (value !== prev && !value) {
         setManualEditFrozenSource(null);
         setManualEditViewportWidth(null);
+        setManualEditSavedAt(null);
       }
       return value;
     });
@@ -3998,6 +3999,7 @@ function HtmlViewer({
   const [manualEditUndone, setManualEditUndone] = useState<ManualEditHistoryEntry[]>([]);
   const [manualEditError, setManualEditError] = useState<string | null>(null);
   const [manualEditSaving, setManualEditSaving] = useState(false);
+  const [manualEditSavedAt, setManualEditSavedAt] = useState<number | null>(null);
   const manualEditSavingRef = useRef(false);
   const manualEditPendingStyleRef = useRef<ManualEditPendingStyleSave | null>(null);
   const manualEditStyleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -5111,6 +5113,7 @@ function HtmlViewer({
         reconcileManualEditStyleSave(patch.id, patch.styles, result.source);
       }
       setManualEditError(null);
+      setManualEditSavedAt(Date.now());
       await onFileSaved?.();
       return true;
     } finally {
@@ -5162,6 +5165,7 @@ function HtmlViewer({
       setManualEditHistory(rest);
       setManualEditUndone((current) => [latest, ...current]);
       setManualEditDraft((current) => ({ ...current, fullSource: latest.beforeSource }));
+      setManualEditSavedAt(Date.now());
       await onFileSaved?.();
     } finally {
       manualEditSavingRef.current = false;
@@ -5194,6 +5198,7 @@ function HtmlViewer({
       setManualEditUndone(rest);
       setManualEditHistory((current) => [latest, ...current]);
       setManualEditDraft((current) => ({ ...current, fullSource: latest.afterSource }));
+      setManualEditSavedAt(Date.now());
       await onFileSaved?.();
     } finally {
       manualEditSavingRef.current = false;
@@ -6068,6 +6073,7 @@ function HtmlViewer({
       canUndo={manualEditHistory.length > 0}
       canRedo={manualEditUndone.length > 0}
       busy={manualEditSaving}
+      savedAt={manualEditSavedAt}
       pageStylesEnabled={manualEditPageStylesEnabled}
       onSelectTarget={selectManualEditTarget}
       onDraftChange={setManualEditDraft}

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -27,6 +27,9 @@ export function ManualEditPanel({
   draft,
   error,
   canUndo,
+  canRedo,
+  busy = false,
+  savedAt = null,
   onDraftChange,
   onStyleChange,
   onInvalidStyle,
@@ -35,6 +38,8 @@ export function ManualEditPanel({
   onExit,
   onApplyPatch,
   onPickImage,
+  onUndo,
+  onRedo,
   pageStylesEnabled = true,
 }: {
   targets: ManualEditTarget[];
@@ -58,16 +63,45 @@ export function ManualEditPanel({
   onCancelDraft: () => void;
   onUndo: () => void;
   onRedo: () => void;
+  savedAt?: number | null;
 }) {
   const t = useT();
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [uploadingImage, setUploadingImage] = useState(false);
+  const [showSaved, setShowSaved] = useState(false);
   const selectedTargetRef = useRef<ManualEditTarget | null>(selectedTarget);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const targetForInspector = selectedTarget;
   useEffect(() => {
     selectedTargetRef.current = selectedTarget;
   }, [selectedTarget]);
+  useEffect(() => {
+    if (savedAt == null) {
+      setShowSaved(false);
+      return;
+    }
+    setShowSaved(true);
+    const timer = window.setTimeout(() => setShowSaved(false), 4000);
+    return () => window.clearTimeout(timer);
+  }, [savedAt]);
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (busy) return;
+      const mod = event.metaKey || event.ctrlKey;
+      if (!mod || event.altKey) return;
+      if (event.key.toLowerCase() === 'z' && !event.shiftKey && canUndo) {
+        event.preventDefault();
+        onUndo();
+        return;
+      }
+      if (event.key.toLowerCase() === 'z' && event.shiftKey && canRedo) {
+        event.preventDefault();
+        onRedo();
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [busy, canRedo, canUndo, onRedo, onUndo]);
 
   const changeTargetStyle = (key: keyof ManualEditStyles, value: string) => {
     const nextStyles = { ...draft.styles, [key]: value };
@@ -89,7 +123,18 @@ export function ManualEditPanel({
     <aside className="manual-edit-right">
       <section className="manual-edit-modal cc-panel">
         <div className="manual-edit-titlebar">
-          <span>Edit</span>
+          <div className="manual-edit-titlebar-main">
+            <span>{t('manualEdit.title')}</span>
+            {busy ? (
+              <em className="manual-edit-status" data-testid="manual-edit-status">
+                Saving…
+              </em>
+            ) : showSaved ? (
+              <em className="manual-edit-status" data-testid="manual-edit-status">
+                Saved ✓
+              </em>
+            ) : null}
+          </div>
           {onExit ? (
             <button
               type="button"
@@ -101,6 +146,28 @@ export function ManualEditPanel({
               <Icon name="close" size={16} />
             </button>
           ) : null}
+        </div>
+        <div className="manual-edit-history-actions">
+          <button
+            type="button"
+            className="cc-action-btn"
+            data-testid="manual-edit-undo"
+            disabled={!canUndo || busy}
+            aria-label={t('manualEdit.undo')}
+            onClick={onUndo}
+          >
+            {t('manualEdit.undo')}
+          </button>
+          <button
+            type="button"
+            className="cc-action-btn"
+            data-testid="manual-edit-redo"
+            disabled={!canRedo || busy}
+            aria-label={t('manualEdit.redo')}
+            onClick={onRedo}
+          >
+            {t('manualEdit.redo')}
+          </button>
         </div>
         {targetForInspector ? (
           <StyleInspector

--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -935,7 +935,22 @@
   padding: 14px 18px 10px;
 }
 
-.manual-edit-titlebar > span {
+.manual-edit-titlebar-main {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.manual-edit-status {
+  color: var(--accent);
+  font-size: 11px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.manual-edit-titlebar > span,
+.manual-edit-titlebar-main > span {
   min-width: 0;
   overflow: hidden;
   color: var(--text);

--- a/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
@@ -293,6 +293,67 @@ describe('FileViewer manual edit history regressions', () => {
         .not.toContain('data-od-id="hero"');
     });
   });
+
+  it('restores a deleted element when the user clicks Undo (#2866)', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero">Hero</h1><p data-od-id="body">Body</p></body></html>';
+    let persistedSource = initialSource;
+    const savedSources: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.includes('/api/projects/project-1/deployments')) {
+        return new Response(JSON.stringify({ deployments: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/projects/project-1/files') && init?.method === 'POST') {
+        const payload = JSON.parse(String(init.body)) as { content: string };
+        persistedSource = payload.content;
+        savedSources.push(payload.content);
+        return new Response(JSON.stringify({ file: htmlPreviewFile() }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/projects/project-1/raw/preview.html')) {
+        return new Response(persistedSource, { status: 200 });
+      }
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+    await waitFor(() => expect(panelState.props).not.toBeNull());
+
+    await act(async () => {
+      await panelState.props?.onSelectTarget(heroTarget());
+    });
+
+    act(() => {
+      panelState.props?.onApplyPatch(
+        { id: 'hero', kind: 'remove-element' },
+        'Delete element',
+      );
+    });
+    await waitFor(() => expect(savedSources).toHaveLength(1));
+    expect(savedSources[0]).not.toContain('data-od-id="hero"');
+
+    act(() => {
+      panelState.props?.onUndo();
+    });
+    await waitFor(() => expect(savedSources).toHaveLength(2));
+    expect(savedSources[1]).toContain('data-od-id="hero"');
+    await waitFor(() => {
+      expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc)
+        .toContain('data-od-id="hero"');
+    });
+  });
 });
 
 function htmlPreviewFile(): ProjectFile {

--- a/apps/web/tests/components/ManualEditPanel.test.tsx
+++ b/apps/web/tests/components/ManualEditPanel.test.tsx
@@ -52,6 +52,55 @@ describe('ManualEditPanel', () => {
     Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT');
   });
 
+  it('renders undo and redo controls wired to the edit history callbacks', () => {
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    renderPanel({ canUndo: true, canRedo: true, onUndo, onRedo });
+
+    const undoButton = host.querySelector('[data-testid="manual-edit-undo"]') as HTMLButtonElement | null;
+    const redoButton = host.querySelector('[data-testid="manual-edit-redo"]') as HTMLButtonElement | null;
+    if (!undoButton || !redoButton) throw new Error('History controls not found');
+
+    expect(undoButton.disabled).toBe(false);
+    expect(redoButton.disabled).toBe(false);
+
+    act(() => {
+      undoButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports undo and redo keyboard shortcuts while the panel is open', () => {
+    const onUndo = vi.fn();
+    const onRedo = vi.fn();
+    renderPanel({ canUndo: true, canRedo: true, onUndo, onRedo });
+
+    act(() => {
+      dom.window.dispatchEvent(new dom.window.KeyboardEvent('keydown', {
+        key: 'z',
+        ctrlKey: true,
+        bubbles: true,
+      }));
+    });
+    expect(onUndo).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      dom.window.dispatchEvent(new dom.window.KeyboardEvent('keydown', {
+        key: 'z',
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+      }));
+    });
+    expect(onRedo).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a saved confirmation after a successful edit timestamp arrives', () => {
+    renderPanel({ savedAt: Date.now() });
+
+    expect(host.querySelector('[data-testid="manual-edit-status"]')?.textContent).toContain('Saved ✓');
+  });
+
   it('renders the style inspector without the advanced editor entry', () => {
     renderPanel();
 
@@ -445,6 +494,11 @@ describe('ManualEditPanel', () => {
     selectedTarget = target,
     styles = emptyManualEditStyles(),
     pageStylesEnabled = true,
+    canUndo = false,
+    canRedo = false,
+    savedAt = null,
+    onUndo,
+    onRedo,
   }: {
     onDraftChange?: OnDraftChange;
     onApplyPatch?: OnApplyPatch;
@@ -456,6 +510,11 @@ describe('ManualEditPanel', () => {
     selectedTarget?: ManualEditTarget | null;
     styles?: ReturnType<typeof emptyManualEditStyles>;
     pageStylesEnabled?: boolean;
+    canUndo?: boolean;
+    canRedo?: boolean;
+    savedAt?: number | null;
+    onUndo?: () => void;
+    onRedo?: () => void;
   } = {}) {
     const draft = {
       ...emptyManualEditDraft('<html></html>'),
@@ -472,8 +531,9 @@ describe('ManualEditPanel', () => {
           draft={draft}
           history={[]}
           error={null}
-          canUndo={false}
-          canRedo={false}
+          canUndo={canUndo ?? false}
+          canRedo={canRedo ?? false}
+          savedAt={savedAt ?? null}
           pageStylesEnabled={pageStylesEnabled}
           onSelectTarget={vi.fn<(target: ManualEditTarget) => void>()}
           onDraftChange={onDraftChange}
@@ -483,8 +543,8 @@ describe('ManualEditPanel', () => {
           onError={onError}
           onClearSelection={onClearSelection}
           onCancelDraft={vi.fn<() => void>()}
-          onUndo={vi.fn<() => void>()}
-          onRedo={vi.fn<() => void>()}
+          onUndo={onUndo ?? vi.fn<() => void>()}
+          onRedo={onRedo ?? vi.fn<() => void>()}
         />,
       );
     });


### PR DESCRIPTION
Fixes #2866

Also helps #2905 — the edit panel now shows transient **Saved ✓** / **Saving…** feedback after persisted manual edits (including deletes), even though the legacy HTML tab UI is no longer present.

## Summary
Manual edit history (`undoManualEdit` / `redoManualEdit`) already worked in `FileViewer`, but `ManualEditPanel` never rendered controls or keyboard shortcuts, so deletes felt irreversible.

## Surface area
- `apps/web/src/components/ManualEditPanel.tsx` — Undo/Redo buttons, Cmd/Ctrl+Z shortcuts, saved status line.
- `apps/web/src/components/FileViewer.tsx` — track `manualEditSavedAt` after successful writes/undo/redo.
- `apps/web/src/styles/viewer/memory.css` — titlebar status styling.
- Tests in `ManualEditPanel.test.tsx` and `FileViewer.manual-edit-history.test.tsx`.

## Validation
- `cd apps/web && pnpm test tests/components/ManualEditPanel.test.tsx tests/components/FileViewer.manual-edit-history.test.tsx` — 27 passed.

Made with [Cursor](https://cursor.com)