### PR TITLE
fix(web): show overflow affordance on edit-mode tabs (#2907)

### DIFF
--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -401,10 +401,24 @@ function StyleInspector({
   onChange: (key: keyof ManualEditStyles, value: string) => void;
 }) {
   const u = (key: keyof ManualEditStyles, value: string) => onChange(key, value);
+  const navRef = useRef<HTMLDivElement | null>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
+
+  useEffect(() => {
+    const el = navRef.current;
+    if (!el) return;
+    const checkOverflow = () => {
+      setHasOverflow(el.scrollWidth > el.clientWidth);
+    };
+    checkOverflow();
+    const observer = new ResizeObserver(checkOverflow);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <div className="cc-inspector">
-      <div className="cc-inspector-nav">
+      <div className={`cc-inspector-nav${hasOverflow ? ' has-overflow' : ''}`} ref={navRef}>
         <button type="button" className="cc-inspector-page" onClick={onClearSelection} aria-label="Show page inspector">
           Page
         </button>

--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -661,9 +661,29 @@
 .cc-panel { display: flex; flex-direction: column; gap: 8px; padding: 8px 0; overflow: auto; background: var(--bg-panel); }
 .cc-inspector { display: flex; flex-direction: column; gap: 12px; padding: 6px 12px; }
 .cc-inspector-nav {
+  position: relative;
   display: flex;
   justify-content: flex-start;
+  gap: 4px;
   margin-bottom: -4px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+}
+
+.cc-inspector-nav::-webkit-scrollbar {
+  display: none;
+}
+
+.cc-inspector-nav.has-overflow::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 28px;
+  background: linear-gradient(to right, transparent, var(--bg-panel));
+  pointer-events: none;
 }
 .cc-inspector-page {
   height: 24px;


### PR DESCRIPTION
PR retracted by author. Opened in error by automated tooling against the wrong repository. Please disregard. No follow-up needed.