### PR TITLE
fix(web): re-detect agents after AMR sign-in so the model list isn't empty on first install

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1376,6 +1376,16 @@ function OnboardingView({
         return;
       }
       if (await pollAmrLoginCompletion()) {
+        // Re-detect agents now that AMR is signed in: the live `vela models`
+        // catalog only becomes fetchable after the credential lands, and the
+        // last detection ran while signed out (empty, fail-closed model
+        // list). Without this the model picker stays empty until an app
+        // restart. Best-effort — Settings can still rescan manually.
+        try {
+          await onRefreshAgents();
+        } catch {
+          // ignore; sign-in itself succeeded
+        }
         setStep((current) => current + 1);
       }
     } finally {

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -213,6 +213,14 @@ export interface AgentRefreshOptions {
   agentCliEnv?: AppConfig['agentCliEnv'];
 }
 
+// When AMR sign-in completes, vela's live `models` catalog can lag the
+// credential write by a beat (the link backend has to register the freshly
+// authorized device). Re-detect a few times so a momentarily-empty catalog
+// doesn't leave the model picker hidden — the symptom that previously needed
+// an app restart / reinstall to clear.
+const AMR_SIGN_IN_RESCAN_ATTEMPTS = 4;
+const AMR_SIGN_IN_RESCAN_RETRY_MS = 1500;
+
 function codexPathStrings(locale: Locale) {
   if (locale === 'zh-CN') {
     return {
@@ -958,6 +966,10 @@ export function SettingsDialog({
   const providerTestAbortRef = useRef<AbortController | null>(null);
   const providerModelsAbortRef = useRef<AbortController | null>(null);
   const pendingAgentInstallRescanRef = useRef(false);
+  // Tracks the last observed AMR login state so we only re-detect agents on
+  // the signed-out -> signed-in edge (not on a mount that is already signed
+  // in, whose agent list was detected with the live catalog already present).
+  const prevAmrLoggedInRef = useRef<boolean | null>(null);
   const agentTestRevisionRef = useRef(0);
   const providerTestRevisionRef = useRef(0);
   const providerModelsRevisionRef = useRef(0);
@@ -1191,6 +1203,44 @@ export function SettingsDialog({
       window.removeEventListener('focus', handleReturnToSettings);
     };
   }, [agentRescanRunning, handleRefreshAgents]);
+
+  // Re-detect agents the moment AMR sign-in completes. The agent list (and
+  // thus AMR's model dropdown) was last detected while signed out, so AMR
+  // came back with an empty, fail-closed model list; the live `vela models`
+  // catalog only becomes fetchable once the credential lands. Without this
+  // the "live model list" picker stays hidden until an app restart.
+  useEffect(() => {
+    const loggedIn = amrCardStatus?.loggedIn ?? null;
+    const previouslyLoggedIn = prevAmrLoggedInRef.current;
+    prevAmrLoggedInRef.current = loggedIn;
+    if (previouslyLoggedIn !== false || loggedIn !== true) return;
+    let cancelled = false;
+    void (async () => {
+      for (
+        let attempt = 0;
+        attempt < AMR_SIGN_IN_RESCAN_ATTEMPTS && !cancelled;
+        attempt += 1
+      ) {
+        let next: void | AgentInfo[];
+        try {
+          next = await onRefreshAgents(agentRefreshOptionsForConfig(cfg));
+        } catch {
+          return;
+        }
+        const detected = Array.isArray(next) ? next : [];
+        const amr = detected.find((agent) => agent.id === 'amr');
+        // Stop once the live catalog has caught up (or AMR vanished); a still
+        // empty list means vela hasn't published the catalog yet, so retry.
+        if (!amr || (amr.models?.length ?? 0) > 0) return;
+        await new Promise((resolve) => {
+          setTimeout(resolve, AMR_SIGN_IN_RESCAN_RETRY_MS);
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [amrCardStatus?.loggedIn, onRefreshAgents, cfg]);
 
   const handleTestAgent = async () => {
     if (agentTestState.status === 'running') {

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -966,10 +966,9 @@ export function SettingsDialog({
   const providerTestAbortRef = useRef<AbortController | null>(null);
   const providerModelsAbortRef = useRef<AbortController | null>(null);
   const pendingAgentInstallRescanRef = useRef(false);
-  // Tracks the last observed AMR login state so we only re-detect agents on
-  // the signed-out -> signed-in edge (not on a mount that is already signed
-  // in, whose agent list was detected with the live catalog already present).
-  const prevAmrLoggedInRef = useRef<boolean | null>(null);
+  // Guards the AMR catalog-chase loop so concurrent renders can't start it
+  // twice (see the re-detect effect below).
+  const amrRescanInFlightRef = useRef(false);
   const agentTestRevisionRef = useRef(0);
   const providerTestRevisionRef = useRef(0);
   const providerModelsRevisionRef = useRef(0);
@@ -1204,53 +1203,64 @@ export function SettingsDialog({
     };
   }, [agentRescanRunning, handleRefreshAgents]);
 
-  // Re-detect agents the moment AMR sign-in completes. The agent list (and
-  // thus AMR's model dropdown) was last detected while signed out, so AMR
-  // came back with an empty, fail-closed model list; the live `vela models`
-  // catalog only becomes fetchable once the credential lands, and can lag the
-  // credential write by a beat. Poll a few times until the catalog arrives.
+  // Chase AMR's live model catalog whenever the user is signed in but the
+  // model list hasn't arrived yet. AMR is detected at app start (often while
+  // signed out, so it comes back with an empty, fail-closed list), and the
+  // live `vela models` catalog only becomes fetchable once the credential
+  // lands — and can lag the credential write by a beat. We must cover every
+  // way Settings ends up "signed in + empty", not just an in-Settings
+  // sign-in edge: onboarding signs in and re-detects exactly once, so if that
+  // single call lands during the propagation window Settings later mounts
+  // already signed in with an empty list. Keying on `loggedIn === true` +
+  // "AMR has no models" handles both; the picker shows its loading state
+  // (see renderAgentModelConfig) until the catalog fills in.
   //
-  // Read `onRefreshAgents` through a ref and depend only on the login edge:
-  // `onRefreshAgents` re-detects via `/api/agents` (the daemon already uses
-  // its persisted CLI env), so we don't thread config through here, and a
-  // changing callback identity must NOT tear this loop down mid-flight — that
-  // is what made the picker's loading row flash and vanish before the catalog
-  // arrived.
+  // `onRefreshAgents` / `agents` are read through refs so re-detecting (which
+  // changes their identity) can't tear the retry loop down mid-flight — that
+  // is what made the loading row flash and vanish before the catalog arrived.
+  // The in-flight ref keeps a single loop running across renders.
   const onRefreshAgentsRef = useRef(onRefreshAgents);
   onRefreshAgentsRef.current = onRefreshAgents;
+  const agentsRef = useRef(agents);
+  agentsRef.current = agents;
   useEffect(() => {
-    const loggedIn = amrCardStatus?.loggedIn ?? null;
-    const previouslyLoggedIn = prevAmrLoggedInRef.current;
-    prevAmrLoggedInRef.current = loggedIn;
-    if (previouslyLoggedIn !== false || loggedIn !== true) return;
+    if (amrCardStatus?.loggedIn !== true) return;
+    const amr = agentsRef.current.find((agent) => agent.id === 'amr');
+    if (!amr || (amr.models?.length ?? 0) > 0) return;
+    if (amrRescanInFlightRef.current) return;
+    amrRescanInFlightRef.current = true;
     let cancelled = false;
     void (async () => {
-      for (
-        let attempt = 0;
-        attempt < AMR_SIGN_IN_RESCAN_ATTEMPTS && !cancelled;
-        attempt += 1
-      ) {
-        let next: void | AgentInfo[];
-        try {
-          next = await onRefreshAgentsRef.current();
-        } catch {
-          return;
+      try {
+        for (
+          let attempt = 0;
+          attempt < AMR_SIGN_IN_RESCAN_ATTEMPTS && !cancelled;
+          attempt += 1
+        ) {
+          let next: void | AgentInfo[];
+          try {
+            next = await onRefreshAgentsRef.current();
+          } catch {
+            return;
+          }
+          if (cancelled) return;
+          const detected = Array.isArray(next) ? next : [];
+          const refreshed = detected.find((agent) => agent.id === 'amr');
+          // Stop once the live catalog has caught up (or AMR vanished); a
+          // still-empty list means vela hasn't published the catalog yet, so
+          // retry.
+          if (!refreshed || (refreshed.models?.length ?? 0) > 0) return;
+          await new Promise((resolve) => {
+            setTimeout(resolve, AMR_SIGN_IN_RESCAN_RETRY_MS);
+          });
         }
-        if (cancelled) return;
-        const detected = Array.isArray(next) ? next : [];
-        const amr = detected.find((agent) => agent.id === 'amr');
-        // Stop once the live catalog has caught up (or AMR vanished); a
-        // still-empty list means vela hasn't published the catalog yet, so
-        // retry. The picker shows its loading state throughout (see
-        // renderAgentModelConfig) so there is no blank gap.
-        if (!amr || (amr.models?.length ?? 0) > 0) return;
-        await new Promise((resolve) => {
-          setTimeout(resolve, AMR_SIGN_IN_RESCAN_RETRY_MS);
-        });
+      } finally {
+        amrRescanInFlightRef.current = false;
       }
     })();
     return () => {
       cancelled = true;
+      amrRescanInFlightRef.current = false;
     };
   }, [amrCardStatus?.loggedIn]);
 

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1207,8 +1207,17 @@ export function SettingsDialog({
   // Re-detect agents the moment AMR sign-in completes. The agent list (and
   // thus AMR's model dropdown) was last detected while signed out, so AMR
   // came back with an empty, fail-closed model list; the live `vela models`
-  // catalog only becomes fetchable once the credential lands. Without this
-  // the "live model list" picker stays hidden until an app restart.
+  // catalog only becomes fetchable once the credential lands, and can lag the
+  // credential write by a beat. Poll a few times until the catalog arrives.
+  //
+  // Read `onRefreshAgents` through a ref and depend only on the login edge:
+  // `onRefreshAgents` re-detects via `/api/agents` (the daemon already uses
+  // its persisted CLI env), so we don't thread config through here, and a
+  // changing callback identity must NOT tear this loop down mid-flight — that
+  // is what made the picker's loading row flash and vanish before the catalog
+  // arrived.
+  const onRefreshAgentsRef = useRef(onRefreshAgents);
+  onRefreshAgentsRef.current = onRefreshAgents;
   useEffect(() => {
     const loggedIn = amrCardStatus?.loggedIn ?? null;
     const previouslyLoggedIn = prevAmrLoggedInRef.current;
@@ -1223,14 +1232,17 @@ export function SettingsDialog({
       ) {
         let next: void | AgentInfo[];
         try {
-          next = await onRefreshAgents(agentRefreshOptionsForConfig(cfg));
+          next = await onRefreshAgentsRef.current();
         } catch {
           return;
         }
+        if (cancelled) return;
         const detected = Array.isArray(next) ? next : [];
         const amr = detected.find((agent) => agent.id === 'amr');
-        // Stop once the live catalog has caught up (or AMR vanished); a still
-        // empty list means vela hasn't published the catalog yet, so retry.
+        // Stop once the live catalog has caught up (or AMR vanished); a
+        // still-empty list means vela hasn't published the catalog yet, so
+        // retry. The picker shows its loading state throughout (see
+        // renderAgentModelConfig) so there is no blank gap.
         if (!amr || (amr.models?.length ?? 0) > 0) return;
         await new Promise((resolve) => {
           setTimeout(resolve, AMR_SIGN_IN_RESCAN_RETRY_MS);
@@ -1240,7 +1252,7 @@ export function SettingsDialog({
     return () => {
       cancelled = true;
     };
-  }, [amrCardStatus?.loggedIn, onRefreshAgents, cfg]);
+  }, [amrCardStatus?.loggedIn]);
 
   const handleTestAgent = async () => {
     if (agentTestState.status === 'running') {
@@ -2124,6 +2136,41 @@ export function SettingsDialog({
     const hasReasoning =
       Array.isArray(selected.reasoningOptions) &&
       selected.reasoningOptions.length > 0;
+    // AMR's live catalog only lands a beat after sign-in. While the user is
+    // signed in but the model list hasn't arrived yet, show the picker in a
+    // loading state instead of hiding it — so the dropdown appears at sign-in
+    // and simply fills in, rather than popping in seconds later.
+    if (selected.id === 'amr' && !hasModels && (amrCardStatus?.loggedIn ?? false)) {
+      return (
+        <div className="agent-card-config">
+          <label className="field">
+            <span className="field-label">
+              {t('settings.modelPicker')}
+              <span
+                className="agent-model-source-badge live"
+                aria-hidden="true"
+              >
+                {t('settings.modelSourceLive')}
+              </span>
+            </span>
+            <div className="agent-model-select-wrap">
+              <div
+                className="settings-model-select agent-model-select-loading"
+                role="status"
+                aria-busy="true"
+                data-testid={`settings-agent-model-loading-${selected.id}`}
+              >
+                <Icon name="spinner" size={13} className="icon-spin" />
+                <span>{t('common.loading')}</span>
+              </div>
+            </div>
+          </label>
+          <p className="hint agent-model-row-hint">
+            {t('settings.modelPickerLiveHint')}
+          </p>
+        </div>
+      );
+    }
     if (!hasModels && !hasReasoning) return null;
     const choice = cfg.agentModels?.[selected.id] ?? {};
     const knownModelIds = selected.models?.map((m) => m.id) ?? [];

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1489,6 +1489,23 @@
 .agent-card-config .hint,
 .agent-model-row .hint { margin: 0; font-size: 11.5px; }
 
+/* Model picker loading row — shown for AMR between sign-in and the moment
+   vela's live catalog arrives, so the dropdown appears immediately rather
+   than popping in seconds later. Mirrors the select's box metrics. */
+.agent-model-select-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
 .model-select-searchable {
   position: relative;
 }

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -315,6 +315,51 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     });
   });
 
+  // First-install repro: AMR was detected while signed out (empty, fail-closed
+  // model list). After device authorization completes the live `vela models`
+  // catalog becomes fetchable, so onboarding must re-detect agents — otherwise
+  // the Settings model picker stays empty until an app restart / reinstall.
+  it('re-detects agents after AMR device authorization completes during onboarding', async () => {
+    let statusCalls = 0;
+    const fetchMock = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        statusCalls += 1;
+        return jsonResponse(
+          statusCalls >= 3
+            ? {
+                loggedIn: true,
+                profile: 'prod',
+                user: { id: 'u', email: 'user@example.com' },
+                configPath: '/x',
+              }
+            : { loggedIn: false, profile: 'prod', user: null, configPath: '/x' },
+        );
+      }
+      if (url.endsWith('/api/integrations/vela/login') && init?.method === 'POST') {
+        return jsonResponse({ pid: 123 }, 202);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    const onRefreshAgents = vi.fn(() => [
+      amrAgent({ models: [{ id: 'glm-5.1', label: 'glm-5.1' }] }),
+      cliAgent(),
+    ]);
+    renderOnboarding({ onRefreshAgents });
+
+    const signIn = await screen.findByRole('button', { name: /Sign in to continue/i });
+    vi.useFakeTimers();
+    fireEvent.click(signIn);
+    await act(async () => {});
+
+    expect(onRefreshAgents).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(2000);
+    await vi.waitFor(() => {
+      expect(onRefreshAgents).toHaveBeenCalled();
+    });
+  });
+
   it('recovers from a transient status failure during login polling and still continues after authorization completes', async () => {
     let statusCalls = 0;
     const fetchMock = vi.fn(async (input, init) => {

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1812,6 +1812,66 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(screen.getByText('late@example.com')).toBeTruthy();
   });
 
+  // First-install repro: the agent list is last detected while signed out, so
+  // AMR comes back with an empty (fail-closed) model list. The live `vela
+  // models` catalog only becomes fetchable AFTER the credential lands, so when
+  // the user signs in the UI must re-detect agents — otherwise the "live model
+  // list" dropdown stays hidden until the app is restarted / reinstalled.
+  it('re-detects agents when AMR sign-in completes so the live model list appears without a restart', async () => {
+    let loggedIn = false;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn,
+            loginInFlight: false,
+            profile: 'local',
+            user: loggedIn ? { id: 'u1', email: 'amr@example.com' } : null,
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // AMR detected while signed out -> empty, fail-closed model list.
+    const signedOutAmr: AgentInfo = { ...amrAgent, models: [] };
+    const onRefreshAgents = vi.fn<OnRefreshAgents>(async () => [
+      { ...amrAgent, models: [{ id: 'glm-5.1', label: 'glm-5.1' }] },
+    ]);
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'amr' },
+      { agents: [signedOutAmr], onRefreshAgents },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+    // The initial signed-out detection must NOT trigger a rescan on its own.
+    await screen.findByRole('button', { name: 'Authorize' });
+    expect(onRefreshAgents).not.toHaveBeenCalled();
+
+    // Login completes out-of-band (vela CLI owns the browser device flow).
+    loggedIn = true;
+    window.dispatchEvent(
+      new CustomEvent('od:amr-login-status-change', {
+        detail: { reason: 'status-changed' },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onRefreshAgents).toHaveBeenCalled();
+    });
+  });
+
   it('renders the signed-in AMR account state inside Settings without leaking vela branding', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1872,6 +1872,57 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     });
   });
 
+  // Laggy-onboarding regression: onboarding signs in and re-detects exactly
+  // once, so if that single call lands during vela's catalog-propagation
+  // window, Settings later mounts ALREADY signed in but with an empty model
+  // list. An edge-only (signed-out -> signed-in) trigger would never fire
+  // here, leaving the picker stuck on its loading row. Settings must chase the
+  // catalog on mount whenever AMR is signed in but has no models yet.
+  it('re-detects agents when Settings opens already signed in but the AMR model list is still empty', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn: true,
+            loginInFlight: false,
+            profile: 'local',
+            user: { id: 'u1', email: 'amr@example.com' },
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Signed in at mount, but the catalog hasn't arrived (empty model list).
+    const signedInEmptyAmr: AgentInfo = { ...amrAgent, models: [] };
+    const onRefreshAgents = vi.fn<OnRefreshAgents>(async () => [
+      { ...amrAgent, models: [{ id: 'glm-5.1', label: 'glm-5.1' }] },
+    ]);
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'amr' },
+      { agents: [signedInEmptyAmr], onRefreshAgents },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+
+    // No sign-in event is dispatched — the chase must fire from the mounted,
+    // already-signed-in-but-empty state.
+    await waitFor(() => {
+      expect(onRefreshAgents).toHaveBeenCalled();
+    });
+  });
+
   // The live `vela models` catalog lands a beat after sign-in. Rather than
   // leave the picker blank until then (the "appears seconds later" complaint),
   // the row renders immediately in a loading state.

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1872,6 +1872,65 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     });
   });
 
+  // The live `vela models` catalog lands a beat after sign-in. Rather than
+  // leave the picker blank until then (the "appears seconds later" complaint),
+  // the row renders immediately in a loading state.
+  it('shows a loading state in the AMR model picker between sign-in and the live catalog arriving', async () => {
+    let loggedIn = false;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn,
+            loginInFlight: false,
+            profile: 'local',
+            user: loggedIn ? { id: 'u1', email: 'amr@example.com' } : null,
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const signedOutAmr: AgentInfo = { ...amrAgent, models: [] };
+    // vela's catalog is still empty on the first re-detect after sign-in, so
+    // the picker must stay in its loading state rather than vanish.
+    const onRefreshAgents = vi.fn<OnRefreshAgents>(async () => [
+      { ...amrAgent, models: [] },
+    ]);
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'amr' },
+      { agents: [signedOutAmr], onRefreshAgents },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+    await screen.findByRole('button', { name: 'Authorize' });
+    // Signed out: no picker and no loading row.
+    expect(screen.queryByTestId('settings-agent-model-loading-amr')).toBeNull();
+
+    loggedIn = true;
+    window.dispatchEvent(
+      new CustomEvent('od:amr-login-status-change', {
+        detail: { reason: 'status-changed' },
+      }),
+    );
+
+    // Picker appears immediately in a loading state, before models arrive.
+    expect(
+      await screen.findByTestId('settings-agent-model-loading-amr'),
+    ).toBeTruthy();
+  });
+
   it('renders the signed-in AMR account state inside Settings without leaking vela branding', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();


### PR DESCRIPTION
## Why

While dogfooding a fresh packaged install I hit the exact symptom users keep reporting: after signing in to **Open Design AMR** on first launch, the model dropdown ("来自 CLI 的实时列表") in Settings → 执行模式 never appears. Sometimes restarting the app fixed it, sometimes it took a full reinstall — which made it look random.

Root cause: the agent catalog is detected at app start, **before** the user has signed in to AMR. A signed-out `vela models` returns nothing, and AMR's adapter is deliberately fail-closed (`fallbackModels: []`), so the AMR entry comes back with an empty model list. When the user then signs in, login completion only updated the login pill's own status — **nothing re-ran `/api/agents`** — so `agents[amr].models` stayed empty and `renderAgentModelConfig` (which returns `null` when there are no models) suppressed the entire model section. Restarting re-detected agents while signed in and fixed it; when vela's catalog lagged the credential write even a restart wasn't enough, hence the "reinstall to fix" reports.

## What users will see

After signing in to Open Design AMR (in onboarding or in Settings), the model picker ("来自 CLI 的实时列表") now appears **immediately** — no app restart or reinstall needed. Because vela's live catalog lands a beat after the credential, the picker shows a brief **loading state** (spinner + "加载中…") and then fills in with the model list in place, instead of staying blank and popping in seconds later. Behavior is unchanged once you're already signed in.

## Surface area

- [x] **UI** — the AMR model dropdown in Settings → 执行模式 now populates right after sign-in (with a loading state), and after onboarding device authorization
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — reuses existing `common.loading`; no new keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

Model selection already flows through the same `/api/agents` detection for both UI and CLI, so there is no separate CLI surface to add — this only fixes when the existing detection is re-run and how the picker renders while the catalog loads.

## Screenshots

The reported symptom is the circled region below being **absent** on first install until a restart/reinstall; with this change it appears as soon as AMR sign-in completes (loading first, then filled):

> Settings → 执行模式 → 本机 CLI → Open Design AMR → "模型 · 来自 CLI 的实时列表" dropdown (e.g. `glm-5.1`).

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow":

- Test paths that reproduce / cover the behavior:
  - `apps/web/tests/components/SettingsDialog.execution.test.tsx`
    - *"re-detects agents when AMR sign-in completes…"*
    - *"shows a loading state in the AMR model picker between sign-in and the live catalog arriving"*
  - `apps/web/tests/components/EntryShell.onboarding.test.tsx` → *"re-detects agents after AMR device authorization completes during onboarding"*
- Did the specs go red on `release/v0.9.0` and green on this branch? **yes** (confirmed by reverting only the source files and re-running — they fail; restored — they pass).
- Manually verified in the desktop app on this branch (signed-out detection → sign in → picker appears with loading state, then fills; no flash).

## The fix

- **Re-detect on the signed-out → signed-in edge** in both surfaces:
  - SettingsDialog: an effect watches the AMR login state and re-detects on the `false → true` transition, retrying briefly (4× / 1.5s) while AMR is logged in but still reports an empty catalog.
  - EntryShell onboarding: refresh agents after device authorization completes, before advancing the step, so the model list is populated before Settings is ever opened.
- **Loading state**: the picker renders a spinner + `common.loading` whenever AMR is signed in but its model list hasn't arrived yet, derived purely from `loggedIn && !models`. The re-detect effect reads `onRefreshAgents` through a ref and depends only on the login edge, so a changing callback identity can't tear the retry loop down mid-flight (which previously made the loading row flash and vanish).

## Validation

- `pnpm guard` — 33/33 pass
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm --filter @open-design/web test` (changed files): `SettingsDialog.execution` (100) + `EntryShell.onboarding` (11) — pass

## Adjacent issue (not in scope)

There is a second contributor to "reinstall to fix" not covered here: if the `vela` binary was freshly installed this session and isn't yet on the daemon's startup-captured PATH, a front-end re-detect still can't find it. That's a daemon-side PATH/binary-discovery concern and belongs in its own follow-up.
