### PR TITLE
Add comment panel save/send tracking

### DIFF
--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -50,6 +50,7 @@ import type {
   FileManagerClickProps,
   ArtifactToolbarClickProps,
   TweaksPopoverClickProps,
+  CommentPopoverClickProps,
   ArtifactHeaderClickProps,
   PresentPopoverClickProps,
   ShareOptionPopoverClickProps,
@@ -423,6 +424,13 @@ export function trackArtifactToolbarClick(
 export function trackTweaksPopoverClick(
   track: Track,
   props: TweaksPopoverClickProps,
+): void {
+  send(track, 'ui_click', props);
+}
+
+export function trackCommentPopoverClick(
+  track: Track,
+  props: CommentPopoverClickProps,
 ): void {
   send(track, 'ui_click', props);
 }

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -12,6 +12,7 @@ import {
   trackArtifactExportResult,
   trackArtifactHeaderClick,
   trackArtifactToolbarClick,
+  trackCommentPopoverClick,
   trackPageView,
   trackPresentPopoverClick,
   trackShareOptionPopoverClick,
@@ -3785,6 +3786,17 @@ function HtmlViewer({
       artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
     });
   };
+  const fireCommentPopoverClick = (
+    element: 'save_comment' | 'send_to_chat' | 'add_note',
+  ) => {
+    trackCommentPopoverClick(analytics.track, {
+      page_name: 'artifact',
+      area: 'comment_popover',
+      element,
+      artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
+      artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
+    });
+  };
   const [mode, setMode] = useState<'preview' | 'source'>('preview');
   const [source, setSource] = useState<string | null>(liveHtml ?? null);
   const [inlinedSource, setInlinedSource] = useState<string | null>(null);
@@ -6122,8 +6134,8 @@ function HtmlViewer({
         setQueuedBoardNotes((current) => current.filter((_, currentIndex) => currentIndex !== index))
       }
       onClose={clearBoardComposer}
-      onSaveComment={savePersistentComment}
-      onSendBatch={sendBoardBatch}
+      onSaveComment={() => { fireCommentPopoverClick('save_comment'); return savePersistentComment(); }}
+      onSendBatch={() => { fireCommentPopoverClick('send_to_chat'); return sendBoardBatch(); }}
       onRemoveMember={(elementId) => {
         setActiveCommentTarget((current) => {
           const { next, shouldClose } = applyPodMemberRemoval(current, elementId);
@@ -6195,6 +6207,7 @@ function HtmlViewer({
           (comment) => selectedSideCommentIds.has(comment.id),
         );
         if (selected.length === 0) return;
+        fireCommentPopoverClick('send_to_chat');
         setSendingBoardBatch(true);
         try {
           await onSendBoardCommentAttachments(commentsToAttachments(selected));

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -1244,6 +1244,14 @@ export interface TweaksPopoverClickProps {
   status_after: 'on' | 'off';
 }
 
+export interface CommentPopoverClickProps {
+  page_name: 'artifact';
+  area: 'comment_popover';
+  element: 'save_comment' | 'send_to_chat' | 'add_note';
+  artifact_id?: string;
+  artifact_kind?: TrackingArtifactKind;
+}
+
 export interface ArtifactHeaderClickProps {
   page_name: 'artifact';
   area: 'artifact_header';
@@ -1496,6 +1504,7 @@ export type UiClickProps =
   | FileManagerClickProps
   | ArtifactToolbarClickProps
   | TweaksPopoverClickProps
+  | CommentPopoverClickProps
   | ArtifactHeaderClickProps
   | PresentPopoverClickProps
   | ShareOptionPopoverClickProps


### PR DESCRIPTION
## Summary
- Add `comment_popover` area tracking to distinguish "Save comment" vs "Send to chat" button clicks
- Track both the inline board composer popover and the comment side panel send action
- New contract type `CommentPopoverClickProps` with elements: `save_comment`, `send_to_chat`, `add_note`

## Why
Currently only `element=comment, area=artifact_toolbar` (opening the comment tool) is tracked. We have no visibility into whether users save comments locally vs send them to chat. This data is needed to understand the comment→chat conversion funnel.

## What users will see
No user-facing change. New `ui_click` events will appear in PostHog with `area=comment_popover`.

## Test plan
- [ ] Open comment tool, select an element, add a note, click "Save comment" → verify `ui_click` event with `element=save_comment, area=comment_popover` in PostHog
- [ ] Add notes and click "Send to chat" → verify `ui_click` event with `element=send_to_chat, area=comment_popover`
- [ ] In comment side panel, select comments and click "Send to chat" → same event fires