### PR TITLE
Polish OD-native tweak panels and project context controls

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -69,6 +69,7 @@ import { buildReactComponentSrcdoc } from '../runtime/react-component';
 import { findHtmlEntriesReferencing } from '../runtime/jsx-module-refs';
 import { buildLazySrcdocTransport, buildSrcdoc, canActivateSrcDocTransport } from '../runtime/srcdoc';
 import {
+  hasTweaksTemplate,
   hasUrlModeBridge,
   htmlNeedsFocusGuard,
   htmlNeedsSandboxShim,
@@ -170,6 +171,10 @@ type CloudflarePagesZoneOption = {
   status?: string;
   type?: string;
 };
+function hasEmbeddedTweaksPanel(source: string | null | undefined): boolean {
+  if (!source) return false;
+  return hasTweaksTemplate(source) || /\btweaks-panel\.jsx\b|\bTweaksPanel\b/.test(source);
+}
 type DeployResultCard = {
   id: string;
   label: string;
@@ -4055,6 +4060,8 @@ function HtmlViewer({
   const [inspectMode, setInspectMode] = useState(false);
   const [agentToolsOpen, setAgentToolsOpen] = useState(false);
   const [drawOverlayOpen, setDrawOverlayOpen] = useState(false);
+  const [tweaksAvailable, setTweaksAvailable] = useState(false);
+  const [tweaksPanelVisible, setTweaksPanelVisible] = useState(false);
   // for hint managing hint box state
   const [openHintBox, setOpenHintBox] = useState(true);
   const [manualEditMode, setManualEditModeRaw] = useState(false);
@@ -4489,6 +4496,8 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     : livePreviewSource;
   const manualEditPageStylesEnabled = typeof source === 'string' && isManualEditFullHtmlDocument(source);
   const urlModeBridge = hasUrlModeBridge(source);
+  const sourceHasTweaksPanel = hasEmbeddedTweaksPanel(source);
+  const tweaksBridgeRequired = hasTweaksTemplate(source);
   // When we URL-load the iframe directly, skip every in-host inlining /
   // srcDoc-rebuilding step. The browser does the asset resolution itself,
   // which is the whole point of the URL-load path.
@@ -4515,6 +4524,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     urlModeBridge,
     inspectMode,
     drawMode: drawOverlayOpen,
+    tweaksBridge: tweaksBridgeRequired,
     forceInline: forceInline || needsSandboxShim,
     needsFocusGuard,
   });
@@ -4695,6 +4705,11 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
   }, [boardMode, manualEditMode, srcDoc, restorePreviewScrollPosition]);
 
   useEffect(() => {
+    setTweaksAvailable(sourceHasTweaksPanel);
+    setTweaksPanelVisible(false);
+  }, [file.name, sourceHasTweaksPanel]);
+
+  useEffect(() => {
     function onMessage(ev: MessageEvent) {
       if (!isOurPreviewIframeSource(ev.source)) return;
       if (!isActivePreviewIframeSource(ev.source)) return;
@@ -4807,6 +4822,35 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
   }, [effectiveDeck, isActivePreviewIframeSource, isOurPreviewIframeSource, previewStateKey]);
 
   useEffect(() => {
+    function onMessage(ev: MessageEvent) {
+      if (!isOurPreviewIframeSource(ev.source)) return;
+      const data = ev.data as {
+        type?: string;
+        available?: boolean;
+        visible?: boolean;
+      } | null;
+      if (!data?.type) return;
+      if (data.type === '__edit_mode_available') {
+        setTweaksAvailable(true);
+        return;
+      }
+      if (data.type === '__edit_mode_dismissed') {
+        setTweaksPanelVisible(false);
+        return;
+      }
+      if (data.type === 'od:tweaks-available') {
+        setTweaksAvailable(Boolean(data.available) || sourceHasTweaksPanel);
+        return;
+      }
+      if (data.type === 'od:tweaks-panel-state') {
+        setTweaksPanelVisible(Boolean(data.visible));
+      }
+    }
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [isOurPreviewIframeSource, sourceHasTweaksPanel]);
+
+  useEffect(() => {
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
     win.postMessage({
@@ -4836,6 +4880,13 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     win.postMessage({ type: 'od-edit-selected-target', id }, '*');
   }
 
+  function postTweaksPanelVisible(visible: boolean, target: HTMLIFrameElement | null = iframeRef.current) {
+    const win = target?.contentWindow;
+    if (!win) return;
+    win.postMessage({ type: 'od:tweaks-panel-visible', visible }, '*');
+    win.postMessage({ type: visible ? '__activate_edit_mode' : '__deactivate_edit_mode' }, '*');
+  }
+
   function syncBridgeModes(target: HTMLIFrameElement | null = iframeRef.current) {
     const win = target?.contentWindow;
     if (!win) return;
@@ -4847,6 +4898,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     win.postMessage({ type: 'od-edit-mode', enabled: manualEditMode }, '*');
     postSelectedManualEditTargetToIframe(manualEditMode ? selectedManualEditTarget?.id ?? null : null, target);
     win.postMessage({ type: 'od:inspect-mode', enabled: inspectMode }, '*');
+    postTweaksPanelVisible(tweaksPanelVisible, target);
   }
 
   useEffect(() => {
@@ -4854,6 +4906,10 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     if (!win) return;
     win.postMessage({ type: 'od:inspect-mode', enabled: inspectMode }, '*');
   }, [inspectMode, srcDoc]);
+
+  useEffect(() => {
+    postTweaksPanelVisible(tweaksPanelVisible);
+  }, [tweaksPanelVisible, srcDoc]);
 
   // Mirror the bridge's `od:comment-targets` broadcast into
   // `liveCommentTargets` whenever EITHER Inspect or Comments mode is
@@ -6095,6 +6151,32 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     activateCommentCreate();
   }
 
+  function activateTweaksTool() {
+    fireArtifactToolbarClick('tweaks');
+    const next = !tweaksPanelVisible;
+    const activateTweaks = () => {
+      setMode('preview');
+      if (next) {
+        setCommentPanelOpen(false);
+        setCommentCreateMode(false);
+        setBoardMode(false);
+        clearBoardComposer();
+        setInspectMode(false);
+        setDrawOverlayOpen(false);
+      }
+      setTweaksPanelVisible(next);
+      postTweaksPanelVisible(next);
+      closeArtifactToolMenus();
+    };
+    if (manualEditMode && next) {
+      void exitManualEditModeAfterFlush().then((ok) => {
+        if (ok) activateTweaks();
+      });
+      return;
+    }
+    activateTweaks();
+  }
+
   function activateManualEditTool() {
     fireArtifactToolbarClick('edit');
     capturePreviewScrollPosition();
@@ -6545,6 +6627,24 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
                 onViewport={setPreviewViewport}
                 t={t}
               />
+              {sourceHasTweaksPanel || tweaksAvailable ? (
+                <>
+                  <span className="viewer-divider" aria-hidden />
+                  <button
+                    className={`viewer-action viewer-tweaks-trigger${tweaksPanelVisible ? ' active' : ''}`}
+                    type="button"
+                    data-testid="tweaks-panel-toggle"
+                    title={tweaksAvailable ? t('fileViewer.tweaks') : t('fileViewer.tweaksUnavailable')}
+                    aria-label={t('fileViewer.tweaks')}
+                    aria-pressed={tweaksPanelVisible}
+                    disabled={!tweaksAvailable}
+                    onClick={activateTweaksTool}
+                  >
+                    <Icon name="tweaks" size={15} />
+                    <span>{t('fileViewer.tweaks')}</span>
+                  </button>
+                </>
+              ) : null}
             </>
           ) : null}
           {showPreviewToolbarControls && effectiveDeck ? (

--- a/apps/web/src/components/Icon.tsx
+++ b/apps/web/src/components/Icon.tsx
@@ -22,6 +22,7 @@ export type IconName =
   | 'eye-off'
   | 'file'
   | 'file-code'
+  | 'file-text'
   | 'folder'
   | 'folder-filled'
   | 'github'
@@ -252,6 +253,15 @@ export function Icon({ name, size = 14, strokeWidth = 1.6, ...rest }: Props) {
           <path d="M14 2v6h6" />
           <path d="m10 13-2 2 2 2" />
           <path d="m14 17 2-2-2-2" />
+        </svg>
+      );
+    case 'file-text':
+      return (
+        <svg {...common}>
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <path d="M14 2v6h6" />
+          <path d="M8 13h8" />
+          <path d="M8 17h6" />
         </svg>
       );
     case 'folder':

--- a/apps/web/src/components/ProjectDesignSystemPicker.tsx
+++ b/apps/web/src/components/ProjectDesignSystemPicker.tsx
@@ -167,6 +167,8 @@ export function ProjectDesignSystemPicker({
         onClick={() => setOpen((v) => !v)}
         disabled={loading}
         title={selected?.title ?? t('designSystemPicker.select')}
+        aria-haspopup="listbox"
+        aria-expanded={open}
       >
         {selected && selected.swatches && selected.swatches.length > 0 ? (
           <span className="project-ds-picker-swatches" aria-hidden>
@@ -184,9 +186,9 @@ export function ProjectDesignSystemPicker({
         <span className="project-ds-picker-label">
           {loading
             ? t('designSystemPicker.loading')
-            : selected?.title ?? t('designSystemPicker.select')}
+            : selected?.title ?? t('misc.designSystem')}
         </span>
-        <Icon name="chevron-down" size={11} />
+        <Icon name="chevron-down" size={11} className="project-ds-picker-chevron" />
       </button>
       {open && anchor && typeof document !== 'undefined'
         ? createPortal(
@@ -197,7 +199,6 @@ export function ProjectDesignSystemPicker({
               style={{ top: anchor.top, left: anchor.left, width: anchor.width }}
             >
               <div className="project-ds-picker-search">
-                <Icon name="search" size={12} />
                 <input
                   ref={inputRef}
                   type="text"

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -594,22 +594,52 @@ export function ProjectView({
   const [byokImageModelOverride, setByokImageModelOverride] = useState<string>(
     config.byokImageModel ?? '',
   );
-  // `closed` → no surface; `review` → read-only saved-state panel with a
-  // preview + reopen-to-edit action (#1822); `edit` → the textarea editor.
-  const [instructionsMode, setInstructionsMode] = useState<'closed' | 'review' | 'edit'>('closed');
+  // `open` renders the live autosaving editor; the capsule is the only
+  // open/close affordance so the panel chrome does not duplicate it.
+  const [instructionsMode, setInstructionsMode] = useState<'closed' | 'open'>('closed');
   const [instructionsDraft, setInstructionsDraft] = useState(project.customInstructions ?? '');
   const [instructionsSaving, setInstructionsSaving] = useState(false);
-  // Keep the draft in sync with the server value while the editor is not
-  // open (e.g. after an external update or project switch). If the saved
-  // value disappears while the review panel is showing, collapse the
-  // surface so it never renders a stale or empty read-back.
+  const instructionsDraftRef = useRef(instructionsDraft);
+  const latestProjectRef = useRef(project);
+  const latestOnProjectChangeRef = useRef(onProjectChange);
+  const instructionsSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const instructionsSaveInFlightRef = useRef(false);
+  const instructionsSaveQueuedRef = useRef(false);
+  const instructionsSaveQueuedValueRef = useRef<string | undefined>(undefined);
+  const instructionsSaveRequestRef = useRef(0);
+  const instructionsDesiredValueRef = useRef(normalizeProjectInstructions(project.customInstructions ?? ''));
+  // Keep the draft in sync with the server value while the editor is closed
+  // or when switching projects. While open, local typing stays authoritative
+  // so server echoes from debounced autosaves cannot make the textarea jump.
   useEffect(() => {
-    if (instructionsMode === 'edit') return;
+    if (instructionsMode === 'open') return;
     setInstructionsDraft(project.customInstructions ?? '');
-    if (instructionsMode === 'review' && !(project.customInstructions ?? '').trim()) {
-      setInstructionsMode('closed');
-    }
+    instructionsDesiredValueRef.current = normalizeProjectInstructions(project.customInstructions ?? '');
   }, [project.customInstructions, instructionsMode]);
+  useEffect(() => {
+    if (instructionsMode !== 'open') return;
+    instructionsDesiredValueRef.current = normalizeProjectInstructions(instructionsDraft);
+  }, [instructionsDraft, instructionsMode]);
+  useEffect(() => {
+    if (instructionsSaveTimerRef.current) {
+      clearTimeout(instructionsSaveTimerRef.current);
+      instructionsSaveTimerRef.current = null;
+    }
+    instructionsSaveQueuedRef.current = false;
+    instructionsSaveQueuedValueRef.current = undefined;
+    instructionsDesiredValueRef.current = normalizeProjectInstructions(project.customInstructions ?? '');
+    setInstructionsDraft(project.customInstructions ?? '');
+    setInstructionsMode('closed');
+  }, [project.id]);
+  useEffect(() => {
+    instructionsDraftRef.current = instructionsDraft;
+  }, [instructionsDraft]);
+  useEffect(() => {
+    latestProjectRef.current = project;
+  }, [project]);
+  useEffect(() => {
+    latestOnProjectChangeRef.current = onProjectChange;
+  }, [onProjectChange]);
 
   // PR #974 round 7 (mrcfps @ useDesignMdState.ts:131): counter that
   // bumps on file-changed SSE events, live_artifact* events, and the
@@ -3720,22 +3750,60 @@ export function ProjectView({
     [project, onProjectChange, designSystems, analytics.track],
   );
 
-  const handleSaveInstructions = useCallback(async () => {
-    const value = instructionsDraft.trim() || undefined;
-    // After a save, land on the review panel so the saved value is read
-    // back immediately (#1822); collapse only when it was cleared.
-    const settle = () => setInstructionsMode(value ? 'review' : 'closed');
-    if (value === (project.customInstructions ?? undefined)) {
-      settle();
+  const flushInstructionsAutosave = useCallback((draft: string) => {
+    const value = normalizeProjectInstructions(draft);
+    instructionsDesiredValueRef.current = value;
+    const currentProject = latestProjectRef.current;
+    if (!instructionsSaveInFlightRef.current && value === normalizeProjectInstructions(currentProject.customInstructions ?? '')) {
       return;
     }
+    if (instructionsSaveInFlightRef.current) {
+      instructionsSaveQueuedRef.current = true;
+      instructionsSaveQueuedValueRef.current = value;
+      return;
+    }
+    instructionsSaveInFlightRef.current = true;
     setInstructionsSaving(true);
-    const result = await patchProject(project.id, { customInstructions: value ?? null });
-    setInstructionsSaving(false);
-    if (!result) return;
-    onProjectChange(result);
-    settle();
-  }, [project, onProjectChange, instructionsDraft]);
+    const requestId = ++instructionsSaveRequestRef.current;
+    const projectId = currentProject.id;
+    void patchProject(projectId, { customInstructions: value ?? null })
+      .then((result) => {
+        const stillCurrentProject = latestProjectRef.current.id === projectId;
+        if (result && stillCurrentProject && requestId === instructionsSaveRequestRef.current && instructionsDesiredValueRef.current === value) {
+          latestOnProjectChangeRef.current(result);
+        }
+      })
+      .finally(() => {
+        instructionsSaveInFlightRef.current = false;
+        if (instructionsSaveQueuedRef.current) {
+          const nextValue = instructionsSaveQueuedValueRef.current;
+          instructionsSaveQueuedRef.current = false;
+          instructionsSaveQueuedValueRef.current = undefined;
+          flushInstructionsAutosave(nextValue ?? '');
+          return;
+        }
+        setInstructionsSaving(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (instructionsMode !== 'open') return undefined;
+    const value = normalizeProjectInstructions(instructionsDraft);
+    if (value === normalizeProjectInstructions(project.customInstructions ?? '')) return undefined;
+    if (instructionsSaveTimerRef.current) {
+      clearTimeout(instructionsSaveTimerRef.current);
+    }
+    instructionsSaveTimerRef.current = setTimeout(() => {
+      instructionsSaveTimerRef.current = null;
+      flushInstructionsAutosave(instructionsDraft);
+    }, 500);
+    return () => {
+      if (instructionsSaveTimerRef.current) {
+        clearTimeout(instructionsSaveTimerRef.current);
+        instructionsSaveTimerRef.current = null;
+      }
+    };
+  }, [flushInstructionsAutosave, instructionsDraft, instructionsMode, project.customInstructions]);
 
   const projectMeta = useMemo(() => {
     // Design system is rendered by the adjacent picker chip — keep the
@@ -4278,20 +4346,6 @@ export function ProjectView({
         )}
         actions={(
           <>
-            <button
-              type="button"
-              className="settings-icon-btn"
-              data-testid="project-settings-trigger"
-              title={t('project.customInstructions')}
-              aria-label={t('project.customInstructions')}
-              aria-expanded={instructionsMode !== 'closed'}
-              onClick={() => {
-                setInstructionsDraft(project.customInstructions ?? '');
-                setInstructionsMode(hasProjectInstructions ? 'review' : 'edit');
-              }}
-            >
-              <Icon name="file-text" size={16} />
-            </button>
             <HandoffButton projectId={project.id} />
             <AvatarMenu
               config={config}
@@ -4330,51 +4384,43 @@ export function ProjectView({
             {projectMeta !== t('project.metaFreeform') ? (
               <span className="meta" data-testid="project-meta">{projectMeta}</span>
             ) : null}
-            <ProjectDesignSystemPicker
-              designSystems={designSystems}
-              selectedId={project.designSystemId ?? null}
-              onChange={handleChangeDesignSystemId}
-            />
+            <div className="project-context-capsule" role="group" aria-label="Project context">
+              <ProjectDesignSystemPicker
+                designSystems={designSystems}
+                selectedId={project.designSystemId ?? null}
+                onChange={handleChangeDesignSystemId}
+              />
+              <button
+                type="button"
+                className={`project-context-instructions${instructionsMode !== 'closed' ? ' is-open' : ''}${hasProjectInstructions ? ' has-instructions' : ''}`}
+                data-testid="project-settings-trigger"
+                title={t('project.customInstructions')}
+                aria-label={t('project.customInstructions')}
+                aria-expanded={instructionsMode !== 'closed'}
+                onClick={() => {
+                  if (instructionsMode !== 'closed') {
+                    if (instructionsSaveTimerRef.current) {
+                      clearTimeout(instructionsSaveTimerRef.current);
+                      instructionsSaveTimerRef.current = null;
+                    }
+                    flushInstructionsAutosave(instructionsDraftRef.current);
+                    setInstructionsMode('closed');
+                    return;
+                  }
+                  setInstructionsDraft(project.customInstructions ?? '');
+                  setInstructionsMode('open');
+                }}
+              >
+                <Icon name="file-text" size={14} />
+                <span className="project-context-instructions-label">{t('project.customInstructions')}</span>
+                <Icon name="chevron-down" size={11} className="project-context-instructions-chevron" />
+              </button>
+            </div>
           </span>
         </div>
       </AppChromeHeader>
-      {instructionsMode === 'review' && (
-        <div className="project-instructions-bar project-instructions-review">
-          <div className="project-instructions-bar-head">
-            <label className="project-instructions-label">{t('project.customInstructions')}</label>
-            <span className="project-instructions-status">
-              <Icon name="check" size={11} />
-              {t('project.instructionsActive')}
-            </span>
-          </div>
-          <div className="project-instructions-preview" data-testid="project-instructions-preview">
-            {project.customInstructions}
-          </div>
-          <div className="project-instructions-actions">
-            <button
-              type="button"
-              className="btn-sm"
-              onClick={() => setInstructionsMode('closed')}
-            >
-              {t('common.close')}
-            </button>
-            <button
-              type="button"
-              className="btn-sm btn-primary"
-              data-testid="project-instructions-edit"
-              onClick={() => {
-                setInstructionsDraft(project.customInstructions ?? '');
-                setInstructionsMode('edit');
-              }}
-            >
-              {t('common.edit')}
-            </button>
-          </div>
-        </div>
-      )}
-      {instructionsMode === 'edit' && (
-        <div className="project-instructions-bar">
-          <label className="project-instructions-label">{t('project.customInstructions')}</label>
+      {instructionsMode === 'open' && (
+        <div className="project-instructions-bar" aria-busy={instructionsSaving}>
           <textarea
             className="project-instructions-input"
             data-testid="project-instructions-textarea"
@@ -4383,20 +4429,9 @@ export function ProjectView({
             placeholder={t('project.customInstructionsPlaceholder')}
             value={instructionsDraft}
             onChange={(e) => setInstructionsDraft(e.target.value)}
-            disabled={instructionsSaving}
+            aria-label={t('project.customInstructions')}
             autoFocus
           />
-          <div className="project-instructions-actions">
-            <button type="button" className="btn-sm" disabled={instructionsSaving} onClick={() => {
-              setInstructionsDraft(project.customInstructions ?? '');
-              setInstructionsMode((project.customInstructions ?? '').trim() ? 'review' : 'closed');
-            }}>
-              {t('common.cancel')}
-            </button>
-            <button type="button" className="btn-sm btn-primary" data-testid="project-instructions-save" disabled={instructionsSaving} onClick={handleSaveInstructions}>
-              {t('common.save')}
-            </button>
-          </div>
         </div>
       )}
       {/* ProjectActionsToolbar removed per 00efdcba — hide finalize-design
@@ -4712,6 +4747,11 @@ export interface RetryTarget {
   failedAssistant: ChatMessage;
   userMsg: ChatMessage;
   priorMessages: ChatMessage[];
+}
+
+function normalizeProjectInstructions(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 export function resolveRetryTarget(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -606,8 +606,10 @@ export function ProjectView({
   const instructionsSaveInFlightRef = useRef(false);
   const instructionsSaveQueuedRef = useRef(false);
   const instructionsSaveQueuedValueRef = useRef<string | undefined>(undefined);
+  const instructionsSaveQueuedResolversRef = useRef<Array<(ok: boolean) => void>>([]);
   const instructionsSaveRequestRef = useRef(0);
   const instructionsDesiredValueRef = useRef(normalizeProjectInstructions(project.customInstructions ?? ''));
+  const instructionsPersistedValueRef = useRef(normalizeProjectInstructions(project.customInstructions ?? ''));
   // Keep the draft in sync with the server value while the editor is closed
   // or when switching projects. While open, local typing stays authoritative
   // so server echoes from debounced autosaves cannot make the textarea jump.
@@ -627,10 +629,15 @@ export function ProjectView({
     }
     instructionsSaveQueuedRef.current = false;
     instructionsSaveQueuedValueRef.current = undefined;
+    instructionsSaveQueuedResolversRef.current.splice(0).forEach((resolve) => resolve(false));
     instructionsDesiredValueRef.current = normalizeProjectInstructions(project.customInstructions ?? '');
+    instructionsPersistedValueRef.current = normalizeProjectInstructions(project.customInstructions ?? '');
     setInstructionsDraft(project.customInstructions ?? '');
     setInstructionsMode('closed');
   }, [project.id]);
+  useEffect(() => {
+    instructionsPersistedValueRef.current = normalizeProjectInstructions(project.customInstructions ?? '');
+  }, [project.customInstructions]);
   useEffect(() => {
     instructionsDraftRef.current = instructionsDraft;
   }, [instructionsDraft]);
@@ -3750,39 +3757,52 @@ export function ProjectView({
     [project, onProjectChange, designSystems, analytics.track],
   );
 
-  const flushInstructionsAutosave = useCallback((draft: string) => {
+  const flushInstructionsAutosave = useCallback((draft: string): Promise<boolean> => {
     const value = normalizeProjectInstructions(draft);
     instructionsDesiredValueRef.current = value;
     const currentProject = latestProjectRef.current;
-    if (!instructionsSaveInFlightRef.current && value === normalizeProjectInstructions(currentProject.customInstructions ?? '')) {
-      return;
+    if (!instructionsSaveInFlightRef.current && value === instructionsPersistedValueRef.current) {
+      return Promise.resolve(true);
     }
     if (instructionsSaveInFlightRef.current) {
       instructionsSaveQueuedRef.current = true;
       instructionsSaveQueuedValueRef.current = value;
-      return;
+      return new Promise((resolve) => {
+        instructionsSaveQueuedResolversRef.current.push(resolve);
+      });
     }
     instructionsSaveInFlightRef.current = true;
     setInstructionsSaving(true);
     const requestId = ++instructionsSaveRequestRef.current;
     const projectId = currentProject.id;
-    void patchProject(projectId, { customInstructions: value ?? null })
+    return patchProject(projectId, { customInstructions: value ?? null })
       .then((result) => {
         const stillCurrentProject = latestProjectRef.current.id === projectId;
-        if (result && stillCurrentProject && requestId === instructionsSaveRequestRef.current && instructionsDesiredValueRef.current === value) {
+        if (!result || !stillCurrentProject) return false;
+        instructionsPersistedValueRef.current = normalizeProjectInstructions(result.customInstructions ?? '');
+        if (requestId === instructionsSaveRequestRef.current && instructionsDesiredValueRef.current === value) {
           latestOnProjectChangeRef.current(result);
         }
+        return true;
       })
-      .finally(() => {
+      .catch(() => false)
+      .then((ok) => {
         instructionsSaveInFlightRef.current = false;
         if (instructionsSaveQueuedRef.current) {
           const nextValue = instructionsSaveQueuedValueRef.current;
+          const queuedResolvers = instructionsSaveQueuedResolversRef.current.splice(0);
           instructionsSaveQueuedRef.current = false;
           instructionsSaveQueuedValueRef.current = undefined;
-          flushInstructionsAutosave(nextValue ?? '');
-          return;
+          return flushInstructionsAutosave(nextValue ?? '').then((queuedOk) => {
+            queuedResolvers.forEach((resolve) => resolve(queuedOk));
+            if (!instructionsSaveInFlightRef.current && !instructionsSaveQueuedRef.current) {
+              setInstructionsSaving(false);
+            }
+            return queuedOk;
+          });
         }
         setInstructionsSaving(false);
+        return ok;
       });
   }, []);
 
@@ -4403,8 +4423,9 @@ export function ProjectView({
                       clearTimeout(instructionsSaveTimerRef.current);
                       instructionsSaveTimerRef.current = null;
                     }
-                    flushInstructionsAutosave(instructionsDraftRef.current);
-                    setInstructionsMode('closed');
+                    void flushInstructionsAutosave(instructionsDraftRef.current).then((ok) => {
+                      if (ok) setInstructionsMode('closed');
+                    });
                     return;
                   }
                   setInstructionsDraft(project.customInstructions ?? '');

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4259,7 +4259,6 @@ export function ProjectView({
   const critiqueTheaterEnabled = useCritiqueTheaterEnabled();
   const projectInstructions = (project.customInstructions ?? '').trim();
   const hasProjectInstructions = projectInstructions.length > 0;
-  const projectInstructionsPreview = compactInlinePreview(projectInstructions);
 
   return (
     <div className="app">
@@ -4291,7 +4290,7 @@ export function ProjectView({
                 setInstructionsMode(hasProjectInstructions ? 'review' : 'edit');
               }}
             >
-              <Icon name="sliders" size={16} />
+              <Icon name="file-text" size={16} />
             </button>
             <HandoffButton projectId={project.id} />
             <AvatarMenu
@@ -4336,20 +4335,6 @@ export function ProjectView({
               selectedId={project.designSystemId ?? null}
               onChange={handleChangeDesignSystemId}
             />
-            {hasProjectInstructions ? (
-              <button
-                type="button"
-                className={`project-instructions-chip${instructionsMode !== 'closed' ? ' is-open' : ''}`}
-                data-testid="project-instructions-chip"
-                title={projectInstructions}
-                aria-label={t('project.customInstructions')}
-                aria-expanded={instructionsMode !== 'closed'}
-                onClick={() => setInstructionsMode((m) => (m === 'closed' ? 'review' : 'closed'))}
-              >
-                <Icon name="sliders" size={11} />
-                <span>&quot;{projectInstructionsPreview}&quot;</span>
-              </button>
-            ) : null}
           </span>
         </div>
       </AppChromeHeader>
@@ -4721,10 +4706,6 @@ function isTerminalRunStatus(status: ChatMessage['runStatus']): boolean {
 
 function isActiveRunStatus(status: ChatMessage['runStatus']): boolean {
   return status === 'queued' || status === 'running';
-}
-
-function compactInlinePreview(value: string): string {
-  return value.replace(/\s+/g, ' ').trim();
 }
 
 export interface RetryTarget {

--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -62,7 +62,7 @@ export interface UrlLoadDecision {
  */
 export function hasTweaksTemplate(source: string | null | undefined): boolean {
   if (!source) return false;
-  return /\btw-(?:panel|hidden)\b/.test(source);
+  return /\btw-(?:panel|hidden)\b|\btwk-panel\b/.test(source);
 }
 
 /**

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1996,12 +1996,159 @@ function injectTweaksBridge(doc: string): string {
   // opacity) so the CSS transition plays in both directions. `.tw-restore` is
   // kept permanently hidden — the host toolbar is the only entry point.
   const style = `<style data-od-tweaks-bridge-style>
+:root {
+  color-scheme: light dark;
+  --od-tweaks-bg-panel: #ffffff;
+  --od-tweaks-bg-subtle: #f6f5f2;
+  --od-tweaks-bg-muted: #ebe9e3;
+  --od-tweaks-border: #dedbd2;
+  --od-tweaks-text: #1f1f1f;
+  --od-tweaks-text-muted: #6f6a63;
+  --od-tweaks-selected: #111111;
+  --od-tweaks-shadow-lg: 0 24px 60px rgba(28, 27, 26, 0.16), 0 8px 16px rgba(28, 27, 26, 0.07);
+  --od-tweaks-radius: 12px;
+  --od-tweaks-radius-sm: 8px;
+  --od-tweaks-sans: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --od-tweaks-bg-panel: #222120;
+    --od-tweaks-bg-subtle: #272523;
+    --od-tweaks-bg-muted: #2e2c29;
+    --od-tweaks-border: #333128;
+    --od-tweaks-text: #e8e4dc;
+    --od-tweaks-text-muted: #9a9690;
+    --od-tweaks-selected: #f2ede4;
+    --od-tweaks-shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.3);
+  }
+}
 [data-od-tweaks-hidden] .tw-panel {
   transform: translateX(calc(100% + 32px)) !important;
   opacity: 0 !important;
   pointer-events: none !important;
 }
 .tw-restore { display: none !important; }
+.twk-panel[data-omelette-chrome],
+.twk-panel {
+  background: var(--od-tweaks-bg-panel) !important;
+  color: var(--od-tweaks-text) !important;
+  border: 1px solid var(--od-tweaks-border) !important;
+  border-radius: var(--od-tweaks-radius) !important;
+  box-shadow: var(--od-tweaks-shadow-lg) !important;
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+  font: 13px/1.35 var(--od-tweaks-sans) !important;
+}
+.twk-hd {
+  padding: 10px 10px 9px 12px !important;
+  border-bottom: 1px solid var(--od-tweaks-border) !important;
+}
+.twk-hd b {
+  color: var(--od-tweaks-text) !important;
+  font-size: 13px !important;
+  font-weight: 650 !important;
+  letter-spacing: 0 !important;
+}
+.twk-x {
+  width: 30px !important;
+  height: 30px !important;
+  border-radius: var(--od-tweaks-radius-sm) !important;
+  color: var(--od-tweaks-text-muted) !important;
+}
+.twk-x:hover {
+  background: var(--od-tweaks-bg-subtle) !important;
+  color: var(--od-tweaks-text) !important;
+}
+.twk-body {
+  padding: 12px !important;
+  gap: 12px !important;
+  scrollbar-color: var(--od-tweaks-border) transparent !important;
+}
+.twk-lbl,
+.twk-val,
+.twk-sect,
+.twk-num-lbl,
+.twk-num-unit {
+  color: var(--od-tweaks-text-muted) !important;
+}
+.twk-row-h {
+  align-items: center !important;
+  gap: 12px !important;
+}
+.twk-row-h .twk-lbl {
+  flex: 1 1 auto !important;
+  min-width: 0 !important;
+}
+.twk-sect {
+  font-size: 11px !important;
+  letter-spacing: .04em !important;
+}
+.twk-field,
+.twk-num,
+.twk-seg {
+  background: var(--od-tweaks-bg-subtle) !important;
+  border: 1px solid var(--od-tweaks-border) !important;
+  border-radius: var(--od-tweaks-radius-sm) !important;
+}
+.twk-field:focus,
+.twk-field:focus-visible,
+.twk-seg button:focus-visible,
+.twk-toggle:focus-visible,
+.twk-btn:focus-visible,
+.twk-chip:focus-visible,
+.twk-x:focus-visible {
+  outline: 2px solid var(--od-tweaks-selected) !important;
+  outline-offset: 2px !important;
+}
+.twk-seg-thumb {
+  background: var(--od-tweaks-bg-panel) !important;
+  box-shadow: 0 1px 0 rgba(0,0,0,.04), 0 1px 4px rgba(0,0,0,.08) !important;
+}
+.twk-seg button {
+  color: var(--od-tweaks-text) !important;
+  min-height: 28px !important;
+}
+.twk-toggle {
+  box-sizing: border-box !important;
+  display: inline-flex !important;
+  flex: 0 0 auto !important;
+  align-items: center !important;
+  justify-content: flex-start !important;
+  min-width: 38px !important;
+  width: 38px !important;
+  height: 22px !important;
+  padding: 2px !important;
+  position: relative !important;
+  background: var(--od-tweaks-bg-muted) !important;
+  border: 1px solid var(--od-tweaks-border) !important;
+  border-radius: 999px !important;
+}
+.twk-toggle[data-on="1"] {
+  background: var(--od-tweaks-selected) !important;
+}
+.twk-toggle i {
+  display: block !important;
+  position: static !important;
+  flex: 0 0 auto !important;
+  width: 16px !important;
+  height: 16px !important;
+  background: var(--od-tweaks-bg-panel) !important;
+  border-radius: 50% !important;
+  box-shadow: 0 1px 4px rgba(0,0,0,.22) !important;
+  transform: translateX(0) !important;
+  transition: transform 140ms cubic-bezier(0.23, 1, 0.32, 1) !important;
+}
+.twk-toggle[data-on="1"] i {
+  transform: translateX(16px) !important;
+}
+.twk-btn {
+  background: var(--od-tweaks-selected) !important;
+  border-radius: var(--od-tweaks-radius-sm) !important;
+}
+.twk-btn.secondary {
+  background: var(--od-tweaks-bg-subtle) !important;
+  color: var(--od-tweaks-text) !important;
+}
 </style>`;
   const script = `<script data-od-tweaks-bridge>(function(){
   // Synchronously hide BEFORE the artifact body parses so the panel never

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -75,7 +75,7 @@ export function buildSrcdoc(
     : withSelection;
   const withEdit = options.editBridge ? injectManualEditBridge(withPalette) : withPalette;
   // The tweaks bridge is always injected — it's a passive listener that
-  // toggles a `.tw-panel`'s visibility in response to host postMessage. Tying
+  // toggles a tweaks panel's visibility in response to host postMessage. Tying
   // it to a per-call option would force iframe srcdoc regeneration (and a
   // visible flash) every time the host toggle flips.
   const withTweaks = injectTweaksBridge(withEdit);
@@ -1990,7 +1990,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
 // drive panel visibility; bridge posts `od:tweaks-panel-state` back whenever the
 // artifact's own `× close` button or `T` shortcut flips the `.tw-hidden` class,
 // so the toolbar toggle stays in sync. Also reports `od:tweaks-available` so the
-// host can disable the toggle on artifacts without a `.tw-panel`.
+// host can disable the toggle on artifacts without a supported tweaks panel.
 function injectTweaksBridge(doc: string): string {
   // Hide-state styling mirrors the artifact's own `.tw-hidden` (transform +
   // opacity) so the CSS transition plays in both directions. `.tw-restore` is
@@ -2022,7 +2022,8 @@ function injectTweaksBridge(doc: string): string {
     --od-tweaks-shadow-lg: 0 24px 60px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.3);
   }
 }
-[data-od-tweaks-hidden] .tw-panel {
+[data-od-tweaks-hidden] .tw-panel,
+[data-od-tweaks-hidden] .twk-panel {
   transform: translateX(calc(100% + 32px)) !important;
   opacity: 0 !important;
   pointer-events: none !important;
@@ -2159,7 +2160,7 @@ function injectTweaksBridge(doc: string): string {
   var suppressEcho = false;
   var observer = null;
 
-  function panelEl(){ return document.querySelector('.tw-panel'); }
+  function panelEl(){ return document.querySelector('.tw-panel, .twk-panel'); }
 
   function applyClassesToPanel(visible){
     var panel = panelEl();

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -851,23 +851,7 @@
   background: color-mix(in srgb, var(--accent, #7c5cff) 12%, var(--bg-subtle));
 }
 
-/* Project instructions toggle & editor bar */
-.project-instructions-toggle {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  padding: 2px 4px;
-  margin-left: 4px;
-  border-radius: 4px;
-  opacity: 0.6;
-  transition: opacity 0.15s;
-  flex-shrink: 0;
-}
-.project-instructions-toggle:hover {
-  opacity: 1;
-  background: var(--bg-hover, rgba(128, 128, 128, 0.1));
-}
+/* Project instructions editor bar */
 .project-instructions-bar {
   padding: 8px 16px 10px;
   border-bottom: 1px solid var(--border);
@@ -875,12 +859,6 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-}
-.project-instructions-label {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-muted);
-  letter-spacing: 0.3px;
 }
 .project-instructions-input {
   width: 100%;
@@ -898,42 +876,8 @@
 }
 .project-instructions-input:focus {
   outline: none;
-  border-color: var(--accent, #646cff);
-}
-.project-instructions-actions {
-  display: flex;
-  gap: 6px;
-  justify-content: flex-end;
-}
-
-.project-instructions-bar-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-.project-instructions-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--accent, #646cff);
-  flex-shrink: 0;
-}
-.project-instructions-preview {
-  width: 100%;
-  max-height: 160px;
-  overflow-y: auto;
-  padding: 8px 10px;
-  font-size: 13px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--bg);
-  color: var(--text);
+  border-color: var(--border-strong, var(--border));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--text) 8%, transparent);
 }
 
 /* Settings: custom instructions textarea */

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -906,36 +906,6 @@
   justify-content: flex-end;
 }
 
-/* Saved-state entry point: a persistent header chip that reveals the
-   review panel so saved Project instructions stay discoverable (#1822). */
-.project-instructions-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  margin-left: 6px;
-  padding: 2px 8px;
-  font-size: 11px;
-  font-weight: 600;
-  line-height: 1.6;
-  color: var(--text-muted);
-  background: var(--bg-hover, rgba(128, 128, 128, 0.1));
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
-  flex-shrink: 0;
-  max-width: 220px;
-}
-.project-instructions-chip span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.project-instructions-chip:hover,
-.project-instructions-chip.is-open {
-  color: var(--text);
-  border-color: var(--accent, #646cff);
-}
 .project-instructions-bar-head {
   display: flex;
   align-items: center;

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -748,8 +748,7 @@
 }
 .app .app-chrome-back,
 .app .settings-icon-btn,
-.app .avatar-btn,
-.app .project-instructions-toggle {
+.app .avatar-btn {
   width: 30px;
   height: 30px;
   border-radius: 8px;
@@ -1669,6 +1668,96 @@
   padding: 4px 10px 6px;
 }
 
+/* -- Project-page context capsule (design system + instructions) -- */
+.project-context-capsule {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: min(100%, 430px);
+  height: 30px;
+  flex: 0 1 auto;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+}
+.project-context-capsule .project-ds-picker {
+  flex: 1 1 auto;
+}
+.project-context-capsule .project-ds-picker-trigger,
+.project-context-instructions {
+  appearance: none;
+  height: 28px;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  transition:
+    background 200ms cubic-bezier(0.23, 1, 0.32, 1),
+    color 200ms cubic-bezier(0.23, 1, 0.32, 1),
+    box-shadow 200ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.project-context-capsule .project-ds-picker-trigger {
+  width: 100%;
+  max-width: none;
+  padding: 0 10px 0 11px;
+  border-radius: 999px 0 0 999px;
+  color: var(--text-strong, var(--text));
+}
+.project-context-capsule .project-ds-picker-trigger:hover,
+.project-context-capsule .project-ds-picker-trigger:active,
+.project-context-capsule .project-ds-picker-trigger.picked,
+.project-context-capsule .project-context-instructions:hover,
+.project-context-capsule .project-context-instructions:hover:not(:disabled),
+.project-context-capsule .project-context-instructions:active,
+.project-context-capsule .project-context-instructions.is-open {
+  background: transparent;
+}
+.project-context-capsule .project-ds-picker-trigger:hover,
+.project-context-capsule .project-context-instructions:hover {
+  color: var(--text-strong, var(--text));
+}
+.project-context-capsule .project-ds-picker-trigger.picked,
+.project-context-instructions.is-open {
+  color: var(--text-strong, var(--text));
+}
+.project-ds-picker-chevron,
+.project-context-instructions-chevron {
+  flex: 0 0 auto;
+  transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.project-ds-picker.open .project-ds-picker-chevron,
+.project-context-instructions.is-open .project-context-instructions-chevron {
+  transform: rotate(180deg);
+}
+.project-context-capsule .project-ds-picker-trigger:focus-visible,
+.project-context-instructions:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: none;
+  box-shadow:
+    inset 0 0 0 1px var(--border-strong, var(--border)),
+    0 0 0 2px color-mix(in srgb, var(--text) 10%, transparent);
+}
+.project-context-instructions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 174px;
+  padding: 0 11px 0 10px;
+  border-left: 1px solid var(--border);
+  border-radius: 0 999px 999px 0;
+  font: inherit;
+  font-size: 11.5px;
+  line-height: 1;
+  cursor: pointer;
+}
+.project-context-instructions-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 /* -- Project-page design-system picker (project chrome header) -- */
 .project-ds-picker {
   position: relative;
@@ -1739,18 +1828,22 @@
 .project-ds-picker-search {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 10px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--border);
-  color: var(--text-muted);
 }
 .project-ds-picker-search input {
   flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
   border: 0;
   outline: none;
   background: transparent;
   font: inherit;
   color: var(--text);
+}
+.project-ds-picker-search input:focus {
+  border-color: transparent;
+  box-shadow: none;
 }
 .project-ds-picker-body {
   display: grid;

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1712,6 +1712,39 @@ describe('FileViewer tweaks toolbar', () => {
     expect(button.textContent).toContain('Tweaks');
   });
 
+  it('toggles legacy twk tweak panels through the OD toolbar entry point', async () => {
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><aside class="twk-panel" data-omelette-chrome="">Tweaks</aside><main>Hero</main></body></html>'
+      />,
+    );
+
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(frame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+    expect(frame.srcdoc).toContain('data-od-tweaks-bridge');
+    expect(frame.srcdoc).toContain('function panelEl(){ return document.querySelector(\'.tw-panel, .twk-panel\'); }');
+    expect(frame.srcdoc).toContain('[data-od-tweaks-hidden] .twk-panel');
+
+    const postMessageSpy = vi.spyOn(frame.contentWindow!, 'postMessage');
+    const button = screen.getByTestId('tweaks-panel-toggle') as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    fireEvent.click(button);
+
+    expect(button.getAttribute('aria-pressed')).toBe('true');
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { type: 'od:tweaks-panel-visible', visible: true },
+      '*',
+    );
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { type: '__activate_edit_mode' },
+      '*',
+    );
+  });
+
   it('keeps preview viewport selection scoped to each HTML file', async () => {
     const firstFile = htmlPreviewFile({ name: 'first.html', path: 'first.html' });
     const secondFile = htmlPreviewFile({ name: 'second.html', path: 'second.html' });

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1671,6 +1671,7 @@ describe('FileViewer tweaks toolbar', () => {
     );
 
     expect(screen.queryByTestId('palette-tweaks-toggle')).toBeNull();
+    expect(screen.queryByTestId('tweaks-panel-toggle')).toBeNull();
     expect(screen.queryByTestId('inspect-mode-toggle')).toBeNull();
     expect(screen.getByTestId('board-mode-toggle')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'More annotation tools' })).toBeNull();
@@ -1693,6 +1694,22 @@ describe('FileViewer tweaks toolbar', () => {
 
     clickAgentTool('draw-overlay-toggle');
     expect(screen.queryByPlaceholderText('Add a note for this mark')).toBeNull();
+  });
+
+  it('renders a labeled Tweaks entry point for artifacts that embed a tweak panel', async () => {
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><script type="text/babel" src="tweaks-panel.jsx"></script><main>Hero</main></body></html>'
+      />,
+    );
+
+    const button = screen.getByTestId('tweaks-panel-toggle') as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    expect(button.getAttribute('aria-label')).toBe('Tweaks');
+    expect(button.textContent).toContain('Tweaks');
   });
 
   it('keeps preview viewport selection scoped to each HTML file', async () => {

--- a/apps/web/tests/components/ProjectView.projectInstructions.test.tsx
+++ b/apps/web/tests/components/ProjectView.projectInstructions.test.tsx
@@ -184,6 +184,14 @@ function ProjectViewHarness({ initialProject }: { initialProject: Project }) {
 
 const SAVED = 'Always use tabs, never spaces.';
 
+function deferredProjectPatch() {
+  let resolve!: (value: Project | null) => void;
+  const promise = new Promise<Project | null>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 async function openProjectInstructions() {
   const trigger = await screen.findByTestId('project-settings-trigger');
   fireEvent.click(trigger);
@@ -266,11 +274,78 @@ describe('ProjectView – saved Project instructions surface (#1822)', () => {
     });
     fireEvent.click(trigger);
 
-    expect(screen.queryByTestId('project-instructions-textarea')).toBeNull();
     await waitFor(() => {
       expect(mockedPatchProject).toHaveBeenCalledWith('project-1', {
         customInstructions: nextInstructions,
       });
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('project-instructions-textarea')).toBeNull();
+    });
+  });
+
+  it('keeps typed instructions recoverable when close-time autosave fails', async () => {
+    const nextInstructions = 'Keep this draft if saving fails.';
+    mockedPatchProject.mockResolvedValue(null);
+    render(<ProjectViewHarness initialProject={baseProject} />);
+
+    const trigger = await openProjectInstructions();
+    fireEvent.change(screen.getByTestId('project-instructions-textarea'), {
+      target: { value: nextInstructions },
+    });
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(mockedPatchProject).toHaveBeenCalledWith('project-1', {
+        customInstructions: nextInstructions,
+      });
+    });
+    const textarea = screen.getByTestId('project-instructions-textarea') as HTMLTextAreaElement;
+    expect(textarea.value).toBe(nextInstructions);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('saves a queued final revert after an in-flight autosave succeeds', async () => {
+    const initialInstructions = 'A';
+    const intermediateInstructions = 'AB';
+    const firstSave = deferredProjectPatch();
+    const secondSave = deferredProjectPatch();
+    mockedPatchProject
+      .mockReturnValueOnce(firstSave.promise)
+      .mockReturnValueOnce(secondSave.promise);
+    render(<ProjectViewHarness initialProject={{ ...baseProject, customInstructions: initialInstructions }} />);
+
+    const trigger = await openProjectInstructions();
+    fireEvent.change(screen.getByTestId('project-instructions-textarea'), {
+      target: { value: intermediateInstructions },
+    });
+
+    await waitFor(() => {
+      expect(mockedPatchProject).toHaveBeenCalledWith('project-1', {
+        customInstructions: intermediateInstructions,
+      });
+    });
+
+    fireEvent.change(screen.getByTestId('project-instructions-textarea'), {
+      target: { value: initialInstructions },
+    });
+    fireEvent.click(trigger);
+
+    firstSave.resolve({ ...baseProject, customInstructions: intermediateInstructions });
+
+    await waitFor(() => {
+      expect(mockedPatchProject).toHaveBeenCalledWith('project-1', {
+        customInstructions: initialInstructions,
+      });
+    });
+
+    const bar = screen.getByTestId('project-instructions-textarea').parentElement;
+    expect(bar?.getAttribute('aria-busy')).toBe('true');
+
+    secondSave.resolve({ ...baseProject, customInstructions: initialInstructions });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('project-instructions-textarea')).toBeNull();
     });
   });
 });

--- a/apps/web/tests/components/ProjectView.projectInstructions.test.tsx
+++ b/apps/web/tests/components/ProjectView.projectInstructions.test.tsx
@@ -184,8 +184,10 @@ function ProjectViewHarness({ initialProject }: { initialProject: Project }) {
 
 const SAVED = 'Always use tabs, never spaces.';
 
-async function openProjectInstructionsFromSettings() {
-  fireEvent.click(await screen.findByTestId('project-settings-trigger'));
+async function openProjectInstructions() {
+  const trigger = await screen.findByTestId('project-settings-trigger');
+  fireEvent.click(trigger);
+  return trigger;
 }
 
 describe('ProjectView – saved Project instructions surface (#1822)', () => {
@@ -202,68 +204,73 @@ describe('ProjectView – saved Project instructions surface (#1822)', () => {
     vi.clearAllMocks();
   });
 
-  it('shows a persistent saved-state chip (not just a bare pencil) when instructions exist', async () => {
+  it('shows a persistent project-instructions capsule when instructions exist', async () => {
     render(<ProjectViewHarness initialProject={{ ...baseProject, customInstructions: SAVED }} />);
 
-    const chip = await screen.findByTestId('project-instructions-chip');
-    expect(chip).toBeTruthy();
-    // The empty-state add affordance must not be the surface once a value exists.
-    expect(screen.queryByTestId('project-instructions-add')).toBeNull();
+    const trigger = await screen.findByTestId('project-settings-trigger');
+    expect(trigger.textContent).toContain('project.customInstructions');
+    expect(trigger.className).toContain('has-instructions');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
     // Nothing is expanded until the user opts in.
     expect(screen.queryByTestId('project-instructions-preview')).toBeNull();
     expect(screen.queryByTestId('project-instructions-textarea')).toBeNull();
   });
 
-  it('opens a read-only review panel that previews the saved instructions', async () => {
+  it('opens the live editor with the saved instructions prefilled', async () => {
     render(<ProjectViewHarness initialProject={{ ...baseProject, customInstructions: SAVED }} />);
 
-    fireEvent.click(await screen.findByTestId('project-instructions-chip'));
-
-    const preview = screen.getByTestId('project-instructions-preview');
-    expect(preview.textContent).toBe(SAVED);
-    // The panel makes the active/injected state explicit.
-    expect(screen.getByText('project.instructionsActive')).toBeTruthy();
-    // Review is read-only — no editor until the user asks to edit.
-    expect(screen.queryByTestId('project-instructions-textarea')).toBeNull();
-  });
-
-  it('reopens the editor from the review panel with the saved value prefilled', async () => {
-    render(<ProjectViewHarness initialProject={{ ...baseProject, customInstructions: SAVED }} />);
-
-    fireEvent.click(await screen.findByTestId('project-instructions-chip'));
-    fireEvent.click(screen.getByTestId('project-instructions-edit'));
+    const trigger = await openProjectInstructions();
 
     const textarea = screen.getByTestId('project-instructions-textarea') as HTMLTextAreaElement;
     expect(textarea.value).toBe(SAVED);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.queryByTestId('project-instructions-preview')).toBeNull();
+    expect(screen.queryByTestId('project-instructions-edit')).toBeNull();
+    expect(screen.queryByTestId('project-instructions-save')).toBeNull();
   });
 
-  it('offers an add affordance and opens an empty editor when no instructions are saved', async () => {
+  it('opens an empty live editor when no instructions are saved', async () => {
     render(<ProjectViewHarness initialProject={baseProject} />);
 
     expect(await screen.findByTestId('project-settings-trigger')).toBeTruthy();
-    expect(screen.queryByTestId('project-instructions-chip')).toBeNull();
 
-    await openProjectInstructionsFromSettings();
+    await openProjectInstructions();
 
     const textarea = screen.getByTestId('project-instructions-textarea') as HTMLTextAreaElement;
     expect(textarea.value).toBe('');
   });
 
-  it('reads the saved value back in the review panel right after a save', async () => {
+  it('autosaves changed instructions through the project patch endpoint', async () => {
     mockedPatchProject.mockResolvedValue({ ...baseProject, customInstructions: SAVED });
     render(<ProjectViewHarness initialProject={baseProject} />);
 
-    await openProjectInstructionsFromSettings();
+    await openProjectInstructions();
     fireEvent.change(screen.getByTestId('project-instructions-textarea'), {
       target: { value: SAVED },
     });
-    fireEvent.click(screen.getByTestId('project-instructions-save'));
 
-    expect(mockedPatchProject).toHaveBeenCalledWith('project-1', { customInstructions: SAVED });
-    // Save lands on the review panel so the stored value is confirmed back.
     await waitFor(() => {
-      expect(screen.getByTestId('project-instructions-preview').textContent).toBe(SAVED);
+      expect(mockedPatchProject).toHaveBeenCalledWith('project-1', { customInstructions: SAVED });
     });
-    expect(screen.getByTestId('project-instructions-chip')).toBeTruthy();
+    expect(screen.getByTestId('project-instructions-textarea')).toBeTruthy();
+  });
+
+  it('flushes pending instruction edits when the capsule closes', async () => {
+    const nextInstructions = 'Use compact terminal spacing.';
+    mockedPatchProject.mockResolvedValue({ ...baseProject, customInstructions: nextInstructions });
+    render(<ProjectViewHarness initialProject={baseProject} />);
+
+    const trigger = await openProjectInstructions();
+    fireEvent.change(screen.getByTestId('project-instructions-textarea'), {
+      target: { value: nextInstructions },
+    });
+    fireEvent.click(trigger);
+
+    expect(screen.queryByTestId('project-instructions-textarea')).toBeNull();
+    await waitFor(() => {
+      expect(mockedPatchProject).toHaveBeenCalledWith('project-1', {
+        customInstructions: nextInstructions,
+      });
+    });
   });
 });

--- a/apps/web/tests/components/file-viewer-render-mode.test.ts
+++ b/apps/web/tests/components/file-viewer-render-mode.test.ts
@@ -85,9 +85,14 @@ describe('hasTweaksTemplate', () => {
     expect(hasTweaksTemplate(source)).toBe(true);
   });
 
+  it('matches legacy `.twk-panel` artifacts', () => {
+    const source = '<script type="text/babel" src="tweaks-panel.jsx"></script><div className="twk-panel" />';
+    expect(hasTweaksTemplate(source)).toBe(true);
+  });
+
   it('does not match unrelated identifiers that merely contain `tw`', () => {
     expect(hasTweaksTemplate('<div class="container">tweet</div>')).toBe(false);
-    expect(hasTweaksTemplate('twk-panel, btw-panel, mtw-hidden')).toBe(false);
+    expect(hasTweaksTemplate('btwk-panel, btw-panel, mtw-hidden')).toBe(false);
   });
 
   it('returns false for empty / null / undefined input', () => {

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { buildSrcdoc } from '../../src/runtime/srcdoc';
 
@@ -41,11 +41,53 @@ describe('buildSrcdoc', () => {
     const srcdoc = buildSrcdoc('<main><div class="twk-panel" data-omelette-chrome="">Tweaks</div></main>');
 
     expect(srcdoc).toContain('data-od-tweaks-bridge-style');
+    expect(srcdoc).toContain('[data-od-tweaks-hidden] .twk-panel');
     expect(srcdoc).toContain('.twk-panel[data-omelette-chrome]');
     expect(srcdoc).toContain('--od-tweaks-bg-panel');
     expect(srcdoc).toContain('backdrop-filter: none !important');
     expect(srcdoc).toContain('min-width: 38px !important');
     expect(srcdoc).toContain('position: static !important');
+  });
+
+  it('lets the host visibility bridge control legacy twk tweak panels', async () => {
+    const parentPostMessage = vi.fn();
+    const srcdoc = buildSrcdoc('<main><div class="twk-panel" data-omelette-chrome="">Tweaks</div></main>');
+    const dom = new JSDOM(srcdoc, {
+      runScripts: 'dangerously',
+      beforeParse(win) {
+        Object.defineProperty(win, 'parent', {
+          configurable: true,
+          value: { postMessage: parentPostMessage },
+        });
+      },
+    });
+
+    await new Promise((resolve) => dom.window.setTimeout(resolve, 0));
+
+    const panel = dom.window.document.querySelector('.twk-panel');
+    expect(panel).toBeTruthy();
+    expect(parentPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'od:tweaks-available', available: true }),
+      '*',
+    );
+    expect(parentPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'od:tweaks-panel-state', visible: true }),
+      '*',
+    );
+
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od:tweaks-panel-visible', visible: false },
+    }));
+    await new Promise((resolve) => dom.window.setTimeout(resolve, 0));
+    expect(panel?.classList.contains('tw-hidden')).toBe(true);
+    expect(dom.window.document.documentElement.hasAttribute('data-od-tweaks-hidden')).toBe(true);
+
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od:tweaks-panel-visible', visible: true },
+    }));
+    await new Promise((resolve) => dom.window.setTimeout(resolve, 0));
+    expect(panel?.classList.contains('tw-hidden')).toBe(false);
+    expect(dom.window.document.documentElement.hasAttribute('data-od-tweaks-hidden')).toBe(false);
   });
 
   it('renders snapshot SVGs through data URLs so canvas export stays origin-clean', () => {

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -37,6 +37,17 @@ describe('buildSrcdoc', () => {
     expect(srcdoc).toContain('foreignObject');
   });
 
+  it('normalizes legacy twk tweak panels to Open Design chrome', () => {
+    const srcdoc = buildSrcdoc('<main><div class="twk-panel" data-omelette-chrome="">Tweaks</div></main>');
+
+    expect(srcdoc).toContain('data-od-tweaks-bridge-style');
+    expect(srcdoc).toContain('.twk-panel[data-omelette-chrome]');
+    expect(srcdoc).toContain('--od-tweaks-bg-panel');
+    expect(srcdoc).toContain('backdrop-filter: none !important');
+    expect(srcdoc).toContain('min-width: 38px !important');
+    expect(srcdoc).toContain('position: static !important');
+  });
+
   it('renders snapshot SVGs through data URLs so canvas export stays origin-clean', () => {
     const srcdoc = buildSrcdoc('<main style="color:red">Hero</main>');
 


### PR DESCRIPTION
## Why

While refining an imported HTML artifact, the project-level context controls and embedded tweak panel controls were competing with the rest of OD's chrome instead of feeling like part of it.

The user-facing pain was mostly review and editing friction: project instructions appeared in more than one place, the design-system picker and instructions control looked related but behaved visually differently, and embedded `twk`/`tw` tweak panels carried their own non-OD chrome. The formatting lesson from this pass is that related controls should be grouped by intent, use flat shell-native borders/dividers, and avoid colored focus or status treatments unless the color carries real state.

## What users will see

- HTML previews with embedded tweak templates now expose a toolbar `Tweaks` control from OD's viewer chrome, and the embedded tweak panel is restyled to match OD's panel spacing, typography, borders, and light/dark token treatment.
- The project header now has a single flat project-context capsule: `Design system` and `Project instructions` sit together as related but distinct segments.
- The old redundant Project Instructions chip/button has been removed from the right-side chrome.
- Project instructions open directly into a live autosaving editor from the capsule. There is no separate read-only review header, active status label, Close button, Edit button, or Save button.
- The design-system picker search row no longer has a decorative search icon, colored focus ring, or extra-thick divider; it keeps one normal divider and uses the input itself for search.
- Both capsule chevrons rotate consistently for open/closed state.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

UI was verified locally in the in-app browser against an imported HTML project preview. The visible entry points are the file preview toolbar `Tweaks` control and the top-left project context capsule containing `Design system` and `Project instructions`.

## Bug fix verification

-

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/ProjectDesignSystemPicker.test.tsx tests/components/ProjectView.projectInstructions.test.tsx` from `apps/web` — 2 files, 8 tests passed.
- `pnpm --filter @open-design/web test` — 247 files, 2382 tests passed.
- `pnpm --filter @open-design/web typecheck`.
- `pnpm guard`.
- `git diff --check`.
- In-app browser computed-style checks confirmed the design-system search divider is a single `1px` border with no extra box shadow, and the picker search input has no colored focus shadow.

Notes:
- The repo requires Node `~24`; final validation used Node 24. The default local shell was on a newer Node, which produced unrelated localStorage failures in Vitest.
- The same focused and full web suites pass under Node 24.
