### PR TITLE
fix(daemon): bind db param when passing getProject to design-system tool routes

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5845,7 +5845,7 @@ export async function startServer({
     auth: authDeps,
     http: httpDeps,
     paths: pathDeps,
-    projects: { getProject },
+    projects: { getProject: (id: string) => getProject(db, id) },
   });
   app.use('/artifacts', express.static(ARTIFACTS_DIR));
   registerDeployRoutes(app, {


### PR DESCRIPTION
## Why

Design system preview files failed to load in the UI. The `/api/tools/design-systems/read` endpoint returned `{"ok":false,"status":500,"error":{"code":"INTERNAL_ERROR","message":"db.prepare is not a function"}}` because `server.ts` passed the raw two-arg `getProject(db, id)` where a one-arg `(id) => ...` callback was expected. The `// @ts-nocheck` directive on `server.ts` line 1 prevented TypeScript from catching this signature mismatch at compile time.

## What users will see

Design system preview files (e.g. `preview/app.html`) load correctly in the UI instead of showing an error.

## Surface area

- [x] **None** — internal bug fix, no new surface

## Bug fix verification

Verified manually in the app — preview files returned a 500 before the fix and load successfully after.

## Validation

- `pnpm --filter @open-design/daemon build`