### PR TITLE
fix: keep header buttons fixed to the right in project view

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4249,6 +4249,12 @@ export function ProjectView({
         onBack={onBack}
         backLabel={t('project.backToProjects')}
         fileActionsBefore={(
+          <div
+            className="app-chrome-file-actions-before workspace-tabs-file-actions"
+            data-app-chrome-file-actions="true"
+          />
+        )}
+        actions={(
           <>
             <button
               type="button"
@@ -4276,14 +4282,7 @@ export function ProjectView({
               onRefreshAgents={onRefreshAgents}
               onBack={onBack}
             />
-            <div
-              className="app-chrome-file-actions-before workspace-tabs-file-actions"
-              data-app-chrome-file-actions="true"
-            />
           </>
-        )}
-        actions={(
-          null
         )}
       >
         <div className="app-project-title">


### PR DESCRIPTION
## Summary
- Move settings/handoff/avatar buttons from `fileActionsBefore` to `actions` slot in `AppChromeHeader`
- Portal container for file-specific actions (Share, Present, etc.) stays in `fileActionsBefore`
- Three buttons now always pin to the right edge, regardless of HTML preview injecting extra controls

## Test plan
- [ ] Open a project, verify settings/handoff/avatar buttons are on the far right
- [ ] Open an HTML file preview, verify buttons stay on the right while Share/Present appear to their left
- [ ] Verify no visual regression when no file is open (Design Files tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)