### PR TITLE
fix(web): ensure manual edit canvas wrapper fills full height

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -7282,7 +7282,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
               className={manualEditMode ? 'manual-edit-canvas' : 'comment-preview-canvas'}
               data-testid={manualEditMode ? undefined : 'comment-preview-canvas'}
             >
-              <div className={manualEditMode ? undefined : 'comment-frame-clip'}>
+              <div className={manualEditMode ? undefined : 'comment-frame-clip'} style={manualEditMode ? {height: "100%"} : undefined}>
                 <div
                   style={
                     manualEditMode


### PR DESCRIPTION
Add style={height: "100%"} to the wrapper div inside the manual-edit-canvas so the manual edit canvas is visible when manual edit mode is active.


## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->
  The wrapper `<div>` inside `.manual-edit-canvas` didn't have an explicit
   height, so the manual edit canvas wouldn't show when toggled into manual
   edit mode. This adds `style={{ height: "100%" }}` to that wrapper.
   
   ### Before
   Manual edit canvas appeared blank (zero height).
   
   ### After
   Manual edit canvas renders correctly, filling the available space.

## What users will see

Editing section after clicking manual edit shows as expected with correct height.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

### Before

<img width="2537" height="1379" alt="image" src="https://github.com/user-attachments/assets/b69569b2-726b-4c77-935c-bb32e8123db3" />

### After

<img width="2539" height="1377" alt="image" src="https://github.com/user-attachments/assets/5d880024-03e4-4609-a4bc-b9cde264e78c" />

## Bug fix verification

Open an existing project, click on a html design file, click on manual edit button, the design should show the iframe area allows user to click and edit elements

## Validation
- ran `pnpm guard`
- ran `pnpm typecheck`
- ran `pnpm tools-dev web` and manually verify editting section show as expected
