### PR TITLE
fix(composer): truncate long referenced filenames with ellipsis (#3261)

### DIFF
--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -537,26 +537,24 @@
   color: transparent;
 }
 .composer-inline-mention {
-  display: inline;
-  max-width: none;
+  display: inline-block;
+  max-width: min(240px, 25vw);
   margin: 0;
-  padding: 0;
+  padding: 0 1px;
   border: 0;
   border-radius: 5px;
   background: color-mix(in srgb, var(--accent) 8%, transparent);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 12%, transparent);
-  box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
   color: color-mix(in srgb, var(--accent) 62%, var(--text));
   font: inherit;
   font-size: inherit;
   font-weight: inherit;
   line-height: inherit;
   letter-spacing: inherit;
-  vertical-align: baseline;
-  overflow: visible;
-  text-overflow: clip;
-  white-space: inherit;
+  vertical-align: bottom;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .composer-row {
   display: flex;


### PR DESCRIPTION
## Summary

Referenced filenames in the composer (@-mentions) currently display in full, which can cause line wrapping and visual crowding.

## Changes

CSS text-overflow truncation on `.composer-inline-mention`:
- `display: inline-block` for max-width support
- `max-width: min(240px, 25vw)` sensible cap
- `overflow: hidden + text-overflow: ellipsis + white-space: nowrap`
- Removed `box-decoration-break: clone` (no wrapping)
- `vertical-align: bottom` for alignment

Closes #3261