### PR TITLE
[codex] Fix packaged mac Dock identity and AMR label

### DIFF
--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -37,7 +37,7 @@ const AMR_DEFAULT_MODEL: RuntimeModelOption = {
 
 export const amrAgentDef = {
   id: 'amr',
-  name: 'AMR (vela)',
+  name: 'AMR',
   bin: 'vela',
   versionArgs: ['--version'],
   fetchModels: async (resolvedBin, env) =>

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -54,6 +54,7 @@ describe('AMR runtime def', () => {
     const def = getAgentDef('amr');
     expect(def).toBeTruthy();
     expect(def?.id).toBe('amr');
+    expect(def?.name).toBe('AMR');
     expect(def?.bin).toBe('vela');
     expect(def?.streamFormat).toBe('acp-json-rpc');
   });

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdir, open, type FileHandle } from "node:fs/promises";
+import { access, mkdir, open, type FileHandle } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { delimiter, dirname, join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -93,6 +93,43 @@ function resolveSidecarEntry(packageName: string, exportName: string): string {
 
 function logPathFor(paths: PackagedNamespacePaths, app: AppKey): string {
   return join(paths.logsRoot, app, "latest.log");
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolvePackagedElectronNodeCommand(
+  execPath = process.execPath,
+  platform = process.platform,
+): Promise<string> {
+  if (platform !== "darwin") return execPath;
+
+  const executableName = execPath.split("/").pop();
+  if (executableName == null || executableName.length === 0) return execPath;
+
+  const marker = "/Contents/MacOS/";
+  const markerIndex = execPath.lastIndexOf(marker);
+  if (markerIndex === -1) return execPath;
+
+  const appPath = execPath.slice(0, markerIndex);
+  const helperName = `${executableName} Helper`;
+  const helperPath = join(
+    appPath,
+    "Contents",
+    "Frameworks",
+    `${helperName}.app`,
+    "Contents",
+    "MacOS",
+    helperName,
+  );
+
+  return (await pathExists(helperPath)) ? helperPath : execPath;
 }
 
 async function openLog(path: string): Promise<FileHandle> {
@@ -340,7 +377,7 @@ async function spawnSidecarChild(options: {
     },
     stamp,
   });
-  const command = options.nodeCommand ?? process.execPath;
+  const command = options.nodeCommand ?? (await resolvePackagedElectronNodeCommand());
   const child = spawn(
     command,
     [options.entryPath, ...createProcessStampArgs(stamp, OPEN_DESIGN_SIDECAR_CONTRACT)],

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -16,15 +16,16 @@
  * @see https://github.com/nexu-io/open-design/issues/710
  */
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { delimiter, join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
   buildPackagedDaemonSpawnEnv,
   resolveDaemonStatusTimeoutMs,
   resolvePackagedChildBaseEnv,
+  resolvePackagedElectronNodeCommand,
   resolvePackagedPathEnv,
   waitForStatus,
 } from '../src/sidecars.js';
@@ -121,6 +122,53 @@ describe('packaged child Vite+ environment forwarding', () => {
       else process.env.VP_HOME = originalVpHome;
       rmSync(vpHome, { recursive: true, force: true });
     }
+  });
+});
+
+describe('resolvePackagedElectronNodeCommand', () => {
+  it('uses the hidden Electron helper as the macOS Electron-as-Node command when available', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-electron-helper-'));
+    try {
+      const appPath = join(root, 'Open Design.app');
+      const execPath = join(appPath, 'Contents', 'MacOS', 'Open Design');
+      const helperPath = join(
+        appPath,
+        'Contents',
+        'Frameworks',
+        'Open Design Helper.app',
+        'Contents',
+        'MacOS',
+        'Open Design Helper',
+      );
+
+      mkdirSync(join(appPath, 'Contents', 'MacOS'), { recursive: true });
+      mkdirSync(dirname(helperPath), { recursive: true });
+      writeFileSync(execPath, '#!/bin/sh\n', 'utf8');
+      writeFileSync(helperPath, '#!/bin/sh\n', 'utf8');
+
+      await expect(resolvePackagedElectronNodeCommand(execPath, 'darwin')).resolves.toBe(helperPath);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the main executable when the macOS helper is unavailable', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-no-electron-helper-'));
+    try {
+      const execPath = join(root, 'Open Design.app', 'Contents', 'MacOS', 'Open Design');
+      mkdirSync(dirname(execPath), { recursive: true });
+      writeFileSync(execPath, '#!/bin/sh\n', 'utf8');
+
+      await expect(resolvePackagedElectronNodeCommand(execPath, 'darwin')).resolves.toBe(execPath);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the main executable on non-macOS platforms', async () => {
+    const execPath = '/opt/Open Design/open-design';
+
+    await expect(resolvePackagedElectronNodeCommand(execPath, 'linux')).resolves.toBe(execPath);
   });
 });
 


### PR DESCRIPTION
## Why

This PR fixes a packaged macOS startup bug I hit while launching Open Design: the app could show a second Dock item while the packaged runtime was starting sidecars.

The root cause is that packaged sidecars were launched through the foreground macOS app executable (`Contents/MacOS/Open Design`) with `ELECTRON_RUN_AS_NODE=1`. macOS can still treat those children as visible application processes, so the Dock can show an extra app item.

It also simplifies the AMR runtime display name for new assistant rows from `AMR (vela)` to `AMR`. Historical persisted rows are intentionally not rewritten or compatibility-mapped.

## What users will see

Packaged macOS launches should no longer create an extra Dock-visible app item for the daemon/web sidecars.

New AMR assistant messages will show `AMR` as the assistant name.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The Dock symptom is OS-level process identity behavior, and the AMR change is label-only for new assistant rows.

## Bug fix verification

- Test path that reproduces the bug: `apps/packaged/tests/sidecars.test.ts`
- Did the test go red on `main` and green on this branch? No. The repro was process-level (`System Events` reported two foreground `Open Design` app processes); the regression test pins the command selection that prevents the sidecar from using the foreground app executable.
- Additional runtime label coverage: `apps/daemon/tests/amr-acp-integration.test.ts`

## Validation

- `pnpm --filter @open-design/packaged test -- tests/sidecars.test.ts`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/amr-acp-integration.test.ts tests/runtimes/env-and-detection.test.ts`
- `pnpm --filter @open-design/packaged typecheck`
- `git diff --check`

Earlier broad package-script attempts expanded beyond the requested files and exposed unrelated existing failures:

- `pnpm --filter @open-design/web test -- tests/utils/apiProtocol.test.ts` expanded to the broader web suite and failed in `tests/components/MarketplaceView.test.tsx` looking for `Sample Plugin` while still loading.
- `pnpm --filter @open-design/daemon test -- tests/amr-acp-integration.test.ts tests/runtimes/env-and-detection.test.ts` expanded to the broader daemon suite and failed in unrelated `connection-test.test.ts` diagnostics expectations, plus a flaky-looking ACP child-exit assertion.