### PR TITLE
fix(web): remove passive video play badge

### DIFF
--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -68,11 +68,6 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
           preload="none"
         />
       ) : null}
-      {preview.mediaType === 'video' && !preview.imageOnly ? (
-        <span className="plugins-home__media-badge" aria-hidden>
-          <Icon name="play" size={12} />
-        </span>
-      ) : null}
     </div>
   );
 }

--- a/apps/web/src/styles/home/plugins-home.css
+++ b/apps/web/src/styles/home/plugins-home.css
@@ -514,24 +514,6 @@
     background-position: -200% 0, 0 0;
   }
 }
-.plugins-home__media-badge {
-  position: absolute;
-  bottom: 8px;
-  right: 8px;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: rgba(0, 0, 0, 0.55);
-  color: white;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 2;
-  pointer-events: none;
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-}
-
 /* Sandboxed HTML iframe — scaled-down "thumbnail" of a real page */
 .plugins-home__html {
   position: absolute;

--- a/apps/web/tests/components/plugins-home-media-surface.test.tsx
+++ b/apps/web/tests/components/plugins-home-media-surface.test.tsx
@@ -30,6 +30,13 @@ const POSTER: MediaPreviewSpec = {
   imageOnly: true,
 };
 
+const VIDEO_POSTER: MediaPreviewSpec = {
+  ...POSTER,
+  mediaType: 'video',
+  videoUrl: 'https://example.invalid/preview.mp4',
+  imageOnly: false,
+};
+
 afterEach(() => {
   cleanup();
 });
@@ -98,5 +105,12 @@ describe('MediaSurface broken-poster fallback (#2955)', () => {
     );
     expect(container.querySelector('img.plugins-home__media-img')).toBeNull();
     expect(container.querySelector('.plugins-home__media-fallback')).not.toBeNull();
+  });
+
+  it('does not render a passive play badge for video cards that already auto-play on hover', () => {
+    const { container } = render(
+      <MediaSurface preview={VIDEO_POSTER} pluginTitle="Video example" inView={true} />,
+    );
+    expect(container.querySelector('.plugins-home__media-badge')).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #3206.

## Summary
- remove the passive play badge overlay from video media cards
- drop the now-unused badge styles
- add a MediaSurface regression test so video cards keep hover playback without rendering a non-clickable badge

## Validation
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/plugins-home-media-surface.test.tsx`
- `git diff --check`