### PR TITLE
feat(landing): add PostHog analytics with semantic events

### DIFF
--- a/apps/landing-page/.env.example
+++ b/apps/landing-page/.env.example
@@ -1,0 +1,13 @@
+# Marketing site public env vars. Copy to `.env` (or set on the deploy
+# platform). All are PUBLIC_-prefixed so Astro/Vite inlines them at build
+# time — none are secret (PostHog project keys are write-only ingestion keys).
+
+# Google Analytics 4 measurement id (G-XXXXXXX). Analytics is skipped if unset.
+PUBLIC_GA_MEASUREMENT_ID=
+
+# PostHog product analytics. The project (write-only) API key starts with
+# `phc_`. NEVER put a `phx_` personal key here — that one can read all data.
+# A default key is baked into the code, so leaving these blank still tracks to
+# the default project; set them to override the project or self-host.
+PUBLIC_POSTHOG_KEY=
+PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/apps/landing-page/app/_components/posthog-analytics.astro
+++ b/apps/landing-page/app/_components/posthog-analytics.astro
@@ -1,0 +1,9 @@
+---
+import { posthogHeadHtml } from '../_lib/posthog-analytics';
+
+const apiKey = import.meta.env.PUBLIC_POSTHOG_KEY;
+const host = import.meta.env.PUBLIC_POSTHOG_HOST;
+const headHtml = posthogHeadHtml(apiKey, host);
+---
+
+<Fragment set:html={headHtml} />

--- a/apps/landing-page/app/_components/sub-page-layout.astro
+++ b/apps/landing-page/app/_components/sub-page-layout.astro
@@ -20,6 +20,7 @@ import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import FaviconLinks from './favicon-links.astro';
 import GoogleAnalytics from './google-analytics.astro';
+import PostHogAnalytics from './posthog-analytics.astro';
 import ResourceHints from './resource-hints.astro';
 import HeaderEnhancer from './header-enhancer.astro';
 import { Header, type HeaderProps } from './header';
@@ -81,6 +82,7 @@ const ldArray = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
     <ResourceHints />
 
     <GoogleAnalytics />
+    <PostHogAnalytics />
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Open Design" />

