### PR TITLE
fix(media): enforce legacy media policy for run tokens

### DIFF
--- a/apps/daemon/src/media-routes.ts
+++ b/apps/daemon/src/media-routes.ts
@@ -13,7 +13,7 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
   const { db, design } = ctx;
   const { sendApiError, requireLocalDaemonRequest, isLocalSameOrigin, resolvedPortRef } = ctx.http;
   const { PROJECT_ROOT, PROJECTS_DIR, RUNTIME_DATA_DIR } = ctx.paths;
-  const { authorizeToolRequest } = ctx.auth;
+  const { authorizeToolRequest, optionalToolGrantFromRequest } = ctx.auth;
   const { randomUUID } = ctx.ids;
   const { MEDIA_PROVIDERS, IMAGE_MODELS, VIDEO_MODELS, AUDIO_MODELS_BY_KIND, MEDIA_ASPECTS, VIDEO_LENGTHS_SEC, AUDIO_DURATIONS_SEC, readMaskedConfig, writeConfig, generateMedia, createMediaTask, persistMediaTask, appendTaskProgress, notifyTaskWaiters, getLiveMediaTask, mediaTaskSnapshot, listMediaTasksByProject, listElevenLabsVoiceOptions } = ctx.media;
   const { readAppConfig, writeAppConfig } = ctx.appConfig;
