### PR TITLE
fix(e2e): match new "running instances close via <shell>.exe" installer log

### DIFF
--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -502,7 +502,10 @@ winDescribe('packaged windows runtime smoke', () => {
         started = false;
         expect(reinstall.code).toBe(0);
         expect(reinstall.nsisLogTail.join('\n')).toContain('running instances detected before silent install');
-        expect(reinstall.nsisLogTail.join('\n')).toContain('running instances close exit=0');
+        // The installer closes running instances via pwsh.exe, falling back to
+        // powershell.exe (#2799), so the log reads "running instances close via
+        // <shell>.exe exit=0" rather than the older "running instances close exit=0".
+        expect(reinstall.nsisLogTail.join('\n')).toMatch(/running instances close via (?:pwsh|powershell)\.exe exit=0/);
 
         start = await measureSmokeStep(timings, 'restart after direct reinstall', async () =>
           runToolsPackJson<WinStartResult>('start'),


### PR DESCRIPTION
## Why

With Windows packaging unblocked by #3289, the nightly run finally reaches the Windows packaged **smoke test** — and it fails on a stale assertion ([run 26627606212](https://github.com/nexu-io/open-design/actions/runs/26627606212), win x64):

```
AssertionError: expected 'running instances detected before sil…' to contain 'running instances close exit=0'
  + running instances close via pwsh.exe exit=0 output=…
```

`specs/win.spec.ts` (direct-reinstall-while-running case) asserts the NSIS installer logs `running instances close exit=0`. But #2799 ("add PowerShell 7 fallback for Windows installer process detection") changed the installer to log `running instances close via pwsh.exe exit=0` (or `via powershell.exe exit=0` on fallback). The substring check no longer matches.

This drift was invisible because Windows packaging had been failing earlier at the `electron.exe` rename step, so the smoke test never ran. Now that the build is fixed (#3289), the test runs for the first time in a while and trips on the outdated string.

mac arm64 + mac intel already go green on that run; this is the last thing blocking a published nightly.

## What users will see

No user-facing change — test-only. Unblocks producing/publishing Windows nightly artifacts.

## What changed

- `e2e/specs/win.spec.ts`: replace the exact-substring assertion with a regex that matches the current installer log for both shells: `/running instances close via (?:pwsh|powershell)\.exe exit=0/`. The behavior under test (running instances closed with exit 0 before silent reinstall) is unchanged.

## Validation

- `pnpm --filter @open-design/e2e typecheck` ✅
- Real validation is the Windows smoke step in the release workflow (cannot run a Windows packaged smoke on macOS locally).

## Surface area

- [x] e2e tests (`e2e/specs/win.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)