### PR TITLE
fix(web): keep pet composer menu expanded

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -373,7 +373,13 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       // Right-align by default (menu right edge ≈ button right edge).
       // Shift left when the menu would spill past the viewport left edge.
       const left = Math.max(8, Math.min(viewW - menuW - 8, rect.right - menuW));
-      setPetMenuStyle({ position: 'fixed', top, left });
+      setPetMenuStyle({
+        position: 'fixed',
+        top,
+        left,
+        bottom: 'auto',
+        right: 'auto',
+      });
     }, [petMenuOpen]);
 
     // Lazy-fetch the user's external MCP servers list once on mount so the

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -344,4 +344,34 @@ describe('ChatComposer context pickers', () => {
     });
     expect(screen.getByText('Private export workflow')).toBeTruthy();
   });
+
+  it('clears absolute anchors when the pet popover switches to fixed positioning', async () => {
+    renderComposer({
+      petConfig: {
+        adopted: false,
+        enabled: false,
+        petId: 'custom',
+        custom: {
+          name: 'Buddy',
+          glyph: '🐾',
+          accent: '#7c3aed',
+          greeting: 'hi',
+        },
+      },
+      onAdoptPet: vi.fn(),
+      onTogglePet: vi.fn(),
+      onOpenPetSettings: vi.fn(),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pets — wake, tuck, or pick one' }));
+
+    const menu = screen.getByText('Show pet').closest('.composer-pet-menu') as HTMLElement | null;
+    expect(menu).not.toBeNull();
+
+    await waitFor(() => {
+      expect(menu?.style.position).toBe('fixed');
+      expect(menu?.style.bottom).toBe('auto');
+      expect(menu?.style.right).toBe('auto');
+    });
+  });
 });


### PR DESCRIPTION
## Why

I hit a visible layout regression in the chat composer Pets menu while inspecting the app: the popover collapsed to a tiny strip and its menu rows overflowed into the prompt textarea.

The pain being addressed is user-facing UI breakage in a frequently-visible composer control. The pet quick-action menu should open as a normal popover, not overlap the input area or toolbar.

## What users will see

Opening the Pets button in the chat composer now shows a correctly-sized menu containing the heading, `/pet` hint, "Show pet" / tuck action, and "Manage Pets" action. The menu no longer collapses over the prompt field.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

GitHub's CLI cannot attach PR images the same way the web editor upload box can, so these are placeholders for the captured local artifacts:

### Before

<img width="596" height="528" alt="image" src="https://github.com/user-attachments/assets/25cf5e62-36cb-46f4-9ccf-3908ba298cba" />

### After

<img width="596" height="528" alt="image" src="https://github.com/user-attachments/assets/82abf056-e433-47e8-ba9c-74227b0dbf4e" />

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ChatComposer.context-pickers.test.tsx`
- Did the test go red on `main` and green on this branch? yes
  - Red: the new regression test failed because `bottom` / `right` stayed unset when the menu switched to fixed positioning.
  - Green: after clearing fixed-position anchors, the same test passed.

## Validation

- `pnpm --filter @open-design/web test -- tests/components/ChatComposer.context-pickers.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- Headless browser screenshots captured with `agent-browser`:
  - `.tmp/pets-ui-layout/before-open.png`
  - `.tmp/pets-ui-layout/after-open.png`

🤖 *This content was generated with AI assistance using GPT 5.5.*
