### PR TITLE
fix(ci): resolve blog-SEO base ref to a SHA in merge queue

### DIFF
--- a/.github/workflows/landing-page-ci.yml
+++ b/.github/workflows/landing-page-ci.yml
@@ -123,9 +123,12 @@ jobs:
 
       - name: Lint changed blog SEO
         run: |
-          BASE="${{ github.event.pull_request.base.sha || github.event.before || 'HEAD^' }}"
-          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-            BASE="HEAD^"
+          BASE="${{ github.event.pull_request.base.sha || github.event.before || '' }}"
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            # merge_group (and first-push) events have no base SHA. Resolve a
+            # concrete commit instead of passing the literal "HEAD^", which the
+            # blog-indexing scripts' assertSafeGitRef rejects (no "^" allowed).
+            BASE="$(git rev-parse HEAD^)"
           fi
           pnpm --filter @open-design/landing-page exec tsx scripts/blog-indexing/lint-blog-seo.ts \
             --base "$BASE" \
@@ -134,9 +137,12 @@ jobs:
 
       - name: Guard blog URL changes
         run: |
-          BASE="${{ github.event.pull_request.base.sha || github.event.before || 'HEAD^' }}"
-          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-            BASE="HEAD^"
+          BASE="${{ github.event.pull_request.base.sha || github.event.before || '' }}"
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            # merge_group (and first-push) events have no base SHA. Resolve a
+            # concrete commit instead of passing the literal "HEAD^", which the
+            # blog-indexing scripts' assertSafeGitRef rejects (no "^" allowed).
+            BASE="$(git rev-parse HEAD^)"
           fi
           pnpm --filter @open-design/landing-page exec tsx scripts/blog-indexing/check-blog-url-changes.ts \
             --base "$BASE" \


### PR DESCRIPTION
## Why

The merge queue is broken for **every** PR. The `Lint changed blog SEO` step in `.github/workflows/landing-page-ci.yml` fails with:

```
Error: Unsafe git ref for base: HEAD^
  at assertSafeGitRef (apps/landing-page/scripts/blog-indexing/lib.ts:503)
```

The step computes:

```sh
BASE="${{ github.event.pull_request.base.sha || github.event.before || 'HEAD^' }}"
if [ "$BASE" = "0000…0" ]; then BASE="HEAD^"; fi
```

On `merge_group` (and first-push) events there is no `pull_request.base.sha` / `github.event.before`, so `BASE` becomes the literal `"HEAD^"`. The blog-indexing scripts' `assertSafeGitRef` (regex `/^[A-Za-z0-9_./:-]+$/`, which intentionally forbids `^`) then rejects it — a deterministic failure that blocks the merge queue regardless of PR contents. `Guard blog URL changes` has the identical bug.

## What users will see

Nothing user-facing — the merge queue's landing-page CI stops failing on the `HEAD^` base ref, so PRs can merge again.

## Surface area

- [x] **None** — CI workflow fix only

## Bug fix verification

- Reproduction: any PR entering the merge queue runs `landing-page-ci.yml` with `BASE=HEAD^` → `assertSafeGitRef` throws (see e.g. the failing `Lint changed blog SEO` job on recent merge-queue runs).
- Fix: resolve the fallback to a concrete commit with `git rev-parse HEAD^` (checkout uses `fetch-depth: 0`, so `HEAD^` always exists). The resulting 40-hex SHA passes the ref guard. This mirrors `blog-indexing-on-deploy.yml`, which already does `BASE="$(git rev-parse HEAD^)"`.

## Validation

- `git rev-parse HEAD^` → 40-hex SHA, verified to match `/^[A-Za-z0-9_./:-]+$/`.
- `landing-page-ci.yml` re-parsed as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)