### PR TITLE
chore(pack): ship AMR on Windows/Intel-mac via vela-cli 0.0.6 + require-vela-cli guard

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -231,6 +231,7 @@ jobs:
             --app-version "${{ needs.metadata.outputs.release_version }}"
             --mac-compression normal
             --to all
+            --require-vela-cli
             --json
             --signed
           )
@@ -415,6 +416,7 @@ jobs:
             --app-version "${{ needs.metadata.outputs.release_version }}" \
             --mac-compression normal \
             --to all \
+            --require-vela-cli \
             --json \
             --signed
 
@@ -508,6 +510,7 @@ jobs:
             "--portable",
             "--app-version", "${{ needs.metadata.outputs.release_version }}",
             "--to", "all",
+            "--require-vela-cli",
             "--json"
           )
           "cache_failed=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
@@ -526,6 +529,7 @@ jobs:
               --portable `
               --app-version "${{ needs.metadata.outputs.release_version }}" `
               --to all `
+              --require-vela-cli `
               --json
             if ($LASTEXITCODE -ne 0) {
               throw "Windows tools-pack uncached fallback build exited with code $LASTEXITCODE"

--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-nSMVyVSHfcXV5fLMXM3tfdQxZRb+FNF6P4iuJw/Z8Mo=";
-  webHash = "sha256-QOufFb3Hb5js3jK6QEl3WfnxNAa4DdZfMKoALTHY4hI=";
+  daemonHash = "sha256-Igx7hFM1okbUNNJIz6n4sEpkEq6BKF3Kj97WnNIeEws=";
+  webHash = "sha256-euLiJ/t0zqzV3hxIlo5xcNsWDiqIkzw52HRTHYDbDVM=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,8 +601,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.4
-        version: 0.0.4
+        specifier: 0.0.6
+        version: 0.0.6
 
   tools/serve:
     dependencies:
@@ -1642,13 +1642,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.4':
-    resolution: {integrity: sha512-PleB0cl42Iv7s+TrhsBFu1KZ0p3tQa+Qpm5PAS21p0INUU6kQ9H45DJ6bKB/CAoGuhq5lPL1XT3NdkLPe+V46A==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.6':
+    resolution: {integrity: sha512-NhZOudkaGGNPeTSrA2BubzXl8xKs74HQuTn3zRMqlVrxVc6LkGgtzhRkHHebeuEVvv66fNtme3hfxiKqPQ396A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli@0.0.4':
-    resolution: {integrity: sha512-63QzbvQ3JRkFwHf9cETAn4WTkbIjYc48Z4Et+pYFRyIwu3CtUUBxsPy93k/L9I1AcXOGjyJT7vFMm1gfs8amew==}
+  '@powerformer/vela-cli-darwin-x64@0.0.6':
+    resolution: {integrity: sha512-5urixFfgNHR4b0mZ2NLQeQyv2Ze3XPtvwpt4oHcSxxvE4E/4C/+YO9owwV6KzVnEY0i+/RocZnAbFusgwy7a8Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@powerformer/vela-cli-linux-arm64@0.0.6':
+    resolution: {integrity: sha512-nujuvebyoZhkfLDrWVVFC5WM5KaClHEMgX7GX+yfvLSd7zcfrH1zu4aBvd3vA62jKSYpSKRTH3vqei5Avo56sg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@powerformer/vela-cli-linux-x64@0.0.6':
+    resolution: {integrity: sha512-qX1VHfFVjiNNllzftBnuJ/k32gvc6J4yk/L8soVyfJQUadjO+YCL6GZ3S+h5jDkPD5Ao/l++YBXHFB07aXPwew==}
+    cpu: [x64]
+    os: [linux]
+
+  '@powerformer/vela-cli-win32-x64@0.0.6':
+    resolution: {integrity: sha512-LCTNtYO3jAw8Z5TQHoeckaHHDlMpj581ZluiOgV4Z103ZRAI3wOxZxSLJWgCV4ayvgfiNOp4vwR0Nnechphtlw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@powerformer/vela-cli@0.0.6':
+    resolution: {integrity: sha512-jBUf7//UQ5o+9ZrUPXv/jFsJhObw78m0wBCuxD2EM+6gF7YzsLbe7x9Xn8Y3jTvPxeEgHySzfeHEUDJdvJtnOQ==}
     hasBin: true
 
   '@rollup/pluginutils@5.3.0':
@@ -6043,12 +6063,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.4':
+  '@powerformer/vela-cli-darwin-arm64@0.0.6':
     optional: true
 
-  '@powerformer/vela-cli@0.0.4':
+  '@powerformer/vela-cli-darwin-x64@0.0.6':
+    optional: true
+
+  '@powerformer/vela-cli-linux-arm64@0.0.6':
+    optional: true
+
+  '@powerformer/vela-cli-linux-x64@0.0.6':
+    optional: true
+
+  '@powerformer/vela-cli-win32-x64@0.0.6':
+    optional: true
+
+  '@powerformer/vela-cli@0.0.6':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.4
+      '@powerformer/vela-cli-darwin-arm64': 0.0.6
+      '@powerformer/vela-cli-darwin-x64': 0.0.6
+      '@powerformer/vela-cli-linux-arm64': 0.0.6
+      '@powerformer/vela-cli-linux-x64': 0.0.6
+      '@powerformer/vela-cli-win32-x64': 0.0.6
     optional: true
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -22,7 +22,7 @@
     "electron-builder": "26.8.1"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.4"
+    "@powerformer/vela-cli": "0.0.6"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

AMR only appeared on Apple-Silicon mac packaged builds. Two reasons:

1. `@powerformer/vela-cli@0.0.4` only published the **darwin-arm64** native package. `tools-pack` bundles the CLI by resolving `@powerformer/vela-cli` for the packaging host, so Windows and Intel-mac builds resolved nothing.
2. That bundling is **optional and silent** — when the platform binary can't be resolved, tools-pack just skips it, so the AMR-less Windows/Intel-mac apps shipped unnoticed.

`@powerformer/vela-cli@0.0.6` now publishes per-platform packages for all five targets (`darwin-arm64/x64`, `linux-arm64/x64`, `win32-x64`), each bundling the same custom OpenCode fork (powerformer/vela #166, #169).

## What changed

- `tools/pack/package.json`: `@powerformer/vela-cli` `0.0.4` → `0.0.6`; `pnpm-lock.yaml` regenerated (resolves the meta + all five platform packages). The nix pnpm-deps hash was refreshed by the autofix bot.
- `.github/workflows/release-stable.yml`: pass `--require-vela-cli` to the **mac (arm64 + intel)** and **win** build commands, so packaging **fails loudly** if the bundled Vela CLI is missing instead of silently shipping an AMR-less app. (Linux containerized is left as-is for a separate follow-up.)

## What users will see

Windows and Intel-mac users get **Open Design AMR** in the agent picker after installing — same as Apple-Silicon. Each CI host installs and bundles its matching `@powerformer/vela-cli-<platform>@0.0.6` binary.

## Validation

- `pnpm install --lockfile-only` resolves all five `@powerformer/vela-cli-*@0.0.6` platform packages + meta.
- `--require-vela-cli` turns "silently no AMR" into a hard build failure, so a green release/nightly now **guarantees** AMR is bundled on mac + win.
- Definitive confirmation is the next release/nightly build on each platform.

## Surface area

- [x] Packaging (`tools/pack`)
- [x] CI / release workflow (`release-stable.yml`)
- [x] Updated dependency (`@powerformer/vela-cli`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)