### PR TITLE
fix(daemon): confine sandbox project roots and host discovery

### DIFF
--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -6,6 +6,7 @@ import {
   inlineRelativeAssets,
   type InlineAssetReader,
 } from './inline-assets.js';
+import { isSandboxModeEnabled } from './sandbox-mode.js';
 
 export interface RegisterImportRoutesDeps extends RouteDeps<'db' | 'http' | 'uploads' | 'node' | 'ids' | 'paths' | 'imports' | 'auth' | 'projectStore' | 'conversations' | 'projectFiles' | 'validation'> {}
 
@@ -28,6 +29,11 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
   const { insertConversation } = ctx.conversations;
   const { setTabs } = ctx.projectFiles;
   const { validateProjectDesignSystemId } = ctx.validation;
+  const rejectSandboxFolderImport = () =>
+    isSandboxModeEnabled(process.env)
+      ? 'folder imports are disabled when OD_SANDBOX_MODE is enabled'
+      : null;
+
   app.post(
     '/api/import/claude-design',
     importUpload.single('file'),
@@ -106,6 +112,10 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
       const { baseDir } = req.body || {};
       if (typeof baseDir !== 'string' || !baseDir.trim()) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'baseDir required');
+      }
+      const sandboxReason = rejectSandboxFolderImport();
+      if (sandboxReason) {
+        return sendApiError(res, 400, 'BAD_REQUEST', sandboxReason);
       }
       let trustedPickerImport = false;
       if (isDesktopAuthGateActive()) {
@@ -203,6 +213,10 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
       const { baseDir, name, skillId, designSystemId } = req.body || {};
       if (typeof baseDir !== 'string' || !baseDir.trim()) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'baseDir required');
