### PR TITLE
fix: prevent JSON characters from being included in parsed links

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -1894,7 +1894,7 @@ function renderStatusDetail(detail: string): ReactNode {
 }
 
 function splitStatusDetailUrlPunctuation(url: string): [string, string] {
-  const match = /([.,!?;:，。！？；：、'"」』】》〉）]+)$/.exec(url);
+  const match = /([.,!?;:，。！？；：、'"」』】》〉）}]+)$/.exec(url);
   if (!match?.[1]) return [url, ''];
   const trimmed = url.slice(0, -match[1].length);
   return trimmed ? [trimmed, match[1]] : [url, ''];


### PR DESCRIPTION
## Summary

Fixes link parsing in publish repo output where trailing JSON characters (like `}` and `"`) were incorrectly included in the rendered link.

## Changes

Added `}` to the URL punctuation trimming regex in `splitStatusDetailUrlPunctuation` function.

**Before:**
```
https://github.com/user/repo"}
```

**After:**
```
https://github.com/user/repo
```

## Technical Details

The `renderStatusDetail` function parses URLs from status messages and uses `splitStatusDetailUrlPunctuation` to strip trailing punctuation. The regex was missing `}` which is common in JSON-like output from the publish repo flow.

## Testing

- Create a plugin
- Trigger "Publish repo"
- Verify the GitHub link in the output is clean without trailing `}` or `"`

Fixes #3202