### PR TITLE
feat(desktop): add Contact/Report/Discord links to Help menu

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -236,11 +236,31 @@ function installDesktopMenu(
       },
       {
         label: "Help",
+        role: "help",
         submenu: [
           {
-            label: "Open Design",
+            label: "Documentation",
             click() {
-              void shell.openExternal("https://github.com/nexu-io/open-design");
+              void shell.openExternal("https://github.com/nexu-io/open-design#readme");
+            },
+          },
+          { type: "separator" },
+          {
+            label: "Contact Us",
+            click() {
+              void shell.openExternal("https://x.com/nexudotio");
+            },
+          },
+          {
+            label: "Report Issue",
+            click() {
+              void shell.openExternal("https://github.com/nexu-io/open-design/issues/new");
+            },
+          },
+          {
+            label: "Join Discord",
+            click() {
+              void shell.openExternal("https://discord.gg/mHAjSMV6gz");
             },
           },
           { type: "separator" },


### PR DESCRIPTION
## Why

While using the packaged desktop app I noticed its **Help** menu only had a single repo link plus *Export Diagnostics…* — there was no in-app way to read the docs, file a bug, or reach the community. The web entry rail already gives users one-click access to docs / issues / Discord (`EntryHelpMenu`), but standalone desktop users had no equivalent. This closes that gap so the packaged client isn't a dead end for support.

## What users will see

The macOS/Windows menu bar **Help** menu now lists:

- **Documentation** → opens the project README
- **Contact Us** → opens the official X account (@nexudotio)
- **Report Issue** → opens GitHub "new issue"
- **Join Discord** → opens the community invite

*Export Diagnostics…* stays where it was. All items open in the user's browser. The submenu is now tagged `role: "help"`, so on macOS it gets the standard Help menu treatment (auto-positioned with the built-in search box).

## Surface area

- [x] **UI** — new menu items in the `apps/desktop` Electron menu bar (Help submenu)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — desktop menu strings are hardcoded English (matching the existing `Edit`/`View`/`Help`/`Export Diagnostics…` items); they don't go through the web i18n dictionary
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

URLs are not invented — they reuse the canonical links already used by `apps/web/src/components/EntryHelpMenu.tsx` and the README (`discord.gg/mHAjSMV6gz`, `issues/new`, `x.com/nexudotio`).

## Screenshots

_Menu bar → Help. Will attach a capture from a local run._

## Validation

- `pnpm --filter @open-design/desktop typecheck`