+      }
+      const sandboxReason = rejectSandboxFolderImport();
+      if (sandboxReason) {
+        return sendApiError(res, 400, 'BAD_REQUEST', sandboxReason);
       }
       let trustedPickerImport = false;
       if (isDesktopAuthGateActive()) {

--- a/apps/daemon/src/media-config.ts
+++ b/apps/daemon/src/media-config.ts
@@ -41,6 +41,7 @@ import path from 'node:path';
 import { MEDIA_PROVIDERS } from './media-models.js';
 import { expandHomePrefix } from './home-expansion.js';
 import { resolveXAIBearer } from './xai-credentials.js';
+import { isSandboxModeEnabled } from './sandbox-mode.js';
 
 const PROVIDER_IDS = MEDIA_PROVIDERS.map((p) => p.id);
 type ProviderEntry = { apiKey?: string; baseUrl?: string; model?: string };
@@ -291,6 +292,7 @@ function apiKeyFromCodexAuth(data: unknown): string {
 }
 
 async function resolveOpenAIAuthFileCredential(): Promise<OAuthCredential | null> {
+  if (isSandboxModeEnabled(process.env)) return null;
   const home = os.homedir();
   const codexAuth = await readJsonIfPresent(
     path.join(home, '.codex', 'auth.json'),
@@ -317,6 +319,8 @@ async function resolveXAIOAuthCredential(
       source: `oauth-xai-${odBearer.source}`,
     };
   }
+
+  if (isSandboxModeEnabled(process.env)) return null;
 
   // 2. Borrow the xAI OAuth token Hermes wrote to ~/.hermes/auth.json
   //    when the user ran `hermes auth add xai-oauth`. A user who has already authorized

--- a/apps/daemon/src/project-root.ts
+++ b/apps/daemon/src/project-root.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+
+export function resolveProjectRoot(moduleDir: string): string {
+  const base = path.basename(moduleDir);
+  const daemonDir =
+    base === 'dist' || base === 'src' ? path.dirname(moduleDir) : moduleDir;
+  return path.resolve(daemonDir, '../..');
+}
+
+export function resolveProjectRootFromNestedModule(moduleDir: string): string {
+  let current = path.resolve(moduleDir);
+  while (true) {
+    const base = path.basename(current);
+    if (base === 'dist' || base === 'src') {
+      return resolveProjectRoot(current);
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return resolveProjectRoot(moduleDir);
+    }
+    current = parent;
+  }
+}

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -419,7 +419,9 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
     const project = getProject(db, req.params.id);
     if (!project)
       return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'not found');
-    const resolvedDir = resolveProjectDir(PROJECTS_DIR, project.id, project.metadata);
+    const resolvedDir = resolveProjectDir(PROJECTS_DIR, project.id, project.metadata, {
+      allowUnavailableSandboxImportedProject: true,
+    });
     /** @type {import('@open-design/contracts').ProjectResponse} */
     const body = { project, resolvedDir };
     res.json(body);

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -1,4 +1,5 @@
 import type { Express } from 'express';
+import path from 'node:path';
 import {
   defaultScenarioPluginIdForProjectMetadata,
   type PluginManifest,
@@ -20,6 +21,25 @@ import { listSkills } from './skills.js';
 import { auditDesignSystemPackage } from './tools-connectors-cli.js';
 
 export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids' | 'telemetry' | 'validation'> {}
+
+function projectDetailResolvedDir(
+  projectsRoot: string,
+  project: any,
+  resolveProjectDir: (
+    projectsRoot: string,
+    projectId: string,
+    metadata?: unknown,
+    opts?: { allowUnavailableSandboxImportedProject?: boolean },
+  ) => string,
+): string {
+  const baseDir = typeof project?.metadata?.baseDir === 'string'
+    ? path.normalize(project.metadata.baseDir)
+    : null;
+  if (baseDir && path.isAbsolute(baseDir)) return baseDir;
+  return resolveProjectDir(projectsRoot, project.id, project.metadata, {
+    allowUnavailableSandboxImportedProject: true,
+  });
+}
 
 const URL_PREVIEW_SCROLL_BRIDGE = `<script data-od-url-scroll-bridge>
 (function(){
@@ -419,9 +439,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
     const project = getProject(db, req.params.id);
     if (!project)
       return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'not found');
-    const resolvedDir = resolveProjectDir(PROJECTS_DIR, project.id, project.metadata, {
-      allowUnavailableSandboxImportedProject: true,
-    });
+    const resolvedDir = projectDetailResolvedDir(PROJECTS_DIR, project, resolveProjectDir);
     /** @type {import('@open-design/contracts').ProjectResponse} */
     const body = { project, resolvedDir };
     res.json(body);

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -71,7 +71,10 @@ function usesExternalProjectRoot(metadata?) {
 // Returns the folder a project's files live in. For git-linked projects
 // (metadata.baseDir set), this is the user's own folder. Otherwise falls
 // back to the standard computed path under projectsRoot.
-export function resolveProjectDir(projectsRoot, projectId, metadata?) {
+export function resolveProjectDir(projectsRoot, projectId, metadata?, opts = {}) {
+  if (!opts.allowUnavailableSandboxImportedProject) {
+    assertSandboxProjectRootAvailable(metadata);
+  }
   if (usesExternalProjectRoot(metadata)) {
     return path.normalize(metadata.baseDir);
   }

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -26,6 +26,7 @@ import {
   isPublicationGuardedArtifactKind,
 } from './artifact-publication-guard.js';
 import { isIgnoredProjectDirName } from './project-ignored-dirs.js';
+import { isSandboxModeEnabled } from './sandbox-mode.js';
 
 const FORBIDDEN_SEGMENT = /^$|^\.\.?$/;
 const RESERVED_PROJECT_FILE_SEGMENTS = new Set(['.live-artifacts']);
@@ -40,13 +41,18 @@ export function projectDir(projectsRoot, projectId) {
   return path.join(projectsRoot, projectId);
 }
 
+function usesExternalProjectRoot(metadata?) {
+  if (isSandboxModeEnabled(process.env)) return false;
+  if (typeof metadata?.baseDir !== 'string') return false;
+  return path.isAbsolute(path.normalize(metadata.baseDir));
+}
+
 // Returns the folder a project's files live in. For git-linked projects
 // (metadata.baseDir set), this is the user's own folder. Otherwise falls
 // back to the standard computed path under projectsRoot.
 export function resolveProjectDir(projectsRoot, projectId, metadata?) {
-  if (typeof metadata?.baseDir === 'string') {
-    const p = path.normalize(metadata.baseDir);
-    if (path.isAbsolute(p)) return p;
+  if (usesExternalProjectRoot(metadata)) {
+    return path.normalize(metadata.baseDir);
   }
   if (!isSafeId(projectId)) throw new Error('invalid project id');
   return path.join(projectsRoot, projectId);
@@ -55,7 +61,7 @@ export function resolveProjectDir(projectsRoot, projectId, metadata?) {
 export async function ensureProject(projectsRoot, projectId, metadata?) {
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   // Git-linked folders already exist; skip mkdir to avoid side-effects.
-  if (typeof metadata?.baseDir !== 'string') {
+  if (!usesExternalProjectRoot(metadata)) {
     await mkdir(dir, { recursive: true });
   }
   return dir;
@@ -67,7 +73,7 @@ export async function listFiles(projectsRoot, projectId, opts = {}) {
   const out = [];
   // Skip build/install dirs for linked folders so node_modules doesn't stall
   // the walk on large repos.
-  const skipDirs = metadata?.baseDir ? isIgnoredProjectDirName : undefined;
+  const skipDirs = usesExternalProjectRoot(metadata) ? isIgnoredProjectDirName : undefined;
   await collectFiles(dir, '', out, skipDirs, dir);
   // Newest first — matches the visual order users expect after generating.
   out.sort((a, b) => b.mtime - a.mtime);

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -41,16 +41,38 @@ export function projectDir(projectsRoot, projectId) {
   return path.join(projectsRoot, projectId);
 }
 
-function usesExternalProjectRoot(metadata?) {
-  if (isSandboxModeEnabled(process.env)) return false;
+export class SandboxImportedProjectError extends Error {
+  code = 'SANDBOX_IMPORTED_PROJECT_UNAVAILABLE';
+
+  constructor() {
+    super(
+      'Imported-folder projects are not available in OD_SANDBOX_MODE until their files are mirrored into the managed project directory.',
+    );
+    this.name = 'SandboxImportedProjectError';
+  }
+}
+
+function hasExternalProjectRoot(metadata?) {
   if (typeof metadata?.baseDir !== 'string') return false;
   return path.isAbsolute(path.normalize(metadata.baseDir));
+}
+
+function assertSandboxProjectRootAvailable(metadata?) {
+  if (isSandboxModeEnabled(process.env) && hasExternalProjectRoot(metadata)) {
+    throw new SandboxImportedProjectError();
+  }
+}
+
+function usesExternalProjectRoot(metadata?) {
+  if (isSandboxModeEnabled(process.env)) return false;
+  return hasExternalProjectRoot(metadata);
 }
 
 // Returns the folder a project's files live in. For git-linked projects
 // (metadata.baseDir set), this is the user's own folder. Otherwise falls
 // back to the standard computed path under projectsRoot.
 export function resolveProjectDir(projectsRoot, projectId, metadata?) {
+  assertSandboxProjectRootAvailable(metadata);
   if (usesExternalProjectRoot(metadata)) {
     return path.normalize(metadata.baseDir);
   }

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -57,7 +57,7 @@ function hasExternalProjectRoot(metadata?) {
   return path.isAbsolute(path.normalize(metadata.baseDir));
 }
 
-function assertSandboxProjectRootAvailable(metadata?) {
+export function assertSandboxProjectRootAvailable(metadata?) {
   if (isSandboxModeEnabled(process.env) && hasExternalProjectRoot(metadata)) {
     throw new SandboxImportedProjectError();
   }
@@ -72,7 +72,6 @@ function usesExternalProjectRoot(metadata?) {
 // (metadata.baseDir set), this is the user's own folder. Otherwise falls
 // back to the standard computed path under projectsRoot.
 export function resolveProjectDir(projectsRoot, projectId, metadata?) {
-  assertSandboxProjectRootAvailable(metadata);
   if (usesExternalProjectRoot(metadata)) {
     return path.normalize(metadata.baseDir);
   }

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -1,9 +1,12 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { mergeProxyAwareEnv, resolveSystemProxyEnv } from '@open-design/platform';
+import { resolveProjectRelativePath } from '../home-expansion.js';
 import { expandConfiguredEnv } from './paths.js';
 import { resolveAmrOpenCodeExecutable } from './executables.js';
 import { amrVelaProfileEnv } from '../integrations/vela-profile.js';
+import { resolveProjectRootFromNestedModule } from '../project-root.js';
 import {
   applySandboxRuntimeEnv,
   isSandboxModeEnabled,
@@ -12,6 +15,10 @@ import {
 } from '../sandbox-mode.js';
 
 type RuntimeEnvMap = NodeJS.ProcessEnv | Record<string, string>;
+
+const RUNTIME_MODULE_PROJECT_ROOT = resolveProjectRootFromNestedModule(
+  path.dirname(fileURLToPath(import.meta.url)),
+);
 
 // Build the env passed to spawn() for a given agent adapter.
 //
@@ -87,7 +94,11 @@ function sandboxRuntimeConfigForBaseEnv(
   if (!isSandboxModeEnabled(baseEnv)) return null;
   const dataDir = baseEnv.OD_DATA_DIR?.trim();
   if (!dataDir) return null;
-  return resolveSandboxRuntimeConfig(true, dataDir);
+  const resolvedDataDir = resolveProjectRelativePath(
+    dataDir,
+    RUNTIME_MODULE_PROJECT_ROOT,
+  );
+  return resolveSandboxRuntimeConfig(true, resolvedDataDir);
 }
 
 function reapplySandboxRuntimeEnv(

--- a/apps/daemon/src/runtimes/local-profiles.ts
+++ b/apps/daemon/src/runtimes/local-profiles.ts
@@ -192,11 +192,11 @@ function createLocalAgentDef(
 export function readLocalAgentProfileDefs(
   baseDefs: RuntimeAgentDef[],
 ): RuntimeAgentDef[] {
+  const profilesFile = localAgentProfilesFile();
+  if (profilesFile == null) return [];
   let parsed: unknown;
   try {
-    const file = localAgentProfilesFile();
-    if (!file) return [];
-    parsed = JSON.parse(readFileSync(file, 'utf8'));
+    parsed = JSON.parse(readFileSync(profilesFile, 'utf8'));
   } catch {
     return [];
   }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -355,6 +355,7 @@ import {
   renameProjectFile,
   removeProjectDir,
   resolveProjectDir,
+  SandboxImportedProjectError,
   sanitizeName,
   searchProjectFiles,
   resolveProjectDir,
@@ -10773,14 +10774,12 @@ export async function startServer({
       try {
         const chatProject = getProject(db, projectId);
         const chatMeta = chatProject?.metadata;
-        if (chatMeta?.baseDir) {
-          cwd = path.normalize(chatMeta.baseDir);
-          existingProjectFiles = await listFiles(PROJECTS_DIR, projectId, { metadata: chatMeta });
-        } else {
-          cwd = await ensureProject(PROJECTS_DIR, projectId);
-          existingProjectFiles = await listFiles(PROJECTS_DIR, projectId);
+        cwd = await ensureProject(PROJECTS_DIR, projectId, chatMeta);
+        existingProjectFiles = await listFiles(PROJECTS_DIR, projectId, { metadata: chatMeta });
+      } catch (err) {
+        if (err instanceof SandboxImportedProjectError) {
+          return design.runs.fail(run, 'BAD_REQUEST', err.message);
         }
-      } catch {
         cwd = null;
       }
     }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -261,6 +261,7 @@ import {
   type ObservabilityEventRequest,
 } from '@open-design/contracts/analytics';
 import {
+  mergeNoProxyWithLoopbackDefaults,
   redactSecrets,
   testAgentConnection,
   testProviderConnection,
@@ -1650,6 +1651,11 @@ export function createAgentRuntimeEnv(
   const sidecarIpcPath = baseEnv[SIDECAR_ENV.IPC_PATH];
   if (typeof sidecarIpcPath === 'string' && sidecarIpcPath.length > 0) {
     env[SIDECAR_ENV.IPC_PATH] = sidecarIpcPath;
+  }
+  const noProxy = mergeNoProxyWithLoopbackDefaults(env.NO_PROXY ?? env.no_proxy);
+  if (noProxy) {
+    env.NO_PROXY = noProxy;
+    if (process.platform !== 'win32') env.no_proxy = noProxy;
   }
 
   // Ensure the node binary directory is on PATH so agent sub-processes —

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -25,7 +25,10 @@ import {
   shouldRenderCodexImagegenOverride,
 } from './prompts/system.js';
 import { expandHomePrefix, resolveProjectRelativePath } from './home-expansion.js';
+import { resolveProjectRoot } from './project-root.js';
 import { userFacingAgentLabel } from './user-facing-agent-label.js';
+
+export { resolveProjectRoot };
 import { createCommandInvocation } from '@open-design/platform';
 import { SIDECAR_DEFAULTS, SIDECAR_ENV } from '@open-design/sidecar-proto';
 import {
@@ -482,13 +485,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const require = createRequire(import.meta.url);
 const DAEMON_CLI_PATH_ENV = 'OD_DAEMON_CLI_PATH';
-export function resolveProjectRoot(moduleDir: string): string {
-  const base = path.basename(moduleDir);
-  const daemonDir =
-    base === 'dist' || base === 'src' ? path.dirname(moduleDir) : moduleDir;
-  return path.resolve(daemonDir, '../..');
-}
-
 function cleanOptionalPath(value: string | undefined): string | null {
   return typeof value === 'string' && value.trim().length > 0
     ? path.resolve(value)

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -344,6 +344,7 @@ import {
   buildBatchArchive,
   decodeMultipartFilename,
   deleteProjectFile,
+  assertSandboxProjectRootAvailable,
   detectEntryFile,
   ensureProject,
   isSafeId,
@@ -10774,6 +10775,7 @@ export async function startServer({
       try {
         const chatProject = getProject(db, projectId);
         const chatMeta = chatProject?.metadata;
+        assertSandboxProjectRootAvailable(chatMeta);
         cwd = await ensureProject(PROJECTS_DIR, projectId, chatMeta);
         existingProjectFiles = await listFiles(PROJECTS_DIR, projectId, { metadata: chatMeta });
       } catch (err) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1652,10 +1652,12 @@ export function createAgentRuntimeEnv(
   if (typeof sidecarIpcPath === 'string' && sidecarIpcPath.length > 0) {
     env[SIDECAR_ENV.IPC_PATH] = sidecarIpcPath;
   }
-  const noProxy = mergeNoProxyWithLoopbackDefaults(env.NO_PROXY ?? env.no_proxy);
-  if (noProxy) {
-    env.NO_PROXY = noProxy;
-    if (process.platform !== 'win32') env.no_proxy = noProxy;
+  if (SANDBOX_RUNTIME.enabled) {
+    const noProxy = mergeNoProxyWithLoopbackDefaults(env.NO_PROXY ?? env.no_proxy);
+    if (noProxy) {
+      env.NO_PROXY = noProxy;
+      if (process.platform !== 'win32') env.no_proxy = noProxy;
+    }
   }
 
   // Ensure the node binary directory is on PATH so agent sub-processes —

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -87,7 +87,7 @@ describe('agent runtime tool environment', () => {
     expect(env.OD_DATA_DIR).toBe(process.env.OD_DATA_DIR);
   });
 
-  it('keeps loopback daemon tool requests off inherited HTTP proxies', () => {
+  it('keeps non-sandbox NO_PROXY behavior unchanged', () => {
     const env = createAgentRuntimeEnv(
       { PATH: '/bin', HTTP_PROXY: 'http://127.0.0.1:9', NO_PROXY: '' },
       'http://127.0.0.1:7456',
@@ -96,12 +96,8 @@ describe('agent runtime tool environment', () => {
     );
 
     expect(env.HTTP_PROXY).toBe('http://127.0.0.1:9');
-    expect(env.NO_PROXY?.split(',')).toEqual(
-      expect.arrayContaining(['localhost', '127.0.0.1', '[::1]']),
-    );
-    if (process.platform !== 'win32') {
-      expect(env.no_proxy).toBe(env.NO_PROXY);
-    }
+    expect(env.NO_PROXY).toBe('');
+    expect(env.no_proxy).toBeUndefined();
   });
 
   it('passes the daemon sidecar IPC path from the explicit base env into agent wrapper sessions', () => {

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -87,6 +87,23 @@ describe('agent runtime tool environment', () => {
     expect(env.OD_DATA_DIR).toBe(process.env.OD_DATA_DIR);
   });
 
+  it('keeps loopback daemon tool requests off inherited HTTP proxies', () => {
+    const env = createAgentRuntimeEnv(
+      { PATH: '/bin', HTTP_PROXY: 'http://127.0.0.1:9', NO_PROXY: '' },
+      'http://127.0.0.1:7456',
+      { token: 'fresh-token' },
+      '/opt/open-design/bin/node',
+    );
+
+    expect(env.HTTP_PROXY).toBe('http://127.0.0.1:9');
+    expect(env.NO_PROXY?.split(',')).toEqual(
+      expect.arrayContaining(['localhost', '127.0.0.1', '[::1]']),
+    );
+    if (process.platform !== 'win32') {
+      expect(env.no_proxy).toBe(env.NO_PROXY);
+    }
+  });
+
   it('passes the daemon sidecar IPC path from the explicit base env into agent wrapper sessions', () => {
     const env = createAgentRuntimeEnv(
       { PATH: '/bin', [SIDECAR_ENV.IPC_PATH]: '/tmp/open-design/ipc/daemon.sock' },

--- a/apps/daemon/tests/folder-import-projects.test.ts
+++ b/apps/daemon/tests/folder-import-projects.test.ts
@@ -6,6 +6,17 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { detectEntryFile, listFiles, resolveProjectDir } from '../src/projects.js';
 
+function withSandboxMode<T>(run: () => T): T {
+  const previous = process.env.OD_SANDBOX_MODE;
+  process.env.OD_SANDBOX_MODE = '1';
+  try {
+    return run();
+  } finally {
+    if (previous == null) delete process.env.OD_SANDBOX_MODE;
+    else process.env.OD_SANDBOX_MODE = previous;
+  }
+}
+
 describe('resolveProjectDir', () => {
   const projectsRoot = '/var/od/projects';
   const projectId = 'proj-abc';
@@ -49,6 +60,21 @@ describe('resolveProjectDir', () => {
         baseDir: '/Users/me/site',
       }),
     ).not.toThrow();
+  });
+
+  it('ignores metadata.baseDir when sandbox mode is enabled', () => {
+    withSandboxMode(() => {
+      const baseDir = '/Users/me/projects/site';
+      expect(
+        resolveProjectDir(projectsRoot, projectId, { kind: 'prototype', baseDir }),
+      ).toBe(path.join(projectsRoot, projectId));
+      expect(() =>
+        resolveProjectDir(projectsRoot, '../escape', {
+          kind: 'prototype',
+          baseDir,
+        }),
+      ).toThrowError();
+    });
   });
 });
 

--- a/apps/daemon/tests/folder-import-projects.test.ts
+++ b/apps/daemon/tests/folder-import-projects.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { detectEntryFile, listFiles, resolveProjectDir } from '../src/projects.js';
+import {
+  detectEntryFile,
+  listFiles,
+  resolveProjectDir,
+  SandboxImportedProjectError,
+} from '../src/projects.js';
 
 function withSandboxMode<T>(run: () => T): T {
   const previous = process.env.OD_SANDBOX_MODE;
@@ -62,18 +67,15 @@ describe('resolveProjectDir', () => {
     ).not.toThrow();
   });
 
-  it('ignores metadata.baseDir when sandbox mode is enabled', () => {
+  it('rejects metadata.baseDir when sandbox mode is enabled', () => {
     withSandboxMode(() => {
       const baseDir = '/Users/me/projects/site';
-      expect(
-        resolveProjectDir(projectsRoot, projectId, { kind: 'prototype', baseDir }),
-      ).toBe(path.join(projectsRoot, projectId));
       expect(() =>
-        resolveProjectDir(projectsRoot, '../escape', {
-          kind: 'prototype',
-          baseDir,
-        }),
-      ).toThrowError();
+        resolveProjectDir(projectsRoot, projectId, { kind: 'prototype', baseDir }),
+      ).toThrowError(SandboxImportedProjectError);
+      expect(() =>
+        resolveProjectDir(projectsRoot, '../escape', { kind: 'prototype', baseDir }),
+      ).toThrowError(SandboxImportedProjectError);
     });
   });
 });

--- a/apps/daemon/tests/folder-import-projects.test.ts
+++ b/apps/daemon/tests/folder-import-projects.test.ts
@@ -68,12 +68,12 @@ describe('resolveProjectDir', () => {
     ).not.toThrow();
   });
 
-  it('routes metadata.baseDir to the managed root but leaves a run-start guard in sandbox mode', () => {
+  it('rejects metadata.baseDir in sandbox mode before resolving a project file root', () => {
     withSandboxMode(() => {
       const baseDir = '/Users/me/projects/site';
       expect(
-        resolveProjectDir(projectsRoot, projectId, { kind: 'prototype', baseDir }),
-      ).toBe(path.join(projectsRoot, projectId));
+        () => resolveProjectDir(projectsRoot, projectId, { kind: 'prototype', baseDir }),
+      ).toThrowError(SandboxImportedProjectError);
       expect(() =>
         assertSandboxProjectRootAvailable({ kind: 'prototype', baseDir }),
       ).toThrowError(SandboxImportedProjectError);

--- a/apps/daemon/tests/folder-import-projects.test.ts
+++ b/apps/daemon/tests/folder-import-projects.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  assertSandboxProjectRootAvailable,
   detectEntryFile,
   listFiles,
   resolveProjectDir,
@@ -67,15 +68,19 @@ describe('resolveProjectDir', () => {
     ).not.toThrow();
   });
 
-  it('rejects metadata.baseDir when sandbox mode is enabled', () => {
+  it('routes metadata.baseDir to the managed root but leaves a run-start guard in sandbox mode', () => {
     withSandboxMode(() => {
       const baseDir = '/Users/me/projects/site';
-      expect(() =>
+      expect(
         resolveProjectDir(projectsRoot, projectId, { kind: 'prototype', baseDir }),
-      ).toThrowError(SandboxImportedProjectError);
+      ).toBe(path.join(projectsRoot, projectId));
       expect(() =>
-        resolveProjectDir(projectsRoot, '../escape', { kind: 'prototype', baseDir }),
+        assertSandboxProjectRootAvailable({ kind: 'prototype', baseDir }),
       ).toThrowError(SandboxImportedProjectError);
+      expect(() => resolveProjectDir(projectsRoot, '../escape', {
+        kind: 'prototype',
+        baseDir,
+      })).toThrowError();
     });
   });
 });

--- a/apps/daemon/tests/folder-import-route.test.ts
+++ b/apps/daemon/tests/folder-import-route.test.ts
@@ -132,6 +132,25 @@ describe('POST /api/import/folder', () => {
     });
   });
 
+  it('still opens an imported-folder project record in sandbox mode', async () => {
+    const folder = makeFolder();
+    await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+
+    const importResp = await importFolder({ baseDir: folder });
+    expect(importResp.status).toBe(200);
+    const { project } = (await importResp.json()) as { project: { id: string } };
+
+    await withSandboxMode(async () => {
+      const resp = await fetch(`${baseUrl}/api/projects/${project.id}`);
+      expect(resp.status).toBe(200);
+      const body = (await resp.json()) as {
+        project?: { id?: string; metadata?: { baseDir?: string } };
+      };
+      expect(body.project?.id).toBe(project.id);
+      expect(body.project?.metadata?.baseDir).toBeTruthy();
+    });
+  });
+
   it('auto-detects the entry file when present', async () => {
     const folder = makeFolder();
     await writeFile(path.join(folder, 'index.html'), '');

--- a/apps/daemon/tests/folder-import-route.test.ts
+++ b/apps/daemon/tests/folder-import-route.test.ts
@@ -56,6 +56,26 @@ describe('POST /api/import/folder', () => {
     }
   }
 
+  async function waitForRunStatus(
+    runId: string,
+  ): Promise<{ status: string; error?: string | null; errorCode?: string | null }> {
+    let lastStatus = 'unknown';
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      const statusResponse = await fetch(`${baseUrl}/api/runs/${runId}`);
+      const statusBody = (await statusResponse.json()) as {
+        status: string;
+        error?: string | null;
+        errorCode?: string | null;
+      };
+      lastStatus = statusBody.status;
+      if (statusBody.status !== 'queued' && statusBody.status !== 'running') {
+        return statusBody;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error(`run did not reach a terminal status; last status: ${lastStatus}`);
+  }
+
   it('creates a project rooted at the submitted folder', async () => {
     const folder = makeFolder();
     await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
@@ -82,6 +102,33 @@ describe('POST /api/import/folder', () => {
       expect(resp.status).toBe(400);
       const body = (await resp.json()) as { error?: { message?: string } };
       expect(body.error?.message).toMatch(/OD_SANDBOX_MODE/i);
+    });
+  });
+
+  it('fails sandbox runs for imported folders instead of using an empty managed project', async () => {
+    const folder = makeFolder();
+    await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+
+    const importResp = await importFolder({ baseDir: folder });
+    expect(importResp.status).toBe(200);
+    const { project } = (await importResp.json()) as { project: { id: string } };
+
+    await withSandboxMode(async () => {
+      const runResp = await fetch(`${baseUrl}/api/runs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          agentId: 'claude',
+          projectId: project.id,
+          message: 'Inspect the imported project.',
+        }),
+      });
+      expect(runResp.status).toBe(202);
+      const { runId } = (await runResp.json()) as { runId: string };
+      const status = await waitForRunStatus(runId);
+      expect(status.status).toBe('failed');
+      expect(status.errorCode).toBe('BAD_REQUEST');
+      expect(status.error).toMatch(/imported-folder projects.*OD_SANDBOX_MODE/i);
     });
   });
 

