### PR TITLE
fix(web): queue preview comments while busy on release

### DIFF
--- a/apps/web/src/components/BoardComposerPopover.tsx
+++ b/apps/web/src/components/BoardComposerPopover.tsx
@@ -233,6 +233,8 @@ export function BoardComposerPopover({
   onHoverMember,
   onDeleteComment,
   sending,
+  queueOnSend = false,
+  sendDisabled = false,
   t,
   scale = 1,
   bounds,
@@ -254,6 +256,8 @@ export function BoardComposerPopover({
   onHoverMember?: (elementId: string | null) => void;
   onDeleteComment?: (commentId: string) => void | Promise<void>;
   sending: boolean;
+  queueOnSend?: boolean;
+  sendDisabled?: boolean;
   t: TranslateFn;
   scale?: number;
   bounds?: PopoverBounds;
@@ -265,7 +269,12 @@ export function BoardComposerPopover({
   const hasCommentChange = !existing || draft.trim() !== existing.note.trim();
   const podMembers = target.podMembers ?? [];
   const composingRef = useRef(false);
-  const sendDisabled = pendingCount === 0 || sending;
+  const submitDisabled = pendingCount === 0 || sending || sendDisabled;
+  const primaryLabel = sending
+    ? t('chat.comments.sending')
+    : queueOnSend
+      ? t('chat.annotationQueue')
+      : t('chat.comments.sendToChat');
   return (
     <div
       className={`comment-popover${docked ? ' comment-popover-docked' : ''}`}
@@ -354,7 +363,7 @@ export function BoardComposerPopover({
                 (event.metaKey || event.ctrlKey)
               ) {
                 event.preventDefault();
-                if (sendDisabled) return;
+                if (submitDisabled) return;
                 void onSendBatch();
               }
             }}
@@ -409,10 +418,10 @@ export function BoardComposerPopover({
                 type="button"
                 className="primary"
                 data-testid="comment-add-send"
-                disabled={sendDisabled}
+                disabled={submitDisabled}
                 onClick={() => void onSendBatch()}
               >
-                {sending ? t('chat.comments.sending') : t('chat.comments.sendToChat')}
+                {primaryLabel}
               </button>
             </div>
           </div>

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -684,10 +684,12 @@ interface Props {
   isDeck?: boolean;
   onExportAsPptx?: ((fileName: string) => void) | undefined;
   streaming?: boolean;
+  commentQueueOnSend?: boolean;
+  commentSendDisabled?: boolean;
   previewComments?: PreviewComment[];
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
-  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
+  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<boolean | void> | boolean | void;
   onFileSaved?: () => Promise<void> | void;
   // Open `openName` as a tab (focusing it) and close `closeName` in one
   // atomic tab-state update. The React module pointer uses this to jump to the
@@ -706,6 +708,8 @@ export function FileViewer({
   isDeck,
   onExportAsPptx,
   streaming,
+  commentQueueOnSend = false,
+  commentSendDisabled = false,
   previewComments = [],
   onSavePreviewComment,
   onRemovePreviewComment,
@@ -746,6 +750,8 @@ export function FileViewer({
         isDeck={rendererMatch.renderer.id === 'deck-html'}
         onExportAsPptx={onExportAsPptx}
         streaming={Boolean(streaming)}
+        commentQueueOnSend={commentQueueOnSend}
+        commentSendDisabled={commentSendDisabled}
         previewComments={previewComments}
         onSavePreviewComment={onSavePreviewComment}
         onRemovePreviewComment={onRemovePreviewComment}
@@ -2067,6 +2073,8 @@ export function CommentSidePanel({
   onSendSelected,
   onCreateComment,
   sending,
+  queueOnSend = false,
+  sendDisabled = false,
   t,
   composer,
 }: {
@@ -2083,6 +2091,8 @@ export function CommentSidePanel({
   onSendSelected: () => void | Promise<void>;
   onCreateComment?: (note: string) => boolean | Promise<boolean>;
   sending: boolean;
+  queueOnSend?: boolean;
+  sendDisabled?: boolean;
   t: TranslateFn;
   composer?: ReactNode;
 }) {
@@ -2092,7 +2102,7 @@ export function CommentSidePanel({
   const selectedCount = visibleSelectedIds.size;
   const allSelected = comments.length > 0 && selectedCount === comments.length;
   const commentsLabel = t('chat.tabComments');
-  const canCreateComment = Boolean(onCreateComment) && newCommentDraft.trim().length > 0 && !sending;
+  const canCreateComment = Boolean(onCreateComment) && newCommentDraft.trim().length > 0 && !sending && !sendDisabled;
   const submitNewComment = async () => {
     if (!onCreateComment || !newCommentDraft.trim()) return;
     const saved = await onCreateComment(newCommentDraft.trim());
@@ -2201,10 +2211,14 @@ export function CommentSidePanel({
             type="button"
             className="primary"
             data-testid="comment-side-send-claude"
-            disabled={sending}
+            disabled={sending || sendDisabled}
             onClick={() => void onSendSelected()}
           >
-            {sending ? t('chat.comments.sending') : t('chat.comments.sendToChat')}
+            {sending
+              ? t('chat.comments.sending')
+              : queueOnSend
+                ? t('chat.annotationQueue')
+                : t('chat.comments.sendToChat')}
           </button>
         </div>
       ) : null}
@@ -3841,6 +3855,8 @@ function HtmlViewer({
   isDeck,
   onExportAsPptx,
   streaming,
+  commentQueueOnSend = false,
+  commentSendDisabled = false,
   previewComments = [],
   onSavePreviewComment,
   onRemovePreviewComment,
@@ -3857,10 +3873,12 @@ function HtmlViewer({
   isDeck: boolean;
   onExportAsPptx?: ((fileName: string) => void) | undefined;
   streaming: boolean;
+  commentQueueOnSend?: boolean;
+  commentSendDisabled?: boolean;
   previewComments?: PreviewComment[];
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
-  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
+  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<boolean | void> | boolean | void;
   onFileSaved?: () => Promise<void> | void;
   commentPortalId?: string;
   onCommentModeChange?: (active: boolean) => void;
@@ -6129,12 +6147,13 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     if (nextNotes.length === 0) return;
     setSendingBoardBatch(true);
     try {
-      await onSendBoardCommentAttachments(
+      const accepted = await onSendBoardCommentAttachments(
         buildBoardCommentAttachments({
           target: targetFromSnapshot(activeCommentTarget),
           notes: nextNotes,
         }),
       );
+      if (accepted === false) return;
       clearBoardComposer();
     } finally {
       setSendingBoardBatch(false);
@@ -6429,7 +6448,9 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         });
         setActivePreviewCommentId((current) => (current === commentId ? null : current));
       } : undefined}
-      sending={sendingBoardBatch || streaming}
+      sending={sendingBoardBatch}
+      queueOnSend={commentQueueOnSend}
+      sendDisabled={commentSendDisabled}
       t={t}
       scale={overlayPreviewScale}
       offset={{ x: overlayPreviewTransform.offsetX, y: overlayPreviewTransform.offsetY }}
@@ -6500,14 +6521,16 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         fireCommentPopoverClick('send_to_chat');
         setSendingBoardBatch(true);
         try {
-          await onSendBoardCommentAttachments(commentsToAttachments(selected));
-          setSelectedSideCommentIds(new Set());
+          const accepted = await onSendBoardCommentAttachments(commentsToAttachments(selected));
+          if (accepted !== false) setSelectedSideCommentIds(new Set());
         } finally {
           setSendingBoardBatch(false);
         }
       }}
       onCreateComment={savePanelComment}
-      sending={sendingBoardBatch || streaming}
+      sending={sendingBoardBatch}
+      queueOnSend={commentQueueOnSend}
+      sendDisabled={commentSendDisabled}
       t={t}
       composer={null}
     />

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -69,6 +69,8 @@ interface Props {
   isDeck: boolean;
   onExportAsPptx?: ((fileName: string) => void) | undefined;
   streaming?: boolean;
+  commentQueueOnSend?: boolean;
+  commentSendDisabled?: boolean;
   openRequest?: { name: string; nonce: number } | null;
   liveArtifactEvents?: LiveArtifactEventItem[];
   designSystemActivityEvents?: AgentEvent[];
@@ -79,7 +81,7 @@ interface Props {
   previewComments?: PreviewComment[];
   onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
-  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
+  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<boolean | void> | boolean | void;
   onPluginFolderAgentAction?: (
     relativePath: string,
     action: PluginFolderAgentAction,
@@ -200,6 +202,8 @@ export function FileWorkspace({
   isDeck,
   onExportAsPptx,
   streaming,
+  commentQueueOnSend = false,
+  commentSendDisabled = false,
   openRequest,
   liveArtifactEvents = [],
   designSystemActivityEvents = [],
@@ -1063,6 +1067,8 @@ export function FileWorkspace({
             isDeck={isDeck}
             onExportAsPptx={onExportAsPptx}
             streaming={streaming}
+            commentQueueOnSend={commentQueueOnSend}
+            commentSendDisabled={commentSendDisabled}
             previewComments={previewComments.filter((comment) => comment.filePath === activeFile.name)}
             onSavePreviewComment={onSavePreviewComment}
             onRemovePreviewComment={onRemovePreviewComment}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -741,6 +741,8 @@ export function ProjectView({
     || failedMessagesConversationId === activeConversationId
     || currentConversationAwaitingActiveRunAttach;
   const currentConversationActionDisabled = currentConversationBusy || currentConversationSendDisabled;
+  const currentConversationQueueDisabled = currentConversationLoading
+    || failedMessagesConversationId === activeConversationId;
   const currentConversationQueuedItems = activeConversationId
     ? queuedChatSends
         .filter((item) => item.conversationId === activeConversationId)
@@ -3060,13 +3062,15 @@ export function ProjectView({
 
   const handleSendBoardCommentAttachments = useCallback(
     async (commentAttachments: ChatCommentAttachment[]) => {
-      if (currentConversationActionDisabled || commentAttachments.length === 0) return;
+      if (currentConversationQueueDisabled || commentAttachments.length === 0) return false;
       setWorkspaceFocused(false);
       setCommentInspectorActive(false);
       await handleSend('', [], commentAttachments);
+      return true;
     },
-    [handleSend, currentConversationActionDisabled],
+    [handleSend, currentConversationQueueDisabled],
   );
+  const commentQueueOnSend = currentConversationBusy && !currentConversationQueueDisabled;
 
   const handleContinueRemainingTasks = useCallback(
     (_assistantMessage: ChatMessage, todos: TodoItem[]) => {
@@ -4552,6 +4556,8 @@ export function ProjectView({
           isDeck={isDeck}
           onExportAsPptx={handleExportAsPptx}
           streaming={currentConversationActionDisabled}
+          commentQueueOnSend={commentQueueOnSend}
+          commentSendDisabled={currentConversationQueueDisabled}
           openRequest={openRequest}
           liveArtifactEvents={liveArtifactEvents}
           designSystemActivityEvents={designSystemActivityEvents}

--- a/apps/web/tests/components/BoardComposerPopover.queue-on-busy.test.tsx
+++ b/apps/web/tests/components/BoardComposerPopover.queue-on-busy.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BoardComposerPopover } from '../../src/components/BoardComposerPopover';
+import type { PreviewCommentSnapshot } from '../../src/comments';
+
+afterEach(() => {
+  cleanup();
+});
+
+const target: PreviewCommentSnapshot = {
+  filePath: 'index.html',
+  elementId: 'hero-title',
+  selector: '#hero-title',
+  label: 'Hero title',
+  text: '',
+  position: { x: 0, y: 0, width: 100, height: 24 },
+  htmlHint: '',
+  selectionKind: 'element',
+};
+
+const labels: Record<string, string> = {
+  'chat.annotationQueue': 'Queue',
+  'chat.comments.comment': 'Comment',
+  'chat.comments.placeholder': 'Comment on this element...',
+  'chat.comments.sendToChat': 'Send to chat',
+  'chat.comments.sending': 'Sending...',
+};
+
+describe('BoardComposerPopover queue on busy conversation', () => {
+  it('shows Queue and stays clickable while a run is in flight', () => {
+    const onSendBatch = vi.fn();
+
+    render(
+      <BoardComposerPopover
+        target={target}
+        existing={null}
+        draft="Make this text white"
+        notes={[]}
+        onDraft={() => {}}
+        onAddDraft={() => {}}
+        onRemoveQueuedNote={() => {}}
+        onClose={() => {}}
+        onSaveComment={() => {}}
+        onSendBatch={onSendBatch}
+        onRemoveMember={() => {}}
+        sending={false}
+        queueOnSend
+        sendDisabled={false}
+        t={((key: string) => labels[key] ?? key) as never}
+      />,
+    );
+
+    const send = screen.getByTestId('comment-add-send') as HTMLButtonElement;
+    expect(send.textContent).toBe('Queue');
+    expect(send.disabled).toBe(false);
+
+    fireEvent.click(send);
+    expect(onSendBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Sending only while the batch submit is in flight', () => {
+    render(
+      <BoardComposerPopover
+        target={target}
+        existing={null}
+        draft="Make this text white"
+        notes={[]}
+        onDraft={() => {}}
+        onAddDraft={() => {}}
+        onRemoveQueuedNote={() => {}}
+        onClose={() => {}}
+        onSaveComment={() => {}}
+        onSendBatch={() => {}}
+        onRemoveMember={() => {}}
+        sending
+        queueOnSend
+        sendDisabled={false}
+        t={((key: string) => labels[key] ?? key) as never}
+      />,
+    );
+
+    const send = screen.getByTestId('comment-add-send') as HTMLButtonElement;
+    expect(send.textContent).toBe('Sending...');
+    expect(send.disabled).toBe(true);
+  });
+});

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -108,17 +108,23 @@ vi.mock('../../src/components/AvatarMenu', () => ({
 vi.mock('../../src/components/FileWorkspace', () => ({
   FileWorkspace: ({
     streaming,
+    commentQueueOnSend,
+    commentSendDisabled,
     onSendBoardCommentAttachments,
     onCommentModeChange,
     onFocusModeChange,
   }: {
     streaming: boolean;
+    commentQueueOnSend?: boolean;
+    commentSendDisabled?: boolean;
     onSendBoardCommentAttachments: (attachments: unknown[]) => void;
     onCommentModeChange?: (active: boolean) => void;
     onFocusModeChange?: (focused: boolean) => void;
   }) => (
     <>
       <output data-testid="workspace-streaming-state">{streaming ? 'streaming' : 'idle'}</output>
+      <output data-testid="workspace-comment-queue-on-send">{commentQueueOnSend ? 'queue' : 'send'}</output>
+      <output data-testid="workspace-comment-send-disabled">{commentSendDisabled ? 'disabled' : 'enabled'}</output>
       <button
         type="button"
         data-testid="workspace-open-comments"
@@ -612,6 +618,40 @@ describe('ProjectView conversation run isolation', () => {
       projectId: 'project-1',
     }));
   });
+
+  it('queues board comments while the active conversation is busy', async () => {
+    let finishReattach: (() => void) | null = null;
+    let reattachHandlers: { onDone: () => void } | null = null;
+    reattachDaemonRun.mockImplementation(async (input: unknown) => {
+      reattachHandlers = (input as { handlers: { onDone: () => void } }).handlers;
+      return new Promise<void>((resolve) => {
+        finishReattach = resolve;
+      });
+    });
+
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
+    expect(screen.getByTestId('workspace-comment-queue-on-send').textContent).toBe('queue');
+    expect(screen.getByTestId('workspace-comment-send-disabled').textContent).toBe('enabled');
+
+    fireEvent.click(screen.getByTestId('workspace-send-comment'));
+
+    await waitFor(() => expect(screen.getByTestId('send-queued-0')).toBeTruthy());
+    expect(streamViaDaemon).not.toHaveBeenCalled();
+
+    await act(async () => {
+      reattachHandlers?.onDone();
+      finishReattach?.();
+    });
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    expect(streamViaDaemon).toHaveBeenCalledWith(expect.objectContaining({
+      commentAttachments: [expect.objectContaining({ id: 'comment-1' })],
+    }));
+  });
+
   it('detaches saved comment attachments after queueing them for a busy conversation', async () => {
     fetchPreviewComments.mockResolvedValue([previewComment]);
 


### PR DESCRIPTION
## Why

This release branch needs the preview-comment queue behavior from #3347 without pulling the larger main-only comments/deck stack into `release/v0.9.0`. The release branch is far enough behind main that cherry-picking #3347 brings avoidable conflicts and unrelated surface area.

The user-facing pain is that sending a preview comment while the current chat run is busy can leave the comment surface stuck in a Sending state instead of queueing the follow-up for the active conversation.

## What users will see

When users send a preview comment while the current chat run is still active, the comment action stays clickable, shows Queue, appears in the queued chat strip, and runs automatically after the current task finishes. A comment submit that is actually in flight still shows Sending.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a release hotfix for a busy-state transition; the behavior is covered by focused component/regression tests.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/BoardComposerPopover.queue-on-busy.test.tsx`; `apps/web/tests/components/ProjectView.run-isolation.test.tsx`
- Did the test go red on `main` and green on this branch? No. This is a release-targeted reimplementation of #3347; I verified the release branch behavior with focused regression coverage on this branch rather than reusing the main PR stack.

## Validation

- `pnpm install --frozen-lockfile` (completed; local Node is v26 so pnpm printed the expected unsupported-engine warning for this repo's Node ~24 target)
- `pnpm exec vitest run -c vitest.config.ts tests/components/BoardComposerPopover.queue-on-busy.test.tsx tests/components/ProjectView.run-isolation.test.tsx` (20 tests passed)
- `pnpm --filter @open-design/web typecheck` (passed; same Node engine warning)
- `pnpm guard` (passed; same Node engine warning)