### PR TITLE
feat: add code-scaffold community plugin v0.1.0

### DIFF
--- a/plugins/community/code-scaffold/SKILL.md
+++ b/plugins/community/code-scaffold/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: code-scaffold
+description: Multi-stage code generation and scaffolding workflow — accepts a brief, files, or URL references, plans file structure, generates code, and self-reviews before delivery.
+od:
+  scenario: code-scaffold
+  mode: scenario
+---
+
+# code-scaffold (scenario)
+
+Use this scenario when the user wants to generate code files from a natural-language brief, reference files, or a URL. The workflow discovers requirements, plans the output tree, generates every file, and reviews the result before delivering.
+
+## Required outcome
+
+Produce a working set of code files in the project workspace matching the user's brief. The output may be a single file or an entire project tree depending on scope.
+
+## Inputs
+
+The user provides one or more of:
+
+- **A natural-language brief** — what to build, the language/framework, constraints.
+- **Reference files** — existing code, images, docs, or configs that inform the scaffold.
+- **A URL** — documentation, API reference, or example repo to pull context from.
+
+The agent receives these through the plugin's declared inputs:
+
+| Input | Type | Required | Purpose |
+|-------|------|----------|---------|
+| `brief` | string | yes | What to scaffold — the core requirement |
+| `language` | string | no | Target language or framework (inferred if omitted) |
+| `referenceUrl` | string | no | URL for documentation, API spec, or example repo |
+| `outputDir` | string | no | Subdirectory for generated files (defaults to project root) |
+
+## Pipeline
+
+### Stage 1 — Discovery
+
+Ask focused questions to lock scope before generating anything:
+
+1. **What are we building?** — component, module, full project, config, script, API endpoint, CLI tool, etc.
+2. **Target stack** — language, framework version, package manager, runtime.
+3. **Scale** — how many files, rough structure, entry points.
+4. **Constraints** — naming conventions, existing patterns to match, things to avoid.
+
+If the brief already answers these, skip the question and confirm the inferred values. Emit a `<question-form>` only for genuinely ambiguous fields.
+
+### Stage 2 — Plan
+
+Before writing any code:
+
+1. State the planned file tree aloud — every file path and its one-line purpose.
+2. Identify shared patterns (imports, config shape, naming) that must be consistent across files.
+3. Note any dependencies or setup the user will need after scaffolding.
+4. Write the plan as a todo list (one item per file or logical group).
+
+### Stage 3 — Build
+
+Generate the code files in dependency order:
+
+- **Shared first** — types, configs, utilities that other files import.
+- **Core modules** — the main logic, components, or endpoints.
+- **Entry points** — index files, main scripts, route registrations.
+- **Supporting** — tests, configs, READMEs, CI files.
+
+Rules during generation:
+
+- Use the declared language/framework conventions (naming, file extensions, import style).
+- No placeholder code — every function body must be real or have a clear `// TODO:` with a specific description.
+- No invented dependencies — only import packages the user's stack actually uses.
+- Match the user's existing code style if reference files were provided.
+- Keep files focused — one concern per file, under 300 lines each.
+
+### Stage 4 — Review
+
+After all files are written, self-review across five dimensions:
+
+1. **Correctness** — does the code compile/parse? Are imports valid? Are types consistent?
+2. **Completeness** — does every file from the plan exist? Are all entry points wired up?
+3. **Consistency** — same naming, same patterns, same style across all files?
+4. **Specificity** — is the code specific to the brief, not generic boilerplate?
+5. **Usability** — can the user run/use the output immediately? Are setup steps documented?
+
+Score each 1–5. Any dimension under 3 → fix before delivering. Emit the review as a `critique.json` in the project root.
+
+## Anti-patterns
+
+- Generating a single monolithic file when the brief calls for a project structure.
+- Inventing npm packages or APIs that don't exist.
+- Using outdated framework patterns (class components in React, CommonJS in ESM projects).
+- Adding boilerplate the user didn't ask for (license files, CI configs, contributing guides) unless the brief says "full project setup".
+- Placeholder functions with empty bodies and no TODO comment.
+
+## Convergence
+
+The review stage repeats until `critique.score >= 4` or `iterations >= 3`. The critique score is the minimum across all five dimensions.
+
+## Signals emitted
+
+- `discovery.complete: boolean` — all required scope questions answered.
+- `plan.ready: boolean` — file tree confirmed, todo list written.
+- `build.complete: boolean` — all planned files generated.
+- `critique.score: number` — min score across review dimensions (0–5).

