### PR TITLE
fix(web): protect BYOK provider model cache keys

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -212,6 +212,9 @@ function AppInner() {
   const [integrationInitialTab, setIntegrationInitialTab] = useState<IntegrationTab>('mcp');
   const [daemonLive, setDaemonLive] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
+  const [providerModelsCache, setProviderModelsCache] = useState<
+    Record<string, ProviderModelOption[]>
+  >({});
   // Functional skills (capabilities the agent invokes mid-task) — stays
   // small and lives under the Settings → Skills surface.
   const [skills, setSkills] = useState<SkillSummary[]>([]);
@@ -233,9 +236,6 @@ function AppInner() {
   const [appVersionInfo, setAppVersionInfo] = useState<AppVersionInfo | null>(
     null,
   );
-  const [providerModelsCache, setProviderModelsCache] = useState<
-    Record<string, ProviderModelOption[]>
-  >({});
   const [daemonMediaProviders, setDaemonMediaProviders] = useState<
     AppConfig['mediaProviders'] | null
   >(null);

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -116,6 +116,10 @@ import {
   amrLoginPollOutcome,
 } from './amrLoginPolling';
 import { renderModelOptions } from './modelOptions';
+import {
+  providerModelsCacheKey,
+  type ProviderModelsCache,
+} from './providerModelsCache';
 
 // The topbar chips (GitHub star, model switcher, Use everywhere)
 // collapse into the settings dropdown when the viewport gets
@@ -236,8 +240,8 @@ interface Props {
   // top-bar `InlineModelSwitcher` can render the active mode/agent/model
   // and persist changes through the same callbacks the project view uses.
   config: AppConfig;
-  providerModelsCache?: Record<string, ProviderModelOption[]>;
-  onProviderModelsCacheChange?: Dispatch<SetStateAction<Record<string, ProviderModelOption[]>>>;
+  providerModelsCache?: ProviderModelsCache;
+  onProviderModelsCacheChange?: Dispatch<SetStateAction<ProviderModelsCache>>;
   agents: AgentInfo[];
   daemonLive: boolean;
   onModeChange: (mode: ExecMode) => void;
@@ -403,6 +407,18 @@ export function EntryShell({
   const view: EntryViewKind = route.kind === 'home' ? route.view : 'home';
   const [previewSystemId, setPreviewSystemId] = useState<string | null>(null);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
+  const [localProviderModelsCache, setLocalProviderModelsCache] =
+    useState<ProviderModelsCache>({});
+  const hasSharedProviderModelsCache =
+    Boolean(sharedProviderModelsCache) && Boolean(onProviderModelsCacheChange);
+  const activeProviderModelsCache =
+    hasSharedProviderModelsCache
+      ? sharedProviderModelsCache!
+      : localProviderModelsCache;
+  const activeSetProviderModelsCache =
+    hasSharedProviderModelsCache
+      ? onProviderModelsCacheChange!
+      : setLocalProviderModelsCache;
   const [newProjectInitialTab, setNewProjectInitialTab] =
     useState<CreateTab>('prototype');
   const [integrationTab, setIntegrationTab] = useState<IntegrationTab>(integrationInitialTab);
@@ -553,6 +569,8 @@ export function EntryShell({
           <OnboardingView
             config={config}
             agents={agents}
+            providerModelsCache={activeProviderModelsCache}
+            onProviderModelsCacheChange={activeSetProviderModelsCache}
             daemonLive={daemonLive}
             onModeChange={onModeChange}
             onAgentChange={onAgentChange}
@@ -592,9 +610,9 @@ export function EntryShell({
                 <span className="entry-discord-badge__label">Join Discord</span>
               </a>
               <InlineModelSwitcher
-                providerModelsCache={sharedProviderModelsCache}
                 config={config}
                 agents={agents}
+                providerModelsCache={activeProviderModelsCache}
                 daemonLive={daemonLive}
                 onModeChange={onModeChange}
                 onAgentChange={onAgentChange}
@@ -777,8 +795,8 @@ function OnboardingView({
   onFinish,
 }: {
   config: AppConfig;
-  providerModelsCache?: Record<string, ProviderModelOption[]>;
-  onProviderModelsCacheChange?: Dispatch<SetStateAction<Record<string, ProviderModelOption[]>>>;
+  providerModelsCache?: ProviderModelsCache;
+  onProviderModelsCacheChange?: Dispatch<SetStateAction<ProviderModelsCache>>;
   agents: AgentInfo[];
   daemonLive: boolean;
   onModeChange: (mode: ExecMode) => void;
@@ -826,11 +844,18 @@ function OnboardingView({
     | { status: 'running'; inputKey: string }
     | { status: 'done'; inputKey: string; result: ProviderModelsResponse }
   >({ status: 'idle' });
-  const [localProviderModelsCache, setLocalProviderModelsCache] = useState<
-    Record<string, ProviderModelOption[]>
-  >({});
-  const providerModelsCache = sharedProviderModelsCache ?? localProviderModelsCache;
-  const setProviderModelsCache = onProviderModelsCacheChange ?? setLocalProviderModelsCache;
+  const [localProviderModelsCache, setLocalProviderModelsCache] =
+    useState<ProviderModelsCache>({});
+  const hasSharedProviderModelsCache =
+    Boolean(sharedProviderModelsCache) && Boolean(onProviderModelsCacheChange);
+  const activeProviderModelsCache =
+    hasSharedProviderModelsCache
+      ? sharedProviderModelsCache!
+      : localProviderModelsCache;
+  const activeSetProviderModelsCache =
+    hasSharedProviderModelsCache
+      ? onProviderModelsCacheChange!
+      : setLocalProviderModelsCache;
   const [profile, setProfile] = useState({
     role: '',
     orgSize: '',
@@ -861,12 +886,12 @@ function OnboardingView({
     config.apiKey.trim(),
     config.apiVersion?.trim() ?? '',
   ].join('\n');
-  const providerModelsInputKey = [
+  const providerModelsInputKey = providerModelsCacheKey(
     apiProtocol,
-    config.baseUrl.trim().replace(/\/+$/, ''),
-    config.apiKey.trim(),
-    config.apiVersion?.trim() ?? '',
-  ].join('\n');
+    config.baseUrl,
+    config.apiKey,
+    config.apiVersion ?? '',
+  );
   const canTestProvider =
     Boolean(config.apiKey.trim()) &&
     Boolean(config.baseUrl.trim()) &&
@@ -1265,7 +1290,8 @@ function OnboardingView({
       value: model.id,
       label: model.label ?? model.id,
     })) ?? [];
-  const fetchedProviderModels = providerModelsCache[providerModelsInputKey] ?? [];
+  const fetchedProviderModels =
+    activeProviderModelsCache[providerModelsInputKey] ?? [];
   const byokModelOptions = mergeOnboardingProviderModelOptions(
     fetchedProviderModels,
     SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol],
@@ -1547,7 +1573,7 @@ function OnboardingView({
   async function fetchProviderModelsInline() {
     if (!canFetchProviderModels || providerModelsState.status === 'running') return;
     const inputKey = providerModelsInputKey;
-    const cachedModels = providerModelsCache[inputKey];
+    const cachedModels = activeProviderModelsCache[inputKey];
     if (cachedModels) {
       setProviderModelsState({
         status: 'done',
@@ -1569,7 +1595,7 @@ function OnboardingView({
         apiKey: config.apiKey,
       });
       if (result.ok && result.models?.length) {
-        setProviderModelsCache((current) => ({
+        activeSetProviderModelsCache((current) => ({
           ...current,
           [inputKey]: result.models ?? [],
         }));

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -11,13 +11,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useT } from '../i18n';
 import { KNOWN_PROVIDERS } from '../state/config';
+import { SUGGESTED_MODELS_BY_PROTOCOL } from '../state/apiProtocols';
 import {
   cancelVelaLogin,
   fetchVelaLoginStatus,
   startVelaLogin,
   type VelaLoginStatus,
 } from '../providers/daemon';
-import type { AgentInfo, ApiProtocol, AppConfig, ExecMode, ProviderModelOption } from '../types';
+import type { AgentInfo, ApiProtocol, AppConfig, ExecMode } from '../types';
 import { apiProtocolLabel } from '../utils/apiProtocol';
 import { AgentIcon } from './AgentIcon';
 import { Icon } from './Icon';
@@ -31,10 +32,16 @@ import {
 } from './amrLoginPolling';
 import { normalizeAgentModelChoice } from './agentModelSelection';
 import { SearchableModelSelect } from './modelOptions';
+import {
+  mergeProviderModelOptions,
+  providerModelsCacheKey,
+  type ProviderModelsCache,
+} from './providerModelsCache';
 
 interface Props {
   config: AppConfig;
   agents: AgentInfo[];
+  providerModelsCache?: ProviderModelsCache;
   daemonLive: boolean;
   onModeChange: (mode: ExecMode) => void;
   onAgentChange: (id: string) => void;
@@ -44,7 +51,6 @@ interface Props {
   ) => void;
   onApiProtocolChange: (protocol: ApiProtocol) => void;
   onApiModelChange: (model: string) => void;
-  providerModelsCache?: Record<string, ProviderModelOption[]>;
   onOpenSettings: (
     section?:
       | 'execution'
@@ -103,13 +109,13 @@ function displayAgentChipName(agent: Pick<AgentInfo, 'id' | 'name'>): string {
 export function InlineModelSwitcher({
   config,
   agents,
+  providerModelsCache,
   daemonLive,
   onModeChange,
   onAgentChange,
   onAgentModelChange,
   onApiProtocolChange,
   onApiModelChange,
-  providerModelsCache,
   onOpenSettings,
 }: Props) {
   const t = useT();
@@ -350,12 +356,6 @@ export function InlineModelSwitcher({
         : null;
 
   const apiProtocol = config.apiProtocol ?? 'anthropic';
-  const providerModelsInputKey = [
-    apiProtocol,
-    config.baseUrl.trim().replace(/\/+$/, ''),
-    config.apiKey.trim(),
-    config.apiVersion?.trim() ?? '',
-  ].join('\n');
   const providerForProtocol = useMemo(
     () =>
       KNOWN_PROVIDERS.find(
@@ -367,16 +367,38 @@ export function InlineModelSwitcher({
       ) ?? KNOWN_PROVIDERS.find((p) => p.protocol === apiProtocol),
     [apiProtocol, config.apiProviderBaseUrl],
   );
-  const fetchedProviderModels = providerModelsCache?.[providerModelsInputKey] ?? [];
-  const apiModelOptions = useMemo(() => {
-    const discovered = fetchedProviderModels.map((model) => model.id);
-    const staticOptions = providerForProtocol?.models ?? [];
-    const merged = new Set<string>([...discovered, ...staticOptions]);
-    if (config.model.trim()) merged.add(config.model.trim());
-    return Array.from(merged);
-  }, [config.model, fetchedProviderModels, providerForProtocol?.models]);
+  const providerModelsKey = useMemo(
+    () =>
+      providerModelsCacheKey(
+        apiProtocol,
+        config.baseUrl,
+        config.apiKey,
+        config.apiVersion ?? '',
+      ),
+    [apiProtocol, config.apiKey, config.apiVersion, config.baseUrl],
+  );
+  const fetchedApiModelOptions = providerModelsCache?.[providerModelsKey] ?? [];
+  const suggestedApiModelIds = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          providerForProtocol?.models?.length
+            ? providerForProtocol.models
+            : SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol],
+        ),
+      ),
+    [apiProtocol, providerForProtocol],
+  );
+  const apiModelOptions = useMemo(
+    () => mergeProviderModelOptions(fetchedApiModelOptions, suggestedApiModelIds),
+    [fetchedApiModelOptions, suggestedApiModelIds],
+  );
+  const apiModelIds = useMemo(
+    () => apiModelOptions.map((model) => model.id),
+    [apiModelOptions],
+  );
   const apiModelChoices = useMemo(
-    () => apiModelOptions.map((id) => ({ id, label: id })),
+    () => apiModelOptions.map((model) => ({ id: model.id, label: model.label })),
     [apiModelOptions],
   );
 
@@ -712,7 +734,7 @@ export function InlineModelSwitcher({
                     value={config.model}
                     onChange={(nextValue) => onApiModelChange?.(nextValue)}
                     additionalOptions={
-                      config.model && !apiModelOptions.includes(config.model)
+                      config.model && !apiModelIds.includes(config.model)
                         ? [
                             {
                               value: config.model,

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -59,6 +59,15 @@ import {
   SUGGESTED_MODELS_BY_PROTOCOL,
 } from '../state/apiProtocols';
 import {
+  mergeProviderModelOptions,
+  providerModelsCacheKey,
+  type ProviderModelsCache,
+} from './providerModelsCache';
+export {
+  mergeProviderModelOptions,
+  providerModelsCacheKey,
+} from './providerModelsCache';
+import {
   MAX_MAX_TOKENS,
   MIN_MAX_TOKENS,
   modelMaxTokensDefault,
@@ -159,6 +168,7 @@ interface Props {
   welcome?: boolean;
   initialSection?: SettingsSection;
   initialHighlight?: SettingsHighlight;
+  providerModelsCache?: ProviderModelsCache;
   /**
    * Persist the current draft. Invoked by the dialog's autosave loop on
    * every committed edit. Returns a promise that resolves once both
@@ -204,8 +214,7 @@ interface Props {
   onSkillsChanged?: (affectedSkillId?: string) => void;
   /** Same channel for design-system registry mutations. */
   onDesignSystemsChanged?: (affectedDesignSystemId?: string) => void;
-  providerModelsCache?: Record<string, ProviderModelOption[]>;
-  onProviderModelsCacheChange?: Dispatch<SetStateAction<Record<string, ProviderModelOption[]>>>;
+  onProviderModelsCacheChange?: Dispatch<SetStateAction<ProviderModelsCache>>;
 }
 
 export interface AgentRefreshOptions {
@@ -346,20 +355,6 @@ function missingByokModelFetchFields(
   return missing;
 }
 
-export function providerModelsCacheKey(
-  protocol: ApiProtocol,
-  baseUrl: string,
-  apiKey: string,
-  apiVersion = '',
-): string {
-  return [
-    protocol,
-    baseUrl.trim().replace(/\/+$/, ''),
-    apiKey,
-    protocol === 'azure' ? apiVersion.trim() : '',
-  ].join('\n');
-}
-
 function providerConnectionTestKey(
   protocol: ApiProtocol,
   config: Pick<AppConfig, 'apiKey' | 'baseUrl' | 'model' | 'apiVersion'>,
@@ -455,23 +450,6 @@ function cleanAgentVersionLabel(
 
 function displayAgentName(agent: Pick<AgentInfo, 'id' | 'name'>): string {
   return agent.id === 'amr' ? 'Open Design AMR' : agent.name;
-}
-
-export function mergeProviderModelOptions(
-  fetchedModels: readonly ProviderModelOption[],
-  suggestedModelIds: readonly string[],
-): ProviderModelOption[] {
-  const seen = new Set<string>();
-  const out: ProviderModelOption[] = [];
-  const add = (model: ProviderModelOption) => {
-    const id = model.id.trim();
-    if (!id || seen.has(id)) return;
-    seen.add(id);
-    out.push({ id, label: model.label.trim() || id });
-  };
-  for (const model of fetchedModels) add(model);
-  for (const id of suggestedModelIds) add({ id, label: id });
-  return out;
 }
 
 const AGENT_CLI_ENV_FIELDS = [
@@ -930,6 +908,18 @@ export function SettingsDialog({
   } | null>(null);
   const [providerModelsState, setProviderModelsState] =
     useState<ProviderModelsState>({ status: 'idle' });
+  const [localProviderModelsCache, setLocalProviderModelsCache] =
+    useState<ProviderModelsCache>({});
+  const hasSharedProviderModelsCache =
+    Boolean(sharedProviderModelsCache) && Boolean(onProviderModelsCacheChange);
+  const activeProviderModelsCache =
+    hasSharedProviderModelsCache
+      ? sharedProviderModelsCache!
+      : localProviderModelsCache;
+  const activeSetProviderModelsCache =
+    hasSharedProviderModelsCache
+      ? onProviderModelsCacheChange!
+      : setLocalProviderModelsCache;
   const [providerModelsCommittedKey, setProviderModelsCommittedKey] =
     useState<string | null>(() => {
       const protocol = initial.apiProtocol ?? 'anthropic';
@@ -949,11 +939,6 @@ export function SettingsDialog({
         initial.apiVersion ?? '',
       );
     });
-  const [localProviderModelsCache, setLocalProviderModelsCache] = useState<
-    Record<string, ProviderModelOption[]>
-  >({});
-  const providerModelsCache = sharedProviderModelsCache ?? localProviderModelsCache;
-  const setProviderModelsCache = onProviderModelsCacheChange ?? setLocalProviderModelsCache;
   const agentTestAbortRef = useRef<AbortController | null>(null);
   const providerTestAbortRef = useRef<AbortController | null>(null);
   const providerModelsAbortRef = useRef<AbortController | null>(null);
@@ -1433,7 +1418,7 @@ export function SettingsDialog({
       cfg.apiKey,
       cfg.apiVersion ?? '',
     );
-    const cachedModels = providerModelsCache[cacheKey];
+    const cachedModels = activeProviderModelsCache[cacheKey];
     if (cachedModels) {
       setProviderModelsState({
         status: 'done',
@@ -1471,7 +1456,7 @@ export function SettingsDialog({
         return;
       }
       if (result.ok && result.models?.length) {
-        setProviderModelsCache((prev) => ({
+        activeSetProviderModelsCache((prev) => ({
           ...prev,
           [cacheKey]: result.models ?? [],
         }));
@@ -1832,7 +1817,8 @@ export function SettingsDialog({
     ),
     [apiProtocol, cfg.baseUrl, cfg.apiKey, cfg.apiVersion],
   );
-  const fetchedApiModelOptions = providerModelsCache[providerModelsKey] ?? [];
+  const fetchedApiModelOptions =
+    activeProviderModelsCache[providerModelsKey] ?? [];
   const commitProviderModelsInputs = () => {
     if (missingByokModelFetchFields(cfg).length > 0 || !baseUrlValid) {
       setProviderModelsCommittedKey(null);

--- a/apps/web/src/components/providerModelsCache.ts
+++ b/apps/web/src/components/providerModelsCache.ts
@@ -1,0 +1,43 @@
+import type { ApiProtocol, ProviderModelOption } from '../types';
+
+export type ProviderModelsCache = Record<string, ProviderModelOption[]>;
+
+function fingerprintSecret(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${value.length}:${(hash >>> 0).toString(36)}`;
+}
+
+export function providerModelsCacheKey(
+  protocol: ApiProtocol,
+  baseUrl: string,
+  apiKey: string,
+  apiVersion = '',
+): string {
+  return [
+    protocol,
+    baseUrl.trim().replace(/\/+$/, ''),
+    fingerprintSecret(apiKey.trim()),
+    protocol === 'azure' ? apiVersion.trim() : '',
+  ].join('\n');
+}
+
+export function mergeProviderModelOptions(
+  fetchedModels: readonly ProviderModelOption[],
+  suggestedModelIds: readonly string[],
+): ProviderModelOption[] {
+  const seen = new Set<string>();
+  const out: ProviderModelOption[] = [];
+  const add = (model: ProviderModelOption) => {
+    const id = model.id.trim();
+    if (!id || seen.has(id)) return;
+    seen.add(id);
+    out.push({ id, label: model.label.trim() || id });
+  };
+  for (const model of fetchedModels) add(model);
+  for (const id of suggestedModelIds) add({ id, label: id });
+  return out;
+}

--- a/apps/web/tests/components/InlineModelSwitcher.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testi
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { InlineModelSwitcher } from '../../src/components/InlineModelSwitcher';
 import { AMR_LOGIN_TIMEOUT_MS } from '../../src/components/amrLoginPolling';
+import { providerModelsCacheKey } from '../../src/components/providerModelsCache';
 import type { AgentInfo, AppConfig, ProviderModelOption } from '../../src/types';
 
 const baseConfig: AppConfig = {
@@ -48,20 +49,20 @@ const codexAgent: AgentInfo = {
 function renderSwitcher(
   config: Partial<AppConfig> = {},
   agents: AgentInfo[] = [amrAgent],
-  providerModelsCache?: Record<string, ProviderModelOption[]>,
+  providerModelsCache: Record<string, ProviderModelOption[]> = {},
 ) {
   const onAgentModelChange = vi.fn();
   const view = render(
     <InlineModelSwitcher
       config={{ ...baseConfig, ...config }}
       agents={agents}
+      providerModelsCache={providerModelsCache}
       daemonLive={true}
       onModeChange={vi.fn()}
       onAgentChange={vi.fn()}
       onAgentModelChange={onAgentModelChange}
       onApiProtocolChange={vi.fn()}
       onApiModelChange={vi.fn()}
-      providerModelsCache={providerModelsCache}
       onOpenSettings={vi.fn()}
     />,
   );
@@ -264,7 +265,11 @@ describe('InlineModelSwitcher AMR row', () => {
       },
       [amrAgent, codexAgent],
       {
-        ['openai\nhttps://api.openai.com/v1\nsk-test\n']: [
+        [providerModelsCacheKey(
+          'openai',
+          'https://api.openai.com/v1',
+          'sk-test',
+        )]: [
           { id: 'gpt-4.1-mini', label: 'gpt-4.1-mini' },
           { id: 'gpt-4.1', label: 'gpt-4.1' },
           { id: 'gpt-5.5', label: 'gpt-5.5' },
@@ -305,7 +310,11 @@ describe('InlineModelSwitcher AMR row', () => {
       },
       [amrAgent, codexAgent],
       {
-        ['openai\nhttps://api.openai.com/v1\nsk-test\n']: [
+        [providerModelsCacheKey(
+          'openai',
+          'https://api.openai.com/v1',
+          'sk-test',
+        )]: [
           { id: 'gpt-4.1-mini', label: 'gpt-4.1-mini' },
           { id: 'gpt-4.1', label: 'gpt-4.1' },
           { id: 'gpt-5.5', label: 'gpt-5.5' },
@@ -678,5 +687,40 @@ describe('InlineModelSwitcher AMR row', () => {
       expect(loginCalls).toBe(1);
       expect(onAgentChange).toHaveBeenCalledWith('amr');
     });
+  });
+
+  it('lists fetched BYOK provider models from the shared cache', () => {
+    const cacheKey = providerModelsCacheKey(
+      'anthropic',
+      baseConfig.baseUrl,
+      'sk-test',
+      '',
+    );
+    renderSwitcher(
+      {
+        mode: 'api',
+        apiKey: 'sk-test',
+        model: 'claude-3-5-haiku-latest',
+      },
+      [amrAgent],
+      {
+        [cacheKey]: [
+          { id: 'claude-3-5-haiku-latest', label: 'Claude 3.5 Haiku' },
+        ],
+      },
+    );
+
+    fireEvent.click(screen.getByTestId('inline-model-switcher-chip'));
+
+    const select = screen.getByTestId(
+      'inline-model-switcher-api-model',
+    );
+    fireEvent.click(select);
+    const modelPopover = screen.getByTestId(
+      'inline-model-switcher-api-model-popover',
+    );
+    expect(
+      within(modelPopover).getByRole('option', { name: 'Claude 3.5 Haiku' }),
+    ).toBeTruthy();
   });
 });

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -8,6 +8,7 @@ import {
   isOrbitRunDisabled,
   isValidApiBaseUrl,
   mergeProviderModelOptions,
+  providerModelsCacheKey,
   sanitizeSettingsSavePayload,
   shouldEnableSettingsSave,
   shouldShowCustomModelInput,
@@ -40,6 +41,24 @@ afterEach(() => {
 });
 
 describe('SettingsDialog API protocol switching', () => {
+  it('builds provider model cache keys without exposing raw API keys', () => {
+    const key = providerModelsCacheKey(
+      'anthropic',
+      'https://api.anthropic.com/',
+      'sk-secret-value',
+    );
+
+    expect(key).toContain('https://api.anthropic.com');
+    expect(key).not.toContain('sk-secret-value');
+    expect(key).toBe(
+      providerModelsCacheKey(
+        'anthropic',
+        'https://api.anthropic.com',
+        'sk-secret-value',
+      ),
+    );
+  });
+
   it('stores the current custom protocol config while preserving custom endpoint details', () => {
     const config: AppConfig = {
       ...baseConfig,


### PR DESCRIPTION
## Summary
- Rebase the BYOK provider model cache work on top of the merged searchable picker / shared catalog implementation.
- Move provider model cache key and merge helpers into a shared module used by Settings, onboarding, and the inline model switcher.
- Avoid putting raw API keys directly into provider model cache keys while preserving per-key cache separation.

Follow-up to #3264 after #3278 landed.

## Surface area
- [x] UI
- [x] Default behavior change
- [x] Tests

## Validation
- pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/InlineModelSwitcher.test.tsx tests/components/SettingsDialog.test.ts tests/components/EntryShell.onboarding.test.tsx
- pnpm --dir apps/web run typecheck
- git diff --check