### PR TITLE
feat(daemon): allow BYOK private targets via admin allowlist (#2986)

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -51,9 +51,14 @@ import type { RuntimeAgentDef } from './runtimes/types.js';
 import {
   isBlockedExternalApiHostname,
   isLoopbackApiHost,
+  isPrivateTargetAllowedByAllowlist,
+  parseByokPrivateAllowlistFromEnv,
+  serializeByokPrivateAllowlist,
   validateBaseUrl,
   type AgentTestRequest,
   type BaseUrlValidationResult,
+  type ByokPrivateAllowlist,
+  type ByokPrivateTargetAllowlist,
   type ConnectionTestDiagnostics,
   type ConnectionTestKind,
   type ConnectionTestPhase,
@@ -65,6 +70,36 @@ import {
 import { googleGenerateContentUrl } from './google-models.js';
 
 export { validateBaseUrl } from '@open-design/contracts/api/connectionTest';
+
+export {
+  parseByokPrivateAllowlistFromEnv,
+  serializeByokPrivateAllowlist,
+} from '@open-design/contracts/api/connectionTest';
+
+let cachedByokPrivateAllowlist: ByokPrivateAllowlist | undefined;
+
+export function getByokPrivateAllowlist(
+  env: NodeJS.ProcessEnv = process.env,
+): ByokPrivateAllowlist {
+  if (cachedByokPrivateAllowlist === undefined) {
+    cachedByokPrivateAllowlist = parseByokPrivateAllowlistFromEnv(env);
+  }
+  return cachedByokPrivateAllowlist;
+}
+
+export function getByokPrivateTargetAllowlistForApi(
+  env: NodeJS.ProcessEnv = process.env,
+): ByokPrivateTargetAllowlist {
+  return serializeByokPrivateAllowlist(getByokPrivateAllowlist(env));
+}
+
+export function __resetByokPrivateAllowlistCacheForTests() {
+  cachedByokPrivateAllowlist = undefined;
+}
+
+export type ValidateBaseUrlResolvedOptions = {
+  allowlist?: ByokPrivateAllowlist | null;
+};
 
 // DNS-aware companion to `validateBaseUrl`. The contracts-side check only
 // inspects the literal hostname string, so a public DNS name pointing at
@@ -102,12 +137,17 @@ function looksLikeIpLiteral(hostname: string): boolean {
 export async function validateBaseUrlResolved(
   baseUrl: string,
   lookup: DnsLookupFn = defaultDnsLookup,
+  options: ValidateBaseUrlResolvedOptions = {},
 ): Promise<BaseUrlValidationResult> {
-  const sync = validateBaseUrl(baseUrl);
+  const allowlist = options.allowlist === undefined
+    ? getByokPrivateAllowlist()
+    : (options.allowlist ?? null);
+  const sync = validateBaseUrl(baseUrl, { allowlist });
   if (sync.error || !sync.parsed) return sync;
 
   const hostname = sync.parsed.hostname.toLowerCase();
   if (isLoopbackApiHost(hostname)) return sync;
+  if (isPrivateTargetAllowedByAllowlist(hostname, allowlist)) return sync;
   if (looksLikeIpLiteral(hostname)) return sync;
 
   let addresses: DnsLookupAddress[];
@@ -121,6 +161,7 @@ export async function validateBaseUrlResolved(
     const ip = String(addr.address).toLowerCase();
     if (isLoopbackApiHost(ip)) continue;
     if (isBlockedExternalApiHostname(ip)) {
+      if (isPrivateTargetAllowedByAllowlist(hostname, allowlist, ip)) continue;
       return { error: 'Internal IPs blocked', forbidden: true };
     }
   }
@@ -151,7 +192,7 @@ export async function assertExternalAssetUrl(
   if (typeof rawUrl !== 'string' || !rawUrl) {
     return { ok: false, error: 'empty download url' };
   }
-  const validated = await validateBaseUrlResolved(rawUrl);
+  const validated = await validateBaseUrlResolved(rawUrl, defaultDnsLookup, { allowlist: null });
   if (validated.error || !validated.parsed) {
     return {
       ok: false,

--- a/apps/daemon/src/media-routes.ts
+++ b/apps/daemon/src/media-routes.ts
@@ -1,4 +1,5 @@
 import type { Express } from 'express';
+import { getByokPrivateTargetAllowlistForApi } from './connectionTest.js';
 import type { RouteDeps } from './server-context.js';
 
 export interface RegisterMediaRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'ids' | 'media' | 'appConfig' | 'orbit' | 'nativeDialogs' | 'projectStore' | 'projectFiles' | 'conversations' | 'research'> {}
@@ -74,7 +75,10 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
     }
     try {
       const config = await readAppConfig(RUNTIME_DATA_DIR);
-      res.json({ config });
+      res.json({
+        config,
+        byokPrivateTargetAllowlist: getByokPrivateTargetAllowlistForApi(),
+      });
     } catch (err: any) {
       res
         .status(500)

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2871,4 +2871,27 @@ describe('validateBaseUrlResolved (DNS-aware base URL validation)', () => {
     expect(result.error).toBeUndefined();
     expect(failingLookup).toHaveBeenCalledOnce();
   });
+
+  it('allows private targets covered by the BYOK admin allowlist (#2986)', async () => {
+    const allowlist = {
+      hostnames: new Set(['host.docker.internal']),
+      cidrs: ['192.168.0.0/16'],
+    };
+    expect(
+      (
+        await validateBaseUrlResolved(
+          'http://host.docker.internal:1234/v1',
+          lookupReturning([{ address: '192.168.65.2', family: 4 }]),
+          { allowlist },
+        )
+      ).error,
+    ).toBeUndefined();
+    expect(
+      (
+        await validateBaseUrlResolved('http://192.168.1.50:4000/v1', lookupReturning([]), {
+          allowlist,
+        })
+      ).error,
+    ).toBeUndefined();
+  });
 });

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, Dispatch, SetStateAction } from 'react';
-import { validateBaseUrl } from '@open-design/contracts/api/connectionTest';
+import { validateBaseUrl, byokAllowlistFromResponse } from '@open-design/contracts/api/connectionTest';
+import { getByokPrivateTargetAllowlist } from '../state/config';
 import {
   agentIdToTracking,
   byokProtocolToTracking,
@@ -602,7 +603,9 @@ function applyApiProtocolConfig(
 export function isValidApiBaseUrl(value: string): boolean {
   const trimmed = value.trim();
   if (!/^https?:\/\//i.test(trimmed)) return false;
-  const result = validateBaseUrl(trimmed);
+  const result = validateBaseUrl(trimmed, {
+    allowlist: byokAllowlistFromResponse(getByokPrivateTargetAllowlist()),
+  });
   return Boolean(result.parsed && !result.error);
 }
 

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -1,4 +1,5 @@
 import type { AppConfigPrefs } from '@open-design/contracts';
+import type { ByokPrivateTargetAllowlist } from '@open-design/contracts/api/connectionTest';
 import { MEDIA_PROVIDERS } from '../media/models';
 import { isOpenAICompatible } from '../providers/openai-compatible';
 import type {
@@ -20,6 +21,18 @@ import {
 
 const STORAGE_KEY = 'open-design:config';
 const CONFIG_MIGRATION_VERSION = 1;
+
+let byokPrivateTargetAllowlist: ByokPrivateTargetAllowlist | null = null;
+
+export function getByokPrivateTargetAllowlist(): ByokPrivateTargetAllowlist | null {
+  return byokPrivateTargetAllowlist;
+}
+
+export function setByokPrivateTargetAllowlistForTests(
+  allowlist: ByokPrivateTargetAllowlist | null,
+) {
+  byokPrivateTargetAllowlist = allowlist;
+}
 
 // Hatched out of the box, but tucked away — the user has to go through
 // either the entry-view "adopt a pet" callout or Settings → Pets to
@@ -769,6 +782,7 @@ export async function fetchDaemonConfig(): Promise<AppConfigPrefs | null> {
     const res = await fetch('/api/app-config');
     if (!res.ok) return null;
     const data = await res.json();
+    byokPrivateTargetAllowlist = data?.byokPrivateTargetAllowlist ?? null;
     return data?.config ?? null;
   } catch {
     return null;

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setByokPrivateTargetAllowlistForTests } from '../../src/state/config';
 import {
   agentRefreshOptionsForConfig,
   canFetchProviderModels,
@@ -299,6 +300,17 @@ describe('SettingsDialog API Base URL validation', () => {
     expect(isValidApiBaseUrl('http://[fd00::1]:11434/v1')).toBe(false);
     expect(isValidApiBaseUrl('http://[fe80::1]:11434/v1')).toBe(false);
     expect(isValidApiBaseUrl('http://[::ffff:192.168.1.5]:11434/v1')).toBe(false);
+  });
+
+  it('accepts private targets when the daemon exposes a BYOK allowlist (#2986)', () => {
+    setByokPrivateTargetAllowlistForTests({
+      hostnames: ['host.docker.internal'],
+      cidrs: ['192.168.0.0/16'],
+    });
+    expect(isValidApiBaseUrl('http://host.docker.internal:1234/v1')).toBe(true);
+    expect(isValidApiBaseUrl('http://192.168.1.50:4000/v1')).toBe(true);
+    expect(isValidApiBaseUrl('http://10.0.0.5:11434/v1')).toBe(false);
+    setByokPrivateTargetAllowlistForTests(null);
   });
 });
 

--- a/packages/contracts/src/api/app-config.ts
+++ b/packages/contracts/src/api/app-config.ts
@@ -1,3 +1,5 @@
+import type { ByokPrivateTargetAllowlist } from './connectionTest.js';
+
 export interface AgentModelPrefs {
   model?: string;
   reasoning?: string;
@@ -44,6 +46,8 @@ export interface AppConfigPrefs {
 
 export interface AppConfigResponse {
   config: AppConfigPrefs;
+  /** Read-only daemon policy from env; not persisted in app-config.json (#2986). */
+  byokPrivateTargetAllowlist?: ByokPrivateTargetAllowlist;
 }
 
 export type UpdateAppConfigRequest = Partial<AppConfigPrefs>;

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -107,7 +107,121 @@ export function isBlockedExternalApiHostname(hostname: string): boolean {
   return Boolean(mapped && isBlockedIpv4(mapped));
 }
 
-export function validateBaseUrl(baseUrl: string): BaseUrlValidationResult {
+/** Daemon-admin allowlist for trusted internal BYOK gateways (#2986). */
+export interface ByokPrivateTargetAllowlist {
+  hostnames: string[];
+  cidrs: string[];
+}
+
+export interface ByokPrivateAllowlist {
+  hostnames: Set<string>;
+  cidrs: string[];
+}
+
+function ipv4ToUint32(hostname: string): number | null {
+  const parts = parseIpv4(normalizeBracketedIpv6(hostname));
+  if (!parts) return null;
+  return (
+    ((parts[0] << 24) >>> 0) +
+    (parts[1] << 16) +
+    (parts[2] << 8) +
+    parts[3]
+  ) >>> 0;
+}
+
+function parseIpv4Cidr(cidr: string): { network: number; mask: number } | null {
+  const trimmed = cidr.trim();
+  const slash = trimmed.indexOf('/');
+  if (slash <= 0) return null;
+  const ipPart = trimmed.slice(0, slash);
+  const prefix = Number(trimmed.slice(slash + 1));
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > 32) return null;
+  const network = ipv4ToUint32(ipPart);
+  if (network === null) return null;
+  const mask = prefix === 0 ? 0 : ((0xffffffff << (32 - prefix)) >>> 0);
+  return { network: network & mask, mask };
+}
+
+export function ipv4MatchesCidr(ip: string, cidr: string): boolean {
+  const parsed = parseIpv4Cidr(cidr);
+  const value = ipv4ToUint32(ip);
+  if (!parsed || value === null) return false;
+  return (value & parsed.mask) === parsed.network;
+}
+
+export function parseByokPrivateAllowlistFromEnv(
+  env: Record<string, string | undefined> = typeof process === 'undefined'
+    ? {}
+    : process.env,
+): ByokPrivateAllowlist {
+  const hostnames = new Set<string>();
+  for (const entry of String(env.OD_BYOK_PRIVATE_HOST_ALLOWLIST ?? '').split(',')) {
+    const normalized = entry.trim().toLowerCase().replace(/\.+$/, '');
+    if (normalized) hostnames.add(normalized);
+  }
+  const cidrs = String(env.OD_BYOK_PRIVATE_CIDR_ALLOWLIST ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return { hostnames, cidrs };
+}
+
+export function serializeByokPrivateAllowlist(
+  allowlist: ByokPrivateAllowlist,
+): ByokPrivateTargetAllowlist {
+  return {
+    hostnames: [...allowlist.hostnames],
+    cidrs: [...allowlist.cidrs],
+  };
+}
+
+export function byokAllowlistFromResponse(
+  response: ByokPrivateTargetAllowlist | null | undefined,
+): ByokPrivateAllowlist | null {
+  if (!response) return null;
+  const hostnames = new Set<string>();
+  for (const entry of response.hostnames ?? []) {
+    const normalized = String(entry).trim().toLowerCase().replace(/\.+$/, '');
+    if (normalized) hostnames.add(normalized);
+  }
+  const cidrs = (response.cidrs ?? []).map((entry) => String(entry).trim()).filter(Boolean);
+  if (hostnames.size === 0 && cidrs.length === 0) return null;
+  return { hostnames, cidrs };
+}
+
+export function isHostnameAllowlisted(
+  hostname: string,
+  allowlist: ByokPrivateAllowlist,
+): boolean {
+  const host = normalizeBracketedIpv6(hostname);
+  return allowlist.hostnames.has(host);
+}
+
+export function ipv4MatchesAnyCidr(ip: string, allowlist: ByokPrivateAllowlist): boolean {
+  return allowlist.cidrs.some((cidr) => ipv4MatchesCidr(ip, cidr));
+}
+
+export function isPrivateTargetAllowedByAllowlist(
+  hostname: string,
+  allowlist: ByokPrivateAllowlist | null | undefined,
+  resolvedIp?: string,
+): boolean {
+  if (!allowlist) return false;
+  if (isHostnameAllowlisted(hostname, allowlist)) return true;
+  const ip = resolvedIp ?? normalizeBracketedIpv6(hostname);
+  if (parseIpv4(ip)) return ipv4MatchesAnyCidr(ip, allowlist);
+  const mapped = ipv4MappedToDotted(ip);
+  return Boolean(mapped && ipv4MatchesAnyCidr(mapped, allowlist));
+}
+
+export interface ValidateBaseUrlOptions {
+  allowlist?: ByokPrivateAllowlist | null;
+}
+
+export function validateBaseUrl(
+  baseUrl: string,
+  options?: ValidateBaseUrlOptions,
+): BaseUrlValidationResult {
   let parsed: ParsedBaseUrl;
   try {
     parsed = new URL(String(baseUrl).replace(/\/+$/, ''));
@@ -118,7 +232,10 @@ export function validateBaseUrl(baseUrl: string): BaseUrlValidationResult {
     return { error: 'Only http/https allowed' };
   }
   const hostname = parsed.hostname.toLowerCase();
-  if (!isLoopbackApiHost(hostname) && isBlockedExternalApiHostname(hostname)) {
+  if (isLoopbackApiHost(hostname)) return { parsed };
+  const allowlist = options?.allowlist ?? null;
+  if (isPrivateTargetAllowedByAllowlist(hostname, allowlist)) return { parsed };
+  if (isBlockedExternalApiHostname(hostname)) {
     return { error: 'Internal IPs blocked', forbidden: true };
   }
   return { parsed };

--- a/packages/contracts/tests/connection-test.test.ts
+++ b/packages/contracts/tests/connection-test.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  byokAllowlistFromResponse,
   isLoopbackApiHost,
+  parseByokPrivateAllowlistFromEnv,
   validateBaseUrl,
 } from '../src/api/connectionTest';
 
@@ -65,5 +67,33 @@ describe('provider base URL validation', () => {
         forbidden: true,
       });
     }
+  });
+});
+
+describe('BYOK private target allowlist (#2986)', () => {
+  it('parses host and CIDR entries from env vars', () => {
+    const allowlist = parseByokPrivateAllowlistFromEnv({
+      OD_BYOK_PRIVATE_HOST_ALLOWLIST: 'host.docker.internal, LiteLLM.internal.',
+      OD_BYOK_PRIVATE_CIDR_ALLOWLIST: '192.168.0.0/16, 10.0.0.0/8',
+    });
+    expect([...allowlist.hostnames]).toEqual(['host.docker.internal', 'litellm.internal']);
+    expect(allowlist.cidrs).toEqual(['192.168.0.0/16', '10.0.0.0/8']);
+  });
+
+  it('allows allowlisted hostnames and CIDRs while keeping default blocks', () => {
+    const allowlist = byokAllowlistFromResponse({
+      hostnames: ['host.docker.internal'],
+      cidrs: ['192.168.0.0/16'],
+    });
+    expect(validateBaseUrl('http://host.docker.internal:1234/v1', { allowlist }).error).toBeUndefined();
+    expect(validateBaseUrl('http://192.168.1.50:4000/v1', { allowlist }).error).toBeUndefined();
+    expect(validateBaseUrl('http://10.0.0.5:11434/v1', { allowlist })).toMatchObject({
+      error: 'Internal IPs blocked',
+      forbidden: true,
+    });
+    expect(validateBaseUrl('http://10.0.0.5:11434/v1')).toMatchObject({
+      error: 'Internal IPs blocked',
+      forbidden: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Keep the default private-network block for BYOK `baseUrl` values (#1176), but add daemon-admin opt-in via env vars:
  - `OD_BYOK_PRIVATE_HOST_ALLOWLIST` — comma-separated hostnames (e.g. `host.docker.internal,litellm.internal.example.com`)
  - `OD_BYOK_PRIVATE_CIDR_ALLOWLIST` — comma-separated IPv4 CIDRs (e.g. `192.168.0.0/16,10.0.0.0/8`)
- Expose the effective allowlist on `GET /api/app-config` as read-only `byokPrivateTargetAllowlist` so Settings validation matches daemon/proxy checks.
- Asset download SSRF checks (`assertExternalAssetUrl`) still ignore the allowlist.

Fixes #2986

## Surface area

- `packages/contracts/src/api/connectionTest.ts` — allowlist parsing + `validateBaseUrl` options
- `apps/daemon/src/connectionTest.ts` — DNS-aware validation + env cache
- `apps/daemon/src/media-routes.ts` — attach allowlist to app-config GET
- `apps/web/src/state/config.ts`, `SettingsDialog.tsx` — honor daemon allowlist in client validation

## Validation

- `cd packages/contracts && pnpm test tests/connection-test.test.ts`
- `cd apps/daemon && pnpm test tests/connection-test.test.ts -t "BYOK admin allowlist"`
- `cd apps/web && pnpm test tests/components/SettingsDialog.test.ts -t "BYOK allowlist"`

/claim

Made with [Cursor](https://cursor.com)