### PR TITLE
fix: remove bottom-right overlay button from template cards

### DIFF
--- a/apps/landing-page/app/_components/template-card.astro
+++ b/apps/landing-page/app/_components/template-card.astro
@@ -161,22 +161,5 @@ const isVideoPreview = record.previewType === 'video' && record.previewVideo;
 
   <div class="tpl-actions">
     <a class="tpl-cta" href={detailHref}>{pcopy.cardUseTemplate}</a>
-    <button
-      type="button"
-      class="tpl-share"
-      data-tpl-card-share
-      data-share-text={shareText}
-      data-share-url={shareUrl}
-      data-share-title={name}
-      aria-label={pcopy.cardShareAria(name)}
-    >
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <circle cx="18" cy="5" r="3" />
-        <circle cx="6" cy="12" r="3" />
-        <circle cx="18" cy="19" r="3" />
-        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-        <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
-      </svg>
-    </button>
   </div>
 </article>

--- a/apps/landing-page/app/sub-pages.css
+++ b/apps/landing-page/app/sub-pages.css
@@ -1964,9 +1964,7 @@ body.sub-page {
 }
 
 .tpl-actions {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 10px;
+  display: block;
 }
 .tpl-cta {
   display: flex;


### PR DESCRIPTION
## Summary

Removes the share button overlay from example template cards that was obscuring text content.

## Changes

- Removed the share button from 
- Updated  CSS to use  instead of grid layout
- The "Use this template" button now spans the full width

## Why

The bottom-right overlay button was covering part of the text content on template cards, making them harder to read. Removing it improves readability and makes the template previews feel cleaner.

## Testing

- Visual inspection of template cards on the home page
- Verified the "Use this template" button still works correctly

Fixes #3203