### PR TITLE
fix: simplify PPT preview zoom to use direct scaling

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -516,8 +516,8 @@ function previewScaleShellStyle(
 ): CSSProperties & Record<string, string | number> {
   if (viewport === 'desktop') {
     return {
-      width: `${100 / previewScale}%`,
-      height: `${100 / previewScale}%`,
+      width: '100%',
+      height: '100%',
       transform: `scale(${previewScale})`,
       transformOrigin: '0 0',
     };
@@ -537,8 +537,8 @@ function manualEditPreviewShellStyle(
 ): CSSProperties & Record<string, string | number> {
   if (viewport === 'desktop' && frozenWidth) {
     return {
-      width: `${frozenWidth / previewScale}px`,
-      height: `${100 / previewScale}%`,
+      width: `${frozenWidth}px`,
+      height: '100%',
       transform: `scale(${previewScale})`,
       transformOrigin: '0 0',
     };


### PR DESCRIPTION
## Summary

Fixes the PPT preview zoom behavior by replacing the inverse-scale technique with direct scaling.

## Problem

The previous implementation used an inverse-scale approach:
- Container: `width: 100/scale%`, `height: 100/scale%`
- Transform: `scale(scale)`

This caused the container to shrink as zoom increased, which could affect pagination controls and other overlay elements that depend on container dimensions. It also made the zoom behavior feel reversed or unintuitive.

## Solution

Use direct scaling instead:
- Container: `width: 100%`, `height: 100%`
- Transform: `scale(scale)`

## Changes

1. **previewScaleShellStyle**: Changed from `100/previewScale%` to `100%`
2. **manualEditPreviewShellStyle**: Changed from `frozenWidth/previewScale` to `frozenWidth`

## Benefits

- Zoom direction is intuitive (+ enlarges, - shrinks)
- Container dimensions remain stable
- Pagination controls and overlays maintain correct size
- Simpler mental model for scaling behavior

## Testing

1. Open a PPT/deck preview
2. Click zoom out (-) → content should shrink
3. Click zoom in (+) → content should enlarge
4. Verify pagination controls maintain stable size
5. Test with different viewport modes (desktop, mobile, tablet)

Fixes #3177