### PR TITLE
fix(daemon): align Codex launch permissions on Windows and WSL (#2834)

### DIFF
--- a/apps/daemon/src/runtimes/defs/codex.ts
+++ b/apps/daemon/src/runtimes/defs/codex.ts
@@ -44,6 +44,16 @@ export function parseCodexDebugModels(stdout: string): RuntimeModelOption[] | nu
   return out.length > 1 ? out : null;
 }
 
+export function codexNeedsDangerFullAccessSandbox(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (platform === 'win32') return true;
+  // WSL reports `linux` but Codex still hits the Windows read-only
+  // workspace-write sandbox path when launched from there (#2834).
+  return Boolean(env.WSL_DISTRO_NAME?.trim());
+}
+
 export const codexAgentDef = {
     id: 'codex',
     name: 'Codex CLI',
@@ -98,8 +108,8 @@ export const codexAgentDef = {
       // back to a coarse policy that rejects any shell. macOS (Seatbelt)
       // and Linux (Landlock+seccomp) keep workspace-write because their
       // sandbox enforcement permits shell while restricting writes.
-      const isWindows = process.platform === 'win32';
-      const args = isWindows
+      const needsDangerFullAccess = codexNeedsDangerFullAccessSandbox();
+      const args = needsDangerFullAccess
         ? ['exec', '--json', '--skip-git-repo-check', '--sandbox', 'danger-full-access']
         : [
             'exec',
@@ -110,6 +120,9 @@ export const codexAgentDef = {
             '-c',
             'sandbox_workspace_write.network_access=true',
           ];
+      // Newer Codex builds honor permissions config over legacy sandbox
+      // flags; without this, Windows/WSL launches can stay read-only (#2834).
+      args.push('-c', 'default_permissions=":workspace"');
       if (process.env.OD_CODEX_DISABLE_PLUGINS === '1') {
         args.push('--disable', 'plugins');
       }

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -2,6 +2,7 @@ import { test } from 'vitest';
 import {
   AGENT_DEFS, assert, chmodSync, codex, cursorAgent, detectAgents, join, mkdtempSync, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
+import { codexNeedsDangerFullAccessSandbox } from '../../src/runtimes/defs/codex.js';
 import { readLocalAgentProfileDefs } from '../../src/runtimes/registry.js';
 
 test('AGENT_DEFS ids are unique', () => {
@@ -107,7 +108,7 @@ test('codex args disable plugins when OD_CODEX_DISABLE_PLUGINS is 1', () => {
   withPlatform('darwin', () => {
     const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
 
-    assert.deepEqual(args.slice(0, 9), [
+    assert.deepEqual(args.slice(0, 11), [
       'exec',
       '--json',
       '--skip-git-repo-check',
@@ -115,6 +116,8 @@ test('codex args disable plugins when OD_CODEX_DISABLE_PLUGINS is 1', () => {
       'workspace-write',
       '-c',
       'sandbox_workspace_write.network_access=true',
+      '-c',
+      'default_permissions=":workspace"',
       '--disable',
       'plugins',
     ]);
@@ -126,17 +129,48 @@ test('codex args use workspace-write sandbox on macOS and Linux', () => {
 
   for (const platform of ['darwin', 'linux'] as const) {
     withPlatform(platform, () => {
+      withEnvSnapshot(['WSL_DISTRO_NAME'], () => {
+        delete process.env.WSL_DISTRO_NAME;
+        const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
+        assert.equal(args.includes('--full-auto'), false);
+        assert.deepEqual(args.slice(0, 5), [
+          'exec',
+          '--json',
+          '--skip-git-repo-check',
+          '--sandbox',
+          'workspace-write',
+        ]);
+        assert.equal(
+          args.includes('-c'),
+          true,
+        );
+        assert.equal(
+          args.includes('default_permissions=":workspace"'),
+          true,
+        );
+      });
+    });
+  }
+});
+
+test('codex args use danger-full-access sandbox on WSL because workspace-write stays read-only', () => {
+  delete process.env.OD_CODEX_DISABLE_PLUGINS;
+
+  withPlatform('linux', () => {
+    withEnvSnapshot(['WSL_DISTRO_NAME'], () => {
+      process.env.WSL_DISTRO_NAME = 'Ubuntu';
+      assert.equal(codexNeedsDangerFullAccessSandbox('linux', process.env), true);
       const args = codex.buildArgs('', [], [], {}, { cwd: '/tmp/od-project' });
-      assert.equal(args.includes('--full-auto'), false);
       assert.deepEqual(args.slice(0, 5), [
         'exec',
         '--json',
         '--skip-git-repo-check',
         '--sandbox',
-        'workspace-write',
+        'danger-full-access',
       ]);
+      assert.equal(args.includes('default_permissions=":workspace"'), true);
     });
-  }
+  });
 });
 
 test('codex args use danger-full-access sandbox on Windows because workspace-write blocks PowerShell', () => {
@@ -165,6 +199,7 @@ test('codex args use danger-full-access sandbox on Windows because workspace-wri
       args.includes('sandbox_workspace_write.network_access=true'),
       false,
     );
+    assert.equal(args.includes('default_permissions=":workspace"'), true);
   });
 });
 


### PR DESCRIPTION
Fixes #2834

## Summary

Codex launches from Open Design could stay read-only on Windows-like environments when the legacy `--sandbox workspace-write` path was used. This aligns with newer Codex permissions behavior by:

- Treating WSL (`WSL_DISTRO_NAME`) like Windows and using `danger-full-access` instead of `workspace-write`
- Passing `-c default_permissions=":workspace"` on every Codex launch so newer CLI builds get workspace write access

## Surface area

- `apps/daemon/src/runtimes/defs/codex.ts` — sandbox selection helper + permissions override
- `apps/daemon/tests/runtimes/registry-and-args.test.ts` — WSL + permissions regression tests

## Validation

```bash
cd apps/daemon && pnpm test tests/runtimes/registry-and-args.test.ts
```

Made with [Cursor](https://cursor.com)