--- a/plugins/community/code-scaffold/SKILL.md
+++ b/plugins/community/code-scaffold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-scaffold
-description: Multi-stage code generation and scaffolding workflow — accepts a brief, files, or URL references, plans file structure, generates code, and self-reviews before delivery.
+description: K-Universe code scaffolding — multi-stage generation using --ku-* design tokens, Power Grotesk type system, and monochrome-first conventions.
 od:
   scenario: code-scaffold
   mode: scenario
@@ -8,21 +8,73 @@ od:
 
 # code-scaffold (scenario)
 
-Use this scenario when the user wants to generate code files from a natural-language brief, reference files, or a URL. The workflow discovers requirements, plans the output tree, generates every file, and reviews the result before delivering.
+Use this scenario when the user wants to scaffold code files using K-Universe design conventions. The workflow discovers requirements, plans the file tree, generates code referencing `--ku-*` design tokens, and self-reviews before delivery.
 
 ## Required outcome
 
-Produce a working set of code files in the project workspace matching the user's brief. The output may be a single file or an entire project tree depending on scope.
+Produce a working set of code files matching the user's brief. All visual output must use K-Universe design tokens (`--ku-*`) — never hardcoded hex colors or ad-hoc values.
+
+## K-Universe Design Conventions
+
+These conventions MUST be followed in all generated code. Deviations require explicit brief override.
+
+### Color — monochrome-first, color earned
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `--ku-bg` | `#000000` | Page background |
+| `--ku-surface` | `#111111` | Cards, panels (L1) |
+| `--ku-surface-raised` | `#1A1A1A` | Raised elements (L2) |
+| `--ku-surface-muted` | `#2A2A2A` | Disabled / inactive |
+| `--ku-text` | `#FFFFFF` | Primary text |
+| `--ku-text-secondary` | `rgba(255,255,255,0.6)` | Secondary text |
+| `--ku-text-muted` | `rgba(255,255,255,0.35)` | Muted text |
+| `--ku-primary` | `#0066FF` | Interactive CTA / accent |
+| `--ku-primary-hover` | `#0052CC` | Hovered CTA |
+| `--ku-primary-subtle` | `rgba(0,102,255,0.08)` | Subtle primary bg |
+| `--ku-secondary` | `#00CC88` | Success / teal |
+| `--ku-hud` | `#00FF41` | Live operational state ONLY |
+| `--ku-success` | `#00DD77` | Success indicator |
+| `--ku-warning` | `#FFAA00` | Warning |
+| `--ku-error` | `#FF3333` | Error |
+| `--ku-border` | `rgba(255,255,255,0.08)` | Default border |
+| `--ku-border-strong` | `rgba(255,255,255,0.14)` | Emphasized border |
+
+**Rules**: Never use `--ku-hud` for anything other than live operational state. Never hardcode hex when a `--ku-*` token exists. Color is earned — start monochrome, add color only for interactive or stateful elements.
+
+### Typography — Power Grotesk, compact scale
+
+| Token | Size | Weight | Line-height | Tracking |
+|-------|------|--------|-------------|---------|
+| `--ku-type-display` | 36px / 2.25rem | 700 | 1.1 | -0.02em |
+| `--ku-type-h1` | 28px / 1.75rem | 700 | 1.1 | -0.02em |
+| `--ku-type-h2` | 20px / 1.25rem | 500 | 1.25 | 0 |
+| `--ku-type-h3` | 16px / 1rem | 500 | 1.25 | 0 |
+| `--ku-type-body` | 14px / 0.875rem | 400 | 1.4 | 0 |
+| `--ku-type-body13` | 13px / 0.8125rem | 400 | 1.4 | 0 |
+| `--ku-type-tiny` | 12px / 0.75rem | 400 | 1.333 | 0.01em |
+| `--ku-type-micro` | 10px / 0.625rem | 400 | 1.333 | 0.05em |
+
+**Font stacks**:
+- Primary/Display: `"Power Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`
+- Mono: `"JetBrains Mono", "Fira Code", "Consolas", monospace`
+
+**Rules**: Never use `border-radius` unless the brief explicitly requests it. K-Universe default is `0` (sharp corners). Mono tracking is `0` — no letter-spacing on code.
+
+### Spacing & layout
+
+- Page gutters: 60px (desktop), 24px (mobile)
+- Component gaps: 8px / 16px / 24px / 32px scale
+- Max content width: 1320px
+- Section spacing: 96px vertical between major sections
+
+### Component patterns
+
+- **Badge**: `font-family: var(--ku-font-primary)`, `font-size: var(--ku-type-micro)`, `text-transform: uppercase`, `tracking: 0.06em`, no `border-radius`
+- **Button CTA**: `bg: var(--ku-primary)`, `color: #000`, `font-weight: 600`, `text-transform: uppercase`, `font-size: var(--ku-type-tiny)`, `px: 18px / py: 8px`
+- **Section label**: `font-family: var(--ku-font-mono)`, `font-size: var(--ku-type-micro)`, `color: var(--ku-text-muted)`, `text-transform: uppercase`, `tracking: 0.16em`, `border-top: 1px solid var(--ku-border)`
 
 ## Inputs
