### PR TITLE
ci: show per-case pass/fail status emoji in agent report

### DIFF
--- a/.github/scripts/agent-pr-explore-sandbox.sh
+++ b/.github/scripts/agent-pr-explore-sandbox.sh
@@ -1303,7 +1303,7 @@ One short paragraph explaining the verdict in terms of the diff and observed beh
 
 ### 🧪 Cases Tested
 
-- Case name: what was exercised and why it matters.
+- Start every case bullet with a status emoji for its outcome -- ✅ pass, ❌ fail, ⚠️ warning, or ⚪ inconclusive -- followed by a bold case name, then what was exercised and why it matters. Example: "- ✅ **Empty-state CTA opens modal**: clicked the new CTA on /projects and the existing dialog opened in place."
 - Include at least two distinct UI/runtime cases for UI/runtime diffs unless setup is blocked or the changed surface is unreachable.
 
 ### 🔍 Concrete Evidence


### PR DESCRIPTION
Small report-formatting tweak: instruct the agent to begin each **Cases Tested** bullet with a status emoji for its outcome — ✅ pass / ❌ fail / ⚠️ warning / ⚪ inconclusive — and a bold case name, so reviewers can see which checks passed or failed at a glance instead of reading each line.

Before:
- `Empty-state CTA opens the existing modal: ...`

After:
- `✅ Empty-state CTA opens modal: ...`

Prompt-only change; no behavior change to the exploration itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)