### PR TITLE
fix(web): guard ChatPane scroll setState to prevent Maximum update depth error

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -658,7 +658,12 @@ export function ChatPane({
       snapshot(target);
       const distance =
         target.scrollHeight - target.scrollTop - target.clientHeight;
-      setScrolledFromBottom(distance > 120);
+      // Functional updater bails out when the value is unchanged so a flood
+      // of scroll events (e.g. programmatic scrollTop + ResizeObserver
+      // follow-up during streaming) does not schedule a re-render per tick
+      // and trip React's "Maximum update depth exceeded" guard.
+      const next = distance > 120;
+      setScrolledFromBottom((prev) => (prev === next ? prev : next));
       pinnedToBottomRef.current = distance < 80;
     }
     el.addEventListener('scroll', onScroll);


### PR DESCRIPTION
## Why

While streaming a chat response (or just rapidly scrolling the chat-log), the dev console fires:

```
Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.

    at HTMLDivElement.onScroll (apps/web/src/components/ChatPane.tsx:661)
```

The scroll handler called `setScrolledFromBottom(distance > 120)` unconditionally on every scroll event. While streaming, `followLatestIfPinned` programmatically assigns `scrollTop = scrollHeight` inside a rAF and is re-triggered by `ResizeObserver` whenever message chunks change the chat-log's height. Each of those programmatic scrolls emits a synchronous scroll event, so React sees a fresh setState per tick while still committing the previous render — eventually tripping the update-depth guard and dumping the stack trace into the user-visible Next.js dev overlay.

## What users will see

No visible behavior change in the chat. The dev-overlay red toast for "Maximum update depth exceeded" disappears from the streaming/scrolling path. The "jump to bottom" affordance still appears when the user scrolls > 120px from bottom and still hides when they return.

## How

`onScroll` now writes `scrolledFromBottom` through a functional updater that returns `prev` when the boolean is unchanged:

```ts
const next = distance > 120;
setScrolledFromBottom((prev) => (prev === next ? prev : next));
```

React skips the re-render when the updater returns the previous value, so a flood of "same-value" setState calls inside one commit window no longer accumulates against the update-depth guard. The auto-follow rAF + `ResizeObserver` logic is untouched — they still scroll the log to the bottom on new content, they just stop racing the scroll handler into a state-update storm.

## Surface area

- [x] **Web (`apps/web`)** — `ChatPane.tsx` scroll handler only
- [ ] Daemon (`apps/daemon`)
- [ ] Desktop (`apps/desktop`)
- [ ] Packaged (`apps/packaged`)
- [ ] Sidecar / Platform / Contracts
- [ ] tools-dev / tools-pack / tools-serve
- [ ] Skills / Design systems / Design templates / Craft
- [ ] CLI flags / env vars / i18n keys
- [ ] New root `package.json` dependencies
- [ ] **Default behavior change** — no, dev-only error elimination
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

**Red on `main`:** Open the chat-log while streaming, scroll lightly, and the Next.js 16 dev overlay surfaces "Maximum update depth exceeded" pointing at `ChatPane.tsx:661` (the line that does `setScrolledFromBottom(distance > 120)`).

**Green on this branch:** Same flow — the dev overlay no longer fires because `setScrolledFromBottom` is a no-op when the boolean did not actually change, so React skips the re-render and the cascade chain breaks.

No app-local Vitest test was added because the loop requires real scroll/`ResizeObserver` timing during streaming, which jsdom cannot reproduce cheaply; the change is one functional-updater hardening at the call site that the surrounding effects already assume should be idempotent.

## Screenshots

Not applicable — no visible UI change.

## Adjacent issues

`scrolledFromBottom` has four other `setScrolledFromBottom(...)` call sites (lines 544, 553, 590, 687 on `main`). Those are one-shot transitions (button click, tab change, post-follow reset), not in the scroll/streaming loop, so they don't contribute to the bug and stay untouched per `Hold the spec's scope`.
