### PR TITLE
feat(daemon): add contained project preview URLs

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { rm } from 'node:fs/promises';
 import path from 'node:path';
 import type { Express, Response } from 'express';
@@ -1197,7 +1196,7 @@ export function registerProjectArtifactRoutes(app: Express, ctx: RegisterProject
 
 }
 
-export interface RegisterProjectFileRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'uploads' | 'node' | 'projectStore' | 'projectFiles' | 'documents' | 'artifacts'> {}
+export interface RegisterProjectFileRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'uploads' | 'node' | 'projectStore' | 'projectFiles' | 'documents' | 'artifacts' | 'projectPreviewScopes'> {}
 
 export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFileRoutesDeps) {
   const { db } = ctx;
@@ -1209,6 +1208,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
   const { listFiles, searchProjectFiles, readProjectFile, resolveProjectDir, resolveProjectFilePath, parseByteRange, renameProjectFile, deleteProjectFile, writeProjectFile, sanitizeName, ensureProject } = ctx.projectFiles;
   const { buildDocumentPreview } = ctx.documents;
   const { validateArtifactManifestInput } = ctx.artifacts;
+  const { projectPreviewScopes } = ctx;
   const projectPreviewIframeSandbox = 'allow-scripts allow-forms';
   const projectPreviewCsp = [
     `sandbox ${projectPreviewIframeSandbox}`,
@@ -1379,7 +1379,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
         requestedPath,
         project.metadata,
       );
-      const scope = randomUUID();
+      const scope = projectPreviewScopes.mint(project.id);
       /** @type {import('@open-design/contracts').ProjectPreviewUrlResponse} */
       const body = {
         url: `/api/projects/${encodeURIComponent(project.id)}/preview/${scope}/${encodeProjectPathForUrl(meta.name)}`,
@@ -1414,6 +1414,10 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       const project = getProject(db, projectId);
       if (!project) {
         sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
+        return;
+      }
+      if (!projectPreviewScopes.validate(project.id, scope)) {
+        sendApiError(res, 404, 'PREVIEW_SCOPE_NOT_FOUND', 'preview scope not found');
         return;
       }
       if (req.headers.origin === 'null') {

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -1,6 +1,7 @@
-import type { Express } from 'express';
+import { randomUUID } from 'node:crypto';
 import { rm } from 'node:fs/promises';
 import path from 'node:path';
+import type { Express, Response } from 'express';
 import {
   defaultScenarioPluginIdForProjectMetadata,
   type PluginManifest,
@@ -1208,6 +1209,104 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
   const { listFiles, searchProjectFiles, readProjectFile, resolveProjectDir, resolveProjectFilePath, parseByteRange, renameProjectFile, deleteProjectFile, writeProjectFile, sanitizeName, ensureProject } = ctx.projectFiles;
   const { buildDocumentPreview } = ctx.documents;
   const { validateArtifactManifestInput } = ctx.artifacts;
+  const projectPreviewIframeSandbox = 'allow-scripts allow-forms';
+  const projectPreviewCsp = [
+    `sandbox ${projectPreviewIframeSandbox}`,
+    "default-src 'self' data: blob:",
+    "img-src 'self' data: blob:",
+    "media-src 'self' data: blob:",
+    "font-src 'self' data:",
+    "style-src 'self' 'unsafe-inline'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+    "connect-src 'none'",
+    "form-action 'none'",
+    "base-uri 'none'",
+    "object-src 'none'",
+  ].join('; ');
+  const previewScopeRe = /^[A-Za-z0-9_-]{8,128}$/u;
+
+  function setProjectPreviewHeaders(res: Response) {
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('Content-Security-Policy', projectPreviewCsp);
+  }
+
+  async function sendProjectFile(
+    req: any,
+    res: Response,
+    projectId: string,
+    relPath: string,
+    metadata?: unknown,
+    beforeSend?: (mime: string) => void,
+    transformFile?: (file: { mime: string; buffer: Buffer }) => Buffer | string,
+  ) {
+    const meta = await resolveProjectFilePath(
+      PROJECTS_DIR,
+      projectId,
+      relPath,
+      metadata,
+    );
+    beforeSend?.(meta.mime);
+
+    if (meta.mime.startsWith('video/') || meta.mime.startsWith('audio/')) {
+      res.setHeader('Accept-Ranges', 'bytes');
+      res.setHeader('Content-Type', meta.mime);
+
+      if (meta.size === 0) {
+        res.setHeader('Content-Length', '0');
+        return res.status(200).end();
+      }
+
+      const range = parseByteRange(req.headers.range, meta.size);
+
+      if (range === 'unsatisfiable') {
+        res.setHeader('Content-Range', `bytes */${meta.size}`);
+        return res.status(416).end();
+      }
+
+      let start;
+      let end;
+      let statusCode;
+      if (range) {
+        ({ start, end } = range);
+        statusCode = 206;
+        res.setHeader('Content-Range', `bytes ${start}-${end}/${meta.size}`);
+        res.setHeader('Content-Length', String(end - start + 1));
+      } else {
+        start = 0;
+        end = meta.size - 1;
+        statusCode = 200;
+        res.setHeader('Content-Length', String(meta.size));
+      }
+
+      res.status(statusCode);
+      const stream = fs.createReadStream(meta.filePath, { start, end });
+      stream.on('error', (streamErr: any) => {
+        if (!res.headersSent) {
+          sendApiError(res, 500, 'STREAM_ERROR', String(streamErr));
+        } else {
+          res.destroy(streamErr);
+        }
+      });
+      stream.pipe(res);
+      return;
+    }
+
+    const file = await readProjectFile(PROJECTS_DIR, projectId, relPath, metadata);
+    res.type(file.mime).send(transformFile ? transformFile(file) : file.buffer);
+  }
+
+  function previewFilePathForProject(project: any, queryFile: unknown): string {
+    if (typeof queryFile === 'string' && queryFile.trim().length > 0) {
+      return queryFile;
+    }
+    const entryFile = project?.metadata?.entryFile;
+    return typeof entryFile === 'string' && entryFile.length > 0 ? entryFile : 'index.html';
+  }
+
+  function encodeProjectPathForUrl(filePath: string): string {
+    return filePath.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+  }
 
   // Project files. Each project owns a flat folder under .od/projects/<id>/
   // containing every file the user has uploaded, pasted, sketched, or that
@@ -1266,6 +1365,79 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
     }
   });
 
+  app.get('/api/projects/:id/preview-url', async (req, res) => {
+    try {
+      const project = getProject(db, req.params.id);
+      if (!project) {
+        sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
+        return;
+      }
+      const requestedPath = previewFilePathForProject(project, req.query.file);
+      const meta = await resolveProjectFilePath(
+        PROJECTS_DIR,
+        project.id,
+        requestedPath,
+        project.metadata,
+      );
+      const scope = randomUUID();
+      /** @type {import('@open-design/contracts').ProjectPreviewUrlResponse} */
+      const body = {
+        url: `/api/projects/${encodeURIComponent(project.id)}/preview/${scope}/${encodeProjectPathForUrl(meta.name)}`,
+        file: meta.name,
+        csp: projectPreviewCsp,
+        iframeSandbox: projectPreviewIframeSandbox,
+        opaqueOrigin: true,
+      };
+      res.setHeader('Cache-Control', 'no-store');
+      res.json(body);
+    } catch (err: any) {
+      const status = err && err.code === 'ENOENT' ? 404 : 400;
+      sendApiError(
+        res,
+        status,
+        status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST',
+        String(err),
+      );
+    }
+  });
+
+  app.get(/^\/api\/projects\/([^/]+)\/preview\/([^/]+)\/(.+)$/u, async (req, res) => {
+    try {
+      const params = req.params as unknown as { 0?: string; 1?: string; 2?: string };
+      const projectId = String(params[0] ?? '');
+      const scope = String(params[1] ?? '');
+      const relPath = String(params[2] ?? '');
+      if (!previewScopeRe.test(scope)) {
+        sendApiError(res, 400, 'BAD_REQUEST', 'invalid preview scope');
+        return;
+      }
+      const project = getProject(db, projectId);
+      if (!project) {
+        sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
+        return;
+      }
+      if (req.headers.origin === 'null') {
+        res.header('Access-Control-Allow-Origin', '*');
+      }
+      await sendProjectFile(
+        req,
+        res,
+        project.id,
+        relPath,
+        project.metadata,
+        () => setProjectPreviewHeaders(res),
+      );
+    } catch (err: any) {
+      const status = err && err.code === 'ENOENT' ? 404 : 400;
+      sendApiError(
+        res,
+        status,
+        status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST',
+        String(err),
+      );
+    }
+  });
+
 
   // Preflight for the raw file route. Current artifact fetches are simple GETs
   // (no preflight needed), but an explicit handler future-proofs the route if
@@ -1293,66 +1465,23 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
         res.header('Access-Control-Allow-Origin', '*');
       }
 
