### PR TITLE
fix(daemon): map Claude Not logged in output to /login guidance (#1928)

### DIFF
--- a/apps/daemon/src/claude-diagnostics.ts
+++ b/apps/daemon/src/claude-diagnostics.ts
@@ -78,6 +78,8 @@ export function diagnoseClaudeCliFailure(
   const authFailure =
     /\b401\b/.test(text) ||
     /apikeysource["'\s:]+none/i.test(text) ||
+    /not logged in/i.test(text) ||
+    /please run \/login/i.test(text) ||
     /(auth|oauth|credential|token).*(fail|invalid|missing|expired|not found|none|unauthorized)/i.test(text) ||
     /(unauthorized|invalid api key|missing api key|could not authenticate|authentication failed)/i.test(text);
   if (authFailure && hasCustomBaseUrl) {

--- a/apps/daemon/tests/claude-diagnostics.test.ts
+++ b/apps/daemon/tests/claude-diagnostics.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { diagnoseClaudeCliFailure } from '../src/claude-diagnostics.js';
 
 describe('diagnoseClaudeCliFailure', () => {
+  it('maps Claude Not logged in stdout to /login guidance (#1928)', () => {
+    const diagnostic = diagnoseClaudeCliFailure({
+      agentId: 'claude',
+      exitCode: 1,
+      stdoutTail: 'Not logged in · Please run /login.',
+      env: {},
+    });
+
+    expect(diagnostic?.message).toContain('/login');
+    expect(diagnostic?.detail).toContain('CLAUDE_CONFIG_DIR');
+  });
+
   it('maps Claude auth failures to /login guidance', () => {
     const diagnostic = diagnoseClaudeCliFailure({
       agentId: 'claude',


### PR DESCRIPTION
Refs #1928

## Summary

When Claude Code exits during a connection test with stdout like `Not logged in · Please run /login.`, Open Design now classifies it as an auth failure and returns the existing `/login` + `CLAUDE_CONFIG_DIR` guidance instead of surfacing the raw CLI text.

## Surface area

- `apps/daemon/src/claude-diagnostics.ts` — recognize `not logged in` / `please run /login` output
- `apps/daemon/tests/claude-diagnostics.test.ts` — regression test for the reported message shape

## Validation

- `cd apps/daemon && pnpm test tests/claude-diagnostics.test.ts`

Made with [Cursor](https://cursor.com)