### PR TITLE
fix(skills): stream-copy fallback when skill staging hits cross-fs EPERM

### DIFF
--- a/apps/daemon/src/cwd-aliases.ts
+++ b/apps/daemon/src/cwd-aliases.ts
@@ -30,7 +30,7 @@
 
 import { createReadStream, createWriteStream } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { cp, lstat, mkdir, readdir, rm, stat } from 'node:fs/promises';
+import { chmod, cp, lstat, mkdir, readdir, rm, stat, utimes } from 'node:fs/promises';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 
@@ -81,6 +81,13 @@ async function copyTreeDereferenced(srcDir: string, destDir: string): Promise<vo
       await copyTreeDereferenced(from, to);
     } else if (entryStat.isFile()) {
       await pipeline(createReadStream(from), createWriteStream(to));
+      // createWriteStream opens the destination with the default 0644, so
+      // restore the source's permission bits (notably the exec bit on
+      // skill helper scripts) and mtime — `fs.cp` preserves these, and
+      // skills shell out to staged scripts. Mask to 0o777 so the
+      // agent-writable staging copy never inherits setuid/setgid/sticky.
+      await chmod(to, entryStat.mode & 0o777);
+      await utimes(to, entryStat.atime, entryStat.mtime);
     }
     // Sockets, FIFOs, and devices can't appear in a sane skill folder and
     // copying them would hang or fail — skip them.

--- a/apps/daemon/src/cwd-aliases.ts
+++ b/apps/daemon/src/cwd-aliases.ts
@@ -28,9 +28,11 @@
 // source root so an environment that puts `skills/` itself behind a
 // symlink (e.g. a content-addressable mount) is followed correctly.
 
+import { createReadStream, createWriteStream } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { cp, lstat, rm, stat } from 'node:fs/promises';
+import { cp, lstat, mkdir, readdir, rm, stat } from 'node:fs/promises';
 import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
 
 export const SKILLS_CWD_ALIAS = '.od-skills';
 
@@ -52,6 +54,39 @@ export function skillCwdAliasSegment(dir: string): string {
   return `${folder}-${digest}`;
 }
 
