### PR TITLE
[codex] Harden AMR Link startup model discovery

### DIFF
--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -1,6 +1,9 @@
 import { execAgentFile } from './shared.js';
 import type { RuntimeAgentDef, RuntimeModelOption } from '../types.js';
 
+const AMR_MODELS_TIMEOUT_MS = 10_000;
+const AMR_MODELS_RETRY_DELAYS_MS = [250, 750] as const;
+
 const PREFERRED_AMR_CHAT_MODEL_ORDER = [
   'deepseek-v4-flash',
   'deepseek-v3.2',
@@ -128,19 +131,65 @@ function orderAmrChatModels(
     .map(({ model }) => model);
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function velaModelsErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error ?? '');
+}
+
+function isRetriableVelaModelsError(error: unknown): boolean {
+  const message = velaModelsErrorMessage(error).toLowerCase();
+  return [
+    'deadline exceeded',
+    'timed out',
+    'timeout',
+    'temporarily unavailable',
+    'temporary failure',
+    'econnreset',
+    'econnrefused',
+    'enotfound',
+    '502',
+    '503',
+    '504',
+  ].some((pattern) => message.includes(pattern));
+}
+
+async function fetchVelaModelsWithRetry(
+  resolvedBin: string,
+  env: NodeJS.ProcessEnv,
+): Promise<RuntimeModelOption[]> {
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt <= AMR_MODELS_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      const { stdout } = await execAgentFile(resolvedBin, ['models'], {
+        env,
+        timeout: AMR_MODELS_TIMEOUT_MS,
+        maxBuffer: 1024 * 1024,
+      });
+      return parseVelaModels(String(stdout));
+    } catch (error) {
+      lastError = error;
+      if (
+        attempt === AMR_MODELS_RETRY_DELAYS_MS.length ||
+        !isRetriableVelaModelsError(error)
+      ) {
+        throw error;
+      }
+      await sleep(AMR_MODELS_RETRY_DELAYS_MS[attempt] ?? 0);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(velaModelsErrorMessage(lastError));
+}
+
 export const amrAgentDef = {
   id: 'amr',
   name: 'AMR',
   bin: 'vela',
   versionArgs: ['--version'],
-  fetchModels: async (resolvedBin, env) => {
-    const { stdout } = await execAgentFile(resolvedBin, ['models'], {
-      env,
-      timeout: 10_000,
-      maxBuffer: 1024 * 1024,
-    });
-    return parseVelaModels(String(stdout));
-  },
+  fetchModels: fetchVelaModelsWithRetry,
   // Fail closed when Vela's live catalog is unavailable. Stale static
   // fallbacks let users select models that link/opencode no longer accepts.
   fallbackModels: [] as RuntimeModelOption[],

--- a/apps/daemon/src/runtimes/models.ts
+++ b/apps/daemon/src/runtimes/models.ts
@@ -25,6 +25,18 @@ export function rememberLiveModels(agentId: string, models: RuntimeModelOption[]
   liveModelOrder.set(agentId, ids);
 }
 
+export function getRememberedLiveModels(agentId: string): RuntimeModelOption[] {
+  const ids = liveModelOrder.get(agentId) ?? [];
+  return ids.map((id) => ({ id, label: id }));
+}
+
+export function preferFreshLiveModels(
+  freshModels: RuntimeModelOption[],
+  rememberedModels: RuntimeModelOption[],
+): RuntimeModelOption[] {
+  return freshModels.length > 0 ? freshModels : rememberedModels;
+}
+
 export function isKnownModel(def: RuntimeAgentDef, modelId: string | null | undefined) {
   if (!modelId) return false;
   const live = liveModelCache.get(def.id);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -40,7 +40,12 @@ import {
   sanitizeCustomModel,
   spawnEnvForAgent,
 } from './agents.js';
-import { rememberLiveModels, resolveModelForAgent } from './runtimes/models.js';
+import {
+  getRememberedLiveModels,
+  preferFreshLiveModels,
+  rememberLiveModels,
+  resolveModelForAgent,
+} from './runtimes/models.js';
 import {
   cancelVelaLogin,
   forgetVelaLogin,
@@ -10884,7 +10889,11 @@ export async function startServer({
       } catch {
         liveModels = [];
       }
-      rememberLiveModels(def.id, liveModels);
+      const rememberedLiveModels = getRememberedLiveModels(def.id);
+      if (liveModels.length > 0) {
+        rememberLiveModels(def.id, liveModels);
+      }
+      liveModels = preferFreshLiveModels(liveModels, rememberedLiveModels);
       const liveModelIds = new Set(
         liveModels.map((candidate) => candidate?.id).filter(Boolean),
       );

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -15,6 +15,8 @@
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -148,6 +150,61 @@ describe('AMR runtime def', () => {
       { id: 'minimax-m2.7', label: 'minimax-m2.7' },
       { id: 'qwen3-235b-a22b', label: 'qwen3-235b-a22b' },
     ]);
+  });
+
+  it('retries transient `vela models` failures before succeeding', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'od-amr-retry-'));
+    const stateFile = path.join(tempDir, 'retry-state.json');
+    const wrapperPath = path.join(tempDir, 'vela-wrapper');
+    const wrapperSource = `#!/usr/bin/env node
+const { existsSync, readFileSync, writeFileSync } = require('node:fs');
+const { spawn } = require('node:child_process');
+const stateFile = process.env.RETRY_STATE_FILE;
+const fakeVela = process.env.FAKE_VELA_PATH;
+const args = process.argv.slice(2);
+if (args[0] === 'models') {
+  const state = stateFile && existsSync(stateFile)
+    ? JSON.parse(readFileSync(stateFile, 'utf8'))
+    : { attempts: 0 };
+  state.attempts += 1;
+  if (stateFile) writeFileSync(stateFile, JSON.stringify(state), 'utf8');
+  if (state.attempts < 3) {
+    process.stderr.write('Get "https://amr-link.open-design.ai/v1/models": context deadline exceeded\\n');
+    process.exit(1);
+  }
+}
+const child = spawn(process.execPath, [fakeVela, ...args], {
+  stdio: ['ignore', 'pipe', 'pipe'],
+  env: process.env,
+});
+let stdout = '';
+let stderr = '';
+child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+child.on('exit', (code) => {
+  if (stdout) process.stdout.write(stdout);
+  if (stderr) process.stderr.write(stderr);
+  process.exit(code ?? 0);
+});
+`;
+    writeFileSync(wrapperPath, wrapperSource, 'utf8');
+    chmodSync(wrapperPath, 0o755);
+    try {
+      const models = await amrAgentDef.fetchModels?.(
+        wrapperPath,
+        {
+          ...process.env,
+          FAKE_VELA_PATH: FAKE_VELA,
+          RETRY_STATE_FILE: stateFile,
+        },
+      );
+      expect(models?.[0]?.id).toBe('deepseek-v4-flash');
+      expect(existsSync(stateFile)).toBe(true);
+      const attempts = JSON.parse(readFileSync(stateFile, 'utf8')) as { attempts: number };
+      expect(attempts.attempts).toBe(3);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -29,6 +29,8 @@ import { getAgentDef } from '../src/agents.js';
 import { readMemoryConfig, writeMemoryConfig } from '../src/memory.js';
 import { renderCodexImagegenOverride } from '../src/prompts/system.js';
 
+const FAKE_VELA_FIXTURE = resolve(process.cwd(), 'tests', 'fixtures', 'fake-vela.mjs');
+
 function symlinkDir(target: string, link: string): void {
   symlinkSync(target, link, process.platform === 'win32' ? 'junction' : 'dir');
 }
@@ -212,6 +214,71 @@ process.exit(0);
         });
       },
     );
