### PR TITLE
fix(web): clear pendingPrompt when navigating back to Home (#2878)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1088,8 +1088,17 @@ export function App() {
   }, []);
 
   const handleBack = useCallback(() => {
+    const projectId = route.kind === 'project' ? route.projectId : null;
+    if (projectId) {
+      setProjects((curr) =>
+        curr.map((p) =>
+          p.id === projectId ? { ...p, pendingPrompt: undefined } : p,
+        ),
+      );
+      void patchProject(projectId, { pendingPrompt: null });
+    }
     navigate({ kind: 'home', view: 'home' });
-  }, []);
+  }, [route]);
 
   const handleClearPendingPrompt = useCallback(() => {
     const projectId = route.kind === 'project' ? route.projectId : null;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -170,6 +170,16 @@ export function resolveSettingsCloseConfig(
   return base.onboardingCompleted ? base : { ...base, onboardingCompleted: true };
 }
 
+export function projectsWithClearedPendingPrompt(
+  projects: Project[],
+  projectId: string | null | undefined,
+): Project[] {
+  if (!projectId) return projects;
+  return projects.map((p) =>
+    p.id === projectId ? { ...p, pendingPrompt: undefined } : p,
+  );
+}
+
 export function App() {
   const { t } = useI18n();
   const clientType = useMemo(() => detectClientType(), []);
@@ -1090,11 +1100,7 @@ export function App() {
   const handleBack = useCallback(() => {
     const projectId = route.kind === 'project' ? route.projectId : null;
     if (projectId) {
-      setProjects((curr) =>
-        curr.map((p) =>
-          p.id === projectId ? { ...p, pendingPrompt: undefined } : p,
-        ),
-      );
+      setProjects((curr) => projectsWithClearedPendingPrompt(curr, projectId));
       void patchProject(projectId, { pendingPrompt: null });
     }
     navigate({ kind: 'home', view: 'home' });
@@ -1103,11 +1109,7 @@ export function App() {
   const handleClearPendingPrompt = useCallback(() => {
     const projectId = route.kind === 'project' ? route.projectId : null;
     if (!projectId) return;
-    setProjects((curr) =>
-      curr.map((p) =>
-        p.id === projectId ? { ...p, pendingPrompt: undefined } : p,
-      ),
-    );
+    setProjects((curr) => projectsWithClearedPendingPrompt(curr, projectId));
     void patchProject(projectId, { pendingPrompt: null });
   }, [route]);
 

--- a/apps/web/tests/App.test.ts
+++ b/apps/web/tests/App.test.ts
@@ -4,10 +4,11 @@ import {
   buildPersistedConfig,
   isAutosaveDraftOnlyChange,
   persistComposioConfigChange,
+  projectsWithClearedPendingPrompt,
   resolveSettingsCloseConfig,
   shouldSyncMediaProvidersOnSave,
 } from '../src/App';
-import type { AppConfig } from '../src/types';
+import type { AppConfig, Project } from '../src/types';
 
 const baseConfig: AppConfig = {
   mode: 'api',
@@ -121,5 +122,22 @@ describe('resolveSettingsCloseConfig', () => {
       onboardingCompleted: true,
       orbit: { enabled: true, time: '11:30', templateSkillId: 'fresh-template' },
     });
+  });
+});
+
+describe('projectsWithClearedPendingPrompt', () => {
+  const projects: Project[] = [
+    { id: 'a', name: 'A', pendingPrompt: 'keep me' } as Project,
+    { id: 'b', name: 'B', pendingPrompt: 'stale seed' } as Project,
+  ];
+
+  it('clears pendingPrompt for the target project (#2878)', () => {
+    const next = projectsWithClearedPendingPrompt(projects, 'b');
+    expect(next.find((p) => p.id === 'b')?.pendingPrompt).toBeUndefined();
+    expect(next.find((p) => p.id === 'a')?.pendingPrompt).toBe('keep me');
+  });
+
+  it('returns the original list when projectId is missing', () => {
+    expect(projectsWithClearedPendingPrompt(projects, null)).toBe(projects);
   });
 });


### PR DESCRIPTION
Refs #2878

Rebases the approach from conflicting PR #2898 onto current `main`.

## Summary

When the user leaves a project via the back affordance, clear any persisted `pendingPrompt` on that project so a later Home entry or project reopen does not inherit stale composer seed text from the previous session.

## Surface area

- `apps/web/src/App.tsx` — extend `handleBack` to mirror `handleClearPendingPrompt` before navigating home

## Validation

- `cd apps/web && pnpm test tests/components/ProjectView.pendingPrompt.test.tsx tests/state/projects.test.ts`

Made with [Cursor](https://cursor.com)