### PR TITLE
style: improve layout constraints and text truncation for design file…

### DIFF
--- a/apps/web/src/styles/workspace/design-files.css
+++ b/apps/web/src/styles/workspace/design-files.css
@@ -384,6 +384,8 @@
 .df-cell-name {
   padding: 10px 12px 10px 0;
   vertical-align: middle;
+  width: 100%;
+  max-width: 0;
 }
 .df-cell-openable {
   cursor: pointer;
@@ -395,6 +397,7 @@
   flex-direction: column;
   gap: 2px;
   min-width: 0;
+  max-width: 100%;
 }
 .df-row-name-btn:hover:not(:disabled) {
   background: transparent;
@@ -655,7 +658,7 @@
 .df-row-icon[data-kind="code"] { background: #fff7d8; color: #8c6700; }
 .df-row-icon[data-kind="text"] { background: var(--bg-subtle); color: var(--text-muted); }
 .df-row-icon[data-kind="sketch"] { background: var(--purple-bg); color: var(--purple); }
-.df-row-name-wrap { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.df-row-name-wrap { display: flex; flex-direction: column; gap: 2px; min-width: 0; max-width: 100%; }
 .df-row-name {
   font-size: 13px;
   font-weight: 500;
@@ -663,6 +666,8 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 100%;
+  display: block;
 }
 .df-rename-input {
   width: 100%;


### PR DESCRIPTION
Fixes #3260 

## Why

- **Your use case:** Scratching an itch for users and the team who rely on the Design Files list being easily scannable, ensuring long filenames don't ruin the visual hierarchy of the workspace.
- **The pain being addressed:** A user-facing layout bug where extremely long filenames inside the list row component would blow past the bounds of the table cell. Because the filename text was nested inside flex containers, it forced the table to stretch horizontally, pushing other columns off-screen and breaking the UI.

## What users will see

- Extremely long filenames in the Design Files list now correctly truncate with an ellipsis instead of breaking the table layout.
- The truncation dynamically adapts to the window size, preserving list scannability while keeping the full filename accessible via the preview/detail pane.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots
<img width="1452" height="645" alt="image" src="https://github.com/user-attachments/assets/6f3ca4cd-cd75-45dd-ab81-c5fac394f883" />

<!-- Please attach the before/after screenshots showing the truncated filename vs the overflowing table here. -->

## Bug fix verification

- **Test path that reproduces the bug:** Visually reproducible by adding a file with an extremely long name to a project's design files and observing the table layout stretch out of bounds.
- **Did the test go red on `main` and green on this branch?** N/A (Visual CSS change)
- **If a red spec wasn't cheap to write, explain why and what verification you did instead:** This is a purely visual CSS fix regarding flexbox constraints inside auto-layout table cells (`table-layout: fixed` vs `auto` interacting with `display: flex`). Writing an E2E test to measure pixel bounds of the text node is brittle; it is best verified visually to ensure it truncates correctly without leaving massive gaps on wide monitors.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm tools-dev run web --daemon-port 3001 --web-port 3000` (Verified visually in the local runtime loop)
