### PR TITLE
fix: capture Antigravity diagnostic logs

### DIFF
--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -227,16 +227,23 @@ export const antigravityAgentDef = {
     // and the change actually ships in the auto-update channel that
     // packaged OD users get, `-p -` is the contract that actually
     // produces a print-mode reply on the installed CLI.
-    const args: string[] = ['-p'];
+    const args: string[] = [];
     // Always opt into `--log-file` when the daemon supplied a path so
     // it can post-exit grep for the actual upstream failure shape
     // (auth missing vs quota reached vs upstream error) — without it
     // the chat surfaces a generic "empty response" because print mode
     // never echoes those errors on stdout. See server.ts empty-output
     // guard for the consumer.
+    //
+    // Flag order is load-bearing on agy v1.0.3: `agy -p --log-file
+    // /tmp/x -` runs successfully but leaves /tmp/x empty, while `agy
+    // --log-file /tmp/x -p -` captures the diagnostic log, including
+    // `Propagating selected model override to backend: label="<model>"`
+    // and auth/quota failures.
     if (runtimeContext.agentLogFilePath) {
       args.push('--log-file', runtimeContext.agentLogFilePath);
     }
+    args.push('-p');
     args.push('-');
     return args;
   },

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -469,6 +469,11 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
   const args = antigravity.buildArgs('write hello world', [], [], {}, {});
   assert.deepEqual(args, ['-p', '-']);
 
+  const argsWithLog = antigravity.buildArgs('write hello world', [], [], {}, {
+    agentLogFilePath: '/tmp/od-agy-test.log',
+  });
+  assert.deepEqual(argsWithLog, ['--log-file', '/tmp/od-agy-test.log', '-p', '-']);
+
   // No `--model` flag exists upstream, so buildArgs argv must stay the
   // same regardless of which label the user picks.
   // Pass a temp antigravitySettingsPath so buildArgs does not touch the
@@ -477,9 +482,12 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
   try {
     const withModel = antigravity.buildArgs('hi', [], [], {
       model: 'Gemini 3.1 Pro (High)',
-    }, { antigravitySettingsPath: join(settingsDir, 'settings.json') });
+    }, {
+      agentLogFilePath: '/tmp/od-agy-test.log',
+      antigravitySettingsPath: join(settingsDir, 'settings.json'),
+    });
     assert.equal(withModel.includes('--model'), false);
-    assert.deepEqual(withModel, ['-p', '-']);
+    assert.deepEqual(withModel, ['--log-file', '/tmp/od-agy-test.log', '-p', '-']);
   } finally {
     rmSync(settingsDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes #3390

## Why

Antigravity CLI users reported that the connection test can pass, but a real design run then times out, terminates with no response, opens an empty project, or repeatedly shows the same default design. The daemon already asks Antigravity for a diagnostic log so it can distinguish auth, quota, model propagation, and upstream failures from a generic empty response, but the current argv order leaves that log empty on `agy` v1.0.3.

This PR keeps the adapter surface small and aligns it with the existing daemon runtime contract: when OD supplies an agent log path, the Antigravity adapter must pass `--log-file` early enough that the installed CLI actually writes the diagnostic file before print mode consumes stdin.

## What users will see

Antigravity-backed design runs should now preserve the upstream diagnostic log OD needs to report the real failure shape instead of collapsing into a generic timeout, empty response, or default-design fallback when the CLI fails after the connection check.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A; this changes daemon runtime argv construction and diagnostics, not UI.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/agent-args.test.ts`
- Did the test go red on `main` and green on this branch? Not rerun on `main` during PR prep; the new assertion encodes the previous bad ordering (`-p` before `--log-file`) and is green on this branch.
- Additional verification: direct local `agy` checks showed `agy -p --log-file <path> -` exits successfully but leaves the requested log empty, while `agy --log-file <path> -p -` writes the diagnostic log including model propagation details.

## Validation

- `git diff --check`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm exec vitest run -c vitest.config.ts tests/runtimes/agent-args.test.ts tests/runtimes/antigravity-model-lock.test.ts` from `apps/daemon`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm --filter @open-design/daemon typecheck`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm --filter @open-design/daemon build`
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm guard`
- Live OD smoke in an isolated temp runtime with Antigravity selected: created a project, streamed a run, answered a generated question form, and persisted an HTML artifact. A broader prompt-routing behavior observed there is called out separately for maintainer discussion.
