### PR TITLE
security: resolve vulnerable tmp transitive dependency

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-nSMVyVSHfcXV5fLMXM3tfdQxZRb+FNF6P4iuJw/Z8Mo=";
-  webHash = "sha256-IlXE7iNoT/+mcVbtzhJdcP5fNs7Hk8AYZMxfJ33dXck=";
+  daemonHash = "sha256-cHVStKsh5vDiplA7QVCZuC9xbXKOoE7v7VfwX0A3Pes=";
+  webHash = "sha256-THVcqWm8iPpF65gBaV8/nK27ZjOwVJzsAAfVQZxN+As=";
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
       "postcss": "8.5.15",
       "protobufjs": "8.4.0",
       "qs": "6.15.2",
+      "tmp": "0.2.7",
       "yaml": "2.9.0"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   postcss: 8.5.15
   protobufjs: 8.4.0
   qs: 6.15.2
+  tmp: 0.2.7
   yaml: 2.9.0
 
 importers:
@@ -4446,8 +4447,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   toidentifier@1.0.1:
@@ -9413,9 +9414,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.7
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   toidentifier@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ overrides:
   postcss: 8.5.15
   protobufjs: 8.4.0
   qs: 6.15.2
+  tmp: 0.2.7
   yaml: 2.9.0
 
 onlyBuiltDependencies:


### PR DESCRIPTION
## Why

This PR addresses a high-severity advisory affecting `tmp@0.2.5`.

Advisory: `GHSA-ph9p-34f9-6g65` / `CVE-2026-44705`  
Primary advisory: https://github.com/advisories/GHSA-ph9p-34f9-6g65

The issue is a path traversal vulnerability in `tmp` where unsafe `prefix`, `postfix`, or `dir` options can allow generated temporary file paths to escape the intended temp directory. This matters when attacker-controlled input can reach those options.

## Advisory References

- GitHub Advisory Database: https://github.com/advisories/GHSA-ph9p-34f9-6g65
- Upstream package advisory: https://github.com/raszi/node-tmp/security/advisories/GHSA-ph9p-34f9-6g65
- OSV: https://osv.dev/vulnerability/GHSA-ph9p-34f9-6g65
- GitLab Advisory Database: https://advisories.gitlab.com/npm/tmp/CVE-2026-44705/
- NVD CVE page: https://nvd.nist.gov/vuln/detail/CVE-2026-44705
- Upstream fix commit: https://github.com/raszi/node-tmp/commit/efa4a06f24374797ae32ab2b6ae39b7a611ae429

## Where It Appears

Dependency path:

```text
tools/pack/package.json
-> electron-builder@26.8.1
-> app-builder-lib@26.8.1
-> @malept/flatpak-bundler@0.4.0
-> tmp-promise@3.0.3
-> tmp@0.2.5
```

Evidence:

- [`tools/pack/package.json`](https://github.com/gateway/open-design/blob/security/tmp-0-2-7-override/tools/pack/package.json#L22): declares `electron-builder@26.8.1`.
- [`pnpm-lock.yaml`](https://github.com/gateway/open-design/blob/security/tmp-0-2-7-override/pnpm-lock.yaml#L586-L588): resolves `electron-builder@26.8.1`.
- [`pnpm-lock.yaml`](https://github.com/gateway/open-design/blob/security/tmp-0-2-7-override/pnpm-lock.yaml#L6653-L6664): `app-builder-lib` pulls `@malept/flatpak-bundler`.
- [`pnpm-lock.yaml`](https://github.com/gateway/open-design/blob/security/tmp-0-2-7-override/pnpm-lock.yaml#L5902-L5908): `@malept/flatpak-bundler` pulls `tmp-promise@3.0.3`.
- [`pnpm-lock.yaml`](https://github.com/gateway/open-design/blob/security/tmp-0-2-7-override/pnpm-lock.yaml#L9414-L9419): `tmp-promise@3.0.3` now resolves `tmp@0.2.7` after this PR.

## Code Usage Review

Direct `tmp` imports found outside the lockfile: none.  
Direct `tmp-promise` imports found outside the lockfile: none.  
Observed exposure: transitive packaging-toolchain dependency.

That means this does not appear to be direct application runtime usage. It is still worth resolving because the vulnerable version was present in the workspace lockfile and reachable through packaging tooling.

## Fix

This PR adds `tmp: 0.2.7` to the existing pnpm override list and regenerates the lockfile so `tmp-promise@3.0.3` resolves to the patched `tmp` version.

Affected: `tmp@0.2.5`  
Patched range: `tmp >= 0.2.6`  
Target used: `tmp@0.2.7`

This follows the existing repo pattern of central pnpm overrides for dependency security pins and avoids a broader `electron-builder` dependency upgrade.

## Alternatives Considered

| Option | Why not / why chosen |
| --- | --- |
| Upgrade `electron-builder` | Broader dependency churn and higher packaging breakage risk. |
| Override `tmp` only | Chosen. Smallest change, keeps the parent packaging toolchain stable, and moves within the same `0.2.x` line. |

## Risk Assessment

Upgrade risk: low to medium.

Reasoning:

- `tmp` moves from `0.2.5` to `0.2.7`, staying within the same `0.2.x` release line.
- No direct repo imports of `tmp` or `tmp-promise` were found.
- The affected path is transitive through packaging tooling, so packaging smoke tests are still the right maintainer validation target.

## Validation

Ran:

- `pnpm install --lockfile-only --ignore-scripts`: completed and updated only dependency resolution metadata.
- `pnpm audit --json`: clean after the change (`0` vulnerabilities).
- Guardian dependency scan: clean after the change; previous `tmp@0.2.5` finding is reported as resolved.
- OSV check: `tmp@0.2.5` matches `GHSA-ph9p-34f9-6g65`; `tmp@0.2.7` does not.
- Static usage search for direct `tmp` / `tmp-promise` imports outside `pnpm-lock.yaml`: no matches.

Not run:

- `pnpm --filter @open-design/tools-pack test`: this temp validation clone did not have `node_modules` installed, and I avoided installing/executing the project dependency tree. The command also warned my local Node was `v25.6.1` while this repo expects Node `~24`.

Suggested maintainer validation:

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/tools-pack test`
- `pnpm --filter @open-design/tools-pack typecheck`
- Packaging smoke test for the platforms this toolchain supports

## Notes

This PR is not claiming active exploitation in this repo. It removes a known vulnerable transitive package version from the resolved dependency graph and documents the scope of the change.
