### PR TITLE
fix(daemon): don't fail a run when a post-completion SessionEnd hook exits non-zero

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3762,6 +3762,7 @@ export function classifyChatRunCloseStatus(params: {
   signal: NodeJS.Signals | string | null;
   acpCleanCompletion: boolean;
   artifactQuietShutdownRequested: boolean;
+  turnCompletedCleanly: boolean;
 }): 'canceled' | 'succeeded' | 'failed' {
   if (params.cancelRequested) return 'canceled';
   if (params.code === 0) return 'succeeded';
@@ -3773,6 +3774,22 @@ export function classifyChatRunCloseStatus(params: {
     params.code === null &&
     (params.signal === 'SIGTERM' || params.signal === 'SIGKILL');
   if (artifactQuietShutdown) return 'succeeded';
+  // Post-completion teardown carve-out (#3372). When the model already
+  // emitted a clean terminal turn (a `turn_end`/`usage` event with no
+  // outstanding host answer, the same condition that closes the child's
+  // stdin), a later non-zero exit or kill signal is a teardown artifact,
+  // not a generation failure: a SessionEnd hook the agent runs on its way
+  // out (e.g. the Honcho memory plugin) can exit non-zero and drag the
+  // whole `claude` process to `exit 1` long after the deliverable was
+  // produced. Treating that as `failed` surfaces a red banner and halts
+  // the flow for work that already succeeded. Same family as the ACP and
+  // artifact-quiet-shutdown carve-outs above: the work completed; the odd
+  // exit is teardown noise. This deliberately does NOT cover non-zero
+  // exits *before* a clean turn — those stay `failed` (real CLI bug,
+  // model error, mid-turn crash), and the agent-specific auth/quota/AMR
+  // guards in the close handler run before this classifier so a genuine
+  // post-turn auth failure is still surfaced with its specific code.
+  if (params.turnCompletedCleanly) return 'succeeded';
   return 'failed';
 }
 
@@ -12112,6 +12129,11 @@ export async function startServer({
                 try { run.child.stdin.end(); } catch {}
               }
               run.stdinOpen = false;
+              // Single source of truth for "the model emitted a clean
+              // terminal turn." The close-status classifier reads this so
+              // a SessionEnd hook that exits non-zero during teardown does
+              // not fail a run whose deliverable was already produced (#3372).
+              run.turnCompletedCleanly = true;
             }
           }
         } catch {}
