### PR TITLE
[codex] Accelerate AMR startup defaults

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -148,6 +148,7 @@ const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
     'VELA_RUNTIME_KEY',
     'VELA_OPENCODE_BIN',
     'OPEN_DESIGN_AMR_PROFILE',
+    'OPENCODE_TEST_HOME',
   ])],
   ['aider', new Set(['AIDER_BIN'])],
   ['claude', new Set(['CLAUDE_CONFIG_DIR', 'CLAUDE_BIN', 'ANTHROPIC_BASE_URL', 'ANTHROPIC_API_KEY'])],

--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -1,6 +1,17 @@
 import { execAgentFile } from './shared.js';
 import type { RuntimeAgentDef, RuntimeModelOption } from '../types.js';
 
+const PREFERRED_AMR_CHAT_MODEL_ORDER = [
+  'deepseek-v4-flash',
+  'deepseek-v3.2',
+  'glm-5.1',
+  'gemini-2.5-flash',
+] as const;
+
+const PREFERRED_AMR_CHAT_MODEL_RANK: ReadonlyMap<string, number> = new Map(
+  PREFERRED_AMR_CHAT_MODEL_ORDER.map((id, index) => [id, index]),
+);
+
 // AMR is the vela CLI's ACP stdio mode. `vela agent run --runtime opencode`
 // starts a private OpenCode server and forwards stream-json over ACP JSON-RPC.
 // Required env (set on the daemon process or via Settings → CLI env):
@@ -92,7 +103,22 @@ export function parseVelaModels(stdout: string): RuntimeModelOption[] {
     seen.add(id);
     models.push({ id, label: id });
   }
