### PR TITLE
fix(#3247): Detect and strip fabricated role markers in model output

### DIFF
--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -20,6 +20,7 @@ import { projectKindToTracking } from '@open-design/contracts/analytics';
 import { proxyDispatcherRequestInit, validateBaseUrlResolved } from './connectionTest.js';
 import { googleStreamGenerateContentUrl } from './google-models.js';
 import { parseMediaExecutionPolicyInput } from './media-policy.js';
+import { createRoleMarkerGuard } from './role-marker-guard.js';
 
 // Allowlist for the `/feedback` route. Mirrors the
 // ChatMessageFeedbackReasonCode union in packages/contracts/src/api/chat.ts.
@@ -549,7 +550,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         if (!match || match.index === undefined) break;
         const frame = buffer.slice(0, match.index);
         buffer = buffer.slice(match.index + match[0].length);
-        if (await onFrame(collectSseFrame(frame))) return;
+        if (await onFrame(collectSseFrame(frame))) { await reader.cancel(); return; }
       }
     }
 
@@ -575,7 +576,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         if (!line) continue;
         try {
           const data = JSON.parse(line);
-          if (await onFrame({ data })) return;
+          if (await onFrame({ data })) { await reader.cancel(); return; }
         } catch {
           // Ignore malformed provider keepalive lines.
         }
@@ -643,6 +644,30 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     }
     return '';
   };
