### PR TITLE
ci: fetch agent sandbox PR source on the host over SSH via a local mirror

### DIFF
--- a/.github/scripts/agent-pr-explore-sandbox.sh
+++ b/.github/scripts/agent-pr-explore-sandbox.sh
@@ -991,6 +991,50 @@ else
   docker pull "$image"
 fi
 
+# --- Fetch PR source on the trusted host; hand it to the container read-only ---
+# The runner's bandwidth to github.com is throttled across every transport
+# (HTTPS / SSH / codeload / API all ~30-90 KB/s), so a from-scratch fetch of this
+# ~200MB repo is impractical per run. Keep a persistent local mirror and fetch
+# only the PR's delta into it over SSH (the one transport that is not RST'd). The
+# PR head is taken from the BASE repo's refs/pull/<n>/head so fork PRs work too,
+# and the read-only deploy key stays on the trusted host -- it is never exposed to
+# the untrusted PR code, which only ever sees the checked-out files inside Docker.
+mirror="${OD_SANDBOX_REPO_MIRROR:-$HOME/.cache/agent-pr-explore/open-design.git}"
+git_ssh_key="${OD_SANDBOX_GIT_SSH_KEY:-$HOME/.ssh/od_agent_deploy}"
+pr_src="$root/pr-src"
+export GIT_SSH_COMMAND="ssh -i $git_ssh_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20"
+
+if [ ! -d "$mirror" ]; then
+  echo "::error::Repo mirror $mirror is missing on the runner. Seed it once with:"
+  echo "::error::  git clone --bare --depth=1 --single-branch --branch main git@github.com:${BASE_REPO}.git $mirror"
+  exit 1
+fi
+
+pr_fetched=
+for fetch_attempt in 1 2 3; do
+  if git --git-dir="$mirror" fetch --no-tags --depth=1 origin \
+      "+refs/pull/${PR_NUMBER}/head:refs/pull/${PR_NUMBER}/head"; then
+    pr_fetched=1
+    break
+  fi
+  echo "PR source fetch failed; retrying (${fetch_attempt}/3)"
+  sleep $((fetch_attempt * 5))
+done
+[ -n "$pr_fetched" ] || { echo "::error::Failed to fetch PR #${PR_NUMBER} source over SSH after 3 attempts."; exit 1; }
+
+fetched_sha="$(git --git-dir="$mirror" rev-parse "refs/pull/${PR_NUMBER}/head")"
+if [ "$fetched_sha" != "$HEAD_SHA" ]; then
+  echo "::error::Fetched PR head $fetched_sha does not match expected $HEAD_SHA"
+  exit 1
+fi
+
+rm -rf "$pr_src"
+mkdir -p "$pr_src"
+git -C "$pr_src" init -q
+git -C "$pr_src" fetch --no-tags --depth=1 "$mirror" "$HEAD_SHA"
+git -C "$pr_src" checkout -q --detach FETCH_HEAD
+unset GIT_SSH_COMMAND
+
 docker run -d \
   --name "$container_name" \
   --cpus "$cpus" \
@@ -1002,6 +1046,7 @@ docker run -d \
   --publish "127.0.0.1:${host_web_port}:${container_proxy_port}" \
   --mount "type=bind,src=$artifacts,dst=/artifacts" \
   --mount "type=bind,src=$pnpm_store,dst=/pnpm-store" \
+  --mount "type=bind,src=$pr_src,dst=/pr-src,readonly" \
   --env "PR_NUMBER=$PR_NUMBER" \
   --env "HEAD_SHA=$HEAD_SHA" \
   --env "HEAD_REPO=$HEAD_REPO" \
@@ -1015,25 +1060,12 @@ docker run -d \
   bash -lc '
     set -euo pipefail
 
