### PR TITLE
test(web): verify the Web Storage shim end-to-end (#1403)

### DIFF
--- a/apps/web/tests/runtime/srcdoc-sandbox-shim.test.ts
+++ b/apps/web/tests/runtime/srcdoc-sandbox-shim.test.ts
@@ -1,0 +1,205 @@
+// End-to-end verification for the #1403 fix: an HTML artifact whose
+// React tree reads `localStorage` / `sessionStorage` during initial
+// render used to throw `SecurityError` in the sandboxed preview
+// iframe and unmount, because the URL-load path runs raw HTML under
+// `sandbox="allow-scripts"` (no `allow-same-origin`) where the
+// browser's real Web Storage access is rejected.
+//
+// PR #1306 landed the narrower fix: artifacts whose source matches
+// `htmlNeedsSandboxShim()` are routed through `buildSrcdoc()`, which
+// injects a Web Storage polyfill *before* any user script runs. This
+// file exists to prove the fix end-to-end by:
+//
+//   1. Composing a real-shape React artifact that reads localStorage
+//      from a `useState` initializer (the exact repro in #1403's
+//      summary).
+//   2. Running the produced srcDoc string through a sandboxed VM
+//      context whose `window` raises `SecurityError` on every
+//      Web Storage touch — modeling the browser's `allow-scripts`
+//      iframe behavior, which jsdom's default `window.localStorage`
+//      does not simulate on its own.
+//   3. Asserting (a) the shim takes over `window.localStorage` /
+//      `window.sessionStorage`, and (b) the user script reads/writes
+//      without throwing.
+//
+// Closing the loop on the original report — the routing decision is
+// already covered by `file-viewer-render-mode.test.ts`; this file
+// covers the runtime payload the routing decision delivers.
+
+import { describe, expect, it } from 'vitest';
+import * as vm from 'node:vm';
+import { buildSrcdoc } from '../../src/runtime/srcdoc';
+
+// Pull every <script> body out of a doc in document order. Lets us
+// run the shim and the user script under the same fake-sandbox window
+// without spinning up a real iframe.
+function extractScriptBodies(doc: string): string[] {
+  const bodies: string[] = [];
+  const re = /<script\b[^>]*>([\s\S]*?)<\/script>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(doc)) !== null) {
+    bodies.push(match[1] ?? '');
+  }
+  return bodies;
+}
+
+// Build a VM context that models an `allow-scripts` sandbox iframe:
+// `window` is its own globalThis and native `localStorage` /
+// `sessionStorage` accessors throw `SecurityError` on read.
+//
+// `vm.createContext` does not preserve `Object.defineProperty`
+// descriptors that we install from outside, so we install the
+// throwing getters from *inside* the VM after the context exists —
+// that way V8 keeps the accessor semantics intact and a later
+// `Object.defineProperty(window, 'localStorage', ...)` from the shim
+// can override them normally.
+function createSandboxedIframeVmContext(): vm.Context {
+  const ctx = vm.createContext({});
+  vm.runInContext(
+    `(function () {
+       this.window = this;
+       this.globalThis = this;
+       this.document = { addEventListener: function () {} };
+       for (var name of ['localStorage', 'sessionStorage']) {
+         (function (n) {
+           Object.defineProperty(window, n, {
+             configurable: true,
+             get: function () {
+               var err = new Error('SecurityError');
+               err.name = 'SecurityError';
+               throw err;
+             },
+           });
+         })(name);
+       }
+     }).call(this);`,
+    ctx,
+  );
+  return ctx;
+}
+
+describe('buildSrcdoc shim isolates Web Storage from a sandboxed window (#1403 verify)', () => {
+  // Real-shape React prototype: useState initializer reads localStorage,
+  // i18next-style cookie/storage detector, and an external `<script>`
+  // (which on its own forces the shim path per #2361). This mirrors the
+  // repro #1403's summary describes ("React app whose `useState`
+  // initializer reads from `localStorage`").
+  const REACT_ARTIFACT = `<!doctype html>
+<html>
+  <head><meta charset="utf-8"></head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel" src="app.jsx"></script>
+    <script>
+      // Inline boot code: read theme + locale, write a session marker.
+      var theme = localStorage.getItem('theme') || 'system';
+      var lang = sessionStorage.getItem('locale') || 'en';
+      localStorage.setItem('boot:last', String(Date.now()));
+      window.__bootResult = { theme: theme, lang: lang, ok: true };
+    </script>
+  </body>
+</html>`;
+
+  it('injects the Web Storage shim into the srcDoc output', () => {
+    const doc = buildSrcdoc(REACT_ARTIFACT);
+    // The shim ships under a stable marker attribute so the host can
+    // sanity-check that it landed without a brittle string search.
+    expect(doc).toContain('data-od-sandbox-shim');
+  });
+
+  it('places the shim BEFORE the user script so the polyfill is in place at first read', () => {
+    const doc = buildSrcdoc(REACT_ARTIFACT);
+    const shimIdx = doc.indexOf('data-od-sandbox-shim');
+    const userBootIdx = doc.indexOf('var theme = localStorage.getItem');
+    expect(shimIdx).toBeGreaterThan(0);
+    expect(userBootIdx).toBeGreaterThan(0);
+    // Ordering is the whole point — a shim that ran after the user's
+    // first read would not save the React tree from the initial
+    // SecurityError.
+    expect(shimIdx).toBeLessThan(userBootIdx);
+  });
+
+  it('the shim plus the user script run cleanly when the host window forbids native Web Storage (the #1403 sandbox model)', () => {
+    const doc = buildSrcdoc(REACT_ARTIFACT);
+    const scripts = extractScriptBodies(doc);
+    // Skip the type="text/babel" tag — its body is empty (just src=)
+    // and Babel-standalone is not present in the VM. We only need the
+    // shim + the inline boot script to validate the SecurityError
+    // suppression model.
+    const shimScript = scripts.find((s) => /data-od-sandbox-shim/.test(s) === false && /makeStore/.test(s));
+    const bootScript = scripts.find((s) => /var theme = localStorage\.getItem/.test(s));
+    expect(shimScript, 'shim script body must be present').toBeDefined();
+    expect(bootScript, 'user boot script body must be present').toBeDefined();
+
+    const ctx = createSandboxedIframeVmContext();
+    // 1. Confirm the bare sandbox raises SecurityError on Web Storage
+    //    access — without this the test would not actually be modeling
+    //    the iframe behavior the fix is supposed to neutralize.
+    expect(() => vm.runInContext('window.localStorage.getItem("x");', ctx)).toThrow(/SecurityError/);
+
+    // 2. Run the shim. After this, window.localStorage / sessionStorage
+    //    must point at the in-memory polyfill rather than the throwing
+    //    accessor.
+    vm.runInContext(shimScript as string, ctx);
+    const ls = vm.runInContext('window.localStorage', ctx) as { getItem: (k: string) => string | null };
+    const ss = vm.runInContext('window.sessionStorage', ctx) as { setItem: (k: string, v: string) => void };
+    expect(typeof ls.getItem).toBe('function');
+    expect(typeof ss.setItem).toBe('function');
+
+    // 3. Run the original boot script. It must complete without
+    //    throwing — the exact failure mode #1403 reports. The script
+    //    uses bare `localStorage` identifiers (no `window.` prefix),
+    //    which the VM now resolves to `win.localStorage` because the
+    //    sandbox window is its own globalThis.
+    vm.runInContext(bootScript as string, ctx);
+    const result = vm.runInContext('window.__bootResult', ctx) as { theme: string; lang: string; ok: boolean };
+    expect(result.ok).toBe(true);
+    expect(result.theme).toBe('system');
+    expect(result.lang).toBe('en');
+    // And the writes the boot script issued landed in the in-memory store.
+    expect(ls.getItem('boot:last')).toMatch(/^\d+$/);
+  });
+
+  it('the shim preserves a working native localStorage when one is already present (no clobber on environments that allow Web Storage)', () => {
+    // PR #1306 round-2 review point: the shim must only replace the
+    // window storage when the native one is broken. Iframes loaded
+    // with `allow-same-origin` (or anywhere outside the sandbox) keep
+    // their real, persistent storage so the user's data survives the
+    // shim.
+    const doc = buildSrcdoc(REACT_ARTIFACT);
+    const scripts = extractScriptBodies(doc);
+    const shimScript = scripts.find((s) => /makeStore/.test(s));
+    expect(shimScript).toBeDefined();
+
+    const realStorage = (() => {
+      const data: Record<string, string> = { theme: 'dark' };
+      return {
+        getItem: (k: string) => (k in data ? data[k]! : null),
+        setItem: (k: string, v: string) => {
+          data[k] = String(v);
+        },
+        removeItem: (k: string) => {
+          delete data[k];
+        },
+        clear: () => {
+          for (const k of Object.keys(data)) delete data[k];
+        },
+        key: (i: number) => Object.keys(data)[i] ?? null,
+        get length() {
+          return Object.keys(data).length;
+        },
+      };
+    })();
+    const win: Record<string, unknown> = {
+      localStorage: realStorage,
+      sessionStorage: realStorage,
+      document: { addEventListener: () => {} },
+    };
+    const ctx = vm.createContext({ window: win, document: win.document, console });
+    vm.runInContext(shimScript as string, ctx);
+    // The host-supplied storage survives — the shim's `works = true`
+    // branch leaves it alone.
+    const survived = vm.runInContext('window.localStorage.getItem("theme")', ctx);
+    expect(survived).toBe('dark');
+  });
+});


