### PR TITLE
[codex] Surface AMR insufficient balance wallet URL

### DIFF
--- a/apps/daemon/src/integrations/vela-errors.ts
+++ b/apps/daemon/src/integrations/vela-errors.ts
@@ -13,7 +13,7 @@ const AMR_AUTH_REQUIRED_MESSAGE =
   'AMR sign-in is required. Sign in to AMR Cloud again, then retry this run.';
 
 const AMR_INSUFFICIENT_BALANCE_MESSAGE =
-  'AMR Cloud reported insufficient balance for this model. Recharge your AMR wallet, then retry this run.';
+  `AMR Cloud reported insufficient balance for this model. Recharge your AMR wallet at ${DEFAULT_AMR_RECHARGE_URL}, then retry this run.`;
 
 function normalizeFailureText(text: string): string {
   return String(text || '').toLowerCase();

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -20,6 +20,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { attachAcpSession, detectAcpModels } from '../src/acp.js';
+import { classifyAmrAccountFailure } from '../src/integrations/vela-errors.js';
 import {
   amrAgentDef,
   normalizeVelaModelId,
@@ -363,6 +364,42 @@ describe('AMR ACP transport — end-to-end against fake vela stub', () => {
     };
     expect(String(payload?.message ?? '')).toContain('Model not found');
     expect(payload?.error?.code).toBe('AMR_MODEL_UNAVAILABLE');
+  });
+
+  it('keeps ACP insufficient-balance prompt errors classifiable as AMR recharge failures', async () => {
+    const child = spawnFakeVela({
+      FAKE_VELA_PROMPT_ERROR:
+        'HTTP 429: {"error":{"code":"insufficient_balance","message":"insufficient wallet balance"}}',
+    });
+    const errors: Array<{ event: string; payload: unknown }> = [];
+    try {
+      const session = attachAcpSession({
+        child: child as never,
+        prompt: 'Say hello',
+        cwd: process.cwd(),
+        model: 'claude-opus-4-6',
+        mcpServers: [],
+        send: (event, payload) => {
+          if (event === 'error') errors.push({ event, payload });
+        },
+      });
+
+      await waitForExit(child);
+      expect(session.hasFatalError()).toBe(true);
+      expect(session.completedSuccessfully()).toBe(false);
+    } finally {
+      if (child.exitCode === null) child.kill('SIGTERM');
+    }
+
+    const message = String(
+      (errors[0]?.payload as { message?: unknown })?.message ?? '',
+    );
+    expect(message).toContain('insufficient_balance');
+    expect(classifyAmrAccountFailure(message)).toMatchObject({
+      code: 'AMR_INSUFFICIENT_BALANCE',
+      action: 'recharge',
+      actionUrl: 'https://open-design.ai/amr/wallet',
+    });
   });
 
   it('allows non-AMR ACP completions that produce no assistant text', async () => {

--- a/apps/daemon/tests/integrations/vela-errors.test.ts
+++ b/apps/daemon/tests/integrations/vela-errors.test.ts
@@ -17,6 +17,7 @@ describe('AMR account failure classification', () => {
       action: 'recharge',
       actionUrl: DEFAULT_AMR_RECHARGE_URL,
     });
+    expect(failure?.message).toContain(DEFAULT_AMR_RECHARGE_URL);
     expect(amrAccountFailureDetails(failure!)).toEqual({
       kind: 'amr_account',
       action: 'recharge',


### PR DESCRIPTION
## Why

This PR is part of the AMR ACP error propagation repair. The root provider failure fix lives in the companion Vela PR: https://github.com/powerformer/vela/pull/121

When AMR/Link returns an insufficient-balance failure, Open Design should preserve the account-error classification and show a direct recharge destination instead of leaving users with a generic failure path.

## What users will see

AMR insufficient-balance errors now include the visible recharge URL `https://open-design.ai/amr/wallet` in the displayed message. The structured error details still include `code: AMR_INSUFFICIENT_BALANCE`, `action: recharge`, and `actionUrl: https://open-design.ai/amr/wallet`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is error-message behavior covered by daemon integration tests.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/amr-acp-integration.test.ts`
- Did the test go red on `main` and green on this branch? No; this branch targets `feat/amr-runtime-acp`, and I added focused regression coverage on that branch.
- Companion root-fix coverage: https://github.com/powerformer/vela/pull/121

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/integrations/vela-errors.test.ts tests/amr-acp-integration.test.ts` from `apps/daemon`
- `git diff --check`
