### PR TITLE
fix(amr): stage external image attachments into workspace

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -65,6 +65,7 @@ interface AttachAcpSessionOptions {
   prompt: string;
   cwd?: string;
   model?: string | null;
+  imagePaths?: string[];
   mcpServers?: AcpMcpServerInput[];
   send: (event: string, payload: unknown) => void;
   clientName?: string;
@@ -114,6 +115,15 @@ function sendRpc(writable: RpcWritable, id: JsonRpcId, method: string, params: u
 
 function sendRpcResult(writable: RpcWritable, id: JsonRpcId, result: unknown): void {
   writable.write(`${JSON.stringify({ jsonrpc: '2.0', id, result })}\n`);
+}
+
+function buildPromptBlocks(prompt: string, imagePaths: string[]): Array<Record<string, string>> {
+  const blocks: Array<Record<string, string>> = [{ type: 'text', text: prompt }];
+  for (const imagePath of imagePaths) {
+    if (typeof imagePath !== 'string' || imagePath.trim().length === 0) continue;
+    blocks.push({ type: 'resource_link', uri: imagePath });
+  }
+  return blocks;
 }
 
 function isJsonRpcId(value: unknown): value is JsonRpcId {
@@ -422,6 +432,7 @@ export function attachAcpSession({
   prompt,
   cwd,
   model,
+  imagePaths = [],
   mcpServers,
   send,
   clientName = 'open-design',
@@ -525,7 +536,7 @@ export function attachAcpSession({
       'session/prompt',
       {
         sessionId,
-        prompt: [{ type: 'text', text: prompt }],
+        prompt: buildPromptBlocks(prompt, imagePaths),
       },
       'session/prompt',
     );

--- a/apps/daemon/src/amr-image-staging.ts
+++ b/apps/daemon/src/amr-image-staging.ts
@@ -40,9 +40,13 @@ async function pruneStagedAttachments(stagingDir: string): Promise<void> {
 export async function stageAmrImagePaths(
   cwd: string | null | undefined,
   imagePaths: string[],
+  uploadRoot?: string | null,
 ): Promise<string[]> {
   if (!cwd || !Array.isArray(imagePaths) || imagePaths.length === 0) return [];
   const root = path.resolve(cwd);
+  const uploadRootReal = uploadRoot
+    ? await fs.promises.realpath(uploadRoot).catch(() => null)
+    : null;
   const stagingDir = path.join(root, STAGING_DIRNAME);
   await fs.promises.mkdir(stagingDir, { recursive: true });
   await pruneStagedAttachments(stagingDir);
@@ -52,15 +56,17 @@ export async function stageAmrImagePaths(
     if (typeof inputPath !== 'string' || inputPath.trim().length === 0) continue;
     try {
       const resolved = path.resolve(inputPath);
-      const stat = await fs.promises.stat(resolved);
+      const real = await fs.promises.realpath(resolved);
+      if (uploadRootReal && !isWithinRoot(uploadRootReal, real)) continue;
+      const stat = await fs.promises.stat(real);
       if (!stat.isFile()) continue;
-      if (isWithinRoot(root, resolved)) {
-        staged.push(resolved);
+      if (isWithinRoot(root, real)) {
+        staged.push(real);
         continue;
       }
-      const basename = path.basename(resolved);
+      const basename = path.basename(real);
       const destination = path.join(stagingDir, `${randomUUID()}-${basename}`);
-      await fs.promises.copyFile(resolved, destination);
+      await fs.promises.copyFile(real, destination);
       staged.push(destination);
     } catch {
       // Ignore malformed or missing files; attachments are advisory input.

--- a/apps/daemon/src/amr-image-staging.ts
+++ b/apps/daemon/src/amr-image-staging.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const STAGING_DIRNAME = '.amr-attachments';
+const STAGING_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+function isWithinRoot(root: string, candidate: string): boolean {
+  const relativePath = path.relative(root, candidate);
+  return (
+    relativePath === '' ||
+    (relativePath.length > 0 &&
+      !relativePath.startsWith('..') &&
+      !path.isAbsolute(relativePath))
+  );
+}
+
+async function pruneStagedAttachments(stagingDir: string): Promise<void> {
+  let entries;
+  try {
+    entries = await fs.promises.readdir(stagingDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  const cutoff = Date.now() - STAGING_MAX_AGE_MS;
+  await Promise.all(entries.map(async (entry) => {
+    if (!entry.isFile()) return;
+    const filePath = path.join(stagingDir, entry.name);
+    try {
+      const stat = await fs.promises.stat(filePath);
+      if (stat.mtimeMs < cutoff) {
+        await fs.promises.rm(filePath, { force: true });
+      }
+    } catch {
+      // Best-effort cleanup only.
+    }
+  }));
+}
+
+export async function stageAmrImagePaths(
+  cwd: string | null | undefined,
+  imagePaths: string[],
+): Promise<string[]> {
+  if (!cwd || !Array.isArray(imagePaths) || imagePaths.length === 0) return [];
+  const root = path.resolve(cwd);
+  const stagingDir = path.join(root, STAGING_DIRNAME);
+  await fs.promises.mkdir(stagingDir, { recursive: true });
+  await pruneStagedAttachments(stagingDir);
+
+  const staged: string[] = [];
+  for (const inputPath of imagePaths) {
+    if (typeof inputPath !== 'string' || inputPath.trim().length === 0) continue;
+    try {
+      const resolved = path.resolve(inputPath);
+      const stat = await fs.promises.stat(resolved);
+      if (!stat.isFile()) continue;
+      if (isWithinRoot(root, resolved)) {
+        staged.push(resolved);
+        continue;
+      }
+      const basename = path.basename(resolved);
+      const destination = path.join(stagingDir, `${randomUUID()}-${basename}`);
+      await fs.promises.copyFile(resolved, destination);
+      staged.push(destination);
+    } catch {
+      // Ignore malformed or missing files; attachments are advisory input.
+    }
+  }
+  return staged;
+}

--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -146,6 +146,7 @@ export const amrAgentDef = {
   fallbackModels: [] as RuntimeModelOption[],
   buildArgs: () => ['agent', 'run', '--runtime', 'opencode'],
   streamFormat: 'acp-json-rpc',
+  supportsImagePaths: true,
   // Daemon-process env override for emergency operator pinning. Normal UI
   // selection comes from the live `vela models` catalog and is preflighted
   // before spawn.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1990,6 +1990,14 @@ function shouldSkipPluginContextEntry(name) {
   return PLUGIN_CONTEXT_SKIP_DIRS.has(name) || PLUGIN_CONTEXT_SKIP_FILES.has(name);
 }
 
+export function selectPromptImagePaths(
+  agentId,
+  safeImages,
+  amrStagedImages,
+) {
+  return agentId === 'amr' ? amrStagedImages : safeImages;
+}
+
 async function ensureGhReady() {
   const version = await execGhBuffered(['--version'], { timeout: 10_000 });
   if (!version.ok) {
@@ -10401,7 +10409,7 @@ export async function startServer({
     });
     const amrStagedImages =
       def.id === 'amr'
-        ? await stageAmrImagePaths(cwd ?? PROJECT_ROOT, safeImages)
+        ? await stageAmrImagePaths(cwd ?? PROJECT_ROOT, safeImages, UPLOAD_DIR)
         : safeImages;
 
     // Project-scoped attachments: project-relative paths inside cwd. Each
@@ -10665,6 +10673,11 @@ export async function startServer({
     // instructions and request) — see server.ts:9920 composer notes.
     const ECHO_GUARD =
       '\n\n(Do not quote, restate, or echo the # Instructions block above in your reply. Begin your response with the answer to the # User request below.)';
+    const promptImagePaths = selectPromptImagePaths(
+      def.id,
+      safeImages,
+      amrStagedImages,
+    );
     const composed = [
       instructionPrompt
         ? `# Instructions (read first)\n\n${instructionPrompt}${cwdHint}${linkedDirsHint}${ECHO_GUARD}\n\n---\n`
@@ -10674,8 +10687,8 @@ export async function startServer({
             ? `# Instructions${linkedDirsHint}${ECHO_GUARD}\n\n---\n`
             : '',
       `# User request\n\n${userRequestPrompt}${attachmentHint}${commentHint}`,
-      safeImages.length
-        ? `\n\n${safeImages.map((p) => `@${p}`).join(' ')}`
+      promptImagePaths.length
+        ? `\n\n${promptImagePaths.map((p) => `@${p}`).join(' ')}`
         : '',
     ].join('');
     // Per-agent model + reasoning the user picked in the model menu.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11694,6 +11694,7 @@ export async function startServer({
         prompt: composed,
         cwd: effectiveCwd,
         model: safeModel,
+        imagePaths: def.supportsImagePaths ? safeImages : [],
         mcpServers,
         ...(def.id === 'amr' ? { modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE' } : {}),
         send: (event, data) => {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -171,6 +171,7 @@ import {
 } from './memory-connectors.js';
 import { attachAcpSession } from './acp.js';
 import { attachPiRpcSession } from './pi-rpc.js';
+import { stageAmrImagePaths } from './amr-image-staging.js';
 import {
   applyAutomationProposal,
   createAutomationProposal,
@@ -10398,6 +10399,10 @@ export async function startServer({
         resolved.startsWith(UPLOAD_DIR + path.sep) && fs.existsSync(resolved)
       );
     });
+    const amrStagedImages =
+      def.id === 'amr'
+        ? await stageAmrImagePaths(cwd ?? PROJECT_ROOT, safeImages)
+        : safeImages;
 
     // Project-scoped attachments: project-relative paths inside cwd. Each
     // is run through the same path-traversal guard the file CRUD endpoints
@@ -11684,7 +11689,7 @@ export async function startServer({
             send(channel, payload);
           }
         },
-        imagePaths: def.supportsImagePaths ? safeImages : [],
+        imagePaths: def.supportsImagePaths ? amrStagedImages : [],
         uploadRoot: UPLOAD_DIR,
       });
     } else if (def.streamFormat === 'acp-json-rpc') {
@@ -11694,7 +11699,7 @@ export async function startServer({
         prompt: composed,
         cwd: effectiveCwd,
         model: safeModel,
-        imagePaths: def.supportsImagePaths ? safeImages : [],
+        imagePaths: def.supportsImagePaths ? amrStagedImages : [],
         mcpServers,
         ...(def.id === 'amr' ? { modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE' } : {}),
         send: (event, data) => {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
 import { PassThrough } from 'node:stream';
 import path from 'node:path';
 import { test, vi } from 'vitest';
@@ -200,6 +202,39 @@ test('attachAcpSession keeps legacy session/set_model when no model config optio
     modelId: 'legacy-model',
   });
   assert.equal(requests.some((entry) => entry.method === 'session/set_config_option'), false);
+});
+
+test('attachAcpSession includes image attachments as ACP resource links', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-acp-image-'));
+  const imagePath = path.join(tmpDir, 'screenshot.png');
+  fs.writeFileSync(imagePath, 'png');
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'describe this image',
+    cwd: '/tmp/od-project',
+    model: null,
+    imagePaths: [imagePath],
+    mcpServers: [],
+    send: () => {},
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpResult(child, 3, {});
+
+  const requests = parseRpcWrites(writes);
+  const promptRequest = requests.find((entry) => entry.method === 'session/prompt');
+  assert.deepEqual(promptRequest?.params, {
+    sessionId: 'session-1',
+    prompt: [
+      { type: 'text', text: 'describe this image' },
+      { type: 'resource_link', uri: imagePath },
+    ],
+  });
 });
 
 test('attachAcpSession exposes abort and sends session cancel after session creation', () => {

--- a/apps/daemon/tests/amr-image-staging.test.ts
+++ b/apps/daemon/tests/amr-image-staging.test.ts
@@ -1,0 +1,33 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, expect, test } from 'vitest';
+
+import { stageAmrImagePaths } from '../src/amr-image-staging.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+test('stageAmrImagePaths rejects upload symlinks that resolve outside the upload root', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'od-amr-stage-'));
+  tempDirs.push(root);
+  const projectDir = path.join(root, 'project');
+  const uploadRoot = path.join(root, 'uploads');
+  const outsideDir = path.join(root, 'outside');
+  await Promise.all([
+    mkdir(projectDir, { recursive: true }),
+    mkdir(uploadRoot, { recursive: true }),
+    mkdir(outsideDir, { recursive: true }),
+  ]);
+  const outsideFile = path.join(outsideDir, 'secret.png');
+  const symlinkPath = path.join(uploadRoot, 'escape.png');
+  await writeFile(outsideFile, 'not-an-image');
+  await symlink(outsideFile, symlinkPath);
+
+  await expect(
+    stageAmrImagePaths(projectDir, [symlinkPath], uploadRoot),
+  ).resolves.toEqual([]);
+});

--- a/apps/daemon/tests/server-image-paths.test.ts
+++ b/apps/daemon/tests/server-image-paths.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest';
+
+import { selectPromptImagePaths } from '../src/server.js';
+
+test('selectPromptImagePaths uses staged AMR paths in prompt text', () => {
+  expect(
+    selectPromptImagePaths(
+      'amr',
+      ['/tmp/od-uploads/original.png'],
+      ['/project/.amr-attachments/staged.png'],
+    ),
+  ).toEqual(['/project/.amr-attachments/staged.png']);
+});
+
+test('selectPromptImagePaths keeps original paths for non-AMR agents', () => {
+  expect(
+    selectPromptImagePaths(
+      'opencode',
+      ['/tmp/od-uploads/original.png'],
+      ['/project/.amr-attachments/staged.png'],
+    ),
+  ).toEqual(['/tmp/od-uploads/original.png']);
+});


### PR DESCRIPTION
## Summary
- stage external AMR image attachments into a workspace-local `.amr-attachments/` folder before ACP serialization
- keep in-worktree image paths unchanged
- prune staged attachment files older than 24 hours

## Verification
- pnpm --filter @open-design/daemon build
- pnpm --filter @open-design/daemon typecheck
- runtime validation: staged Desktop image into workspace and verified the real AMR flow returned a final image description instead of hanging in the read tool