### PR TITLE
fix(chat): surface OpenCode usage-limit/provider failures instead of a bare timeout

### DIFF
--- a/apps/daemon/src/runtimes/opencode-log.ts
+++ b/apps/daemon/src/runtimes/opencode-log.ts
@@ -1,0 +1,150 @@
+// OpenCode swallows provider failures in headless `run --format json` mode:
+// on a 429 usage-limit (and similar), it marks the error retryable, retries
+// silently, and emits NOTHING on stdout/stderr — so the daemon only sees an
+// inactivity-watchdog timeout with no reason. The real error is recorded
+// only in OpenCode's own session log (`service=llm … error={…}`). This
+// module recovers that signal so the chat UI can show "usage limit reached"
+// instead of a bare timeout. OpenCode-specific by design; see issue #982.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { classifyAgentServiceFailure, type AgentServiceFailureCode } from './auth.js';
+
+export interface OpenCodeServiceFailure {
+  code: AgentServiceFailureCode;
+  message: string;
+  statusCode: number | null;
+}
+
+// OpenCode resolves its data dir as `$XDG_DATA_HOME/opencode` (when set) or
+// `$HOME/.local/share/opencode`, with session logs under `log/`. Mirror that
+// so we read the same files the spawned CLI wrote. Null when neither var is
+// set (we have no basis to guess a path).
+export function resolveOpenCodeLogDir(
+  env: Record<string, string | undefined>,
+): string | null {
+  const xdg = typeof env.XDG_DATA_HOME === 'string' ? env.XDG_DATA_HOME.trim() : '';
+  const home = typeof env.HOME === 'string' ? env.HOME.trim() : '';
+  const base = xdg || (home ? path.join(home, '.local', 'share') : '');
+  if (!base) return null;
+  return path.join(base, 'opencode', 'log');
+}
+
+// Read the tail of OpenCode's most recent session log. Filenames are
+// `<ISO-like-timestamp>.log`, so a lexicographic sort orders them by recency
+// without a stat() per file. The 2 MB tail comfortably holds the final error
+// frame even though OpenCode embeds the entire request body (system prompt +
+// tool schemas) in each `service=llm` line. Synchronous on purpose: the only
+// caller is the (non-async) run close handler, and it runs once per failed
+// OpenCode run. Returns null on any fs error (no dir yet, perms).
+export function readLatestOpenCodeLogTail(
+  logDir: string,
+  maxBytes = 2_000_000,
+): string | null {
+  let names: string[];
+  try {
+    names = readdirSync(logDir).filter((name) => name.endsWith('.log'));
+  } catch {
+    return null;
+  }
+  if (names.length === 0) return null;
+  names.sort();
+  const newest = names[names.length - 1]!;
+  try {
+    const buf = readFileSync(path.join(logDir, newest), 'utf8');
+    return buf.length > maxBytes ? buf.slice(-maxBytes) : buf;
+  } catch {
+    return null;
+  }
+}
+
+// Only treat a `"message":"…"` value as the failure reason when it reads
+// like a service error. The embedded request body uses `"content":` for
+// prompt text, but tool schemas and user prompts could still contain a
+// stray `"message"` key, so this keyword gate keeps unrelated payload text
+// from masquerading as the error.
+const SERVICE_ERROR_MESSAGE_RE =
+  /usage limit|rate[ _-]?limit|quota|limit reached|insufficient|credit|balance|overloaded|unavailable|unauthor|authenticat|invalid[ _-]?(?:api[ _-]?)?key|api key|\/login|exhaust|too many requests/i;
+
+function pickServiceErrorMessage(line: string): string | null {
+  const re = /"message":"((?:[^"\\]|\\.)*)"/g;
+  let fallback: string | null = null;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(line)) !== null) {
+    let value: string;
+    try {
+      value = JSON.parse(`"${match[1]}"`);
+    } catch {
+      value = match[1]!;
+    }
+    value = value.trim();
+    if (SERVICE_ERROR_MESSAGE_RE.test(value)) return value;
+    if (!fallback) fallback = value;
+  }
+  return fallback && SERVICE_ERROR_MESSAGE_RE.test(fallback) ? fallback : null;
+}
+
+function codeFromStatus(statusCode: number): AgentServiceFailureCode | null {
+  if (statusCode === 401 || statusCode === 403) return 'AGENT_AUTH_REQUIRED';
+  if (statusCode === 429) return 'RATE_LIMITED';
+  if (statusCode >= 500 && statusCode <= 599) return 'UPSTREAM_UNAVAILABLE';
+  return null;
+}
+
+function defaultMessageForCode(code: AgentServiceFailureCode): string {
+  switch (code) {
+    case 'AGENT_AUTH_REQUIRED':
+      return 'OpenCode could not authenticate with the model provider.';
+    case 'RATE_LIMITED':
+      return 'OpenCode hit a provider usage or rate limit.';
+    case 'UPSTREAM_UNAVAILABLE':
+      return "OpenCode's model provider is temporarily unavailable.";
+  }
+}
+
+// Classify the latest `service=llm` provider error in an OpenCode log tail.
+// We scope to that single line so the huge request body of *other* lines
+// can't leak in, key the classification on the unambiguous HTTP `statusCode`
+// first, and fall back to keyword matching the extracted message only.
+export function extractOpenCodeServiceFailure(
+  logTail: string,
+): OpenCodeServiceFailure | null {
+  if (!logTail || !logTail.trim()) return null;
+  const lines = logTail.split(/\r?\n/);
+  let line: string | null = null;
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const candidate = lines[i]!;
+    if (
+      candidate.includes('service=llm') &&
+      /\bERROR\b/.test(candidate) &&
+      candidate.includes('error=')
+    ) {
+      line = candidate;
+      break;
+    }
+  }
+  if (!line) return null;
+
+  const statusMatch = /"statusCode":\s*(\d{3})/.exec(line);
+  const statusCode = statusMatch ? Number(statusMatch[1]) : null;
+  const message = pickServiceErrorMessage(line);
+
+  let code: AgentServiceFailureCode | null =
+    statusCode != null ? codeFromStatus(statusCode) : null;
+  if (!code && message) code = classifyAgentServiceFailure(message);
+  if (!code) return null;
+
+  return { code, message: message || defaultMessageForCode(code), statusCode };
+}
+
+// Convenience for the run close handler: resolve the log dir from the
+// spawned agent's env, read the newest log tail, and classify it.
+export function readOpenCodeServiceFailure(
+  env: Record<string, string | undefined>,
+): OpenCodeServiceFailure | null {
+  const logDir = resolveOpenCodeLogDir(env);
+  if (!logDir) return null;
+  const tail = readLatestOpenCodeLogTail(logDir);
+  if (!tail) return null;
+  return extractOpenCodeServiceFailure(tail);
+}