--- a/apps/daemon/tests/folder-import-route.test.ts
+++ b/apps/daemon/tests/folder-import-route.test.ts
@@ -151,6 +151,22 @@ describe('POST /api/import/folder', () => {
     });
   });
 
+  it('rejects imported-folder project file listing in sandbox mode', async () => {
+    const folder = makeFolder();
+    await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+
+    const importResp = await importFolder({ baseDir: folder });
+    expect(importResp.status).toBe(200);
+    const { project } = (await importResp.json()) as { project: { id: string } };
+
+    await withSandboxMode(async () => {
+      const resp = await fetch(`${baseUrl}/api/projects/${project.id}/files`);
+      expect(resp.status).toBe(400);
+      const body = (await resp.json()) as { error?: { message?: string } };
+      expect(body.error?.message).toMatch(/imported-folder projects.*OD_SANDBOX_MODE/i);
+    });
+  });
+
   it('auto-detects the entry file when present', async () => {
     const folder = makeFolder();
     await writeFile(path.join(folder, 'index.html'), '');

--- a/apps/daemon/tests/folder-import-route.test.ts
+++ b/apps/daemon/tests/folder-import-route.test.ts
@@ -45,6 +45,17 @@ describe('POST /api/import/folder', () => {
     });
   }
 
+  async function withSandboxMode<T>(run: () => Promise<T>): Promise<T> {
+    const previous = process.env.OD_SANDBOX_MODE;
+    process.env.OD_SANDBOX_MODE = '1';
+    try {
+      return await run();
+    } finally {
+      if (previous == null) delete process.env.OD_SANDBOX_MODE;
+      else process.env.OD_SANDBOX_MODE = previous;
+    }
+  }
+
   it('creates a project rooted at the submitted folder', async () => {
     const folder = makeFolder();
     await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
@@ -60,6 +71,18 @@ describe('POST /api/import/folder', () => {
     expect(body.project.metadata?.importedFrom).toBe('folder');
     expect(body.conversationId).toBeTruthy();
     expect(body.entryFile).toBe('index.html');
+  });
+
+  it('rejects folder imports in sandbox mode', async () => {
+    await withSandboxMode(async () => {
+      const folder = makeFolder();
+      await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+
+      const resp = await importFolder({ baseDir: folder });
+      expect(resp.status).toBe(400);
+      const body = (await resp.json()) as { error?: { message?: string } };
+      expect(body.error?.message).toMatch(/OD_SANDBOX_MODE/i);
+    });
   });
 
   it('auto-detects the entry file when present', async () => {

--- a/apps/daemon/tests/media-config.test.ts
+++ b/apps/daemon/tests/media-config.test.ts
@@ -30,6 +30,7 @@ describe('media-config OpenAI auth-file fallback', () => {
   );
   const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
   const originalDataDir = process.env.OD_DATA_DIR;
+  const originalSandboxMode = process.env.OD_SANDBOX_MODE;
   let homedirSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
@@ -42,6 +43,7 @@ describe('media-config OpenAI auth-file fallback', () => {
     }
     delete process.env.OD_MEDIA_CONFIG_DIR;
     delete process.env.OD_DATA_DIR;
+    delete process.env.OD_SANDBOX_MODE;
   });
 
   afterEach(async () => {
@@ -66,6 +68,11 @@ describe('media-config OpenAI auth-file fallback', () => {
       delete process.env.OD_DATA_DIR;
     } else {
       process.env.OD_DATA_DIR = originalDataDir;
+    }
+    if (originalSandboxMode == null) {
+      delete process.env.OD_SANDBOX_MODE;
+    } else {
+      process.env.OD_SANDBOX_MODE = originalSandboxMode;
     }
     homedirSpy.mockRestore();
     await rm(homeDir, { recursive: true, force: true });
@@ -121,6 +128,30 @@ describe('media-config OpenAI auth-file fallback', () => {
       configured: false,
       source: 'unset',
       apiKeyTail: '',
+    });
+  });
+
+  it('does not read host OpenAI auth files in sandbox mode', async () => {
+    process.env.OD_SANDBOX_MODE = '1';
+    await writeHomeJson('.hermes/auth.json', {
+      providers: {
+        'openai-codex': {
+          tokens: { access_token: 'hermes-oauth-token' },
+        },
+      },
+    });
+    await writeHomeJson('.codex/auth.json', {
+      tokens: { access_token: 'codex-oauth-token' },
+      OPENAI_API_KEY: 'host-codex-api-key',
+    });
+
+    const resolved = await resolveProviderConfig(projectRoot, 'openai');
+    const masked = await readMaskedConfig(projectRoot);
+
+    expect(resolved.apiKey).toBe('');
+    expect(openaiProvider(masked)).toMatchObject({
+      configured: false,
+      source: 'unset',
     });
   });
 

--- a/apps/daemon/tests/media-policy-routes.test.ts
+++ b/apps/daemon/tests/media-policy-routes.test.ts
@@ -1,11 +1,12 @@
 import type http from 'node:http';
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
+import { memoryDir, writeMemoryConfig } from '../src/memory.js';
 
 type FakeMediaEndpoint = 'tool' | 'legacy';
 
@@ -19,6 +20,7 @@ describe('run-scoped media policy routes', () => {
   let binDir: string;
   let oldPath: string | undefined;
   let oldCapture: string | undefined;
+  let oldMemoryConfigRaw: string | null = null;
   let server: http.Server | null = null;
   let shutdown: (() => Promise<void> | void) | undefined;
 
@@ -28,6 +30,12 @@ describe('run-scoped media policy routes', () => {
     oldPath = process.env.PATH;
     oldCapture = process.env.OD_CAPTURE_MEDIA_RESPONSE;
     process.env.PATH = `${binDir}${path.delimiter}${oldPath ?? ''}`;
+    const memoryConfig = memoryConfigPath();
+    oldMemoryConfigRaw = await readFile(memoryConfig, 'utf8').catch(() => null);
+    await writeMemoryConfig(process.env.OD_DATA_DIR!, {
+      chatExtractionEnabled: false,
+      extraction: null,
+    });
   });
 
   afterEach(async () => {
@@ -41,6 +49,14 @@ describe('run-scoped media policy routes', () => {
     else process.env.PATH = oldPath;
     if (oldCapture === undefined) delete process.env.OD_CAPTURE_MEDIA_RESPONSE;
     else process.env.OD_CAPTURE_MEDIA_RESPONSE = oldCapture;
+    const memoryConfig = memoryConfigPath();
+    if (oldMemoryConfigRaw === null) {
+      await rm(memoryConfig, { force: true });
+    } else {
+      await mkdir(path.dirname(memoryConfig), { recursive: true });
+      await writeFile(memoryConfig, oldMemoryConfigRaw);
+    }
+    oldMemoryConfigRaw = null;
     await rm(tempDir, { recursive: true, force: true });
     await rm(binDir, { recursive: true, force: true });
   });
@@ -466,6 +482,10 @@ describe('run-scoped media policy routes', () => {
       projectId,
       conversationId: projectBody.conversationId,
     };
+  }
+
+  function memoryConfigPath(): string {
+    return path.join(memoryDir(process.env.OD_DATA_DIR!), '.config.json');
   }
 
   async function writeFakeAgent(

--- a/apps/daemon/tests/projects-routes.test.ts
+++ b/apps/daemon/tests/projects-routes.test.ts
@@ -77,6 +77,35 @@ describe('GET /api/projects/:id resolvedDir', () => {
     expect(detail.resolvedDir).toBe(baseDir);
   });
 
+  it('keeps imported-folder resolvedDir stable in sandbox mode', async () => {
+    const folder = makeFolder();
+    await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+
+    const importResp = await fetch(`${baseUrl}/api/import/folder`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ baseDir: folder }),
+    });
+    expect(importResp.status).toBe(200);
+    const importBody = (await importResp.json()) as {
+      project: { id: string; metadata?: { baseDir?: string } };
+    };
+    const projectId = importBody.project.id;
+    const baseDir = importBody.project.metadata?.baseDir;
+    expect(baseDir).toBeTruthy();
+
+    await withSandboxMode(async () => {
+      const detailResp = await fetch(`${baseUrl}/api/projects/${projectId}`);
+      expect(detailResp.status).toBe(200);
+      const detail = (await detailResp.json()) as {
+        project: { id: string };
+        resolvedDir: string;
+      };
+      expect(detail.project.id).toBe(projectId);
+      expect(detail.resolvedDir).toBe(baseDir);
+    });
+  });
+
   it('returns resolvedDir under <projects root>/<id> for a native project', async () => {
     const projectId = `proj-routes-${Date.now()}`;
     const createResp = await fetch(`${baseUrl}/api/projects`, {
@@ -269,3 +298,14 @@ describe('GET /api/projects/:id resolvedDir', () => {
     expect(body.error?.message).toMatch(/fromTrustedPicker/i);
   });
 });
+
+async function withSandboxMode<T>(run: () => Promise<T>): Promise<T> {
+  const previous = process.env.OD_SANDBOX_MODE;
+  process.env.OD_SANDBOX_MODE = '1';
+  try {
+    return await run();
+  } finally {
+    if (previous == null) delete process.env.OD_SANDBOX_MODE;
+    else process.env.OD_SANDBOX_MODE = previous;
+  }
+}

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -1,6 +1,8 @@
 import { symlinkSync } from 'node:fs';
 import { test, vi } from 'vitest';
 import { homedir } from 'node:os';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import * as platform from '@open-design/platform';
 import {
   assert, chmodSync, detectAgents, inspectAgentExecutableResolution, join, minimalAgentDef, mkdirSync, mkdtempSync, opencode, resolveAgentExecutable, rmSync, spawnEnvForAgent, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
@@ -8,6 +10,7 @@ import {
 import { isCursorAuthFailureText } from '../../src/runtimes/auth.js';
 
 const fsTest = process.platform === 'win32' ? test.skip : test;
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
 
 // Issue #398: Claude Code prefers ANTHROPIC_API_KEY over `claude login`
 // credentials, silently billing API usage. Strip it for the claude
@@ -129,6 +132,33 @@ test('spawnEnvForAgent keeps sandbox roots pinned to the base OD_DATA_DIR', () =
 
     assert.equal(env.OD_DATA_DIR, dataDir);
     assert.equal(env.CODEX_HOME, join(dataDir, 'sandbox', 'agent-home', '.codex'));
+    assert.equal(env.HOME, join(dataDir, 'sandbox', 'agent-home'));
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+test('spawnEnvForAgent resolves relative OD_DATA_DIR before applying sandbox roots', () => {
+  const dataDir = mkdtempSync(join(tmpdir(), 'od-agent-env-sandbox-relative-'));
+  try {
+    const relativeDataDir = relative(repoRoot, dataDir);
+    const env = spawnEnvForAgent(
+      'codex',
+      {
+        OD_DATA_DIR: relativeDataDir,
+        OD_SANDBOX_MODE: '1',
+        PATH: '/usr/bin',
+      },
+      {
+        CODEX_HOME: '/Users/test/.codex-host',
+      },
+    );
+
+    assert.equal(
+      env.CODEX_HOME,
+      join(dataDir, 'sandbox', 'agent-home', '.codex'),
+    );
+    assert.equal(env.CLAUDE_CONFIG_DIR, join(dataDir, 'sandbox', 'config', 'claude'));
     assert.equal(env.HOME, join(dataDir, 'sandbox', 'agent-home'));
   } finally {
     rmSync(dataDir, { recursive: true, force: true });

--- a/apps/daemon/tests/runtimes/executables.test.ts
+++ b/apps/daemon/tests/runtimes/executables.test.ts
@@ -408,35 +408,37 @@ fsTest(
 );
 
 fsTest(
-  'OD_SANDBOX_MODE derives agent-home isolation from OD_DATA_DIR during detection',
+  'OD_SANDBOX_MODE scopes fallback toolchain discovery to OD_DATA_DIR',
   () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'od-agents-sandbox-data-'));
+    const emptyPath = mkdtempSync(join(tmpdir(), 'od-agents-empty-path-'));
     const realPrefix = mkdtempSync(join(tmpdir(), 'od-agents-real-prefix-'));
     const realPrefixBin = join(realPrefix, 'bin');
     try {
       return withEnvSnapshot(
-        ['OD_SANDBOX_MODE', 'OD_DATA_DIR', 'OD_AGENT_HOME', 'PATH', 'NPM_CONFIG_PREFIX'],
+        ['PATH', 'OD_AGENT_HOME', 'OD_DATA_DIR', 'OD_SANDBOX_MODE', 'NPM_CONFIG_PREFIX'],
         () => {
           mkdirSync(realPrefixBin, { recursive: true });
           writeFileSync(join(realPrefixBin, 'gemini'), '');
           chmodSync(join(realPrefixBin, 'gemini'), 0o755);
 
-          process.env.OD_SANDBOX_MODE = '1';
-          process.env.OD_DATA_DIR = dataDir;
           delete process.env.OD_AGENT_HOME;
-          process.env.PATH = '/usr/bin:/bin';
+          process.env.OD_DATA_DIR = dataDir;
+          process.env.OD_SANDBOX_MODE = '1';
+          process.env.PATH = emptyPath;
           process.env.NPM_CONFIG_PREFIX = realPrefix;
 
           const resolved = resolveAgentExecutable(minimalAgentDef({ bin: 'gemini' }));
           assert.equal(
             resolved,
             null,
-            `sandbox mode must not see the real $NPM_CONFIG_PREFIX bin; got ${resolved}`,
+            `sandbox mode must not see the host $NPM_CONFIG_PREFIX bin; got ${resolved}`,
           );
         },
       );
     } finally {
       rmSync(dataDir, { recursive: true, force: true });
+      rmSync(emptyPath, { recursive: true, force: true });
       rmSync(realPrefix, { recursive: true, force: true });
     }
   },

--- a/apps/daemon/tests/runtimes/executables.test.ts
+++ b/apps/daemon/tests/runtimes/executables.test.ts
@@ -1,4 +1,5 @@
 import { test } from 'vitest';
+import { relative, resolve } from 'node:path';
 import {
   assert, chmodSync, claude, deepseek, gemini, join, minimalAgentDef, mkdirSync, mkdtempSync, resolveAgentExecutable, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
@@ -440,6 +441,40 @@ fsTest(
       rmSync(dataDir, { recursive: true, force: true });
       rmSync(emptyPath, { recursive: true, force: true });
       rmSync(realPrefix, { recursive: true, force: true });
+    }
+  },
+);
+
+fsTest(
+  'OD_SANDBOX_MODE resolves relative OD_DATA_DIR before fallback toolchain discovery',
+  () => {
+    const projectRoot = resolve(process.cwd(), '../..');
+    const parent = mkdtempSync(join(tmpdir(), 'od-agents-relative-data-parent-'));
+    const dataDir = join(parent, 'data');
+    const sandboxBin = join(dataDir, 'sandbox', 'agent-home', '.local', 'bin');
+    const emptyPath = mkdtempSync(join(tmpdir(), 'od-agents-empty-path-'));
+    try {
+      return withEnvSnapshot(
+        ['PATH', 'OD_AGENT_HOME', 'OD_DATA_DIR', 'OD_SANDBOX_MODE', 'NPM_CONFIG_PREFIX'],
+        () => {
+          mkdirSync(sandboxBin, { recursive: true });
+          const geminiPath = join(sandboxBin, 'gemini');
+          writeFileSync(geminiPath, '');
+          chmodSync(geminiPath, 0o755);
+
+          delete process.env.OD_AGENT_HOME;
+          delete process.env.NPM_CONFIG_PREFIX;
+          process.env.OD_DATA_DIR = relative(projectRoot, dataDir);
+          process.env.OD_SANDBOX_MODE = '1';
+          process.env.PATH = emptyPath;
+
+          const resolved = resolveAgentExecutable(minimalAgentDef({ bin: 'gemini' }));
+          assert.equal(resolved, geminiPath);
+        },
+      );
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+      rmSync(emptyPath, { recursive: true, force: true });
     }
   },
 );

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -102,10 +102,10 @@ test('local agent profiles skip explicit unknown baseAgent without falling back'
   }
 });
 
-test('sandbox mode ignores implicit local agent profiles but keeps explicit config', async () => {
+test('sandbox mode ignores implicit and host explicit local agent profiles', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-local-agent-profiles-sandbox-'));
   try {
-    await withEnvSnapshot(['OD_AGENT_PROFILES_CONFIG', 'OD_SANDBOX_MODE'], async () => {
+    await withEnvSnapshot(['OD_AGENT_PROFILES_CONFIG', 'OD_SANDBOX_MODE', 'OD_DATA_DIR'], async () => {
       const config = join(dir, 'agents.local.json');
       writeFileSync(
         config,
@@ -115,14 +115,12 @@ test('sandbox mode ignores implicit local agent profiles but keeps explicit conf
       );
 
       process.env.OD_SANDBOX_MODE = '1';
+      delete process.env.OD_DATA_DIR;
       delete process.env.OD_AGENT_PROFILES_CONFIG;
       assert.deepEqual(readLocalAgentProfileDefs(), []);
 
       process.env.OD_AGENT_PROFILES_CONFIG = config;
-      assert.deepEqual(
-        readLocalAgentProfileDefs().map((profile) => profile.id),
-        ['explicit-wrapper'],
-      );
+      assert.deepEqual(readLocalAgentProfileDefs(), []);
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -102,6 +102,33 @@ test('local agent profiles skip explicit unknown baseAgent without falling back'
   }
 });
 
+test('sandbox mode ignores implicit local agent profiles but keeps explicit config', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-local-agent-profiles-sandbox-'));
+  try {
+    await withEnvSnapshot(['OD_AGENT_PROFILES_CONFIG', 'OD_SANDBOX_MODE'], async () => {
+      const config = join(dir, 'agents.local.json');
+      writeFileSync(
+        config,
+        JSON.stringify({
+          agents: [{ id: 'explicit-wrapper', bin: 'explicit-wrapper' }],
+        }),
+      );
+
+      process.env.OD_SANDBOX_MODE = '1';
+      delete process.env.OD_AGENT_PROFILES_CONFIG;
+      assert.deepEqual(readLocalAgentProfileDefs(), []);
+
+      process.env.OD_AGENT_PROFILES_CONFIG = config;
+      assert.deepEqual(
+        readLocalAgentProfileDefs().map((profile) => profile.id),
+        ['explicit-wrapper'],
+      );
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('codex args disable plugins when OD_CODEX_DISABLE_PLUGINS is 1', () => {
   process.env.OD_CODEX_DISABLE_PLUGINS = '1';
 


### PR DESCRIPTION
## Why

This is the second sandbox-runtime slice for disposable OD runs. The use case is running OD inside a sandbox without accidentally inheriting host projects, folders, credentials, local agent profiles, or toolchain paths.

The pain being addressed is implicit host discovery: a sandboxed daemon should be easy to launch as a throwaway runtime, but it should not silently reach into global user state unless the caller explicitly mounted that state.

Stack note: this branch builds on #3242. It targets `nexu-io/main` as requested.

## What users will see

When `OD_SANDBOX_MODE` is enabled, folder imports and linked project roots stay confined to the sandbox data root, media config stops falling back to host credential files, and local agent/toolchain discovery uses sandbox-scoped paths. Non-sandbox launches keep existing behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/folder-import-projects.test.ts tests/folder-import-route.test.ts tests/media-config.test.ts tests/runtimes/executables.test.ts tests/runtimes/registry-and-args.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
