### PR TITLE
Fix deck comment slide scoping

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -116,12 +116,12 @@ function migrate(db: SqliteDb): void {
       text TEXT NOT NULL,
       position_json TEXT NOT NULL,
       html_hint TEXT NOT NULL,
+      slide_index INTEGER,
       style_json TEXT,
       note TEXT NOT NULL,
       status TEXT NOT NULL,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
-      UNIQUE(project_id, conversation_id, file_path, element_id),
       FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE,
       FOREIGN KEY(conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
     );
@@ -265,6 +265,10 @@ function migrate(db: SqliteDb): void {
   if (!previewCommentCols.some((c: DbRow) => c.name === 'style_json')) {
     db.exec(`ALTER TABLE preview_comments ADD COLUMN style_json TEXT`);
   }
+  if (!previewCommentCols.some((c: DbRow) => c.name === 'slide_index')) {
+    db.exec(`ALTER TABLE preview_comments ADD COLUMN slide_index INTEGER`);
+  }
+  migratePreviewCommentSlideIdentity(db);
   const deploymentCols = db.prepare(`PRAGMA table_info(deployments)`).all() as DbRow[];
   if (!deploymentCols.some((c: DbRow) => c.name === 'status')) {
     db.exec(`ALTER TABLE deployments ADD COLUMN status TEXT NOT NULL DEFAULT 'ready'`);
@@ -293,6 +297,66 @@ function migrate(db: SqliteDb): void {
   migrateCritique(db);
   migrateMediaTasks(db);
   migratePlugins(db);
+}
+
+function migratePreviewCommentSlideIdentity(db: SqliteDb): void {
+  const table = db
+    .prepare(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'preview_comments'`)
+    .get() as { sql?: string } | undefined;
+  const hasLegacyUnique = Boolean(table?.sql?.includes('UNIQUE(project_id, conversation_id, file_path, element_id)'));
+  const hasSlideIdentityIndex = Boolean(db
+    .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'ux_preview_comments_identity'`)
+    .get());
+  if (!hasLegacyUnique && hasSlideIdentityIndex) return;
+
+  db.transaction(() => {
+    db.exec(`
+      DROP TABLE IF EXISTS preview_comments_next;
+
+      CREATE TABLE preview_comments_next (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        conversation_id TEXT NOT NULL,
+        file_path TEXT NOT NULL,
+        element_id TEXT NOT NULL,
+        selector TEXT NOT NULL,
+        label TEXT NOT NULL,
+        text TEXT NOT NULL,
+        position_json TEXT NOT NULL,
+        html_hint TEXT NOT NULL,
+        slide_index INTEGER,
+        selection_kind TEXT,
+        member_count INTEGER,
+        pod_members_json TEXT,
+        style_json TEXT,
+        note TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE,
+        FOREIGN KEY(conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+      );
+
+      INSERT INTO preview_comments_next
+        (id, project_id, conversation_id, file_path, element_id, selector, label,
+         text, position_json, html_hint, slide_index, selection_kind, member_count,
+         pod_members_json, style_json, note, status, created_at, updated_at)
+      SELECT id, project_id, conversation_id, file_path, element_id, selector, label,
+             text, position_json, html_hint, slide_index, selection_kind, member_count,
+             pod_members_json, style_json, note, status, created_at, updated_at
+        FROM preview_comments
+       ORDER BY updated_at DESC;
+
+      DROP TABLE preview_comments;
+      ALTER TABLE preview_comments_next RENAME TO preview_comments;
+
+      CREATE UNIQUE INDEX ux_preview_comments_identity
+        ON preview_comments(project_id, conversation_id, file_path, element_id, COALESCE(slide_index, -1));
+
+      CREATE INDEX idx_preview_comments_conversation
+        ON preview_comments(project_id, conversation_id, updated_at DESC);
+    `);
+  })();
 }
 
 // ---------- deployments ----------
@@ -1070,6 +1134,7 @@ export function listPreviewComments(db: SqliteDb, projectId: string, conversatio
       `SELECT id, project_id AS projectId, conversation_id AS conversationId,
               file_path AS filePath, element_id AS elementId, selector, label,
               text, position_json AS positionJson, html_hint AS htmlHint,
+              slide_index AS slideIndex,
               selection_kind AS selectionKind, member_count AS memberCount,
               pod_members_json AS podMembersJson, style_json AS styleJson,
               note, status, created_at AS createdAt, updated_at AS updatedAt
@@ -1092,6 +1157,9 @@ export function upsertPreviewComment(db: SqliteDb, projectId: string, conversati
   const text = typeof target.text === 'string' ? compactWhitespace(target.text).slice(0, 160) : '';
   const htmlHint = typeof target.htmlHint === 'string' ? compactWhitespace(target.htmlHint).slice(0, 180) : '';
   const position = normalizePosition(target.position);
+  const slideIndex = Number.isFinite(target.slideIndex)
+    ? Math.max(0, Math.round(target.slideIndex))
+    : null;
   const selectionKind = target.selectionKind === 'pod' ? 'pod' : 'element';
   const podMembers = selectionKind === 'pod' ? normalizePodMembers(target.podMembers) : [];
   const style = normalizeAnnotationStyle(target.style);
@@ -1103,35 +1171,33 @@ export function upsertPreviewComment(db: SqliteDb, projectId: string, conversati
           : 0)
     : 0;
   const now = Date.now();
-  const existing = db
-    .prepare(
-      `SELECT id, created_at AS createdAt
-         FROM preview_comments
-        WHERE project_id = ? AND conversation_id = ? AND file_path = ? AND element_id = ?`,
-    )
-    .get(projectId, conversationId, filePath, elementId) as DbRow | undefined;
-  const id = existing?.id ?? randomCommentId();
-  const createdAt = existing?.createdAt ?? now;
-  db.prepare(
+  const id = randomCommentId();
+  const memberCountValue = selectionKind === 'pod' ? memberCount : null;
+  const podMembersValue = selectionKind === 'pod' ? JSON.stringify(podMembers) : null;
+  const styleValue = style ? JSON.stringify(style) : null;
+  const saved = db.prepare(
     `INSERT INTO preview_comments
        (id, project_id, conversation_id, file_path, element_id, selector, label,
-        text, position_json, html_hint, selection_kind, member_count, pod_members_json,
+        text, position_json, html_hint, slide_index, selection_kind, member_count, pod_members_json,
         style_json, note, status, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(project_id, conversation_id, file_path, element_id) DO UPDATE SET
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(project_id, conversation_id, file_path, element_id, COALESCE(slide_index, -1))
+     DO UPDATE SET
        selector = excluded.selector,
        label = excluded.label,
        text = excluded.text,
        position_json = excluded.position_json,
        html_hint = excluded.html_hint,
+       slide_index = excluded.slide_index,
        selection_kind = excluded.selection_kind,
        member_count = excluded.member_count,
        pod_members_json = excluded.pod_members_json,
        style_json = excluded.style_json,
        note = excluded.note,
        status = 'open',
-       updated_at = excluded.updated_at`,
-  ).run(
+       updated_at = excluded.updated_at
+     RETURNING id`,
+  ).get(
     id,
     projectId,
     conversationId,
@@ -1142,16 +1208,17 @@ export function upsertPreviewComment(db: SqliteDb, projectId: string, conversati
     text,
     JSON.stringify(position),
     htmlHint,
+    slideIndex,
     selectionKind,
-    selectionKind === 'pod' ? memberCount : null,
-    selectionKind === 'pod' ? JSON.stringify(podMembers) : null,
-    style ? JSON.stringify(style) : null,
+    memberCountValue,
+    podMembersValue,
+    styleValue,
     note,
     'open',
-    createdAt,
     now,
-  );
-  return getPreviewComment(db, projectId, conversationId, id);
+    now,
+  ) as DbRow | undefined;
+  return getPreviewComment(db, projectId, conversationId, String(saved?.id ?? id));
 }
 
 export function updatePreviewCommentStatus(db: SqliteDb, projectId: string, conversationId: string, id: string, status: string) {
@@ -1181,6 +1248,7 @@ function getPreviewComment(db: SqliteDb, projectId: string, conversationId: stri
       `SELECT id, project_id AS projectId, conversation_id AS conversationId,
               file_path AS filePath, element_id AS elementId, selector, label,
               text, position_json AS positionJson, html_hint AS htmlHint,
+              slide_index AS slideIndex,
               selection_kind AS selectionKind, member_count AS memberCount,
               pod_members_json AS podMembersJson, style_json AS styleJson,
               note, status, created_at AS createdAt, updated_at AS updatedAt
@@ -1205,6 +1273,7 @@ function normalizePreviewComment(row: DbRow) {
     text: row.text,
     position: parseJsonOrUndef(row.positionJson) ?? { x: 0, y: 0, width: 0, height: 0 },
     htmlHint: row.htmlHint,
+    ...(Number.isFinite(row.slideIndex) ? { slideIndex: Math.max(0, Math.round(row.slideIndex)) } : {}),
     style: normalizeAnnotationStyle(parseJsonOrUndef(row.styleJson)),
     selectionKind: row.selectionKind === 'pod' ? 'pod' : 'element',
     memberCount:

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -830,6 +830,9 @@ export function normalizeCommentAttachments(input) {
       if (selectionKind !== 'visual' && !selector) return null;
       if (selectionKind === 'visual' && !screenshotPath) return null;
       const podMembers = selectionKind === 'pod' ? normalizeAttachmentPodMembers(raw.podMembers) : [];
+      const slideIndex = Number.isFinite(raw.slideIndex)
+        ? Math.max(0, Math.round(raw.slideIndex))
+        : undefined;
       const memberCount =
         selectionKind === 'pod'
           ? (podMembers.length > 0
@@ -851,6 +854,7 @@ export function normalizeCommentAttachments(input) {
         currentText: compactString(raw.currentText, 160),
         pagePosition: normalizeAttachmentPosition(raw.pagePosition),
         htmlHint: compactString(raw.htmlHint, 180),
+        slideIndex,
         style: normalizeAnnotationStyle(raw.style),
         selectionKind,
         memberCount,
@@ -885,6 +889,7 @@ export function renderCommentAttachmentHint(commentAttachments) {
       `file: ${item.filePath}`,
       `label: ${item.label || '(unlabeled)'}`,
       `position: ${formatAttachmentPosition(item.pagePosition)}`,
+      ...(Number.isFinite(item.slideIndex) ? [`slideIndex: ${item.slideIndex}`] : []),
       `currentText: ${item.currentText || '(empty)'}`,
       `htmlHint: ${item.htmlHint || '(none)'}`,
       `computedStyle: ${formatAnnotationStyle(item.style) || '(none)'}`,

--- a/apps/daemon/tests/comment-attachments.test.ts
+++ b/apps/daemon/tests/comment-attachments.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import Database from 'better-sqlite3';
 import {
   closeDatabase,
   deleteConversation,
@@ -49,11 +50,107 @@ describe('preview comment persistence', () => {
     const critiqueTable = db
       .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='critique_runs'`)
       .get() as { name?: string } | undefined;
+    const identityIndex = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type='index' AND name='ux_preview_comments_identity'`)
+      .get() as { sql?: string } | undefined;
 
     expect(tableColumnNames(previewColumns)).toEqual(
-      expect.arrayContaining(['selection_kind', 'member_count', 'pod_members_json']),
+      expect.arrayContaining(['selection_kind', 'member_count', 'pod_members_json', 'slide_index']),
     );
     expect(critiqueTable?.name).toBe('critique_runs');
+    expect(identityIndex?.sql).toContain('COALESCE(slide_index, -1)');
+  });
+
+  it('migrates the legacy preview comment unique key to include slide scope', () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-comments-'));
+    const odDir = path.join(tempDir, '.od');
+    fs.mkdirSync(odDir, { recursive: true });
+    const legacy = new Database(path.join(odDir, 'app.sqlite'));
+    legacy.exec(`
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        skill_id TEXT,
+        design_system_id TEXT,
+        pending_prompt TEXT,
+        metadata_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE conversations (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        title TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+      );
+      CREATE TABLE preview_comments (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        conversation_id TEXT NOT NULL,
+        file_path TEXT NOT NULL,
+        element_id TEXT NOT NULL,
+        selector TEXT NOT NULL,
+        label TEXT NOT NULL,
+        text TEXT NOT NULL,
+        position_json TEXT NOT NULL,
+        html_hint TEXT NOT NULL,
+        note TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        UNIQUE(project_id, conversation_id, file_path, element_id),
+        FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE,
+        FOREIGN KEY(conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+      );
+      INSERT INTO projects (id, name, created_at, updated_at)
+      VALUES ('project-1', 'Project', 1, 1);
+      INSERT INTO conversations (id, project_id, title, created_at, updated_at)
+      VALUES ('conversation-1', 'project-1', 'Chat', 1, 1);
+      INSERT INTO preview_comments
+        (id, project_id, conversation_id, file_path, element_id, selector, label,
+         text, position_json, html_hint, note, status, created_at, updated_at)
+      VALUES
+        ('legacy-comment', 'project-1', 'conversation-1', 'index.html', 'hero-title',
+         '[data-od-id="hero-title"]', 'Hero title', 'Hero title',
+         '{"x":10,"y":20,"width":300,"height":80}', '<h1 data-od-id="hero-title">',
+         'Legacy note', 'open', 1, 1);
+    `);
+    legacy.close();
+
+    const db = openDatabase(tempDir);
+    const table = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='preview_comments'`)
+      .get() as { sql?: string } | undefined;
+    const identityIndex = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type='index' AND name='ux_preview_comments_identity'`)
+      .get() as { sql?: string } | undefined;
+    const comments = listPreviewComments(db, 'project-1', 'conversation-1');
+
+    expect(table?.sql).not.toContain('UNIQUE(project_id, conversation_id, file_path, element_id)');
+    expect(identityIndex?.sql).toContain('COALESCE(slide_index, -1)');
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.id).toBe('legacy-comment');
+    expect(comments[0]?.note).toBe('Legacy note');
+    expect(comments[0]?.slideIndex).toBeUndefined();
+
+    const scoped = upsertPreviewComment(db, 'project-1', 'conversation-1', {
+      target: target({ elementId: 'hero-title', slideIndex: 1 }),
+      note: 'New scoped note',
+    });
+
+    expect(scoped?.id).not.toBe('legacy-comment');
+    const afterScopedSave = listPreviewComments(db, 'project-1', 'conversation-1');
+    expect(afterScopedSave).toHaveLength(2);
+    expect(afterScopedSave.find((comment) => comment.id === 'legacy-comment')).toMatchObject({
+      note: 'Legacy note',
+    });
+    expect(afterScopedSave.find((comment) => comment.id === 'legacy-comment')?.slideIndex).toBeUndefined();
+    expect(afterScopedSave.find((comment) => comment.id === scoped?.id)).toMatchObject({
+      note: 'New scoped note',
+      slideIndex: 1,
+    });
   });
 
   it('upserts the latest comment by conversation, file, and element', () => {
@@ -73,6 +170,110 @@ describe('preview comment persistence', () => {
     expect(second.id).toBe(first.id);
     expect(second.note).toBe('Make it more specific');
     expect(second.text).toBe('New title');
+    expect(listPreviewComments(db, 'project-1', 'conversation-1')).toHaveLength(1);
+  });
+
+  it('persists the deck slide index with preview comments', () => {
+    const db = seededDb();
+    const saved = upsertPreviewComment(db, 'project-1', 'conversation-1', {
+      target: target({ elementId: 'pin-slide-one', slideIndex: 1 }),
+      note: 'Fix this slide',
+    });
+
+    expect(saved?.slideIndex).toBe(1);
+    expect(listPreviewComments(db, 'project-1', 'conversation-1')[0]?.slideIndex).toBe(1);
+  });
+
+  it('keeps comments for the same deck element on different slides', () => {
+    const db = seededDb();
+    const first = upsertPreviewComment(db, 'project-1', 'conversation-1', {
+      target: target({ elementId: 'shared-title', slideIndex: 0 }),
+      note: 'Fix slide one',
+    });
+    const second = upsertPreviewComment(db, 'project-1', 'conversation-1', {
+      target: target({ elementId: 'shared-title', slideIndex: 1 }),
+      note: 'Fix slide two',
+    });
+    const secondUpdated = upsertPreviewComment(db, 'project-1', 'conversation-1', {
+      target: target({ elementId: 'shared-title', slideIndex: 1, text: 'Updated title' }),
+      note: 'Update only slide two',
+    });
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(secondUpdated).not.toBeNull();
+    if (!first || !second || !secondUpdated) throw new Error('comment upsert failed');
+    expect(second.id).not.toBe(first.id);
+    expect(secondUpdated.id).toBe(second.id);
+    expect(secondUpdated.note).toBe('Update only slide two');
+    expect(listPreviewComments(db, 'project-1', 'conversation-1')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: first.id, slideIndex: 0, note: 'Fix slide one' }),
+        expect.objectContaining({ id: second.id, slideIndex: 1, note: 'Update only slide two' }),
+      ]),
+    );
+    expect(listPreviewComments(db, 'project-1', 'conversation-1')).toHaveLength(2);
+  });
+
+  it('does not expose a stale lookup before inserting duplicate slide-scoped comments', () => {
+    const db = seededDb();
+    const originalPrepare = db.prepare.bind(db);
+    const duplicateSlideIndex = 2;
+    const duplicateTarget = target({ elementId: 'shared-title', slideIndex: duplicateSlideIndex });
+    let injectedDuplicate = false;
+
+    (db as unknown as { prepare: typeof db.prepare }).prepare = ((source: string) => {
+      const statement = originalPrepare(source);
+      if (
+        source.includes('INSERT INTO preview_comments') &&
+        source.includes('ON CONFLICT(project_id, conversation_id, file_path, element_id, COALESCE(slide_index, -1))')
+      ) {
+        const originalGet = statement.get.bind(statement);
+        statement.get = (...args: unknown[]) => {
+          if (!injectedDuplicate) {
+            injectedDuplicate = true;
+            originalPrepare(
+              `INSERT INTO preview_comments
+                 (id, project_id, conversation_id, file_path, element_id, selector, label,
+                  text, position_json, html_hint, slide_index, selection_kind, member_count,
+                  pod_members_json, style_json, note, status, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            ).run(
+              'competing-comment',
+              'project-1',
+              'conversation-1',
+              duplicateTarget.filePath,
+              duplicateTarget.elementId,
+              duplicateTarget.selector,
+              duplicateTarget.label,
+              duplicateTarget.text,
+              JSON.stringify(duplicateTarget.position),
+              duplicateTarget.htmlHint,
+              duplicateSlideIndex,
+              'element',
+              null,
+              null,
+              null,
+              'Competing note',
+              'open',
+              1,
+              1,
+            );
+          }
+          return originalGet(...args);
+        };
+      }
+      return statement;
+    }) as typeof db.prepare;
+
+    const saved = upsertPreviewComment(db, 'project-1', 'conversation-1', {
+      target: duplicateTarget,
+      note: 'Latest note',
+    });
+
+    expect(injectedDuplicate).toBe(true);
+    expect(saved?.note).toBe('Latest note');
+    expect(saved?.slideIndex).toBe(2);
     expect(listPreviewComments(db, 'project-1', 'conversation-1')).toHaveLength(1);
   });
 
