### PR TITLE
fix(web): typographic fallback for failed Home media posters (#2955)

### DIFF
--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -6,7 +6,7 @@
 // home view. Until then the poster image is the only thing the
 // browser fetches — keeps a 50-tile gallery cheap.
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { MediaPreviewSpec } from '../preview';
 import { Icon } from '../../Icon';
 
@@ -18,9 +18,20 @@ interface Props {
 
 export function MediaSurface({ preview, pluginTitle, inView }: Props) {
   const [hovering, setHovering] = useState(false);
+  // Track per-URL poster load failure so a 404 / decode error / dead
+  // host swaps in the typographic fallback instead of leaving the
+  // browser's default broken-image glyph on the card. Reset whenever
+  // the poster URL itself changes — the previous failure must not
+  // poison a freshly-assigned URL (filter rotations, daemon
+  // repopulating a preview after an offline flip). #2955.
+  const [posterLoadFailed, setPosterLoadFailed] = useState(false);
+  useEffect(() => {
+    setPosterLoadFailed(false);
+  }, [preview.poster]);
   const showVideo =
     inView && hovering && preview.mediaType === 'video' && Boolean(preview.videoUrl);
   const hasPoster = Boolean(preview.poster);
+  const useFallback = !hasPoster || posterLoadFailed;
 
   return (
     <div
@@ -28,7 +39,7 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}
     >
-      {inView && preview.poster ? (
+      {inView && preview.poster && !posterLoadFailed ? (
         <img
           className="plugins-home__media-img"
           src={preview.poster}
@@ -36,8 +47,9 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
           loading="lazy"
           decoding="async"
           referrerPolicy="no-referrer"
+          onError={() => setPosterLoadFailed(true)}
         />
-      ) : !hasPoster ? (
+      ) : useFallback ? (
         <MediaFallback pluginTitle={pluginTitle} mediaType={preview.mediaType} />
       ) : (
         <div

--- a/apps/web/tests/components/plugins-home-media-surface.test.tsx
+++ b/apps/web/tests/components/plugins-home-media-surface.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+// Plugins-home media preview surface — broken-poster fallback.
+//
+// Before #2955 the MediaSurface card rendered `preview.poster`
+// straight into an `<img>` with no error handler. When an official
+// project's poster URL pointed at an asset the browser could not
+// fetch (404, decode error, CSP/CORS reject, or just a dead host),
+// the card was left with the browser's default broken-image glyph
+// instead of the typographic fallback that no-poster cards already
+// use. On the Home page that turned the discovery surface into a
+// row of "looks-broken" tiles for official content (issue #2955).
+//
+// This file pins the new behavior: a failed poster load swaps in
+// the same `plugins-home__media-fallback` element that runs for
+// poster-less entries, so the discovery surface degrades cleanly
+// instead of leaving a broken-image state.
+
+import { describe, expect, it, afterEach } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { MediaSurface } from '../../src/components/plugins-home/cards/MediaSurface';
+import type { MediaPreviewSpec } from '../../src/components/plugins-home/preview';
+
+const POSTER: MediaPreviewSpec = {
+  kind: 'media',
+  mediaType: 'image',
+  poster: 'https://example.invalid/poster.png',
+  videoUrl: null,
+  audioUrl: null,
+  imageOnly: true,
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MediaSurface broken-poster fallback (#2955)', () => {
+  it('renders the poster <img> by default when a poster URL is provided and the card is in view', () => {
+    const { container } = render(
+      <MediaSurface preview={POSTER} pluginTitle="Example" inView={true} />,
+    );
+    const img = container.querySelector('img.plugins-home__media-img');
+    expect(img).not.toBeNull();
+    expect((img as HTMLImageElement).src).toContain('poster.png');
+    expect(container.querySelector('.plugins-home__media-fallback')).toBeNull();
+  });
+
+  it('swaps in the typographic fallback when the poster fails to load (the headline #2955 scenario)', () => {
+    // Browsers emit an `error` event on the <img> when the URL 404s,
+    // the decode fails, or the host is unreachable. Without an
+    // onError handler the element stayed in the DOM and the browser
+    // painted its default broken-image glyph — the broken tile users
+    // were seeing on official Home cards.
+    const { container } = render(
+      <MediaSurface preview={POSTER} pluginTitle="Example" inView={true} />,
+    );
+    const img = container.querySelector('img.plugins-home__media-img');
+    expect(img).not.toBeNull();
+    fireEvent.error(img as HTMLImageElement);
+    // After the error, the broken <img> is gone and the typographic
+    // fallback element is mounted in its place.
+    expect(container.querySelector('img.plugins-home__media-img')).toBeNull();
+    expect(container.querySelector('.plugins-home__media-fallback')).not.toBeNull();
+  });
+
+  it('resets the failed-state when the poster URL changes so a recovered/different poster gets a fresh attempt', () => {
+    // Two real-world scenarios that hit this path:
+    //   1. The Home page rotates through filters and the same
+    //      `MediaSurface` instance gets a different plugin's poster
+    //      assigned. The previous failure must not poison the new
+    //      URL.
+    //   2. An offline-then-online flip where the daemon repopulates
+    //      poster URLs. The card has to recover instead of staying
+    //      stuck on the fallback for the session.
+    const { container, rerender } = render(
+      <MediaSurface preview={POSTER} pluginTitle="Example" inView={true} />,
+    );
+    const img = container.querySelector('img.plugins-home__media-img');
+    fireEvent.error(img as HTMLImageElement);
+    expect(container.querySelector('.plugins-home__media-fallback')).not.toBeNull();
+
+    const recovered: MediaPreviewSpec = {
+      ...POSTER,
+      poster: 'https://example.invalid/different-poster.png',
+    };
+    rerender(<MediaSurface preview={recovered} pluginTitle="Example" inView={true} />);
+    expect(container.querySelector('img.plugins-home__media-img')).not.toBeNull();
+    expect(container.querySelector('.plugins-home__media-fallback')).toBeNull();
+  });
+
+  it('still renders the typographic fallback directly when the spec has no poster URL (no regression for poster-less entries)', () => {
+    // Regression guard for the original `!hasPoster` branch — the new
+    // error-handling logic must not break entries that never had a
+    // poster URL to begin with.
+    const noPoster: MediaPreviewSpec = { ...POSTER, poster: null };
+    const { container } = render(
+      <MediaSurface preview={noPoster} pluginTitle="Example" inView={true} />,
+    );
+    expect(container.querySelector('img.plugins-home__media-img')).toBeNull();
+    expect(container.querySelector('.plugins-home__media-fallback')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #2955

## Why

**Use case.** Picking this up from the community queue after lefarcen's first-pass triage pointed at \`PluginsHomeSection\` → \`PluginCard\` → \`MediaSurface\` as the affected path.

**Pain.** \`MediaSurface\` rendered \`preview.poster\` straight into an \`<img>\` with no \`onError\` handler. When an official Community card's poster URL 404'd, failed to decode, or hit a dead host, the browser left its default broken-image glyph in place — on the Home gallery that turned several official image-template tiles into "looks-broken" placeholders sitting right next to healthy ones, hurting the discovery surface's credibility.

## What users will see

- Home → Community cards whose poster URL fails to load now show the same typographic fallback (first-letter glyph + media-type icon) that poster-less cards already use, instead of the browser's broken-image state.
- No change for cards whose poster loads successfully, no change for cards that already had no poster URL.
- Recovery: if the poster URL changes (filter rotation, daemon repopulating a preview after an offline flip), the card re-attempts the new URL instead of staying stuck on the fallback for the session.

## Surface area

- [x] **UI** — broken-image fallback on Home Community plugin cards
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change

CSS class names reused as-is (\`plugins-home__media-fallback\` already exists for the no-poster branch); no new tokens or i18n keys.

## Bug fix verification

Per \`AGENTS.md\` → Bug follow-up workflow:

- Test path that reproduces the bug: \`apps/web/tests/components/plugins-home-media-surface.test.tsx\` — the headline case is "swaps in the typographic fallback when the poster fails to load (the headline #2955 scenario)".
- Did the test go red on \`main\` and green on this branch? **Yes.** On the spec file alone (before the source change), 2/4 cases went red (the broken-poster swap + the URL-change reset). After wiring \`onError\` + the per-URL effect reset on \`preview.poster\`, all 4/4 cases pass.
- The suite also pins (a) the default \`<img>\` render path, (b) reset-on-URL-change so a different poster gets a fresh attempt, and (c) the original poster-less branch still goes straight to the fallback (regression guard).

## Validation

- \`pnpm --filter @open-design/web exec vitest run plugins-home-media-surface\` — 4/4 pass
- \`pnpm --filter @open-design/web exec vitest run components/plugins-home\` — 53/53 pass across 6 files (no neighboring regressions)
- \`pnpm --filter @open-design/web typecheck\` — clean for the changed files (two pre-existing \`osLocale\` errors in \`src/i18n/index.tsx\` exist on \`main\` independent of this branch)

## Implementation summary

\`apps/web/src/components/plugins-home/cards/MediaSurface.tsx\`:

- New \`posterLoadFailed\` state, set by \`<img onError>\`.
- \`useEffect\` resets it whenever \`preview.poster\` changes — failures must not poison a freshly-assigned URL.
- Render path: if there's a poster and it has not failed yet, mount the \`<img>\`; otherwise reuse the existing \`MediaFallback\` element. The skeleton branch for the "not yet in view" case is preserved.

## Things I considered but did not include

- A separate follow-up to identify the failing official records from the screenshots and verify their preview URLs against the daemon. That belongs on the data / official-content side and would be much cheaper as a separate small PR with the actual URLs in hand.
- Surfacing a console diagnostic on poster failure. Skipped — adds noise on every dead poster and the typographic fallback already communicates the state visually.