### PR TITLE
Hide social sharing without explicit preview URLs

### DIFF
--- a/apps/web/src/components/PreviewModal.tsx
+++ b/apps/web/src/components/PreviewModal.tsx
@@ -183,8 +183,8 @@ interface Props {
   // affordance reads consistently across HTML / design-system / media
   // variants.
   headerExtras?: ReactNode;
-  // Social-share target for the active preview. When omitted, the modal uses
-  // the current browser URL so non-plugin callers still get copy/share actions.
+  // Social-share target for the active preview. Callers must pass an explicit
+  // recipient-openable URL before the modal exposes copy/social actions.
   shareTarget?: PreviewShareTarget;
   // Optional analytics callbacks. Fires when the user clicks the
   // chrome-level affordances (fullscreen, share trigger, sidebar
@@ -367,13 +367,8 @@ export function PreviewModal({
   );
   const exportTitle = exportTitleFor(activeView?.id ?? '');
   const canExportFiles = Boolean(activeHtml);
-  const fallbackShareUrl = canExportFiles && typeof window !== 'undefined'
-    ? window.location.href
-    : '';
-  const hasExplicitShareUrl = shareTarget && 'url' in shareTarget;
-  const explicitShareUrl = typeof shareTarget?.url === 'string' ? shareTarget.url : '';
   const previewShareTitle = shareTarget?.title || exportTitle || title;
-  const previewShareUrl = hasExplicitShareUrl ? explicitShareUrl : fallbackShareUrl;
+  const previewShareUrl = typeof shareTarget?.url === 'string' ? shareTarget.url : '';
   const previewShareText = t('preview.shareTextDefault', { title: previewShareTitle });
   const previewShareCopy = previewShareUrl
     ? `${previewShareText}\n${previewShareUrl}`

--- a/apps/web/tests/components/preview-modal-unavailable-state.test.tsx
+++ b/apps/web/tests/components/preview-modal-unavailable-state.test.tsx
@@ -361,6 +361,31 @@ describe('PreviewModal unavailable state', () => {
     expect(screen.getByRole('menuitem', { name: /Export as standalone HTML/i })).toBeTruthy();
   });
 
+  it('keeps generic preview modals export-only without an explicit share target', () => {
+    render(
+      <PreviewModal
+        {...baseProps}
+        views={[
+          {
+            id: 'preview',
+            label: 'Preview',
+            html: '<!doctype html><p>Generic preview</p>',
+          },
+        ]}
+        onView={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /share/i }));
+
+    expect(screen.queryByRole('menuitem', { name: /X \/ Twitter/i })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: /Copy template link/i })).toBeNull();
+    expect(screen.getByRole('menuitem', { name: /Export as PDF/i })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: /Download as \.zip/i })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: /Export as standalone HTML/i })).toBeTruthy();
+  });
+
   it('does not call onView for an unavailable view (no fetch to retry)', () => {
     // PreviewModal fires onView on mount so the parent can lazy-load
     // the active view. For an unavailable view that signal is harmless


### PR DESCRIPTION
## Why

PR #2924 was merged while one late review follow-up was still being addressed. This follow-up lands that narrow fix: generic PreviewModal callers should not inherit social sharing from `window.location.href` when they have not provided a recipient-openable template URL.

The pain being addressed is misleading share actions: older preview surfaces can export files, but they do not always have a stable public deep link to copy or post.

## What users will see

Preview modals that do not pass an explicit share target keep the merged Share menu for file export actions only. Social platform buttons and Copy template link appear only when the caller provides a shareable URL.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this is a defensive removal of misleading fallback actions from generic preview share menus, covered by the regression test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/preview-modal-unavailable-state.test.tsx`
- Did the test go red on `main` and green on this branch? The new regression covers the old fallback path and passes on this branch.

## Validation

- `pnpm --filter @open-design/web test -- tests/components/preview-modal-unavailable-state.test.tsx`
- `pnpm --filter @open-design/contracts build && pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check origin/main...HEAD`