### PR TITLE
feat(daemon): add sandbox runtime foundation

### DIFF
--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -4,6 +4,11 @@ import { mergeProxyAwareEnv, resolveSystemProxyEnv } from '@open-design/platform
 import { expandConfiguredEnv } from './paths.js';
 import { resolveAmrOpenCodeExecutable } from './executables.js';
 import { amrVelaProfileEnv } from '../integrations/vela-profile.js';
+import {
+  applySandboxRuntimeEnv,
+  isSandboxModeEnabled,
+  resolveSandboxRuntimeConfig,
+} from '../sandbox-mode.js';
 
 type RuntimeEnvMap = NodeJS.ProcessEnv | Record<string, string>;
 
@@ -58,20 +63,30 @@ export function spawnEnvForAgent(
       const opencodeBin = resolveAmrOpenCodeExecutable(env);
       if (opencodeBin) env.VELA_OPENCODE_BIN = opencodeBin;
     }
-    return env;
+    return reapplySandboxRuntimeEnv(env);
   }
   if (agentId === 'claude') {
     stripUnlessCustomBaseUrl(env, 'ANTHROPIC_BASE_URL', ['ANTHROPIC_API_KEY']);
-    return env;
+    return reapplySandboxRuntimeEnv(env);
   }
   if (agentId === 'codex') {
     stripUnlessCustomBaseUrl(env, 'OPENAI_BASE_URL', [
       'OPENAI_API_KEY',
       'CODEX_API_KEY',
     ]);
-    return env;
+    return reapplySandboxRuntimeEnv(env);
   }
-  return env;
+  return reapplySandboxRuntimeEnv(env);
+}
+
+function reapplySandboxRuntimeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  if (!isSandboxModeEnabled(env)) return env;
+  const dataDir = env.OD_DATA_DIR?.trim();
+  if (!dataDir) return env;
+  return applySandboxRuntimeEnv(
+    env,
+    resolveSandboxRuntimeConfig(true, dataDir),
+  );
 }
 
 // Remove `secretKeys` from `env` unless `baseUrlKey` is set to a non-empty

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -8,6 +8,7 @@ import {
   applySandboxRuntimeEnv,
   isSandboxModeEnabled,
   resolveSandboxRuntimeConfig,
+  type SandboxRuntimeConfig,
 } from '../sandbox-mode.js';
 
 type RuntimeEnvMap = NodeJS.ProcessEnv | Record<string, string>;
@@ -44,6 +45,7 @@ export function spawnEnvForAgent(
   configuredEnv: unknown = {},
   systemProxyEnv: RuntimeEnvMap = resolveSystemProxyEnv(),
 ): NodeJS.ProcessEnv {
+  const sandboxRuntime = sandboxRuntimeConfigForBaseEnv(baseEnv);
   const env = mergeProxyAwareEnv(
     process.platform,
     systemProxyEnv,
@@ -63,30 +65,37 @@ export function spawnEnvForAgent(
       const opencodeBin = resolveAmrOpenCodeExecutable(env);
       if (opencodeBin) env.VELA_OPENCODE_BIN = opencodeBin;
     }
-    return reapplySandboxRuntimeEnv(env);
+    return reapplySandboxRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'claude') {
     stripUnlessCustomBaseUrl(env, 'ANTHROPIC_BASE_URL', ['ANTHROPIC_API_KEY']);
-    return reapplySandboxRuntimeEnv(env);
+    return reapplySandboxRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'codex') {
     stripUnlessCustomBaseUrl(env, 'OPENAI_BASE_URL', [
       'OPENAI_API_KEY',
       'CODEX_API_KEY',
     ]);
-    return reapplySandboxRuntimeEnv(env);
+    return reapplySandboxRuntimeEnv(env, sandboxRuntime);
   }
-  return reapplySandboxRuntimeEnv(env);
+  return reapplySandboxRuntimeEnv(env, sandboxRuntime);
 }
 
-function reapplySandboxRuntimeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  if (!isSandboxModeEnabled(env)) return env;
-  const dataDir = env.OD_DATA_DIR?.trim();
-  if (!dataDir) return env;
-  return applySandboxRuntimeEnv(
-    env,
-    resolveSandboxRuntimeConfig(true, dataDir),
-  );
+function sandboxRuntimeConfigForBaseEnv(
+  baseEnv: RuntimeEnvMap,
+): SandboxRuntimeConfig | null {
+  if (!isSandboxModeEnabled(baseEnv)) return null;
+  const dataDir = baseEnv.OD_DATA_DIR?.trim();
+  if (!dataDir) return null;
+  return resolveSandboxRuntimeConfig(true, dataDir);
+}
+
+function reapplySandboxRuntimeEnv(
+  env: NodeJS.ProcessEnv,
+  sandboxRuntime: SandboxRuntimeConfig | null,
+): NodeJS.ProcessEnv {
+  if (!sandboxRuntime) return env;
+  return applySandboxRuntimeEnv(env, sandboxRuntime);
 }
 
 // Remove `secretKeys` from `env` unless `baseUrlKey` is set to a non-empty

--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -2,9 +2,16 @@ import { accessSync, constants, existsSync, statSync } from 'node:fs';
 import { delimiter } from 'node:path';
 import path from 'node:path';
 import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import { wellKnownUserToolchainBins } from '@open-design/platform';
+import { resolveSandboxRuntimeConfigFromEnv } from '../sandbox-mode.js';
 import { expandHomePath } from './paths.js';
 import type { RuntimeAgentDef } from './types.js';