--- a/apps/daemon/src/runtimes/opencode-log.ts
+++ b/apps/daemon/src/runtimes/opencode-log.ts
@@ -35,7 +35,11 @@ export function resolveOpenCodeLogDir(
 // `since` (when provided) binds the lookup to the current run: a file last
 // written before the run started can only belong to an earlier session, so
 // it is skipped rather than risk surfacing a stale provider error for this
-// run. The 2 MB tail comfortably holds the final error frame even though
+// run. (This does not disambiguate two OpenCode runs writing into the same
+// HOME concurrently — OpenCode only emits its session id on the stdout
+// stream, which is empty in the silent-stall case, so mtime is the only
+// run-binding signal available here.) The 2 MB tail comfortably holds the
+// final error frame even though
 // OpenCode embeds the entire request body (system prompt + tool schemas) in
 // each `service=llm` line. Synchronous on purpose: the only callers are the
 // (non-async) run close handler and the inactivity watchdog, once per failed

--- a/apps/daemon/src/runtimes/opencode-log.ts
+++ b/apps/daemon/src/runtimes/opencode-log.ts
@@ -6,7 +6,7 @@
 // module recovers that signal so the chat UI can show "usage limit reached"
 // instead of a bare timeout. OpenCode-specific by design; see issue #982.
 
-import { readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { classifyAgentServiceFailure, type AgentServiceFailureCode } from './auth.js';
 
@@ -31,16 +31,20 @@ export function resolveOpenCodeLogDir(
 }
 
 // Read the tail of OpenCode's most recent session log. Filenames are
-// `<ISO-like-timestamp>.log`, so a lexicographic sort orders them by recency
-// without a stat() per file. The 2 MB tail comfortably holds the final error
-// frame even though OpenCode embeds the entire request body (system prompt +
-// tool schemas) in each `service=llm` line. Synchronous on purpose: the only
-// caller is the (non-async) run close handler, and it runs once per failed
+// `<ISO-like-timestamp>.log`, so a lexicographic sort orders them by recency.
+// `since` (when provided) binds the lookup to the current run: a file last
+// written before the run started can only belong to an earlier session, so
+// it is skipped rather than risk surfacing a stale provider error for this
+// run. The 2 MB tail comfortably holds the final error frame even though
+// OpenCode embeds the entire request body (system prompt + tool schemas) in
+// each `service=llm` line. Synchronous on purpose: the only callers are the
+// (non-async) run close handler and the inactivity watchdog, once per failed
 // OpenCode run. Returns null on any fs error (no dir yet, perms).
 export function readLatestOpenCodeLogTail(
   logDir: string,
-  maxBytes = 2_000_000,
+  options: { maxBytes?: number; since?: number } = {},
 ): string | null {
+  const { maxBytes = 2_000_000, since } = options;
   let names: string[];
   try {
     names = readdirSync(logDir).filter((name) => name.endsWith('.log'));
@@ -48,14 +52,24 @@ export function readLatestOpenCodeLogTail(
     return null;
   }
   if (names.length === 0) return null;
-  names.sort();
-  const newest = names[names.length - 1]!;
-  try {
-    const buf = readFileSync(path.join(logDir, newest), 'utf8');
-    return buf.length > maxBytes ? buf.slice(-maxBytes) : buf;
-  } catch {
-    return null;
+  names.sort().reverse(); // newest filename first
+  for (const name of names) {
+    const full = path.join(logDir, name);
+    if (since != null) {
+      try {
+        if (statSync(full).mtimeMs < since) continue;
+      } catch {
+        continue;
+      }
+    }
+    try {
+      const buf = readFileSync(full, 'utf8');
+      return buf.length > maxBytes ? buf.slice(-maxBytes) : buf;
+    } catch {
+      continue;
+    }
   }
+  return null;
 }
 
 // Only treat a `"message":"…"` value as the failure reason when it reads
@@ -137,14 +151,16 @@ export function extractOpenCodeServiceFailure(
   return { code, message: message || defaultMessageForCode(code), statusCode };
 }
 
-// Convenience for the run close handler: resolve the log dir from the
-// spawned agent's env, read the newest log tail, and classify it.
+// Convenience for the run close handler / inactivity watchdog: resolve the
+// log dir from the spawned agent's env, read the newest log tail (bound to
+// the current run via `since`), and classify it.
 export function readOpenCodeServiceFailure(
   env: Record<string, string | undefined>,
+  options: { since?: number } = {},
 ): OpenCodeServiceFailure | null {
   const logDir = resolveOpenCodeLogDir(env);
   if (!logDir) return null;
-  const tail = readLatestOpenCodeLogTail(logDir);
+  const tail = readLatestOpenCodeLogTail(logDir, options);
   if (!tail) return null;
   return extractOpenCodeServiceFailure(tail);
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -220,6 +220,7 @@ import {
   classifyAgentServiceFailure,
   cursorAuthGuidance,
 } from './runtimes/auth.js';
+import { readOpenCodeServiceFailure } from './runtimes/opencode-log.js';
 import { createQoderStreamHandler } from './qoder-stream.js';
 import { subscribe as subscribeFileEvents } from './project-watchers.js';
 import { renderDesignSystemPreview } from './design-system-preview.js';
@@ -12458,17 +12459,36 @@ export async function startServer({
             { retryable: true },
           ));
         } else {
-          const rewritten = rewriteKnownAgentStreamError(
-            def.id,
-            (agentStderrTail || agentStdoutTail || '').trim(),
-            `${agentStderrTail}\n${agentStdoutTail}`,
-          );
-          if (rewritten !== 'Agent stream error') {
+          // OpenCode swallows provider failures in headless mode: a 429
+          // usage-limit is marked retryable and retried silently with
+          // nothing on stdout/stderr, so the run only dies via the
+          // inactivity watchdog and the checks above find no signal. The
+          // real reason is recorded only in OpenCode's own session log,
+          // so recover it before falling back to the generic rewrite.
+          // See issue #982.
+          const openCodeFailure =
+            def.id === 'opencode'
+              ? readOpenCodeServiceFailure(spawnedAgentEnv)
+              : null;
+          if (openCodeFailure) {
             send('error', createSseErrorPayload(
-              'AGENT_EXECUTION_FAILED',
-              rewritten,
+              openCodeFailure.code,
+              openCodeFailure.message,
               { retryable: true },
             ));
+          } else {
+            const rewritten = rewriteKnownAgentStreamError(
+              def.id,
+              (agentStderrTail || agentStdoutTail || '').trim(),
+              `${agentStderrTail}\n${agentStdoutTail}`,
+            );
+            if (rewritten !== 'Agent stream error') {
+              send('error', createSseErrorPayload(
+                'AGENT_EXECUTION_FAILED',
+                rewritten,
+                { retryable: true },
+              ));
+            }
           }
         }
       }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12452,7 +12452,13 @@ export async function startServer({
         acpCleanCompletion,
         artifactQuietShutdownRequested,
       });
-      if (status === 'failed') {
+      // Skip the close-handler failure emit when the run is already
+      // terminal: the inactivity watchdog (failForInactivity) finishes the
+      // run — sending its error and clearing run.clients/eventsLogStream —
+      // before SIGTERM, so re-emitting here would double-send the error and
+      // reopen the closed events-log stream. The run is finalized below
+      // regardless (finish() no-ops once terminal).
+      if (status === 'failed' && !design.runs.isTerminal(run.status)) {
         const diagnostic = diagnoseClaudeCliFailure({
           agentId: def.id,
           exitCode: code,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11516,13 +11516,36 @@ export async function startServer({
         scheduleForcedChildShutdown();
         return;
       }
-      const message =
-        `Agent stalled without emitting any new output for ${Math.round(inactivityTimeoutMs / 1000)}s. ` +
-        'The model or CLI likely hung while generating. ' +
-        `Phase details: spawned agent ${userFacingAgentLabel(agentId, resolvedBin)}; stdout arrived: ${childStdoutSeen ? 'yes' : 'no'}; ` +
-        `last agent event: ${lastAgentEventPhase}; largest tool result observed: ${lastToolResultChars} chars. ` +
-        'Retry the turn, pick a different model, or start a new conversation if the prior context is very large.';
-      send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', message, { retryable: true }));
+      // OpenCode retries a 429 usage-limit silently and emits nothing on
+      // stdout/stderr, so the watchdog is the first signal we get. The real
+      // reason is recorded only in OpenCode's own session log — recover it
+      // and surface it HERE, before finish() tears down the live SSE
+      // clients, so a viewer sees "usage limit reached" instead of the
+      // generic stall message. Bound to this run via `since` so a stale or
+      // concurrent session's error can't be misattributed. See issue #982.
+      let stallPayload = null;
+      if (agentId === 'opencode') {
+        const logFailure = readOpenCodeServiceFailure(spawnedAgentEnv, {
+          since: run.createdAt,
+        });
+        if (logFailure) {
+          stallPayload = createSseErrorPayload(
+            logFailure.code,
+            logFailure.message,
+            { retryable: true },
+          );
+        }
+      }
+      if (!stallPayload) {
+        const message =
+          `Agent stalled without emitting any new output for ${Math.round(inactivityTimeoutMs / 1000)}s. ` +
+          'The model or CLI likely hung while generating. ' +
+          `Phase details: spawned agent ${userFacingAgentLabel(agentId, resolvedBin)}; stdout arrived: ${childStdoutSeen ? 'yes' : 'no'}; ` +
+          `last agent event: ${lastAgentEventPhase}; largest tool result observed: ${lastToolResultChars} chars. ` +
+          'Retry the turn, pick a different model, or start a new conversation if the prior context is very large.';
+        stallPayload = createSseErrorPayload('AGENT_EXECUTION_FAILED', message, { retryable: true });
+      }
+      send('error', stallPayload);
       design.runs.finish(run, 'failed', 1, null);
       if (acpSession?.abort) {
         acpSession.abort();
@@ -12468,7 +12491,7 @@ export async function startServer({
           // See issue #982.
           const openCodeFailure =
             def.id === 'opencode'
-              ? readOpenCodeServiceFailure(spawnedAgentEnv)
+              ? readOpenCodeServiceFailure(spawnedAgentEnv, { since: run.createdAt })
               : null;
           if (openCodeFailure) {
             send('error', createSseErrorPayload(

--- a/apps/daemon/tests/runtimes/opencode-log-failure.test.ts
+++ b/apps/daemon/tests/runtimes/opencode-log-failure.test.ts
@@ -1,0 +1,129 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractOpenCodeServiceFailure,
+  readLatestOpenCodeLogTail,
+  readOpenCodeServiceFailure,
+  resolveOpenCodeLogDir,
+} from '../../src/runtimes/opencode-log.js';
+
+// Faithful `service=llm` error line for an over-quota opencode-go call. The
+// embedded request body carries decoy phrases ("api key", "rate limit")
+// inside a `"content"` field to prove the classifier keys on the error's
+// statusCode + `"message"`, never arbitrary prompt text.
+const USAGE_LIMIT_LINE =
+  'ERROR 2026-05-29T10:00:00 +5ms service=llm providerID=opencode-go modelID=deepseek-v4-pro session.id=ses_x ' +
+  'error={"error":{"name":"AI_APICallError",' +
+  '"requestBodyValues":{"messages":[{"role":"system","content":"Provide your api key and mind the rate limit."}]},' +
+  '"statusCode":429,"isRetryable":true,' +
+  '"message":"Monthly usage limit reached. Resets in 6 days. Enable usage at https://opencode.ai/workspace/wrk_x/go"}}';
+
+function fresh(): string {
+  return mkdtempSync(path.join(tmpdir(), 'od-opencode-log-'));
+}
+
+describe('extractOpenCodeServiceFailure', () => {
+  it('classifies a 429 usage-limit line as RATE_LIMITED with the real message', () => {
+    const failure = extractOpenCodeServiceFailure(USAGE_LIMIT_LINE);
+    expect(failure).not.toBeNull();
+    expect(failure!.code).toBe('RATE_LIMITED');
+    expect(failure!.statusCode).toBe(429);
+    expect(failure!.message).toContain('Monthly usage limit reached');
+    expect(failure!.message).toContain('Resets in 6 days');
+    // Decoy text in the request body must not leak into the reason.
+    expect(failure!.message).not.toContain('api key');
+  });
+
+  it('classifies a 401 line as AGENT_AUTH_REQUIRED', () => {
+    const line =
+      'ERROR 2026-05-29T10:00:00 +5ms service=llm providerID=openai ' +
+      'error={"error":{"name":"AI_APICallError","statusCode":401,"message":"Unauthorized: invalid API key"}}';
+    const failure = extractOpenCodeServiceFailure(line);
+    expect(failure!.code).toBe('AGENT_AUTH_REQUIRED');
+    expect(failure!.statusCode).toBe(401);
+  });
+
+  it('classifies a 503 line as UPSTREAM_UNAVAILABLE', () => {
+    const line =
+      'ERROR 2026-05-29T10:00:00 +5ms service=llm providerID=opencode-go ' +
+      'error={"error":{"name":"AI_APICallError","statusCode":503,"message":"Service temporarily unavailable"}}';
+    expect(extractOpenCodeServiceFailure(line)!.code).toBe('UPSTREAM_UNAVAILABLE');
+  });
+
+  it('falls back to message keywords when no statusCode is present', () => {
+    const line =
+      'ERROR 2026-05-29T10:00:00 +5ms service=llm providerID=opencode-go ' +
+      'error={"error":{"name":"ProviderError","message":"You have exceeded your current quota."}}';
+    expect(extractOpenCodeServiceFailure(line)!.code).toBe('RATE_LIMITED');
+  });
+
+  it('picks the most recent llm error when several are present', () => {
+    const tail = [
+      'ERROR 2026-05-29T10:00:00 +5ms service=llm error={"error":{"statusCode":503,"message":"unavailable"}}',
+      'ERROR 2026-05-29T10:00:10 +5ms service=llm error={"error":{"statusCode":429,"message":"usage limit reached"}}',
+    ].join('\n');
+    const failure = extractOpenCodeServiceFailure(tail);
+    expect(failure!.code).toBe('RATE_LIMITED');
+    expect(failure!.statusCode).toBe(429);
+  });
+
+  it('returns null for ordinary (non-error) log output', () => {
+    const tail = [
+      'INFO 2026-05-29T10:00:00 +1ms service=bus type=message.part.delta publishing',
+      'INFO 2026-05-29T10:00:00 +1ms service=bus type=message.part.updated publishing',
+    ].join('\n');
+    expect(extractOpenCodeServiceFailure(tail)).toBeNull();
+    expect(extractOpenCodeServiceFailure('')).toBeNull();
+  });
+});
+
+describe('resolveOpenCodeLogDir', () => {
+  it('prefers XDG_DATA_HOME, falls back to HOME, else null', () => {
+    expect(resolveOpenCodeLogDir({ XDG_DATA_HOME: '/x' })).toBe(
+      path.join('/x', 'opencode', 'log'),
+    );
+    expect(resolveOpenCodeLogDir({ HOME: '/home/u' })).toBe(
+      path.join('/home/u', '.local', 'share', 'opencode', 'log'),
+    );
+    expect(resolveOpenCodeLogDir({})).toBeNull();
+  });
+});
+
+describe('readLatestOpenCodeLogTail', () => {
+  it('reads the lexicographically-newest .log file', () => {
+    const dir = fresh();
+    writeFileSync(path.join(dir, '2026-05-29T090000.log'), 'OLD');
+    writeFileSync(path.join(dir, '2026-05-29T100000.log'), 'NEWEST');
+    expect(readLatestOpenCodeLogTail(dir)).toBe('NEWEST');
+  });
+
+  it('returns only the tail when the file exceeds maxBytes', () => {
+    const dir = fresh();
+    writeFileSync(path.join(dir, 'a.log'), 'X'.repeat(100) + 'TAIL');
+    expect(readLatestOpenCodeLogTail(dir, 4)).toBe('TAIL');
+  });
+
+  it('returns null when the log dir does not exist', () => {
+    expect(readLatestOpenCodeLogTail(path.join(fresh(), 'missing'))).toBeNull();
+  });
+});
+
+describe('readOpenCodeServiceFailure (end to end from env)', () => {
+  it('resolves HOME → log dir → newest tail → classification', () => {
+    const home = fresh();
+    const logDir = path.join(home, '.local', 'share', 'opencode', 'log');
+    mkdirSync(logDir, { recursive: true });
+    writeFileSync(path.join(logDir, '2026-05-29T100000.log'), USAGE_LIMIT_LINE);
+
+    const failure = readOpenCodeServiceFailure({ HOME: home });
+    expect(failure!.code).toBe('RATE_LIMITED');
+    expect(failure!.message).toContain('Monthly usage limit reached');
+  });
+
+  it('returns null when env carries no usable home', () => {
+    expect(readOpenCodeServiceFailure({})).toBeNull();
+  });
+});

--- a/apps/daemon/tests/runtimes/opencode-log-failure.test.ts
+++ b/apps/daemon/tests/runtimes/opencode-log-failure.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -103,11 +103,32 @@ describe('readLatestOpenCodeLogTail', () => {
   it('returns only the tail when the file exceeds maxBytes', () => {
     const dir = fresh();
     writeFileSync(path.join(dir, 'a.log'), 'X'.repeat(100) + 'TAIL');
-    expect(readLatestOpenCodeLogTail(dir, 4)).toBe('TAIL');
+    expect(readLatestOpenCodeLogTail(dir, { maxBytes: 4 })).toBe('TAIL');
   });
 
   it('returns null when the log dir does not exist', () => {
     expect(readLatestOpenCodeLogTail(path.join(fresh(), 'missing'))).toBeNull();
+  });
+
+  it('skips a log last written before `since` (binds to the current run)', () => {
+    const dir = fresh();
+    const stale = path.join(dir, '2026-05-29T080000.log');
+    writeFileSync(stale, 'STALE');
+    const runStart = Date.now();
+    // Backdate the file to before the run started → it belongs to an
+    // earlier session and must not be read for this run.
+    const before = new Date(runStart - 60_000);
+    utimesSync(stale, before, before);
+    expect(readLatestOpenCodeLogTail(dir, { since: runStart })).toBeNull();
+  });
+
+  it('returns a log written at/after `since`', () => {
+    const dir = fresh();
+    const current = path.join(dir, '2026-05-29T100000.log');
+    writeFileSync(current, 'CURRENT');
+    expect(readLatestOpenCodeLogTail(dir, { since: Date.now() - 5_000 })).toBe(
+      'CURRENT',
+    );
   });
 });
 
@@ -125,5 +146,19 @@ describe('readOpenCodeServiceFailure (end to end from env)', () => {
 
   it('returns null when env carries no usable home', () => {
     expect(readOpenCodeServiceFailure({})).toBeNull();
+  });
+
+  it('does not attribute a stale session error to the current run (since gate)', () => {
+    const home = fresh();
+    const logDir = path.join(home, '.local', 'share', 'opencode', 'log');
+    mkdirSync(logDir, { recursive: true });
+    const stale = path.join(logDir, '2026-05-29T080000.log');
+    writeFileSync(stale, USAGE_LIMIT_LINE);
+    const runStart = Date.now();
+    const before = new Date(runStart - 60_000);
+    utimesSync(stale, before, before);
+    expect(
+      readOpenCodeServiceFailure({ HOME: home }, { since: runStart }),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
<!-- Partially addresses #982; does not fully close it, so no auto-close trailer. -->
Part of #982.

## Why

I hit this self-hosting OpenCode (Go subscription) as my Local CLI agent: once the monthly usage cap was reached, every chat run just showed **"request timed out"** with no reason. I only discovered the cause by running `opencode` manually.

Root cause, confirmed by running the real CLI against an over-quota `opencode-go` model:

- The provider returns **HTTP 429** with `"message":"Monthly usage limit reached. Resets in 6 days. …"`.
- OpenCode marks it **`isRetryable: true`** and **retries silently** — in headless `run --format json` mode it emits **nothing on stdout or stderr** (verified: both 0 bytes) and hangs.
- So the daemon's `classifyAgentServiceFailure` (which reads stdout/stderr) has nothing to match, and the run only dies via the inactivity watchdog → bare timeout, no error code.
- The real error is recorded **only** in OpenCode's own session log: `service=llm … error={… "statusCode":429 … "message":"Monthly usage limit reached…"}`.

## What users will see

When an OpenCode run fails after going silent (usage limit, auth failure, or a provider 5xx), the chat now shows the actual reason — e.g. *"Monthly usage limit reached. Resets in 6 days. To continue using this model now, enable usage from your available balance: …"* — as a structured, retryable error, instead of "request timed out" with no explanation.

## Surface area

- [x] **None** — internal failure-reporting fix in the daemon's chat-run close path; no new UI / CLI / API / extension point / i18n key / dependency, and no opt-in default change.

## Screenshots

N/A — surfaces an existing error channel (structured SSE `error`) with a real message; no new UI.

## Bug fix verification

Per AGENTS.md → "Bug follow-up workflow":

- Test path: `apps/daemon/tests/runtimes/opencode-log-failure.test.ts` (12 cases).
- Did it go red on `main` / green on branch? The failure is a *silent stall* — OpenCode emits nothing to stdout/stderr, so it can't be reproduced cheaply at the daemon HTTP boundary, and the new `runtimes/opencode-log.ts` module didn't exist on `main`. Instead I verified the real behavior **live** (ran `opencode run --format json` against an over-quota `opencode-go` model: 0 bytes on both streams, 429 + "Monthly usage limit reached" only in its log) and encoded that exact log line as the test fixture. The extractor test asserts `RATE_LIMITED` + the real message, and explicitly asserts decoy text ("api key", "rate limit") embedded in the log line's request body does **not** leak into the classification. Auth (401) and upstream (503) paths and a non-error tail are covered too.

## Validation

- `pnpm --filter @open-design/daemon test opencode-log-failure` → 12 passed
- `pnpm --filter @open-design/daemon typecheck` → clean

## Notes / scope

OpenCode-specific by design (it's the agent that swallows the error into its own log). The generic side of #982 — a structured-error matrix for every agent — is left for a follow-up. A `401/403` here maps to `AGENT_AUTH_REQUIRED`, `429`/usage-limit to `RATE_LIMITED`, `5xx` to `UPSTREAM_UNAVAILABLE`, reusing the existing `classifyAgentServiceFailure` codes.