### PR TITLE
fix(web): keep Style tab active state within its own bounds (#2904)

### DIFF
--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -1026,9 +1026,10 @@
 }
 
 .manual-edit-tabs button.selected {
-  border-color: var(--accent);
+  border-color: var(--border);
   color: var(--text);
   background: var(--accent-soft);
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
 
 .manual-edit-tab-body {


### PR DESCRIPTION
PR retracted by author. Opened in error by automated tooling against the wrong repository. Please disregard. No follow-up needed.