### PR TITLE
Add release-beta-s self-hosted workflow placeholder

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,3 +6,5 @@ paths:
 self-hosted-runner:
   labels:
     - agent-pr-explore
+    - nexu-win
+    - release-beta

--- a/.github/workflows/release-beta-s.yml
+++ b/.github/workflows/release-beta-s.yml
@@ -1,0 +1,64 @@
+# Self-hosted release-beta lane. Hosted baseline remains release-beta.yml.
+name: release-beta-s
+
+on:
+  workflow_dispatch:
+    inputs:
+      enable_win:
+        description: "Run the Windows self-hosted beta lane."
+        required: true
+        type: boolean
+        default: true
+      publish:
+        description: "Publish release assets and metadata. Keep disabled while validating the runner lane."
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: release-beta-s-win
+  cancel-in-progress: false
+
+jobs:
+  windows_probe:
+    name: Probe Windows self-hosted runner
+    if: ${{ inputs.enable_win }}
+    runs-on: [self-hosted, Windows, X64, nexu-win, release-beta]
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          lfs: true
+
+      - name: Verify preinstalled toolchain
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          where.exe git
+          where.exe git-lfs
+          where.exe node
+          where.exe pnpm
+          where.exe cargo
+          where.exe makensis
+          git --version
+          git lfs version
+          node --version
+          pnpm --version
+          cargo --version
+          makensis /VERSION
+
+      - name: Confirm workflow boundary
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          "workspace=$env:GITHUB_WORKSPACE"
+          "runner_temp=$env:RUNNER_TEMP"
+          "runner_tool_cache=$env:RUNNER_TOOL_CACHE"
+          if ($env:GITHUB_WORKSPACE -like "C:\Users\runner\Projects\*") {
+            throw "GITHUB_WORKSPACE must not point at the operator Projects directory"
+          }


### PR DESCRIPTION
## Summary
- Add a short `release-beta-s` workflow as the self-hosted beta release lane placeholder.
- Keep the hosted `release-beta.yml` baseline untouched.
- Start with a Windows self-hosted runner probe that verifies the preinstalled toolchain and confirms the checkout stays inside the runner workspace boundary.

## Notes
- `publish` is present but unused for now and defaults to `false`.
- The job targets `[self-hosted, Windows, X64, nexu-win, release-beta]` so it will not run on generic self-hosted runners.

## Testing
- Not run locally; workflow placeholder only.