### PR TITLE
Fix workspace tab separator artifact

### DIFF
--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -167,7 +167,11 @@
   box-shadow: 0 1px 1px color-mix(in srgb, var(--text) 6%, transparent);
 }
 .workspace-tab:hover::before,
-.workspace-tab.is-active::before {
+.workspace-tab:hover + .workspace-tab::before,
+.workspace-tab:focus-within::before,
+.workspace-tab:focus-within + .workspace-tab::before,
+.workspace-tab.is-active::before,
+.workspace-tab.is-active + .workspace-tab::before {
   opacity: 0;
 }
 .workspace-tab__main {


### PR DESCRIPTION
Fixes #3104

## Why

Workspace tab separators could remain visible after hover, focus, or active state changes because the separator is drawn by the next tab's `::before` pseudo-element, not by the tab currently being interacted with.

## What users will see

Workspace tabs no longer show a stray vertical separator at the boundary next to the active, hovered, or keyboard-focused tab.

## Surface area

- [x] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys
- [ ] **New top-level dependency** - adding any new entry to the root `package.json`
- [ ] **Default behavior change** - changes what existing users experience without opting in
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

No manual screenshots attached. The PR visual regression workflow captured the workspace UI surfaces and reported `0 changed`, `17 unchanged`, `0 missing baseline`, and `0 failed` for this CSS-only fix.

## Bug fix verification

- Test path that reproduces the bug: not added; this is a small CSS pseudo-element ownership issue best covered by the existing workspace/browser/visual CI surface.
- Did the test go red on `main` and green on this branch? no
- Additional verification: the adjacent separator selector now targets the tab that owns the visible pseudo-element.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `git diff --check`

## Security

UI-only CSS change. No auth, storage, network, workspace data, or dependency changes.