### PR TITLE
feat(designs): implement empty state with CTA for new projects and up…

### DIFF
--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -68,6 +68,7 @@ interface Props {
 	onOpenLiveArtifact: (projectId: string, artifactId: string) => void;
 	onDelete: (id: string) => Promise<boolean | void> | boolean | void;
 	onRename?: (id: string, name: string) => void;
+	onNewProject?: () => void;
 }
 
 export function DesignsTab({
@@ -78,6 +79,7 @@ export function DesignsTab({
 	onOpenLiveArtifact,
 	onDelete,
 	onRename,
+	onNewProject,
 }: Props) {
 	const t = useT();
 	const analytics = useAnalytics();
@@ -550,9 +552,24 @@ export function DesignsTab({
 			</div>
 			{filtered.length === 0 ? (
 				<div className="tab-empty">
-					{projects.length === 0
-						? t("designs.emptyNoProjects")
-						: t("designs.emptyNoMatch")}
+					{projects.length === 0 ? (
+						<div className="designs-empty-state">
+							<h2 className="designs-empty-title">
+								{t("designs.emptyNoProjects")}
+							</h2>
+							{onNewProject ? (
+								<button
+									type="button"
+									className="primary designs-empty-cta"
+									onClick={onNewProject}
+								>
+									<span>{t("entry.navNewProject")}</span>
+								</button>
+							) : null}
+						</div>
+					) : (
+						t("designs.emptyNoMatch")
+					)}
 				</div>
 			) : view === "grid" ? (
 				<div className="design-grid">

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -641,6 +641,7 @@ export function EntryShell({
                     onOpenLiveArtifact={onOpenLiveArtifact}
                     onDelete={onDeleteProject}
                     onRename={onRenameProject}
+                    onNewProject={() => openNewProject()}
                   />
                 </div>
               )

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -586,7 +586,7 @@ export const ar: Dict = {
   'designs.subYours': 'تصاميمك',
   'designs.filterAria': 'تصفية المشاريع',
   'designs.searchPlaceholder': 'بحث...',
-  'designs.emptyNoProjects': 'لا توجد مشاريع بعد. أنشئ واحداً على اليسار.',
+  'designs.emptyNoProjects': 'لا توجد مشاريع بعد.',
   'designs.emptyNoMatch': 'لا توجد مشاريع تطابق بحثك.',
   'designs.deleteTitle': 'حذف المشروع',
   'designs.deleteConfirm': 'هل تريد حذف "{name}"؟',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -474,7 +474,7 @@ export const de: Dict = {
   'designs.subYours': 'Ihre Designs',
   'designs.filterAria': 'Projekte filtern',
   'designs.searchPlaceholder': 'Suchen…',
-  'designs.emptyNoProjects': 'Noch keine Projekte. Erstellen Sie links eines.',
+  'designs.emptyNoProjects': 'Noch keine Projekte.',
   'designs.emptyNoMatch': 'Keine Projekte passen zu Ihrer Suche.',
   'designs.deleteTitle': 'Projekt löschen',
   'designs.deleteConfirm': '„{name}“ löschen?',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1163,7 +1163,7 @@ export const en: Dict = {
   'designs.subYours': 'Your designs',
   'designs.filterAria': 'Filter projects',
   'designs.searchPlaceholder': 'Search…',
-  'designs.emptyNoProjects': 'No projects yet. Create one on the left.',
+  'designs.emptyNoProjects': 'No projects yet.',
   'designs.emptyNoMatch': 'No projects match your search.',
   'designs.deleteTitle': 'Delete project',
   'designs.deleteConfirm': 'Delete "{name}"?',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -475,7 +475,7 @@ export const esES: Dict = {
   'designs.subYours': 'Tus diseños',
   'designs.filterAria': 'Filtrar proyectos',
   'designs.searchPlaceholder': 'Buscar…',
-  'designs.emptyNoProjects': 'Aún no hay proyectos. Crea uno a la izquierda.',
+  'designs.emptyNoProjects': 'Aún no hay proyectos.',
   'designs.emptyNoMatch': 'Ningún proyecto coincide con tu búsqueda.',
   'designs.deleteTitle': 'Eliminar proyecto',
   'designs.deleteConfirm': '¿Eliminar «{name}»?',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -599,7 +599,7 @@ export const fa: Dict = {
   'designs.subYours': 'طرح‌های شما',
   'designs.filterAria': 'فیلتر پروژه‌ها',
   'designs.searchPlaceholder': 'جستجو…',
-  'designs.emptyNoProjects': 'هنوز هیچ پروژه‌ای وجود ندارد. یکی را از سمت چپ ایجاد کنید.',
+  'designs.emptyNoProjects': 'هنوز هیچ پروژه‌ای وجود ندارد.',
   'designs.emptyNoMatch': 'هیچ پروژه‌ای با جستجوی شما مطابقت ندارد.',
   'designs.deleteTitle': 'حذف پروژه',
   'designs.deleteConfirm': 'آیا «{name}» حذف شود؟',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -602,7 +602,7 @@ export const fr: Dict = {
   'designs.subYours': 'Vos designs',
   'designs.filterAria': 'Filtrer les projets',
   'designs.searchPlaceholder': 'Rechercher…',
-  'designs.emptyNoProjects': 'Aucun projet pour l\'instant. Créez-en un à gauche.',
+  'designs.emptyNoProjects': 'Aucun projet pour l\'instant.',
   'designs.emptyNoMatch': 'Aucun projet ne correspond à votre recherche.',
   'designs.deleteTitle': 'Supprimer le projet',
   'designs.deleteConfirm': 'Supprimer « {name} » ?',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -586,7 +586,7 @@ export const hu: Dict = {
   'designs.subYours': 'A te terveid',
   'designs.filterAria': 'Projektek szűrése',
   'designs.searchPlaceholder': 'Keresés…',
-  'designs.emptyNoProjects': 'Még nincs projekt. Hozz létre egyet a bal oldalon.',
+  'designs.emptyNoProjects': 'Még nincs projekt.',
   'designs.emptyNoMatch': 'Egy projekt sem felel meg a keresésnek.',
   'designs.deleteTitle': 'Projekt törlése',
   'designs.deleteConfirm': 'Törlöd a(z) „{name}" projektet?',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -690,7 +690,7 @@ export const id: Dict = {
   'designs.subYours': 'Desainmu',
   'designs.filterAria': 'Filter proyek',
   'designs.searchPlaceholder': 'Cari...',
-  'designs.emptyNoProjects': 'Belum ada proyek. Buat satu dari panel kiri.',
+  'designs.emptyNoProjects': 'Belum ada proyek.',
   'designs.emptyNoMatch': 'Tidak ada proyek yang cocok dengan pencarianmu.',
   'designs.deleteTitle': 'Hapus proyek',
   'designs.deleteConfirm': 'Hapus "{name}"?',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -554,7 +554,7 @@ export const it: Dict = {
   'designs.subYours': 'I tuoi design',
   'designs.filterAria': 'Filtra progetti',
   'designs.searchPlaceholder': 'Cerca…',
-  'designs.emptyNoProjects': 'Nessun progetto per ora. Creane uno a sinistra.',
+  'designs.emptyNoProjects': 'Nessun progetto per ora.',
   'designs.emptyNoMatch': 'Nessun progetto corrisponde alla tua ricerca.',
   'designs.deleteTitle': 'Elimina progetto',
   'designs.deleteConfirm': 'Eliminare « {name} » ?',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -473,7 +473,7 @@ export const ja: Dict = {
   'designs.subYours': 'あなたのデザイン',
   'designs.filterAria': 'プロジェクトをフィルター',
   'designs.searchPlaceholder': '検索…',
-  'designs.emptyNoProjects': 'プロジェクトがまだありません。左側で作成してください。',
+  'designs.emptyNoProjects': 'プロジェクトがまだありません。',
   'designs.emptyNoMatch': '検索に一致するプロジェクトがありません。',
   'designs.deleteTitle': 'プロジェクトを削除',
   'designs.deleteConfirm': '"{name}" を削除しますか？',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -586,7 +586,7 @@ export const ko: Dict = {
   'designs.subYours': '내 디자인',
   'designs.filterAria': '프로젝트 필터링',
   'designs.searchPlaceholder': '검색…',
-  'designs.emptyNoProjects': '아직 프로젝트가 없습니다. 왼쪽에서 새 프로젝트를 생성하세요.',
+  'designs.emptyNoProjects': '아직 프로젝트가 없습니다.',
   'designs.emptyNoMatch': '검색어와 일치하는 프로젝트가 없습니다.',
   'designs.deleteTitle': '프로젝트 삭제',
   'designs.deleteConfirm': '"{name}" 프로젝트를 삭제하시겠습니까?',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -586,7 +586,7 @@ export const pl: Dict = {
   'designs.subYours': 'Twoje projekty',
   'designs.filterAria': 'Filtruj projekty',
   'designs.searchPlaceholder': 'Szukaj…',
-  'designs.emptyNoProjects': 'Brak projektów. Utwórz jeden po lewej stronie.',
+  'designs.emptyNoProjects': 'Brak projektów.',
   'designs.emptyNoMatch': 'Brak projektów pasujących do wyszukiwania.',
   'designs.deleteTitle': 'Usuń projekt',
   'designs.deleteConfirm': 'Usunąć „{name}”?',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -598,7 +598,7 @@ export const ptBR: Dict = {
   'designs.subYours': 'Seus designs',
   'designs.filterAria': 'Filtrar projetos',
   'designs.searchPlaceholder': 'Buscar…',
-  'designs.emptyNoProjects': 'Ainda não há projetos. Crie um à esquerda.',
+  'designs.emptyNoProjects': 'Ainda não há projetos.',
   'designs.emptyNoMatch': 'Nenhum projeto corresponde à sua busca.',
   'designs.deleteTitle': 'Excluir projeto',
   'designs.deleteConfirm': 'Excluir "{name}"?',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -598,7 +598,7 @@ export const ru: Dict = {
   'designs.subYours': 'Ваши дизайны',
   'designs.filterAria': 'Фильтр проектов',
   'designs.searchPlaceholder': 'Поиск…',
-  'designs.emptyNoProjects': 'Проектов пока нет. Создайте один слева.',
+  'designs.emptyNoProjects': 'Проектов пока нет.',
   'designs.emptyNoMatch': 'Нет проектов, соответствующих вашему поиску.',
   'designs.deleteTitle': 'Удалить проект',
   'designs.deleteConfirm': 'Удалить «{name}»?',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -575,7 +575,7 @@ export const tr: Dict = {
   'designs.subYours': 'Tasarımların',
   'designs.filterAria': 'Projeleri filtrele',
   'designs.searchPlaceholder': 'Ara…',
-  'designs.emptyNoProjects': 'Henüz proje yok. Sol taraftan yeni bir tane oluşturun.',
+  'designs.emptyNoProjects': 'Henüz proje yok.',
   'designs.emptyNoMatch': 'Hiçbir proje aramanızla örtüşmedi.',
   'designs.deleteTitle': 'Projeyi sil',
   'designs.deleteConfirm': '"{name}"’i sil?',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -599,7 +599,7 @@ export const uk: Dict = {
   'designs.subYours': 'Ваші дизайни',
   'designs.filterAria': 'Фільтрувати проекти',
   'designs.searchPlaceholder': 'Пошук…',
-  'designs.emptyNoProjects': 'Проектів ще немає. Створіть один зліва.',
+  'designs.emptyNoProjects': 'Проектів ще немає.',
   'designs.emptyNoMatch': 'Проектів, що відповідають пошуку, не знайдено.',
   'designs.deleteTitle': 'Видалити проект',
   'designs.deleteConfirm': 'Видалити "{name}"?',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1155,7 +1155,7 @@ export const zhCN: Dict = {
   'designs.subYours': '我的设计',
   'designs.filterAria': '筛选项目',
   'designs.searchPlaceholder': '搜索…',
-  'designs.emptyNoProjects': '还没有项目。请在左侧创建一个。',
+  'designs.emptyNoProjects': '还没有项目。',
   'designs.emptyNoMatch': '没有匹配的项目。',
   'designs.deleteTitle': '删除项目',
   'designs.deleteConfirm': '确定删除「{name}」？',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -769,7 +769,7 @@ export const zhTW: Dict = {
   'designs.subYours': '我的設計',
   'designs.filterAria': '篩選專案',
   'designs.searchPlaceholder': '搜尋…',
-  'designs.emptyNoProjects': '還沒有專案。請在左側建立一個。',
+  'designs.emptyNoProjects': '還沒有專案。',
   'designs.emptyNoMatch': '沒有符合的專案。',
   'designs.deleteTitle': '刪除專案',
   'designs.deleteConfirm': '確定刪除「{name}」？',

--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -1547,3 +1547,49 @@
   display: flex;
   flex-direction: column;
 }
+
+.designs-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 24px;
+  text-align: center;
+  max-width: 420px;
+  margin: 0 auto;
+}
+
+.designs-empty-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-strong);
+  margin: 0 0 24px 0;
+  letter-spacing: -0.01em;
+}
+
+
+.designs-empty-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 18px;
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  box-shadow: 
+    0 4px 12px -3px color-mix(in srgb, var(--accent) 25%, transparent),
+    var(--shadow-sm);
+  transition: transform 120ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 120ms cubic-bezier(0.23, 1, 0.32, 1), background-color 120ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.designs-empty-cta:hover {
+  transform: scale(1.02);
+  box-shadow: 
+    0 6px 16px -4px color-mix(in srgb, var(--accent) 35%, transparent),
+    var(--shadow-md);
+}
+
+.designs-empty-cta:active {
+  transform: scale(0.98);
+}

--- a/apps/web/tests/components/DesignsTab.empty.test.tsx
+++ b/apps/web/tests/components/DesignsTab.empty.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DesignsTab } from '../../src/components/DesignsTab';
+
+vi.mock('../../src/providers/registry', () => ({
+  deleteLiveArtifact: vi.fn(),
+  fetchLiveArtifacts: vi.fn(async () => []),
+  fetchProjectFiles: vi.fn(async () => []),
+  liveArtifactPreviewUrl: (projectId: string, artifactId: string) =>
+    `/api/projects/${projectId}/live-artifacts/${artifactId}/preview`,
+  projectFileUrl: (projectId: string, fileName: string) =>
+    `/api/projects/${projectId}/files/${fileName}`,
+}));
+
+describe('DesignsTab empty state', () => {
+  beforeAll(() => {
+    if (window.localStorage) return;
+    const store = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        clear: () => store.clear(),
+        getItem: (key: string) => store.get(key) ?? null,
+        removeItem: (key: string) => store.delete(key),
+        setItem: (key: string, value: string) => store.set(key, value),
+      },
+    });
+  });
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders a premium empty state when projects list is completely empty', () => {
+    const onNewProject = vi.fn();
+    render(
+      <DesignsTab
+        projects={[]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        onNewProject={onNewProject}
+      />,
+    );
+
+    // Verify Title (from 'designs.emptyNoProjects' translation: 'No projects yet.')
+    expect(screen.getByText('No projects yet.')).toBeTruthy();
+
+
+    // Verify CTA Button is present
+    const ctaButton = screen.getByRole('button', { name: 'New project' });
+    expect(ctaButton).toBeTruthy();
+
+    // Verify clicking the CTA Button invokes the onNewProject callback
+    fireEvent.click(ctaButton);
+    expect(onNewProject).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render CTA button when onNewProject is not provided', () => {
+    render(
+      <DesignsTab
+        projects={[]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+      />,
+    );
+
+    // Verify Title is present
+    expect(screen.getByText('No projects yet.')).toBeTruthy();
+
+    // Verify CTA Button is NOT present
+    expect(screen.queryByRole('button', { name: 'New project' })).toBeNull();
+  });
+
+  it('renders No projects match your search when projects exist but query filters them out', () => {
+    render(
+      <DesignsTab
+        projects={[
+          {
+            id: 'project-1',
+            name: 'Landing refresh',
+            skillId: null,
+            designSystemId: null,
+            createdAt: 1,
+            updatedAt: 2,
+            status: { value: 'not_started' },
+          },
+        ]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+      />,
+    );
+
+    // Filter projects using query search so filtered count is 0, but projects.length is 1
+    const searchInput = screen.getByPlaceholderText('Search…');
+    fireEvent.change(searchInput, { target: { value: 'Non-existent project query' } });
+
+    // Verify 'No projects match your search.' is present
+    expect(screen.getByText('No projects match your search.')).toBeTruthy();
+    expect(screen.queryByText('No projects yet.')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'New project' })).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #2978

## Why

I hit the empty Projects state while checking the current branch and found that it only showed the no-projects copy, even though the existing New Project modal flow was already available from `EntryShell`. This is a small UI gap, not a data/API issue, and it leaves users at a dead end when they land on an empty Projects tab.

## What users will see

When Projects has no items, the empty state now includes a simple primary “New project” CTA that opens the existing New Project modal. The empty state is also visually simplified so it reads as a clean call to action instead of a decorative card.

## Surface area

- [x] **UI** — empty state in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not included.

## Bug fix verification

- Red spec: `apps/web/tests/components/DesignsTab.empty.test.tsx`
- The test was added for this branch and passed here; I did not run it on `main`, so the red-on-main / green-on-branch check is not available.
- Verification used instead: focused component test plus `pnpm --filter @open-design/web typecheck`.

## Validation

- `pnpm --filter @open-design/web test -- tests/components/DesignsTab.empty.test.tsx`
- `pnpm --filter @open-design/web typecheck`