### PR TITLE
fix(plugins-home): remove overlapping fallback icon from media surface

### DIFF
--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -8,7 +8,6 @@
 
 import { useEffect, useState } from 'react';
 import type { MediaPreviewSpec } from '../preview';
-import { Icon } from '../../Icon';
 
 interface Props {
   preview: MediaPreviewSpec;
@@ -50,7 +49,7 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
           onError={() => setPosterLoadFailed(true)}
         />
       ) : useFallback ? (
-        <MediaFallback pluginTitle={pluginTitle} mediaType={preview.mediaType} />
+        <MediaFallback pluginTitle={pluginTitle} />
       ) : (
         <div
           className={`plugins-home__media-skeleton${inView ? ' is-active' : ''}`}
@@ -73,15 +72,12 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
 }
 
 function MediaFallback({
-  mediaType,
   pluginTitle,
 }: {
-  mediaType: MediaPreviewSpec['mediaType'];
   pluginTitle: string;
 }) {
   const trimmed = pluginTitle.trim();
   const glyph = String.fromCodePoint(trimmed.codePointAt(0) ?? 0x2022).toUpperCase();
-  const icon = mediaType === 'video' ? 'play' : mediaType === 'audio' ? 'mic' : 'image';
   return (
     <div className="plugins-home__media-fallback" aria-hidden>
       <span className="plugins-home__media-fallback-glyph">{glyph}</span>

--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -85,9 +85,6 @@ function MediaFallback({
   return (
     <div className="plugins-home__media-fallback" aria-hidden>
       <span className="plugins-home__media-fallback-glyph">{glyph}</span>
-      <span className="plugins-home__media-fallback-icon">
-        <Icon name={icon} size={15} />
-      </span>
     </div>
   );
 }

--- a/apps/web/src/styles/home/plugins-home.css
+++ b/apps/web/src/styles/home/plugins-home.css
@@ -494,21 +494,6 @@
   line-height: 1;
   opacity: 0.86;
 }
-.plugins-home__media-fallback-icon {
-  position: absolute;
-  right: 10px;
-  bottom: 10px;
-  width: 28px;
-  height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--bg-panel) 74%, transparent);
-  color: var(--accent);
-  box-shadow: var(--shadow-xs);
-}
 @keyframes plugins-home-shimmer {
   to {
     background-position: -200% 0, 0 0;


### PR DESCRIPTION
Fixes #3203 

## Why

* **Use case**: We noticed that when viewing the plugins discovery page (Plugins Home gallery), the typographic fallback for card previews (rendered when a plugin has no poster image or when the poster image fails to load) displayed a redundant, absolute-positioned media-type icon badge in the bottom-right corner of the fallback surface in addition to the primary centered letter glyph.
* **Pain being addressed**: This small media-type icon badge (`.plugins-home__media-fallback-icon`) overlapped and clashed visually with other card-level items and layout constraints. Removing it simplifies the typographic fallback, delivering a cleaner, more polished, and clutter-free aesthetic for the Home discovery gallery.


## What users will see

When a plugin does not have a preview media poster (or its poster URL fails to load), the card degrades gracefully to a clean typographic fallback displaying a centered initial glyph, without the overlapping small media-type badge in the bottom-right corner.


## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

*N/A — Minor CSS/markup cleanup that removes an overlapping icon layout conflict in the card's typographic fallback.*


## Bug fix verification

* **Test path that reproduces the bug**: `apps/web/tests/components/plugins-home-media-surface.test.tsx`
* **Did the test go red on `main` and green on this branch?**: N/A (The bug is visual layout clutter caused by the presence of the `.plugins-home__media-fallback-icon` element. The corresponding Vitest suites pass cleanly, confirming there are no logic regressions).


## Validation

- `pnpm --filter @open-design/web test -- /tests/components/plugins-home-media-surface.test.tsx`
- `pnpm --filter @open-design/web typecheck`
