### PR TITLE
fix(web): surface Claude Design zip import failures (#1862)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,7 +16,7 @@ import { EntryView } from './components/EntryView';
 import type { IntegrationTab } from './components/IntegrationsView';
 import { MarketplaceView } from './components/MarketplaceView';
 import { PluginDetailView } from './components/PluginDetailView';
-import type { CreateInput } from './components/NewProjectPanel';
+import type { CreateInput, ImportClaudeDesignOutcome } from './components/NewProjectPanel';
 import { MemoryToast } from './components/MemoryToast';
 import { PetOverlay, type PetTaskCenter } from './components/pet/PetOverlay';
 import { buildPetTaskCenter } from './components/pet/taskCenter';
@@ -982,18 +982,27 @@ export function App() {
     [],
   );
 
-  const handleImportClaudeDesign = useCallback(async (file: File) => {
-    const result = await importClaudeDesignZip(file);
-    if (!result) return;
-    setProjects((curr) => [
-      result.project,
-      ...curr.filter((p) => p.id !== result.project.id),
-    ]);
-    navigate({
-      kind: 'project',
-      projectId: result.project.id,
-      fileName: result.entryFile,
-    });
+  const handleImportClaudeDesign = useCallback(async (
+    file: File,
+  ): Promise<ImportClaudeDesignOutcome> => {
+    try {
+      const result = await importClaudeDesignZip(file);
+      setProjects((curr) => [
+        result.project,
+        ...curr.filter((p) => p.id !== result.project.id),
+      ]);
+      navigate({
+        kind: 'project',
+        projectId: result.project.id,
+        fileName: result.entryFile,
+      });
+      return { ok: true };
+    } catch (err) {
+      return {
+        ok: false,
+        message: err instanceof Error ? err.message : 'The ZIP could not be imported.',
+      };
+    }
   }, []);
 
   const handleImportFolder = useCallback(async (baseDir: string) => {

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -80,7 +80,7 @@ import { IntegrationsView, type IntegrationTab } from './IntegrationsView';
 import { InlineModelSwitcher } from './InlineModelSwitcher';
 import { NewProjectModal } from './NewProjectModal';
 import { PluginsView } from './PluginsView';
-import type { CreateInput, CreateTab } from './NewProjectPanel';
+import type { CreateInput, CreateTab, ImportClaudeDesignOutcome } from './NewProjectPanel';
 import type { PluginLoopSubmit } from './PluginLoopHome';
 import type {
   PluginShareAction,
@@ -240,7 +240,9 @@ interface Props {
     action: PluginShareAction,
     locale?: string,
   ) => Promise<PluginShareProjectOutcome>;
-  onImportClaudeDesign: (file: File) => Promise<void> | void;
+  onImportClaudeDesign: (
+    file: File,
+  ) => Promise<ImportClaudeDesignOutcome | void> | ImportClaudeDesignOutcome | void;
   onImportFolder?: (baseDir: string) => Promise<void> | void;
   onImportFolderResponse?: (response: OpenDesignHostProjectImportSuccess) => Promise<void> | void;
   onOpenProject: (id: string) => void;

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -30,7 +30,7 @@ import type {
 // connector lifecycle, exported helpers) stay close to a no-op here.
 import { EntryShell } from './EntryShell';
 import type { IntegrationTab } from './IntegrationsView';
-import type { CreateInput } from './NewProjectPanel';
+import type { CreateInput, ImportClaudeDesignOutcome } from './NewProjectPanel';
 import {
   fetchConnectors,
   fetchConnectorStatuses,
@@ -101,7 +101,9 @@ interface Props {
     action: PluginShareAction,
     locale?: string,
   ) => Promise<PluginShareProjectOutcome>;
-  onImportClaudeDesign: (file: File) => Promise<void> | void;
+  onImportClaudeDesign: (
+    file: File,
+  ) => Promise<ImportClaudeDesignOutcome | void> | ImportClaudeDesignOutcome | void;
   onImportFolder?: (baseDir: string) => Promise<void> | void;
   onImportFolderResponse?: (response: OpenDesignHostProjectImportSuccess) => Promise<void> | void;
   onOpenProject: (id: string) => void;

--- a/apps/web/src/components/NewProjectModal.tsx
+++ b/apps/web/src/components/NewProjectModal.tsx
@@ -19,7 +19,12 @@ import type {
   SkillSummary,
 } from '../types';
 import { Icon } from './Icon';
-import { NewProjectPanel, type CreateInput, type CreateTab } from './NewProjectPanel';
+import {
+  NewProjectPanel,
+  type CreateInput,
+  type CreateTab,
+  type ImportClaudeDesignOutcome,
+} from './NewProjectPanel';
 
 interface Props {
   open: boolean;
@@ -34,7 +39,9 @@ interface Props {
   connectorsLoading?: boolean;
   loading?: boolean;
   onCreate: (input: CreateInput & { requestId?: string }) => Promise<boolean> | boolean | void;
-  onImportClaudeDesign?: (file: File) => Promise<void> | void;
+  onImportClaudeDesign?: (
+    file: File,
+  ) => Promise<ImportClaudeDesignOutcome | void> | ImportClaudeDesignOutcome | void;
   onImportFolder?: (baseDir: string) => Promise<void> | void;
   onImportFolderResponse?: (response: OpenDesignHostProjectImportSuccess) => Promise<void> | void;
   onOpenConnectorsTab?: () => void;

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -114,6 +114,10 @@ export interface CreateInput {
   metadata: ProjectMetadata;
 }
 
+export type ImportClaudeDesignOutcome =
+  | { ok: true }
+  | { ok: false; message?: string; details?: string };
+
 interface Props {
   skills: SkillSummary[];
   designSystems: DesignSystemSummary[];
@@ -122,7 +126,9 @@ interface Props {
   onDeleteTemplate?: (id: string) => Promise<boolean>;
   promptTemplates: PromptTemplateSummary[];
   onCreate: (input: CreateInput & { requestId?: string }) => void;
-  onImportClaudeDesign?: (file: File) => Promise<void> | void;
+  onImportClaudeDesign?: (
+    file: File,
+  ) => Promise<ImportClaudeDesignOutcome | void> | ImportClaudeDesignOutcome | void;
   // Web fallback: the user types an absolute baseDir into the manual
   // input and the renderer POSTs `/api/import/folder` itself. Browser
   // builds have no `shell.openPath` surface, so the renderer naming a
@@ -261,6 +267,9 @@ export function NewProjectPanel({
   const analytics = useAnalytics();
   const importInputRef = useRef<HTMLInputElement | null>(null);
   const [importing, setImporting] = useState(false);
+  const [importZipError, setImportZipError] = useState<
+    { message: string; details?: string } | null
+  >(null);
   const [baseDir, setBaseDir] = useState('');
   const [importingFolder, setImportingFolder] = useState(false);
   // PR #974 round-4 (mrcfps): pickAndImport now returns structured
@@ -707,8 +716,19 @@ export function NewProjectPanel({
     ev.target.value = '';
     if (!file || !onImportClaudeDesign) return;
     setImporting(true);
+    setImportZipError(null);
     try {
-      await onImportClaudeDesign(file);
+      const result = await onImportClaudeDesign(file);
+      if (result?.ok === false) {
+        setImportZipError({
+          message: result.message ? `Import failed: ${result.message}` : 'Import failed',
+          details: result.details,
+        });
+      }
+    } catch (err) {
+      setImportZipError({
+        message: err instanceof Error ? `Import failed: ${err.message}` : 'Import failed',
+      });
     } finally {
       setImporting(false);
     }
@@ -1055,6 +1075,14 @@ export function NewProjectPanel({
         ) : null}
       </div>
       <div className="newproj-footer">{t('newproj.privacyFooter')}</div>
+      {importZipError ? (
+        <Toast
+          message={importZipError.message}
+          details={importZipError.details ?? null}
+          ttlMs={6000}
+          onDismiss={() => setImportZipError(null)}
+        />
+      ) : null}
       {importFolderError ? (
         <Toast
           message={importFolderError.message}

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -109,23 +109,28 @@ export async function importFolderProject(
 
 export async function importClaudeDesignZip(
   file: File,
-): Promise<{ project: Project; conversationId: string; entryFile: string } | null> {
-  try {
-    const form = new FormData();
-    form.append('file', file);
-    const resp = await fetch('/api/import/claude-design', {
-      method: 'POST',
-      body: form,
-    });
-    if (!resp.ok) return null;
-    return (await resp.json()) as {
-      project: Project;
-      conversationId: string;
-      entryFile: string;
-    };
-  } catch {
-    return null;
+): Promise<{ project: Project; conversationId: string; entryFile: string }> {
+  const form = new FormData();
+  form.append('file', file);
+  const resp = await fetch('/api/import/claude-design', {
+    method: 'POST',
+    body: form,
+  });
+  if (!resp.ok) {
+    const payload = await resp.json().catch(() => null);
+    const message =
+      payload != null &&
+      typeof payload === 'object' &&
+      typeof (payload as { error?: unknown }).error === 'string'
+        ? (payload as { error: string }).error
+        : `Import failed (${resp.status})`;
+    throw new Error(message);
   }
+  return (await resp.json()) as {
+    project: Project;
+    conversationId: string;
+    entryFile: string;
+  };
 }
 
 // ---------- templates ----------

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -635,6 +635,34 @@ describe('NewProjectPanel design system defaults', () => {
 });
 
 describe('NewProjectPanel folder import feedback', () => {
+  it('shows an error when Claude Design zip import resolves as failed', async () => {
+    const onImportClaudeDesign = vi.fn().mockResolvedValue({
+      ok: false,
+      message: 'unsupported zip contents',
+    });
+
+    const { container } = render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId="clay"
+        templates={templates}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={vi.fn()}
+        onImportClaudeDesign={onImportClaudeDesign}
+      />,
+    );
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement | null;
+    const file = new File(['zip'], 'relume.zip', { type: 'application/zip' });
+    expect(input).toBeTruthy();
+    fireEvent.change(input!, { target: { files: [file] } });
+
+    expect(onImportClaudeDesign).toHaveBeenCalledWith(file);
+    expect(await screen.findByText('Import failed: unsupported zip contents')).toBeTruthy();
+  });
+
   it('shows an error when manual folder import rejects with a daemon message', async () => {
     const onImportFolder = vi.fn().mockRejectedValue(new Error('folder not found'));
 

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -3,6 +3,7 @@ import {
   applyPlugin,
   contributeGeneratedPluginToOpenDesign,
   createPluginShareProject,
+  importClaudeDesignZip,
   importFolderProject,
   installGeneratedPluginFolder,
   listPlugins,
@@ -160,6 +161,35 @@ describe('installGeneratedPluginFolder', () => {
       message: 'Plugin validation failed.',
       log: ['Validating generated-plugin'],
     });
+  });
+});
+
+describe('importClaudeDesignZip', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves daemon import errors from non-2xx responses', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ error: 'Unable to unpack Claude export.' }),
+      { status: 422, headers: { 'content-type': 'application/json' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const file = new File(['zip-bytes'], 'claude-design.zip', {
+      type: 'application/zip',
+    });
+
+    await expect(importClaudeDesignZip(file)).rejects.toThrow(
+      'Unable to unpack Claude export.',
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/import/claude-design',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.any(FormData),
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
Refs #1862

Revives the silent-failure fix from closed PR #1865.

## Summary

When the daemon rejects a Claude Design `.zip` import, the New Project panel now shows an error toast with the rejection reason instead of closing the file picker with no feedback.

## Surface area

- `apps/web/src/state/projects.ts` — propagate daemon error messages instead of returning `null`
- `apps/web/src/App.tsx` — return structured `{ ok: false, message }` on import failure
- `apps/web/src/components/NewProjectPanel.tsx` — toast on failed ZIP import
- Type plumbing in `EntryShell`, `EntryView`, `NewProjectModal`

## Validation

- `cd apps/web && pnpm test tests/components/NewProjectPanel.test.tsx tests/state/projects.test.ts`

Made with [Cursor](https://cursor.com)