### PR DESCRIPTION
Closes #1403

## Why

**Use case.** Picking this up from the verify-and-close queue — issue #1403 was kept open after PR #1306 landed the narrower fix so the runtime payload could be pinned against the original repro shape.

**Pain.** \`file-viewer-render-mode.test.ts\` already covers the routing decision (i.e. \"this source needs the shim\"), but nothing in the suite was asserting that the produced srcDoc actually keeps a React tree from throwing \`SecurityError\` on the first \`localStorage\` read inside an \`allow-scripts\` sandbox iframe. A future refactor that drops the shim script body, moves it after user code, or accidentally narrows the routing predicate could regress to the #1403 blank-preview behavior without any test red.

## What users will see

Nothing user-visible — this is test-only. The verification it provides is what unlocks safely closing #1403 with the existing fix.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [x] **None** — test-only (no production code changes)

## Bug fix verification

Per \`AGENTS.md\` → Bug follow-up workflow:

- Test path that reproduces the bug: \`apps/web/tests/runtime/srcdoc-sandbox-shim.test.ts\` — the headline case is \"the shim plus the user script run cleanly when the host window forbids native Web Storage\".
- Did the test go red on \`main\` and green on this branch? **Mixed by design.** The test exercises the shipped \`buildSrcdoc()\` payload as-is. To confirm the assertions still pin the fix, I locally moved the \`injectSandboxShim\` call to *after* the user script in \`apps/web/src/runtime/srcdoc.ts\` and re-ran the suite: the \"places the shim BEFORE the user script\" and \"runs cleanly under a sandboxed window\" cases both go red. Restored to current behavior → green.
- The suite covers four shapes:
  1. \`data-od-sandbox-shim\` marker is present in the output (smoke).
  2. Shim ordering — the script must appear in the doc before the first user storage read.
  3. End-to-end runtime: a real-shape React artifact's boot script runs cleanly in a Node \`vm\` context whose \`window.localStorage\` / \`sessionStorage\` accessors throw \`SecurityError\` exactly like an \`allow-scripts\` iframe does, after the shim has overwritten them.
  4. No-clobber guard — the shim must NOT replace a working native \`localStorage\` (the \`allow-same-origin\` path stays untouched so user data survives).

## Validation

- \`pnpm --filter @open-design/web exec vitest run srcdoc-sandbox-shim\` — 4/4 pass
- \`pnpm --filter @open-design/web exec vitest run runtime\` — 243/243 across 19 files (no neighbouring regressions)
- \`pnpm --filter @open-design/web typecheck\` — no new errors

## Implementation summary

\`apps/web/tests/runtime/srcdoc-sandbox-shim.test.ts\` (new, 205 lines):

- Composes a React-style artifact with \`<script type=\"text/babel\">\`, an external script ref (\`#2361\` shape), and an inline boot script that reads \`localStorage\`/\`sessionStorage\` from \`useState\`-style initializers.
- Feeds it through \`buildSrcdoc()\` and extracts the produced \`<script>\` bodies.
- Builds a Node \`vm\` context where \`window\` is its own globalThis and \`Object.defineProperty\` installs throwing accessors for the two Web Storage globals — the closest faithful model of an \`allow-scripts\` sandbox the test surface can provide without spinning up a real iframe / Playwright.
- Runs shim first, then the boot script — asserts no throw, asserts the in-memory store keeps writes the boot script issued.
- Re-runs the shim against a context that *does* have working \`localStorage\` to pin the no-clobber invariant.

## Closing the issue

Issue #1403 has lingered open as a verify-and-close placeholder; with these regression assertions in place I'm using \`Closes #1403\` so the auto-link reverse lookup matches the eventual release tag.