### PR TITLE
chore(pack): pin Vela CLI 0.0.3-test.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,8 +601,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.3-test.0
-        version: 0.0.3-test.0
+        specifier: 0.0.3-test.1
+        version: 0.0.3-test.1
 
   tools/serve:
     dependencies:
@@ -1642,13 +1642,13 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.3-test.0':
-    resolution: {integrity: sha512-9YXyQgkP4C2ux7aG5NvZI/X5MH4tb2jYugf9AXYuMPqXm+d8dG+PplnLwgyz0RDeSl0sbOSvh9twr8TVxSpUUA==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.3-test.1':
+    resolution: {integrity: sha512-0SgaLu/Hqc0DqyLHgf+V/4J8SOgxbBEl48ibnl11Z3ISO0P2LHxLiyQmpEeBmhiTr/NSbVndbPwDNPHx3Vqmxw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli@0.0.3-test.0':
-    resolution: {integrity: sha512-aPulYBkREf+D7FXy7XHqH710LeXxTb0vcqUMCKlGDiIILZx8OJD2w/ZehmFvcUWHAIaPBZLhMjFLuwjU6vFNeQ==}
+  '@powerformer/vela-cli@0.0.3-test.1':
+    resolution: {integrity: sha512-mxtxscV3MzbD++NN38EQqsTrDBejfTuQmhP0zF5S+QHEkXVidqg1woQIqPeGlABLV8ut5pLSOBnlQjhp51316w==}
     hasBin: true
 
   '@rollup/pluginutils@5.3.0':
@@ -6043,12 +6043,12 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.3-test.0':
+  '@powerformer/vela-cli-darwin-arm64@0.0.3-test.1':
     optional: true
 
-  '@powerformer/vela-cli@0.0.3-test.0':
+  '@powerformer/vela-cli@0.0.3-test.1':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.3-test.0
+      '@powerformer/vela-cli-darwin-arm64': 0.0.3-test.1
     optional: true
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -22,7 +22,7 @@
     "electron-builder": "26.8.1"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.3-test.0"
+    "@powerformer/vela-cli": "0.0.3-test.1"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

This pins the packaged Vela CLI dependency to the already-published `0.0.3-test.1` test package so the next beta package build uses the exact runtime version intended for AMR ACP validation.

The previous branch still resolved `@powerformer/vela-cli` to `0.0.3-test.0`, which made release-beta builds unsuitable for validating the latest Vela timeout/error propagation fix.

## What users will see

No UI change. The beta DMG built after this branch is merged will bundle Vela CLI `0.0.3-test.1`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- Not applicable; package pin only.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/tools-pack typecheck`
- `git diff --check`
- `pnpm nix:update-hash` was attempted but could not run locally because `nix` is not installed in PATH (`spawnSync nix ENOENT`).
