### PR TITLE
fix(daemon): surface Pi turn errors

### DIFF
--- a/apps/daemon/src/pi-rpc.ts
+++ b/apps/daemon/src/pi-rpc.ts
@@ -182,6 +182,14 @@ export function mapPiRpcEvent(
         });
       }
     }
+
+    if (message?.stopReason === 'error') {
+      const messageText =
+        typeof message.errorMessage === 'string' && message.errorMessage.length > 0
+          ? message.errorMessage
+          : 'Pi agent error';
+      send('agent', { type: 'error', message: messageText, raw });
+    }
     return null;
   }
 

--- a/apps/daemon/tests/pi-rpc.test.ts
+++ b/apps/daemon/tests/pi-rpc.test.ts
@@ -243,6 +243,30 @@ test('pi RPC: usage extracted from turn_end', () => {
   });
 });
 
+test('pi RPC: turn_end assistant error maps to visible error event', () => {
+  const events = simulateRpcSession([
+    { type: 'agent_start' },
+    { type: 'turn_start' },
+    {
+      type: 'turn_end',
+      message: {
+        role: 'assistant',
+        content: [],
+        api: 'openai-completions',
+        provider: 'openai-compatible-provider',
+        model: 'example-model',
+        usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+        stopReason: 'error',
+        errorMessage: 'Upstream provider rejected the request',
+      },
+    },
+  ]);
+
+  const errorEvent = events.find((e) => e.type === 'error');
+  assert.ok(errorEvent, 'turn_end stopReason=error should fail visibly instead of completing empty');
+  assert.equal(errorEvent.message, 'Upstream provider rejected the request');
+});
+
 test('pi RPC: tool execution events mapped correctly', () => {
   const events = simulateRpcSession([
     { type: 'tool_execution_start', toolCallId: 'tc-1', toolName: 'read', args: { path: 'foo.txt' } },


### PR DESCRIPTION
## Why

A Pi-backed OpenAI-compatible route was completing with zero input/output tokens and the generic “agent completed without producing any output” message. Direct Pi RPC reproduced the upstream failure outside Open Design and showed that Pi was already carrying the real provider error in the assistant `turn_end` message.

That means the original zero-token provider response was caused by local Pi/provider configuration, not by Open Design generating an empty prompt. But Open Design still had a bug: the daemon ignored Pi `turn_end` messages with `stopReason: "error"`, so users saw an empty zero-token completion instead of the actual provider failure.

## What users will see

Pi-backed runs that fail at the provider layer now surface the real Pi error and fail visibly instead of ending as zero-token empty completions.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — daemon error handling only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/pi-rpc.test.ts`
- Did the test go red on `main` and green on this branch? yes
  - Red: `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/pi-rpc.test.ts -t "turn_end assistant error"` failed before the fix.
  - Green: same command passed after the fix.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/pi-rpc.test.ts -t "turn_end assistant error"`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/pi-rpc.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`

🤖 *This content was generated with AI assistance using GPT-5.5.*