-
-The user provides one or more of:
-
-- **A natural-language brief** — what to build, the language/framework, constraints.
-- **Reference files** — existing code, images, docs, or configs that inform the scaffold.
-- **A URL** — documentation, API reference, or example repo to pull context from.
-
-The agent receives these through the plugin's declared inputs:
 
 | Input | Type | Required | Purpose |
 |-------|------|----------|---------|
@@ -30,6 +82,7 @@ The agent receives these through the plugin's declared inputs:
 | `language` | string | no | Target language or framework (inferred if omitted) |
 | `referenceUrl` | string | no | URL for documentation, API spec, or example repo |
 | `outputDir` | string | no | Subdirectory for generated files (defaults to project root) |
+| `kuStyle` | boolean | no | Apply K-Universe design tokens and conventions (default: true) |
 
 ## Pipeline
 
@@ -41,6 +94,7 @@ Ask focused questions to lock scope before generating anything:
 2. **Target stack** — language, framework version, package manager, runtime.
 3. **Scale** — how many files, rough structure, entry points.
 4. **Constraints** — naming conventions, existing patterns to match, things to avoid.
+5. **Surface type** — app (compact tokens) vs marketing (editorial/canon tokens). Default: app.
 
 If the brief already answers these, skip the question and confirm the inferred values. Emit a `<question-form>` only for genuinely ambiguous fields.
 
@@ -50,8 +104,9 @@ Before writing any code:
 
 1. State the planned file tree aloud — every file path and its one-line purpose.
 2. Identify shared patterns (imports, config shape, naming) that must be consistent across files.
-3. Note any dependencies or setup the user will need after scaffolding.
-4. Write the plan as a todo list (one item per file or logical group).
+3. Map which `--ku-*` tokens each file will reference.
+4. Note any dependencies or setup the user will need after scaffolding.
+5. Write the plan as a todo list (one item per file or logical group).
 
 ### Stage 3 — Build
 
@@ -64,7 +119,10 @@ Generate the code files in dependency order:
 
 Rules during generation:
 
-- Use the declared language/framework conventions (naming, file extensions, import style).
+- Use `--ku-*` CSS custom properties for all visual values. No hardcoded hex.
+- Match the font stacks exactly: Power Grotesk for UI, JetBrains Mono for code.
+- No `border-radius` unless the brief explicitly requests rounded corners.
+- Use `var(--ku-type-*)` tokens for all typography — never inline font sizes.
 - No placeholder code — every function body must be real or have a clear `// TODO:` with a specific description.
 - No invented dependencies — only import packages the user's stack actually uses.
 - Match the user's existing code style if reference files were provided.
@@ -74,20 +132,23 @@ Rules during generation:
 
 After all files are written, self-review across five dimensions:
 
