### PR TITLE
fix: show cumulative conversation duration

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -752,12 +752,31 @@ export function listConversations(db: SqliteDb, projectId: string) {
                  AND m.run_status IS NOT NULL
             )
            WHERE rn = 1
+        ),
+        total_run_durations AS (
+          SELECT m.conversation_id AS conversationId,
+                 SUM(
+                   CASE
+                     WHEN CAST(m.ended_at AS INTEGER) >= CAST(m.started_at AS INTEGER)
+                       THEN CAST(m.ended_at AS INTEGER) - CAST(m.started_at AS INTEGER)
+                     ELSE 0
+                   END
+                 ) AS totalDurationMs
+            FROM messages m
+            JOIN project_conversations c ON c.id = m.conversation_id
+           WHERE m.role = 'assistant'
+             AND m.run_status IN ('succeeded', 'failed', 'canceled')
+             AND m.started_at IS NOT NULL
+             AND m.ended_at IS NOT NULL
+           GROUP BY m.conversation_id
         )
         SELECT c.id, c.projectId, c.title, c.createdAt, c.updatedAt,
                lr.latestRunStatus, lr.latestRunStartedAt,
-               lr.latestRunEndedAt, lr.latestRunEventsJson
+               lr.latestRunEndedAt, lr.latestRunEventsJson,
+               trd.totalDurationMs
           FROM project_conversations c
           LEFT JOIN latest_runs lr ON lr.conversationId = c.id
