### PR TITLE
Add run-scoped media execution policy

### DIFF
--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -19,6 +19,7 @@ import { isSafeId as isSafeProjectId } from './projects.js';
 import { projectKindToTracking } from '@open-design/contracts/analytics';
 import { proxyDispatcherRequestInit, validateBaseUrlResolved } from './connectionTest.js';
 import { googleStreamGenerateContentUrl } from './google-models.js';
+import { parseMediaExecutionPolicyInput } from './media-policy.js';
 
 // Allowlist for the `/feedback` route. Mirrors the
 // ChatMessageFeedbackReasonCode union in packages/contracts/src/api/chat.ts.
@@ -220,9 +221,17 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     if (isDaemonShuttingDown()) {
       return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', 'daemon is shutting down');
     }
-    const run = design.runs.create();
+    const body = req.body && typeof req.body === 'object' ? req.body : {};
+    const mediaExecution = parseMediaExecutionPolicyInput(
+      (body as { mediaExecution?: unknown }).mediaExecution,
+    );
+    if (!mediaExecution.ok) {
+      return sendApiError(res, 400, 'BAD_REQUEST', mediaExecution.message);
+    }
+    const runBody = { ...body, mediaExecution: mediaExecution.policy };
+    const run = design.runs.create(runBody);
     design.runs.stream(run, req, res);