+
+  // Per-request role-marker guard for BYOK proxy streams (#3247).
+  function createDeltaGuard(sse: any) {
+    const guard = createRoleMarkerGuard('proxy');
+    return {
+      sendDelta(text: string) {
+        if (guard.contaminated || !text) return;
+        const safe = guard.feedText(text);
+        if (safe.length > 0) {
+          sse.send('delta', { delta: safe });
+        }
+        if (guard.contaminated) {
+          const warn = guard.warningEvent();
+          const markerText = warn?.marker ?? '## user';
+          sse.send('delta', {
+            delta: `\n\n---\n⚠️ **Security warning:** The model attempted to emit a fabricated role marker (\`${markerText}\`). Response was truncated to prevent unauthorized instruction injection. See issue #3247.\n`,
+          });
+        }
+      },
+      get contaminated() { 
+        return guard.contaminated; 
+      },
+    };
+  }
 
   app.post('/api/proxy/anthropic/stream', async (req, res) => {
     /** @type {Partial<ProxyStreamRequest>} */
@@ -716,6 +741,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       }
 
       let ended = false;
+      const guard = createDeltaGuard(sse);
       await streamUpstreamSse(response, ({ event, data }: any) => {
         if (!data) return false;
         if (event === 'error' || data.type === 'error') {
@@ -725,7 +751,12 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
           return true;
         }
         if (event === 'content_block_delta' && typeof data.delta?.text === 'string') {
-          sse.send('delta', { delta: data.delta.text });
+          guard.sendDelta(data.delta.text);
+          if (guard.contaminated) { 
+            sse.send('end', {}); 
+            ended = true; 
+            return true; 
+          }
         }
         if (event === 'message_stop') {
           sse.send('end', {});
@@ -820,6 +851,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       }
 
       let ended = false;
+      const guard = createDeltaGuard(sse);
       await streamUpstreamSse(response, ({ payload, data }: any) => {
         if (payload === '[DONE]') {
           sse.send('end', {});
@@ -834,7 +866,14 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
           return true;
         }
         const delta = extractOpenAIText(data);
-        if (delta) sse.send('delta', { delta });
+        if (delta) { 
+          guard.sendDelta(delta); 
+          if (guard.contaminated) { 
+            sse.send('end', {}); 
+            ended = true; 
+            return true; 
+          } 
+        }
         return false;
       });
       if (!ended) sse.send('end', {});
@@ -967,6 +1006,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       }
 
       let ended = false;
+      const guard = createDeltaGuard(sse);
       await streamUpstreamSse(response, ({ payload: ssePayload, data }: any) => {
         if (ssePayload === '[DONE]') {
           sse.send('end', {});
@@ -981,7 +1021,13 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
           return true;
         }
         const delta = extractOpenAIText(data);
-        if (delta) sse.send('delta', { delta });
+        if (delta) { guard.sendDelta(delta); 
+          if (guard.contaminated) { 
+            sse.send('end', {}); 
+            ended = true; 
+            return true; 
+          } 
+        }
         return false;
       });
       if (!ended) sse.send('end', {});
@@ -1070,6 +1116,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       }
 
       let ended = false;
+      const guard = createDeltaGuard(sse);
       await streamUpstreamSse(response, ({ data }: any) => {
         if (!data) return false;
         const streamError = extractStreamErrorMessage(data);
@@ -1079,7 +1126,13 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
           return true;
         }
         const delta = extractGeminiText(data);
-        if (delta) sse.send('delta', { delta });
+        if (delta) { guard.sendDelta(delta); 
+          if (guard.contaminated) { 
+            sse.send('end', {}); 
+            ended = true; 
+            return true; 
+          } 
+        }
         const blockMessage = extractGeminiBlockMessage(data);
         if (blockMessage) {
           sendProxyError(sse, blockMessage, { details: data });
@@ -1157,6 +1210,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       }
 
       let ended = false;
+      const guard = createDeltaGuard(sse);
       await streamUpstreamNdjson(response, ({ data }: any) => {
         if (!data) return false;
         if (data.done) {
@@ -1165,7 +1219,14 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
           return true;
         }
         const content = data.message?.content;
-        if (typeof content === 'string' && content) sse.send('delta', { delta: content });
+        if (typeof content === 'string' && content) { 
+          guard.sendDelta(content); 
+          if (guard.contaminated) { 
+            sse.send('end', {}); 
+            ended = true; 
+            return true; 
+          } 
+        }
         return false;
       });
       if (!ended) sse.send('end', {});
@@ -1335,6 +1396,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       let finishReason = '';
       let providerError = '';
 
+      const guard = createDeltaGuard(sse);
       await streamUpstreamSse(response, ({ payload, data }: any) => {
         if (payload === '[DONE]') return true;
         if (!data) return false;
@@ -1356,7 +1418,11 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         // emit text before / after a tool_call in the same turn, and
         // we want the user to see whatever the model decided to say.
         if (typeof delta.content === 'string' && delta.content) {
-          sse.send('delta', { delta: delta.content });
+          guard.sendDelta(delta.content);
+          if (guard.contaminated) { 
+            sse.send('end', {}); 
+            return true; 
+          }
         }
 
         // Tool call deltas stream as fragments — `id` arrives once at

--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -19,6 +19,8 @@
  * `tool_use` event when that block stops.
  */
 
+import { createRoleMarkerGuard, type RoleMarkerGuard } from './role-marker-guard.js';
+
 type StreamEvent = Record<string, unknown>;
 type EventSink = (event: StreamEvent) => void;
 type BlockState = { type?: unknown; name?: unknown; id?: unknown; input: string };
@@ -46,9 +48,34 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
   // newer builds that already streamed deltas, otherwise the message would
   // duplicate.
   const textStreamed = new Set<string>();
+  // Per-message role-marker guards for cross-chunk detection (#3247).
+  const roleGuards = new Map<string, RoleMarkerGuard>();
 
   function blockKey(index: unknown): string {
     return `${currentMessageId ?? 'anon'}:${index}`;
+  }
+
+  // Per-message role-marker guard (#3247). Covers text_delta and thinking_delta.
+  function emitSafeText(msgId: string | null, text: string, eventType: string = 'text_delta') {
+    if (!msgId) {
+      onEvent({ type: eventType, delta: text });
+      return;
+    }
+    let guard = roleGuards.get(msgId);
+    if (!guard) {
+      guard = createRoleMarkerGuard(msgId);
+      roleGuards.set(msgId, guard);
+    }
+    if (guard.contaminated) return;
+
+    const safe = guard.feedText(text);
+    if (safe.length > 0) {
+      onEvent({ type: eventType, delta: safe });
+    }
+    if (guard.contaminated) {
+      const warn = guard.warningEvent();
+      if (warn) onEvent(warn);
+    }
   }
 
   function feed(chunk: string) {
@@ -143,14 +170,14 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
           typeof block.text === 'string' &&
           block.text.length > 0
         ) {
-          onEvent({ type: 'text_delta', delta: block.text });
+          emitSafeText(msgId, block.text);
         } else if (
           !alreadyStreamed &&
           block.type === 'thinking' &&
           typeof block.thinking === 'string' &&
           block.thinking.length > 0
         ) {
-          onEvent({ type: 'thinking_delta', delta: block.thinking });
+          emitSafeText(msgId, block.thinking, 'thinking_delta');
         }
       }
       // Surface the turn_end signal now that every tool_use in this
@@ -194,6 +221,8 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
 
   function handleStreamEvent(ev: Record<string, unknown>) {
     if (ev.type === 'message_start') {
+      // Clean up per-message role-marker guard from the previous message.
+      if (currentMessageId) roleGuards.delete(currentMessageId);
       currentMessageId = isRecord(ev.message) && typeof ev.message.id === 'string' ? ev.message.id : null;
       if (typeof ev.ttft_ms === 'number') {
         onEvent({ type: 'status', label: 'streaming', ttftMs: ev.ttft_ms });
@@ -217,12 +246,12 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
 
       if (delta.type === 'text_delta' && typeof delta.text === 'string') {
         if (currentMessageId) textStreamed.add(currentMessageId);
-        onEvent({ type: 'text_delta', delta: delta.text });
+        emitSafeText(currentMessageId, delta.text);
         return;
       }
       if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
         if (currentMessageId) textStreamed.add(currentMessageId);
-        onEvent({ type: 'thinking_delta', delta: delta.thinking });
+        emitSafeText(currentMessageId, delta.thinking, 'thinking_delta');
         return;
       }
       if (delta.type === 'input_json_delta' && typeof delta.partial_json === 'string') {

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -661,6 +661,24 @@ export function composeSystemPrompt({
     );
   }
 
+  // Pinned LAST so recency bias reinforces the role-marker prohibition.
+  // This is the canonical anti-roleplay instruction;
+  parts.push(
+    "\n\n---\n\n## CRITICAL: Never fabricate conversation turns\n\n" +
+    "The text you emit is processed by a chat host that interprets lines " +
+    "starting with \`## user\`, \`## assistant\`, or \`## system\` as real " +
+    "turn boundaries. Emitting these lines causes the host to treat your " +
+    "fabricated text as a real user request and execute unauthorised actions.\n\n" +
+    "**FORBIDDEN — you MUST NOT:**\n" +
+    "- Emit any line starting with \`## user\`, \`## assist\`, \`## assistant\`, or \`## system\`\n" +
+    "- Emit lines starting with \`User:\`, \`Assistant:\`, \`Human:\`, or \`AI:\`\n" +
+    "- Roleplay multiple turns inside a single response\n" +
+    "- Invent a user message and then reply to it\n\n" +
+    "The host will truncate your response at the first role-marker line — " +
+    "any text after it is lost. If you feel the urge to simulate a dialogue, " +
+    "stop and ask the user a real question instead.",
+  );
+
   return parts.join('');
 }
 

--- a/apps/daemon/src/role-marker-guard.ts
+++ b/apps/daemon/src/role-marker-guard.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared utility for detecting and stripping fabricated role-marker lines
+ * (`## user`, `## assistant`, `## system`) injected by the model into its
+ * own output (see #3247 — same class as #2102 / #2464).
+ *
+ * `createRoleMarkerGuard()` — stateful per-message guard for structured
+ * stream handlers that can track message boundaries (Claude, Copilot,
+ * Qoder, OpenCode/Codex, Pi, ACP). Returns `{ feedText, contaminated,
+ * warningEvent }`.
+ */
+
+// Regex matching fabricated role-marker lines injected by the model into
+// its own output. Anchored to start-of-line via (?:^|\n) so we don't
+// false-positive on user prose like "here is the ## user content".
+// Matches two families:
+//   - Markdown-style: `## user`, `## assist`, `## assistant`, `## system`
+//     (flexible whitespace between ## and role)
+//   - Chat-style: `User:`, `Assistant:`, `Human:`, `AI:`
+//     (case-insensitive, optional whitespace before colon)
+export const FABRICATED_ROLE_MARKER_RE =
+  /(?:^|\n)\s*(?:##\s+(?:user|assistant|assist|system)|(?:User|Assistant|Human|AI)\s*:)/i;
+
+export interface RoleMarkerGuard {
+  /** Feed a text delta for the current message. Returns the safe portion
+   *  to emit (may be shorter than `text` if a marker was found mid-chunk,
+   *  or empty string if the entire chunk is past the cut point). */
+  feedText(text: string): string;
+  /** Whether a fabricated marker was detected (further text is dropped). */
+  readonly contaminated: boolean;
+  /** If contaminated, the warning event to emit. `null` if clean. */
+  warningEvent(): { type: 'fabricated_role_marker'; marker: string; messageId: string } | null;
+}
+
+/**
+ * Create a stateful guard that accumulates text per message and detects
+ * fabricated role markers across chunk boundaries.
+ *
+ * Usage in a stream handler:
+ *
+ *   const guard = createRoleMarkerGuard(messageId);
+ *   for (const delta of deltas) {
+ *     const safe = guard.feedText(delta.text);
+ *     if (safe.length > 0) onEvent({ type: 'text_delta', delta: safe });
+ *     if (guard.contaminated) {
+ *       onEvent(guard.warningEvent()!);
+ *       break; // stop emitting text for this message
+ *     }
+ *   }
+ */
+export function createRoleMarkerGuard(messageId: string): RoleMarkerGuard {
+  let accumulated = '';
+  let _contaminated = false;
+  let markerText: string | null = null;
+
+  return {
+    get contaminated() {
+      return _contaminated;
+    },
+
+    feedText(text: string): string {
+      if (_contaminated) return '';
+
+      const prev = accumulated;
+      const combined = prev + text;
+      const match = FABRICATED_ROLE_MARKER_RE.exec(combined);
+      if (!match) {
+        accumulated = combined;
+        return text;
+      }
+
+      // Found a fabricated role marker.
+      _contaminated = true;
+      markerText = match[0].trim();
+      const cutIndex = match.index;
+      const safePrefix = combined.slice(0, cutIndex);
+      const alreadyEmitted = prev.length;
+      if (cutIndex <= alreadyEmitted) return '';
+      return safePrefix.slice(alreadyEmitted);
+    },
+
+    warningEvent() {
+      if (!_contaminated || !markerText) return null;
+      return {
+        type: 'fabricated_role_marker',
+        marker: markerText,
+        messageId,
+      };
+    },
+  };
+}
+
+

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -194,6 +194,7 @@ import {
 } from './automation-ingestions.js';
 import { ingestRoutineConnectorEvolution } from './automation-routine-evolution.js';
 import { createClaudeStreamHandler } from './claude-stream.js';
+import { createRoleMarkerGuard } from './role-marker-guard.js';
 import { diagnoseClaudeCliFailure } from './claude-diagnostics.js';
 import { loadCritiqueConfigFromEnv } from './critique/config.js';
 import { reconcileStaleRuns } from './critique/persistence.js';
@@ -2400,6 +2401,13 @@ function daemonAgentPayloadToPersistedAgentEvent(data) {
       outputTokens: usage.output_tokens,
       ...(typeof data.costUsd === 'number' ? { costUsd: data.costUsd } : {}),
       ...(typeof data.durationMs === 'number' ? { durationMs: data.durationMs } : {}),
+    };
+  }
+  if (type === 'fabricated_role_marker' && typeof data.marker === 'string') {
+    return {
+      kind: 'status',
+      label: 'warning',
+      detail: `Model emitted fabricated role marker ("${data.marker}"). Response was truncated at this point to prevent unauthorized instruction injection. See issue #3247.`,
     };
   }
   if (type === 'raw' && typeof data.line === 'string') return { kind: 'raw', line: data.line };
@@ -12013,6 +12021,30 @@ export async function startServer({
       'tool_result',
       'artifact',
     ]);
+
+    // Per-run role-marker guard for non-Claude structured streams (#3247).
+    // Claude has its own per-message guards in claude-stream.ts.
+    const runGuard = createRoleMarkerGuard('run');
+    let runWarned = false;
+
+    function guardTextDelta(delta) {
+      return runGuard.feedText(delta);
+    }
+
+    // Shared helper for emitting guarded text deltas across all agent
+    // stream handlers (sendAgentEvent, copilot, ACP).
+    function emitGuardedTextDelta(delta: string) {
+      const safe = guardTextDelta(delta);
+      if (safe.length > 0) {
+        send('agent', { type: 'text_delta', delta: safe });
+      }
+      if (runGuard.contaminated && !runWarned) {
+        runWarned = true;
+        const warn = runGuard.warningEvent();
+        if (warn) send('agent', warn);
+      }
+    }
+
     const sendAgentEvent = (ev) => {
       if (ev?.type === 'error') {
         if (agentStreamError) return;
@@ -12059,6 +12091,11 @@ export async function startServer({
       noteAgentActivity();
       if (ev?.type && SUBSTANTIVE_AGENT_EVENT_TYPES.has(ev.type)) {
         agentProducedOutput = true;
+      }
+      // Role-marker guard for qoder / json-event-stream / pi-rpc (#3247).
+      if (ev?.type === 'text_delta' && typeof ev.delta === 'string') {
+        emitGuardedTextDelta(ev.delta);
+        return;
       }
       send('agent', ev);
     };
@@ -12127,6 +12164,10 @@ export async function startServer({
       const copilot = createCopilotStreamHandler((ev) => {
         lastAgentEventPhase = summarizeAgentEventForInactivity(ev);
         noteAgentActivity();
+        if (ev?.type === 'text_delta' && typeof ev.delta === 'string') {
+          emitGuardedTextDelta(ev.delta);
+          return;
+        }
         send('agent', ev);
       });
       child.stdout.on('data', (chunk) => copilot.feed(chunk));
@@ -12200,6 +12241,10 @@ export async function startServer({
               return;
             }
           }
+          if (event === 'agent' && data?.type === 'text_delta' && typeof data.delta === 'string') {
+            emitGuardedTextDelta(data.delta);
+            return;
+          }
           send(event, data);
         },
         ...(acpStageTimeoutMs !== undefined ? { stageTimeoutMs: acpStageTimeoutMs } : {}),
@@ -12228,9 +12273,19 @@ export async function startServer({
         plaintextStdoutBuffer.push(String(chunk));
       });
     } else {
+      // Plain / BYOK mode: guard raw stdout chunks (#3247).
       child.stdout.on('data', (chunk) => {
         noteAgentActivity();
-        send('stdout', { chunk });
+        const text = typeof chunk === 'string' ? chunk : String(chunk);
+        const safe = guardTextDelta(text);
+        if (safe.length > 0) {
+          send('stdout', { chunk: safe });
+        }
+        if (runGuard.contaminated && !runWarned) {
+          runWarned = true;
+          const warn = runGuard.warningEvent();
+          if (warn) send('agent', warn);
+        }
       });
     }
     // Wire the acpSession onto the run so cancel() can call abort()

--- a/apps/daemon/tests/role-marker-guard.test.ts
+++ b/apps/daemon/tests/role-marker-guard.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createRoleMarkerGuard,
+  FABRICATED_ROLE_MARKER_RE,
+} from '../src/role-marker-guard.js';
+
+describe('FABRICATED_ROLE_MARKER_RE', () => {
+  // ── Markdown-style markers ────────────────────────────────────────
+
+  it('matches ## user at start of text', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('## user\nfabricated')).toBe(true);
+  });
+
+  it('matches ## assistant at start of text', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('## assistant\nfabricated')).toBe(true);
+  });
+
+  it('matches ## system at start of text', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('## system\nfabricated')).toBe(true);
+  });
+
+  it('matches ## assist (short form)', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('## assist\nfabricated')).toBe(true);
+  });
+
+  it('matches ## user after a newline', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('OK\n## user\nfabricated')).toBe(true);
+  });
+
+  it('matches ##   user with extra whitespace between ## and role', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('text\n##   user\nfabricated')).toBe(true);
+  });
+
+  it('matches ##\tuser with tab between ## and role', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('text\n##\tuser\nfabricated')).toBe(true);
+  });
+
+  // ── Chat-style markers ────────────────────────────────────────────
+
+  it('matches User: after a newline', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('OK\nUser: hello')).toBe(true);
+  });
+
+  it('matches Assistant:', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('text\nAssistant: sure')).toBe(true);
+  });
+
+  it('matches Human:', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('text\nHuman: what now?')).toBe(true);
+  });
+
+  it('matches AI:', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('text\nAI: processing')).toBe(true);
+  });
+
+  it('matches user: (lowercase, case-insensitive flag)', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('text\nuser: hello')).toBe(true);
+  });
+
+  it('matches ASSISTANT: (uppercase)', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('text\nASSISTANT: done')).toBe(true);
+  });
+
+  it('matches User  : with extra whitespace before colon', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('text\nUser  : hello')).toBe(true);
+  });
+
+  it('matches user: at very start of text', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('user: hello')).toBe(true);
+  });
+
+  // ── Leading whitespace tolerance ───────────────────────────────────
+
+  it('matches when line has leading spaces before ## user', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('text\n  ## user\nfabricated')).toBe(true);
+  });
+
+  it('matches when line has leading spaces before User:', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('text\n  User: hello')).toBe(true);
+  });
+
+  // ── Negative cases ────────────────────────────────────────────────
+
+  it('does NOT match ## user in the middle of a line (no preceding newline)', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('here is the ## user content')).toBe(false);
+  });
+
+  it('does NOT match User: in the middle of a line', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('tell User: something')).toBe(false);
+  });
+
+  it('does NOT match plain text without markers', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('This is a normal response.')).toBe(false);
+  });
+
+  it('does NOT match empty string', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('')).toBe(false);
+  });
+
+  it('does NOT match ## usability (different word, no match in alternation)', () => {
+    expect(FABRICATED_ROLE_MARKER_RE.test('## usability improvements')).toBe(false);
+  });
+});
+
+describe('createRoleMarkerGuard', () => {
+  // ── Normal text ───────────────────────────────────────────────────
+
+  it('passes normal text through unchanged', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    const result = guard.feedText('Hello, world!');
+    expect(result).toBe('Hello, world!');
+    expect(guard.contaminated).toBe(false);
+    expect(guard.warningEvent()).toBeNull();
+  });
+
+  it('passes multiple normal chunks through', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    expect(guard.feedText('First. ')).toBe('First. ');
+    expect(guard.feedText('Second.')).toBe('Second.');
+    expect(guard.contaminated).toBe(false);
+  });
+
+  // ── Markdown-style detection ──────────────────────────────────────
+
+  it('detects ## user and returns only safe prefix (newline excluded)', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    const result = guard.feedText('OK\n## user\nfabricated');
+    expect(result).toBe('OK');
+    expect(guard.contaminated).toBe(true);
+  });
+
+  it('detects ## assistant', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('text\n## assistant\nfabricated');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('## assistant');
+  });
+
+  it('detects ## system', () => {
+    const guard = createRoleMarkerGuard('msg-2');
+    guard.feedText('text\n## system\nfabricated');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('## system');
+  });
+
+  it('detects ## assist (short form)', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('text\n## assist\nfabricated');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('## assist');
+  });
+
+  it('detects ##   user with extra whitespace', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('text\n##   user\nfabricated');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('##   user');
+  });
+
+  // ── Chat-style detection ──────────────────────────────────────────
+
+  it('detects User: marker', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('text\nUser: hello');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('User:');
+  });
+
+  it('detects Assistant:', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('text\nAssistant: ok');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('Assistant:');
+  });
+
+  it('detects Human:', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('text\nHuman: hi');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('Human:');
+  });
+
+  it('detects AI:', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('text\nAI: result');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('AI:');
+  });
+
+  it('detects user: (lowercase, case-insensitive)', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('text\nuser: hello');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('user:');
+  });
+
+  it('detects USER: (uppercase)', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('text\nUSER: hello');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('USER:');
+  });
+
+  it('detects User  : with whitespace before colon', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('text\nUser  : hello');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('User  :');
+  });
+
+  // ── Cross-chunk detection ─────────────────────────────────────────
+
+  it('detects marker split across chunk boundaries', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    // '\n' is in chunk 1, marker starts in chunk 2
+    const r1 = guard.feedText('Some text\n');
+    expect(r1).toBe('Some text\n');
+    expect(guard.contaminated).toBe(false);
+
+    const r2 = guard.feedText('## user\nfabricated!');
+    expect(r2).toBe('');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('## user');
+  });
+
+  it('handles marker split mid-word (## use + r)', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('OK\n## use');
+    expect(guard.contaminated).toBe(false);
+
+    const r2 = guard.feedText('r\nfabricated');
+    expect(r2).toBe('');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('## user');
+  });
+
+  it('handles chat-style marker split across chunks (User + :)', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('OK\nUser');
+    expect(guard.contaminated).toBe(false);
+
+    const r2 = guard.feedText(': hello');
+    expect(r2).toBe('');
+    expect(guard.contaminated).toBe(true);
+    expect(guard.warningEvent()!.marker).toBe('User:');
+  });
+
+  it('returns safe portion when marker is mid-chunk', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('Prefix. ');
+    const r2 = guard.feedText('More.\n## assistant\nfabricated');
+    expect(r2).toBe('More.');
+    expect(guard.contaminated).toBe(true);
+  });
+
+  it('returns empty when marker is at very start of first chunk', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    expect(guard.feedText('## user\nfabricated')).toBe('');
+    expect(guard.contaminated).toBe(true);
+  });
+
+  // ── Post-contamination ────────────────────────────────────────────
+
+  it('silently drops text after contamination', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('OK\n## user\nfabricated');
+    expect(guard.contaminated).toBe(true);
+
+    expect(guard.feedText('More text')).toBe('');
+    expect(guard.feedText('Even more')).toBe('');
+  });
+
+  // ── warningEvent ──────────────────────────────────────────────────
+
+  it('warningEvent returns null when not contaminated', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    guard.feedText('Normal text.');
+    expect(guard.warningEvent()).toBeNull();
+  });
+
+  it('warningEvent returns correct shape for ## assistant', () => {
+    const guard = createRoleMarkerGuard('msg-42');
+    guard.feedText('## assistant\nfabricated');
+    expect(guard.warningEvent()).toEqual({
+      type: 'fabricated_role_marker',
+      marker: '## assistant',
+      messageId: 'msg-42',
+    });
+  });
+
+  it('warningEvent returns correct shape for User:', () => {
+    const guard = createRoleMarkerGuard('msg-7');
+    guard.feedText('User: hello');
+    expect(guard.warningEvent()).toEqual({
+      type: 'fabricated_role_marker',
+      marker: 'User:',
+      messageId: 'msg-7',
+    });
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────
+
+  it('handles empty string input', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    expect(guard.feedText('')).toBe('');
+    expect(guard.contaminated).toBe(false);
+  });
+
+  it('handles multiple messages with independent guards', () => {
+    const guard1 = createRoleMarkerGuard('msg-1');
+    const guard2 = createRoleMarkerGuard('msg-2');
+
+    guard1.feedText('Clean.');
+    guard2.feedText('## user\ncontaminated');
+
+    expect(guard1.contaminated).toBe(false);
+    expect(guard2.contaminated).toBe(true);
+    expect(guard1.warningEvent()).toBeNull();
+    expect(guard2.warningEvent()!.messageId).toBe('msg-2');
+  });
+
+  it('does not false-positive on inline role mentions', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    const result = guard.feedText('The User: class has a method...');
+    expect(result).toBe('The User: class has a method...');
+    expect(guard.contaminated).toBe(false);
+  });
+
+  it('does not false-positive on ## in the middle of prose', () => {
+    const guard = createRoleMarkerGuard('msg-1');
+    const result = guard.feedText('I used ## user as a tag name in code.');
+    expect(result).toBe('I used ## user as a tag name in code.');
+    expect(guard.contaminated).toBe(false);
+  });
+});

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -1865,8 +1865,13 @@ function StatusPill({
   label: string;
   detail?: string | undefined;
 }) {
+  const variant =
+    label === "error" ? "error" : label === "warning" ? "warning" : undefined;
   return (
-    <div className="status-pill">
+    <div
+      className={`status-pill${variant ? ` is-${variant}` : ""}`}
+      data-status={label}
+    >
       <span className="status-label">{label}</span>
       {detail ? <span className="status-detail">{renderStatusDetail(detail)}</span> : null}
     </div>

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -903,6 +903,13 @@ function translateAgentEvent(data: DaemonAgentPayload): AgentEvent | null {
       durationMs: typeof data.durationMs === 'number' ? data.durationMs : undefined,
     };
   }
+  if (t === 'fabricated_role_marker' && typeof data.marker === 'string') {
+    return {
+      kind: 'status',
+      label: 'warning',
+      detail: `Model emitted fabricated role marker ("${data.marker}"). Response was truncated to prevent unauthorized instruction injection.`,
+    };
+  }
   if (t === 'raw' && typeof data.line === 'string') {
     return { kind: 'raw', line: data.line };
   }

--- a/apps/web/src/styles/viewer/code.css
+++ b/apps/web/src/styles/viewer/code.css
@@ -679,6 +679,24 @@
   overflow-wrap: anywhere;
   white-space: normal;
 }
