### PR TITLE
fix: preserve cursor position when inserting async references

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1331,7 +1331,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       const prevEntries = pluginInsertedTokensRef.current;
       const prevActiveId = activePluginIdRef.current;
 
-      const result = replaceMentionWithText(`${inlineMentionToken(record.title)} `);
+      // Capture mention state before async operation to prevent cursor
+      // position issues if state changes during apply.
+      const mentionSnapshot = mention;
+
+      const result = replaceMentionWithText(
+        `${inlineMentionToken(record.title)} `,
+        mentionSnapshot,
+      );
       if (!result) return;
       // Capture the post-insert draft *snapshot* — the value the
       // composer is in immediately after our optimistic write.
@@ -1468,10 +1475,12 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
 
     function replaceMentionWithText(
       text: string,
+      mentionSnapshot?: typeof mention,
     ): { insertStart: number } | null {
-      if (!mention) return null;
+      const activeMention = mentionSnapshot ?? mention;
+      if (!activeMention) return null;
       const ta = textareaRef.current;
-      const cursor = mention.cursor;
+      const cursor = activeMention.cursor;
       const before = draft.slice(0, cursor);
       const after = draft.slice(cursor);
       const replaced = before.replace(/(^|\s)@([^\s@]*)$/, `$1${text}`);

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -950,9 +950,10 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     }
 
     async function insertSkillMention(skill: SkillSummary) {
+      const mentionSnapshot = mention;
       const applied = await applyProjectSkill(skill);
       if (!applied) return;
-      replaceMentionWithText(`${inlineMentionToken(skill.name)} `);
+      replaceMentionWithText(`${inlineMentionToken(skill.name)} `, mentionSnapshot);
     }
 
     function removeStagedSkill(id: string) {


### PR DESCRIPTION
## Summary

Fixes incorrect cursor position after inserting skill, plugin, or design file references by capturing mention state before async operations.

## Problem

When inserting references that trigger async operations (skills, plugins), the cursor could land in the wrong position. This happened because:

1. User types `@sk` and selects a skill
2. `insertSkillMention` calls `await applyProjectSkill(skill)`
3. The async operation triggers component re-renders
4. The `mention` state (containing cursor position) gets invalidated
5. When `replaceMentionWithText` finally executes, it uses stale cursor data

## Solution

Capture a snapshot of the `mention` state **before** async operations, then pass it to `replaceMentionWithText` to ensure cursor position is calculated from the original context.

## Changes

1. **replaceMentionWithText**: Added optional `mentionSnapshot` parameter
   - Uses snapshot if provided, falls back to current `mention` state
   - Ensures cursor position is calculated from stable data

2. **insertSkillMention**: Captures `mention` before `await applyProjectSkill`
   - Passes snapshot to `replaceMentionWithText`

3. **insertPluginMention**: Captures `mention` before async plugin application
   - Passes snapshot to `replaceMentionWithText`

## Testing

1. Type `@` and select a skill → cursor should land after the inserted reference
2. Type `@` and select a plugin → cursor should land after the inserted reference
3. Type `@` and select a design file → cursor should land after the inserted reference
4. Continue typing immediately after insertion → text should appear in the correct position

## Technical Details

This is a classic React async state management issue. The `mention` state is captured during user input but consumed after async operations complete. By creating a snapshot before the async boundary, we preserve the original cursor context regardless of subsequent re-renders.

Fixes #3195