### PR TITLE
style: truncate task font labels with ellipsis to prevent overflow

### DIFF
--- a/apps/web/src/styles/home/tasks.css
+++ b/apps/web/src/styles/home/tasks.css
@@ -1444,6 +1444,9 @@
   font-size: 12.5px;
   font-weight: 680;
   color: var(--text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .automation-popover__hint {


### PR DESCRIPTION
Fixes #3274 

## Why

The project items in the automation popover were not truncating long names properly because `.automation-popover__label` lacked the standard CSS text truncation triad. The parent container `.automation-popover__body` already had `min-width: 0` set, so this was simply a missing style on the label itself. This fixes the layout so long project names don't overflow the popover.

## What users will see

Long project names in the automation popover will now properly truncate with an ellipsis (`...`) instead of overflowing or wrapping awkwardly.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots
<img width="1055" height="584" alt="image" src="https://github.com/user-attachments/assets/50f607af-baa5-435c-8492-3fa630c12026" />

## Bug fix verification

- Test path that reproduces the bug: N/A (Visual CSS layout issue)
- If a red spec wasn't cheap to write, explain why and what verification you did instead: This is a pure CSS styling fix. Verified visually by rendering the automation popover with an artificially long project name to confirm truncation works.

## Validation

- **Visual Check:** Visually verified the popover UI and confirmed that long project names now truncate properly with an ellipsis.
- `pnpm guard`
- `pnpm typecheck`
