### PR TITLE
fix(analytics): fill run and feedback metadata

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -234,6 +234,7 @@ import { observePendingInstallerApplyAttempts } from './update-apply-observation
 import {
   agentIdToTracking,
   deriveConfigureGlobals,
+  projectKindToTracking,
   type ObservabilityEventRequest,
 } from '@open-design/contracts/analytics';
 import {
@@ -1859,6 +1860,19 @@ async function readProjectPluginManifest(folder) {
 }
 
 export const __forTestReadProjectPluginManifest = readProjectPluginManifest;
+
+function resolveRunProjectKindForAnalytics({
+  hintProjectKind,
+  projectMetadata,
+}) {
+  if (typeof hintProjectKind === 'string') return hintProjectKind;
+  if (projectMetadata?.importedFrom === 'design-system') return 'design_system';
+  return projectKindToTracking(projectMetadata?.kind);
+}
+
+export function __forTestResolveRunProjectKindForAnalytics(args) {
+  return resolveRunProjectKindForAnalytics(args);
+}
 
 function githubRepoNameFromPluginName(name) {
   const slug = String(name)
@@ -12351,13 +12365,19 @@ export async function startServer({
       const hintProjectKind = typeof analyticsHints.projectKind === 'string'
         ? analyticsHints.projectKind
         : null;
+      const requestProjectId = typeof reqBody.projectId === 'string' ? reqBody.projectId : null;
+      const runProject = requestProjectId ? getProject(db, requestProjectId) : null;
+      const runProjectKind = resolveRunProjectKindForAnalytics({
+        hintProjectKind,
+        projectMetadata: runProject?.metadata,
+      });
       const dsRunContext =
         analyticsHints.designSystemRunContext
           && typeof analyticsHints.designSystemRunContext === 'object'
           ? (analyticsHints.designSystemRunContext as Record<string, unknown>)
           : {};
       const isDesignSystemRun =
-        hintProjectKind === 'design_system'
+        runProjectKind === 'design_system'
         || hintEntryFrom === 'design_system_create'
         || hintEntryFrom === 'onboarding_design_system'
         || hintEntryFrom === 'regenerate_from_review';
@@ -12367,18 +12387,19 @@ export async function startServer({
       // companion_surfaces / connectors / use_speaker_notes /
       // include_animations / reference_template / aspect /
       // project_source) — most aren't on the wire yet, but
-      // entry_from / projectKind / DS run context land here when the
-      // client populates `analyticsHints`. Other dimensions stay
-      // omitted until follow-up PRs thread them through.
+      // project_kind falls back to the stored project metadata so ordinary
+      // project runs are classified even when callers do not send
+      // `analyticsHints`. Other dimensions stay omitted until follow-up PRs
+      // thread them through.
       const baseProps: Record<string, unknown> = {
         page_name: isDesignSystemRun ? 'design_system_project' : 'chat_panel',
         area: isDesignSystemRun ? 'design_system_generation' : 'chat_composer',
         ...configureGlobals,
-        project_id: typeof reqBody.projectId === 'string' ? reqBody.projectId : null,
+        project_id: requestProjectId,
         conversation_id:
           typeof reqBody.conversationId === 'string' ? reqBody.conversationId : null,
         run_id: run.id,
-        project_kind: hintProjectKind,
+        project_kind: runProjectKind,
         ...(hintEntryFrom ? { entry_from: hintEntryFrom } : {}),
         design_system_id:
           typeof reqBody.designSystemId === 'string'

--- a/apps/daemon/tests/run-lifecycle-analytics.test.ts
+++ b/apps/daemon/tests/run-lifecycle-analytics.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { __forTestResolveRunProjectKindForAnalytics } from '../src/server.js';
+
+describe('run lifecycle analytics', () => {
+  it('falls back to stored project metadata when analytics hints omit project kind', () => {
+    expect(
+      __forTestResolveRunProjectKindForAnalytics({
+        hintProjectKind: null,
+        projectMetadata: { kind: 'prototype' },
+      }),
+    ).toBe('prototype');
+  });
+
+  it('maps project metadata kind to the analytics project_kind enum', () => {
+    expect(
+      __forTestResolveRunProjectKindForAnalytics({
+        hintProjectKind: null,
+        projectMetadata: { kind: 'deck' },
+      }),
+    ).toBe('slide_deck');
+  });
+
+  it('preserves explicit analytics hints over project metadata', () => {
+    expect(
+      __forTestResolveRunProjectKindForAnalytics({
+        hintProjectKind: 'design_system',
+        projectMetadata: { kind: 'other' },
+      }),
+    ).toBe('design_system');
+  });
+
+  it('classifies design-system workspace projects when hints are absent', () => {
+    expect(
+      __forTestResolveRunProjectKindForAnalytics({
+        hintProjectKind: null,
+        projectMetadata: { kind: 'other', importedFrom: 'design-system' },
+      }),
+    ).toBe('design_system');
+  });
+});

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -20,7 +20,7 @@ import {
   trackFeedbackSubmitResult,
 } from "../analytics/events";
 import {
-  agentIdToTracking,
+  feedbackAgentProviderIdToTracking,
   normalizeCustomReason,
   type TrackingFeedbackReasonCode,
   type TrackingFeedbackRatingWithNone,
@@ -646,7 +646,7 @@ export function AssistantMessage({
                 runId={message.runId ?? null}
                 assistantMessageId={message.id}
                 modelId={assistantFeedbackModelId(message)}
-                agentProviderId={message.agentId ? agentIdToTracking(message.agentId) : null}
+                agentProviderId={feedbackAgentProviderIdToTracking(message.agentId)}
                 producedFileCount={displayedProduced.length}
                 hasDesignSystemContext={hasDesignSystemContext}
                 footerProps={{
@@ -870,7 +870,7 @@ function AssistantFeedback({
   runId: string | null;
   assistantMessageId: string;
   modelId: string | null;
-  agentProviderId: ReturnType<typeof agentIdToTracking> | null;
+  agentProviderId: ReturnType<typeof feedbackAgentProviderIdToTracking>;
   producedFileCount: number;
 }) {
   const t = useT();

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -20,6 +20,7 @@ import {
   trackFeedbackSubmitResult,
 } from "../analytics/events";
 import {
+  agentIdToTracking,
   normalizeCustomReason,
   type TrackingFeedbackReasonCode,
   type TrackingFeedbackRatingWithNone,
@@ -644,6 +645,8 @@ export function AssistantMessage({
                 conversationId={conversationId}
                 runId={message.runId ?? null}
                 assistantMessageId={message.id}
+                modelId={assistantFeedbackModelId(message)}
+                agentProviderId={message.agentId ? agentIdToTracking(message.agentId) : null}
                 producedFileCount={displayedProduced.length}
                 hasDesignSystemContext={hasDesignSystemContext}
                 footerProps={{
@@ -767,6 +770,16 @@ function assistantModelDetail(message: ChatMessage): string | null {
   return detail;
 }
 
+function assistantFeedbackModelId(message: ChatMessage): string | null {
+  const detail = assistantModelDetail(message);
+  if (detail) return detail;
+  const displayName = message.agentName?.trim();
+  if (!displayName) return null;
+  const parts = displayName.split(" · ");
+  const model = parts.length > 1 ? parts[parts.length - 1]?.trim() : "";
+  return model || null;
+}
+
 function appendRoleModel(label: string, model: string | null): string {
   if (!model || label.includes(" · ")) return label;
   return `${label} · ${model}`;
@@ -843,6 +856,8 @@ function AssistantFeedback({
   conversationId,
   runId,
   assistantMessageId,
+  modelId,
+  agentProviderId,
   producedFileCount,
 }: {
   feedback: ChatMessage["feedback"];
@@ -854,6 +869,8 @@ function AssistantFeedback({
   conversationId: string | null;
   runId: string | null;
   assistantMessageId: string;
+  modelId: string | null;
+  agentProviderId: ReturnType<typeof agentIdToTracking> | null;
   producedFileCount: number;
 }) {
   const t = useT();
@@ -1024,6 +1041,8 @@ function AssistantFeedback({
         conversation_id: conversationId,
         assistant_message_id: assistantMessageId,
         run_id: runId ?? "",
+        model_id: modelId,
+        agent_provider_id: agentProviderId,
         rating: reasonRating,
         ...(reasonJoined ? { reason: reasonJoined } : {}),
         reason_count: reasonCodes.length,

--- a/apps/web/tests/components/AssistantMessage.feedback-analytics.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.feedback-analytics.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AssistantMessage } from '../../src/components/AssistantMessage';
 import type { ChatMessage } from '../../src/types';
 
@@ -32,6 +32,10 @@ beforeEach(() => {
   analyticsMocks.track.mockReset();
 });
 
+afterEach(() => {
+  cleanup();
+});
+
 function assistantMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
   return {
     id: 'assistant-1',
@@ -48,10 +52,10 @@ function assistantMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
 }
 
 describe('AssistantMessage feedback analytics', () => {
-  it('includes model and agent provider on feedback_submit_result', async () => {
+  async function submitHelpfulFeedback(message: ChatMessage) {
     render(
       <AssistantMessage
-        message={assistantMessage()}
+        message={message}
         streaming={false}
         projectId="project-1"
         projectKind="prototype"
@@ -68,9 +72,25 @@ describe('AssistantMessage feedback analytics', () => {
       ([event]) => event === 'feedback_submit_result',
     );
     expect(resultCall).toBeTruthy();
-    expect(resultCall?.[1]).toMatchObject({
+    return resultCall?.[1];
+  }
+
+  it('includes model and CLI provider on feedback_submit_result', async () => {
+    const resultProps = await submitHelpfulFeedback(assistantMessage());
+    expect(resultProps).toMatchObject({
       model_id: 'claude-sonnet-4-6',
       agent_provider_id: 'claude_code',
+    });
+  });
+
+  it('maps API-mode agent ids on feedback_submit_result', async () => {
+    const resultProps = await submitHelpfulFeedback(assistantMessage({
+      agentId: 'anthropic-api',
+      agentName: 'Anthropic API · claude-sonnet-4-6',
+    }));
+    expect(resultProps).toMatchObject({
+      model_id: 'claude-sonnet-4-6',
+      agent_provider_id: 'anthropic',
     });
   });
 });

--- a/apps/web/tests/components/AssistantMessage.feedback-analytics.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.feedback-analytics.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AssistantMessage } from '../../src/components/AssistantMessage';
+import type { ChatMessage } from '../../src/types';
+
+const analyticsMocks = vi.hoisted(() => ({
+  newRequestId: vi.fn(() => 'request-1'),
+  track: vi.fn(),
+}));
+
+vi.mock('../../src/analytics/provider', () => ({
+  useAnalytics: () => ({
+    newRequestId: analyticsMocks.newRequestId,
+    setConfigureGlobals: vi.fn(),
+    setConsent: vi.fn(),
+    setIdentity: vi.fn(),
+    track: analyticsMocks.track,
+  }),
+}));
+
+beforeAll(() => {
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+beforeEach(() => {
+  analyticsMocks.newRequestId.mockReturnValue('request-1');
+  analyticsMocks.track.mockReset();
+});
+
+function assistantMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: 'Done.',
+    agentId: 'claude',
+    agentName: 'Claude · claude-sonnet-4-6',
+    runId: 'run-1',
+    runStatus: 'succeeded',
+    events: [{ kind: 'text', text: 'Done.' } as NonNullable<ChatMessage['events']>[number]],
+    producedFiles: [],
+    ...overrides,
+  } as ChatMessage;
+}
+
+describe('AssistantMessage feedback analytics', () => {
+  it('includes model and agent provider on feedback_submit_result', async () => {
+    render(
+      <AssistantMessage
+        message={assistantMessage()}
+        streaming={false}
+        projectId="project-1"
+        projectKind="prototype"
+        conversationId="conversation-1"
+        onFeedback={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Helpful' }));
+    fireEvent.click(await screen.findByLabelText('Understood my request'));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    const resultCall = analyticsMocks.track.mock.calls.find(
+      ([event]) => event === 'feedback_submit_result',
+    );
+    expect(resultCall).toBeTruthy();
+    expect(resultCall?.[1]).toMatchObject({
+      model_id: 'claude-sonnet-4-6',
+      agent_provider_id: 'claude_code',
+    });
+  });
+});

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -157,6 +157,10 @@ export type TrackingCliProviderId =
   | 'kilo'
   | 'other';
 
+export type TrackingFeedbackProviderId =
+  | TrackingCliProviderId
+  | TrackingByokProviderId;
+
 export type TrackingArtifactKind =
   | 'html'
   | 'markdown'
@@ -1850,7 +1854,7 @@ export interface FeedbackSubmitResultProps {
   assistant_message_id: string;
   run_id: string;
   model_id: string | null;
-  agent_provider_id: TrackingCliProviderId | null;
+  agent_provider_id: TrackingFeedbackProviderId | null;
   rating: 'positive' | 'negative';
   reason?: string;
   reason_count: number;
@@ -2096,6 +2100,27 @@ export function agentIdToTracking(agentId: string | null | undefined): TrackingC
       return 'kilo';
     default:
       return 'other';
+  }
+}
+
+export function feedbackAgentProviderIdToTracking(
+  agentId: string | null | undefined,
+): TrackingFeedbackProviderId | null {
+  switch (agentId) {
+    case 'anthropic-api':
+      return byokProtocolToTracking('anthropic');
+    case 'openai-api':
+      return byokProtocolToTracking('openai');
+    case 'azure-openai-api':
+      return byokProtocolToTracking('azure');
+    case 'google-gemini-api':
+      return byokProtocolToTracking('google');
+    case 'ollama-cloud-api':
+      return byokProtocolToTracking('ollama');
+    case 'senseaudio-api':
+      return byokProtocolToTracking('senseaudio');
+    default:
+      return agentId ? agentIdToTracking(agentId) : null;
   }
 }
 

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -1849,6 +1849,8 @@ export interface FeedbackSubmitResultProps {
   conversation_id: string | null;
   assistant_message_id: string;
   run_id: string;
+  model_id: string | null;
+  agent_provider_id: TrackingCliProviderId | null;
   rating: 'positive' | 'negative';
   reason?: string;
   reason_count: number;


### PR DESCRIPTION
## Why

本次修复数据上报字段缺失问题：`run_created` / `run_finished` 在普通项目运行时经常没有 `analyticsHints.projectKind`，导致 `project_kind` 为空；`feedback_submit_result` 也缺少模型和 agent provider 上下文，影响按模型/provider 分析反馈质量。

## What users will see

无可见 UI 变化。埋点事件会携带更完整的项目、模型和 agent provider 元数据。

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. No UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/run-lifecycle-analytics.test.ts`, `apps/web/tests/components/AssistantMessage.feedback-analytics.test.tsx`
- Did the test go red on `main` and green on this branch? No. I did not switch back to `main`; the tests were added on this branch and pass here.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/run-lifecycle-analytics.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/AssistantMessage.feedback-analytics.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm typecheck`
- `git diff --check`
- `pnpm guard` fails on an existing unrelated tools layout guard: `tools/pr/ -> tools/ top-level entries are allowlisted; expected only AGENTS.md, dev/, pack/, and serve/`.
