### PR TITLE
fix: cap composer shell height to prevent excessive expansion

### DIFF
--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -480,6 +480,7 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+  max-height: min(420px, calc(100vh - 180px));
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 .composer-shell:focus-within {


### PR DESCRIPTION
## Summary

Adds a maximum height constraint to the composer shell to prevent it from dominating the viewport when many files are staged.

## Changes

- Added `max-height: min(420px, calc(100vh - 180px))` to `.composer-shell`
- On desktop, the composer won't exceed ~420px
- On smaller viewports, it scales down proportionally to maintain usable chat area
- Complements existing height caps:
  - `.staged-row`: `max-height: min(148px, 22vh)` with `overflow-y: auto`
  - `textarea`: `max-height: min(184px, 34vh)`

## Testing

- Verified the CSS change follows the suggested sizing in the issue
- The composer shell now has a sensible maximum height that prevents excessive vertical expansion
- Chat history above maintains adequate visible space

Fixes #3155