### PR TITLE
ci: add skip_comment dry-run input to agent PR exploration

### DIFF
--- a/.github/workflows/agent-pr-explore-sandbox.yml
+++ b/.github/workflows/agent-pr-explore-sandbox.yml
@@ -10,6 +10,11 @@ on:
         description: Pull request number to explore.
         required: true
         type: string
+      skip_comment:
+        description: Skip posting the exploration report comment on the PR (the report is still uploaded as an artifact). Use for validation/dry runs.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -127,7 +132,7 @@ jobs:
           retention-days: 7
 
       - name: Comment exploration report
-        if: always()
+        if: ${{ always() && !inputs.skip_comment }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Why

When validating the agent-pr-explore pipeline against a real PR (e.g. an external contributor's PR), the `Comment exploration report` step posts a public comment on that PR on every successful run. For dry/validation runs we want to exercise the full pipeline and inspect the report **without** posting to the PR.

## Change

Add a `skip_comment` `workflow_dispatch` input (boolean, default `false`). When `true`, the `Comment exploration report` step is skipped via `if: ${{ always() && !inputs.skip_comment }}`. The report is still uploaded as an artifact, so it can be reviewed out of band.

Normal (auto-comment) behavior is unchanged when the input is omitted.

## Validation

`python -c "yaml.safe_load(...)"` parses clean. Functional check: dispatch with `skip_comment=true` and confirm the comment step is skipped while the artifact upload still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)