### PR TITLE
docs: sync CONTRIBUTING translations with English source

### DIFF
--- a/CONTRIBUTING.de.md
+++ b/CONTRIBUTING.de.md
@@ -36,7 +36,7 @@ pnpm typecheck            # tsc -b --noEmit
 pnpm --filter @open-design/web build  # Web-Paket bei Bedarf bauen
 ```
 
-Node `~24` und pnpm `10.33.x` sind erforderlich. `nvm` / `fnm` sind optional; nutzen Sie `nvm install 24 && nvm use 24` oder `fnm install 24 && fnm use 24`, wenn Sie Node so verwalten. macOS, Linux und WSL2 sind die primären Pfade. Windows nativ sollte funktionieren, ist aber kein primäres Ziel.
+Node `~24` und pnpm `10.33.x` sind erforderlich. `nvm` / `fnm` sind optional; nutzen Sie `nvm install 24 && nvm use 24` oder `fnm install 24 && fnm use 24`, wenn Sie Node so verwalten. macOS, Linux und WSL2 sind die primären Pfade. Windows nativ wird unterstützt; siehe [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) für die häufigsten Setup-Stolpersteine.
 
 Sie brauchen keine Agent-CLI im `PATH`, um OD selbst zu entwickeln. Der daemon meldet dann "no agents found" und fällt auf den **Anthropic API · BYOK** Pfad zurück, der oft die schnellste Dev-Schleife ist.
 
@@ -217,6 +217,7 @@ Außerdem:
 
 - **Ein Anliegen pro PR.**
 - **Titel ist imperativ + Scope.** `add dating-web skill`, `fix daemon SSE backpressure when CLI hangs`, `docs: clarify .od layout`.
+- **Nutzen Sie das PR-Template.** Füllen Sie jeden Abschnitt von [`.github/pull_request_template.md`](.github/pull_request_template.md) aus — Why, What users will see, Surface area, Screenshots (bei UI), Bug fix verification (bei Bugfix), Validation. Leere Abschnitte ergeben einen "please fill in"-Kommentar.
 - **Body erklärt das Warum.** Der Diff zeigt oft das Was, aber selten den Grund.
 - **Issue referenzieren**, falls vorhanden. Bei nicht-trivialen PRs ohne Issue bitte zuerst eines öffnen.
 - **Während Review nicht squashen.** Fixups pushen; wir squashen beim Merge.

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -48,8 +48,8 @@ Node `~24` et pnpm `10.33.x` sont requis. `nvm` / `fnm` sont optionnels ;
 utilisez `nvm install 24 && nvm use 24` ou `fnm install 24 && fnm use 24` si
 vous gérez Node comme cela. macOS, Linux et WSL2 sont les environnements
 principaux pris en charge.
-Windows natif devrait fonctionner, mais ce n'est pas la cible principale :
-ouvrez une issue si ce n'est pas le cas.
+Windows natif est supporté ; voir [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md)
+pour les pièges de configuration les plus courants.
 
 Vous n'avez pas besoin d'une CLI d'agent dans votre `PATH` pour développer OD.
 Le daemon indiquera "no agents found" ; utilisez alors le mode API/BYOK
@@ -357,6 +357,11 @@ Au-delà de ça :
   dépendance : ce sont trois PR.
 - **Titre impératif + scope.** `add dating-web skill`,
   `fix daemon SSE backpressure when CLI hangs`, `docs: clarify .od layout`.
+- **Utilisez le template de PR.** Remplissez chaque section de
+  [`.github/pull_request_template.md`](.github/pull_request_template.md) — Why,
+  What users will see, Surface area, Screenshots (si UI), Bug fix verification
+  (si correctif), Validation. Les sections vides recevront un commentaire
+  « please fill in ».
 - **Le body explique le pourquoi.** Le diff montre souvent le quoi ; le pourquoi
   est rarement évident.
 - **Référencez une issue** s'il y en a une. S'il n'y en a pas et que la PR est

--- a/CONTRIBUTING.ja-JP.md
+++ b/CONTRIBUTING.ja-JP.md
@@ -36,7 +36,7 @@ pnpm typecheck            # tsc -b --noEmit
 pnpm --filter @open-design/web build  # 必要に応じて web パッケージをビルド
 ```
 
