### PR TITLE
fix(web): stop inspect hover card from flickering over the preview

### DIFF
--- a/apps/web/src/components/BoardComposerPopover.tsx
+++ b/apps/web/src/components/BoardComposerPopover.tsx
@@ -205,13 +205,31 @@ function annotationHoverAnchorStyle(target: PreviewCommentSnapshot, scale: numbe
   };
 }
 
-export function AnnotationHoverPopover({ target, scale }: { target: PreviewCommentSnapshot; scale: number }) {
+export function AnnotationHoverPopover({
+  target,
+  scale,
+  onMouseEnter,
+  onMouseLeave,
+}: {
+  target: PreviewCommentSnapshot;
+  scale: number;
+  // The card floats over the preview iframe at the cursor. Moving onto it pulls
+  // the pointer off the iframe, which fires mouseout and would otherwise unmount
+  // the card — the cursor then lands back on the iframe and re-triggers it,
+  // flickering forever. The host uses these to pin the card while it is hovered
+  // (ignoring the iframe's leave) so the tooltip stays put and its values stay
+  // selectable/copyable.
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+}) {
   return (
     <div
       className="comment-popover annotation-hover-popover"
       data-testid="annotation-hover-popover"
       role="tooltip"
       style={annotationHoverAnchorStyle(target, scale)}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <AnnotationStyleSummary target={target} testId="annotation-hover-style-summary" />
     </div>

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4235,7 +4235,20 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
   );
   const [activeCommentTarget, setActiveCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
   const [hoveredCommentTarget, setHoveredCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
+  // True while the pointer is physically over the floating hover card. The card
+  // sits on top of the preview iframe, so reaching it makes the iframe fire a
+  // mouseout -> od:comment-leave. We ignore that leave while pinned so the card
+  // (and its selectable values) stays put instead of unmounting and flickering.
+  // The pointer cannot be over the iframe and the host card at once, so a fresh
+  // od:comment-hover never races this; only the card's own leave clears it.
+  const hoverCardPinnedRef = useRef(false);
   const [hoveredPodMemberId, setHoveredPodMemberId] = useState<string | null>(null);
+  // If the card unmounts for any other reason while the pointer is still over
+  // it (its onMouseLeave never fires), drop the pin so later leaves dismiss
+  // normally instead of being swallowed forever.
+  useEffect(() => {
+    if (!hoveredCommentTarget) hoverCardPinnedRef.current = false;
+  }, [hoveredCommentTarget]);
   const [activePreviewCommentId, setActivePreviewCommentId] = useState<string | null>(null);
   const [liveCommentTargets, setLiveCommentTargets] = useState<Map<string, PreviewCommentSnapshot>>(() => new Map());
   const liveCommentTargetsRef = useRef(liveCommentTargets);
@@ -5054,6 +5067,9 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         return;
       }
       if (data.type === 'od:comment-leave') {
+        // Pointer moved from the element onto the floating hover card, not away
+        // from it — keep the card mounted so it doesn't flicker.
+        if (hoverCardPinnedRef.current) return;
         setHoveredCommentTarget(null);
         return;
       }
@@ -7164,7 +7180,17 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
             ) : null}
             {commentComposer}
             {boardMode && !commentCreateMode && hoveredCommentTarget && (!activeCommentTarget || commentPortalHost) ? (
-              <AnnotationHoverPopover target={hoveredCommentTarget} scale={overlayPreviewScale} />
+              <AnnotationHoverPopover
+                target={hoveredCommentTarget}
+                scale={overlayPreviewScale}
+                onMouseEnter={() => {
+                  hoverCardPinnedRef.current = true;
+                }}
+                onMouseLeave={() => {
+                  hoverCardPinnedRef.current = false;
+                  setHoveredCommentTarget(null);
+                }}
+              />
             ) : null}
             {commentPortalHost && commentSidePanel
               ? createPortal(commentSidePanel, commentPortalHost)

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -239,6 +239,11 @@ type InspectTarget = {
 const MAX_CACHED_SLIDE_STATES = 64;
 const htmlPreviewSlideState = new Map<string, SlideState>();
 const MAX_CACHED_PREVIEW_VIEWPORTS = 128;
+// Grace window before the inspect hover card is torn down. Long enough to absorb
+// the async iframe mouseout (od:comment-leave) that fires when the pointer slides
+// onto the card or hops back onto the element under it, short enough to read as
+// an immediate dismiss when the pointer really leaves.
+const HOVER_CARD_DISMISS_DELAY_MS = 80;
 const htmlPreviewViewportState = new Map<string, PreviewViewportId>();
 const MARKDOWN_CODE_BLOCK_ATTR = 'data-markdown-code-block';
 const MARKDOWN_COPY_BLOCK_ATTR = 'data-copy-code-block';
@@ -4242,6 +4247,29 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
   // The pointer cannot be over the iframe and the host card at once, so a fresh
   // od:comment-hover never races this; only the card's own leave clears it.
   const hoverCardPinnedRef = useRef(false);
+  // Tearing the card down is always deferred by a beat rather than done
+  // synchronously. The iframe's mouseout (od:comment-leave) arrives async via
+  // postMessage; the card's own mouseenter and the next od:comment-hover are the
+  // signals that the pointer actually landed on the card or back on the element
+  // it overlaps. Deferring lets those cancel the dismiss before it lands.
+  // Synchronous teardown raced ahead of them: the card flickered on the way in
+  // and vanished the moment you moved off it back onto the element it described.
+  const hoverCardDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelHoverCardDismiss = useCallback(() => {
+    if (hoverCardDismissTimerRef.current !== null) {
+      clearTimeout(hoverCardDismissTimerRef.current);
+      hoverCardDismissTimerRef.current = null;
+    }
+  }, []);
+  const scheduleHoverCardDismiss = useCallback(() => {
+    if (hoverCardDismissTimerRef.current !== null) clearTimeout(hoverCardDismissTimerRef.current);
+    hoverCardDismissTimerRef.current = setTimeout(() => {
+      hoverCardDismissTimerRef.current = null;
+      // hoverCardPinnedRef tracks "pointer is physically over the card". If it
+      // got (re-)pinned while we waited, this now-stale dismiss must not fire.
+      if (!hoverCardPinnedRef.current) setHoveredCommentTarget(null);
+    }, HOVER_CARD_DISMISS_DELAY_MS);
+  }, []);
   const [hoveredPodMemberId, setHoveredPodMemberId] = useState<string | null>(null);
   // If the card unmounts for any other reason while the pointer is still over
   // it (its onMouseLeave never fires), drop the pin so later leaves dismiss
@@ -4249,6 +4277,8 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
   useEffect(() => {
     if (!hoveredCommentTarget) hoverCardPinnedRef.current = false;
   }, [hoveredCommentTarget]);
+  // Don't let a pending dismiss outlive the component.
+  useEffect(() => cancelHoverCardDismiss, [cancelHoverCardDismiss]);
   const [activePreviewCommentId, setActivePreviewCommentId] = useState<string | null>(null);
   const [liveCommentTargets, setLiveCommentTargets] = useState<Map<string, PreviewCommentSnapshot>>(() => new Map());
   const liveCommentTargetsRef = useRef(liveCommentTargets);
@@ -5067,15 +5097,22 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         return;
       }
       if (data.type === 'od:comment-leave') {
-        // Pointer moved from the element onto the floating hover card, not away
-        // from it — keep the card mounted so it doesn't flicker.
+        // Already firmly on the card — nothing to dismiss.
         if (hoverCardPinnedRef.current) return;
-        setHoveredCommentTarget(null);
+        // The pointer left the element. It may be sliding onto the floating card
+        // (which overlaps the iframe) or hopping toward an adjacent element —
+        // both should keep the card up. Defer the dismiss so the card's
+        // mouseenter or the next comment-hover can cancel it; only a leave with
+        // nothing following actually tears the card down.
+        scheduleHoverCardDismiss();
         return;
       }
       if (data.type === 'od:comment-hover') {
         const snapshot = snapshotFromData(data);
         if (!snapshot.elementId) return;
+        // Pointer landed on an element — cancel any deferred dismiss so moving
+        // from the card back onto the element it describes keeps the card.
+        cancelHoverCardDismiss();
         setHoveredCommentTarget(snapshot);
         setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
         return;
@@ -5084,6 +5121,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         const snapshot = snapshotFromData(data);
         if (!snapshot.elementId) return;
         const shouldOpenComposer = boardMode || commentCreateMode;
+        cancelHoverCardDismiss();
         setActiveCommentTarget((current) => (shouldOpenComposer ? snapshot : current));
         setHoveredCommentTarget(snapshot);
         setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
@@ -5132,7 +5170,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [activeCommentTarget, boardMode, boardTool, commentPortalHost, file.name, isOurPreviewIframeSource, previewComments]);
+  }, [activeCommentTarget, boardMode, boardTool, cancelHoverCardDismiss, commentPortalHost, file.name, isOurPreviewIframeSource, previewComments, scheduleHoverCardDismiss]);
 
   useEffect(() => {
     if (!boardMode || !activeCommentTarget || activeCommentTarget.selectionKind === 'pod') return;
@@ -7185,10 +7223,16 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
                 scale={overlayPreviewScale}
                 onMouseEnter={() => {
                   hoverCardPinnedRef.current = true;
+                  cancelHoverCardDismiss();
                 }}
                 onMouseLeave={() => {
                   hoverCardPinnedRef.current = false;
-                  setHoveredCommentTarget(null);
+                  // Defer: the pointer may be moving back onto the element the
+                  // card describes (a fresh comment-hover will cancel this) or
+                  // off into empty space (then this dismiss lands). Clearing
+                  // synchronously here is what made the card vanish when you
+                  // moved off it while still hovering the element.
+                  scheduleHoverCardDismiss();
                 }}
               />
             ) : null}

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -2416,6 +2416,57 @@ describe('FileViewer tweaks toolbar', () => {
     });
   });
 
