### PR TITLE
Refine edit target selection for grouped elements

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5088,14 +5088,6 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     setManualEditError('Saved styles differed from the active preview. Reconciled the selected target from source.');
   }
 
-  function scheduleManualEditStyleSave() {
-    if (manualEditStyleTimerRef.current) clearTimeout(manualEditStyleTimerRef.current);
-    manualEditStyleTimerRef.current = setTimeout(() => {
-      manualEditStyleTimerRef.current = null;
-      void flushManualEditStyleSave();
-    }, 1000);
-  }
-
   function clearManualEditStyleTimer() {
     if (!manualEditStyleTimerRef.current) return;
     clearTimeout(manualEditStyleTimerRef.current);
@@ -5122,18 +5114,43 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     manualEditPendingStyleRef.current = pending;
     setManualEditError(null);
     previewStyleToIframe(id, styles, version);
-    scheduleManualEditStyleSave();
   }
 
   async function flushManualEditStyleSave(): Promise<boolean> {
     const pending = manualEditPendingStyleRef.current;
     if (!pending) return true;
-    if (manualEditSavingRef.current) {
-      scheduleManualEditStyleSave();
-      return false;
-    }
+    if (manualEditSavingRef.current) return false;
     manualEditPendingStyleRef.current = null;
     return applyManualEdit({ id: pending.id, kind: 'set-style', styles: pending.styles }, pending.label);
+  }
+
+  function cancelManualEditStyleDraft() {
+    const pending = manualEditPendingStyleRef.current;
+    if (!pending) return;
+    clearManualEditStyleTimer();
+    manualEditPendingStyleRef.current = null;
+    const base = sourceRef.current ?? '';
+    const target = pending.id === '__body__'
+      ? null
+      : selectedManualEditTarget?.id === pending.id
+        ? selectedManualEditTarget
+        : manualEditTargets.find((item) => item.id === pending.id) ?? null;
+    const sourceStyles = target
+      ? inspectorManualEditStyles(target, base)
+      : readManualEditStyles(base, pending.id);
+    const resetStyles = MANUAL_EDIT_STYLE_PROPS.reduce<Partial<ManualEditStyles>>((acc, key) => {
+      acc[key] = sourceStyles[key] ?? '';
+      return acc;
+    }, {});
+    previewStyleToIframe(pending.id, resetStyles, nextManualEditPreviewVersion());
+    if (!target || target.id === selectedManualEditTarget?.id) {
+      setManualEditDraft((current) => ({
+        ...current,
+        styles: target ? sourceStyles : current.styles,
+        fullSource: base,
+      }));
+    }
+    setManualEditError(null);
   }
 
   async function exitManualEditModeAfterFlush(): Promise<boolean> {
@@ -5145,7 +5162,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
   }
 
   async function selectManualEditTarget(target: ManualEditTarget) {
-    if (!(await flushManualEditStyleSave())) return;
+    if (manualEditPendingStyleRef.current?.id !== target.id) cancelManualEditStyleDraft();
     const base = sourceRef.current ?? '';
     const fields = readManualEditFields(base, target.id);
     setSelectedManualEditTarget(target);
@@ -5163,7 +5180,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
   }
 
   async function clearManualEditTargetSelection() {
-    if (!(await flushManualEditStyleSave())) return;
+    cancelManualEditStyleDraft();
     setSelectedManualEditTarget(null);
     setManualEditPanelPosition(null);
     setManualEditDraft(emptyManualEditDraft(sourceRef.current ?? ''));
@@ -5239,7 +5256,6 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     } finally {
       manualEditSavingRef.current = false;
       setManualEditSaving(false);
-      if (manualEditPendingStyleRef.current) scheduleManualEditStyleSave();
     }
   }
 
