### PR TITLE
fix: clear selected preview comments

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -2834,6 +2834,12 @@ function CommentPreviewOverlays({
     .filter((item): item is { comment: PreviewComment; index: number; snapshot: PreviewCommentSnapshot } =>
       Boolean(item.snapshot),
     );
+  const activeSavedIndex = activeTarget
+    ? visibleComments.findIndex(({ snapshot }) => snapshot.elementId === activeTarget.elementId)
+    : -1;
+  const activePinNumber = activeSavedIndex >= 0
+    ? activeSavedIndex + 1
+    : visibleComments.length + 1;
   const targetOverlay = activeTarget ?? hoveredTarget;
   return (
     <div className="comment-overlay-layer" aria-hidden={false}>
@@ -2884,7 +2890,7 @@ function CommentPreviewOverlays({
           data-testid="comment-active-pin"
           aria-hidden="true"
         >
-          {visibleComments.length + 1}
+          {activePinNumber}
         </div>
       ) : null}
       {boardTool === 'pod' && strokePoints.length > 1 ? (

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1996,7 +1996,7 @@ export function CommentSidePanel({
           <div className="comment-side-empty">
             {t('chat.comments.emptySaved')}
           </div>
-        ) : sorted.map((comment) => {
+        ) : sorted.map((comment, index) => {
           const selected = visibleSelectedIds.has(comment.id);
           const active = comment.id === activeCommentId;
           return (
@@ -2009,7 +2009,7 @@ export function CommentSidePanel({
             >
               <div className="comment-side-item-head">
                 <span className="comment-side-author">
-                  <strong>{commentDisplayLabel(comment, t)}</strong>
+                  <strong>{`${index + 1}. ${commentDisplayLabel(comment, t)}`}</strong>
                 </span>
                 <span className="comment-side-time">{formatCommentTime(comment.createdAt, t)}</span>
                 <button
@@ -2861,10 +2861,10 @@ function CommentPreviewOverlays({
                 event.stopPropagation();
                 onOpenComment(comment, snapshot);
               }}
-              title={`${label}: ${comment.note}`}
+              title={`${index + 1}. ${label}: ${comment.note}`}
               aria-label={`Open comment for ${label}`}
             >
-              C
+              {index + 1}
             </button>
           </div>
         );
@@ -2884,7 +2884,7 @@ function CommentPreviewOverlays({
           data-testid="comment-active-pin"
           aria-hidden="true"
         >
-          C
+          {visibleComments.length + 1}
         </div>
       ) : null}
       {boardTool === 'pod' && strokePoints.length > 1 ? (
@@ -6171,7 +6171,25 @@ function HtmlViewer({
           return next;
         });
       }}
-      onClearSelection={() => setSelectedSideCommentIds(new Set())}
+      onClearSelection={() => {
+        if (selectedSideCommentIds.size === 0) return;
+        if (!onRemovePreviewComment) {
+          setSelectedSideCommentIds(new Set());
+          return;
+        }
+        const selectedIds = new Set(selectedSideCommentIds);
+        const targets = visibleSideComments
+          .filter((comment) => selectedIds.has(comment.id))
+          .map((comment) => comment.id);
+        if (targets.length === 0) {
+          setSelectedSideCommentIds(new Set());
+          return;
+        }
+        void (async () => {
+          await Promise.allSettled(targets.map((id) => onRemovePreviewComment(id)));
+          setSelectedSideCommentIds(new Set());
+        })();
+      }}
       onReply={(comment) => {
         // Reply == edit on a flat-thread model: prefill the
         // popover with the existing note so the user sees and

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1690,8 +1690,8 @@ describe('FileViewer tweaks toolbar', () => {
     fireEvent.click(screen.getByTestId('comment-panel-toggle'));
 
     expect(screen.getByTestId('comment-side-panel')).toBeTruthy();
-    expect(screen.getByTestId('comment-saved-marker-pin-newer').textContent).toBe('C');
-    expect(screen.getByTestId('comment-saved-marker-pin-older').textContent).toBe('C');
+    expect(screen.getByTestId('comment-saved-marker-pin-newer').textContent).toBe('1');
+    expect(screen.getByTestId('comment-saved-marker-pin-older').textContent).toBe('2');
 
     clickAgentTool('board-mode-toggle');
 
@@ -1716,7 +1716,7 @@ describe('FileViewer tweaks toolbar', () => {
       },
     }));
 
-    expect((await screen.findByTestId('comment-active-pin')).textContent).toBe('C');
+    expect((await screen.findByTestId('comment-active-pin')).textContent).toBe('3');
     expect(screen.getByTestId('comment-saved-marker-pin-newer')).toBeTruthy();
     expect(screen.getByTestId('comment-saved-marker-pin-older')).toBeTruthy();
 
@@ -2069,6 +2069,75 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.queryByText('不要github，换成微信')).toBeNull();
     expect(screen.queryByTestId('comment-side-selectbar')).toBeNull();
     expect(screen.queryByTestId('comment-side-collapsed-rail')).toBeNull();
+  });
+
+  it('deletes selected comments when clear is clicked', async () => {
+    const removed: string[] = [];
+
+    function Harness() {
+      const [comments, setComments] = useState<PreviewComment[]>([
+        {
+          id: 'comment-1',
+          projectId: 'project-1',
+          conversationId: 'conversation-1',
+          filePath: 'preview.html',
+          elementId: 'pin-1',
+          selector: '[data-od-pin="pin-1"]',
+          label: 'pin-1',
+          text: '',
+          htmlHint: '',
+          position: { x: 16, y: 20, width: 18, height: 18 },
+          note: 'First',
+          status: 'open',
+          createdAt: 10,
+          updatedAt: 10,
+        },
+        {
+          id: 'comment-2',
+          projectId: 'project-1',
+          conversationId: 'conversation-1',
+          filePath: 'preview.html',
+          elementId: 'pin-2',
+          selector: '[data-od-pin="pin-2"]',
+          label: 'pin-2',
+          text: '',
+          htmlHint: '',
+          position: { x: 48, y: 20, width: 18, height: 18 },
+          note: 'Second',
+          status: 'open',
+          createdAt: 20,
+          updatedAt: 20,
+        },
+      ]);
+
+      return (
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile()}
+          liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+          previewComments={comments}
+          onRemovePreviewComment={async (commentId) => {
+            removed.push(commentId);
+            setComments((current) => current.filter((comment) => comment.id !== commentId));
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+    const selectButtons = screen.getAllByRole('button', { name: /select/i });
+    const firstSelectButton = selectButtons[0];
+    expect(firstSelectButton).toBeTruthy();
+    if (!firstSelectButton) return;
+    fireEvent.click(firstSelectButton);
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Second')).toBeNull();
+    });
+    expect(removed).toEqual(['comment-2']);
   });
 });
 

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1726,6 +1726,7 @@ describe('FileViewer tweaks toolbar', () => {
       expect(activeItem?.className).toContain('active');
       expect(activeItem?.getAttribute('aria-current')).toBe('true');
     });
+    expect(screen.getByTestId('comment-active-pin').textContent).toBe('1');
     expect(document.querySelector('[data-comment-id="comment-older"]')?.className).not.toContain('active');
   });
 


### PR DESCRIPTION
Fixes #3143

## Why

Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? I am scratching an itch for a team.
       - The pain being addressed — user-facing problem.
    

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


### What users will see

Clear in the comment sidebar now removes selected comments.
Comment indices are restored and stay consistent between the comment list and preview markers.

## Screenshots
Before clicking the "Clear" button
<img width="1245" height="769" alt="e9b53c48-134d-4bd8-b11a-5569e4eb1a42" src="https://github.com/user-attachments/assets/143c0ac6-5321-41ec-a218-43958030a6c7" />
After clicking the "Clear" button
<img width="1146" height="766" alt="b9f4aa72-4feb-4342-88a2-ce24532801f1" src="https://github.com/user-attachments/assets/72c43150-3c9c-4f77-9fe0-af74db85cc0a" />



## Bug fix verification

Test path that reproduces the bug: apps/web/tests/components/FileViewer.test.tsx
Added/updated tests for:
deletes selected comments when clear is clicked (regression for Clear only deselecting)
comment marker numbering in both side panel and preview overlay (1, 2, ... instead of missing/C)
Did the test go red on main and green on this branch? Yes.
On main, the new clear-delete regression test fails because Clear only clears selection.
On this branch, the same test passes after wiring Clear to delete selected comments via onRemovePreviewComment.

-


## Validation

Ran: pnpm --filter @open-design/web test -- FileViewer.test.tsx
Result: all tests passed.
Checked edited files for diagnostics/lint issues; no errors remained.

-
