### PR TITLE
ci: reuse cached docker image and persist pnpm store for agent sandbox

### DIFF
--- a/.github/scripts/agent-pr-explore-sandbox.sh
+++ b/.github/scripts/agent-pr-explore-sandbox.sh
@@ -42,7 +42,12 @@ done
 
 root="$RUNNER_TEMP/agent-pr-explore-sandbox"
 artifacts="$root/artifacts"
-pnpm_store="$RUNNER_TEMP/agent-pr-explore-pnpm-store"
+# Persist the pnpm store outside RUNNER_TEMP (which the Actions runner wipes
+# per job) so dependencies are reused across runs instead of being fully
+# re-downloaded every time -- the self-hosted runner's network to the npm
+# registry is as unreliable as its docker.io access. Content-addressed, so
+# sharing across PRs is safe; override with OD_SANDBOX_PNPM_STORE if needed.
+pnpm_store="${OD_SANDBOX_PNPM_STORE:-$HOME/.cache/agent-pr-explore/pnpm-store}"
 context_file="$artifacts/pr-context.md"
 trimmed_context_file="$artifacts/pr-context-trimmed.md"
 changed_files_file="$artifacts/changed-files.txt"

--- a/.github/scripts/agent-pr-explore-sandbox.sh
+++ b/.github/scripts/agent-pr-explore-sandbox.sh
@@ -975,7 +975,16 @@ if [ "$(wc -c < "$context_file" | tr -d " ")" -gt "$context_max_bytes" ]; then
   } >> "$trimmed_context_file"
 fi
 
-docker pull "$image"
+# Use the locally cached image when present. The self-hosted runner's
+# network to docker.io is unreliable, and the base image is referenced by
+# a tag we treat as stable for the duration of a run, so don't pay for (or
+# fail on) a pull when the image is already available. Only pull when it is
+# missing; refreshing the cached image is a separate, explicit operation.
+if docker image inspect "$image" >/dev/null 2>&1; then
+  echo "Using locally cached image $image (skipping pull)."
+else
+  docker pull "$image"
+fi
 
 docker run -d \
   --name "$container_name" \


### PR DESCRIPTION
With the trusted checkout fixed (#3071), the re-run of #3060 ([run 26490782540](https://github.com/nexu-io/open-design/actions/runs/26490782540)) finally reached the Docker step — and exposed two places where the self-hosted runner's flaky network is a hard dependency on every run. Both are fixed here.

## 1. Skip `docker pull` when the image is already cached

The script ran an unconditional `docker pull "$image"` before `docker run`. Under `set -e`, a transient registry timeout aborted the whole run even though `node:24-bookworm` was **already cached** on the runner:

```
Error response from daemon: failed to resolve reference "docker.io/library/node:24-bookworm":
dial tcp 128.121.243.75:443: i/o timeout
```

Now: use the locally cached image when present (no pull, no timeout wait), and only pull when it is missing. This also keeps a run's base image stable. Refreshing the cached image is a separate, explicit operation on the runner.

## 2. Persist the pnpm store across runs

The pnpm store lived under `$RUNNER_TEMP`, which the Actions runner **wipes per job** (verified on the runner: no store survives between runs). So every exploration re-downloaded the full dependency set from the npm registry — slow, and the same network-fragility class that just broke the docker pull.

Now: the store lives at a persistent host path (`$HOME/.cache/agent-pr-explore/pnpm-store`, overridable via `OD_SANDBOX_PNPM_STORE`), so a warm, content-addressed store is reused across runs. It is no longer under the per-run root that `rm -rf` clears.

- pnpm's store is content-addressed (integrity-hash keyed), so sharing it across PR runs is safe; combined with `--frozen-lockfile` a warm store makes installs effectively offline.

## Follow-up (not in this PR)

The runner's docker.io / npm-registry reachability should still be made reliable (registry mirror). These changes stop a single PR run from being hostage to it.

## Validation plan

After merge: re-dispatch #3060 from `main`, approve the environment, and confirm the run reaches the expect agent and produces a real UI/runtime report with a working `trace.playwright.dev` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)