-Node `~24` と pnpm `10.33.x` が必要です。`nvm` / `fnm` はオプション。使用する場合は `nvm install 24 && nvm use 24` または `fnm install 24 && fnm use 24` を実行してください。macOS、Linux、WSL2 が主要プラットフォームです。Windows ネイティブでも動作するはずですが、主要ターゲットではありません — 動作しない場合は issue を作成してください。
+Node `~24` と pnpm `10.33.x` が必要です。`nvm` / `fnm` はオプション。使用する場合は `nvm install 24 && nvm use 24` または `fnm install 24 && fnm use 24` を実行してください。macOS、Linux、WSL2 が主要プラットフォームです。Windows ネイティブもサポートされています — 一般的なセットアップ時の落とし穴については [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) を参照してください。
 
 OD 自体の開発に agent CLI は `PATH` 上に不要です — daemon は「no agents found」と表示し、**Anthropic API · BYOK** パスにフォールバックします。このパスが最も高速な開発ループです。
 
@@ -213,6 +213,7 @@ design-systems/your-brand/
 
 - **PR 1 つにつき 1 つの関心事。** Skill の追加 + パーサーのリファクタリング + 依存関係のバンプは 3 つの PR です。
 - **タイトルは命令形 + スコープ。** `add dating-web skill`、`fix daemon SSE backpressure when CLI hangs`、`docs: clarify .od layout`。
+- **PR テンプレートを使用する。** [`.github/pull_request_template.md`](.github/pull_request_template.md) の各セクション（Why、What users will see、Surface area、Screenshots（UI の場合）、Bug fix verification（バグ修正の場合）、Validation）をすべて埋めてください。空欄のセクションには "please fill in" のコメントが付きます。
 - **本文は「なぜ」を説明。** 「何をするか」は通常 diff から明らかです。「なぜこれが必要か」はほとんどの場合そうではありません。
 - **issue がある場合は参照。** ない場合で、PR が自明でないなら、先に issue を作成して変更が求められていることを合意してから時間を費やしてください。
 - **レビュー中にスカッシュしない。** fixup をプッシュしてください。マージ時にスカッシュします。

--- a/CONTRIBUTING.pt-BR.md
+++ b/CONTRIBUTING.pt-BR.md
@@ -36,7 +36,7 @@ pnpm typecheck            # tsc -b --noEmit
 pnpm --filter @open-design/web build  # build do pacote web quando necessário
 ```
 
-Node `~24` e pnpm `10.33.x` são obrigatórios. `nvm` / `fnm` são opcionais; use `nvm install 24 && nvm use 24` ou `fnm install 24 && fnm use 24` se preferir gerenciar Node assim. macOS, Linux e WSL2 são os caminhos principais. Windows nativo costuma funcionar, mas não é alvo principal — abra uma issue se quebrar.
+Node `~24` e pnpm `10.33.x` são obrigatórios. `nvm` / `fnm` são opcionais; use `nvm install 24 && nvm use 24` ou `fnm install 24 && fnm use 24` se preferir gerenciar Node assim. macOS, Linux e WSL2 são os caminhos principais. Windows nativo é suportado; veja [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md) para os tropeços de configuração mais comuns.
 
 Você não precisa de nenhum CLI de agente no `PATH` para desenvolver o próprio OD — o daemon dirá "no agents found" e cairá no caminho **Anthropic API · BYOK**, que é o loop de dev mais rápido de qualquer jeito.
 
@@ -243,6 +243,7 @@ Além disso:
 
 - **Uma preocupação por PR.** Adicionar uma skill + refatorar o parser + bumpar uma dep são três PRs.
 - **Título é imperativo + escopo.** `add dating-web skill`, `fix daemon SSE backpressure when CLI hangs`, `docs: clarify .od layout`.
+- **Use o template de PR.** Preencha cada seção de [`.github/pull_request_template.md`](.github/pull_request_template.md) — Why, What users will see, Surface area, Screenshots (se UI), Bug fix verification (se correção de bug), Validation. Seções vazias ganham um comentário "please fill in".
 - **Corpo explica o porquê.** "O que isso faz" geralmente é óbvio do diff; "por que isso precisa existir" raramente é.
 - **Referencie uma issue** se houver. Se não houver e o PR for não-trivial, abra uma antes para combinarmos que a mudança é desejada antes de você gastar o tempo.
 - **Sem squash durante review.** Empurre fixups; squash no merge.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -36,7 +36,7 @@ pnpm typecheck            # tsc -b --noEmit
 pnpm --filter @open-design/web build  # 需要时构建 web package
 ```
 
