### PR TITLE
ci: make agent PR exploration trusted checkout lightweight

### DIFF
--- a/.github/workflows/agent-pr-explore-sandbox.yml
+++ b/.github/workflows/agent-pr-explore-sandbox.yml
@@ -28,11 +28,25 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - name: Checkout trusted base scripts
-        uses: actions/checkout@v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
-          persist-credentials: false
+      - name: Fetch trusted base script
+        # Only the self-contained sandbox script is needed on the trusted host;
+        # PR code is checked out inside Docker. A full actions/checkout of this
+        # large repo stalled on the self-hosted runner before the agent ever
+        # ran, so fetch just the one trusted file via the API instead. The ref
+        # is pinned to the trusted base/dispatch commit, never PR head.
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRUSTED_REF: ${{ github.event.pull_request.base.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p .github/scripts
+          gh api \
+            -H 'Accept: application/vnd.github.raw' \
+            "repos/$GITHUB_REPOSITORY/contents/.github/scripts/agent-pr-explore-sandbox.sh?ref=$TRUSTED_REF" \
+            > .github/scripts/agent-pr-explore-sandbox.sh
+          chmod +x .github/scripts/agent-pr-explore-sandbox.sh
+          echo "Fetched trusted agent-pr-explore-sandbox.sh at $TRUSTED_REF"
 
       - name: Resolve PR metadata
         id: pr


### PR DESCRIPTION
## Problem

The `agent-pr-explore-sandbox` workflow's first step, **Checkout trusted base scripts**, ran a full `actions/checkout@v6` of this (large) repo on the self-hosted Mac mini runner. On run [26488649341](https://github.com/nexu-io/open-design/actions/runs/26488649341) (manual dispatch for #3060) it stalled for many minutes in the initial `git fetch --depth=1 origin <sha>` — before any sandbox/Docker/agent code ran — and had to be cancelled. `--depth=1` is already the checkout default, so the bottleneck is transferring the full tree+blobs of one commit of a large repo over the runner's network, not fetch depth.

## Change

The trusted host side only needs the self-contained `.github/scripts/agent-pr-explore-sandbox.sh` (PR code is checked out *inside* Docker; PR context comes from the GitHub API). So this replaces the full checkout with a single-file fetch via `gh api` raw:

- pinned to the same trusted ref (`github.event.pull_request.base.sha || github.sha`), never PR head;
- writes the script into `.github/scripts/` in the workspace and `chmod +x`, so the existing `Run expect …` step (`run: .github/scripts/agent-pr-explore-sandbox.sh`) is unchanged;
- avoids the git-protocol fetch of the whole repo entirely.

## Safety / provenance

- The fetched ref is always the trusted base/dispatch commit, identical to what the previous checkout used — no PR-head code reaches the trusted host.
- The script is self-contained (fixtures are generated inline; it does not source sibling files or read other repo paths), so a single-file fetch is sufficient.

## Validation plan

After merge: re-dispatch #3060 from `main`, approve the environment, and confirm the run reaches Docker and produces a real UI/runtime exploration report with a working `trace.playwright.dev` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)