### PR TITLE
[codex] Add OpenAI-compatible custom media router

### DIFF
--- a/apps/daemon/src/media-config.ts
+++ b/apps/daemon/src/media-config.ts
@@ -89,6 +89,10 @@ const ENV_KEYS: Record<string, string[]> = {
   nanobanana: ['OD_NANOBANANA_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_API_KEY'],
   imagerouter: ['OD_IMAGEROUTER_API_KEY', 'IMAGEROUTER_API_KEY'],
   'custom-image': ['OD_CUSTOM_IMAGE_API_KEY', 'CUSTOM_IMAGE_API_KEY'],
+  'custom-media-router': [
+    'OD_CUSTOM_MEDIA_ROUTER_API_KEY',
+    'CUSTOM_MEDIA_ROUTER_API_KEY',
+  ],
   bfl: ['OD_BFL_API_KEY', 'BFL_API_KEY'],
   fal: ['OD_FAL_KEY', 'FAL_KEY'],
   replicate: ['OD_REPLICATE_API_TOKEN', 'REPLICATE_API_TOKEN'],

--- a/apps/daemon/src/media-models.ts
+++ b/apps/daemon/src/media-models.ts
@@ -38,6 +38,7 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
   { id: 'nanobanana', label: 'Nano Banana', hint: 'Google official by default; custom gateway configurable', integrated: true, defaultBaseUrl: 'https://generativelanguage.googleapis.com', supportsCustomModel: true },
   { id: 'imagerouter', label: 'ImageRouter', hint: 'OpenAI-compatible image + video routing', integrated: true, defaultBaseUrl: 'https://api.imagerouter.io/v1/openai', docsUrl: 'https://docs.imagerouter.io/api-reference/image-generation/', supportsCustomModel: true, customModelPlaceholder: 'openai/gpt-image-2 or xAI/grok-imagine-video' },
   { id: 'custom-image', label: 'Custom Image API', hint: 'OpenAI-compatible images/generations + images/edits (local or cloud)', integrated: true, docsUrl: 'https://platform.openai.com/docs/api-reference/images', supportsCustomModel: true, customModelPlaceholder: 'my-image-model' },
+  { id: 'custom-media-router', label: 'Custom Media Router', hint: 'OpenAI-compatible image + video gateway', integrated: true, supportsCustomModel: true, customModelPlaceholder: 'auto or provider/model-id' },
   { id: 'comfyui', label: 'ComfyUI', hint: 'Local JSON workflow server (planned adapter)', integrated: false, defaultBaseUrl: 'http://127.0.0.1:8188', docsUrl: 'https://docs.comfy.org/development/core-concepts/workflow' },
   { id: 'bfl', label: 'Black Forest Labs', hint: 'FLUX 1.1 Pro / FLUX Pro / Dev', integrated: false, defaultBaseUrl: 'https://api.bfl.ai' },
   { id: 'fal', label: 'Fal.ai', hint: 'Sora / Seedance / Veo / FLUX', integrated: false, defaultBaseUrl: 'https://fal.run' },
@@ -94,6 +95,7 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'black-forest-labs/FLUX-1.1-pro', label: 'FLUX-1.1-pro', hint: 'ImageRouter · Black Forest Labs', provider: 'imagerouter', caps: ['t2i'] },
 
   { id: 'custom-image', label: 'custom-image', hint: 'Custom · OpenAI-compatible endpoint', provider: 'custom-image', caps: ['t2i', 'i2i'] },
+  { id: 'custom-media-image', label: 'custom-media-image', hint: 'Custom Media Router · image', provider: 'custom-media-router', caps: ['t2i', 'i2i'] },
 
   { id: 'flux-1.1-pro', label: 'flux-1.1-pro', hint: 'BFL · flagship', provider: 'bfl', caps: ['t2i', 'i2i'] },
   { id: 'flux-pro', label: 'flux-pro', hint: 'BFL', provider: 'bfl', caps: ['t2i'] },
