### PR TITLE
fix: dismiss tab search on outside mouse down

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -473,10 +473,10 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
         setTabsMenuOpen(false);
       }
     }
-    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('mousedown', onPointerDown, true);
     document.addEventListener('keydown', onKeyDown);
     return () => {
-      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('mousedown', onPointerDown, true);
       document.removeEventListener('keydown', onKeyDown);
     };
   }, [tabsMenuOpen]);

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -64,6 +64,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
 
   afterEach(() => {
     cleanup();
+    document.querySelector('[data-testid="blank-workspace-area"]')?.remove();
   });
 
   it('keeps Home tab as a singleton and avoids duplication', async () => {
@@ -201,5 +202,26 @@ describe('WorkspaceTabsBar navigation semantics', () => {
       expect(labels[0]).toContain('Home');
     });
     expect(navigate).toHaveBeenCalledWith(homeRoute);
+  });
+
+  it('dismisses tab search when a blank page area handles the mouse down', async () => {
+    const outsideArea = document.createElement('div');
+    outsideArea.setAttribute('data-testid', 'blank-workspace-area');
+    outsideArea.addEventListener('mousedown', (event) => event.stopPropagation());
+    document.body.append(outsideArea);
+
+    render(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Search tabs' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: 'Search tabs' })).toBeTruthy();
+    });
+
+    fireEvent.mouseDown(outsideArea);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Search tabs' })).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Fixes #3095

## Why

The tab search popover looked open, but clicking back into the blank workspace could leave it hanging around instead of getting out of the way. That makes the top-bar search feel a little sticky, especially when a user is just trying to dismiss it and return to the canvas.

This keeps the fix focused on that default dismissal behavior.

## What users will see

Clicking outside the tab search popover, including on blank workspace areas that handle mouse events themselves, closes the popover.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual change; this only changes the outside-click dismissal path.

## Changes

- Listen for tab-search outside mouse-down events during capture so blank workspace areas can still dismiss the portaled popover even if they handle the event themselves.
- Added a WorkspaceTabsBar regression test for that path.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/WorkspaceTabsBar.test.tsx`
- Did the test go red on `main` and green on this branch? Yes. The new regression test fails without the capture-phase listener because the blank workspace handler stops propagation before the document bubble listener sees the event.

## Validation

- `pnpm --config.store-dir=F:\work\.codex-tools\pnpm-store --filter @open-design/web exec vitest run tests/components/WorkspaceTabsBar.test.tsx`
- `pnpm --config.store-dir=F:\work\.codex-tools\pnpm-store --filter @open-design/web run typecheck`
- `git diff --check`
