### PR TITLE
fix(memory): deliver OpenCode memory extraction prompt on stdin

### DIFF
--- a/apps/daemon/src/memory-llm.ts
+++ b/apps/daemon/src/memory-llm.ts
@@ -61,9 +61,6 @@ import {
 } from './memory-extractions.js';
 import { resolveProviderConfig } from './media-config.js';
 import { spawn } from 'node:child_process';
-import { promises as fsp } from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 import { createCommandInvocation } from '@open-design/platform';
 import {
   applyAgentLaunchEnv,
@@ -789,16 +786,6 @@ function extractJsonEventText(kind, raw, agentName) {
     .trim();
 }
 
-async function writeLocalCliPromptAttachment(agentId, prompt) {
-  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), `od-memory-${agentId}-`));
-  const file = path.join(dir, 'prompt.md');
-  await fsp.writeFile(file, prompt, 'utf8');
-  return {
-    file,
-    cleanup: () => fsp.rm(dir, { recursive: true, force: true }).catch(() => {}),
-  };
-}
-
 async function callLocalCli(provider, system, user, options) {
   if (typeof options?.localCliRunner === 'function') {
     return options.localCliRunner({
@@ -843,7 +830,6 @@ async function callLocalCli(provider, system, user, options) {
 
   let args;
   let stdinText = prompt;
-  let cleanupPromptAttachment = () => Promise.resolve();
   let parseStdout = (raw) => raw.trim();
   if (provider.agentId === 'claude') {
     args = ['-p', '--input-format', 'text', '--output-format', 'text'];
@@ -860,8 +846,12 @@ async function callLocalCli(provider, system, user, options) {
     );
     parseStdout = (raw) => extractJsonEventText(def.eventParser || def.id, raw, def.name);
   } else if (provider.agentId === 'opencode') {
-    const attachment = await writeLocalCliPromptAttachment(provider.agentId, prompt);
-    cleanupPromptAttachment = attachment.cleanup;
+    // Deliver the prompt on stdin, matching the chat-run path
+    // (def.promptViaStdin). `opencode run`'s `-f, --file` is a yargs array
+    // option that greedily consumes every trailing non-flag token, so
+    // `--file <prompt-file> "<message>"` made OpenCode treat the message
+    // text as a second attachment and exit with "File not found". Bare
+    // `opencode run --format json` reads the message from stdin instead.
     args = def.buildArgs(
       '',
       [],
@@ -869,12 +859,6 @@ async function callLocalCli(provider, system, user, options) {
       { model: provider.model },
       { cwd },
     );
-    args.push(
-      '--file',
-      attachment.file,
-      'Read the attached OpenDesign memory extraction prompt and return strict JSON only.',
-    );
-    stdinText = '';
     parseStdout = (raw) => extractJsonEventText(def.eventParser || def.id, raw, def.name);
   } else {
     throw new Error(`Local CLI memory extraction is not supported for ${provider.agentId}`);
@@ -907,10 +891,8 @@ async function callLocalCli(provider, system, user, options) {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
-      void cleanupPromptAttachment().finally(() => {
-        if (err) reject(err);
-        else resolve(text);
-      });
+      if (err) reject(err);
+      else resolve(text);
     };
 
     const timeout = setTimeout(() => {

--- a/apps/daemon/tests/memory-connectors.test.ts
+++ b/apps/daemon/tests/memory-connectors.test.ts
@@ -1023,7 +1023,7 @@ process.stdout.write(JSON.stringify({
     }
   });
 
-  it('runs OpenCode Local CLI with a message argument and attached prompt file', async () => {
+  it('runs OpenCode Local CLI memory extraction with the prompt on stdin', async () => {
     await writeMemoryConfig(dataDir, { extraction: null });
     const tempDir = await fsp.mkdtemp(path.join(tmpdir(), 'od-opencode-memory-'));
     const binPath = path.join(tempDir, 'opencode-cli');
@@ -1031,16 +1031,33 @@ process.stdout.write(JSON.stringify({
     const previousPath = process.env.PATH;
     const previousCapture = process.env.OD_MEMORY_OPENCODE_ARGS_OUT;
 
+    // Model the real `opencode run` arg parser: `-f, --file` is a yargs
+    // *array* option, so it greedily swallows every following non-flag
+    // token as a file path. Any captured path that doesn't exist makes the
+    // real CLI exit 1 with "File not found: <token>" — which is exactly how
+    // a trailing positional message after `--file` crashed extraction. The
+    // supported one-shot shape is bare `run` with the prompt on stdin.
     await fsp.writeFile(
       binPath,
       `#!/usr/bin/env node
 const fs = require('node:fs');
 const args = process.argv.slice(2);
-const fileIndex = args.indexOf('--file');
-const attachedFile = fileIndex >= 0 ? args[fileIndex + 1] : null;
-const prompt = attachedFile ? fs.readFileSync(attachedFile, 'utf8') : '';
 const stdin = fs.readFileSync(0, 'utf8');
-fs.writeFileSync(process.env.OD_MEMORY_OPENCODE_ARGS_OUT, JSON.stringify({ args, attachedFile, prompt, stdin }));
+const files = [];
+const fileFlag = args.findIndex((a) => a === '--file' || a === '-f');
+if (fileFlag >= 0) {
+  for (let i = fileFlag + 1; i < args.length; i += 1) {
+    if (args[i].startsWith('-')) break;
+    files.push(args[i]);
+  }
+}
+fs.writeFileSync(process.env.OD_MEMORY_OPENCODE_ARGS_OUT, JSON.stringify({ args, stdin, files }));
+for (const f of files) {
+  if (!fs.existsSync(f)) {
+    process.stderr.write('Error: File not found: ' + f + '\\n');
+    process.exit(1);
+  }
+}
 process.stdout.write(JSON.stringify({
   type: 'text',
   part: {
@@ -1048,9 +1065,9 @@ process.stdout.write(JSON.stringify({
     text: JSON.stringify({
       entries: [{
         type: 'project',
-        name: 'OpenCode prompt attachment',
-        description: 'OpenCode memory used a prompt file',
-        body: 'OpenDesign connector memory extraction should pass the compacted prompt to OpenCode as an attached file while sending a short message argument.'
+        name: 'OpenCode stdin prompt',
+        description: 'OpenCode memory used stdin',
+        body: 'OpenDesign connector memory extraction should pass the compacted prompt to OpenCode on stdin and parse the JSON event stream response.'
       }]
     })
   }
@@ -1077,7 +1094,7 @@ process.stdout.write(JSON.stringify({
       expect(result.suggestions).toEqual([
         expect.objectContaining({
           type: 'project',
-          name: 'OpenCode prompt attachment',
+          name: 'OpenCode stdin prompt',
         }),
       ]);
 
@@ -1086,14 +1103,15 @@ process.stdout.write(JSON.stringify({
         'run',
         '--format',
         'json',
-        '--file',
-        'Read the attached OpenDesign memory extraction prompt and return strict JSON only.',
+        'openai/gpt-5',
       ]));
-      expect(captured.args).toContain('openai/gpt-5');
-      expect(captured.prompt).toContain('You are a design-memory extractor');
-      expect(captured.prompt).toContain('OpenDesign connector memory should collect design preferences');
-      expect(captured.stdin).toBe('');
-      await expect(fsp.access(captured.attachedFile)).rejects.toThrow();
+      // The prompt rides on stdin like the chat-run path; no `--file`
+      // attachment (whose array option would swallow any trailing message).
+      expect(captured.args).not.toContain('--file');
+      expect(captured.args).not.toContain('-f');
+      expect(captured.files).toEqual([]);
+      expect(captured.stdin).toContain('You are a design-memory extractor');
+      expect(captured.stdin).toContain('OpenDesign connector memory should collect design preferences');
     } finally {
       if (previousPath == null) {
         delete process.env.PATH;


### PR DESCRIPTION
Fixes #3237

## Why

I hit this running **OpenCode as my Local CLI agent** in a self-hosted Docker deployment: every background memory-extraction attempt failed, and the daemon log showed

```
[memory-llm] openai call failed OpenCode CLI exit 1: Error: File not found: Read the attached OpenDesign memory extraction prompt and return strict JSON only.
```

The pain: LLM auto-memory is completely dark for OpenCode users — the Memory settings panel shows a "failed" extraction on every turn, and nothing is ever written to the store.

Root cause: `apps/daemon/src/memory-llm.ts` (`callLocalCli`, `opencode` branch) builds

```
opencode run --format json -m <model> --file <tmpfile> "Read the attached … strict JSON only."
```

`opencode run`'s `-f, --file` is a **yargs array option** (`file(s) to attach to message  [array]`), so it greedily swallows the trailing positional message as a *second* attachment path. OpenCode can't open that "file" and exits 1. Claude/Codex are unaffected because they deliver the prompt on stdin / their own arg shapes.

## What users will see

OpenCode Local CLI users get working LLM memory extraction again (both background chat extraction and connector memory). Previously every attempt failed with the `File not found` error; now the Memory history shows successful extractions. No other visible/UI change.

## Surface area

- [x] **None** — internal bug fix to the memory extractor's OpenCode invocation; no new UI / CLI / API / extension point / i18n key / dependency, and no opt-in default change.

## Screenshots

N/A — no UI change.

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow":

- Test path that reproduces the bug: `apps/daemon/tests/memory-connectors.test.ts` → *"runs OpenCode Local CLI memory extraction with the prompt on stdin"*
- Did the test go red on `main` and green on this branch? **yes.** On `main` the red run reproduces the exact production error (`OpenCode CLI exit 1: Error: File not found: Read the attached …`) and the suggestions assertion fails; on this branch all 16 tests pass.
- The previous OpenCode test was green despite the bug because its mock `opencode-cli` read `args[indexOf('--file') + 1]` and never modeled yargs' `--file` array-greediness. The rewritten mock now collects every non-flag token after `--file` and exits 1 if any captured "file" doesn't exist — i.e. it would catch this regression.

## Fix

Deliver the prompt on **stdin**, matching the chat-run path (`opencode` def already declares `promptViaStdin: true` and `buildArgs` emits a bare `run --format json`), and drop the `--file` attachment entirely. Also removes the now-dead `writeLocalCliPromptAttachment` helper + its cleanup plumbing and the imports it pulled in.

## Validation

- `pnpm --filter @open-design/daemon test memory-connectors` → 16 passed (red→green confirmed)
- `pnpm --filter @open-design/daemon typecheck` → clean
- `pnpm guard` → the only failures on my checkout are pre-existing and unrelated to this PR (local untracked `*.obsidian` plugin JS, `.DS_Store` files); neither file in this PR is implicated.