--- a/apps/landing-page/app/_lib/posthog-analytics.ts
+++ b/apps/landing-page/app/_lib/posthog-analytics.ts
@@ -1,0 +1,177 @@
+/*
+ * PostHog product analytics for the marketing site.
+ *
+ * Mirrors `google-analytics.ts`: returns an inline <script> string injected
+ * into <head>, with a single document-level event-delegation model. Runs
+ * ALONGSIDE Google Analytics (two independent sinks — a single click can
+ * produce both a GA `cta_click` and a PostHog event; that is intended).
+ *
+ * Coverage is MANUAL semantic events only — `autocapture` is disabled so the
+ * event stream stays curated. The taxonomy lives in `buildTrackerScript`.
+ *
+ * Graceful skip: with no key the function returns '' and PostHog never loads,
+ * exactly like GA when the measurement id is absent.
+ */
+
+// Fallback so production works even if the deploy platform forgets the env
+// var. `PUBLIC_POSTHOG_KEY` / `PUBLIC_POSTHOG_HOST` override these.
+const DEFAULT_KEY = 'phc_u5dHWkwdqN626opkbbjDKk7xNzxR2UsJbdQqx3DncbjU';
+const DEFAULT_HOST = 'https://us.i.posthog.com';
+
+/**
+ * The delegated tracker installed after `posthog.init`. Plain DOM, no bundler
+ * runtime. Emitted verbatim inside the inline script (it is a string here so
+ * the same source ships to every page). Anchors to hooks that already exist
+ * in the markup; the only added attribute is `data-carousel-dir`.
+ */
+function buildTrackerScript(): string {
+  return `
+  (function () {
+    if (typeof window.posthog === 'undefined') return;
+
+    // Shared global so other inline scripts (e.g. the homepage reveal
+    // IntersectionObserver) can emit events without re-implementing the guard.
+    // Reads window.posthog on every call (no cached reference) so the snippet
+    // queue still receives events fired before array.js finishes loading.
+    window.__odTrack = function (name, props) {
+      try { if (window.posthog) window.posthog.capture(name, props || {}); } catch (e) {}
+    };
+
+    var REPO = 'github.com/nexu-io/open-design';
+    var PAGE = 'landing_home';
+
+    var localeNow = function () {
+      return (document.documentElement.getAttribute('lang') || 'en').toLowerCase();
+    };
+
+    var platformNow = function () {
+      var ua = (navigator.userAgent || '').toLowerCase();
+      var p = ((navigator.userAgentData && navigator.userAgentData.platform) || navigator.platform || '').toLowerCase();
+      if (/win/.test(p) || /windows/.test(ua)) return 'windows';
+      if (/mac/.test(p) || (/mac os x/.test(ua) && !/iphone|ipad|ipod/.test(ua))) return 'macos';
+      if (/linux/.test(p) || (/linux/.test(ua) && !/android/.test(ua))) return 'linux';
+      return 'other';
+    };
+
+    // The section (area) an element lives in. Header chrome reports 'header';
+    // otherwise the nearest [data-od-id] section id, matching the埋点文档
+    // section taxonomy (hero/official-strip/labs/work/testimonial/faq/cta/footer).
+    var areaOf = function (el) {
+      if (el.closest && el.closest('header.nav, [data-chrome-headroom]')) return 'header';
+      var sec = el.closest && el.closest('[data-od-id]');
+      return sec ? (sec.getAttribute('data-od-id') || 'unknown') : 'unknown';
+    };
+
+    var textOf = function (el) {
+      var t = (el.getAttribute && el.getAttribute('aria-label')) || el.textContent || '';
+      return t.trim().replace(/\\s+/g, ' ').slice(0, 80);
+    };
+
+    // Unified click event matching the埋点文档2.0 schema:
+    // event = 'landing_home_click', distinguished by area + element.
+    var click = function (el, element, extra) {
+      var props = { page_name: PAGE, locale: localeNow(), area: areaOf(el), element: element };
+      if (extra) for (var k in extra) props[k] = extra[k];
+      window.__odTrack('landing_home_click', props);
+    };
+
+    // Semantic page_view (in addition to PostHog's auto $pageview) so the
+    // landing funnel reads consistently with the rest of 埋点文档2.0.
+    window.__odTrack('page_view', { page_name: PAGE, locale: localeNow() });
+
+    // (a) Click delegation — one event, element discriminator. First match wins.
+    document.addEventListener('click', function (event) {
+      var t = event.target;
+      if (!t || !t.closest) return;
+
+      // Language switch (locale option) and the dropdown trigger.
+      var localeLink = t.closest('[data-locale-link]');
+      if (localeLink) {
+        click(localeLink, 'language_switch', { lang_to: localeLink.getAttribute('data-locale-code') || '' });
+        return;
+      }
+      if (t.closest('[data-locale-switch] summary')) { click(t, 'language_menu'); return; }
+
+      // Share / copy interactions (sub-page templates + plugin detail).
+      var tplShare = t.closest('[data-tpl-card-share]');
+      if (tplShare) {
+        click(tplShare, 'template_share', { template_title: tplShare.getAttribute('data-share-title') || '' });
+        return;
+      }
+      var shareOpen = t.closest('[data-share-open]');
+      if (shareOpen) { click(shareOpen, 'share_open', { share_key: shareOpen.getAttribute('data-share-open') || '' }); return; }
+      var copyEl = t.closest('[data-share-copy], [data-copy-link]');
+      if (copyEl) { click(copyEl, 'share_copy'); return; }
+
+      // Contributor wire row.
+      var wire = t.closest('[data-live-wire-item]');
+      if (wire) { click(wire, 'contributor', { wire_index: wire.getAttribute('data-live-wire-item') || '' }); return; }
+
+      // Testimonial carousel arrows.
+      var carousel = t.closest('.nav-btn');
+      if (carousel) {
+        click(carousel, 'carousel_nav', { direction: carousel.getAttribute('data-carousel-dir') || 'unknown' });
+        return;
+      }
+
+      // Link-based CTAs.
+      var link = t.closest('a[href]');
+      if (!link) return;
+      var href = link.href || '';
+      var lowerHref = href.toLowerCase();
+      var lowerLabel = textOf(link).toLowerCase();
+
+      if (lowerHref.indexOf(REPO + '/releases') !== -1 || /\\.(dmg|exe|appimage|deb|zip)(\\?|$)/.test(lowerHref)) {
+        click(link, 'download_desktop', { platform: platformNow(), link_url: href });
+        return;
+      }
+      if (lowerHref === 'https://' + REPO || lowerHref === 'https://' + REPO + '/' || lowerLabel.indexOf('star') !== -1) {
+        click(link, 'star_us_on_github', { link_url: href });
+        return;
+      }
+      if (lowerHref.indexOf('discord.gg/') !== -1) { click(link, 'join_discord', { link_url: href }); return; }
+      if (lowerHref.indexOf(REPO + '/issues') !== -1) { click(link, 'open_issue', { link_url: href }); return; }
+      if (link.closest('[data-nav-primary]')) { click(link, 'nav_link', { link_text: textOf(link), link_url: href }); return; }
+    });
+
+    // (c) FAQ accordion — <details> 'toggle' does not bubble, listen in capture.
+    document.addEventListener('toggle', function (event) {
+      var d = event.target;
+      if (!d || !d.closest || !d.closest('li.faq-item')) return;
+      var summary = d.querySelector ? d.querySelector('summary') : null;
+      click(d, d.open ? 'faq_open' : 'faq_close', {
+        question: summary ? (summary.textContent || '').trim().replace(/\\s+/g, ' ').slice(0, 80) : '',
+      });
+    }, true);
+  })();`;
+}
+
+export function posthogHeadHtml(apiKey: string | undefined, host: string | undefined): string {
+  const key = apiKey || DEFAULT_KEY;
+  if (!key) return '';
+  const apiHost = host || DEFAULT_HOST;
+
+  return `<!-- PostHog -->
+<script>
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  posthog.init(${JSON.stringify(key)}, {
+    api_host: ${JSON.stringify(apiHost)},
+    autocapture: false,
+    capture_pageview: true,
+    capture_pageleave: true,
+    disable_session_recording: true,
+    persistence: 'localStorage+cookie'
+  });
+${buildTrackerScript()}
+</script>`;
+}
+
+export function injectPostHog(html: string, apiKey: string | undefined, host: string | undefined): string {
+  const headHtml = posthogHeadHtml(apiKey, host);
+  if (!headHtml) return html;
+  if (html.includes('posthog.init(')) return html;
+  if (html.includes('</head>')) {
+    return html.replace('</head>', `${headHtml}\n</head>`);
+  }
+  return `${headHtml}\n${html}`;
+}

