### PR TITLE
fix: increase subtab-pill gap to prevent active tab overlap

### DIFF
--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -393,7 +393,7 @@
   background: var(--bg-subtle);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  gap: 2px;
+  gap: 4px;
   max-width: 100%;
   overflow-x: auto;
   scrollbar-width: none;


### PR DESCRIPTION
## Summary

Fixes the visual overlap issue where the active Style tab's styling extends beyond its bounds and obscures adjacent tabs (Content, Attributes, HTML) in the right-side editor panel.

## Changes

- Increased  gap from  to  in 

## Root Cause

The active tab has  which creates a subtle 1px shadow. With only 2px gap between tabs, the shadow visually bleeds into the adjacent tab area, creating the appearance of overlap and making neighboring tabs harder to read.

## Solution

Increasing the gap to 4px provides sufficient spacing for the shadow to render cleanly without encroaching on adjacent tabs, while maintaining the compact pill design.

## Testing

Visual inspection in edit mode:
1. Open a file in edit mode
2. Select an element to show the right-side editing panel
3. Click through Content → Style → Attributes → HTML tabs
4. Verify that the active tab styling stays within its bounds and doesn't obscure neighboring tabs

Closes #2904