### PR TITLE
fix: read AMR login state from ~/.amr

### DIFF
--- a/apps/daemon/scripts/verify-amr-real-vela.mjs
+++ b/apps/daemon/scripts/verify-amr-real-vela.mjs
@@ -41,7 +41,7 @@ if (
   console.error(
     'Provide credentials via either:\n' +
       '  - VELA_RUNTIME_KEY + VELA_LINK_URL env vars, or\n' +
-      '  - VELA_PROFILE (e.g. "local") with a logged-in ~/.vela/config.json.',
+      '  - VELA_PROFILE (e.g. "local") with a logged-in ~/.amr/config.json.',
   );
   process.exit(2);
 }

--- a/apps/daemon/src/integrations/vela.ts
+++ b/apps/daemon/src/integrations/vela.ts
@@ -49,15 +49,15 @@ export function mergeVelaEnv(
 }
 
 function configDir(): string {
-  return path.join(homedir(), '.vela');
+  return path.join(homedir(), '.amr');
 }
 
-export function velaConfigPath(): string {
+export function amrConfigPath(): string {
   return path.join(configDir(), 'config.json');
 }
 
 function readConfigFile(): VelaConfigFileShape | null {
-  const file = velaConfigPath();
+  const file = amrConfigPath();
   if (!existsSync(file)) return null;
   try {
     const data = readFileSync(file, 'utf8');
@@ -75,7 +75,7 @@ export function readVelaLoginStatus(
 ): VelaLoginStatus {
   const mergedEnv = mergeVelaEnv(env, configuredEnv);
   const profile = resolveAmrProfile(mergedEnv);
-  const configPath = velaConfigPath();
+  const configPath = amrConfigPath();
   const loginInFlight = isVelaLoginInFlight();
   const runtimeKey = mergedEnv.VELA_RUNTIME_KEY?.trim() ?? '';
   const linkUrl = mergedEnv.VELA_LINK_URL?.trim() ?? '';
@@ -102,7 +102,7 @@ export function readVelaLoginStatus(
 }
 
 export function forgetVelaLogin(env: NodeJS.ProcessEnv = process.env): void {
-  const file = velaConfigPath();
+  const file = amrConfigPath();
   if (!existsSync(file)) return;
   const parsed = readConfigFile();
   if (!parsed?.profiles) return;

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -2,7 +2,7 @@
 /**
  * Fake vela CLI used by AMR integration tests. Routes by the first argv:
  *
- *   `vela login`                        → writes ~/.vela/config.json (the
+ *   `vela login`                        → writes ~/.amr/config.json (the
  *                                         active VELA_PROFILE only) and
  *                                         exits 0. Mirrors the real
  *                                         device-authorization flow's
@@ -221,7 +221,7 @@ stdin.on('end', () => {
 
 // `vela login`: the daemon's /api/integrations/vela/login route spawns this
 // without expecting any ACP traffic. Real vela goes through a device-auth
-// loop and writes ~/.vela/config.json on success; the stub skips the loop
+// loop and writes ~/.amr/config.json on success; the stub skips the loop
 // and just writes the file so Open Design's status reader and AmrLoginPill
 // poller see the same on-disk projection production produces. The stdin EOF
 // handler above ignores login mode so delayed login tests can keep this
@@ -241,7 +241,7 @@ function loginAndExit() {
   const userEmail = env.FAKE_VELA_LOGIN_USER_EMAIL || 'fake-user@example.com';
   const userPlan = env.FAKE_VELA_LOGIN_USER_PLAN || 'free';
   const finish = () => {
-    const file = join(homedir(), '.vela', 'config.json');
+    const file = join(homedir(), '.amr', 'config.json');
     mkdirSync(dirname(file), { recursive: true });
     const payload = {
       profiles: {

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -4,10 +4,10 @@
 // memory-config-route.test.ts) and exercises the three endpoints from the
 // outside — `/api/integrations/vela/{status,login,logout}` — so the Settings
 // AmrLoginPill provider helpers, the spawn lifecycle, and the
-// ~/.vela/config.json projection all stay in lockstep.
+// ~/.amr/config.json projection all stay in lockstep.
 //
 // HOME is redirected to a tmpdir per test so the suite never touches the
-// developer's real `~/.vela/config.json`. VELA_BIN points at the
+// developer's real `~/.amr/config.json`. VELA_BIN points at the
 // `tests/fixtures/fake-vela.mjs` stub, which handles the `login` argv by
 // writing the config file with the active VELA_PROFILE and exiting 0 —
 // mirroring real vela's on-disk side-effect without the device-auth loop.
@@ -49,6 +49,10 @@ async function postJson<T = unknown>(url: string): Promise<{ status: number; bod
 }
 
 function configPath(): string {
+  return path.join(tmpHome, '.amr', 'config.json');
+}
+
+function legacyVelaConfigPath(): string {
   return path.join(tmpHome, '.vela', 'config.json');
 }
 
@@ -123,7 +127,7 @@ afterEach(() => {
 });
 
 describe('GET /api/integrations/vela/status', () => {
-  it('reports loggedIn=false when ~/.vela/config.json is absent', async () => {
+  it('reports loggedIn=false when ~/.amr/config.json is absent', async () => {
     const { status, body } = await getJson<{
       loggedIn: boolean;
       loginInFlight: boolean;
@@ -139,6 +143,34 @@ describe('GET /api/integrations/vela/status', () => {
     // configPath must point inside the temp HOME so the suite never leaks
     // into the developer's real config file.
     expect(body.configPath.startsWith(tmpHome)).toBe(true);
+    expect(body.configPath).toContain('/.amr/');
+  });
+
+  it('ignores legacy ~/.vela/config.json when reporting AMR status', async () => {
+    const legacyPath = legacyVelaConfigPath();
+    mkdirSync(path.dirname(legacyPath), { recursive: true });
+    writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        profiles: {
+          local: {
+            runtimeKey: 'rt-legacy',
+            user: { id: 'legacy-user', email: 'legacy@example.com' },
+          },
+        },
+      }),
+      'utf8',
+    );
+
+    const { status, body } = await getJson<{
+      loggedIn: boolean;
+      user: { email?: string } | null;
+      configPath: string;
+    }>(`${baseUrl}/api/integrations/vela/status`);
+    expect(status).toBe(200);
+    expect(body.loggedIn).toBe(false);
+    expect(body.user).toBeNull();
+    expect(body.configPath).toContain('/.amr/');
   });
 
   it('reports Settings-configured AMR env credentials as logged in', async () => {
@@ -265,7 +297,7 @@ describe('POST /api/integrations/vela/login', () => {
     expect(body.profile).toBe('local');
     expect(body.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 
-    // The fake vela writes ~/.vela/config.json synchronously before exit.
+    // The fake vela writes ~/.amr/config.json synchronously before exit.
     // Wait briefly for the child to finish so the next status read sees
     // the on-disk projection production produces.
     for (let i = 0; i < 50; i += 1) {
@@ -493,7 +525,7 @@ describe('POST /api/integrations/vela/logout', () => {
     }
   });
 
-  it('logs out the Settings-configured AMR profile from the vela config file', async () => {
+  it('logs out the Settings-configured AMR profile from the AMR config file', async () => {
     const dataDir = process.env.OD_DATA_DIR as string;
     const previous = await readAppConfig(dataDir);
     seedLogin('local');

--- a/apps/daemon/tests/integrations/vela.test.ts
+++ b/apps/daemon/tests/integrations/vela.test.ts
@@ -4,7 +4,7 @@
  * `tests/amr-acp-integration.test.ts` (which uses the fake-vela stub); here
  * we focus on the status reader that drives the Settings UI.
  *
- * `~/.vela/config.json` is the source of truth — vela CLI writes it on
+ * `~/.amr/config.json` is the source of truth — vela CLI writes it on
  * successful `vela login` and Open Design just surfaces a small projection.
  * Tests redirect HOME via env so we never touch the real user file.
  */
@@ -20,7 +20,7 @@ import {
   readVelaLoginStatus,
   resolveAmrProfile,
   spawnVelaLogin,
-  velaConfigPath,
+  amrConfigPath,
 } from '../../src/integrations/vela.js';
 
 let originalHome: string | undefined;
@@ -29,6 +29,14 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const FAKE_VELA = path.resolve(HERE, '..', 'fixtures', 'fake-vela.mjs');
 
 function writeConfig(payload: unknown): string {
+  const dir = path.join(tmpHome, '.amr');
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'config.json');
+  writeFileSync(file, JSON.stringify(payload), 'utf8');
+  return file;
+}
+
+function writeLegacyVelaConfig(payload: unknown): string {
   const dir = path.join(tmpHome, '.vela');
   mkdirSync(dir, { recursive: true });
   const file = path.join(dir, 'config.json');
@@ -83,15 +91,30 @@ describe('resolveAmrProfile', () => {
 });
 
 describe('readVelaLoginStatus', () => {
-  it('returns loggedIn=false when ~/.vela/config.json is absent', () => {
+  it('returns loggedIn=false when ~/.amr/config.json is absent', () => {
     const status = readVelaLoginStatus({ OPEN_DESIGN_AMR_PROFILE: 'local' });
     expect(status.loggedIn).toBe(false);
     expect(status.user).toBeNull();
     expect(status.profile).toBe('local');
-    expect(status.configPath).toBe(velaConfigPath());
+    expect(status.configPath).toBe(amrConfigPath());
   });
 
-  it('treats configured AMR env credentials as logged in without a vela config file', () => {
+  it('ignores legacy ~/.vela/config.json when ~/.amr/config.json is absent', () => {
+    writeLegacyVelaConfig({
+      profiles: {
+        local: {
+          runtimeKey: 'rt-legacy',
+          user: { id: 'legacy-user', email: 'legacy@example.com' },
+        },
+      },
+    });
+    const status = readVelaLoginStatus({ OPEN_DESIGN_AMR_PROFILE: 'local' });
+    expect(status.loggedIn).toBe(false);
+    expect(status.user).toBeNull();
+    expect(status.configPath).toBe(amrConfigPath());
+  });
+
+  it('treats configured AMR env credentials as logged in without an AMR config file', () => {
     const status = readVelaLoginStatus(
       { OPEN_DESIGN_AMR_PROFILE: 'local' },
       {
@@ -121,7 +144,7 @@ describe('readVelaLoginStatus', () => {
     expect(status.user?.email).toBe('local@example.com');
   });
 
-  it('treats daemon process AMR env credentials as logged in without a vela config file', () => {
+  it('treats daemon process AMR env credentials as logged in without an AMR config file', () => {
     const status = readVelaLoginStatus({
       OPEN_DESIGN_AMR_PROFILE: 'local',
       VELA_RUNTIME_KEY: 'rt-process-secret',
@@ -213,7 +236,7 @@ describe('readVelaLoginStatus', () => {
   });
 
   it('treats malformed JSON as logged-out rather than crashing', () => {
-    const file = path.join(tmpHome, '.vela', 'config.json');
+    const file = path.join(tmpHome, '.amr', 'config.json');
     mkdirSync(path.dirname(file), { recursive: true });
     writeFileSync(file, '{not json', 'utf8');
     expect(readVelaLoginStatus({ OPEN_DESIGN_AMR_PROFILE: 'local' }).loggedIn).toBe(false);
@@ -321,7 +344,7 @@ describe('spawnVelaLogin', () => {
     expect(result.pid).toBeGreaterThan(0);
     expect(result.profile).toBe('test');
 
-    const file = path.join(tmpHome, '.vela', 'config.json');
+    const file = path.join(tmpHome, '.amr', 'config.json');
     for (let i = 0; i < 20; i += 1) {
       if (existsSync(file)) break;
       await new Promise((resolve) => setTimeout(resolve, 25));
@@ -350,7 +373,7 @@ describe('spawnVelaLogin', () => {
     expect(result.pid).toBeGreaterThan(0);
     expect(result.profile).toBe('local');
 
-    const file = path.join(tmpHome, '.vela', 'config.json');
+    const file = path.join(tmpHome, '.amr', 'config.json');
     for (let i = 0; i < 20; i += 1) {
       if (existsSync(file)) break;
       await new Promise((resolve) => setTimeout(resolve, 25));

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -403,10 +403,10 @@ export interface VelaLoginStatus {
 }
 
 // AMR (vela) login surfaces three thin endpoints on the daemon:
-//   GET  /api/integrations/vela/status   — read ~/.vela/config.json projection
+//   GET  /api/integrations/vela/status   — read ~/.amr/config.json projection
 //   POST /api/integrations/vela/login    — spawn `vela login` (vela opens browser itself)
 //   POST /api/integrations/vela/login/cancel — terminate a still-pending login
-//   POST /api/integrations/vela/logout   — clear ~/.vela auth and Settings-backed AMR auth env
+//   POST /api/integrations/vela/logout   — clear ~/.amr auth and Settings-backed AMR auth env
 // The Settings UI polls /status after kicking off /login to detect completion.
 export async function fetchVelaLoginStatus(): Promise<VelaLoginStatus | null> {
   try {

--- a/apps/web/tests/components/InlineModelSwitcher.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.test.tsx
@@ -85,7 +85,7 @@ describe('InlineModelSwitcher AMR row', () => {
             loggedIn: false,
             profile: 'default',
             user: null,
-            configPath: '/Users/test/.vela/config.json',
+            configPath: '/Users/test/.amr/config.json',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
@@ -135,7 +135,7 @@ describe('InlineModelSwitcher AMR row', () => {
             loggedIn: false,
             profile: 'default',
             user: null,
-            configPath: '/Users/test/.vela/config.json',
+            configPath: '/Users/test/.amr/config.json',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
@@ -187,7 +187,7 @@ describe('InlineModelSwitcher AMR row', () => {
               email: 'manual-amr@example.local',
               name: 'Manual AMR Test User',
             },
-            configPath: '/Users/test/.vela/config.json',
+            configPath: '/Users/test/.amr/config.json',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
@@ -219,7 +219,7 @@ describe('InlineModelSwitcher AMR row', () => {
             loginInFlight: true,
             profile: 'default',
             user: null,
-            configPath: '/Users/test/.vela/config.json',
+            configPath: '/Users/test/.amr/config.json',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
@@ -253,14 +253,14 @@ describe('InlineModelSwitcher AMR row', () => {
                   loginInFlight: false,
                   profile: 'default',
                   user: { id: 'user-1', email: 'manual-amr@example.local' },
-                  configPath: '/Users/test/.vela/config.json',
+                  configPath: '/Users/test/.amr/config.json',
                 }
               : {
                   loggedIn: false,
                   loginInFlight: false,
                   profile: 'default',
                   user: null,
-                  configPath: '/Users/test/.vela/config.json',
+                  configPath: '/Users/test/.amr/config.json',
                 },
           ),
           { status: 200, headers: { 'content-type': 'application/json' } },
@@ -307,7 +307,7 @@ describe('InlineModelSwitcher AMR row', () => {
             loginInFlight: loginStarted,
             profile: 'default',
             user: null,
-            configPath: '/Users/test/.vela/config.json',
+            configPath: '/Users/test/.amr/config.json',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
@@ -372,7 +372,7 @@ describe('InlineModelSwitcher AMR row', () => {
             loginInFlight: loginStarted,
             profile: 'default',
             user: null,
-            configPath: '/Users/test/.vela/config.json',
+            configPath: '/Users/test/.amr/config.json',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
@@ -442,13 +442,13 @@ describe('InlineModelSwitcher AMR row', () => {
                   loggedIn: true,
                   profile: 'default',
                   user: { id: 'user-1', email: 'manual-amr@example.local' },
-                  configPath: '/Users/test/.vela/config.json',
+                  configPath: '/Users/test/.amr/config.json',
                 }
               : {
                   loggedIn: false,
                   profile: 'default',
                   user: null,
-                  configPath: '/Users/test/.vela/config.json',
+                  configPath: '/Users/test/.amr/config.json',
                 },
           ),
           { status: 200, headers: { 'content-type': 'application/json' } },
@@ -483,7 +483,7 @@ describe('InlineModelSwitcher AMR row', () => {
             loggedIn: false,
             profile: 'default',
             user: null,
-            configPath: '/Users/test/.vela/config.json',
+            configPath: '/Users/test/.amr/config.json',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1367,7 +1367,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
             loggedIn: false,
             profile: 'default',
             user: null,
-            configPath: '/Users/test/.vela/config.json',
+            configPath: '/Users/test/.amr/config.json',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
@@ -1450,7 +1450,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
               email: 'signed-in@example.com',
               name: 'Signed In User',
             },
-            configPath: '/Users/test/.vela/config.json',
+            configPath: '/Users/test/.amr/config.json',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
@@ -1492,13 +1492,13 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
                   loggedIn: true,
                   profile: 'local',
                   user: { id: 'user-1', email: 'signed-in@example.com' },
-                  configPath: '/Users/test/.vela/config.json',
+                  configPath: '/Users/test/.amr/config.json',
                 }
               : {
                   loggedIn: false,
                   profile: 'local',
                   user: null,
-                  configPath: '/Users/test/.vela/config.json',
+                  configPath: '/Users/test/.amr/config.json',
                 },
           ),
           { status: 200, headers: { 'content-type': 'application/json' } },
@@ -1543,7 +1543,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
             loggedIn: statusCalls === 1,
             profile: 'local',
             user: statusCalls === 1 ? { id: 'user-1', email: 'signed-in@example.com' } : null,
-            configPath: '/Users/test/.vela/config.json',
+            configPath: '/Users/test/.amr/config.json',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );

--- a/e2e/lib/amr.ts
+++ b/e2e/lib/amr.ts
@@ -28,7 +28,7 @@ export async function seedVelaLoginConfig(
   } = {},
 ): Promise<string> {
   const profile = options.profile ?? 'local';
-  const configDir = join(homeDir, '.vela');
+  const configDir = join(homeDir, '.amr');
   const file = join(configDir, 'config.json');
   await mkdir(configDir, { recursive: true });
   await writeFile(
@@ -58,7 +58,7 @@ export async function seedVelaLoginConfig(
 }
 
 export async function clearVelaLoginConfig(homeDir: string): Promise<void> {
-  await rm(join(homeDir, '.vela', 'config.json'), { force: true });
+  await rm(join(homeDir, '.amr', 'config.json'), { force: true });
 }
 
 function renderFakeVelaScript(options: FakeVelaOptions): string {
@@ -90,7 +90,7 @@ function currentProfile() {
   return (env.OPEN_DESIGN_AMR_PROFILE || env.VELA_PROFILE || 'local').trim() || 'local';
 }
 function readLoginConfig() {
-  const file = join(homedir(), '.vela', 'config.json');
+  const file = join(homedir(), '.amr', 'config.json');
   if (!existsSync(file)) return null;
   try {
     return JSON.parse(readFileSync(file, 'utf8'));
@@ -105,7 +105,7 @@ function hasRuntimeKey() {
 }
 
 if (argv[2] === 'login') {
-  const file = join(homedir(), '.vela', 'config.json');
+  const file = join(homedir(), '.amr', 'config.json');
   mkdirSync(dirname(file), { recursive: true });
   const profile = currentProfile();
   writeFileSync(file, JSON.stringify({

--- a/e2e/tests/amr/turn.test.ts
+++ b/e2e/tests/amr/turn.test.ts
@@ -4,7 +4,7 @@
  * End-to-end coverage for an AMR (vela) chat run driven through the real
  * tools-dev orchestrated daemon. Boots a namespaced daemon + web pair,
  * configures it to spawn a self-contained fake `vela` binary, pre-seeds
- * `~/.vela/config.json` as if the user had already approved CLI login,
+ * `~/.amr/config.json` as if the user had already approved CLI login,
  * then drives a complete /api/runs lifecycle for `agentId: 'amr'` and
  * asserts the assistant message picks up the fake's canned text.
  *
@@ -24,7 +24,7 @@
  *   3. The full ACP transport (`initialize` → `session/new` →
  *      `session/set_model` → `session/prompt` → `session/update*`) flows
  *      between the daemon and a spawned subprocess that respects vela's
- *      `~/.vela/config.json` resolution path.
+ *      `~/.amr/config.json` resolution path.
  */
 
 import { mkdir, writeFile, chmod } from 'node:fs/promises';
@@ -46,7 +46,7 @@ type ProjectResponse = {
 // Inline fake `vela` binary. Handles the two argv shapes Open Design's
 // daemon ever spawns:
 //
-//   `vela login`                        — write ~/.vela/config.json and exit 0.
+//   `vela login`                        — write ~/.amr/config.json and exit 0.
 //   `vela agent run --runtime opencode` — ACP stdio runtime (initialize →
 //                                          session/new → session/set_model →
 //                                          session/prompt → session/update*).
@@ -74,7 +74,7 @@ function writeNotification(method, params) {
 }
 
 if (argv[2] === 'login') {
-  const file = join(homedir(), '.vela', 'config.json');
+  const file = join(homedir(), '.amr', 'config.json');
   mkdirSync(dirname(file), { recursive: true });
   const profile = (env.VELA_PROFILE || 'local').trim() || 'local';
   writeFileSync(file, JSON.stringify({
@@ -183,10 +183,10 @@ describe('AMR chat-run end-to-end', () => {
     await suite.with.toolsDev(async ({ webUrl }) => {
       const velaBin = await writeFakeVelaBin(join(suite.scratchDir, 'fake-vela'));
 
-      // Pre-seed `~/.vela/config.json` so `vela agent run` (the fake) does
+      // Pre-seed `~/.amr/config.json` so `vela agent run` (the fake) does
       // not need to negotiate device-auth. Production AMR works the same
       // way: once login has happened once, the runtime reads the file.
-      const velaConfigDir = join(suite.scratchDir, 'home', '.vela');
+      const velaConfigDir = join(suite.scratchDir, 'home', '.amr');
       await mkdir(velaConfigDir, { recursive: true });
       await writeFile(
         join(velaConfigDir, 'config.json'),
@@ -209,7 +209,7 @@ describe('AMR chat-run end-to-end', () => {
 
       // Persist agentCliEnv so the daemon's runtime resolver picks up the
       // fake binary and the pre-run AMR status guard sees configured runtime
-      // credentials without touching the developer's real ~/.vela config.
+      // credentials without touching the developer's real ~/.amr config.
       await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
         body: {
           agentCliEnv: {

--- a/e2e/ui/amr-login-pill.test.ts
+++ b/e2e/ui/amr-login-pill.test.ts
@@ -91,7 +91,7 @@ async function wireDaemonMocks(page: Page, state: VelaMockState) {
       ? {
           loggedIn: true,
           profile: 'local',
-          configPath: '/tmp/.vela/config.json',
+          configPath: '/tmp/.amr/config.json',
           user: {
             id: 'fake-user',
             email: 'pill-test@example.com',
@@ -103,7 +103,7 @@ async function wireDaemonMocks(page: Page, state: VelaMockState) {
           loggedIn: false,
           profile: 'local',
           user: null,
-          configPath: '/tmp/.vela/config.json',
+          configPath: '/tmp/.amr/config.json',
         };
     await route.fulfill({ json: body });
   });
@@ -112,7 +112,7 @@ async function wireDaemonMocks(page: Page, state: VelaMockState) {
     // Real daemon spawns `vela login` async and returns 202; we mirror
     // that shape and flip the in-memory state so the next status poll
     // sees a logged-in user — equivalent to vela CLI completing the
-    // device-auth flow and writing ~/.vela/config.json.
+    // device-auth flow and writing ~/.amr/config.json.
     state.loggedIn = true;
     await route.fulfill({ status: 202, json: { pid: 4242, startedAt: new Date().toISOString(), profile: 'local' } });
   });

--- a/e2e/ui/amr-logout-requires-relogin.test.ts
+++ b/e2e/ui/amr-logout-requires-relogin.test.ts
@@ -32,13 +32,13 @@ test('after local Sign out, AMR runs require re-login and Settings keeps AMR sel
         ? {
             loggedIn: true,
             profile: 'local',
-            configPath: '/tmp/.vela/config.json',
+            configPath: '/tmp/.amr/config.json',
             user: { id: 'logout-ui', email: 'logout-ui@example.com' },
           }
         : {
             loggedIn: false,
             profile: 'local',
-            configPath: '/tmp/.vela/config.json',
+            configPath: '/tmp/.amr/config.json',
             user: null,
           },
     });

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -172,13 +172,13 @@ async function wireOnboardingMocks(
         ? {
             loggedIn: true,
             profile: 'local',
-            configPath: '/tmp/.vela/config.json',
+            configPath: '/tmp/.amr/config.json',
             user: { id: 'user-1', email: 'onboarding@example.com', plan: 'free' },
           }
         : {
             loggedIn: false,
             profile: 'local',
-            configPath: '/tmp/.vela/config.json',
+            configPath: '/tmp/.amr/config.json',
             user: null,
           },
     });

--- a/e2e/ui/entry-topbar.test.ts
+++ b/e2e/ui/entry-topbar.test.ts
@@ -103,7 +103,7 @@ test.beforeEach(async ({ page }) => {
       body: JSON.stringify({
         loggedIn: true,
         profile: 'local',
-        configPath: '/tmp/.vela/config.json',
+        configPath: '/tmp/.amr/config.json',
         user: {
           id: 'topbar-user',
           email: 'topbar@example.com',

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -238,7 +238,7 @@ test.beforeEach(async ({ page }) => {
       body: JSON.stringify({
         loggedIn: true,
         profile: 'local',
-        configPath: '/tmp/.vela/config.json',
+        configPath: '/tmp/.amr/config.json',
         user: {
           id: 'hero-user',
           email: 'hero@example.com',


### PR DESCRIPTION
## Why

Vela CLI 0.0.1 writes AMR login confirmation to `~/.amr/config.json`, but Open Design was still projecting AMR login status from the legacy `~/.vela/config.json` path. That made Beta report AMR as signed out even after the browser confirmation flow completed successfully.

This PR aligns Open Design's AMR integration with the current CLI account-state path and intentionally drops legacy `~/.vela` compatibility for AMR login state.

## What users will see

After completing AMR login, Open Design Beta will recognize the signed-in state from `~/.amr/config.json`.

Users who only have legacy `~/.vela/config.json` will be treated as signed out and asked to sign in again.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes the daemon-side AMR account-state source and keeps the UI shape unchanged.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/integrations/vela.test.ts` and `apps/daemon/tests/integrations/vela.routes.test.ts`
- Did the test go red on `main` and green on this branch? No; the target branch is `feat/amr-runtime-acp`, and I validated the new regression cases on this branch after implementation.
- Additional verification: browser verification against a temporary local runtime confirmed `loggedIn: true` when `~/.amr/config.json` exists, and `loggedIn: false` when only legacy `~/.vela/config.json` remains.

## Validation

- `pnpm --filter @open-design/daemon test tests/integrations/vela.test.ts tests/integrations/vela.routes.test.ts`
- `pnpm --filter @open-design/web test tests/components/InlineModelSwitcher.test.tsx tests/components/SettingsDialog.execution.test.tsx`
- `pnpm -C e2e test tests/amr/relogin-required.test.ts tests/amr/logout-state-persistence.test.ts tests/amr/turn.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `git diff --check`
- Browser verification with the in-app Browser skill against a temporary local runtime
