### PR TITLE
fix(web): show cumulative session time in conversation list

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -722,7 +722,7 @@ function normalizeTemplate(row: DbRow) {
 // ---------- conversations ----------
 
 export function listConversations(db: SqliteDb, projectId: string) {
-  return rows(db
+  const conversations = rows(db
     .prepare(
       `WITH project_conversations AS (
           SELECT id, project_id AS projectId, title,
@@ -761,6 +761,10 @@ export function listConversations(db: SqliteDb, projectId: string) {
          ORDER BY c.updatedAt DESC`,
     )
     .all(projectId)).map(normalizeConversation);
+  return conversations.map((c) => ({
+    ...c,
+    totalDurationMs: cumulativeConversationRunDurationMs(db, c.id),
+  }));
 }
 
 export function getConversation(db: SqliteDb, id: string) {
@@ -775,6 +779,7 @@ export function getConversation(db: SqliteDb, id: string) {
   return {
     ...normalizeConversation(r),
     latestRun: latestConversationRunSummary(db, r.id) ?? undefined,
+    totalDurationMs: cumulativeConversationRunDurationMs(db, r.id as string),
   };
 }
 
@@ -830,6 +835,51 @@ function conversationRunSummaryFromRow(row: DbRow | undefined) {
       ? { durationMs }
       : {}),
   };
+}
+
+// Sum durationMs across every completed assistant run in the
+// conversation. "Completed" means `run_status` is one of the terminal
+// statuses (succeeded / failed / canceled) — running / pending runs
+// are excluded so an in-flight turn does not inflate the displayed
+// total. Per-run duration prefers wall-clock (started_at - ended_at);
+// when those are missing we fall back to the latest usage event in
+// `events_json`, mirroring `conversationRunSummaryFromRow`. Returns
+// undefined when no completed runs contributed a finite duration so
+// callers can decide between rendering "0s" and falling back to a
+// different label (#3287).
+function cumulativeConversationRunDurationMs(
+  db: SqliteDb,
+  conversationId: string,
+): number | undefined {
+  const rs = db
+    .prepare(
+      `SELECT run_status AS runStatus,
+              started_at AS startedAt,
+              ended_at AS endedAt,
+              events_json AS eventsJson
+         FROM messages
+        WHERE conversation_id = ?
+          AND role = 'assistant'
+          AND run_status IN ('succeeded', 'failed', 'canceled')`,
+    )
+    .all(conversationId) as DbRow[];
+  let sum = 0;
+  let contributed = false;
+  for (const row of rs) {
+    const startedAt = row.startedAt == null ? undefined : Number(row.startedAt);
+    const endedAt = row.endedAt == null ? undefined : Number(row.endedAt);
+    const wallClock =
+      Number.isFinite(startedAt) && Number.isFinite(endedAt)
+        ? Math.max(0, (endedAt as number) - (startedAt as number))
+        : undefined;
+    const usage = latestUsageDurationMs(row.eventsJson);
+    const durationMs = wallClock ?? usage;
+    if (typeof durationMs === 'number' && Number.isFinite(durationMs)) {
+      sum += durationMs;
+      contributed = true;
+    }
+  }
+  return contributed ? sum : undefined;
 }
 
 function latestUsageDurationMs(eventsJson: unknown): number | undefined {

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -722,6 +722,11 @@ function normalizeTemplate(row: DbRow) {
 // ---------- conversations ----------
 
 export function listConversations(db: SqliteDb, projectId: string) {
+  // Single prepared statement: latest run summary + cumulative wall-clock
+  // duration + a count of completed runs that are missing wall-clock data
+  // (so JS can decide whether to fall back to per-row usage events). The
+  // batching invariant (one prepare per call regardless of conversation
+  // count) is asserted by `project-status.test.ts:127` (#3371 review).
   const conversations = rows(db
     .prepare(
       `WITH project_conversations AS (
@@ -752,19 +757,60 @@ export function listConversations(db: SqliteDb, projectId: string) {
                  AND m.run_status IS NOT NULL
             )
            WHERE rn = 1
+        ),
+        total_durations AS (
+          SELECT m.conversation_id AS conversationId,
+                 SUM(
+                   CASE
+                     WHEN m.started_at IS NOT NULL AND m.ended_at IS NOT NULL
+                       THEN MAX(0, m.ended_at - m.started_at)
+                     ELSE 0
+                   END
+                 ) AS wallClockTotalMs,
+                 SUM(
+                   CASE
+                     WHEN m.started_at IS NULL OR m.ended_at IS NULL THEN 1
+                     ELSE 0
+                   END
+                 ) AS incompleteRunCount
+            FROM messages m
+            JOIN project_conversations c ON c.id = m.conversation_id
+           WHERE m.role = 'assistant'
+             AND m.run_status IN ('succeeded', 'failed', 'canceled')
+           GROUP BY m.conversation_id
         )
         SELECT c.id, c.projectId, c.title, c.createdAt, c.updatedAt,
                lr.latestRunStatus, lr.latestRunStartedAt,
-               lr.latestRunEndedAt, lr.latestRunEventsJson
+               lr.latestRunEndedAt, lr.latestRunEventsJson,
+               td.wallClockTotalMs, td.incompleteRunCount
           FROM project_conversations c
           LEFT JOIN latest_runs lr ON lr.conversationId = c.id
+          LEFT JOIN total_durations td ON td.conversationId = c.id
          ORDER BY c.updatedAt DESC`,
     )
-    .all(projectId)).map(normalizeConversation);
-  return conversations.map((c) => ({
-    ...c,
-    totalDurationMs: cumulativeConversationRunDurationMs(db, c.id),
-  }));
+    .all(projectId)).map((row) => {
+      const base = normalizeConversation(row);
+      const wallClock =
+        row.wallClockTotalMs == null ? undefined : Number(row.wallClockTotalMs);
+      const incomplete =
+        row.incompleteRunCount == null ? 0 : Number(row.incompleteRunCount);
+      // Fast path: no rows with missing wall-clock → SQL sum is exact.
+      // Slow path: a completed run was missing started_at/ended_at — fall
+      // back to the JS helper that scans usage events. In practice this
+      // only happens for very old conversations; the typical sidebar load
+      // never enters this branch.
+      const totalDurationMs =
+        incomplete === 0
+          ? Number.isFinite(wallClock) && (wallClock as number) > 0
+            ? wallClock
+            : undefined
+          : cumulativeConversationRunDurationMs(db, base.id as string);
+      return {
+        ...base,
+        ...(totalDurationMs === undefined ? {} : { totalDurationMs }),
+      };
+    });
+  return conversations;
 }
 
 export function getConversation(db: SqliteDb, id: string) {

--- a/apps/daemon/tests/conversation-total-duration.test.ts
+++ b/apps/daemon/tests/conversation-total-duration.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  closeDatabase,
+  insertConversation,
+  insertProject,
+  listConversations,
+  openDatabase,
+  upsertMessage,
+} from '../src/db.js';
+
+// Regression coverage for #3287. The conversation list previously surfaced
+// the latest run's `durationMs` as the only duration signal (via `latestRun`),
+// so a session built up over multiple runs displayed the most recent run's
+// time only — not the cumulative session time. This spec asserts that
+// `listConversations` exposes a `totalDurationMs` aggregated across every
+// completed assistant run for the conversation, while `latestRun` is kept
+// intact so existing UI code that needs the latest run's status can
+// continue to read it.
+
+describe('conversation total duration aggregation (#3287)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'od-conv-total-duration-'));
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('sums durationMs across all completed assistant runs in the conversation', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+
+    insertProject(db, {
+      id: 'proj-1',
+      name: 'Multi-run project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-1',
+      projectId: 'proj-1',
+      title: 'multi-run conversation',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Three completed assistant runs, each with explicit start/end:
+    // 5s, 12s, 7s → cumulative 24s = 24_000 ms.
+    const runs = [
+      { id: 'msg-1', runId: 'run-1', startedAt: now,           endedAt: now + 5_000  },
+      { id: 'msg-2', runId: 'run-2', startedAt: now + 10_000,  endedAt: now + 22_000 },
+      { id: 'msg-3', runId: 'run-3', startedAt: now + 30_000,  endedAt: now + 37_000 },
+    ];
+    for (const r of runs) {
+      upsertMessage(db, 'conv-1', {
+        id: r.id,
+        role: 'assistant',
+        content: '',
+        runId: r.runId,
+        runStatus: 'succeeded',
+        startedAt: r.startedAt,
+        endedAt: r.endedAt,
+      });
+    }
+
+    const list = listConversations(db, 'proj-1');
+    expect(list).toHaveLength(1);
+    const conv = list[0]!;
+
+    // The latest run still surfaces — existing UI code that wants the
+    // most recent run's status continues to read it.
+    expect(conv.latestRun?.status).toBe('succeeded');
+    expect(conv.latestRun?.durationMs).toBe(7_000);
+
+    // The aggregate covers every completed assistant run.
+    expect(conv.totalDurationMs).toBe(24_000);
+  });
+
+  it('falls back to per-run usage durationMs when start/end are missing', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+
+    insertProject(db, {
+      id: 'proj-2',
+      name: 'Usage-only project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-2',
+      projectId: 'proj-2',
+      title: 'usage-only',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Both runs lack startedAt/endedAt but report durationMs via usage events.
+    upsertMessage(db, 'conv-2', {
+      id: 'msg-a',
+      role: 'assistant',
+      content: '',
+      runId: 'run-a',
+      runStatus: 'succeeded',
+      events: [{ kind: 'usage', durationMs: 4_500 }],
+    });
+    upsertMessage(db, 'conv-2', {
+      id: 'msg-b',
+      role: 'assistant',
+      content: '',
+      runId: 'run-b',
+      runStatus: 'succeeded',
+      events: [{ kind: 'usage', durationMs: 8_500 }],
+    });
+
+    const list = listConversations(db, 'proj-2');
+    expect(list).toHaveLength(1);
+    expect(list[0]!.totalDurationMs).toBe(13_000);
+  });
+
+  it('omits in-flight runs from the aggregate (status: running)', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+
+    insertProject(db, {
+      id: 'proj-3',
+      name: 'Mixed status project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-3',
+      projectId: 'proj-3',
+      title: 'mixed status',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Two completed runs (3s + 9s) plus one still-running.
+    upsertMessage(db, 'conv-3', {
+      id: 'msg-x',
+      role: 'assistant',
+      content: '',
+      runId: 'run-x',
+      runStatus: 'succeeded',
+      startedAt: now,
+      endedAt: now + 3_000,
+    });
+    upsertMessage(db, 'conv-3', {
+      id: 'msg-y',
+      role: 'assistant',
+      content: '',
+      runId: 'run-y',
+      runStatus: 'succeeded',
+      startedAt: now + 5_000,
+      endedAt: now + 14_000,
+    });
+    upsertMessage(db, 'conv-3', {
+      id: 'msg-z',
+      role: 'assistant',
+      content: '',
+      runId: 'run-z',
+      runStatus: 'running',
+      startedAt: now + 20_000,
+      // no endedAt — still in flight
+    });
+
+    const list = listConversations(db, 'proj-3');
+    expect(list).toHaveLength(1);
+    // Only the two completed runs contribute: 3s + 9s = 12s.
+    expect(list[0]!.totalDurationMs).toBe(12_000);
+  });
+});

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -2013,6 +2013,15 @@ export function conversationMetaLabel(
   conversation: Conversation,
   t: TranslateFn,
 ): string {
+  // Prefer the cumulative session runtime when the daemon supplied it
+  // so multi-run conversations show the full time spent, not just the
+  // latest run (#3287). Fall back to the latest run's durationMs for
+  // single-run sessions, then to relative-time when neither aggregate
+  // is available (e.g. a freshly created conversation with no runs).
+  const totalDurationMs = conversation.totalDurationMs;
+  if (typeof totalDurationMs === 'number' && Number.isFinite(totalDurationMs)) {
+    return formatDurationShort(totalDurationMs);
+  }
   const latestRun = conversation.latestRun;
   if (
     latestRun &&

--- a/apps/web/tests/components/conversation-timestamps.test.tsx
+++ b/apps/web/tests/components/conversation-timestamps.test.tsx
@@ -132,4 +132,47 @@ describe('conversation timestamps', () => {
 
     expect(conversationMetaLabel(conversation, t as never)).toBe('15s');
   });
+
+  it('prefers totalDurationMs over latestRun.durationMs so multi-run sessions show cumulative time (#3287)', () => {
+    const t = (key: string) => key;
+    const conversation: Conversation = {
+      id: 'conv-multi',
+      projectId: 'project-1',
+      title: 'Multi-run conversation',
+      createdAt: Date.parse('2025-01-15T12:00:00Z'),
+      updatedAt: Date.parse('2025-01-15T12:30:00Z'),
+      // Three runs of 5s + 12s + 7s — the latest is 7s but the
+      // session total is 24s. Pre-fix the label rendered "7s" because
+      // it only saw `latestRun`.
+      latestRun: {
+        status: 'succeeded',
+        startedAt: 30_000,
+        endedAt: 37_000,
+        durationMs: 7_000,
+      },
+      totalDurationMs: 24_000,
+    };
+
+    expect(conversationMetaLabel(conversation, t as never)).toBe('24s');
+  });
+
+  it('falls back to latestRun.durationMs when totalDurationMs is absent (single-run / older daemons)', () => {
+    const t = (key: string) => key;
+    const conversation: Conversation = {
+      id: 'conv-legacy',
+      projectId: 'project-1',
+      title: 'Legacy single run',
+      createdAt: Date.parse('2025-01-15T12:00:00Z'),
+      updatedAt: Date.parse('2025-01-15T12:01:00Z'),
+      latestRun: {
+        status: 'succeeded',
+        startedAt: 1_000,
+        endedAt: 16_000,
+        durationMs: 15_000,
+      },
+      // totalDurationMs intentionally absent
+    };
+
+    expect(conversationMetaLabel(conversation, t as never)).toBe('15s');
+  });
 });

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -201,6 +201,11 @@ export interface Conversation {
     endedAt?: number;
     durationMs?: number;
   };
+  // Cumulative runtime across every completed assistant run in this
+  // conversation. Surfaced for the conversation-list duration label so
+  // multi-run sessions report the full session time instead of just the
+  // most recent run's `durationMs` (#3287).
+  totalDurationMs?: number;
 }
 
 export interface CreateProjectRequest {


### PR DESCRIPTION
Closes #3287

## Why

The conversation list's right-column duration label always surfaced just `latestRun.durationMs`, populated by `latestConversationRunSummary`'s `ORDER BY position DESC LIMIT 1` query in `apps/daemon/src/db.ts`. Sessions built up over multiple runs displayed only the most recent run's time — which read as the session total to users and didn't match the actual time spent on that conversation.

Per the issue triage notes ([#3287 (comment)](https://github.com/nexu-io/open-design/issues/3287#issuecomment-...)) the fix lives across three layers: a daemon-side aggregate query, a new contracts field, and the web-side label preferring the aggregate.

## What users will see

- The conversation list's right-column duration on multi-run sessions now shows the cumulative time spent across every completed assistant run, not just the latest one. (e.g. three runs of 5s + 12s + 7s now read **24s** instead of **7s**.)
- Single-run sessions render exactly as before (the new aggregate equals the latest run's duration in that case).
- In-flight runs are excluded so an active turn never inflates the displayed total.

## Surface area

- [ ] **UI** — visual change to the existing `.chat-conv-item-meta` label. No new entry point.
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — `Conversation` gains an optional `totalDurationMs?: number` in `packages/contracts/src/api/projects.ts`. Backwards compatible: existing consumers continue to read `latestRun` unchanged; the only consumer of the new field is `conversationMetaLabel`, which falls back to `latestRun.durationMs` when the daemon hasn't yet been updated.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — strictly speaking the displayed label changes for multi-run sessions; that is the bug fix.
- [ ] **None**

## Bug fix verification

Red specs (apps/daemon):

- `apps/daemon/tests/conversation-total-duration.test.ts` — 3 specs:
  1. Sums `durationMs` across all completed assistant runs in a conversation.
  2. Falls back to per-run usage `durationMs` when `started_at` / `ended_at` are absent.
  3. Excludes in-flight runs (status `running`) from the aggregate.

Red spec (apps/web):

- `apps/web/tests/components/conversation-timestamps.test.tsx` — 2 new cases:
  1. `conversationMetaLabel` prefers `totalDurationMs` over `latestRun.durationMs`.
  2. Falls back to `latestRun.durationMs` when `totalDurationMs` is absent (single-run / older daemons).

Did the specs go red on `main` and green on this branch? **yes** — daemon specs fail on `main` with `expected 24000 to be undefined` (the field doesn't exist); pass after this branch.

## Approach

1. **`apps/daemon/src/db.ts`**: add `cumulativeConversationRunDurationMs(db, conversationId)` helper that selects every completed (`succeeded` / `failed` / `canceled`) assistant message and sums `durationMs` per run, preferring wall-clock `endedAt - startedAt` and falling back to the latest usage event in `events_json` — mirroring the existing `conversationRunSummaryFromRow`. Both `listConversations` and `getConversation` now expose the aggregate as `totalDurationMs`.

2. **`packages/contracts/src/api/projects.ts`**: add optional `totalDurationMs?: number` field on the `Conversation` interface, with a comment pointing to #3287.

3. **`apps/web/src/components/ChatPane.tsx`**: `conversationMetaLabel` prefers `totalDurationMs` when finite. Existing `latestRun.durationMs` path stays as a fallback so single-run conversations and older daemon versions render unchanged.

The follow-up shape from the issue triage is preserved: `latestRun` is left intact for callers that need the most recent run's status; the new field is purely additive.

## Validation

- `pnpm exec vitest run tests/conversation-total-duration.test.ts` (apps/daemon) → **3/3 passed**
- `pnpm exec vitest run tests/components/conversation-timestamps.test.tsx` (apps/web) → **6/6 passed** (4 prior + 2 new)
- `pnpm --filter @open-design/web test` → **2500/2500 passed** (259 files)
- `pnpm --filter @open-design/web typecheck` → green
- `pnpm --filter @open-design/daemon typecheck` → green
- `pnpm --filter @open-design/contracts typecheck` → green
- `pnpm guard` → green

> Note: my local daemon `vitest run` reports unrelated failures in `connection-test.test.ts` and `chat-route.test.ts` (LLM provider auth probes against external endpoints). Those reproduce identically on plain `main`, so they're not regressions from this change. CI's `daemon` job will give a clean signal.
