### PR TITLE
fix(web): target comment picker elements precisely

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -7155,7 +7155,9 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
             ) : null}
             {commentPortalHost && commentSidePanel
               ? createPortal(commentSidePanel, commentPortalHost)
-              : commentSidePanel}
+              : commentPortalId
+                ? null
+                : commentSidePanel}
             {inspectMode && activeInspectTarget ? (
               <InspectPanel
                 target={activeInspectTarget}

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1016,7 +1016,7 @@ function meaningfulDomFallbackTarget(el) {
 
   var tag = el.tagName ? el.tagName.toLowerCase() : '';
 
-  if (/^(a|button|input|textarea|select|label|img|video|canvas|h1|h2|h3|h4|h5|h6|p|li|td|th|section|article|main|aside|nav)$/.test(tag)) {
+  if (/^(a|button|input|textarea|select|label|img|video|canvas|h1|h2|h3|h4|h5|h6|p|li|td|th)$/.test(tag)) {
     return true;
   }
 
@@ -1045,9 +1045,13 @@ function meaningfulDomFallbackTarget(el) {
   var text = (el.textContent || '').replace(/\s+/g, ' ').trim();
   if (!text) return false;
 
+  if (/^(span|strong|em|b|i|small|code|mark)$/.test(tag)) return true;
+
   var meaningfulChildren = 0;
   for (var child = el.firstElementChild;child;child = child.nextElementSibling) {
-    if ((child.textContent || '').replace(/\s+/g, ' ').trim()) {
+    var childTag = child.tagName ? child.tagName.toLowerCase() : '';
+    if (/^(script|style|template|meta|link|title|noscript)$/.test(childTag)) continue;
+    if ((child.textContent || '').replace(/\s+/g, ' ').trim() || /^(img|video|canvas|svg|input|textarea|select)$/.test(childTag)) {
       meaningfulChildren++;
       if (meaningfulChildren > 1) return false;
     }
@@ -1055,8 +1059,12 @@ function meaningfulDomFallbackTarget(el) {
 
   return true;
 }
+  function generatedRootAnnotation(el, id){
+    return id === 'path-0' && el && el.parentElement === document.body && el.id === 'root';
+  }
   function targetFrom(el, allowDomFallback, clickedEl, clickPoint){
     var id = el.getAttribute('data-od-id') || el.getAttribute('data-screen-label');
+    if (allowDomFallback && id && generatedRootAnnotation(el, id)) return null;
     var selector = annotatedSelectorFor(el);
     if (!id && allowDomFallback && meaningfulDomFallbackTarget(el)) {
       selector = domSelectorFor(el);
@@ -1069,9 +1077,6 @@ function meaningfulDomFallbackTarget(el) {
     var html = '';
     try { html = (el.outerHTML || '').replace(/\\s+/g, ' ').match(/^<[^>]+>/)?.[0] || ''; } catch (_) {}
     var position = { x: Math.round(rect.x), y: Math.round(rect.y), width: Math.round(rect.width), height: Math.round(rect.height) };
-    if (clickPoint) {
-      position = { x: Math.round(clickPoint.x), y: Math.round(clickPoint.y), width: 1, height: 1 };
-    }
     var payload = {
       type: 'od:comment-target',
       elementId: id,
@@ -1163,21 +1168,67 @@ function meaningfulDomFallbackTarget(el) {
     window.parent.postMessage({ type: type, points: stroke.slice() }, '*');
   }
   function canUseDomFallback(){
-    return commentEnabled && !inspectEnabled && document.querySelectorAll('[data-od-id], [data-screen-label]').length === 0;
+    return commentEnabled && !inspectEnabled;
+  }
+  function eventCandidateElements(event){
+    var items = [];
+    function push(node){
+      if (!node || node.nodeType !== 1) return;
+      if (items.indexOf(node) >= 0) return;
+      items.push(node);
+    }
+    try {
+      if (event && typeof event.composedPath === 'function') {
+        var path = event.composedPath();
+        for (var i = 0; i < path.length; i++) push(path[i]);
+      }
+    } catch (_) {}
+    push(event && event.target);
+    try {
+      if (
+        event &&
+        typeof event.clientX === 'number' &&
+        typeof event.clientY === 'number' &&
+        document.elementsFromPoint
+      ) {
+        var stack = document.elementsFromPoint(event.clientX, event.clientY);
+        for (var s = 0; s < stack.length; s++) push(stack[s]);
+      } else if (
+        event &&
+        typeof event.clientX === 'number' &&
+        typeof event.clientY === 'number' &&
+        document.elementFromPoint
+      ) {
+        push(document.elementFromPoint(event.clientX, event.clientY));
+      }
+    } catch (_) {}
+    return items;
   }
   function closestTarget(event){
-    var clicked = event.target;
-    var el = clicked;
-    var fallback = null;
+    var candidates = eventCandidateElements(event);
     var allowDomFallback = mode === 'picker' && canUseDomFallback();
-    while (el && el !== document.documentElement) {
-      if (el.getAttribute && (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label'))) {
-        return { target: el, clicked: clicked };
+    var annotatedFallback = null;
+    for (var i = 0; i < candidates.length; i++) {
+      var clicked = candidates[i];
+      var el = clicked;
+      while (el && el !== document.documentElement) {
+        if (allowDomFallback && meaningfulDomFallbackTarget(el)) {
+          return { target: el, clicked: clicked };
+        }
+        if (el.getAttribute && (el.hasAttribute('data-od-id') || el.hasAttribute('data-screen-label'))) {
+          var id = el.getAttribute('data-od-id') || el.getAttribute('data-screen-label');
+          if (allowDomFallback && generatedRootAnnotation(el, id)) {
+            el = el.parentElement;
+            continue;
+          }
+          if (allowDomFallback && !annotatedFallback) annotatedFallback = { target: el, clicked: clicked };
+          if (allowDomFallback) break;
+          return { target: el, clicked: clicked };
+        }
+        el = el.parentElement;
       }
-      if (!fallback && allowDomFallback && meaningfulDomFallbackTarget(el)) fallback = el;
-      el = el.parentElement;
     }
-    return fallback ? { target: fallback, clicked: clicked } : null;
+    return annotatedFallback;
   }
   function applyOverride(elementId, selector, prop, value){
     if (!elementId || !prop) return;

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1791,6 +1791,22 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.queryByText('Already sent to Claude')).toBeNull();
   });
 
+  it('does not render the comments drawer over the preview while waiting for a configured dock portal', () => {
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+        commentPortalId="project-comments-dock"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+
+    expect(container.querySelector('.comment-preview-layer > .comment-side-panel')).toBeNull();
+  });
+
   it('shows the open comment count beside the comments icon', () => {
     const openComment: PreviewComment = {
       id: 'comment-open',

--- a/apps/web/tests/runtime/srcdoc-bridge-empty-targets.test.ts
+++ b/apps/web/tests/runtime/srcdoc-bridge-empty-targets.test.ts
@@ -16,12 +16,10 @@ import { buildSrcdoc } from '../../src/runtime/srcdoc';
 //      this, FileViewer's `liveCommentTargets` map never updates and
 //      the hint banner sticks at its instructive-default state even
 //      though there's nothing to click.
-//   2. Drop click events on unannotated elements without posting an
-//      `od:comment-target` — the click handler walks up to <html>,
-//      finds nothing tagged, and must bail. Posting a synthetic id
-//      here would change save-to-source semantics for inspect
-//      overrides (the persisted CSS keys off the same elementId), so
-//      this test pins the no-fallback contract.
+//   2. In Comment picker mode, fall back to meaningful DOM selectors
+//      for unannotated surfaces so imported or partially annotated HTML
+//      can still be reviewed. Inspect mode still needs a real annotated
+//      selector for live style persistence.
 //
 // The host-side hint switch lives in `apps/web/src/components/FileViewer.tsx`
 // (search for `inspect-empty-hint-no-targets`); these tests pin the
@@ -252,7 +250,7 @@ describe('selection bridge — empty annotation surface (#890)', () => {
     expect(clickMessages[0].text).toBe('Launch');
   });
 
-  it('does not use Picker DOM fallback on mixed annotated and unannotated pages', async () => {
+  it('uses Picker DOM fallback for meaningful unannotated elements on mixed pages', async () => {
     const { win, parentPostMessage } = setupBridgeDom(
       '<main><section data-od-id="hero">Hero</section><button id="cta">Launch</button></main>',
       'comment',
@@ -269,7 +267,67 @@ describe('selection bridge — empty annotation surface (#890)', () => {
     const clickMessages = parentPostMessage.mock.calls
       .map((call) => call[0])
       .filter((message) => message?.type === 'od:comment-target');
-    expect(clickMessages).toEqual([]);
+    expect(clickMessages).toHaveLength(1);
+    expect(clickMessages[0]).toMatchObject({
+      elementId: 'dom:body > main:nth-of-type(1) > button:nth-of-type(1)',
+      selector: 'body > main:nth-of-type(1) > button:nth-of-type(1)',
+      text: 'Launch',
+    });
+  });
+
+  it('uses leaf-first DOM fallback in Comment mode instead of an annotated section ancestor', async () => {
+    const { win, parentPostMessage } = setupBridgeDom(
+      '<section data-screen-label="01 Hero"><h1 id="headline"><span>ERP</span> and CRM delivery</h1><p>Subhead</p></section>',
+      'comment',
+      ['#headline'],
+    );
+
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 10));
+    parentPostMessage.mockClear();
+
+    win.document.getElementById('headline')!.dispatchEvent(
+      new win.MouseEvent('click', { bubbles: true, cancelable: true }),
+    );
+
+    const clickMessages = parentPostMessage.mock.calls
+      .map((call) => call[0])
+      .filter((message) => message?.type === 'od:comment-target');
+    expect(clickMessages).toHaveLength(1);
+    expect(clickMessages[0]).toMatchObject({
+      elementId: 'dom:body > section:nth-of-type(1) > h1:nth-of-type(1)',
+      selector: 'body > section:nth-of-type(1) > h1:nth-of-type(1)',
+      label: 'h1',
+      text: 'ERP and CRM delivery',
+      position: {
+        x: 10,
+        y: 20,
+        width: 120,
+        height: 48,
+      },
+    });
+  });
+
+  it('does not broadcast the generated React root as a page-sized Comment target', async () => {
+    const { win, parentPostMessage } = setupBridgeDom(
+      '<div id="root" data-od-id="path-0"><header><a>Brand</a></header><main><h1 id="headline">Hero</h1></main><footer>Footer</footer></div>',
+      'comment',
+      ['#root', '#headline'],
+    );
+
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 10));
+
+    const targetMessages = parentPostMessage.mock.calls
+      .map((call) => call[0])
+      .filter((message) => message?.type === 'od:comment-targets');
+    expect(targetMessages.length).toBeGreaterThan(0);
+    const last = targetMessages.at(-1);
+    expect(last.targets).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          elementId: 'path-0',
+        }),
+      ]),
+    );
   });
 
   it('broadcasts DOM fallback targets in comment mode so Pods can hit-test unannotated pages', async () => {


### PR DESCRIPTION
## Summary
- make Comment picker resolve meaningful visible DOM leaf targets before annotated ancestors, while preserving Inspect mode's annotation-first behavior
- filter the generated `#root` / `path-0` annotation out of Comment target broadcasts so page-sized roots do not dominate hit testing or overlays
- keep real element bounds in comment target payloads and use `hoverPoint` only for the click anchor
- avoid rendering the comments side panel inside the preview when a dock portal is configured but has not mounted yet

## Surface area
- [x] UI
- [x] Default behavior change
- [ ] API
- [ ] Database
- [ ] Authentication / permissions
- [ ] Build / dependencies
- [ ] Documentation only

## Bug fix verification
The new `leaf-first|generated React root` Vitest regression specs cover the pre-fix failures: Comment mode selected an annotated ancestor or generated `#root[data-od-id="path-0"]` instead of the visible leaf target. They are now green on this branch.

## Why
Comment mode is a review workflow, so users expect the element under the pointer to become the comment target. On imported or partially annotated HTML, the bridge could resolve clicks on visible text or controls to a large annotated ancestor or generated root. That makes an entire section or page appear selected instead of the actual content being reviewed.

Inspect mode has a different persistence contract for style overrides, so this keeps Inspect on stable annotated targets and applies the leaf-first DOM fallback only to Comment picker mode.

## Related
- #890
- #1022
- #1706
- #2039
- #2045
- #2073
- #2143
- #2616

## Implementation notes
- `closestTarget()` now gathers candidates from `composedPath()`, the event target, and `elementsFromPoint()`/`elementFromPoint()`.
- In Comment picker mode, it resolves the first meaningful visible leaf and only falls back to annotated ancestors when no meaningful leaf exists.
- `targetFrom()` skips generated `#root[data-od-id="path-0"]` for Comment fallback and preserves `getBoundingClientRect()` bounds.
- Inspect continues to use annotated targets for stable override selectors.

## Validation
- `npx -y node@24.16.0 /opt/homebrew/bin/pnpm --filter @open-design/web exec vitest run tests/runtime/srcdoc-bridge-empty-targets.test.ts -t "leaf-first|generated React root"`
- `npx -y node@24.16.0 /opt/homebrew/bin/pnpm --filter @open-design/web exec vitest run tests/runtime/srcdoc-bridge-empty-targets.test.ts tests/runtime/srcdoc.test.ts tests/comments.test.ts tests/components/FileViewer.test.tsx tests/components/BoardComposerPopover.pod-chip-hover.test.tsx tests/components/CommentTargetOverlay.hover-class.test.tsx`
- `npx -y node@24.16.0 /opt/homebrew/bin/pnpm --filter @open-design/web typecheck`
- `npx -y node@24.16.0 /opt/homebrew/bin/pnpm guard`
- `git diff --check`
- manual browser verification on a local imported HTML artifact; no project-specific data included