-    mkdir -p /work
-    cd /work
-
-    git init repo
-    cd repo
-    git remote add base "https://github.com/${BASE_REPO}.git"
-    git remote add head "https://github.com/${HEAD_REPO}.git"
-    for fetch_attempt in 1 2 3; do
-      if git fetch --no-tags --depth=1 head "${HEAD_SHA}"; then
-        break
-      fi
-      if [ "$fetch_attempt" = 3 ]; then
-        echo "git fetch failed after ${fetch_attempt} attempt(s)"
-        exit 1
-      fi
-      echo "git fetch failed; retrying (${fetch_attempt}/3)"
-      sleep $((fetch_attempt * 5))
-    done
-    git checkout --detach FETCH_HEAD
+    # PR source was fetched on the trusted host and mounted read-only at
+    # /pr-src; copy it into a writable workdir. The sandbox needs (and has) no
+    # github network access of its own.
+    mkdir -p /work/repo
+    cp -a /pr-src/. /work/repo/
+    cd /work/repo
 
     git rev-parse HEAD | tee /artifacts/checked-out-sha.txt
     test "$(git rev-parse HEAD)" = "${HEAD_SHA}"


### PR DESCRIPTION
## Problem

After the trusted-checkout (#3071) and cached-image/pnpm-store (#3074) fixes, the re-run of #3060 ([run 26491460889](https://github.com/nexu-io/open-design/actions/runs/26491460889)) reached the container — confirmed `Using locally cached image node:24-bookworm (skipping pull)` — and then failed when the container fetched PR code from github:

```
fatal: unable to access 'https://github.com/Kushaal-k/open-design.git/':
gnutls_handshake() failed: The TLS connection was non-properly terminated.
git fetch failed after 3 attempt(s)
##[error]Sandbox container exited before dev server became reachable
```

Diagnosing the runner's network (host **and** colima VM):

| target | result |
|---|---|
| `api.github.com` (tiny) | 200 in 0.4s |
| `api.github.com` (bulk blob) | **~86 KB/s** (throttled) |
| `github.com:443` git | TLS reset (RST) |
| `codeload.github.com` tarball | ~30 KB/s, no Range/resume |
| `github.com:22` / `ssh.github.com:443` SSH | reachable, but pack data **~30 KB/s** |
| `registry.npmjs.org` | fast ✅ |

So **every** transport to github is bandwidth-throttled (~30–90 KB/s) and HTTPS is frequently RST'd, while npm is fine. The repo is **~200 MB / 4764 files** (≈131 MB of that is large docs/video assets), so a from-scratch per-run fetch takes tens of minutes and is unreliable. #2992 only succeeded earlier because it hit a non-throttled window (GFW is intermittent).

## Change

Move PR-source acquisition to the trusted host and make it **incremental**, so per-run cost is just the PR's delta:

- **Persistent bare mirror** of the base repo on the runner (`$HOME/.cache/agent-pr-explore/open-design.git`, override `OD_SANDBOX_REPO_MIRROR`). Each run does `git fetch --depth=1 origin refs/pull/<n>/head` into it **over SSH** (the one transport GFW doesn't RST) with a **read-only deploy key** (`OD_SANDBOX_GIT_SSH_KEY`). Because the mirror already holds the base tree, only the PR's changed blobs transfer.
- Head is taken from the **base repo's** `refs/pull/<n>/head` (works for fork PRs, no dependency on the head fork) and verified `== HEAD_SHA`.
- The PR head is checked out into a per-run worktree and **mounted read-only** into the container; the container copies it into a writable workdir and no longer needs any github access.

## Security

- The read-only deploy key lives only on the trusted host and is **never** mounted into the container — untrusted PR code only ever sees the checked-out files, consistent with the existing isolation model.
- PR source is fetched as data on the host (not executed); execution still happens only inside the locked-down container.

## Operational note

The mirror is seeded once on the runner (done as part of this rollout). If it is ever missing, the step fails fast and prints the exact `git clone --bare --depth=1 --single-branch --branch main …` command to recreate it. A periodic mirror refresh keeps PR deltas small.

## Validation plan

Re-dispatch #3060 from `main`, approve the environment, and confirm the container fetches source via the mounted worktree (no in-container github access), installs deps, boots the app, and the expect agent produces a real UI/runtime report with a working `trace.playwright.dev` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)