### PR TITLE
fix(daemon): raise opencode model-list timeout to 15s so the full model list loads

### DIFF
--- a/apps/daemon/src/runtimes/defs/opencode.ts
+++ b/apps/daemon/src/runtimes/defs/opencode.ts
@@ -7,11 +7,16 @@ export const opencodeAgentDef = {
     bin: 'opencode-cli',
     fallbackBins: ['opencode'],
     versionArgs: ['--version'],
-    // `opencode models` prints `provider/model` per line.
+    // `opencode models` prints `provider/model` per line. Real-world
+    // `opencode models` calls can take >8s (network round-trip to the
+    // provider registry), so the previous 8s budget timed out and fell back
+    // to the hardcoded `fallbackModels`, hiding the user's actual catalog.
+    // 15s matches the listModels budget the rest of the agent defs use
+    // (devin, hermes, kiro, kilo, kimi, trae-cli, vibe, reasonix).
     listModels: {
       args: ['models'],
       parse: parseLineSeparatedModels,
-      timeoutMs: 8000,
+      timeoutMs: 15_000,
     },
     fallbackModels: [
       DEFAULT_MODEL_OPTION,


### PR DESCRIPTION
## Why

- **My use case** — I was setting up the OpenCode CLI as my agent in Open Design and hit this while picking a model. My `opencode auth list` only has the `OpenCode Go` provider, but the model dropdown only offered `default`, `anthropic/claude-sonnet-4-5`, `openai/gpt-5`, and `google/gemini-2.5-pro` — none of which I'm authenticated for. My real models (`opencode-go/deepseek-v4-pro`, `opencode-go/qwen3.7-max`, …) never showed up.
- **The pain** — The OpenCode adapter detects models with `opencode models`, but that command does a network round-trip to the provider registry and on my machine consistently takes ~8.4s. The adapter's `listModels.timeoutMs` was `8000`, so detection timed out by a few hundred ms and silently fell back to the hardcoded `fallbackModels`. The result is a model picker that lists models the user can't use and hides the ones they can — a confusing dead end with no error.

## What users will see

OpenCode users whose `opencode models` is a bit slow will now see their **real, authenticated model catalog** in the model picker (e.g. the full `opencode-go/*` list) instead of the 4-item hardcoded fallback. No UI or workflow changes — the dropdown just gets populated correctly. Worst-case OpenCode model-detection now waits up to 15s (was 8s) before falling back.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — OpenCode model detection now waits up to 15s (was 8s); slow-but-valid `opencode models` results that previously fell back to the hardcoded list now populate with the user's live catalog.
- [ ] **None**

## Screenshots

Not a UI-code change, so no new entry point. Behavior before/after on a machine where `opencode models` takes ~8.4s:

- **Before:** picker shows 4 entries — `default`, `anthropic/claude-sonnet-4-5`, `openai/gpt-5`, `google/gemini-2.5-pro` (`modelsSource: fallback`).
- **After:** picker shows 17 entries — `default` + the live `opencode/*` and `opencode-go/*` catalog including `opencode-go/deepseek-v4-pro` (`modelsSource: live`).

## Bug fix verification

A cheap red spec isn't a good fit here: reproducing the timeout requires a real ~9s-latency `opencode models` invocation, so the test would be timing-dependent and flaky — exactly what AGENTS.md's bug-follow-up guidance says to avoid. Instead this is a one-line config alignment, and `apps/daemon/src/runtimes/defs/opencode.ts` was the only def stuck at 8s — every other agent that lists models already uses 15s (`devin`, `hermes`, `kiro`, `kilo`, `kimi`, `trae-cli`, `vibe`, `reasonix`).

Manual repro on the affected machine: `opencode models` measured at 8.4s; before the change `/api/agents` reported the opencode entry as `modelsSource: fallback` with 4 models, and after the change (rebuild + restart) it reported `modelsSource: live` with the full 17-model catalog. A real generation through the adapter on `model: default` succeeded end-to-end.

- Test path that reproduces the bug: n/a (timing-dependent; see above)
- Did the test go red on `main` and green on this branch? n/a

## Validation

- `pnpm guard` — 36/36 pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/resolve-model.test.ts tests/runtimes/env-and-detection.test.ts tests/runtimes/agent-args.test.ts tests/runtimes/opencode-log-failure.test.ts` — 115/115 pass
- Manual: real `opencode` generation through the daemon on `model: default` succeeded; `/api/agents` now reports `modelsSource: live` (17 models) for opencode.
