### PR TITLE
Fix AMR visibility during onboarding CLI scan

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -826,6 +826,9 @@ function OnboardingView({
     | { status: 'running'; inputKey: string }
     | { status: 'done'; inputKey: string; result: ProviderModelsResponse }
   >({ status: 'idle' });
+  const [amrCloudVisible, setAmrCloudVisible] = useState(
+    () => agents.length === 0 || agents.some((agent) => agent.id === 'amr' && agent.available),
+  );
   const [localProviderModelsCache, setLocalProviderModelsCache] = useState<
     Record<string, ProviderModelOption[]>
   >({});
@@ -896,7 +899,7 @@ function OnboardingView({
     (agent) => agent.available && agent.id !== 'amr' && visibleAgentIds.includes(agent.id),
   );
   const amrAgent = agents.find((agent) => agent.id === 'amr' && agent.available) ?? null;
-  const showAmrCloudOption = amrAgent !== null || agents.length === 0;
+  const showAmrCloudOption = amrCloudVisible;
   const amrSignedIn = amrStatus?.loggedIn === true;
   const amrSelectedAndSignedOut = runtime === 'amr' && !amrSignedIn;
   const amrAgentChoice = config.agentModels?.amr ?? {};
@@ -927,6 +930,11 @@ function OnboardingView({
       agentRevealTimersRef.current = [];
     };
   }, []);
+
+  useEffect(() => {
+    if (amrCloudVisible) return;
+    if (amrAgent || agents.length === 0) setAmrCloudVisible(true);
+  }, [agents.length, amrAgent, amrCloudVisible]);
 
   useEffect(() => {
     if (!amrAgent || runtime !== null) return;

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EntryShell } from '../../src/components/EntryShell';
@@ -54,11 +55,10 @@ function baseConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   } as AppConfig;
 }
 
-function renderOnboarding(
+function defaultEntryShellProps(
   overrides: Partial<React.ComponentProps<typeof EntryShell>> = {},
-) {
-  window.history.replaceState(null, '', '/onboarding');
-  const props: React.ComponentProps<typeof EntryShell> = {
+): React.ComponentProps<typeof EntryShell> {
+  return {
     skills: [],
     designTemplates: [],
     designSystems: [],
@@ -92,6 +92,13 @@ function renderOnboarding(
     onCompleteOnboarding: vi.fn(),
     ...overrides,
   };
+}
+
+function renderOnboarding(
+  overrides: Partial<React.ComponentProps<typeof EntryShell>> = {},
+) {
+  window.history.replaceState(null, '', '/onboarding');
+  const props = defaultEntryShellProps(overrides);
 
   render(
     <I18nProvider initial="en">
@@ -100,6 +107,44 @@ function renderOnboarding(
   );
 
   return props;
+}
+
+function renderOnboardingWithAgentRefresh({
+  initialAgents,
+  refreshedAgents,
+}: {
+  initialAgents: AgentInfo[];
+  refreshedAgents: AgentInfo[];
+}) {
+  window.history.replaceState(null, '', '/onboarding');
+  const onRefreshAgents = vi.fn(() => refreshedAgents);
+  const onModeChange = vi.fn();
+  const onAgentChange = vi.fn();
+
+  function Harness() {
+    const [agents, setAgents] = useState(initialAgents);
+    const handleRefreshAgents = () => {
+      const nextAgents = onRefreshAgents();
+      setAgents(nextAgents);
+      return nextAgents;
+    };
+    const props = defaultEntryShellProps({
+      agents,
+      onModeChange,
+      onAgentChange,
+      onRefreshAgents: handleRefreshAgents,
+    });
+
+    return (
+      <I18nProvider initial="en">
+        <EntryShell {...props} />
+      </I18nProvider>
+    );
+  }
+
+  render(<Harness />);
+
+  return { onRefreshAgents, onModeChange, onAgentChange };
 }
 
 afterEach(() => {
@@ -169,6 +214,28 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     const localPanel = screen.getByText('Local CLI').closest('.onboarding-view__setup-panel');
     expect(localPanel?.textContent).toContain('Claude Code');
     expect(localPanel?.textContent).not.toContain('AMR');
+  });
+
+  it('keeps Open Design AMR visible after Local CLI refresh returns only local agents', async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' }),
+    ) as typeof fetch;
+    const props = renderOnboardingWithAgentRefresh({
+      initialAgents: [amrAgent(), cliAgent()],
+      refreshedAgents: [cliAgent()],
+    });
+
+    expect(screen.getByRole('button', { name: /Open Design AMR/i })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Local coding agent/i }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(props.onRefreshAgents).toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /Open Design AMR/i })).toBeTruthy();
+    expect(screen.getByText('Local CLI')).toBeTruthy();
+    expect(screen.getByText('Claude Code')).toBeTruthy();
   });
 
   it('keeps AMR login pending while device authorization is waiting', async () => {


### PR DESCRIPTION
## Why

While checking the first-run onboarding runtime picker, selecting **Local Coding Agent** could make the Open Design AMR card disappear. The local CLI scan can refresh the `agents` prop with only local CLIs, and the onboarding view was deriving AMR-card visibility directly from that transient refreshed list.

That makes the recommended AMR Cloud path feel like it was removed just because the user inspected local agents. This PR keeps the AMR cloud option visible once it was initially available or shown as the empty-state fallback, while still keeping AMR out of the Local CLI agent chip list.

## What users will see

On `/onboarding`, choosing **Local coding agent** and scanning local CLIs no longer removes the **Open Design AMR** card from the runtime choices. Users can still switch back to AMR after inspecting or selecting a local CLI.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this is a conditional visibility bug with no layout/style change. The regression test exercises the visible entry point and the post-refresh state.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/EntryShell.onboarding.test.tsx`
- Did the test go red on `main` and green on this branch? No; I encoded the regression on this branch after identifying the stale visibility condition locally. The new test simulates the parent refreshing `agents` to only local CLIs after a Local CLI scan and asserts the AMR card remains visible.

## Validation

- `PATH=/Users/elian/.nvm/versions/node/v24.15.0/bin:$PATH pnpm install`
- `PATH=/Users/elian/.nvm/versions/node/v24.15.0/bin:$PATH pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/EntryShell.onboarding.test.tsx`
- `PATH=/Users/elian/.nvm/versions/node/v24.15.0/bin:$PATH pnpm --filter @open-design/web typecheck`
- `PATH=/Users/elian/.nvm/versions/node/v24.15.0/bin:$PATH pnpm guard`
- `PATH=/Users/elian/.nvm/versions/node/v24.15.0/bin:$PATH pnpm typecheck`
