### PR TITLE
fix(web): disable Draw direct-send during an active run, keep Queue

### DIFF
--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -364,6 +364,9 @@ export function PreviewDrawOverlay({
     const shouldCapture = hasInk || hasTarget || captureViewport;
     const canSubmit = shouldCapture || Boolean(note.trim());
     if (sending || !canSubmit) return;
+    // While a task is running the primary Send is disabled (use Queue instead).
+    // The note/attachment is not lost: Queue still stages it for the next turn.
+    if (action === 'send' && sendDisabled) return;
     setCaptureWarning(null);
     setPendingAction(action);
     try {
@@ -425,7 +428,7 @@ export function PreviewDrawOverlay({
   const overlayPointer = active ? 'auto' : 'none';
   const showCanvas = active || hasInk;
   const canSubmit = hasInk || Boolean(captureTarget) || captureViewport || Boolean(note.trim());
-  const canSend = canSubmit;
+  const canSend = canSubmit && !sendDisabled;
   const canUndo = undoCount > 0 && !sending;
   const canRedo = redoCount > 0 && !sending;
 

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1722,7 +1722,7 @@ describe('FileViewer tweaks toolbar', () => {
     expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc).toBe(frame.srcdoc);
   });
 
-  it('lets Draw direct send emit a queued annotation while a task is running', async () => {
+  it('disables Draw direct send during a run but keeps Queue available so the annotation is not lost', async () => {
     const annotationSpy = vi.fn();
     window.addEventListener(ANNOTATION_EVENT, annotationSpy);
 
@@ -1738,17 +1738,22 @@ describe('FileViewer tweaks toolbar', () => {
       target: { value: 'mark this' },
     });
 
+    // While a task is running the primary Send is disabled; Queue stays available
+    // so the annotation is staged for the next turn rather than sent mid-run.
+    const send = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
+    expect(send.disabled).toBe(true);
     const queue = screen.getByRole('button', { name: 'Queue' }) as HTMLButtonElement;
     expect(queue.disabled).toBe(false);
-    const send = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
-    expect(send.disabled).toBe(false);
 
     fireEvent.click(send);
+    expect(annotationSpy).not.toHaveBeenCalled();
+
+    fireEvent.click(queue);
 
     await waitFor(() => expect(annotationSpy).toHaveBeenCalledTimes(1));
     expect(annotationSpy.mock.calls[0]?.[0]).toMatchObject({
       detail: {
-        action: 'send',
+        action: 'queue',
         note: 'mark this',
         filePath: 'preview.html',
       },

--- a/apps/web/tests/components/PreviewDrawOverlay.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.test.tsx
@@ -61,6 +61,65 @@ describe('PreviewDrawOverlay', () => {
     }
   });
 
+  it('does not direct-send via Enter while a task is running', () => {
+    const annotation = vi.fn();
+    window.addEventListener('opendesign:annotation', annotation);
+
+    try {
+      const { container } = render(
+        <PreviewDrawOverlay active sendDisabled sendDisabledReason="A task is currently running">
+          <div style={{ width: 320, height: 200 }} />
+        </PreviewDrawOverlay>,
+      );
+
+      const input = container.querySelector<HTMLInputElement>('.preview-draw-note-input');
+      expect(input).toBeTruthy();
+
+      fireEvent.change(input!, { target: { value: 'Please inspect this panel.' } });
+      fireEvent.keyDown(input!, { key: 'Enter' });
+
+      expect(annotation).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('opendesign:annotation', annotation);
+    }
+  });
+
+  it('disables the primary Send action while a task is running', () => {
+    const { getByRole } = render(
+      <PreviewDrawOverlay active sendDisabled sendDisabledReason="A task is currently running">
+        <div style={{ width: 320, height: 200 }} />
+      </PreviewDrawOverlay>,
+    );
+
+    const sendButton = getByRole('button', { name: 'Send' });
+    expect((sendButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('keeps Queue available so an annotation is not lost while a task is running', async () => {
+    const annotation = vi.fn();
+    window.addEventListener('opendesign:annotation', annotation);
+
+    try {
+      const { container, getByRole } = render(
+        <PreviewDrawOverlay active sendDisabled sendDisabledReason="A task is currently running">
+          <div style={{ width: 320, height: 200 }} />
+        </PreviewDrawOverlay>,
+      );
+
+      const input = container.querySelector<HTMLInputElement>('.preview-draw-note-input');
+      fireEvent.change(input!, { target: { value: 'Queue this up.' } });
+
+      const queueButton = getByRole('button', { name: 'Queue' });
+      expect((queueButton as HTMLButtonElement).disabled).toBe(false);
+      fireEvent.click(queueButton);
+
+      await waitFor(() => expect(annotation).toHaveBeenCalledTimes(1));
+      expect(annotation.mock.calls[0]?.[0].detail).toMatchObject({ action: 'queue' });
+    } finally {
+      window.removeEventListener('opendesign:annotation', annotation);
+    }
+  });
+
   it('clears transient ink when draw mode exits', async () => {
     const { container, rerender } = render(
       <PreviewDrawOverlay active>


### PR DESCRIPTION
## Why

An internal contributor's Studio hardening (#3081) landed only on a stacked intermediate branch and never reached `main` — the squash of the parent #3000 went to `main` first, dropping the two stacked layers on top. Meanwhile `main` independently picked up #1961 (kami) which does the *opposite* for the same control. So today on `main` the Draw/annotation **Send** button shows a "task is currently running" disabled reason but is still clickable, and pressing **Enter** still direct-sends mid-run. The UI looks guarded but the behavior leaks through.

A design colleague reported the Studio tools "weren't there" after starting locally — the root cause for the toolbar itself was a stale local branch (506 commits behind, pre-#3000); the toolbar is already on `main`. The only genuinely-missing behavior is this Draw send guard, which the team chose to follow #3081 for.

## What users will see

While a task is running, the Draw/annotation **Send** action is now disabled (and Enter no longer direct-sends), matching the disabled reason the button already shows. **Queue stays available**, so an annotation made during a run is staged for the next turn instead of being sent into the active run. Nothing is lost — you just queue it instead of sending mid-run.

This is a deliberate synthesis, not a wholesale revert: #3081's guard is applied, but kami's #1961 value (annotations during a run are staged, not dropped) is preserved by keeping Queue and the downstream streaming-staging handler in `ChatComposer` untouched.

## Surface area

- [x] **UI** — changed Draw/annotation primary Send + Enter behavior in `apps/web`
- [x] **Default behavior change** — Draw direct Send is disabled while a task is running; Queue remains available
- [ ] Keyboard shortcut / CLI / API / Extension point / i18n keys / New dependency
- [ ] None

No new i18n keys (reuses the existing `chat.annotationSendDisabledReason`).

## Screenshots

Not attached: the change is a button enabled→disabled state that only appears *during* an active streaming run, plus an Enter-key guard — there is no static visual difference outside a live run. Behavior is locked by component + FileViewer integration tests below.

## Bug fix verification

- Red spec on `main`: `apps/web/tests/components/PreviewDrawOverlay.test.tsx` — "does not direct-send via Enter while a task is running" fails on `main` (Enter dispatches a `send` annotation), passes on this branch.
- Reframed the existing streaming Draw test in `apps/web/tests/components/FileViewer.test.tsx` (previously "lets Draw direct send emit a queued annotation while a task is running", from #1961) to assert Send is disabled while Queue still emits a queued annotation — preserving the "annotate during a run" coverage.

## Validation

- `pnpm --filter @open-design/web test` on `tests/components/PreviewDrawOverlay.test.tsx` + `tests/components/FileViewer.test.tsx` — 115 passed
- `pnpm --filter @open-design/web typecheck` — clean (0 errors)
- `pnpm guard` — pass