### PR TITLE
fix: insert skill reference when selecting from tools panel

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1662,20 +1662,21 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                         onPick={async (skill) => {
                           const applied = await applyProjectSkill(skill);
                           if (!applied) return;
-                          // Insert skill reference at cursor position
                           const ta = textareaRef.current;
                           const insert = `${inlineMentionToken(skill.name)} `;
-                          const cursor = ta?.selectionStart ?? draft.length;
-                          const before = draft.slice(0, cursor);
-                          const after = draft.slice(cursor);
+                          const currentDraft = ta?.value ?? draft;
+                          const cursor = ta?.selectionStart ?? currentDraft.length;
+                          const before = currentDraft.slice(0, cursor);
+                          const after = currentDraft.slice(cursor);
                           const next = before + insert + after;
                           setDraft(next);
                           setToolsOpen(false);
                           requestAnimationFrame(() => {
-                            if (!ta) return;
-                            ta.focus();
+                            const el = textareaRef.current;
+                            if (!el) return;
+                            el.focus();
                             const pos = before.length + insert.length;
-                            ta.setSelectionRange(pos, pos);
+                            el.setSelectionRange(pos, pos);
                           });
                         }}
                       />

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1661,7 +1661,22 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                         currentSkillId={currentSkillId}
                         onPick={async (skill) => {
                           const applied = await applyProjectSkill(skill);
-                          if (applied) setToolsOpen(false);
+                          if (!applied) return;
+                          // Insert skill reference at cursor position
+                          const ta = textareaRef.current;
+                          const insert = `${inlineMentionToken(skill.name)} `;
+                          const cursor = ta?.selectionStart ?? draft.length;
+                          const before = draft.slice(0, cursor);
+                          const after = draft.slice(cursor);
+                          const next = before + insert + after;
+                          setDraft(next);
+                          setToolsOpen(false);
+                          requestAnimationFrame(() => {
+                            if (!ta) return;
+                            ta.focus();
+                            const pos = before.length + insert.length;
+                            ta.setSelectionRange(pos, pos);
+                          });
                         }}
                       />
                     ) : null}


### PR DESCRIPTION
## Summary

Fixes the issue where selecting a skill from the tools panel does not insert the `@skill` reference into the input after manually deleting a previous reference.

## Problem

When a user:
1. Inserts a skill reference (`@skill-name`)
2. Manually deletes it from the input
3. Opens the tools panel and selects a skill again

**Expected:** The new `@skill` reference should be inserted at the cursor position  
**Actual:** Nothing happens — the skill is applied to the project but no text is inserted

## Root Cause

The tools panel skill picker only called `applyProjectSkill()` without inserting the text token. This is inconsistent with how other reference types (MCP, connectors) work in the tools panel, which insert their tokens at the cursor position.

## Solution

Make the tools panel skill picker behave like MCP and connector pickers:
- Insert the `@skill` token at the current cursor position
- Set focus and move cursor after the inserted reference
- Close the tools panel after successful insertion

## Changes

Modified the `onPick` handler in the tools panel's `ToolsSkillsPanel`:
- After `applyProjectSkill()` succeeds, insert the skill reference text
- Calculate cursor position and insert at that location
- Use `requestAnimationFrame` to set focus and cursor position
- Pattern matches the existing MCP insertion logic (lines 1626-1642)

## Testing

1. Insert a skill reference via `@` mention → verify it appears
2. Manually delete the `@skill` text from the input
3. Open the tools panel (@ button) → Skills tab
4. Select a skill
5. **Verify:** The `@skill` reference is inserted at the cursor position
6. Continue typing → text should appear after the reference

## Before/After

**Before:**
- Tools panel skill picker: applies skill, no text insertion
- Mention popover skill picker: inserts text (but requires `@` trigger)

**After:**
- Both pickers insert text consistently
- Users can re-insert skills after deleting them

Fixes #3188