-1. **Correctness** — does the code compile/parse? Are imports valid? Are types consistent?
-2. **Completeness** — does every file from the plan exist? Are all entry points wired up?
+1. **Correctness** — does the code compile/parse? Are imports valid? Types consistent?
+2. **Completeness** — does every file from the plan exist? All entry points wired up?
 3. **Consistency** — same naming, same patterns, same style across all files?
-4. **Specificity** — is the code specific to the brief, not generic boilerplate?
-5. **Usability** — can the user run/use the output immediately? Are setup steps documented?
+4. **Specificity** — code specific to the brief, not generic boilerplate?
+5. **Token compliance** — zero hardcoded hex colors, all fonts via `--ku-*` tokens, no unearned `border-radius`?
 
 Score each 1–5. Any dimension under 3 → fix before delivering. Emit the review as a `critique.json` in the project root.
 
 ## Anti-patterns
 
+- Hardcoding hex colors when `--ku-*` tokens exist (`#000` → `var(--ku-bg)`, `#fff` → `var(--ku-text)`).
+- Using `--ku-hud` (`#00FF41`) for anything other than live operational state.
+- Adding `border-radius` without the brief explicitly requesting it.
+- Using letter-spacing on monospace text (`--ku-font-mono` tracking is always `0`).
 - Generating a single monolithic file when the brief calls for a project structure.
 - Inventing npm packages or APIs that don't exist.
 - Using outdated framework patterns (class components in React, CommonJS in ESM projects).
-- Adding boilerplate the user didn't ask for (license files, CI configs, contributing guides) unless the brief says "full project setup".
 - Placeholder functions with empty bodies and no TODO comment.
 
 ## Convergence
@@ -100,3 +161,4 @@ The review stage repeats until `critique.score >= 4` or `iterations >= 3`. The c
 - `plan.ready: boolean` — file tree confirmed, todo list written.
 - `build.complete: boolean` — all planned files generated.
 - `critique.score: number` — min score across review dimensions (0–5).
+- `ku.tokens.used: string[]` — list of `--ku-*` tokens referenced in generated code.

--- a/plugins/community/code-scaffold/examples/example-brief.md
+++ b/plugins/community/code-scaffold/examples/example-brief.md
@@ -1,0 +1,35 @@
+# Example brief
+
+> Scaffold a REST API with Express + TypeScript for a todo app.
+> CRUD endpoints, Zod validation, Drizzle ORM with SQLite.
+> Include tests with Vitest.
+
+## Expected output
+
+```
+src/
+  index.ts           — entry point, server setup
+  routes/
+    todos.ts         — CRUD route handlers
+  db/
+    schema.ts        — Drizzle schema
+    client.ts        — DB connection
+  middleware/
+    validate.ts      — Zod validation middleware
+  types/
+    todo.ts          — shared types
+tests/
+  todos.test.ts      — endpoint tests
+package.json
+tsconfig.json
+```
+
+## Plugin inputs for this example
+
+```json
+{
+  "brief": "REST API with Express + TypeScript for a todo app. CRUD endpoints, Zod validation, Drizzle ORM with SQLite. Include tests with Vitest.",
+  "language": "TypeScript",
+  "outputDir": "."
+}
+```

--- a/plugins/community/code-scaffold/examples/example-brief.md
+++ b/plugins/community/code-scaffold/examples/example-brief.md
@@ -1,35 +1,44 @@
 # Example brief
 
-> Scaffold a REST API with Express + TypeScript for a todo app.
-> CRUD endpoints, Zod validation, Drizzle ORM with SQLite.
-> Include tests with Vitest.
+> Scaffold a K-Universe dashboard panel showing active agents, system status, and recent activity.
+> Use React 19, TypeScript, and the `--ku-*` token system.
+> Compact layout for desktop, 13px body text, no border-radius.
 
 ## Expected output
 
 ```
 src/
-  index.ts           — entry point, server setup
-  routes/
-    todos.ts         — CRUD route handlers
-  db/
-    schema.ts        — Drizzle schema
-    client.ts        — DB connection
-  middleware/
-    validate.ts      — Zod validation middleware
-  types/
-    todo.ts          — shared types
-tests/
-  todos.test.ts      — endpoint tests
+  components/
+    AgentStatusCard.tsx   — per-agent card with HUD dot, name, status badge
+    SystemHealthRow.tsx   — health bar with --ku-primary fill
+    ActivityFeed.tsx       — recent events list with --ku-text-muted timestamps
+    PanelShell.tsx         — chrome wrapper (--ku-surface bg, --ku-border top)
+  hooks/
+    useAgentStatus.ts      — SWR hook for /api/agents endpoint
+    useSystemHealth.ts     — SWR hook for /api/health endpoint
+  panels/
+    DashboardPanel.tsx     — orchestrates all components in compact grid
+  tokens.ts                — re-exports from @k-universe/design-tokens
 package.json
 tsconfig.json
 ```
