### PR TITLE
[codex] Suppress AMR exit 130 fallback noise

### DIFF
--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -235,6 +235,21 @@ function daemonSseError(data: SseErrorPayload): Error {
   return error;
 }
 
+function shouldSuppressLifecycleExitFallback(
+  agentId: string | undefined,
+  exitCode: number | null,
+  exitSignal: string | null,
+  stderrTail: string,
+): boolean {
+  if (exitCode !== 130 || exitSignal) return false;
+  if (agentId === 'amr') return true;
+  const normalizedStderr = stderrTail.toLowerCase();
+  return (
+    normalizedStderr.includes('opencode server listening') ||
+    normalizedStderr.includes('opencode_server_password')
+  );
+}
+
 export async function streamViaDaemon({
   agentId,
   history,
@@ -327,6 +342,7 @@ export async function streamViaDaemon({
     notifyRunsChanged();
     emitRunStatus('queued');
     await consumeDaemonRun({
+      agentId,
       runId,
       signal,
       cancelSignal,
@@ -517,6 +533,7 @@ export async function listProjectRuns(): Promise<ChatRunStatusResponse[]> {
 }
 
 async function consumeDaemonRun({
+  agentId,
   runId,
   signal,
   cancelSignal,
@@ -524,7 +541,7 @@ async function consumeDaemonRun({
   initialLastEventId,
   onRunStatus,
   onRunEventId,
-}: DaemonReattachOptions): Promise<void> {
+}: DaemonReattachOptions & { agentId?: string }): Promise<void> {
   let acc = '';
   let stderrBuf = '';
   let exitCode: number | null = null;
@@ -701,6 +718,10 @@ async function consumeDaemonRun({
       (!serverDeclaredSuccess &&
         (exitSignal || (exitCode !== null && exitCode !== 0)));
     if (looksLikeFailure) {
+      if (shouldSuppressLifecycleExitFallback(agentId, exitCode, exitSignal, stderrBuf)) {
+        handlers.onDone(acc);
+        return;
+      }
       const tail = stderrBuf.trim().slice(-400);
       handlers.onError(
         new Error(`agent exited with ${exitSignal ? `signal ${exitSignal}` : `code ${exitCode}`}${tail ? `\n${tail}` : ''}`),

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -492,6 +492,45 @@ describe('streamViaDaemon', () => {
     expect(handlers.onDone).not.toHaveBeenCalled();
   });
 
+  it('suppresses AMR exit code 130 lifecycle noise from the chat error surface', async () => {
+    const handlers = createDaemonHandlers();
+    const onRunStatus = vi.fn();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: stderr',
+              'data: {"chunk":"Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.\\n"}',
+              '',
+              'event: stderr',
+              'data: {"chunk":"opencode server listening on http://127.0.0.1:1234\\n"}',
+              '',
+              'event: end',
+              'data: {"code":130,"status":"failed"}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'amr',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+      onRunStatus,
+    });
+
+    expect(onRunStatus).toHaveBeenCalledWith('failed');
+    expect(handlers.onError).not.toHaveBeenCalled();
+    expect(handlers.onDone).toHaveBeenCalledWith('');
+  });
+
   it('still surfaces an error when the end event has a signal but no status field', async () => {
     // Same regression as above for the signal arm of the safety net. Without
     // explicit `status: 'succeeded'` from the server, a SIGTERM-style signal


### PR DESCRIPTION
## Why

I hit a frequent AMR/OpenCode failure where the chat showed lifecycle noise instead of a useful provider error:

```text
agent exited with code 130 Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured. opencode server listening on http://127.0.0.1:<port>
```

That message is not the real upstream/provider failure. It is a client-generated fallback built from the run end payload plus stderr after the daemon reports `code: 130`. The root OpenCode/Vela error propagation still needs deeper investigation, but this PR prevents the noisy fallback from becoming the user-facing chat error while that work continues.

Related upstream tracking: https://github.com/powerformer/vela/issues/134

## What users will see

When an AMR/OpenCode run ends with this `code 130` lifecycle shape, users should no longer see the red chat error banner containing the OpenCode password warning and localhost server URL.

Real structured daemon/provider errors still surface normally, and non-AMR non-zero exits continue to use the existing safety net.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI surface. This removes a noisy fallback error banner for the AMR/OpenCode `code 130` lifecycle case.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/providers/sse.test.ts`
- Did the test go red on `main` and green on this branch? The new test failed before the provider change with the existing `agent exited with code 130` fallback path, then passed after the fix.

## Validation

- `pnpm install` after rebasing to refresh generated workspace package output
- `pnpm --filter @open-design/web test -- sse.test.ts`
- `pnpm --filter @open-design/web typecheck`

## Notes

This is intentionally a temporary downstream mitigation. The root issue remains that OpenCode/Vela should propagate structured upstream provider/model errors instead of allowing callers to infer failures from empty completions, retry text, process exit code, or startup stderr.
