### PR TITLE
feat(landing): platform-aware direct download CTAs

### DIFF
--- a/apps/landing-page/app/_components/header-enhancer.astro
+++ b/apps/landing-page/app/_components/header-enhancer.astro
@@ -22,6 +22,70 @@
       return fromName(release?.name) ?? fromTag(release?.tag_name) ?? null;
     };
 
+    // Best-effort OS + arch detection so the header download CTA points
+    // straight at the matching installer. Mirrors app/pages/index.astro — keep
+    // the two in sync. arm64 vs x64 on macOS isn't reliably exposed (Safari
+    // hides CPU arch), so we sniff the WebGL renderer and otherwise default to
+    // arm64. Linux has no artifact, so it keeps the releases-page fallback.
+    const detectPlatform = () => {
+      const ua = (navigator.userAgent || '').toLowerCase();
+      const uaPlatform = (
+        (navigator.userAgentData && navigator.userAgentData.platform) ||
+        navigator.platform ||
+        ''
+      ).toLowerCase();
+      const isWindows = /win/.test(uaPlatform) || /windows/.test(ua);
+      const isMac = /mac/.test(uaPlatform) || (/mac os x/.test(ua) && !/iphone|ipad|ipod/.test(ua));
+      const isLinux = /linux/.test(uaPlatform) || (/linux/.test(ua) && !/android/.test(ua));
+      if (isWindows) return { os: 'Windows', arch: 'Windows', match: (n) => /win.*setup\.exe$/.test(n) };
+      if (isMac) {
+        const isIntel = (() => {
+          try {
+            const gl = document.createElement('canvas').getContext('webgl');
+            const dbg = gl && gl.getExtension('WEBGL_debug_renderer_info');
+            const renderer = dbg ? String(gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL)) : '';
+            return /intel|radeon|amd/i.test(renderer) && !/apple/i.test(renderer);
+          } catch {
+            return false;
+          }
+        })();
+        const suffix = isIntel ? 'mac-x64.dmg' : 'mac-arm64.dmg';
+        const arch = isIntel ? 'Apple Intel' : 'Apple Silicon';
+        return { os: 'macOS', arch, match: (n) => n.endsWith(suffix) };
+      }
+      if (isLinux) return { os: 'Linux', arch: '', match: () => false };
+      return null;
+    };
+
+    const enhanceDownloadCtas = (release) => {
+      const ctas = document.querySelectorAll('[data-download-cta]');
+      if (ctas.length === 0) return;
+      const platform = detectPlatform();
+      if (!platform) return;
+      for (const slot of document.querySelectorAll('[data-download-os]')) {
+        slot.textContent = platform.os;
+      }
+      for (const slot of document.querySelectorAll('[data-download-arch]')) {
+        if (!platform.arch) continue;
+        slot.textContent = `（${platform.arch}）`;
+        slot.hidden = false;
+      }
+      const assets = Array.isArray(release?.assets) ? release.assets : [];
+      const asset = assets.find(
+        (a) =>
+          a &&
+          typeof a.name === 'string' &&
+          typeof a.browser_download_url === 'string' &&
+          platform.match(a.name),
+      );
+      if (!asset) return;
+      for (const cta of ctas) {
+        cta.href = asset.browser_download_url;
+        cta.removeAttribute('target');
+        cta.removeAttribute('rel');
+      }
+    };
+
     const chrome = document.querySelector('[data-chrome-headroom]');
     if (chrome) {
       // Wrap the scroll listener in requestAnimationFrame so a burst of
@@ -96,12 +160,14 @@
     }
 
     const versionSlots = document.querySelectorAll('[data-github-version]');
