### PR TITLE
chore(web): translate AMR card / error keys for 16 remaining locales

### DIFF
--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -3,6 +3,16 @@ import type { Dict } from '../types';
 
 export const ar: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'فشل استدعاء النموذج — تم إيقاف هذه المهمة مؤقتًا',
+  'chat.amrCard.switchBody': 'بدِّل إلى خدمة نماذج AMR الرسمية من Open Design — لا حاجة لإعداد مفتاح API. بعد تسجيل الدخول والتفويض والشحن، ستُعاد محاولة هذه المهمة تلقائيًا.',
+  'chat.amrCard.chipOfficial': 'استضافة رسمية',
+  'chat.amrCard.chipNoKey': 'بدون مفتاح API',
+  'chat.amrCard.chipAutoRetry': 'إعادة المحاولة تلقائيًا بعد تسجيل الدخول',
+  'chat.amrCard.switchCta': 'التبديل إلى AMR وإعادة المحاولة',
+  'chat.amrError.authMessage': 'حساب AMR الخاص بك لم يتم تفويضه بعد. فوِّضه وستُعاد محاولة هذه المهمة تلقائيًا.',
+  'chat.amrError.balanceMessage': 'نفد رصيد AMR الخاص بك. اشحن للاستمرار في هذه المهمة.',
+  'chat.amrError.authorizeCta': 'تفويض وإعادة المحاولة',
+  'chat.amrError.rechargeCta': 'شحن AMR',
   'plugins.actions.copyInstallCommand': 'نسخ أمر التثبيت',
   'plugins.actions.copyPluginId': 'نسخ معرّف الإضافة',
   'plugins.actions.copyReadmeBadge': 'نسخ شارة README',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -3,6 +3,16 @@ import { en } from './en';
 
 export const de: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'Modellaufruf fehlgeschlagen — dieser Lauf ist pausiert',
+  'chat.amrCard.switchBody': 'Wechsle zum offiziellen AMR-Modelldienst von Open Design — kein API-Key-Setup nötig. Nach Anmeldung, Autorisierung und Aufladung wird dieser Lauf automatisch wiederholt.',
+  'chat.amrCard.chipOfficial': 'Offizielles Hosting',
+  'chat.amrCard.chipNoKey': 'Kein API-Key',
+  'chat.amrCard.chipAutoRetry': 'Auto-Wiederholung nach Anmeldung',
+  'chat.amrCard.switchCta': 'Zu AMR wechseln und wiederholen',
+  'chat.amrError.authMessage': 'Dein AMR-Konto ist noch nicht autorisiert. Autorisiere es, und dieser Lauf wird automatisch wiederholt.',
+  'chat.amrError.balanceMessage': 'Dein AMR-Guthaben ist aufgebraucht. Lade auf, um diesen Lauf fortzusetzen.',
+  'chat.amrError.authorizeCta': 'Autorisieren und wiederholen',
+  'chat.amrError.rechargeCta': 'AMR aufladen',
   'plugins.actions.copyInstallCommand': 'Installationsbefehl kopieren',
   'plugins.actions.copyPluginId': 'Plugin-ID kopieren',
   'plugins.actions.copyReadmeBadge': 'README-Badge kopieren',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -3,6 +3,16 @@ import { en } from './en';
 
 export const esES: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'Falló la llamada al modelo — esta ejecución está en pausa',
+  'chat.amrCard.switchBody': 'Cambia al servicio oficial de modelos AMR de Open Design — sin configurar API Key. Tras iniciar sesión, autorizar y recargar, esta ejecución se reintentará automáticamente.',
+  'chat.amrCard.chipOfficial': 'Alojamiento oficial',
+  'chat.amrCard.chipNoKey': 'Sin API Key',
+  'chat.amrCard.chipAutoRetry': 'Reintento automático tras iniciar sesión',
+  'chat.amrCard.switchCta': 'Cambiar a AMR y reintentar',
+  'chat.amrError.authMessage': 'Tu cuenta de AMR aún no está autorizada. Autorízala y esta ejecución se reintentará automáticamente.',
+  'chat.amrError.balanceMessage': 'Tu saldo de AMR se ha agotado. Recarga para continuar esta ejecución.',
+  'chat.amrError.authorizeCta': 'Autorizar y reintentar',
+  'chat.amrError.rechargeCta': 'Recargar AMR',
   'plugins.actions.copyInstallCommand': 'Copiar comando de instalación',
   'plugins.actions.copyPluginId': 'Copiar ID del plugin',
   'plugins.actions.copyReadmeBadge': 'Copiar insignia README',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -3,6 +3,16 @@ import { en } from './en';
 
 export const fa: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'فراخوانی مدل ناموفق بود — این اجرا متوقف شد',
