### PR TITLE
fix(web): finalize canceled daemon runs

### DIFF
--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -782,7 +782,10 @@ async function consumeDaemonRun({
       }
     }
 
-    if (endStatus === 'canceled') return;
+    if (endStatus === 'canceled') {
+      handlers.onDone(acc);
+      return;
+    }
 
     // Trust the server's authoritative success declaration. When the server
     // explicitly sets `status: 'succeeded'` (either in the SSE end payload

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -601,6 +601,69 @@ describe('streamViaDaemon', () => {
     expect(handlers.onError).not.toHaveBeenCalled();
   });
 
+  it('finalizes streamed output when a run ends as canceled', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: stdout',
+              'data: {"chunk":"partial output"}',
+              '',
+              'event: end',
+              'data: {"code":null,"signal":"SIGTERM","status":"canceled"}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onDone).toHaveBeenCalledWith('partial output');
+    expect(handlers.onError).not.toHaveBeenCalled();
+  });
+
+  it('finalizes textless canceled runs so ProjectView can compute produced files', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: end',
+              'data: {"code":null,"signal":"SIGTERM","status":"canceled"}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onDone).toHaveBeenCalledWith('');
+    expect(handlers.onError).not.toHaveBeenCalled();
+  });
+
   it('still surfaces an error when the end event has a non-zero code and no status field', async () => {
     // Regression guard for the local 'succeeded' fallback at the end-event
     // handler: a compatible or older daemon may omit `status` from the end


### PR DESCRIPTION
﻿Fixes #2760

## Why

I hit this while running Open Design with OpenCode against a linked local repo. The daemon event stream contained a final assistant summary and the linked repo had real file changes, but because the run ended as `status: "canceled"` after SIGTERM, the web client returned before the normal finalization path. From the UI, the run looked effectively empty even though useful output existed.

This PR also incorporates the blocking review feedback on #3023: canceled runs must finalize even when no assistant text was streamed, because `ProjectView` uses the `onDone` path to compute produced files.

## What users will see

Canceled daemon runs that already reached a terminal `canceled` event still go through the normal web finalization path. If the agent produced assistant text, it is preserved. If the agent only changed files, the existing produced-files computation still gets a chance to run instead of leaving the assistant turn empty.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes daemon-run stream finalization behavior and is covered by provider regression tests. No new visual surface was added.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/providers/sse.test.ts`
- Did the test go red on `main` and green on this branch? yes
  - Red on `main` with the new specs: `finalizes streamed output when a run ends as canceled` and `finalizes textless canceled runs so ProjectView can compute produced files`
  - Green after the source change

## Validation

- `pnpm --filter @open-design/web test -- tests/providers/sse.test.ts`
- `pnpm --filter @open-design/web typecheck`

Note: local Windows validation ran under Node `v26.1.0` with pnpm `10.33.2`, so pnpm emitted the repo's expected `node: ~24` engine warning. The focused test and web typecheck both passed.
