### PR TITLE
skills: fix GSAP review follow-ups

### DIFF
--- a/skills/gsap-frameworks/SKILL.md
+++ b/skills/gsap-frameworks/SKILL.md
@@ -33,7 +33,7 @@ Apply when writing or reviewing GSAP code in Vue (or Nuxt), Svelte (or SvelteKit
 
 ## Vue 3 (Composition API)
 
-See `examples/vue/` for a runnable Vite + Vue 3 project demonstrating these patterns.
+For a runnable Vite + Vue 3 project demonstrating these patterns, see the upstream example at https://github.com/greensock/gsap-skills/tree/main/examples/vue.
 
 Use **onMounted** to run GSAP after the component is in the DOM. Use **onUnmounted** to clean up.
 
@@ -104,7 +104,7 @@ onUnmounted(() => {
 
 ## Nuxt 4
 
-> See `examples/nuxt/` for a runnable Nuxt 4 project with plugin registration, lazy loading, and SSR-safe patterns.
+> For a runnable Nuxt 4 project with plugin registration, lazy loading, and SSR-safe patterns, see https://github.com/greensock/gsap-skills/tree/main/examples/nuxt.
 
 Use a **reusable composable** to register GSAP Plugins and also to lazy load Plugins that are not extensively used in your application:
 
@@ -112,35 +112,6 @@ Use a **reusable composable** to register GSAP Plugins and also to lazy load Plu
 // composables/useGSAP.ts
 import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
-
-const PLUGINS = [
-  "CSSRulePlugin",
-  "CustomBounce",
-  "CustomEase",
-  "CustomWiggle",
-  "Draggable",
-  "DrawSVGPlugin",
-  "EaselPlugin",
-  "EasePack",
-  "Flip",
-  "GSDevTools",
-  "InertiaPlugin",
-  "MorphSVGPlugin",
-  "MotionPathHelper",
-  "MotionPathPlugin",
-  "Observer",
-  "Physics2DPlugin",
-  "PhysicsPropsPlugin",
-  "PixiPlugin",
-  "ScrambleTextPlugin",
-  "ScrollSmoother",
-  "ScrollToPlugin",
-  "ScrollTrigger",
-  "SplitText",
-  "TextPlugin",
-] as const;
-
-type Plugins = (typeof PLUGINS)[number];
 
 // In order to dynamically load all the GSAP plugins
 const pluginMap = {
@@ -171,12 +142,12 @@ const pluginMap = {
 } as const;
 
 type PluginMap = typeof pluginMap;
-type Plugins = keyof PluginMap;
+type LoadablePlugin = keyof PluginMap;
 
 // Resolves the module type for a given key, then picks the named export matching the key
 // this allows to have the type definitions for autocomplete in your code editor
-type PluginModule<K extends Plugins> = Awaited<ReturnType<PluginMap[K]>>;
-type PluginExport<K extends Plugins> = PluginModule<K>[K & keyof PluginModule<K>];
+type PluginModule<K extends LoadablePlugin> = Awaited<ReturnType<PluginMap[K]>>;
+type PluginExport<K extends LoadablePlugin> = PluginModule<K>[K & keyof PluginModule<K>];
 
 export default function () {
   // Register all the GSAP Plugins you want at this point
@@ -187,7 +158,7 @@ export default function () {
     not widely used in your app (for example in just a couple
     of components or a single route), you can use this method
   */
-  async function lazyLoadPlugin<K extends Plugins>(plugin: K): Promise<PluginExport<K>> {
+  async function lazyLoadPlugin<K extends LoadablePlugin>(plugin: K): Promise<PluginExport<K>> {
     const loader = pluginMap[plugin];
     const m = await loader();
     const p = (m as any)[plugin];

--- a/skills/gsap-scrolltrigger/SKILL.md
+++ b/skills/gsap-scrolltrigger/SKILL.md
@@ -245,13 +245,15 @@ A common pattern: **pin** a section, then as the user scrolls **vertically**, co
 const scrollingEl = document.querySelector(".horizontal-el");
 // Panel = pinned viewport-sized section. .horizontal-wrap = inner content that moves left.
 const scrollTween = gsap.to(scrollingEl, { 
-  xPercent: () => Max.max(0, window.innerWidth - scrollingEl.offsetWidth), 
+  x: () => Math.min(0, window.innerWidth - scrollingEl.scrollWidth),
   ease: "none", // ease: "none" is required
   scrollTrigger: {
     trigger: scrollingEl,
     pin: scrollingEl.parentNode, // wrapper so that we're not animating the pinned element
     start: "top top",
-    end: "+=1000"
+    end: () => `+=${Math.max(0, scrollingEl.scrollWidth - window.innerWidth)}`,
+    invalidateOnRefresh: true,
+    scrub: true
   }
 }); 
 
@@ -306,4 +308,3 @@ In React, use the `useGSAP()` hook (@gsap/react NPM package) to ensure proper cl
 ### Learn More
 
 https://gsap.com/docs/v3/Plugins/ScrollTrigger/
-


### PR DESCRIPTION
Fixes #

## Why

This follow-up addresses review feedback from #3109 after the GSAP bundle was merged. The merged skill guidance still had a few user-facing papercuts: it pointed agents at local example folders that are not vendored in Open Design, and two copied snippets could fail or behave incorrectly if a user pasted them directly. The goal is to make the GSAP skills trustworthy as catalog guidance without changing runtime behavior.

## What users will see

Users invoking the GSAP framework and ScrollTrigger skills will see clearer, copy-pasteable guidance: Vue and Nuxt runnable examples now link to the upstream GreenSock repository, the Nuxt lazy-plugin TypeScript snippet avoids duplicate type aliases, and the horizontal ScrollTrigger sample uses valid pixel-based motion math.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI changes.

## Bug fix verification

-

## Validation

- Parsed all added/updated `SKILL.md` frontmatter with Ruby YAML.
- Checked the reviewed snippets no longer contain `examples/vue/`, `examples/nuxt/`, duplicate `type Plugins`, `Max.max`, or the broken `xPercent` calculation.
- GitHub CI is green on #3111.
