### PR TITLE
fix(platform): resolve pnpm via corepack when npm_execpath is absent (#2438)

### DIFF
--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -295,9 +295,9 @@ export function createPackageManagerInvocation(args: string[], env: NodeJS.Proce
     return createCommandInvocation({ args, command: execPath, env });
   }
   if (process.platform === "win32") {
-    return buildCmdShimInvocation("pnpm", args, env);
+    return buildCmdShimInvocation("corepack", ["pnpm", ...args], env);
   }
-  return { args, command: "pnpm" };
+  return { args: ["pnpm", ...args], command: "corepack" };
 }
 
 function createLoggedStdio(logFd?: number | null): StdioOptions {

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -370,13 +370,13 @@ describe("createPackageManagerInvocation", () => {
     ]);
   });
 
-  it("returns plain pnpm invocation on POSIX without npm_execpath", () => {
+  it("returns corepack pnpm invocation on POSIX without npm_execpath", () => {
     setPlatform("linux");
     const invocation = createPackageManagerInvocation(["install"], {} as NodeJS.ProcessEnv);
-    expect(invocation).toEqual({ args: ["install"], command: "pnpm" });
+    expect(invocation).toEqual({ args: ["pnpm", "install"], command: "corepack" });
   });
 
-  it("wraps pnpm through cmd.exe with verbatim arguments on Windows", () => {
+  it("wraps corepack pnpm through cmd.exe with verbatim arguments on Windows", () => {
     setPlatform("win32");
     const invocation = createPackageManagerInvocation(["--filter", "@open-design/desktop", "build"], {
       ComSpec: "cmd.exe",
@@ -387,7 +387,7 @@ describe("createPackageManagerInvocation", () => {
       "/d",
       "/s",
       "/c",
-      '"pnpm --filter @open-design/desktop build"',
+      '"corepack pnpm --filter @open-design/desktop build"',
     ]);
   });
 });


### PR DESCRIPTION
Fixes #2438

## Summary

When `npm_execpath` is not set (common on Windows Corepack-only setups), nested package-manager invocations from `tools-dev` now run `corepack pnpm …` instead of assuming a global `pnpm` binary is on PATH.

## Surface area

- `packages/platform/src/index.ts` — `createPackageManagerInvocation` fallback
- `packages/platform/tests/index.test.ts` — updated fallback expectations

## Validation

```bash
cd packages/platform && pnpm test tests/index.test.ts
```

Made with [Cursor](https://cursor.com)