### PR TITLE
Improve workspace model pickers

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1470,6 +1470,8 @@ function AppInner() {
         onModeChange={handleModeChange}
         onAgentChange={handleAgentChange}
         onAgentModelChange={handleAgentModelChange}
+        onApiModelChange={handleApiModelChange}
+        providerModelsCache={providerModelsCache}
         onRefreshAgents={refreshAgents}
         onOpenSettings={openSettings}
         onOpenAmrSettings={openAmrSettings}

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -8,6 +8,7 @@ import { SUGGESTED_MODELS_BY_PROTOCOL } from '../state/apiProtocols';
 import { KNOWN_PROVIDERS } from '../state/config';
 import { mergeProviderModelOptions, providerModelsCacheKey } from './SettingsDialog';
 import { apiProtocolLabel } from '../utils/apiProtocol';
+import { fetchProviderModels } from '../providers/provider-models';
 import { isMacPlatform } from '../utils/platform';
 
 interface Props {
@@ -51,6 +52,7 @@ export function AvatarMenu({
 }: Props) {
   const t = useT();
   const [open, setOpen] = useState(false);
+  const [discoveredProviderModels, setDiscoveredProviderModels] = useState<Record<string, ProviderModelOption[]>>({});
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
 
@@ -102,7 +104,40 @@ export function AvatarMenu({
     config.apiKey ?? '',
     config.apiVersion ?? '',
   );
-  const fetchedByokModels = providerModelsCache?.[byokProviderModelsKey] ?? [];
+  const fetchedByokModels = providerModelsCache?.[byokProviderModelsKey] ?? discoveredProviderModels[byokProviderModelsKey] ?? [];
+
+  useEffect(() => {
+    if (!open || config.mode !== 'api') return;
+    if (fetchedByokModels.length > 0) return;
+    if (apiProtocol === 'azure' || apiProtocol === 'ollama') return;
+    const baseUrl = config.baseUrl?.trim() ?? '';
+    const apiKey = config.apiKey?.trim() ?? '';
+    if (!baseUrl || !apiKey) return;
+    let cancelled = false;
+    void fetchProviderModels({
+      protocol: apiProtocol,
+      baseUrl,
+      apiKey,
+    }).then((result) => {
+      if (cancelled || !result.ok || !result.models?.length) return;
+      setDiscoveredProviderModels((current) => ({
+        ...current,
+        [byokProviderModelsKey]: result.models ?? [],
+      }));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    open,
+    config.mode,
+    apiProtocol,
+    config.baseUrl,
+    config.apiKey,
+    byokProviderModelsKey,
+    fetchedByokModels.length,
+  ]);
+
   const byokModelOptions = mergeProviderModelOptions(
     fetchedByokModels,
     SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol] ?? [],

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -20,7 +20,7 @@ interface Props {
     id: string,
     choice: { model?: string; reasoning?: string },
   ) => void;
-  onApiModelChange: (model: string) => void;
+  onApiModelChange?: (model: string) => void;
   providerModelsCache?: Record<string, ProviderModelOption[]>;
   onOpenSettings: () => void;
   onRefreshAgents: () => void;
@@ -94,9 +94,10 @@ export function AvatarMenu({
     (m) => m.id === currentModelId,
   )?.label;
 
-  const byokProvider = KNOWN_PROVIDERS.find((provider) => provider.protocol === config.apiProtocol);
+  const apiProtocol = config.apiProtocol ?? 'openai';
+  const byokProvider = KNOWN_PROVIDERS.find((provider) => provider.protocol === apiProtocol);
   const byokProviderModelsKey = providerModelsCacheKey(
-    config.apiProtocol,
+    apiProtocol,
     config.baseUrl ?? '',
     config.apiKey ?? '',
     config.apiVersion ?? '',
@@ -104,7 +105,7 @@ export function AvatarMenu({
   const fetchedByokModels = providerModelsCache?.[byokProviderModelsKey] ?? [];
   const byokModelOptions = mergeProviderModelOptions(
     fetchedByokModels,
-    SUGGESTED_MODELS_BY_PROTOCOL[config.apiProtocol] ?? [],
+    SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol] ?? [],
   );
 
   return (
@@ -324,14 +325,14 @@ export function AvatarMenu({
                 <SearchableModelSelect
                   className="inline-switcher__select avatar-select"
                   value={config.model ?? ''}
-                  onChange={(value) => onApiModelChange(value)}
+                  onChange={(value) => onApiModelChange?.(value)}
                   models={byokModelOptions.map((m) => ({ id: m.id, label: m.label }))}
                   additionalOptions={
                     config.model && !byokModelOptions.some((m) => m.id === config.model)
                       ? [
                           {
                             value: config.model,
-                            label: byokProvider && byokProvider.models.includes(config.model)
+                            label: byokProvider?.models?.includes(config.model)
                               ? config.model
                               : `${config.model} ${t('avatar.customSuffix')}`,
                           },

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -2,8 +2,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useT } from '../i18n';
 import { AgentIcon } from './AgentIcon';
 import { RemixIcon } from './RemixIcon';
-import { renderModelOptions } from './modelOptions';
-import type { AgentInfo, AppConfig, ExecMode } from '../types';
+import { SearchableModelSelect } from './modelOptions';
+import type { AgentInfo, AppConfig, ExecMode, ProviderModelOption } from '../types';
+import { SUGGESTED_MODELS_BY_PROTOCOL } from '../state/apiProtocols';
+import { KNOWN_PROVIDERS } from '../state/config';
+import { mergeProviderModelOptions, providerModelsCacheKey } from './SettingsDialog';
 import { apiProtocolLabel } from '../utils/apiProtocol';
 import { isMacPlatform } from '../utils/platform';
 
@@ -17,6 +20,8 @@ interface Props {
     id: string,
     choice: { model?: string; reasoning?: string },
   ) => void;
+  onApiModelChange: (model: string) => void;
+  providerModelsCache?: Record<string, ProviderModelOption[]>;
   onOpenSettings: () => void;
   onRefreshAgents: () => void;
   onBack?: () => void;
@@ -38,6 +43,8 @@ export function AvatarMenu({
   onModeChange,
   onAgentChange,
   onAgentModelChange,
+  onApiModelChange,
+  providerModelsCache,
   onOpenSettings,
   onRefreshAgents,
   onBack,
@@ -86,6 +93,19 @@ export function AvatarMenu({
   const currentModelLabel = currentAgent?.models?.find(
     (m) => m.id === currentModelId,
   )?.label;
+
+  const byokProvider = KNOWN_PROVIDERS.find((provider) => provider.protocol === config.apiProtocol);
+  const byokProviderModelsKey = providerModelsCacheKey(
+    config.apiProtocol,
+    config.baseUrl ?? '',
+    config.apiKey ?? '',
+    config.apiVersion ?? '',
+  );
+  const fetchedByokModels = providerModelsCache?.[byokProviderModelsKey] ?? [];
+  const byokModelOptions = mergeProviderModelOptions(
+    fetchedByokModels,
+    SUGGESTED_MODELS_BY_PROTOCOL[config.apiProtocol] ?? [],
+  );
 
   return (
     <div className="avatar-menu" ref={wrapRef}>
@@ -223,38 +243,36 @@ export function AvatarMenu({
                 (currentAgent.reasoningOptions &&
                   currentAgent.reasoningOptions.length > 0)) ? (
                 <div className="avatar-model-section">
-                  <div className="avatar-section-label">
-                    {t('avatar.modelSection')}
-                  </div>
                   {currentAgent.models && currentAgent.models.length > 0 ? (
                     <label className="avatar-select-row">
                       <span className="avatar-select-label">
                         {t('avatar.modelLabel')}
                       </span>
-                      <select
-                        className="avatar-select"
+                      <SearchableModelSelect
+                        className="inline-switcher__select avatar-select"
                         value={currentModelId ?? ''}
-                        onChange={(e) =>
+                        onChange={(value) =>
                           onAgentModelChange(currentAgent.id, {
-                            model: e.target.value,
+                            model: value,
                           })
                         }
-                      >
-                        {renderModelOptions(currentAgent.models)}
-                        {/* When the user has typed a custom id in
-                            Settings, surface it here too so the dropdown
-                            actually shows the active selection rather
-                            than collapsing to "Default". */}
-                        {currentModelId &&
-                        !currentAgent.models.some(
-                          (m) => m.id === currentModelId,
-                        ) ? (
-                          <option value={currentModelId}>
-                            {currentModelId}{' '}
-                            {t('avatar.customSuffix')}
-                          </option>
-                        ) : null}
-                      </select>
+                        models={currentAgent.models}
+                        additionalOptions={
+                          currentModelId &&
+                          !currentAgent.models.some((m) => m.id === currentModelId)
+                            ? [
+                                {
+                                  value: currentModelId,
+                                  label: `${currentModelId} ${t('avatar.customSuffix')}` ,
+                                },
+                              ]
+                            : undefined
+                        }
+                        searchPlaceholder={t('newproj.modelSearch')}
+                        searchInputTestId="avatar-model-search"
+                        popoverTestId="avatar-model-popover"
+                        popoverMinWidth={280}
+                      />
                     </label>
                   ) : null}
                   {currentAgent.reasoningOptions &&
@@ -295,6 +313,38 @@ export function AvatarMenu({
                 <span>{t('avatar.rescan')}</span>
               </button>
             </>
+          ) : null}
+
+          {config.mode === 'api' ? (
+            <div className="avatar-model-section">
+              <label className="avatar-select-row">
+                <span className="avatar-select-label">
+                  {t('avatar.modelLabel')}
+                </span>
+                <SearchableModelSelect
+                  className="inline-switcher__select avatar-select"
+                  value={config.model ?? ''}
+                  onChange={(value) => onApiModelChange(value)}
+                  models={byokModelOptions.map((m) => ({ id: m.id, label: m.label }))}
+                  additionalOptions={
+                    config.model && !byokModelOptions.some((m) => m.id === config.model)
+                      ? [
+                          {
+                            value: config.model,
+                            label: byokProvider && byokProvider.models.includes(config.model)
+                              ? config.model
+                              : `${config.model} ${t('avatar.customSuffix')}`,
+                          },
+                        ]
+                      : undefined
+                  }
+                  searchPlaceholder={t('newproj.modelSearch')}
+                  searchInputTestId="avatar-byok-model-search"
+                  popoverTestId="avatar-byok-model-popover"
+                  popoverMinWidth={280}
+                />
+              </label>
+            </div>
           ) : null}
 
           <div style={{ height: 1, background: 'var(--border-soft)', margin: '4px 6px' }} />

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -273,7 +273,6 @@ export function AvatarMenu({
                         searchInputTestId="avatar-model-search"
                         popoverTestId="avatar-model-popover"
                         minSearchableOptions={5}
-                        popoverMinWidth={340}
                       />
                     </label>
                   ) : null}
@@ -344,7 +343,6 @@ export function AvatarMenu({
                   searchInputTestId="avatar-byok-model-search"
                   popoverTestId="avatar-byok-model-popover"
                   minSearchableOptions={5}
-                  popoverMinWidth={340}
                 />
               </label>
             </div>

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -272,7 +272,8 @@ export function AvatarMenu({
                         searchPlaceholder={t('newproj.modelSearch')}
                         searchInputTestId="avatar-model-search"
                         popoverTestId="avatar-model-popover"
-                        popoverMinWidth={280}
+                        minSearchableOptions={5}
+                        popoverMinWidth={340}
                       />
                     </label>
                   ) : null}
@@ -342,7 +343,8 @@ export function AvatarMenu({
                   searchPlaceholder={t('newproj.modelSearch')}
                   searchInputTestId="avatar-byok-model-search"
                   popoverTestId="avatar-byok-model-popover"
-                  popoverMinWidth={280}
+                  minSearchableOptions={5}
+                  popoverMinWidth={340}
                 />
               </label>
             </div>

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -48,6 +48,8 @@ import {
 } from '../utils/inlineMentions';
 import { isImeComposing } from '../utils/imeComposing';
 import { ANNOTATION_EVENT, type AnnotationEventDetail } from "./PreviewDrawOverlay";
+import { DesignSystemSwitchPicker } from "./DesignSystemSwitchPicker";
+import { SearchableModelSelect } from './modelOptions';
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 
@@ -1374,31 +1376,24 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               >
                 {t('settings.byokImageModel')}
               </label>
-              <select
+              <SearchableModelSelect
                 id="composer-byok-image-model-select"
+                className="inline-switcher__select composer-byok-image-model__select"
                 value={byokImageModel ?? ''}
-                onChange={(e) => onChangeByokImageModel(e.target.value)}
-                style={{
-                  background: 'transparent',
-                  border: '1px solid var(--border, #444)',
-                  borderRadius: 4,
-                  padding: '2px 6px',
-                  color: 'inherit',
-                  fontSize: 12,
-                }}
-              >
-                <option value="">
-                  {(IMAGE_MODELS.find((m) => m.provider === 'senseaudio')?.label
-                    ?? 'senseaudio-image-2.0') + ' (default)'}
-                </option>
-                {IMAGE_MODELS.filter((m) => m.provider === 'senseaudio').map(
-                  (m) => (
-                    <option key={m.id} value={m.id}>
-                      {m.label}
-                    </option>
-                  ),
-                )}
-              </select>
+                onChange={(value) => onChangeByokImageModel(value)}
+                models={IMAGE_MODELS.filter((m) => m.provider === 'senseaudio').map((m) => ({ id: m.id, label: m.label }))}
+                additionalOptions={[
+                  {
+                    value: '',
+                    label: (IMAGE_MODELS.find((m) => m.provider === 'senseaudio')?.label
+                      ?? 'senseaudio-image-2.0') + ' (default)',
+                  },
+                ]}
+                searchPlaceholder={t('newproj.modelSearch')}
+                searchInputTestId="composer-byok-image-model-search"
+                popoverTestId="composer-byok-image-model-popover"
+                style={{ fontSize: 12 }}
+              />
             </div>
           ) : null}
           {/*

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -48,7 +48,6 @@ import {
 } from '../utils/inlineMentions';
 import { isImeComposing } from '../utils/imeComposing';
 import { ANNOTATION_EVENT, type AnnotationEventDetail } from "./PreviewDrawOverlay";
-import { DesignSystemSwitchPicker } from "./DesignSystemSwitchPicker";
 import { SearchableModelSelect } from './modelOptions';
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -868,7 +868,7 @@ function OnboardingView({
     apiProtocol,
     config.baseUrl.trim().replace(/\/+$/, ''),
     config.apiKey.trim(),
-    config.apiVersion?.trim() ?? '',
+    apiProtocol === 'azure' ? (config.apiVersion?.trim() ?? '') : '',
   ].join('\n');
   const canTestProvider =
     Boolean(config.apiKey.trim()) &&

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -115,7 +115,7 @@ import {
   AMR_LOGIN_POLL_INTERVAL_MS,
   amrLoginPollOutcome,
 } from './amrLoginPolling';
-import { renderModelOptions } from './modelOptions';
+import { SearchableModelSelect } from './modelOptions';
 
 // The topbar chips (GitHub star, model switcher, Use everywhere)
 // collapse into the settings dropdown when the viewport gets
@@ -2053,13 +2053,24 @@ function OnboardingCliSetupPanel({
         </div>
       ) : null}
       {selectedAgent && modelOptions.length > 0 ? (
-        <OnboardingDropdown
-          label={`${t('settings.modelPicker')} · ${selectedAgent.name}`}
-          placeholder={t('settings.modelSourceFallback')}
-          value={selectedModel}
-          options={modelOptions}
-          onChange={onSelectModel}
-        />
+        <label className="onboarding-view__model-picker">
+          <span className="onboarding-view__model-label">
+            {`${t('settings.modelPicker')} · ${selectedAgent.name}`}
+          </span>
+          <span className="onboarding-view__model-select-wrap">
+            <SearchableModelSelect
+              className="inline-switcher__select onboarding-view__model-select"
+              value={selectedModel}
+              onChange={onSelectModel}
+              models={modelOptions.map((option) => ({ id: option.value, label: option.label }))}
+              searchPlaceholder={t('newproj.modelSearch')}
+              searchInputTestId="onboarding-cli-model-search"
+              popoverTestId="onboarding-cli-model-popover"
+              minSearchableOptions={5}
+              popoverMinWidth={340}
+            />
+          </span>
+        </label>
       ) : null}
     </div>
   );
@@ -2095,16 +2106,21 @@ function OnboardingAmrModelSelect({
         </span>
       </span>
       <span className="onboarding-view__model-select-wrap">
-        <select
+        <SearchableModelSelect
+          className="inline-switcher__select onboarding-view__model-select"
           value={selectedModel}
-          onChange={(event) => onSelectModel(event.target.value)}
-        >
-          {renderModelOptions(displayModels)}
-        </select>
-        <Icon
-          name="chevron-down"
-          size={12}
-          className="onboarding-view__model-select-chevron"
+          onChange={onSelectModel}
+          models={displayModels}
+          additionalOptions={
+            selectedModel && !displayModels.some((model) => model.id === selectedModel)
+              ? [{ value: selectedModel, label: selectedModel }]
+              : undefined
+          }
+          searchPlaceholder={t('newproj.modelSearch')}
+          searchInputTestId="onboarding-amr-model-search"
+          popoverTestId="onboarding-amr-model-popover"
+          minSearchableOptions={5}
+          popoverMinWidth={340}
         />
       </span>
     </label>
@@ -2281,14 +2297,27 @@ function OnboardingByokSetupPanel({
           />
         </label>
         {modelOptions.length > 0 ? (
-          <OnboardingDropdown
-            label={t('settings.model')}
-            placeholder={selectedProvider?.model ?? 'claude-sonnet-4-5'}
-            value={model}
-            options={modelOptions}
-            onChange={onModelChange}
-            placement="top"
-          />
+          <label className="onboarding-view__model-picker onboarding-view__setup-model-picker">
+            <span className="onboarding-view__model-label">{t('settings.model')}</span>
+            <span className="onboarding-view__model-select-wrap">
+              <SearchableModelSelect
+                className="inline-switcher__select onboarding-view__model-select"
+                value={model}
+                onChange={onModelChange}
+                models={modelOptions.map((option) => ({ id: option.value, label: option.label }))}
+                searchPlaceholder={t('newproj.modelSearch')}
+                searchInputTestId="onboarding-byok-model-search"
+                popoverTestId="onboarding-byok-model-popover"
+                minSearchableOptions={5}
+                popoverMinWidth={340}
+                additionalOptions={
+                  model && !modelOptions.some((option) => option.value === model)
+                    ? [{ value: model, label: model }]
+                    : undefined
+                }
+              />
+            </span>
+          </label>
         ) : (
           <label className="onboarding-view__inline-field">
             <span>{t('settings.model')}</span>

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -30,6 +30,7 @@ import {
   notifyAmrLoginStatusChanged,
 } from './amrLoginPolling';
 import { normalizeAgentModelChoice } from './agentModelSelection';
+import { fetchProviderModels } from '../providers/provider-models';
 import { SearchableModelSelect } from './modelOptions';
 
 interface Props {
@@ -116,6 +117,7 @@ export function InlineModelSwitcher({
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const [amrStatus, setAmrStatus] = useState<VelaLoginStatus | null>(null);
+  const [discoveredProviderModels, setDiscoveredProviderModels] = useState<Record<string, ProviderModelOption[]>>({});
   const [amrLoginPending, setAmrLoginPending] = useState(false);
   const [amrLoginError, setAmrLoginError] = useState(false);
   const [amrReminderSeen, setAmrReminderSeen] = useState(readAmrReminderSeen);
@@ -367,7 +369,7 @@ export function InlineModelSwitcher({
       ) ?? KNOWN_PROVIDERS.find((p) => p.protocol === apiProtocol),
     [apiProtocol, config.apiProviderBaseUrl],
   );
-  const fetchedProviderModels = providerModelsCache?.[providerModelsInputKey] ?? [];
+  const fetchedProviderModels = providerModelsCache?.[providerModelsInputKey] ?? discoveredProviderModels[providerModelsInputKey] ?? [];
   const apiModelOptions = useMemo(() => {
     const discovered = fetchedProviderModels.map((model) => model.id);
     const staticOptions = providerForProtocol?.models ?? [];

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -356,7 +356,7 @@ export function InlineModelSwitcher({
     apiProtocol,
     config.baseUrl.trim().replace(/\/+$/, ''),
     config.apiKey.trim(),
-    config.apiVersion?.trim() ?? '',
+    apiProtocol === 'azure' ? (config.apiVersion?.trim() ?? '') : '',
   ].join('\n');
   const providerForProtocol = useMemo(
     () =>
@@ -381,6 +381,38 @@ export function InlineModelSwitcher({
     () => apiModelOptions.map((id) => ({ id, label: id })),
     [apiModelOptions],
   );
+
+  useEffect(() => {
+    if (!open || config.mode !== 'api') return;
+    if (fetchedProviderModels.length > 0) return;
+    if (apiProtocol === 'azure' || apiProtocol === 'ollama') return;
+    const baseUrl = config.baseUrl?.trim() ?? '';
+    const apiKey = config.apiKey?.trim() ?? '';
+    if (!baseUrl || !apiKey) return;
+    let cancelled = false;
+    void fetchProviderModels({
+      protocol: apiProtocol,
+      baseUrl,
+      apiKey,
+    }).then((result) => {
+      if (cancelled || !result.ok || !result.models?.length) return;
+      setDiscoveredProviderModels((current) => ({
+        ...current,
+        [providerModelsInputKey]: result.models ?? [],
+      }));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    open,
+    config.mode,
+    apiProtocol,
+    config.baseUrl,
+    config.apiKey,
+    providerModelsInputKey,
+    fetchedProviderModels.length,
+  ]);
 
   // Chip text — keep it tight so the pill doesn't wrap on small viewports.
   // CLI: "Claude · Sonnet 4.5"; BYOK: "Anthropic · sonnet-4.5".

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -643,7 +643,6 @@ export function InlineModelSwitcher({
                     searchInputTestId="inline-model-switcher-agent-model-search"
                     popoverTestId="inline-model-switcher-agent-model-popover"
                     minSearchableOptions={5}
-                    popoverMinWidth={340}
                     searchPlaceholder={t('designs.searchPlaceholder')}
                     aria-label={t('inlineSwitcher.modelLabel')}
                     models={currentAgent.models}

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -642,6 +642,8 @@ export function InlineModelSwitcher({
                     data-testid="inline-model-switcher-agent-model"
                     searchInputTestId="inline-model-switcher-agent-model-search"
                     popoverTestId="inline-model-switcher-agent-model-popover"
+                    minSearchableOptions={5}
+                    popoverMinWidth={340}
                     searchPlaceholder={t('designs.searchPlaceholder')}
                     aria-label={t('inlineSwitcher.modelLabel')}
                     models={currentAgent.models}

--- a/apps/web/src/components/MemoryModelInline.tsx
+++ b/apps/web/src/components/MemoryModelInline.tsx
@@ -40,11 +40,11 @@ import type {
   MemoryExtractionProvider,
   MemoryListResponse,
 } from '@open-design/contracts';
-import type { ApiProtocol, ExecMode } from '../types';
+import type { AgentModelOption, ApiProtocol, ExecMode } from '../types';
 import {
   SUGGESTED_MODELS_BY_PROTOCOL,
 } from '../state/apiProtocols';
-import { CUSTOM_MODEL_SENTINEL } from './modelOptions';
+import { CUSTOM_MODEL_SENTINEL, SearchableModelSelect } from './modelOptions';
 
 interface Props {
   mode: ExecMode;
@@ -224,6 +224,9 @@ export function MemoryModelInline({
     if (mode === 'api') return SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol];
     return cliModelOptions ?? [];
   }, [mode, apiProtocol, cliModelOptions]);
+  const searchableModelOptions = useMemo<AgentModelOption[]>(() => (
+    modelOptions.map((modelId) => ({ id: modelId, label: modelId }))
+  ), [modelOptions]);
 
   const savedModel = config?.model ?? '';
   const savedInOptions =
@@ -419,38 +422,39 @@ export function MemoryModelInline({
           {flash}
         </span>
       ) : null}
-      <select
+      <SearchableModelSelect
         aria-labelledby={labelId}
+        className="inline-switcher__select memory-model-inline__select"
         value={selectValue}
         disabled={busy}
-        onChange={(e) => void onSelectChange(e.target.value)}
-      >
-        <option value={SAME_AS_CHAT_SENTINEL}>
-          {sameAsChatCliLabel
-            ? t('settings.memoryModelInlineSameAsChatWithModel', {
-                model: sameAsChatCliLabel,
-              })
-            : effectiveChatProtocol
-            ? t('settings.memoryModelInlineSameAsChatWithProvider', {
-                provider: effectiveChatProtocol,
-              })
-            : chatModel
+        onChange={(nextValue) => void onSelectChange(nextValue)}
+        models={showSuggestedOptions ? searchableModelOptions : []}
+        additionalOptions={[
+          {
+            value: SAME_AS_CHAT_SENTINEL,
+            label: sameAsChatCliLabel
               ? t('settings.memoryModelInlineSameAsChatWithModel', {
-                  model: chatModel,
+                  model: sameAsChatCliLabel,
                 })
-              : t('settings.memoryModelInlineSameAsChat')}
-        </option>
-        {showSuggestedOptions
-          ? modelOptions.map((m) => (
-              <option key={m} value={m}>
-                {m}
-              </option>
-            ))
-          : null}
-        <option value={CUSTOM_MODEL_SENTINEL}>
-          {t('settings.modelCustom')}
-        </option>
-      </select>
+              : effectiveChatProtocol
+              ? t('settings.memoryModelInlineSameAsChatWithProvider', {
+                  provider: effectiveChatProtocol,
+                })
+              : chatModel
+                ? t('settings.memoryModelInlineSameAsChatWithModel', {
+                    model: chatModel,
+                  })
+                : t('settings.memoryModelInlineSameAsChat'),
+          },
+          {
+            value: CUSTOM_MODEL_SENTINEL,
+            label: t('settings.modelCustom'),
+          },
+        ]}
+        searchPlaceholder={t('newproj.modelSearch')}
+        searchInputTestId="memory-model-inline-search"
+        popoverTestId="memory-model-inline-popover"
+      />
       {customActive ? (
         <div
           className="field-row"

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -214,6 +214,8 @@ interface Props {
     id: string,
     choice: { model?: string; reasoning?: string },
   ) => void;
+  onApiModelChange: (model: string) => void;
+  providerModelsCache?: Record<string, ProviderModelOption[]>;
   onRefreshAgents: () => void;
   onOpenSettings: (section?: SettingsSection) => void;
   onOpenAmrSettings?: () => void;
@@ -497,6 +499,8 @@ export function ProjectView({
   onModeChange,
   onAgentChange,
   onAgentModelChange,
+  onApiModelChange,
+  providerModelsCache,
   onRefreshAgents,
   onOpenSettings,
   onOpenAmrSettings,
@@ -4301,6 +4305,8 @@ export function ProjectView({
               onModeChange={onModeChange}
               onAgentChange={onAgentChange}
               onAgentModelChange={onAgentModelChange}
+              onApiModelChange={onApiModelChange}
+              providerModelsCache={providerModelsCache}
               onOpenSettings={onOpenSettings}
               onRefreshAgents={onRefreshAgents}
               onBack={onBack}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -127,6 +127,7 @@ import type {
   ProjectTemplate,
   LiveArtifactEventItem,
   LiveArtifactSummary,
+  ProviderModelOption,
   SkillSummary,
 } from '../types';
 import { historyWithApiAttachmentContext } from '../api-attachment-context';
@@ -214,7 +215,7 @@ interface Props {
     id: string,
     choice: { model?: string; reasoning?: string },
   ) => void;
-  onApiModelChange: (model: string) => void;
+  onApiModelChange?: (model: string) => void;
   providerModelsCache?: Record<string, ProviderModelOption[]>;
   onRefreshAgents: () => void;
   onOpenSettings: (section?: SettingsSection) => void;

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2259,6 +2259,8 @@ export function SettingsDialog({
                   searchPlaceholder={t('designs.searchPlaceholder')}
                   searchInputTestId={`settings-agent-model-search-${selected.id}`}
                   popoverTestId={`settings-agent-model-popover-${selected.id}`}
+                  minSearchableOptions={5}
+                  popoverMinWidth={340}
                   models={selected.models!}
                   onChange={(nextValue) => {
                     if (nextValue === CUSTOM_MODEL_SENTINEL) {

--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -91,6 +91,7 @@ export const SearchableModelSelect = forwardRef<
   const [query, setQuery] = useState('');
   const [popoverStyle, setPopoverStyle] = useState<({ left: number; width: number; maxHeight: number } & ({ top: number; bottom?: never } | { bottom: number; top?: never })) | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
   const listboxId = useMemo(
@@ -144,7 +145,9 @@ export const SearchableModelSelect = forwardRef<
   useLayoutEffect(() => {
     if (!open) return;
     const updatePosition = () => {
-      const rect = wrapRef.current?.getBoundingClientRect();
+      const rect =
+        buttonRef.current?.getBoundingClientRect() ??
+        wrapRef.current?.getBoundingClientRect();
       if (!rect) return;
       const viewportWidth = typeof window === 'undefined' ? rect.width : window.innerWidth;
       const viewportHeight = typeof window === 'undefined' ? rect.height : window.innerHeight;
@@ -197,7 +200,11 @@ export const SearchableModelSelect = forwardRef<
     <div className={`model-select-searchable${open ? ' is-open' : ''}`} ref={wrapRef}>
       <button
         {...buttonProps}
-        ref={ref}
+        ref={(node) => {
+          buttonRef.current = node;
+          if (typeof ref === 'function') ref(node);
+          else if (ref) ref.current = node;
+        }}
         type="button"
         role="combobox"
         aria-expanded={open}
@@ -218,6 +225,8 @@ export const SearchableModelSelect = forwardRef<
               className="model-select-searchable__popover"
               role="presentation"
               data-testid={popoverTestId}
+              onMouseDown={(event) => event.stopPropagation()}
+              onClick={(event) => event.stopPropagation()}
               style={{
                 position: 'fixed',
                 top: popoverStyle.top != null ? `${popoverStyle.top}px` : 'auto',

--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from 'react-dom';
-import { forwardRef, useEffect, useLayoutEffect, useMemo, useRef, useState, type ButtonHTMLAttributes } from 'react';
+import { forwardRef, useEffect, useLayoutEffect, useMemo, useRef, useState, type ButtonHTMLAttributes, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { AgentModelOption } from '../types';
 
 export function renderModelOptions(models: AgentModelOption[]) {
@@ -141,6 +141,13 @@ export const SearchableModelSelect = forwardRef<
     };
   }, [open]);
 
+  const handlePopoverKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    event.stopPropagation();
+    setOpen(false);
+    buttonRef.current?.focus();
+  };
 
   useLayoutEffect(() => {
     if (!open) return;
@@ -227,6 +234,7 @@ export const SearchableModelSelect = forwardRef<
               data-testid={popoverTestId}
               onMouseDown={(event) => event.stopPropagation()}
               onClick={(event) => event.stopPropagation()}
+              onKeyDown={handlePopoverKeyDown}
               style={{
                 position: 'fixed',
                 top: popoverStyle.top != null ? `${popoverStyle.top}px` : 'auto',

--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -65,6 +65,7 @@ interface SearchableModelSelectProps
   popoverTestId?: string;
   additionalOptions?: Array<{ value: string; label: string }>;
   minSearchableOptions?: number;
+  popoverMinWidth?: number;
 }
 
 export const SearchableModelSelect = forwardRef<
@@ -80,6 +81,7 @@ export const SearchableModelSelect = forwardRef<
     popoverTestId,
     additionalOptions,
     minSearchableOptions = 8,
+    popoverMinWidth,
     className,
     ...buttonProps
   },
@@ -87,7 +89,7 @@ export const SearchableModelSelect = forwardRef<
 ) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
-  const [popoverStyle, setPopoverStyle] = useState<{ top: number; left: number; width: number } | null>(null);
+  const [popoverStyle, setPopoverStyle] = useState<({ left: number; width: number; maxHeight: number } & ({ top: number; bottom?: never } | { bottom: number; top?: never })) | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
@@ -144,10 +146,33 @@ export const SearchableModelSelect = forwardRef<
     const updatePosition = () => {
       const rect = wrapRef.current?.getBoundingClientRect();
       if (!rect) return;
+      const viewportWidth = typeof window === 'undefined' ? rect.width : window.innerWidth;
+      const viewportHeight = typeof window === 'undefined' ? rect.height : window.innerHeight;
+      const desiredWidth = Math.max(rect.width, popoverMinWidth ?? 0);
+      const maxWidth = Math.max(160, viewportWidth - 16);
+      const width = Math.min(desiredWidth, maxWidth);
+      const left = Math.min(
+        Math.max(8, rect.left),
+        Math.max(8, viewportWidth - width - 8),
+      );
+      const availableBelow = Math.max(140, viewportHeight - rect.bottom - 12);
+      const availableAbove = Math.max(140, rect.top - 12);
+      const shouldOpenUpward = availableBelow < 260 && availableAbove > availableBelow;
+      const maxHeight = Math.min(360, shouldOpenUpward ? availableAbove : availableBelow);
+      if (shouldOpenUpward) {
+        setPopoverStyle({
+          bottom: Math.max(8, viewportHeight - rect.top + 6),
+          left,
+          width,
+          maxHeight,
+        });
+        return;
+      }
       setPopoverStyle({
         top: rect.bottom + 6,
-        left: rect.left,
-        width: rect.width,
+        left,
+        width,
+        maxHeight,
       });
     };
     updatePosition();
@@ -195,9 +220,11 @@ export const SearchableModelSelect = forwardRef<
               data-testid={popoverTestId}
               style={{
                 position: 'fixed',
-                top: `${popoverStyle.top}px`,
+                top: popoverStyle.top != null ? `${popoverStyle.top}px` : 'auto',
+                bottom: popoverStyle.bottom != null ? `${popoverStyle.bottom}px` : 'auto',
                 left: `${popoverStyle.left}px`,
                 width: `${popoverStyle.width}px`,
+                maxHeight: `${popoverStyle.maxHeight}px`,
               }}
             >
               {shouldShowSearch ? (
@@ -214,7 +241,14 @@ export const SearchableModelSelect = forwardRef<
                   />
                 </div>
               ) : null}
-              <div className="model-select-searchable__list" id={listboxId} role="listbox">
+              <div
+                className="model-select-searchable__list"
+                id={listboxId}
+                role="listbox"
+                style={{
+                  maxHeight: `${Math.max(96, popoverStyle.maxHeight - (shouldShowSearch ? 52 : 12))}px`,
+                }}
+              >
                 {filteredOptions.map((option) => {
                   const active = option.id === value;
                   return (

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1016,6 +1016,9 @@
 /* Shared select inside the popover */
 .model-select-searchable {
   position: relative;
+  display: block;
+  width: 100%;
+  min-width: 0;
 }
 .model-select-searchable.is-open {
   z-index: 1400;
@@ -1033,7 +1036,7 @@
   overflow: hidden;
 }
 .model-select-searchable__search-row {
-  padding: 6px;
+  padding: 0;
   border-bottom: 1px solid var(--border);
 }
 .model-select-searchable__input {

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1033,11 +1033,13 @@
   overflow: hidden;
 }
 .model-select-searchable__search-row {
-  padding: 8px;
+  padding: 6px;
   border-bottom: 1px solid var(--border);
 }
 .model-select-searchable__input {
+  display: block;
   width: 100%;
+  box-sizing: border-box;
 }
 .model-select-searchable__list {
   max-height: 280px;

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1104,6 +1104,7 @@
     no-repeat right 10px center;
   font-size: 12px;
   color: var(--text);
+  text-align: left;
   cursor: pointer;
 }
 .inline-switcher__select:focus-visible {

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -2077,6 +2077,19 @@
 }
 
 .onboarding-view__card-model .onboarding-view__model-picker {
+  width: min(260px, 100%);
+}
+
+.onboarding-view__card--amr .onboarding-view__model-picker {
+  width: 100%;
+}
+
+.onboarding-view__alternatives .onboarding-view__model-picker {
+  width: 100%;
+}
+
+.onboarding-view__setup-panel .onboarding-view__model-picker,
+.onboarding-view__setup-panel .onboarding-view__setup-model-picker {
   width: 100%;
 }
 
@@ -2121,43 +2134,28 @@
   display: block;
 }
 
-.onboarding-view__model-select-wrap select {
-  appearance: none;
-  -webkit-appearance: none;
-  display: block;
+.onboarding-view__model-select-wrap .onboarding-view__model-select {
   width: 100%;
   min-height: 42px;
   padding: 0 34px 0 13px;
-  border: 1px solid var(--border);
   border-radius: 8px;
-  background: var(--bg-panel);
+  background-color: var(--bg-panel);
   color: var(--text-strong);
-  font: inherit;
   font-size: 13px;
   font-weight: 500;
   line-height: 1.2;
   box-shadow: var(--shadow-xs);
-  cursor: pointer;
   transition: background-color 160ms cubic-bezier(0.23, 1, 0.32, 1), border-color 160ms cubic-bezier(0.23, 1, 0.32, 1), color 160ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 160ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
-.onboarding-view__model-select-wrap select:hover {
+.onboarding-view__model-select-wrap .onboarding-view__model-select:hover {
   border-color: color-mix(in srgb, var(--accent) 38%, var(--border));
-  background: color-mix(in srgb, var(--bg-panel) 97%, var(--accent) 3%);
+  background-color: color-mix(in srgb, var(--bg-panel) 97%, var(--accent) 3%);
 }
 
-.onboarding-view__model-select-wrap select:focus-visible {
+.onboarding-view__model-select-wrap .onboarding-view__model-select:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent) 42%, transparent);
   outline-offset: 2px;
-}
-
-.onboarding-view__model-select-chevron {
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--text-soft);
-  pointer-events: none;
 }
 
 .onboarding-view__benefits {

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1180,17 +1180,18 @@ a.avatar-item:visited {
 }
 .avatar-select-row {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
   font-size: 12px;
   color: var(--text-muted);
 }
 .avatar-select-label {
   flex-shrink: 0;
-  min-width: 64px;
+  min-width: 0;
 }
 .avatar-select {
-  flex: 1;
+  width: 100%;
   min-width: 0;
   font-size: 12px;
   padding: 4px 6px;

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1183,6 +1183,7 @@ a.avatar-item:visited {
   flex-direction: column;
   align-items: stretch;
   gap: 6px;
+  width: 100%;
   font-size: 12px;
   color: var(--text-muted);
 }
@@ -1191,8 +1192,9 @@ a.avatar-item:visited {
   min-width: 0;
 }
 .avatar-select {
+  display: block;
   width: 100%;
-  min-width: 0;
+  min-width: min(340px, 100%);
   font-size: 12px;
   padding: 4px 6px;
   border-radius: var(--radius-sm);

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1520,6 +1520,9 @@
 
 .model-select-searchable {
   position: relative;
+  display: block;
+  width: 100%;
+  min-width: 0;
 }
 .model-select-searchable.is-open {
   z-index: 1400;
@@ -1537,7 +1540,7 @@
   overflow: hidden;
 }
 .model-select-searchable__search-row {
-  padding: 6px;
+  padding: 0;
   border-bottom: 1px solid var(--border);
 }
 .model-select-searchable__input {

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -574,6 +574,18 @@
 .section-head .hint { margin-top: 2px; }
 .field { display: flex; flex-direction: column; gap: 4px; }
 .field-label { font-size: 12px; font-weight: 500; color: var(--text-muted); }
+.memory-model-inline__select {
+  width: 100%;
+  min-width: 0;
+  justify-content: space-between;
+}
+
+.composer-byok-image-model__select {
+  min-width: 220px;
+  flex: 1 1 240px;
+  max-width: 320px;
+}
+
 .field-required {
   margin-left: 4px;
   color: var(--red);

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1537,11 +1537,13 @@
   overflow: hidden;
 }
 .model-select-searchable__search-row {
-  padding: 8px;
+  padding: 6px;
   border-bottom: 1px solid var(--border);
 }
 .model-select-searchable__input {
+  display: block;
   width: 100%;
+  box-sizing: border-box;
 }
 .model-select-searchable__list {
   max-height: 280px;

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -253,4 +253,37 @@ describe('AvatarMenu', () => {
 
     expect(onAgentModelChange).toHaveBeenCalledWith('codex', { model: 'deepseek-v4-flash' });
   });
+  it('closes only the nested Local CLI model popover on Escape and keeps the avatar menu open', async () => {
+    render(
+      <I18nProvider>
+        <AvatarMenu
+          config={daemonConfig}
+          agents={agents}
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onApiModelChange={vi.fn()}
+          onOpenSettings={vi.fn()}
+          providerModelsCache={{}}
+          onRefreshAgents={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Account & settings' }));
+    const menu = await screen.findByRole('dialog', { name: 'Account & settings' });
+    const modelCombobox = within(menu).getByRole('combobox', { name: 'Model' });
+    fireEvent.click(modelCombobox);
+
+    const modelPopover = await screen.findByTestId('avatar-model-popover');
+    const search = within(modelPopover).getByTestId('avatar-model-search');
+    fireEvent.keyDown(search, { key: 'Escape' });
+
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId('avatar-model-popover')).toBeNull();
+    });
+    expect(screen.getByRole('dialog', { name: 'Account & settings' })).toBeTruthy();
+  });
+
 });

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -72,6 +72,48 @@ const byokModelsCache: Record<string, ProviderModelOption[]> = {
 
 describe('AvatarMenu', () => {
 
+  it('fetches BYOK models on demand in project detail when no shared catalog is present', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/provider/models') {
+        return new Response(JSON.stringify({
+          ok: true,
+          kind: 'success',
+          latencyMs: 12,
+          models: [
+            { id: 'gpt-4o', label: 'gpt-4o' },
+            { id: 'gpt-5.5', label: 'gpt-5.5' },
+          ],
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <I18nProvider>
+        <AvatarMenu
+          config={{ ...byokConfig, model: 'gpt-4o' }}
+          agents={agents}
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onApiModelChange={vi.fn()}
+          onOpenSettings={vi.fn()}
+          onRefreshAgents={vi.fn()}
+          providerModelsCache={{}}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Account & settings' }));
+    await screen.findByRole('combobox', { name: 'Model' });
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+
   it('lets project detail BYOK mode search and switch models from the shared provider catalog', async () => {
     const onApiModelChange = vi.fn();
     render(
@@ -100,7 +142,9 @@ describe('AvatarMenu', () => {
     const search = within(popover).getByTestId('avatar-byok-model-search');
     fireEvent.change(search, { target: { value: 'image' } });
 
-    fireEvent.click(within(popover).getByRole('option', { name: 'gpt-image-2' }));
+    const option = within(popover).getByRole('option', { name: 'gpt-image-2' });
+    fireEvent.mouseDown(option);
+    fireEvent.click(option);
     expect(onApiModelChange).toHaveBeenCalledWith('gpt-image-2');
   });
 
@@ -178,5 +222,35 @@ describe('AvatarMenu', () => {
 
     expect(within(popover).getByRole('option', { name: 'deepseek-v4-flash' })).toBeTruthy();
     expect(within(popover).queryByRole('option', { name: 'gpt-5.4-mini' })).toBeNull();
+  });
+
+  it('keeps the project-detail menu open long enough for Local CLI model clicks to apply', async () => {
+    const onAgentModelChange = vi.fn();
+    render(
+      <I18nProvider>
+        <AvatarMenu
+          config={daemonConfig}
+          agents={agents}
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={onAgentModelChange}
+          onApiModelChange={vi.fn()}
+          onOpenSettings={vi.fn()}
+          providerModelsCache={{}}
+          onRefreshAgents={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Account & settings' }));
+    const modelCombobox = await screen.findByRole('combobox', { name: 'Model' });
+    fireEvent.click(modelCombobox);
+    const popover = await screen.findByTestId('avatar-model-popover');
+    const option = within(popover).getByRole('option', { name: 'deepseek-v4-flash' });
+    fireEvent.mouseDown(option);
+    fireEvent.click(option);
+
+    expect(onAgentModelChange).toHaveBeenCalledWith('codex', { model: 'deepseek-v4-flash' });
   });
 });

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+});
+
+import { AvatarMenu } from '../../src/components/AvatarMenu';
+import { I18nProvider } from '../../src/i18n';
+import type { AgentInfo, AppConfig, ProviderModelOption } from '../../src/types';
+
+const agents: AgentInfo[] = [
+  {
+    id: 'codex',
+    name: 'Codex CLI',
+    bin: 'codex',
+    available: true,
+    version: '1.0.0',
+    models: [
+      { id: 'gpt-5.4', label: 'gpt-5.4' },
+      { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
+      { id: 'gpt-5.5', label: 'gpt-5.5' },
+      { id: 'o3', label: 'o3' },
+      { id: 'o4-mini', label: 'o4-mini' },
+      { id: 'deepseek-v3.2', label: 'deepseek-v3.2' },
+      { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
+      { id: 'glm-5', label: 'glm-5' },
+      { id: 'qwen3-235b', label: 'qwen3-235b' },
+    ],
+  },
+];
+
+const daemonConfig: AppConfig = {
+  mode: 'daemon',
+  apiProtocol: 'openai',
+  apiKey: '',
+  baseUrl: '',
+  apiVersion: '',
+  model: '',
+  byokImageModel: '',
+  reasoningSummary: 'auto',
+  agentId: 'codex',
+  agentModels: { codex: { model: 'gpt-5.4' } },
+};
+
+
+const byokConfig: AppConfig = {
+  ...daemonConfig,
+  mode: 'api',
+  apiProtocol: 'openai',
+  apiKey: 'sk-test',
+  baseUrl: 'https://api.openai.com/v1',
+  model: 'gpt-5.5',
+};
+
+const byokModelsCache: Record<string, ProviderModelOption[]> = {
+  ['openai\nhttps://api.openai.com/v1\nsk-test\n']: [
+    { id: 'gpt-5.5', label: 'gpt-5.5' },
+    { id: 'gpt-5.4', label: 'gpt-5.4' },
+    { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
+    { id: 'gpt-image-2', label: 'gpt-image-2' },
+    { id: 'o3', label: 'o3' },
+    { id: 'o4-mini', label: 'o4-mini' },
+    { id: 'deepseek-v3.2', label: 'deepseek-v3.2' },
+    { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
+    { id: 'glm-5', label: 'glm-5' },
+  ],
+};
+
+describe('AvatarMenu', () => {
+
+  it('lets project detail BYOK mode search and switch models from the shared provider catalog', async () => {
+    const onApiModelChange = vi.fn();
+    render(
+      <I18nProvider>
+        <AvatarMenu
+          config={byokConfig}
+          agents={agents}
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onApiModelChange={onApiModelChange}
+          onOpenSettings={vi.fn()}
+          onRefreshAgents={vi.fn()}
+          providerModelsCache={byokModelsCache}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Account & settings' }));
+    const modelCombobox = await screen.findByRole('combobox', { name: 'Model' });
+    expect(modelCombobox.textContent?.trim()).toBe('gpt-5.5');
+
+    fireEvent.click(modelCombobox);
+    const popover = await screen.findByTestId('avatar-byok-model-popover');
+    const search = within(popover).getByTestId('avatar-byok-model-search');
+    fireEvent.change(search, { target: { value: 'image' } });
+
+    fireEvent.click(within(popover).getByRole('option', { name: 'gpt-image-2' }));
+    expect(onApiModelChange).toHaveBeenCalledWith('gpt-image-2');
+  });
+
+  it('uses a searchable model dropdown for the active Local CLI model picker', async () => {
+    render(
+      <I18nProvider>
+        <AvatarMenu
+          config={daemonConfig}
+          agents={agents}
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onApiModelChange={vi.fn()}
+          onOpenSettings={vi.fn()}
+          providerModelsCache={{}}
+          onRefreshAgents={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Account & settings' }));
+    const modelCombobox = await screen.findByRole('combobox', { name: 'Model' });
+    expect(modelCombobox.className).toContain('inline-switcher__select');
+
+    fireEvent.click(modelCombobox);
+    const popover = await screen.findByTestId('avatar-model-popover');
+    const search = within(popover).getByTestId('avatar-model-search');
+    fireEvent.change(search, { target: { value: 'deepseek' } });
+
+    expect(within(popover).getByRole('option', { name: 'deepseek-v4-flash' })).toBeTruthy();
+    expect(within(popover).queryByRole('option', { name: 'gpt-5.4-mini' })).toBeNull();
+  });
+});

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -40,8 +40,9 @@ const daemonConfig: AppConfig = {
   apiVersion: '',
   model: '',
   byokImageModel: '',
-  reasoningSummary: 'auto',
   agentId: 'codex',
+  skillId: null,
+  designSystemId: null,
   agentModels: { codex: { model: 'gpt-5.4' } },
 };
 

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -104,6 +104,51 @@ describe('AvatarMenu', () => {
     expect(onApiModelChange).toHaveBeenCalledWith('gpt-image-2');
   });
 
+
+  it('still shows search for shorter Local CLI catalogs such as Claude fallback models', async () => {
+    const claudeAgents: AgentInfo[] = [
+      {
+        id: 'claude',
+        name: 'Claude Code',
+        bin: 'claude',
+        available: true,
+        version: '1.0.0',
+        models: [
+          { id: 'default', label: 'Default (CLI config)' },
+          { id: 'sonnet', label: 'Sonnet (alias)' },
+          { id: 'opus', label: 'Opus (alias)' },
+          { id: 'haiku', label: 'Haiku (alias)' },
+          { id: 'claude-opus-4-5', label: 'claude-opus-4-5' },
+          { id: 'claude-sonnet-4-5', label: 'claude-sonnet-4-5' },
+          { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },
+        ],
+      },
+    ];
+
+    render(
+      <I18nProvider>
+        <AvatarMenu
+          config={{ ...daemonConfig, agentId: 'claude', agentModels: { claude: { model: 'claude-sonnet-4-5' } } }}
+          agents={claudeAgents}
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onApiModelChange={vi.fn()}
+          onOpenSettings={vi.fn()}
+          providerModelsCache={{}}
+          onRefreshAgents={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Account & settings' }));
+    const modelCombobox = await screen.findByRole('combobox', { name: 'Model' });
+    fireEvent.click(modelCombobox);
+    const popover = await screen.findByTestId('avatar-model-popover');
+    expect(within(popover).getByTestId('avatar-model-search')).toBeTruthy();
+  });
+
   it('uses a searchable model dropdown for the active Local CLI model picker', async () => {
     render(
       <I18nProvider>

--- a/apps/web/tests/components/InlineModelSwitcher.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.test.tsx
@@ -767,4 +767,54 @@ describe('InlineModelSwitcher AMR row', () => {
       expect(onAgentChange).toHaveBeenCalledWith('amr');
     });
   });
+  it('closes only the nested Home BYOK model popover on Escape and keeps the switcher open', async () => {
+    render(
+      <InlineModelSwitcher
+        config={{
+          ...baseConfig,
+          mode: 'api',
+          apiProtocol: 'openai',
+          baseUrl: 'https://api.openai.com/v1',
+          apiProviderBaseUrl: 'https://api.openai.com/v1',
+          apiKey: 'sk-test',
+          model: 'gpt-4.1-mini',
+        }}
+        agents={[amrAgent, codexAgent]}
+        daemonLive={true}
+        onModeChange={vi.fn()}
+        onAgentChange={vi.fn()}
+        onAgentModelChange={vi.fn()}
+        onApiProtocolChange={vi.fn()}
+        onApiModelChange={vi.fn()}
+        providerModelsCache={{
+          ['openai\nhttps://api.openai.com/v1\nsk-test\n']: [
+            { id: 'gpt-4.1-mini', label: 'gpt-4.1-mini' },
+            { id: 'gpt-5.5', label: 'gpt-5.5' },
+            { id: 'gpt-image-2', label: 'gpt-image-2' },
+            { id: 'o4-mini', label: 'o4-mini' },
+            { id: 'o3', label: 'o3' },
+            { id: 'gpt-4o', label: 'gpt-4o' },
+            { id: 'gpt-4o-mini', label: 'gpt-4o-mini' },
+            { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
+          ],
+        }}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('inline-model-switcher-chip'));
+    const switcherPopover = await screen.findByTestId('inline-model-switcher-popover');
+    const modelPicker = within(switcherPopover).getByTestId('inline-model-switcher-api-model');
+    fireEvent.click(modelPicker);
+
+    const modelPopover = await screen.findByTestId('inline-model-switcher-api-model-popover');
+    const search = within(modelPopover).getByTestId('inline-model-switcher-api-model-search');
+    fireEvent.keyDown(search, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('inline-model-switcher-api-model-popover')).toBeNull();
+    });
+    expect(screen.getByTestId('inline-model-switcher-popover')).toBeTruthy();
+  });
+
 });

--- a/apps/web/tests/components/InlineModelSwitcher.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.test.tsx
@@ -252,6 +252,53 @@ describe('InlineModelSwitcher AMR row', () => {
     expect(within(popover).queryByRole('button', { name: 'Sign out' })).toBeNull();
   });
 
+  it('fetches BYOK models on demand in Home when the shared catalog is empty', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/provider/models') {
+        return new Response(JSON.stringify({
+          ok: true,
+          kind: 'success',
+          latencyMs: 12,
+          models: [
+            { id: 'gpt-4.1-mini', label: 'gpt-4.1-mini' },
+            { id: 'gpt-5.5', label: 'gpt-5.5' },
+          ],
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <InlineModelSwitcher
+        config={{
+          ...baseConfig,
+          mode: 'api',
+          apiProtocol: 'openai',
+          baseUrl: 'https://api.openai.com/v1',
+          apiProviderBaseUrl: 'https://api.openai.com/v1',
+          apiKey: 'sk-test',
+          model: 'gpt-4.1-mini',
+        }}
+        agents={[amrAgent, codexAgent]}
+        daemonLive={true}
+        onModeChange={vi.fn()}
+        onAgentChange={vi.fn()}
+        onAgentModelChange={vi.fn()}
+        onApiProtocolChange={vi.fn()}
+        onApiModelChange={vi.fn()}
+        providerModelsCache={{}}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('inline-model-switcher-chip'));
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+
   it('filters fetched BYOK provider models in the Home switcher search box', async () => {
     renderSwitcher(
       {
@@ -291,6 +338,47 @@ describe('InlineModelSwitcher AMR row', () => {
     expect(
       within(modelPopover).getAllByRole('option').map((option) => option.textContent?.trim()),
     ).toEqual(['gpt-4.1-mini', 'gpt-5.5']);
+  });
+
+  it('keeps the Home switcher popover open long enough for BYOK model clicks to apply', async () => {
+    const onApiModelChange = vi.fn();
+    render(
+      <InlineModelSwitcher
+        config={{
+          ...baseConfig,
+          mode: 'api',
+          apiProtocol: 'openai',
+          baseUrl: 'https://api.openai.com/v1',
+          apiProviderBaseUrl: 'https://api.openai.com/v1',
+          apiKey: 'sk-test',
+          model: 'gpt-4.1-mini',
+        }}
+        agents={[amrAgent, codexAgent]}
+        daemonLive={true}
+        onModeChange={vi.fn()}
+        onAgentChange={vi.fn()}
+        onAgentModelChange={vi.fn()}
+        onApiProtocolChange={vi.fn()}
+        onApiModelChange={onApiModelChange}
+        providerModelsCache={{
+          ['openai\nhttps://api.openai.com/v1\nsk-test\n']: [
+            { id: 'gpt-4.1-mini', label: 'gpt-4.1-mini' },
+            { id: 'gpt-5.5', label: 'gpt-5.5' },
+          ],
+        }}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('inline-model-switcher-chip'));
+    const modelPicker = screen.getByTestId('inline-model-switcher-api-model');
+    fireEvent.click(modelPicker);
+    const modelPopover = screen.getByTestId('inline-model-switcher-api-model-popover');
+    const option = within(modelPopover).getByRole('option', { name: 'gpt-5.5' });
+    fireEvent.mouseDown(option);
+    fireEvent.click(option);
+
+    expect(onApiModelChange).toHaveBeenCalledWith('gpt-5.5');
   });
 
   it('prefers fetched BYOK provider models over only showing the currently selected custom model', async () => {

--- a/apps/web/tests/components/MemoryModelInline.test.tsx
+++ b/apps/web/tests/components/MemoryModelInline.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MemoryModelInline } from '../../src/components/MemoryModelInline';
+import { I18nProvider } from '../../src/i18n';
+
+function renderMemoryModelInline() {
+  return render(
+    <I18nProvider>
+      <MemoryModelInline
+        mode="daemon"
+        apiProtocol="openai"
+        chatApiKey=""
+        chatBaseUrl=""
+        chatApiVersion=""
+        chatModel="gpt-5.4"
+        cliAgentId="codex"
+        cliModelOptions={[
+          'gpt-5.4',
+          'gpt-5.4-mini',
+          'gpt-5.5',
+          'o3',
+          'o4-mini',
+          'claude-sonnet-4-5',
+          'claude-opus-4-1',
+          'gemini-2.5-pro',
+          'gemini-2.5-flash',
+        ]}
+      />
+    </I18nProvider>,
+  );
+}
+
+describe('MemoryModelInline', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the searchable dropdown for memory models and filters options inside the popover', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/memory/config') {
+        return new Response(
+          JSON.stringify({ enabled: true, extraction: JSON.parse(String(init?.body)).extraction }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderMemoryModelInline();
+
+    const combobox = await screen.findByRole('combobox', { name: 'Memory model' });
+    expect(combobox.className).toContain('inline-switcher__select');
+
+    fireEvent.click(combobox);
+    const popover = await screen.findByTestId('memory-model-inline-popover');
+    const search = within(popover).getByTestId('memory-model-inline-search') as HTMLInputElement;
+    expect(search).toBeTruthy();
+
+    fireEvent.change(search, { target: { value: 'gemini' } });
+
+    await waitFor(() => {
+      expect(within(popover).getByRole('option', { name: 'gemini-2.5-pro' })).toBeTruthy();
+      expect(within(popover).queryByRole('option', { name: 'gpt-5.4-mini' })).toBeNull();
+    });
+  });
+});

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1308,8 +1308,8 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*2 installed/i }));
 
-    const memoryModel = await screen.findByRole('combobox', { name: 'Memory model' }) as HTMLSelectElement;
-    expect(memoryModel.options[memoryModel.selectedIndex]?.textContent).toBe('Same as chat (Claude Code)');
+    const memoryModel = await screen.findByRole('combobox', { name: 'Memory model' });
+    expect(memoryModel.textContent?.trim()).toBe('Same as chat (Claude Code)');
     expect(screen.getByText(/anthropic is only the fallback provider family/i)).toBeTruthy();
   });
 

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -39,6 +39,41 @@ test('onboarding lets AMR Cloud sign in and continue after the login poll succee
   await expect(page.getByRole('button', { name: /Continue/i })).toBeVisible({ timeout: 10_000 });
 });
 
+test('onboarding Local CLI card lets the user search agent models before continuing', async ({ page }) => {
+  const config = await wireOnboardingMocks(page, {
+    amrAvailable: false,
+    initialLoggedIn: false,
+    codexModels: [
+      { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
+      { id: 'gpt-5.5', label: 'gpt-5.5' },
+      { id: 'o3', label: 'o3' },
+      { id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash' },
+      { id: 'glm-5', label: 'GLM 5' },
+      { id: 'qwen3-235b', label: 'Qwen3 235B' },
+      { id: 'claude-sonnet-4.5', label: 'Claude Sonnet 4.5' },
+      { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+      { id: 'kimi-k2.6', label: 'Kimi K2.6' },
+    ],
+  });
+
+  await page.addInitScript(
+    ({ key, value }) => window.localStorage.setItem(key, JSON.stringify(value)),
+    { key: STORAGE_KEY, value: config },
+  );
+
+  await gotoOnboarding(page);
+
+  await page.getByRole('button', { name: /Local coding agent/i }).click();
+  const modelPicker = page.getByRole('combobox', { name: /Model/i });
+  await modelPicker.click();
+  const popover = page.getByTestId('onboarding-cli-model-popover');
+  await popover.getByTestId('onboarding-cli-model-search').fill('glm');
+  await popover.getByRole('option', { name: 'GLM 5' }).click();
+
+  await expect(modelPicker).toContainText('GLM 5');
+  await expect(page.getByRole('button', { name: /Continue/i })).toBeVisible();
+});
+
 test('onboarding falls back to Local CLI when AMR is unavailable', async ({ page }) => {
   const config = await wireOnboardingMocks(page, {
     amrAvailable: false,
@@ -77,12 +112,48 @@ test('onboarding recovers from a transient AMR status failure and still continue
   await expect(page.getByRole('button', { name: /Continue/i })).toBeVisible({ timeout: 12_000 });
 });
 
+test('onboarding AMR card lets the user search live models before continuing', async ({ page }) => {
+  const config = await wireOnboardingMocks(page, {
+    amrAvailable: true,
+    initialLoggedIn: true,
+    amrModels: [
+      { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
+      { id: 'gpt-5.5', label: 'gpt-5.5' },
+      { id: 'gpt-5', label: 'gpt-5' },
+      { id: 'o3', label: 'o3' },
+      { id: 'o4-mini', label: 'o4-mini' },
+      { id: 'deepseek-v3.2', label: 'DeepSeek V3.2' },
+      { id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash' },
+      { id: 'glm-5', label: 'GLM 5' },
+      { id: 'qwen3-235b', label: 'Qwen3 235B' },
+    ],
+  });
+
+  await page.addInitScript(
+    ({ key, value }) => window.localStorage.setItem(key, JSON.stringify(value)),
+    { key: STORAGE_KEY, value: config },
+  );
+
+  await gotoOnboarding(page);
+
+  const modelPicker = page.getByRole('combobox', { name: /Model/i });
+  await modelPicker.click();
+  const popover = page.getByTestId('onboarding-amr-model-popover');
+  await popover.getByTestId('onboarding-amr-model-search').fill('glm');
+  await popover.getByRole('option', { name: 'GLM 5' }).click();
+
+  await expect(modelPicker).toContainText('GLM 5');
+  await expect(page.getByRole('button', { name: /Continue/i })).toBeVisible();
+});
+
 async function wireOnboardingMocks(
   page: Page,
   options: {
     amrAvailable: boolean;
     initialLoggedIn: boolean;
     failFirstStatusPollAfterLogin?: boolean;
+    amrModels?: Array<{ id: string; label: string }>;
+    codexModels?: Array<{ id: string; label: string }>;
   },
 ): Promise<OnboardingConfig> {
   const config: OnboardingConfig = {
@@ -139,7 +210,7 @@ async function wireOnboardingMocks(
                 bin: 'vela',
                 available: true,
                 version: '1.0.0',
-                models: [{ id: 'default', label: 'Default' }],
+                models: options.amrModels ?? [{ id: 'default', label: 'Default' }],
               }]
             : []),
           {
@@ -148,7 +219,7 @@ async function wireOnboardingMocks(
             bin: 'codex',
             available: true,
             version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
+            models: options.codexModels ?? [{ id: 'default', label: 'Default' }],
           },
         ],
       },


### PR DESCRIPTION
## Summary

This PR improves model picker behavior across Open Design, with a focus on large model catalogs and consistency between Home, Settings, workspace, and onboarding surfaces.

It addresses the original `#3262` issue around searchable BYOK model selection, and also fixes follow-up interaction and discovery gaps that became visible once the shared searchable picker was rolled out more broadly.

Closes #3262.

## What changed

### Shared searchable model pickers
- Replaced plain model dropdowns with the shared searchable picker across:
  - Home
  - Settings
  - workspace / project detail surfaces
  - onboarding
- The search field now lives inside the dropdown popover and stays visually aligned with the rest of the picker UI.
- Model labels are left-aligned consistently across surfaces.

### BYOK catalog sharing and discovery
- Settings-fetched BYOK provider model catalogs are now shared with other picker surfaces.
- Home and workspace BYOK pickers now also fetch provider models on demand when the shared catalog is empty, instead of requiring the user to visit Settings first.
- Preserves the currently selected custom model even when it is not part of the discovered catalog.

### Workspace and onboarding picker refinements
- Unified Local CLI / AMR / BYOK picker styling and search behavior in onboarding.
- Refined workspace and avatar-menu picker sizing so the trigger width and popover width behave consistently.
- Adjusted popover viewport clamping so dropdowns do not overrun the window edge.

### Interaction fixes for portal-based pickers
- The searchable picker popover now stops parent outside-click handlers from closing menus before an option click is applied.
- This fixes Home and workspace model switching regressions introduced by the portal-based dropdown implementation.

## Validation

Validated with focused component and E2E coverage, including:
- searchable model pickers in Home / Settings / workspace / onboarding
- onboarding Local CLI and AMR live-model search
- BYOK picker search and shared catalog behavior
- Home and workspace model switching after portal-based picker rollout
- on-demand BYOK model discovery when Settings has not been visited first

## Scope

This PR now covers:
- search UX for large model catalogs
- consistent picker presentation across app surfaces
- BYOK model discovery flow outside Settings
- model switcher interaction correctness in portal-based menus