-  return models;
+  return orderAmrChatModels(models);
+}
+
+function orderAmrChatModels(
+  models: RuntimeModelOption[],
+): RuntimeModelOption[] {
+  return models
+    .map((model, index) => ({ model, index }))
+    .sort((a, b) => {
+      const aRank =
+        PREFERRED_AMR_CHAT_MODEL_RANK.get(a.model.id) ?? Number.MAX_SAFE_INTEGER;
+      const bRank =
+        PREFERRED_AMR_CHAT_MODEL_RANK.get(b.model.id) ?? Number.MAX_SAFE_INTEGER;
+      return aRank - bRank || a.index - b.index;
+    })
+    .map(({ model }) => model);
 }
 
 export const amrAgentDef = {

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { expandConfiguredEnv } from './paths.js';
 import { resolveAmrOpenCodeExecutable } from './executables.js';
 import { amrVelaProfileEnv } from '../integrations/vela-profile.js';
@@ -41,6 +43,13 @@ export function spawnEnvForAgent(
   };
   if (agentId === 'amr') {
     Object.assign(env, amrVelaProfileEnv(env));
+    if (!env.OPENCODE_TEST_HOME?.trim() && env.OD_DATA_DIR?.trim()) {
+      env.OPENCODE_TEST_HOME = path.join(
+        env.OD_DATA_DIR.trim(),
+        'amr',
+        'opencode-home',
+      );
+    }
     if (!env.VELA_OPENCODE_BIN?.trim()) {
       const opencodeBin = resolveAmrOpenCodeExecutable(env);
       if (opencodeBin) env.VELA_OPENCODE_BIN = opencodeBin;

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -102,9 +102,11 @@ describe('AMR runtime def', () => {
     expect(normalizeVelaModelId('vela/deepseek-v3.2')).toBe('deepseek-v3.2');
   });
 
-  it('parses `vela models` output with plain canonical labels', () => {
+  it('parses `vela models` output with fast chat defaults and plain canonical labels', () => {
     const models = parseVelaModels([
+      'public_model_claude_opus_4_6  vela',
       'public_model_deepseek_v3_2    vela',
+      'public_model_deepseek_v4_flash    vela',
       'public_model_glm_5_1          vela',
       'public_model_gpt_image_2      vela',
       'vela/kimi-k2.6                vela',
@@ -113,8 +115,10 @@ describe('AMR runtime def', () => {
       '',
     ].join('\n'));
     expect(models).toEqual([
+      { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
       { id: 'deepseek-v3.2', label: 'deepseek-v3.2' },
       { id: 'glm-5.1', label: 'glm-5.1' },
+      { id: 'claude-opus-4-6', label: 'claude-opus-4-6' },
       { id: 'kimi-k2.6', label: 'kimi-k2.6' },
     ]);
     expect(models.every((model) => !model.label.includes('vela/'))).toBe(true);
@@ -125,16 +129,16 @@ describe('AMR runtime def', () => {
   it('fetches AMR picker models from `vela models`', async () => {
     const models = await amrAgentDef.fetchModels?.(FAKE_VELA, process.env);
     expect(models).toEqual([
-      { id: 'deepseek-v3.2', label: 'deepseek-v3.2' },
       { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
-      { id: 'deepseek-v4-pro', label: 'deepseek-v4-pro' },
+      { id: 'deepseek-v3.2', label: 'deepseek-v3.2' },
+      { id: 'glm-5.1', label: 'glm-5.1' },
       { id: 'gemini-2.5-flash', label: 'gemini-2.5-flash' },
+      { id: 'deepseek-v4-pro', label: 'deepseek-v4-pro' },
       { id: 'gemini-3.1-flash-lite-preview', label: 'gemini-3.1-flash-lite-preview' },
       { id: 'gemini-3.1-pro-preview', label: 'gemini-3.1-pro-preview' },
       { id: 'gpt-5.4', label: 'gpt-5.4' },
       { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
       { id: 'glm-5', label: 'glm-5' },
-      { id: 'glm-5.1', label: 'glm-5.1' },
       { id: 'kimi-k2.6', label: 'kimi-k2.6' },
       { id: 'minimax-m2.7', label: 'minimax-m2.7' },
       { id: 'qwen3-235b-a22b', label: 'qwen3-235b-a22b' },

--- a/apps/daemon/tests/app-config.test.ts
+++ b/apps/daemon/tests/app-config.test.ts
@@ -320,6 +320,7 @@ describe('app-config', () => {
           amr: {
             VELA_BIN: '~/bin/vela',
             OPEN_DESIGN_AMR_PROFILE: '  local  ',
+            OPENCODE_TEST_HOME: '  ~/.open-design-amr-opencode  ',
             HOME: 'should-not-persist',
           },
           'trae-cli': {
@@ -339,7 +340,11 @@ describe('app-config', () => {
       expect(cfg.agentCliEnv).toEqual({
         claude: { CLAUDE_CONFIG_DIR: '~/.claude-2', ANTHROPIC_API_KEY: 'sk-proxy-anthropic' },
         codex: { CODEX_HOME: '~/.codex-alt', CODEX_BIN: '~/bin/codex-next', OPENAI_API_KEY: 'sk-proxy-openai' },
-        amr: { VELA_BIN: '~/bin/vela', OPEN_DESIGN_AMR_PROFILE: 'local' },
+        amr: {
+          VELA_BIN: '~/bin/vela',
+          OPEN_DESIGN_AMR_PROFILE: 'local',
+          OPENCODE_TEST_HOME: '~/.open-design-amr-opencode',
+        },
         'trae-cli': { TRAE_CLI_BIN: '~/bin/traecli-public' },
       });
     });

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -83,6 +83,44 @@ test('spawnEnvForAgent injects the resolved AMR profile after configured env', (
   assert.equal(env.PATH, '/usr/bin');
 });
 
+test('spawnEnvForAgent gives AMR a stable OpenCode home under OD_DATA_DIR', () => {
+  const dataDir = mkdtempSync(join(tmpdir(), 'od-amr-data-'));
+  try {
+    const env = spawnEnvForAgent('amr', {
+      OD_DATA_DIR: dataDir,
+      PATH: '/usr/bin',
+    });
+
+    assert.equal(
+      env.OPENCODE_TEST_HOME,
+      join(dataDir, 'amr', 'opencode-home'),
+    );
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+test('spawnEnvForAgent preserves a configured AMR OpenCode home override', () => {
+  const dataDir = mkdtempSync(join(tmpdir(), 'od-amr-data-'));
+  try {
+    const configuredHome = join(dataDir, 'custom-opencode-home');
+    const env = spawnEnvForAgent(
+      'amr',
+      {
+        OD_DATA_DIR: dataDir,
+        PATH: '/usr/bin',
+      },
+      {
+        OPENCODE_TEST_HOME: configuredHome,
+      },
+    );
+
+    assert.equal(env.OPENCODE_TEST_HOME, configuredHome);
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
 fsTest('spawnEnvForAgent gives AMR a discovered OpenCode binary under a minimal child PATH', () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-amr-opencode-home-'));
   try {


### PR DESCRIPTION
## Why

This PR carries the remaining AMR acceleration work on top of `feat/amr-runtime-acp` after the link-catalog/model-id work was merged back into that branch.

The production pain is that AMR turns can spend 70-90 seconds in OpenCode startup when Vela/OpenCode creates a fresh temporary home and reinstalls dependencies for every run. The measured bottleneck included `100 packages installed [70.85s]` inside a new `vela-opencode-*` temp home.

## What users will see

New AMR turns reuse a stable OpenCode home under `OD_DATA_DIR`, so repeated startup should stay near a few seconds instead of reinstalling dependencies every time.

When no AMR model is explicitly selected, the live catalog now places faster chat models first, starting with `deepseek-v4-flash`, before slower entries such as `claude-opus-4-6`.

Explicit user model selections are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — adds AMR `OPENCODE_TEST_HOME` support through spawn env and configured env allowlist.
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — AMR default model resolution now prefers faster live chat catalog entries when no explicit model is selected.
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No screenshots required. The change is daemon runtime startup behavior plus AMR catalog ordering.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/env-and-detection.test.ts`, `apps/daemon/tests/amr-acp-integration.test.ts`, `apps/daemon/tests/app-config.test.ts`
- Did the test go red on `main` and green on this branch? No; the key startup bottleneck was production/manual-smoke behavior rather than a cheap main-branch red spec.
- Manual verification: packaged Beta `vela` production smoke with stable `OPENCODE_TEST_HOME` showed consecutive `session/new` startup at `3750ms` and `3872ms`.

## Validation

- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/runtimes/env-and-detection.test.ts tests/amr-acp-integration.test.ts tests/runtimes/resolve-model.test.ts tests/app-config.test.ts`
- `pnpm --filter @open-design/daemon build`
- `git diff --check`
