### PR TITLE
fix: tolerate multiline ACP startup responses

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -289,6 +289,7 @@ function currentModelFromSessionResult(result: JsonObject): string | null {
 export function createJsonLineStream(onMessage: (message: unknown, rawLine: string) => void) {
   let buffer = '';
   let pendingJson = '';
+  let pendingJsonLineCount = 0;
 
   const emit = (candidate: string): boolean => {
     try {
@@ -301,18 +302,32 @@ export function createJsonLineStream(onMessage: (message: unknown, rawLine: stri
 
   const startPendingJson = (line: string) => {
     pendingJson = line;
+    pendingJsonLineCount = 1;
   };
 
   const handleLine = (line: string) => {
     const trimmed = line.trim();
     if (!trimmed) return;
     if (pendingJson) {
+      if ((trimmed.startsWith('{') || trimmed.startsWith('[')) && emit(trimmed)) {
+        pendingJson = '';
+        pendingJsonLineCount = 0;
+        return;
+      }
       const nextCandidate = `${pendingJson}\n${trimmed}`;
       if (emit(nextCandidate)) {
         pendingJson = '';
+        pendingJsonLineCount = 0;
         return;
       }
-      pendingJson = nextCandidate.length <= 128_000 ? nextCandidate : '';
+      pendingJsonLineCount += 1;
+      if (nextCandidate.length <= 128_000 && pendingJsonLineCount <= 256) {
+        pendingJson = nextCandidate;
+        return;
+      }
+      pendingJson = '';
+      pendingJsonLineCount = 0;
+      handleLine(trimmed);
       return;
     }
     if (emit(trimmed)) return;

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -288,30 +288,62 @@ function currentModelFromSessionResult(result: JsonObject): string | null {
 
 export function createJsonLineStream(onMessage: (message: unknown, rawLine: string) => void) {
   let buffer = '';
+  let pendingJson = '';
+
+  const emit = (candidate: string): boolean => {
+    try {
+      onMessage(JSON.parse(candidate), candidate);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const startPendingJson = (line: string) => {
+    pendingJson = line;
+  };
+
+  const handleLine = (line: string) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    if (pendingJson) {
+      const nextCandidate = `${pendingJson}\n${trimmed}`;
+      if (emit(nextCandidate)) {
+        pendingJson = '';
+        return;
+      }
+      pendingJson = nextCandidate.length <= 128_000 ? nextCandidate : '';
+      return;
+    }
+    if (emit(trimmed)) return;
+    // ACP is line-delimited JSON-RPC, but a few bridges have emitted
+    // pretty-printed JSON during startup. Keep a bounded aggregate so an
+    // otherwise valid multiline initialize response does not get discarded
+    // line-by-line and leave the session stuck in spawn pending.
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      startPendingJson(trimmed);
+    }
+  };
+
   return {
     feed(chunk: string) {
       buffer += chunk;
       const lines = buffer.split('\n');
       buffer = lines.pop() || '';
       for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        try {
-          onMessage(JSON.parse(trimmed), trimmed);
-        } catch {
-          // Ignore non-JSON log lines on stdout.
-        }
+        handleLine(line);
       }
     },
     flush() {
       const trimmed = buffer.trim();
       buffer = '';
-      if (!trimmed) return;
-      try {
-        onMessage(JSON.parse(trimmed), trimmed);
-      } catch {
-        // Ignore trailing non-JSON log lines on stdout.
+      if (trimmed) {
+        handleLine(trimmed);
       }
+      if (pendingJson && emit(pendingJson)) {
+        pendingJson = '';
+      }
+      // Ignore trailing non-JSON log lines on stdout.
     },
   };
 }

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -305,28 +305,40 @@ export function createJsonLineStream(onMessage: (message: unknown, rawLine: stri
     pendingJsonLineCount = 1;
   };
 
+  const resetPendingJson = () => {
+    pendingJson = '';
+    pendingJsonLineCount = 0;
+  };
+
   const handleLine = (line: string) => {
     const trimmed = line.trim();
     if (!trimmed) return;
     if (pendingJson) {
-      if ((trimmed.startsWith('{') || trimmed.startsWith('[')) && emit(trimmed)) {
-        pendingJson = '';
-        pendingJsonLineCount = 0;
-        return;
-      }
       const nextCandidate = `${pendingJson}\n${trimmed}`;
       if (emit(nextCandidate)) {
-        pendingJson = '';
-        pendingJsonLineCount = 0;
+        resetPendingJson();
         return;
       }
       pendingJsonLineCount += 1;
-      if (nextCandidate.length <= 128_000 && pendingJsonLineCount <= 256) {
+      if (
+        pendingJsonLineCount === 2 &&
+        pendingJson !== '{' &&
+        pendingJson !== '[' &&
+        emit(trimmed)
+      ) {
+        resetPendingJson();
+        return;
+      }
+      const state = classifyJsonCandidate(nextCandidate);
+      if (
+        state === 'incomplete' &&
+        nextCandidate.length <= 128_000 &&
+        pendingJsonLineCount <= 256
+      ) {
         pendingJson = nextCandidate;
         return;
       }
-      pendingJson = '';
-      pendingJsonLineCount = 0;
+      resetPendingJson();
       handleLine(trimmed);
       return;
     }
@@ -361,6 +373,68 @@ export function createJsonLineStream(onMessage: (message: unknown, rawLine: stri
       // Ignore trailing non-JSON log lines on stdout.
     },
   };
+}
+
+function classifyJsonCandidate(value: string): 'complete' | 'incomplete' | 'invalid' {
+  const stack: string[] = [];
+  let started = false;
+  let complete = false;
+  let inString = false;
+  let escaping = false;
+
+  for (const char of value) {
+    if (!started) {
+      if (/\s/.test(char)) continue;
+      if (char === '{') {
+        started = true;
+        stack.push('}');
+        continue;
+      }
+      if (char === '[') {
+        started = true;
+        stack.push(']');
+        continue;
+      }
+      return 'invalid';
+    }
+
+    if (complete) {
+      if (/\s/.test(char)) continue;
+      return 'invalid';
+    }
+
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (char === '\\') {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === '{') {
+      stack.push('}');
+      continue;
+    }
+    if (char === '[') {
+      stack.push(']');
+      continue;
+    }
+    if (char === '}' || char === ']') {
+      if (stack.pop() !== char) return 'invalid';
+      if (stack.length === 0) complete = true;
+    }
+  }
+
+  if (!started) return 'invalid';
+  if (inString || escaping || stack.length > 0) return 'incomplete';
+  return complete ? 'complete' : 'invalid';
 }
 
 export async function detectAcpModels({

--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -320,15 +320,6 @@ export function createJsonLineStream(onMessage: (message: unknown, rawLine: stri
         return;
       }
       pendingJsonLineCount += 1;
-      if (
-        pendingJsonLineCount === 2 &&
-        pendingJson !== '{' &&
-        pendingJson !== '[' &&
-        emit(trimmed)
-      ) {
-        resetPendingJson();
-        return;
-      }
       const state = classifyJsonCandidate(nextCandidate);
       if (
         state === 'incomplete' &&
@@ -347,7 +338,10 @@ export function createJsonLineStream(onMessage: (message: unknown, rawLine: stri
     // pretty-printed JSON during startup. Keep a bounded aggregate so an
     // otherwise valid multiline initialize response does not get discarded
     // line-by-line and leave the session stuck in spawn pending.
-    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    if (
+      (trimmed.startsWith('{') || trimmed.startsWith('[')) &&
+      classifyJsonCandidate(trimmed) === 'incomplete'
+    ) {
       startPendingJson(trimmed);
     }
   };
@@ -376,65 +370,185 @@ export function createJsonLineStream(onMessage: (message: unknown, rawLine: stri
 }
 
 function classifyJsonCandidate(value: string): 'complete' | 'incomplete' | 'invalid' {
-  const stack: string[] = [];
-  let started = false;
-  let complete = false;
-  let inString = false;
-  let escaping = false;
+  type Frame =
+    | { kind: 'object'; expect: 'keyOrEnd' | 'colon' | 'value' | 'commaOrEnd' }
+    | { kind: 'array'; expect: 'valueOrEnd' | 'commaOrEnd' };
+  const stack: Frame[] = [];
+  let rootComplete = false;
 
-  for (const char of value) {
-    if (!started) {
-      if (/\s/.test(char)) continue;
-      if (char === '{') {
-        started = true;
-        stack.push('}');
+  const afterValue = () => {
+    const parent = stack.at(-1);
+    if (!parent) {
+      rootComplete = true;
+      return;
+    }
+    parent.expect = 'commaOrEnd';
+  };
+
+  const closeFrame = (kind: 'object' | 'array'): boolean => {
+    const current = stack.pop();
+    if (!current || current.kind !== kind) return false;
+    afterValue();
+    return true;
+  };
+
+  const parseString = (start: number): number | null => {
+    for (let index = start + 1; index < value.length; index += 1) {
+      const char = value[index];
+      if (char === '\\') {
+        index += 1;
         continue;
       }
-      if (char === '[') {
-        started = true;
-        stack.push(']');
-        continue;
-      }
-      return 'invalid';
+      if (char === '"') return index;
     }
+    return null;
+  };
 
-    if (complete) {
-      if (/\s/.test(char)) continue;
-      return 'invalid';
+  const parseLiteral = (start: number, literal: string): number | null | false => {
+    for (let offset = 0; offset < literal.length; offset += 1) {
+      const char = value[start + offset];
+      if (char === undefined) return null;
+      if (char !== literal[offset]) return false;
     }
+    return start + literal.length - 1;
+  };
 
-    if (inString) {
-      if (escaping) {
-        escaping = false;
-      } else if (char === '\\') {
-        escaping = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
+  const parseNumber = (start: number): number | false => {
+    let index = start;
+    if (value[index] === '-') index += 1;
+    if (value[index] === '0') {
+      index += 1;
+    } else if (/[1-9]/.test(value[index] ?? '')) {
+      while (/[0-9]/.test(value[index] ?? '')) index += 1;
+    } else {
+      return false;
     }
+    if (value[index] === '.') {
+      index += 1;
+      if (!/[0-9]/.test(value[index] ?? '')) return false;
+      while (/[0-9]/.test(value[index] ?? '')) index += 1;
+    }
+    if (value[index] === 'e' || value[index] === 'E') {
+      index += 1;
+      if (value[index] === '+' || value[index] === '-') index += 1;
+      if (!/[0-9]/.test(value[index] ?? '')) return false;
+      while (/[0-9]/.test(value[index] ?? '')) index += 1;
+    }
+    return index - 1;
+  };
 
+  const parseValue = (index: number): number | null | false => {
+    const char = value[index];
     if (char === '"') {
-      inString = true;
-      continue;
+      const end = parseString(index);
+      if (end === null) return null;
+      afterValue();
+      return end;
     }
     if (char === '{') {
-      stack.push('}');
-      continue;
+      stack.push({ kind: 'object', expect: 'keyOrEnd' });
+      return index;
     }
     if (char === '[') {
-      stack.push(']');
+      stack.push({ kind: 'array', expect: 'valueOrEnd' });
+      return index;
+    }
+    if (char === 't') {
+      const end = parseLiteral(index, 'true');
+      if (end === false || end === null) return end;
+      afterValue();
+      return end;
+    }
+    if (char === 'f') {
+      const end = parseLiteral(index, 'false');
+      if (end === false || end === null) return end;
+      afterValue();
+      return end;
+    }
+    if (char === 'n') {
+      const end = parseLiteral(index, 'null');
+      if (end === false || end === null) return end;
+      afterValue();
+      return end;
+    }
+    if (char === '-' || /[0-9]/.test(char ?? '')) {
+      const end = parseNumber(index);
+      if (end === false) return false;
+      afterValue();
+      return end;
+    }
+    return false;
+  };
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === undefined) break;
+    if (/\s/.test(char)) continue;
+
+    const current = stack.at(-1);
+    if (!current) {
+      if (rootComplete) return 'invalid';
+      const end = parseValue(index);
+      if (end === false) return 'invalid';
+      if (end === null) return 'incomplete';
+      index = end;
       continue;
     }
-    if (char === '}' || char === ']') {
-      if (stack.pop() !== char) return 'invalid';
-      if (stack.length === 0) complete = true;
+
+    if (current.kind === 'object') {
+      if (current.expect === 'keyOrEnd') {
+        if (char === '}') {
+          if (!closeFrame('object')) return 'invalid';
+          continue;
+        }
+        if (char !== '"') return 'invalid';
+        const end = parseString(index);
+        if (end === null) return 'incomplete';
+        current.expect = 'colon';
+        index = end;
+        continue;
+      }
+      if (current.expect === 'colon') {
+        if (char !== ':') return 'invalid';
+        current.expect = 'value';
+        continue;
+      }
+      if (current.expect === 'value') {
+        const end = parseValue(index);
+        if (end === false) return 'invalid';
+        if (end === null) return 'incomplete';
+        index = end;
+        continue;
+      }
+      if (char === '}') {
+        if (!closeFrame('object')) return 'invalid';
+        continue;
+      }
+      if (char !== ',') return 'invalid';
+      current.expect = 'keyOrEnd';
+      continue;
     }
+
+    if (current.expect === 'valueOrEnd') {
+      if (char === ']') {
+        if (!closeFrame('array')) return 'invalid';
+        continue;
+      }
+      const end = parseValue(index);
+      if (end === false) return 'invalid';
+      if (end === null) return 'incomplete';
+      index = end;
+      continue;
+    }
+    if (char === ']') {
+      if (!closeFrame('array')) return 'invalid';
+      continue;
+    }
+    if (char !== ',') return 'invalid';
+    current.expect = 'valueOrEnd';
   }
 
-  if (!started) return 'invalid';
-  if (inString || escaping || stack.length > 0) return 'incomplete';
-  return complete ? 'complete' : 'invalid';
+  return rootComplete && stack.length === 0 ? 'complete' : 'incomplete';
 }
 
 export async function detectAcpModels({

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -398,7 +398,7 @@ test('attachAcpSession accepts pretty-printed ACP startup responses', () => {
     send: (event, payload) => events.push({ event, payload }),
   });
 
-  child.stdout.write('{\n  "id": 1,\n  "result": {}\n}\n');
+  child.stdout.write('{\n  "id": 1,\n  "result":\n  {}\n}\n');
   child.stdout.write('{\n  "id": 2,\n  "result":\n  {\n    "sessionId": "session-1"\n  }\n}\n');
 
   const methods = parseRpcWrites(writes)

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -408,6 +408,33 @@ test('attachAcpSession accepts pretty-printed ACP startup responses', () => {
   assert.equal(events.some((entry) => entry.event === 'error'), false);
 });
 
+test('attachAcpSession recovers when bracket-prefixed logs precede JSON frames', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  const events: Array<{ event: string; payload: unknown }> = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  child.stdout.write('[vela] starting OpenCode bridge\n');
+  child.stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
+  child.stdout.write('{not json but looks like an object log\n');
+  child.stdout.write(`${JSON.stringify({ id: 2, result: { sessionId: 'session-1' } })}\n`);
+
+  const methods = parseRpcWrites(writes)
+    .map((entry) => entry.method)
+    .filter(Boolean);
+  assert.deepEqual(methods, ['initialize', 'session/new', 'session/prompt']);
+  assert.equal(events.some((entry) => entry.event === 'error'), false);
+});
+
 function parseRpcWrites(writes: string[]): Array<Record<string, unknown>> {
   return writes
     .join('')

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -426,6 +426,7 @@ test('attachAcpSession recovers when bracket-prefixed logs precede JSON frames',
   child.stdout.write('[vela] starting OpenCode bridge\n');
   child.stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
   child.stdout.write('{not json but looks like an object log\n');
+  child.stdout.write('more startup text after the bad object log\n');
   child.stdout.write(`${JSON.stringify({ id: 2, result: { sessionId: 'session-1' } })}\n`);
 
   const methods = parseRpcWrites(writes)

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -383,6 +383,31 @@ test('attachAcpSession.abort during startup ends stdin without sending session/c
   assert.equal(cancelRequests.length, 0);
 });
 
+test('attachAcpSession accepts pretty-printed ACP startup responses', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  const events: Array<{ event: string; payload: unknown }> = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  child.stdout.write('{\n  "id": 1,\n  "result": {}\n}\n');
+  child.stdout.write('{\n  "id": 2,\n  "result":\n  {\n    "sessionId": "session-1"\n  }\n}\n');
+
+  const methods = parseRpcWrites(writes)
+    .map((entry) => entry.method)
+    .filter(Boolean);
+  assert.deepEqual(methods, ['initialize', 'session/new', 'session/prompt']);
+  assert.equal(events.some((entry) => entry.event === 'error'), false);
+});
+
 function parseRpcWrites(writes: string[]): Array<Record<string, unknown>> {
   return writes
     .join('')


### PR DESCRIPTION
## Summary
- make the ACP JSON stream parser keep a bounded pending JSON aggregate instead of discarding pretty-printed JSON-RPC startup responses line by line
- recover from bracket/object-prefixed non-JSON stdout logs so later one-line JSON-RPC frames still get delivered
- preserve existing single-line JSON-RPC behavior and continue ignoring non-JSON stdout logs
- add regression tests for pretty-printed startup responses and bracket-prefixed log recovery

Fixes #3326.

## Surface area
- [x] None — daemon-internal ACP stream parsing only

## Validation
- PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" pnpm --filter @open-design/daemon exec vitest run tests/acp.test.ts
- PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" pnpm --filter @open-design/daemon run typecheck