### PR TITLE
fix(web): suppress stale AMR login echoes after cancel

### DIFF
--- a/apps/web/src/components/AmrLoginPill.tsx
+++ b/apps/web/src/components/AmrLoginPill.tsx
@@ -196,6 +196,7 @@ export function AmrLoginPill({
   const pollRef = useRef<number | null>(null);
   const loginStartedAtRef = useRef<number | null>(null);
   const loginPendingRef = useRef(false);
+  const suppressLoginInFlightRef = useRef(false);
 
   const stopPolling = useCallback(() => {
     if (pollRef.current !== null) {
@@ -215,6 +216,7 @@ export function AmrLoginPill({
     return () => {
       loginPendingRef.current = false;
       loginStartedAtRef.current = null;
+      suppressLoginInFlightRef.current = false;
       stopPolling();
     };
   }, [refresh, skipInitialRefresh, stopPolling]);
@@ -245,6 +247,7 @@ export function AmrLoginPill({
         stopPolling();
         loginStartedAtRef.current = null;
         loginPendingRef.current = false;
+        suppressLoginInFlightRef.current = false;
         setPending(null);
         return;
       }
@@ -257,6 +260,7 @@ export function AmrLoginPill({
         }
         loginStartedAtRef.current = null;
         loginPendingRef.current = false;
+        suppressLoginInFlightRef.current = false;
         setPending(null);
         setErrorMessage(t('settings.amrLoginErrorCompact'));
       }
@@ -270,6 +274,7 @@ export function AmrLoginPill({
     const onStatusChange = (event: Event) => {
       const reason = amrLoginStatusEventReason(event);
       if (reason === 'login-started') {
+        suppressLoginInFlightRef.current = false;
         const startedAt = Date.now();
         loginStartedAtRef.current = startedAt;
         setErrorMessage(null);
@@ -303,12 +308,13 @@ export function AmrLoginPill({
           stopPolling();
           loginStartedAtRef.current = null;
           loginPendingRef.current = false;
+          suppressLoginInFlightRef.current = false;
           setPending(null);
           setCanceledVisible(false);
           setErrorMessage(null);
           return;
         }
-        if (next.loginInFlight) {
+        if (next.loginInFlight && !suppressLoginInFlightRef.current) {
           setErrorMessage(null);
           setPending('login');
           startPolling();
@@ -334,6 +340,7 @@ export function AmrLoginPill({
     async (event: MouseEvent<HTMLButtonElement>) => {
       event.stopPropagation();
       if (loginPendingRef.current) return;
+      suppressLoginInFlightRef.current = false;
       loginPendingRef.current = true;
       const startedAt = Date.now();
       loginStartedAtRef.current = startedAt;
@@ -379,6 +386,7 @@ export function AmrLoginPill({
               configPath: '',
             }
       ));
+      suppressLoginInFlightRef.current = true;
       setPending(null);
       setCanceledVisible(true);
       notifyAmrLoginStatusChanged('login-canceled');
@@ -394,6 +402,7 @@ export function AmrLoginPill({
       const result = await velaLogout();
       loginStartedAtRef.current = null;
       loginPendingRef.current = false;
+      suppressLoginInFlightRef.current = false;
       setPending(null);
       if (!result.ok) {
         setErrorMessage(t('settings.amrLoginErrorCompact'));
@@ -408,7 +417,11 @@ export function AmrLoginPill({
   const loggedIn = status?.loggedIn === true;
   const userEmail = status?.user?.email ?? '';
   const loginInFlight =
-    pending === 'login' || (status?.loggedIn !== true && status?.loginInFlight === true);
+    pending === 'login' || (
+      status?.loggedIn !== true &&
+      status?.loginInFlight === true &&
+      !suppressLoginInFlightRef.current
+    );
   const logoutInFlight = pending === 'logout';
   const cancelInFlight = pending === 'cancel';
   const accountStatus: AmrAccountControlStatus = errorMessage

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1727,6 +1727,74 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(screen.getByText('late@example.com')).toBeTruthy();
   });
 
+  it('does not resurrect Signing in from a stale loginInFlight echo after cancel', async () => {
+    let statusStage: 'pending' | 'stale-pending' | 'signed-out' = 'pending';
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/status') {
+        const body =
+          statusStage === 'signed-out'
+            ? {
+                loggedIn: false,
+                loginInFlight: false,
+                profile: 'local',
+                user: null,
+                configPath: '/Users/test/.amr/config.json',
+              }
+            : {
+                loggedIn: false,
+                loginInFlight: true,
+                profile: 'local',
+                user: null,
+                configPath: '/Users/test/.amr/config.json',
+              };
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/integrations/vela/login/cancel' && init?.method === 'POST') {
+        statusStage = 'stale-pending';
+        return new Response(JSON.stringify({ canceled: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'amr' },
+      { agents: [amrAgent] },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+    const amrCard = screen.getByRole('button', { name: /^Open Design AMR\b/ }).closest('.agent-card') as HTMLElement;
+    expect(await screen.findByText('Signing in…')).toBeTruthy();
+
+    fireEvent.mouseEnter(amrCard);
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+    expect(await screen.findByText('Canceled')).toBeTruthy();
+
+    window.dispatchEvent(
+      new CustomEvent('od:amr-login-status-change', {
+        detail: { reason: 'login-canceled' },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Signing in…')).toBeNull();
+    });
+    expect(screen.getByRole('button', { name: 'Authorize' })).toBeTruthy();
+  });
+
   it('renders the signed-in AMR account state inside Settings without leaking vela branding', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();


### PR DESCRIPTION
## Why

I was following up on the AMR login cancel flow after the initial Settings card work had already landed.

`main` already prevents the most obvious `login-canceled` bounce, but there is still a narrower race where stale daemon `loginInFlight: true` echoes can be trusted again during the local cancel path. That can bring the pill back into `Signing in…` even after the user already canceled.

## What users will see

On Settings → Execution mode → Local CLI, canceling an in-flight Open Design AMR login now stays canceled locally instead of briefly bouncing back into `Signing in…` when the daemon still reports the old login process as in-flight.

The card still accepts a real later browser completion and will switch to the signed-in state when AMR actually finishes logging in.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached in PR body.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SettingsDialog.execution.test.tsx`
- Added focused regression coverage for the stale `loginInFlight: true` echo after local cancel.
- Did the test go red on `main` and green on this branch? yes

## Validation

- `pnpm --filter @open-design/web test tests/components/SettingsDialog.execution.test.tsx -t "AMR"`
