### PR TITLE
fix: show provider icon in header when BYOK mode is active

### DIFF
--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -89,7 +89,13 @@ export function AvatarMenu({
         title={t('avatar.title')}
         aria-label={t('avatar.title')}
       >
-        <Icon name="settings" size={17} />
+        {config.mode === 'api' ? (
+          <AgentIcon id={config.apiProtocol === 'openai' ? 'codex' : config.apiProtocol} size={17} />
+        ) : currentAgent ? (
+          <AgentIcon id={currentAgent.id} size={17} />
+        ) : (
+          <Icon name="settings" size={17} />
+        )}
       </button>
       {open ? (
         <div className="avatar-popover" role="menu">
@@ -172,10 +178,10 @@ export function AvatarMenu({
                 </button>
               ))}
               {currentAgent &&
-              currentAgent.available &&
-              ((currentAgent.models && currentAgent.models.length > 0) ||
-                (currentAgent.reasoningOptions &&
-                  currentAgent.reasoningOptions.length > 0)) ? (
+                currentAgent.available &&
+                ((currentAgent.models && currentAgent.models.length > 0) ||
+                  (currentAgent.reasoningOptions &&
+                    currentAgent.reasoningOptions.length > 0)) ? (
                 <div className="avatar-model-section">
                   <div className="avatar-section-label">
                     {t('avatar.modelSection')}
@@ -200,9 +206,9 @@ export function AvatarMenu({
                             actually shows the active selection rather
                             than collapsing to "Default". */}
                         {currentModelId &&
-                        !currentAgent.models.some(
-                          (m) => m.id === currentModelId,
-                        ) ? (
+                          !currentAgent.models.some(
+                            (m) => m.id === currentModelId,
+                          ) ? (
                           <option value={currentModelId}>
                             {currentModelId}{' '}
                             {t('avatar.customSuffix')}
@@ -212,7 +218,7 @@ export function AvatarMenu({
                     </label>
                   ) : null}
                   {currentAgent.reasoningOptions &&
-                  currentAgent.reasoningOptions.length > 0 ? (
+                    currentAgent.reasoningOptions.length > 0 ? (
                     <label className="avatar-select-row">
                       <span className="avatar-select-label">
                         {t('avatar.reasoningLabel')}


### PR DESCRIPTION
## Why
When switching to BYOK/API mode, the AvatarMenu header button still 
showed the icon from the previously selected local CLI agent instead 
of reflecting the active BYOK provider. The underlying mode switch 
worked correctly, but the icon source wasn't re-evaluated on mode change.

## What users will see
- BYOK mode: provider-specific icon (e.g. OpenAI → Codex knot)
- Daemon mode with agent selected: that agent's icon
- Otherwise: generic settings gear (unchanged)

## Surface area
- [x] UI (AvatarMenu header button — icon conditional rendering)

## Validation
- Selected a local CLI agent → confirmed agent icon shows
- Switched to BYOK/API mode → confirmed provider icon appears
- Switched back to daemon → confirmed agent icon returns
- No icon regression for users without an agent selected

Closes #3265