-      const meta = await resolveProjectFilePath(
-        PROJECTS_DIR,
+      await sendProjectFile(
+        req,
+        res,
         projectId,
         relPath,
         project?.metadata,
-      );
-
-      if (meta.mime.startsWith('video/') || meta.mime.startsWith('audio/')) {
-        res.setHeader('Accept-Ranges', 'bytes');
-        res.setHeader('Content-Type', meta.mime);
-
-        if (meta.size === 0) {
-          res.setHeader('Content-Length', '0');
-          return res.status(200).end();
-        }
-
-        const range = parseByteRange(req.headers.range, meta.size);
-
-        if (range === 'unsatisfiable') {
-          res.setHeader('Content-Range', `bytes */${meta.size}`);
-          return res.status(416).end();
-        }
-
-        let start;
-        let end;
-        let statusCode;
-        if (range) {
-          ({ start, end } = range);
-          statusCode = 206;
-          res.setHeader('Content-Range', `bytes ${start}-${end}/${meta.size}`);
-          res.setHeader('Content-Length', String(end - start + 1));
-        } else {
-          start = 0;
-          end = meta.size - 1;
-          statusCode = 200;
-          res.setHeader('Content-Length', String(meta.size));
-        }
-
-        res.status(statusCode);
-        const stream = fs.createReadStream(meta.filePath, { start, end });
-        stream.on('error', (streamErr: any) => {
-          if (!res.headersSent) {
-            sendApiError(res, 500, 'STREAM_ERROR', String(streamErr));
-          } else {
-            res.destroy(streamErr);
+        undefined,
+        (file) => {
+          if (
+            wantsUrlPreviewScrollBridge(req.query.odPreviewBridge) &&
+            /^text\/html(?:;|$)/i.test(file.mime)
+          ) {
+            return injectUrlPreviewScrollBridge(file.buffer.toString('utf8'));
           }
-        });
-        stream.pipe(res);
-        return;
-      }
-
-      const file = await readProjectFile(PROJECTS_DIR, projectId, relPath, project?.metadata);
-      if (
-        wantsUrlPreviewScrollBridge(req.query.odPreviewBridge) &&
-        /^text\/html(?:;|$)/i.test(file.mime)
-      ) {
-        res.type(file.mime).send(injectUrlPreviewScrollBridge(file.buffer.toString('utf8')));
-        return;
-      }
-      res.type(file.mime).send(file.buffer);
+          return file.buffer;
+        },
+      );
     } catch (err: any) {
       const status = err && err.code === 'ENOENT' ? 404 : 400;
       sendApiError(

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -626,7 +626,8 @@ export async function resolveProjectFilePath(projectsRoot, projectId, name, meta
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const file = await resolveSafeReal(dir, name);
   const st = await stat(file);
-  const rel = toProjectPath(path.relative(dir, file));
+  const rootReal = await realpath(dir).catch(() => dir);
+  const rel = toProjectPath(path.relative(rootReal, file));
   return {
     filePath: file,
     name: rel,

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -32,9 +32,15 @@ const FORBIDDEN_SEGMENT = /^$|^\.\.?$/;
 const RESERVED_PROJECT_FILE_SEGMENTS = new Set(['.live-artifacts']);
 const DESIGN_HANDOFF_FILENAME = 'DESIGN-HANDOFF.md';
 const DESIGN_MANIFEST_FILENAME = 'DESIGN-MANIFEST.json';
+export const RUN_ARTIFACT_RECONCILE_MTIME_GRACE_MS = 1000;
 export const projectFileRenameTestHooks = {
   beforeCommit: null as null | ((paths: { source: string; target: string }) => Promise<void> | void),
 };
+
+export function isRunTouchedProjectFile(fileMtimeMs, runStartTimeMs) {
+  if (!Number.isFinite(fileMtimeMs) || !Number.isFinite(runStartTimeMs)) return false;
+  return fileMtimeMs + RUN_ARTIFACT_RECONCILE_MTIME_GRACE_MS >= runStartTimeMs;
+}
 
 export function projectDir(projectsRoot, projectId) {
   if (!isSafeId(projectId)) throw new Error('invalid project id');

--- a/apps/daemon/src/server-context.ts
+++ b/apps/daemon/src/server-context.ts
@@ -53,6 +53,11 @@ export interface RoutineDeps {
   routineService: RoutineRoutesService;
 }
 
+export interface ProjectPreviewScopeDeps {
+  mint: (projectId: string) => string;
+  validate: (projectId: string, scope: string) => boolean;
+}
+
 export interface TelemetryDeps {
   reportFinalizedMessage: (saved: any, body?: any) => void;
   /**
@@ -101,6 +106,7 @@ export interface ServerContext {
   mcp: any;
   resources: ResourceDeps;
   routines: RoutineDeps;
+  projectPreviewScopes: ProjectPreviewScopeDeps;
   telemetry?: TelemetryDeps;
   validation: any;
   finalize: any;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4175,7 +4175,7 @@ export async function startServer({
   // Routes that serve content to sandboxed iframes (Origin: null) for
   // read-only purposes.  All other /api routes reject Origin: null.
   const _NULL_ORIGIN_SAFE_GET_RE =
-    /^\/projects\/[^/]+\/raw\/|^\/codex-pets\/[^/]+\/spritesheet$/;
+    /^\/projects\/[^/]+\/(?:raw|preview)\/|^\/codex-pets\/[^/]+\/spritesheet$/;
 
   // Reject cross-origin requests to API endpoints.
   // Health/version remain open for monitoring probes.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2841,6 +2841,54 @@ function isLoopbackPeerAddress(address) {
   return false;
 }
 
+const PROJECT_PREVIEW_SCOPE_TTL_MS = 60 * 60 * 1000;
+const PROJECT_PREVIEW_ASSET_PATH_RE = /^\/projects\/([^/]+)\/preview\/([^/]+)\/.+$/u;
+
+function createProjectPreviewScopeRegistry() {
+  const scopes = new Map();
+
+  function pruneExpired(now = Date.now()) {
+    for (const [scope, entry] of scopes) {
+      if (entry.expiresAt <= now) scopes.delete(scope);
+    }
+  }
+
+  return {
+    mint(projectId) {
+      pruneExpired();
+      const scope = randomUUID();
+      scopes.set(scope, {
+        projectId: String(projectId),
+        expiresAt: Date.now() + PROJECT_PREVIEW_SCOPE_TTL_MS,
+      });
+      return scope;
+    },
+    validate(projectId, scope) {
+      const key = String(scope || '');
+      const entry = scopes.get(key);
+      if (!entry) return false;
+      if (entry.expiresAt <= Date.now()) {
+        scopes.delete(key);
+        return false;
+      }
+      return entry.projectId === String(projectId);
+    },
+  };
+}
+
+function parseProjectPreviewAssetPath(pathname) {
+  const match = PROJECT_PREVIEW_ASSET_PATH_RE.exec(String(pathname || ''));
+  if (!match) return null;
+  try {
+    return {
+      projectId: decodeURIComponent(match[1]),
+      scope: match[2],
+    };
+  } catch {
+    return null;
+  }
+}
+
 function localOriginFromHeader(value) {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
@@ -3869,6 +3917,7 @@ export async function startServer({
 
   const app = express();
   app.use(express.json({ limit: '4mb' }));
+  const projectPreviewScopes = createProjectPreviewScopeRegistry();
 
   // Plan §3.K1 — bearer-token middleware.
   //
@@ -3876,8 +3925,11 @@ export async function startServer({
   // check (the desktop UI / local CLI never carry a bearer); every
   // other request must present `Authorization: Bearer <token>` with a
   // value matching `OD_API_TOKEN`. Health / readiness / version remain
-  // open so monitoring probes don't need the token. Rich daemon status
-  // stays authenticated because it includes local runtime paths.
+  // open so monitoring probes don't need the token. Server-minted
+  // project preview asset scopes are also accepted for GETs so sandboxed
+  // browser iframes can load HTML/CSS/JS without privileged headers.
+  // Rich daemon status stays authenticated because it includes local
+  // runtime paths.
   if (apiToken.length > 0) {
     const openProbePaths = new Set([
       '/health',
@@ -3889,6 +3941,15 @@ export async function startServer({
     ]);
     app.use('/api', (req, res, next) => {
       if (openProbePaths.has(req.path)) return next();
+      if (req.method === 'GET') {
+        const previewAsset = parseProjectPreviewAssetPath(req.path);
+        if (
+          previewAsset &&
+          projectPreviewScopes.validate(previewAsset.projectId, previewAsset.scope)
+        ) {
+          return next();
+        }
+      }
       // Loopback short-circuit. We ignore the proxied X-Forwarded-For
       // header here because a reverse proxy MUST always forward the
       // bearer; the loopback bypass exists for the localhost desktop
@@ -5833,6 +5894,7 @@ export async function startServer({
     projectFiles: projectFileDeps,
     documents: { buildDocumentPreview },
     artifacts: artifactDeps,
+    projectPreviewScopes,
   });
 
   registerMediaRoutes(app, {
@@ -14073,6 +14135,7 @@ export async function startServer({
       mimeFor,
     },
     routines: { routineService },
+    projectPreviewScopes,
     validation: validationDeps,
     finalize: finalizeDeps,
     handoff: handoffDeps,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -354,6 +354,7 @@ import {
   assertSandboxProjectRootAvailable,
   detectEntryFile,
   ensureProject,
+  isRunTouchedProjectFile,
   isSafeId,
   listFiles,
   mimeFor,
@@ -12752,7 +12753,7 @@ export async function startServer({
               try {
                 const filePath = path.join(dir, f.name);
                 const st = await fs.promises.stat(filePath);
-                if (st.mtimeMs < runStartTimeMs) continue;
+                if (!isRunTouchedProjectFile(st.mtimeMs, runStartTimeMs)) continue;
                 await reconcileHtmlArtifactManifest(
                   PROJECTS_DIR,
                   run.projectId,

--- a/apps/daemon/tests/artifact-manifest-reconcile-on-run-end.test.ts
+++ b/apps/daemon/tests/artifact-manifest-reconcile-on-run-end.test.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { closeDatabase, insertProject, openDatabase } from '../src/db.js';
-import { reconcileHtmlArtifactManifest, writeProjectFile } from '../src/projects.js';
+import { isRunTouchedProjectFile, reconcileHtmlArtifactManifest, writeProjectFile } from '../src/projects.js';
 
 const PROJECT_ID = 'reconcile-test';
 let tempDir = null;
@@ -146,14 +146,9 @@ describe('run-end artifact manifest reconciliation (#2893)', () => {
 
     // File written during the run
     await writeProjectFile(projectsRoot, PROJECT_ID, 'new-output.html', '<p>new</p>');
-    // Force the new file's mtime strictly above runStartTimeMs. Without this,
-    // CI runners occasionally produce a file whose ms-truncated mtime equals
-    // (or, due to NTP jitter, falls a hair below) Date.now() captured a few
-    // microseconds earlier, which made the `<` mtime filter incorrectly skip
-    // the new file and the sidecar-existence assertion flaked.
     const newPath = path.join(projectsRoot, PROJECT_ID, 'new-output.html');
-    const futureTime = new Date(runStartTimeMs + 1_000);
-    fs.utimesSync(newPath, futureTime, futureTime);
+    const coarseFsTime = new Date(runStartTimeMs - 500);
+    fs.utimesSync(newPath, coarseFsTime, coarseFsTime);
 
     // Simulate the close-handler reconciliation with mtime filter
     const dir = path.join(projectsRoot, PROJECT_ID);
@@ -162,7 +157,7 @@ describe('run-end artifact manifest reconciliation (#2893)', () => {
       const ext = path.extname(name).toLowerCase();
       if (ext !== '.html' && ext !== '.htm') continue;
       const st = fs.statSync(path.join(dir, name));
-      if (st.mtimeMs < runStartTimeMs) continue;
+      if (!isRunTouchedProjectFile(st.mtimeMs, runStartTimeMs)) continue;
       await reconcileHtmlArtifactManifest(projectsRoot, PROJECT_ID, name);
     }
 

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -107,6 +107,102 @@ describe('project preview containment routes', () => {
     expect(await assetResponse.text()).toContain('color: black');
   });
 
+  it('serves minted preview HTML and assets without bearer headers when API token auth is enabled', async () => {
+    const previousToken = process.env.OD_API_TOKEN;
+    const token = `preview-token-${randomUUID()}`;
+    process.env.OD_API_TOKEN = token;
+    let tokenServer: http.Server | undefined;
+    let shutdown: (() => Promise<void> | void) | undefined;
+    let tokenBaseUrl = '';
+    const projectId = `preview-token-${randomUUID()}`;
+
+    try {
+      const started = (await startServer({ port: 0, returnServer: true })) as {
+        url: string;
+        server: http.Server;
+        shutdown?: () => Promise<void> | void;
+      };
+      tokenBaseUrl = started.url;
+      tokenServer = started.server;
+      shutdown = started.shutdown;
+      const authHeaders = {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      };
+
+      const createResponse = await fetch(`${tokenBaseUrl}/api/projects`, {
+        method: 'POST',
+        headers: authHeaders,
+        body: JSON.stringify({
+          id: projectId,
+          name: 'Token preview containment project',
+          metadata: { entryFile: 'pages/index.html' },
+        }),
+      });
+      expect(createResponse.ok).toBe(true);
+
+      const writeIndex = await fetch(`${tokenBaseUrl}/api/projects/${projectId}/files`, {
+        method: 'POST',
+        headers: authHeaders,
+        body: JSON.stringify({
+          name: 'pages/index.html',
+          content: '<!doctype html><title>Hosted Preview</title><link rel="stylesheet" href="../styles/app.css">',
+        }),
+      });
+      expect(writeIndex.ok).toBe(true);
+
+      const writeAsset = await fetch(`${tokenBaseUrl}/api/projects/${projectId}/files`, {
+        method: 'POST',
+        headers: authHeaders,
+        body: JSON.stringify({
+          name: 'styles/app.css',
+          content: 'body { color: rebeccapurple; }',
+        }),
+      });
+      expect(writeAsset.ok).toBe(true);
+
+      const urlResponse = await fetch(
+        `${tokenBaseUrl}/api/projects/${projectId}/preview-url?file=${encodeURIComponent('pages/index.html')}`,
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      expect(urlResponse.ok).toBe(true);
+      const body = await urlResponse.json() as { url: string };
+      const scope = body.url.match(/\/preview\/([^/]+)\//u)?.[1];
+      expect(scope).toBeTruthy();
+
+      const previewResponse = await fetch(`${tokenBaseUrl}${body.url}`, {
+        headers: { Origin: 'null' },
+      });
+      expect(previewResponse.status).toBe(200);
+      expect(previewResponse.headers.get('access-control-allow-origin')).toBe('*');
+      expect(await previewResponse.text()).toContain('<title>Hosted Preview</title>');
+
+      const assetResponse = await fetch(
+        `${tokenBaseUrl}/api/projects/${projectId}/preview/${scope}/styles/app.css`,
+        { headers: { Origin: 'null' } },
+      );
+      expect(assetResponse.status).toBe(200);
+      expect(await assetResponse.text()).toContain('rebeccapurple');
+
+      const forgedResponse = await fetch(
+        `${tokenBaseUrl}/api/projects/${projectId}/preview/${randomUUID()}/pages/index.html`,
+        { headers: { Origin: 'null' } },
+      );
+      expect(forgedResponse.status).toBe(404);
+    } finally {
+      if (tokenBaseUrl) {
+        await fetch(`${tokenBaseUrl}/api/projects/${projectId}`, {
+          method: 'DELETE',
+          headers: { authorization: `Bearer ${token}` },
+        }).catch(() => {});
+      }
+      if (shutdown) await Promise.resolve(shutdown());
+      if (tokenServer) await new Promise<void>((resolve) => tokenServer!.close(() => resolve()));
+      if (previousToken === undefined) delete process.env.OD_API_TOKEN;
+      else process.env.OD_API_TOKEN = previousToken;
+    }
+  });
+
   it('rejects invalid preview scopes and escaping preview-url paths', async () => {
     const projectId = await createProject();
     await writeProjectFile(projectId, 'index.html', '<!doctype html>');

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -1,0 +1,122 @@
+import type http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+describe('project preview containment routes', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  const projectsToClean: string[] = [];
+
+  beforeAll(async () => {
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+  });
+
+  afterAll(async () => {
+    for (const id of projectsToClean.splice(0)) {
+      await fetch(`${baseUrl}/api/projects/${id}`, { method: 'DELETE' }).catch(() => {});
+    }
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  async function createProject(metadata: Record<string, unknown> = {}): Promise<string> {
+    const id = `preview-containment-${randomUUID()}`;
+    const response = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id,
+        name: 'Preview containment project',
+        metadata,
+      }),
+    });
+    expect(response.ok).toBe(true);
+    projectsToClean.push(id);
+    return id;
+  }
+
+  async function writeProjectFile(projectId: string, name: string, content: string): Promise<void> {
+    const response = await fetch(`${baseUrl}/api/projects/${projectId}/files`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name, content }),
+    });
+    expect(response.ok).toBe(true);
+  }
+
+  it('returns a scoped preview URL with sandbox guidance and serves it with an opaque-origin CSP', async () => {
+    const projectId = await createProject({ entryFile: 'pages/index.html' });
+    await writeProjectFile(
+      projectId,
+      'pages/index.html',
+      '<!doctype html><title>Preview</title><link rel="stylesheet" href="../styles/app.css">',
+    );
+    await writeProjectFile(projectId, 'styles/app.css', 'body { color: black; }');
+
+    const urlResponse = await fetch(
+      `${baseUrl}/api/projects/${projectId}/preview-url?file=${encodeURIComponent('pages/index.html')}`,
+    );
+    expect(urlResponse.ok).toBe(true);
+    expect(urlResponse.headers.get('cache-control')).toBe('no-store');
+    const body = await urlResponse.json() as {
+      url: string;
+      file: string;
+      csp: string;
+      iframeSandbox: string;
+      opaqueOrigin: true;
+    };
+
+    expect(body.file).toBe('pages/index.html');
+    expect(body.url).toContain(`/api/projects/${projectId}/preview/`);
+    expect(body.url).toMatch(/\/preview\/[A-Za-z0-9_-]{8,128}\/pages\/index\.html$/u);
+    expect(body.iframeSandbox).toBe('allow-scripts allow-forms');
+    expect(body.iframeSandbox).not.toContain('allow-same-origin');
+    expect(body.csp).toContain('sandbox allow-scripts allow-forms');
+    expect(body.csp).toContain("connect-src 'none'");
+    expect(body.csp).not.toContain('allow-same-origin');
+    expect(body.opaqueOrigin).toBe(true);
+
+    const previewResponse = await fetch(`${baseUrl}${body.url}`, {
+      headers: { Origin: 'null' },
+    });
+    expect(previewResponse.status).toBe(200);
+    expect(previewResponse.headers.get('access-control-allow-origin')).toBe('*');
+    expect(previewResponse.headers.get('cache-control')).toBe('no-store');
+    expect(previewResponse.headers.get('x-content-type-options')).toBe('nosniff');
+    const csp = previewResponse.headers.get('content-security-policy') ?? '';
+    expect(csp).toContain('sandbox allow-scripts allow-forms');
+    expect(csp).toContain("connect-src 'none'");
+    expect(csp).not.toContain('allow-same-origin');
+    expect(await previewResponse.text()).toContain('<title>Preview</title>');
+
+    const scope = body.url.match(/\/preview\/([^/]+)\//u)?.[1];
+    expect(scope).toBeTruthy();
+    const assetResponse = await fetch(
+      `${baseUrl}/api/projects/${projectId}/preview/${scope}/styles/app.css`,
+      { headers: { Origin: 'null' } },
+    );
+    expect(assetResponse.status).toBe(200);
+    expect(assetResponse.headers.get('access-control-allow-origin')).toBe('*');
+    expect(assetResponse.headers.get('content-type')).toContain('text/css');
+    expect(await assetResponse.text()).toContain('color: black');
+  });
+
+  it('rejects invalid preview scopes and escaping preview-url paths', async () => {
+    const projectId = await createProject();
+    await writeProjectFile(projectId, 'index.html', '<!doctype html>');
+
+    const invalidScope = await fetch(`${baseUrl}/api/projects/${projectId}/preview/bad/index.html`);
+    expect(invalidScope.status).toBe(400);
+
+    const escapingPath = await fetch(
+      `${baseUrl}/api/projects/${projectId}/preview-url?file=${encodeURIComponent('../index.html')}`,
+    );
+    expect(escapingPath.status).toBe(400);
+  });
+});

--- a/packages/contracts/src/api/files.ts
+++ b/packages/contracts/src/api/files.ts
@@ -81,6 +81,14 @@ export interface ProjectExportManifestResponse {
   artifacts: ProjectExportManifestArtifact[];
 }
 
+export interface ProjectPreviewUrlResponse {
+  url: string;
+  file: string;
+  csp: string;
+  iframeSandbox: string;
+  opaqueOrigin: true;
+}
+
 export interface ProjectFileResponse {
   file: ProjectFile;
 }


### PR DESCRIPTION
## Why

This is the fifth sandbox-runtime slice for disposable OD runs. The use case is giving generated previews a run-scoped render URL and explicit sandbox guidance without granting privileged same-origin access to OD admin APIs.

The pain being addressed is preview containment: raw project files are useful for local rendering, but sandboxed production preview embeds need a clearly scoped path and response policy that keeps generated HTML in an opaque browser origin.

Stack note: this branch builds on #3242, #3243, #3244, and #3245. It targets `nexu-io/main` as requested.

## What users will see

Callers can request `GET /api/projects/:id/preview-url` to receive a scoped preview URL plus CSP and iframe sandbox guidance. The preview route serves project assets under the same scope, applies a CSP `sandbox` without `allow-same-origin`, and blocks preview scripts from connecting back to daemon APIs.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/project-preview-containment.test.ts tests/project-file-range.test.ts`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
