### PR TITLE
feat: show success toast after HTML edits in manual editor

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4062,11 +4062,12 @@ function HtmlViewer({
   const [inspectSavedAt, setInspectSavedAt] = useState<number | null>(null);
   const [inspectError, setInspectError] = useState<string | null>(null);
   const [queuedBoardNotes, setQueuedBoardNotes] = useState<string[]>([]);
-  const [sendingBoardBatch, setSendingBoardBatch] = useState(false);
+  const [screenshotToast, setScreenshotToast] = useState(false);
   const [commentSavedToast, setCommentSavedToast] = useState<string | null>(null);
   const [templateSavedToast, setTemplateSavedToast] = useState<string | null>(null);
   const [deploySavedToast, setDeploySavedToast] = useState<{ message: string; details: string } | null>(null);
   const [exportToast, setExportToast] = useState<string | null>(null);
+  const [manualEditSavedToast, setManualEditSavedToast] = useState<string | null>(null);
   const [selectedSideCommentIds, setSelectedSideCommentIds] = useState<Set<string>>(() => new Set());
   const [commentSidePanelCollapsed, setCommentSidePanelCollapsed] = useState(false);
   const [strokePoints, setStrokePoints] = useState<StrokePoint[]>([]);
@@ -5137,6 +5138,8 @@ function HtmlViewer({
         reconcileManualEditStyleSave(patch.id, patch.styles, result.source);
       }
       setManualEditError(null);
+      // Show success feedback
+      setManualEditSavedToast(label);
       await onFileSaved?.();
       return true;
     } finally {
@@ -6871,6 +6874,15 @@ function HtmlViewer({
                   message={templateSavedToast}
                   ttlMs={2200}
                   onDismiss={() => setTemplateSavedToast(null)}
+                />
+              </div>
+            ) : null}
+            {manualEditSavedToast ? (
+              <div className="comment-toast-anchor">
+                <Toast
+                  message={manualEditSavedToast}
+                  ttlMs={2200}
+                  onDismiss={() => setManualEditSavedToast(null)}
                 />
               </div>
             ) : null}


### PR DESCRIPTION
## Summary

Adds visual confirmation feedback when HTML edits are successfully applied in the manual editor.

## Problem

When editing HTML in the manual editor:
1. User selects an element
2. Opens the HTML tab
3. Modifies the HTML
4. Clicks "Apply HTML"
5. The change takes effect, but **no confirmation is shown**

This creates uncertainty — users don't know if the edit succeeded, may retry unnecessarily, or lose confidence in the editor.

## Solution

Show a success toast notification after successful HTML edits, matching the pattern used for other file operations (export, comment save, template save).

## Changes

1. **Add state**: `manualEditSavedToast` to track success messages
2. **Set toast**: In `applyManualEdit()`, after successful save, call `setManualEditSavedToast(label)`
3. **Render toast**: Add `<Toast>` component with 2.2s auto-dismiss

## Toast Message

The toast displays the patch label, which varies by operation:
- "Set text" (text edits)
- "Set image" (image uploads)
- "Delete element" (element removal)
- "Style: <element>" (style changes)
- Custom labels from other patch types

## UI Consistency

- Toast appears in the same position as other file operation toasts
- Uses the same 2.2s auto-dismiss duration
- Same visual style and dismiss behavior

## Testing

1. Open a file in edit mode
2. Select an element
3. Open the HTML tab (or any edit tab)
4. Make a change and click Apply
5. **Verify**: Success toast appears briefly showing the operation name
6. Toast auto-dismisses after 2.2 seconds
7. User can manually dismiss by clicking

## Before/After

**Before:**
- Edit succeeds silently
- No visual confirmation
- User uncertain if change was applied

**After:**
- Success toast appears: "Set text" / "Delete element" / etc.
- Clear confirmation of successful edit
- Auto-dismisses after 2.2s

Fixes #2905