### PR TITLE
fix(web): remove design file mentions with chips

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1132,6 +1132,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     function removeStaged(p: string) {
       setStaged((s) => s.filter((a) => a.path !== p));
       setStagedVisualComments((current) => current.filter((attachment) => attachment.screenshotPath !== p));
+      setDraft((current) => stripInlineMentionToken(current, p));
     }
 
     function removeCommentAttachment(id: string) {
@@ -2709,6 +2710,14 @@ function MentionPopover({
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function stripInlineMentionToken(text: string, label: string): string {
+  const token = inlineMentionToken(label);
+  return text.replace(
+    new RegExp(`(^|[\\s([{"'])${escapeRegExp(token)}(?=$|\\s|[.,;:!?)}\\]"'])([^\\S\\r\\n])?`, 'g'),
+    '$1',
+  );
 }
 
 function loadComposerDraft(key?: string): string | null {

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -284,6 +284,138 @@ describe('ChatComposer context pickers', () => {
     expect(screen.getByTestId('chat-composer-mention-overlay').textContent).toContain('@My Export');
   });
 
+  it('removes the inline design file token when its staged chip is removed', async () => {
+    renderComposer({
+      projectFiles: [
+        {
+          path: 'designs/landing.html',
+          name: 'landing.html',
+          kind: 'html',
+          mime: 'text/html',
+          mtime: 1,
+          size: 128,
+        },
+      ],
+    });
+    const input = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement;
+
+    fireEvent.change(input, {
+      target: { value: 'Use @landing', selectionStart: 12 },
+    });
+
+    await waitFor(() => expect(screen.getByText('designs/landing.html')).toBeTruthy());
+    fireEvent.click(screen.getByText('designs/landing.html'));
+
+    expect(input.value).toBe('Use @designs/landing.html ');
+    expect(screen.getByTestId('staged-attachments').textContent).toContain('landing.html');
+
+    fireEvent.click(screen.getByLabelText('Remove landing.html'));
+
+    expect(input.value).toBe('Use ');
+    expect(screen.queryByTestId('staged-attachments')).toBeNull();
+  });
+
+  it('preserves surrounding draft formatting when removing a design file token', async () => {
+    renderComposer({
+      projectFiles: [
+        {
+          path: 'designs/landing.html',
+          name: 'landing.html',
+          kind: 'html',
+          mime: 'text/html',
+          mtime: 1,
+          size: 128,
+        },
+      ],
+    });
+    const input = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement;
+    const draft = 'Plan:\n\n@landing\n\nKeep spacing';
+
+    fireEvent.change(input, {
+      target: { value: draft, selectionStart: 'Plan:\n\n@landing'.length },
+    });
+
+    await waitFor(() => expect(screen.getByText('designs/landing.html')).toBeTruthy());
+    fireEvent.click(screen.getByText('designs/landing.html'));
+
+    expect(input.value).toBe('Plan:\n\n@designs/landing.html \n\nKeep spacing');
+
+    fireEvent.click(screen.getByLabelText('Remove landing.html'));
+
+    expect(input.value).toBe('Plan:\n\n\n\nKeep spacing');
+    expect(screen.queryByTestId('staged-attachments')).toBeNull();
+  });
+
+  it('removes a design file token when punctuation follows it', async () => {
+    renderComposer({
+      projectFiles: [
+        {
+          path: 'designs/landing.html',
+          name: 'landing.html',
+          kind: 'html',
+          mime: 'text/html',
+          mtime: 1,
+          size: 128,
+        },
+      ],
+    });
+    const input = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement;
+
+    fireEvent.change(input, {
+      target: { value: 'Use @landing', selectionStart: 12 },
+    });
+
+    await waitFor(() => expect(screen.getByText('designs/landing.html')).toBeTruthy());
+    fireEvent.click(screen.getByText('designs/landing.html'));
+
+    fireEvent.change(input, {
+      target: {
+        value: 'Use @designs/landing.html, please',
+        selectionStart: 'Use @designs/landing.html, please'.length,
+      },
+    });
+
+    fireEvent.click(screen.getByLabelText('Remove landing.html'));
+
+    expect(input.value).toBe('Use , please');
+    expect(screen.queryByTestId('staged-attachments')).toBeNull();
+  });
+
+  it('removes a quoted design file token when its chip is removed', async () => {
+    renderComposer({
+      projectFiles: [
+        {
+          path: 'designs/landing.html',
+          name: 'landing.html',
+          kind: 'html',
+          mime: 'text/html',
+          mtime: 1,
+          size: 128,
+        },
+      ],
+    });
+    const input = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement;
+
+    fireEvent.change(input, {
+      target: { value: '@landing', selectionStart: 8 },
+    });
+
+    await waitFor(() => expect(screen.getByText('designs/landing.html')).toBeTruthy());
+    fireEvent.click(screen.getByText('designs/landing.html'));
+
+    fireEvent.change(input, {
+      target: {
+        value: '"@designs/landing.html"',
+        selectionStart: '"@designs/landing.html"'.length,
+      },
+    });
+
+    fireEvent.click(screen.getByLabelText('Remove landing.html'));
+
+    expect(input.value).toBe('""');
+    expect(screen.queryByTestId('staged-attachments')).toBeNull();
+  });
+
   it('lets the tools panel switch between Official and My plugins', async () => {
     renderComposer();
     fireEvent.click(screen.getByLabelText('Open CLI and model settings'));


### PR DESCRIPTION
Fixes #3200

## Why

While checking the fresh composer issues, I reproduced the design-file reference sync bug from #3200. Removing the staged design file chip cleared the chip but left the inline `@designs/...` token in the draft, so the composer showed two different states for the same reference.

This is a user-facing consistency bug in the chat composer: if a user removes a referenced design file, the prompt text should stop referencing it too.

## What users will see

When a design file is inserted through `@` and then removed from the staged file chip row, the matching inline `@design file` token is removed from the input at the same time.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual layout change. This is a composer state-sync fix covered by the red/green regression test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ChatComposer.context-pickers.test.tsx`
- Did the test go red on `main` and green on this branch? yes
  - Red on `main`: `expected 'Use @designs/landing.html ' to be 'Use '`
  - Green on this branch: focused test and full composer context-picker suite pass

## Validation

- `source ~/.nvm/nvm.sh && nvm use 24.15.0 >/dev/null && pnpm --filter @open-design/web exec vitest run tests/components/ChatComposer.context-pickers.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use 24.15.0 >/dev/null && pnpm --filter @open-design/web typecheck`
- `pnpm guard` currently fails on existing repository layout entries outside this patch: `tools/.DS_Store` and `tools/pr/` are not in the root tools allowlist.
