### PR TITLE
fix(web): polish onboarding controls

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1546,11 +1546,6 @@ function OnboardingView({
     : isLastStep
       ? t('settings.onboardingFinish')
       : t('settings.onboardingContinue');
-  const primaryActionIcon = step === 1
-    ? null
-    : isLastStep
-      ? 'check'
-      : 'chevron-right';
 
   return (
     <section className="onboarding-view" aria-labelledby="onboarding-title">
@@ -1899,7 +1894,6 @@ function OnboardingView({
                 disabled={amrLoginPending}
               >
                 <span>{primaryActionLabel}</span>
-                {primaryActionIcon ? <Icon name={primaryActionIcon} size={16} /> : null}
               </button>
             </div>
           )}

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1139,7 +1139,7 @@
 
 .onboarding-view__steps {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
   width: min(860px, 100%);
   margin: 0;
@@ -1413,6 +1413,13 @@
 .onboarding-view__secondary:hover,
 .onboarding-view__ghost:hover {
   transform: translateY(-1px);
+}
+
+.onboarding-view__primary:hover:not(:disabled) {
+  color: var(--accent-contrast, #fff);
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--accent) 24%, transparent);
 }
 
 .onboarding-view__primary:focus-visible,


### PR DESCRIPTION
## Why

While validating the AMR onboarding flow from #2355, the first-run controls had two visible polish issues:

- The step indicator still reserved space for a third step even though the flow now has only two steps.
- The primary onboarding CTA rendered an extra trailing chevron and inherited the global button hover treatment, which made it look gray right before click.

This PR tightens those onboarding controls without changing the flow logic.

## What users will see

On the onboarding page, the two steps now occupy two equal columns. The primary CTA no longer shows a trailing arrow, and hover keeps the button in the orange primary-action treatment with a subtle lift and shadow.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Verified locally in the browser against `/onboarding` at a 1212x655 viewport.

## Bug fix verification

- Test path that reproduces the bug: not added; this is a small visual polish fix and was verified in browser.
- Did the test go red on `main` and green on this branch? no.
- Manual verification: checked that the two step items fill the step bar as two equal columns, the CTA contains no SVG icon, and hover keeps the primary orange treatment instead of turning gray.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm typecheck`
- Browser verification on `http://127.0.0.1:51192/onboarding`
- `pnpm guard` currently fails on an existing repository guard issue: `tools/pr/ -> tools/ top-level entries are allowlisted; expected only AGENTS.md, dev/, pack/, and serve/`
