### PR TITLE
[codex] Bundle Vela CLI 0.0.2 for AMR beta

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-BAs/v7AXyYchClBo+smuP0fSsblnW6Uh7LFywfJkIZY=";
-  webHash = "sha256-nzaScs0187VBcyp3NT+zXQuqORwj0C8DOu0cXy8ZxAQ=";
+  daemonHash = "sha256-w3YO3GyOG4gQ3lUiBDvWmaC8bYIVNr0mzkyrAlHg1bM=";
+  webHash = "sha256-N02hgI9AUOLReeFi3zrxTnSJYYSgMQ5R9/qkeI7lEL0=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,8 +601,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.1
-        version: 0.0.1
+        specifier: 0.0.2
+        version: 0.0.2
 
   tools/serve:
     dependencies:
@@ -1642,13 +1642,13 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.1':
-    resolution: {integrity: sha512-DBUWX3siQPm6BYa+CbTVtHuDJu0MKFHVQHIEM9ESbfuHGbBP0rOmASTQqcmPWhUYOyEZcVzpDYcX4exjxh2P7g==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.2':
+    resolution: {integrity: sha512-ac8SvTXT+b48SswJJG96uyshw/ySUqeWwsKj2bZ3L0NNJYOF5VC4xahiQEgm6r7aigNX/IGMvogtJFsyKlQMBg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli@0.0.1':
-    resolution: {integrity: sha512-C82uWQWf6uTIy5UXiyqK7+i+5oknS4VKjueWuQoZ+B8UUczRvQsHuguVDD4i9OnBrFXCxh8PltkVOhsKlOLw/A==}
+  '@powerformer/vela-cli@0.0.2':
+    resolution: {integrity: sha512-FHrY3/LZJKShJrNmF+CfRLPzwnd7dbtYBqOWQmmKek4kw9rLsti5dpStXK2/pCzgcV8G13wDkRuzLq8Soe2/nQ==}
     hasBin: true
 
   '@rollup/pluginutils@5.3.0':
@@ -6043,12 +6043,12 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.1':
+  '@powerformer/vela-cli-darwin-arm64@0.0.2':
     optional: true
 
-  '@powerformer/vela-cli@0.0.1':
+  '@powerformer/vela-cli@0.0.2':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.1
+      '@powerformer/vela-cli-darwin-arm64': 0.0.2
     optional: true
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -22,7 +22,7 @@
     "electron-builder": "26.8.1"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.1"
+    "@powerformer/vela-cli": "0.0.2"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

Vela CLI 0.0.2 is now published and contains the ACP/OpenCode error-propagation fix needed for AMR insufficient-balance failures to return promptly instead of falling through to the generic stall watchdog.

This PR updates Open Design packaging so the AMR runtime ACP branch bundles `@powerformer/vela-cli@0.0.2` in beta DMGs.

## What users will see

Packaged Open Design beta builds from this branch will include Vela CLI 0.0.2. AMR runs should receive the upstream ACP prompt/provider error propagation behavior from Vela 0.0.2.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — no root dependency change; this updates a tools-pack optional dependency
- [x] **Default behavior change** — packaged AMR runtime now bundles Vela CLI 0.0.2 instead of 0.0.1
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; packaging dependency update only.

## Bug fix verification

- Test path that reproduces the bug: Vela-side coverage lives in powerformer/vela#121 and was released in Vela CLI 0.0.2.
- Did the test go red on `main` and green on this branch? Not applicable in Open Design; this branch consumes the fixed Vela package.

## Validation

- `pnpm --filter @open-design/tools-pack exec node -e "import(\"@powerformer/vela-cli\").then(async m => console.log(await m.resolveVelaCliBin({strict:true})))"` resolved the 0.0.2 darwin-arm64 package path
- `pnpm exec vitest run -c vitest.config.ts tests/integrations/vela-errors.test.ts tests/amr-acp-integration.test.ts tests/integrations/vela.routes.test.ts tests/integrations/vela.test.ts tests/runtimes/resolve-model.test.ts` from `apps/daemon`
- `pnpm --filter @open-design/tools-pack test`
- `pnpm --filter @open-design/tools-pack typecheck`
- `git diff --check`