+  'chat.amrCard.switchBody': 'به سرویس رسمی مدل AMR از Open Design سوئیچ کنید — بدون نیاز به تنظیم کلید API. پس از ورود، اعطای دسترسی و شارژ، این اجرا به‌طور خودکار دوباره انجام می‌شود.',
+  'chat.amrCard.chipOfficial': 'میزبانی رسمی',
+  'chat.amrCard.chipNoKey': 'بدون کلید API',
+  'chat.amrCard.chipAutoRetry': 'تلاش مجدد خودکار پس از ورود',
+  'chat.amrCard.switchCta': 'سوئیچ به AMR و تلاش مجدد',
+  'chat.amrError.authMessage': 'حساب AMR شما هنوز مجاز نشده است. آن را مجاز کنید تا این اجرا به‌طور خودکار دوباره انجام شود.',
+  'chat.amrError.balanceMessage': 'موجودی AMR شما تمام شده است. برای ادامه این اجرا شارژ کنید.',
+  'chat.amrError.authorizeCta': 'اعطای دسترسی و تلاش مجدد',
+  'chat.amrError.rechargeCta': 'شارژ AMR',
   'plugins.actions.copyInstallCommand': 'کپی دستور نصب',
   'plugins.actions.copyPluginId': 'کپی شناسهٔ افزونه',
   'plugins.actions.copyReadmeBadge': 'کپی نشان README',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -3,6 +3,16 @@ import type { Dict } from '../types';
 
 export const fr: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'Échec de l\'appel du modèle — cette exécution est en pause',
+  'chat.amrCard.switchBody': 'Passez au service de modèles AMR officiel d\'Open Design — aucune clé API à configurer. Après connexion, autorisation et recharge, cette exécution sera relancée automatiquement.',
+  'chat.amrCard.chipOfficial': 'Hébergement officiel',
+  'chat.amrCard.chipNoKey': 'Sans clé API',
+  'chat.amrCard.chipAutoRetry': 'Reprise automatique après connexion',
+  'chat.amrCard.switchCta': 'Passer à AMR et relancer',
+  'chat.amrError.authMessage': 'Votre compte AMR n\'est pas encore autorisé. Autorisez-le et cette exécution sera relancée automatiquement.',
+  'chat.amrError.balanceMessage': 'Votre solde AMR est épuisé. Rechargez pour poursuivre cette exécution.',
+  'chat.amrError.authorizeCta': 'Autoriser et relancer',
+  'chat.amrError.rechargeCta': 'Recharger AMR',
   'plugins.actions.copyInstallCommand': 'Copier la commande d’installation',
   'plugins.actions.copyPluginId': 'Copier l’ID du plugin',
   'plugins.actions.copyReadmeBadge': 'Copier le badge README',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -3,6 +3,16 @@ import type { Dict } from '../types';
 
 export const hu: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'Sikertelen modellhívás — ez a futtatás szünetel',