-    design.runs.start(run, () => startChatRun(req.body || {}, run));
+    design.runs.start(run, () => startChatRun(runBody, run));
   });
 
   // ---- Connection tests (single-shot JSON; no SSE) ------------------------

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -477,7 +477,8 @@ async function runMediaGenerate(rawArgs) {
 
   const daemonUrl = await cliDaemonUrl(flags);
   const projectId = flags.project || process.env.OD_PROJECT_ID;
-  if (!projectId) {
+  const token = process.env.OD_TOOL_TOKEN;
+  if (!projectId && !token) {
     console.error(
       'project id required. Pass --project <id> or set OD_PROJECT_ID. The daemon injects this when it spawns the code agent.',
     );
@@ -511,12 +512,17 @@ async function runMediaGenerate(rawArgs) {
   if (flags['prompt-influence'] != null) body.promptInfluence = Number(flags['prompt-influence']);
   if (flags.loop === true) body.loop = true;
 
-  const url = `${daemonUrl.replace(/\/$/, '')}/api/projects/${encodeURIComponent(projectId)}/media/generate`;
+  const url = token
+    ? `${daemonUrl.replace(/\/$/, '')}/api/tools/media/generate`
+    : `${daemonUrl.replace(/\/$/, '')}/api/projects/${encodeURIComponent(projectId)}/media/generate`;
   let resp;
   try {
     resp = await fetch(url, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
       body: JSON.stringify(body),
     });
   } catch (err) {
@@ -787,7 +793,7 @@ Common options:
                             it, and forwards it to the upstream API.
   --daemon-url <url>
 
-Output: a single line of JSON: {"file": { name, size, kind, mime, ... }}.
+Output: a single line of JSON: {"file": { name, size, kind, mime, ... }}
 
 Skills should call this and then reference the returned filename in their
 artifact / message body. The daemon writes the bytes into the project's

--- a/apps/daemon/src/media-policy.ts
+++ b/apps/daemon/src/media-policy.ts
@@ -1,0 +1,113 @@
+import type { MediaExecutionMode, MediaExecutionPolicy, MediaSurface } from '@open-design/contracts';
+
+const MEDIA_EXECUTION_MODES = new Set<MediaExecutionMode>(['enabled', 'disabled']);
+const MEDIA_SURFACES = new Set<MediaSurface>(['image', 'video', 'audio']);
+
+export interface MediaPolicyTarget {
+  surface: MediaSurface;
+  model?: string;
+}
+
+export function defaultMediaExecutionPolicy(): MediaExecutionPolicy {
+  return { mode: 'enabled' };
+}
+
+export function normalizeMediaExecutionPolicyForRun(value: unknown): MediaExecutionPolicy {
+  const parsed = parseMediaExecutionPolicyInput(value);
+  return parsed.ok ? parsed.policy : defaultMediaExecutionPolicy();
+}
+
+export function parseMediaExecutionPolicyInput(value: unknown):
+  | { ok: true; policy: MediaExecutionPolicy }
+  | { ok: false; message: string } {
+  if (value === undefined || value === null) {
+    return { ok: true, policy: defaultMediaExecutionPolicy() };
+  }
+  if (!isRecord(value)) {
+    return { ok: false, message: 'mediaExecution must be an object when provided' };
+  }
+
+  const rawMode = typeof value.mode === 'string' ? value.mode : 'enabled';
+  if (!MEDIA_EXECUTION_MODES.has(rawMode as MediaExecutionMode)) {
+    return {
+      ok: false,
+      message: 'mediaExecution.mode must be enabled or disabled',
+    };
+  }
+  const mode = rawMode as MediaExecutionMode;
+
+  const policy: MediaExecutionPolicy = { mode };
+
+  if (value.allowedSurfaces !== undefined) {
+    if (!Array.isArray(value.allowedSurfaces)) {
+      return { ok: false, message: 'mediaExecution.allowedSurfaces must be an array' };
+    }
+    const surfaces: MediaSurface[] = [];
+    for (const surface of value.allowedSurfaces) {
+      const candidate = surface as MediaSurface;
+      if (typeof surface !== 'string' || !MEDIA_SURFACES.has(candidate)) {
+        return {
+          ok: false,
+          message: 'mediaExecution.allowedSurfaces may only include image, video, or audio',
+        };
+      }
+      if (!surfaces.includes(candidate)) surfaces.push(candidate);
+    }
+    policy.allowedSurfaces = surfaces;
+  }
+
+  if (value.allowedModels !== undefined) {
+    if (!Array.isArray(value.allowedModels)) {
+      return { ok: false, message: 'mediaExecution.allowedModels must be an array' };
+    }
+    const models: string[] = [];
+    for (const rawModel of value.allowedModels) {
+      if (typeof rawModel !== 'string' || rawModel.trim().length === 0) {
+        return { ok: false, message: 'mediaExecution.allowedModels must contain non-empty strings' };
+      }
+      const model = rawModel.trim();
+      if (!models.includes(model)) models.push(model);
+    }
+    policy.allowedModels = models;
+  }
+
+  return { ok: true, policy };
+}
+
+export function mediaPolicyDenial(
+  policy: MediaExecutionPolicy,
+  target: MediaPolicyTarget,
+): { code: string; message: string } | null {
+  if (policy.mode === 'disabled') {
+    return {
+      code: 'MEDIA_EXECUTION_DISABLED',
+      message: 'media generation is disabled for this run',
+    };
+  }
+  if (
+    Array.isArray(policy.allowedSurfaces) &&
+    policy.allowedSurfaces.length > 0 &&
+    !policy.allowedSurfaces.includes(target.surface)
+  ) {
+    return {
+      code: 'MEDIA_SURFACE_DENIED',
+      message: `media surface "${target.surface}" is not allowed for this run`,
+    };
+  }
+  if (
+    target.model &&
+    Array.isArray(policy.allowedModels) &&
+    policy.allowedModels.length > 0 &&
+    !policy.allowedModels.includes(target.model)
+  ) {
+    return {
+      code: 'MEDIA_MODEL_DENIED',
+      message: `media model "${target.model}" is not allowed for this run`,
+    };
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/apps/daemon/src/media-routes.ts
+++ b/apps/daemon/src/media-routes.ts
@@ -1,25 +1,154 @@
 import type { Express } from 'express';
+import type { MediaExecutionPolicy } from '@open-design/contracts';
+import { defaultMediaExecutionPolicy, mediaPolicyDenial } from './media-policy.js';
 import type { RouteDeps } from './server-context.js';
 import { proxyDispatcherRequestInit } from './connectionTest.js';
+import type { ToolTokenGrant } from './tool-tokens.js';
 
 const LONG_MEDIA_PROXY_TIMEOUT_MS = 10 * 60 * 1000;
 
-export interface RegisterMediaRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'ids' | 'media' | 'appConfig' | 'orbit' | 'nativeDialogs' | 'projectStore' | 'projectFiles' | 'conversations' | 'research'> {}
+export interface RegisterMediaRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'ids' | 'auth' | 'media' | 'appConfig' | 'orbit' | 'nativeDialogs' | 'projectStore' | 'projectFiles' | 'conversations' | 'research'> {}
 
 export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) {
-  const { db } = ctx;
+  const { db, design } = ctx;
   const { sendApiError, requireLocalDaemonRequest, isLocalSameOrigin, resolvedPortRef } = ctx.http;
   const { PROJECT_ROOT, PROJECTS_DIR, RUNTIME_DATA_DIR } = ctx.paths;
+  const { authorizeToolRequest } = ctx.auth;
   const { randomUUID } = ctx.ids;
   const { MEDIA_PROVIDERS, IMAGE_MODELS, VIDEO_MODELS, AUDIO_MODELS_BY_KIND, MEDIA_ASPECTS, VIDEO_LENGTHS_SEC, AUDIO_DURATIONS_SEC, readMaskedConfig, writeConfig, generateMedia, createMediaTask, persistMediaTask, appendTaskProgress, notifyTaskWaiters, getLiveMediaTask, mediaTaskSnapshot, listMediaTasksByProject, listElevenLabsVoiceOptions } = ctx.media;
   const { readAppConfig, writeAppConfig } = ctx.appConfig;
   const { orbitService } = ctx.orbit;
   const { openNativeFolderDialog } = ctx.nativeDialogs;
   const { getProject } = ctx.projectStore;
-  const { writeProjectFile } = ctx.projectFiles;
   const { insertConversation, upsertMessage } = ctx.conversations;
   const { searchResearch, ResearchError } = ctx.research;
   const getResolvedPort = () => resolvedPortRef.current;
+
+  const mediaPolicyForGrant = (grant: ToolTokenGrant | null): MediaExecutionPolicy => {
+    if (!grant?.runId) return defaultMediaExecutionPolicy();
+    const run = design.runs.get(grant.runId);
+    return run?.mediaExecution ?? defaultMediaExecutionPolicy();
+  };
+
+  const handleGenerate = async (
+    req: any,
+    res: any,
+    options: { projectId: string; grant: ToolTokenGrant | null },
+  ) => {
+    const projectId = options.projectId;
+    const project = getProject(db, projectId);
+    if (!project) return res.status(404).json({ error: 'project not found' });
+
+    const surface = req.body?.surface;
+    if (surface !== 'image' && surface !== 'video' && surface !== 'audio') {
+      return sendApiError(res, 400, 'BAD_REQUEST', 'surface must be image, video, or audio');
+    }
+    const model = typeof req.body?.model === 'string' ? req.body.model : '';
+    if (!model) {
+      return sendApiError(res, 400, 'BAD_REQUEST', 'model is required');
+    }
+
+    const policy = mediaPolicyForGrant(options.grant);
+    const denial = mediaPolicyDenial(policy, { surface, model });
+    if (denial) {
+      return sendApiError(res, 403, denial.code, denial.message);
+    }
+
+    let task: ReturnType<typeof createMediaTask> | null = null;
+    try {
+      const taskId = randomUUID();
+      task = createMediaTask(taskId, projectId, {
+        surface: req.body?.surface,
+        model: req.body?.model,
+      });
+      console.error(
+        `[task ${taskId.slice(0, 8)}] queued model=${req.body?.model} ` +
+          `surface=${req.body?.surface} ` +
+          `image=${req.body?.image ? 'yes' : 'no'} ` +
+          `compositionDir=${req.body?.compositionDir ? 'yes' : 'no'}`,
+      );
+
+      const proxyDispatcher = proxyDispatcherRequestInit(process.env, {
+        headersTimeout: LONG_MEDIA_PROXY_TIMEOUT_MS,
+        bodyTimeout: LONG_MEDIA_PROXY_TIMEOUT_MS,
+      });
+      task.status = 'running';
+      persistMediaTask(task);
+      generateMedia({
+        projectRoot: PROJECT_ROOT,
+        projectsRoot: PROJECTS_DIR,
+        projectId,
+        surface: req.body?.surface,
+        model: req.body?.model,
+        prompt: req.body?.prompt,
+        output: req.body?.output,
+        aspect: req.body?.aspect,
+        length:
+          typeof req.body?.length === 'number' ? req.body.length : undefined,
+        duration:
+          typeof req.body?.duration === 'number'
+            ? req.body.duration
+            : undefined,
+        voice: req.body?.voice,
+        audioKind: req.body?.audioKind,
+        language: typeof req.body?.language === 'string' ? req.body.language : undefined,
+        loop: typeof req.body?.loop === 'boolean' ? req.body.loop : undefined,
+        promptInfluence: typeof req.body?.promptInfluence === 'number'
+          ? req.body.promptInfluence
+          : undefined,
+        compositionDir: req.body?.compositionDir,
+        image: req.body?.image,
+        onProgress: (line: any) => appendTaskProgress(task, line),
+        requestInit: proxyDispatcher.requestInit,
+      })
+        .then((meta: any) => {
+          task.status = 'done';
+          task.file = meta;
+          task.endedAt = Date.now();
+          persistMediaTask(task);
+          notifyTaskWaiters(task);
+          console.error(
+            `[task ${taskId.slice(0, 8)}] done size=${meta?.size} mime=${meta?.mime} ` +
+              `elapsed=${Math.round((task.endedAt - task.startedAt) / 1000)}s`,
+          );
+        })
+        .catch((err: any) => {
+          task.status = 'failed';
+          task.error = {
+            message: String(err && err.message ? err.message : err),
+            status: typeof err?.status === 'number' ? err.status : 400,
+            code: err?.code,
+          };
+          task.endedAt = Date.now();
+          persistMediaTask(task);
+          notifyTaskWaiters(task);
+          console.error(
+            `[task ${taskId.slice(0, 8)}] failed status=${task.error.status} ` +
+              `message=${(task.error.message || '').slice(0, 240)}`,
+          );
+        })
+        .finally(() => proxyDispatcher.close());
+
+      return res.status(202).json({
+        taskId,
+        status: task.status,
+        startedAt: task.startedAt,
+      });
+    } catch (err: any) {
+      if (task) {
+        task.status = 'failed';
+        task.error = {
+          message: String(err && err.message ? err.message : err),
+          status: typeof err?.status === 'number' ? err.status : 400,
+          code: err?.code,
+        };
+        task.endedAt = Date.now();
+        persistMediaTask(task);
+        notifyTaskWaiters(task);
+      }
+      throw err;
+    }
+  };
   app.get('/api/media/models', (_req, res) => {
     res.json({
       providers: MEDIA_PROVIDERS,
@@ -158,102 +287,23 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
       });
     }
 
-    let task: ReturnType<typeof createMediaTask> | null = null;
     try {
-      const projectId = req.params.id;
-      const project = getProject(db, projectId);
-      if (!project) return res.status(404).json({ error: 'project not found' });
-
-      const taskId = randomUUID();
-      task = createMediaTask(taskId, projectId, {
-        surface: req.body?.surface,
-        model: req.body?.model,
-      });
-      console.error(
-        `[task ${taskId.slice(0, 8)}] queued model=${req.body?.model} ` +
-          `surface=${req.body?.surface} ` +
-          `image=${req.body?.image ? 'yes' : 'no'} ` +
-          `compositionDir=${req.body?.compositionDir ? 'yes' : 'no'}`,
-      );
-
-      const proxyDispatcher = proxyDispatcherRequestInit(process.env, {
-        headersTimeout: LONG_MEDIA_PROXY_TIMEOUT_MS,
-        bodyTimeout: LONG_MEDIA_PROXY_TIMEOUT_MS,
-      });
-      task.status = 'running';
-      persistMediaTask(task);
-      generateMedia({
-        projectRoot: PROJECT_ROOT,
-        projectsRoot: PROJECTS_DIR,
-        projectId,
-        surface: req.body?.surface,
-        model: req.body?.model,
-        prompt: req.body?.prompt,
-        output: req.body?.output,
-        aspect: req.body?.aspect,
-        length:
-          typeof req.body?.length === 'number' ? req.body.length : undefined,
-        duration:
-          typeof req.body?.duration === 'number'
-            ? req.body.duration
-            : undefined,
-        voice: req.body?.voice,
-        audioKind: req.body?.audioKind,
-        language: typeof req.body?.language === 'string' ? req.body.language : undefined,
-        loop: typeof req.body?.loop === 'boolean' ? req.body.loop : undefined,
-        promptInfluence: typeof req.body?.promptInfluence === 'number'
-          ? req.body.promptInfluence
-          : undefined,
-        compositionDir: req.body?.compositionDir,
-        image: req.body?.image,
-        onProgress: (line: any) => appendTaskProgress(task, line),
-        requestInit: proxyDispatcher.requestInit,
-      })
-        .then((meta: any) => {
-          task.status = 'done';
-          task.file = meta;
-          task.endedAt = Date.now();
-          persistMediaTask(task);
-          notifyTaskWaiters(task);
-          console.error(
-            `[task ${taskId.slice(0, 8)}] done size=${meta?.size} mime=${meta?.mime} ` +
-              `elapsed=${Math.round((task.endedAt - task.startedAt) / 1000)}s`,
-          );
-        })
-        .catch((err: any) => {
-          task.status = 'failed';
-          task.error = {
-            message: String(err && err.message ? err.message : err),
-            status: typeof err?.status === 'number' ? err.status : 400,
-            code: err?.code,
-          };
-          task.endedAt = Date.now();
-          persistMediaTask(task);
-          notifyTaskWaiters(task);
-          console.error(
-            `[task ${taskId.slice(0, 8)}] failed status=${task.error.status} ` +
-              `message=${(task.error.message || '').slice(0, 240)}`,
-          );
-        })
-        .finally(() => proxyDispatcher.close());
-
-      res.status(202).json({
-        taskId,
-        status: task.status,
-        startedAt: task.startedAt,
-      });
+      await handleGenerate(req, res, { projectId: req.params.id, grant: null });
     } catch (err: any) {
-      if (task) {
-        task.status = 'failed';
-        task.error = {
-          message: String(err && err.message ? err.message : err),
-          status: typeof err?.status === 'number' ? err.status : 400,
-          code: err?.code,
-        };
-        task.endedAt = Date.now();
-        persistMediaTask(task);
-        notifyTaskWaiters(task);
-      }
+      const status = typeof err?.status === 'number' ? err.status : 400;
+      const code = err?.code;
+      const body: any = { error: String(err && err.message ? err.message : err) };
+      if (code) body.code = code;
+      res.status(status).json(body);
+    }
+  });
+
+  app.post('/api/tools/media/generate', async (req, res) => {
+    const grant = authorizeToolRequest(req, res, 'media:generate');
+    if (!grant) return;
+    try {
+      await handleGenerate(req, res, { projectId: grant.projectId, grant });
+    } catch (err: any) {
       const status = typeof err?.status === 'number' ? err.status : 400;
       const code = err?.code;
       const body: any = { error: String(err && err.message ? err.message : err) };

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -23,6 +23,7 @@ import {
   IMAGE_MODELS,
   VIDEO_MODELS,
 } from '../media-models.js';
+import type { MediaExecutionPolicy, MediaSurface } from '@open-design/contracts';
 
 function fmtList(ids: string[]): string {
   return ids.map((id) => `\`${id}\``).join(', ');
@@ -33,6 +34,67 @@ const VIDEO_IDS = fmtList(VIDEO_MODELS.map((m) => m.id));
 const AUDIO_MUSIC_IDS = fmtList(AUDIO_MODELS_BY_KIND.music.map((m) => m.id));
 const AUDIO_SPEECH_IDS = fmtList(AUDIO_MODELS_BY_KIND.speech.map((m) => m.id));
 const AUDIO_SFX_IDS = fmtList(AUDIO_MODELS_BY_KIND.sfx.map((m) => m.id));
+
+export function renderMediaGenerationContract(
+  mediaExecution?: MediaExecutionPolicy | undefined,
+): string {
+  const mode = mediaExecution?.mode ?? 'enabled';
+  if (mode === 'enabled') {
+    return renderEnabledMediaGenerationContract(mediaExecution);
+  }
+  const scope = renderMediaPolicyScope(mediaExecution);
+  if (mode === 'disabled') {
+    return `
+---
+
+## Media generation policy (load-bearing — overrides softer wording above)
+
+Open Design-owned media execution is **disabled for this run**. Do not call
+\`"$OD_NODE_BIN" "$OD_BIN" media generate\`, Codex built-in imagegen, OD media
+provider APIs, local renderers, or ad-hoc scripts that create media bytes on
+OD's behalf.
+
+External MCP media tools, when explicitly configured for this run, are outside
+this OD-owned media policy. If no such external tool is available and the user
+asks for media, describe the intended creative brief, prompt, surface, model
+preference, references, and output filename in chat, then stop. Do not claim a
+file was generated and do not emit an \`<artifact>\` block for media.
+${scope}`;
+  }
+  return renderEnabledMediaGenerationContract(mediaExecution);
+}
+
+function renderEnabledMediaGenerationContract(
+  mediaExecution?: MediaExecutionPolicy | undefined,
+): string {
+  const scope = renderMediaPolicyScope(mediaExecution);
+  if (!scope) return MEDIA_GENERATION_CONTRACT;
+  return MEDIA_GENERATION_CONTRACT.replace(
+    '\n### Allowed model IDs (per surface)',
+    `
+### Active media policy scope
+
+The dispatcher will reject surfaces or models outside this run's active
+allowlist. Treat this allowlist as narrower than the full catalogue below;
+select only from it.
+${scope}
+
+### Allowed model IDs (per surface)`,
+  );
+}
+
+function renderMediaPolicyScope(
+  mediaExecution?: MediaExecutionPolicy | undefined,
+): string {
+  const lines: string[] = [];
+  if (Array.isArray(mediaExecution?.allowedSurfaces) && mediaExecution.allowedSurfaces.length > 0) {
+    lines.push(`Allowed surfaces for this run: ${fmtList(mediaExecution.allowedSurfaces as MediaSurface[])}.`);
+  }
+  if (Array.isArray(mediaExecution?.allowedModels) && mediaExecution.allowedModels.length > 0) {
+    lines.push(`Allowed models for this run: ${fmtList(mediaExecution.allowedModels)}.`);
+  }
+  return lines.length > 0 ? `\n\n${lines.join('\n')}` : '';
+}
 
 export const MEDIA_GENERATION_CONTRACT = `
 ---

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -32,10 +32,11 @@
 import { OFFICIAL_DESIGNER_PROMPT } from './official-system.js';
 import { DISCOVERY_AND_PHILOSOPHY } from './discovery.js';
 import { DECK_FRAMEWORK_DIRECTIVE } from './deck-framework.js';
-import { MEDIA_GENERATION_CONTRACT } from './media-contract.js';
+import { renderMediaGenerationContract } from './media-contract.js';
 import { IMAGE_MODELS } from '../media-models.js';
 import { renderPanelPrompt } from './panel.js';
 import { defaultCritiqueConfig, type CritiqueConfig } from '@open-design/contracts/critique';
+import type { MediaExecutionPolicy, MediaSurface } from '@open-design/contracts';
 
 const ELEVENLABS_VOICE_PROMPT_OPTION_LIMIT = 100;
 const ELEVENLABS_VOICE_OPTIONS_PROMPT_PREFIX = 'ElevenLabs voice list could not be loaded';
@@ -371,6 +372,9 @@ export interface ComposeInput {
   // UI locale selected by the client. User-visible generated form copy
   // must follow this locale even when the user's initial prompt is brief.
   locale?: string | undefined;
+  // Run-scoped media policy. Defaults to enabled when omitted so existing
+  // local OD behavior keeps the same media prompt contract.
+  mediaExecution?: MediaExecutionPolicy | undefined;
 }
 
 export function composeSystemPrompt({
@@ -405,6 +409,7 @@ export function composeSystemPrompt({
   locale,
   userInstructions,
   projectInstructions,
+  mediaExecution,
 }: ComposeInput): string {
   // Discovery + philosophy goes FIRST so its hard rules ("emit a form on
   // turn 1", "branch on brand on turn 2", "TodoWrite on turn 3", run
@@ -557,7 +562,13 @@ export function composeSystemPrompt({
     }
   }
 
-  const metaBlock = renderMetadataBlock(metadata, template, audioVoiceOptions, audioVoiceOptionsError);
+  const metaBlock = renderMetadataBlock(
+    metadata,
+    template,
+    audioVoiceOptions,
+    audioVoiceOptionsError,
+    mediaExecution,
+  );
   if (metaBlock) parts.push(metaBlock);
 
   // Decks have a load-bearing framework (nav, counter, scroll JS, print
@@ -602,10 +613,10 @@ export function composeSystemPrompt({
     || resolvedExclusiveSurface === 'video'
     || resolvedExclusiveSurface === 'audio';
   if (isMediaSurface) {
-    parts.push(MEDIA_GENERATION_CONTRACT);
+    parts.push(renderMediaGenerationContract(mediaExecution));
   }
 
-  if (includeCodexImagegenOverride) {
+  if (includeCodexImagegenOverride && shouldAllowCodexImagegenOverride(metadata, mediaExecution)) {
     const codexImagegenOverride = renderCodexImagegenOverride(
       agentId,
       metadata,
@@ -757,6 +768,31 @@ export function shouldRenderCodexImagegenOverride(
   );
 }
 
+function shouldAllowCodexImagegenOverride(
+  metadata: ProjectMetadata | undefined,
+  mediaExecution: MediaExecutionPolicy | undefined,
+): boolean {
+  const mode = mediaExecution?.mode ?? 'enabled';
+  if (mode !== 'enabled') return false;
+  if (
+    Array.isArray(mediaExecution?.allowedSurfaces) &&
+    mediaExecution.allowedSurfaces.length > 0 &&
+    !mediaExecution.allowedSurfaces.includes('image')
+  ) {
+    return false;
+  }
+  const model = resolveCodexImagegenModelId(metadata);
+  if (
+    model &&
+    Array.isArray(mediaExecution?.allowedModels) &&
+    mediaExecution.allowedModels.length > 0 &&
+    !mediaExecution.allowedModels.includes(model)
+  ) {
+    return false;
+  }
+  return true;
+}
+
 export function renderCodexImagegenOverride(
   agentId: string | null | undefined,
   metadata: ProjectMetadata | undefined,
@@ -813,6 +849,7 @@ function renderMetadataBlock(
   template: ProjectTemplate | undefined,
   audioVoiceOptions: AudioVoiceOption[] | undefined,
   audioVoiceOptionsError: string | undefined,
+  mediaExecution: MediaExecutionPolicy | undefined,
 ): string {
   if (!metadata) return '';
   const lines: string[] = [];
@@ -921,9 +958,11 @@ function renderMetadataBlock(
       lines.push(`- **referenceTemplate**: ${metadata.promptTemplate.title}`);
     }
     lines.push('');
-    lines.push(
-      'This is an **image** project. Plan the prompt carefully, then dispatch via the **media generation contract** using `"$OD_NODE_BIN" "$OD_BIN" media generate --surface image --model <imageModel>`. Do NOT emit `<artifact>` HTML for media surfaces.',
-    );
+    lines.push(renderMediaMetadataAction(
+      'image',
+      '`"$OD_NODE_BIN" "$OD_BIN" media generate --surface image --model <imageModel>`',
+      mediaExecution,
+    ));
   }
   if (metadata.kind === 'video') {
     lines.push(
@@ -943,9 +982,11 @@ function renderMetadataBlock(
       lines.push(`- **referenceTemplate**: ${metadata.promptTemplate.title}`);
     }
     lines.push('');
-    lines.push(
-      'This is a **video** project. Plan the shotlist and motion, then dispatch via the **media generation contract** using `"$OD_NODE_BIN" "$OD_BIN" media generate --surface video --model <videoModel> --length <seconds> --aspect <ratio>`. Do NOT emit `<artifact>` HTML.',
-    );
+    lines.push(renderMediaMetadataAction(
+      'video',
+      '`"$OD_NODE_BIN" "$OD_BIN" media generate --surface video --model <videoModel> --length <seconds> --aspect <ratio>`',
+      mediaExecution,
+    ));
     if (metadata.videoModel === 'hyperframes-html') {
       lines.push(
         'Special case: `hyperframes-html` is a local HTML-to-MP4 renderer, not a photoreal text-to-video model. Treat it like a motion design renderer, ask at most one clarifying question, then dispatch immediately.',
@@ -995,9 +1036,11 @@ function renderMetadataBlock(
       );
     }
     lines.push('');
-    lines.push(
-      'This is an **audio** project. Lock the content intent first, then dispatch via the **media generation contract** using `"$OD_NODE_BIN" "$OD_BIN" media generate --surface audio --audio-kind <kind> --model <audioModel> --duration <seconds>` and add `--voice <voice-id>` for speech when you have a provider-specific voice id. Do NOT emit `<artifact>` HTML.',
-    );
+    lines.push(renderMediaMetadataAction(
+      'audio',
+      '`"$OD_NODE_BIN" "$OD_BIN" media generate --surface audio --audio-kind <kind> --model <audioModel> --duration <seconds>` and add `--voice <voice-id>` for speech when you have a provider-specific voice id',
+      mediaExecution,
+    ));
   }
 
   if (metadata.inspirationDesignSystemIds && metadata.inspirationDesignSystemIds.length > 0) {
@@ -1138,6 +1181,19 @@ function renderMetadataBlock(
   }
 
   return lines.join('\n');
+}
+
+function renderMediaMetadataAction(
+  surface: MediaSurface,
+  command: string,
+  mediaExecution: MediaExecutionPolicy | undefined,
+): string {
+  const article = surface === 'audio' ? 'an' : 'a';
+  const mode = mediaExecution?.mode ?? 'enabled';
+  if (mode === 'disabled') {
+    return `This is ${article} **${surface}** project, but Open Design-owned media execution is disabled for this run. Plan the creative brief only unless an external MCP media tool is explicitly configured. Do NOT call OD media generation tools and do NOT emit \`<artifact>\` HTML for media surfaces.`;
+  }
+  return `This is ${article} **${surface}** project. Plan the creative brief carefully, then dispatch via the **media generation contract** using ${command}. Do NOT emit \`<artifact>\` HTML for media surfaces.`;
 }
 
 function shouldRenderElevenLabsVoiceOptions(

--- a/apps/daemon/src/runs.ts
+++ b/apps/daemon/src/runs.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { randomUUID } from 'node:crypto';
+import { normalizeMediaExecutionPolicyForRun } from './media-policy.js';
 
 export const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
 
@@ -45,6 +46,7 @@ export function createChatRunService({
           : null,
       pluginId:
         typeof meta.pluginId === 'string' && meta.pluginId ? meta.pluginId : null,
+      mediaExecution: normalizeMediaExecutionPolicyForRun(meta.mediaExecution),
       status: 'queued',
       createdAt: now,
       updatedAt: now,
@@ -102,6 +104,7 @@ export function createChatRunService({
     signal: run.signal,
     error: run.error ?? null,
     errorCode: run.errorCode ?? null,
+    mediaExecution: run.mediaExecution ?? normalizeMediaExecutionPolicyForRun(null),
   });
 
   const finish = (run, status, code: number | null = null, signal: string | null = null) => {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -20,6 +20,7 @@ import {
 import {
   composeSystemPrompt,
   renderCodexImagegenOverride,
+  resolveCodexImagegenModelId,
   resolveExclusiveSurface,
   shouldRenderCodexImagegenOverride,
 } from './prompts/system.js';
@@ -83,6 +84,7 @@ import { installFromTarget, uninstallById, sanitizeRepoName } from './library-in
 import { buildWindowsFolderDialogCommand, parseFolderDialogStdout } from './native-folder-dialog.js';
 import { listCodexPets, readCodexPetSpritesheet } from './codex-pets.js';
 import { syncCommunityPets } from './community-pets-sync.js';
+import { parseMediaExecutionPolicyInput } from './media-policy.js';
 import {
   createUserDesignSystem,
   deleteUserDesignSystem,
@@ -536,7 +538,9 @@ export function resolveCodexGeneratedImagesDir(
   metadata,
   env = process.env,
   homeDir = os.homedir(),
+  mediaExecution: any = undefined,
 ) {
+  if (!shouldAllowCodexImagegenForMediaPolicy(metadata, mediaExecution)) return null;
   if (!shouldRenderCodexImagegenOverride(agentId, metadata)) return null;
   const rawCodexHome =
     typeof env?.CODEX_HOME === 'string' && env.CODEX_HOME.trim().length > 0
@@ -751,12 +755,17 @@ export function resolveGrantedCodexImagegenOverride({
   metadata,
   codexGeneratedImagesDir,
   extraAllowedDirs = [],
+  mediaExecution,
 }: {
   agentId?: string | null;
   metadata?: unknown;
   codexGeneratedImagesDir?: string | null;
   extraAllowedDirs?: string[];
+  mediaExecution?: unknown;
 }): string | null {
+  if (!shouldAllowCodexImagegenForMediaPolicy(metadata, mediaExecution)) {
+    return null;
+  }
   if (
     typeof codexGeneratedImagesDir !== 'string' ||
     codexGeneratedImagesDir.length === 0 ||
@@ -766,6 +775,28 @@ export function resolveGrantedCodexImagegenOverride({
     return null;
   }
   return renderCodexImagegenOverride(agentId, metadata);
+}
+
+function shouldAllowCodexImagegenForMediaPolicy(metadata, mediaExecution) {
+  const mode = mediaExecution?.mode ?? 'enabled';
+  if (mode !== 'enabled') return false;
+  if (
+    Array.isArray(mediaExecution?.allowedSurfaces) &&
+    mediaExecution.allowedSurfaces.length > 0 &&
+    !mediaExecution.allowedSurfaces.includes('image')
+  ) {
+    return false;
+  }
+  const model = resolveCodexImagegenModelId(metadata);
+  if (
+    model &&
+    Array.isArray(mediaExecution?.allowedModels) &&
+    mediaExecution.allowedModels.length > 0 &&
+    !mediaExecution.allowedModels.includes(model)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function normalizeCommentAttachments(input) {
@@ -5418,9 +5449,11 @@ export async function startServer({
 
   registerMediaRoutes(app, {
     db,
+    design,
     http: httpDeps,
     paths: pathDeps,
     ids: idDeps,
+    auth: authDeps,
     media: mediaDeps,
     appConfig: appConfigDeps,
     orbit: orbitDeps,
@@ -9750,6 +9783,7 @@ export async function startServer({
     locale,
     connectedExternalMcp,
     appliedPluginSnapshotId,
+    mediaExecution,
   }) => {
     const project =
       typeof projectId === 'string' && projectId
@@ -10197,6 +10231,7 @@ export async function startServer({
       critiqueBrand: critiqueShouldRun ? critiqueBrand : undefined,
       critiqueSkill: critiqueShouldRun ? critiqueSkill : undefined,
       locale: typeof locale === 'string' ? locale : undefined,
+      mediaExecution,
       streamFormat,
       connectedExternalMcp: Array.isArray(connectedExternalMcp)
         ? connectedExternalMcp
@@ -10552,6 +10587,7 @@ export async function startServer({
         streamFormat: def?.streamFormat ?? 'plain',
         locale,
         connectedExternalMcp,
+        mediaExecution: run?.mediaExecution,
         // Plan §3.M2 / §3.V1 — forward the run's snapshot id so the
         // prompt composer can splice in `## Active stage` blocks.
         // Default ON; set OD_BUNDLED_ATOM_PROMPTS=0 to opt out.
@@ -10611,6 +10647,9 @@ export async function startServer({
     let codexGeneratedImagesDir = resolveCodexGeneratedImagesDir(
       agentId,
       projectRecord?.metadata,
+      process.env,
+      os.homedir(),
+      run?.mediaExecution,
     );
     if (codexGeneratedImagesDir) {
       codexGeneratedImagesDir = validateCodexGeneratedImagesDir(
@@ -10632,6 +10671,7 @@ export async function startServer({
       metadata: projectRecord?.metadata,
       codexGeneratedImagesDir,
       extraAllowedDirs,
+      mediaExecution: run?.mediaExecution,
     });
     const researchCommandContract = resolveResearchCommandContract(
       research,
@@ -12141,6 +12181,10 @@ export async function startServer({
     if (daemonShuttingDown) {
       return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', 'daemon is shutting down');
     }
+    const mediaExecution = parseMediaExecutionPolicyInput(req.body?.mediaExecution);
+    if (!mediaExecution.ok) {
+      return sendApiError(res, 400, 'BAD_REQUEST', mediaExecution.message);
+    }
     // Plan §3.A1 / spec §11.5: resolve any pluginId / appliedPluginSnapshotId
     // before the run is created. The resolver returns null when the body
     // does not mention a plugin (legacy runs unchanged), an error envelope
@@ -12200,7 +12244,7 @@ export async function startServer({
         resolvedSnapshot = resolved;
       }
     }
-    const meta = { ...(req.body || {}) };
+    const meta = { ...(req.body || {}), mediaExecution: mediaExecution.policy };
     if (resolvedSnapshot?.ok) {
       meta.appliedPluginSnapshotId = resolvedSnapshot.snapshotId;
       if (!meta.pluginId) meta.pluginId = resolvedSnapshot.snapshot.pluginId;
@@ -12607,9 +12651,14 @@ export async function startServer({
     if (daemonShuttingDown) {
       return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', 'daemon is shutting down');
     }
-    const run = design.runs.create();
+    const mediaExecution = parseMediaExecutionPolicyInput(req.body?.mediaExecution);
+    if (!mediaExecution.ok) {
+      return sendApiError(res, 400, 'BAD_REQUEST', mediaExecution.message);
+    }
+    const meta = { ...(req.body || {}), mediaExecution: mediaExecution.policy };
+    const run = design.runs.create(meta);
     design.runs.stream(run, req, res);
-    design.runs.start(run, () => startChatRun(req.body || {}, run));
+    design.runs.start(run, () => startChatRun(meta, run));
   });
 
   // Each routine fire resolves an agent, prepares project/conversation state,

--- a/apps/daemon/src/tool-tokens.ts
+++ b/apps/daemon/src/tool-tokens.ts
@@ -10,6 +10,7 @@ export const CHAT_TOOL_ENDPOINTS = [
   '/api/tools/connectors/list',
   '/api/tools/connectors/execute',
   '/api/tools/design-systems/read',
+  '/api/tools/media/generate',
 ] as const;
 
 export const CHAT_TOOL_OPERATIONS = [
@@ -20,6 +21,7 @@ export const CHAT_TOOL_OPERATIONS = [
   'connectors:list',
   'connectors:execute',
   'design-systems:read',
+  'media:generate',
 ] as const;
 
 export type ToolEndpoint = (typeof CHAT_TOOL_ENDPOINTS)[number] | (string & {});

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -523,6 +523,65 @@ process.stdin.on('end', () => {
     );
   });
 
+  it('honors mediaExecution on legacy chat requests', async () => {
+    const conversationId = `conv-${randomUUID()}`;
+
+    const response = await fetch(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: `missing-agent-${randomUUID()}`,
+        conversationId,
+        message: 'plan an image without using OD media',
+        skillId: 'imagegen',
+        mediaExecution: {
+          mode: 'disabled',
+          allowedSurfaces: ['image'],
+        },
+      }),
+    });
+    const body = await response.text();
+
+    expect(response.ok).toBe(true);
+    expect(body).toContain('unknown agent');
+
+    const runsResponse = await fetch(
+      `${baseUrl}/api/runs?conversationId=${encodeURIComponent(conversationId)}`,
+    );
+    const runsBody = await runsResponse.json() as {
+      runs: Array<{ mediaExecution?: { mode?: string; allowedSurfaces?: string[] } }>;
+    };
+    expect(runsBody.runs).toHaveLength(1);
+    expect(runsBody.runs[0]?.mediaExecution).toMatchObject({
+      mode: 'disabled',
+      allowedSurfaces: ['image'],
+    });
+  });
+
+  it('rejects invalid mediaExecution on legacy chat requests', async () => {
+    const conversationId = `conv-${randomUUID()}`;
+    const response = await fetch(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        conversationId,
+        message: 'generate an image',
+        mediaExecution: { mode: 'provider-router' },
+      }),
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(body).toContain('mediaExecution.mode');
+
+    const runsResponse = await fetch(
+      `${baseUrl}/api/runs?conversationId=${encodeURIComponent(conversationId)}`,
+    );
+    const runsBody = await runsResponse.json() as { runs: unknown[] };
+    expect(runsBody.runs).toEqual([]);
+  });
+
   it('propagates ad-hoc skill critique policy into the chat resolver', async () => {
     if (!process.env.OD_DATA_DIR) {
       throw new Error('OD_DATA_DIR is required for user skill critique-policy tests');
@@ -1554,6 +1613,43 @@ describe('chat prompt helpers', () => {
     expect(clientIdx).toBeGreaterThan(-1);
     expect(overrideIdx).toBeGreaterThan(clientIdx);
     expect(prompt.match(/## Codex built-in imagegen override/g)).toHaveLength(1);
+  });
+
+  it('omits the Codex final imagegen override when run media policy blocks execution', () => {
+    const metadata = {
+      kind: 'image',
+      imageModel: 'gpt-image-2',
+      imageAspect: '1:1',
+    };
+    const mediaExecution = {
+      mode: 'disabled',
+      allowedSurfaces: ['image'],
+    };
+    const generatedImagesDir = resolveCodexGeneratedImagesDir(
+      'codex',
+      metadata,
+      { CODEX_HOME: '/tmp/custom-codex-home' },
+      '/home/tester',
+      mediaExecution,
+    );
+    const otherwiseGrantedDir = resolve('/tmp/custom-codex-home/generated_images');
+    const override = resolveGrantedCodexImagegenOverride({
+      agentId: 'codex',
+      metadata,
+      codexGeneratedImagesDir: otherwiseGrantedDir,
+      extraAllowedDirs: [otherwiseGrantedDir],
+      mediaExecution,
+    });
+    const prompt = composeLiveInstructionPrompt({
+      daemonSystemPrompt: 'daemon media policy prompt',
+      runtimeToolPrompt: 'runtime tools',
+      clientSystemPrompt: 'client instructions',
+      finalPromptOverride: override,
+    });
+
+    expect(generatedImagesDir).toBeNull();
+    expect(override).toBeNull();
+    expect(prompt).not.toContain('## Codex built-in imagegen override');
   });
 
   it('defaults enabled research without an explicit query to the current message', () => {

--- a/apps/daemon/tests/cli-startup.test.ts
+++ b/apps/daemon/tests/cli-startup.test.ts
@@ -1,4 +1,5 @@
 import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import http from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -56,5 +57,76 @@ describe('CLI startup boundaries', () => {
       await chmod(dataDir, 0o700).catch(() => undefined);
       await rm(root, { recursive: true, force: true });
     }
+  });
+
+  it('uses the token-gated media endpoint without falling back when policy denies generation', async () => {
+    const seen: Array<{ url: string | undefined; authorization: string | undefined }> = [];
+    const server = http.createServer((req, res) => {
+      seen.push({
+        url: req.url,
+        authorization: req.headers.authorization,
+      });
+      req.resume();
+      if (req.url === '/api/tools/media/generate') {
+        res.writeHead(403, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          error: {
+            code: 'MEDIA_EXECUTION_DISABLED',
+            message: 'media generation is disabled for this run',
+          },
+        }));
+        return;
+      }
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unexpected fallback' }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    const daemonUrl = `http://127.0.0.1:${port}`;
+
+    try {
+      await execFileAsync(
+        process.execPath,
+        [
+          '--import',
+          'tsx',
+          cliEntry,
+          'media',
+          'generate',
+          '--project',
+          'project-1',
+          '--surface',
+          'image',
+          '--model',
+          'gpt-image-2',
+          '--prompt',
+          'test',
+          '--daemon-url',
+          daemonUrl,
+        ],
+        {
+          cwd: daemonRoot,
+          env: {
+            ...process.env,
+            OD_TOOL_TOKEN: 'run-token',
+          },
+        },
+      );
+      throw new Error('media command unexpectedly succeeded');
+    } catch (error: unknown) {
+      const failed = error as { code?: number; stderr?: string };
+      expect(failed.code).toBe(4);
+      expect(failed.stderr ?? '').toContain('MEDIA_EXECUTION_DISABLED');
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+
+    expect(seen).toEqual([
+      {
+        url: '/api/tools/media/generate',
+        authorization: 'Bearer run-token',
+      },
+    ]);
   });
 });

--- a/apps/daemon/tests/media-policy-routes.test.ts
+++ b/apps/daemon/tests/media-policy-routes.test.ts
@@ -1,0 +1,350 @@
+import type http from 'node:http';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+describe('run-scoped media policy routes', () => {
+  let tempDir: string;
+  let binDir: string;
+  let oldPath: string | undefined;
+  let oldCapture: string | undefined;
+  let server: http.Server | null = null;
+  let shutdown: (() => Promise<void> | void) | undefined;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-media-policy-route-'));
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-media-policy-bin-'));
+    oldPath = process.env.PATH;
+    oldCapture = process.env.OD_CAPTURE_MEDIA_RESPONSE;
+    process.env.PATH = `${binDir}${path.delimiter}${oldPath ?? ''}`;
+  });
+
+  afterEach(async () => {
+    await Promise.resolve(shutdown?.());
+    shutdown = undefined;
+    if (server) {
+      await new Promise<void>((resolve) => server?.close(() => resolve()));
+      server = null;
+    }
+    if (oldPath === undefined) delete process.env.PATH;
+    else process.env.PATH = oldPath;
+    if (oldCapture === undefined) delete process.env.OD_CAPTURE_MEDIA_RESPONSE;
+    else process.env.OD_CAPTURE_MEDIA_RESPONSE = oldCapture;
+    await rm(tempDir, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
+  });
+
+  it('rejects in-run media generation when media execution is disabled', async () => {
+    const capturePath = path.join(tempDir, 'media-disabled-response.json');
+    await writeFakeAgent(capturePath, {
+      surface: 'image',
+      model: 'gpt-image-2',
+      prompt: 'Create a launch poster',
+      output: 'poster.png',
+    });
+
+    const { url, projectId, conversationId } = await startProjectServer('Disabled media project');
+
+    const createResponse = await fetch(`${url}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        projectId,
+        conversationId,
+        message: 'Try to create a poster image.',
+        mediaExecution: { mode: 'disabled' },
+      }),
+    });
+    expect(createResponse.status).toBe(202);
+
+    const captured = await waitForCapturedMediaResponse(capturePath);
+    expect(captured.status).toBe(403);
+    expect(captured.tokenAvailable).toBe(true);
+    expect(captured.body.error).toMatchObject({
+      code: 'MEDIA_EXECUTION_DISABLED',
+    });
+  });
+
+  it('rejects disallowed surfaces and models on token-gated media generation', async () => {
+    const surfaceCapturePath = path.join(tempDir, 'media-surface-denied.json');
+    await writeFakeAgent(surfaceCapturePath, {
+      surface: 'image',
+      model: 'gpt-image-2',
+      prompt: 'Create a launch poster',
+      output: 'poster.png',
+    });
+    const surfaceProject = await startProjectServer('Surface denied media project');
+    const surfaceResponse = await fetch(`${surfaceProject.url}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        projectId: surfaceProject.projectId,
+        conversationId: surfaceProject.conversationId,
+        message: 'Try to create a poster image.',
+        mediaExecution: {
+          mode: 'enabled',
+          allowedSurfaces: ['video'],
+        },
+      }),
+    });
+    expect(surfaceResponse.status).toBe(202);
+    const surfaceCaptured = await waitForCapturedMediaResponse(surfaceCapturePath);
+    expect(surfaceCaptured.status).toBe(403);
+    expect(surfaceCaptured.body.error).toMatchObject({
+      code: 'MEDIA_SURFACE_DENIED',
+    });
+
+    const modelCapturePath = path.join(tempDir, 'media-model-denied.json');
+    await writeFakeAgent(modelCapturePath, {
+      surface: 'image',
+      model: 'gpt-image-2',
+      prompt: 'Create a launch poster',
+      output: 'poster.png',
+    });
+    const modelProject = await startProjectServer('Model denied media project');
+    const modelResponse = await fetch(`${modelProject.url}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        projectId: modelProject.projectId,
+        conversationId: modelProject.conversationId,
+        message: 'Try to create a poster image.',
+        mediaExecution: {
+          mode: 'enabled',
+          allowedModels: ['different-image-model'],
+        },
+      }),
+    });
+    expect(modelResponse.status).toBe(202);
+    const modelCaptured = await waitForCapturedMediaResponse(modelCapturePath);
+    expect(modelCaptured.status).toBe(403);
+    expect(modelCaptured.body.error).toMatchObject({
+      code: 'MEDIA_MODEL_DENIED',
+    });
+  });
+
+  it('applies legacy chat disabled policy to the spawned media tool path', async () => {
+    const capturePath = path.join(tempDir, 'legacy-chat-disabled-response.json');
+    await writeFakeAgent(capturePath, {
+      surface: 'image',
+      model: 'gpt-image-2',
+      prompt: 'Create a launch poster',
+      output: 'poster.png',
+    });
+
+    const { url, projectId, conversationId } = await startProjectServer(
+      'Legacy chat disabled media project',
+    );
+
+    const chatResponse = await fetch(`${url}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        projectId,
+        conversationId,
+        message: 'Create a poster image from legacy chat.',
+        mediaExecution: { mode: 'disabled' },
+      }),
+    });
+    expect(chatResponse.status).toBe(200);
+
+    const captured = await waitForCapturedMediaResponse(capturePath);
+    expect(captured.status).toBe(403);
+    expect(captured.tokenAvailable).toBe(true);
+    expect(captured.body.error).toMatchObject({
+      code: 'MEDIA_EXECUTION_DISABLED',
+    });
+
+    await chatResponse.text();
+  });
+
+  it('defaults omitted mediaExecution to enabled on run and legacy chat creation', async () => {
+    const { url, projectId, conversationId } = await startProjectServer('Default policy project');
+
+    const runResponse = await fetch(`${url}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: `missing-agent-${randomUUID()}`,
+        projectId,
+        conversationId,
+        message: 'Create a poster image.',
+      }),
+    });
+    expect(runResponse.status).toBe(202);
+    const runBody = await runResponse.json() as { runId: string };
+    const runStatusResponse = await fetch(`${url}/api/runs/${encodeURIComponent(runBody.runId)}`);
+    const runStatus = await runStatusResponse.json() as {
+      mediaExecution?: { mode?: string };
+    };
+    expect(runStatus.mediaExecution).toEqual({ mode: 'enabled' });
+
+    const legacyConversationId = `legacy-${randomUUID()}`;
+    const chatResponse = await fetch(`${url}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: `missing-agent-${randomUUID()}`,
+        projectId,
+        conversationId: legacyConversationId,
+        message: 'Create a poster image.',
+      }),
+    });
+    expect(chatResponse.status).toBe(200);
+    await chatResponse.text();
+    const runsResponse = await fetch(
+      `${url}/api/runs?conversationId=${encodeURIComponent(legacyConversationId)}`,
+    );
+    const runsBody = await runsResponse.json() as {
+      runs: Array<{ mediaExecution?: { mode?: string } }>;
+    };
+    expect(runsBody.runs).toHaveLength(1);
+    expect(runsBody.runs[0]?.mediaExecution).toEqual({ mode: 'enabled' });
+  });
+
+  it('fails closed when a media tool request does not carry a valid run token', async () => {
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    server = started.server;
+    shutdown = started.shutdown;
+
+    const response = await fetch(`${started.url}/api/tools/media/generate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer invalid-token',
+      },
+      body: JSON.stringify({
+        surface: 'image',
+        model: 'gpt-image-2',
+        prompt: 'Create a launch poster',
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json() as { error?: { code?: string } };
+    expect(body.error).toMatchObject({ code: 'TOOL_TOKEN_INVALID' });
+  });
+
+  async function startProjectServer(name: string): Promise<{
+    url: string;
+    projectId: string;
+    conversationId: string;
+  }> {
+    if (server) {
+      await Promise.resolve(shutdown?.());
+      shutdown = undefined;
+      await new Promise<void>((resolve) => server?.close(() => resolve()));
+      server = null;
+    }
+
+    const projectId = `project_${randomUUID()}`;
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+      shutdown?: () => Promise<void> | void;
+    };
+    server = started.server;
+    shutdown = started.shutdown;
+
+    const projectResponse = await fetch(`${started.url}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name,
+        metadata: { kind: 'image' },
+      }),
+    });
+    expect(projectResponse.status).toBe(200);
+    const projectBody = await projectResponse.json() as { conversationId: string };
+    return {
+      url: started.url,
+      projectId,
+      conversationId: projectBody.conversationId,
+    };
+  }
+
+  async function writeFakeAgent(capturePath: string, requestBody: unknown): Promise<void> {
+    const source = `#!/usr/bin/env node
+const fs = require('node:fs');
+
+(async () => {
+  if (process.argv.includes('--version')) {
+    console.log('opencode 1.0.0');
+    return;
+  }
+  if (process.argv[2] === 'models') {
+    console.log('default');
+    return;
+  }
+  if (process.argv[2] !== 'run') {
+    return;
+  }
+  const token = process.env.OD_TOOL_TOKEN;
+  const response = await fetch(process.env.OD_DAEMON_URL + '/api/tools/media/generate', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Bearer ' + token,
+    },
+    body: JSON.stringify(${JSON.stringify(requestBody)}),
+  });
+  const text = await response.text();
+  fs.writeFileSync(process.env.OD_CAPTURE_MEDIA_RESPONSE, JSON.stringify({
+    status: response.status,
+    tokenAvailable: Boolean(token),
+    body: JSON.parse(text),
+  }));
+  console.log(JSON.stringify({ type: 'text', part: { text: 'media policy checked' } }));
+})().catch((error) => {
+  fs.writeFileSync(process.env.OD_CAPTURE_MEDIA_RESPONSE, JSON.stringify({
+    status: 0,
+    tokenAvailable: Boolean(process.env.OD_TOOL_TOKEN),
+    body: { error: String(error && error.message ? error.message : error) },
+  }));
+  process.exit(1);
+});
+`;
+    if (process.platform === 'win32') {
+      const runner = path.join(binDir, 'opencode-runner.cjs');
+      await writeFile(runner, source.replace(/^#![^\n]*\n/, ''));
+      await writeFile(
+        path.join(binDir, 'opencode.cmd'),
+        `@echo off\r\nnode "${runner}" %*\r\n`,
+      );
+    } else {
+      const bin = path.join(binDir, 'opencode');
+      await writeFile(bin, source);
+      await chmod(bin, 0o755);
+    }
+    process.env.OD_CAPTURE_MEDIA_RESPONSE = capturePath;
+  }
+
+  async function waitForCapturedMediaResponse(capturePath: string): Promise<{
+    status: number;
+    tokenAvailable: boolean;
+    body: any;
+  }> {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < 10_000) {
+      try {
+        return JSON.parse(await readFile(capturePath, 'utf8'));
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    throw new Error('timed out waiting for fake agent media response');
+  }
+});

--- a/apps/daemon/tests/media-policy.test.ts
+++ b/apps/daemon/tests/media-policy.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultMediaExecutionPolicy,
+  mediaPolicyDenial,
+  normalizeMediaExecutionPolicyForRun,
+  parseMediaExecutionPolicyInput,
+} from '../src/media-policy.js';
+
+describe('media execution policy parsing', () => {
+  it('defaults omitted policy to enabled', () => {
+    expect(parseMediaExecutionPolicyInput(undefined)).toEqual({
+      ok: true,
+      policy: { mode: 'enabled' },
+    });
+    expect(defaultMediaExecutionPolicy()).toEqual({ mode: 'enabled' });
+  });
+
+  it('normalizes allowed surfaces and models', () => {
+    expect(parseMediaExecutionPolicyInput({
+      mode: 'enabled',
+      allowedSurfaces: ['image', 'video', 'image'],
+      allowedModels: [' gpt-image-2 ', 'gpt-image-2', 'video-model'],
+    })).toEqual({
+      ok: true,
+      policy: {
+        mode: 'enabled',
+        allowedSurfaces: ['image', 'video'],
+        allowedModels: ['gpt-image-2', 'video-model'],
+      },
+    });
+  });
+
+  it('rejects invalid modes and surfaces', () => {
+    expect(parseMediaExecutionPolicyInput({ mode: 'provider-router' })).toMatchObject({
+      ok: false,
+      message: expect.stringContaining('mediaExecution.mode'),
+    });
+    expect(parseMediaExecutionPolicyInput({
+      mode: 'enabled',
+      allowedSurfaces: ['image', 'text'],
+    })).toMatchObject({
+      ok: false,
+      message: expect.stringContaining('allowedSurfaces'),
+    });
+  });
+
+  it('falls back to enabled when normalizing invalid direct run-service input', () => {
+    expect(normalizeMediaExecutionPolicyForRun({ mode: 'bad' })).toEqual({
+      mode: 'enabled',
+    });
+  });
+
+  it('denies disabled runs and allowlist mismatches', () => {
+    expect(mediaPolicyDenial({ mode: 'disabled' }, {
+      surface: 'image',
+      model: 'gpt-image-2',
+    })).toMatchObject({ code: 'MEDIA_EXECUTION_DISABLED' });
+    expect(mediaPolicyDenial({
+      mode: 'enabled',
+      allowedSurfaces: ['video'],
+    }, {
+      surface: 'image',
+      model: 'gpt-image-2',
+    })).toMatchObject({ code: 'MEDIA_SURFACE_DENIED' });
+    expect(mediaPolicyDenial({
+      mode: 'enabled',
+      allowedModels: ['gpt-image-2'],
+    }, {
+      surface: 'image',
+      model: 'dall-e-3',
+    })).toMatchObject({ code: 'MEDIA_MODEL_DENIED' });
+  });
+});

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -389,6 +389,19 @@ describe('composeSystemPrompt', () => {
       expect(prompt).toContain('- `github`\n');
       expect(prompt).not.toContain('- `github` (github)');
     });
+
+    it('keeps external MCP tools visible when OD-owned media execution is disabled', () => {
+      const prompt = composeSystemPrompt({
+        connectedExternalMcp: [{ id: 'external-media', label: 'External media' }],
+        metadata: { kind: 'image' },
+        mediaExecution: { mode: 'disabled' },
+      });
+
+      expect(prompt).toContain('## External MCP servers — already authenticated');
+      expect(prompt).toContain('`external-media`');
+      expect(prompt).toContain('Open Design-owned media execution is **disabled for this run**');
+      expect(prompt).not.toContain('## Media generation contract');
+    });
   });
 
   // The daemon experiment for compiling a brand's design system from prose

--- a/apps/daemon/tests/runs.test.ts
+++ b/apps/daemon/tests/runs.test.ts
@@ -43,6 +43,23 @@ describe('chat run service shutdown', () => {
     ).toEqual([runB]);
   });
 
+  it('stores effective media execution policy on run status bodies', () => {
+    const runs = createRuns();
+    const defaultRun = runs.create({ projectId: 'project-1', conversationId: 'conv-a' });
+    const scopedRun = runs.create({
+      projectId: 'project-1',
+      conversationId: 'conv-b',
+      mediaExecution: { mode: 'enabled', allowedSurfaces: ['image'] },
+    });
+
+    expect(runs.statusBody(defaultRun)).toMatchObject({
+      mediaExecution: { mode: 'enabled' },
+    });
+    expect(runs.statusBody(scopedRun)).toMatchObject({
+      mediaExecution: { mode: 'enabled', allowedSurfaces: ['image'] },
+    });
+  });
+
   it('cancels active runs and terminates their child process during daemon shutdown', async () => {
     const runs = createRuns();
     const child = new FakeChildProcess({ closeOn: 'SIGTERM' });

--- a/apps/daemon/tests/system-prompt-template.test.ts
+++ b/apps/daemon/tests/system-prompt-template.test.ts
@@ -304,6 +304,87 @@ describe('composeSystemPrompt — metadata.promptTemplate', () => {
     expect(out).not.toContain('## Codex built-in imagegen override');
   });
 
+  it('renders disabled media policy without byte-generation instructions or imagegen override', () => {
+    const out = composeSystemPrompt({
+      agentId: 'codex',
+      metadata: {
+        kind: 'image',
+        imageModel: 'gpt-image-2',
+        imageAspect: '1:1',
+        promptTemplate: { ...baseSummary },
+      },
+      mediaExecution: { mode: 'disabled' },
+    });
+
+    expect(out).toContain('## Media generation policy');
+    expect(out).toContain('Open Design-owned media execution is **disabled for this run**');
+    expect(out).toContain('External MCP media tools, when explicitly configured for this run, are outside');
+    expect(out).toMatch(/Do not call\s+`"\$OD_NODE_BIN" "\$OD_BIN" media generate`/);
+    expect(out).not.toContain('## Media generation contract');
+    expect(out).not.toContain('## Codex built-in imagegen override');
+    expect(out).not.toContain('Generate the image with Codex built-in imagegen');
+  });
+
+  it('suppresses the Codex imagegen override when the enabled policy denies the selected model', () => {
+    const out = composeSystemPrompt({
+      agentId: 'codex',
+      metadata: {
+        kind: 'image',
+        imageModel: 'gpt-image-2',
+        imageAspect: '1:1',
+        promptTemplate: { ...baseSummary },
+      },
+      mediaExecution: {
+        mode: 'enabled',
+        allowedModels: ['different-image-model'],
+      },
+    });
+
+    expect(out).toContain('## Media generation contract');
+    expect(out).not.toContain('## Codex built-in imagegen override');
+  });
+
+  it('renders enabled media allowlists in the media contract', () => {
+    const out = composeSystemPrompt({
+      metadata: {
+        kind: 'image',
+        imageModel: 'gpt-image-2',
+        imageAspect: '1:1',
+        promptTemplate: { ...baseSummary },
+      },
+      mediaExecution: {
+        mode: 'enabled',
+        allowedSurfaces: ['image'],
+        allowedModels: ['gpt-image-2'],
+      },
+    });
+
+    expect(out).toContain('## Media generation contract');
+    expect(out).toContain('### Active media policy scope');
+    expect(out).toContain('The dispatcher will reject surfaces or models outside this run');
+    expect(out).toContain('Allowed surfaces for this run: `image`.');
+    expect(out).toContain('Allowed models for this run: `gpt-image-2`.');
+    expect(out).toContain('### Allowed model IDs (per surface)');
+    expect(out).not.toContain('Open Design-owned media execution is **disabled for this run**');
+  });
+
+  it('keeps unrestricted enabled media contract unchanged', () => {
+    const out = composeSystemPrompt({
+      metadata: {
+        kind: 'image',
+        imageModel: 'gpt-image-2',
+        imageAspect: '1:1',
+        promptTemplate: { ...baseSummary },
+      },
+      mediaExecution: { mode: 'enabled' },
+    });
+
+    expect(out).toContain('## Media generation contract');
+    expect(out).not.toContain('### Active media policy scope');
+    expect(out).not.toContain('Allowed surfaces for this run');
+    expect(out).not.toContain('Allowed models for this run');
+  });
+
   it('documents ElevenLabs speech and SFX routing in the media contract', () => {
     const out = composeSystemPrompt({
       metadata: {

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -8,6 +8,7 @@ import type {
 } from './comments';
 import type { ResearchOptions } from './research';
 import type { RunContextSelection } from './context.js';
+import type { MediaExecutionPolicy } from './media.js';
 
 export type ChatRole = 'user' | 'assistant';
 export type ChatCommentSelectionKind = PreviewCommentSelectionKind | 'visual';
@@ -38,6 +39,12 @@ export interface ChatRequest {
   locale?: string;
   research?: ResearchOptions;
   context?: RunContextSelection;
+  /**
+   * Run-scoped media execution policy. Omitted means current Open Design
+   * behavior: media generation is enabled and OD may execute its configured
+   * local providers.
+   */
+  mediaExecution?: MediaExecutionPolicy;
   /**
    * Optional analytics context for the v2 run_created / run_finished
    * events. The daemon never trusts these for behavior — they only
@@ -184,6 +191,8 @@ export interface ChatRunStatusResponse {
   signal?: string | null;
   error?: string | null;
   errorCode?: string | null;
+  /** Present on daemon run status responses that know the effective run policy. */
+  mediaExecution?: MediaExecutionPolicy;
 }
 
 export interface ChatRunListResponse {

--- a/packages/contracts/src/api/media.ts
+++ b/packages/contracts/src/api/media.ts
@@ -1,0 +1,25 @@
+export const MEDIA_EXECUTION_MODES = [
+  'enabled',
+  'disabled',
+] as const;
+
+export type MediaExecutionMode = (typeof MEDIA_EXECUTION_MODES)[number];
+
+export type MediaSurface = 'image' | 'video' | 'audio';
+
+/**
+ * Run-scoped policy controlling Open Design-owned media generation only.
+ *
+ * `allowedSurfaces` and `allowedModels` apply solely to `/api/tools/media/generate`
+ * and in-run `od media generate`. External MCP media tools are intentionally
+ * unaffected: provider policy for those belongs to the MCP server / orchestrator.
+ */
+export interface MediaExecutionPolicy {
+  mode: MediaExecutionMode;
+  allowedSurfaces?: MediaSurface[];
+  allowedModels?: string[];
+}
+
+export const DEFAULT_MEDIA_EXECUTION_POLICY: MediaExecutionPolicy = {
+  mode: 'enabled',
+};

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -15,6 +15,7 @@ export * from './api/finalize.js';
 export * from './api/github.js';
 export * from './api/handoff.js';
 export * from './api/live-artifacts.js';
+export * from './api/media.js';
 export * from './api/mcp.js';
 export * from './api/memory.js';
 export * from './api/orbit.js';

--- a/packages/contracts/tests/media-contracts.test.ts
+++ b/packages/contracts/tests/media-contracts.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_MEDIA_EXECUTION_POLICY,
+  MEDIA_EXECUTION_MODES,
+  type MediaExecutionPolicy,
+} from '../src/api/media';
+import type { ChatRunStatusResponse } from '../src/api/chat';
+
+describe('media execution contracts', () => {
+  it('keeps enabled as the default run policy', () => {
+    expect(DEFAULT_MEDIA_EXECUTION_POLICY).toEqual({ mode: 'enabled' });
+    expect(MEDIA_EXECUTION_MODES).toEqual(['enabled', 'disabled']);
+  });
+
+  it('allows run status responses to carry the effective media policy', () => {
+    const mediaExecution: MediaExecutionPolicy = {
+      mode: 'enabled',
+      allowedSurfaces: ['image', 'video'],
+    };
+    const status: ChatRunStatusResponse = {
+      id: 'run_1',
+      projectId: 'project_1',
+      conversationId: 'conversation_1',
+      assistantMessageId: 'assistant_1',
+      agentId: 'codex',
+      status: 'queued',
+      createdAt: 1,
+      updatedAt: 1,
+      mediaExecution,
+    };
+
+    expect(status.mediaExecution).toEqual(mediaExecution);
+  });
+});


### PR DESCRIPTION
## Why

This is the v1 implementation paired with #3096 so maintainers can inspect the smallest code shape while the architecture note is still under review. The use case is external orchestration: a caller may want OD to contribute creative context, skills, project files, previews, and structured artifact intent without letting in-run agents spend provider credentials or bypass caller-side provider policy.

The pain this addresses is that today in-run media handoffs use the same daemon media execution path as normal local OD use. That makes it hard for an upstream service to safely delegate design/runtime work to OD while keeping provider auth, budgets, retries, and accounting outside OD.

## What users will see

Default OD behavior stays enabled. Existing local UI and outside-run `od media generate` calls continue to queue daemon media tasks as before.

Callers that create a run may pass `mediaExecution`. In `request-only` mode, in-run `od media generate` calls create structured media requests instead of generating media bytes. In `disabled` mode, in-run media generation fails closed. OD also exposes local request list/get/fulfill/cancel routes, matching `od media requests ...` CLI commands, and `media_request` SSE events for runs/projects.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `OD_RUN_ID`; `od media generate` uses the token-gated tool endpoint when `OD_TOOL_TOKEN` is present; `od media requests list|get|cancel|fulfill` manages recorded requests
- [x] **API / contract** — `mediaExecution` run contract, media request DTOs, `/api/tools/media/generate`, media request routes, `media_request` SSE events
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — SQLite schema gains `media_requests`; existing media execution remains default-enabled
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface.

## Bug fix verification

-

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/contracts test -- media-contracts.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/media-policy.test.ts tests/media-requests.test.ts tests/media-requests-routes.test.ts tests/agent-runtime-env.test.ts tests/tool-tokens.test.ts tests/runs.test.ts tests/system-prompt-template.test.ts`
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/chat-route.test.ts tests/media-requests-routes.test.ts`
- `pnpm --dir e2e typecheck`
- Remote CI on `fdbbb5f5`: fork approval, visual capture, strict visual tests, Validate Nix flake, Preflight, workspace unit tests, daemon workspace tests, web workspace tests, Browser tests, build workspaces, and Validate workspace all passed.

Local note: this machine is currently on Node v26, so pnpm emitted the repo's Node `~24` engine warning while the commands above passed. The targeted e2e reproducer cannot run locally under Node v26 because `tools-dev` requires Node `~24`; CI uses Node 24.