@@ -6237,7 +6253,10 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         void exitManualEditModeAfterFlush();
       }}
       onCancelDraft={() => {
-        if (selectedManualEditTarget) selectManualEditTarget(selectedManualEditTarget);
+        cancelManualEditStyleDraft();
+      }}
+      onSaveDraft={() => {
+        void flushManualEditStyleSave();
       }}
       onUndo={() => {
         void undoManualEdit();
@@ -6442,34 +6461,6 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         <div className="viewer-toolbar-actions">
           {showPreviewToolbarControls ? (
             <>
-              <div className="artifact-tool-menu-anchor">
-                <button
-                  type="button"
-                  className={`viewer-action viewer-action-icon viewer-comment-toggle${boardMode && !commentCreateMode && boardTool === 'inspect' ? ' active' : ''}`}
-                  data-testid="board-mode-toggle"
-                  data-tooltip={t('fileViewer.comment')}
-                  title={t('fileViewer.comment')}
-                  aria-label={t('fileViewer.comment')}
-                  aria-pressed={boardMode && !commentCreateMode && boardTool === 'inspect'}
-                  onClick={activateCommentTool}
-                >
-                  <RemixIcon name="chat-new-line" size={15} />
-                  {boardMode && !commentCreateMode && boardTool === 'inspect' ? <span className="viewer-action-active-dot" aria-hidden /> : null}
-                </button>
-              </div>
-              <button
-                type="button"
-                className={`viewer-action viewer-action-icon viewer-comment-toggle${boardMode && commentCreateMode ? ' active' : ''}`}
-                data-testid="comment-panel-toggle"
-                data-tooltip={t('chat.tabComments')}
-                title={t('chat.tabComments')}
-                aria-label={t('chat.tabComments')}
-                aria-pressed={boardMode && commentCreateMode}
-                onClick={activateCommentCreateTool}
-              >
-                <RemixIcon name="message-3-line" size={15} />
-                {boardMode && commentCreateMode ? <span className="viewer-action-active-dot" aria-hidden /> : null}
-              </button>
               <button
                 className={`viewer-action viewer-action-icon${manualEditMode ? ' active' : ''}`}
                 type="button"
@@ -6505,6 +6496,35 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
                 onClick={activateScreenshotTool}
               >
                 <RemixIcon name="screenshot-2-line" size={15} />
+              </button>
+              <span className="viewer-toolbar-tool-divider" aria-hidden />
+              <div className="artifact-tool-menu-anchor">
+                <button
+                  type="button"
+                  className={`viewer-action viewer-action-icon viewer-comment-toggle${boardMode && !commentCreateMode && boardTool === 'inspect' ? ' active' : ''}`}
+                  data-testid="board-mode-toggle"
+                  data-tooltip={t('fileViewer.comment')}
+                  title={t('fileViewer.comment')}
+                  aria-label={t('fileViewer.comment')}
+                  aria-pressed={boardMode && !commentCreateMode && boardTool === 'inspect'}
+                  onClick={activateCommentTool}
+                >
+                  <RemixIcon name="chat-new-line" size={15} />
+                  {boardMode && !commentCreateMode && boardTool === 'inspect' ? <span className="viewer-action-active-dot" aria-hidden /> : null}
+                </button>
+              </div>
+              <button
+                type="button"
+                className={`viewer-action viewer-action-icon viewer-comment-toggle${boardMode && commentCreateMode ? ' active' : ''}`}
+                data-testid="comment-panel-toggle"
+                data-tooltip={t('chat.tabComments')}
+                title={t('chat.tabComments')}
+                aria-label={t('chat.tabComments')}
+                aria-pressed={boardMode && commentCreateMode}
+                onClick={activateCommentCreateTool}
+              >
+                <RemixIcon name="message-3-line" size={15} />
+                {boardMode && commentCreateMode ? <span className="viewer-action-active-dot" aria-hidden /> : null}
               </button>
               {source !== null && mode === 'preview' ? (
                 <div className="zoom-menu viewer-toolbar-zoom" ref={zoomMenuRef}>

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -597,7 +597,7 @@ function manualEditFloatingPanelStyle(
 ): CSSProperties {
   const scale = Number.isFinite(previewScale) && previewScale > 0 ? previewScale : 1;
   const panelWidth = 320;
-  const preferredPanelHeight = 560;
+  const preferredPanelHeight = 380;
   const pad = 12;
   const canvasWidth = canvasSize?.width ?? 1200;
   const canvasHeight = canvasSize?.height ?? 800;

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4102,8 +4102,9 @@ function HtmlViewer({
       });
     });
   }, []);
-  const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([]);
+const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([]);
   const [selectedManualEditTarget, setSelectedManualEditTarget] = useState<ManualEditTarget | null>(null);
+  const [manualEditPanelPosition, setManualEditPanelPosition] = useState<{ left: number; top: number } | null>(null);
   const selectedManualEditTargetIdRef = useRef<string | null>(null);
   const [manualEditDraft, setManualEditDraft] = useState<ManualEditDraft>(() => emptyManualEditDraft());
   const [manualEditHistory, setManualEditHistory] = useState<ManualEditHistoryEntry[]>([]);
@@ -4803,6 +4804,7 @@ function HtmlViewer({
     setManualEditViewportWidth(null);
     setManualEditTargets([]);
     setSelectedManualEditTarget(null);
+    setManualEditPanelPosition(null);
     selectedManualEditTargetIdRef.current = null;
     setManualEditDraft(emptyManualEditDraft());
     setManualEditHistory([]);
@@ -4995,6 +4997,7 @@ function HtmlViewer({
     if (!manualEditMode) {
       setManualEditTargets([]);
       setSelectedManualEditTarget(null);
+      setManualEditPanelPosition(null);
       setManualEditError(null);
       manualEditPendingStyleRef.current = null;
       if (manualEditStyleTimerRef.current) {
@@ -5136,6 +5139,7 @@ function HtmlViewer({
   async function exitManualEditModeAfterFlush(): Promise<boolean> {
     const ok = await flushManualEditStyleSave();
     if (!ok) return false;
+    setManualEditPanelPosition(null);
     setManualEditMode(false);
     return true;
   }
@@ -5161,6 +5165,7 @@ function HtmlViewer({
   async function clearManualEditTargetSelection() {
     if (!(await flushManualEditStyleSave())) return;
     setSelectedManualEditTarget(null);
+    setManualEditPanelPosition(null);
     setManualEditDraft(emptyManualEditDraft(sourceRef.current ?? ''));
     setManualEditError(null);
   }
@@ -6241,12 +6246,16 @@ function HtmlViewer({
         void redoManualEdit();
       }}
       floatingStyle={selectedManualEditTarget
-        ? manualEditFloatingPanelStyle(
-            selectedManualEditTarget,
-            overlayPreviewScale,
-            previewBodySize,
-          )
+        ? {
+            ...manualEditFloatingPanelStyle(
+              selectedManualEditTarget,
+              overlayPreviewScale,
+              previewBodySize,
+            ),
+            ...(manualEditPanelPosition ?? {}),
+          }
         : undefined}
+      onFloatingPositionChange={setManualEditPanelPosition}
       onPickImage={async (pickedFile) => {
         const result = await uploadProjectFiles(projectId, [pickedFile]);
         const uploaded = result.uploaded[0];

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5161,6 +5161,17 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     return true;
   }
 
+  function cancelManualEditModeAndExit() {
+    cancelManualEditStyleDraft();
+    selectedManualEditTargetIdRef.current = null;
+    setSelectedManualEditTarget(null);
+    setManualEditPanelPosition(null);
+    setManualEditDraft(emptyManualEditDraft(sourceRef.current ?? ''));
+    setManualEditError(null);
+    setManualEditMode(false);
+    postSelectedManualEditTargetToIframe(null);
+  }
+
   async function selectManualEditTarget(target: ManualEditTarget) {
     if (manualEditPendingStyleRef.current?.id !== target.id) cancelManualEditStyleDraft();
     const base = sourceRef.current ?? '';
@@ -6253,10 +6264,10 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         void exitManualEditModeAfterFlush();
       }}
       onCancelDraft={() => {
-        cancelManualEditStyleDraft();
+        cancelManualEditModeAndExit();
       }}
       onSaveDraft={() => {
-        void flushManualEditStyleSave();
+        void exitManualEditModeAfterFlush();
       }}
       onUndo={() => {
         void undoManualEdit();

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -6236,7 +6236,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
   };
   const boardAvailable = mode === 'preview' && source !== null;
   const showPreviewToolbarControls = mode === 'preview';
-  const manualEditPanel = manualEditMode ? (
+  const manualEditPanel = manualEditMode && selectedManualEditTarget ? (
     <ManualEditPanel
       targets={manualEditTargets}
       selectedTarget={selectedManualEditTarget}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -597,10 +597,11 @@ function manualEditFloatingPanelStyle(
 ): CSSProperties {
   const scale = Number.isFinite(previewScale) && previewScale > 0 ? previewScale : 1;
   const panelWidth = 320;
-  const panelHeight = target.kind === 'text' || target.kind === 'link' ? 280 : 520;
+  const preferredPanelHeight = 560;
   const pad = 12;
   const canvasWidth = canvasSize?.width ?? 1200;
   const canvasHeight = canvasSize?.height ?? 800;
+  const panelHeight = Math.min(preferredPanelHeight, Math.max(260, canvasHeight - pad * 2));
   const targetLeft = target.rect.x * scale;
   const targetTop = target.rect.y * scale;
   const targetRight = (target.rect.x + target.rect.width) * scale;
@@ -616,7 +617,8 @@ function manualEditFloatingPanelStyle(
     left,
     top,
     width: panelWidth,
-    maxHeight: `min(${panelHeight}px, calc(100% - ${pad * 2}px))`,
+    height: panelHeight,
+    maxHeight: `calc(100% - ${pad * 2}px)`,
   };
 }
 

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -6515,15 +6515,16 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
               </div>
               <button
                 type="button"
-                className={`viewer-action viewer-action-icon viewer-comment-toggle${boardMode && commentCreateMode ? ' active' : ''}`}
+                className={`viewer-action viewer-comment-count-trigger viewer-comment-toggle${boardMode && commentCreateMode ? ' active' : ''}`}
                 data-testid="comment-panel-toggle"
                 data-tooltip={t('chat.tabComments')}
                 title={t('chat.tabComments')}
-                aria-label={t('chat.tabComments')}
+                aria-label={`${t('chat.tabComments')} (${visibleSideComments.length})`}
                 aria-pressed={boardMode && commentCreateMode}
                 onClick={activateCommentCreateTool}
               >
                 <RemixIcon name="message-3-line" size={15} />
+                <span className="viewer-comment-count" aria-hidden>{visibleSideComments.length}</span>
                 {boardMode && commentCreateMode ? <span className="viewer-action-active-dot" aria-hidden /> : null}
               </button>
               {source !== null && mode === 'preview' ? (

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -6476,7 +6476,6 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
                   {boardMode && !commentCreateMode && boardTool === 'inspect' ? <span className="viewer-action-active-dot" aria-hidden /> : null}
                 </button>
               </div>
-              <span className="viewer-toolbar-tool-divider" aria-hidden />
               <button
                 className={`viewer-action viewer-action-icon${manualEditMode ? ' active' : ''}`}
                 type="button"

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -6461,6 +6461,22 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         <div className="viewer-toolbar-actions">
           {showPreviewToolbarControls ? (
             <>
+              <div className="artifact-tool-menu-anchor">
+                <button
+                  type="button"
+                  className={`viewer-action viewer-action-icon viewer-comment-toggle${boardMode && !commentCreateMode && boardTool === 'inspect' ? ' active' : ''}`}
+                  data-testid="board-mode-toggle"
+                  data-tooltip={t('fileViewer.comment')}
+                  title={t('fileViewer.comment')}
+                  aria-label={t('fileViewer.comment')}
+                  aria-pressed={boardMode && !commentCreateMode && boardTool === 'inspect'}
+                  onClick={activateCommentTool}
+                >
+                  <RemixIcon name="chat-new-line" size={15} />
+                  {boardMode && !commentCreateMode && boardTool === 'inspect' ? <span className="viewer-action-active-dot" aria-hidden /> : null}
+                </button>
+              </div>
+              <span className="viewer-toolbar-tool-divider" aria-hidden />
               <button
                 className={`viewer-action viewer-action-icon${manualEditMode ? ' active' : ''}`}
                 type="button"
@@ -6498,21 +6514,6 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
                 <RemixIcon name="screenshot-2-line" size={15} />
               </button>
               <span className="viewer-toolbar-tool-divider" aria-hidden />
-              <div className="artifact-tool-menu-anchor">
-                <button
-                  type="button"
-                  className={`viewer-action viewer-action-icon viewer-comment-toggle${boardMode && !commentCreateMode && boardTool === 'inspect' ? ' active' : ''}`}
-                  data-testid="board-mode-toggle"
-                  data-tooltip={t('fileViewer.comment')}
-                  title={t('fileViewer.comment')}
-                  aria-label={t('fileViewer.comment')}
-                  aria-pressed={boardMode && !commentCreateMode && boardTool === 'inspect'}
-                  onClick={activateCommentTool}
-                >
-                  <RemixIcon name="chat-new-line" size={15} />
-                  {boardMode && !commentCreateMode && boardTool === 'inspect' ? <span className="viewer-action-active-dot" aria-hidden /> : null}
-                </button>
-              </div>
               <button
                 type="button"
                 className={`viewer-action viewer-comment-count-trigger viewer-comment-toggle${boardMode && commentCreateMode ? ' active' : ''}`}

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -67,6 +67,7 @@ export function ManualEditPanel({
   const selectedTargetRef = useRef<ManualEditTarget | null>(selectedTarget);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const targetForInspector = selectedTarget;
+  const panelTitle = targetForInspector ? readableManualEditTargetName(targetForInspector) : 'Edit';
   useEffect(() => {
     selectedTargetRef.current = selectedTarget;
   }, [selectedTarget]);
@@ -94,7 +95,7 @@ export function ManualEditPanel({
     >
       <section className="manual-edit-modal cc-panel">
         <div className="manual-edit-titlebar">
-          <span>Edit</span>
+          <span title={panelTitle}>{panelTitle}</span>
           {onExit ? (
             <button
               type="button"
@@ -221,6 +222,93 @@ export function ManualEditPanel({
       </section>
     </aside>
   );
+}
+
+function readableManualEditTargetName(target: ManualEditTarget): string {
+  const explicit = firstReadableText(
+    target.attributes['data-od-label'],
+    target.attributes['aria-label'],
+    target.attributes.title,
+  );
+  if (explicit) return explicit;
+
+  if (target.kind === 'text' || target.kind === 'link' || target.kind === 'token') {
+    const textName = readableContentName(target.text || target.fields.text || target.label);
+    if (textName) return textName;
+  }
+  if (target.kind === 'image') {
+    const imageName = readableContentName(target.fields.alt || target.label);
+    if (imageName) return imageName;
+  }
+
+  const identifierName = readableIdentifierName(
+    target.attributes.id ||
+    target.attributes['data-od-id'] ||
+    target.id,
+  );
+  if (identifierName) return identifierName;
+
+  const className = readableClassName(target.className);
+  if (className) return className;
+
+  const labelName = readableContentName(target.label);
+  if (labelName && !looksCodeLikeLabel(labelName)) return labelName;
+
+  if (target.kind === 'container') return 'Container';
+  if (target.kind === 'image') return 'Image';
+  if (target.kind === 'link') return 'Link';
+  return 'Text';
+}
+
+function firstReadableText(...values: Array<string | undefined>): string {
+  for (const value of values) {
+    const readable = readableContentName(value);
+    if (readable) return readable;
+  }
+  return '';
+}
+
+function readableContentName(value: string | undefined): string {
+  const clean = (value ?? '').replace(/\s+/g, ' ').trim();
+  if (!clean) return '';
+  if (looksGeneratedIdentifier(clean)) return '';
+  return clean.length > 42 ? `${clean.slice(0, 39).trim()}...` : clean;
+}
+
+function readableIdentifierName(value: string | undefined): string {
+  const raw = (value ?? '').trim();
+  if (!raw || looksGeneratedIdentifier(raw)) return '';
+  const lastSelectorPart = (raw.includes('.') ? raw.split('.').filter(Boolean).at(-1) : raw) ?? '';
+  const lastIdPart = (lastSelectorPart.includes('#') ? lastSelectorPart.split('#').filter(Boolean).at(-1) : lastSelectorPart) ?? '';
+  return humanizeIdentifier(lastIdPart);
+}
+
+function readableClassName(value: string | undefined): string {
+  const classes = (value ?? '').split(/\s+/).map((item) => item.trim()).filter(Boolean);
+  const candidate = classes.find((item) => {
+    const lower = item.toLowerCase();
+    return !looksGeneratedIdentifier(item) && !['container', 'wrapper', 'group', 'section', 'row', 'col'].includes(lower);
+  }) ?? classes.find((item) => !looksGeneratedIdentifier(item));
+  return humanizeIdentifier(candidate);
+}
+
+function humanizeIdentifier(value: string | undefined): string {
+  const clean = (value ?? '')
+    .replace(/^[_#.\s-]+|[_#.\s-]+$/g, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!clean || looksGeneratedIdentifier(clean)) return '';
+  return clean.charAt(0).toUpperCase() + clean.slice(1);
+}
+
+function looksCodeLikeLabel(value: string): boolean {
+  return /^[a-z][a-z0-9-]*(?:[#.][\w-]+)+$/i.test(value) || /^[a-z][a-z0-9-]*\s+#/.test(value);
+}
+
+function looksGeneratedIdentifier(value: string): boolean {
+  return /^path(?:-\d+)+$/i.test(value) || /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/i.test(value);
 }
 
 function PageInspector({

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -27,11 +27,14 @@ export function ManualEditPanel({
   draft,
   error,
   canUndo,
+  busy,
   onDraftChange,
   onStyleChange,
   onInvalidStyle,
   onError,
   onClearSelection,
+  onCancelDraft,
+  onSaveDraft,
   onExit,
   onApplyPatch,
   onPickImage,
@@ -60,6 +63,7 @@ export function ManualEditPanel({
   onClearSelection: () => void;
   onExit?: () => void;
   onCancelDraft: () => void;
+  onSaveDraft: () => void;
   onUndo: () => void;
   onRedo: () => void;
 }) {
@@ -223,15 +227,16 @@ export function ManualEditPanel({
         </div>
 
         <div className="manual-edit-footer">
-          {targetForInspector ? (
-            <div className="cc-section">
-              <div className="cc-section-body">
-                {confirmDelete ? (
-                  <>
-                    <p className="cc-delete-confirm">{canUndo ? t('manualEdit.deleteElementConfirm') : t('manualEdit.deleteElement')}</p>
+          <div className="manual-edit-footer-actions">
+            <div className="manual-edit-footer-left">
+              {targetForInspector ? (
+                confirmDelete ? (
+                  <div className="manual-edit-delete-confirm">
+                    <span>{canUndo ? t('manualEdit.deleteElementConfirm') : t('manualEdit.deleteElement')}</span>
                     <button
                       type="button"
-                      className="cc-action-btn cc-action-danger"
+                      className="manual-edit-footer-btn danger"
+                      disabled={busy}
                       onClick={() => {
                         setConfirmDelete(false);
                         onApplyPatch(
@@ -244,24 +249,46 @@ export function ManualEditPanel({
                     </button>
                     <button
                       type="button"
-                      className="cc-action-btn"
+                      className="manual-edit-footer-btn subtle"
+                      disabled={busy}
                       onClick={() => setConfirmDelete(false)}
                     >
                       {t('common.cancel')}
                     </button>
-                  </>
+                  </div>
                 ) : (
                   <button
                     type="button"
-                    className="cc-action-btn cc-action-danger"
+                    className="manual-edit-delete-btn"
+                    aria-label={t('manualEdit.deleteElement')}
+                    title={t('manualEdit.deleteElement')}
+                    disabled={busy}
                     onClick={() => setConfirmDelete(true)}
                   >
-                    {t('manualEdit.deleteElement')}
+                    <Icon name="trash" size={15} />
                   </button>
-                )}
-              </div>
+                )
+              ) : null}
             </div>
-          ) : null}
+            <div className="manual-edit-footer-right">
+              <button
+                type="button"
+                className="manual-edit-footer-btn subtle"
+                disabled={busy}
+                onClick={onCancelDraft}
+              >
+                {t('common.cancel')}
+              </button>
+              <button
+                type="button"
+                className="manual-edit-footer-btn primary"
+                disabled={busy}
+                onClick={onSaveDraft}
+              >
+                {t('common.save')}
+              </button>
+            </div>
+          </div>
 
           {error ? <div className="manual-edit-error">{error}</div> : null}
         </div>

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from 'react';
 import { useT } from '../i18n';
 import { emptyManualEditStyles, type ManualEditHistoryEntry, type ManualEditPatch, type ManualEditStyles, type ManualEditTarget } from '../edit-mode/types';
 import { Icon } from './Icon';
@@ -37,6 +37,7 @@ export function ManualEditPanel({
   onPickImage,
   pageStylesEnabled = true,
   floatingStyle,
+  onFloatingPositionChange,
 }: {
   targets: ManualEditTarget[];
   selectedTarget: ManualEditTarget | null;
@@ -54,6 +55,7 @@ export function ManualEditPanel({
   onApplyPatch: (patch: ManualEditPatch, label: string) => void;
   onPickImage?: (file: File) => Promise<string | null>;
   floatingStyle?: CSSProperties;
+  onFloatingPositionChange?: (position: { left: number; top: number }) => void;
   onError: (message: string) => void;
   onClearSelection: () => void;
   onExit?: () => void;
@@ -88,6 +90,39 @@ export function ManualEditPanel({
     onStyleChange?.(targetForInspector.id, normalized.styles, `Style: ${targetForInspector.label}`);
   };
 
+  const startPanelDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (!onFloatingPositionChange) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const panel = event.currentTarget.closest('.manual-edit-right') as HTMLElement | null;
+    const parent = panel?.parentElement;
+    if (!panel || !parent) return;
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startLeft = panel.offsetLeft;
+    const startTop = panel.offsetTop;
+    const parentRect = parent.getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+    const pad = 8;
+    const maxLeft = Math.max(pad, parentRect.width - panelRect.width - pad);
+    const maxTop = Math.max(pad, parentRect.height - panelRect.height - pad);
+    const ownerDocument = panel.ownerDocument;
+    const move = (moveEvent: PointerEvent) => {
+      onFloatingPositionChange({
+        left: clamp(startLeft + moveEvent.clientX - startX, pad, maxLeft),
+        top: clamp(startTop + moveEvent.clientY - startY, pad, maxTop),
+      });
+    };
+    const up = () => {
+      ownerDocument.removeEventListener('pointermove', move);
+      ownerDocument.removeEventListener('pointerup', up);
+      ownerDocument.removeEventListener('pointercancel', up);
+    };
+    ownerDocument.addEventListener('pointermove', move);
+    ownerDocument.addEventListener('pointerup', up);
+    ownerDocument.addEventListener('pointercancel', up);
+  };
+
   return (
     <aside
       className={`manual-edit-right${floatingStyle ? ' manual-edit-floating' : ''}`}
@@ -95,6 +130,17 @@ export function ManualEditPanel({
     >
       <section className="manual-edit-modal cc-panel">
         <div className="manual-edit-titlebar">
+          {floatingStyle ? (
+            <button
+              type="button"
+              className="manual-edit-drag-handle"
+              aria-label="Move edit panel"
+              title="Move edit panel"
+              onPointerDown={startPanelDrag}
+            >
+              <span aria-hidden />
+            </button>
+          ) : null}
           <span title={panelTitle}>{panelTitle}</span>
           {onExit ? (
             <button
@@ -258,6 +304,10 @@ function readableManualEditTargetName(target: ManualEditTarget): string {
   if (target.kind === 'image') return 'Image';
   if (target.kind === 'link') return 'Link';
   return 'Text';
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
 function firstReadableText(...values: Array<string | undefined>): string {

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -107,113 +107,117 @@ export function ManualEditPanel({
             </button>
           ) : null}
         </div>
-        {targetForInspector ? (
-          <StyleInspector
-            targetKind={targetForInspector.kind}
-            styles={draft.styles}
-            layoutEnabled={targetForInspector.isLayoutContainer}
-            onClearSelection={onClearSelection}
-            onChange={changeTargetStyle}
-          />
-        ) : !targetForInspector ? (
-          <PageInspector
-            enabled={pageStylesEnabled}
-            onStyleChange={(styles) => {
-              const normalized = normalizeManualEditStyles(styles, { layoutEnabled: true });
-              if (!normalized.ok) {
-                onError(normalized.error);
-                onInvalidStyle?.('__body__', Object.keys(styles) as Array<keyof ManualEditStyles>);
-                return;
-              }
-              onError('');
-              onStyleChange?.('__body__', normalized.styles, 'Page styles');
-            }}
-          />
-        ) : null}
+        <div className="manual-edit-scroll">
+          {targetForInspector ? (
+            <StyleInspector
+              targetKind={targetForInspector.kind}
+              styles={draft.styles}
+              layoutEnabled={targetForInspector.isLayoutContainer}
+              onClearSelection={onClearSelection}
+              onChange={changeTargetStyle}
+            />
+          ) : !targetForInspector ? (
+            <PageInspector
+              enabled={pageStylesEnabled}
+              onStyleChange={(styles) => {
+                const normalized = normalizeManualEditStyles(styles, { layoutEnabled: true });
+                if (!normalized.ok) {
+                  onError(normalized.error);
+                  onInvalidStyle?.('__body__', Object.keys(styles) as Array<keyof ManualEditStyles>);
+                  return;
+                }
+                onError('');
+                onStyleChange?.('__body__', normalized.styles, 'Page styles');
+              }}
+            />
+          ) : null}
 
           {targetForInspector?.kind === 'image' && onPickImage ? (
-          <div className="cc-section">
-            <header className="cc-section-head">IMAGE</header>
-            <div className="cc-section-body">
-              <button
-                type="button"
-                className="cc-action-btn"
-                disabled={uploadingImage}
-                onClick={() => fileInputRef.current?.click()}
-              >
-                {uploadingImage ? t('manualEdit.uploadingImage') : t('manualEdit.uploadImage')}
-              </button>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                style={{ display: 'none' }}
-                onChange={async (e) => {
-                  const file = e.currentTarget.files?.[0];
-                  if (!file) return;
-                  e.currentTarget.value = '';
-                  setUploadingImage(true);
-                  try {
-                    const src = await onPickImage(file);
-                    if (src) {
-                      const activeTargetId = selectedTargetRef.current?.id ?? targetForInspector.id;
-                      onApplyPatch(
-                        { id: activeTargetId, kind: 'set-image', src, alt: draft.alt },
-                        t('manualEdit.uploadImage'),
-                      );
-                    } else {
-                      onError(t('manualEdit.uploadImageFailed'));
+            <div className="cc-section">
+              <header className="cc-section-head">IMAGE</header>
+              <div className="cc-section-body">
+                <button
+                  type="button"
+                  className="cc-action-btn"
+                  disabled={uploadingImage}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  {uploadingImage ? t('manualEdit.uploadingImage') : t('manualEdit.uploadImage')}
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  style={{ display: 'none' }}
+                  onChange={async (e) => {
+                    const file = e.currentTarget.files?.[0];
+                    if (!file) return;
+                    e.currentTarget.value = '';
+                    setUploadingImage(true);
+                    try {
+                      const src = await onPickImage(file);
+                      if (src) {
+                        const activeTargetId = selectedTargetRef.current?.id ?? targetForInspector.id;
+                        onApplyPatch(
+                          { id: activeTargetId, kind: 'set-image', src, alt: draft.alt },
+                          t('manualEdit.uploadImage'),
+                        );
+                      } else {
+                        onError(t('manualEdit.uploadImageFailed'));
+                      }
+                    } finally {
+                      setUploadingImage(false);
                     }
-                  } finally {
-                    setUploadingImage(false);
-                  }
-                }}
-              />
+                  }}
+                />
+              </div>
             </div>
-          </div>
-        ) : null}
+          ) : null}
+        </div>
 
-        {targetForInspector ? (
-          <div className="cc-section">
-            <div className="cc-section-body">
-              {confirmDelete ? (
-                <>
-                  <p className="cc-delete-confirm">{canUndo ? t('manualEdit.deleteElementConfirm') : t('manualEdit.deleteElement')}</p>
+        <div className="manual-edit-footer">
+          {targetForInspector ? (
+            <div className="cc-section">
+              <div className="cc-section-body">
+                {confirmDelete ? (
+                  <>
+                    <p className="cc-delete-confirm">{canUndo ? t('manualEdit.deleteElementConfirm') : t('manualEdit.deleteElement')}</p>
+                    <button
+                      type="button"
+                      className="cc-action-btn cc-action-danger"
+                      onClick={() => {
+                        setConfirmDelete(false);
+                        onApplyPatch(
+                          { id: targetForInspector.id, kind: 'remove-element' },
+                          t('manualEdit.deleteElement'),
+                        );
+                      }}
+                    >
+                      {t('manualEdit.deleteElement')}
+                    </button>
+                    <button
+                      type="button"
+                      className="cc-action-btn"
+                      onClick={() => setConfirmDelete(false)}
+                    >
+                      {t('common.cancel')}
+                    </button>
+                  </>
+                ) : (
                   <button
                     type="button"
                     className="cc-action-btn cc-action-danger"
-                    onClick={() => {
-                      setConfirmDelete(false);
-                      onApplyPatch(
-                        { id: targetForInspector.id, kind: 'remove-element' },
-                        t('manualEdit.deleteElement'),
-                      );
-                    }}
+                    onClick={() => setConfirmDelete(true)}
                   >
                     {t('manualEdit.deleteElement')}
                   </button>
-                  <button
-                    type="button"
-                    className="cc-action-btn"
-                    onClick={() => setConfirmDelete(false)}
-                  >
-                    {t('common.cancel')}
-                  </button>
-                </>
-              ) : (
-                <button
-                  type="button"
-                  className="cc-action-btn cc-action-danger"
-                  onClick={() => setConfirmDelete(true)}
-                >
-                  {t('manualEdit.deleteElement')}
-                </button>
-              )}
+                )}
+              </div>
             </div>
-          </div>
-        ) : null}
+          ) : null}
 
-        {error ? <div className="manual-edit-error">{error}</div> : null}
+          {error ? <div className="manual-edit-error">{error}</div> : null}
+        </div>
       </section>
     </aside>
   );

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -78,12 +78,6 @@ export function buildManualEditBridge(enabled: boolean): string {
   function isDiscoveryTarget(el){
     return !!(el && el.matches && el.matches(discoverySelector));
   }
-  function isPrimaryTarget(el){
-    if (!el || !el.hasAttribute) return false;
-    if (el.hasAttribute('data-od-id') || el.hasAttribute('data-od-edit')) return true;
-    var tag = el.tagName ? el.tagName.toLowerCase() : '';
-    return tag === 'a' || tag === 'button';
-  }
   function inferKind(el){
     var explicit = el.getAttribute('data-od-edit');
     if (explicit) return explicit;
@@ -205,15 +199,13 @@ export function buildManualEditBridge(enabled: boolean): string {
   }
   function closestTarget(event){
     var el = event.target;
-    var fallback = null;
     while (el && el !== document.documentElement) {
       if (el !== document.body && el !== document.documentElement && isSourceMappable(el) && isDiscoveryTarget(el)) {
-        if (isPrimaryTarget(el)) return el;
-        if (!fallback) fallback = el;
+        return el;
       }
       el = el.parentElement;
     }
-    return fallback;
+    return null;
   }
   function caretRangeFromClick(clickEvent){
     try {
@@ -378,9 +370,11 @@ export function buildManualEditBridgeStyle(): string {
   return `<style data-od-edit-bridge-style>
 html[data-od-edit-mode] body * { cursor: pointer !important; }
 html[data-od-edit-mode] [data-od-id],
-html[data-od-edit-mode] [data-od-runtime-id] { outline: 1px dashed rgba(37, 99, 235, 0.35); outline-offset: 3px; }
+html[data-od-edit-mode] [data-od-runtime-id],
+html[data-od-edit-mode] [data-od-source-path] { outline: 1px dashed rgba(37, 99, 235, 0.35); outline-offset: 3px; }
 html[data-od-edit-mode] [data-od-id]:hover,
-html[data-od-edit-mode] [data-od-runtime-id]:hover { outline: 2px solid #2563eb; }
+html[data-od-edit-mode] [data-od-runtime-id]:hover,
+html[data-od-edit-mode] [data-od-source-path]:hover { outline: 2px solid #2563eb; }
 html[data-od-edit-mode] [data-od-edit-selected] {
   outline: 2px solid #2563eb !important;
   outline-offset: 4px;

--- a/apps/web/src/styles/viewer/core.css
+++ b/apps/web/src/styles/viewer/core.css
@@ -20,6 +20,12 @@
 }
 .viewer-toolbar-left { display: inline-flex; align-items: center; gap: 8px; }
 .viewer-toolbar-actions { display: inline-flex; gap: 2px; align-items: center; }
+.viewer-toolbar-tool-divider {
+  width: 1px;
+  height: 18px;
+  margin: 0 5px;
+  background: var(--border);
+}
 .viewer-toolbar .icon-only,
 .viewer-toolbar-actions .icon-only {
   width: 28px;

--- a/apps/web/src/styles/viewer/core.css
+++ b/apps/web/src/styles/viewer/core.css
@@ -147,6 +147,23 @@
   height: 30px;
   padding: 0;
 }
+.viewer-comment-count-trigger {
+  position: relative;
+  justify-content: center;
+  min-width: 42px;
+  height: 30px;
+  padding: 0 8px;
+  gap: 5px;
+}
+.viewer-comment-count {
+  min-width: 12px;
+  color: currentColor;
+  font-size: 11px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  text-align: left;
+}
 .viewer-action-icon[data-tooltip]::after {
   content: attr(data-tooltip);
   position: absolute;

--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -947,6 +947,7 @@
 .manual-edit-footer {
   flex: 0 0 auto;
   padding: 8px 12px 0;
+  border-top: 1px solid var(--border);
   background: var(--bg-panel);
 }
 .manual-edit-footer .cc-section {
@@ -954,6 +955,89 @@
 }
 .manual-edit-footer .manual-edit-error {
   margin: 8px 0 0;
+}
+.manual-edit-footer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 34px;
+}
+.manual-edit-footer-left,
+.manual-edit-footer-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.manual-edit-footer-left {
+  flex: 1 1 auto;
+}
+.manual-edit-footer-right {
+  flex: 0 0 auto;
+}
+.manual-edit-delete-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 0;
+  border-radius: 8px;
+  padding: 0;
+  background: transparent;
+  color: var(--text);
+}
+.manual-edit-delete-btn:hover:not(:disabled) {
+  background: var(--bg-subtle);
+}
+.manual-edit-delete-btn:disabled,
+.manual-edit-footer-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.manual-edit-footer-btn {
+  min-width: 62px;
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0 14px;
+  color: var(--text);
+  background: var(--bg-panel);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+}
+.manual-edit-footer-btn:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--bg-subtle);
+}
+.manual-edit-footer-btn.primary {
+  border-color: transparent;
+  background: var(--text);
+  color: var(--bg-panel);
+}
+.manual-edit-footer-btn.primary:hover:not(:disabled) {
+  background: var(--text-muted);
+}
+.manual-edit-footer-btn.danger {
+  border-color: var(--red-border);
+  color: var(--red);
+  background: var(--red-bg);
+}
+.manual-edit-delete-confirm {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.manual-edit-delete-confirm span {
+  max-width: 170px;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .manual-edit-floating .manual-edit-titlebar {
   min-height: 42px;

--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -969,13 +969,13 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
   min-height: 52px;
   padding: 14px 18px 10px;
 }
 
 .manual-edit-titlebar > span {
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   color: var(--text);
@@ -984,6 +984,39 @@
   line-height: 1.2;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.manual-edit-drag-handle {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 28px;
+  border: 0;
+  border-radius: 6px;
+  padding: 0;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: grab;
+  touch-action: none;
+}
+
+.manual-edit-drag-handle:active {
+  cursor: grabbing;
+}
+
+.manual-edit-drag-handle:hover {
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+
+.manual-edit-drag-handle span {
+  width: 14px;
+  height: 18px;
+  background-image: radial-gradient(currentColor 1.5px, transparent 1.6px);
+  background-position: 0 0;
+  background-size: 7px 6px;
 }
 
 .manual-edit-titlebar-close {

--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -664,7 +664,7 @@
 }
 
 /* Claude Code-style edit inspector panel. */
-.cc-panel { display: flex; flex-direction: column; gap: 8px; padding: 8px 0; overflow: auto; background: var(--bg-panel); }
+.cc-panel { display: flex; flex-direction: column; gap: 0; padding: 8px 0; overflow: hidden; background: var(--bg-panel); }
 .cc-inspector { display: flex; flex-direction: column; gap: 12px; padding: 6px 12px; }
 .cc-inspector-nav {
   display: flex;
@@ -926,16 +926,34 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: hidden;
   overscroll-behavior: contain;
-  padding-bottom: 72px;
   scrollbar-gutter: stable;
 }
 .manual-edit-floating .manual-edit-modal.cc-panel {
-  max-height: inherit;
+  height: 100%;
   padding-bottom: 10px;
   border-radius: 12px;
   box-shadow: 0 18px 48px rgba(15, 23, 42, 0.18);
+}
+.manual-edit-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+.manual-edit-footer {
+  flex: 0 0 auto;
+  padding: 8px 12px 0;
+  background: var(--bg-panel);
+}
+.manual-edit-footer .cc-section {
+  margin: 0;
+}
+.manual-edit-footer .manual-edit-error {
+  margin: 8px 0 0;
 }
 .manual-edit-floating .manual-edit-titlebar {
   min-height: 42px;
@@ -948,6 +966,7 @@
 }
 
 .manual-edit-titlebar {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
@@ -36,6 +36,21 @@ function clickAgentTool(testId: string) {
   fireEvent.click(screen.getByTestId(testId));
 }
 
+async function hoverManualEditTarget(target = heroTarget()) {
+  const frame = await waitFor(() => {
+    const node = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    if (!node.contentWindow) throw new Error('Preview frame not ready');
+    return node;
+  });
+  act(() => {
+    window.dispatchEvent(new MessageEvent('message', {
+      data: { type: 'od-edit-hover', target },
+      source: frame.contentWindow,
+    }));
+  });
+  await waitFor(() => expect(panelState.props).not.toBeNull());
+}
+
 afterEach(() => {
   cleanup();
   panelState.props = null;
@@ -78,7 +93,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await waitFor(() => expect(panelState.props).not.toBeNull());
+    await hoverManualEditTarget();
 
     act(() => {
       panelState.props?.onStyleChange?.('hero', { color: '#ef4444' }, 'Style: Hero');
@@ -141,7 +156,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await waitFor(() => expect(panelState.props).not.toBeNull());
+    await hoverManualEditTarget();
 
     act(() => {
       panelState.props?.onApplyPatch(
@@ -203,7 +218,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-    await waitFor(() => expect(panelState.props).not.toBeNull());
+    await hoverManualEditTarget();
     const getActivePreviewFrame = () => screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
 
     await waitFor(() => {
@@ -261,13 +276,10 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-    await waitFor(() => expect(panelState.props).not.toBeNull());
+    await hoverManualEditTarget();
     const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     const postMessageSpy = vi.spyOn(frame.contentWindow!, 'postMessage');
 
-    await act(async () => {
-      await panelState.props?.onSelectTarget(heroTarget());
-    });
     await waitFor(() => expect(panelState.props?.selectedTarget?.id).toBe('hero'));
     expect(panelState.props?.draft.text).toBe('Hero');
 
@@ -281,9 +293,7 @@ describe('FileViewer manual edit history regressions', () => {
     await waitFor(() => expect(savedSources).toHaveLength(1));
     expect(savedSources[0]).not.toContain('data-od-id="hero"');
     expect(savedSources[0]).toContain('data-od-id="body"');
-    await waitFor(() => expect(panelState.props?.selectedTarget).toBeNull());
-    expect(panelState.props?.draft.text).toBe('');
-    expect(panelState.props?.draft.fullSource).not.toContain('data-od-id="hero"');
+    await waitFor(() => expect(screen.queryByTestId('mock-manual-edit-panel')).toBeNull());
     expect(postMessageSpy).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'od-edit-selected-target', id: null }),
       '*',

--- a/apps/web/tests/components/FileViewer.manual-edit.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit.test.tsx
@@ -190,11 +190,13 @@ describe('FileViewer manual edit regressions', () => {
     });
 
     fireEvent.change(baseSizeInput, { target: { value: '18' } });
+    fireEvent.click(screen.getByText('Save'));
     await waitFor(() => {
       expect(screen.getByText(/Could not save the edited file/)).toBeTruthy();
     });
 
     fireEvent.change(baseSizeInput, { target: { value: '19' } });
+    fireEvent.click(screen.getByText('Save'));
     await waitFor(() => {
       expect(screen.queryByText(/Could not save the edited file/)).toBeNull();
     });

--- a/apps/web/tests/components/FileViewer.manual-edit.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit.test.tsx
@@ -201,6 +201,81 @@ describe('FileViewer manual edit regressions', () => {
       expect(screen.queryByText(/Could not save the edited file/)).toBeNull();
     });
   });
+
+  it('closes manual edit without saving when footer cancel is clicked', async () => {
+    const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>';
+    const fetchMock = vi.fn(async () =>
+      new Response(source, { status: 200, headers: { 'Content-Type': 'text/html' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={source}
+      />,
+    );
+
+    clickManualTool('manual-edit-mode-toggle');
+    const baseSizeInput = await waitFor(() => {
+      const input = Array.from(document.querySelectorAll('.cc-row'))
+        .find((row) => row.textContent?.includes('Base size'))
+        ?.querySelector('input') as HTMLInputElement | null;
+      if (!input) throw new Error('Base size input not found');
+      return input;
+    });
+
+    fireEvent.change(baseSizeInput, { target: { value: '18' } });
+    fireEvent.click(screen.getByText('Cancel'));
+
+    await waitFor(() => {
+      expect(document.querySelector('.manual-edit-right')).toBeNull();
+    });
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/projects/project-1/files',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('closes manual edit after footer save succeeds', async () => {
+    const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>';
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.includes('/api/projects/project-1/files') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ file: htmlPreviewFile() }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(source, { status: 200, headers: { 'Content-Type': 'text/html' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={source}
+      />,
+    );
+
+    clickManualTool('manual-edit-mode-toggle');
+    const baseSizeInput = await waitFor(() => {
+      const input = Array.from(document.querySelectorAll('.cc-row'))
+        .find((row) => row.textContent?.includes('Base size'))
+        ?.querySelector('input') as HTMLInputElement | null;
+      if (!input) throw new Error('Base size input not found');
+      return input;
+    });
+
+    fireEvent.change(baseSizeInput, { target: { value: '18' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/projects/project-1/files',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      expect(document.querySelector('.manual-edit-right')).toBeNull();
+    });
+  });
 });
 
 function htmlPreviewFile(): ProjectFile {

--- a/apps/web/tests/components/FileViewer.manual-edit.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit.test.tsx
@@ -6,6 +6,7 @@ import {
   FileViewer,
   cancelManualEditPendingStyleSnapshot,
 } from '../../src/components/FileViewer';
+import { emptyManualEditStyles, type ManualEditTarget } from '../../src/edit-mode/types';
 import type { ProjectFile } from '../../src/types';
 
 afterEach(() => {
@@ -17,6 +18,33 @@ afterEach(() => {
 describe('FileViewer manual edit regressions', () => {
   function clickManualTool(testId: string) {
     fireEvent.click(screen.getByTestId(testId));
+  }
+
+  async function hoverManualEditTarget(target = heroTarget()) {
+    const frame = await waitFor(() => {
+      const node = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      if (!node.contentWindow) throw new Error('Preview frame not ready');
+      return node;
+    });
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'od-edit-hover', target },
+        source: frame.contentWindow,
+      }));
+    });
+    await waitFor(() => {
+      expect(document.querySelector('.manual-edit-right')).not.toBeNull();
+    });
+  }
+
+  async function findStyleInput(label: string) {
+    return waitFor(() => {
+      const input = Array.from(document.querySelectorAll('.cc-row'))
+        .find((row) => row.textContent?.includes(label))
+        ?.querySelector('input') as HTMLInputElement | null;
+      if (!input) throw new Error(`${label} input not found`);
+      return input;
+    });
   }
 
   it('removes invalid fields from pending manual edit style saves without dropping unrelated fields', () => {
@@ -48,8 +76,26 @@ describe('FileViewer manual edit regressions', () => {
     expect(cancelManualEditPendingStyleSnapshot(otherTargetPending, 'cta', ['fontSize'])).toBe(otherTargetPending);
   });
 
-  it('does not let a pending manual edit style save survive a file switch', () => {
-    vi.useFakeTimers();
+  it('does not open the edit panel until a target is hovered or selected', async () => {
+    const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>';
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(source, { status: 200, headers: { 'Content-Type': 'text/html' } }),
+    ));
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={source}
+      />,
+    );
+
+    clickManualTool('manual-edit-mode-toggle');
+    expect(document.querySelector('.manual-edit-right')).toBeNull();
+
+    await hoverManualEditTarget();
+    expect(document.querySelector('.manual-edit-right')).not.toBeNull();
+  });
+
+  it('does not let a pending manual edit style save survive a file switch', async () => {
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
       if (url.includes('/api/projects/project-1/files') && init?.method === 'POST') {
@@ -61,39 +107,29 @@ describe('FileViewer manual edit regressions', () => {
       return new Response('<!doctype html><html><body></body></html>', { status: 200 });
     });
     vi.stubGlobal('fetch', fetchMock);
-    try {
-      const first = htmlPreviewFile();
-      const second = { ...htmlPreviewFile(), name: 'second.html', path: 'second.html' };
-      const { rerender } = render(
-        <FileViewer projectId="project-1" projectKind="prototype" file={first}
-          liveHtml='<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>'
-        />,
-      );
+    const first = htmlPreviewFile();
+    const second = { ...htmlPreviewFile(), name: 'second.html', path: 'second.html' };
+    const { rerender } = render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={first}
+        liveHtml='<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
 
-      fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-      const baseSizeInput = Array.from(document.querySelectorAll('.cc-row'))
-        .find((row) => row.textContent?.includes('Base size'))
-        ?.querySelector('input') as HTMLInputElement | null;
-      if (!baseSizeInput) throw new Error('Base size input not found');
-      fireEvent.change(baseSizeInput, { target: { value: '18' } });
+    fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+    await hoverManualEditTarget();
+    const baseSizeInput = await findStyleInput('Size');
+    fireEvent.change(baseSizeInput, { target: { value: '18' } });
 
-      rerender(
-        <FileViewer projectId="project-1" projectKind="prototype" file={second}
-          liveHtml='<!doctype html><html><body><main data-od-id="second">Second</main></body></html>'
-        />,
-      );
+    rerender(
+      <FileViewer projectId="project-1" projectKind="prototype" file={second}
+        liveHtml='<!doctype html><html><body><main data-od-id="second">Second</main></body></html>'
+      />,
+    );
 
-      act(() => {
-        vi.advanceTimersByTime(1100);
-      });
-
-      expect(fetchMock).not.toHaveBeenCalledWith(
-        '/api/projects/project-1/files',
-        expect.objectContaining({ method: 'POST' }),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/projects/project-1/files',
+      expect.objectContaining({ method: 'POST' }),
+    );
   });
 
   it('clears loaded source immediately on file switch without liveHtml before manual edit can save', async () => {
@@ -125,13 +161,8 @@ describe('FileViewer manual edit regressions', () => {
         {},
       ));
       fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-      const baseSizeInput = await waitFor(() => {
-        const input = Array.from(document.querySelectorAll('.cc-row'))
-          .find((row) => row.textContent?.includes('Base size'))
-          ?.querySelector('input') as HTMLInputElement | null;
-        if (!input) throw new Error('Base size input not found');
-        return input;
-      });
+      await hoverManualEditTarget();
+      const baseSizeInput = await findStyleInput('Size');
       fireEvent.change(baseSizeInput, { target: { value: '18' } });
 
       rerender(<FileViewer projectId="project-1" projectKind="prototype" file={second} />);
@@ -181,13 +212,8 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    const baseSizeInput = await waitFor(() => {
-      const input = Array.from(document.querySelectorAll('.cc-row'))
-        .find((row) => row.textContent?.includes('Base size'))
-        ?.querySelector('input') as HTMLInputElement | null;
-      if (!input) throw new Error('Base size input not found');
-      return input;
-    });
+    await hoverManualEditTarget();
+    const baseSizeInput = await findStyleInput('Size');
 
     fireEvent.change(baseSizeInput, { target: { value: '18' } });
     fireEvent.click(screen.getByText('Save'));
@@ -216,13 +242,8 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    const baseSizeInput = await waitFor(() => {
-      const input = Array.from(document.querySelectorAll('.cc-row'))
-        .find((row) => row.textContent?.includes('Base size'))
-        ?.querySelector('input') as HTMLInputElement | null;
-      if (!input) throw new Error('Base size input not found');
-      return input;
-    });
+    await hoverManualEditTarget();
+    const baseSizeInput = await findStyleInput('Size');
 
     fireEvent.change(baseSizeInput, { target: { value: '18' } });
     fireEvent.click(screen.getByText('Cancel'));
@@ -257,13 +278,8 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    const baseSizeInput = await waitFor(() => {
-      const input = Array.from(document.querySelectorAll('.cc-row'))
-        .find((row) => row.textContent?.includes('Base size'))
-        ?.querySelector('input') as HTMLInputElement | null;
-      if (!input) throw new Error('Base size input not found');
-      return input;
-    });
+    await hoverManualEditTarget();
+    const baseSizeInput = await findStyleInput('Size');
 
     fireEvent.change(baseSizeInput, { target: { value: '18' } });
     fireEvent.click(screen.getByText('Save'));
@@ -277,6 +293,23 @@ describe('FileViewer manual edit regressions', () => {
     });
   });
 });
+
+function heroTarget(): ManualEditTarget {
+  return {
+    id: 'hero',
+    kind: 'text',
+    label: 'Hero',
+    tagName: 'main',
+    className: '',
+    text: 'Hero',
+    rect: { x: 24, y: 24, width: 160, height: 48 },
+    fields: { text: 'Hero' },
+    attributes: { 'data-od-id': 'hero' },
+    styles: emptyManualEditStyles(),
+    isLayoutContainer: false,
+    outerHtml: '<main data-od-id="hero">Hero</main>',
+  };
+}
 
 function htmlPreviewFile(): ProjectFile {
   return {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1574,6 +1574,49 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.queryByText('Already sent to Claude')).toBeNull();
   });
 
+  it('shows the open comment count beside the comments icon', () => {
+    const openComment: PreviewComment = {
+      id: 'comment-open',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      filePath: 'preview.html',
+      elementId: 'pin-open',
+      selector: '[data-od-pin="pin-open"]',
+      label: 'pin-open',
+      text: '',
+      htmlHint: '',
+      position: { x: 24, y: 32, width: 18, height: 18 },
+      note: 'Open comment',
+      status: 'open',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    const otherFileComment: PreviewComment = {
+      ...openComment,
+      id: 'comment-other',
+      filePath: 'other.html',
+    };
+    const resolvedComment: PreviewComment = {
+      ...openComment,
+      id: 'comment-resolved',
+      status: 'applying',
+    };
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+        previewComments={[openComment, otherFileComment, resolvedComment]}
+      />,
+    );
+
+    const commentsButton = screen.getByTestId('comment-panel-toggle');
+    expect(commentsButton.textContent).toContain('1');
+    expect(commentsButton.getAttribute('aria-label')).toBe('Comments (1)');
+  });
+
   it('keeps comments and annotation picker mutually exclusive', () => {
     const { container } = render(
       <FileViewer

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1615,6 +1615,14 @@ describe('FileViewer tweaks toolbar', () => {
     const commentsButton = screen.getByTestId('comment-panel-toggle');
     expect(commentsButton.textContent).toContain('1');
     expect(commentsButton.getAttribute('aria-label')).toBe('Comments (1)');
+    expect(
+      screen.getByTestId('board-mode-toggle').compareDocumentPosition(screen.getByTestId('manual-edit-mode-toggle')) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen.getByTestId('screenshot-capture-toggle').compareDocumentPosition(commentsButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it('keeps comments and annotation picker mutually exclusive', () => {

--- a/apps/web/tests/components/ManualEditPanel.test.tsx
+++ b/apps/web/tests/components/ManualEditPanel.test.tsx
@@ -59,6 +59,23 @@ describe('ManualEditPanel', () => {
     expect(host.textContent).not.toContain('Advanced');
   });
 
+  it('shows a readable selected element name in the titlebar', () => {
+    renderPanel({
+      selectedTarget: {
+        ...target,
+        id: 'path-0-0',
+        kind: 'container',
+        label: 'div.container.hero-split',
+        className: 'container hero-split',
+        text: 'Turn a brand brief into an editorial collage system.',
+        attributes: { 'data-od-source-path': 'path-0-0' },
+      },
+    });
+
+    expect(host.querySelector('.manual-edit-titlebar')?.textContent).toContain('Hero split');
+    expect(host.querySelector('.manual-edit-titlebar')?.textContent).not.toContain('div.container');
+  });
+
   it('allows returning from an element inspector to the page inspector', () => {
     const onClearSelection = vi.fn();
     renderPanel({ onClearSelection });

--- a/apps/web/tests/components/ManualEditPanel.test.tsx
+++ b/apps/web/tests/components/ManualEditPanel.test.tsx
@@ -28,6 +28,8 @@ type OnInvalidStyle = (id: string, keys: Array<keyof ManualEditStyles>) => void;
 type OnApplyPatch = (patch: ManualEditPatch, label: string) => void;
 type OnError = (message: string) => void;
 type OnClearSelection = () => void;
+type OnSaveDraft = () => void;
+type OnCancelDraft = () => void;
 
 describe('ManualEditPanel', () => {
   let dom: JSDOM;
@@ -103,12 +105,32 @@ describe('ManualEditPanel', () => {
 
     const scrollRegion = host.querySelector('.manual-edit-scroll');
     const footer = host.querySelector('.manual-edit-footer');
-    const deleteButton = Array.from(host.querySelectorAll('button'))
-      .find((button) => button.textContent === 'Delete element');
+    const deleteButton = host.querySelector('button[aria-label="Delete element"]');
 
     expect(scrollRegion?.textContent).toContain('TYPOGRAPHY');
-    expect(scrollRegion?.contains(deleteButton ?? null)).toBe(false);
-    expect(footer?.contains(deleteButton ?? null)).toBe(true);
+    expect(scrollRegion?.contains(deleteButton)).toBe(false);
+    expect(footer?.contains(deleteButton)).toBe(true);
+    expect(footer?.textContent).toContain('Cancel');
+    expect(footer?.textContent).toContain('Save');
+  });
+
+  it('routes footer cancel and save actions', () => {
+    const onCancelDraft = vi.fn<OnCancelDraft>();
+    const onSaveDraft = vi.fn<OnSaveDraft>();
+    renderPanel({ onCancelDraft, onSaveDraft });
+
+    const footerButtons = Array.from(host.querySelectorAll('.manual-edit-footer button'));
+    const cancel = footerButtons.find((button) => button.textContent === 'Cancel') as HTMLButtonElement | undefined;
+    const save = footerButtons.find((button) => button.textContent === 'Save') as HTMLButtonElement | undefined;
+    if (!cancel || !save) throw new Error('Footer action buttons not found');
+
+    act(() => {
+      cancel.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      save.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onCancelDraft).toHaveBeenCalledTimes(1);
+    expect(onSaveDraft).toHaveBeenCalledTimes(1);
   });
 
   it('normalizes font stacks and writes a usable font-family value', () => {
@@ -476,6 +498,8 @@ describe('ManualEditPanel', () => {
     onStyleChange = vi.fn<OnStyleChange>(),
     onInvalidStyle = vi.fn<OnInvalidStyle>(),
     onClearSelection = vi.fn<OnClearSelection>(),
+    onCancelDraft = vi.fn<OnCancelDraft>(),
+    onSaveDraft = vi.fn<OnSaveDraft>(),
     attributesText = '{}',
     selectedTarget = target,
     styles = emptyManualEditStyles(),
@@ -489,6 +513,8 @@ describe('ManualEditPanel', () => {
     onStyleChange?: OnStyleChange;
     onInvalidStyle?: OnInvalidStyle;
     onClearSelection?: OnClearSelection;
+    onCancelDraft?: OnCancelDraft;
+    onSaveDraft?: OnSaveDraft;
     attributesText?: string;
     selectedTarget?: ManualEditTarget | null;
     styles?: ReturnType<typeof emptyManualEditStyles>;
@@ -521,7 +547,8 @@ describe('ManualEditPanel', () => {
           onApplyPatch={onApplyPatch}
           onError={onError}
           onClearSelection={onClearSelection}
-          onCancelDraft={vi.fn<() => void>()}
+          onCancelDraft={onCancelDraft}
+          onSaveDraft={onSaveDraft}
           onUndo={vi.fn<() => void>()}
           onRedo={vi.fn<() => void>()}
           floatingStyle={floatingStyle}

--- a/apps/web/tests/components/ManualEditPanel.test.tsx
+++ b/apps/web/tests/components/ManualEditPanel.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
+import type { CSSProperties } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { Simulate } from 'react-dom/test-utils';
 import { JSDOM } from 'jsdom';
@@ -74,6 +75,13 @@ describe('ManualEditPanel', () => {
 
     expect(host.querySelector('.manual-edit-titlebar')?.textContent).toContain('Hero split');
     expect(host.querySelector('.manual-edit-titlebar')?.textContent).not.toContain('div.container');
+  });
+
+  it('shows a drag handle for floating edit panels', () => {
+    renderPanel({ floatingStyle: { left: 20, top: 24, width: 320, height: 380 } });
+
+    expect(host.querySelector('.manual-edit-drag-handle')).not.toBeNull();
+    expect(host.querySelector('.manual-edit-drag-handle')?.getAttribute('aria-label')).toBe('Move edit panel');
   });
 
   it('allows returning from an element inspector to the page inspector', () => {
@@ -472,6 +480,8 @@ describe('ManualEditPanel', () => {
     selectedTarget = target,
     styles = emptyManualEditStyles(),
     pageStylesEnabled = true,
+    floatingStyle,
+    onFloatingPositionChange,
   }: {
     onDraftChange?: OnDraftChange;
     onApplyPatch?: OnApplyPatch;
@@ -483,6 +493,8 @@ describe('ManualEditPanel', () => {
     selectedTarget?: ManualEditTarget | null;
     styles?: ReturnType<typeof emptyManualEditStyles>;
     pageStylesEnabled?: boolean;
+    floatingStyle?: CSSProperties;
+    onFloatingPositionChange?: (position: { left: number; top: number }) => void;
   } = {}) {
     const draft = {
       ...emptyManualEditDraft('<html></html>'),
@@ -512,6 +524,8 @@ describe('ManualEditPanel', () => {
           onCancelDraft={vi.fn<() => void>()}
           onUndo={vi.fn<() => void>()}
           onRedo={vi.fn<() => void>()}
+          floatingStyle={floatingStyle}
+          onFloatingPositionChange={onFloatingPositionChange}
         />,
       );
     });

--- a/apps/web/tests/components/ManualEditPanel.test.tsx
+++ b/apps/web/tests/components/ManualEditPanel.test.tsx
@@ -73,6 +73,19 @@ describe('ManualEditPanel', () => {
     expect(onClearSelection).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps inspector controls scrollable separately from footer actions', () => {
+    renderPanel();
+
+    const scrollRegion = host.querySelector('.manual-edit-scroll');
+    const footer = host.querySelector('.manual-edit-footer');
+    const deleteButton = Array.from(host.querySelectorAll('button'))
+      .find((button) => button.textContent === 'Delete element');
+
+    expect(scrollRegion?.textContent).toContain('TYPOGRAPHY');
+    expect(scrollRegion?.contains(deleteButton ?? null)).toBe(false);
+    expect(footer?.contains(deleteButton ?? null)).toBe(true);
+  });
+
   it('normalizes font stacks and writes a usable font-family value', () => {
     const onDraftChange = vi.fn();
     const onStyleChange = vi.fn();

--- a/apps/web/tests/edit-mode/bridge.test.ts
+++ b/apps/web/tests/edit-mode/bridge.test.ts
@@ -259,7 +259,32 @@ describe('manual edit bridge target normalization', () => {
     expect(bridge).toContain('targets.push(targetFrom(nodes[i], false))');
     expect(bridge).toContain("target: targetFrom(el, true)");
     expect(bridge).toContain('if (!isSourceMappable(nodes[i])) continue;');
-    expect(bridge).toContain('if (isPrimaryTarget(el)) return el;');
+    expect(bridge).toContain('return el;');
+    expect(bridge).not.toContain('if (isPrimaryTarget(el)) return el;');
+  });
+
+  it('prefers the deepest source-mapped child over an annotated group on hover', async () => {
+    const posts: Array<{ type?: string; target?: { id: string; label?: string } }> = [];
+    const dom = new JSDOM(
+      `<main>
+        <section data-od-id="hero-group">
+          <span data-od-source-path="path-0-0-0">Small label</span>
+        </section>
+      </main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const span = dom.window.document.querySelector('span')!;
+    dom.window.parent.postMessage = ((message: unknown) => {
+      posts.push(message as { type?: string; target?: { id: string; label?: string } });
+    }) as typeof dom.window.parent.postMessage;
+
+    span.dispatchEvent(new dom.window.Event('pointerover', { bubbles: true }));
+
+    const hover = posts.find((message) => message.type === 'od-edit-hover');
+    expect(hover?.target?.id).toBe('path-0-0-0');
+    expect(hover?.target?.label).toBe('Small label');
+
+    dom.window.close();
   });
 
   it('acks live preview style patches by id and version', () => {


### PR DESCRIPTION
## Why

While testing Studio edit mode, grouped preview elements could swallow smaller source-mapped children. That made the edit panel describe the parent group instead of the individual label/button/span the user was actually pointing at, which becomes hard to scan when the group contains many small parts.

This PR is stacked on #3000 and keeps the scope focused on target selection plus the edit inspector layout needed for dense single-element controls.

## What users will see

In Edit mode, hovering or clicking a source-mapped child inside a grouped region now selects that child first. The floating edit panel can show parameters for the single small element instead of expanding into a large grouped-element panel. Source-path-backed nodes also receive the same edit outline treatment as existing edit targets.

The edit inspector now keeps a shorter fixed panel height: the titlebar stays pinned at the top, delete/error actions stay pinned at the bottom, and only the middle parameter controls scroll. The titlebar shows a readable selected-element name, using labels/ARIA/title or humanized id/class names instead of code-like selectors such as `div.container.hero-split`.

Floating edit panels now have a drag handle. By default the panel still appears near the hovered/selected element; once the user drags it, the panel stays pinned at that position while hover/selection updates only swap the inspected element content. Exiting Edit mode, switching files, or returning to Page clears the pinned position.

Edit style changes now preview immediately but persist only when users click Save. Cancel reverts the pending preview change back to the saved source state. The footer matches the Codex-style layout with delete on the left and Cancel / Save on the right.

The preview toolbar now separates annotation, edit tools, and collaboration comments: Annotation sits to the left of Edit, then Edit / Draw / Screenshot, then Comments immediately to the left of the zoom control. The Comments button shows the current file open-comment count to the right of its icon.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The grouped-element selection behavior is covered by a focused DOM bridge test. I also verified the mounted in-app browser edit panel structure: panel overflow is hidden, `manual-edit-scroll` is the only scroll region, and footer actions are outside that scroll region. The current in-app browser automation cannot click into this sandboxed preview iframe to select an inner preview element.

## Bug fix verification

- Test path that reproduces the grouped-target behavior: `apps/web/tests/edit-mode/bridge.test.ts`
- Layout, readable title, drag-handle, and footer action coverage: `apps/web/tests/components/ManualEditPanel.test.tsx`
- Explicit save regression coverage: `apps/web/tests/components/FileViewer.manual-edit.test.tsx` and `apps/web/tests/components/FileViewer.manual-edit-history.test.tsx`
- Comment toolbar count/order coverage: `apps/web/tests/components/FileViewer.test.tsx`
- Did the test go red on `main` and green on this branch? no; this is stacked on #3000, and the regressions are covered as new behavior specs on this branch.

## Validation

- `PATH="/opt/homebrew/Cellar/node@24/24.16.0/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" pnpm --filter @open-design/web test -- tests/edit-mode/bridge.test.ts tests/runtime/srcdoc.test.ts tests/edit-mode/source-patches.test.ts`
- `PATH="/opt/homebrew/Cellar/node@24/24.16.0/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" pnpm --filter @open-design/web test -- tests/components/FileViewer.test.tsx`
- `PATH="/opt/homebrew/Cellar/node@24/24.16.0/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" pnpm --filter @open-design/web typecheck`
- `PATH="/opt/homebrew/Cellar/node@24/24.16.0/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" pnpm guard`