+  'chat.amrCard.switchBody': 'Válts az Open Design hivatalos AMR modellszolgáltatására — nincs szükség API-kulcs beállítására. Bejelentkezés, engedélyezés és feltöltés után ez a futtatás automatikusan újraindul.',
+  'chat.amrCard.chipOfficial': 'Hivatalos szolgáltatás',
+  'chat.amrCard.chipNoKey': 'Nincs API-kulcs',
+  'chat.amrCard.chipAutoRetry': 'Automatikus újrapróbálkozás bejelentkezés után',
+  'chat.amrCard.switchCta': 'Váltás AMR-re és újrapróbálkozás',
+  'chat.amrError.authMessage': 'Az AMR-fiókod még nincs engedélyezve. Engedélyezd, és ez a futtatás automatikusan újraindul.',
+  'chat.amrError.balanceMessage': 'Az AMR-egyenleged elfogyott. Tölts fel a futtatás folytatásához.',
+  'chat.amrError.authorizeCta': 'Engedélyezés és újrapróbálkozás',
+  'chat.amrError.rechargeCta': 'AMR feltöltése',
   'plugins.actions.copyInstallCommand': 'Telepítési parancs másolása',
   'plugins.actions.copyPluginId': 'Pluginazonosító másolása',
   'plugins.actions.copyReadmeBadge': 'README jelvény másolása',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -3,6 +3,16 @@ import { en } from './en';
 
 export const id: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'Panggilan model gagal — proses ini dijeda',
+  'chat.amrCard.switchBody': 'Beralih ke layanan model AMR resmi Open Design — tanpa perlu mengatur API Key. Setelah masuk, otorisasi, dan isi ulang, proses ini akan dicoba ulang otomatis.',
+  'chat.amrCard.chipOfficial': 'Hosting resmi',
+  'chat.amrCard.chipNoKey': 'Tanpa API Key',
+  'chat.amrCard.chipAutoRetry': 'Coba ulang otomatis setelah masuk',
+  'chat.amrCard.switchCta': 'Beralih ke AMR & coba lagi',
+  'chat.amrError.authMessage': 'Akun AMR Anda belum diotorisasi. Otorisasi sekarang dan proses ini akan dicoba ulang otomatis.',
+  'chat.amrError.balanceMessage': 'Saldo AMR Anda habis. Isi ulang untuk melanjutkan proses ini.',
+  'chat.amrError.authorizeCta': 'Otorisasi & coba lagi',
+  'chat.amrError.rechargeCta': 'Isi ulang AMR',
   'plugins.actions.copyInstallCommand': 'Salin perintah instal',
   'plugins.actions.copyPluginId': 'Salin ID plugin',
   'plugins.actions.copyReadmeBadge': 'Salin lencana README',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -3,6 +3,16 @@ import type { Dict } from '../types';
 
 export const it: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'Chiamata al modello fallita — questa esecuzione è in pausa',
+  'chat.amrCard.switchBody': 'Passa al servizio modelli AMR ufficiale di Open Design — nessuna chiave API da configurare. Dopo accesso, autorizzazione e ricarica, questa esecuzione verrà ritentata automaticamente.',
+  'chat.amrCard.chipOfficial': 'Hosting ufficiale',
+  'chat.amrCard.chipNoKey': 'Senza chiave API',
+  'chat.amrCard.chipAutoRetry': 'Ritenta automatico dopo l\'accesso',
+  'chat.amrCard.switchCta': 'Passa ad AMR e riprova',
+  'chat.amrError.authMessage': 'Il tuo account AMR non è ancora autorizzato. Autorizzalo e questa esecuzione verrà ritentata automaticamente.',
+  'chat.amrError.balanceMessage': 'Il tuo saldo AMR è esaurito. Ricarica per continuare questa esecuzione.',
+  'chat.amrError.authorizeCta': 'Autorizza e riprova',
+  'chat.amrError.rechargeCta': 'Ricarica AMR',
   'plugins.actions.copyInstallCommand': 'Copia comando di installazione',
   'plugins.actions.copyPluginId': 'Copia ID plugin',
   'plugins.actions.copyReadmeBadge': 'Copia badge README',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -3,6 +3,16 @@ import { en } from './en';
 
 export const ja: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'モデル呼び出しに失敗しました — このタスクは一時停止中です',
