### PR TITLE
fix(pack): stop release builds depending on node_modules Electron dist

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -132,11 +132,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Verify mac Electron framework symlinks
+      - name: Inspect mac Electron framework symlinks
         run: |
           set -euo pipefail
           electron_dist="$(node -e 'const path = require("node:path"); const { createRequire } = require("node:module"); const requireFromDesktop = createRequire(path.join(process.cwd(), "apps/desktop/package.json")); const electron = requireFromDesktop.resolve("electron"); process.stdout.write(path.join(path.dirname(electron), "dist"));')"
           framework="$electron_dist/Electron.app/Contents/Frameworks/Electron Framework.framework"
+          missing_links=0
           for link in \
             "$framework/Electron Framework" \
             "$framework/Helpers" \
@@ -144,12 +145,15 @@ jobs:
             "$framework/Resources" \
             "$framework/Versions/Current"; do
             if [ ! -L "$link" ]; then
-              echo "Expected Electron framework symlink, got non-symlink: $link" >&2
-              ls -la "$framework" >&2 || true
-              ls -la "$framework/Versions" >&2 || true
-              exit 1
+              echo "::warning::Expected Electron framework symlink, got non-symlink: $link"
+              missing_links=1
             fi
           done
+          if [ "$missing_links" -ne 0 ]; then
+            ls -la "$framework" >&2 || true
+            ls -la "$framework/Versions" >&2 || true
+            echo "Continuing into tools-pack because electron-builder is the source of truth for whether packaging actually works."
+          fi
 
       - name: Prepare Apple signing certificate
         env:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -173,11 +173,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Verify mac Electron framework symlinks
+      - name: Inspect mac Electron framework symlinks
         run: |
           set -euo pipefail
           electron_dist="$(node -e 'const path = require("node:path"); const { createRequire } = require("node:module"); const requireFromDesktop = createRequire(path.join(process.cwd(), "apps/desktop/package.json")); const electron = requireFromDesktop.resolve("electron"); process.stdout.write(path.join(path.dirname(electron), "dist"));')"
           framework="$electron_dist/Electron.app/Contents/Frameworks/Electron Framework.framework"
+          missing_links=0
           for link in \
             "$framework/Electron Framework" \
             "$framework/Helpers" \
@@ -185,12 +186,15 @@ jobs:
             "$framework/Resources" \
             "$framework/Versions/Current"; do
             if [ ! -L "$link" ]; then
-              echo "Expected Electron framework symlink, got non-symlink: $link" >&2
-              ls -la "$framework" >&2 || true
-              ls -la "$framework/Versions" >&2 || true
-              exit 1
+              echo "::warning::Expected Electron framework symlink, got non-symlink: $link"
+              missing_links=1
             fi
           done
+          if [ "$missing_links" -ne 0 ]; then
+            ls -la "$framework" >&2 || true
+            ls -la "$framework/Versions" >&2 || true
+            echo "Continuing into tools-pack because electron-builder is the source of truth for whether packaging actually works."
+          fi
 
       - name: Prepare Apple signing certificate
         env:

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -544,7 +544,9 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
       buildResources: dirname(linuxResources.icon),
     },
     electronVersion: config.electronVersion.replace(/^[^\d]*/, ""),
-    electronDist: config.electronDistPath,
+    // See tools/pack/src/win/builder.ts: rely on electron-builder's own
+    // Electron download rather than node_modules' dist, which pnpm does not
+    // reliably materialize on CI runners.
     executableName: PRODUCT_NAME,
     extraMetadata: {
       main: "./main.cjs",

--- a/tools/pack/src/win/builder.ts
+++ b/tools/pack/src/win/builder.ts
@@ -106,7 +106,12 @@ async function runElectronBuilderRaw(config: ToolPackConfig, paths: WinPaths, pr
     buildDependenciesFromSource: ELECTRON_BUILDER_BUILD_DEPENDENCIES_FROM_SOURCE,
     compression: "maximum",
     directories: { output: paths.appBuilderOutputRoot },
-    electronDist: config.electronDistPath,
+    // Let electron-builder download the win32 Electron itself instead of
+    // pointing at node_modules' dist. pnpm does not reliably materialize the
+    // Electron dist on CI runners (electron.exe can be missing), which made
+    // the rename to `${PRODUCT_NAME}.exe` fail with ENOENT. The mac builder
+    // already relies on electron-builder's own download and is the only
+    // platform that stayed green through this regression.
     electronVersion: config.electronVersion,
     executableName: PRODUCT_NAME,
     extraMetadata: {


### PR DESCRIPTION
## Why

The release/v0.9.0 **nightly/stable packaging fails** on two platforms (e.g. run [26624889109](https://github.com/nexu-io/open-design/actions/runs/26624889109)), which blocks cutting 0.9.0:

- **mac arm64** — the `Verify mac Electron framework symlinks` step exits 1 because `node_modules/.pnpm/electron@41.3.0/.../dist/Electron.app/Contents/Frameworks/Electron Framework.framework` is **missing**.
- **win x64** — electron-builder fails renaming `electron.exe` → `Open Design.exe` with `ENOENT` because `electron.exe` is **missing** from that same dist.

**Root cause:** pnpm does not reliably materialize Electron's prebuilt dist (a symlinked `.framework` on mac, the unpacked binaries on win) under `node_modules` on the CI runners. Evidence this is *not* a cache / download-speed issue:

- Both failing runs were **cache-cold** — the win job logged `Cache not found`, and there are **no win/mac/electron GHA caches** in the repo at all.
- `release-beta.yml` built **green the same day** with the *identical* missing framework — its inspect step is non-fatal and mac packaging still succeeded, because electron-builder downloads its own Electron (`downloaded …darwin-arm64.zip … duration=950ms`).
- Not reproducible locally (a normal install yields a complete dist).

The **mac builder never passed `electronDist`** and is the only platform that stayed green — electron-builder downloads its own complete Electron. The **win/linux** builders pinned `electronDist` at the fragile node_modules dist, and **stable/preview** still ran the old *fatal* verify step (beta was already relaxed to a non-fatal inspect). This PR makes every platform follow the working mac approach.

## What users will see

No user-facing change. This is release-infrastructure only: it unblocks producing macOS / Windows packaged artifacts for 0.9.0. The shipped app is identical (same Electron version) — only the *source* of the Electron binaries during packaging changes (electron-builder's own download instead of node_modules).

## What changed

- **`tools/pack/src/win/builder.ts`** and **`tools/pack/src/linux.ts`**: drop `electronDist: config.electronDistPath` so electron-builder downloads its own complete Electron for the target platform (matching the mac builder).
- **`.github/workflows/release-stable.yml`** and **`.github/workflows/release-preview.yml`**: replace the fatal `Verify mac Electron framework symlinks` step with the non-fatal `Inspect …` step already used by `release-beta.yml` (electron-builder is the source of truth for whether packaging works; the node_modules dist is no longer consumed by any builder).

## Validation

- `pnpm --filter @open-design/tools-pack typecheck` ✅
- `pnpm guard` ✅
- tools-pack `win-builder` / `linux` / `win-app` / `workspace-build` suites — 54 tests ✅
- Real win/linux/mac packaging is validated by the release workflow on this branch.

## Surface area

- [x] CI / release workflows (`.github/workflows/release-stable.yml`, `release-preview.yml`)
- [x] Packaging tooling (`tools/pack`)

> Targeting `release/v0.9.0` to unblock the in-flight nightly. If you'd prefer this land on `main` first and flow back, say so and I'll retarget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)