### PR TITLE
fix: remove @plugin mention when deleting plugin chip

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1376,6 +1376,18 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                   setDraft((cur) => (cur.trim().length === 0 ? brief : cur));
                 }
               }}
+              onCleared={(clearedRecord) => {
+                // When the user removes a plugin chip, also strip the
+                // corresponding @plugin mention from the draft so the chip
+                // and textarea stay in sync (fixes #3190).
+                if (clearedRecord) {
+                  setDraft((d) =>
+                    d
+                      .replace(new RegExp(`(^|\\s)@${escapeRegExp(clearedRecord.id)}(\\s|$)`, 'g'), '$1$2')
+                      .replace(/\s{2,}/g, ' '),
+                  );
+                }
+              }}
               onChipDetails={(item: ContextItem) => {
                 if (item.kind !== 'plugin') return;
                 const record = installedPlugins.find((p) => p.id === item.id);

--- a/apps/web/src/components/PluginsSection.tsx
+++ b/apps/web/src/components/PluginsSection.tsx
@@ -67,7 +67,7 @@ interface Props {
   showRail?: boolean;
   // Optional hooks — see file header.
   onApplied?: (brief: string, applied: ApplyResult) => void;
-  onCleared?: () => void;
+  onCleared?: (clearedRecord: InstalledPluginRecord | null) => void;
   onValidityChange?: (valid: boolean) => void;
   // Forwarded to ContextChipStrip so chips can open the plugin details
   // modal when the user clicks one (kind === 'plugin').
@@ -124,11 +124,12 @@ export const PluginsSection = forwardRef<PluginsSectionHandle, Props>(
     );
 
     const clear = useCallback(() => {
+      const recordBeforeClear = activeRecord;
       setApplied(null);
       setActiveRecord(null);
       setPluginInputs({});
-      props.onCleared?.();
-    }, [props]);
+      props.onCleared?.(recordBeforeClear);
+    }, [props, activeRecord]);
 
     const onChipRemove = useCallback(
       (_item: ContextItem) => {


### PR DESCRIPTION
## Summary

Fixes inconsistent plugin reference deletion: when a user removes a plugin chip, the chip disappears but the `@plugin` mention remains in the textarea.

## Problem

**Steps to reproduce:**
1. Add a plugin reference (e.g., `@my-plugin`)
2. Plugin chip appears above the input
3. Click the X button on the chip to remove it
4. **Bug**: Chip disappears, but `@plugin` mention stays in the textarea

**Result:** UI shows no active plugin, but the input still contains the reference.

## Root Cause

1. `PluginsSection.clear()` calls `onCleared()` but doesn't pass the cleared record
2. `ChatComposer` doesn't implement `onCleared` callback to sync the draft
3. When chip is removed, only internal state is cleared — the textarea is never updated

## Solution

### 1. Pass cleared record to callback

**Before:**
```typescript
const clear = useCallback(() => {
  setApplied(null);
  setActiveRecord(null);
  setPluginInputs({});
  props.onCleared?.();  // ❌ No context about what was cleared
}, [props]);
```

**After:**
```typescript
const clear = useCallback(() => {
  const recordBeforeClear = activeRecord;  // ✅ Capture before clearing
  setApplied(null);
  setActiveRecord(null);
  setPluginInputs({});
  props.onCleared?.(recordBeforeClear);  // ✅ Pass the record
}, [props, activeRecord]);
```

### 2. Update callback signature

```typescript
// Before
onCleared?: () => void;

// After
onCleared?: (clearedRecord: InstalledPluginRecord | null) => void;
```

### 3. Implement cleanup in ChatComposer

```typescript
onCleared={(clearedRecord) => {
  if (clearedRecord) {
    setDraft((d) =>
      d
        .replace(new RegExp(`(^|\\s)@${escapeRegExp(clearedRecord.id)}(\\s|$)`, 'g'), '')
        .replace(/\s{2,}/g, ' '),
    );
  }
}}
```

This mirrors the existing `removeStagedSkill()` logic (line 771-780) for consistency.

## Testing

1. Add a plugin reference: type `@` and select a plugin
2. Verify chip appears and `@plugin-id` is in the textarea
3. Click the X button on the chip
4. **Verify**: Both chip AND `@plugin-id` mention are removed
5. Textarea should be clean (or preserve other content)

## Before/After

**Before:**
- Click X on chip → chip disappears
- `@plugin-id` remains in textarea ❌
- Inconsistent state

**After:**
- Click X on chip → chip disappears
- `@plugin-id` is also removed from textarea ✅
- Consistent state

## Related

- Mirrors `removeStagedSkill()` pattern (ChatComposer.tsx:771-780)
- Same regex cleanup: strip mention + collapse whitespace
- Consistent with skill/file reference deletion behavior

Fixes #3190