+  'chat.amrCard.switchBody': 'Open Design 公式の AMR モデルサービスに切り替えてください — API キーの設定は不要です。サインイン・認可・チャージが完了すると、このタスクは自動で再試行されます。',
+  'chat.amrCard.chipOfficial': '公式ホスティング',
+  'chat.amrCard.chipNoKey': 'API キー不要',
+  'chat.amrCard.chipAutoRetry': 'サインイン後に自動再試行',
+  'chat.amrCard.switchCta': 'AMR に切り替えて再試行',
+  'chat.amrError.authMessage': 'AMR アカウントがまだ認可されていません。認可するとこのタスクは自動で再試行されます。',
+  'chat.amrError.balanceMessage': 'AMR の残高が不足しています。チャージしてこのタスクを続行してください。',
+  'chat.amrError.authorizeCta': '認可して再試行',
+  'chat.amrError.rechargeCta': 'AMR にチャージ',
   'plugins.actions.copyInstallCommand': 'インストールコマンドをコピー',
   'plugins.actions.copyPluginId': 'プラグイン ID をコピー',
   'plugins.actions.copyReadmeBadge': 'README バッジをコピー',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -3,6 +3,16 @@ import type { Dict } from '../types';
 
 export const ko: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': '모델 호출 실패 — 이 작업이 일시중지되었습니다',
+  'chat.amrCard.switchBody': 'Open Design 공식 AMR 모델 서비스로 전환하세요 — API 키 설정이 필요 없습니다. 로그인・인증・충전이 완료되면 이 작업이 자동으로 재시도됩니다.',
+  'chat.amrCard.chipOfficial': '공식 호스팅',
+  'chat.amrCard.chipNoKey': 'API 키 불필요',
+  'chat.amrCard.chipAutoRetry': '로그인 후 자동 재시도',
+  'chat.amrCard.switchCta': 'AMR로 전환하고 재시도',
+  'chat.amrError.authMessage': 'AMR 계정이 아직 인증되지 않았습니다. 인증하면 이 작업이 자동으로 재시도됩니다.',
+  'chat.amrError.balanceMessage': 'AMR 잔액이 부족합니다. 충전하여 이 작업을 계속 진행하세요.',
+  'chat.amrError.authorizeCta': '인증하고 재시도',
+  'chat.amrError.rechargeCta': 'AMR 충전',
   'plugins.actions.copyInstallCommand': '설치 명령 복사',
   'plugins.actions.copyPluginId': '플러그인 ID 복사',
   'plugins.actions.copyReadmeBadge': 'README 배지 복사',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -3,6 +3,16 @@ import type { Dict } from '../types';
 
 export const pl: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'Wywołanie modelu nieudane — to zadanie jest wstrzymane',
+  'chat.amrCard.switchBody': 'Przełącz się na oficjalną usługę modeli AMR od Open Design — bez konfigurowania klucza API. Po zalogowaniu, autoryzacji i doładowaniu zadanie zostanie automatycznie ponowione.',
+  'chat.amrCard.chipOfficial': 'Oficjalny hosting',
+  'chat.amrCard.chipNoKey': 'Bez klucza API',
+  'chat.amrCard.chipAutoRetry': 'Automatyczne ponowienie po zalogowaniu',
+  'chat.amrCard.switchCta': 'Przełącz na AMR i ponów',
+  'chat.amrError.authMessage': 'Twoje konto AMR nie zostało jeszcze autoryzowane. Autoryzuj je, a zadanie zostanie automatycznie ponowione.',
+  'chat.amrError.balanceMessage': 'Saldo AMR zostało wyczerpane. Doładuj, aby kontynuować zadanie.',
+  'chat.amrError.authorizeCta': 'Autoryzuj i ponów',
+  'chat.amrError.rechargeCta': 'Doładuj AMR',
   'plugins.actions.copyInstallCommand': 'Kopiuj polecenie instalacji',
   'plugins.actions.copyPluginId': 'Kopiuj ID wtyczki',
   'plugins.actions.copyReadmeBadge': 'Kopiuj odznakę README',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -3,6 +3,16 @@ import { en } from './en';
 
 export const ptBR: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'Falha ao chamar o modelo — esta execução está pausada',