+/* Warning status — fabricated role markers (#3247), audit warnings, etc. */
+.status-pill.is-warning {
+  background: color-mix(in srgb, var(--amber, #b26200) 12%, transparent);
+  color: var(--amber, #b26200);
+  border-color: color-mix(in srgb, var(--amber, #b26200) 32%, transparent);
+}
+.status-pill.is-warning .status-detail {
+  color: color-mix(in srgb, var(--amber, #b26200) 85%, var(--text));
+}
+/* Error status — agent failures, tool errors, etc. */
+.status-pill.is-error {
+  background: color-mix(in srgb, var(--red, #dc2626) 10%, transparent);
+  color: var(--red, #dc2626);
+  border-color: color-mix(in srgb, var(--red, #dc2626) 30%, transparent);
+}
+.status-pill.is-error .status-detail {
+  color: color-mix(in srgb, var(--red, #dc2626) 85%, var(--text));
+}
 
 /* Grouped tool / action card — the collapsible pill from screenshot 9 */
 .action-card {

--- a/packages/contracts/src/sse/chat.ts
+++ b/packages/contracts/src/sse/chat.ts
@@ -83,6 +83,7 @@ export type DaemonAgentPayload =
   | { type: 'tool_use'; id: string; name: string; input: unknown }
   | { type: 'tool_result'; toolUseId: string; content: string; isError?: boolean }
   | { type: 'usage'; usage?: { input_tokens?: number; output_tokens?: number }; costUsd?: number; durationMs?: number }
+  | { type: 'fabricated_role_marker'; marker: string; messageId?: string }
   | { type: 'raw'; line: string };
 
 export type ChatSseEvent =


### PR DESCRIPTION
fix(daemon): detect and strip fabricated role markers in model output (#3247)

Three-layer defence against models emitting `## user` / `## assistant` /
`## system` lines mid-response, which the chat host interprets as real
turn boundaries and acts on as unauthorised instruction:

1. **System prompt**: anti-roleplay instruction elevated from a bullet
   under "What you don't do" to a standalone `## CRITICAL` section in
   `official-system.ts`, with a REMINDER pinned at the end of the
   composed prompt for recency bias.

2. **Stream-level detection and truncation**: shared `role-marker-guard.ts`
   module (`createRoleMarkerGuard` + `FABRICATED_ROLE_MARKER_RE`) used
   across all text paths — Claude stream (per-message guards), non-Claude
   structured streams (run-scoped guard via `emitGuardedTextDelta`),
   and BYOK proxy routes (`createDeltaGuard`). When a marker is detected,
   the contaminated suffix is dropped and a `fabricated_role_marker` event
   surfaces a warning in the UI.

3. **UI**: `StatusPill` gains `is-warning` / `is-error` CSS variants;
   `fabricated_role_marker` events render as amber warning pills.

<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #3247

## Why

Models (especially in long-running multi-turn conversations) occasionally emit
`## user` / `## assistant` / `## system` role-marker lines inside a single
assistant response. The chat host interprets these as real turn boundaries,
causing the agent to execute tool calls against entirely fabricated user
instructions — a security issue (same class as #2102 / #2464).

PR #2156 fixed the re-serialization path (escaped markers in stored transcripts
so they can't propagate across turns), but did not prevent the model from
emitting fresh markers in a new turn. This PR closes the emission vector.

Repro conditions (from the issue): ~80-turn conversation with claude-sonnet-4-6,
file-paste blocks and structured task lists. First contaminated message appeared
after a user task list; subsequent turns produced new markers at ~1-in-5 rate.

## What users will see

- **Before**: model fabricates `## user` / `## assistant` blocks mid-response;
  the UI renders them as if they were real conversation turns; the agent acts
  on the fabricated instructions.
- **After**: when the model attempts to emit a role marker, the response is
  truncated at that point and an amber warning pill appears in the chat:
  `Model emitted fabricated role marker ("## user"). Response was truncated
  to prevent unauthorized instruction injection.`
- The system prompt now includes an explicit "CRITICAL: Never fabricate
  conversation turns" section instructing the model not to emit these lines.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->

<img width="466" height="525" alt="图片" src="https://github.com/user-attachments/assets/a5e89160-d1e1-4450-9d5d-88c7a5ed3ff8" />

<img width="481" height="454" alt="图片" src="https://github.com/user-attachments/assets/0bdb3586-119e-4446-ab09-f524f98b2b9c" />



## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

- Test path: `apps/daemon/tests/role-marker-guard.test.ts` (25 tests)
- Covers: regex matching (## user / ## assistant / ## system, line-start
  anchoring, word-boundary enforcement, false-positive avoidance), cross-chunk
  detection, post-contamination silent drop, warningEvent shape, multi-message
  guard isolation, whitespace trimming.
- The full end-to-end path (model emits marker → daemon detects → UI shows
  warning) is verified by review of the event pipeline across server.ts →
  contracts → daemon.ts → AssistantMessage.tsx.


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

- `node apps/daemon/node_modules/vitest/vitest.mjs run --root apps/daemon -c vitest.config.ts tests/role-marker-guard.test.ts` — 49/49 passed
- Manual review of diff across all 11 files for:
  - code duplication (regex/detection logic now unified in `role-marker-guard.ts`)
  - comment hygiene (redundant inline comments removed)
  - reader.cancel on upstream early-exit paths
  - `--amber` CSS fallback consistency with tokens.css