-要求 Node `~24` 和 pnpm `10.33.x`。`nvm` / `fnm` 是可选路径；如果你习惯用它们，先执行 `nvm install 24 && nvm use 24` 或 `fnm install 24 && fnm use 24`。macOS、Linux、WSL2 是主要路径。Windows 原生应该能跑但不是主要目标 —— 跑不起来请开 issue。
+要求 Node `~24` 和 pnpm `10.33.x`。`nvm` / `fnm` 是可选路径；如果你习惯用它们，先执行 `nvm install 24 && nvm use 24` 或 `fnm install 24 && fnm use 24`。macOS、Linux、WSL2 是主要路径。Windows 原生已支持；常见的安装与配置坑请参见 [`docs/windows-troubleshooting.md`](docs/windows-troubleshooting.md)。
 
 **开发 OD 本身不需要在 `PATH` 上装任何 agent CLI** —— daemon 会告诉你「找不到 agent」并落到 **Anthropic API · BYOK** 路径，反而是最快的开发循环。
 
@@ -234,6 +234,7 @@ node --experimental-strip-types scripts/sync-litellm-models.ts
 
 - **一个 PR 只做一件事。** 加 skill + 重构 parser + 升依赖，是三个 PR。
 - **标题用动词起头 + 范围。** `add dating-web skill`、`fix daemon SSE backpressure when CLI hangs`、`docs: clarify .od layout`。
+- **使用 PR 模板。** 把 [`.github/pull_request_template.md`](.github/pull_request_template.md) 的每一节都填上 —— Why、What users will see、Surface area、Screenshots（如果有 UI 改动）、Bug fix verification（如果是修 bug）、Validation。留空的节会被 reviewer 回 "please fill in"。
 - **正文解释 why。** 「这个 PR 改了什么」从 diff 一般能看出来；「为什么要改」很少能。
 - **如果有 issue，引用它。** 没有、且改动非平凡，请先开 issue 让我们先就「值不值得做」达成一致，再投入时间。
 - **Review 期间不要 squash。** 推 fixup commit；merge 时我们会 squash。


### PR DESCRIPTION
Fixes #

## Why

The English `CONTRIBUTING.md` got two updates that never made it into the localized variants:

- `3790c003` (#1170) — replaced the Windows-native disclaimer with a pointer to the new `docs/windows-troubleshooting.md` guide.
- `6341b267` (#1520) — added a "Use the PR template" bullet to the Commits & pull requests checklist so reviewers can call out empty sections instead of asking for them piecemeal.

Both commits modified `CONTRIBUTING.md` only. `CONTRIBUTING.de.md`, `CONTRIBUTING.fr.md`, `CONTRIBUTING.ja-JP.md`, `CONTRIBUTING.pt-BR.md`, and `CONTRIBUTING.zh-CN.md` were last touched at `12ac2e98` (#1290, May 11), so non-English contributors have been landing on a stale merge bar.

## What users will see

Contributors reading any of the five translated `CONTRIBUTING` files now see:

- a link to the Windows troubleshooting guide instead of the old "Windows native isn't a primary target" disclaimer in the environment-baseline paragraph
- a "Use the PR template" bullet in the Commits & pull requests checklist, between "Title is imperative + scope" and "Body explains the why"

No change to the English file or to non-`CONTRIBUTING` docs.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — translation drift fix in repo-level `CONTRIBUTING.*.md` files; no `apps/web/src/i18n/` keys touched
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — translation sync only

## Screenshots

N/A — text-only docs change.

## Bug fix verification

N/A — this is a translation drift fix, not a bug fix with a red spec.

## Validation

- `git diff 12ac2e98..HEAD -- CONTRIBUTING.md` shows exactly the two hunks ported here, confirming no other English-side updates were missed since the translations were last synced.
- `ls docs/windows-troubleshooting.md .github/pull_request_template.md` — both link targets exist.
- `git diff --check` — clean, no whitespace errors.
