### PR TITLE
fix(daemon): sanitize spawn error paths in agent execution failures (#2161)

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -2,6 +2,8 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import type { Writable } from 'node:stream';
 import path from 'node:path';
 
+import { sanitizeAgentErrorDetail } from './user-facing-agent-error.js';
+
 const ACP_PROTOCOL_VERSION = 1;
 const DEFAULT_TIMEOUT_MS = 15_000;
 const MAX_TIMEOUT_MS = 24 * 60 * 60 * 1000;
@@ -392,7 +394,9 @@ export async function detectAcpModels({
     child.stderr.on('data', (chunk) => {
       stderrBuf = `${stderrBuf}${chunk}`.slice(-16_000);
     });
-    child.on('error', (err) => fail(`spawn failed: ${err.message}`));
+    child.on('error', (err) =>
+      fail(`spawn failed: ${sanitizeAgentErrorDetail(err.message)}`),
+    );
     child.on('close', (code, signal) => {
       parser.flush();
       if (!settled) {

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -32,6 +32,7 @@ import { attachAcpSession } from './acp.js';
 import { attachPiRpcSession } from './pi-rpc.js';
 import { createClaudeStreamHandler } from './claude-stream.js';
 import { diagnoseClaudeCliFailure } from './claude-diagnostics.js';
+import { sanitizeAgentErrorDetail } from './user-facing-agent-error.js';
 import { createCopilotStreamHandler } from './copilot-stream.js';
 import { createJsonEventStreamHandler } from './json-event-stream.js';
 import { agentCliEnvForAgent, validateAgentCliEnv } from './app-config.js';
@@ -1336,7 +1337,7 @@ async function testAgentConnectionInternal(
       latencyMs,
       model,
       agentName: def.name,
-      detail,
+      detail: sanitizeAgentErrorDetail(detail),
       diagnostics: buildDiagnostics(),
     };
   };
@@ -1378,7 +1379,7 @@ async function testAgentConnectionInternal(
         latencyMs: Date.now() - start,
         model,
         agentName: def.name,
-        detail: redactSecrets(detail),
+        detail: sanitizeAgentErrorDetail(detail),
         diagnostics: buildDiagnostics(),
       };
     }
@@ -1460,7 +1461,7 @@ async function testAgentConnectionInternal(
     ): ConnectionTestResponse => {
       if (winner.kind === 'spawnError') {
         const latencyMs = Date.now() - start;
-        const detail = redactSecrets(winner.error.message);
+        const detail = sanitizeAgentErrorDetail(winner.error.message);
         const guidance = redactSecrets(
           `${codexExecutableGuidance(
             input.agentId,
@@ -1574,9 +1575,7 @@ async function testAgentConnectionInternal(
           }),
         };
       }
-      const detail = redactSecrets(
-        rawDetail,
-      );
+      const detail = sanitizeAgentErrorDetail(rawDetail);
       const guidance = redactSecrets(
         `${codexExecutableGuidance(
           input.agentId,
@@ -1667,7 +1666,7 @@ async function testAgentConnectionInternal(
       latencyMs: Date.now() - start,
       model,
       agentName: def.name,
-      detail: redactSecrets(detail),
+      detail: sanitizeAgentErrorDetail(detail),
       diagnostics: buildDiagnostics(),
     };
   } finally {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -193,6 +193,7 @@ import { narrowProjectCritiqueOverride } from './critique/spawn-inputs.js';
 import { createCopilotStreamHandler } from './copilot-stream.js';
 import { createJsonEventStreamHandler } from './json-event-stream.js';
 import { classifyAgentAuthFailure, cursorAuthGuidance } from './runtimes/auth.js';
+import { sanitizeAgentErrorDetail } from './user-facing-agent-error.js';
 import { createQoderStreamHandler } from './qoder-stream.js';
 import { subscribe as subscribeFileEvents } from './project-watchers.js';
 import { renderDesignSystemPreview } from './design-system-preview.js';
@@ -11073,7 +11074,13 @@ export async function startServer({
     } catch (err) {
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
-      send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', `spawn failed: ${err.message}`));
+      send(
+        'error',
+        createSseErrorPayload(
+          'AGENT_EXECUTION_FAILED',
+          `spawn failed: ${sanitizeAgentErrorDetail(err.message)}`,
+        ),
+      );
       design.runs.finish(run, 'failed', 1, null);
       return;
     }

--- a/apps/daemon/src/user-facing-agent-error.ts
+++ b/apps/daemon/src/user-facing-agent-error.ts
@@ -1,0 +1,29 @@
+import { redactSecrets } from './redact.js';
+
+const SPAWN_ERRNO =
+  /\bspawn\s+.+(?=\s+(?:ENOENT|EACCES|EPERM|EINVAL|ETIMEDOUT)\b)/i;
+
+const UNIX_ABSOLUTE_PATH =
+  /\/(?:Users|home|var|tmp|Applications|opt|usr|private)\/[^\s'",\]]+/g;
+
+const WINDOWS_ABSOLUTE_PATH =
+  /[A-Za-z]:\\(?:[^\\s'",\]]+\\)*[^\\s'",\]]+/g;
+
+const NODE_MODULES_PATH = /\bnode_modules\/[^\s'",\]]+/g;
+
+const SCOPED_PACKAGE_PATH = /\B@[^/\s'",\]]+\/[^\s'",\]]+/g;
+
+/**
+ * Strip filesystem paths from agent spawn / execution errors before they
+ * reach the web UI (issue #2161, complements #2874).
+ */
+export function sanitizeAgentErrorDetail(message: string): string {
+  let out = redactSecrets(String(message ?? ''));
+  out = out.replace(/,?\s*spawnargs:\s*\[[\s\S]*?\]\s*$/i, '');
+  out = out.replace(SPAWN_ERRNO, 'spawn [path]');
+  out = out.replace(UNIX_ABSOLUTE_PATH, '[path]');
+  out = out.replace(WINDOWS_ABSOLUTE_PATH, '[path]');
+  out = out.replace(NODE_MODULES_PATH, '[package-path]');
+  out = out.replace(SCOPED_PACKAGE_PATH, '[package-path]');
+  return out.replace(/\s+/g, ' ').trim();
+}

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2307,6 +2307,26 @@ process.exit(1);
     );
   });
 
+  it('sanitizes absolute paths from agent connection test failure details (#1912)', async () => {
+    const leakedPath = '/var/folders/leaked/od-conn-test-secretDir/extra';
+    await withFakeCodex(
+      `
+console.error('failed in ${leakedPath}');
+process.exit(1);
+`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'codex' });
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'agent_spawn_failed',
+          agentName: 'Codex CLI',
+        });
+        expect(result.detail).not.toContain(leakedPath);
+        expect(result.detail).toContain('[path]');
+      },
+    );
+  });
+
   it('rejects invalid custom model ids before spawning an agent', async () => {
     const markerDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-argv-'));
     const argvFile = path.join(markerDir, 'argv.json');

--- a/apps/daemon/tests/user-facing-agent-error.test.ts
+++ b/apps/daemon/tests/user-facing-agent-error.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeAgentErrorDetail } from '../src/user-facing-agent-error.js';
+
+describe('sanitizeAgentErrorDetail', () => {
+  it('strips spawnargs arrays with local executable paths (#2161)', () => {
+    const raw =
+      "spawn /Users/me/Library/Application Support/Open Design/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex/codex ENOENT, spawnargs: [ 'exec', '--json', '--skip-git-repo-check' ]";
+
+    expect(sanitizeAgentErrorDetail(raw)).toBe(
+      'spawn [path] ENOENT',
+    );
+  });
+
+  it('redacts Windows Program Files paths', () => {
+    const raw =
+      "spawn C:\\Program Files\\Open Design\\bin\\codex.exe failed, spawnargs: [ 'exec' ]";
+
+    expect(sanitizeAgentErrorDetail(raw)).toContain('[path]');
+    expect(sanitizeAgentErrorDetail(raw)).not.toContain('Program Files');
+    expect(sanitizeAgentErrorDetail(raw)).not.toContain('spawnargs');
+  });
+
+  it('still redacts secrets via redactSecrets', () => {
+    const raw = 'auth failed sk-ant-api03-abcdefghijklmnopqrstuvwxyz1234567890';
+
+    expect(sanitizeAgentErrorDetail(raw)).toContain('[REDACTED:sk_key]');
+    expect(sanitizeAgentErrorDetail(raw)).not.toContain('sk-ant-api03');
+  });
+});


### PR DESCRIPTION
Refs #2161
Refs #1912

## Summary
Strip filesystem paths and `spawnargs` tails from agent spawn/execution errors before they reach the web UI. Extends the same sanitization to Settings **Test connection** failures so Codex CLI errors no longer expose temp dirs or argv fragments.

## Surface area
- `apps/daemon/src/user-facing-agent-error.ts` — `sanitizeAgentErrorDetail()`
- `apps/daemon/src/server.ts`, `apps/daemon/src/acp.ts` — chat spawn failures (#2161)
- `apps/daemon/src/connectionTest.ts` — agent connection test spawn/exit failures (#1912)

## Validation
- `cd apps/daemon && pnpm test tests/user-facing-agent-error.test.ts`
- `cd apps/daemon && pnpm test tests/connection-test.test.ts -t "sanitizes absolute paths"`