### PR TITLE
feat(analytics): mark clarification-turn runs in run_finished

### DIFF
--- a/apps/daemon/src/run-artifacts.ts
+++ b/apps/daemon/src/run-artifacts.ts
@@ -36,6 +36,16 @@ const WRITE_OR_EDIT_TOOL_NAMES: ReadonlySet<string> = new Set([
   'multi_edit',
 ]);
 
+// Tool names the daemon recognizes as an intent-clarification card. Claude
+// emits `AskUserQuestion`; the ACP/MCP snake_case proxy shape emits
+// `ask_user_question`. Keep aligned with the AskUserQuestion detection in
+// `apps/daemon/src/server.ts` and the card rendering in
+// `apps/web/src/components/ToolCard.tsx`.
+const ASK_USER_QUESTION_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'AskUserQuestion',
+  'ask_user_question',
+]);
+
 function extractToolFilePath(input: unknown): string | null {
   if (!input || typeof input !== 'object') return null;
   const obj = input as { file_path?: unknown; path?: unknown };
@@ -196,4 +206,27 @@ export function countNewHtmlArtifacts(events: readonly RunEventLike[]): number {
     writtenPaths.add(path);
   }
   return writtenPaths.size;
+}
+
+// True iff the run raised an AskUserQuestion clarification card. Fed into
+// `run_finished.asked_user_question`. A clarification turn is the agent
+// stopping to ask the user a finite-choice question; it inherently produces
+// no artifact, so the dashboard uses this flag to exclude such runs from the
+// "run finished -> has artifact" funnel rather than scoring them as
+// artifact-generation failures.
+export function runAskedUserQuestion(
+  events: readonly RunEventLike[],
+): boolean {
+  if (!events || events.length === 0) return false;
+  for (const rec of events) {
+    if (rec?.event !== 'agent') continue;
+    const data = rec.data as
+      | { type?: string; name?: unknown }
+      | null
+      | undefined;
+    if (data?.type !== 'tool_use') continue;
+    if (typeof data.name !== 'string') continue;
+    if (ASK_USER_QUESTION_TOOL_NAMES.has(data.name)) return true;
+  }
+  return false;
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -241,6 +241,7 @@ import {
   countDesignSystemPreviewModules,
   countNewHtmlArtifacts,
   didRunCreateDesignSystemFile,
+  runAskedUserQuestion,
 } from './run-artifacts.js';
 import {
   reportRunCompletedFromDaemon,
@@ -13532,6 +13533,12 @@ export async function startServer({
             // for the dedup semantics; tested in
             // `tests/run-artifacts.test.ts`.
             artifact_count: countNewHtmlArtifacts(run.events),
+            // True when the run raised an AskUserQuestion clarification
+            // card. Clarification turns inherently produce no artifact, so
+            // the dashboard excludes them from the "run finished -> has
+            // artifact" funnel instead of counting them as failures. See
+            // `run-artifacts.ts`; tested in `tests/run-artifacts.test.ts`.
+            asked_user_question: runAskedUserQuestion(run.events),
             ...(isDesignSystemRun ? {
               // DS runs land a `DESIGN.md` write when generation
               // succeeded; the run-artifacts inspector reuses the

--- a/apps/daemon/tests/run-artifacts.test.ts
+++ b/apps/daemon/tests/run-artifacts.test.ts
@@ -20,6 +20,7 @@ import {
   countDesignSystemPreviewModules,
   countNewHtmlArtifacts,
   didRunCreateDesignSystemFile,
+  runAskedUserQuestion,
 } from '../src/run-artifacts.js';
 
 let nextId = 0;
@@ -286,5 +287,49 @@ describe('countDesignSystemPreviewModules', () => {
         ...pair('Write', '/proj/preview/typography.html'),
       ]),
     ).toBe(1);
+  });
+});
+
+// Helper: emit a bare tool_use (no result) for a named tool. Clarification
+// detection only needs the tool_use to appear; AskUserQuestion is answered
+// out-of-band via POST /api/runs/:id/tool-result, not a stream tool_result.
+function toolUse(name: string, id = freshId()) {
+  return [
+    {
+      event: 'agent',
+      data: { type: 'tool_use', id, name, input: {} },
+    },
+  ];
+}
+
+describe('runAskedUserQuestion', () => {
+  it('returns false for an empty event list', () => {
+    expect(runAskedUserQuestion([])).toBe(false);
+  });
+
+  it('returns true when the run raised an AskUserQuestion card', () => {
+    expect(runAskedUserQuestion(toolUse('AskUserQuestion'))).toBe(true);
+  });
+
+  it('matches the snake_case ask_user_question proxy shape', () => {
+    expect(runAskedUserQuestion(toolUse('ask_user_question'))).toBe(true);
+  });
+
+  it('returns false for a run that only wrote artifacts', () => {
+    expect(
+      runAskedUserQuestion([
+        ...pair('Write', '/proj/index.html'),
+        ...toolUse('Read'),
+      ]),
+    ).toBe(false);
+  });
+
+  it('detects the card even when mixed with other tool calls', () => {
+    expect(
+      runAskedUserQuestion([
+        ...pair('Write', '/proj/index.html'),
+        ...toolUse('AskUserQuestion'),
+      ]),
+    ).toBe(true);
   });
 });

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -1757,6 +1757,12 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   result: TrackingRunResult;
   error_code?: string;
   artifact_count: number;
+  // True when the run raised an AskUserQuestion clarification card. Such runs
+  // are intent-clarification turns (the agent stops to ask the user a question)
+  // and therefore inherently produce no artifact, so the dashboard can exclude
+  // them from the "run finished -> has artifact" funnel instead of counting
+  // them as artifact-generation failures.
+  asked_user_question: boolean;
   input_tokens?: number;
   output_tokens?: number;
   total_tokens?: number;


### PR DESCRIPTION
## Why

While analyzing the run funnel on PostHog (project 420348), the biggest single dropoff is "run finished → has artifact" (~71%). Investigation showed a large share of those zero-artifact runs are **not** failures: the first session of a task does intent clarification by raising an `AskUserQuestion` card, and a clarification turn inherently produces no artifact — the agent stops to ask the user a question and waits for the answer.

Because nothing on the wire distinguished a clarification turn from a genuine artifact-generation failure, the dashboard counted both the same way, inflating the dropoff and making the funnel unactionable. This PR adds the missing signal so the artifact funnel can exclude clarification turns instead of scoring them as failures.

This is scratching an itch for the growth/analytics work on the run funnel — it unblocks an accurate "did this run actually try to produce an artifact?" read.

## What users will see

No user-facing change. This is an analytics-only field on the `run_finished` event. On the dashboard side, `run_finished` now carries `asked_user_question: boolean`, letting funnels filter out intent-clarification turns from the artifact-conversion step.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

> Note on the dual-track UI/CLI rule: this is an analytics property emitted automatically daemon-side on every `run_finished`, not a user-invokable capability, so there is no UI or CLI surface to add. The field rides along the existing `run_finished` emission that both surfaces already trigger.

## Screenshots

N/A — no UI surface.

## Bug fix verification

Not a bug fix; this is an analytics-signal addition. New unit coverage was added regardless (see Validation).

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/contracts typecheck` — pass
- `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm --filter @open-design/daemon test run-artifacts` — pass (27 tests, including 5 new `runAskedUserQuestion` cases: empty list, `AskUserQuestion`, snake_case `ask_user_question`, artifact-only run, and mixed tool calls)
- `pnpm typecheck` (full) currently fails only on **pre-existing, unrelated** `apps/web` errors (`ProjectLocation`, `ProxyMessageContent`, `AppConfigPrefs`, `totalDurationMs`, `fabricated_role_marker`); confirmed identical failures on the branch base with my changes stashed. None reference this change.