### PR TITLE
chore: add sensitive path CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Repository governance, CI, release, packaging, and local runtime boundaries.
+/.github/ @nexu-io/core-maintainers
+/scripts/ @nexu-io/core-maintainers
+/tools/pack/ @nexu-io/core-maintainers
+/tools/dev/ @nexu-io/core-maintainers
+/tools/serve/ @nexu-io/core-maintainers
+/apps/packaged/ @nexu-io/core-maintainers
+/apps/desktop/ @nexu-io/core-maintainers
+/packages/platform/ @nexu-io/core-maintainers
+/packages/sidecar/ @nexu-io/core-maintainers
+/packages/sidecar-proto/ @nexu-io/core-maintainers


### PR DESCRIPTION
## Why

This is part of the repository-permission hardening work before the main-history cleanup window. We need a small, explicit owner boundary for governance, CI, release, packaging, and runtime surfaces before enabling code owner review in the default-branch ruleset.

The pain being addressed is that many write+ collaborators can currently provide merge-counting approval, so sensitive repository surfaces need a narrower review gate without disrupting ordinary contribution flow.

## What users will see

No product behavior changes. Maintainers will see code owner review requests when PRs touch sensitive repository paths after code-owner review is enabled in GitHub rulesets.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes repository review routing for sensitive paths once code-owner review is enabled
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A.

## Bug fix verification

N/A.

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm typecheck`
