### PR TITLE
fix(web): theme home hero select menu

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -1272,7 +1272,7 @@
   padding: 6px;
   border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
   border-radius: 13px;
-  background: #fff;
+  background: color-mix(in srgb, var(--bg-panel) 98%, var(--bg-subtle) 2%);
   box-shadow: 0 18px 44px rgba(15, 23, 42, 0.16), 0 1px 2px rgba(15, 23, 42, 0.08);
   isolation: isolate;
 }
@@ -1299,7 +1299,7 @@
   top: 0;
   z-index: 1;
   padding-bottom: 8px;
-  background: #fff;
+  background: color-mix(in srgb, var(--bg-panel) 98%, var(--bg-subtle) 2%);
 }
 .home-hero__footer-option--select[data-field-name='designSystem'] .home-hero__footer-select-search {
   margin: 0;
@@ -1311,7 +1311,7 @@
   height: 42px;
   border: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
   border-radius: 10px;
-  background: #fff;
+  background: var(--bg-panel);
   color: var(--text);
   font: inherit;
   font-size: 14px;
@@ -1335,7 +1335,7 @@
 .home-hero__footer-select-search input:focus {
   border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 10%, transparent);
-  background: #fff;
+  background: var(--bg-panel);
 }
 .home-hero__footer-option--select[data-field-name='designSystem'] .home-hero__footer-select-search input:focus {
   border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
@@ -1624,6 +1624,22 @@
 }
 .home-hero__model-option-icon--custom {
   color: var(--text-muted);
+}
+[data-theme="dark"] .home-hero__model-option-icon--openai img,
+[data-theme="dark"] .home-hero__model-option-icon--dalle img,
+[data-theme="dark"] .home-hero__model-option-icon--grok img,
+[data-theme="dark"] .home-hero__model-option-icon--elevenlabs img,
+[data-theme="dark"] .home-hero__model-option-icon--suno img {
+  filter: invert(1) brightness(1.2);
+}
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) .home-hero__model-option-icon--openai img,
+  html:not([data-theme="light"]) .home-hero__model-option-icon--dalle img,
+  html:not([data-theme="light"]) .home-hero__model-option-icon--grok img,
+  html:not([data-theme="light"]) .home-hero__model-option-icon--elevenlabs img,
+  html:not([data-theme="light"]) .home-hero__model-option-icon--suno img {
+    filter: invert(1) brightness(1.2);
+  }
 }
 .home-hero__ratio-option-icon {
   width: 26px;

--- a/apps/web/tests/styles/home-hero-select-theme.test.ts
+++ b/apps/web/tests/styles/home-hero-select-theme.test.ts
@@ -35,4 +35,15 @@ describe('HomeHero footer select theme styles', () => {
       expect(background, selector).toMatch(/var\(--bg-panel\)/);
     }
   });
+
+  it('inverts monochrome model logos in dark dropdown panels', () => {
+    for (const icon of ['openai', 'dalle', 'grok', 'elevenlabs', 'suno']) {
+      const selector = `[data-theme="dark"] .home-hero__model-option-icon--${icon} img`;
+      expect(ruleValue(cssDeclarations(selector), 'filter'), selector)
+        .toBe('invert(1) brightness(1.2)');
+      expect(homeHeroCss).toContain(
+        `html:not([data-theme="light"]) .home-hero__model-option-icon--${icon} img`,
+      );
+    }
+  });
 });

--- a/apps/web/tests/styles/home-hero-select-theme.test.ts
+++ b/apps/web/tests/styles/home-hero-select-theme.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const homeHeroCss = readFileSync(new URL('../../src/styles/home/home-hero.css', import.meta.url), 'utf8');
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(homeHeroCss)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g'))];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('HomeHero footer select theme styles', () => {
+  it('uses theme-aware dropdown backgrounds instead of light-only white panels', () => {
+    for (const selector of [
+      '.home-hero__footer-select-menu',
+      '.home-hero__footer-select-search',
+      '.home-hero__footer-select-search input',
+      '.home-hero__footer-select-search input:focus',
+    ]) {
+      const background = ruleValue(cssDeclarations(selector), 'background');
+      expect(background, selector).not.toBe('#fff');
+      expect(background, selector).toMatch(/var\(--bg-panel\)/);
+    }
+  });
+});


### PR DESCRIPTION
## Why

While checking the media-generation home composer in dark theme, the model dropdown rendered a white panel while its text still used dark-theme variables. The result was low-contrast / unreadable options in the HomeHero footer select menu.

This is a user-facing theme bug in `origin/main`; the dropdown CSS hardcoded `background: #fff` for the menu, sticky search area, and search input instead of using app theme tokens.

## What users will see

The HomeHero footer dropdowns now keep the correct panel/input background in dark theme. Opening the image model selector no longer shows a light-only white dropdown with inverted/low-contrast text, and monochrome brand logos are inverted so they remain visible on the dark panel.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from CLI. Local Playwright verification opened the dark-theme HomeHero image model dropdown and confirmed the menu background resolves to `color(srgb 0.133725 0.129726 0.125725)` instead of white.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/home-hero-select-theme.test.ts`
- Did the test go red on `main` and green on this branch? No — I did not run the new test against `main`; source inspection of `origin/main` showed the hardcoded `background: #fff` values, and the test is green on this branch.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/styles/home-hero-select-theme.test.ts tests/styles/home-hero-prompt-metrics.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`
- Local Playwright computed-style check against `http://127.0.0.1:17575/` in dark theme

