### PR TITLE
fix(web): align chat composer caret with the mention highlight overlay

### DIFF
--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -531,7 +531,10 @@
   pointer-events: none;
   white-space: pre-wrap;
   overflow: hidden;
-  overflow-wrap: anywhere;
+  /* Match the textarea's overflow-wrap so both layers break long runs at the
+     same points; `anywhere` here against the textarea's `break-word` can
+     diverge on long unbroken tokens and drift the caret off the glyphs. */
+  overflow-wrap: break-word;
 }
 .composer-input-overlay-inner {
   min-height: 100%;
@@ -547,15 +550,18 @@
   color: transparent;
 }
 .composer-inline-mention {
-  display: inline-block;
-  max-width: min(240px, 25vw);
-  /* The 1px horizontal padding pads the highlight background, but it also
-     widens this inline-block past the raw token width. The transparent
-     textarea that owns the caret has no such padding, so its caret lands
-     ~2px left of the rendered glyphs after every mention. Cancel the
-     padding's layout advance with a matching negative margin: the
-     background still fills the padded box, but the net horizontal advance
-     equals the token's content width, keeping caret and glyphs aligned. */
+  /* Render the mention as an inline run, not an atomic inline-block chip.
+     The transparent textarea that owns the caret breaks long tokens at
+     normal opportunities (e.g. after the hyphens in a filename), so a
+     nowrap inline-block that refuses to break wraps the whole token to the
+     next line while the textarea splits it. That drifts the caret off the
+     glyphs the moment a mention sits across a wrap boundary. An inline run
+     wraps at the same points as the textarea text, keeping the two locked. */
+  display: inline;
+  /* Padding pads the highlight background; the matching negative margin
+     cancels its layout advance so the net width equals the token's content
+     width. box-decoration-break stays default (slice), so the 1px pads apply
+     only at the run's start and end, never at a wrap fragment. */
   margin: 0 -1px;
   padding: 0 1px;
   border: 0;
@@ -568,10 +574,6 @@
   font-weight: inherit;
   line-height: inherit;
   letter-spacing: inherit;
-  vertical-align: bottom;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .composer-row {
   display: flex;

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -508,6 +508,12 @@
 .composer-textarea-layer {
   position: relative;
   min-height: 88px;
+  /* Single source of truth for the input font size. The real (transparent)
+     textarea owns the caret and the .composer-input-overlay renders the
+     visible glyphs; both inherit from here so they stay metric-identical.
+     Pinning the size on only one layer drifts them ~0.5px/em apart, which
+     reads as the caret sitting a full character off after a mention. */
+  font-size: 13px;
 }
 .composer-input-overlay {
   position: absolute;
@@ -517,7 +523,11 @@
   padding: 0;
   color: var(--text);
   font: inherit;
-  line-height: normal;
+  /* Mirror the textarea's inherited line-height (body is 1.5) instead of
+     forcing `normal`. The overlay is a visual echo of the transparent
+     textarea that owns the caret, so any line-height difference drifts the
+     glyphs off the caret vertically and accumulates per wrapped line. */
+  line-height: inherit;
   pointer-events: none;
   white-space: pre-wrap;
   overflow: hidden;
@@ -539,7 +549,14 @@
 .composer-inline-mention {
   display: inline-block;
   max-width: min(240px, 25vw);
-  margin: 0;
+  /* The 1px horizontal padding pads the highlight background, but it also
+     widens this inline-block past the raw token width. The transparent
+     textarea that owns the caret has no such padding, so its caret lands
+     ~2px left of the rendered glyphs after every mention. Cancel the
+     padding's layout advance with a matching negative margin: the
+     background still fills the padded box, but the net horizontal advance
+     equals the token's content width, keeping caret and glyphs aligned. */
+  margin: 0 -1px;
   padding: 0 1px;
   border: 0;
   border-radius: 5px;

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -1088,7 +1088,9 @@
 .app .composer textarea {
   min-height: 88px;
   max-height: min(184px, 34vh);
-  font-size: 13px;
+  /* Font size lives on .composer-textarea-layer so the textarea and its
+     mention-highlight overlay share one value. Re-pinning it here would
+     only set the textarea, drifting the overlay glyphs off the caret. */
 }
 .app .composer-row {
   min-height: 32px;


### PR DESCRIPTION
## Why

I was working through composer bugs and hit this one myself: type `@`, pick a file, then keep typing, and the text caret sits left of where the text actually ends. It shows up on every mention, so the input feels broken whenever there is one in it.

Two separate bugs cause the same symptom. First, a font-size mismatch between the two layers that make up the composer input: it renders a transparent `<textarea>` that owns the caret on top of a `<div>` overlay that draws the @-mention highlights. `routines.css` pinned the textarea to `font-size: 13px` via `.app .composer textarea`, but the overlay is a div and never matches that selector, so it inherited the body's `13.5px`. Half a pixel per em adds up to about 7px over a line, roughly one character.

Second, once there are several mentions or the line wraps, the highlight was an atomic inline-block with `white-space: nowrap`, so it wrapped the whole token to the next line. The textarea breaks the same token at normal opportunities (for example after the hyphens in a filename), so the two layers wrapped at different points and the caret drifted about 108px from the glyphs.

## What users will see

In the chat composer, after inserting one or more `@` mentions (file, skill, or plugin) and continuing to type, the caret sits right at the end of the text. This now holds with several mentions and when the input wraps to more than one line, not just on a single short line. Nothing is restyled; the highlight looks the same in the common case.

## Surface area

- [x] **UI**: rendering fix to the existing chat composer input in `apps/web` (not a new surface)

This fixes how an existing input renders. It does not add a capability, so there is no matching `od` CLI surface to add.

## Screenshots

Before, caret left of the end after an `@` mention, and further off with multiple mentions or a wrapped line:

<!-- drag-drop the before image here -->

After, caret at the end:

<!-- drag-drop the after image here -->

## Bug fix verification

A red spec before the change was not cheap here. The bug is sub-pixel text layout, and jsdom (the web package's test environment) has no layout engine, so a unit test cannot see caret-versus-glyph position. I verified in the running app instead, reading computed styles and measuring caret position against the overlay text in the Electron renderer:

- font size: textarea was `13px`, overlay `13.5px`; the same string measured 210.89px against 217.88px, about 7px or one character. After: both `13px`, delta `0px`.
- several mentions with the line wrapping: caret-to-glyph gap was 108.12px. After: 0.01px. A single mention stays at 0.02px.

## Validation

- Live computed-style and caret-position measurement in the running desktop app via `tools-dev inspect desktop eval` (numbers above). CSS-only change in `apps/web`, no type surface touched.
- `pnpm guard` has one pre-existing failure unrelated to this PR (design-system component fixture coverage under `design-systems/*/components.html`); this change touches neither that area nor any `.js/.mjs/.cjs` policy surface.
