### PR TITLE
feat: add OpenClaw ACP agent runtime

### DIFF
--- a/apps/daemon/src/runtimes/defs/openclaw.ts
+++ b/apps/daemon/src/runtimes/defs/openclaw.ts
@@ -1,0 +1,34 @@
+import { detectAcpModels, DEFAULT_MODEL_OPTION } from './shared.js';
+import type { RuntimeAgentDef } from '../types.js';
+
+export const openclawAgentDef = {
+    id: 'openclaw',
+    name: 'OpenClaw',
+    bin: 'openclaw',
+    versionArgs: ['--version'],
+    fetchModels: async (resolvedBin, env) =>
+      detectAcpModels({
+        bin: resolvedBin,
+        args: ['acp'],
+        env,
+        timeoutMs: 15_000,
+        defaultModelOption: DEFAULT_MODEL_OPTION,
+      }),
+    fallbackModels: [
+      DEFAULT_MODEL_OPTION,
+      // MiniMax — OpenClaw's default provider
+      { id: 'minimax/MiniMax-M2.7', label: 'MiniMax-M2.7 (default)' },
+      { id: 'minimax/MiniMax-M4', label: 'MiniMax-M4' },
+      // Anthropic via OpenClaw gateway
+      { id: 'anthropic/claude-opus-4-5', label: 'Claude Opus 4.5' },
+      { id: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+      { id: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+      // OpenAI via OpenClaw gateway
+      { id: 'openai/gpt-5', label: 'GPT-5' },
+      { id: 'openai/gpt-4o', label: 'GPT-4o' },
+    ],
+    buildArgs: () => ['acp'],
+    streamFormat: 'acp-json-rpc',
+    mcpDiscovery: 'mature-acp',
+    externalMcpInjection: 'acp-merge',
+} satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/registry.ts
+++ b/apps/daemon/src/runtimes/registry.ts
@@ -4,6 +4,7 @@ import { codexAgentDef } from './defs/codex.js';
 import { devinAgentDef } from './defs/devin.js';
 import { geminiAgentDef } from './defs/gemini.js';
 import { opencodeAgentDef } from './defs/opencode.js';
+import { openclawAgentDef } from './defs/openclaw.js';
 import { hermesAgentDef } from './defs/hermes.js';
 import { traeCliAgentDef } from './defs/trae-cli.js';
 import { grokBuildAgentDef } from './defs/grok-build.js';
@@ -29,6 +30,7 @@ const BASE_AGENT_DEFS: RuntimeAgentDef[] = [
   devinAgentDef,
   geminiAgentDef,
   opencodeAgentDef,
+  openclawAgentDef,
   hermesAgentDef,
   traeCliAgentDef,
   grokBuildAgentDef,


### PR DESCRIPTION
## Summary

Adds OpenClaw as a supported ACP-based coding agent runtime, following the same pattern as existing ACP runtimes (Hermes, Kimi, Vibe).

### Changes

- **New file `apps/daemon/src/runtimes/defs/openclaw.ts`**: Agent definition with:
  - `bin: 'openclaw'` — auto-detected on PATH
  - `streamFormat: 'acp-json-rpc'` — OpenClaw speaks ACP natively over stdio (no extra flags)
  - `detectAcpModels()` for live model enumeration (same as Kimi/Vibe)
  - Static fallback model list: MiniMax-M2.7, MiniMax-M4, Claude Opus/Sonnet/Haiku, GPT-5/GPT-4o
  - `mcpDiscovery: 'mature-acp'` + `externalMcpInjection: 'acp-merge'`

- **Updated `apps/daemon/src/runtimes/registry.ts`**: Added import + registration of `openclawAgentDef`

### Why this works

`openclaw acp` exposes the ACP JSON-RPC protocol over stdio without requiring `--accept-hooks` or any gateway. Verified by sending a raw `initialize` RPC call — it returns protocol capabilities and supports the full ACP session lifecycle (`session/new`, `session/prompt`, `session/cancel`).

### Test plan

- [ ] `pnpm tools-dev` detects `openclaw` on PATH in the agent picker
- [ ] Model enumeration works via `detectAcpModels`
- [ ] ACP session (prompt delivery) works end-to-end
- [ ] MCP server discovery works with `mcpDiscovery: 'mature-acp'`

## Checklist

- [ ] Tests added/updated if applicable
- [ ] Documentation updated if applicable
- [ ] No breaking changes to existing agent runtimes