### PR TITLE
fix(amr): close ACP stdin on abort so vela tears down OpenCode

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -708,6 +708,15 @@ export function attachAcpSession({
       } catch {
         // The caller owns process-signal fallback if the ACP transport is gone.
       }
+      // Close stdin so the agent receives EOF and shuts down its own runtime
+      // — the vela ACP bridge tears down its private OpenCode server on EOF —
+      // instead of lingering (and leaking that server) until the caller's
+      // SIGTERM fallback fires. Mirrors the clean-completion path above.
+      try {
+        child.stdin.end();
+      } catch {
+        // Best effort; the caller still owns the SIGTERM/SIGKILL fallback.
+      }
     },
   };
 }

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -701,17 +701,23 @@ export function attachAcpSession({
       aborted = true;
       finished = true;
       clearStageTimer();
-      if (!sessionId || !child.stdin || child.stdin.destroyed || child.stdin.writableEnded) return;
-      try {
-        sendRpc(child.stdin, nextId, 'session/cancel', { sessionId });
-        nextId += 1;
-      } catch {
-        // The caller owns process-signal fallback if the ACP transport is gone.
+      if (!child.stdin || child.stdin.destroyed || child.stdin.writableEnded)
+        return;
+      // Only cancel an established session; before session/new resolves there
+      // is no sessionId to cancel, but we must still close stdin below.
+      if (sessionId) {
+        try {
+          sendRpc(child.stdin, nextId, 'session/cancel', { sessionId });
+          nextId += 1;
+        } catch {
+          // The caller owns process-signal fallback if the ACP transport is gone.
+        }
       }
-      // Close stdin so the agent receives EOF and shuts down its own runtime
-      // — the vela ACP bridge tears down its private OpenCode server on EOF —
-      // instead of lingering (and leaking that server) until the caller's
-      // SIGTERM fallback fires. Mirrors the clean-completion path above.
+      // Always close stdin so the agent receives EOF and shuts down its own
+      // runtime — the vela ACP bridge tears down its private OpenCode server on
+      // EOF — instead of lingering (and leaking that server) until the caller's
+      // SIGTERM fallback fires. This also covers aborts during ACP startup,
+      // before session/new returns. Mirrors the clean-completion path above.
       try {
         child.stdin.end();
       } catch {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -231,6 +231,28 @@ test('attachAcpSession exposes abort and sends session cancel after session crea
   assert.deepEqual(cancelRequest.params, { sessionId: 'session-1' });
 });
 
+test('attachAcpSession.abort closes stdin so the agent shuts down on EOF', () => {
+  const child = new FakeAcpChild();
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: () => {},
+  });
+
+  child.stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
+  child.stdout.write(`${JSON.stringify({ id: 2, result: { sessionId: 'session-1' } })}\n`);
+
+  assert.equal(child.stdin.writableEnded, false);
+  session.abort();
+  // EOF on stdin lets the vela ACP bridge tear down its OpenCode server
+  // without waiting for the caller's SIGTERM fallback.
+  assert.equal(child.stdin.writableEnded, true);
+});
+
 function parseRpcWrites(writes: string[]): Array<Record<string, unknown>> {
   return writes
     .join('')

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -253,6 +253,33 @@ test('attachAcpSession.abort closes stdin so the agent shuts down on EOF', () =>
   assert.equal(child.stdin.writableEnded, true);
 });
 
+test('attachAcpSession.abort during startup ends stdin without sending session/cancel', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: () => {},
+  });
+
+  // Abort before session/new resolves (no sessionId yet) — e.g. the user
+  // cancels during ACP startup. stdin must still close so OpenCode tears down.
+  assert.equal(child.stdin.writableEnded, false);
+  session.abort();
+  assert.equal(child.stdin.writableEnded, true);
+
+  // No session to cancel yet, so no session/cancel RPC should be emitted.
+  const cancelRequests = parseRpcWrites(writes).filter(
+    (entry) => entry.method === 'session/cancel',
+  );
+  assert.equal(cancelRequests.length, 0);
+});
+
 function parseRpcWrites(writes: string[]): Array<Record<string, unknown>> {
   return writes
     .join('')


### PR DESCRIPTION
## Why

While debugging the AMR runtime (`pr-2355`) I hit piles of orphaned `opencode serve` processes accumulating on the host. AMR runs `vela agent run --runtime opencode` over ACP; when a chat turn is cancelled/aborted, `attachAcpSession.abort()` sent a `session/cancel` RPC but **left the child's stdin open**. The vela ACP bridge keeps running until it sees stdin EOF, and only tears down its private OpenCode server on a clean exit — so on abort the OpenCode server lingered until the caller's SIGTERM fallback in `runs.cancel()`, and a parent hard-kill before that fallback stranded the `opencode serve` process entirely (reparented to launchd/init).

## What users will see

No more stray `opencode serve` processes piling up after cancelling or timing out AMR chat turns — cancellation now shuts the agent (and its private OpenCode server) down promptly instead of leaving background processes behind.

## Surface area

- [x] **None** — internal fix to the daemon's ACP session teardown (no UI / CLI / API / contract change)

## Bug fix verification

- Test path: `apps/daemon/tests/acp.test.ts`
  - `attachAcpSession.abort closes stdin so the agent shuts down on EOF`
  - `attachAcpSession.abort during startup ends stdin without sending session/cancel`
- Red on `main` / green on this branch? **yes** — reverting the `stdin.end()` change (and restoring the old `!sessionId` early-return) makes these cases fail with `stdin.writableEnded === false`.

## Validation

- `npx tsc --noEmit` (apps/daemon) — clean
- `npx vitest run tests/acp.test.ts` — 17 passed (incl. the two above)

---

### Fix

`abort()` now closes stdin whenever the pipe is writable (gating only the `session/cancel` RPC on `sessionId`), so the EOF teardown also covers aborts during ACP startup before `session/new` resolves:

```ts
if (!child.stdin || child.stdin.destroyed || child.stdin.writableEnded) return;
if (sessionId) {
  try { sendRpc(child.stdin, nextId, 'session/cancel', { sessionId }); nextId += 1; } catch {}
}
try { child.stdin.end(); } catch {}
```

The caller still owns the SIGTERM/SIGKILL fallback. (The vela CLI side — signal handling + reaping its OpenCode process group — is fixed separately in the Vela repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)