+// copy_file_range(2) — used by fs.cp under the hood — is rejected with
+// these errno codes when source and destination live on different
+// filesystems (commonly EXDEV; a container image layer copied onto a
+// ZFS/overlay bind mount surfaces EPERM). Node doesn't fall back to a
+// userspace copy on any of them, so we do.
+const RECOVERABLE_COPY_CODES = new Set(['EPERM', 'EXDEV', 'ENOTSUP', 'EOPNOTSUPP']);
+
+type SkillCopyFn = (
+  source: string,
+  destination: string,
+  options: { recursive: boolean; dereference: boolean; preserveTimestamps: boolean },
+) => Promise<void>;
+
+// Recursive copy that mirrors `cp({ dereference: true })` without going
+// through copy_file_range. `stat()` (not `lstat`) follows symlinks, so
+// every staged entry lands as a real directory or regular file — keeping
+// `.od-skills/` a self-contained write barrier even on the fallback path.
+async function copyTreeDereferenced(srcDir: string, destDir: string): Promise<void> {
+  await mkdir(destDir, { recursive: true });
+  for (const entry of await readdir(srcDir, { withFileTypes: true })) {
+    const from = path.join(srcDir, entry.name);
+    const to = path.join(destDir, entry.name);
+    const entryStat = await stat(from);
+    if (entryStat.isDirectory()) {
+      await copyTreeDereferenced(from, to);
+    } else if (entryStat.isFile()) {
+      await pipeline(createReadStream(from), createWriteStream(to));
+    }
+    // Sockets, FIFOs, and devices can't appear in a sane skill folder and
+    // copying them would hang or fail — skip them.
+  }
+}
+
 /**
  * Copy `<sourceDir>` to `<cwd>/.od-skills/<folderName>/` so an agent can
  * reach skill side files via a cwd-relative path. Idempotent and
@@ -68,6 +103,11 @@ export async function stageActiveSkill(
   folderName: string,
   sourceDir: string,
   log: SkillStagingLogger = () => {},
+  // Seam for tests: the real copy_file_range EPERM only reproduces on
+  // specific cross-filesystem mounts (ZFS/overlay), so tests inject a
+  // copy that rejects with a synthetic code to drive the fallback path.
+  nativeCopy: SkillCopyFn = (source, destination, options) =>
+    cp(source, destination, options),
 ): Promise<SkillStagingResult> {
   if (!cwd) {
     return { staged: false, reason: 'no project cwd' };
@@ -123,16 +163,26 @@ export async function stageActiveSkill(
     // reflected and a partially-failed previous run cannot leave junk
     // behind.
     await rm(stagedPath, { recursive: true, force: true });
-    await cp(sourceDir, stagedPath, {
-      recursive: true,
-      // Resolve every symlink we find inside the skill so the staged
-      // copy is a fully self-contained set of regular files. This is
-      // what makes the copy a true write barrier — no entry under
-      // `.od-skills/...` can resolve back to a real file outside the
-      // project cwd.
-      dereference: true,
-      preserveTimestamps: true,
-    });
+    try {
+      await nativeCopy(sourceDir, stagedPath, {
+        recursive: true,
+        // Resolve every symlink we find inside the skill so the staged
+        // copy is a fully self-contained set of regular files. This is
+        // what makes the copy a true write barrier — no entry under
+        // `.od-skills/...` can resolve back to a real file outside the
+        // project cwd.
+        dereference: true,
+        preserveTimestamps: true,
+      });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code ?? '';
+      if (!RECOVERABLE_COPY_CODES.has(code)) throw err;
+      log(
+        `[od] skill-stage: native copy failed (${code}); retrying with stream copy`,
+      );
+      await rm(stagedPath, { recursive: true, force: true });
+      await copyTreeDereferenced(sourceDir, stagedPath);
+    }
     return { staged: true, stagedPath };
   } catch (err) {
     log(`[od] skill-stage failed: ${(err as Error).message}`);

--- a/apps/daemon/tests/cwd-aliases.test.ts
+++ b/apps/daemon/tests/cwd-aliases.test.ts
@@ -1,9 +1,11 @@
 import {
+  chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -293,6 +295,41 @@ describe('stageActiveSkill', () => {
     expect(lstatSync(linked).isFile()).toBe(true);
     expect(readFileSync(linked, 'utf8')).toContain('original');
     expect(messages.some((m) => m.includes('stream copy'))).toBe(true);
+  });
+
+  it('preserves the source exec bit through the stream-copy fallback (EPERM path)', async () => {
+    // Regression for PR #3249 review: skills shell out to staged helper
+    // scripts, so the fallback copy must keep the source's exec bit. A
+    // plain stream copy would reset it to the default 0644 and the agent
+    // would hit EACCES on the exact cross-fs path this fallback repairs.
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
+    const sourceDir = writeSampleSkill(path.join(fs, 'skills'), 'blog-post');
+    const script = path.join(sourceDir, 'scripts', 'run.sh');
+    mkdirSync(path.dirname(script));
+    writeFileSync(script, '#!/usr/bin/env bash\necho hi\n');
+    chmodSync(script, 0o755);
+    mkdirSync(cwd);
+
+    const eperm = Object.assign(new Error('EPERM: operation not permitted'), {
+      code: 'EPERM',
+    });
+    const result = await stageActiveSkill(
+      cwd,
+      'blog-post',
+      sourceDir,
+      () => {},
+      () => Promise.reject(eperm),
+    );
+
+    expect(result.staged).toBe(true);
+    const stagedScript = path.join(result.stagedPath!, 'scripts', 'run.sh');
+    // Exec bit survives on the helper script…
+    expect(statSync(stagedScript).mode & 0o111).not.toBe(0);
+    // …while a non-executable sibling is not made executable.
+    expect(statSync(path.join(result.stagedPath!, 'SKILL.md')).mode & 0o111).toBe(
+      0,
+    );
   });
 
   it('degrades to the absolute-path fallback on a non-recoverable copy error', async () => {

--- a/apps/daemon/tests/cwd-aliases.test.ts
+++ b/apps/daemon/tests/cwd-aliases.test.ts
@@ -1,4 +1,5 @@
 import {
+  existsSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
@@ -251,4 +252,76 @@ describe('stageActiveSkill', () => {
       expect(result.reason).toContain(expectedReason);
     },
   );
+
+  it('falls back to a dereferenced stream copy when the native copy fails with EPERM', async () => {
+    // Repro for the Docker/ZFS report: `fs.cp` -> copy_file_range(2) is
+    // rejected with EPERM across the image-layer -> bind-mount boundary
+    // and Node doesn't fall back. The real errno only appears on those
+    // mounts, so inject a copy that rejects with a synthetic EPERM.
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
+    const sourceDir = writeSampleSkill(path.join(fs, 'skills'), 'blog-post');
+    // A symlinked side file proves the fallback still dereferences, so the
+    // staged copy stays a self-contained write barrier.
+    symlinkSync(
+      path.join(sourceDir, 'assets', 'template.html'),
+      path.join(sourceDir, 'assets', 'linked.html'),
+    );
+    mkdirSync(cwd);
+
+    const messages: string[] = [];
+    const eperm = Object.assign(
+      new Error('EPERM: operation not permitted, copyfile'),
+      { code: 'EPERM' },
+    );
+
+    const result = await stageActiveSkill(
+      cwd,
+      'blog-post',
+      sourceDir,
+      (m) => messages.push(m),
+      () => Promise.reject(eperm),
+    );
+
+    expect(result.staged).toBe(true);
+    const staged = result.stagedPath!;
+    expect(readFileSync(path.join(staged, 'SKILL.md'), 'utf8')).toContain(
+      'original SKILL',
+    );
+    const linked = path.join(staged, 'assets', 'linked.html');
+    expect(lstatSync(linked).isSymbolicLink()).toBe(false);
+    expect(lstatSync(linked).isFile()).toBe(true);
+    expect(readFileSync(linked, 'utf8')).toContain('original');
+    expect(messages.some((m) => m.includes('stream copy'))).toBe(true);
+  });
+
+  it('degrades to the absolute-path fallback on a non-recoverable copy error', async () => {
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
+    const sourceDir = writeSampleSkill(path.join(fs, 'skills'), 'blog-post');
+    mkdirSync(cwd);
+
+    const enospc = Object.assign(
+      new Error('ENOSPC: no space left on device'),
+      { code: 'ENOSPC' },
+    );
+    const messages: string[] = [];
+
+    const result = await stageActiveSkill(
+      cwd,
+      'blog-post',
+      sourceDir,
+      (m) => messages.push(m),
+      () => Promise.reject(enospc),
+    );
+
+    // Not a cross-filesystem rejection — propagates to the existing
+    // degrade path instead of attempting the stream-copy fallback.
+    expect(result.staged).toBe(false);
+    expect(result.reason).toMatch(/ENOSPC/);
+    expect(
+      existsSync(path.join(cwd, SKILLS_CWD_ALIAS, 'blog-post', 'SKILL.md')),
+    ).toBe(false);
+    expect(messages.some((m) => m.includes('stream copy'))).toBe(false);
+  });
 });


### PR DESCRIPTION
Fixes #3248

## Why

I hit this self-hosting the daemon in Docker on TrueNAS, where `OD_DATA_DIR` is a ZFS bind mount on a different filesystem from the image layer. Every turn logged:

```
[od] skill-stage failed: EPERM: operation not permitted, copyfile '/app/plugins/.../example.html' -> '/data/projects/<id>/.od-skills/.../example.html'
[od] skill-stage skipped: ... falling back to absolute paths
```

Root cause: `stageActiveSkill` (`apps/daemon/src/cwd-aliases.ts`) uses `fs.cp`, which copies each file via `copy_file_range(2)`. The kernel rejects that syscall across different filesystems (`/app` image layer → `/data` ZFS/overlay bind mount); the usual errno is `EXDEV`, but this pairing surfaces `EPERM`, and Node's `fs.cp` doesn't fall back to a userspace copy. The pain: it's not just log noise — staging degrades to absolute paths (`/app/plugins/...`), which loses the `.od-skills` write-barrier isolation the per-project copy exists to provide.

## What users will see

Self-hosted/containerized users whose data dir is on a different filesystem from the install get working per-project skill staging again (the `.od-skills/<folder>/` copy) instead of a per-turn `skill-stage failed: EPERM` log and a silent drop to absolute paths. No visible UI change.

## Surface area

- [x] **None** — internal bug fix to skill staging; no new UI / CLI / API / extension point / i18n key / dependency, and no opt-in default change. (Adds an optional, test-only `nativeCopy` seam to one internal function signature; default behavior unchanged.)

## Screenshots

N/A — no UI change.

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow":

- Test path that reproduces the bug: `apps/daemon/tests/cwd-aliases.test.ts` → *"falls back to a dereferenced stream copy when the native copy fails with EPERM"* (+ a companion test that a non-recoverable code still degrades).
- Did the test go red on `main` and green on this branch? The real `copy_file_range` EPERM only reproduces on specific cross-filesystem mounts (ZFS/overlay) — not on APFS dev machines or CI — so the test injects a synthetic EPERM through a copy seam rather than relying on the mount. I confirmed the spec is **falsifiable**: with the fallback branch neutered (rethrow on every code), exactly this test goes red (`1 failed | 18 passed`); with the fallback in place all 19 pass. The companion non-recoverable test (`ENOSPC`) stays green both ways, proving the gate doesn't over-broaden.

## Fix

Keep `fs.cp` as the fast path (preserves CoW reflinks where available). On a recoverable cross-fs copy error (`EPERM`/`EXDEV`/`ENOTSUP`/`EOPNOTSUPP`), retry with `copyTreeDereferenced` — a recursive read/write copy that `stat()`s each entry (so symlinks are dereferenced into real files, keeping the write barrier) and streams file contents, which doesn't use `copy_file_range`. Non-recoverable errors still propagate to the existing degrade-to-absolute-paths path, so the change can't make any current case worse.

## Validation

- `pnpm --filter @open-design/daemon test cwd-aliases` → 19 passed (incl. the 2 new tests; falsifiability checked as above)
- `pnpm --filter @open-design/daemon typecheck` → clean