### PR TITLE
fix(web): Mark-mode capture fails on decks (snapshot the srcDoc bridge frame)

### DIFF
--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -172,6 +172,18 @@ export function PreviewDrawOverlay({
     ) ?? null;
   }
 
+  // The snapshot bridge only lives in the srcDoc transport iframe. For URL-load
+  // previews (e.g. decks) that iframe is mounted but hidden (data-od-active is on
+  // the bridgeless URL iframe), so snapshotting the *active* frame times out and
+  // capture fails. Prefer the srcDoc-render-mode frame; capture mode keeps it on
+  // full content, so it carries the bridge.
+  function snapshotHostIframe(): HTMLIFrameElement | null {
+    return (
+      wrapRef.current?.querySelector<HTMLIFrameElement>('iframe[data-od-render-mode="srcdoc"]') ??
+      activePreviewIframe()
+    );
+  }
+
   function onPointerDown(e: PointerEvent) {
     if (!active || sending) return;
     (e.target as Element).setPointerCapture?.(e.pointerId);
@@ -335,9 +347,16 @@ export function PreviewDrawOverlay({
   }
 
   async function requestSnapshot(): Promise<{ dataUrl: string; w: number; h: number } | null> {
-    const iframe = activePreviewIframe();
+    const iframe = snapshotHostIframe();
     if (!iframe) return null;
-    return requestPreviewSnapshot(iframe);
+    // Capture mode may still be swapping the srcDoc frame to full content when
+    // the user submits, so retry with growing timeouts before giving up.
+    const timeouts = [1500, 3000, 6000];
+    for (const timeout of timeouts) {
+      const snapshot = await requestPreviewSnapshot(iframe, timeout);
+      if (snapshot) return snapshot;
+    }
+    return null;
   }
 
   function drawCaptureTarget(

--- a/apps/web/tests/components/PreviewDrawOverlay.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.test.tsx
@@ -4,9 +4,19 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { PreviewDrawOverlay } from '../../src/components/PreviewDrawOverlay';
+import { requestPreviewSnapshot } from '../../src/runtime/exports';
+
+vi.mock('../../src/runtime/exports', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/runtime/exports')>();
+  return {
+    ...actual,
+    requestPreviewSnapshot: vi.fn(async () => ({ dataUrl: 'data:image/png;base64,AAAA', w: 10, h: 10 })),
+  };
+});
 
 afterEach(() => {
   cleanup();
+  vi.mocked(requestPreviewSnapshot).mockClear();
 });
 
 describe('PreviewDrawOverlay', () => {
@@ -159,5 +169,23 @@ describe('PreviewDrawOverlay', () => {
     fireEvent.click(getByRole('button', { name: 'Close' }));
 
     expect(onActiveChange).toHaveBeenCalledWith(false);
+  });
+
+  it('snapshots the srcDoc bridge iframe, not the visible URL-load frame', async () => {
+    const snapshot = vi.mocked(requestPreviewSnapshot);
+    const { getByRole } = render(
+      <PreviewDrawOverlay active captureViewport>
+        {/* URL-load frame is the visible/active one (e.g. a deck) but has no bridge */}
+        <iframe title="url" data-od-active="true" />
+        {/* srcDoc frame is mounted but hidden; it hosts the snapshot bridge */}
+        <iframe title="srcdoc" data-od-render-mode="srcdoc" data-od-active="false" />
+      </PreviewDrawOverlay>,
+    );
+
+    fireEvent.click(getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => expect(snapshot).toHaveBeenCalled());
+    const usedIframe = snapshot.mock.calls[0]?.[0] as HTMLIFrameElement;
+    expect(usedIframe.getAttribute('data-od-render-mode')).toBe('srcdoc');
   });
 });


### PR DESCRIPTION
## Why

After the Studio Mark tool landed (#3081 / #3277), Send in Mark mode fails on deck artifacts with **"Could not capture the preview. Try again to avoid sending only ink."** (reported on `pitch-deck.html`). The mark/box selection registers, but the snapshot comes back empty so the annotation is never sent.

Root cause: the Mark overlay snapshots the **active** preview iframe (`activePreviewIframe()` → `[data-od-active="true"]`). For URL-load previews — decks in particular — the active frame is the URL-load iframe, which does **not** carry the snapshot bridge. The bridge only lives in the srcDoc transport frame, which is mounted but hidden for URL-load. So the snapshot postMessage goes to a bridgeless frame and times out → null blob → the capture-missing warning.

This is specific to the new Mark overlay's capture path (it uses the active frame), not the older clipboard-screenshot path, and not covered by the earlier capture fixes.

## What users will see

Mark mode (box select / pen / viewport capture) on a deck now captures the preview and sends the annotation, instead of failing with the capture warning. Non-deck (srcDoc-active) previews are unaffected.

## How

`PreviewDrawOverlay` now snapshots the srcDoc-render-mode frame (`iframe[data-od-render-mode="srcdoc"]`), which hosts the bridge — capture mode already forces that frame onto full content (`useLazySrcDocTransport` is false while `captureModeActive`), so the bridge is present. A short retry (1.5s/3s/6s) covers the brief window where the frame is still swapping to full content. Falls back to the active frame when they are the same (non-URL-load previews).

## Surface area

- [x] **UI** — fixes Draw/Mark capture (Send) on URL-load previews in `apps/web`
- [ ] Default behavior change / Keyboard / CLI / API / Extension / i18n / dependency

## Bug fix verification

- Red spec: `apps/web/tests/components/PreviewDrawOverlay.test.tsx` → "snapshots the srcDoc bridge iframe, not the visible URL-load frame". Renders the overlay with a visible URL frame (`data-od-active="true"`) and a hidden srcDoc bridge frame (`data-od-render-mode="srcdoc"`); asserts the snapshot targets the srcDoc frame. Verified red on `main` (targets the URL frame), green on this branch.

## Validation

- `pnpm --filter @open-design/web test` on `PreviewDrawOverlay.test.tsx` + `FileViewer.test.tsx` — 121 passed
- `pnpm --filter @open-design/web typecheck` — clean
- Note: `pnpm guard` currently fails on `main` itself (design-system component-fixture coverage, unrelated to this change) — confirmed the same failure on a clean `origin/main` checkout.