### PR TITLE
Fix memory action alignment

### DIFF
--- a/apps/web/src/components/MemorySection.tsx
+++ b/apps/web/src/components/MemorySection.tsx
@@ -1421,33 +1421,35 @@ export function MemorySection({
 	          {entry.description || '—'}
 	        </div>
 	      </div>
-	      <button
-	        type="button"
-	        className="library-card-expand"
-	        onClick={() => openPreview(entry.id)}
-	        title={t('settings.memoryPreview')}
-	      >
-	        <Icon
-	          name={previewId === entry.id ? 'chevron-down' : 'chevron-right'}
-	          size={14}
-	        />
-	      </button>
-	      <button
-	        type="button"
-	        className="ghost library-card-action"
-	        onClick={() => startEdit(entry.id)}
-	        title={t('settings.memoryEdit')}
-	      >
-	        <Icon name="edit" size={14} />
-	      </button>
-	      <button
-	        type="button"
-	        className="ghost library-card-action"
-	        onClick={() => onDelete(entry.id)}
-	        title={t('settings.memoryDelete')}
-	      >
-	        <Icon name="close" size={14} />
-	      </button>
+	      <div className="memory-card-actions">
+	        <button
+	          type="button"
+	          className="library-card-expand"
+	          onClick={() => openPreview(entry.id)}
+	          title={t('settings.memoryPreview')}
+	        >
+	          <Icon
+	            name={previewId === entry.id ? 'chevron-down' : 'chevron-right'}
+	            size={14}
+	          />
+	        </button>
+	        <button
+	          type="button"
+	          className="ghost library-card-action"
+	          onClick={() => startEdit(entry.id)}
+	          title={t('settings.memoryEdit')}
+	        >
+	          <Icon name="edit" size={14} />
+	        </button>
+	        <button
+	          type="button"
+	          className="ghost library-card-action"
+	          onClick={() => onDelete(entry.id)}
+	          title={t('settings.memoryDelete')}
+	        >
+	          <Icon name="close" size={14} />
+	        </button>
+	      </div>
 	      {previewId === entry.id && (
 	        <div className="library-preview" style={{ width: '100%' }}>
 	          {previewBody === null ? (
@@ -1530,15 +1532,17 @@ export function MemorySection({
             </div>
           ) : null}
         </div>
-        <button
-          type="button"
-          className="ghost library-card-action"
-          onClick={() => void onDeleteExtraction(record.id)}
-          title={t('settings.memoryExtractionDelete')}
-          aria-label={t('settings.memoryExtractionDelete')}
-        >
-          <Icon name="close" size={14} />
-        </button>
+        <div className="memory-card-actions">
+          <button
+            type="button"
+            className="ghost library-card-action"
+            onClick={() => void onDeleteExtraction(record.id)}
+            title={t('settings.memoryExtractionDelete')}
+            aria-label={t('settings.memoryExtractionDelete')}
+          >
+            <Icon name="close" size={14} />
+          </button>
+        </div>
       </div>
     );
   };
@@ -2280,12 +2284,7 @@ export function MemorySection({
                             {children.map((child) => (
                               <li
                                 key={child.id}
-                                style={{
-                                  display: 'grid',
-                                  gridTemplateColumns: 'minmax(0, 1fr) auto',
-                                  alignItems: 'center',
-                                  gap: 8,
-                                }}
+                                className="memory-tree-child-row"
                               >
                                 <span style={{ minWidth: 0 }}>
                                   <span className="library-card-name">{child.name}</span>{' '}
@@ -2299,14 +2298,16 @@ export function MemorySection({
                                     </span>
                                   ) : null}
                                 </span>
-                                <button
-                                  type="button"
-                                  className="ghost library-card-action"
-                                  onClick={() => startEdit(child.id)}
-                                  title={t('settings.memoryEdit')}
-                                >
-                                  <Icon name="edit" size={14} />
-                                </button>
+                                <div className="memory-card-actions">
+                                  <button
+                                    type="button"
+                                    className="ghost library-card-action"
+                                    onClick={() => startEdit(child.id)}
+                                    title={t('settings.memoryEdit')}
+                                  >
+                                    <Icon name="edit" size={14} />
+                                  </button>
+                                </div>
                               </li>
                             ))}
                           </ul>

--- a/apps/web/src/styles/viewer/library.css
+++ b/apps/web/src/styles/viewer/library.css
@@ -1345,7 +1345,7 @@
 
 .memory-records-section .library-card {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) repeat(3, 30px);
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
   min-height: 58px;
@@ -1392,6 +1392,21 @@
   -webkit-line-clamp: 1;
   font-size: 12px;
   line-height: 1.35;
+}
+
+.memory-card-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  justify-self: end;
+}
+
+.memory-tree-child-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
 }
 
 .memory-records-section .library-card-expand,
@@ -2211,6 +2226,15 @@
   .memory-connector-state {
     grid-column: 2;
     width: fit-content;
+  }
+
+  .memory-records-section .library-card,
+  .memory-tree-child-row {
+    grid-template-columns: 1fr;
+  }
+
+  .memory-card-actions {
+    width: 100%;
   }
 }
 

--- a/apps/web/tests/components/MemorySection.test.tsx
+++ b/apps/web/tests/components/MemorySection.test.tsx
@@ -281,6 +281,89 @@ describe('MemorySection', () => {
     expect(screen.getByDisplayValue('- Keep design-system extraction in the loop')).toBeTruthy();
   });
 
+  it('anchors memory tree entry edit controls in the right-side action zone', async () => {
+    globalThis.EventSource = StubEventSource as unknown as typeof EventSource;
+    const entry = {
+      id: 'project_design_agent_goal',
+      name: 'Design agent goal',
+      description: 'Open Design should evolve from accepted work',
+      type: 'project',
+      body: '- Keep design-system extraction in the loop',
+      updatedAt: Date.now(),
+    };
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(JSON.stringify({
+          enabled: true,
+          rootDir: '/tmp/memory',
+          index: '# Memory\n',
+          entries: [entry],
+          extraction: null,
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/api/memory/tree') {
+        return new Response(JSON.stringify({
+          enabled: true,
+          rootDir: '/tmp/memory',
+          tree: [
+            {
+              id: 'folder:project',
+              parentId: null,
+              path: '/project',
+              name: 'Project',
+              kind: 'folder',
+              type: 'project',
+              scope: 'project',
+              sourcePacketIds: [],
+              proposalIds: [],
+              createdAt: new Date(entry.updatedAt).toISOString(),
+              updatedAt: new Date(entry.updatedAt).toISOString(),
+              childrenCount: 1,
+            },
+            {
+              id: entry.id,
+              parentId: 'folder:project',
+              path: `/project/${entry.id}`,
+              name: entry.name,
+              description: entry.description,
+              kind: 'entry',
+              type: 'project',
+              scope: 'project',
+              sourcePacketIds: [],
+              proposalIds: [],
+              createdAt: new Date(entry.updatedAt).toISOString(),
+              updatedAt: new Date(entry.updatedAt).toISOString(),
+              childrenCount: 0,
+            },
+          ],
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/api/memory/extractions') {
+        return new Response(JSON.stringify({ extractions: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as typeof fetch;
+
+    renderMemorySection();
+
+    const treeDetails = (await screen.findByText('Memory tree')).closest('details')!;
+    const childRow = within(treeDetails)
+      .getByText('Design agent goal')
+      .closest('.memory-tree-child-row') as HTMLElement;
+    const editButton = within(childRow).getByTitle('Edit');
+    const actionZone = editButton.closest('.memory-card-actions');
+    const childContent = childRow.firstElementChild as HTMLElement;
+
+    expect(actionZone).toBeTruthy();
+    expect(actionZone?.parentElement).toBe(childRow);
+    expect(childContent.contains(editButton)).toBe(false);
+  });
+
   it('shows unsaved index state and saves the updated index', async () => {
     globalThis.EventSource = StubEventSource as unknown as typeof EventSource;
     let savedIndex = '# Memory\n\n- Existing bullet\n';


### PR DESCRIPTION
Fixes #3166

## Why

I picked this up from issue #3166 after the Memory settings screenshots showed the edit action floating in different places between grouped memory tree rows and the saved-memory rows.

The pain being addressed is a visible layout inconsistency in Settings -> Memory: users have to scan different parts of each row to find the same edit action, which makes the memory list feel less structured.

## What users will see

Settings -> Memory now keeps row actions anchored in a consistent right-side action area. Saved memory rows keep preview / edit / delete grouped together, extraction rows keep their delete action in the same action zone, and Memory tree child rows right-align their edit action instead of letting it sit inside the content area.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Validated locally in the browser at `http://127.0.0.1:17573/` with Settings -> Memory open. DOM/layout inspection confirmed the grouped memory child edit action lives in `.memory-card-actions` at the right edge of `.memory-tree-child-row`, and saved memory rows expose preview / edit / delete in the same action group.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/MemorySection.test.tsx`
- Did the test go red on `main` and green on this branch? yes. The new `anchors memory tree entry edit controls in the right-side action zone` spec failed before the layout change because tree child rows had no `.memory-tree-child-row` / `.memory-card-actions` split, then passed after the fix.

## Validation

- [x] `git diff --check`
- [x] `corepack pnpm install` to refresh workspace links and generated package output
- [x] `corepack pnpm --filter @open-design/web test -- apps/web/tests/components/MemorySection.test.tsx`
- [x] `corepack pnpm --filter @open-design/web typecheck`
- [x] `corepack pnpm --filter @open-design/web build`
- [x] `corepack pnpm --filter @open-design/daemon build`
- [x] `corepack pnpm --filter @open-design/desktop typecheck`
- [x] Direct daemon typecheck equivalent with pinned pnpm/corepack: `contracts build`, `registry-protocol build`, `tsc -p apps/daemon/tsconfig.json --noEmit`, `tsc -p apps/daemon/tsconfig.tests.json --noEmit`
- [x] `corepack pnpm exec tsc -p scripts/tsconfig.json --noEmit`
- [ ] `corepack pnpm guard` currently fails on an unrelated pre-existing tools layout violation: `tools/pr/ -> tools/ top-level entries are allowlisted; expected only AGENTS.md, dev/, pack/, and serve/`. This PR does not touch `tools/pr/`.
- [ ] `corepack pnpm typecheck` currently fails before running checks because the root script invokes global `pnpm` 10.11.0 while the repo requires `>=10.33.2 <11`. The equivalent recursive checks were run through Corepack; `apps/web`, `e2e`, daemon direct checks, desktop, packages, tools, and scripts checks completed as noted above.