-    if (versionSlots.length > 0) {
+    const hasDownloadCtas = document.querySelector('[data-download-cta]') !== null;
+    if (versionSlots.length > 0 || hasDownloadCtas) {
       fetch(`${REPO_API}/releases/latest`, {
         headers: { Accept: 'application/vnd.github+json' },
       })
         .then((r) => (r.ok ? r.json() : Promise.reject(new Error('http error'))))
         .then((data) => {
+          enhanceDownloadCtas(data);
           const label = formatVersion(data);
           if (!label) return;
           for (const slot of versionSlots) slot.textContent = label;

--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -323,9 +323,11 @@ export function Header({
             href={REPO_RELEASES}
             aria-label={headerCopy.downloadAria}
             title={headerCopy.downloadTitle}
+            data-download-cta
             {...ext}
           >
             {headerCopy.download}
+            <span className='download-arch' data-download-arch hidden />
           </a>
           <a
             className='nav-cta'

--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -319,7 +319,17 @@ export function Header({
             </span>
           </a>
           <a
-            className='nav-cta ghost'
+            className='nav-cta ghost is-star'
+            href={REPO}
+            aria-label={headerCopy.starAria}
+            title={headerCopy.starTitle}
+            {...ext}
+          >
+            {headerCopy.starPrefix} ·{' '}
+            <span data-github-stars>{github?.starsLabel ?? '40K+'}</span>
+          </a>
+          <a
+            className='nav-cta is-download'
             href={REPO_RELEASES}
             aria-label={headerCopy.downloadAria}
             title={headerCopy.downloadTitle}
@@ -328,16 +338,6 @@ export function Header({
           >
             {headerCopy.download}
             <span className='download-arch' data-download-arch hidden />
-          </a>
-          <a
-            className='nav-cta'
-            href={REPO}
-            aria-label={headerCopy.starAria}
-            title={headerCopy.starTitle}
-            {...ext}
-          >
-            {headerCopy.starPrefix} ·{' '}
-            <span data-github-stars>{github?.starsLabel ?? '40K+'}</span>
           </a>
           <span className='status-dot' aria-hidden='true' />
         </div>

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -723,6 +723,18 @@ body::before {
   color: var(--ink);
   font-size: 12px;
 }
+/* Download as the primary nav CTA: coral fill (matches the hero primary
+   button), carrying its own ↓ glyph regardless of the ghost/solid base. */
+.nav-cta.is-download {
+  background: var(--coral);
+  color: #fff;
+  box-shadow: 0 12px 22px -16px rgba(237, 111, 92, 1);
+  transition: background 160ms ease, transform 160ms ease;
+}
+.nav-cta.is-download:hover { background: #e25e4a; transform: translateY(-1px); }
+.nav-cta.is-download::after { content: '↓'; color: #fff; font-size: 12px; }
+/* Star demoted to the ghost/secondary slot but keeps its ★ glyph. */
+.nav-cta.ghost.is-star::after { content: '★'; color: var(--mustard); font-size: 11px; }
 .status-dot {
   width: 28px; height: 28px;
   border-radius: 50%;

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -832,6 +832,13 @@ body::before {
   border-color: rgba(21, 20, 15, 0.2);
 }
 .btn-ghost:hover { background: rgba(21, 20, 15, 0.04); }
+/* Platform suffix appended to download CTAs, e.g. 下载桌面端（Apple Silicon）.
+   Injected + unhidden by the enhancer scripts once the OS is detected. */
+.download-arch {
+  margin-left: 0.3em;
+  opacity: 0.62;
+  font-weight: 500;
+}
 .btn .arrow {
   width: 16px; height: 16px;
   display: inline-flex;

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -356,8 +356,14 @@ export default function Page({
                   {home.hero.star}
                   <span className='arrow'>{arrowOut}</span>
                 </a>
-                <a className='btn btn-ghost' href={REPO_RELEASES} {...ext}>
+                <a
+                  className='btn btn-ghost'
+                  href={REPO_RELEASES}
+                  data-download-cta
+                  {...ext}
+                >
                   {home.hero.download}
+                  <span className='download-arch' data-download-arch hidden />
                   <span className='arrow'>{arrowPlus}</span>
                 </a>
               </div>
@@ -1307,11 +1313,13 @@ export default function Page({
                   className='foot-cta'
                   href={REPO_RELEASES}
                   aria-label={home.footer.downloadAria}
+                  data-download-cta
                   {...ext}
                 >
                   {home.footer.download}
                   <span className='meta'>
-                    macOS · <span data-github-version>{github.versionLabel}</span>
+                    <span data-download-os>macOS</span> ·{' '}
+                    <span data-github-version>{github.versionLabel}</span>
                   </span>
                 </a>
               </div>

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -352,12 +352,12 @@ export default function Page({
                 {home.hero.lead(skills, systems)}
               </p>
               <div className='hero-actions' data-reveal>
-                <a className='btn btn-primary' href={REPO} {...ext}>
+                <a className='btn btn-ghost' href={REPO} {...ext}>
                   {home.hero.star}
                   <span className='arrow'>{arrowOut}</span>
                 </a>
                 <a
-                  className='btn btn-ghost'
+                  className='btn btn-primary'
                   href={REPO_RELEASES}
                   data-download-cta
                   {...ext}

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -226,6 +226,89 @@ const pageHtml = renderToStaticMarkup(
           return fromName(release?.name) ?? fromTag(release?.tag_name) ?? null;
         };
 
+        // Best-effort OS + arch detection so the download CTAs point straight
+        // at the matching installer instead of bouncing through the releases
+        // page.
+        //
+        // Release assets are named (see the v0.x GitHub release):
+        //   open-design-<ver>-mac-arm64.dmg     Apple Silicon
+        //   open-design-<ver>-mac-x64.dmg       Intel Mac
+        //   open-design-<ver>-win-x64-setup.exe Windows
+        // There is no Linux artifact, so Linux/unknown leaves the CTA's
+        // pre-rendered releases-page href untouched.
+        //
+        // arm64 vs x64 on macOS is NOT reliably exposed to the browser
+        // (Safari hides CPU arch). We sniff the WebGL renderer for an Intel/AMD
+        // GPU and otherwise DEFAULT TO arm64, since every Mac shipped since
+        // late 2020 is Apple Silicon. Intel-Mac holdouts can still grab the x64
+        // build from the releases page.
+        const detectPlatform = () => {
+          const ua = (navigator.userAgent || '').toLowerCase();
+          const uaPlatform = (
+            (navigator.userAgentData && navigator.userAgentData.platform) ||
+            navigator.platform ||
+            ''
+          ).toLowerCase();
+          const isWindows = /win/.test(uaPlatform) || /windows/.test(ua);
+          const isMac = /mac/.test(uaPlatform) || (/mac os x/.test(ua) && !/iphone|ipad|ipod/.test(ua));
+          const isLinux = /linux/.test(uaPlatform) || (/linux/.test(ua) && !/android/.test(ua));
+          if (isWindows) return { os: 'Windows', arch: 'Windows', match: (n) => /win.*setup\.exe$/.test(n) };
+          if (isMac) {
+            const isIntel = (() => {
+              try {
+                const gl = document.createElement('canvas').getContext('webgl');
+                const dbg = gl && gl.getExtension('WEBGL_debug_renderer_info');
+                const renderer = dbg ? String(gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL)) : '';
+                return /intel|radeon|amd/i.test(renderer) && !/apple/i.test(renderer);
+              } catch {
+                return false;
+              }
+            })();
+            const suffix = isIntel ? 'mac-x64.dmg' : 'mac-arm64.dmg';
+            const arch = isIntel ? 'Apple Intel' : 'Apple Silicon';
+            return { os: 'macOS', arch, match: (n) => n.endsWith(suffix) };
+          }
+          // Linux has no published artifact: report the OS for the label but
+          // never match an asset, so the CTA keeps its releases-page fallback.
+          if (isLinux) return { os: 'Linux', arch: '', match: () => false };
+          return null;
+        };
+
+        // Rewrite every [data-download-cta] anchor to the matching installer
+        // URL from the latest release, swap any [data-download-os] label to the
+        // detected OS, and append the arch suffix to [data-download-arch] slots
+        // (下载 -> 下载（Apple Silicon）). No-ops (keeping the releases-page
+        // fallback) when the platform is unknown or no matching asset exists.
+        const enhanceDownloadCtas = (release) => {
+          const ctas = document.querySelectorAll('[data-download-cta]');
+          if (ctas.length === 0) return;
+          const platform = detectPlatform();
+          if (!platform) return;
+          for (const slot of document.querySelectorAll('[data-download-os]')) {
+            slot.textContent = platform.os;
+          }
+          for (const slot of document.querySelectorAll('[data-download-arch]')) {
+            if (!platform.arch) continue;
+            slot.textContent = `（${platform.arch}）`;
+            slot.hidden = false;
+          }
+          const assets = Array.isArray(release?.assets) ? release.assets : [];
+          const asset = assets.find(
+            (a) =>
+              a &&
+              typeof a.name === 'string' &&
+              typeof a.browser_download_url === 'string' &&
+              platform.match(a.name),
+          );
+          if (!asset) return;
+          for (const cta of ctas) {
+            cta.href = asset.browser_download_url;
+            // A direct file download should not open a blank tab.
+            cta.removeAttribute('target');
+            cta.removeAttribute('rel');
+          }
+        };
+
         const enhanceHeader = () => {
           const chrome = document.querySelector('[data-chrome-headroom]');
           if (chrome) {
@@ -304,16 +387,19 @@ const pageHtml = renderToStaticMarkup(
           }
 
           // Latest stable release powers every "v0.x.y" badge on the page
-          // (topbar pulse, hero CTA-foot, footer download). Hits one
-          // unauthenticated API call per page view; the static fallback in
-          // each slot keeps the layout sane if the request fails or 403s.
+          // (topbar pulse, hero CTA-foot, footer download) AND the per-OS
+          // direct download CTAs. One unauthenticated API call per page view;
+          // the static fallbacks (version slot text, releases-page href) keep
+          // things sane if the request fails or 403s.
           const versionSlots = document.querySelectorAll('[data-github-version]');
-          if (versionSlots.length === 0) return;
+          const hasDownloadCtas = document.querySelector('[data-download-cta]') !== null;
+          if (versionSlots.length === 0 && !hasDownloadCtas) return;
           fetch('https://api.github.com/repos/nexu-io/open-design/releases/latest', {
             headers: { Accept: 'application/vnd.github+json' },
           })
             .then((r) => (r.ok ? r.json() : Promise.reject(new Error('http error'))))
             .then((data) => {
+              enhanceDownloadCtas(data);
               const label = formatVersion(data);
               if (!label) return;
               for (const slot of versionSlots) slot.textContent = label;


### PR DESCRIPTION
## Why

Scratching an itch on the marketing site: every download button on
open-design.ai sent visitors to the GitHub releases page, where they then
had to figure out which asset matches their OS and CPU. That extra hop and
the "which file do I pick?" friction costs conversions on the primary
funnel (get the desktop app). This PR makes one click start the right
download.

## What users will see

- The header **下载 / Download** button and the hero **下载桌面端 / Download
  desktop** button now download the installer for the visitor's own machine
  directly, instead of opening the GitHub releases page:
  - Windows → `*-win-x64-setup.exe`
  - macOS → `*-mac-arm64.dmg` (default; an Intel GPU is detected via the
    WebGL renderer and switches to `*-mac-x64.dmg`)
  - Linux / unknown / API failure → unchanged: still opens the releases page
- The CTA label gains a platform suffix, e.g. **下载（Apple Silicon）**,
  **Download（Windows）**, **下载桌面端（Apple Intel）**.
- Download is now the coral **primary** CTA in both the header and hero
  (the GitHub-star button moves to the ghost/secondary style). Star stays
  first, download second in each pair.
- The footer download CTA's meta line reflects the detected OS (macOS /
  Windows / Linux) instead of the hard-coded "macOS".

Implementation note: detection + rewrite reuses the existing
`releases/latest` request already made by the homepage and sub-page
enhancer scripts, so it adds **no extra network call**. Everything degrades
to the pre-rendered releases-page href if the request fails or the platform
is unknown.

## Surface area

- [x] **UI** — download CTAs in `apps/landing-page` (header, hero, footer) now download the matching installer and are restyled as the primary action
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

This is landing-page only; no `apps/web` / `apps/desktop` surface, no CLI
counterpart applies.

## Screenshots

_To attach: header + hero showing the coral "下载（Apple Silicon）" primary
CTA on a Mac visitor._

## Validation

- `pnpm --filter @open-design/landing-page typecheck` (astro check) — 0 errors
- Browser-tested via Playwright with mocked UA/platform for Windows, macOS
  (arm64 default), and Linux: confirmed each CTA's rewritten `href`, label
  suffix, and the Linux releases-page fallback.