+          LEFT JOIN total_run_durations trd ON trd.conversationId = c.id
          ORDER BY c.updatedAt DESC`,
     )
     .all(projectId)).map(normalizeConversation);
@@ -775,6 +794,7 @@ export function getConversation(db: SqliteDb, id: string) {
   return {
     ...normalizeConversation(r),
     latestRun: latestConversationRunSummary(db, r.id) ?? undefined,
+    ...numberProperty('totalDurationMs', totalConversationRunDurationMs(db, r.id)),
   };
 }
 
@@ -791,8 +811,14 @@ function normalizeConversation(r: DbRow) {
     title: r.title ?? null,
     createdAt: Number(r.createdAt),
     updatedAt: Number(r.updatedAt),
+    ...numberProperty('totalDurationMs', r.totalDurationMs),
     latestRun: latestRun ?? undefined,
   };
+}
+
+function numberProperty(key: string, value: unknown) {
+  const n = value == null ? undefined : Number(value);
+  return typeof n === 'number' && Number.isFinite(n) ? { [key]: n } : {};
 }
 
 function latestConversationRunSummary(db: SqliteDb, conversationId: string) {
@@ -811,6 +837,27 @@ function latestConversationRunSummary(db: SqliteDb, conversationId: string) {
     )
     .get(conversationId) as DbRow | undefined;
   return conversationRunSummaryFromRow(row);
+}
+
+function totalConversationRunDurationMs(db: SqliteDb, conversationId: string): number | undefined {
+  const row = db
+    .prepare(
+      `SELECT SUM(
+                CASE
+                  WHEN CAST(ended_at AS INTEGER) >= CAST(started_at AS INTEGER)
+                    THEN CAST(ended_at AS INTEGER) - CAST(started_at AS INTEGER)
+                  ELSE 0
+                END
+              ) AS totalDurationMs
+         FROM messages
+        WHERE conversation_id = ?
+          AND role = 'assistant'
+          AND run_status IN ('succeeded', 'failed', 'canceled')
+          AND started_at IS NOT NULL
+          AND ended_at IS NOT NULL`,
+    )
+    .get(conversationId) as DbRow | undefined;
+  return row?.totalDurationMs == null ? undefined : Number(row.totalDurationMs);
 }
 
 function conversationRunSummaryFromRow(row: DbRow | undefined) {

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -755,19 +755,11 @@ export function listConversations(db: SqliteDb, projectId: string) {
         ),
         total_run_durations AS (
           SELECT m.conversation_id AS conversationId,
-                 SUM(
-                   CASE
-                     WHEN CAST(m.ended_at AS INTEGER) >= CAST(m.started_at AS INTEGER)
-                       THEN CAST(m.ended_at AS INTEGER) - CAST(m.started_at AS INTEGER)
-                     ELSE 0
-                   END
-                 ) AS totalDurationMs
+                 SUM(${terminalRunDurationSql('m')}) AS totalDurationMs
             FROM messages m
             JOIN project_conversations c ON c.id = m.conversation_id
            WHERE m.role = 'assistant'
              AND m.run_status IN ('succeeded', 'failed', 'canceled')
-             AND m.started_at IS NOT NULL
-             AND m.ended_at IS NOT NULL
            GROUP BY m.conversation_id
         )
         SELECT c.id, c.projectId, c.title, c.createdAt, c.updatedAt,
@@ -842,22 +834,45 @@ function latestConversationRunSummary(db: SqliteDb, conversationId: string) {
 function totalConversationRunDurationMs(db: SqliteDb, conversationId: string): number | undefined {
   const row = db
     .prepare(
-      `SELECT SUM(
-                CASE
-                  WHEN CAST(ended_at AS INTEGER) >= CAST(started_at AS INTEGER)
-                    THEN CAST(ended_at AS INTEGER) - CAST(started_at AS INTEGER)
-                  ELSE 0
-                END
-              ) AS totalDurationMs
+      `SELECT SUM(${terminalRunDurationSql()}) AS totalDurationMs
          FROM messages
         WHERE conversation_id = ?
           AND role = 'assistant'
-          AND run_status IN ('succeeded', 'failed', 'canceled')
-          AND started_at IS NOT NULL
-          AND ended_at IS NOT NULL`,
+          AND run_status IN ('succeeded', 'failed', 'canceled')`,
     )
     .get(conversationId) as DbRow | undefined;
   return row?.totalDurationMs == null ? undefined : Number(row.totalDurationMs);
+}
+
+function terminalRunDurationSql(alias?: string) {
+  const p = alias ? `${alias}.` : '';
+  return `CASE
+            WHEN ${p}started_at IS NOT NULL AND ${p}ended_at IS NOT NULL THEN
+              CASE
+                WHEN CAST(${p}ended_at AS INTEGER) >= CAST(${p}started_at AS INTEGER)
+                  THEN CAST(${p}ended_at AS INTEGER) - CAST(${p}started_at AS INTEGER)
+                ELSE 0
+              END
+            ELSE (
+              SELECT CASE
+                       WHEN json_extract(usage_event.value, '$.durationMs') >= 0
+                         THEN json_extract(usage_event.value, '$.durationMs')
+                       ELSE 0
+                     END
+                FROM json_each(
+                  CASE
+                    WHEN json_valid(${p}events_json) AND json_type(${p}events_json) = 'array'
+                      THEN ${p}events_json
+                    ELSE '[]'
+                  END
+                ) AS usage_event
+               WHERE usage_event.type = 'object'
+                 AND json_extract(usage_event.value, '$.kind') = 'usage'
+                 AND json_type(usage_event.value, '$.durationMs') IN ('integer', 'real')
+               ORDER BY CAST(usage_event.key AS INTEGER) DESC
+               LIMIT 1
+            )
+          END`;
 }
 
 function conversationRunSummaryFromRow(row: DbRow | undefined) {

--- a/apps/daemon/tests/project-status.test.ts
+++ b/apps/daemon/tests/project-status.test.ts
@@ -124,6 +124,55 @@ test('conversation latest run follows assistant message position', () => {
   assert.equal(getConversation(db, conversationId)?.latestRun?.status, 'running');
 });
 
+test('conversation summaries expose cumulative completed run duration', () => {
+  const db = createDb();
+  insertProject(db, {
+    id: 'project-duration',
+    name: 'project-duration',
+    createdAt: 1,
+    updatedAt: 1,
+  });
+  insertConversation(db, {
+    id: 'project-duration-conversation',
+    projectId: 'project-duration',
+    title: 'Duration test',
+    createdAt: 1,
+    updatedAt: 4,
+  });
+  upsertMessage(db, 'project-duration-conversation', {
+    id: 'project-duration-first',
+    role: 'assistant',
+    content: 'first done',
+    runId: 'project-duration-first-run',
+    runStatus: 'succeeded',
+    startedAt: 10_000,
+    endedAt: 40_000,
+  });
+  upsertMessage(db, 'project-duration-conversation', {
+    id: 'project-duration-running',
+    role: 'assistant',
+    content: 'still running',
+    runId: 'project-duration-running-run',
+    runStatus: 'running',
+    startedAt: 45_000,
+  });
+  upsertMessage(db, 'project-duration-conversation', {
+    id: 'project-duration-second',
+    role: 'assistant',
+    content: 'second done',
+    runId: 'project-duration-second-run',
+    runStatus: 'failed',
+    startedAt: 50_000,
+    endedAt: 125_000,
+  });
+
+  const listed = listConversations(db, 'project-duration')[0] as { totalDurationMs?: number };
+  const fetched = getConversation(db, 'project-duration-conversation') as { totalDurationMs?: number } | null;
+
+  assert.equal(listed.totalDurationMs, 105_000);
+  assert.equal(fetched?.totalDurationMs, 105_000);
+});
+
 test('conversation listing batches latest run summaries for large projects', () => {
   const db = createDb();
   insertProject(db, {

--- a/apps/daemon/tests/project-status.test.ts
+++ b/apps/daemon/tests/project-status.test.ts
@@ -173,6 +173,46 @@ test('conversation summaries expose cumulative completed run duration', () => {
   assert.equal(fetched?.totalDurationMs, 105_000);
 });
 
+test('conversation summaries include usage-only terminal run durations', () => {
+  const db = createDb();
+  insertProject(db, {
+    id: 'project-usage-duration',
+    name: 'project-usage-duration',
+    createdAt: 1,
+    updatedAt: 1,
+  });
+  insertConversation(db, {
+    id: 'project-usage-duration-conversation',
+    projectId: 'project-usage-duration',
+    title: 'Usage duration test',
+    createdAt: 1,
+    updatedAt: 4,
+  });
+  upsertMessage(db, 'project-usage-duration-conversation', {
+    id: 'project-usage-duration-imported',
+    role: 'assistant',
+    content: 'imported done',
+    runId: 'project-usage-duration-imported-run',
+    runStatus: 'succeeded',
+    events: [{ kind: 'usage', durationMs: 22_000 }],
+  });
+  upsertMessage(db, 'project-usage-duration-conversation', {
+    id: 'project-usage-duration-timestamped',
+    role: 'assistant',
+    content: 'timestamped done',
+    runId: 'project-usage-duration-timestamped-run',
+    runStatus: 'succeeded',
+    startedAt: 30_000,
+    endedAt: 60_000,
+  });
+
+  const listed = listConversations(db, 'project-usage-duration')[0] as { totalDurationMs?: number };
+  const fetched = getConversation(db, 'project-usage-duration-conversation') as { totalDurationMs?: number } | null;
+
+  assert.equal(listed.totalDurationMs, 52_000);
+  assert.equal(fetched?.totalDurationMs, 52_000);
+});
+
 test('conversation listing batches latest run summaries for large projects', () => {
   const db = createDb();
   insertProject(db, {

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -2019,6 +2019,16 @@ export function conversationMetaLabel(
     (latestRun.status === 'succeeded' ||
       latestRun.status === 'failed' ||
       latestRun.status === 'canceled') &&
+    typeof conversation.totalDurationMs === 'number' &&
+    Number.isFinite(conversation.totalDurationMs)
+  ) {
+    return formatDurationShort(conversation.totalDurationMs);
+  }
+  if (
+    latestRun &&
+    (latestRun.status === 'succeeded' ||
+      latestRun.status === 'failed' ||
+      latestRun.status === 'canceled') &&
     typeof latestRun.durationMs === 'number' &&
     Number.isFinite(latestRun.durationMs)
   ) {

--- a/apps/web/tests/components/conversation-timestamps.test.tsx
+++ b/apps/web/tests/components/conversation-timestamps.test.tsx
@@ -132,4 +132,27 @@ describe('conversation timestamps', () => {
 
     expect(conversationMetaLabel(conversation, t as never)).toBe('15s');
   });
+
+  it('prefers cumulative conversation duration over the latest run duration', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-15T14:00:00Z'));
+    const t = (key: string, vars?: Record<string, string | number>) =>
+      key === 'common.minutesShort' ? `${vars?.n}m` : key;
+    const conversation = {
+      id: 'conv-1',
+      projectId: 'project-1',
+      title: 'Multi-run session',
+      createdAt: Date.parse('2025-01-15T12:00:00Z'),
+      updatedAt: Date.parse('2025-01-15T12:03:00Z'),
+      totalDurationMs: 85_000,
+      latestRun: {
+        status: 'succeeded',
+        startedAt: 120_000,
+        endedAt: 130_000,
+        durationMs: 10_000,
+      },
+    } satisfies Conversation & { totalDurationMs: number };
+
+    expect(conversationMetaLabel(conversation, t as never)).toBe('1m 25s');
+  });
 });

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -195,6 +195,7 @@ export interface Conversation {
   title: string | null;
   createdAt: number;
   updatedAt: number;
+  totalDurationMs?: number;
   latestRun?: {
     status: ChatRunStatus;
     startedAt?: number;


### PR DESCRIPTION
Fixes #3287

## Why

While fixing #3287, I found that conversation metadata only exposed the latest assistant run duration. In a conversation with multiple completed runs, the sidebar could show a short latest-run time even though earlier runs made the conversation take much longer overall.

This PR carries cumulative completed run duration through the daemon contract and has the web sidebar prefer that total when displaying completed conversations.

## What users will see

Conversations with multiple completed assistant runs now show the total completed run duration in the conversation metadata instead of only the most recent run's duration. Running conversations keep the existing in-progress elapsed display.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this is a metadata text display fix covered by a component regression test, with no new UI entry point.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/conversation-timestamps.test.tsx` and `apps/daemon/tests/project-status.test.ts`
- Did the test go red on `main` and green on this branch? yes. The web regression expected cumulative duration and got the latest-run duration before the fix; the daemon regression expected `totalDurationMs` and got `undefined` before the fix.

## Validation

- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/project-status.test.ts`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/conversation-timestamps.test.tsx`
- `git diff --check FETCH_HEAD...HEAD`
- `pnpm guard`
- `env XDG_CONFIG_HOME=/tmp/open-design-xdg pnpm typecheck`
- `gpt-5.3-codex-spark` subagent review: no blocking findings