+
+## K-Universe style notes
+
+- All colors via `var(--ku-*)` — zero hardcoded hex
+- Font: `var(--ku-font-primary)` for UI, `var(--ku-font-mono)` for timestamps
+- Type scale: `var(--ku-type-body13)` for dense panels, `var(--ku-type-tiny)` for badges
+- `--ku-hud` ONLY on live agent dots — never on badges or labels
+- No `border-radius` anywhere — K-Universe uses sharp corners
+- Section labels: `font-family: var(--ku-font-mono)`, `font-size: var(--ku-type-micro)`, `text-transform: uppercase`, `letter-spacing: 0.16em`, `border-top: 1px solid var(--ku-border)`
 
 ## Plugin inputs for this example
 
 ```json
 {
-  "brief": "REST API with Express + TypeScript for a todo app. CRUD endpoints, Zod validation, Drizzle ORM with SQLite. Include tests with Vitest.",
+  "brief": "K-Universe dashboard panel with agent status, system health, activity feed. React 19 + TypeScript. Compact desktop layout, --ku-* tokens, no border-radius.",
   "language": "TypeScript",
-  "outputDir": "."
+  "outputDir": "src",
+  "kuStyle": true
 }
 ```

--- a/plugins/community/code-scaffold/open-design.json
+++ b/plugins/community/code-scaffold/open-design.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "code-scaffold",
+  "title": "Code scaffold",
+  "version": "0.1.0",
+  "description": "Multi-stage code generation and scaffolding workflow — accepts a natural-language brief, files, or URL references, plans file structure, generates code, and self-reviews before delivery.",
+  "license": "MIT",
+  "author": {
+    "name": "K-Universe",
+    "url": "https://github.com/k-universe-dev"
+  },
+  "tags": [
+    "scenario",
+    "code-generation",
+    "scaffolding",
+    "multi-stage"
+  ],
+  "compat": {
+    "agentSkills": [
+      {
+        "path": "./SKILL.md"
+      }
+    ]
+  },
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "scenario",
+    "scenario": "code-scaffold",
+    "capabilities": [
+      "prompt:inject",
+      "fs:read",
+      "fs:write"
+    ],
+    "useCase": {
+      "query": {
+        "en": "Scaffold code from a brief, reference files, or URL. Discovers requirements, plans the file tree, generates all code, and self-reviews before delivery.",
+        "zh-CN": "根据简要描述、参考文件或 URL 生成代码脚手架。发现需求、规划文件树、生成所有代码，并在交付前自审。"
+      }
+    },
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "discovery",
+          "atoms": [
+            "discovery-question-form"
+          ]
+        },
+        {
+          "id": "plan",
+          "atoms": [
+            "todo-write"
+          ]
+        },
+        {
+          "id": "build",
+          "atoms": [
+            "file-write"
+          ]
+        },
+        {
+          "id": "review",
+          "atoms": [
+            "critique-theater"
+          ],
+          "repeat": true,
+          "until": "critique.score >= 4 || iterations >= 3"
+        }
+      ]
+    },
+    "inputs": [
+      {
+        "name": "brief",
+        "type": "string",
+        "required": true,
+        "label": "What to scaffold",
+        "placeholder": "A REST API with Express + TypeScript for a todo app with CRUD endpoints"
+      },
+      {
+        "name": "language",
+        "type": "string",
+        "required": false,
+        "label": "Language / framework",
+        "placeholder": "TypeScript, Python, Rust, Go..."
+      },
+      {
+        "name": "referenceUrl",
+        "type": "string",
+        "required": false,
+        "label": "Reference URL",
+        "placeholder": "https://docs.example.com/api or a GitHub repo URL"
+      },
+      {
+        "name": "outputDir",
+        "type": "string",
+        "required": false,
+        "default": ".",
+        "label": "Output directory",
+        "placeholder": "src/modules/new-feature"
+      }
+    ]
+  },
+  "plugin": {
+    "repo": "https://github.com/k-universe-dev/code-scaffold"
+  },
+  "homepage": "https://github.com/k-universe-dev/code-scaffold"
+}

