### PR TITLE
fix(design-systems): align mission-control success and danger tokens (#2961)

### DIFF
--- a/design-systems/mission-control/DESIGN.md
+++ b/design-systems/mission-control/DESIGN.md
@@ -90,6 +90,8 @@ Dark mode is the native mode. No light mode variant by design — mission contro
 }
 ```
 
+Consumable bindings in `tokens.css` mirror the telemetry palette as `--success` (`#26DE81`) and `--danger` (`#FF4757`).
+
 ## 3. Typography
 
 ### Font Stack

--- a/design-systems/mission-control/components.html
+++ b/design-systems/mission-control/components.html
@@ -20,9 +20,9 @@
         --accent-on: #06101d;
         --accent-hover: color-mix(in oklab, var(--accent), black 8%);
         --accent-active: color-mix(in oklab, var(--accent), black 14%);
-        --success: #22c55e;
+        --success: #26de81;
         --warn: #fbbf24;
-        --danger: #fb7185;
+        --danger: #ff4757;
         --font-display: Inter, system-ui, sans-serif;
         --font-body: Inter, system-ui, sans-serif;
         --font-mono: "SF Mono", ui-monospace, Menlo, monospace;

--- a/design-systems/mission-control/tokens.css
+++ b/design-systems/mission-control/tokens.css
@@ -17,9 +17,9 @@
   --accent-on: #06101d;
   --accent-hover: color-mix(in oklab, var(--accent), black 8%);
   --accent-active: color-mix(in oklab, var(--accent), black 14%);
-  --success: #22c55e;
+  --success: #26de81;
   --warn: #fbbf24;
-  --danger: #fb7185;
+  --danger: #ff4757;
   --font-display: Inter, system-ui, sans-serif;
   --font-body: Inter, system-ui, sans-serif;
   --font-mono: "SF Mono", ui-monospace, Menlo, monospace;

--- a/plugins/_official/design-systems/mission-control/DESIGN.md
+++ b/plugins/_official/design-systems/mission-control/DESIGN.md
@@ -90,6 +90,8 @@ Dark mode is the native mode. No light mode variant by design — mission contro
 }
 ```
 
+Consumable bindings in `tokens.css` mirror the telemetry palette as `--success` (`#26DE81`) and `--danger` (`#FF4757`).
+
 ## 3. Typography
 
 ### Font Stack


### PR DESCRIPTION
Fixes #2961

## Summary

Aligns `design-systems/mission-control/tokens.css` (and the matching `components.html` fixture) with the telemetry palette documented in `DESIGN.md`. Success now uses `#26DE81` and danger uses `#FF4757`, matching the spec's Data Palette. Added a short note in `DESIGN.md` documenting the `--success` / `--danger` binding.

## Surface area

- `design-systems/mission-control/tokens.css`
- `design-systems/mission-control/components.html`
- `design-systems/mission-control/DESIGN.md`
- `plugins/_official/design-systems/mission-control/DESIGN.md`

## Validation

```bash
node --import tsx scripts/check-tokens-fixture-sync.ts
```

Made with [Cursor](https://cursor.com)