### PR TITLE
fix: render plugin preview modal via portal to escape stacking context

### DIFF
--- a/apps/web/src/components/PreviewModal.tsx
+++ b/apps/web/src/components/PreviewModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { useT } from '../i18n';
 import { copyToClipboard } from '../lib/copy-to-clipboard';
 import { exportAsHtml, exportAsPdf, exportAsZip, openSandboxedPreviewInNewTab } from '../runtime/exports';
@@ -456,7 +457,7 @@ export function PreviewModal({
   const showTemplateShareMenu = !isCustomView || Boolean(shareTarget?.url);
   const canOpenTemplateShareMenu = canExportFiles || Boolean(previewShareUrl);
 
-  return (
+  const modalContent = (
     <div className="ds-modal-backdrop" role="dialog" aria-modal="true" aria-label={`${title} preview`}>
       <div className={`ds-modal ${fullscreen ? 'ds-modal-fullscreen' : ''}`}>
         <header className="ds-modal-header">
@@ -864,4 +865,6 @@ export function PreviewModal({
       </div>
     </div>
   );
+
+  return createPortal(modalContent, document.body);
 }


### PR DESCRIPTION
## Description
Fixes the plugin preview details modal rendering under sticky workspace headers when opened from the chat composer's @ plugin picker.

## Root Cause
The modal was rendered from inside the chat composer subtree, which has its own stacking context. Fixed-position modal descendants cannot reliably escape above sibling sticky headers (chat-header and ws-tabs-shell), even though the modal's z-index (900) is much higher than the headers' z-index (4).

## Solution
Use React Portal to render the modal directly to document.body, ensuring it renders above all other page content regardless of parent stacking context.

## Changes
- Import `createPortal` from 'react-dom'
- Wrap modal JSX in a variable `modalContent`
- Return `createPortal(modalContent, document.body)` instead of returning JSX directly

## Testing
- Verified the modal now renders correctly above sticky headers
- No changes to modal functionality or appearance
- All existing modal features (sidebar, fullscreen, share menu) continue to work

Closes #3064