+
+const RUNTIME_PROJECT_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../..',
+);
 
 const AGENT_BIN_ENV_KEYS = new Map<string, string>([
   ['amr', 'VELA_BIN'],
@@ -35,7 +42,12 @@ let cachedToolchainDirs: string[] | null = null;
 let cachedToolchainDirsAt = 0;
 
 function userToolchainDirs() {
-  const homeOverride = process.env.OD_AGENT_HOME;
+  const sandboxRuntime = resolveSandboxRuntimeConfigFromEnv(
+    process.env,
+    RUNTIME_PROJECT_ROOT,
+  );
+  const homeOverride =
+    sandboxRuntime?.roots.agentHomeDir ?? process.env.OD_AGENT_HOME;
   const home = homeOverride || homedir();
   const now = Date.now();
   if (

--- a/apps/daemon/src/runtimes/local-profiles.ts
+++ b/apps/daemon/src/runtimes/local-profiles.ts
@@ -20,16 +20,16 @@ const RUNTIME_PROJECT_ROOT = path.resolve(
 );
 
 function localAgentProfilesFile(): string {
+  const explicit = process.env.OD_AGENT_PROFILES_CONFIG;
+  if (typeof explicit === 'string' && explicit.trim()) {
+    return explicit.trim();
+  }
   const sandboxRuntime = resolveSandboxRuntimeConfigFromEnv(
     process.env,
     RUNTIME_PROJECT_ROOT,
   );
   if (sandboxRuntime?.enabled) {
     return sandboxAgentProfilesConfigPath(sandboxRuntime);
-  }
-  const explicit = process.env.OD_AGENT_PROFILES_CONFIG;
-  if (typeof explicit === 'string' && explicit.trim()) {
-    return explicit.trim();
   }
   return path.join(homedir(), '.open-design', 'agents.local.json');
 }

--- a/apps/daemon/src/runtimes/local-profiles.ts
+++ b/apps/daemon/src/runtimes/local-profiles.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
 import path from 'node:path';
 
+import {
+  resolveSandboxRuntimeConfigFromEnv,
+  sandboxAgentProfilesConfigPath,
+} from '../sandbox-mode.js';
 import { DEFAULT_MODEL_OPTION, sanitizeCustomModel } from './models.js';
 import type {
   RuntimeAgentDef,
@@ -9,7 +14,19 @@ import type {
   RuntimeModelOption,
 } from './types.js';
 
+const RUNTIME_PROJECT_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../..',
+);
+
 function localAgentProfilesFile(): string {
+  const sandboxRuntime = resolveSandboxRuntimeConfigFromEnv(
+    process.env,
+    RUNTIME_PROJECT_ROOT,
+  );
+  if (sandboxRuntime?.enabled) {
+    return sandboxAgentProfilesConfigPath(sandboxRuntime);
+  }
   const explicit = process.env.OD_AGENT_PROFILES_CONFIG;
   if (typeof explicit === 'string' && explicit.trim()) {
     return explicit.trim();

--- a/apps/daemon/src/runtimes/local-profiles.ts
+++ b/apps/daemon/src/runtimes/local-profiles.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import path from 'node:path';
 
 import {
+  isSandboxModeEnabled,
   resolveSandboxRuntimeConfigFromEnv,
   sandboxAgentProfilesConfigPath,
 } from '../sandbox-mode.js';
@@ -19,17 +20,39 @@ const RUNTIME_PROJECT_ROOT = path.resolve(
   '../../../..',
 );
 
-function localAgentProfilesFile(): string {
-  const explicit = process.env.OD_AGENT_PROFILES_CONFIG;
-  if (typeof explicit === 'string' && explicit.trim()) {
-    return explicit.trim();
-  }
-  const sandboxRuntime = resolveSandboxRuntimeConfigFromEnv(
-    process.env,
-    RUNTIME_PROJECT_ROOT,
+function isInsideDir(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return (
+    relative === '' ||
+    (!relative.startsWith('..') && !path.isAbsolute(relative))
   );
-  if (sandboxRuntime?.enabled) {
+}
+
+function localAgentProfilesFile(): string | null {
+  const explicit = process.env.OD_AGENT_PROFILES_CONFIG;
+  const explicitPath =
+    typeof explicit === 'string' && explicit.trim()
+      ? path.resolve(explicit.trim())
+      : null;
+
+  if (isSandboxModeEnabled(process.env)) {
+    if (!process.env.OD_DATA_DIR?.trim()) return null;
+    const sandboxRuntime = resolveSandboxRuntimeConfigFromEnv(
+      process.env,
+      RUNTIME_PROJECT_ROOT,
+    );
+    if (!sandboxRuntime?.enabled) return null;
+    if (
+      explicitPath &&
+      isInsideDir(sandboxRuntime.roots.agentHomeDir, explicitPath)
+    ) {
+      return explicitPath;
+    }
     return sandboxAgentProfilesConfigPath(sandboxRuntime);
+  }
+
+  if (explicitPath) {
+    return explicitPath;
   }
   return path.join(homedir(), '.open-design', 'agents.local.json');
 }
@@ -171,7 +194,9 @@ export function readLocalAgentProfileDefs(
 ): RuntimeAgentDef[] {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(readFileSync(localAgentProfilesFile(), 'utf8'));
+    const file = localAgentProfilesFile();
+    if (!file) return [];
+    parsed = JSON.parse(readFileSync(file, 'utf8'));
   } catch {
     return [];
   }

--- a/apps/daemon/src/sandbox-mode.ts
+++ b/apps/daemon/src/sandbox-mode.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { resolveProjectRelativePath } from './home-expansion.js';
+
 export const SANDBOX_MODE_ENV = 'OD_SANDBOX_MODE';
 
 export interface SandboxRuntimeRoots {
@@ -64,6 +66,31 @@ export function resolveSandboxRuntimeConfig(
   };
 }
 
+export function resolveSandboxRuntimeConfigFromEnv(
+  env: Record<string, string | undefined>,
+  projectRoot: string,
+): SandboxRuntimeConfig | null {
+  if (!isSandboxModeEnabled(env)) return null;
+  const rawDataDir = env.OD_DATA_DIR?.trim();
+  if (!rawDataDir) {
+    throw new Error('OD_DATA_DIR is required when OD_SANDBOX_MODE is enabled');
+  }
+  return resolveSandboxRuntimeConfig(
+    true,
+    resolveProjectRelativePath(rawDataDir, projectRoot),
+  );
+}
+
+export function sandboxAgentProfilesConfigPath(
+  config: SandboxRuntimeConfig,
+): string {
+  return path.join(
+    config.roots.agentHomeDir,
+    '.open-design',
+    'agents.local.json',
+  );
+}
+
 export function ensureSandboxRuntimeDirs(config: SandboxRuntimeConfig): void {
   if (!config.enabled) return;
   for (const dir of new Set(Object.values(config.roots))) {
@@ -99,6 +126,7 @@ export function applySandboxRuntimeEnv(
   env.CODEX_HOME = codexHome;
   env.CLAUDE_CONFIG_DIR = claudeConfigDir;
   env.OPENCODE_TEST_HOME = opencodeHome;
+  env.OD_AGENT_PROFILES_CONFIG = sandboxAgentProfilesConfigPath(config);
   env.NPM_CONFIG_USERCONFIG = npmUserConfig;
   env.npm_config_userconfig = npmUserConfig;
 

--- a/apps/daemon/src/sandbox-mode.ts
+++ b/apps/daemon/src/sandbox-mode.ts
@@ -81,6 +81,7 @@ export function applySandboxRuntimeEnv(
   const { roots } = config;
   const codexHome = path.join(roots.agentHomeDir, '.codex');
   const claudeConfigDir = path.join(roots.configDir, 'claude');
+  const opencodeHome = path.join(roots.agentHomeDir, '.opencode');
   const npmUserConfig = path.join(roots.toolConfigDir, 'npmrc');
 
   env[SANDBOX_MODE_ENV] = '1';
@@ -97,6 +98,7 @@ export function applySandboxRuntimeEnv(
   env.TMP = roots.tempDir;
   env.CODEX_HOME = codexHome;
   env.CLAUDE_CONFIG_DIR = claudeConfigDir;
+  env.OPENCODE_TEST_HOME = opencodeHome;
   env.NPM_CONFIG_USERCONFIG = npmUserConfig;
   env.npm_config_userconfig = npmUserConfig;
 

--- a/apps/daemon/src/sandbox-mode.ts
+++ b/apps/daemon/src/sandbox-mode.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const SANDBOX_MODE_ENV = 'OD_SANDBOX_MODE';
+
+export interface SandboxRuntimeRoots {
+  agentHomeDir: string;
+  cacheDir: string;
+  configDir: string;
+  generatedFilesDir: string;
+  logsDir: string;
+  mcpConfigDir: string;
+  pluginStateDir: string;
+  previewStateDir: string;
+  skillsCacheDir: string;
+  tempDir: string;
+  toolConfigDir: string;
+}
+
+export interface SandboxRuntimeConfig {
+  enabled: boolean;
+  dataDir: string;
+  roots: SandboxRuntimeRoots;
+}
+
+const TRUTHY_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const FALSY_VALUES = new Set(['0', 'false', 'no', 'off', '']);
+
+export function isSandboxModeEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const raw = env[SANDBOX_MODE_ENV];
+  if (typeof raw !== 'string') return false;
+  const value = raw.trim().toLowerCase();
+  if (TRUTHY_VALUES.has(value)) return true;
+  if (FALSY_VALUES.has(value)) return false;
+  throw new Error(
+    `${SANDBOX_MODE_ENV} must be one of ${Array.from(TRUTHY_VALUES).join(', ')} ` +
+      `or ${Array.from(FALSY_VALUES).join(', ')}`,
+  );
+}
+
+export function resolveSandboxRuntimeConfig(
+  enabled: boolean,
+  dataDir: string,
+): SandboxRuntimeConfig {
+  const sandboxRoot = path.join(dataDir, 'sandbox');
+  return {
+    enabled,
+    dataDir,
+    roots: {
+      agentHomeDir: path.join(sandboxRoot, 'agent-home'),
+      cacheDir: path.join(sandboxRoot, 'cache'),
+      configDir: path.join(sandboxRoot, 'config'),
+      generatedFilesDir: path.join(dataDir, 'generated-files'),
+      logsDir: path.join(dataDir, 'logs'),
+      mcpConfigDir: dataDir,
+      pluginStateDir: path.join(dataDir, 'plugins'),
+      previewStateDir: path.join(dataDir, 'previews'),
+      skillsCacheDir: path.join(dataDir, 'skills'),
+      tempDir: path.join(sandboxRoot, 'tmp'),
+      toolConfigDir: path.join(sandboxRoot, 'tools'),
+    },
+  };
+}
+
+export function ensureSandboxRuntimeDirs(config: SandboxRuntimeConfig): void {
+  if (!config.enabled) return;
+  for (const dir of new Set(Object.values(config.roots))) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function applySandboxRuntimeEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  config: SandboxRuntimeConfig,
+): NodeJS.ProcessEnv {
+  if (!config.enabled) return baseEnv;
+
+  const env: NodeJS.ProcessEnv = { ...baseEnv };
+  const { roots } = config;
+  const codexHome = path.join(roots.agentHomeDir, '.codex');
+  const claudeConfigDir = path.join(roots.configDir, 'claude');
+  const npmUserConfig = path.join(roots.toolConfigDir, 'npmrc');
+
+  env[SANDBOX_MODE_ENV] = '1';
+  env.OD_DATA_DIR = config.dataDir;
+  env.OD_AGENT_HOME = roots.agentHomeDir;
+  env.HOME = roots.agentHomeDir;
+  env.USERPROFILE = roots.agentHomeDir;
+  env.XDG_CONFIG_HOME = roots.configDir;
+  env.XDG_CACHE_HOME = roots.cacheDir;
+  env.XDG_DATA_HOME = path.join(roots.configDir, 'data');
+  env.XDG_STATE_HOME = path.join(roots.configDir, 'state');
+  env.TMPDIR = roots.tempDir;
+  env.TEMP = roots.tempDir;
+  env.TMP = roots.tempDir;
+  env.CODEX_HOME = codexHome;
+  env.CLAUDE_CONFIG_DIR = claudeConfigDir;
+  env.NPM_CONFIG_USERCONFIG = npmUserConfig;
+  env.npm_config_userconfig = npmUserConfig;
+
+  return env;
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -91,6 +91,12 @@ import { listCodexPets, readCodexPetSpritesheet } from './codex-pets.js';
 import { syncCommunityPets } from './community-pets-sync.js';
 import { parseMediaExecutionPolicyInput } from './media-policy.js';
 import {
+  applySandboxRuntimeEnv,
+  ensureSandboxRuntimeDirs,
+  isSandboxModeEnabled,
+  resolveSandboxRuntimeConfig,
+} from './sandbox-mode.js';
+import {
   createUserDesignSystem,
   deleteUserDesignSystem,
   LEGACY_DESIGN_SYSTEM_ARTIFACTS,
@@ -1271,8 +1277,13 @@ function createMarketplaceFetcher(seedId, bundledMarketplaceEntries) {
   };
 }
 
-export function resolveDataDir(raw, projectRoot) {
-  if (!raw) return path.join(projectRoot, '.od');
+export function resolveDataDir(raw, projectRoot, options = {}) {
+  if (!raw) {
+    if (options.requireExplicit) {
+      throw new Error('OD_DATA_DIR is required when OD_SANDBOX_MODE is enabled');
+    }
+    return path.join(projectRoot, '.od');
+  }
   // expandHomePrefix is shared with media-config.ts so OD_DATA_DIR and
   // OD_MEDIA_CONFIG_DIR can never split state under a $HOME-style value.
   // Some launchers (systemd unit files, NixOS modules, certain Docker
@@ -1307,7 +1318,12 @@ export function resolveDataDir(raw, projectRoot) {
   }
   return resolved;
 }
-const RUNTIME_DATA_DIR = resolveDataDir(process.env.OD_DATA_DIR, PROJECT_ROOT);
+const SANDBOX_MODE_ENABLED = isSandboxModeEnabled(process.env);
+const RUNTIME_DATA_DIR = resolveDataDir(process.env.OD_DATA_DIR, PROJECT_ROOT, {
+  requireExplicit: SANDBOX_MODE_ENABLED,
+});
+const SANDBOX_RUNTIME = resolveSandboxRuntimeConfig(SANDBOX_MODE_ENABLED, RUNTIME_DATA_DIR);
+ensureSandboxRuntimeDirs(SANDBOX_RUNTIME);
 const PLUGIN_LOCKFILE_PATH = path.join(RUNTIME_DATA_DIR, 'od-plugin-lock.json');
 // Canonical (realpath-resolved) form of RUNTIME_DATA_DIR for the few callers
 // that compare it against a user-supplied realpath() result. On macOS, /var
@@ -1566,12 +1582,15 @@ export function createAgentRuntimeEnv(
   toolTokenGrant: { token?: string } | null = null,
   nodeBin: string = process.execPath,
 ): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {
-    ...baseEnv,
-    OD_DATA_DIR: RUNTIME_DATA_DIR,
-    OD_DAEMON_URL: daemonUrl,
-    OD_NODE_BIN: nodeBin,
-  };
+  const env: NodeJS.ProcessEnv = applySandboxRuntimeEnv(
+    {
+      ...baseEnv,
+      OD_DATA_DIR: RUNTIME_DATA_DIR,
+      OD_DAEMON_URL: daemonUrl,
+      OD_NODE_BIN: nodeBin,
+    },
+    SANDBOX_RUNTIME,
+  );
   const sidecarIpcPath = baseEnv[SIDECAR_ENV.IPC_PATH];
   if (typeof sidecarIpcPath === 'string' && sidecarIpcPath.length > 0) {
     env[SIDECAR_ENV.IPC_PATH] = sidecarIpcPath;
@@ -3646,7 +3665,16 @@ export async function startServer({
   // value matching `OD_API_TOKEN`. Health / version / status remain
   // open so monitoring probes don't need the token.
   if (apiToken.length > 0) {
-    const openProbePaths = new Set(['/api/health', '/api/version', '/api/daemon/status']);
+    const openProbePaths = new Set([
+      '/health',
+      '/api/health',
+      '/ready',
+      '/api/ready',
+      '/version',
+      '/api/version',
+      '/daemon/status',
+      '/api/daemon/status',
+    ]);
     app.use('/api', (req, res, next) => {
       if (openProbePaths.has(req.path)) return next();
       // Loopback short-circuit. We ignore the proxied X-Forwarded-For
@@ -4129,6 +4157,22 @@ export async function startServer({
     res.json({ ok: true, version: versionInfo.version });
   });
 
+  app.get('/api/ready', async (_req, res) => {
+    const versionInfo = await readCurrentAppVersionInfo();
+    const ready = !daemonShuttingDown;
+    res.status(ready ? 200 : 503).json({
+      ok: ready,
+      ready,
+      version: versionInfo.version,
+      dataDir: RUNTIME_DATA_DIR,
+      sandboxMode: SANDBOX_RUNTIME.enabled,
+      sandbox: SANDBOX_RUNTIME.enabled
+        ? { enabled: true, roots: SANDBOX_RUNTIME.roots }
+        : { enabled: false },
+      shuttingDown: daemonShuttingDown,
+    });
+  });
+
   app.get('/api/version', async (_req, res) => {
     const version = await readCurrentAppVersionInfo();
     res.json({ version });
@@ -4182,6 +4226,10 @@ export async function startServer({
       port: Number(process.env.OD_PORT ?? 7456),
       dataDir: RUNTIME_DATA_DIR,
       mediaConfigDir: process.env.OD_MEDIA_CONFIG_DIR ?? null,
+      sandboxMode: SANDBOX_RUNTIME.enabled,
+      sandbox: SANDBOX_RUNTIME.enabled
+        ? { enabled: true, roots: SANDBOX_RUNTIME.roots }
+        : { enabled: false },
       pid: process.pid,
       shuttingDown: daemonShuttingDown,
       installedPlugins: (() => {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3662,8 +3662,9 @@ export async function startServer({
   // Active only when OD_API_TOKEN is set. Loopback origins skip the
   // check (the desktop UI / local CLI never carry a bearer); every
   // other request must present `Authorization: Bearer <token>` with a
-  // value matching `OD_API_TOKEN`. Health / version / status remain
-  // open so monitoring probes don't need the token.
+  // value matching `OD_API_TOKEN`. Health / readiness / version remain
+  // open so monitoring probes don't need the token. Rich daemon status
+  // stays authenticated because it includes local runtime paths.
   if (apiToken.length > 0) {
     const openProbePaths = new Set([
       '/health',
@@ -3672,8 +3673,6 @@ export async function startServer({
       '/api/ready',
       '/version',
       '/api/version',
-      '/daemon/status',
-      '/api/daemon/status',
     ]);
     app.use('/api', (req, res, next) => {
       if (openProbePaths.has(req.path)) return next();
@@ -4164,12 +4163,6 @@ export async function startServer({
       ok: ready,
       ready,
       version: versionInfo.version,
-      dataDir: RUNTIME_DATA_DIR,
-      sandboxMode: SANDBOX_RUNTIME.enabled,
-      sandbox: SANDBOX_RUNTIME.enabled
-        ? { enabled: true, roots: SANDBOX_RUNTIME.roots }
-        : { enabled: false },
-      shuttingDown: daemonShuttingDown,
     });
   });
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1278,7 +1278,8 @@ function createMarketplaceFetcher(seedId, bundledMarketplaceEntries) {
 }
 
 export function resolveDataDir(raw, projectRoot, options = {}) {
-  if (!raw) {
+  const value = raw?.trim();
+  if (!value) {
     if (options.requireExplicit) {
       throw new Error('OD_DATA_DIR is required when OD_SANDBOX_MODE is enabled');
     }
@@ -1292,7 +1293,7 @@ export function resolveDataDir(raw, projectRoot, options = {}) {
   // expandHomePrefix turns those (and the ~ shorthand, with both / and \
   // separators) into os.homedir() before path.resolve runs so launch
   // surfaces stay consistent.
-  const resolved = resolveProjectRelativePath(raw, projectRoot);
+  const resolved = resolveProjectRelativePath(value, projectRoot);
   try {
     fs.mkdirSync(resolved, { recursive: true });
     fs.accessSync(resolved, fs.constants.W_OK);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12407,7 +12407,18 @@ export async function startServer({
     ) {
       try {
         const convs = listConversations(db, meta.projectId);
-        const defaultConv = Array.isArray(convs) && convs.length > 0 ? convs[0] : null;
+        // listConversations is ordered for the UI by recent activity; this
+        // fallback must bind to the seeded default conversation instead.
+        const defaultConv = Array.isArray(convs) && convs.length > 0
+          ? [...convs].sort((a, b) => {
+              const aCreated = Number(a?.createdAt);
+              const bCreated = Number(b?.createdAt);
+              if (Number.isFinite(aCreated) && Number.isFinite(bCreated) && aCreated !== bCreated) {
+                return aCreated - bCreated;
+              }
+              return String(a?.id ?? '').localeCompare(String(b?.id ?? ''));
+            })[0]
+          : null;
         if (defaultConv && typeof defaultConv.id === 'string' && defaultConv.id) {
           meta.conversationId = defaultConv.id;
           if (typeof meta.assistantMessageId !== 'string' || !meta.assistantMessageId) {
@@ -12441,10 +12452,13 @@ export async function startServer({
         const cfgAgent = typeof appCfg.agentId === 'string' && appCfg.agentId
           ? appCfg.agentId
           : null;
-        if (cfgAgent) {
+        const agents = await detectAgents(appCfg.agentCliEnv ?? {}).catch(() => []);
+        const cfgAgentAvailable = cfgAgent
+          ? agents.some((agent) => agent.id === cfgAgent && agent.available)
+          : false;
+        if (cfgAgent && cfgAgentAvailable) {
           meta.agentId = cfgAgent;
         } else {
-          const agents = await detectAgents(appCfg.agentCliEnv ?? {}).catch(() => []);
           const firstAvailable = agents.find((a) => a.available)?.id ?? null;
           if (firstAvailable) meta.agentId = firstAvailable;
         }

--- a/apps/daemon/tests/api-token-guard.test.ts
+++ b/apps/daemon/tests/api-token-guard.test.ts
@@ -5,7 +5,7 @@
 //      OD_API_TOKEN is set.
 //   2. When OD_API_TOKEN is set, every /api/* request from a non-loopback
 //      peer must carry `Authorization: Bearer <OD_API_TOKEN>`. The
-//      health/version/status probes stay open for monitoring.
+//      health/readiness/version probes stay open for monitoring.
 //
 // Tests force the bearer-required code path by stamping the env vars
 // before startServer. The daemon listens on 127.0.0.1 throughout (so
@@ -77,8 +77,8 @@ describe('bearer middleware', () => {
     expect(resp.status).toBe(200);
   });
 
-  it('keeps health / readiness / version / daemon-status open without a bearer', async () => {
-    for (const path of ['/api/health', '/api/ready', '/api/version', '/api/daemon/status']) {
+  it('keeps health / readiness / version probes open without a bearer', async () => {
+    for (const path of ['/api/health', '/api/ready', '/api/version']) {
       const resp = await fetch(`${baseUrl}${path}`);
       expect(resp.status).toBe(200);
     }

--- a/apps/daemon/tests/api-token-guard.test.ts
+++ b/apps/daemon/tests/api-token-guard.test.ts
@@ -77,8 +77,8 @@ describe('bearer middleware', () => {
     expect(resp.status).toBe(200);
   });
 
-  it('keeps health / version / daemon-status open without a bearer', async () => {
-    for (const path of ['/api/health', '/api/version', '/api/daemon/status']) {
+  it('keeps health / readiness / version / daemon-status open without a bearer', async () => {
+    for (const path of ['/api/health', '/api/ready', '/api/version', '/api/daemon/status']) {
       const resp = await fetch(`${baseUrl}${path}`);
       expect(resp.status).toBe(200);
     }

--- a/apps/daemon/tests/daemon-lifecycle.test.ts
+++ b/apps/daemon/tests/daemon-lifecycle.test.ts
@@ -38,6 +38,8 @@ describe('GET /api/daemon/status', () => {
       version: unknown;
       bindHost: unknown;
       port: unknown;
+      sandboxMode: boolean;
+      sandbox: { enabled: boolean };
       pid: unknown;
       installedPlugins: unknown;
       shuttingDown: boolean;
@@ -49,8 +51,34 @@ describe('GET /api/daemon/status', () => {
     expect(typeof body.port).toBe('number');
     expect(typeof body.pid).toBe('number');
     expect(typeof body.installedPlugins).toBe('number');
+    expect(body.sandboxMode).toBe(false);
+    expect(body.sandbox).toEqual({ enabled: false });
     expect(body.shuttingDown).toBe(false);
     expect(body).not.toHaveProperty('namespace');
+  });
+});
+
+describe('GET /api/ready', () => {
+  it('returns a readiness snapshot for headless launchers', async () => {
+    const resp = await fetch(`${baseUrl}/api/ready`);
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as {
+      ok: boolean;
+      ready: boolean;
+      version: unknown;
+      dataDir: unknown;
+      sandboxMode: boolean;
+      sandbox: { enabled: boolean };
+      shuttingDown: boolean;
+    };
+
+    expect(body.ok).toBe(true);
+    expect(body.ready).toBe(true);
+    expect(typeof body.version === 'string' || typeof body.version === 'object').toBe(true);
+    expect(typeof body.dataDir).toBe('string');
+    expect(body.sandboxMode).toBe(false);
+    expect(body.sandbox).toEqual({ enabled: false });
+    expect(body.shuttingDown).toBe(false);
   });
 });
 

--- a/apps/daemon/tests/daemon-lifecycle.test.ts
+++ b/apps/daemon/tests/daemon-lifecycle.test.ts
@@ -66,19 +66,14 @@ describe('GET /api/ready', () => {
       ok: boolean;
       ready: boolean;
       version: unknown;
-      dataDir: unknown;
-      sandboxMode: boolean;
-      sandbox: { enabled: boolean };
-      shuttingDown: boolean;
     };
 
     expect(body.ok).toBe(true);
     expect(body.ready).toBe(true);
     expect(typeof body.version === 'string' || typeof body.version === 'object').toBe(true);
-    expect(typeof body.dataDir).toBe('string');
-    expect(body.sandboxMode).toBe(false);
-    expect(body.sandbox).toEqual({ enabled: false });
-    expect(body.shuttingDown).toBe(false);
+    expect(body).not.toHaveProperty('dataDir');
+    expect(body).not.toHaveProperty('sandboxMode');
+    expect(body).not.toHaveProperty('sandbox');
   });
 });
 

--- a/apps/daemon/tests/headless-runs.test.ts
+++ b/apps/daemon/tests/headless-runs.test.ts
@@ -1,0 +1,194 @@
+import type http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+type StartedServer = {
+  url: string;
+  server: http.Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+describe('POST /api/runs headless fallbacks', () => {
+  let started: StartedServer | null = null;
+  const oldPath = process.env.PATH;
+  const oldAgentHome = process.env.OD_AGENT_HOME;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (oldPath === undefined) delete process.env.PATH;
+    else process.env.PATH = oldPath;
+    if (oldAgentHome === undefined) delete process.env.OD_AGENT_HOME;
+    else process.env.OD_AGENT_HOME = oldAgentHome;
+  });
+
+  it('binds omitted conversationId to the seeded project conversation', async () => {
+    started = await startTestServer();
+    const { projectId, conversationId: seededConversationId } = await createProject(
+      started.url,
+      'Headless default conversation project',
+    );
+    await delay(5);
+    const newerConversationId = await createConversation(started.url, projectId, 'Newer user chat');
+
+    const conversationsResponse = await fetch(
+      `${started.url}/api/projects/${encodeURIComponent(projectId)}/conversations`,
+    );
+    expect(conversationsResponse.status).toBe(200);
+    const conversationsBody = await conversationsResponse.json() as {
+      conversations: Array<{ id: string }>;
+    };
+    expect(conversationsBody.conversations[0]?.id).toBe(newerConversationId);
+
+    const runResponse = await fetch(`${started.url}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: `missing-agent-${randomUUID()}`,
+        projectId,
+        message: 'Headless prompt',
+      }),
+    });
+    expect(runResponse.status).toBe(202);
+    const runBody = await runResponse.json() as { conversationId: string | null };
+    expect(runBody.conversationId).toBe(seededConversationId);
+  });
+
+  it('falls back past a stale saved agent to the first detected available runtime', async () => {
+    started = await startTestServer();
+    const binDir = await mkdtemp(path.join(os.tmpdir(), 'od-headless-run-bin-'));
+    const emptyAgentHome = await mkdtemp(path.join(os.tmpdir(), 'od-headless-run-home-'));
+    const priorConfig = await readAppConfigFromServer(started.url);
+    try {
+      const opencodeBin = await writeFakeOpencode(binDir);
+      process.env.PATH = '';
+      process.env.OD_AGENT_HOME = emptyAgentHome;
+
+      const configResponse = await fetch(`${started.url}/api/app-config`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          agentId: 'claude',
+          agentCliEnv: {
+            claude: { CLAUDE_BIN: path.join(binDir, 'missing-claude') },
+            opencode: { OPENCODE_BIN: opencodeBin },
+          },
+        }),
+      });
+      expect(configResponse.status).toBe(200);
+
+      const { projectId } = await createProject(started.url, 'Headless stale agent project');
+      const runResponse = await fetch(`${started.url}/api/runs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          projectId,
+          message: 'Headless prompt',
+        }),
+      });
+      expect(runResponse.status).toBe(202);
+      const runBody = await runResponse.json() as { runId: string };
+      const statusResponse = await fetch(
+        `${started.url}/api/runs/${encodeURIComponent(runBody.runId)}`,
+      );
+      expect(statusResponse.status).toBe(200);
+      const statusBody = await statusResponse.json() as { agentId: string | null };
+      expect(statusBody.agentId).toBe('opencode');
+    } finally {
+      await restoreAppConfig(started.url, priorConfig);
+      await rm(binDir, { recursive: true, force: true });
+      await rm(emptyAgentHome, { recursive: true, force: true });
+    }
+  });
+});
+
+async function startTestServer(): Promise<StartedServer> {
+  return await startServer({ port: 0, returnServer: true }) as StartedServer;
+}
+
+async function createProject(url: string, name: string): Promise<{
+  projectId: string;
+  conversationId: string;
+}> {
+  const projectId = `project_${randomUUID()}`;
+  const response = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name,
+      metadata: { kind: 'prototype' },
+    }),
+  });
+  expect(response.status).toBe(200);
+  const body = await response.json() as { conversationId: string };
+  return { projectId, conversationId: body.conversationId };
+}
+
+async function createConversation(
+  url: string,
+  projectId: string,
+  title: string,
+): Promise<string> {
+  const response = await fetch(`${url}/api/projects/${encodeURIComponent(projectId)}/conversations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  });
+  expect(response.status).toBe(200);
+  const body = await response.json() as { conversation: { id: string } };
+  return body.conversation.id;
+}
+
+async function readAppConfigFromServer(url: string): Promise<Record<string, unknown>> {
+  const response = await fetch(`${url}/api/app-config`);
+  expect(response.status).toBe(200);
+  const body = await response.json() as { config?: Record<string, unknown> };
+  return body.config ?? {};
+}
+
+async function restoreAppConfig(url: string, config: Record<string, unknown>): Promise<void> {
+  await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      agentId: Object.hasOwn(config, 'agentId') ? config.agentId : null,
+      agentCliEnv: Object.hasOwn(config, 'agentCliEnv') ? config.agentCliEnv : null,
+    }),
+  });
+}
+
+async function writeFakeOpencode(dir: string): Promise<string> {
+  const bin = path.join(dir, 'opencode');
+  await writeFile(bin, `#!/usr/bin/env node
+if (process.argv.includes('--version')) {
+  console.log('opencode 0.0.0');
+  process.exit(0);
+}
+if (process.argv[2] === 'models') {
+  console.log('test/model');
+  process.exit(0);
+}
+if (process.argv[2] === 'run') {
+  process.stdin.resume();
+  process.stdin.on('end', () => process.exit(0));
+  setTimeout(() => process.exit(0), 50);
+} else {
+  process.exit(0);
+}
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/daemon/tests/resolve-data-dir.test.ts
+++ b/apps/daemon/tests/resolve-data-dir.test.ts
@@ -37,6 +37,15 @@ describe('resolveDataDir', () => {
     expect(resolveDataDir('', projectRoot)).toBe(path.join(projectRoot, '.od'));
   });
 
+  it('requires an explicit OD_DATA_DIR when sandbox mode requires one', () => {
+    expect(() =>
+      resolveDataDir(undefined, projectRoot, { requireExplicit: true }),
+    ).toThrow('OD_DATA_DIR is required when OD_SANDBOX_MODE is enabled');
+    expect(() => resolveDataDir('', projectRoot, { requireExplicit: true })).toThrow(
+      'OD_DATA_DIR is required when OD_SANDBOX_MODE is enabled',
+    );
+  });
+
   it('expands a leading ~/ against the user home directory', () => {
     const out = resolveDataDir('~/od-test', projectRoot);
     expect(out).toBe(path.join(fakeHome, 'od-test'));

--- a/apps/daemon/tests/resolve-data-dir.test.ts
+++ b/apps/daemon/tests/resolve-data-dir.test.ts
@@ -44,6 +44,14 @@ describe('resolveDataDir', () => {
     expect(() => resolveDataDir('', projectRoot, { requireExplicit: true })).toThrow(
       'OD_DATA_DIR is required when OD_SANDBOX_MODE is enabled',
     );
+    expect(() =>
+      resolveDataDir('   ', projectRoot, { requireExplicit: true }),
+    ).toThrow('OD_DATA_DIR is required when OD_SANDBOX_MODE is enabled');
+  });
+
+  it('trims OD_DATA_DIR before resolving the storage root', () => {
+    const out = resolveDataDir('  rel-od  ', projectRoot, { requireExplicit: true });
+    expect(out).toBe(path.join(projectRoot, 'rel-od'));
   });
 
   it('expands a leading ~/ against the user home directory', () => {

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -55,6 +55,62 @@ test('spawnEnvForAgent applies configured Codex env without mutating the base en
   assert.equal('CODEX_BIN' in base, false);
 });
 
+test('spawnEnvForAgent reapplies sandbox state roots after configured env overrides', () => {
+  const dataDir = mkdtempSync(join(tmpdir(), 'od-agent-env-sandbox-'));
+  try {
+    const codexEnv = spawnEnvForAgent(
+      'codex',
+      {
+        OD_DATA_DIR: dataDir,
+        OD_SANDBOX_MODE: '1',
+        PATH: '/usr/bin',
+      },
+      {
+        CODEX_HOME: '/Users/test/.codex-host',
+      },
+    );
+    assert.equal(
+      codexEnv.CODEX_HOME,
+      join(dataDir, 'sandbox', 'agent-home', '.codex'),
+    );
+    assert.equal(codexEnv.HOME, join(dataDir, 'sandbox', 'agent-home'));
+
+    const claudeEnv = spawnEnvForAgent(
+      'claude',
+      {
+        OD_DATA_DIR: dataDir,
+        OD_SANDBOX_MODE: '1',
+        PATH: '/usr/bin',
+      },
+      {
+        CLAUDE_CONFIG_DIR: '/Users/test/.claude-host',
+      },
+    );
+    assert.equal(
+      claudeEnv.CLAUDE_CONFIG_DIR,
+      join(dataDir, 'sandbox', 'config', 'claude'),
+    );
+
+    const amrEnv = spawnEnvForAgent(
+      'amr',
+      {
+        OD_DATA_DIR: dataDir,
+        OD_SANDBOX_MODE: '1',
+        PATH: '/usr/bin',
+      },
+      {
+        OPENCODE_TEST_HOME: '/Users/test/.opencode-host',
+      },
+    );
+    assert.equal(
+      amrEnv.OPENCODE_TEST_HOME,
+      join(dataDir, 'sandbox', 'agent-home', '.opencode'),
+    );
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
 test('spawnEnvForAgent applies system proxy env to all agent runtimes before base env overrides', () => {
   const env = spawnEnvForAgent(
     'gemini',

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -111,6 +111,30 @@ test('spawnEnvForAgent reapplies sandbox state roots after configured env overri
   }
 });
 
+test('spawnEnvForAgent keeps sandbox roots pinned to the base OD_DATA_DIR', () => {
+  const dataDir = mkdtempSync(join(tmpdir(), 'od-agent-env-sandbox-base-'));
+  try {
+    const env = spawnEnvForAgent(
+      'codex',
+      {
+        OD_DATA_DIR: dataDir,
+        OD_SANDBOX_MODE: '1',
+        PATH: '/usr/bin',
+      },
+      {
+        CODEX_HOME: '/Users/test/.codex-host',
+        OD_DATA_DIR: '/host/path/.od',
+      },
+    );
+
+    assert.equal(env.OD_DATA_DIR, dataDir);
+    assert.equal(env.CODEX_HOME, join(dataDir, 'sandbox', 'agent-home', '.codex'));
+    assert.equal(env.HOME, join(dataDir, 'sandbox', 'agent-home'));
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
 test('spawnEnvForAgent applies system proxy env to all agent runtimes before base env overrides', () => {
   const env = spawnEnvForAgent(
     'gemini',

--- a/apps/daemon/tests/runtimes/executables.test.ts
+++ b/apps/daemon/tests/runtimes/executables.test.ts
@@ -408,6 +408,41 @@ fsTest(
 );
 
 fsTest(
+  'OD_SANDBOX_MODE derives agent-home isolation from OD_DATA_DIR during detection',
+  () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'od-agents-sandbox-data-'));
+    const realPrefix = mkdtempSync(join(tmpdir(), 'od-agents-real-prefix-'));
+    const realPrefixBin = join(realPrefix, 'bin');
+    try {
+      return withEnvSnapshot(
+        ['OD_SANDBOX_MODE', 'OD_DATA_DIR', 'OD_AGENT_HOME', 'PATH', 'NPM_CONFIG_PREFIX'],
+        () => {
+          mkdirSync(realPrefixBin, { recursive: true });
+          writeFileSync(join(realPrefixBin, 'gemini'), '');
+          chmodSync(join(realPrefixBin, 'gemini'), 0o755);
+
+          process.env.OD_SANDBOX_MODE = '1';
+          process.env.OD_DATA_DIR = dataDir;
+          delete process.env.OD_AGENT_HOME;
+          process.env.PATH = '/usr/bin:/bin';
+          process.env.NPM_CONFIG_PREFIX = realPrefix;
+
+          const resolved = resolveAgentExecutable(minimalAgentDef({ bin: 'gemini' }));
+          assert.equal(
+            resolved,
+            null,
+            `sandbox mode must not see the real $NPM_CONFIG_PREFIX bin; got ${resolved}`,
+          );
+        },
+      );
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+      rmSync(realPrefix, { recursive: true, force: true });
+    }
+  },
+);
+
+fsTest(
   'OD_AGENT_HOME isolates resolution from $VP_HOME leakage',
   () => {
     const sandbox = mkdtempSync(join(tmpdir(), 'od-agents-vp-sandbox-'));

--- a/apps/daemon/tests/sandbox-mode.test.ts
+++ b/apps/daemon/tests/sandbox-mode.test.ts
@@ -77,6 +77,8 @@ describe('sandbox runtime roots', () => {
       {
         HOME: '/real/home',
         CODEX_HOME: '/real/home/.codex',
+        CLAUDE_CONFIG_DIR: '/real/home/.claude',
+        OPENCODE_TEST_HOME: '/real/home/.opencode',
         NPM_CONFIG_USERCONFIG: '/real/home/.npmrc',
         OD_DATA_DIR: dataDir,
         PATH: '/bin',
@@ -88,6 +90,8 @@ describe('sandbox runtime roots', () => {
     expect(env.USERPROFILE).toBe(config.roots.agentHomeDir);
     expect(env.OD_AGENT_HOME).toBe(config.roots.agentHomeDir);
     expect(env.CODEX_HOME).toBe(path.join(config.roots.agentHomeDir, '.codex'));
+    expect(env.CLAUDE_CONFIG_DIR).toBe(path.join(config.roots.configDir, 'claude'));
+    expect(env.OPENCODE_TEST_HOME).toBe(path.join(config.roots.agentHomeDir, '.opencode'));
     expect(env.NPM_CONFIG_USERCONFIG).toBe(path.join(config.roots.toolConfigDir, 'npmrc'));
     expect(env.PATH).toBe('/bin');
   });

--- a/apps/daemon/tests/sandbox-mode.test.ts
+++ b/apps/daemon/tests/sandbox-mode.test.ts
@@ -1,0 +1,94 @@
+import os from 'node:os';
+import path from 'node:path';
+import { existsSync, mkdtempSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  applySandboxRuntimeEnv,
+  ensureSandboxRuntimeDirs,
+  isSandboxModeEnabled,
+  resolveSandboxRuntimeConfig,
+} from '../src/sandbox-mode.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+function tempDataDir(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'od-sandbox-mode-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe('sandbox mode env parsing', () => {
+  it('is disabled when OD_SANDBOX_MODE is unset or false-like', () => {
+    expect(isSandboxModeEnabled({})).toBe(false);
+    expect(isSandboxModeEnabled({ OD_SANDBOX_MODE: '0' })).toBe(false);
+    expect(isSandboxModeEnabled({ OD_SANDBOX_MODE: 'false' })).toBe(false);
+  });
+
+  it('is enabled for explicit true-like values', () => {
+    expect(isSandboxModeEnabled({ OD_SANDBOX_MODE: '1' })).toBe(true);
+    expect(isSandboxModeEnabled({ OD_SANDBOX_MODE: 'true' })).toBe(true);
+    expect(isSandboxModeEnabled({ OD_SANDBOX_MODE: 'YES' })).toBe(true);
+  });
+
+  it('rejects ambiguous non-empty values', () => {
+    expect(() => isSandboxModeEnabled({ OD_SANDBOX_MODE: 'sandbox' })).toThrow(
+      'OD_SANDBOX_MODE must be one of',
+    );
+  });
+});
+
+describe('sandbox runtime roots', () => {
+  it('keeps all run-scoped roots under OD_DATA_DIR', () => {
+    const dataDir = tempDataDir();
+    const config = resolveSandboxRuntimeConfig(true, dataDir);
+
+    expect(config.enabled).toBe(true);
+    for (const dir of Object.values(config.roots)) {
+      expect(dir === dataDir || dir.startsWith(dataDir + path.sep)).toBe(true);
+    }
+  });
+
+  it('creates scoped runtime directories only when enabled', () => {
+    const dataDir = tempDataDir();
+    const enabled = resolveSandboxRuntimeConfig(true, dataDir);
+    const disabled = resolveSandboxRuntimeConfig(false, dataDir);
+
+    ensureSandboxRuntimeDirs(disabled);
+    expect(existsSync(enabled.roots.agentHomeDir)).toBe(false);
+
+    ensureSandboxRuntimeDirs(enabled);
+    expect(existsSync(enabled.roots.agentHomeDir)).toBe(true);
+    expect(existsSync(enabled.roots.previewStateDir)).toBe(true);
+    expect(existsSync(enabled.roots.toolConfigDir)).toBe(true);
+  });
+
+  it('pins agent home and tool config env to sandbox roots', () => {
+    const dataDir = tempDataDir();
+    const config = resolveSandboxRuntimeConfig(true, dataDir);
+    const env = applySandboxRuntimeEnv(
+      {
+        HOME: '/real/home',
+        CODEX_HOME: '/real/home/.codex',
+        NPM_CONFIG_USERCONFIG: '/real/home/.npmrc',
+        OD_DATA_DIR: dataDir,
+        PATH: '/bin',
+      },
+      config,
+    );
+
+    expect(env.HOME).toBe(config.roots.agentHomeDir);
+    expect(env.USERPROFILE).toBe(config.roots.agentHomeDir);
+    expect(env.OD_AGENT_HOME).toBe(config.roots.agentHomeDir);
+    expect(env.CODEX_HOME).toBe(path.join(config.roots.agentHomeDir, '.codex'));
+    expect(env.NPM_CONFIG_USERCONFIG).toBe(path.join(config.roots.toolConfigDir, 'npmrc'));
+    expect(env.PATH).toBe('/bin');
+  });
+});

--- a/apps/daemon/tests/sandbox-runtime-bootstrap.test.ts
+++ b/apps/daemon/tests/sandbox-runtime-bootstrap.test.ts
@@ -42,7 +42,8 @@ function withEnvSnapshot<T>(
 test('sandbox runtime registry ignores host-local agent profiles at module load', async () => {
   const root = mkdtempSync(path.join(tmpdir(), 'od-sandbox-registry-'));
   const dataDir = path.join(root, 'data');
-  const hostConfigDir = path.join(root, 'host-open-design');
+  const hostHome = path.join(root, 'host-home');
+  const hostConfigDir = path.join(hostHome, '.open-design');
   const hostConfig = path.join(hostConfigDir, 'agents.local.json');
   const sandboxConfigDir = path.join(
     dataDir,
@@ -79,9 +80,13 @@ test('sandbox runtime registry ignores host-local agent profiles at module load'
       async () => {
         process.env.OD_SANDBOX_MODE = '1';
         process.env.OD_DATA_DIR = dataDir;
-        process.env.OD_AGENT_PROFILES_CONFIG = hostConfig;
+        delete process.env.OD_AGENT_PROFILES_CONFIG;
 
         vi.resetModules();
+        vi.doMock('node:os', async () => ({
+          ...(await vi.importActual<typeof import('node:os')>('node:os')),
+          homedir: () => hostHome,
+        }));
         const { AGENT_DEFS } = await import('../src/runtimes/registry.js');
         const ids = AGENT_DEFS.map((def) => def.id);
 
@@ -90,6 +95,7 @@ test('sandbox runtime registry ignores host-local agent profiles at module load'
       },
     );
   } finally {
+    vi.doUnmock('node:os');
     vi.resetModules();
     rmSync(root, { recursive: true, force: true });
   }

--- a/apps/daemon/tests/sandbox-runtime-bootstrap.test.ts
+++ b/apps/daemon/tests/sandbox-runtime-bootstrap.test.ts
@@ -80,7 +80,7 @@ test('sandbox runtime registry ignores host-local agent profiles at module load'
       async () => {
         process.env.OD_SANDBOX_MODE = '1';
         process.env.OD_DATA_DIR = dataDir;
-        delete process.env.OD_AGENT_PROFILES_CONFIG;
+        process.env.OD_AGENT_PROFILES_CONFIG = hostConfig;
 
         vi.resetModules();
         vi.doMock('node:os', async () => ({
@@ -92,6 +92,46 @@ test('sandbox runtime registry ignores host-local agent profiles at module load'
 
         assert.equal(ids.includes('host-wrapper'), false);
         assert.equal(ids.includes('sandbox-wrapper'), true);
+      },
+    );
+  } finally {
+    vi.doUnmock('node:os');
+    vi.resetModules();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('sandbox runtime registry ignores implicit profiles without OD_DATA_DIR', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'od-sandbox-registry-missing-data-'));
+  const hostHome = path.join(root, 'host-home');
+  const hostConfigDir = path.join(hostHome, '.open-design');
+  const hostConfig = path.join(hostConfigDir, 'agents.local.json');
+
+  try {
+    mkdirSync(hostConfigDir, { recursive: true });
+    writeFileSync(
+      hostConfig,
+      JSON.stringify({
+        agents: [{ id: 'host-wrapper', baseAgent: 'claude', bin: 'host-wrapper' }],
+      }),
+    );
+
+    await withEnvSnapshot(
+      ['OD_SANDBOX_MODE', 'OD_DATA_DIR', 'OD_AGENT_PROFILES_CONFIG'],
+      async () => {
+        process.env.OD_SANDBOX_MODE = '1';
+        delete process.env.OD_DATA_DIR;
+        delete process.env.OD_AGENT_PROFILES_CONFIG;
+
+        vi.resetModules();
+        vi.doMock('node:os', async () => ({
+          ...(await vi.importActual<typeof import('node:os')>('node:os')),
+          homedir: () => hostHome,
+        }));
+        const { AGENT_DEFS } = await import('../src/runtimes/registry.js');
+        const ids = AGENT_DEFS.map((def) => def.id);
+
+        assert.equal(ids.includes('host-wrapper'), false);
       },
     );
   } finally {

--- a/apps/daemon/tests/sandbox-runtime-bootstrap.test.ts
+++ b/apps/daemon/tests/sandbox-runtime-bootstrap.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test, vi } from 'vitest';
+
+function withEnvSnapshot<T>(
+  keys: readonly string[],
+  run: () => T | Promise<T>,
+): T | Promise<T> {
+  const snapshot = new Map(keys.map((key) => [key, process.env[key]]));
+  const restore = () => {
+    for (const key of keys) {
+      const value = snapshot.get(key);
+      if (value == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+
+  let result: T | Promise<T>;
+  try {
+    result = run();
+  } catch (error) {
+    restore();
+    throw error;
+  }
+  if (result instanceof Promise) {
+    return result.finally(restore);
+  }
+  restore();
+  return result;
+}
+
+test('sandbox runtime registry ignores host-local agent profiles at module load', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'od-sandbox-registry-'));
+  const dataDir = path.join(root, 'data');
+  const hostConfigDir = path.join(root, 'host-open-design');
+  const hostConfig = path.join(hostConfigDir, 'agents.local.json');
+  const sandboxConfigDir = path.join(
+    dataDir,
+    'sandbox',
+    'agent-home',
+    '.open-design',
+  );
+  const sandboxConfig = path.join(sandboxConfigDir, 'agents.local.json');
+
+  try {
+    mkdirSync(hostConfigDir, { recursive: true });
+    mkdirSync(sandboxConfigDir, { recursive: true });
+    writeFileSync(
+      hostConfig,
+      JSON.stringify({
+        agents: [{ id: 'host-wrapper', baseAgent: 'claude', bin: 'host-wrapper' }],
+      }),
+    );
+    writeFileSync(
+      sandboxConfig,
+      JSON.stringify({
+        agents: [
+          {
+            id: 'sandbox-wrapper',
+            baseAgent: 'claude',
+            bin: 'sandbox-wrapper',
+          },
+        ],
+      }),
+    );
+
+    await withEnvSnapshot(
+      ['OD_SANDBOX_MODE', 'OD_DATA_DIR', 'OD_AGENT_PROFILES_CONFIG'],
+      async () => {
+        process.env.OD_SANDBOX_MODE = '1';
+        process.env.OD_DATA_DIR = dataDir;
+        process.env.OD_AGENT_PROFILES_CONFIG = hostConfig;
+
+        vi.resetModules();
+        const { AGENT_DEFS } = await import('../src/runtimes/registry.js');
+        const ids = AGENT_DEFS.map((def) => def.id);
+
+        assert.equal(ids.includes('host-wrapper'), false);
+        assert.equal(ids.includes('sandbox-wrapper'), true);
+      },
+    );
+  } finally {
+    vi.resetModules();
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Why

This splits out the first OD sandbox-runtime foundation change for disposable production creative runs. The immediate use case is letting OD start as a scoped, throwaway daemon where runtime state is rooted under `OD_DATA_DIR` and headless launchers have a stable readiness probe.

The pain being addressed is that OD historically assumed a durable local app install: implicit state roots and UI-oriented health checks make it hard for orchestrator-style callers to treat one creative run as disposable.

## What users will see

Opt-in sandbox launches can require and report a scoped data root, and callers can check `/api/ready` for a headless readiness snapshot. Normal local OD launches keep their existing behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/sandbox-mode.test.ts tests/resolve-data-dir.test.ts tests/daemon-lifecycle.test.ts tests/api-token-guard.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