+  'chat.amrCard.switchBody': 'Mude para o serviço oficial de modelos AMR do Open Design — sem precisar configurar API Key. Após entrar, autorizar e recarregar, esta execução será repetida automaticamente.',
+  'chat.amrCard.chipOfficial': 'Hospedagem oficial',
+  'chat.amrCard.chipNoKey': 'Sem API Key',
+  'chat.amrCard.chipAutoRetry': 'Nova tentativa automática após entrar',
+  'chat.amrCard.switchCta': 'Mudar para AMR e tentar novamente',
+  'chat.amrError.authMessage': 'Sua conta AMR ainda não está autorizada. Autorize-a e esta execução será repetida automaticamente.',
+  'chat.amrError.balanceMessage': 'Seu saldo AMR acabou. Recarregue para continuar esta execução.',
+  'chat.amrError.authorizeCta': 'Autorizar e tentar novamente',
+  'chat.amrError.rechargeCta': 'Recarregar AMR',
   'plugins.actions.copyInstallCommand': 'Copiar comando de instalação',
   'plugins.actions.copyPluginId': 'Copiar ID do plugin',
   'plugins.actions.copyReadmeBadge': 'Copiar selo do README',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -3,6 +3,16 @@ import { en } from './en';
 
 export const ru: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'Не удалось вызвать модель — это выполнение приостановлено',
+  'chat.amrCard.switchBody': 'Переключитесь на официальный сервис моделей AMR от Open Design — без настройки API-ключа. После входа, авторизации и пополнения это выполнение будет автоматически повторено.',
+  'chat.amrCard.chipOfficial': 'Официальный хостинг',
+  'chat.amrCard.chipNoKey': 'Без API-ключа',
+  'chat.amrCard.chipAutoRetry': 'Авто-повтор после входа',
+  'chat.amrCard.switchCta': 'Переключиться на AMR и повторить',
+  'chat.amrError.authMessage': 'Ваш аккаунт AMR ещё не авторизован. Авторизуйте его, и это выполнение будет автоматически повторено.',
+  'chat.amrError.balanceMessage': 'Баланс AMR исчерпан. Пополните, чтобы продолжить это выполнение.',
+  'chat.amrError.authorizeCta': 'Авторизовать и повторить',
+  'chat.amrError.rechargeCta': 'Пополнить AMR',
   'plugins.actions.copyInstallCommand': 'Скопировать команду установки',
   'plugins.actions.copyPluginId': 'Скопировать ID плагина',
   'plugins.actions.copyReadmeBadge': 'Скопировать бейдж README',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -3,6 +3,16 @@ import type { Dict } from '../types';
 
 export const th: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'เรียกใช้โมเดลล้มเหลว — งานนี้ถูกหยุดชั่วคราว',
+  'chat.amrCard.switchBody': 'สลับไปยังบริการโมเดล AMR อย่างเป็นทางการของ Open Design — ไม่ต้องตั้งค่า API Key หลังจากเข้าสู่ระบบ ให้สิทธิ์ และเติมเงินแล้ว งานนี้จะถูกลองใหม่โดยอัตโนมัติ',
+  'chat.amrCard.chipOfficial': 'โฮสติ้งอย่างเป็นทางการ',
+  'chat.amrCard.chipNoKey': 'ไม่ต้องใช้ API Key',
+  'chat.amrCard.chipAutoRetry': 'ลองใหม่อัตโนมัติหลังเข้าสู่ระบบ',
+  'chat.amrCard.switchCta': 'สลับไปยัง AMR และลองใหม่',
+  'chat.amrError.authMessage': 'บัญชี AMR ของคุณยังไม่ได้รับอนุญาต ให้สิทธิ์แล้วงานนี้จะถูกลองใหม่โดยอัตโนมัติ',
+  'chat.amrError.balanceMessage': 'ยอดเงิน AMR ของคุณหมดแล้ว เติมเงินเพื่อดำเนินงานนี้ต่อ',
+  'chat.amrError.authorizeCta': 'ให้สิทธิ์และลองใหม่',
+  'chat.amrError.rechargeCta': 'เติมเงิน AMR',
   'plugins.actions.copyInstallCommand': 'คัดลอกคำสั่งติดตั้ง',
   'plugins.actions.copyPluginId': 'คัดลอก ID ปลั๊กอิน',
   'plugins.actions.copyReadmeBadge': 'คัดลอกแบดจ์ README',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -3,6 +3,16 @@ import type { Dict } from '../types';
 
 export const tr: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'Model çağrısı başarısız oldu — bu çalıştırma duraklatıldı',
