### PR TITLE
fix(web): truncate long filenames in file list (no-preview state)

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -766,7 +766,12 @@ export function DesignFilesPanel({
               }}
             >
               <span className="df-row-name-wrap">
-                <span className="df-row-name">{currentDir === '' ? f.name : f.name.slice(currentDir.length + 1)}</span>
+                <span
+                  className="df-row-name"
+                  title={currentDir === '' ? f.name : f.name.slice(currentDir.length + 1)}
+                >
+                  {currentDir === '' ? f.name : f.name.slice(currentDir.length + 1)}
+                </span>
                 <span className="df-row-sub">{humanBytes(f.size)}</span>
               </span>
             </button>
@@ -828,7 +833,7 @@ export function DesignFilesPanel({
         <td className="df-cell-name df-cell-openable" onClick={() => setCurrentDir(fullPath)}>
           <button type="button" className="df-row-name-btn" onClick={() => setCurrentDir(fullPath)}>
             <span className="df-row-name-wrap">
-              <span className="df-row-name">{dirName}</span>
+              <span className="df-row-name" title={dirName}>{dirName}</span>
               <span className="df-row-sub">{t('designFiles.folderCount', { n: count })}</span>
             </span>
           </button>
@@ -1240,7 +1245,9 @@ export function DesignFilesPanel({
                         ◉
                       </span>
                       <span className="df-row-name-wrap">
-                        <span className="df-row-name">{artifact.title}</span>
+                        <span className="df-row-name" title={artifact.title}>
+                          {artifact.title}
+                        </span>
                         <span className="df-row-sub">
                           <span>{t('designFiles.kindLiveArtifact')}</span>
                           <LiveArtifactBadges

--- a/apps/web/src/styles/workspace/design-files.css
+++ b/apps/web/src/styles/workspace/design-files.css
@@ -384,6 +384,15 @@
 .df-cell-name {
   padding: 10px 12px 10px 0;
   vertical-align: middle;
+  /* Force ellipsis truncation in auto-layout tables (#3260). Without
+     `max-width: 0` and `min-width: 0`, a long `f.name` would expand
+     this td and push the kind / mtime / menu cells off-screen — even
+     though `.df-row-name` already has `text-overflow: ellipsis`. The
+     `:not(.no-preview)` overrides in `routines.css` already pin the
+     row's children to `width: 100%` when a preview pane is open; this
+     baseline rule covers the no-preview state the issue reports. */
+  max-width: 0;
+  min-width: 0;
 }
 .df-cell-openable {
   cursor: pointer;
@@ -655,7 +664,16 @@
 .df-row-icon[data-kind="code"] { background: #fff7d8; color: #8c6700; }
 .df-row-icon[data-kind="text"] { background: var(--bg-subtle); color: var(--text-muted); }
 .df-row-icon[data-kind="sketch"] { background: var(--purple-bg); color: var(--purple); }
-.df-row-name-wrap { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.df-row-name-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  /* Constrain the wrap to the cell's content box so the ellipsis on
+     `.df-row-name` engages even in the auto-layout table state
+     (#3260). */
+  max-width: 100%;
+}
 .df-row-name {
   font-size: 13px;
   font-weight: 500;
@@ -663,6 +681,12 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  /* `max-width: 100%` on a flex child pairs with the wrap's
+     `min-width: 0` so the long filename collapses to the cell width
+     instead of pushing the kind / mtime / menu columns off-screen
+     (#3260). */
+  max-width: 100%;
+  min-width: 0;
 }
 .df-rename-input {
   width: 100%;

--- a/apps/web/tests/components/DesignFilesPanel.long-name-truncate.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.long-name-truncate.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DesignFilesPanel } from '../../src/components/DesignFilesPanel';
+import type { ProjectFile } from '../../src/types';
+
+// Regression coverage for #3260. In the no-preview state of the file
+// list, a very long filename used to expand its `<td>` and push the
+// kind / mtime / menu columns off-screen. The CSS fix locks
+// `.df-cell-name` to `max-width: 0; min-width: 0` so the auto-layout
+// table truncates the name with the existing `text-overflow: ellipsis`
+// instead of growing the cell. The JSX fix adds `title={f.name}` so the
+// browser surfaces the full filename on hover even when the visible
+// text is truncated. (`<DfPreview>` already renders the full name with
+// `word-break: break-word` for users who open the preview pane.)
+//
+// jsdom does not measure layout, so the truncation itself can't be
+// asserted directly. These specs encode the contract: the rendered DOM
+// keeps the structural classes the CSS relies on, and the `title` is
+// present on every name span so hover-tooltip is available even on the
+// very long row.
+
+const lsStore = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => lsStore.get(key) ?? null,
+  setItem: (key: string, value: string) => { lsStore.set(key, value); },
+  removeItem: (key: string) => { lsStore.delete(key); },
+  clear: () => { lsStore.clear(); },
+});
+
+function file(overrides: Partial<ProjectFile> & Pick<ProjectFile, 'name'>): ProjectFile {
+  return {
+    path: overrides.name,
+    type: 'file',
+    size: 1024,
+    mtime: Date.now(),
+    kind: 'image',
+    mime: 'image/png',
+    ...overrides,
+  };
+}
+
+function renderPanel(files: ProjectFile[]) {
+  return render(
+    <DesignFilesPanel
+      projectId="test-project"
+      files={files}
+      liveArtifacts={[]}
+      onRefreshFiles={vi.fn()}
+      onOpenFile={vi.fn()}
+      onOpenLiveArtifact={vi.fn()}
+      onRenameFile={vi.fn()}
+      onDeleteFile={vi.fn()}
+      onDeleteFiles={vi.fn()}
+      onUpload={vi.fn()}
+      onUploadFiles={vi.fn()}
+      onPaste={vi.fn()}
+      onNewSketch={vi.fn()}
+    />,
+  );
+}
+
+beforeEach(() => {
+  lsStore.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const LONG_NAME =
+  'mpqdcf5m-A-1-year-old-boy-_standing_-with-short-black-hair_-big-eyes-with-black-pupils_-wearing-a-watermelon-shaped-helmet.jpeg';
+
+describe('DesignFilesPanel long filename truncation (#3260)', () => {
+  it('renders the file row for a long filename without crashing', () => {
+    const { container } = renderPanel([file({ name: LONG_NAME })]);
+    const row = container.querySelector(`[data-testid="design-file-row-${LONG_NAME}"]`);
+    expect(row).toBeTruthy();
+  });
+
+  it('exposes the full filename via a `title` attribute on the name span (hover tooltip)', () => {
+    const { container } = renderPanel([file({ name: LONG_NAME })]);
+    const nameSpan = container.querySelector('.df-row-name') as HTMLElement | null;
+    expect(nameSpan).toBeTruthy();
+    // The tooltip contract: hovering a truncated row reveals the full
+    // filename. Without this users see "...g-helmet.jpeg" with no way
+    // to read the leading characters until they open the preview pane.
+    expect(nameSpan?.getAttribute('title')).toBe(LONG_NAME);
+  });
+
+  it('keeps the truncate-friendly DOM structure (.df-cell-name > .df-row-name-btn > .df-row-name-wrap > .df-row-name)', () => {
+    const { container } = renderPanel([file({ name: LONG_NAME })]);
+    // The CSS fix relies on this nesting: `td.df-cell-name` constrains
+    // its width, the wrap is min-width:0 / max-width:100%, and
+    // `.df-row-name` carries `text-overflow: ellipsis`. If the JSX
+    // shape ever changes the CSS regression risk returns silently —
+    // this asserts the chain stays intact.
+    const cell = container.querySelector('td.df-cell-name');
+    expect(cell).toBeTruthy();
+    const btn = cell!.querySelector('button.df-row-name-btn');
+    expect(btn).toBeTruthy();
+    const wrap = btn!.querySelector('span.df-row-name-wrap');
+    expect(wrap).toBeTruthy();
+    const name = wrap!.querySelector('span.df-row-name');
+    expect(name).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #3260

## Why

The design files panel uses an auto-layout `<table>` to render the file list. Its `.df-cell-name` cell had no width constraint, so a very long filename would expand the cell and push the kind / mtime / menu columns off-screen — even though `.df-row-name` already had `text-overflow: ellipsis`. Auto-layout `<td>` ignores `overflow: hidden` on a child unless the cell itself has a `max-width`.

The repo already had a fix for the **preview-open** state in `routines.css`:

```css
.app .df-panel:not(.no-preview) .df-cell-name { width: auto; min-width: 0; }
.app .df-panel:not(.no-preview) .df-row-name   { width: 100%; min-width: 0; max-width: 100%; }
```

But the **no-preview** state — the one the reporter's screenshot shows — had no equivalent guard, so the bug surfaced there.

## Repro (matches the screenshot in #3260)

1. Open a project, go to the design files tab, close the preview pane (or simply land in the no-preview state).
2. Add a file with a very long name (e.g. an upload from an image generator that emits sentence-length filenames).
3. Observe: the row's name pushes the kind / mtime / row-menu cells out of view — sometimes off-screen entirely.

## What users will see

- The filename is truncated with an ellipsis when it doesn't fit, regardless of whether the preview pane is open. The kind / mtime / row-menu columns stay in their usual positions.
- Hovering the truncated row now surfaces the full filename via the browser's native `title` tooltip, so the leading characters are still discoverable without opening the preview pane.
- The preview pane already renders the full filename with `word-break: break-word` (`.df-preview-name`); that is unchanged.

## Surface area

- [ ] **UI** — visual change to `.df-file-row` rendering when the filename overflows. No new entry point; behavior change is "now truncates correctly" not "new feature".
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None**

## Bug fix verification

Red spec: `apps/web/tests/components/DesignFilesPanel.long-name-truncate.test.tsx` — 3 specs:

1. The row renders for a long-name file (sanity).
2. The name span has a `title` attribute equal to the full filename (hover-tooltip contract).
3. The DOM nesting `td.df-cell-name → button.df-row-name-btn → span.df-row-name-wrap → span.df-row-name` stays intact (the CSS fix relies on this chain).

Did the spec go red on `main` and green on this branch? **yes** — assertion 2 fails on `main` (`title` was absent), passes here.

> jsdom does not measure layout, so the visual truncation itself can't be asserted directly. The specs encode the structural contract the CSS depends on (and the new `title` attr) so a JSX shape change won't silently regress the fix.

## Approach

CSS — `apps/web/src/styles/workspace/design-files.css`:

- `.df-cell-name`: add `max-width: 0; min-width: 0`. In an auto-layout table this is the canonical trick for ellipsis truncation: the cell still negotiates its share of the row width with siblings, but a `nowrap` child no longer overrides the column allocation.
- `.df-row-name-wrap`: add `max-width: 100%`.
- `.df-row-name`: add `max-width: 100%; min-width: 0` so the flex child clamps to the wrap.

JSX — `apps/web/src/components/DesignFilesPanel.tsx`:

- `title={f.name}` on the `.df-row-name` span for file rows.
- `title={dirName}` for directory rows.
- `title={artifact.title}` for live-artifact rows.

## Validation

- `pnpm exec vitest run tests/components/DesignFilesPanel.long-name-truncate.test.tsx` → **3/3 passed**
- `pnpm --filter @open-design/web test` → **2501/2501 passed** (260 files)
- `pnpm --filter @open-design/web typecheck` → green
- `pnpm guard` → green

Manual visual verification (the visual half) is not something I can run from this environment; happy to re-record once a reviewer is at a desktop.