@@ -130,6 +132,8 @@ export const VIDEO_MODELS: MediaModel[] = [
   { id: 'xAI/grok-imagine-video', label: 'xAI/grok-imagine-video', hint: 'ImageRouter · routed video', provider: 'imagerouter', caps: ['t2v', 'audio'] },
   { id: 'bytedance/seedance-1.5-pro', label: 'seedance-1.5-pro', hint: 'ImageRouter · Bytedance', provider: 'imagerouter', caps: ['t2v'] },
   { id: 'google/veo-3.1-lite', label: 'veo-3.1-lite', hint: 'ImageRouter · Google', provider: 'imagerouter', caps: ['t2v'] },
+
+  { id: 'custom-media-video', label: 'custom-media-video', hint: 'Custom Media Router · video', provider: 'custom-media-router', caps: ['t2v', 'i2v'] },
 
   { id: 'kling-2.0', label: 'kling-2.0', hint: 'Kuaishou · latest', provider: 'kling', caps: ['t2v', 'i2v'] },
   { id: 'kling-1.6', label: 'kling-1.6', hint: 'Kuaishou', provider: 'kling', caps: ['t2v', 'i2v'] },

--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -133,6 +133,8 @@ const NANOBANANA_DEFAULT_MODEL = 'gemini-3.1-flash-image-preview';
 const NANOBANANA_DEFAULT_IMAGE_SIZE = '1K';
 const IMAGEROUTER_DEFAULT_BASE_URL = 'https://api.imagerouter.io/v1/openai';
 const CUSTOM_IMAGE_MODEL_ID = 'custom-image';
+const CUSTOM_MEDIA_IMAGE_MODEL_ID = 'custom-media-image';
+const CUSTOM_MEDIA_VIDEO_MODEL_ID = 'custom-media-video';
 
 const DEFAULT_OUTPUT_BY_SURFACE = {
   image: 'image.png',
@@ -513,6 +515,16 @@ export async function generateMedia(args: {
       suggestedExt = result.suggestedExt;
     } else if (def.provider === 'custom-image' && surface === 'image') {
       const result = await renderCustomOpenAIImage(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'custom-media-router' && surface === 'image') {
+      const result = await renderCustomMediaRouterImage(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'custom-media-router' && surface === 'video') {
+      const result = await renderCustomMediaRouterVideo(ctx, credentials);
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
@@ -910,6 +922,97 @@ async function renderCustomOpenAIImage(ctx: MediaContext, credentials: ProviderC
     bytes,
     providerNote: `custom-image/${wireModel} · ${body.size} · ${bytes.length} bytes`,
     suggestedExt: sniffImageExt(bytes),
+  };
+}
+
+function customMediaRouterWireModel(
+  ctx: MediaContext,
+  credentials: ProviderConfig,
+  placeholderModel: string,
+): string {
+  return (
+    credentials.model
+    || (ctx.wireModel !== placeholderModel ? ctx.wireModel : '')
+  ).trim();
+}
+
+function customMediaRouterHeaders(credentials: ProviderConfig): Record<string, string> {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+  };
+  if (credentials.apiKey) {
+    headers.authorization = `Bearer ${credentials.apiKey}`;
+  }
+  return headers;
+}
+
+function customMediaRouterBaseUrl(credentials: ProviderConfig): string {
+  const baseUrl = (credentials.baseUrl || '').trim();
+  if (!baseUrl) {
+    throw new Error(
+      'Custom Media Router base URL required — configure an OpenAI-compatible media endpoint in Settings',
+    );
+  }
+  return baseUrl;
+}
+
+async function renderCustomMediaRouterImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
+  const baseUrl = customMediaRouterBaseUrl(credentials);
+  const wireModel = customMediaRouterWireModel(ctx, credentials, CUSTOM_MEDIA_IMAGE_MODEL_ID);
+  if (!wireModel) {
+    throw new Error(
+      'Custom Media Router image model required — configure the provider model in Settings',
+    );
+  }
+
+  const size = imageRouterSizeFor(ctx.aspect, 'image');
+  const resp = await fetch(buildOpenAIImageUrl(baseUrl, false), {
+    method: 'POST',
+    headers: customMediaRouterHeaders(credentials),
+    body: JSON.stringify({
+      prompt: ctx.prompt || 'A high-quality reference image.',
+      model: wireModel,
+      size,
+      response_format: 'b64_json',
+    }),
+  });
+  const data = await parseOpenAICompatibleJson(resp, 'custom media router image');
+  const bytes = await bytesFromOpenAICompatibleData(data, 'custom media router image');
+  return {
+    bytes,
+    providerNote: `custom-media-router/${wireModel} · ${size} · ${bytes.length} bytes`,
+    suggestedExt: sniffImageExt(bytes),
+  };
+}
+
+async function renderCustomMediaRouterVideo(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
+  const baseUrl = customMediaRouterBaseUrl(credentials);
+  const wireModel = customMediaRouterWireModel(ctx, credentials, CUSTOM_MEDIA_VIDEO_MODEL_ID);
+  if (!wireModel) {
+    throw new Error(
+      'Custom Media Router video model required — configure the provider model in Settings',
+    );
+  }
+
+  const seconds = typeof ctx.length === 'number' ? ctx.length : 'auto';
+  const size = imageRouterSizeFor(ctx.aspect, 'video');
+  const resp = await fetch(buildOpenAIVideoUrl(baseUrl), {
+    method: 'POST',
+    headers: customMediaRouterHeaders(credentials),
+    body: JSON.stringify({
+      prompt: ctx.prompt || 'A short cinematic clip.',
+      model: wireModel,
+      size,
+      seconds,
+      response_format: 'b64_json',
+    }),
+  });
+  const data = await parseOpenAICompatibleJson(resp, 'custom media router video');
+  const bytes = await bytesFromOpenAICompatibleData(data, 'custom media router video');
+  return {
+    bytes,
+    providerNote: `custom-media-router/${wireModel} · ${size} · ${seconds === 'auto' ? 'auto' : `${seconds}s`} · ${bytes.length} bytes`,
+    suggestedExt: '.mp4',
   };
 }
 

--- a/apps/daemon/tests/media-openai-compatible-providers.test.ts
+++ b/apps/daemon/tests/media-openai-compatible-providers.test.ts
@@ -15,6 +15,7 @@ describe('OpenAI-compatible media providers', () => {
   const realFetch = globalThis.fetch;
   const originalImageRouterKey = process.env.OD_IMAGEROUTER_API_KEY;
   const originalCustomImageKey = process.env.OD_CUSTOM_IMAGE_API_KEY;
+  const originalCustomMediaRouterKey = process.env.OD_CUSTOM_MEDIA_ROUTER_API_KEY;
   const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
   const originalDataDir = process.env.OD_DATA_DIR;
 
@@ -25,6 +26,7 @@ describe('OpenAI-compatible media providers', () => {
     await mkdir(projectsRoot, { recursive: true });
     delete process.env.OD_IMAGEROUTER_API_KEY;
     delete process.env.OD_CUSTOM_IMAGE_API_KEY;
+    delete process.env.OD_CUSTOM_MEDIA_ROUTER_API_KEY;
     delete process.env.OD_MEDIA_CONFIG_DIR;
     delete process.env.OD_DATA_DIR;
   });
@@ -41,6 +43,11 @@ describe('OpenAI-compatible media providers', () => {
       delete process.env.OD_CUSTOM_IMAGE_API_KEY;
     } else {
       process.env.OD_CUSTOM_IMAGE_API_KEY = originalCustomImageKey;
+    }
+    if (originalCustomMediaRouterKey == null) {
+      delete process.env.OD_CUSTOM_MEDIA_ROUTER_API_KEY;
+    } else {
+      process.env.OD_CUSTOM_MEDIA_ROUTER_API_KEY = originalCustomMediaRouterKey;
     }
     if (originalMediaConfigDir == null) {
       delete process.env.OD_MEDIA_CONFIG_DIR;
@@ -60,6 +67,111 @@ describe('OpenAI-compatible media providers', () => {
     await mkdir(path.dirname(file), { recursive: true });
     await writeFile(file, JSON.stringify(data), 'utf8');
   }
+
+  it('renders custom media router images through /v1/images/generations', async () => {
+    await writeConfig({
+      providers: {
+        'custom-media-router': {
+          apiKey: 'router-test-key',
+          baseUrl: 'https://router.example.test/v1',
+          model: 'auto',
+        },
+      },
+    });
+
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe('https://router.example.test/v1/images/generations');
+      expect(init?.method).toBe('POST');
+      expect(init?.headers).toMatchObject({
+        authorization: 'Bearer router-test-key',
+        'content-type': 'application/json',
+      });
+      expect(JSON.parse(String(init?.body))).toEqual({
+        prompt: 'A dashboard hero illustration with glassy cards',
+        model: 'auto',
+        size: '1024x576',
+        response_format: 'b64_json',
+      });
+      return new Response(JSON.stringify({
+        data: [{ b64_json: PNG_BASE64 }],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'custom-media-image',
+      prompt: 'A dashboard hero illustration with glassy cards',
+      aspect: '16:9',
+      output: 'router.png',
+    });
+
+    expect(result.providerId).toBe('custom-media-router');
+    expect(result.providerNote).toContain('custom-media-router/auto');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'router.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  it('renders custom media router videos through /v1/videos/generations', async () => {
+    await writeConfig({
+      providers: {
+        'custom-media-router': {
+          apiKey: 'router-test-key',
+          baseUrl: 'https://router.example.test/v1',
+          model: 'auto',
+        },
+      },
+    });
+
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe('https://router.example.test/v1/videos/generations');
+      expect(init?.method).toBe('POST');
+      expect(init?.headers).toMatchObject({
+        authorization: 'Bearer router-test-key',
+        'content-type': 'application/json',
+      });
+      expect(JSON.parse(String(init?.body))).toEqual({
+        prompt: 'A smooth app onboarding animation',
+        model: 'auto',
+        size: '1024x576',
+        seconds: 8,
+        response_format: 'b64_json',
+      });
+      return new Response(JSON.stringify({
+        data: [{ b64_json: VIDEO_BASE64 }],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'video',
+      model: 'custom-media-video',
+      prompt: 'A smooth app onboarding animation',
+      aspect: '16:9',
+      length: 8,
+      output: 'router.mp4',
+    });
+
+    expect(result.providerId).toBe('custom-media-router');
+    expect(result.name).toBe('router.mp4');
+    expect(result.providerNote).toContain('custom-media-router/auto');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'router.mp4'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
 
   it('renders custom /v1/images/generations providers with configured base URL and model', async () => {
     await writeConfig({

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -36,6 +36,7 @@ export type MediaProviderId =
   | 'imagerouter'
   | 'custom-image'
   | 'comfyui'
+  | 'custom-media-router'
   | 'bfl'
   | 'fal'
   | 'replicate'
@@ -141,6 +142,14 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
     docsUrl: 'https://platform.openai.com/docs/api-reference/images',
     supportsCustomModel: true,
     customModelPlaceholder: 'my-image-model',
+  },
+  {
+    id: 'custom-media-router',
+    label: 'Custom Media Router',
+    hint: 'OpenAI-compatible image + video gateway',
+    integrated: true,
+    supportsCustomModel: true,
+    customModelPlaceholder: 'auto or provider/model-id',
   },
   {
     id: 'comfyui',
@@ -425,6 +434,13 @@ export const IMAGE_MODELS: MediaModel[] = [
     provider: 'custom-image',
     caps: ['t2i', 'i2i'],
   },
+  {
+    id: 'custom-media-image',
+    label: 'custom-media-image',
+    hint: 'Custom Media Router · image',
+    provider: 'custom-media-router',
+    caps: ['t2i', 'i2i'],
+  },
 
   // Black Forest Labs FLUX family.
   { id: 'flux-1.1-pro', label: 'flux-1.1-pro', hint: 'BFL · flagship', provider: 'bfl', caps: ['t2i', 'i2i'] },
@@ -527,6 +543,13 @@ export const VIDEO_MODELS: MediaModel[] = [
     hint: 'ImageRouter · Google',
     provider: 'imagerouter',
     caps: ['t2v'],
+  },
+  {
+    id: 'custom-media-video',
+    label: 'custom-media-video',
+    hint: 'Custom Media Router · video',
+    provider: 'custom-media-router',
+    caps: ['t2v', 'i2v'],
   },
 
   // Kuaishou Kling.

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -161,6 +161,13 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     models: ['gpt-4o', 'gpt-4o-mini', 'o3', 'o4-mini'],
   },
   {
+    label: 'Token Table',
+    protocol: 'openai',
+    baseUrl: 'https://tokentable.asia/v1',
+    model: 'auto',
+    models: ['auto'],
+  },
+  {
     label: 'Azure OpenAI',
     protocol: 'azure',
     baseUrl: '',

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -17,6 +17,7 @@ import {
   updateAgentCliEnvValue,
   updateCurrentApiProtocolConfig,
 } from '../../src/components/SettingsDialog';
+import { KNOWN_PROVIDERS } from '../../src/state/config';
 import type { AppConfig, ConnectionTestResponse } from '../../src/types';
 
 const originalFetch = globalThis.fetch;
@@ -40,6 +41,18 @@ afterEach(() => {
 });
 
 describe('SettingsDialog API protocol switching', () => {
+  it('offers Token Table as an OpenAI-compatible quick-fill provider', () => {
+    expect(KNOWN_PROVIDERS).toContainEqual(
+      expect.objectContaining({
+        label: 'Token Table',
+        protocol: 'openai',
+        baseUrl: 'https://tokentable.asia/v1',
+        model: 'auto',
+        models: ['auto'],
+      }),
+    );
+  });
+
   it('stores the current custom protocol config while preserving custom endpoint details', () => {
     const config: AppConfig = {
       ...baseConfig,


### PR DESCRIPTION
## Summary

Adds an OpenAI-compatible custom media router provider that can route image and video generation through configurable gateways. This makes it possible to use routing services with OpenAI-style media endpoints without adding a one-off provider for each service.

Also adds Token Table as an OpenAI-compatible BYOK quick-fill option with `https://tokentable.asia/v1` and `auto` as the default model.

## Changes

- Adds `custom-media-router` to the daemon and web media provider registries.
- Adds `custom-media-image` for `/v1/images/generations` with text-to-image and image-to-image capabilities.
- Adds `custom-media-video` for `/v1/videos/generations` with text-to-video and image-to-video capabilities.
- Adds daemon rendering paths for OpenAI-compatible image and video responses using `b64_json` or URL data.
- Adds Token Table to known BYOK providers for easier OpenAI-compatible setup.
- Covers the new provider paths with daemon and web tests.

## Validation

- `node scripts/verify-media-models.mjs`
- `pnpm --filter @open-design/daemon test tests/media-openai-compatible-providers.test.ts`
- `pnpm --filter @open-design/web test tests/components/SettingsDialog.test.ts`
- `pnpm --filter @open-design/web test tests/components/SettingsDialog.media.test.tsx`
- `pnpm --filter @open-design/web test tests/components/NewProjectPanel.media.test.tsx`
- `pnpm --filter @open-design/web test tests/components/HomeView.media-options.test.tsx`
- `pnpm typecheck`
- `pnpm guard`

## Notes

This assumes the configured media gateway exposes OpenAI-compatible `/v1/images/generations` and `/v1/videos/generations` endpoints and returns media as `data[0].b64_json` or `data[0].url`.
