### PR TITLE
fix(web): remove overlay icon from HomeHero example card

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1168,7 +1168,6 @@ export const HomeHero = forwardRef<HTMLTextAreaElement, Props>(function HomeHero
                 onClick={() => usePromptExample(example)}
               >
                 <span>{example}</span>
-                <Icon name="external-link" size={14} aria-hidden />
               </button>
             ))}
           </div>

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -1845,11 +1845,8 @@
   appearance: none;
   min-width: 0;
   min-height: 112px;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  grid-template-rows: minmax(0, 1fr) auto;
-  align-items: start;
-  gap: 8px;
+  display: flex;
+  align-items: flex-start;
   padding: 12px;
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -1869,18 +1866,8 @@
     box-shadow 140ms ease;
 }
 .home-hero__prompt-example span {
-  grid-column: 1 / -1;
-  align-self: start;
   min-width: 0;
   overflow-wrap: anywhere;
-}
-.home-hero__prompt-example svg {
-  grid-column: 2;
-  grid-row: 2;
-  align-self: end;
-  justify-self: end;
-  color: var(--text-faint);
-  transition: color 140ms ease, transform 140ms ease;
 }
 .home-hero__prompt-example:hover,
 .home-hero__prompt-example:focus-visible {
@@ -1890,11 +1877,6 @@
   color: var(--text-strong);
   transform: translateY(-1px);
   box-shadow: var(--shadow-sm);
-}
-.home-hero__prompt-example:hover svg,
-.home-hero__prompt-example:focus-visible svg {
-  color: var(--accent);
-  transform: translate(1px, -1px);
 }
 
 .home-hero__plugin-presets-wrap {

--- a/apps/web/tests/components/HomeHero.example-card-overlay.test.tsx
+++ b/apps/web/tests/components/HomeHero.example-card-overlay.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { HomeHero } from '../../src/components/HomeHero';
+
+// Regression coverage for #3203. The example template card on the Home
+// page used to render a small icon overlay in the bottom-right grid
+// cell. Because the card's text span is `grid-column: 1 / -1`, the
+// span's content reflows into the icon's cell whenever the prompt is
+// long enough — visually placing the icon on top of the text. The fix
+// is to drop the overlay entirely; the card itself is still a `<button>`
+// so the affordance is preserved by hover/focus states and the cursor.
+
+afterEach(() => {
+  cleanup();
+});
+
+const HERO_PROPS = {
+  prompt: '',
+  onPromptChange: () => undefined,
+  onSubmit: () => undefined,
+  activePluginTitle: null,
+  activeChipId: 'prototype',
+  onClearActivePlugin: () => undefined,
+  pluginOptions: [],
+  pluginsLoading: false,
+  pendingPluginId: null,
+  pendingChipId: null,
+  onPickPlugin: () => undefined,
+  onPickChip: () => undefined,
+  contextItemCount: 0,
+  error: null,
+};
+
+describe('HomeHero example card overlay (#3203)', () => {
+  it('renders the example cards on the prototype chip', () => {
+    render(<HomeHero {...(HERO_PROPS as any)} />);
+    const cards = screen.queryAllByTestId('home-hero-prompt-example');
+    expect(cards.length).toBeGreaterThan(0);
+  });
+
+  it('does not render an overlay icon inside the example card', () => {
+    render(<HomeHero {...(HERO_PROPS as any)} />);
+    const cards = screen.queryAllByTestId('home-hero-prompt-example');
+    expect(cards.length).toBeGreaterThan(0);
+    for (const card of cards) {
+      // Pre-fix the card contained an `<svg>` icon as a sibling to the
+      // text span, positioned in the bottom-right grid cell. The fix
+      // removes that overlay so card text never collides with the icon.
+      expect(card.querySelector('svg')).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
Closes #3203

## Why

The example template card on the Home page rendered an `<Icon name="external-link">` in the card's bottom-right grid cell. The card's text span had `grid-column: 1 / -1` and `align-self: start`, which let long prompt text reflow into the icon's cell — visually placing the icon on top of the description text. The icon was the affordance hint that the card is clickable, but the card is already a `<button>` with a hover/focus state and a pointer cursor, so the affordance survives without it.

## What users will see

- Long-prompt example cards no longer have a small icon overlapping the trailing text.
- Cards still highlight on hover / focus and still trigger when clicked.

## Surface area

- [ ] **UI** — visual change to existing example cards on the Home page (icon removed). No new entry point or navigation surface.
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — pre-existing button still does the same thing on click.

## Bug fix verification

Red spec: `apps/web/tests/components/HomeHero.example-card-overlay.test.tsx` — 2 specs:
1. The example cards still render under the prototype chip (sanity).
2. None of the rendered cards contain an `<svg>` overlay.

Did the spec go red on `main` and green on this branch? **yes** — the second assertion fails on `main` (`expected element to be null` — the `<Icon>` was an SVG), passes here.

## Approach

- `apps/web/src/components/HomeHero.tsx`: drop the `<Icon name="external-link" size={14} aria-hidden />` line inside the example-card `<button>`. The text `<span>` is now the button's only child.
- `apps/web/src/styles/home/home-hero.css`: replace the explicit `display: grid` layout (with row / column / span placement for the icon's bottom-right cell) with `display: flex; align-items: flex-start`. Remove the now-dead `.home-hero__prompt-example svg` / `:hover svg` / `:focus-visible svg` rules.

## Validation

- `pnpm exec vitest run tests/components/HomeHero.example-card-overlay.test.tsx` → **2/2 passed**
- `pnpm --filter @open-design/web test` → **2500/2500 passed** (260 files)
- `pnpm --filter @open-design/web typecheck` → green
- `pnpm guard` → green
