### PR TITLE
fix(landing): keep auth redirects on AMR wallet

### DIFF
--- a/apps/landing-page/public/_redirects
+++ b/apps/landing-page/public/_redirects
@@ -10,6 +10,52 @@
 
 /sitemap.xml /sitemap-index.xml 301
 
+# AMR wallet lives under `/amr`. Social auth callbacks from the wallet can
+# return to locale-prefixed `/wallet` paths (for example `/zh/wallet`) after a
+# logout/register flow; keep those callbacks on the wallet surface instead of
+# falling through to the marketing site.
+# Keep locale-prefixed entries in sync with `app/i18n.ts:LANDING_LOCALES`.
+# Do not replace them with `/:locale/wallet`: that would also match
+# `/amr/wallet` and redirect the wallet URL to itself.
+/wallet          /amr/wallet  302
+/wallet/         /amr/wallet  302
+/en/wallet       /amr/wallet  302
+/en/wallet/      /amr/wallet  302
+/zh/wallet       /amr/wallet  302
+/zh/wallet/      /amr/wallet  302
+/zh-tw/wallet    /amr/wallet  302
+/zh-tw/wallet/   /amr/wallet  302
+/ja/wallet       /amr/wallet  302
+/ja/wallet/      /amr/wallet  302
+/ko/wallet       /amr/wallet  302
+/ko/wallet/      /amr/wallet  302
+/de/wallet       /amr/wallet  302
+/de/wallet/      /amr/wallet  302
+/fr/wallet       /amr/wallet  302
+/fr/wallet/      /amr/wallet  302
+/ru/wallet       /amr/wallet  302
+/ru/wallet/      /amr/wallet  302
+/es/wallet       /amr/wallet  302
+/es/wallet/      /amr/wallet  302
+/pt-br/wallet    /amr/wallet  302
+/pt-br/wallet/   /amr/wallet  302
+/it/wallet       /amr/wallet  302
+/it/wallet/      /amr/wallet  302
+/vi/wallet       /amr/wallet  302
+/vi/wallet/      /amr/wallet  302
+/pl/wallet       /amr/wallet  302
+/pl/wallet/      /amr/wallet  302
+/id/wallet       /amr/wallet  302
+/id/wallet/      /amr/wallet  302
+/nl/wallet       /amr/wallet  302
+/nl/wallet/      /amr/wallet  302
+/ar/wallet       /amr/wallet  302
+/ar/wallet/      /amr/wallet  302
+/tr/wallet       /amr/wallet  302
+/tr/wallet/      /amr/wallet  302
+/uk/wallet       /amr/wallet  302
+/uk/wallet/      /amr/wallet  302
+
 # Locale-code migration: the previous OD landing-page stack used BCP-47
 # region-qualified codes (zh-CN, zh-TW, pt-BR, es-ES) whereas the
 # current bundle adopts the simpler codes the @astrojs/sitemap plugin


### PR DESCRIPTION
## Why

AMR users who hit insufficient balance can open `open-design.ai/amr/wallet` from the chat recharge action. After logging out on that wallet page and registering again with Google or GitHub, the OAuth callback can drop the `/amr` segment and return to locale-prefixed wallet paths such as `/zh/wallet`. That path falls through to the marketing site instead of the AMR wallet, so users cannot complete recharge from the intended flow.

This PR keeps those malformed wallet callbacks on the AMR wallet surface.

## What users will see

Users who land on `/wallet` or locale-prefixed wallet paths like `/zh/wallet` after social auth are redirected back to `/amr/wallet` instead of seeing the website route.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — redirect-only landing-page route fix.

## Bug fix verification

- Test path that reproduces the bug: no automated red spec was added because this is a Cloudflare Pages `_redirects` deployment rule rather than a runtime route covered by the app test harness.
- Did the test go red on `main` and green on this branch? no.
- Verification performed instead: built `@open-design/landing-page` and confirmed the generated `_redirects` file includes the AMR wallet fallback rules.

## Validation

- `pnpm --filter @open-design/landing-page build`
- `pnpm guard`
- `pnpm typecheck`