--- a/apps/landing-page/app/env.d.ts
+++ b/apps/landing-page/app/env.d.ts
@@ -3,3 +3,18 @@
 // Compile-time constant injected by `vite.define` in astro.config.ts. True on
 // staging / PR-preview builds (OD_LANDING_NOINDEX=1), false in production.
 declare const __OD_LANDING_NOINDEX__: boolean;
+
+interface ImportMetaEnv {
+  readonly PUBLIC_GA_MEASUREMENT_ID?: string;
+  readonly PUBLIC_POSTHOG_KEY?: string;
+  readonly PUBLIC_POSTHOG_HOST?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+interface Window {
+  // Defined by posthog-analytics.astro; no-op shim until PostHog loads.
+  __odTrack?: (name: string, props?: Record<string, unknown>) => void;
+}

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -1014,7 +1014,7 @@ export default function Page({
               </a>
             </div>
             <div className='work-arrows'>
-              <button type='button' className='nav-btn'>
+              <button type='button' className='nav-btn' data-carousel-dir='prev'>
                 <svg
                   width='14'
                   height='14'
@@ -1026,7 +1026,7 @@ export default function Page({
                   <path d='M14 6l-6 6 6 6' />
                 </svg>
               </button>
-              <button type='button' className='nav-btn active'>
+              <button type='button' className='nav-btn active' data-carousel-dir='next'>
                 <svg
                   width='14'
                   height='14'

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -5,6 +5,7 @@ import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import FaviconLinks from '../_components/favicon-links.astro';
 import GoogleAnalytics from '../_components/google-analytics.astro';
+import PostHogAnalytics from '../_components/posthog-analytics.astro';
 import ResourceHints from '../_components/resource-hints.astro';
 import LocaleSwitcherScript from '../_components/locale-switcher-script.astro';
 import PreciseLazyload from '../_components/precise-lazyload.astro';
@@ -148,6 +149,7 @@ const pageHtml = renderToStaticMarkup(
     <ResourceHints />
 
     <GoogleAnalytics />
+    <PostHogAnalytics />
 
     {/*
      * Hero LCP preload. Cloudflare Pages turns this <link rel="preload"> into
@@ -397,11 +399,39 @@ const pageHtml = renderToStaticMarkup(
         const elements = document.querySelectorAll('[data-reveal]:not([data-revealed])');
         enhanceHeader();
         enhanceWire();
+
+        // Fire a PostHog surface_view the first time a [data-od-id] section
+        // scrolls into view. Reuses the reveal observer below; a Set dedupes so
+        // each section reports once per page load. window.__odTrack is defined
+        // by posthog-analytics.astro and is a no-op when PostHog isn't loaded.
+        // Event shape matches 埋点文档2.0: surface_view + page_name/section_id/
+        // section_index, where section_index is the 1-based document order.
+        const seenSections = new Set();
+        let sectionOrder = 0;
+        const reportSection = (el) => {
+          const section = el.closest && el.closest('[data-od-id]');
+          if (!section) return;
+          const id = section.getAttribute('data-od-id');
+          if (!id || seenSections.has(id)) return;
+          seenSections.add(id);
+          sectionOrder += 1;
+          if (window.__odTrack)
+            window.__odTrack('surface_view', {
+              page_name: 'landing_home',
+              section_id: id,
+              section_index: sectionOrder,
+              locale: (document.documentElement.getAttribute('lang') || 'en').toLowerCase(),
+            });
+        };
+
         if (elements.length === 0) return;
 
         const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         if (reduceMotion || !('IntersectionObserver' in window)) {
-          for (const el of elements) el.dataset.revealed = 'true';
+          for (const el of elements) {
+            el.dataset.revealed = 'true';
+            reportSection(el);
+          }
           return;
         }
 
@@ -410,6 +440,7 @@ const pageHtml = renderToStaticMarkup(
             for (const entry of entries) {
               if (!entry.isIntersecting) continue;
               entry.target.dataset.revealed = 'true';
+              reportSection(entry.target);
               observer.unobserve(entry.target);
             }
           },


### PR DESCRIPTION
## Why

The marketing site only had Google Analytics with a thin set of custom
events (releases/star/discord/issue/blog/tutorial). We want product
analytics in **PostHog** covering all key landing-page behaviors so the
growth team can analyze the funnel. Tracked to the team's existing
PostHog project, following the schema already used in 埋点文档2.0
(the `landing_home_click` convention林芯 set up).

## What users will see

Nothing visible — this is instrumentation only. Under the hood, the
homepage and all sub-pages now load PostHog (alongside the untouched GA)
and emit semantic events:

- `landing_home_click` — one click event keyed by `area` + `element`
  (`download_desktop` / `star_us_on_github` / `join_discord` / `nav_link` /
  `language_switch` / `language_menu` / `carousel_nav` / `faq_open|close` /
  `template_share` / `share_open` / `share_copy` / `contributor`), with
  `platform` on downloads and `locale` on every event.
- `surface_view` — section impression via the existing reveal
  IntersectionObserver (`page_name` / `section_id` / `section_index`).
- `page_view` — semantic landing page load.

Manual events only — `autocapture` and session recording are disabled to
keep the stream curated. Mirrors the existing GA integration exactly
(inline `<head>` script + document-level event delegation, zero client
bundler runtime, graceful skip when no key is set).

## Surface area

- [x] **UI** — adds analytics instrumentation to `apps/landing-page` (no visible UI change; data attribute `data-carousel-dir` added to two carousel buttons)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — n/a to app contracts, but introduces two public env vars `PUBLIC_POSTHOG_KEY` / `PUBLIC_POSTHOG_HOST` (documented in new `.env.example`)
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency** — none; PostHog loads via its CDN snippet, no npm package added
- [ ] **Default behavior change**
- [ ] **None**

A baked-in PostHog **project** key (write-only `phc_` ingestion key, safe to
ship in client HTML) is the default so production tracks out of the box;
`PUBLIC_POSTHOG_KEY` / `PUBLIC_POSTHOG_HOST` override it.

## Screenshots

No visible change. PostHog Live Events (project 420348) receives
`landing_home_click` / `surface_view` / `page_view` on interaction.

## Validation

- `pnpm --filter @open-design/landing-page typecheck` (astro check) — 0 errors
- Playwright with the real key/host + a `posthog.capture` spy: confirmed
  every event fires with correct `event` + `area`/`element`/`platform`/
  `section_id`/`section_index` props for download, star, discord,
  language switch, nav, carousel, FAQ, and section scroll-in.
- Confirmed `disable_session_recording` removes the `$snapshot` stream so
  only the curated semantic events remain.

The new events are also documented in the team's 埋点文档2.0 (rows appended
under `landing_home`).