### PR TITLE
fix(web): add New project CTA to projects empty state (#2978)

### DIFF
--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -68,6 +68,7 @@ interface Props {
 	onOpenLiveArtifact: (projectId: string, artifactId: string) => void;
 	onDelete: (id: string) => Promise<boolean | void> | boolean | void;
 	onRename?: (id: string, name: string) => void;
+	onNewProject?: () => void;
 }
 
 export function DesignsTab({
@@ -78,6 +79,7 @@ export function DesignsTab({
 	onOpenLiveArtifact,
 	onDelete,
 	onRename,
+	onNewProject,
 }: Props) {
 	const t = useT();
 	const analytics = useAnalytics();
@@ -549,11 +551,22 @@ export function DesignsTab({
 				</div>
 			</div>
 			{filtered.length === 0 ? (
-				<div className="tab-empty">
-					{projects.length === 0
-						? t("designs.emptyNoProjects")
-						: t("designs.emptyNoMatch")}
-				</div>
+				projects.length === 0 ? (
+					<div className="tab-empty designs-empty" data-testid="designs-empty-no-projects">
+						<p>{t("designs.emptyNoProjects")}</p>
+						{onNewProject ? (
+							<button
+								type="button"
+								className="designs-empty__action"
+								onClick={onNewProject}
+							>
+								{t("entry.navNewProject")}
+							</button>
+						) : null}
+					</div>
+				) : (
+					<div className="tab-empty">{t("designs.emptyNoMatch")}</div>
+				)
 			) : view === "grid" ? (
 				<div className="design-grid">
 					{filtered.map((item) => {

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -643,6 +643,7 @@ export function EntryShell({
                     onOpenLiveArtifact={onOpenLiveArtifact}
                     onDelete={onDeleteProject}
                     onRename={onRenameProject}
+                    onNewProject={() => openNewProject()}
                   />
                 </div>
               )

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1178,7 +1178,7 @@ export const en: Dict = {
   'designs.subYours': 'Your designs',
   'designs.filterAria': 'Filter projects',
   'designs.searchPlaceholder': 'Search…',
-  'designs.emptyNoProjects': 'No projects yet. Create one on the left.',
+  'designs.emptyNoProjects': 'Create your first project to start designing.',
   'designs.emptyNoMatch': 'No projects match your search.',
   'designs.deleteTitle': 'Delete project',
   'designs.deleteConfirm': 'Delete "{name}"?',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1170,7 +1170,7 @@ export const zhCN: Dict = {
   'designs.subYours': '我的设计',
   'designs.filterAria': '筛选项目',
   'designs.searchPlaceholder': '搜索…',
-  'designs.emptyNoProjects': '还没有项目。请在左侧创建一个。',
+  'designs.emptyNoProjects': '还没有项目。创建你的第一个项目开始设计吧。',
   'designs.emptyNoMatch': '没有匹配的项目。',
   'designs.deleteTitle': '删除项目',
   'designs.deleteConfirm': '确定删除「{name}」？',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -779,7 +779,7 @@ export const zhTW: Dict = {
   'designs.subYours': '我的設計',
   'designs.filterAria': '篩選專案',
   'designs.searchPlaceholder': '搜尋…',
-  'designs.emptyNoProjects': '還沒有專案。請在左側建立一個。',
+  'designs.emptyNoProjects': '還沒有專案。建立你的第一個專案開始設計吧。',
   'designs.emptyNoMatch': '沒有符合的專案。',
   'designs.deleteTitle': '刪除專案',
   'designs.deleteConfirm': '確定刪除「{name}」？',

--- a/apps/web/src/styles/workspace/connectors.css
+++ b/apps/web/src/styles/workspace/connectors.css
@@ -630,6 +630,35 @@
   color: var(--text-muted);
   font-size: 13px;
 }
+.designs-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+.designs-empty > p {
+  margin: 0;
+  max-width: 28rem;
+  line-height: 1.5;
+}
+.designs-empty__action {
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 18px;
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.designs-empty__action:hover {
+  filter: brightness(1.05);
+}
+.designs-empty__action:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--accent) 70%, white 30%);
+  outline-offset: 2px;
+}
 
 .connector-inline-error {
   margin: 0 0 12px;

--- a/apps/web/tests/components/DesignsTab.empty-state.test.tsx
+++ b/apps/web/tests/components/DesignsTab.empty-state.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DesignsTab } from '../../src/components/DesignsTab';
+
+vi.mock('../../src/providers/registry', () => ({
+  deleteLiveArtifact: vi.fn(),
+  fetchLiveArtifacts: vi.fn(async () => []),
+  fetchProjectFiles: vi.fn(async () => []),
+  liveArtifactPreviewUrl: (projectId: string, artifactId: string) =>
+    `/api/projects/${projectId}/live-artifacts/${artifactId}/preview`,
+  projectFileUrl: (projectId: string, fileName: string) =>
+    `/api/projects/${projectId}/files/${fileName}`,
+}));
+
+describe('DesignsTab empty state', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows a New project action when there are no projects (#2978)', () => {
+    const onNewProject = vi.fn();
+    render(
+      <DesignsTab
+        projects={[]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onNewProject={onNewProject}
+      />,
+    );
+
+    expect(screen.getByTestId('designs-empty-no-projects')).toBeTruthy();
+    expect(screen.getByText(/Create your first project/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'New project' }));
+    expect(onNewProject).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the search empty state text-only', () => {
+    render(
+      <DesignsTab
+        projects={[
+          {
+            id: 'project-1',
+            name: 'Landing refresh',
+            skillId: null,
+            designSystemId: null,
+            createdAt: 1,
+            updatedAt: 2,
+            status: { value: 'not_started' },
+          },
+        ]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onNewProject={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Search…'), {
+      target: { value: 'does-not-match' },
+    });
+
+    expect(screen.queryByTestId('designs-empty-no-projects')).toBeNull();
+    expect(screen.getByText('No projects match your search.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'New project' })).toBeNull();
+  });
+});


### PR DESCRIPTION
/claim #2978

## Summary

- Add a primary **New project** button to the Projects page empty state in the main content area.
- Update empty-state copy to guide first-time users without referring only to the sidebar.
- Wire the button through the existing `openNewProject()` modal flow from `EntryShell`.

## Surface area

- `apps/web/src/components/DesignsTab.tsx`
- `apps/web/src/components/EntryShell.tsx`
- `apps/web/src/styles/workspace/connectors.css`
- `apps/web/src/i18n/locales/en.ts`, `zh-CN.ts`, `zh-TW.ts`
- `apps/web/tests/components/DesignsTab.empty-state.test.tsx`

## Validation

- [x] `cd apps/web && pnpm test tests/components/DesignsTab.empty-state.test.tsx`

Made with [Cursor](https://cursor.com)