@@ -288,7 +288,9 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
     }
 
     try {
-      await handleGenerate(req, res, { projectId: req.params.id, grant: null });
+      // #3199: valid run tokens enforce media policy here; no-token local calls remain a known v1 gap.
+      const grant = optionalToolGrantFromRequest(req);
+      await handleGenerate(req, res, { projectId: req.params.id, grant });
     } catch (err: any) {
       const status = typeof err?.status === 'number' ? err.status : 400;
       const code = err?.code;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2889,6 +2889,11 @@ function authorizeToolRequest(req, res, operation) {
   return validation.grant;
 }
 
+function optionalToolGrantFromRequest(req) {
+  const validation = toolTokenRegistry.validate(bearerTokenFromRequest(req));
+  return validation.ok ? validation.grant : null;
+}
+
 function requestProjectOverride(projectId, tokenProjectId) {
   return typeof projectId === 'string' && projectId.length > 0 && projectId !== tokenProjectId;
 }
@@ -5280,6 +5285,7 @@ export async function startServer({
     desktopAuthSecret: getDesktopAuthSecret,
     isDesktopAuthGateActive,
     pruneExpiredImportNonces,
+    optionalToolGrantFromRequest,
     requestProjectOverride,
     requestRunOverride,
     verifyDesktopImportToken,

--- a/apps/daemon/tests/media-policy-routes.test.ts
+++ b/apps/daemon/tests/media-policy-routes.test.ts
@@ -7,6 +7,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
 
+type FakeMediaEndpoint = 'tool' | 'legacy';
+
+interface FakeMediaAgentOptions {
+  endpoint?: FakeMediaEndpoint;
+  attachToken?: boolean;
+}
+
 describe('run-scoped media policy routes', () => {
   let tempDir: string;
   let binDir: string;
@@ -67,6 +74,191 @@ describe('run-scoped media policy routes', () => {
     expect(captured.tokenAvailable).toBe(true);
     expect(captured.body.error).toMatchObject({
       code: 'MEDIA_EXECUTION_DISABLED',
+    });
+  });
+
+  it('preserves no-token legacy media generation when run media execution is disabled', async () => {
+    const capturePath = path.join(tempDir, 'legacy-no-token-disabled-response.json');
+    await writeFakeAgent(
+      capturePath,
+      {
+        surface: 'image',
+        model: 'test-image-model',
+        prompt: 'Create a launch poster',
+        output: 'poster.png',
+      },
+      { endpoint: 'legacy', attachToken: false },
+    );
+
+    const { url, projectId, conversationId } = await startProjectServer(
+      'Legacy no-token media project',
+    );
+
+    const createResponse = await fetch(`${url}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        projectId,
+        conversationId,
+        message: 'Try to create a poster image through the legacy path.',
+        mediaExecution: { mode: 'disabled' },
+      }),
+    });
+    expect(createResponse.status).toBe(202);
+
+    const captured = await waitForCapturedMediaResponse(capturePath);
+    expect(captured.status).toBe(202);
+    expect(captured.tokenAvailable).toBe(true);
+    expect(captured.tokenAttached).toBe(false);
+  });
+
+  it('allows token-bearing legacy media generation when enabled policy permits it', async () => {
+    const capturePath = path.join(tempDir, 'legacy-token-enabled-response.json');
+    await writeFakeAgent(
+      capturePath,
+      {
+        surface: 'image',
+        model: 'test-image-model',
+        prompt: 'Create a launch poster',
+        output: 'poster.png',
+      },
+      { endpoint: 'legacy' },
+    );
+
+    const { url, projectId, conversationId } = await startProjectServer(
+      'Legacy token-enabled media project',
+    );
+
+    const createResponse = await fetch(`${url}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        projectId,
+        conversationId,
+        message: 'Try to create a poster image through the legacy path.',
+        mediaExecution: {
+          mode: 'enabled',
+          allowedSurfaces: ['image'],
+          allowedModels: ['test-image-model'],
+        },
+      }),
+    });
+    expect(createResponse.status).toBe(202);
+
+    const captured = await waitForCapturedMediaResponse(capturePath);
+    expect(captured.status).toBe(202);
+    expect(captured.tokenAvailable).toBe(true);
+    expect(captured.tokenAttached).toBe(true);
+  });
+
+  it('rejects token-bearing legacy media generation when media execution is disabled', async () => {
+    const capturePath = path.join(tempDir, 'legacy-token-disabled-response.json');
+    await writeFakeAgent(
+      capturePath,
+      {
+        surface: 'image',
+        model: 'gpt-image-2',
+        prompt: 'Create a launch poster',
+        output: 'poster.png',
+      },
+      { endpoint: 'legacy' },
+    );
+
+    const { url, projectId, conversationId } = await startProjectServer(
+      'Legacy token-disabled media project',
+    );
+
+    const createResponse = await fetch(`${url}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        projectId,
+        conversationId,
+        message: 'Try to create a poster image through the legacy path.',
+        mediaExecution: { mode: 'disabled' },
+      }),
+    });
+    expect(createResponse.status).toBe(202);
+
+    const captured = await waitForCapturedMediaResponse(capturePath);
+    expect(captured.status).toBe(403);
+    expect(captured.tokenAvailable).toBe(true);
+    expect(captured.tokenAttached).toBe(true);
+    expect(captured.body.error).toMatchObject({
+      code: 'MEDIA_EXECUTION_DISABLED',
+    });
+  });
+
+  it('rejects disallowed surfaces and models on token-bearing legacy media generation', async () => {
+    const surfaceCapturePath = path.join(tempDir, 'legacy-surface-denied.json');
+    await writeFakeAgent(
+      surfaceCapturePath,
+      {
+        surface: 'image',
+        model: 'gpt-image-2',
+        prompt: 'Create a launch poster',
+        output: 'poster.png',
+      },
+      { endpoint: 'legacy' },
+    );
+    const surfaceProject = await startProjectServer('Legacy surface denied media project');
+    const surfaceResponse = await fetch(`${surfaceProject.url}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        projectId: surfaceProject.projectId,
+        conversationId: surfaceProject.conversationId,
+        message: 'Try to create a poster image through the legacy path.',
+        mediaExecution: {
+          mode: 'enabled',
+          allowedSurfaces: ['video'],
+        },
+      }),
+    });
+    expect(surfaceResponse.status).toBe(202);
+    const surfaceCaptured = await waitForCapturedMediaResponse(surfaceCapturePath);
+    expect(surfaceCaptured.status).toBe(403);
+    expect(surfaceCaptured.tokenAttached).toBe(true);
+    expect(surfaceCaptured.body.error).toMatchObject({
+      code: 'MEDIA_SURFACE_DENIED',
+    });
+
+    const modelCapturePath = path.join(tempDir, 'legacy-model-denied.json');
+    await writeFakeAgent(
+      modelCapturePath,
+      {
+        surface: 'image',
+        model: 'gpt-image-2',
+        prompt: 'Create a launch poster',
+        output: 'poster.png',
+      },
+      { endpoint: 'legacy' },
+    );
+    const modelProject = await startProjectServer('Legacy model denied media project');
+    const modelResponse = await fetch(`${modelProject.url}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'opencode',
+        projectId: modelProject.projectId,
+        conversationId: modelProject.conversationId,
+        message: 'Try to create a poster image through the legacy path.',
+        mediaExecution: {
+          mode: 'enabled',
+          allowedModels: ['different-image-model'],
+        },
+      }),
+    });
+    expect(modelResponse.status).toBe(202);
+    const modelCaptured = await waitForCapturedMediaResponse(modelCapturePath);
+    expect(modelCaptured.status).toBe(403);
+    expect(modelCaptured.tokenAttached).toBe(true);
+    expect(modelCaptured.body.error).toMatchObject({
+      code: 'MEDIA_MODEL_DENIED',
     });
   });
 
@@ -276,9 +468,17 @@ describe('run-scoped media policy routes', () => {
     };
   }
 
-  async function writeFakeAgent(capturePath: string, requestBody: unknown): Promise<void> {
+  async function writeFakeAgent(
+    capturePath: string,
+    requestBody: unknown,
+    options: FakeMediaAgentOptions = {},
+  ): Promise<void> {
+    const endpoint = options.endpoint ?? 'tool';
+    const attachToken = options.attachToken ?? true;
     const source = `#!/usr/bin/env node
 const fs = require('node:fs');
+const endpoint = ${JSON.stringify(endpoint)};
+const attachToken = ${JSON.stringify(attachToken)};
 
 (async () => {
   if (process.argv.includes('--version')) {
@@ -293,25 +493,42 @@ const fs = require('node:fs');
     return;
   }
   const token = process.env.OD_TOOL_TOKEN;
-  const response = await fetch(process.env.OD_DAEMON_URL + '/api/tools/media/generate', {
+  const daemonUrl = process.env.OD_DAEMON_URL;
+  const projectId = process.env.OD_PROJECT_ID;
+  const url = endpoint === 'legacy'
+    ? daemonUrl + '/api/projects/' + encodeURIComponent(projectId || '') + '/media/generate'
+    : daemonUrl + '/api/tools/media/generate';
+  const headers = { 'content-type': 'application/json' };
+  if (attachToken && token) {
+    headers.authorization = 'Bearer ' + token;
+  }
+  const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      authorization: 'Bearer ' + token,
-    },
+    headers,
     body: JSON.stringify(${JSON.stringify(requestBody)}),
   });
   const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = { raw: text };
+  }
   fs.writeFileSync(process.env.OD_CAPTURE_MEDIA_RESPONSE, JSON.stringify({
     status: response.status,
     tokenAvailable: Boolean(token),
-    body: JSON.parse(text),
+    tokenAttached: Boolean(attachToken && token),
+    endpoint,
+    url,
+    body,
   }));
   console.log(JSON.stringify({ type: 'text', part: { text: 'media policy checked' } }));
 })().catch((error) => {
   fs.writeFileSync(process.env.OD_CAPTURE_MEDIA_RESPONSE, JSON.stringify({
     status: 0,
     tokenAvailable: Boolean(process.env.OD_TOOL_TOKEN),
+    tokenAttached: Boolean(attachToken && process.env.OD_TOOL_TOKEN),
+    endpoint,
     body: { error: String(error && error.message ? error.message : error) },
   }));
   process.exit(1);
@@ -335,6 +552,9 @@ const fs = require('node:fs');
   async function waitForCapturedMediaResponse(capturePath: string): Promise<{
     status: number;
     tokenAvailable: boolean;
+    tokenAttached?: boolean;
+    endpoint?: FakeMediaEndpoint;
+    url?: string;
     body: any;
   }> {
     const startedAt = Date.now();


### PR DESCRIPTION
Fixes #3199

cc @mrcfps — this follows the token-aware-only direction from #3199.

## Why

This PR closes the remaining cooperative-agent bypass for run-scoped media policy: an in-run caller with a valid run tool token could still post to the legacy project media endpoint and skip the run's `mediaExecution` checks.

The scope is intentionally narrow. The legacy route remains available to local UI and outside-run CLI callers that do not attach a run token. Only a valid bearer token that resolves to an active run opts the legacy route into the same OD-owned media policy checks used by `/api/tools/media/generate`.

## What users will see

No UI or default outside-run behavior changes. Local no-token calls to `POST /api/projects/:id/media/generate` still queue media as before.

When an in-run caller attaches its `OD_TOOL_TOKEN` to the legacy project media endpoint, disabled media execution and surface/model allowlists now return the same `MEDIA_EXECUTION_DISABLED`, `MEDIA_SURFACE_DENIED`, and `MEDIA_MODEL_DENIED` errors as the token-gated media tool route.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/media-policy-routes.test.ts`
- Did the test go red on `main` and green on this branch? Not separately run on `main`; the new fake-agent assertions target the previous legacy handler path that always passed `grant: null`, and are green on this branch.
- Added coverage for no-token legacy calls staying allowed under a disabled run policy, token-bearing legacy calls staying allowed when policy permits, disabled policy returning `MEDIA_EXECUTION_DISABLED`, and token-bearing legacy allowlist denials returning `MEDIA_SURFACE_DENIED` / `MEDIA_MODEL_DENIED`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/media-policy-routes.test.ts --reporter verbose`
- `pnpm --filter @open-design/daemon typecheck`
- `git diff --check`
- `rg -n "Muginn|muginn|beads|Beads" apps/daemon/src/media-routes.ts apps/daemon/src/server.ts apps/daemon/tests/media-policy-routes.test.ts` (no matches)
- `pnpm guard`
- `pnpm typecheck`