+  'chat.amrCard.switchBody': 'Open Design\'ın resmi AMR model hizmetine geçin — API anahtarı yapılandırması gerekmez. Oturum açma, yetkilendirme ve bakiye yükleme sonrası bu çalıştırma otomatik olarak yeniden denenir.',
+  'chat.amrCard.chipOfficial': 'Resmi hizmet',
+  'chat.amrCard.chipNoKey': 'API anahtarı gerekmez',
+  'chat.amrCard.chipAutoRetry': 'Giriş sonrası otomatik yeniden deneme',
+  'chat.amrCard.switchCta': 'AMR\'ye geç ve yeniden dene',
+  'chat.amrError.authMessage': 'AMR hesabınız henüz yetkilendirilmedi. Yetkilendirin ve bu çalıştırma otomatik olarak yeniden denensin.',
+  'chat.amrError.balanceMessage': 'AMR bakiyeniz bitti. Çalıştırmaya devam etmek için bakiye yükleyin.',
+  'chat.amrError.authorizeCta': 'Yetkilendir ve yeniden dene',
+  'chat.amrError.rechargeCta': 'AMR bakiyesi yükle',
   'plugins.actions.copyInstallCommand': 'Kurulum komutunu kopyala',
   'plugins.actions.copyPluginId': 'Eklenti ID’sini kopyala',
   'plugins.actions.copyReadmeBadge': 'README rozetini kopyala',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -3,6 +3,16 @@ import { en } from './en';
 
 export const uk: Dict = {
   ...en,
+  'chat.amrCard.switchTitle': 'Не вдалося викликати модель — це виконання призупинено',
+  'chat.amrCard.switchBody': 'Перейдіть на офіційний сервіс моделей AMR від Open Design — без налаштування API-ключа. Після входу, авторизації та поповнення це виконання буде повторено автоматично.',
+  'chat.amrCard.chipOfficial': 'Офіційний хостинг',
+  'chat.amrCard.chipNoKey': 'Без API-ключа',
+  'chat.amrCard.chipAutoRetry': 'Авто-повтор після входу',
+  'chat.amrCard.switchCta': 'Перейти на AMR і повторити',
+  'chat.amrError.authMessage': 'Ваш обліковий запис AMR ще не авторизовано. Авторизуйте, і це виконання буде повторено автоматично.',
+  'chat.amrError.balanceMessage': 'Баланс AMR вичерпано. Поповніть, щоб продовжити це виконання.',
+  'chat.amrError.authorizeCta': 'Авторизувати та повторити',
+  'chat.amrError.rechargeCta': 'Поповнити AMR',
   'plugins.actions.copyInstallCommand': 'Скопіювати команду встановлення',
   'plugins.actions.copyPluginId': 'Скопіювати ID плагіна',
   'plugins.actions.copyReadmeBadge': 'Скопіювати бейдж README',


### PR DESCRIPTION
## Why

PR #3083 added a redesigned AMR guidance UI on top of the gray error card (the "Switch to AMR & retry" promotion card, plus contextual self-error cards for AMR auth / low balance). It shipped 10 new i18n keys but only translated `en`, `zh-CN`, and `zh-TW`. The other 16 locales silently fell back to English, so users on `ar`, `de`, `es-ES`, `fa`, `fr`, `hu`, `id`, `it`, `ja`, `ko`, `pl`, `pt-BR`, `ru`, `th`, `tr`, `uk` see a mixed-language failure card right at the most painful moment in their session — not great for the very flow we're trying to convert.

This PR ships translations for those 16 locales before #2355 lands, so the redesigned AMR card looks polished in every supported language from day one.

## What users will see

When a non-AMR run fails (or an AMR run hits an auth/balance error), the gray error card and the AMR promotion card below it now render fully in the user's language — title, body, three chips (Official hosting / No API key / Auto-retry after sign-in), the primary "Switch to AMR & retry" CTA, the auth/balance messages, and the "Authorize & retry" / "Top up AMR" buttons. No more half-English card on Japanese / French / Russian / Arabic / etc. UI.

## Surface area

- [x] i18n keys (added translations to 16 locale files)

## Validation

- `pnpm --filter @open-design/web typecheck` — passes
