### PR TITLE
fix(web): keep multipage html artifact entry stable

### DIFF
--- a/apps/web/src/artifacts/html-links.ts
+++ b/apps/web/src/artifacts/html-links.ts
@@ -3,12 +3,20 @@ export function resolveHtmlArtifactFileName(input: {
   ext: '.html' | '.jsx' | '.tsx';
   existingFileNames: ReadonlySet<string>;
   savedArtifactName?: string | null;
+  canOverwriteExistingEntry?: boolean;
 }): string {
-  if (input.ext === '.html' && input.baseName.toLowerCase() === 'index') {
+  const preferredFileName = `${input.baseName}${input.ext}`;
+  if (
+    input.ext === '.html' &&
+    input.baseName.toLowerCase() === 'index' &&
+    (!input.existingFileNames.has(preferredFileName) ||
+      input.savedArtifactName === preferredFileName ||
+      input.canOverwriteExistingEntry === true)
+  ) {
     return 'index.html';
   }
 
-  let fileName = `${input.baseName}${input.ext}`;
+  let fileName = preferredFileName;
   let n = 2;
   while (input.existingFileNames.has(fileName) && input.savedArtifactName !== fileName) {
     fileName = `${input.baseName}-${n}${input.ext}`;
@@ -23,6 +31,31 @@ interface HtmlLinkProjectFile {
   kind?: string;
   mime?: string;
   mtime: number;
+  artifactManifest?: {
+    entry: string;
+    metadata?: Record<string, unknown>;
+  };
+}
+
+export function canOverwriteHtmlArtifactEntry(input: {
+  baseName: string;
+  ext: '.html' | '.jsx' | '.tsx';
+  projectFiles: readonly HtmlLinkProjectFile[];
+  savedArtifactName?: string | null;
+  artifactIdentifier?: string;
+}): boolean {
+  if (input.ext !== '.html' || input.baseName.toLowerCase() !== 'index') return false;
+  if (input.savedArtifactName === 'index.html') return true;
+  const existingIndex = input.projectFiles.find((file) => {
+    return file.name === 'index.html' || file.path === 'index.html';
+  });
+  if (!existingIndex) return true;
+  const manifest = existingIndex.artifactManifest;
+  return (
+    Boolean(input.artifactIdentifier) &&
+    manifest?.entry === 'index.html' &&
+    manifest.metadata?.identifier === input.artifactIdentifier
+  );
 }
 
 export function rewriteHtmlLinksToCurrentProjectFiles(

--- a/apps/web/src/artifacts/html-links.ts
+++ b/apps/web/src/artifacts/html-links.ts
@@ -1,0 +1,126 @@
+export function resolveHtmlArtifactFileName(input: {
+  baseName: string;
+  ext: '.html' | '.jsx' | '.tsx';
+  existingFileNames: ReadonlySet<string>;
+  savedArtifactName?: string | null;
+}): string {
+  if (input.ext === '.html' && input.baseName.toLowerCase() === 'index') {
+    return 'index.html';
+  }
+
+  let fileName = `${input.baseName}${input.ext}`;
+  let n = 2;
+  while (input.existingFileNames.has(fileName) && input.savedArtifactName !== fileName) {
+    fileName = `${input.baseName}-${n}${input.ext}`;
+    n += 1;
+  }
+  return fileName;
+}
+
+interface HtmlLinkProjectFile {
+  name: string;
+  path?: string;
+  kind?: string;
+  mime?: string;
+  mtime: number;
+}
+
+export function rewriteHtmlLinksToCurrentProjectFiles(
+  html: string,
+  projectFiles: readonly HtmlLinkProjectFile[],
+): string {
+  const latestByTarget = buildLatestHtmlFileIndex(projectFiles);
+  if (latestByTarget.size === 0) return html;
+
+  return html.replace(
+    /\b(href)\s*=\s*(["'])([^"']+)\2/gi,
+    (match, attr: string, quote: string, rawValue: string) => {
+      const rewritten = rewriteHtmlLinkTarget(rawValue, latestByTarget);
+      return rewritten === rawValue ? match : `${attr}=${quote}${rewritten}${quote}`;
+    },
+  );
+}
+
+function buildLatestHtmlFileIndex(projectFiles: readonly HtmlLinkProjectFile[]): Map<string, string> {
+  const latest = new Map<string, HtmlLinkProjectFile>();
+  for (const file of projectFiles) {
+    if (!isHtmlProjectFile(file)) continue;
+    const key = htmlFileFamilyKey(file.name);
+    if (!key) continue;
+    const current = latest.get(key);
+    if (!current || file.mtime > current.mtime) latest.set(key, file);
+  }
+  return new Map(Array.from(latest, ([key, file]) => [key, file.name]));
+}
+
+function isHtmlProjectFile(file: HtmlLinkProjectFile): boolean {
+  const name = file.name.toLowerCase();
+  return (
+    (file.kind === undefined || file.kind === 'html') &&
+    (file.mime === undefined || file.mime === 'text/html') &&
+    (name.endsWith('.html') || name.endsWith('.htm'))
+  );
+}
+
+function rewriteHtmlLinkTarget(
+  value: string,
+  latestByTarget: ReadonlyMap<string, string>,
+): string {
+  if (!value || value.startsWith('#') || isExternalOrOpaqueUrl(value)) return value;
+
+  const parsed = splitRelativeReference(value);
+  if (!isHtmlPath(parsed.pathname)) return value;
+  const key = htmlFileFamilyKey(parsed.pathname);
+  if (!key) return value;
+
+  const latest = latestByTarget.get(key);
+  if (!latest || latest === parsed.pathname) return value;
+
+  const rewrittenPath = preserveRelativePrefix(parsed.pathname, latest);
+  return `${rewrittenPath}${parsed.search}${parsed.hash}`;
+}
+
+function isExternalOrOpaqueUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value) || value.startsWith('//');
+}
+
+function splitRelativeReference(value: string): {
+  pathname: string;
+  search: string;
+  hash: string;
+} {
+  const hashIndex = value.indexOf('#');
+  const beforeHash = hashIndex >= 0 ? value.slice(0, hashIndex) : value;
+  const hash = hashIndex >= 0 ? value.slice(hashIndex) : '';
+  const queryIndex = beforeHash.indexOf('?');
+  return {
+    pathname: queryIndex >= 0 ? beforeHash.slice(0, queryIndex) : beforeHash,
+    search: queryIndex >= 0 ? beforeHash.slice(queryIndex) : '',
+    hash,
+  };
+}
+
+function isHtmlPath(pathname: string): boolean {
+  const lower = pathname.toLowerCase();
+  return lower.endsWith('.html') || lower.endsWith('.htm');
+}
+
+function htmlFileFamilyKey(pathname: string): string | null {
+  const slash = pathname.lastIndexOf('/');
+  const directory = slash >= 0 ? pathname.slice(0, slash + 1) : '';
+  const fileName = slash >= 0 ? pathname.slice(slash + 1) : pathname;
+  const dot = fileName.lastIndexOf('.');
+  if (dot <= 0) return null;
+  const stem = fileName.slice(0, dot);
+  const ext = fileName.slice(dot).toLowerCase();
+  if (stem.toLowerCase() === 'index') return null;
+  const familyStem = stem.replace(/-\d+$/, '');
+  return `${directory}${familyStem}${ext}`.replace(/^\.\//, '');
+}
+
+function preserveRelativePrefix(originalPathname: string, latestName: string): string {
+  if (originalPathname.startsWith('./') && !latestName.startsWith('./')) {
+    return `./${latestName}`;
+  }
+  return latestName;
+}

--- a/apps/web/src/artifacts/html-links.ts
+++ b/apps/web/src/artifacts/html-links.ts
@@ -81,10 +81,19 @@ function buildLatestHtmlFileIndex(projectFiles: readonly HtmlLinkProjectFile[]):
     if (!isHtmlProjectFile(file)) continue;
     const key = htmlFileFamilyKey(file.name);
     if (!key) continue;
+    if (!htmlFileManifestMatchesFamily(file, key)) continue;
     const current = latest.get(key);
     if (!current || file.mtime > current.mtime) latest.set(key, file);
   }
   return new Map(Array.from(latest, ([key, file]) => [key, file.name]));
+}
+
+function htmlFileManifestMatchesFamily(file: HtmlLinkProjectFile, familyKey: string): boolean {
+  const identifier = file.artifactManifest?.metadata?.identifier;
+  if (typeof identifier !== 'string') return false;
+  const normalizedIdentifier = normalizeArtifactIdentifier(identifier);
+  if (!normalizedIdentifier) return false;
+  return normalizedIdentifier === htmlFileFamilyIdentifier(familyKey);
 }
 
 function isHtmlProjectFile(file: HtmlLinkProjectFile): boolean {
@@ -149,6 +158,21 @@ function htmlFileFamilyKey(pathname: string): string | null {
   const ext = fileName.slice(dot).toLowerCase();
   const familyStem = stem.replace(/-\d+$/, '');
   return `${directory}${familyStem}${ext}`.replace(/^\.\//, '');
+}
+
+function htmlFileFamilyIdentifier(familyKey: string): string {
+  const slash = familyKey.lastIndexOf('/');
+  const fileName = slash >= 0 ? familyKey.slice(slash + 1) : familyKey;
+  const dot = fileName.lastIndexOf('.');
+  const stem = dot > 0 ? fileName.slice(0, dot) : fileName;
+  return normalizeArtifactIdentifier(stem);
+}
+
+function normalizeArtifactIdentifier(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 function preserveRelativePrefix(originalPathname: string, latestName: string): string {

--- a/apps/web/src/artifacts/html-links.ts
+++ b/apps/web/src/artifacts/html-links.ts
@@ -147,7 +147,6 @@ function htmlFileFamilyKey(pathname: string): string | null {
   if (dot <= 0) return null;
   const stem = fileName.slice(0, dot);
   const ext = fileName.slice(dot).toLowerCase();
-  if (stem.toLowerCase() === 'index') return null;
   const familyStem = stem.replace(/-\d+$/, '');
   return `${directory}${familyStem}${ext}`.replace(/^\.\//, '');
 }

--- a/apps/web/src/artifacts/html-links.ts
+++ b/apps/web/src/artifacts/html-links.ts
@@ -37,6 +37,10 @@ interface HtmlLinkProjectFile {
   };
 }
 
+interface HtmlLinkRewriteOptions {
+  artifactGroupIdentifier?: string;
+}
+
 export function canOverwriteHtmlArtifactEntry(input: {
   baseName: string;
   ext: '.html' | '.jsx' | '.tsx';
@@ -62,8 +66,9 @@ export function canOverwriteHtmlArtifactEntry(input: {
 export function rewriteHtmlLinksToCurrentProjectFiles(
   html: string,
   projectFiles: readonly HtmlLinkProjectFile[],
+  options: HtmlLinkRewriteOptions = {},
 ): string {
-  const latestByTarget = buildLatestHtmlFileIndex(projectFiles);
+  const latestByTarget = buildLatestHtmlFileIndex(projectFiles, options);
   if (latestByTarget.size === 0) return html;
 
   return html.replace(
@@ -75,25 +80,42 @@ export function rewriteHtmlLinksToCurrentProjectFiles(
   );
 }
 
-function buildLatestHtmlFileIndex(projectFiles: readonly HtmlLinkProjectFile[]): Map<string, string> {
+function buildLatestHtmlFileIndex(
+  projectFiles: readonly HtmlLinkProjectFile[],
+  options: HtmlLinkRewriteOptions,
+): Map<string, string> {
   const latest = new Map<string, HtmlLinkProjectFile>();
+  const artifactGroupIdentifier = normalizeOptionalIdentifier(options.artifactGroupIdentifier);
   for (const file of projectFiles) {
     if (!isHtmlProjectFile(file)) continue;
     const key = htmlFileFamilyKey(file.name);
     if (!key) continue;
-    if (!htmlFileManifestMatchesFamily(file, key)) continue;
+    if (!htmlFileManifestMatchesFamily(file, key, artifactGroupIdentifier)) continue;
     const current = latest.get(key);
     if (!current || file.mtime > current.mtime) latest.set(key, file);
   }
   return new Map(Array.from(latest, ([key, file]) => [key, file.name]));
 }
 
-function htmlFileManifestMatchesFamily(file: HtmlLinkProjectFile, familyKey: string): boolean {
+function htmlFileManifestMatchesFamily(
+  file: HtmlLinkProjectFile,
+  familyKey: string,
+  artifactGroupIdentifier: string | null,
+): boolean {
   const identifier = file.artifactManifest?.metadata?.identifier;
   if (typeof identifier !== 'string') return false;
   const normalizedIdentifier = normalizeArtifactIdentifier(identifier);
   if (!normalizedIdentifier) return false;
-  return normalizedIdentifier === htmlFileFamilyIdentifier(familyKey);
+  if (normalizedIdentifier !== htmlFileFamilyIdentifier(familyKey)) return false;
+
+  const fileGroupIdentifier = normalizeOptionalIdentifier(
+    file.artifactManifest?.metadata?.artifactGroupIdentifier,
+  );
+  return (
+    artifactGroupIdentifier !== null &&
+    fileGroupIdentifier !== null &&
+    artifactGroupIdentifier === fileGroupIdentifier
+  );
 }
 
 function isHtmlProjectFile(file: HtmlLinkProjectFile): boolean {
@@ -173,6 +195,12 @@ function normalizeArtifactIdentifier(value: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9_-]+/g, '-')
     .replace(/^-+|-+$/g, '');
+}
+
+function normalizeOptionalIdentifier(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = normalizeArtifactIdentifier(value);
+  return normalized || null;
 }
 
 function preserveRelativePrefix(originalPathname: string, latestName: string): string {

--- a/apps/web/src/artifacts/html-links.ts
+++ b/apps/web/src/artifacts/html-links.ts
@@ -84,38 +84,61 @@ function buildLatestHtmlFileIndex(
   projectFiles: readonly HtmlLinkProjectFile[],
   options: HtmlLinkRewriteOptions,
 ): Map<string, string> {
-  const latest = new Map<string, HtmlLinkProjectFile>();
+  const groupedLatest = new Map<string, HtmlLinkProjectFile>();
+  const legacyLatest = new Map<string, HtmlLinkProjectFile>();
+  const groupedFamilies = new Set<string>();
   const artifactGroupIdentifier = normalizeOptionalIdentifier(options.artifactGroupIdentifier);
   for (const file of projectFiles) {
     if (!isHtmlProjectFile(file)) continue;
     const key = htmlFileFamilyKey(file.name);
     if (!key) continue;
-    if (!htmlFileManifestMatchesFamily(file, key, artifactGroupIdentifier)) continue;
-    const current = latest.get(key);
-    if (!current || file.mtime > current.mtime) latest.set(key, file);
+    const manifestMatch = htmlFileManifestFamilyMatch(file, key);
+    if (!manifestMatch) continue;
+
+    if (manifestMatch.artifactGroupIdentifier !== null) {
+      groupedFamilies.add(key);
+    }
+
+    if (
+      artifactGroupIdentifier !== null &&
+      manifestMatch.artifactGroupIdentifier === artifactGroupIdentifier
+    ) {
+      const current = groupedLatest.get(key);
+      if (!current || file.mtime > current.mtime) groupedLatest.set(key, file);
+      continue;
+    }
+
+    if (manifestMatch.artifactGroupIdentifier === null) {
+      const current = legacyLatest.get(key);
+      if (!current || file.mtime > current.mtime) legacyLatest.set(key, file);
+    }
+  }
+
+  const latest = new Map<string, HtmlLinkProjectFile>();
+  for (const [key, file] of legacyLatest) {
+    if (!groupedFamilies.has(key)) latest.set(key, file);
+  }
+  for (const [key, file] of groupedLatest) {
+    latest.set(key, file);
   }
   return new Map(Array.from(latest, ([key, file]) => [key, file.name]));
 }
 
-function htmlFileManifestMatchesFamily(
+function htmlFileManifestFamilyMatch(
   file: HtmlLinkProjectFile,
   familyKey: string,
-  artifactGroupIdentifier: string | null,
-): boolean {
+): { artifactGroupIdentifier: string | null } | null {
   const identifier = file.artifactManifest?.metadata?.identifier;
-  if (typeof identifier !== 'string') return false;
+  if (typeof identifier !== 'string') return null;
   const normalizedIdentifier = normalizeArtifactIdentifier(identifier);
-  if (!normalizedIdentifier) return false;
-  if (normalizedIdentifier !== htmlFileFamilyIdentifier(familyKey)) return false;
+  if (!normalizedIdentifier) return null;
+  if (normalizedIdentifier !== htmlFileFamilyIdentifier(familyKey)) return null;
 
-  const fileGroupIdentifier = normalizeOptionalIdentifier(
-    file.artifactManifest?.metadata?.artifactGroupIdentifier,
-  );
-  return (
-    artifactGroupIdentifier !== null &&
-    fileGroupIdentifier !== null &&
-    artifactGroupIdentifier === fileGroupIdentifier
-  );
+  return {
+    artifactGroupIdentifier: normalizeOptionalIdentifier(
+      file.artifactManifest?.metadata?.artifactGroupIdentifier,
+    ),
+  };
 }
 
 function isHtmlProjectFile(file: HtmlLinkProjectFile): boolean {

--- a/apps/web/src/artifacts/html-links.ts
+++ b/apps/web/src/artifacts/html-links.ts
@@ -51,10 +51,11 @@ export function canOverwriteHtmlArtifactEntry(input: {
   });
   if (!existingIndex) return true;
   const manifest = existingIndex.artifactManifest;
+  const artifactIdentifier = input.artifactIdentifier ?? '';
   return (
-    Boolean(input.artifactIdentifier) &&
+    artifactIdentifier.length > 0 &&
     manifest?.entry === 'index.html' &&
-    manifest.metadata?.identifier === input.artifactIdentifier
+    manifest.metadata?.identifier === artifactIdentifier
   );
 }
 

--- a/apps/web/src/artifacts/html-links.ts
+++ b/apps/web/src/artifacts/html-links.ts
@@ -46,21 +46,13 @@ export function canOverwriteHtmlArtifactEntry(input: {
   ext: '.html' | '.jsx' | '.tsx';
   projectFiles: readonly HtmlLinkProjectFile[];
   savedArtifactName?: string | null;
-  artifactIdentifier?: string;
 }): boolean {
   if (input.ext !== '.html' || input.baseName.toLowerCase() !== 'index') return false;
   if (input.savedArtifactName === 'index.html') return true;
   const existingIndex = input.projectFiles.find((file) => {
     return file.name === 'index.html' || file.path === 'index.html';
   });
-  if (!existingIndex) return true;
-  const manifest = existingIndex.artifactManifest;
-  const artifactIdentifier = input.artifactIdentifier ?? '';
-  return (
-    artifactIdentifier.length > 0 &&
-    manifest?.entry === 'index.html' &&
-    manifest.metadata?.identifier === artifactIdentifier
-  );
+  return !existingIndex;
 }
 
 export function rewriteHtmlLinksToCurrentProjectFiles(

--- a/apps/web/src/artifacts/parser.ts
+++ b/apps/web/src/artifacts/parser.ts
@@ -10,7 +10,7 @@
 
 export type ArtifactEvent =
   | { type: 'text'; delta: string }
-  | { type: 'artifact:start'; identifier: string; artifactType: string; title: string }
+  | { type: 'artifact:start'; identifier: string; artifactType: string; title: string; lineageToken: string }
   | { type: 'artifact:chunk'; identifier: string; delta: string }
   | { type: 'artifact:end'; identifier: string; fullContent: string };
 
@@ -23,6 +23,7 @@ interface ParserState {
   identifier: string;
   artifactType: string;
   title: string;
+  lineageToken: string;
   content: string;
 }
 
@@ -165,6 +166,7 @@ export function createArtifactParser() {
     identifier: '',
     artifactType: '',
     title: '',
+    lineageToken: '',
     content: '',
   };
 
@@ -194,6 +196,7 @@ export function createArtifactParser() {
         state.identifier = attrs['identifier'] ?? '';
         state.artifactType = attrs['type'] ?? '';
         state.title = attrs['title'] ?? '';
+        state.lineageToken = attrs['lineageToken'] ?? '';
         state.content = '';
         state.buffer = state.buffer.slice(open.end);
         yield {
@@ -201,6 +204,7 @@ export function createArtifactParser() {
           identifier: state.identifier,
           artifactType: state.artifactType,
           title: state.title,
+          lineageToken: state.lineageToken,
         };
         continue;
       }
@@ -228,6 +232,7 @@ export function createArtifactParser() {
       state.identifier = '';
       state.artifactType = '';
       state.title = '';
+      state.lineageToken = '';
       state.content = '';
     }
   }

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4665,8 +4665,16 @@ function artifactBaseNameFor(art: Artifact): string {
 interface HtmlArtifactLineage {
   fileName: string;
   identifier: string;
+  title: string;
   artifactType: string;
   artifactGroupIdentifier: string;
+  documentTitle: string;
+}
+
+function htmlDocumentTitle(html: string): string {
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const rawTitle = titleMatch?.[1] ?? '';
+  return rawTitle.replace(/\s+/g, ' ').trim();
 }
 
 function htmlArtifactLineageFor(
@@ -4677,9 +4685,18 @@ function htmlArtifactLineageFor(
   return {
     fileName,
     identifier: art.identifier ?? '',
+    title: art.title ?? '',
     artifactType: art.artifactType ?? '',
     artifactGroupIdentifier,
+    documentTitle: htmlDocumentTitle(art.html ?? ''),
   };
+}
+
+function htmlArtifactLineageTitleMatches(art: Artifact, lineage: HtmlArtifactLineage): boolean {
+  const currentTitle = art.title ?? '';
+  if (currentTitle !== '' && currentTitle === lineage.title) return true;
+  const currentDocumentTitle = htmlDocumentTitle(art.html ?? '');
+  return currentDocumentTitle !== '' && currentDocumentTitle === lineage.documentTitle;
 }
 
 function matchingHtmlArtifactLineageFileName(
@@ -4691,6 +4708,7 @@ function matchingHtmlArtifactLineageFileName(
   if ((art.identifier ?? '') !== lineage.identifier) return null;
   if ((art.artifactType ?? '') !== lineage.artifactType) return null;
   if (lineage.artifactGroupIdentifier === '') return null;
+  if (!htmlArtifactLineageTitleMatches(art, lineage)) return null;
 
   // Verify the lineage file still exists and has the same group
   const lineageFile = projectFiles.find(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4757,7 +4757,11 @@ function htmlArtifactLineageTokenlessFallbackMatches(
   const wrapperTitleMatches = currentTitle !== '' && currentTitle === lineage.title;
   const documentTitleMatches =
     currentDocumentTitle !== '' && currentDocumentTitle === lineage.documentTitle;
-  return wrapperTitleMatches || documentTitleMatches;
+  const lineageHadIndependentWrapperTitle =
+    lineage.title !== '' &&
+    lineage.documentTitle !== '' &&
+    lineage.title !== lineage.documentTitle;
+  return wrapperTitleMatches || (documentTitleMatches && lineageHadIndependentWrapperTitle);
 }
 
 function matchingHtmlArtifactLineage(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4673,7 +4673,8 @@ interface HtmlArtifactLineage {
 
 /**
  * Extract stable document identity signature from HTML content.
- * Captures document title and local href topology, ignoring body copy changes.
+ * Uses only the normalized document <title> to identify the document,
+ * ignoring body copy changes and local href topology changes.
  */
 function htmlArtifactIdentitySignature(html: string): string {
   // Extract <title> text (case-insensitive, trim/collapse whitespace)
@@ -4681,37 +4682,7 @@ function htmlArtifactIdentitySignature(html: string): string {
   const rawTitle = titleMatch?.[1] ?? '';
   const title = rawTitle.replace(/\s+/g, ' ').trim();
 
-  // Extract all href values, filter to local page links only
-  const hrefMatches = html.matchAll(/href=["']([^"']+)["']/gi);
-  const localHrefs: string[] = [];
-
-  for (const match of hrefMatches) {
-    const href = match[1];
-    if (!href) continue;
-    // Skip hash-only, external, protocol-relative, data, mailto, tel
-    if (
-      href.startsWith('#') ||
-      href.startsWith('http://') ||
-      href.startsWith('https://') ||
-      href.startsWith('//') ||
-      href.startsWith('data:') ||
-      href.startsWith('mailto:') ||
-      href.startsWith('tel:')
-    ) {
-      continue;
-    }
-    // Keep local links, normalize and dedupe
-    const hrefWithoutHash = href.split('#')[0] ?? '';
-    const normalized = (hrefWithoutHash.split('?')[0] ?? '').trim();
-    if (normalized && !localHrefs.includes(normalized)) {
-      localHrefs.push(normalized);
-    }
-  }
-
-  // Sort for stable signature
-  localHrefs.sort();
-
-  return `title:${title}|hrefs:${localHrefs.join(',')}`;
+  return JSON.stringify({ title });
 }
 
 function htmlArtifactLineageFor(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -691,7 +691,7 @@ export function ProjectView({
   const savedArtifactRef = useRef<string | null>(null);
   // Preserve HTML artifact ownership across user turns without using it for
   // the same-turn duplicate-write guard above.
-  const lastHtmlArtifactFileRef = useRef<string | null>(null);
+  const lastHtmlArtifactLineageRef = useRef<HtmlArtifactLineage | null>(null);
   // Pending Write tool invocations: tool_use_id -> destination basename.
   // When the matching tool_result lands we refresh the file list and open
   // the file as a tab once. Keying off the tool_use_id (rather than
@@ -786,7 +786,7 @@ export function ProjectView({
     setAudioVoiceOptionsError(null);
     setArtifact(null);
     savedArtifactRef.current = null;
-    lastHtmlArtifactFileRef.current = null;
+    lastHtmlArtifactLineageRef.current = null;
     pendingWritesRef.current.clear();
     (async () => {
       try {
@@ -891,7 +891,7 @@ export function ProjectView({
     streamingConversationIdRef.current = null;
     setStreamingConversationId(null);
     savedArtifactRef.current = null;
-    lastHtmlArtifactFileRef.current = null;
+    lastHtmlArtifactLineageRef.current = null;
     pendingWritesRef.current.clear();
     if (messagesConversationIdRef.current !== activeConversationId) {
       messagesConversationIdRef.current = null;
@@ -910,7 +910,7 @@ export function ProjectView({
         setArtifact(null);
         setError(null);
         savedArtifactRef.current = null;
-        lastHtmlArtifactFileRef.current = null;
+        lastHtmlArtifactLineageRef.current = null;
         pendingWritesRef.current.clear();
         messagesConversationIdRef.current = activeConversationId;
         setMessagesConversationId(activeConversationId);
@@ -924,7 +924,7 @@ export function ProjectView({
         setArtifact(null);
         setError(message);
         savedArtifactRef.current = null;
-        lastHtmlArtifactFileRef.current = null;
+        lastHtmlArtifactLineageRef.current = null;
         pendingWritesRef.current.clear();
         messagesConversationIdRef.current = null;
         setMessagesConversationId(null);
@@ -1151,7 +1151,8 @@ export function ProjectView({
       // keeping index.html stable for multi-page HTML artifacts.
       const currentProjectFiles = projectFilesSnapshot ?? projectFilesRef.current;
       const existing = new Set(currentProjectFiles.map((f) => f.name));
-      const savedArtifactName = savedArtifactRef.current ?? lastHtmlArtifactFileRef.current;
+      const savedArtifactName =
+        savedArtifactRef.current ?? matchingHtmlArtifactLineageFileName(art, lastHtmlArtifactLineageRef.current);
       const canOverwriteExistingEntry = canOverwriteHtmlArtifactEntry({
         baseName,
         ext,
@@ -1188,7 +1189,7 @@ export function ProjectView({
         if (pointerTarget) {
           if (savedArtifactRef.current === pointerTarget) return;
           savedArtifactRef.current = pointerTarget;
-          lastHtmlArtifactFileRef.current = pointerTarget;
+          lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(art, pointerTarget);
           requestOpenFile(pointerTarget);
           return;
         }
@@ -1251,7 +1252,7 @@ export function ProjectView({
         // sees it without an extra click. The Write-tool path already does
         // this for tool-emitted files; this handles the artifact-tag path.
         if (ext === '.html') {
-          lastHtmlArtifactFileRef.current = file.name;
+          lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(art, file.name);
         }
         requestOpenFile(file.name);
       } else {
@@ -2140,7 +2141,10 @@ export function ProjectView({
                   );
                   if (recoveredExistingArtifact) {
                     savedArtifactRef.current = recoveredExistingArtifact.name;
-                    lastHtmlArtifactFileRef.current = recoveredExistingArtifact.name;
+                    lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(
+                      parsedArtifact,
+                      recoveredExistingArtifact.name,
+                    );
                     requestOpenFile(recoveredExistingArtifact.name);
                   } else {
                     await persistArtifact(parsedArtifact, nextFiles);
@@ -4651,6 +4655,33 @@ function artifactBaseNameFor(art: Artifact): string {
       .replace(/^-+|-+$/g, '')
       .slice(0, 60) || 'artifact'
   );
+}
+
+interface HtmlArtifactLineage {
+  fileName: string;
+  identifier: string;
+  title: string;
+  artifactType: string;
+}
+
+function htmlArtifactLineageFor(art: Artifact, fileName: string): HtmlArtifactLineage {
+  return {
+    fileName,
+    identifier: art.identifier ?? '',
+    title: art.title ?? '',
+    artifactType: art.artifactType ?? '',
+  };
+}
+
+function matchingHtmlArtifactLineageFileName(
+  art: Artifact,
+  lineage: HtmlArtifactLineage | null,
+): string | null {
+  if (!lineage) return null;
+  if ((art.identifier ?? '') !== lineage.identifier) return null;
+  if ((art.title ?? '') !== lineage.title) return null;
+  if ((art.artifactType ?? '') !== lineage.artifactType) return null;
+  return lineage.fileName;
 }
 
 function htmlArtifactGroupIdentifierFor(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4748,6 +4748,18 @@ function htmlArtifactLineageTitleFallbackMatches(art: Artifact, lineage: HtmlArt
   );
 }
 
+function htmlArtifactLineageTokenlessFallbackMatches(
+  art: Artifact,
+  lineage: HtmlArtifactLineage,
+): boolean {
+  const currentTitle = art.title ?? '';
+  const currentDocumentTitle = htmlDocumentTitle(art.html ?? '');
+  const wrapperTitleMatches = currentTitle !== '' && currentTitle === lineage.title;
+  const documentTitleMatches =
+    currentDocumentTitle !== '' && currentDocumentTitle === lineage.documentTitle;
+  return wrapperTitleMatches || documentTitleMatches;
+}
+
 function matchingHtmlArtifactLineage(
   art: Artifact,
   lineage: HtmlArtifactLineage | null,
@@ -4778,7 +4790,11 @@ function matchingHtmlArtifactLineage(
   }
   const tokenMatches =
     currentToken !== '' && lineage.lineageToken !== '' && currentToken === lineage.lineageToken;
-  if (!tokenMatches && !htmlArtifactLineageTitleFallbackMatches(art, lineage)) return null;
+  const titleFallbackMatches =
+    currentToken === '' && lineage.lineageToken !== ''
+      ? htmlArtifactLineageTokenlessFallbackMatches(art, lineage)
+      : htmlArtifactLineageTitleFallbackMatches(art, lineage);
+  if (!tokenMatches && !titleFallbackMatches) return null;
 
   return { fileName: lineage.fileName, lineageToken: lineage.lineageToken };
 }

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1152,7 +1152,7 @@ export function ProjectView({
       const currentProjectFiles = projectFilesSnapshot ?? projectFilesRef.current;
       const existing = new Set(currentProjectFiles.map((f) => f.name));
       const savedArtifactName =
-        savedArtifactRef.current ?? matchingHtmlArtifactLineageFileName(art, lastHtmlArtifactLineageRef.current);
+        savedArtifactRef.current ?? matchingHtmlArtifactLineageFileName(art, lastHtmlArtifactLineageRef.current, currentProjectFiles);
       const canOverwriteExistingEntry = canOverwriteHtmlArtifactEntry({
         baseName,
         ext,
@@ -1189,7 +1189,9 @@ export function ProjectView({
         if (pointerTarget) {
           if (savedArtifactRef.current === pointerTarget) return;
           savedArtifactRef.current = pointerTarget;
-          lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(art, pointerTarget);
+          const pointerFile = currentProjectFiles.find((f) => f.name === pointerTarget || f.path === pointerTarget);
+          const pointerGroup = pointerFile?.artifactManifest?.metadata?.artifactGroupIdentifier ?? '';
+          lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(art, pointerTarget, String(pointerGroup));
           requestOpenFile(pointerTarget);
           return;
         }
@@ -1252,7 +1254,8 @@ export function ProjectView({
         // sees it without an extra click. The Write-tool path already does
         // this for tool-emitted files; this handles the artifact-tag path.
         if (ext === '.html') {
-          lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(art, file.name);
+          const groupId = file.artifactManifest?.metadata?.artifactGroupIdentifier ?? artifactGroupIdentifier ?? '';
+          lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(art, file.name, String(groupId));
         }
         requestOpenFile(file.name);
       } else {
@@ -2141,9 +2144,11 @@ export function ProjectView({
                   );
                   if (recoveredExistingArtifact) {
                     savedArtifactRef.current = recoveredExistingArtifact.name;
+                    const recoveredGroupId = recoveredExistingArtifact.artifactManifest?.metadata?.artifactGroupIdentifier ?? '';
                     lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(
                       parsedArtifact,
                       recoveredExistingArtifact.name,
+                      String(recoveredGroupId),
                     );
                     requestOpenFile(recoveredExistingArtifact.name);
                   } else {
@@ -4662,25 +4667,49 @@ interface HtmlArtifactLineage {
   identifier: string;
   title: string;
   artifactType: string;
+  artifactGroupIdentifier: string;
+  htmlContent: string;
 }
 
-function htmlArtifactLineageFor(art: Artifact, fileName: string): HtmlArtifactLineage {
+function htmlArtifactLineageFor(
+  art: Artifact,
+  fileName: string,
+  artifactGroupIdentifier: string,
+): HtmlArtifactLineage {
   return {
     fileName,
     identifier: art.identifier ?? '',
     title: art.title ?? '',
     artifactType: art.artifactType ?? '',
+    artifactGroupIdentifier,
+    htmlContent: art.html ?? '',
   };
 }
 
 function matchingHtmlArtifactLineageFileName(
   art: Artifact,
   lineage: HtmlArtifactLineage | null,
+  projectFiles: ProjectFile[],
 ): string | null {
   if (!lineage) return null;
   if ((art.identifier ?? '') !== lineage.identifier) return null;
   if ((art.title ?? '') !== lineage.title) return null;
   if ((art.artifactType ?? '') !== lineage.artifactType) return null;
+  if (lineage.artifactGroupIdentifier === '') return null;
+
+  // Verify HTML content matches to prevent unrelated artifacts from reusing
+  // the group
+  if ((art.html ?? '') !== lineage.htmlContent) return null;
+
+  // Verify the lineage file still exists and has the same group
+  const lineageFile = projectFiles.find(
+    (f) => f.name === lineage.fileName || f.path === lineage.fileName,
+  );
+  if (!lineageFile) return null;
+  const currentGroup =
+    lineageFile.artifactManifest?.metadata?.artifactGroupIdentifier ?? '';
+  if (currentGroup !== lineage.artifactGroupIdentifier) return null;
+
   return lineage.fileName;
 }
 

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1151,8 +1151,18 @@ export function ProjectView({
       // keeping index.html stable for multi-page HTML artifacts.
       const currentProjectFiles = projectFilesSnapshot ?? projectFilesRef.current;
       const existing = new Set(currentProjectFiles.map((f) => f.name));
+      const htmlArtifactLineageMatch =
+        ext === '.html' && !savedArtifactRef.current
+          ? matchingHtmlArtifactLineage(art, lastHtmlArtifactLineageRef.current, currentProjectFiles)
+          : null;
       const savedArtifactName =
-        savedArtifactRef.current ?? matchingHtmlArtifactLineageFileName(art, lastHtmlArtifactLineageRef.current, currentProjectFiles);
+        savedArtifactRef.current ?? htmlArtifactLineageMatch?.fileName ?? null;
+      const artifactLineageToken =
+        ext === '.html'
+          ? normalizeHtmlArtifactLineageToken(art.lineageToken) ||
+            normalizeHtmlArtifactLineageToken(htmlArtifactLineageMatch?.lineageToken) ||
+            randomUUID()
+          : '';
       const canOverwriteExistingEntry = canOverwriteHtmlArtifactEntry({
         baseName,
         ext,
@@ -1191,7 +1201,15 @@ export function ProjectView({
           savedArtifactRef.current = pointerTarget;
           const pointerFile = currentProjectFiles.find((f) => f.name === pointerTarget || f.path === pointerTarget);
           const pointerGroup = pointerFile?.artifactManifest?.metadata?.artifactGroupIdentifier ?? '';
-          lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(art, pointerTarget, String(pointerGroup));
+          const pointerLineageToken = normalizeHtmlArtifactLineageToken(
+            pointerFile?.artifactManifest?.metadata?.artifactLineageToken,
+          );
+          lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(
+            art,
+            pointerTarget,
+            String(pointerGroup),
+            pointerLineageToken || artifactLineageToken,
+          );
           requestOpenFile(pointerTarget);
           return;
         }
@@ -1216,6 +1234,7 @@ export function ProjectView({
         artifactType: art.artifactType,
         inferred: false,
         ...(artifactGroupIdentifier ? { artifactGroupIdentifier } : {}),
+        ...(ext === '.html' ? { artifactLineageToken } : {}),
       };
       const manifest =
         ext === '.html'
@@ -1255,7 +1274,15 @@ export function ProjectView({
         // this for tool-emitted files; this handles the artifact-tag path.
         if (ext === '.html') {
           const groupId = file.artifactManifest?.metadata?.artifactGroupIdentifier ?? artifactGroupIdentifier ?? '';
-          lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(art, file.name, String(groupId));
+          const fileLineageToken =
+            normalizeHtmlArtifactLineageToken(file.artifactManifest?.metadata?.artifactLineageToken) ||
+            artifactLineageToken;
+          lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(
+            art,
+            file.name,
+            String(groupId),
+            fileLineageToken,
+          );
         }
         requestOpenFile(file.name);
       } else {
@@ -2033,6 +2060,7 @@ export function ProjectView({
                 identifier: ev.identifier,
                 artifactType: ev.artifactType,
                 title: ev.title,
+                lineageToken: ev.lineageToken,
                 html: '',
               };
               setArtifact(parsedArtifact);
@@ -2145,10 +2173,14 @@ export function ProjectView({
                   if (recoveredExistingArtifact) {
                     savedArtifactRef.current = recoveredExistingArtifact.name;
                     const recoveredGroupId = recoveredExistingArtifact.artifactManifest?.metadata?.artifactGroupIdentifier ?? '';
+                    const recoveredLineageToken = normalizeHtmlArtifactLineageToken(
+                      recoveredExistingArtifact.artifactManifest?.metadata?.artifactLineageToken,
+                    );
                     lastHtmlArtifactLineageRef.current = htmlArtifactLineageFor(
                       parsedArtifact,
                       recoveredExistingArtifact.name,
                       String(recoveredGroupId),
+                      recoveredLineageToken,
                     );
                     requestOpenFile(recoveredExistingArtifact.name);
                   } else {
@@ -2585,6 +2617,7 @@ export function ProjectView({
               identifier: ev.identifier,
               artifactType: ev.artifactType,
               title: ev.title,
+              lineageToken: ev.lineageToken,
               html: '',
             };
             setArtifact(parsedArtifact);
@@ -4669,6 +4702,12 @@ interface HtmlArtifactLineage {
   artifactType: string;
   artifactGroupIdentifier: string;
   documentTitle: string;
+  lineageToken: string;
+}
+
+interface HtmlArtifactLineageMatch {
+  fileName: string;
+  lineageToken: string;
 }
 
 function htmlDocumentTitle(html: string): string {
@@ -4677,10 +4716,15 @@ function htmlDocumentTitle(html: string): string {
   return rawTitle.replace(/\s+/g, ' ').trim();
 }
 
+function normalizeHtmlArtifactLineageToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
 function htmlArtifactLineageFor(
   art: Artifact,
   fileName: string,
   artifactGroupIdentifier: string,
+  lineageToken?: string,
 ): HtmlArtifactLineage {
   return {
     fileName,
@@ -4689,26 +4733,30 @@ function htmlArtifactLineageFor(
     artifactType: art.artifactType ?? '',
     artifactGroupIdentifier,
     documentTitle: htmlDocumentTitle(art.html ?? ''),
+    lineageToken: normalizeHtmlArtifactLineageToken(lineageToken ?? art.lineageToken),
   };
 }
 
-function htmlArtifactLineageTitleMatches(art: Artifact, lineage: HtmlArtifactLineage): boolean {
+function htmlArtifactLineageTitleFallbackMatches(art: Artifact, lineage: HtmlArtifactLineage): boolean {
   const currentTitle = art.title ?? '';
-  if (currentTitle !== '' && currentTitle === lineage.title) return true;
   const currentDocumentTitle = htmlDocumentTitle(art.html ?? '');
-  return currentDocumentTitle !== '' && currentDocumentTitle === lineage.documentTitle;
+  return (
+    currentTitle !== '' &&
+    currentTitle === lineage.title &&
+    currentDocumentTitle !== '' &&
+    currentDocumentTitle === lineage.documentTitle
+  );
 }
 
-function matchingHtmlArtifactLineageFileName(
+function matchingHtmlArtifactLineage(
   art: Artifact,
   lineage: HtmlArtifactLineage | null,
   projectFiles: ProjectFile[],
-): string | null {
+): HtmlArtifactLineageMatch | null {
   if (!lineage) return null;
   if ((art.identifier ?? '') !== lineage.identifier) return null;
   if ((art.artifactType ?? '') !== lineage.artifactType) return null;
   if (lineage.artifactGroupIdentifier === '') return null;
-  if (!htmlArtifactLineageTitleMatches(art, lineage)) return null;
 
   // Verify the lineage file still exists and has the same group
   const lineageFile = projectFiles.find(
@@ -4719,7 +4767,20 @@ function matchingHtmlArtifactLineageFileName(
     lineageFile.artifactManifest?.metadata?.artifactGroupIdentifier ?? '';
   if (currentGroup !== lineage.artifactGroupIdentifier) return null;
 
-  return lineage.fileName;
+  const lineageFileToken = normalizeHtmlArtifactLineageToken(
+    lineageFile.artifactManifest?.metadata?.artifactLineageToken,
+  );
+  if (lineage.lineageToken !== '' && lineageFileToken !== lineage.lineageToken) return null;
+
+  const currentToken = normalizeHtmlArtifactLineageToken(art.lineageToken);
+  if (currentToken !== '' && lineage.lineageToken !== '' && currentToken !== lineage.lineageToken) {
+    return null;
+  }
+  const tokenMatches =
+    currentToken !== '' && lineage.lineageToken !== '' && currentToken === lineage.lineageToken;
+  if (!tokenMatches && !htmlArtifactLineageTitleFallbackMatches(art, lineage)) return null;
+
+  return { fileName: lineage.fileName, lineageToken: lineage.lineageToken };
 }
 
 function htmlArtifactGroupIdentifierFor(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4665,24 +4665,8 @@ function artifactBaseNameFor(art: Artifact): string {
 interface HtmlArtifactLineage {
   fileName: string;
   identifier: string;
-  title: string;
   artifactType: string;
   artifactGroupIdentifier: string;
-  identitySignature: string;
-}
-
-/**
- * Extract stable document identity signature from HTML content.
- * Uses only the normalized document <title> to identify the document,
- * ignoring body copy changes and local href topology changes.
- */
-function htmlArtifactIdentitySignature(html: string): string {
-  // Extract <title> text (case-insensitive, trim/collapse whitespace)
-  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
-  const rawTitle = titleMatch?.[1] ?? '';
-  const title = rawTitle.replace(/\s+/g, ' ').trim();
-
-  return JSON.stringify({ title });
 }
 
 function htmlArtifactLineageFor(
@@ -4693,10 +4677,8 @@ function htmlArtifactLineageFor(
   return {
     fileName,
     identifier: art.identifier ?? '',
-    title: art.title ?? '',
     artifactType: art.artifactType ?? '',
     artifactGroupIdentifier,
-    identitySignature: htmlArtifactIdentitySignature(art.html ?? ''),
   };
 }
 
@@ -4707,7 +4689,6 @@ function matchingHtmlArtifactLineageFileName(
 ): string | null {
   if (!lineage) return null;
   if ((art.identifier ?? '') !== lineage.identifier) return null;
-  if ((art.title ?? '') !== lineage.title) return null;
   if ((art.artifactType ?? '') !== lineage.artifactType) return null;
   if (lineage.artifactGroupIdentifier === '') return null;
 
@@ -4719,10 +4700,6 @@ function matchingHtmlArtifactLineageFileName(
   const currentGroup =
     lineageFile.artifactManifest?.metadata?.artifactGroupIdentifier ?? '';
   if (currentGroup !== lineage.artifactGroupIdentifier) return null;
-
-  // Verify document identity signature matches
-  const currentSignature = htmlArtifactIdentitySignature(art.html ?? '');
-  if (currentSignature !== lineage.identitySignature) return null;
 
   return lineage.fileName;
 }

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4668,7 +4668,50 @@ interface HtmlArtifactLineage {
   title: string;
   artifactType: string;
   artifactGroupIdentifier: string;
-  htmlContent: string;
+  identitySignature: string;
+}
+
+/**
+ * Extract stable document identity signature from HTML content.
+ * Captures document title and local href topology, ignoring body copy changes.
+ */
+function htmlArtifactIdentitySignature(html: string): string {
+  // Extract <title> text (case-insensitive, trim/collapse whitespace)
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const rawTitle = titleMatch?.[1] ?? '';
+  const title = rawTitle.replace(/\s+/g, ' ').trim();
+
+  // Extract all href values, filter to local page links only
+  const hrefMatches = html.matchAll(/href=["']([^"']+)["']/gi);
+  const localHrefs: string[] = [];
+
+  for (const match of hrefMatches) {
+    const href = match[1];
+    if (!href) continue;
+    // Skip hash-only, external, protocol-relative, data, mailto, tel
+    if (
+      href.startsWith('#') ||
+      href.startsWith('http://') ||
+      href.startsWith('https://') ||
+      href.startsWith('//') ||
+      href.startsWith('data:') ||
+      href.startsWith('mailto:') ||
+      href.startsWith('tel:')
+    ) {
+      continue;
+    }
+    // Keep local links, normalize and dedupe
+    const hrefWithoutHash = href.split('#')[0] ?? '';
+    const normalized = (hrefWithoutHash.split('?')[0] ?? '').trim();
+    if (normalized && !localHrefs.includes(normalized)) {
+      localHrefs.push(normalized);
+    }
+  }
+
+  // Sort for stable signature
+  localHrefs.sort();
+
+  return `title:${title}|hrefs:${localHrefs.join(',')}`;
 }
 
 function htmlArtifactLineageFor(
@@ -4682,7 +4725,7 @@ function htmlArtifactLineageFor(
     title: art.title ?? '',
     artifactType: art.artifactType ?? '',
     artifactGroupIdentifier,
-    htmlContent: art.html ?? '',
+    identitySignature: htmlArtifactIdentitySignature(art.html ?? ''),
   };
 }
 
@@ -4697,10 +4740,6 @@ function matchingHtmlArtifactLineageFileName(
   if ((art.artifactType ?? '') !== lineage.artifactType) return null;
   if (lineage.artifactGroupIdentifier === '') return null;
 
-  // Verify HTML content matches to prevent unrelated artifacts from reusing
-  // the group
-  if ((art.html ?? '') !== lineage.htmlContent) return null;
-
   // Verify the lineage file still exists and has the same group
   const lineageFile = projectFiles.find(
     (f) => f.name === lineage.fileName || f.path === lineage.fileName,
@@ -4709,6 +4748,10 @@ function matchingHtmlArtifactLineageFileName(
   const currentGroup =
     lineageFile.artifactManifest?.metadata?.artifactGroupIdentifier ?? '';
   if (currentGroup !== lineage.artifactGroupIdentifier) return null;
+
+  // Verify document identity signature matches
+  const currentSignature = htmlArtifactIdentitySignature(art.html ?? '');
+  if (currentSignature !== lineage.identitySignature) return null;
 
   return lineage.fileName;
 }

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -689,6 +689,9 @@ export function ProjectView({
   // last name we persisted so re-renders during streaming don't spawn
   // duplicate writes.
   const savedArtifactRef = useRef<string | null>(null);
+  // Preserve HTML artifact ownership across user turns without using it for
+  // the same-turn duplicate-write guard above.
+  const lastHtmlArtifactFileRef = useRef<string | null>(null);
   // Pending Write tool invocations: tool_use_id -> destination basename.
   // When the matching tool_result lands we refresh the file list and open
   // the file as a tab once. Keying off the tool_use_id (rather than
@@ -783,6 +786,7 @@ export function ProjectView({
     setAudioVoiceOptionsError(null);
     setArtifact(null);
     savedArtifactRef.current = null;
+    lastHtmlArtifactFileRef.current = null;
     pendingWritesRef.current.clear();
     (async () => {
       try {
@@ -887,6 +891,7 @@ export function ProjectView({
     streamingConversationIdRef.current = null;
     setStreamingConversationId(null);
     savedArtifactRef.current = null;
+    lastHtmlArtifactFileRef.current = null;
     pendingWritesRef.current.clear();
     if (messagesConversationIdRef.current !== activeConversationId) {
       messagesConversationIdRef.current = null;
@@ -905,6 +910,7 @@ export function ProjectView({
         setArtifact(null);
         setError(null);
         savedArtifactRef.current = null;
+        lastHtmlArtifactFileRef.current = null;
         pendingWritesRef.current.clear();
         messagesConversationIdRef.current = activeConversationId;
         setMessagesConversationId(activeConversationId);
@@ -918,6 +924,7 @@ export function ProjectView({
         setArtifact(null);
         setError(message);
         savedArtifactRef.current = null;
+        lastHtmlArtifactFileRef.current = null;
         pendingWritesRef.current.clear();
         messagesConversationIdRef.current = null;
         setMessagesConversationId(null);
@@ -1144,24 +1151,26 @@ export function ProjectView({
       // keeping index.html stable for multi-page HTML artifacts.
       const currentProjectFiles = projectFilesSnapshot ?? projectFilesRef.current;
       const existing = new Set(currentProjectFiles.map((f) => f.name));
+      const savedArtifactName = savedArtifactRef.current ?? lastHtmlArtifactFileRef.current;
       const canOverwriteExistingEntry = canOverwriteHtmlArtifactEntry({
         baseName,
         ext,
         projectFiles: currentProjectFiles,
-        savedArtifactName: savedArtifactRef.current,
+        savedArtifactName,
       });
       const fileName = resolveHtmlArtifactFileName({
         baseName,
         ext,
         existingFileNames: existing,
-        savedArtifactName: savedArtifactRef.current,
+        savedArtifactName,
         canOverwriteExistingEntry,
       });
       const artifactGroupIdentifier =
         ext === '.html'
           ? htmlArtifactGroupIdentifierFor(currentProjectFiles, fileName, {
               canReuseExistingGroup:
-                canOverwriteExistingEntry || savedArtifactRef.current === fileName,
+                canOverwriteExistingEntry || savedArtifactName === fileName,
+              savedArtifactName,
             })
           : undefined;
       const html =
@@ -1179,6 +1188,7 @@ export function ProjectView({
         if (pointerTarget) {
           if (savedArtifactRef.current === pointerTarget) return;
           savedArtifactRef.current = pointerTarget;
+          lastHtmlArtifactFileRef.current = pointerTarget;
           requestOpenFile(pointerTarget);
           return;
         }
@@ -1240,6 +1250,9 @@ export function ProjectView({
         // Auto-open the freshly-persisted artifact as a tab so the user
         // sees it without an extra click. The Write-tool path already does
         // this for tool-emitted files; this handles the artifact-tag path.
+        if (ext === '.html') {
+          lastHtmlArtifactFileRef.current = file.name;
+        }
         requestOpenFile(file.name);
       } else {
         // writeProjectTextFile collapses all failure paths (non-OK HTTP
@@ -2127,6 +2140,7 @@ export function ProjectView({
                   );
                   if (recoveredExistingArtifact) {
                     savedArtifactRef.current = recoveredExistingArtifact.name;
+                    lastHtmlArtifactFileRef.current = recoveredExistingArtifact.name;
                     requestOpenFile(recoveredExistingArtifact.name);
                   } else {
                     await persistArtifact(parsedArtifact, nextFiles);
@@ -4642,7 +4656,7 @@ function artifactBaseNameFor(art: Artifact): string {
 function htmlArtifactGroupIdentifierFor(
   projectFiles: ProjectFile[],
   fileName: string,
-  options: { canReuseExistingGroup: boolean },
+  options: { canReuseExistingGroup: boolean; savedArtifactName?: string | null },
 ): string {
   const existingFile = projectFiles.find((file) => file.name === fileName || file.path === fileName);
   const existingFileGroup = existingArtifactGroupIdentifier(
@@ -4650,6 +4664,15 @@ function htmlArtifactGroupIdentifierFor(
   );
   if (options.canReuseExistingGroup && existingFileGroup) {
     return existingFileGroup;
+  }
+  const savedArtifactFile = options.savedArtifactName
+    ? projectFiles.find((file) => file.name === options.savedArtifactName || file.path === options.savedArtifactName)
+    : null;
+  const savedArtifactGroup = existingArtifactGroupIdentifier(
+    savedArtifactFile?.artifactManifest?.metadata?.artifactGroupIdentifier,
+  );
+  if (options.canReuseExistingGroup && savedArtifactGroup) {
+    return savedArtifactGroup;
   }
 
   return `html-artifact:${fileName}`;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1160,7 +1160,7 @@ export function ProjectView({
       });
       const artifactGroupIdentifier =
         ext === '.html'
-          ? htmlArtifactGroupIdentifierFor(art, currentProjectFiles, fileName, {
+          ? htmlArtifactGroupIdentifierFor(currentProjectFiles, fileName, {
               canReuseExistingGroup:
                 canOverwriteExistingEntry || savedArtifactRef.current === fileName,
             })
@@ -4641,7 +4641,6 @@ function artifactBaseNameFor(art: Artifact): string {
 }
 
 function htmlArtifactGroupIdentifierFor(
-  art: Artifact,
   projectFiles: ProjectFile[],
   fileName: string,
   options: { canReuseExistingGroup: boolean },
@@ -4652,22 +4651,6 @@ function htmlArtifactGroupIdentifierFor(
   );
   if (options.canReuseExistingGroup && existingFileGroup) {
     return existingFileGroup;
-  }
-
-  if (options.canReuseExistingGroup) {
-    const identifier = normalizeArtifactGroupSegment(art.identifier);
-    if (identifier) {
-      const existingGroup = projectFiles
-        .filter((file) => {
-          return normalizeArtifactGroupSegment(file.artifactManifest?.metadata?.identifier) === identifier;
-        })
-        .sort((a, b) => b.mtime - a.mtime)
-        .map((file) => file.artifactManifest?.metadata?.artifactGroupIdentifier)
-        .find((value): value is string => {
-          return typeof value === 'string' && normalizeArtifactGroupSegment(value).length > 0;
-        });
-      if (existingGroup) return existingGroup;
-    }
   }
 
   return `html-artifact:${fileName}`;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -12,6 +12,7 @@ import {
 import { createHtmlArtifactManifest, inferLegacyManifest } from '../artifacts/manifest';
 import { resolveHtmlPointerArtifactTarget } from '../artifacts/pointer';
 import {
+  canOverwriteHtmlArtifactEntry,
   resolveHtmlArtifactFileName,
   rewriteHtmlLinksToCurrentProjectFiles,
 } from '../artifacts/html-links';
@@ -1148,6 +1149,13 @@ export function ProjectView({
         ext,
         existingFileNames: existing,
         savedArtifactName: savedArtifactRef.current,
+        canOverwriteExistingEntry: canOverwriteHtmlArtifactEntry({
+          baseName,
+          ext,
+          projectFiles: currentProjectFiles,
+          savedArtifactName: savedArtifactRef.current,
+          artifactIdentifier: art.identifier,
+        }),
       });
       const html =
         ext === '.html'

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -11,6 +11,10 @@ import {
 } from 'react';
 import { createHtmlArtifactManifest, inferLegacyManifest } from '../artifacts/manifest';
 import { resolveHtmlPointerArtifactTarget } from '../artifacts/pointer';
+import {
+  resolveHtmlArtifactFileName,
+  rewriteHtmlLinksToCurrentProjectFiles,
+} from '../artifacts/html-links';
 import { validateHtmlArtifact } from '../artifacts/validate';
 import { createArtifactParser } from '../artifacts/parser';
 import { useI18n } from '../i18n';
@@ -1135,20 +1139,23 @@ export function ProjectView({
     async (art: Artifact, projectFilesSnapshot?: ProjectFile[]) => {
       const baseName = artifactBaseNameFor(art);
       const ext = artifactExtensionFor(art);
-      // Pick a name that doesn't collide with an existing project file.
-      // The first run uses `<base>.<ext>`; subsequent runs append `-2`, `-3`…
-      // so prior artifacts aren't silently overwritten.
+      // Pick a name that doesn't collide with an existing project file while
+      // keeping index.html stable for multi-page HTML artifacts.
       const currentProjectFiles = projectFilesSnapshot ?? projectFilesRef.current;
       const existing = new Set(currentProjectFiles.map((f) => f.name));
-      let fileName = `${baseName}${ext}`;
-      let n = 2;
-      while (existing.has(fileName) && savedArtifactRef.current !== fileName) {
-        fileName = `${baseName}-${n}${ext}`;
-        n += 1;
-      }
+      const fileName = resolveHtmlArtifactFileName({
+        baseName,
+        ext,
+        existingFileNames: existing,
+        savedArtifactName: savedArtifactRef.current,
+      });
+      const html =
+        ext === '.html'
+          ? rewriteHtmlLinksToCurrentProjectFiles(art.html, currentProjectFiles)
+          : art.html;
       if (ext === '.html') {
         const pointerTarget = resolveHtmlPointerArtifactTarget({
-          content: art.html,
+          content: html,
           candidateFileName: fileName,
           projectFiles: currentProjectFiles,
         });
@@ -1165,7 +1172,7 @@ export function ProjectView({
       // when only Edit-tool changes happened this turn. Without this guard,
       // such content lands as a phantom HTML file in the project panel.
       if (ext === '.html') {
-        const validation = validateHtmlArtifact(art.html);
+        const validation = validateHtmlArtifact(html);
         if (!validation.ok) {
           setError(`Refused to save artifact "${art.identifier || art.title || 'untitled'}": ${validation.reason}`);
           return;
@@ -1197,7 +1204,7 @@ export function ProjectView({
                 designSystemId: project.designSystemId,
               },
             });
-      const file = await writeProjectTextFile(project.id, fileName, art.html, {
+      const file = await writeProjectTextFile(project.id, fileName, html, {
         artifactManifest: manifest ?? undefined,
       });
       if (file) {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1157,9 +1157,15 @@ export function ProjectView({
           artifactIdentifier: art.identifier,
         }),
       });
+      const artifactGroupIdentifier =
+        ext === '.html'
+          ? htmlArtifactGroupIdentifierFor(art, currentProjectFiles, fileName)
+          : undefined;
       const html =
         ext === '.html'
-          ? rewriteHtmlLinksToCurrentProjectFiles(art.html, currentProjectFiles)
+          ? rewriteHtmlLinksToCurrentProjectFiles(art.html, currentProjectFiles, {
+              artifactGroupIdentifier,
+            })
           : art.html;
       if (ext === '.html') {
         const pointerTarget = resolveHtmlPointerArtifactTarget({
@@ -1193,6 +1199,7 @@ export function ProjectView({
         identifier: art.identifier,
         artifactType: art.artifactType,
         inferred: false,
+        ...(artifactGroupIdentifier ? { artifactGroupIdentifier } : {}),
       };
       const manifest =
         ext === '.html'
@@ -4627,6 +4634,35 @@ function artifactBaseNameFor(art: Artifact): string {
       .replace(/^-+|-+$/g, '')
       .slice(0, 60) || 'artifact'
   );
+}
+
+function htmlArtifactGroupIdentifierFor(
+  art: Artifact,
+  projectFiles: ProjectFile[],
+  fileName: string,
+): string {
+  const identifier = normalizeArtifactGroupSegment(art.identifier);
+  if (identifier) {
+    const existingGroup = projectFiles
+      .filter((file) => {
+        return normalizeArtifactGroupSegment(file.artifactManifest?.metadata?.identifier) === identifier;
+      })
+      .sort((a, b) => b.mtime - a.mtime)
+      .map((file) => file.artifactManifest?.metadata?.artifactGroupIdentifier)
+      .find((value): value is string => {
+        return typeof value === 'string' && normalizeArtifactGroupSegment(value).length > 0;
+      });
+    if (existingGroup) return existingGroup;
+  }
+  return `html-artifact:${fileName}`;
+}
+
+function normalizeArtifactGroupSegment(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 export function findExistingArtifactProjectFile(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1144,22 +1144,26 @@ export function ProjectView({
       // keeping index.html stable for multi-page HTML artifacts.
       const currentProjectFiles = projectFilesSnapshot ?? projectFilesRef.current;
       const existing = new Set(currentProjectFiles.map((f) => f.name));
+      const canOverwriteExistingEntry = canOverwriteHtmlArtifactEntry({
+        baseName,
+        ext,
+        projectFiles: currentProjectFiles,
+        savedArtifactName: savedArtifactRef.current,
+        artifactIdentifier: art.identifier,
+      });
       const fileName = resolveHtmlArtifactFileName({
         baseName,
         ext,
         existingFileNames: existing,
         savedArtifactName: savedArtifactRef.current,
-        canOverwriteExistingEntry: canOverwriteHtmlArtifactEntry({
-          baseName,
-          ext,
-          projectFiles: currentProjectFiles,
-          savedArtifactName: savedArtifactRef.current,
-          artifactIdentifier: art.identifier,
-        }),
+        canOverwriteExistingEntry,
       });
       const artifactGroupIdentifier =
         ext === '.html'
-          ? htmlArtifactGroupIdentifierFor(art, currentProjectFiles, fileName)
+          ? htmlArtifactGroupIdentifierFor(art, currentProjectFiles, fileName, {
+              canReuseExistingGroup:
+                canOverwriteExistingEntry || savedArtifactRef.current === fileName,
+            })
           : undefined;
       const html =
         ext === '.html'
@@ -4640,21 +4644,38 @@ function htmlArtifactGroupIdentifierFor(
   art: Artifact,
   projectFiles: ProjectFile[],
   fileName: string,
+  options: { canReuseExistingGroup: boolean },
 ): string {
-  const identifier = normalizeArtifactGroupSegment(art.identifier);
-  if (identifier) {
-    const existingGroup = projectFiles
-      .filter((file) => {
-        return normalizeArtifactGroupSegment(file.artifactManifest?.metadata?.identifier) === identifier;
-      })
-      .sort((a, b) => b.mtime - a.mtime)
-      .map((file) => file.artifactManifest?.metadata?.artifactGroupIdentifier)
-      .find((value): value is string => {
-        return typeof value === 'string' && normalizeArtifactGroupSegment(value).length > 0;
-      });
-    if (existingGroup) return existingGroup;
+  const existingFile = projectFiles.find((file) => file.name === fileName || file.path === fileName);
+  const existingFileGroup = existingArtifactGroupIdentifier(
+    existingFile?.artifactManifest?.metadata?.artifactGroupIdentifier,
+  );
+  if (options.canReuseExistingGroup && existingFileGroup) {
+    return existingFileGroup;
   }
+
+  if (options.canReuseExistingGroup) {
+    const identifier = normalizeArtifactGroupSegment(art.identifier);
+    if (identifier) {
+      const existingGroup = projectFiles
+        .filter((file) => {
+          return normalizeArtifactGroupSegment(file.artifactManifest?.metadata?.identifier) === identifier;
+        })
+        .sort((a, b) => b.mtime - a.mtime)
+        .map((file) => file.artifactManifest?.metadata?.artifactGroupIdentifier)
+        .find((value): value is string => {
+          return typeof value === 'string' && normalizeArtifactGroupSegment(value).length > 0;
+        });
+      if (existingGroup) return existingGroup;
+    }
+  }
+
   return `html-artifact:${fileName}`;
+}
+
+function existingArtifactGroupIdentifier(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  return normalizeArtifactGroupSegment(value).length > 0 ? value : null;
 }
 
 function normalizeArtifactGroupSegment(value: unknown): string {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1149,7 +1149,6 @@ export function ProjectView({
         ext,
         projectFiles: currentProjectFiles,
         savedArtifactName: savedArtifactRef.current,
-        artifactIdentifier: art.identifier,
       });
       const fileName = resolveHtmlArtifactFileName({
         baseName,

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -414,6 +414,7 @@ export interface Artifact {
   artifactType?: string;
   title: string;
   html: string;
+  lineageToken?: string;
   savedUrl?: string;
 }
 

--- a/apps/web/tests/artifacts/html-links.test.ts
+++ b/apps/web/tests/artifacts/html-links.test.ts
@@ -100,6 +100,22 @@ describe('rewriteHtmlLinksToCurrentProjectFiles', () => {
     expect(out).toContain('href="#local"');
     expect(out).toContain('href="https://example.com/about.html"');
   });
+
+  it('rewrites home links when the artifact entry had to move off index.html', () => {
+    const html =
+      '<!doctype html><html><body>' +
+      '<a href="index.html">Home</a>' +
+      '<a href="./index.html#top">Top</a>' +
+      '</body></html>';
+
+    const out = rewriteHtmlLinksToCurrentProjectFiles(html, [
+      htmlFile('index.html', 10),
+      htmlFile('index-2.html', 40),
+    ]);
+
+    expect(out).toContain('href="index-2.html"');
+    expect(out).toContain('href="./index-2.html#top"');
+  });
 });
 
 function htmlFile(

--- a/apps/web/tests/artifacts/html-links.test.ts
+++ b/apps/web/tests/artifacts/html-links.test.ts
@@ -89,10 +89,10 @@ describe('rewriteHtmlLinksToCurrentProjectFiles', () => {
       '</body></html>';
 
     const out = rewriteHtmlLinksToCurrentProjectFiles(html, [
-      htmlFile('about.html', 10),
-      htmlFile('about-2.html', 30),
-      htmlFile('contact.html', 20),
-      htmlFile('contact-2.html', 40),
+      htmlFile('about.html', 10, { artifactIdentifier: 'about' }),
+      htmlFile('about-2.html', 30, { artifactIdentifier: 'about' }),
+      htmlFile('contact.html', 20, { artifactIdentifier: 'contact' }),
+      htmlFile('contact-2.html', 40, { artifactIdentifier: 'contact' }),
     ]);
 
     expect(out).toContain('href="about-2.html"');
@@ -109,12 +109,27 @@ describe('rewriteHtmlLinksToCurrentProjectFiles', () => {
       '</body></html>';
 
     const out = rewriteHtmlLinksToCurrentProjectFiles(html, [
-      htmlFile('index.html', 10),
-      htmlFile('index-2.html', 40),
+      htmlFile('index.html', 10, { artifactIdentifier: 'index' }),
+      htmlFile('index-2.html', 40, { artifactIdentifier: 'index' }),
     ]);
 
     expect(out).toContain('href="index-2.html"');
     expect(out).toContain('href="./index-2.html#top"');
+  });
+
+  it('does not rewrite to an unrelated newer numbered html file', () => {
+    const html =
+      '<!doctype html><html><body>' +
+      '<a href="about.html">About</a>' +
+      '</body></html>';
+
+    const out = rewriteHtmlLinksToCurrentProjectFiles(html, [
+      htmlFile('about.html', 10, { artifactIdentifier: 'about' }),
+      htmlFile('about-2.html', 40, { artifactIdentifier: 'other-about' }),
+    ]);
+
+    expect(out).toContain('href="about.html"');
+    expect(out).not.toContain('href="about-2.html"');
   });
 });
 

--- a/apps/web/tests/artifacts/html-links.test.ts
+++ b/apps/web/tests/artifacts/html-links.test.ts
@@ -146,6 +146,40 @@ describe('rewriteHtmlLinksToCurrentProjectFiles', () => {
     expect(out).toContain('href="about.html"');
     expect(out).not.toContain('href="about-2.html"');
   });
+
+  it('falls back to legacy same-identifier files when no group-tagged candidates exist', () => {
+    const html =
+      '<!doctype html><html><body>' +
+      '<a href="about.html">About</a>' +
+      '</body></html>';
+
+    const out = rewriteHtmlLinksToCurrentProjectFiles(html, [
+      htmlFile('about.html', 10, { artifactIdentifier: 'about' }),
+      htmlFile('about-2.html', 40, { artifactIdentifier: 'about' }),
+    ], { artifactGroupIdentifier: 'site-a' });
+
+    expect(out).toContain('href="about-2.html"');
+  });
+
+  it('does not fall back to legacy files when a group-tagged candidate family exists', () => {
+    const html =
+      '<!doctype html><html><body>' +
+      '<a href="about.html">About</a>' +
+      '</body></html>';
+
+    const out = rewriteHtmlLinksToCurrentProjectFiles(html, [
+      htmlFile('about.html', 10, { artifactIdentifier: 'about' }),
+      htmlFile('about-2.html', 20, { artifactIdentifier: 'about' }),
+      htmlFile('about-3.html', 40, {
+        artifactIdentifier: 'about',
+        artifactGroupIdentifier: 'site-b',
+      }),
+    ], { artifactGroupIdentifier: 'site-a' });
+
+    expect(out).toContain('href="about.html"');
+    expect(out).not.toContain('href="about-2.html"');
+    expect(out).not.toContain('href="about-3.html"');
+  });
 });
 
 function htmlFile(

--- a/apps/web/tests/artifacts/html-links.test.ts
+++ b/apps/web/tests/artifacts/html-links.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveHtmlArtifactFileName,
+  rewriteHtmlLinksToCurrentProjectFiles,
+} from '../../src/artifacts/html-links';
+
+describe('resolveHtmlArtifactFileName', () => {
+  it('keeps index.html as the stable entry point when it already exists', () => {
+    expect(
+      resolveHtmlArtifactFileName({
+        baseName: 'index',
+        ext: '.html',
+        existingFileNames: new Set(['index.html']),
+      }),
+    ).toBe('index.html');
+  });
+
+  it('keeps numbered collision names for non-entry html artifacts', () => {
+    expect(
+      resolveHtmlArtifactFileName({
+        baseName: 'about',
+        ext: '.html',
+        existingFileNames: new Set(['about.html', 'about-2.html']),
+      }),
+    ).toBe('about-3.html');
+  });
+});
+
+describe('rewriteHtmlLinksToCurrentProjectFiles', () => {
+  it('rewrites relative html links to the newest matching project file', () => {
+    const html =
+      '<!doctype html><html><body>' +
+      '<a href="about.html">About</a>' +
+      '<a href="contact.html?tab=team#lead">Contact</a>' +
+      '<a href="#local">Local</a>' +
+      '<a href="https://example.com/about.html">External</a>' +
+      '</body></html>';
+
+    const out = rewriteHtmlLinksToCurrentProjectFiles(html, [
+      htmlFile('about.html', 10),
+      htmlFile('about-2.html', 30),
+      htmlFile('contact.html', 20),
+      htmlFile('contact-2.html', 40),
+    ]);
+
+    expect(out).toContain('href="about-2.html"');
+    expect(out).toContain('href="contact-2.html?tab=team#lead"');
+    expect(out).toContain('href="#local"');
+    expect(out).toContain('href="https://example.com/about.html"');
+  });
+});
+
+function htmlFile(name: string, mtime: number) {
+  return {
+    name,
+    kind: 'html',
+    mime: 'text/html',
+    size: 1,
+    mtime,
+  };
+}

--- a/apps/web/tests/artifacts/html-links.test.ts
+++ b/apps/web/tests/artifacts/html-links.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  canOverwriteHtmlArtifactEntry,
   resolveHtmlArtifactFileName,
   rewriteHtmlLinksToCurrentProjectFiles,
 } from '../../src/artifacts/html-links';
@@ -27,6 +28,17 @@ describe('resolveHtmlArtifactFileName', () => {
     ).toBe('index-2.html');
   });
 
+  it('keeps index.html when overwrite ownership is proven by the caller', () => {
+    expect(
+      resolveHtmlArtifactFileName({
+        baseName: 'index',
+        ext: '.html',
+        existingFileNames: new Set(['index.html']),
+        canOverwriteExistingEntry: true,
+      }),
+    ).toBe('index.html');
+  });
+
   it('keeps numbered collision names for non-entry html artifacts', () => {
     expect(
       resolveHtmlArtifactFileName({
@@ -35,6 +47,34 @@ describe('resolveHtmlArtifactFileName', () => {
         existingFileNames: new Set(['about.html', 'about-2.html']),
       }),
     ).toBe('about-3.html');
+  });
+});
+
+describe('canOverwriteHtmlArtifactEntry', () => {
+  it('allows index.html overwrite when the existing manifest identifier matches', () => {
+    expect(
+      canOverwriteHtmlArtifactEntry({
+        baseName: 'index',
+        ext: '.html',
+        projectFiles: [
+          htmlFile('index.html', 10, { artifactIdentifier: 'index' }),
+        ],
+        artifactIdentifier: 'index',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects index.html overwrite when the existing manifest identifier is empty', () => {
+    expect(
+      canOverwriteHtmlArtifactEntry({
+        baseName: 'index',
+        ext: '.html',
+        projectFiles: [
+          htmlFile('index.html', 10, { artifactIdentifier: '' }),
+        ],
+        artifactIdentifier: '',
+      }),
+    ).toBe(false);
   });
 });
 
@@ -62,12 +102,22 @@ describe('rewriteHtmlLinksToCurrentProjectFiles', () => {
   });
 });
 
-function htmlFile(name: string, mtime: number) {
+function htmlFile(
+  name: string,
+  mtime: number,
+  options: { artifactIdentifier?: string } = {},
+) {
   return {
     name,
     kind: 'html',
     mime: 'text/html',
     size: 1,
     mtime,
+    artifactManifest: options.artifactIdentifier !== undefined
+      ? {
+          entry: name,
+          metadata: { identifier: options.artifactIdentifier },
+        }
+      : undefined,
   };
 }

--- a/apps/web/tests/artifacts/html-links.test.ts
+++ b/apps/web/tests/artifacts/html-links.test.ts
@@ -51,7 +51,7 @@ describe('resolveHtmlArtifactFileName', () => {
 });
 
 describe('canOverwriteHtmlArtifactEntry', () => {
-  it('allows index.html overwrite when the existing manifest identifier matches', () => {
+  it('allows index.html overwrite when the saved artifact already owns it', () => {
     expect(
       canOverwriteHtmlArtifactEntry({
         baseName: 'index',
@@ -59,20 +59,22 @@ describe('canOverwriteHtmlArtifactEntry', () => {
         projectFiles: [
           htmlFile('index.html', 10, { artifactIdentifier: 'index' }),
         ],
-        artifactIdentifier: 'index',
+        savedArtifactName: 'index.html',
       }),
     ).toBe(true);
   });
 
-  it('rejects index.html overwrite when the existing manifest identifier is empty', () => {
+  it('rejects index.html overwrite when only the shared manifest identifier matches', () => {
     expect(
       canOverwriteHtmlArtifactEntry({
         baseName: 'index',
         ext: '.html',
         projectFiles: [
-          htmlFile('index.html', 10, { artifactIdentifier: '' }),
+          htmlFile('index.html', 10, {
+            artifactIdentifier: 'index',
+            artifactGroupIdentifier: 'site-a',
+          }),
         ],
-        artifactIdentifier: '',
       }),
     ).toBe(false);
   });

--- a/apps/web/tests/artifacts/html-links.test.ts
+++ b/apps/web/tests/artifacts/html-links.test.ts
@@ -89,11 +89,11 @@ describe('rewriteHtmlLinksToCurrentProjectFiles', () => {
       '</body></html>';
 
     const out = rewriteHtmlLinksToCurrentProjectFiles(html, [
-      htmlFile('about.html', 10, { artifactIdentifier: 'about' }),
-      htmlFile('about-2.html', 30, { artifactIdentifier: 'about' }),
-      htmlFile('contact.html', 20, { artifactIdentifier: 'contact' }),
-      htmlFile('contact-2.html', 40, { artifactIdentifier: 'contact' }),
-    ]);
+      htmlFile('about.html', 10, { artifactIdentifier: 'about', artifactGroupIdentifier: 'site-a' }),
+      htmlFile('about-2.html', 30, { artifactIdentifier: 'about', artifactGroupIdentifier: 'site-a' }),
+      htmlFile('contact.html', 20, { artifactIdentifier: 'contact', artifactGroupIdentifier: 'site-a' }),
+      htmlFile('contact-2.html', 40, { artifactIdentifier: 'contact', artifactGroupIdentifier: 'site-a' }),
+    ], { artifactGroupIdentifier: 'site-a' });
 
     expect(out).toContain('href="about-2.html"');
     expect(out).toContain('href="contact-2.html?tab=team#lead"');
@@ -109,9 +109,9 @@ describe('rewriteHtmlLinksToCurrentProjectFiles', () => {
       '</body></html>';
 
     const out = rewriteHtmlLinksToCurrentProjectFiles(html, [
-      htmlFile('index.html', 10, { artifactIdentifier: 'index' }),
-      htmlFile('index-2.html', 40, { artifactIdentifier: 'index' }),
-    ]);
+      htmlFile('index.html', 10, { artifactIdentifier: 'index', artifactGroupIdentifier: 'site-a' }),
+      htmlFile('index-2.html', 40, { artifactIdentifier: 'index', artifactGroupIdentifier: 'site-a' }),
+    ], { artifactGroupIdentifier: 'site-a' });
 
     expect(out).toContain('href="index-2.html"');
     expect(out).toContain('href="./index-2.html#top"');
@@ -124,9 +124,24 @@ describe('rewriteHtmlLinksToCurrentProjectFiles', () => {
       '</body></html>';
 
     const out = rewriteHtmlLinksToCurrentProjectFiles(html, [
-      htmlFile('about.html', 10, { artifactIdentifier: 'about' }),
-      htmlFile('about-2.html', 40, { artifactIdentifier: 'other-about' }),
-    ]);
+      htmlFile('about.html', 10, { artifactIdentifier: 'about', artifactGroupIdentifier: 'site-a' }),
+      htmlFile('about-2.html', 40, { artifactIdentifier: 'other-about', artifactGroupIdentifier: 'site-b' }),
+    ], { artifactGroupIdentifier: 'site-a' });
+
+    expect(out).toContain('href="about.html"');
+    expect(out).not.toContain('href="about-2.html"');
+  });
+
+  it('does not rewrite to another artifact group with the same page identifier', () => {
+    const html =
+      '<!doctype html><html><body>' +
+      '<a href="about.html">About</a>' +
+      '</body></html>';
+
+    const out = rewriteHtmlLinksToCurrentProjectFiles(html, [
+      htmlFile('about.html', 10, { artifactIdentifier: 'about', artifactGroupIdentifier: 'site-a' }),
+      htmlFile('about-2.html', 40, { artifactIdentifier: 'about', artifactGroupIdentifier: 'site-b' }),
+    ], { artifactGroupIdentifier: 'site-a' });
 
     expect(out).toContain('href="about.html"');
     expect(out).not.toContain('href="about-2.html"');
@@ -136,7 +151,7 @@ describe('rewriteHtmlLinksToCurrentProjectFiles', () => {
 function htmlFile(
   name: string,
   mtime: number,
-  options: { artifactIdentifier?: string } = {},
+  options: { artifactIdentifier?: string; artifactGroupIdentifier?: string } = {},
 ) {
   return {
     name,
@@ -147,7 +162,10 @@ function htmlFile(
     artifactManifest: options.artifactIdentifier !== undefined
       ? {
           entry: name,
-          metadata: { identifier: options.artifactIdentifier },
+          metadata: {
+            identifier: options.artifactIdentifier,
+            artifactGroupIdentifier: options.artifactGroupIdentifier,
+          },
         }
       : undefined,
   };

--- a/apps/web/tests/artifacts/html-links.test.ts
+++ b/apps/web/tests/artifacts/html-links.test.ts
@@ -6,14 +6,25 @@ import {
 } from '../../src/artifacts/html-links';
 
 describe('resolveHtmlArtifactFileName', () => {
-  it('keeps index.html as the stable entry point when it already exists', () => {
+  it('keeps index.html as the stable entry point when the saved artifact already owns it', () => {
+    expect(
+      resolveHtmlArtifactFileName({
+        baseName: 'index',
+        ext: '.html',
+        existingFileNames: new Set(['index.html']),
+        savedArtifactName: 'index.html',
+      }),
+    ).toBe('index.html');
+  });
+
+  it('uses a suffix for index.html when the existing file is unrelated', () => {
     expect(
       resolveHtmlArtifactFileName({
         baseName: 'index',
         ext: '.html',
         existingFileNames: new Set(['index.html']),
       }),
-    ).toBe('index.html');
+    ).toBe('index-2.html');
   });
 
   it('keeps numbered collision names for non-entry html artifacts', () => {

--- a/apps/web/tests/artifacts/parser.test.ts
+++ b/apps/web/tests/artifacts/parser.test.ts
@@ -26,6 +26,18 @@ describe('createArtifactParser', () => {
     expect(trailing).toContain('Done.');
   });
 
+  it('parses an optional artifact lineage token', () => {
+    const events = collect(
+      '<artifact identifier="hello" type="text/html" title="Hi" lineageToken="site-123">\n<h1>Hi</h1>\n</artifact>',
+    );
+    expect(events.find((e) => e.type === 'artifact:start')).toMatchObject({
+      identifier: 'hello',
+      artifactType: 'text/html',
+      title: 'Hi',
+      lineageToken: 'site-123',
+    });
+  });
+
   it('does not enter artifact mode for a tag inside inline backticks', () => {
     const events = collect(
       'To emit an artifact, wrap output in `<artifact identifier="x" type="text/html" title="X">` and continue writing normal prose afterwards.',

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -1067,6 +1067,81 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
+  it('reuses the relocated group when the same site adds new local links', async () => {
+    let currentFiles = [
+      htmlProjectFile('index.html', 10, {
+        artifactIdentifier: 'index',
+        artifactGroupIdentifier: 'site-a',
+      }),
+    ];
+    mockedFetchProjectFiles.mockImplementation(async () => {
+      return currentFiles as never;
+    });
+    mockedWriteProjectTextFile.mockImplementation(async (_projectId, fileName) => {
+      if (mockedWriteProjectTextFile.mock.calls.length === 1) {
+        currentFiles = [
+          htmlProjectFile('index-2.html', 50, {
+            artifactIdentifier: 'index',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+          htmlProjectFile('about-2.html', 60, {
+            artifactIdentifier: 'about',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+        ];
+      }
+      return htmlProjectFile(String(fileName), 70) as never;
+    });
+    const firstArtifact =
+      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    const secondArtifact =
+      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a><a href="pricing.html">Pricing</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    let turn = 0;
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      turn += 1;
+      handlers.onDelta(turn === 1 ? firstArtifact : secondArtifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.[1]).toBe('index-2.html');
+    await waitFor(() => {
+      expect(mockedFetchProjectFiles.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(2);
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about-2.html"');
+    expect(content).toContain('href="pricing.html"');
+    expect(content).not.toContain('href="pricing-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index-2.html',
+    );
+  });
+
   it('injects ElevenLabs voice options into API-mode audio project prompts', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -844,6 +844,80 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
+  it('does not reuse a prior relocated group for a different index artifact', async () => {
+    let currentFiles = [
+      htmlProjectFile('index.html', 10, {
+        artifactIdentifier: 'index',
+        artifactGroupIdentifier: 'site-a',
+      }),
+    ];
+    mockedFetchProjectFiles.mockImplementation(async () => {
+      return currentFiles as never;
+    });
+    mockedWriteProjectTextFile.mockImplementation(async (_projectId, fileName) => {
+      if (mockedWriteProjectTextFile.mock.calls.length === 1) {
+        currentFiles = [
+          htmlProjectFile('index-2.html', 50, {
+            artifactIdentifier: 'index',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+          htmlProjectFile('about-2.html', 60, {
+            artifactIdentifier: 'about',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+        ];
+      }
+      return htmlProjectFile(String(fileName), 70) as never;
+    });
+    const firstArtifact =
+      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    const secondArtifact =
+      '<artifact identifier="index" type="text/html" title="Different Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    let turn = 0;
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      turn += 1;
+      handlers.onDelta(turn === 1 ? firstArtifact : secondArtifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.[1]).toBe('index-2.html');
+    await waitFor(() => {
+      expect(mockedFetchProjectFiles.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(2);
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about.html"');
+    expect(content).not.toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index.html',
+    );
+  });
+
   it('injects ElevenLabs voice options into API-mode audio project prompts', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -779,6 +779,71 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
+  it('keeps the relocated artifact group when reclaiming index.html', async () => {
+    let currentFiles = [
+      htmlProjectFile('index.html', 10, {
+        artifactIdentifier: 'index',
+        artifactGroupIdentifier: 'site-a',
+      }),
+    ];
+    mockedFetchProjectFiles.mockImplementation(async () => {
+      return currentFiles as never;
+    });
+    mockedWriteProjectTextFile.mockImplementation(async (_projectId, fileName) => {
+      if (mockedWriteProjectTextFile.mock.calls.length === 1) {
+        currentFiles = [
+          htmlProjectFile('index-2.html', 50, {
+            artifactIdentifier: 'index',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+          htmlProjectFile('about-2.html', 60, {
+            artifactIdentifier: 'about',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+        ];
+      }
+      return htmlProjectFile(String(fileName), 70) as never;
+    });
+    const artifact =
+      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDelta(artifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.[1]).toBe('index-2.html');
+    await waitFor(() => {
+      expect(mockedFetchProjectFiles.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(2);
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index-2.html',
+    );
+  });
+
   it('injects ElevenLabs voice options into API-mode audio project prompts', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -1154,6 +1154,83 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
+  it('does not reuse a prior relocated group when an unrelated no-token site shares only one title signal', async () => {
+    const lineageToken = 'lineage-tokenless-one-title-signal-original';
+    let currentFiles = [
+      htmlProjectFile('index.html', 10, {
+        artifactIdentifier: 'index',
+        artifactGroupIdentifier: 'site-a',
+      }),
+    ];
+    mockedFetchProjectFiles.mockImplementation(async () => {
+      return currentFiles as never;
+    });
+    mockedWriteProjectTextFile.mockImplementation(async (_projectId, fileName) => {
+      if (mockedWriteProjectTextFile.mock.calls.length === 1) {
+        currentFiles = [
+          htmlProjectFile('index-2.html', 50, {
+            artifactIdentifier: 'index',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
+          }),
+          htmlProjectFile('about-2.html', 60, {
+            artifactIdentifier: 'about',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
+          }),
+        ];
+      }
+      return htmlProjectFile(String(fileName), 70) as never;
+    });
+    const firstArtifact =
+      `<artifact identifier="index" type="text/html" title="Home" lineageToken="${lineageToken}">` +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    const secondArtifact =
+      '<artifact identifier="index" type="text/html" title="Different Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Different Site</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    let turn = 0;
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      turn += 1;
+      handlers.onDelta(turn === 1 ? firstArtifact : secondArtifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.[1]).toBe('index-2.html');
+    await waitFor(() => {
+      expect(mockedFetchProjectFiles.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(2);
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about.html"');
+    expect(content).not.toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index.html',
+    );
+  });
+
   it('does not reuse a prior relocated group when an explicit lineage token changes', async () => {
     const originalLineageToken = 'lineage-explicit-original-site';
     const nextLineageToken = 'lineage-explicit-different-site';

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -918,6 +918,80 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
+  it('does not reuse an unrelated relocated group when a new artifact has the same identifier and title', async () => {
+    let currentFiles = [
+      htmlProjectFile('index.html', 10, {
+        artifactIdentifier: 'index',
+        artifactGroupIdentifier: 'site-a',
+      }),
+    ];
+    mockedFetchProjectFiles.mockImplementation(async () => {
+      return currentFiles as never;
+    });
+    mockedWriteProjectTextFile.mockImplementation(async (_projectId, fileName) => {
+      if (mockedWriteProjectTextFile.mock.calls.length === 1) {
+        currentFiles = [
+          htmlProjectFile('index-2.html', 50, {
+            artifactIdentifier: 'index',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+          htmlProjectFile('about-2.html', 60, {
+            artifactIdentifier: 'about',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+        ];
+      }
+      return htmlProjectFile(String(fileName), 70) as never;
+    });
+    const firstArtifact =
+      '<artifact identifier="index" type="text/html" title="Home">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    const secondArtifact =
+      '<artifact identifier="index" type="text/html" title="Home">' +
+      '<!doctype html><html><head><title>Different Home</title></head><body>' +
+      '<main><h1>Different Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    let turn = 0;
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      turn += 1;
+      handlers.onDelta(turn === 1 ? firstArtifact : secondArtifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.[1]).toBe('index-2.html');
+    await waitFor(() => {
+      expect(mockedFetchProjectFiles.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(2);
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about.html"');
+    expect(content).not.toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index.html',
+    );
+  });
+
   it('injects ElevenLabs voice options into API-mode audio project prompts', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -992,6 +992,81 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
+  it('reuses the relocated group when the same site content changes across turns', async () => {
+    let currentFiles = [
+      htmlProjectFile('index.html', 10, {
+        artifactIdentifier: 'index',
+        artifactGroupIdentifier: 'site-a',
+      }),
+    ];
+    mockedFetchProjectFiles.mockImplementation(async () => {
+      return currentFiles as never;
+    });
+    mockedWriteProjectTextFile.mockImplementation(async (_projectId, fileName) => {
+      if (mockedWriteProjectTextFile.mock.calls.length === 1) {
+        currentFiles = [
+          htmlProjectFile('index-2.html', 50, {
+            artifactIdentifier: 'index',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+          htmlProjectFile('about-2.html', 60, {
+            artifactIdentifier: 'about',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+        ];
+      }
+      return htmlProjectFile(String(fileName), 70) as never;
+    });
+    const firstArtifact =
+      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    const secondArtifact =
+      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Updated Home Content</h1><p>New paragraph</p><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    let turn = 0;
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      turn += 1;
+      handlers.onDelta(turn === 1 ? firstArtifact : secondArtifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.[1]).toBe('index-2.html');
+    await waitFor(() => {
+      expect(mockedFetchProjectFiles.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(2);
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('Updated Home Content');
+    expect(content).toContain('New paragraph');
+    expect(content).toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index-2.html',
+    );
+  });
+
   it('injects ElevenLabs voice options into API-mode audio project prompts', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -847,7 +847,7 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
-  it('reuses the relocated group when the artifact wrapper title changes', async () => {
+  it('reuses the relocated group when the artifact wrapper title changes without a returned lineage token', async () => {
     const lineageToken = 'lineage-wrapper-title-change';
     let currentFiles = [
       htmlProjectFile('index.html', 10, {
@@ -882,7 +882,7 @@ describe('ProjectView API empty response handling', () => {
       '</body></html>' +
       '</artifact>';
     const secondArtifact =
-      `<artifact identifier="index" type="text/html" title="Different Site" lineageToken="${lineageToken}">` +
+      '<artifact identifier="index" type="text/html" title="Different Site">' +
       '<!doctype html><html><head><title>Home</title></head><body>' +
       '<main><h1>Home</h1><a href="about.html">About</a></main>' +
       '</body></html>' +
@@ -923,7 +923,7 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
-  it('reuses the relocated group when the document title changes', async () => {
+  it('reuses the relocated group when the document title changes without a returned lineage token', async () => {
     const lineageToken = 'lineage-document-title-change';
     let currentFiles = [
       htmlProjectFile('index.html', 10, {
@@ -958,7 +958,7 @@ describe('ProjectView API empty response handling', () => {
       '</body></html>' +
       '</artifact>';
     const secondArtifact =
-      `<artifact identifier="index" type="text/html" title="Home" lineageToken="${lineageToken}">` +
+      '<artifact identifier="index" type="text/html" title="Home">' +
       '<!doctype html><html><head><title>Pricing</title></head><body>' +
       '<main><h1>Pricing</h1><a href="about.html">About</a></main>' +
       '</body></html>' +

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -991,6 +991,80 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
+  it('does not reuse a prior relocated group for a different index site', async () => {
+    let currentFiles = [
+      htmlProjectFile('index.html', 10, {
+        artifactIdentifier: 'index',
+        artifactGroupIdentifier: 'site-a',
+      }),
+    ];
+    mockedFetchProjectFiles.mockImplementation(async () => {
+      return currentFiles as never;
+    });
+    mockedWriteProjectTextFile.mockImplementation(async (_projectId, fileName) => {
+      if (mockedWriteProjectTextFile.mock.calls.length === 1) {
+        currentFiles = [
+          htmlProjectFile('index-2.html', 50, {
+            artifactIdentifier: 'index',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+          htmlProjectFile('about-2.html', 60, {
+            artifactIdentifier: 'about',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+          }),
+        ];
+      }
+      return htmlProjectFile(String(fileName), 70) as never;
+    });
+    const firstArtifact =
+      '<artifact identifier="index" type="text/html" title="Home">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    const secondArtifact =
+      '<artifact identifier="index" type="text/html" title="Different Site">' +
+      '<!doctype html><html><head><title>Different Home</title></head><body>' +
+      '<main><h1>Different Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    let turn = 0;
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      turn += 1;
+      handlers.onDelta(turn === 1 ? firstArtifact : secondArtifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.[1]).toBe('index-2.html');
+    await waitFor(() => {
+      expect(mockedFetchProjectFiles.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(2);
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about.html"');
+    expect(content).not.toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index.html',
+    );
+  });
+
   it('reuses the relocated group when the same site content changes across turns', async () => {
     let currentFiles = [
       htmlProjectFile('index.html', 10, {

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -844,7 +844,7 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
-  it('does not reuse a prior relocated group for a different index artifact', async () => {
+  it('reuses the relocated group when the artifact wrapper title changes', async () => {
     let currentFiles = [
       htmlProjectFile('index.html', 10, {
         artifactIdentifier: 'index',
@@ -911,14 +911,13 @@ describe('ProjectView API empty response handling', () => {
     });
     const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
     expect(fileName).toBe('index.html');
-    expect(content).toContain('href="about.html"');
-    expect(content).not.toContain('href="about-2.html"');
+    expect(content).toContain('href="about-2.html"');
     expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
-      'html-artifact:index.html',
+      'html-artifact:index-2.html',
     );
   });
 
-  it('does not reuse an unrelated relocated group when a new artifact has the same identifier and title', async () => {
+  it('reuses the relocated group when the document title changes', async () => {
     let currentFiles = [
       htmlProjectFile('index.html', 10, {
         artifactIdentifier: 'index',
@@ -951,8 +950,8 @@ describe('ProjectView API empty response handling', () => {
       '</artifact>';
     const secondArtifact =
       '<artifact identifier="index" type="text/html" title="Home">' +
-      '<!doctype html><html><head><title>Different Home</title></head><body>' +
-      '<main><h1>Different Home</h1><a href="about.html">About</a></main>' +
+      '<!doctype html><html><head><title>Pricing</title></head><body>' +
+      '<main><h1>Pricing</h1><a href="about.html">About</a></main>' +
       '</body></html>' +
       '</artifact>';
     let turn = 0;
@@ -985,10 +984,10 @@ describe('ProjectView API empty response handling', () => {
     });
     const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
     expect(fileName).toBe('index.html');
-    expect(content).toContain('href="about.html"');
-    expect(content).not.toContain('href="about-2.html"');
+    expect(content).toContain('<title>Pricing</title>');
+    expect(content).toContain('href="about-2.html"');
     expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
-      'html-artifact:index.html',
+      'html-artifact:index-2.html',
     );
   });
 

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -780,6 +780,7 @@ describe('ProjectView API empty response handling', () => {
   });
 
   it('keeps the relocated artifact group when reclaiming index.html', async () => {
+    const lineageToken = 'lineage-relocated-reclaim';
     let currentFiles = [
       htmlProjectFile('index.html', 10, {
         artifactIdentifier: 'index',
@@ -795,17 +796,19 @@ describe('ProjectView API empty response handling', () => {
           htmlProjectFile('index-2.html', 50, {
             artifactIdentifier: 'index',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
           htmlProjectFile('about-2.html', 60, {
             artifactIdentifier: 'about',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
         ];
       }
       return htmlProjectFile(String(fileName), 70) as never;
     });
     const artifact =
-      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      `<artifact identifier="index" type="text/html" title="Relocated Site" lineageToken="${lineageToken}">` +
       '<!doctype html><html><head><title>Home</title></head><body>' +
       '<main><h1>Home</h1><a href="about.html">About</a></main>' +
       '</body></html>' +
@@ -845,6 +848,7 @@ describe('ProjectView API empty response handling', () => {
   });
 
   it('reuses the relocated group when the artifact wrapper title changes', async () => {
+    const lineageToken = 'lineage-wrapper-title-change';
     let currentFiles = [
       htmlProjectFile('index.html', 10, {
         artifactIdentifier: 'index',
@@ -860,23 +864,25 @@ describe('ProjectView API empty response handling', () => {
           htmlProjectFile('index-2.html', 50, {
             artifactIdentifier: 'index',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
           htmlProjectFile('about-2.html', 60, {
             artifactIdentifier: 'about',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
         ];
       }
       return htmlProjectFile(String(fileName), 70) as never;
     });
     const firstArtifact =
-      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      `<artifact identifier="index" type="text/html" title="Relocated Site" lineageToken="${lineageToken}">` +
       '<!doctype html><html><head><title>Home</title></head><body>' +
       '<main><h1>Home</h1><a href="about.html">About</a></main>' +
       '</body></html>' +
       '</artifact>';
     const secondArtifact =
-      '<artifact identifier="index" type="text/html" title="Different Site">' +
+      `<artifact identifier="index" type="text/html" title="Different Site" lineageToken="${lineageToken}">` +
       '<!doctype html><html><head><title>Home</title></head><body>' +
       '<main><h1>Home</h1><a href="about.html">About</a></main>' +
       '</body></html>' +
@@ -918,6 +924,7 @@ describe('ProjectView API empty response handling', () => {
   });
 
   it('reuses the relocated group when the document title changes', async () => {
+    const lineageToken = 'lineage-document-title-change';
     let currentFiles = [
       htmlProjectFile('index.html', 10, {
         artifactIdentifier: 'index',
@@ -933,23 +940,25 @@ describe('ProjectView API empty response handling', () => {
           htmlProjectFile('index-2.html', 50, {
             artifactIdentifier: 'index',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
           htmlProjectFile('about-2.html', 60, {
             artifactIdentifier: 'about',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
         ];
       }
       return htmlProjectFile(String(fileName), 70) as never;
     });
     const firstArtifact =
-      '<artifact identifier="index" type="text/html" title="Home">' +
+      `<artifact identifier="index" type="text/html" title="Home" lineageToken="${lineageToken}">` +
       '<!doctype html><html><head><title>Home</title></head><body>' +
       '<main><h1>Home</h1><a href="about.html">About</a></main>' +
       '</body></html>' +
       '</artifact>';
     const secondArtifact =
-      '<artifact identifier="index" type="text/html" title="Home">' +
+      `<artifact identifier="index" type="text/html" title="Home" lineageToken="${lineageToken}">` +
       '<!doctype html><html><head><title>Pricing</title></head><body>' +
       '<main><h1>Pricing</h1><a href="about.html">About</a></main>' +
       '</body></html>' +
@@ -992,6 +1001,7 @@ describe('ProjectView API empty response handling', () => {
   });
 
   it('does not reuse a prior relocated group for a different index site', async () => {
+    const lineageToken = 'lineage-original-site';
     let currentFiles = [
       htmlProjectFile('index.html', 10, {
         artifactIdentifier: 'index',
@@ -1007,17 +1017,19 @@ describe('ProjectView API empty response handling', () => {
           htmlProjectFile('index-2.html', 50, {
             artifactIdentifier: 'index',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
           htmlProjectFile('about-2.html', 60, {
             artifactIdentifier: 'about',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
         ];
       }
       return htmlProjectFile(String(fileName), 70) as never;
     });
     const firstArtifact =
-      '<artifact identifier="index" type="text/html" title="Home">' +
+      `<artifact identifier="index" type="text/html" title="Home" lineageToken="${lineageToken}">` +
       '<!doctype html><html><head><title>Home</title></head><body>' +
       '<main><h1>Home</h1><a href="about.html">About</a></main>' +
       '</body></html>' +
@@ -1065,7 +1077,8 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
-  it('reuses the relocated group when the same site content changes across turns', async () => {
+  it('does not reuse a prior relocated group when an unrelated site shares only one title signal', async () => {
+    const lineageToken = 'lineage-one-title-signal-original';
     let currentFiles = [
       htmlProjectFile('index.html', 10, {
         artifactIdentifier: 'index',
@@ -1081,23 +1094,181 @@ describe('ProjectView API empty response handling', () => {
           htmlProjectFile('index-2.html', 50, {
             artifactIdentifier: 'index',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
           htmlProjectFile('about-2.html', 60, {
             artifactIdentifier: 'about',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
         ];
       }
       return htmlProjectFile(String(fileName), 70) as never;
     });
     const firstArtifact =
-      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      `<artifact identifier="index" type="text/html" title="Home" lineageToken="${lineageToken}">` +
       '<!doctype html><html><head><title>Home</title></head><body>' +
       '<main><h1>Home</h1><a href="about.html">About</a></main>' +
       '</body></html>' +
       '</artifact>';
     const secondArtifact =
-      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      '<artifact identifier="index" type="text/html" title="Different Site" lineageToken="lineage-different-site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Different Site</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    let turn = 0;
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      turn += 1;
+      handlers.onDelta(turn === 1 ? firstArtifact : secondArtifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.[1]).toBe('index-2.html');
+    await waitFor(() => {
+      expect(mockedFetchProjectFiles.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(2);
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about.html"');
+    expect(content).not.toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index.html',
+    );
+  });
+
+  it('does not reuse a prior relocated group when an explicit lineage token changes', async () => {
+    const originalLineageToken = 'lineage-explicit-original-site';
+    const nextLineageToken = 'lineage-explicit-different-site';
+    let currentFiles = [
+      htmlProjectFile('index.html', 10, {
+        artifactIdentifier: 'index',
+        artifactGroupIdentifier: 'site-a',
+      }),
+    ];
+    mockedFetchProjectFiles.mockImplementation(async () => {
+      return currentFiles as never;
+    });
+    mockedWriteProjectTextFile.mockImplementation(async (_projectId, fileName) => {
+      if (mockedWriteProjectTextFile.mock.calls.length === 1) {
+        currentFiles = [
+          htmlProjectFile('index-2.html', 50, {
+            artifactIdentifier: 'index',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: originalLineageToken,
+          }),
+          htmlProjectFile('about-2.html', 60, {
+            artifactIdentifier: 'about',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: originalLineageToken,
+          }),
+        ];
+      }
+      return htmlProjectFile(String(fileName), 70) as never;
+    });
+    const firstArtifact =
+      `<artifact identifier="index" type="text/html" title="Home" lineageToken="${originalLineageToken}">` +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    const secondArtifact =
+      `<artifact identifier="index" type="text/html" title="Home" lineageToken="${nextLineageToken}">` +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Different Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    let turn = 0;
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      turn += 1;
+      handlers.onDelta(turn === 1 ? firstArtifact : secondArtifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1);
+    });
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.[1]).toBe('index-2.html');
+    await waitFor(() => {
+      expect(mockedFetchProjectFiles.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'send' }));
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(2);
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about.html"');
+    expect(content).not.toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index.html',
+    );
+    expect(options?.artifactManifest?.metadata?.artifactLineageToken).toBe(nextLineageToken);
+  });
+
+  it('reuses the relocated group when the same site content changes across turns', async () => {
+    const lineageToken = 'lineage-same-site-content-change';
+    let currentFiles = [
+      htmlProjectFile('index.html', 10, {
+        artifactIdentifier: 'index',
+        artifactGroupIdentifier: 'site-a',
+      }),
+    ];
+    mockedFetchProjectFiles.mockImplementation(async () => {
+      return currentFiles as never;
+    });
+    mockedWriteProjectTextFile.mockImplementation(async (_projectId, fileName) => {
+      if (mockedWriteProjectTextFile.mock.calls.length === 1) {
+        currentFiles = [
+          htmlProjectFile('index-2.html', 50, {
+            artifactIdentifier: 'index',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
+          }),
+          htmlProjectFile('about-2.html', 60, {
+            artifactIdentifier: 'about',
+            artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
+          }),
+        ];
+      }
+      return htmlProjectFile(String(fileName), 70) as never;
+    });
+    const firstArtifact =
+      `<artifact identifier="index" type="text/html" title="Relocated Site" lineageToken="${lineageToken}">` +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    const secondArtifact =
+      `<artifact identifier="index" type="text/html" title="Relocated Site" lineageToken="${lineageToken}">` +
       '<!doctype html><html><head><title>Home</title></head><body>' +
       '<main><h1>Updated Home Content</h1><p>New paragraph</p><a href="about.html">About</a></main>' +
       '</body></html>' +
@@ -1141,6 +1312,7 @@ describe('ProjectView API empty response handling', () => {
   });
 
   it('reuses the relocated group when the same site adds new local links', async () => {
+    const lineageToken = 'lineage-same-site-new-link';
     let currentFiles = [
       htmlProjectFile('index.html', 10, {
         artifactIdentifier: 'index',
@@ -1156,23 +1328,25 @@ describe('ProjectView API empty response handling', () => {
           htmlProjectFile('index-2.html', 50, {
             artifactIdentifier: 'index',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
           htmlProjectFile('about-2.html', 60, {
             artifactIdentifier: 'about',
             artifactGroupIdentifier: 'html-artifact:index-2.html',
+            artifactLineageToken: lineageToken,
           }),
         ];
       }
       return htmlProjectFile(String(fileName), 70) as never;
     });
     const firstArtifact =
-      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      `<artifact identifier="index" type="text/html" title="Relocated Site" lineageToken="${lineageToken}">` +
       '<!doctype html><html><head><title>Home</title></head><body>' +
       '<main><h1>Home</h1><a href="about.html">About</a></main>' +
       '</body></html>' +
       '</artifact>';
     const secondArtifact =
-      '<artifact identifier="index" type="text/html" title="Relocated Site">' +
+      `<artifact identifier="index" type="text/html" title="Relocated Site" lineageToken="${lineageToken}">` +
       '<!doctype html><html><head><title>Home</title></head><body>' +
       '<main><h1>Home</h1><a href="about.html">About</a><a href="pricing.html">Pricing</a></main>' +
       '</body></html>' +
@@ -1354,7 +1528,11 @@ function hasSavedAssistantMessage(predicate: (message: ChatMessage) => boolean):
 function htmlProjectFile(
   name: string,
   mtime: number,
-  options: { artifactIdentifier?: string; artifactGroupIdentifier?: string } = {},
+  options: {
+    artifactIdentifier?: string;
+    artifactGroupIdentifier?: string;
+    artifactLineageToken?: string;
+  } = {},
 ) {
   return {
     name,
@@ -1376,6 +1554,7 @@ function htmlProjectFile(
           metadata: {
             identifier: options.artifactIdentifier,
             artifactGroupIdentifier: options.artifactGroupIdentifier,
+            artifactLineageToken: options.artifactLineageToken,
           },
         }
       : undefined,

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -561,8 +561,8 @@ describe('ProjectView API empty response handling', () => {
   it('keeps regenerated multipage artifact entry at index.html and rewrites child links', async () => {
     mockedFetchProjectFiles.mockResolvedValue([
       htmlProjectFile('index.html', 10, { artifactIdentifier: 'index' }),
-      htmlProjectFile('about.html', 20),
-      htmlProjectFile('about-2.html', 40),
+      htmlProjectFile('about.html', 20, { artifactIdentifier: 'about' }),
+      htmlProjectFile('about-2.html', 40, { artifactIdentifier: 'about' }),
     ] as never);
     mockedWriteProjectTextFile.mockResolvedValue(htmlProjectFile('index.html', 50) as never);
     const artifact =
@@ -596,8 +596,8 @@ describe('ProjectView API empty response handling', () => {
   it('does not overwrite an unrelated existing index.html when saving a multipage artifact', async () => {
     mockedFetchProjectFiles.mockResolvedValue([
       htmlProjectFile('index.html', 10),
-      htmlProjectFile('about.html', 20),
-      htmlProjectFile('about-2.html', 40),
+      htmlProjectFile('about.html', 20, { artifactIdentifier: 'about' }),
+      htmlProjectFile('about-2.html', 40, { artifactIdentifier: 'about' }),
     ] as never);
     mockedWriteProjectTextFile.mockResolvedValue(htmlProjectFile('index-2.html', 50) as never);
     const artifact =

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -729,6 +729,52 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
+  it('does not inherit a grouped site when regenerating a legacy index owner', async () => {
+    mockedFetchProjectFiles.mockResolvedValue([
+      htmlProjectFile('index.html', 10, { artifactIdentifier: 'index' }),
+      htmlProjectFile('about.html', 20, { artifactIdentifier: 'about' }),
+      htmlProjectFile('index-2.html', 50, {
+        artifactIdentifier: 'index',
+        artifactGroupIdentifier: 'site-b',
+      }),
+      htmlProjectFile('about-2.html', 60, {
+        artifactIdentifier: 'about',
+        artifactGroupIdentifier: 'site-b',
+      }),
+    ] as never);
+    mockedWriteProjectTextFile.mockResolvedValue(htmlProjectFile('index.html', 70) as never);
+    const artifact =
+      '<artifact identifier="index" type="text/html" title="Legacy Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDelta(artifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalled();
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about.html"');
+    expect(content).not.toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index.html',
+    );
+  });
+
   it('injects ElevenLabs voice options into API-mode audio project prompts', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -643,6 +643,44 @@ describe('ProjectView API empty response handling', () => {
     expect(content).toContain('href="about-2.html"');
   });
 
+  it('rewrites child links for legacy multipage artifacts without group metadata', async () => {
+    mockedFetchProjectFiles.mockResolvedValue([
+      htmlProjectFile('index.html', 10, { artifactIdentifier: 'index' }),
+      htmlProjectFile('about.html', 20, { artifactIdentifier: 'about' }),
+      htmlProjectFile('about-2.html', 40, { artifactIdentifier: 'about' }),
+    ] as never);
+    mockedWriteProjectTextFile.mockResolvedValue(htmlProjectFile('index.html', 50) as never);
+    const artifact =
+      '<artifact identifier="index" type="text/html" title="Multipage Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDelta(artifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalled();
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index.html',
+    );
+  });
+
   it('injects ElevenLabs voice options into API-mode audio project prompts', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -558,6 +558,41 @@ describe('ProjectView API empty response handling', () => {
     expect(screen.queryByText(/Refused to save artifact/i)).toBeNull();
   });
 
+  it('keeps regenerated multipage artifact entry at index.html and rewrites child links', async () => {
+    mockedFetchProjectFiles.mockResolvedValue([
+      htmlProjectFile('index.html', 10),
+      htmlProjectFile('about.html', 20),
+      htmlProjectFile('about-2.html', 40),
+    ] as never);
+    mockedWriteProjectTextFile.mockResolvedValue(htmlProjectFile('index.html', 50) as never);
+    const artifact =
+      '<artifact identifier="index" type="text/html" title="Multipage Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDelta(artifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalled();
+    });
+    const [, fileName, content] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about-2.html"');
+  });
+
   it('injects ElevenLabs voice options into API-mode audio project prompts', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
@@ -692,4 +727,15 @@ function hasSavedAssistantMessage(predicate: (message: ChatMessage) => boolean):
     const message = call[2] as ChatMessage;
     return message.role === 'assistant' && predicate(message);
   });
+}
+
+function htmlProjectFile(name: string, mtime: number) {
+  return {
+    name,
+    path: name,
+    kind: 'html',
+    mime: 'text/html',
+    size: 1,
+    mtime,
+  };
 }

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -560,7 +560,7 @@ describe('ProjectView API empty response handling', () => {
 
   it('keeps regenerated multipage artifact entry at index.html and rewrites child links', async () => {
     mockedFetchProjectFiles.mockResolvedValue([
-      htmlProjectFile('index.html', 10),
+      htmlProjectFile('index.html', 10, { artifactIdentifier: 'index' }),
       htmlProjectFile('about.html', 20),
       htmlProjectFile('about-2.html', 40),
     ] as never);
@@ -590,6 +590,41 @@ describe('ProjectView API empty response handling', () => {
     });
     const [, fileName, content] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
     expect(fileName).toBe('index.html');
+    expect(content).toContain('href="about-2.html"');
+  });
+
+  it('does not overwrite an unrelated existing index.html when saving a multipage artifact', async () => {
+    mockedFetchProjectFiles.mockResolvedValue([
+      htmlProjectFile('index.html', 10),
+      htmlProjectFile('about.html', 20),
+      htmlProjectFile('about-2.html', 40),
+    ] as never);
+    mockedWriteProjectTextFile.mockResolvedValue(htmlProjectFile('index-2.html', 50) as never);
+    const artifact =
+      '<artifact identifier="index" type="text/html" title="Multipage Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDelta(artifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalled();
+    });
+    const [, fileName, content] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index-2.html');
     expect(content).toContain('href="about-2.html"');
   });
 
@@ -729,7 +764,11 @@ function hasSavedAssistantMessage(predicate: (message: ChatMessage) => boolean):
   });
 }
 
-function htmlProjectFile(name: string, mtime: number) {
+function htmlProjectFile(
+  name: string,
+  mtime: number,
+  options: { artifactIdentifier?: string } = {},
+) {
   return {
     name,
     path: name,
@@ -737,5 +776,18 @@ function htmlProjectFile(name: string, mtime: number) {
     mime: 'text/html',
     size: 1,
     mtime,
+    artifactManifest: options.artifactIdentifier
+      ? {
+          version: 1,
+          kind: 'html',
+          title: name,
+          entry: name,
+          renderer: 'html',
+          status: 'complete',
+          exports: ['html'],
+          primary: true,
+          metadata: { identifier: options.artifactIdentifier },
+        }
+      : undefined,
   };
 }

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -560,9 +560,18 @@ describe('ProjectView API empty response handling', () => {
 
   it('keeps regenerated multipage artifact entry at index.html and rewrites child links', async () => {
     mockedFetchProjectFiles.mockResolvedValue([
-      htmlProjectFile('index.html', 10, { artifactIdentifier: 'index' }),
-      htmlProjectFile('about.html', 20, { artifactIdentifier: 'about' }),
-      htmlProjectFile('about-2.html', 40, { artifactIdentifier: 'about' }),
+      htmlProjectFile('index.html', 10, {
+        artifactIdentifier: 'index',
+        artifactGroupIdentifier: 'site-a',
+      }),
+      htmlProjectFile('about.html', 20, {
+        artifactIdentifier: 'about',
+        artifactGroupIdentifier: 'site-a',
+      }),
+      htmlProjectFile('about-2.html', 40, {
+        artifactIdentifier: 'about',
+        artifactGroupIdentifier: 'site-a',
+      }),
     ] as never);
     mockedWriteProjectTextFile.mockResolvedValue(htmlProjectFile('index.html', 50) as never);
     const artifact =
@@ -596,8 +605,14 @@ describe('ProjectView API empty response handling', () => {
   it('does not overwrite an unrelated existing index.html when saving a multipage artifact', async () => {
     mockedFetchProjectFiles.mockResolvedValue([
       htmlProjectFile('index.html', 10),
-      htmlProjectFile('about.html', 20, { artifactIdentifier: 'about' }),
-      htmlProjectFile('about-2.html', 40, { artifactIdentifier: 'about' }),
+      htmlProjectFile('about.html', 20, {
+        artifactIdentifier: 'about',
+        artifactGroupIdentifier: 'html-artifact:index-2.html',
+      }),
+      htmlProjectFile('about-2.html', 40, {
+        artifactIdentifier: 'about',
+        artifactGroupIdentifier: 'html-artifact:index-2.html',
+      }),
     ] as never);
     mockedWriteProjectTextFile.mockResolvedValue(htmlProjectFile('index-2.html', 50) as never);
     const artifact =
@@ -767,7 +782,7 @@ function hasSavedAssistantMessage(predicate: (message: ChatMessage) => boolean):
 function htmlProjectFile(
   name: string,
   mtime: number,
-  options: { artifactIdentifier?: string } = {},
+  options: { artifactIdentifier?: string; artifactGroupIdentifier?: string } = {},
 ) {
   return {
     name,
@@ -786,7 +801,10 @@ function htmlProjectFile(
           status: 'complete',
           exports: ['html'],
           primary: true,
-          metadata: { identifier: options.artifactIdentifier },
+          metadata: {
+            identifier: options.artifactIdentifier,
+            artifactGroupIdentifier: options.artifactGroupIdentifier,
+          },
         }
       : undefined,
   };

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -643,6 +643,54 @@ describe('ProjectView API empty response handling', () => {
     expect(content).toContain('href="about-2.html"');
   });
 
+  it('starts a fresh group when a new index artifact is relocated away from an existing owner', async () => {
+    mockedFetchProjectFiles.mockResolvedValue([
+      htmlProjectFile('index.html', 10, {
+        artifactIdentifier: 'Index',
+        artifactGroupIdentifier: 'site-a',
+      }),
+      htmlProjectFile('about.html', 20, {
+        artifactIdentifier: 'about',
+        artifactGroupIdentifier: 'site-a',
+      }),
+      htmlProjectFile('about-2.html', 40, {
+        artifactIdentifier: 'about',
+        artifactGroupIdentifier: 'site-a',
+      }),
+    ] as never);
+    mockedWriteProjectTextFile.mockResolvedValue(htmlProjectFile('index-2.html', 50) as never);
+    const artifact =
+      '<artifact identifier="index" type="text/html" title="Multipage Site">' +
+      '<!doctype html><html><head><title>Home</title></head><body>' +
+      '<main><h1>Home</h1><a href="about.html">About</a></main>' +
+      '</body></html>' +
+      '</artifact>';
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDelta(artifact);
+      handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => {
+      expect(mockedWriteProjectTextFile).toHaveBeenCalled();
+    });
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index-2.html');
+    expect(content).toContain('href="about.html"');
+    expect(content).not.toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index-2.html',
+    );
+  });
+
   it('rewrites child links for legacy multipage artifacts without group metadata', async () => {
     mockedFetchProjectFiles.mockResolvedValue([
       htmlProjectFile('index.html', 10, { artifactIdentifier: 'index' }),

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -558,7 +558,7 @@ describe('ProjectView API empty response handling', () => {
     expect(screen.queryByText(/Refused to save artifact/i)).toBeNull();
   });
 
-  it('keeps regenerated multipage artifact entry at index.html and rewrites child links', async () => {
+  it('relocates a new multipage artifact away from an existing grouped index owner', async () => {
     mockedFetchProjectFiles.mockResolvedValue([
       htmlProjectFile('index.html', 10, {
         artifactIdentifier: 'index',
@@ -597,9 +597,13 @@ describe('ProjectView API empty response handling', () => {
     await waitFor(() => {
       expect(mockedWriteProjectTextFile).toHaveBeenCalled();
     });
-    const [, fileName, content] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
-    expect(fileName).toBe('index.html');
-    expect(content).toContain('href="about-2.html"');
+    const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
+    expect(fileName).toBe('index-2.html');
+    expect(content).toContain('href="about.html"');
+    expect(content).not.toContain('href="about-2.html"');
+    expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
+      'html-artifact:index-2.html',
+    );
   });
 
   it('does not overwrite an unrelated existing index.html when saving a multipage artifact', async () => {
@@ -646,7 +650,7 @@ describe('ProjectView API empty response handling', () => {
   it('starts a fresh group when a new index artifact is relocated away from an existing owner', async () => {
     mockedFetchProjectFiles.mockResolvedValue([
       htmlProjectFile('index.html', 10, {
-        artifactIdentifier: 'Index',
+        artifactIdentifier: 'index',
         artifactGroupIdentifier: 'site-a',
       }),
       htmlProjectFile('about.html', 20, {
@@ -691,7 +695,7 @@ describe('ProjectView API empty response handling', () => {
     );
   });
 
-  it('rewrites child links for legacy multipage artifacts without group metadata', async () => {
+  it('relocates legacy multipage artifacts without group metadata and rewrites child links', async () => {
     mockedFetchProjectFiles.mockResolvedValue([
       htmlProjectFile('index.html', 10, { artifactIdentifier: 'index' }),
       htmlProjectFile('about.html', 20, { artifactIdentifier: 'about' }),
@@ -722,14 +726,14 @@ describe('ProjectView API empty response handling', () => {
       expect(mockedWriteProjectTextFile).toHaveBeenCalled();
     });
     const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
-    expect(fileName).toBe('index.html');
+    expect(fileName).toBe('index-2.html');
     expect(content).toContain('href="about-2.html"');
     expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
-      'html-artifact:index.html',
+      'html-artifact:index-2.html',
     );
   });
 
-  it('does not inherit a grouped site when regenerating a legacy index owner', async () => {
+  it('does not inherit a grouped site when an existing legacy index also collides', async () => {
     mockedFetchProjectFiles.mockResolvedValue([
       htmlProjectFile('index.html', 10, { artifactIdentifier: 'index' }),
       htmlProjectFile('about.html', 20, { artifactIdentifier: 'about' }),
@@ -767,11 +771,11 @@ describe('ProjectView API empty response handling', () => {
       expect(mockedWriteProjectTextFile).toHaveBeenCalled();
     });
     const [, fileName, content, options] = mockedWriteProjectTextFile.mock.calls.at(-1) ?? [];
-    expect(fileName).toBe('index.html');
+    expect(fileName).toBe('index-3.html');
     expect(content).toContain('href="about.html"');
     expect(content).not.toContain('href="about-2.html"');
     expect(options?.artifactManifest?.metadata?.artifactGroupIdentifier).toBe(
-      'html-artifact:index.html',
+      'html-artifact:index-3.html',
     );
   });
 


### PR DESCRIPTION
Fixes #3323

## Why

I picked this up after claiming #3323 because regenerated multi-page HTML artifacts can become hard to use: child pages may be saved with numbered suffixes, while `index.html` keeps linking to the stale unsuffixed filenames. The same collision path can also save a refreshed entry page as a suffixed file, leaving the stable `index.html` behind.

This PR keeps the fix intentionally narrow: preserve a stable entry file and make entry links follow the current project files, without introducing the broader `-latest` archive model yet.

## What users will see

Regenerated multi-page HTML artifacts keep `index.html` as the entry point. When the project contains a newer suffixed child page like `about-2.html`, relative links in the saved HTML are rewritten to that current file before the artifact is persisted.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI surface. This changes artifact persistence behavior and is covered by regression tests.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/artifacts/html-links.test.ts` and `apps/web/tests/components/ProjectView.api-empty-response.test.tsx`
- Did the test go red on `main` and green on this branch? Yes. The branch was created from `upstream/main`; the new test first failed before the helper existed, then failed against the stub implementation, and now passes with the fix.

## Validation

- `PATH=/Users/ryan/.nvm/versions/node/v24.14.0/bin:$PATH pnpm exec vitest run -c vitest.config.ts tests/artifacts/html-links.test.ts tests/components/ProjectView.api-empty-response.test.tsx --reporter=dot`
- `PATH=/Users/ryan/.nvm/versions/node/v24.14.0/bin:$PATH pnpm --filter @open-design/web typecheck`
- `PATH=/Users/ryan/.nvm/versions/node/v24.14.0/bin:$PATH pnpm guard`
- `PATH=/Users/ryan/.nvm/versions/node/v24.14.0/bin:$PATH pnpm typecheck`
