### PR TITLE
fix(daemon): clean up Claude Code test diagnostics

### DIFF
--- a/apps/daemon/src/claude-diagnostics.ts
+++ b/apps/daemon/src/claude-diagnostics.ts
@@ -36,12 +36,15 @@ function withContext(
   message: string,
   detail: string,
   input: ClaudeCliDiagnosticInput,
+  options: { includeOutputTail?: boolean } = {},
 ): ClaudeCliDiagnostic {
   const configDir = envValue(input.env, 'CLAUDE_CONFIG_DIR');
   const baseUrl = envValue(input.env, 'ANTHROPIC_BASE_URL');
   const diagnosticTail = redactSecrets(body(input)).replace(/\s+/g, ' ').trim().slice(-240);
   const context: string[] = [message, detail];
-  if (diagnosticTail) context.push(`Claude output: ${diagnosticTail}`);
+  if (options.includeOutputTail !== false && diagnosticTail) {
+    context.push(`Claude output: ${diagnosticTail}`);
+  }
   if (configDir) context.push(`Effective CLAUDE_CONFIG_DIR: ${configDir}.`);
   if (baseUrl) context.push('ANTHROPIC_BASE_URL is set for this Claude Code process.');
   return {
@@ -49,6 +52,29 @@ function withContext(
     detail: redactSecrets(context.filter(Boolean).join(' ')),
     retryable: true,
   };
+}
+
+function hasOnlyClaudeResultMetadata(text: string): boolean {
+  const hasCompletedTerminalReason = /["']terminal_reason["']\s*:\s*["']completed["']/i.test(text);
+  const hasAssistantText = /["']type["']\s*:\s*["']assistant["']/i.test(text) ||
+    /["']text["']\s*:\s*["'][^"']+/i.test(text);
+  if (hasCompletedTerminalReason && !hasAssistantText) return true;
+
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .some((line) => {
+      try {
+        const parsed = JSON.parse(line) as {
+          type?: unknown;
+          terminal_reason?: unknown;
+        };
+        return parsed.type === 'result' && parsed.terminal_reason === 'completed';
+      } catch {
+        return false;
+      }
+    });
 }
 
 export function diagnoseClaudeCliFailure(
@@ -61,6 +87,15 @@ export function diagnoseClaudeCliFailure(
   const normalized = text.toLowerCase();
   const hasCustomBaseUrl = envValue(input.env, 'ANTHROPIC_BASE_URL') !== null;
   const hasConfigDir = envValue(input.env, 'CLAUDE_CONFIG_DIR') !== null;
+
+  if (hasOnlyClaudeResultMetadata(text)) {
+    return withContext(
+      'Claude Code exited without producing assistant text.',
+      'The CLI reported the request as completed, but Open Design did not receive the required smoke-test reply. Run `claude -p "Reply with only: ok" --output-format stream-json --verbose` in the same environment to see the earlier Claude Code diagnostic, then retry Open Design.',
+      input,
+      { includeOutputTail: false },
+    );
+  }
 
   const customEndpointConnectionFailure =
     hasCustomBaseUrl &&

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -1,3 +1,4 @@
+import { existsSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import { mergeProxyAwareEnv, resolveSystemProxyEnv } from '@open-design/platform';
@@ -61,6 +62,7 @@ export function spawnEnvForAgent(
     return env;
   }
   if (agentId === 'claude') {
+    applyClaudeConfigDirFallback(env);
     stripUnlessCustomBaseUrl(env, 'ANTHROPIC_BASE_URL', ['ANTHROPIC_API_KEY']);
     return env;
   }
@@ -72,6 +74,33 @@ export function spawnEnvForAgent(
     return env;
   }
   return env;
+}
+
+function applyClaudeConfigDirFallback(env: NodeJS.ProcessEnv): void {
+  if (hasNonEmptyEnvKey(env, 'CLAUDE_CONFIG_DIR') || hasNonEmptyEnvKey(env, 'XDG_CONFIG_HOME')) {
+    return;
+  }
+  const home = env.HOME?.trim();
+  if (!home || process.platform === 'win32') return;
+  const legacyDir = path.join(home, '.claude');
+  if (isDirectory(legacyDir)) return;
+  const configDir = path.join(home, '.config', 'claude');
+  if (isDirectory(configDir)) env.CLAUDE_CONFIG_DIR = configDir;
+}
+
+function isDirectory(filePath: string): boolean {
+  try {
+    return statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function hasNonEmptyEnvKey(env: NodeJS.ProcessEnv, key: string): boolean {
+  const upper = key.toUpperCase();
+  return Object.keys(env).some(
+    (k) => k.toUpperCase() === upper && typeof env[k] === 'string' && env[k]!.trim() !== '',
+  );
 }
 
 // Remove `secretKeys` from `env` unless `baseUrlKey` is set to a non-empty

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2233,6 +2233,52 @@ process.stdin.on('end', () => {
     );
   });
 
+  it('returns clean Claude guidance when the CLI exits with only result metadata', async () => {
+    await withFakeClaude(
+      `console.log(JSON.stringify({
+        type: 'result',
+        is_error: false,
+        modelUsage: {},
+        permission_denials: [],
+        terminal_reason: 'completed',
+        fast_mode_state: 'off',
+        uuid: 'fake-uuid',
+      })); process.exit(1);`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'claude' });
+
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'agent_spawn_failed',
+          agentName: 'Claude Code',
+        });
+        expect(result.detail).toContain('Claude Code exited without producing assistant text');
+        expect(result.detail).toContain('The CLI reported the request as completed');
+        expect(result.detail).not.toContain('terminal_reason');
+        expect(result.detail).not.toContain('modelUsage');
+      },
+    );
+  });
+
+  it('returns clean Claude guidance when only the truncated result tail is retained', async () => {
+    await withFakeClaude(
+      `console.log('"input_tokens":0,"output_tokens":0},"modelUsage":{},"permission_denials":[],"terminal_reason":"completed","fast_mode_state":"off","uuid":"fake-uuid"}'); process.exit(1);`,
+      async () => {
+        const result = await testAgentConnection({ agentId: 'claude' });
+
+        expect(result).toMatchObject({
+          ok: false,
+          kind: 'agent_spawn_failed',
+          agentName: 'Claude Code',
+        });
+        expect(result.detail).toContain('Claude Code exited without producing assistant text');
+        expect(result.detail).toContain('The CLI reported the request as completed');
+        expect(result.detail).not.toContain('terminal_reason');
+        expect(result.detail).not.toContain('modelUsage');
+      },
+    );
+  });
+
   it('returns custom endpoint guidance for Claude model access failures', async () => {
     const previous = process.env.ANTHROPIC_BASE_URL;
     process.env.ANTHROPIC_BASE_URL = 'https://proxy.example.com';

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -41,6 +41,93 @@ test('spawnEnvForAgent applies configured Claude Code env before auth stripping'
   assert.equal(env.PATH, '/usr/bin');
 });
 
+fsTest('spawnEnvForAgent points Claude at the XDG config dir for GUI launches', () => {
+  const home = mkdtempSync(join(tmpdir(), 'od-claude-home-'));
+  try {
+    mkdirSync(join(home, '.config', 'claude'), { recursive: true });
+
+    const env = spawnEnvForAgent('claude', {
+      HOME: home,
+      PATH: '/usr/bin',
+    });
+
+    assert.equal(env.CLAUDE_CONFIG_DIR, join(home, '.config', 'claude'));
+    assert.equal(env.PATH, '/usr/bin');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+fsTest('spawnEnvForAgent preserves explicit Claude config env even when defaults exist', () => {
+  const home = mkdtempSync(join(tmpdir(), 'od-claude-home-'));
+  try {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    mkdirSync(join(home, '.config', 'claude'), { recursive: true });
+
+    const env = spawnEnvForAgent('claude', {
+      HOME: home,
+      PATH: '/usr/bin',
+      CLAUDE_CONFIG_DIR: join(home, 'custom-claude'),
+    });
+
+    assert.equal(env.CLAUDE_CONFIG_DIR, join(home, 'custom-claude'));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+fsTest('spawnEnvForAgent does not point Claude at XDG config when legacy ~/.claude exists', () => {
+  const home = mkdtempSync(join(tmpdir(), 'od-claude-home-'));
+  try {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    mkdirSync(join(home, '.config', 'claude'), { recursive: true });
+
+    const env = spawnEnvForAgent('claude', {
+      HOME: home,
+      PATH: '/usr/bin',
+    });
+
+    assert.equal('CLAUDE_CONFIG_DIR' in env, false);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+fsTest('spawnEnvForAgent ignores a non-directory legacy ~/.claude path', () => {
+  const home = mkdtempSync(join(tmpdir(), 'od-claude-home-'));
+  try {
+    writeFileSync(join(home, '.claude'), 'not a directory');
+    mkdirSync(join(home, '.config', 'claude'), { recursive: true });
+
+    const env = spawnEnvForAgent('claude', {
+      HOME: home,
+      PATH: '/usr/bin',
+    });
+
+    assert.equal(env.CLAUDE_CONFIG_DIR, join(home, '.config', 'claude'));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+fsTest('spawnEnvForAgent leaves Claude config discovery alone when XDG_CONFIG_HOME is present', () => {
+  const home = mkdtempSync(join(tmpdir(), 'od-claude-home-'));
+  try {
+    mkdirSync(join(home, '.config', 'claude'), { recursive: true });
+
+    const env = spawnEnvForAgent('claude', {
+      HOME: home,
+      PATH: '/usr/bin',
+      XDG_CONFIG_HOME: join(home, '.config'),
+    });
+
+    assert.equal('CLAUDE_CONFIG_DIR' in env, false);
+    assert.equal(env.XDG_CONFIG_HOME, join(home, '.config'));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test('spawnEnvForAgent applies configured Codex env without mutating the base env', () => {
   const base = { PATH: '/usr/bin' };
   const env = spawnEnvForAgent('codex', base, {


### PR DESCRIPTION
Related: #2058

## Why

I hit the Claude Code local CLI connection test failure from Settings while checking a real screenshot-reported problem. The user-facing pain is that Open Design could report `Could not start Claude Code` and expose a truncated Claude Code stream-json result tail such as `terminal_reason`, `modelUsage`, and `permission_denials`, which is noisy and does not tell the user what to try next.

This PR makes that failure mode diagnosable instead of dumping protocol internals.

## What users will see

When Claude Code exits with only final result metadata and no assistant smoke-test reply, the Settings connection test now returns a clean diagnostic saying Claude Code exited without assistant text and suggests running the equivalent Claude smoke command in the same environment to expose the earlier CLI diagnostic.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI layout changed. This changes daemon-provided diagnostic text surfaced by existing Settings UI.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/connection-test.test.ts`
- Did the test go red on `main` and green on this branch? Yes — the new regression test initially failed because `result.detail` contained the raw Claude result JSON tail instead of clean guidance, then passed after the diagnostic change.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts -t "returns clean Claude guidance when the CLI exits with only result metadata"`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
- Manual/local runtime: `pnpm tools-dev start web --daemon-port 18456 --web-port 18573`
- Live connection smoke check against the running daemon returned `{"ok":true,"kind":"success","model":"opus","agentName":"Claude Code","sample":"ok"}` from `POST /api/test/connection`.

🤖 *This content was generated with AI assistance using GPT-5.5.*