--- a/plugins/community/code-scaffold/open-design.json
+++ b/plugins/community/code-scaffold/open-design.json
@@ -2,9 +2,9 @@
   "$schema": "https://open-design.ai/schemas/plugin.v1.json",
   "specVersion": "1.0.0",
   "name": "code-scaffold",
-  "title": "Code scaffold",
-  "version": "0.1.0",
-  "description": "Multi-stage code generation and scaffolding workflow — accepts a natural-language brief, files, or URL references, plans file structure, generates code, and self-reviews before delivery.",
+  "title": "Code Scaffold (K-Universe)",
+  "version": "0.2.0",
+  "description": "K-Universe code scaffolding — multi-stage generation using --ku-* design tokens, Power Grotesk type system, and monochrome-first conventions.",
   "license": "MIT",
   "author": {
     "name": "K-Universe",
@@ -14,7 +14,10 @@
     "scenario",
     "code-generation",
     "scaffolding",
-    "multi-stage"
+    "multi-stage",
+    "k-universe",
+    "design-tokens",
+    "dark-mode"
   ],
   "compat": {
     "agentSkills": [
@@ -35,8 +38,8 @@
     ],
     "useCase": {
       "query": {
-        "en": "Scaffold code from a brief, reference files, or URL. Discovers requirements, plans the file tree, generates all code, and self-reviews before delivery.",
-        "zh-CN": "根据简要描述、参考文件或 URL 生成代码脚手架。发现需求、规划文件树、生成所有代码，并在交付前自审。"
+        "en": "Scaffold code from a brief using K-Universe design tokens. Zero hardcoded hex, Power Grotesk type stack, monochrome-first, no unearned border-radius.",
+        "zh-CN": "使用 K-Universe 设计令牌从简要描述生成代码脚手架。零硬编码颜色，Power Grotesk 字体，先黑白后彩色，不使用未获得授权的圆角。"
       }
     },
     "context": {
@@ -82,14 +85,14 @@
         "type": "string",
         "required": true,
         "label": "What to scaffold",
-        "placeholder": "A REST API with Express + TypeScript for a todo app with CRUD endpoints"
+        "placeholder": "A dashboard panel with agent status, system health, and activity feed using K-Universe tokens"
       },
       {
         "name": "language",
         "type": "string",
         "required": false,
         "label": "Language / framework",
-        "placeholder": "TypeScript, Python, Rust, Go..."
+        "placeholder": "TypeScript, React 19, Next.js, Rust..."
       },
       {
         "name": "referenceUrl",
@@ -104,7 +107,15 @@
         "required": false,
         "default": ".",
         "label": "Output directory",
-        "placeholder": "src/modules/new-feature"
+        "placeholder": "src/panels"
+      },
+      {
+        "name": "kuStyle",
+        "type": "boolean",
+        "required": false,
+        "default": true,
+        "label": "K-Universe design tokens",
+        "description": "Apply --ku-* CSS custom properties, Power Grotesk font stack, and monochrome-first conventions."
       }
     ]
   },


### PR DESCRIPTION
## Code Scaffold Plugin v0.1.0

Multi-stage code generation and scaffolding workflow for Open Design.

### Features
- Accepts natural-language briefs, reference files, or URLs
- Plans file structure before generating
- Generates code across multiple stages
- Self-reviews with a critique theater stage (score ≥ 4 or 3 iterations)

### Files
- `SKILL.md` — Agent skill definition
- `open-design.json` — Plugin manifest (scenario, pipeline, inputs)
- `examples/example-brief.md` — Example brief

### Checklist
- [x] Plugin manifest follows v1 schema
- [x] SKILL.md present and valid
- [x] Pipeline stages defined (discovery → plan → build → review)
- [x] Repository created: https://github.com/k-universe-dev/code-scaffold