### PR TITLE
fix(daemon): hide agent executable paths from chat status (#2874)

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -24,6 +24,7 @@ import {
   shouldRenderCodexImagegenOverride,
 } from './prompts/system.js';
 import { expandHomePrefix, resolveProjectRelativePath } from './home-expansion.js';
+import { userFacingAgentLabel } from './user-facing-agent-label.js';
 import { createCommandInvocation } from '@open-design/platform';
 import { SIDECAR_DEFAULTS, SIDECAR_ENV } from '@open-design/sidecar-proto';
 import {
@@ -10696,7 +10697,7 @@ export async function startServer({
       const message =
         `Agent stalled without emitting any new output for ${Math.round(inactivityTimeoutMs / 1000)}s. ` +
         'The model or CLI likely hung while generating. ' +
-        `Phase details: spawned agent binary ${resolvedBin}; stdout arrived: ${childStdoutSeen ? 'yes' : 'no'}; ` +
+        `Phase details: spawned agent ${userFacingAgentLabel(agentId, resolvedBin)}; stdout arrived: ${childStdoutSeen ? 'yes' : 'no'}; ` +
         `last agent event: ${lastAgentEventPhase}; largest tool result observed: ${lastToolResultChars} chars. ` +
         'Retry the turn, pick a different model, or start a new conversation if the prior context is very large.';
       send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', message, { retryable: true }));
@@ -10788,7 +10789,7 @@ export async function startServer({
     send('start', {
       runId,
       agentId,
-      bin: resolvedBin,
+      bin: userFacingAgentLabel(agentId, resolvedBin),
       streamFormat: def.streamFormat ?? 'plain',
       projectId: typeof projectId === 'string' ? projectId : null,
       cwd,

--- a/apps/daemon/src/user-facing-agent-label.ts
+++ b/apps/daemon/src/user-facing-agent-label.ts
@@ -1,0 +1,21 @@
+import { basename } from 'node:path';
+
+/**
+ * Labels surfaced in chat status / diagnostics. Never expose resolved
+ * executable paths — packaged installs leak app bundle roots and custom
+ * home directories (issue #2874).
+ */
+export function userFacingAgentLabel(
+  agentId: string | null | undefined,
+  resolvedBin: string | null | undefined,
+): string {
+  const normalizedAgentId = typeof agentId === 'string' ? agentId.trim() : '';
+  if (normalizedAgentId) return normalizedAgentId;
+
+  if (typeof resolvedBin === 'string' && resolvedBin.trim()) {
+    const base = basename(resolvedBin.trim().replace(/\\/g, '/')).replace(/\.(exe|cmd|bat)$/i, '');
+    if (base) return base;
+  }
+
+  return 'agent';
+}

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -1195,7 +1195,8 @@ setInterval(() => {}, 1000);
 
           expect(eventsBody).toContain('event: error');
           expect(eventsBody).toContain('Agent stalled without emitting any new output');
-          expect(eventsBody).toContain('Phase details: spawned agent binary');
+          expect(eventsBody).toContain('Phase details: spawned agent opencode;');
+          expect(eventsBody).not.toContain('spawned agent binary');
           expect(eventsBody).toMatch(/stdout arrived: (yes|no)/);
           expect(statusBody.status).toBe('failed');
         },

--- a/apps/daemon/tests/user-facing-agent-label.test.ts
+++ b/apps/daemon/tests/user-facing-agent-label.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { userFacingAgentLabel } from '../src/user-facing-agent-label.js';
+
+describe('userFacingAgentLabel', () => {
+  it('prefers the configured agent id over the resolved executable path', () => {
+    expect(
+      userFacingAgentLabel(
+        'claude',
+        '/Applications/Open Design Beta.app/Contents/Resources/open-design/bin/claude',
+      ),
+    ).toBe('claude');
+  });
+
+  it('falls back to the executable basename when agent id is missing', () => {
+    expect(
+      userFacingAgentLabel(
+        null,
+        '/Applications/Open Design Beta.app/Contents/Resources/open-design/bin/vela',
+      ),
+    ).toBe('vela');
+  });
+
+  it('strips Windows executable extensions from basename fallbacks', () => {
+    expect(
+      userFacingAgentLabel(
+        '',
+        'C:\\Program Files\\Open Design\\resources\\open-design\\bin\\unknown.exe',
+      ),
+    ).toBe('unknown');
+  });
+
+  it('returns a generic label when neither agent id nor path is available', () => {
+    expect(userFacingAgentLabel(undefined, null)).toBe('agent');
+  });
+});


### PR DESCRIPTION
Refs #2874

## Summary

Daemon chat runs no longer surface resolved agent executable filesystem paths in user-visible status. The `start` SSE payload and inactivity-timeout diagnostics now emit the configured agent id (for example `claude`, `opencode`) instead of paths like `/Applications/Open Design Beta.app/Contents/Resources/open-design/bin/vela`.

This complements the web-side redaction in #2894 by fixing the leak at the source.

## Surface area

- `apps/daemon/src/user-facing-agent-label.ts` — shared label helper
- `apps/daemon/src/server.ts` — chat `start` event `bin` field + inactivity error message
- `apps/daemon/tests/user-facing-agent-label.test.ts` — unit coverage for macOS/Windows path shapes
- `apps/daemon/tests/chat-route.test.ts` — stalled-run regression expects agent id, not binary path

## Validation

- `cd apps/daemon && pnpm test tests/user-facing-agent-label.test.ts`

Made with [Cursor](https://cursor.com)