### PR TITLE
fix: improve queue screenshot preview modal backdrop

### DIFF
--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -817,7 +817,8 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(17, 24, 39, 0.44);
+  background: rgba(17, 24, 39, 0.75);
+  backdrop-filter: blur(4px);
 }
 .staged-preview-card {
   display: flex;


### PR DESCRIPTION
## Summary

Improves the visual separation between the queue screenshot preview modal and the file-list preview panel by enhancing the backdrop.

## Changes

- Increased backdrop opacity from 44% to 75%
- Added  for better visual separation

## Why

When the queue screenshot preview is open, the file-list preview panel can be visible underneath, causing visual overlap and making it unclear which preview surface is active. A stronger backdrop ensures only one preview surface appears dominant at a time.

## Before
- Background:  (44% opacity)
- No blur effect

## After
- Background:  (75% opacity)
- Blur effect: 

## Testing

1. Open a queued screenshot/drawing preview
2. Verify the file-list preview panel is visually obscured by the darker, blurred backdrop
3. Confirm the queue preview is clearly the active surface

Fixes #3167