### PR TITLE
fix: prevent short Chinese labels from stacking vertically in Plugins page

### DIFF
--- a/apps/web/src/styles/home/plugins-view.css
+++ b/apps/web/src/styles/home/plugins-view.css
@@ -284,6 +284,11 @@
   font-size: 12px;
 }
 
+.plugins-view__filter > span {
+  white-space: nowrap;
+  min-width: fit-content;
+}
+
 .plugins-view__filter select {
   min-height: 32px;
   min-width: 180px;
@@ -377,9 +382,11 @@
   justify-content: center;
   gap: 6px;
   min-height: 32px;
+  min-width: 64px;
   padding: 0 11px;
   border-radius: var(--radius-sm);
   font-size: 12px;
+  white-space: nowrap;
   cursor: pointer;
   transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
 }


### PR DESCRIPTION
## Summary

Prevents short Chinese labels from stacking vertically in compact buttons and filter controls on the Plugins page.

## Changes

**Button improvements:**
- Added `min-width: 64px` to `.plugins-view__secondary` and `.plugins-view__danger` buttons
- Added `white-space: nowrap` to prevent text wrapping
- Ensures labels like '刷新' (refresh) and '移除' (remove) stay horizontal

**Filter label improvements:**
- Added `white-space: nowrap` and `min-width: fit-content` to `.plugins-view__filter > span`
- Prevents labels like '来源' (source) from stacking vertically in narrow layouts

## Testing

- Verified CSS changes target the correct elements
- Button and label text will now remain horizontal even with short Chinese characters
- Layout remains responsive and doesn't break on smaller viewports

Fixes #3149