@@ -156,6 +357,7 @@ describe('preview comment agent payload', () => {
     const normalized = normalizeCommentAttachments([
       commentAttachment({
         id: 'c1',
+        slideIndex: 2,
         comment: 'Make the headline shorter',
         currentText: 'A very long headline '.repeat(20),
         htmlHint: `<h1>${'x'.repeat(240)}</h1>`,
@@ -169,6 +371,7 @@ describe('preview comment agent payload', () => {
     expect(normalized[0]?.htmlHint.length).toBeLessThanOrEqual(180);
     expect(hint).toContain('<attached-preview-comments>');
     expect(hint).toContain('file: index.html');
+    expect(hint).toContain('slideIndex: 2');
     expect(hint).toContain('selector: [data-od-id="hero-title"]');
     expect(hint).toContain('comment: Make the headline shorter');
   });

--- a/apps/web/src/comments.ts
+++ b/apps/web/src/comments.ts
@@ -19,6 +19,7 @@ export interface PreviewCommentSnapshot {
   position: { x: number; y: number; width: number; height: number };
   hoverPoint?: { x: number; y: number };
   htmlHint: string;
+  slideIndex?: number;
   style?: PreviewAnnotationStyle;
   selectionKind?: PreviewCommentSelectionKind;
   memberCount?: number;
@@ -40,6 +41,7 @@ export interface VisualAnnotationTarget {
   text?: string;
   position?: { x: number; y: number; width: number; height: number };
   htmlHint?: string;
+  slideIndex?: number;
   style?: PreviewAnnotationStyle;
 }
 
@@ -76,6 +78,7 @@ export function commentTargetDisplayName(
 
 export function targetFromSnapshot(snapshot: PreviewCommentSnapshot): PreviewCommentTarget {
   const podMembers = normalizeMembers(snapshot.podMembers);
+  const slideIndex = normalizeSlideIndex(snapshot.slideIndex);
   return {
     filePath: snapshot.filePath,
     elementId: snapshot.elementId,
@@ -84,6 +87,7 @@ export function targetFromSnapshot(snapshot: PreviewCommentSnapshot): PreviewCom
     text: trimContextText(snapshot.text),
     position: normalizePosition(snapshot.position),
     htmlHint: trimHtmlHint(snapshot.htmlHint),
+    ...(slideIndex !== undefined ? { slideIndex } : {}),
     style: normalizeStyle(snapshot.style),
     selectionKind: snapshot.selectionKind === 'pod' ? 'pod' : 'element',
     memberCount:
@@ -116,10 +120,13 @@ export function overlayBoundsFromSnapshot(
 export function liveSnapshotForComment(
   comment: PreviewComment,
   snapshots: Map<string, PreviewCommentSnapshot>,
+  options: { targetsHydrated?: boolean } = {},
 ): PreviewCommentSnapshot | null {
   const snapshot = snapshots.get(comment.elementId);
   if (snapshot && snapshot.filePath === comment.filePath) return snapshot;
-  if (!comment.elementId.startsWith('pin-')) return null;
+  const slideIndex = normalizeSlideIndex(comment.slideIndex);
+  if (!comment.elementId.startsWith('pin-') && slideIndex === undefined) return null;
+  if (!comment.elementId.startsWith('pin-') && (options.targetsHydrated || snapshots.size > 0)) return null;
   return {
     filePath: comment.filePath,
     elementId: comment.elementId,
@@ -128,6 +135,7 @@ export function liveSnapshotForComment(
     text: trimContextText(comment.text),
     position: normalizePosition(comment.position),
     htmlHint: trimHtmlHint(comment.htmlHint),
+    ...(slideIndex !== undefined ? { slideIndex } : {}),
     style: normalizeStyle(comment.style),
     selectionKind: comment.selectionKind === 'pod' ? 'pod' : 'element',
     memberCount: comment.memberCount,
@@ -140,6 +148,7 @@ export function commentToAttachment(
   order: number,
 ): ChatCommentAttachment {
   const podMembers = normalizeMembers(comment.podMembers);
+  const slideIndex = normalizeSlideIndex(comment.slideIndex);
   return {
     id: comment.id,
     order,
@@ -151,6 +160,7 @@ export function commentToAttachment(
     currentText: trimContextText(comment.text),
     pagePosition: normalizePosition(comment.position),
     htmlHint: trimHtmlHint(comment.htmlHint),
+    ...(slideIndex !== undefined ? { slideIndex } : {}),
     style: normalizeStyle(comment.style),
     selectionKind: comment.selectionKind === 'pod' ? 'pod' : 'element',
     memberCount:
@@ -176,6 +186,7 @@ export function buildBoardCommentAttachments(input: {
 }): ChatCommentAttachment[] {
   const podMembers = normalizeMembers(input.target.podMembers);
   const selectionKind = input.target.selectionKind === 'pod' ? 'pod' : 'element';
+  const slideIndex = normalizeSlideIndex(input.target.slideIndex);
   const memberCount =
     selectionKind === 'pod'
       ? (podMembers.length > 0
@@ -198,6 +209,7 @@ export function buildBoardCommentAttachments(input: {
       currentText: trimContextText(input.target.text),
       pagePosition: normalizePosition(input.target.position),
       htmlHint: trimHtmlHint(input.target.htmlHint),
+      ...(slideIndex !== undefined ? { slideIndex } : {}),
       style: normalizeStyle(input.target.style),
       selectionKind,
       memberCount,
@@ -208,6 +220,7 @@ export function buildBoardCommentAttachments(input: {
 
 export function buildVisualAnnotationAttachment(input: VisualAnnotationAttachmentInput): ChatCommentAttachment {
   const target = input.target ?? null;
+  const slideIndex = normalizeSlideIndex(target?.slideIndex);
   const intent = visualAnnotationIntent(input.markKind);
   const visualId = sanitizeVisualAttachmentId(input.idSeed || input.screenshotPath || String(input.order));
   const elementId = target?.elementId?.trim() || `visual-mark-${visualId}`;
@@ -224,6 +237,7 @@ export function buildVisualAnnotationAttachment(input: VisualAnnotationAttachmen
     currentText: trimContextText(target?.text || ''),
     pagePosition: normalizePosition(target?.position ?? input.bounds),
     htmlHint: trimHtmlHint(target?.htmlHint || ''),
+    ...(slideIndex !== undefined ? { slideIndex } : {}),
     style: normalizeStyle(target?.style),
     selectionKind: 'visual',
     screenshotPath: input.screenshotPath,
@@ -312,6 +326,7 @@ function renderCommentAttachmentContext(commentAttachments: ChatCommentAttachmen
   ];
   commentAttachments.forEach((item) => {
     const position = normalizePosition(item.pagePosition);
+    const slideIndex = normalizeSlideIndex(item.slideIndex);
     const selectionKind =
       item.selectionKind === 'visual' ? 'visual' : item.selectionKind === 'pod' ? 'pod' : 'element';
     lines.push(
@@ -321,6 +336,7 @@ function renderCommentAttachmentContext(commentAttachments: ChatCommentAttachmen
       `file: ${item.filePath}`,
       `label: ${item.label || '(unlabeled)'}`,
       `position: x${position.x} y${position.y} ${position.width}x${position.height}`,
+      ...(slideIndex !== undefined ? [`slideIndex: ${slideIndex}`] : []),
       `currentText: ${trimContextText(item.currentText || '') || '(empty)'}`,
       `htmlHint: ${trimHtmlHint(item.htmlHint || '') || '(none)'}`,
       `computedStyle: ${formatAnnotationStyle(item.style) || '(none)'}`,
@@ -372,6 +388,11 @@ function normalizePosition(input: PreviewComment['position']): PreviewComment['p
 
 function finite(value: number | undefined): number {
   return Number.isFinite(value) ? Math.round(value as number) : 0;
+}
+
+function normalizeSlideIndex(value: unknown): number | undefined {
+  if (!Number.isFinite(value)) return undefined;
+  return Math.max(0, Math.round(value as number));
 }
 
 function normalizeMembers(input: PreviewCommentMember[] | undefined): PreviewCommentMember[] {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -2107,7 +2107,8 @@ export function CommentSidePanel({
   const selectedCount = visibleSelectedIds.size;
   const allSelected = comments.length > 0 && selectedCount === comments.length;
   const commentsLabel = t('chat.tabComments');
-  const canCreateComment = Boolean(onCreateComment) && newCommentDraft.trim().length > 0 && !sending && !sendDisabled;
+  const busyOrBlocked = sending || sendDisabled;
+  const canCreateComment = Boolean(onCreateComment) && newCommentDraft.trim().length > 0 && !busyOrBlocked;
   const submitNewComment = async () => {
     if (!onCreateComment || !newCommentDraft.trim()) return;
     const saved = await onCreateComment(newCommentDraft.trim());
@@ -2216,7 +2217,7 @@ export function CommentSidePanel({
             type="button"
             className="primary"
             data-testid="comment-side-send-claude"
-            disabled={sending || sendDisabled}
+            disabled={busyOrBlocked}
             onClick={() => void onSendSelected()}
           >
             {sending
@@ -2998,6 +2999,7 @@ export function applyInspectOverridesToSource(source: string, css: string): stri
 function CommentPreviewOverlays({
   comments,
   liveTargets,
+  liveTargetsHydrated,
   hoveredTarget,
   hoveredPodMemberId,
   activeTarget,
@@ -3011,6 +3013,7 @@ function CommentPreviewOverlays({
 }: {
   comments: PreviewComment[];
   liveTargets: Map<string, PreviewCommentSnapshot>;
+  liveTargetsHydrated: boolean;
   hoveredTarget: PreviewCommentSnapshot | null;
   hoveredPodMemberId: string | null;
   activeTarget: PreviewCommentSnapshot | null;
@@ -3027,7 +3030,7 @@ function CommentPreviewOverlays({
     .map((comment, index) => ({
       comment,
       index,
-      snapshot: liveSnapshotForComment(comment, liveTargets),
+      snapshot: liveSnapshotForComment(comment, liveTargets, { targetsHydrated: liveTargetsHydrated }),
     }))
     .filter((item): item is { comment: PreviewComment; index: number; snapshot: PreviewCommentSnapshot } =>
       Boolean(item.snapshot),
@@ -3487,6 +3490,61 @@ function clampBridgeCoordinate(value: unknown): number {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return 0;
   return Math.max(-MAX_BRIDGE_COORDINATE, Math.min(MAX_BRIDGE_COORDINATE, Math.round(numeric)));
+}
+
+function previewCommentVisibleOnSlide(
+  comment: PreviewComment,
+  isDeck: boolean,
+  slideState: SlideState | null,
+): boolean {
+  if (!isDeck) return true;
+  if (!Number.isFinite(comment.slideIndex)) return true;
+  const activeSlideIndex = slideState?.active ?? 0;
+  const commentSlideIndex = Math.max(0, Math.round(comment.slideIndex as number));
+  return commentSlideIndex === activeSlideIndex;
+}
+
+function previewCommentMatchesActiveSlide(
+  comment: PreviewComment,
+  isDeck: boolean,
+  slideState: SlideState | null,
+): boolean {
+  if (!isDeck) return true;
+  if (!Number.isFinite(comment.slideIndex)) return false;
+  const activeSlideIndex = slideState?.active ?? 0;
+  const commentSlideIndex = Math.max(0, Math.round(comment.slideIndex as number));
+  return commentSlideIndex === activeSlideIndex;
+}
+
+function previewCommentEditableFromTarget(
+  comment: PreviewComment,
+  isDeck: boolean,
+  slideState: SlideState | null,
+): boolean {
+  if (!isDeck) return true;
+  if (!Number.isFinite(comment.slideIndex)) return true;
+  return previewCommentMatchesActiveSlide(comment, isDeck, slideState);
+}
+
+function snapshotForCommentEdit(
+  comment: PreviewComment,
+  snapshot: PreviewCommentSnapshot,
+): PreviewCommentSnapshot {
+  if (Number.isFinite(comment.slideIndex)) return snapshot;
+  const { slideIndex: _slideIndex, ...unscopedSnapshot } = snapshot;
+  return unscopedSnapshot;
+}
+
+function snapshotForCommentTargetRefresh(
+  current: PreviewCommentSnapshot,
+  next: PreviewCommentSnapshot,
+  preserveUnscopedEdit: boolean,
+): PreviewCommentSnapshot {
+  if (current.elementId !== next.elementId) return next;
+  if (!preserveUnscopedEdit) return next;
+  if (Number.isFinite(current.slideIndex)) return next;
+  const { slideIndex: _slideIndex, ...unscopedSnapshot } = next;
+  return unscopedSnapshot;
 }
 
 // Shown instead of the React runtime when a .jsx/.tsx is a module loaded by a
@@ -4299,6 +4357,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
   useEffect(() => cancelHoverCardDismiss, [cancelHoverCardDismiss]);
   const [activePreviewCommentId, setActivePreviewCommentId] = useState<string | null>(null);
   const [liveCommentTargets, setLiveCommentTargets] = useState<Map<string, PreviewCommentSnapshot>>(() => new Map());
+  const [liveCommentTargetsHydrated, setLiveCommentTargetsHydrated] = useState(false);
   const liveCommentTargetsRef = useRef(liveCommentTargets);
   const [commentDraft, setCommentDraft] = useState('');
   // Inspect mode shares the iframe selection bridge with comment mode but
@@ -4535,6 +4594,9 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     return /class\s*=\s*['"][^'"]*\bslide\b/i.test(source);
   }, [source]);
   const effectiveDeck = isDeck || looksLikeDeck;
+  const currentCommentSlideIndex = effectiveDeck
+    ? (slideState?.active ?? htmlPreviewSlideState.get(previewStateKey)?.active ?? 0)
+    : undefined;
   const livePreviewSource = inlinedSource ?? source;
   // Freeze the iframe input on the snapshot taken at Edit-mode entry. Any
   // source rewrite during edit (1.5s debounced set-style patches) stays
@@ -4930,6 +4992,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
   useEffect(() => {
     if (!inspectMode && !boardMode) {
       setLiveCommentTargets((current) => (current.size > 0 ? new Map() : current));
+      setLiveCommentTargetsHydrated(false);
       return;
     }
     function onMessage(ev: MessageEvent) {
@@ -4958,21 +5021,24 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
             height: clampBridgeCoordinate(item?.position?.height),
           },
           htmlHint: String(item?.htmlHint || ''),
+          ...(currentCommentSlideIndex !== undefined ? { slideIndex: currentCommentSlideIndex } : {}),
           style: normalizeAnnotationStyle(item?.style),
           selectionKind: 'element',
           memberCount: undefined,
         });
       });
       setLiveCommentTargets(next);
+      setLiveCommentTargetsHydrated(true);
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [inspectMode, boardMode, file.name, isOurPreviewIframeSource]);
+  }, [currentCommentSlideIndex, inspectMode, boardMode, file.name, isOurPreviewIframeSource]);
 
   useEffect(() => {
     setActiveCommentTarget(null);
     setHoveredCommentTarget(null);
     setLiveCommentTargets(new Map());
+    setLiveCommentTargetsHydrated(false);
     setCommentDraft('');
     setActiveInspectTarget(null);
     setInspectOverrides({});
@@ -5043,6 +5109,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
       setHoveredCommentTarget((current) => (current ? null : current));
       setActivePreviewCommentId((current) => (current ? null : current));
       setLiveCommentTargets((current) => (current.size > 0 ? new Map() : current));
+      setLiveCommentTargetsHydrated(false);
       setQueuedBoardNotes((current) => (current.length > 0 ? [] : current));
       setStrokePoints((current) => (current.length > 0 ? [] : current));
       return;
@@ -5066,11 +5133,17 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
           }
         : undefined,
       htmlHint: String(data.htmlHint || ''),
+      ...(currentCommentSlideIndex !== undefined ? { slideIndex: currentCommentSlideIndex } : {}),
       style: normalizeAnnotationStyle(data.style),
       selectionKind: data.selectionKind === 'pod' ? 'pod' : 'element',
       memberCount: finiteBridgeInteger(data.memberCount),
       podMembers: Array.isArray(data.podMembers) ? data.podMembers : undefined,
     });
+    const preserveUnscopedCommentEdit = activePreviewCommentId
+      ? previewComments.some((comment) => (
+          comment.id === activePreviewCommentId && !Number.isFinite(comment.slideIndex)
+        ))
+      : false;
     function onMessage(ev: MessageEvent) {
       if (!isOurPreviewIframeSource(ev.source)) return;
       const data = ev.data as (Partial<PreviewCommentSnapshot> & {
@@ -5086,20 +5159,21 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
           if (snapshot.elementId) next.set(snapshot.elementId, snapshot);
         });
         setLiveCommentTargets(next);
-        setActiveCommentTarget((current) => (
-          current
-            ? current.selectionKind === 'pod'
-              ? current
-              : next.get(current.elementId) ?? current
-            : null
-        ));
-        setHoveredCommentTarget((current) => (
-          current
-            ? current.selectionKind === 'pod'
-              ? current
-              : next.get(current.elementId) ?? null
-            : null
-        ));
+        setLiveCommentTargetsHydrated(true);
+        setActiveCommentTarget((current) => {
+          if (!current || current.selectionKind === 'pod') return current;
+          const refreshed = next.get(current.elementId);
+          return refreshed
+            ? snapshotForCommentTargetRefresh(current, refreshed, preserveUnscopedCommentEdit)
+            : current;
+        });
+        setHoveredCommentTarget((current) => {
+          if (!current || current.selectionKind === 'pod') return current;
+          const refreshed = next.get(current.elementId);
+          return refreshed
+            ? snapshotForCommentTargetRefresh(current, refreshed, preserveUnscopedCommentEdit)
+            : null;
+        });
         return;
       }
       if (data.type === 'od:comment-active-target-update') {
@@ -5107,10 +5181,14 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         if (!snapshot.elementId) return;
         setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
         setActiveCommentTarget((current) => (
-          current && current.elementId === snapshot.elementId ? snapshot : current
+          current && current.elementId === snapshot.elementId
+            ? snapshotForCommentTargetRefresh(current, snapshot, preserveUnscopedCommentEdit)
+            : current
         ));
         setHoveredCommentTarget((current) => (
-          current && current.elementId === snapshot.elementId ? snapshot : current
+          current && current.elementId === snapshot.elementId
+            ? snapshotForCommentTargetRefresh(current, snapshot, preserveUnscopedCommentEdit)
+            : current
         ));
         return;
       }
@@ -5138,14 +5216,23 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
       if (data.type === 'od:comment-target') {
         const snapshot = snapshotFromData(data);
         if (!snapshot.elementId) return;
+        const existing = commentCreateMode
+          ? previewComments.find((comment) =>
+              comment.filePath === file.name &&
+              comment.status === 'open' &&
+              previewCommentEditableFromTarget(comment, effectiveDeck, slideState) &&
+              comment.elementId === snapshot.elementId,
+            )
+          : undefined;
         const shouldOpenComposer = boardMode || commentCreateMode;
+        const activeTarget = existing ? snapshotForCommentEdit(existing, snapshot) : snapshot;
         cancelHoverCardDismiss();
-        setActiveCommentTarget((current) => (shouldOpenComposer ? snapshot : current));
+        setActiveCommentTarget((current) => (shouldOpenComposer ? activeTarget : current));
         setHoveredCommentTarget(snapshot);
         setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
         if (shouldOpenComposer) {
-          setActivePreviewCommentId(null);
-          setCommentDraft('');
+          setActivePreviewCommentId(existing?.id ?? null);
+          setCommentDraft(existing?.note ?? '');
           setQueuedBoardNotes([]);
         }
         return;
@@ -5178,8 +5265,11 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
           setStrokePoints([]);
           return;
         }
-        setActiveCommentTarget(nextTarget);
-        setHoveredCommentTarget(nextTarget);
+        const deckScopedTarget = currentCommentSlideIndex !== undefined
+          ? { ...nextTarget, slideIndex: currentCommentSlideIndex }
+          : nextTarget;
+        setActiveCommentTarget(deckScopedTarget);
+        setHoveredCommentTarget(deckScopedTarget);
         setActivePreviewCommentId(null);
         setQueuedBoardNotes([]);
         setCommentDraft('');
@@ -5188,7 +5278,22 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [activeCommentTarget, boardMode, boardTool, cancelHoverCardDismiss, commentPortalHost, file.name, isOurPreviewIframeSource, previewComments, scheduleHoverCardDismiss]);
+  }, [
+    activeCommentTarget,
+    activePreviewCommentId,
+    boardMode,
+    boardTool,
+    cancelHoverCardDismiss,
+    commentPortalHost,
+    commentCreateMode,
+    currentCommentSlideIndex,
+    effectiveDeck,
+    file.name,
+    isOurPreviewIframeSource,
+    previewComments,
+    scheduleHoverCardDismiss,
+    slideState,
+  ]);
 
   useEffect(() => {
     if (!boardMode || !activeCommentTarget || activeCommentTarget.selectionKind === 'pod') return;
@@ -6076,6 +6181,13 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     setStrokePoints([]);
   }
 
+  useEffect(() => {
+    if (!effectiveDeck) return;
+    clearBoardComposer();
+    setLiveCommentTargets(new Map());
+    setLiveCommentTargetsHydrated(false);
+  }, [currentCommentSlideIndex, effectiveDeck]);
+
   function closeArtifactToolMenus() {
     setAgentToolsOpen(false);
   }
@@ -6253,6 +6365,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
           text: '',
           position: { x: 0, y: 0, width: 0, height: 0 },
           htmlHint: '',
+          ...(currentCommentSlideIndex !== undefined ? { slideIndex: currentCommentSlideIndex } : {}),
           selectionKind: 'element',
         };
     setSendingBoardBatch(true);
@@ -6291,9 +6404,13 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
   };
   const visibleSideComments = useMemo(
     () => previewComments
-      .filter((comment) => comment.filePath === file.name && comment.status === 'open')
+      .filter((comment) =>
+        comment.filePath === file.name &&
+        comment.status === 'open' &&
+        previewCommentVisibleOnSlide(comment, effectiveDeck, slideState)
+      )
       .sort((a, b) => commentActivityAt(b) - commentActivityAt(a)),
-    [file.name, previewComments],
+    [effectiveDeck, file.name, previewComments, slideState],
   );
   const activeSideCommentId = activePreviewCommentId;
   const activeCommentTargetVisible = commentTargetIntersectsPreview(
@@ -6551,13 +6668,15 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
           text: comment.text,
           position: comment.position,
           htmlHint: comment.htmlHint,
+          ...(Number.isFinite(comment.slideIndex) ? { slideIndex: comment.slideIndex } : {}),
           style: comment.style,
           selectionKind: comment.selectionKind ?? 'element',
           memberCount: comment.memberCount,
           podMembers: comment.podMembers,
         };
-        setActiveCommentTarget(snapshot);
-        setHoveredCommentTarget(snapshot);
+        const editSnapshot = snapshotForCommentEdit(comment, snapshot);
+        setActiveCommentTarget(editSnapshot);
+        setHoveredCommentTarget(editSnapshot);
         setActivePreviewCommentId(comment.id);
         setCommentDraft(comment.note);
         setQueuedBoardNotes([]);
@@ -7190,6 +7309,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
               <CommentPreviewOverlays
                 comments={commentCreateMode ? visibleSideComments : []}
                 liveTargets={liveCommentTargets}
+                liveTargetsHydrated={liveCommentTargetsHydrated}
                 hoveredTarget={hoveredCommentTarget}
                 hoveredPodMemberId={hoveredPodMemberId}
                 activeTarget={activeCommentTarget}
@@ -7200,12 +7320,13 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
                 offsetY={overlayPreviewTransform.offsetY}
                 strokePoints={strokePoints}
                 onOpenComment={(comment, snapshot) => {
+                  const editSnapshot = snapshotForCommentEdit(comment, snapshot);
                   setCommentPanelOpen(true);
                   setCommentSidePanelCollapsed(false);
                   setCommentCreateMode(true);
                   setBoardMode(true);
-                  setActiveCommentTarget(snapshot);
-                  setHoveredCommentTarget(snapshot);
+                  setActiveCommentTarget(editSnapshot);
+                  setHoveredCommentTarget(editSnapshot);
                   setActivePreviewCommentId(comment.id);
                   setCommentDraft(comment.note);
                   setQueuedBoardNotes([]);

--- a/apps/web/tests/comments.test.ts
+++ b/apps/web/tests/comments.test.ts
@@ -204,7 +204,7 @@ describe('preview comment attachment helpers', () => {
     });
   });
 
-  it('only resolves saved markers from live snapshots for the same file', () => {
+  it('only uses live saved marker snapshots for the same file', () => {
     const saved = comment({ filePath: 'index.html', elementId: 'hero-title' });
     const snapshots = new Map([
       ['hero-title', {
@@ -219,26 +219,91 @@ describe('preview comment attachment helpers', () => {
     ]);
 
     expect(liveSnapshotForComment(saved, snapshots)?.elementId).toBe('hero-title');
-    expect(liveSnapshotForComment(comment({ filePath: 'other.html' }), snapshots)).toBeNull();
+    expect(liveSnapshotForComment(comment({
+      filePath: 'other.html',
+      elementId: 'hero-title',
+      position: { x: 8, y: 9, width: 10, height: 11 },
+    }), snapshots)).toBeNull();
   });
 
-  it('rehydrates saved free-pin markers from persisted comment position after iframe reload', () => {
+  it('hides ordinary element comments when the iframe no longer reports their target', () => {
     const saved = comment({
-      elementId: 'pin-abc123',
-      selector: '[data-od-pin="pin-abc123"]',
-      label: 'pin',
-      text: '',
-      htmlHint: '',
+      elementId: 'hero-title',
+      selector: '[data-od-id="hero-title"]',
+      label: 'Hero title',
+      text: 'Hero title',
+      htmlHint: '<h1 data-od-id="hero-title">Hero title</h1>',
       position: { x: 88, y: 144, width: 24, height: 24 },
     });
 
-    expect(liveSnapshotForComment(saved, new Map())).toMatchObject({
-      filePath: 'index.html',
-      elementId: 'pin-abc123',
-      selector: '[data-od-pin="pin-abc123"]',
-      label: 'pin',
+    expect(liveSnapshotForComment(saved, new Map())).toBeNull();
+  });
+
+  it('rehydrates free pins and deck-scoped saved markers from persisted positions', () => {
+    const pin = comment({
+      elementId: 'pin-hero',
+      selector: '[data-od-pin="pin-hero"]',
+      label: 'Pin',
       position: { x: 88, y: 144, width: 24, height: 24 },
     });
+    const deckScoped = comment({
+      elementId: 'hero-title',
+      selector: '[data-od-id="hero-title"]',
+      label: 'Hero title',
+      text: 'Hero title',
+      htmlHint: '<h1 data-od-id="hero-title">Hero title</h1>',
+      slideIndex: 0,
+      position: { x: 120, y: 80, width: 240, height: 64 },
+    });
+
+    expect(liveSnapshotForComment(pin, new Map())).toMatchObject({
+      filePath: 'index.html',
+      elementId: 'pin-hero',
+      position: { x: 88, y: 144, width: 24, height: 24 },
+    });
+    expect(liveSnapshotForComment(deckScoped, new Map())).toMatchObject({
+      filePath: 'index.html',
+      elementId: 'hero-title',
+      selector: '[data-od-id="hero-title"]',
+      label: 'Hero title',
+      slideIndex: 0,
+      position: { x: 120, y: 80, width: 240, height: 64 },
+    });
+  });
+
+  it('hides deck-scoped element comments once bridge targets are hydrated without that element', () => {
+    const deckScoped = comment({
+      elementId: 'hero-title',
+      selector: '[data-od-id="hero-title"]',
+      label: 'Hero title',
+      slideIndex: 0,
+      position: { x: 120, y: 80, width: 240, height: 64 },
+    });
+    const hydratedTargets = new Map([
+      ['other-title', {
+        filePath: 'index.html',
+        elementId: 'other-title',
+        selector: '[data-od-id="other-title"]',
+        label: 'Other title',
+        text: '',
+        htmlHint: '',
+        position: { x: 24, y: 32, width: 180, height: 40 },
+      }],
+    ]);
+
+    expect(liveSnapshotForComment(deckScoped, hydratedTargets)).toBeNull();
+  });
+
+  it('hides deck-scoped element comments after an empty bridge target hydration', () => {
+    const deckScoped = comment({
+      elementId: 'hero-title',
+      selector: '[data-od-id="hero-title"]',
+      label: 'Hero title',
+      slideIndex: 0,
+      position: { x: 120, y: 80, width: 240, height: 64 },
+    });
+
+    expect(liveSnapshotForComment(deckScoped, new Map(), { targetsHydrated: true })).toBeNull();
   });
 
   it('serializes selected comments into API-mode prompt context without visible input', () => {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1636,6 +1636,8 @@ describe('FileViewer tweaks toolbar', () => {
       'chat.comments.emptySaved': 'No saved comments.',
       'chat.comments.targetText': 'Text',
       'chat.comments.targetLink': 'Link',
+      'chat.comments.sendToChat': 'Send to Chat',
+      'chat.comments.sending': 'Sending',
       'chat.comments.selectAll': 'Select all',
       'common.close': 'Close',
       'common.delete': 'Delete',
@@ -2080,6 +2082,406 @@ describe('FileViewer tweaks toolbar', () => {
     });
     expect(screen.getByTestId('comment-active-pin').textContent).toBe('1');
     expect(document.querySelector('[data-comment-id="comment-older"]')?.className).not.toContain('active');
+  });
+
+  it('shows deck comments only on their slide and restores them when returning', async () => {
+    const slideOneComment: PreviewComment = {
+      id: 'comment-slide-one',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      filePath: 'preview.html',
+      elementId: 'pin-slide-one',
+      selector: '[data-od-pin="pin-slide-one"]',
+      label: 'pin-slide-one',
+      text: '',
+      htmlHint: '',
+      slideIndex: 0,
+      position: { x: 24, y: 32, width: 18, height: 18 },
+      note: 'Only on the first slide',
+      status: 'open',
+      createdAt: 10,
+      updatedAt: 10,
+    };
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><section class="slide">one</section><section class="slide">two</section></body></html>'
+        previewComments={[slideOneComment]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+
+    expect(screen.getByTestId('comment-saved-marker-pin-slide-one')).toBeTruthy();
+    expect(screen.getByText('Only on the first slide')).toBeTruthy();
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:slide-state', active: 1, count: 2 },
+    }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('comment-saved-marker-pin-slide-one')).toBeNull();
+      expect(screen.queryByText('Only on the first slide')).toBeNull();
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:slide-state', active: 0, count: 2 },
+    }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('comment-saved-marker-pin-slide-one')).toBeTruthy();
+      expect(screen.getByText('Only on the first slide')).toBeTruthy();
+    });
+  });
+
+  it('keeps legacy deck comments without slide index visible while changing slides', async () => {
+    const legacyComment: PreviewComment = {
+      id: 'comment-legacy-slide',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      filePath: 'preview.html',
+      elementId: 'pin-legacy-slide',
+      selector: '[data-od-pin="pin-legacy-slide"]',
+      label: 'pin-legacy-slide',
+      text: '',
+      htmlHint: '',
+      position: { x: 24, y: 32, width: 18, height: 18 },
+      note: 'Created before slide scoping',
+      status: 'open',
+      createdAt: 10,
+      updatedAt: 10,
+    };
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><section class="slide">one</section><section class="slide">two</section></body></html>'
+        previewComments={[legacyComment]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+
+    expect(screen.getByTestId('comment-saved-marker-pin-legacy-slide')).toBeTruthy();
+    expect(screen.getByText('Created before slide scoping')).toBeTruthy();
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:slide-state', active: 1, count: 2 },
+    }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('comment-saved-marker-pin-legacy-slide')).toBeTruthy();
+      expect(screen.getByText('Created before slide scoping')).toBeTruthy();
+    });
+  });
+
+  it('updates an unscoped legacy deck comment in place when targeting the same element on another slide', async () => {
+    const legacyComment: PreviewComment = {
+      id: 'comment-legacy-edit-target',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      filePath: 'legacy-target.html',
+      elementId: 'hero-legacy',
+      selector: '[data-od-id="hero-legacy"]',
+      label: 'Hero legacy',
+      text: 'Hero legacy',
+      htmlHint: '<h1 data-od-id="hero-legacy">Hero legacy</h1>',
+      position: { x: 48, y: 64, width: 240, height: 72 },
+      note: 'Legacy unscoped note',
+      status: 'open',
+      createdAt: 10,
+      updatedAt: 10,
+    };
+    const savedTargets: unknown[] = [];
+
+    function Harness() {
+      const [comments, setComments] = useState<PreviewComment[]>([legacyComment]);
+      return (
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile({ name: 'legacy-target.html', path: 'legacy-target.html' })}
+          liveHtml='<html><body><section class="slide"><h1 data-od-id="hero-legacy">One</h1></section><section class="slide"><h1 data-od-id="hero-legacy">Two</h1></section></body></html>'
+          previewComments={comments}
+          onSavePreviewComment={async (target, note) => {
+            savedTargets.push(target);
+            const saved: PreviewComment = {
+              ...legacyComment,
+              ...target,
+              note,
+              updatedAt: 20,
+            };
+            setComments(Number.isFinite(target.slideIndex) ? [
+              legacyComment,
+              { ...saved, id: 'comment-scoped-copy' },
+            ] : [saved]);
+            return saved;
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+    await waitFor(() => {
+      expect(screen.getByTestId('comment-panel-toggle').getAttribute('aria-pressed')).toBe('true');
+    });
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:slide-state', active: 1, count: 2 },
+    }));
+    await waitFor(() => expect(screen.getByText('2 / 2')).toBeTruthy());
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: {
+        type: 'od:comment-target',
+        elementId: 'hero-legacy',
+        selector: '[data-od-id="hero-legacy"]',
+        label: 'Hero legacy',
+        text: 'Hero legacy two',
+        position: { x: 60, y: 72, width: 240, height: 72 },
+        htmlHint: '<h1 data-od-id="hero-legacy">Two</h1>',
+      },
+    }));
+
+    const input = await screen.findByTestId('comment-popover-input') as HTMLTextAreaElement;
+    expect(input.value).toBe('Legacy unscoped note');
+    fireEvent.change(input, { target: { value: 'Updated legacy note' } });
+    fireEvent.click(screen.getByTestId('comment-popover-save'));
+
+    await waitFor(() => expect(savedTargets).toHaveLength(1));
+    expect(savedTargets[0]).toEqual(expect.objectContaining({
+      elementId: 'hero-legacy',
+      filePath: 'legacy-target.html',
+    }));
+    expect(savedTargets[0]).not.toHaveProperty('slideIndex');
+
+    await waitFor(() => expect(screen.queryByTestId('comment-popover')).toBeNull());
+    expect(screen.getByText('Updated legacy note')).toBeTruthy();
+    const sidePanel = screen.getByTestId('comment-side-panel');
+    expect(sidePanel.querySelectorAll('[data-comment-id]')).toHaveLength(1);
+    expect(document.querySelector('[data-comment-id="comment-scoped-copy"]')).toBeNull();
+  });
+
+  it('keeps legacy deck comment edits unscoped after bridge target refreshes', async () => {
+    const legacyComment: PreviewComment = {
+      id: 'comment-legacy-side-edit',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      filePath: 'legacy-edit.html',
+      elementId: 'hero-legacy',
+      selector: '[data-od-id="hero-legacy"]',
+      label: 'Hero legacy',
+      text: 'Hero legacy',
+      htmlHint: '<h1 data-od-id="hero-legacy">Hero legacy</h1>',
+      position: { x: 48, y: 64, width: 240, height: 72 },
+      note: 'Legacy unscoped note',
+      status: 'open',
+      createdAt: 10,
+      updatedAt: 10,
+    };
+    const onSavePreviewComment = vi.fn(async (target, note) => ({
+      ...legacyComment,
+      ...target,
+      note,
+      updatedAt: 20,
+    }));
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile({ name: 'legacy-edit.html', path: 'legacy-edit.html' })}
+        liveHtml='<html><body><section class="slide"><h1 data-od-id="hero-legacy">One</h1></section><section class="slide"><h1 data-od-id="hero-legacy">Two</h1></section></body></html>'
+        previewComments={[legacyComment]}
+        onSavePreviewComment={onSavePreviewComment}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:slide-state', active: 1, count: 2 },
+    }));
+
+    const sideItem = await waitFor(() => document.querySelector('[data-comment-id="comment-legacy-side-edit"]'));
+    if (!sideItem) throw new Error('expected legacy comment in side panel');
+    fireEvent.click(sideItem);
+    const input = await screen.findByTestId('comment-popover-input') as HTMLTextAreaElement;
+    expect(input.value).toBe('Legacy unscoped note');
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: {
+        type: 'od:comment-active-target-update',
+        elementId: 'hero-legacy',
+        selector: '[data-od-id="hero-legacy"]',
+        label: 'Hero legacy',
+        text: 'Hero legacy two',
+        position: { x: 60, y: 72, width: 240, height: 72 },
+        htmlHint: '<h1 data-od-id="hero-legacy">Two</h1>',
+      },
+    }));
+
+    fireEvent.change(input, { target: { value: 'Updated legacy note' } });
+    fireEvent.click(screen.getByTestId('comment-popover-save'));
+
+    await waitFor(() => expect(onSavePreviewComment).toHaveBeenCalled());
+    expect(onSavePreviewComment.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      elementId: 'hero-legacy',
+      filePath: 'legacy-edit.html',
+    }));
+    expect(onSavePreviewComment.mock.calls[0]?.[0]).not.toHaveProperty('slideIndex');
+  });
+
+  it('rehydrates saved deck element comment markers before iframe targets report', async () => {
+    const slideOneComment: PreviewComment = {
+      id: 'comment-slide-one-element',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      filePath: 'rehydrate-preview.html',
+      elementId: 'hero-slide-one',
+      selector: '[data-od-id="hero-slide-one"]',
+      label: 'Hero heading',
+      text: 'Hero heading',
+      htmlHint: '<h1 data-od-id="hero-slide-one">Hero heading</h1>',
+      slideIndex: 0,
+      position: { x: 120, y: 80, width: 240, height: 64 },
+      note: 'Keep this heading visible',
+      status: 'open',
+      createdAt: 10,
+      updatedAt: 10,
+    };
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile({ name: 'rehydrate-preview.html', path: 'rehydrate-preview.html' })}
+        liveHtml='<html><body><section class="slide"><h1 data-od-id="hero-slide-one">Hero heading</h1></section><section class="slide">two</section></body></html>'
+        previewComments={[slideOneComment]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+
+    expect(screen.getByTestId('comment-saved-marker-hero-slide-one')).toBeTruthy();
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:slide-state', active: 1, count: 2 },
+    }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('comment-saved-marker-hero-slide-one')).toBeNull();
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:slide-state', active: 0, count: 2 },
+    }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('comment-saved-marker-hero-slide-one')).toBeTruthy();
+    });
+  });
+
+  it('hides saved deck element comment markers after empty iframe targets hydrate', async () => {
+    const slideOneComment: PreviewComment = {
+      id: 'comment-slide-empty-targets',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      filePath: 'empty-targets-preview.html',
+      elementId: 'hero-empty-targets',
+      selector: '[data-od-id="hero-empty-targets"]',
+      label: 'Hero heading',
+      text: 'Hero heading',
+      htmlHint: '<h1 data-od-id="hero-empty-targets">Hero heading</h1>',
+      slideIndex: 0,
+      position: { x: 120, y: 80, width: 240, height: 64 },
+      note: 'Old marker should disappear',
+      status: 'open',
+      createdAt: 10,
+      updatedAt: 10,
+    };
+    const savedTargets: unknown[] = [];
+
+    function Harness() {
+      const [comments, setComments] = useState<PreviewComment[]>([slideOneComment]);
+      return (
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile({ name: 'empty-targets-preview.html', path: 'empty-targets-preview.html' })}
+          liveHtml='<html><body><section class="slide"><h1>Removed heading</h1></section></body></html>'
+          previewComments={comments}
+          onSavePreviewComment={async (target, note) => {
+            savedTargets.push(target);
+            const saved: PreviewComment = {
+              ...slideOneComment,
+              ...target,
+              note,
+              updatedAt: 20,
+            };
+            setComments(Number.isFinite(target.slideIndex) ? [saved] : [
+              slideOneComment,
+              { ...saved, id: 'comment-unscoped-copy' },
+            ]);
+            return saved;
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+
+    expect(screen.getByTestId('comment-saved-marker-hero-empty-targets')).toBeTruthy();
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:comment-targets', targets: [] },
+    }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('comment-saved-marker-hero-empty-targets')).toBeNull();
+    });
+
+    const sideItem = await waitFor(() => document.querySelector('[data-comment-id="comment-slide-empty-targets"]'));
+    if (!sideItem) throw new Error('expected scoped comment in side panel');
+    fireEvent.click(sideItem);
+
+    const input = await screen.findByTestId('comment-popover-input') as HTMLTextAreaElement;
+    expect(input.value).toBe('Old marker should disappear');
+    fireEvent.change(input, { target: { value: 'Updated scoped note' } });
+    fireEvent.click(screen.getByTestId('comment-popover-save'));
+
+    await waitFor(() => expect(savedTargets).toHaveLength(1));
+    expect(savedTargets[0]).toEqual(expect.objectContaining({
+      elementId: 'hero-empty-targets',
+      filePath: 'empty-targets-preview.html',
+      slideIndex: 0,
+    }));
+    expect(document.querySelector('[data-comment-id="comment-unscoped-copy"]')).toBeNull();
   });
 
   it('orders and timestamps side comments by latest update time', () => {
@@ -2680,6 +3082,48 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.queryByText('不要github，换成微信')).toBeNull();
     expect(screen.queryByTestId('comment-side-selectbar')).toBeNull();
     expect(screen.queryByTestId('comment-side-collapsed-rail')).toBeNull();
+  });
+
+  it('does not label the comment panel action as sending when only blocked by streaming', () => {
+    const comment: PreviewComment = {
+      id: 'comment-1',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      filePath: 'preview.html',
+      elementId: 'pin-1',
+      selector: '[data-od-pin="pin-1"]',
+      label: 'pin',
+      text: '',
+      htmlHint: '',
+      position: { x: 16, y: 24, width: 24, height: 24 },
+      note: 'Send this after the run finishes',
+      status: 'open',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    render(
+      <CommentSidePanel
+        comments={[comment]}
+        selectedIds={new Set(['comment-1'])}
+        activeCommentId={null}
+        collapsed={false}
+        onCollapsedChange={() => {}}
+        onClose={() => {}}
+        onToggleSelect={() => {}}
+        onSelectAll={() => {}}
+        onClearSelection={() => {}}
+        onReply={() => {}}
+        onSendSelected={() => {}}
+        sending={false}
+        sendDisabled
+        t={t}
+      />,
+    );
+
+    const sendButton = screen.getByTestId('comment-side-send-claude') as HTMLButtonElement;
+    expect(sendButton.disabled).toBe(true);
+    expect(sendButton.textContent).toBe('Send to Chat');
   });
 
   it('does not classify text labels containing a standalone article as links', () => {

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -247,6 +247,7 @@ export interface ChatCommentAttachment {
   currentText: string;
   pagePosition: PreviewCommentPosition;
   htmlHint: string;
+  slideIndex?: number;
   style?: PreviewAnnotationStyle;
   selectionKind?: ChatCommentSelectionKind;
   memberCount?: number;

--- a/packages/contracts/src/api/comments.ts
+++ b/packages/contracts/src/api/comments.ts
@@ -51,6 +51,7 @@ export interface PreviewCommentTarget {
   text: string;
   position: PreviewCommentPosition;
   htmlHint: string;
+  slideIndex?: number;
   style?: PreviewAnnotationStyle;
   selectionKind?: PreviewCommentSelectionKind;
   memberCount?: number;
@@ -68,6 +69,7 @@ export interface PreviewComment {
   text: string;
   position: PreviewCommentPosition;
   htmlHint: string;
+  slideIndex?: number;
   style?: PreviewAnnotationStyle;
   selectionKind?: PreviewCommentSelectionKind;
   memberCount?: number;


### PR DESCRIPTION
## Why

Deck comments created from the preview annotation tools were not scoped to the slide where they were placed. I hit this while validating slide navigation: a comment added on slide 1 could remain visible after moving to slide 2, which made the marker look detached from the content it referred to.

This is a user-facing bug fix for the release branch. The change stores the slide index with preview comments and uses that value when rendering saved comment markers and the comment drawer.

## What users will see

When users add a comment to a deck slide, that comment only appears on that slide. Moving to another slide hides it, and returning to the original slide shows it again.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No static screenshot; this is slide-navigation behavior and is covered by the regression test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.test.tsx` (`shows deck comments only on their slide and restores them when returning`)
- Did the test go red on `main` and green on this branch? No. I ported the fix directly to `release/v0.9.0` and verified the regression test passes on this branch.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx -t "shows deck comments only on their slide"`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/comment-attachments.test.ts`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`

Note: commands ran under local Node v22.22.0, so pnpm printed the expected engine warning for the repo's Node `~24` target.