+  });
+
+  it('retries transient AMR Link catalog failures before aborting startup', async () => {
+    const previousRuntimeKey = process.env.VELA_RUNTIME_KEY;
+    const previousLinkUrl = process.env.VELA_LINK_URL;
+    const stateFile = join(tmpdir(), `od-amr-model-retry-${randomUUID()}.json`);
+    try {
+      process.env.VELA_RUNTIME_KEY = 'fake-runtime-key';
+      process.env.VELA_LINK_URL = 'https://amr-link.open-design.ai/v1';
+
+      await withFakeAgent(
+        'vela',
+        `
+const { existsSync, readFileSync, writeFileSync } = require('node:fs');
+const { spawn } = require('node:child_process');
+const fixture = ${JSON.stringify(FAKE_VELA_FIXTURE)};
+const stateFile = ${JSON.stringify(stateFile)};
+const args = process.argv.slice(2);
+if (args[0] === 'models') {
+  const state = existsSync(stateFile)
+    ? JSON.parse(readFileSync(stateFile, 'utf8'))
+    : { attempts: 0 };
+  state.attempts += 1;
+  writeFileSync(stateFile, JSON.stringify(state), 'utf8');
+  if (state.attempts < 3) {
+    process.stderr.write('Get "https://amr-link.open-design.ai/v1/models": context deadline exceeded\\n');
+    process.exit(1);
+  }
+}
+const child = spawn(process.execPath, [fixture, ...args], {
+  stdio: 'inherit',
+  env: process.env,
+});
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exit(code ?? 0);
+});
+`,
+        async () => {
+          const response = await fetch(`${baseUrl}/api/chat`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              agentId: 'amr',
+              message: 'hello',
+              model: 'deepseek-v3.2',
+            }),
+          });
+          const body = await response.text();
+
+          expect(response.ok).toBe(true);
+          expect(body).toContain('"type":"text_delta","delta":"Hello from fake "');
+          expect(body).toContain('"type":"text_delta","delta":"vela."');
+          expect(body).not.toContain('model_catalog_unavailable');
+          const attempts = JSON.parse(readFileSync(stateFile, 'utf8')) as { attempts: number };
+          expect(attempts.attempts).toBe(3);
+        },
+      );
+    } finally {
+      rmSync(stateFile, { force: true });
+      if (previousRuntimeKey == null) delete process.env.VELA_RUNTIME_KEY;
+      else process.env.VELA_RUNTIME_KEY = previousRuntimeKey;
+      if (previousLinkUrl == null) delete process.env.VELA_LINK_URL;
+      else process.env.VELA_LINK_URL = previousLinkUrl;
+    }
   });
 
   it('closes the # Instructions block with an explicit "do not echo" guard so models do not parrot the prompt back', async () => {

--- a/apps/daemon/tests/runtimes/resolve-model.test.ts
+++ b/apps/daemon/tests/runtimes/resolve-model.test.ts
@@ -18,6 +18,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  getRememberedLiveModels,
+  preferFreshLiveModels,
   rememberLiveModels,
   resolveModelForAgent,
 } from '../../src/runtimes/models.js';
@@ -62,6 +64,21 @@ describe('resolveModelForAgent', () => {
 
     expect(resolveModelForAgent(def, null)).toBe('deepseek-v3.2');
     expect(resolveModelForAgent(def, 'default')).toBe('deepseek-v3.2');
+    expect(getRememberedLiveModels(def.id)).toEqual([
+      { id: 'deepseek-v3.2', label: 'deepseek-v3.2' },
+      { id: 'glm-5.1', label: 'glm-5.1' },
+    ]);
+  });
+
+  it('prefers remembered live models only when the fresh AMR catalog is empty', () => {
+    const remembered = [
+      { id: 'deepseek-v3.2', label: 'deepseek-v3.2' },
+      { id: 'glm-5.1', label: 'glm-5.1' },
+    ];
+    const fresh = [{ id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' }];
+
+    expect(preferFreshLiveModels(fresh, remembered)).toEqual(fresh);
+    expect(preferFreshLiveModels([], remembered)).toEqual(remembered);
   });
 
   it('keeps common default-capable defs untouched even when live models are remembered', () => {


### PR DESCRIPTION
## Why
AMR startup was brittle around Link model discovery. The daemon re-fetched the live `vela models` catalog before spawning the AMR runtime, and a single transient timeout could collapse that catalog to empty and fail the whole run even when the user was still signed in.

## What changed
- retry transient `vela models` failures in the AMR runtime definition with short backoff
- keep remembering non-empty live AMR model catalogs and reuse that last-known-good catalog when a fresh startup probe comes back empty
- add focused coverage for AMR retry behavior, remembered-live-model selection, and the AMR chat-route retry path

## User impact
AMR startup no longer fails immediately on a single flaky Link catalog timeout. Signed-in users can carry forward through transient discovery instability, while auth failures and real model-unavailable cases still fail explicitly.

## Root cause
The AMR-only startup preflight treated an empty fresh catalog as authoritative for every failure mode. That conflated temporary Link discovery failures with genuine empty/model-unavailable conditions.

## Validation
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm exec vitest run -c vitest.config.ts tests/amr-acp-integration.test.ts tests/runtimes/resolve-model.test.ts`
- `PATH=/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH ./node_modules/.bin/vitest run -c vitest.config.ts tests/chat-route.test.ts -t 'retries transient AMR Link catalog failures before aborting startup'`

## Notes
- `pnpm exec` was resolving to Homebrew Node 25 in this checkout, so the targeted chat-route verification was forced onto Node 24 to match the repo engine and native module ABI.