@@ -12427,6 +12449,7 @@ export async function startServer({
         signal,
         acpCleanCompletion,
         artifactQuietShutdownRequested,
+        turnCompletedCleanly: !!run.turnCompletedCleanly,
       });
       if (status === 'failed') {
         const diagnostic = diagnoseClaudeCliFailure({

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3793,6 +3793,63 @@ export function classifyChatRunCloseStatus(params: {
   return 'failed';
 }
 
+type ClaudeStreamJsonBookkeepingRun = {
+  stdinOpen?: boolean;
+  pendingHostAnswers?: Set<string>;
+  turnCompletedCleanly?: boolean;
+  child?: {
+    stdin?: {
+      destroyed?: boolean;
+      end: () => void;
+    } | null;
+  } | null;
+};
+
+export function applyClaudeStreamJsonRunBookkeeping(
+  run: ClaudeStreamJsonBookkeepingRun,
+  ev: unknown,
+) {
+  if (!ev || typeof ev !== 'object') return;
+  const event = ev as {
+    type?: unknown;
+    name?: unknown;
+    id?: unknown;
+    stopReason?: unknown;
+  };
+
+  if (
+    run.stdinOpen &&
+    event.type === 'tool_use' &&
+    (event.name === 'AskUserQuestion' || event.name === 'ask_user_question') &&
+    typeof event.id === 'string'
+  ) {
+    if (!run.pendingHostAnswers) run.pendingHostAnswers = new Set();
+    run.pendingHostAnswers.add(event.id);
+    return;
+  }
+
+  const cleanTerminalTurn =
+    ((event.type === 'turn_end' &&
+      // `stop_reason: tool_use` means the model paused to wait for tool
+      // execution (claude-code is about to run an internal tool, or we owe a
+      // host tool_result). Either way the conversation is still in flight.
+      event.stopReason !== 'tool_use') ||
+      event.type === 'usage') &&
+    (!run.pendingHostAnswers || run.pendingHostAnswers.size === 0);
+  if (!cleanTerminalTurn) return;
+
+  // Record clean completion even if stdin was already closed by the
+  // host-answer path. The close-status classifier reads this to ignore late
+  // SessionEnd hook failures after the final assistant turn completed.
+  run.turnCompletedCleanly = true;
+  if (run.stdinOpen) {
+    if (run.child?.stdin && !run.child.stdin.destroyed) {
+      try { run.child.stdin.end(); } catch {}
+    }
+    run.stdinOpen = false;
+  }
+}
+
 function resolveChatRunShutdownGraceMs() {
   const raw = Number(process.env.OD_CHAT_RUN_SHUTDOWN_GRACE_MS);
   if (!Number.isFinite(raw)) return 3_000;
@@ -12097,45 +12154,7 @@ export async function startServer({
         //     means the model paused mid-tool, not "turn complete".
         //   - usage (session result at EOF in single-shot mode).
         try {
-          if (run.stdinOpen) {
-            if (
-              ev &&
-              typeof ev === 'object' &&
-              ev.type === 'tool_use' &&
-              (ev.name === 'AskUserQuestion' || ev.name === 'ask_user_question') &&
-              typeof ev.id === 'string'
-            ) {
-              if (!run.pendingHostAnswers) run.pendingHostAnswers = new Set();
-              run.pendingHostAnswers.add(ev.id);
-            } else if (
-              ev &&
-              typeof ev === 'object' &&
-              ((ev.type === 'turn_end' &&
-                // `stop_reason: tool_use` means the model paused to wait
-                // for tool execution (claude-code is about to run an
-                // internal tool, or we owe a host tool_result). Either
-                // way the conversation is still in flight — do not close.
-                ev.stopReason !== 'tool_use') ||
-                ev.type === 'usage') &&
-              (!run.pendingHostAnswers || run.pendingHostAnswers.size === 0)
-            ) {
-              // Per-turn `turn_end` (synthesized from
-              // `assistant.message.stop_reason` in `claude-stream`) is the
-              // primary close signal; `usage` is the session-level result
-              // that fires at EOF in single-shot mode. Either is a valid
-              // "this turn is done" cue, but only when there's no host
-              // answer outstanding AND the model isn't paused mid-tool.
-              if (run.child && run.child.stdin && !run.child.stdin.destroyed) {
-                try { run.child.stdin.end(); } catch {}
-              }
-              run.stdinOpen = false;
-              // Single source of truth for "the model emitted a clean
-              // terminal turn." The close-status classifier reads this so
-              // a SessionEnd hook that exits non-zero during teardown does
-              // not fail a run whose deliverable was already produced (#3372).
-              run.turnCompletedCleanly = true;
-            }
-          }
+          applyClaudeStreamJsonRunBookkeeping(run, ev);
         } catch {}
       });
       child.stdout.on('data', (chunk) => claude.feed(chunk));

--- a/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
+++ b/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
@@ -239,6 +239,7 @@ describe('classifyChatRunCloseStatus (#1451 close-handler classification)', () =
     signal: null as string | null,
     acpCleanCompletion: false,
     artifactQuietShutdownRequested: false,
+    turnCompletedCleanly: false,
   };
 
   it('returns canceled when cancelRequested wins regardless of other signals', () => {
@@ -333,10 +334,12 @@ describe('classifyChatRunCloseStatus (#1451 close-handler classification)', () =
     ).toBe('failed');
   });
 
-  it('returns failed on a non-zero exit code regardless of the quiet-period flag', () => {
-    // The quiet-period override is signal-only; a clean process exit
-    // that returned non-zero is a real failure (agent CLI bug, model
-    // error, etc.) and must propagate as such.
+  it('returns failed on a non-zero exit code when the turn never completed (regardless of the quiet-period flag)', () => {
+    // The quiet-period override is signal-only; a non-zero process exit
+    // *before the model emitted a clean terminal turn* is a real failure
+    // (agent CLI bug, model error, mid-turn crash) and must propagate as
+    // such. `turnCompletedCleanly` stays false here — this is the genuine
+    // failure case the post-completion carve-out below must NOT swallow.
     expect(
       classifyChatRunCloseStatus({
         ...base,
@@ -347,9 +350,60 @@ describe('classifyChatRunCloseStatus (#1451 close-handler classification)', () =
     ).toBe('failed');
   });
 
-  it('returns failed on the standard failure shape (non-zero exit, no special flags)', () => {
+  it('returns failed on the standard failure shape (non-zero exit, turn not completed, no special flags)', () => {
     expect(
       classifyChatRunCloseStatus({ ...base, code: 1, signal: null }),
     ).toBe('failed');
+  });
+
+  // Issue #3372: post-completion hook failure must not fail the run.
+  //
+  // Reproduction of the screenshot bug. The daemon spawns `claude`,
+  // the model emits a clean terminal `turn_end`/`usage` (so the daemon
+  // closes stdin and sets `turnCompletedCleanly`), and only THEN a
+  // SessionEnd hook (e.g. the Honcho memory plugin) exits non-zero,
+  // which makes the `claude` process itself exit with code 1. That
+  // post-result exit is a teardown artifact, not a generation failure —
+  // the deliverable was already produced. This is the same family as
+  // the `acpForcedShutdown` and `artifactQuietShutdown` carve-outs:
+  // "the work completed; the odd exit is teardown noise."
+  it('returns succeeded on a non-zero exit when the turn already completed cleanly (post-result hook failure)', () => {
+    expect(
+      classifyChatRunCloseStatus({
+        ...base,
+        code: 1,
+        signal: null,
+        turnCompletedCleanly: true,
+      }),
+    ).toBe('succeeded');
+  });
+
+  it('returns succeeded on a signal death after a clean turn completion (hook killed during teardown)', () => {
+    // A SessionEnd hook that hangs past its own grace window can be
+    // SIGKILLed during teardown after the turn already completed. Same
+    // invariant: a clean terminal turn was emitted, so the late signal
+    // exit is teardown noise, not a generation failure.
+    expect(
+      classifyChatRunCloseStatus({
+        ...base,
+        code: null,
+        signal: 'SIGKILL',
+        turnCompletedCleanly: true,
+      }),
+    ).toBe('succeeded');
+  });
+
+  it('still prefers canceled over a clean-completion non-zero exit when the user cancelled', () => {
+    // Cancel intent always wins; a post-cancel hook exit must not
+    // reclassify a user-cancelled run as succeeded.
+    expect(
+      classifyChatRunCloseStatus({
+        ...base,
+        cancelRequested: true,
+        code: 1,
+        signal: null,
+        turnCompletedCleanly: true,
+      }),
+    ).toBe('canceled');
   });
 });

--- a/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
+++ b/apps/daemon/tests/chat-run-artifact-quiet-period.test.ts
@@ -21,6 +21,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   __forTestChatRunHandles,
   __forTestEmitLiveArtifactEvent,
+  applyClaudeStreamJsonRunBookkeeping,
   classifyChatRunCloseStatus,
   resolveActiveInactivityTimeoutMs,
   resolveChatRunArtifactQuietPeriodMs,
@@ -405,5 +406,52 @@ describe('classifyChatRunCloseStatus (#1451 close-handler classification)', () =
         turnCompletedCleanly: true,
       }),
     ).toBe('canceled');
+  });
+});
+
+describe('applyClaudeStreamJsonRunBookkeeping', () => {
+  it('records clean completion when the host-answer path already closed stdin', () => {
+    const run = {
+      stdinOpen: false,
+      pendingHostAnswers: new Set<string>(),
+      turnCompletedCleanly: false,
+      child: {
+        stdin: {
+          destroyed: false,
+          end: vi.fn(),
+        },
+      },
+    };
+
+    applyClaudeStreamJsonRunBookkeeping(run, {
+      type: 'turn_end',
+      stopReason: 'end_turn',
+    });
+
+    expect(run.turnCompletedCleanly).toBe(true);
+    expect(run.child.stdin.end).not.toHaveBeenCalled();
+  });
+
+  it('keeps waiting when a terminal event arrives with host answers still pending', () => {
+    const run = {
+      stdinOpen: true,
+      pendingHostAnswers: new Set(['toolu_1']),
+      turnCompletedCleanly: false,
+      child: {
+        stdin: {
+          destroyed: false,
+          end: vi.fn(),
+        },
+      },
+    };
+
+    applyClaudeStreamJsonRunBookkeeping(run, {
+      type: 'turn_end',
+      stopReason: 'end_turn',
+    });
+
+    expect(run.turnCompletedCleanly).toBe(false);
+    expect(run.stdinOpen).toBe(true);
+    expect(run.child.stdin.end).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #3372

## Why

Hit this myself while generating in Open Design with the Honcho memory plugin installed. A generation finished cleanly — the UI showed the completed turn (`Done · 35s · 1529 out · $0.6428`) — and then a red error appeared and the conversation halted:

```
agent exited with code 1 SessionEnd hook [bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts] failed: Hook cancelled
```

The deliverable was already produced, but the run was reported as failed and the flow stopped. The pain: a memory-logging side-effect that runs *after* a successful turn can fail the whole run. It's not Honcho-specific — any `SessionEnd` hook (present or future, yours or a user's) that exits non-zero during teardown drags the `claude` child to `exit 1` and trips the same misclassification.

Root cause is in `classifyChatRunCloseStatus` (`apps/daemon/src/server.ts`): it maps **any** non-zero child exit to `failed`. It already has two carve-outs for "the work completed; the odd exit is teardown noise" (`acpForcedShutdown`, `artifactQuietShutdown`) — there just wasn't one for "the model emitted a clean terminal turn, then a post-response hook failed." This adds that third carve-out.

It deliberately does **not** weaken the existing guard: a non-zero exit *before* a clean turn still fails (real CLI bug, model error, mid-turn crash), and the agent-specific auth/quota/AMR guards in the close handler still run first, so a genuine post-turn auth failure is still surfaced with its specific code. The intent behind the prior "non-zero = real failure" test is preserved — its case now reads explicitly as the `turnCompletedCleanly: false` failure.

The completion signal is derived from the single source of truth: `turnCompletedCleanly` is set at the exact point the daemon observes a clean terminal turn (`turn_end`/`usage` with no outstanding host answer) and closes the child's stdin — so it cannot drift from the daemon's own "this turn is done" decision.

## What users will see

A generation that completes successfully no longer flips to a red "agent exited with code 1 … SessionEnd hook … failed" error when an installed `SessionEnd` hook (e.g. the Honcho memory plugin) fails on the way out. The completed turn stays a success and the conversation continues instead of halting. No behavior change for users without such a hook, and no change for genuine failures (a model/CLI error before the turn completes still fails as before).

## Surface area

- [x] **None** — daemon-internal run-status classification fix. No new capability, so the UI/CLI dual-track rule doesn't apply: this corrects classification that both existing surfaces already consume identically (the web chat and `od` both read run status from the same `/api/*` path). No contract shape changed — `classifyChatRunCloseStatus` is an internal helper, not part of `packages/contracts`.

## Screenshots

No UI surface added. The observable user effect is the *absence* of the red failure banner shown in #3372 after a successful turn.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/chat-run-artifact-quiet-period.test.ts` — `classifyChatRunCloseStatus … > returns succeeded on a non-zero exit when the turn already completed cleanly (post-result hook failure)` (plus a signal-death-after-clean-turn case and a cancel-still-wins case).
- Did the test go red on `main` and green on this branch? **yes** — the two new post-completion cases asserted `succeeded` and got `failed` against the unmodified classifier (2 failed / 26 passed); after the fix all 28 pass. The reframed genuine-failure case (`turnCompletedCleanly: false` → `failed`) stays green throughout, proving the carve-out doesn't swallow real failures.
- Integration note: per the in-file precedent (the `#1451` block documents that the full fake-agent-over-HTTP story is covered by manual verification), the wiring (`run.turnCompletedCleanly` set at the stdin-close point and read at the close-handler call site) is a 1-line set + 1-line pass in the same closure; the unit cases pin the classifier logic and the reframed failure case guards against over-broad success.

## Validation

- `pnpm guard` — 33/33 pass
- `pnpm typecheck` — all packages `Done`, 0 errors
- `pnpm --filter @open-design/daemon exec vitest run tests/chat-run-artifact-quiet-period.test.ts` — 28/28 pass (was 2 red pre-fix)
- `pnpm --filter @open-design/daemon test` — full suite: 3540 passed, 0 failed (293 files, 4 skipped, 4 todo)
