### PR TITLE
Fix publish repo status link parsing

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -1861,7 +1861,7 @@ function StatusPill({
 
 function renderStatusDetail(detail: string): ReactNode {
   const segments: ReactNode[] = [];
-  const urlRe = /(https?:\/\/[^\s)<>]+)/g;
+  const urlRe = /(https?:\/\/[^\s)<>"}\]]+)/g;
   let lastIndex = 0;
   let match: RegExpExecArray | null;
   let key = 0;
@@ -1894,7 +1894,7 @@ function renderStatusDetail(detail: string): ReactNode {
 }
 
 function splitStatusDetailUrlPunctuation(url: string): [string, string] {
-  const match = /([.,!?;:，。！？；：、'"」』】》〉）]+)$/.exec(url);
+  const match = /([.,!?;:，。！？；：、'"」』】》〉）}\]]+)$/.exec(url);
   if (!match?.[1]) return [url, ''];
   const trimmed = url.slice(0, -match[1].length);
   return trimmed ? [trimmed, match[1]] : [url, ''];

--- a/apps/web/tests/components/assistant-message-tool-status.test.tsx
+++ b/apps/web/tests/components/assistant-message-tool-status.test.tsx
@@ -170,4 +170,27 @@ describe('AssistantMessage tool status', () => {
     expect(container.querySelector('.op-status-running')?.textContent).toBe('running…');
     expect(screen.queryByText('Done')).toBeNull();
   });
+
+  it('renders URLs in JSON-like status details without trailing structural characters', () => {
+    const { container } = render(
+      <AssistantMessage
+        projectKind="prototype"
+        conversationId="conv-1"
+        message={messageWithEvents([
+          {
+            kind: 'status',
+            label: 'publish repo',
+            detail: '{"url":"https://github.com/nexu-io/example-plugin","nameWithOwner":"nexu-io/example-plugin"}',
+          },
+        ])}
+        streaming={false}
+        projectId="project-1"
+      />,
+    );
+
+    const link = container.querySelector('.status-detail a.md-link');
+    expect(link?.getAttribute('href')).toBe('https://github.com/nexu-io/example-plugin');
+    expect(link?.textContent).toBe('https://github.com/nexu-io/example-plugin');
+    expect(container.querySelector('.status-detail')?.textContent).toContain('"}');
+  });
 });


### PR DESCRIPTION
Fixes #3202

## Why

I picked this up from issue #3202 after the publish repo completion output showed GitHub links absorbing adjacent JSON-like characters. The user-facing pain is that a successful publish can still render a malformed-looking repository link, which makes the completion result feel unreliable and can send users to a broken URL.

## What users will see

Publish repo status output now renders repository URLs cleanly when the detail text contains compact JSON such as `{"url":"https://github.com/...","nameWithOwner":"..."}`. The visible link stops at the real URL instead of including trailing quotes, commas, braces, or adjacent JSON fields.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a parser-only UI rendering fix covered by the component regression test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/assistant-message-tool-status.test.tsx`
- Did the test go red on `main` and green on this branch? yes. The new test failed before the fix because the rendered `href` included `","nameWithOwner":"nexu-io/example-plugin"}`; it passes after the URL parsing change.

## Validation

- `pnpm --filter @open-design/web test tests/components/assistant-message-tool-status.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm typecheck` (passes after refreshing local generated declarations with `pnpm --filter @open-design/contracts build` and `pnpm --filter @open-design/sidecar-proto build`; those refreshes left no diff)
- `pnpm guard` (fails on a pre-existing local workspace violation: `tools/pr/ -> tools/ top-level entries are allowlisted; expected only AGENTS.md, dev/, pack/, and serve/`; this PR does not touch `tools/`)
