### PR TITLE
fix: portal plugin details modal

### DIFF
--- a/apps/web/src/components/PluginDetailsModal.tsx
+++ b/apps/web/src/components/PluginDetailsModal.tsx
@@ -19,6 +19,7 @@
 // same callback wiring.
 
 import type { InstalledPluginRecord } from '@open-design/contracts';
+import { createPortal } from 'react-dom';
 import { inferPluginPreview } from './plugins-home/preview';
 import { PluginScenarioDetail } from './plugin-details/PluginScenarioDetail';
 import { PluginExampleDetail } from './plugin-details/PluginExampleDetail';
@@ -39,9 +40,10 @@ export function PluginDetailsModal({
   isApplying,
 }: Props) {
   const preview = inferPluginPreview(record);
+  let detail: JSX.Element;
 
   if (preview.kind === 'media') {
-    return (
+    detail = (
       <PluginMediaDetail
         record={record}
         onClose={onClose}
@@ -49,10 +51,8 @@ export function PluginDetailsModal({
         isApplying={isApplying}
       />
     );
-  }
-
-  if (preview.kind === 'html') {
-    return (
+  } else if (preview.kind === 'html') {
+    detail = (
       <PluginExampleDetail
         record={record}
         exampleStem={
@@ -63,11 +63,18 @@ export function PluginDetailsModal({
         isApplying={isApplying}
       />
     );
-  }
-
-  if (preview.kind === 'design') {
-    return (
+  } else if (preview.kind === 'design') {
+    detail = (
       <PluginDesignSystemDetail
+        record={record}
+        onClose={onClose}
+        onUse={onUse}
+        isApplying={isApplying}
+      />
+    );
+  } else {
+    detail = (
+      <PluginScenarioDetail
         record={record}
         onClose={onClose}
         onUse={onUse}
@@ -76,12 +83,6 @@ export function PluginDetailsModal({
     );
   }
 
-  return (
-    <PluginScenarioDetail
-      record={record}
-      onClose={onClose}
-      onUse={onUse}
-      isApplying={isApplying}
-    />
-  );
+  if (typeof document === 'undefined') return detail;
+  return createPortal(detail, document.body);
 }

--- a/apps/web/tests/components/PluginDetailsModal.layering.test.tsx
+++ b/apps/web/tests/components/PluginDetailsModal.layering.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react';
+import type { InstalledPluginRecord } from '@open-design/contracts';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { PluginDetailsModal } from '../../src/components/PluginDetailsModal';
+import { I18nProvider } from '../../src/i18n';
+
+function makePlugin(
+  id: string,
+  preview?: Record<string, unknown>,
+): InstalledPluginRecord {
+  return {
+    id,
+    title: id,
+    version: '0.1.0',
+    sourceKind: 'bundled',
+    source: '/tmp',
+    trust: 'bundled',
+    capabilitiesGranted: [],
+    manifest: {
+      name: id,
+      version: '0.1.0',
+      title: id,
+      od: {
+        kind: 'scenario',
+        ...(preview ? { preview } : {}),
+        useCase: {
+          query: 'Generate a preview.',
+        },
+      },
+    },
+    fsPath: '/tmp',
+    installedAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function renderInsideStackingContext(record: InstalledPluginRecord) {
+  const host = document.createElement('div');
+  host.className = 'composer';
+  document.body.appendChild(host);
+
+  render(
+    <I18nProvider>
+      <div className="composer-shell">
+        <PluginDetailsModal record={record} onClose={() => {}} onUse={() => {}} />
+      </div>
+    </I18nProvider>,
+    { container: host },
+  );
+
+  return host;
+}
+
+describe('PluginDetailsModal layering', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = '';
+  });
+
+  it('portals rich preview details to the document body so sticky chat and workspace headers cannot cover them', () => {
+    const host = renderInsideStackingContext(
+      makePlugin('video-plugin', {
+        type: 'video',
+        poster: 'https://cdn.example/poster.jpg',
+        video: 'https://cdn.example/clip.mp4',
+      }),
+    );
+
+    const backdrop = document.body.querySelector('.ds-modal-backdrop');
+    expect(backdrop).toBeTruthy();
+    expect(backdrop?.parentElement).toBe(document.body);
+    expect(host.querySelector('.ds-modal-backdrop')).toBeNull();
+  });
+
+  it('portals fallback scenario details through the same top-level layer', () => {
+    const host = renderInsideStackingContext(makePlugin('scenario-plugin'));
+
+    const backdrop = document.body.querySelector('.plugin-details-modal-backdrop');
+    expect(backdrop).toBeTruthy();
+    expect(backdrop?.parentElement).toBe(document.body);
+    expect(host.querySelector('.plugin-details-modal-backdrop')).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #3064 

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->

While checking the macOS desktop project view, the plugin preview/details modal opened from the side chat `@` plugin picker could render under parts of the existing sticky workspace chrome. In particular, `div.chat-header` and `div.ws-tabs-shell` could remain visually on the same layer as the preview overlay.

This is a user-facing layering bug: the preview modal should own the top layer when a user opens plugin details from the side chat.

## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->

Opening a plugin preview/details modal from the project side chat now places the modal and backdrop above the existing project surface, including the sticky chat header and workspace tabs header.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [X] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->
- before 
<img width="3847" height="2097" alt="Screenshot 2026-05-27 at 10 46 14 AM" src="https://github.com/user-attachments/assets/7f44f1f8-8d2e-42fd-bdf7-5d763bd42eec" />


- after 
<img width="3588" height="2009" alt="image" src="https://github.com/user-attachments/assets/41ea98b9-a5c8-4202-90e1-7fc02016ca16" />


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->
- Test path that reproduces the bug: `apps/web/tests/components/PluginDetailsModal.layering.test.tsx`
- Did the test go red on `main` and green on this branch? No, not run against `main`; the added jsdom regression asserts that plugin detail backdrops are portaled to `document.body`, which the previous inline render path did not do.
- If a red spec wasn't cheap to write, explain why and what verification you did instead: The regression is covered at the component boundary by rendering `PluginDetailsModal` inside a simulated composer stacking context and asserting the modal backdrops escape to `document.body`. Local desktop visual verification should be attached in screenshots.

## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->
- `pnpm --filter @open-design/web test -- PluginDetailsModal.layering.test.tsx PluginDetailsModal.dispatch.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