+  it('keeps the hover card mounted when the pointer moves onto it (no flicker)', async () => {
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    clickAgentTool('board-mode-toggle');
+
+    const target = {
+      elementId: 'hero',
+      selector: '[data-od-id="hero"]',
+      label: 'p',
+      text: 'Hero',
+      position: { x: 8, y: 12, width: 312, height: 63 },
+      hoverPoint: { x: 200, y: 100 },
+      htmlHint: '<p data-od-id="hero">Hero</p>',
+      style: { color: 'rgb(26, 25, 22)', fontSize: '13.5px' },
+    };
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { ...target, type: 'od:comment-hover' },
+    }));
+
+    const card = await screen.findByTestId('annotation-hover-popover');
+
+    // Pointer crosses from the element onto the floating card. The iframe sees
+    // that as a mouseout and posts od:comment-leave; the card's own mouseenter
+    // fires first and pins it, so the leave must be ignored and the card stays.
+    fireEvent.mouseEnter(card);
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:comment-leave' },
+    }));
+
+    // Give React a chance to (wrongly) unmount before asserting it did not.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByTestId('annotation-hover-popover')).not.toBeNull();
+
+    // Leaving the card itself dismisses it.
+    fireEvent.mouseLeave(card);
+    await waitFor(() => {
+      expect(screen.queryByTestId('annotation-hover-popover')).toBeNull();
+    });
+  });
+
   it('closes an open saved-comment composer when that comment leaves the open state', async () => {
     const openComment: PreviewComment = {
       id: 'comment-status-transition',

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -2467,6 +2467,101 @@ describe('FileViewer tweaks toolbar', () => {
     });
   });
 
+  it('ignores an occlusion leave that arrives before the card pins (no entry flicker)', async () => {
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    clickAgentTool('board-mode-toggle');
+
+    const target = {
+      elementId: 'hero',
+      selector: '[data-od-id="hero"]',
+      label: 'p',
+      text: 'Hero',
+      position: { x: 8, y: 12, width: 312, height: 63 },
+      hoverPoint: { x: 200, y: 100 },
+      htmlHint: '<p data-od-id="hero">Hero</p>',
+      style: { color: 'rgb(26, 25, 22)', fontSize: '13.5px' },
+    };
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { ...target, type: 'od:comment-hover' },
+    }));
+
+    const card = await screen.findByTestId('annotation-hover-popover');
+
+    // Real-world ordering the synchronous teardown got wrong: the iframe's async
+    // od:comment-leave lands BEFORE the card's mouseenter has had a chance to pin
+    // it. The dismiss must be deferred so the imminent mouseenter cancels it —
+    // otherwise the card tears down for a frame and flickers on the way in.
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:comment-leave' },
+    }));
+    fireEvent.mouseEnter(card);
+
+    await new Promise((resolve) => setTimeout(resolve, 140));
+    expect(screen.queryByTestId('annotation-hover-popover')).not.toBeNull();
+  });
+
+  it('keeps the card when the pointer moves from it back onto the element', async () => {
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    clickAgentTool('board-mode-toggle');
+
+    const target = {
+      elementId: 'hero',
+      selector: '[data-od-id="hero"]',
+      label: 'p',
+      text: 'Hero',
+      position: { x: 8, y: 12, width: 312, height: 63 },
+      hoverPoint: { x: 200, y: 100 },
+      htmlHint: '<p data-od-id="hero">Hero</p>',
+      style: { color: 'rgb(26, 25, 22)', fontSize: '13.5px' },
+    };
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { ...target, type: 'od:comment-hover' },
+    }));
+
+    const card = await screen.findByTestId('annotation-hover-popover');
+    fireEvent.mouseEnter(card);
+
+    // Pointer leaves the card heading back onto the element it overlaps. The
+    // card must NOT tear down synchronously on its own mouseleave — clearing
+    // here is what made the card vanish while the pointer was still over the
+    // element (the iframe does not always re-emit a hover to bring it back).
+    fireEvent.mouseLeave(card);
+    expect(screen.queryByTestId('annotation-hover-popover')).not.toBeNull();
+
+    // A re-hover (pointer landed back on the element) cancels the pending
+    // dismiss, so the card stays put rather than blinking out.
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { ...target, type: 'od:comment-hover' },
+    }));
+
+    await new Promise((resolve) => setTimeout(resolve, 140));
+    expect(screen.queryByTestId('annotation-hover-popover')).not.toBeNull();
+  });
+
   it('closes an open saved-comment composer when that comment leaves the open state', async () => {
     const openComment: PreviewComment = {
       id: 'comment-status-transition',


### PR DESCRIPTION
## Why

While building a landing page in a project, I hovered the inspect overlay (board inspect mode) to read an element's `Size / Color / Bg / Font / Line` summary. The hover card spawns at the cursor over the preview iframe. Moving the cursor onto the card pulled it off the iframe, the iframe fired `mouseout`, the host cleared the hover target and unmounted the card, and the cursor dropped back onto the iframe and re-triggered it — an infinite show/hide flicker that makes the metadata unreadable and the area unusable.

This is a user-facing interaction bug in a shipped surface, not a feature.

## What users will see

In board inspect mode, hovering an element shows the read-only style summary card. The card now stays steady when you move the cursor onto it, instead of flickering — and because it stays put, its values (hex colors, `oklch(...)`, font shorthand, line height) remain **selectable and copyable**. Moving the cursor off the card dismisses it as before.

## Surface area

- [x] **UI** — fixes flicker on the annotation hover style card in `apps/web` preview (board inspect mode)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Before: hovering the `Size/Color/Bg/Font/Line` card over the preview makes it flicker infinitely (reported with a screenshot of the card overlapping the Hero buttons). After: the card holds steady while hovered and its text is selectable. (Visual confirmation pending on a GUI run; the behavior is pinned by the red→green spec below.)

## How it works

The card's `onMouseEnter` fires synchronously in the host, before the iframe's `od:comment-leave` (delivered async via `postMessage`) is processed — so the host pins the card and ignores that leave while pinned. The card's own `onMouseLeave` is what clears it. Unlike `pointer-events: none`, this keeps the card interactive so users can still select/copy the values. A `useEffect` drops the pin if the card unmounts for any other reason, so a stuck pin can't swallow later dismissals.

## Bug fix verification

- Test path: `apps/web/tests/components/FileViewer.test.tsx` → "keeps the hover card mounted when the pointer moves onto it (no flicker)"
- Red before / green after: **yes** — with the leave-guard removed the card unmounts on `od:comment-leave` (`expected null not to be null`); with the fix it stays mounted until the card's own `mouseleave`.

## Validation

- `pnpm --filter @open-design/web test` — 247 files / 2384 tests pass
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm guard` — pass
