### PR TITLE
Harden sandbox orchestration daemon chokepoints

### DIFF
--- a/apps/daemon/src/chat-routes.ts
+++ b/apps/daemon/src/chat-routes.ts
@@ -123,7 +123,11 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       toolUseId?: unknown;
       content?: unknown;
       isError?: unknown;
+      runId?: unknown;
     };
+    if (typeof body.runId === 'string' && body.runId.length > 0 && body.runId !== req.params.id) {
+      return sendApiError(res, 400, 'BAD_REQUEST', 'runId must match the path run id');
+    }
     const toolUseId = typeof body.toolUseId === 'string' ? body.toolUseId : '';
     const content = typeof body.content === 'string' ? body.content : '';
     const isError = body.isError === true;

--- a/apps/daemon/src/route-registration-guard.ts
+++ b/apps/daemon/src/route-registration-guard.ts
@@ -1,0 +1,32 @@
+import type { Express } from 'express';
+
+const guardedRouteKeys = new Set([
+  'POST /api/projects/:id/export/pdf',
+  'POST /api/projects/:id/media/generate',
+]);
+
+const guardedMethods = ['get', 'post', 'put', 'patch', 'delete', 'options'] as const;
+
+export function guardedRouteKey(method: string, path: unknown): string | null {
+  if (typeof path !== 'string') return null;
+  const key = `${method.toUpperCase()} ${path}`;
+  return guardedRouteKeys.has(key) ? key : null;
+}
+
+export function installRouteRegistrationGuard(app: Express): void {
+  const seen = new Set<string>();
+
+  for (const method of guardedMethods) {
+    const original = (app as any)[method].bind(app) as (...args: unknown[]) => unknown;
+    (app as any)[method] = (path: unknown, ...handlers: unknown[]) => {
+      const key = guardedRouteKey(method, path);
+      if (key) {
+        if (seen.has(key)) {
+          throw new Error(`duplicate guarded route registration: ${key}`);
+        }
+        seen.add(key);
+      }
+      return original(path, ...handlers);
+    };
+  }
+}

--- a/apps/daemon/src/run-tool-results.ts
+++ b/apps/daemon/src/run-tool-results.ts
@@ -1,0 +1,89 @@
+export type SubmitToolResultReason =
+  | 'run_terminal'
+  | 'stdin_closed'
+  | 'stdin_text_mode'
+  | 'bad_tool_use_id'
+  | 'write_failed';
+
+export type SubmitToolResultResult =
+  | { ok: true }
+  | { ok: false; reason: SubmitToolResultReason; error?: string };
+
+interface WritableStdin {
+  destroyed?: boolean;
+  write(chunk: string, encoding?: BufferEncoding): unknown;
+  end(): unknown;
+}
+
+interface ToolResultRunState {
+  child?: { stdin?: WritableStdin | null } | null;
+  pendingHostAnswers?: Set<string> | null;
+  stdinOpen?: boolean;
+}
+
+export interface SubmitToolResultInput {
+  content: unknown;
+  isError?: boolean;
+  isTerminal: boolean;
+  toolUseId: unknown;
+}
+
+export function submitToolResultToRunState(
+  run: ToolResultRunState,
+  input: SubmitToolResultInput,
+): SubmitToolResultResult {
+  if (input.isTerminal) {
+    return { ok: false, reason: 'run_terminal' };
+  }
+  if (!run.child?.stdin || run.child.stdin.destroyed) {
+    return { ok: false, reason: 'stdin_closed' };
+  }
+  if (!run.stdinOpen) {
+    return { ok: false, reason: 'stdin_text_mode' };
+  }
+  if (typeof input.toolUseId !== 'string' || input.toolUseId.length === 0) {
+    return { ok: false, reason: 'bad_tool_use_id' };
+  }
+  if (!run.pendingHostAnswers?.has(input.toolUseId)) {
+    return { ok: false, reason: 'bad_tool_use_id' };
+  }
+
+  const safeContent =
+    typeof input.content === 'string' ? input.content : String(input.content ?? '');
+  const userMessage = JSON.stringify({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: input.toolUseId,
+          content: safeContent,
+          is_error: input.isError === true,
+        },
+      ],
+    },
+  });
+
+  try {
+    run.child.stdin.write(`${userMessage}\n`, 'utf8');
+  } catch (err) {
+    return {
+      ok: false,
+      reason: 'write_failed',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  run.pendingHostAnswers.delete(input.toolUseId);
+  if (run.pendingHostAnswers.size === 0 && run.stdinOpen) {
+    if (!run.child.stdin.destroyed) {
+      try {
+        run.child.stdin.end();
+      } catch {}
+    }
+    run.stdinOpen = false;
+  }
+
+  return { ok: true };
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -452,6 +452,8 @@ import { TranscriptExportLockedError } from './transcript-export.js';
 import { registerChatRoutes } from './chat-routes.js';
 import { registerStaticResourceRoutes } from './static-resource-routes.js';
 import { registerRoutineRoutes, routineDbRowToContract } from './routine-routes.js';
+import { installRouteRegistrationGuard } from './route-registration-guard.js';
+import { submitToolResultToRunState } from './run-tool-results.js';
 import { assertServerContextSatisfiesRoutes } from './route-context-contract.js';
 import { configureConnectorCredentialStore, connectorService, ConnectorServiceError, FileConnectorCredentialStore } from './connectors/service.js';
 import { composioConnectorProvider } from './connectors/composio.js';
@@ -3916,6 +3918,7 @@ export async function startServer({
   }
 
   const app = express();
+  installRouteRegistrationGuard(app);
   app.use(express.json({ limit: '4mb' }));
   const projectPreviewScopes = createProjectPreviewScopeRegistry();
 
@@ -9642,41 +9645,6 @@ export async function startServer({
     }
   });
 
-  app.post('/api/projects/:id/export/pdf', async (req, res) => {
-    if (typeof desktopPdfExporter !== 'function') {
-      return sendApiError(
-        res,
-        501,
-        'UPSTREAM_UNAVAILABLE',
-        'desktop PDF export is only available in the desktop runtime',
-      );
-    }
-    try {
-      const { fileName, title, deck } = req.body || {};
-      if (typeof fileName !== 'string' || fileName.length === 0) {
-        return sendApiError(res, 400, 'BAD_REQUEST', 'fileName required');
-      }
-      const input = await buildDesktopPdfExportInput({
-        daemonUrl,
-        deck: deck === true,
-        fileName,
-        projectId: req.params.id,
-        projectsRoot: PROJECTS_DIR,
-        title: typeof title === 'string' ? title : undefined,
-      });
-      const result = await desktopPdfExporter(input);
-      res.json(result);
-    } catch (err) {
-      const status = err && err.code === 'ENOENT' ? 404 : 400;
-      sendApiError(
-        res,
-        status,
-        status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST',
-        String(err?.message || err),
-      );
-    }
-  });
-
   app.delete(/^\/api\/projects\/([^/]+)\/raw\/(.+)$/u, async (req, res) => {
     try {
       const projectId = String(req.params[0] ?? '');
@@ -9974,96 +9942,6 @@ export async function startServer({
       res
         .status(500)
         .json({ error: String(err && err.message ? err.message : err) });
-    }
-  });
-
-  app.post('/api/projects/:id/media/generate', async (req, res) => {
-    if (!isLocalSameOrigin(req, resolvedPort)) {
-      return res.status(403).json({
-        error:
-          'cross-origin request rejected: media generation is restricted to the local UI / CLI',
-      });
-    }
-
-    try {
-      const projectId = req.params.id;
-      const project = getProject(db, projectId);
-      if (!project) return res.status(404).json({ error: 'project not found' });
-
-      const taskId = randomUUID();
-      const task = createMediaTask(db, taskId, projectId, {
-        surface: req.body?.surface,
-        model: req.body?.model,
-      });
-      console.error(
-        `[task ${taskId.slice(0, 8)}] queued model=${req.body?.model} ` +
-          `surface=${req.body?.surface} ` +
-          `image=${req.body?.image ? 'yes' : 'no'} ` +
-          `compositionDir=${req.body?.compositionDir ? 'yes' : 'no'}`,
-      );
-
-      task.status = 'running';
-      persistMediaTask(db, task);
-      generateMedia({
-        projectRoot: PROJECT_ROOT,
-        projectsRoot: PROJECTS_DIR,
-        projectId,
-        surface: req.body?.surface,
-        model: req.body?.model,
-        prompt: req.body?.prompt,
-        output: req.body?.output,
-        aspect: req.body?.aspect,
-        length:
-          typeof req.body?.length === 'number' ? req.body.length : undefined,
-        duration:
-          typeof req.body?.duration === 'number'
-            ? req.body.duration
-            : undefined,
-        voice: req.body?.voice,
-        audioKind: req.body?.audioKind,
-        language: typeof req.body?.language === 'string' ? req.body.language : undefined,
-        compositionDir: req.body?.compositionDir,
-        image: req.body?.image,
-        onProgress: (line) => appendTaskProgress(db, task, line),
-      })
-        .then((meta) => {
-          task.status = 'done';
-          task.file = meta;
-          task.endedAt = Date.now();
-          persistMediaTask(db, task);
-          notifyTaskWaiters(db, task);
-          console.error(
-            `[task ${taskId.slice(0, 8)}] done size=${meta?.size} mime=${meta?.mime} ` +
-              `elapsed=${Math.round((task.endedAt - task.startedAt) / 1000)}s`,
-          );
-        })
-        .catch((err) => {
-          task.status = 'failed';
-          task.error = {
-            message: String(err && err.message ? err.message : err),
-            status: typeof err?.status === 'number' ? err.status : 400,
-            code: err?.code,
-          };
-          task.endedAt = Date.now();
-          persistMediaTask(db, task);
-          notifyTaskWaiters(db, task);
-          console.error(
-            `[task ${taskId.slice(0, 8)}] failed status=${task.error.status} ` +
-              `message=${(task.error.message || '').slice(0, 240)}`,
-          );
-        });
-
-      res.status(202).json({
-        taskId,
-        status: task.status,
-        startedAt: task.startedAt,
-      });
-    } catch (err) {
-      const status = typeof err?.status === 'number' ? err.status : 400;
-      const code = err?.code;
-      const body = { error: String(err && err.message ? err.message : err) };
-      if (code) body.code = code;
-      res.status(status).json(body);
     }
   });
 
@@ -12885,48 +12763,12 @@ export async function startServer({
   const submitToolResultToRun = (runId, toolUseId, content, isError = false) => {
     const run = design.runs.get(runId);
     if (!run) return { ok: false, reason: 'not_found' };
-    if (design.runs.isTerminal(run.status)) {
-      return { ok: false, reason: 'run_terminal' };
-    }
-    if (!run.child || !run.child.stdin || run.child.stdin.destroyed) {
-      return { ok: false, reason: 'stdin_closed' };
-    }
-    if (!run.stdinOpen) {
-      return { ok: false, reason: 'stdin_text_mode' };
-    }
-    if (typeof toolUseId !== 'string' || !toolUseId) {
-      return { ok: false, reason: 'bad_tool_use_id' };
-    }
-    const safeContent = typeof content === 'string' ? content : String(content ?? '');
-    const userMessage = JSON.stringify({
-      type: 'user',
-      message: {
-        role: 'user',
-        content: [
-          {
-            type: 'tool_result',
-            tool_use_id: toolUseId,
-            content: safeContent,
-            is_error: !!isError,
-          },
-        ],
-      },
+    return submitToolResultToRunState(run, {
+      content,
+      isError,
+      isTerminal: design.runs.isTerminal(run.status),
+      toolUseId,
     });
-    try {
-      run.child.stdin.write(`${userMessage}\n`, 'utf8');
-    } catch (err) {
-      return { ok: false, reason: 'write_failed', error: err && err.message };
-    }
-    if (run.pendingHostAnswers) {
-      run.pendingHostAnswers.delete(toolUseId);
-      if (run.pendingHostAnswers.size === 0 && run.stdinOpen) {
-        if (run.child && run.child.stdin && !run.child.stdin.destroyed) {
-          try { run.child.stdin.end(); } catch {}
-        }
-        run.stdinOpen = false;
-      }
-    }
-    return { ok: true };
   };
 
   orbitService.setRunHandler(async ({

--- a/apps/daemon/tests/chat-tool-result-route.test.ts
+++ b/apps/daemon/tests/chat-tool-result-route.test.ts
@@ -1,0 +1,121 @@
+import express from 'express';
+import http from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { registerChatRoutes } from '../src/chat-routes.js';
+
+let server: http.Server | undefined;
+
+afterEach(async () => {
+  await new Promise<void>((resolve, reject) => {
+    if (!server) return resolve();
+    server.close((error?: Error) => (error ? reject(error) : resolve()));
+  });
+  server = undefined;
+});
+
+function baseDeps(calls: unknown[][] = []) {
+  return {
+    agents: {
+      getAgentDef: () => undefined,
+      isKnownModel: () => false,
+      listProviderModels: () => [],
+      sanitizeCustomModel: (model: unknown) => model,
+      testAgentConnection: async () => ({ ok: true }),
+      testProviderConnection: async () => ({ ok: true }),
+    },
+    chat: {
+      submitToolResultToRun: (...args: unknown[]) => {
+        calls.push(args);
+        return { ok: true };
+      },
+    },
+    critique: {
+      critiqueArtifactsRoot: '',
+      critiqueResponseCapBytes: 0,
+      critiqueRunRegistry: new Map(),
+      handleCritiqueArtifact: () => (_req: express.Request, res: express.Response) =>
+        res.status(501).end(),
+      handleCritiqueInterrupt: () => (_req: express.Request, res: express.Response) =>
+        res.status(501).end(),
+    },
+    db: {},
+    design: {
+      runs: {
+        cancel: () => undefined,
+        get: () => null,
+        list: () => [],
+        statusBody: (run: unknown) => run,
+        stream: () => undefined,
+      },
+    },
+    http: {
+      createSseResponse: () => undefined,
+      sendApiError: (
+        res: express.Response,
+        status: number,
+        code: string,
+        message: string,
+        extras: Record<string, unknown> = {},
+      ) => res.status(status).json({ error: { code, message, ...extras } }),
+    },
+    lifecycle: {},
+    paths: {},
+    telemetry: {},
+    validation: {},
+  };
+}
+
+async function startChatRouteServer(calls: unknown[][] = []): Promise<string> {
+  const app = express();
+  app.use(express.json());
+  registerChatRoutes(app, baseDeps(calls) as any);
+  server = app.listen(0);
+  await new Promise<void>((resolve) => server?.once('listening', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('unexpected listen address');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe('chat tool-result route', () => {
+  it('rejects a body runId that disagrees with the path run id before submission', async () => {
+    const calls: unknown[][] = [];
+    const baseUrl = await startChatRouteServer(calls);
+
+    const response = await fetch(`${baseUrl}/api/runs/run-a/tool-result`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: 'answer',
+        runId: 'run-b',
+        toolUseId: 'tool-1',
+      }),
+    });
+    const body = await response.json() as { error: { code: string; message: string } };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'runId must match the path run id',
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it('uses the path run id as the authoritative run id', async () => {
+    const calls: unknown[][] = [];
+    const baseUrl = await startChatRouteServer(calls);
+
+    const response = await fetch(`${baseUrl}/api/runs/run-a/tool-result`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: 'answer',
+        runId: 'run-a',
+        toolUseId: 'tool-1',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual([['run-a', 'tool-1', 'answer', false]]);
+  });
+});

--- a/apps/daemon/tests/route-registration-guard.test.ts
+++ b/apps/daemon/tests/route-registration-guard.test.ts
@@ -1,0 +1,40 @@
+import express from 'express';
+import { describe, expect, it } from 'vitest';
+
+import {
+  guardedRouteKey,
+  installRouteRegistrationGuard,
+} from '../src/route-registration-guard.js';
+
+describe('route registration guard', () => {
+  it('tracks the sensitive extracted routes', () => {
+    expect(guardedRouteKey('post', '/api/projects/:id/export/pdf')).toBe(
+      'POST /api/projects/:id/export/pdf',
+    );
+    expect(guardedRouteKey('post', '/api/projects/:id/media/generate')).toBe(
+      'POST /api/projects/:id/media/generate',
+    );
+    expect(guardedRouteKey('get', '/api/projects/:id/export/pdf')).toBeNull();
+    expect(guardedRouteKey('post', '/api/runs')).toBeNull();
+  });
+
+  it('throws when a guarded route is registered twice', () => {
+    const app = express();
+    installRouteRegistrationGuard(app);
+    app.post('/api/projects/:id/media/generate', (_req, res) => res.end());
+
+    expect(() => {
+      app.post('/api/projects/:id/media/generate', (_req, res) => res.end());
+    }).toThrow(/duplicate guarded route registration: POST \/api\/projects\/:id\/media\/generate/);
+  });
+
+  it('does not blanket reject non-sensitive duplicate routes', () => {
+    const app = express();
+    installRouteRegistrationGuard(app);
+    app.get('/api/runs', (_req, res) => res.end());
+
+    expect(() => {
+      app.get('/api/runs', (_req, res) => res.end());
+    }).not.toThrow();
+  });
+});

--- a/apps/daemon/tests/run-tool-results.test.ts
+++ b/apps/daemon/tests/run-tool-results.test.ts
@@ -1,0 +1,116 @@
+import { PassThrough } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+
+import { submitToolResultToRunState } from '../src/run-tool-results.js';
+
+function makeRun(pendingToolUseIds: string[]) {
+  const stdin = new PassThrough();
+  const writes: string[] = [];
+  stdin.on('data', (chunk) => writes.push(String(chunk)));
+  const run = {
+    child: { stdin },
+    pendingHostAnswers: new Set(pendingToolUseIds),
+    stdinOpen: true,
+  };
+  return { run, stdin, writes };
+}
+
+describe('submitToolResultToRunState', () => {
+  it('rejects unknown toolUseId values before writing to child stdin', () => {
+    const { run, writes } = makeRun(['known-tool']);
+
+    const result = submitToolResultToRunState(run, {
+      content: 'answer',
+      isTerminal: false,
+      toolUseId: 'other-tool',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'bad_tool_use_id' });
+    expect(writes).toEqual([]);
+    expect(run.pendingHostAnswers.has('known-tool')).toBe(true);
+    expect(run.stdinOpen).toBe(true);
+  });
+
+  it('writes valid tool results and closes stdin after the final pending answer', () => {
+    const { run, stdin, writes } = makeRun(['tool-1']);
+
+    const result = submitToolResultToRunState(run, {
+      content: 'choice A',
+      isError: true,
+      isTerminal: false,
+      toolUseId: 'tool-1',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(run.pendingHostAnswers.has('tool-1')).toBe(false);
+    expect(run.stdinOpen).toBe(false);
+    expect(stdin.destroyed || stdin.writableEnded).toBe(true);
+    expect(writes).toHaveLength(1);
+    const [write] = writes;
+    expect(JSON.parse(write!)).toMatchObject({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            content: 'choice A',
+            is_error: true,
+            tool_use_id: 'tool-1',
+            type: 'tool_result',
+          },
+        ],
+      },
+    });
+  });
+
+  it('keeps stdin open when another pending host answer remains', () => {
+    const { run, stdin } = makeRun(['tool-1', 'tool-2']);
+
+    const result = submitToolResultToRunState(run, {
+      content: 'first',
+      isTerminal: false,
+      toolUseId: 'tool-1',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(run.pendingHostAnswers.has('tool-1')).toBe(false);
+    expect(run.pendingHostAnswers.has('tool-2')).toBe(true);
+    expect(run.stdinOpen).toBe(true);
+    expect(stdin.writableEnded).toBe(false);
+  });
+
+  it('rejects duplicate tool results after the first successful submission', () => {
+    const { run, writes } = makeRun(['tool-1', 'tool-2']);
+
+    expect(
+      submitToolResultToRunState(run, {
+        content: 'first',
+        isTerminal: false,
+        toolUseId: 'tool-1',
+      }),
+    ).toEqual({ ok: true });
+
+    const duplicate = submitToolResultToRunState(run, {
+      content: 'second',
+      isTerminal: false,
+      toolUseId: 'tool-1',
+    });
+
+    expect(duplicate).toEqual({ ok: false, reason: 'bad_tool_use_id' });
+    expect(writes).toHaveLength(1);
+    expect(run.stdinOpen).toBe(true);
+  });
+
+  it('rejects terminal runs before touching stdin', () => {
+    const { run, writes } = makeRun(['tool-1']);
+
+    const result = submitToolResultToRunState(run, {
+      content: 'answer',
+      isTerminal: true,
+      toolUseId: 'tool-1',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'run_terminal' });
+    expect(writes).toEqual([]);
+  });
+});

--- a/docs/plans/2026-06-01-sandbox-orchestration-hardening-architecture.md
+++ b/docs/plans/2026-06-01-sandbox-orchestration-hardening-architecture.md
@@ -1,0 +1,289 @@
+# Sandbox Orchestration Hardening Architecture
+
+## Status
+
+Architecture review draft. This document describes the hardening work needed to
+keep Open Design safe to embed under an external orchestrator without adding
+consumer-specific infrastructure to this repository.
+
+The plan is intentionally upstream-neutral. Open Design should refer to this
+integration shape as an external orchestrator, not by any private deployment or
+infrastructure name.
+
+## Goal
+
+Future contributors should not be able to accidentally weaken the sandbox
+runtime contract while adding normal Open Design features. The durable defense is
+not a large inventory of happy-path tests. The durable defense is to make unsafe
+states hard to construct, then pin the remaining public contracts with focused
+guards and smoke coverage.
+
+The protected use case is:
+
+1. An external orchestrator launches Open Design with `OD_SANDBOX_MODE=1` and an
+   isolated `OD_DATA_DIR`.
+2. The orchestrator creates runs over HTTP/SSE and supplies only run-scoped
+   policy, tools, and project context.
+3. Open Design contributes design context, skills, previews, artifacts, CLI/UI
+   parity, and agent execution.
+4. The orchestrator owns caller auth, provider credentials, budgets, rate
+   limits, external media tools, accounting, fanout, retries, and fulfillment.
+
+## Corrected Framing
+
+`OD_SANDBOX_MODE=1` is the spine of the sandbox runtime contract. Several
+important behaviors are deliberately conditional on sandbox mode:
+
+- persisted MCP servers are not mixed into a run-scoped tool bundle;
+- persisted MCP OAuth tokens are not read for sandboxed runs;
+- `HOME`, `XDG_*`, `CODEX_HOME`, and `TMPDIR` are pinned into the sandbox
+  runtime root;
+- imported-folder project access is restricted until files are mirrored into a
+  managed project directory.
+
+Without `OD_SANDBOX_MODE=1`, Open Design is the normal local product runtime, not
+the external-orchestrator containment runtime. Tests and docs must say which mode
+they are proving.
+
+Namespace and data isolation are separate axes. Namespace identifies sidecar
+processes, IPC sockets, pointers, and launcher-managed runtime files. Daemon data
+is isolated by `OD_DATA_DIR` plus sandbox mode, not by namespace alone.
+
+## Safety Invariants
+
+### I1. Public Contracts Stay Product-Neutral
+
+Public contracts, prompts, and docs must not name private orchestrators or
+private infrastructure. They should use "external orchestrator" or
+"orchestrator."
+
+Hardening:
+
+- Add a product-neutrality guard to `pnpm guard` over public contracts, prompts,
+  help strings, docs, and shipped content. The upstream guard should enforce
+  generic orchestrator phrasing and may support private local forbidden terms
+  through developer configuration, but it should not commit private deployment
+  names into the public repository.
+- Keep public docs phrased around the integration role, not deployment-specific
+  names.
+
+### I2. Media Spend Uses an Enforced Chokepoint
+
+The current policy path is easy to bypass because the provider-spending helper is
+lower level than the policy guard. The target architecture is:
+
+- introduce a single `generateMediaForRun(...)` style chokepoint that resolves
+  the run, validates the run-scoped media policy, checks token/run provenance,
+  then calls the provider implementation;
+- make the raw provider implementation private to the media module or guard its
+  imports so it cannot become a new app-level entrypoint;
+- require every run creation path to pass an explicit `mediaExecution` decision
+  into `design.runs.create`, even when the chosen value is the default enabled
+  policy;
+- in sandbox mode, make the legacy local media route require a run-scoped grant
+  or route through the token-gated media endpoint.
+
+This moves the primary guarantee from "known callers are tested" to "new callers
+cannot accidentally skip the policy."
+
+### I3. Run-Scoped Tools Are Mode-Explicit
+
+Run-scoped tool bundles are a sandbox-mode guarantee. In sandbox mode, the spawned
+agent should see only the run-scoped MCP servers supplied for that run, and
+persisted registry/OAuth state should not bleed into the run.
+
+Hardening:
+
+- Keep the existing unit coverage for run-scoped bundle selection.
+- Add one tools-dev/e2e variant that launches with `OD_SANDBOX_MODE=1` and a
+  unique `OD_DATA_DIR`, then asserts run-scoped tools and runtime homes are
+  contained.
+- Pin `applySandboxRuntimeEnv` behavior with primitive tests that inspect the
+  child environment assembled for an agent.
+
+### I4. Sidecar Namespaces Cannot Cross Wires
+
+The namespace contract is about launcher identity and sidecar transport, not
+daemon data. The useful hardening targets are:
+
+- two namespaces must resolve independent IPC sockets, pointers, log paths, and
+  runtime paths;
+- port changes must not change namespace-scoped paths;
+- stale pointer cleanup must only remove the pointer it owns;
+- process matching must not classify a foreign process tree as an Open Design
+  sidecar just because command text looks similar.
+
+These are primitive tests against `packages/sidecar-proto`,
+`packages/sidecar`, `packages/platform`, and `tools/dev`, not broad e2e user
+flows.
+
+### I5. Export And Preview Surfaces Stay Project-Scoped
+
+The export manifest and inline-export coverage is useful. The byte-serving
+surface used by previews is the raw project-file route. The protected contract
+is:
+
+- manifest entries describe project files without leaking host paths;
+- `GET /api/projects/:id/raw/*` cannot traverse or follow symlink escapes;
+- inline export continues to require `inline=1`, HTML owner files, and bounded
+  owner bytes;
+- preview URLs are derived from the project entry file, use the daemon raw route
+  with per-segment encoding, are null when no entry exists, and are not durable
+  public URLs.
+
+Hardening should focus on the byte-serving path as much as the manifest path.
+
+### I6. Stream-JSON Tool Results Stay Run-Scoped
+
+`POST /api/runs/:id/tool-result` is a privileged writeback channel into a live
+stream-json run. It already derives run scope from the path, but it does not yet
+fail closed on a `toolUseId` that is absent from that run's pending host-answer
+set.
+
+Add focused tests for wrong-run IDs, unknown tool IDs, repeated answers, and body
+fields that try to smuggle a different run id, then add the membership check
+before writing to child stdin.
+
+## Already Covered
+
+Do not re-implement these as new broad tests unless the underlying behavior is
+being changed:
+
+| Area | Existing coverage |
+| --- | --- |
+| Media policy parser and denial codes | `apps/daemon/tests/media-policy.test.ts` |
+| In-run media route behavior, disabled policy, surface/model denial, token/no-token legacy behavior | `apps/daemon/tests/media-policy-routes.test.ts` |
+| Run-scoped MCP bundle parsing and sandbox-mode bundle selection | `apps/daemon/tests/run-tool-bundle.test.ts` |
+| Sandbox mode parsing and data-root requirements | `apps/daemon/tests/sandbox-mode.test.ts`, `apps/daemon/tests/resolve-data-dir.test.ts` |
+| Sandbox runtime directory/bootstrap behavior | `apps/daemon/tests/sandbox-runtime-bootstrap.test.ts` |
+| Tool-token issuance and route authorization | `apps/daemon/tests/tool-tokens.test.ts` |
+| Export manifest shape and sandbox imported-folder denial | `apps/daemon/tests/export-manifest-route.test.ts` |
+| Inline export route behavior | `apps/daemon/tests/export-inline-route.test.ts` |
+| `/api/ready` daemon readiness | `apps/daemon/tests/daemon-lifecycle.test.ts` |
+| Always-on tools-dev inspect smoke | `e2e/tests/tools-dev/inspect.test.ts` |
+
+The hardening plan should diff against this list before adding tests.
+
+## Net-New Work
+
+### PR Strategy
+
+Keep the follow-up stack to three PRs unless review uncovers a real ownership
+boundary that needs to split out. This follows the maintainer read on #3416:
+start with the neutrality guard plus daemon-route and `tool_result` hardening,
+then move to media fail-closed behavior, then pin contracts and static ownership
+checks.
+
+1. PR1: product-neutrality guard and daemon-core chokepoints.
+2. PR2: sandbox-mode media fail-closed behavior and the tools-dev/e2e smoke.
+3. PR3: contracts/golden fixtures, static ownership checks, and raw project-file
+   regression coverage.
+
+Dependent branches should be based on the previous branch and updated before
+opening, so review catches conflicts within the stack instead of at merge time.
+
+### Phase 0: Product-Neutrality And Daemon-Core Chokepoints
+
+- Replace any public private-orchestrator references with "external
+  orchestrator."
+- Add a public guard that fails on named orchestrator examples in public
+  contract, prompt, docs, help, and shipped content surfaces; support stricter
+  private terms through local configuration.
+- Keep the allowlist narrow so normal references to Open Design, GitHub
+  repository names, and public package names do not fail.
+- Delete dead shadow handlers for `POST /api/projects/:id/media/generate` and
+  `POST /api/projects/:id/export/pdf`.
+- Add a duplicate-route registration guard so Express registration order is not
+  the safety mechanism.
+- Add red-spec-first tests for `POST /api/runs/:id/tool-result`, then reject
+  unknown, wrong-run, and duplicate `toolUseId` submissions before writing to
+  child stdin.
+
+### Phase 1: Media Chokepoint
+
+- Move stable media policy denial codes into `packages/contracts`.
+- Add a small golden fixture that pins the disabled-policy response shape and
+  code names.
+- Introduce a run-aware media generation entrypoint and make raw provider
+  execution non-exported or statically guarded.
+- Make `mediaExecution` explicit at every `design.runs.create` call site.
+- In sandbox mode, fail closed when an in-run caller reaches the legacy media
+  route without a run-scoped grant.
+
+### Phase 2: Sandbox-Mode E2E Variant
+
+- Plumb `OD_SANDBOX_MODE=1` and a unique `OD_DATA_DIR` through a
+  `createSmokeSuite(...).with.toolsDev(...)` variant.
+- Assert sandbox mode through `/api/daemon/status`.
+- Start one run with a run-scoped MCP tool and verify persisted MCP registry
+  state is not visible in the child.
+- Verify agent home/temp paths resolve under the sandbox runtime root.
+
+### Phase 3: Contract Golden And Static Ownership
+
+Keep the stable shapes in `packages/contracts` so web, daemon, CLI, and
+orchestrators read the same source of truth:
+
+- media policy denial codes;
+- disabled media response skeleton;
+- export manifest v1 skeleton;
+- run status fields relevant to external observation;
+- preview URL shape constraints.
+
+The daemon tests should compare live responses to the golden. The e2e smoke
+should check one live daemon against the same fixture.
+
+- Add a precise web-isolation guard: `apps/web/**` must not import daemon private
+  source, sidecar internals, or platform process primitives.
+- Avoid broad "business logic cannot import sidecar" rules; the daemon is a
+  sidecar host and legitimately imports sidecar modules.
+- Add CODEOWNERS once the owning GitHub team/user names are known, with coverage
+  for sandbox runtime, sidecar/process stamping, tools-dev, media policy,
+  contracts, route registration, and e2e smoke harness files.
+- Mirror these surfaces in the external maintainer PR-duty workflow so review
+  output marks them as sandbox-orchestration-sensitive. Do not restore
+  `tools/pr` without a separate maintainer decision.
+- Ensure every new guard or smoke is invoked by `.github/workflows/ci.yml`; an
+  uncalled guard is documentation, not enforcement.
+
+### Phase 4: Raw Project-File Regression Coverage
+
+- Extend raw route and `resolveProjectFilePath` tests for traversal, symlink
+  escape, and preview URL derivation.
+- Keep inline export route tests as regression coverage for its existing caps and
+  symlink-aware resolution.
+
+## Open Decisions
+
+1. `/api/ready` already exists. Either add `od daemon ready --json` for CLI
+   parity or classify readiness as an internal daemon probe exempt from the
+   UI/CLI dual-track rule.
+2. CODEOWNERS needs real repository owner handles before it can be enforced.
+3. The exact sandbox-mode behavior for the legacy local media route needs a
+   compatibility decision: token-only in sandbox mode is the safest option, but
+   the normal local UI/CLI path should remain compatible outside sandbox mode.
+4. Decide whether the contract golden should live under
+   `packages/contracts/src/api/` as typed exports, under `packages/contracts`
+   tests as JSON fixtures, or both.
+
+## Non-Goals
+
+- Do not add a generic provider router, provider account pool, global media
+  budget system, or external executor API to Open Design.
+- Do not add consumer-specific conformance tests to Open Design CI.
+- Do not claim namespace alone isolates daemon data.
+- Do not use regex-only guards for data-flow properties like "paths are not
+  derived from ports"; write primitive tests instead.
+- Do not use broad sidecar import bans that fail on legitimate daemon host code.
+
+## Suggested PR Slices
+
+1. Product-neutrality guard plus daemon-core chokepoints: corrected plan,
+   guard/test, dead shadow-route deletion, duplicate-route guard, and
+   `tool_result` pending-id enforcement.
+2. Sandbox-mode fail-closed media and e2e smoke: explicit run media policy for
+   orbit/routine paths, sandbox-only legacy media hardening, and one
+   `OD_SANDBOX_MODE=1` tools-dev smoke.
+3. Contracts goldens and static ownership checks: contract-owned denial codes
+   and fixtures, raw project-file regression coverage, web import isolation, and
+   CODEOWNERS/external PR-duty updates if owner handles are known.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tools-pack": "pnpm exec tools-pack",
     "tools-serve": "pnpm exec tools-serve",
     "nix:update-hash": "node --experimental-strip-types ./scripts/update-nix-pnpm-deps-hash.ts",
-    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/postinstall.test.ts",
+    "guard": "tsx ./scripts/guard.ts && node --import tsx --test scripts/style-policy.test.ts scripts/product-neutrality.test.ts scripts/approve-fork-pr-workflows.test.ts scripts/postinstall.test.ts",
     "i18n:check": "tsx ./scripts/i18n-check.ts",
     "i18n:coverage": "tsx ./scripts/i18n-coverage-report.ts",
     "sync:community-pets": "node --experimental-strip-types scripts/sync-community-pets.ts",

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -47,7 +47,7 @@ export interface ChatRequest {
    */
   mediaExecution?: MediaExecutionPolicy;
   /**
-   * Run-scoped tool bundle supplied by an orchestrator such as Muginn.
+   * Run-scoped tool bundle supplied by an external orchestrator.
    * These servers are made available only to the spawned agent for this run
    * and are never written into the persistent Settings MCP registry.
    */

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { checkDesignSystemManifests } from "./check-design-system-manifests.ts";
 import { checkDesignSystemPackageQuality } from "./check-design-system-package-quality.ts";
@@ -495,6 +496,119 @@ async function collectRepositoryFiles(directory: string, skippedDirectoryNames =
   return files;
 }
 
+const productNeutralitySkippedDirectories = new Set([
+  ".git",
+  ".od",
+  ".tmp",
+  "dist",
+  "node_modules",
+  "out",
+  "test-results",
+]);
+// Public contracts, help/prompt strings, docs, and shipped content should
+// describe the integration role, not name a private deployment. The default
+// check blocks named "orchestrator such as ..." examples; private forks can
+// add stricter local terms through OD_PRODUCT_NEUTRALITY_FORBIDDEN_TERMS.
+const productNeutralityCheckedPathPrefixes = [
+  "apps/daemon/src/",
+  "apps/web/src/",
+  "craft/",
+  "design-systems/",
+  "design-templates/",
+  "docs/",
+  "packages/contracts/src/",
+  "skills/",
+];
+const productNeutralityTextExtensions = new Set([".md", ".mdx", ".ts", ".tsx"]);
+const productNeutralityDocFilePattern =
+  /(?:^|\/)(?:AGENTS|CLAUDE|CONTRIBUTING(?:\.[^.]+)?|QUICKSTART|README(?:\.[^.]+)?)\.md$/;
+const namedOrchestratorExamplePattern =
+  /\borchestrator\s+(?:such as|like|for example,?)\s+[`"']?[A-Z][A-Za-z0-9_-]+/gi;
+
+type ProductNeutralityViolation = {
+  filePath: string;
+  lineNumber: number;
+  reason: string;
+};
+
+export function isProductNeutralityCheckedPath(repositoryPath: string): boolean {
+  return (
+    productNeutralityCheckedPathPrefixes.some((prefix) => repositoryPath.startsWith(prefix)) ||
+    productNeutralityDocFilePattern.test(repositoryPath)
+  );
+}
+
+function isProductNeutralityTextFile(repositoryPath: string): boolean {
+  return productNeutralityTextExtensions.has(path.extname(repositoryPath));
+}
+
+function productNeutralityForbiddenTerms(): string[] {
+  return String(process.env.OD_PRODUCT_NEUTRALITY_FORBIDDEN_TERMS ?? "")
+    .split(",")
+    .map((term) => term.trim())
+    .filter((term) => term.length > 0);
+}
+
+export function collectProductNeutralityViolationsFromSource(
+  repositoryPath: string,
+  source: string,
+  forbiddenTerms = productNeutralityForbiddenTerms(),
+): ProductNeutralityViolation[] {
+  if (!isProductNeutralityCheckedPath(repositoryPath) || !isProductNeutralityTextFile(repositoryPath)) {
+    return [];
+  }
+
+  const lowerSource = source.toLowerCase();
+  const violations: ProductNeutralityViolation[] = [];
+
+  for (const match of source.matchAll(namedOrchestratorExamplePattern)) {
+    violations.push({
+      filePath: repositoryPath,
+      lineNumber: lineNumberForIndex(source, match.index ?? 0),
+      reason: "use generic \"external orchestrator\" phrasing instead of named orchestrator examples",
+    });
+  }
+
+  for (const term of forbiddenTerms) {
+    const lowerTerm = term.toLowerCase();
+    let index = lowerSource.indexOf(lowerTerm);
+
+    while (index !== -1) {
+      violations.push({
+        filePath: repositoryPath,
+        lineNumber: lineNumberForIndex(source, index),
+        reason: "use generic \"external orchestrator\" phrasing instead of private deployment names",
+      });
+      index = lowerSource.indexOf(lowerTerm, index + lowerTerm.length);
+    }
+  }
+
+  return violations;
+}
+
+async function checkProductNeutrality(): Promise<boolean> {
+  const violations: ProductNeutralityViolation[] = [];
+
+  for (const repositoryPath of await collectRepositoryFiles(repoRoot, productNeutralitySkippedDirectories)) {
+    if (!isProductNeutralityCheckedPath(repositoryPath) || !isProductNeutralityTextFile(repositoryPath)) {
+      continue;
+    }
+    const source = await readFile(path.join(repoRoot, repositoryPath), "utf8");
+    violations.push(...collectProductNeutralityViolationsFromSource(repositoryPath, source));
+  }
+
+  if (violations.length > 0) {
+    console.error("Product-neutrality violations found:");
+    for (const violation of violations) {
+      console.error(`${violation.filePath}:${violation.lineNumber} -> ${violation.reason}`);
+    }
+    return false;
+  }
+
+  console.log("Product-neutrality check passed: public docs, contracts, and prompts use generic orchestrator naming.");
+  return true;
+}
+
 async function checkE2eLayout(): Promise<boolean> {
   const violations: string[] = [];
   const packageJson = JSON.parse(await readFile(e2ePackageJsonPath, "utf8")) as {
@@ -921,6 +1035,7 @@ async function checkStylePolicy(): Promise<boolean> {
 const checks: GuardCheck[] = [
   { name: "residual JavaScript", run: checkResidualJavaScript },
   { name: "package dependency specs", run: checkPackageDependencySpecs },
+  { name: "product neutrality", run: checkProductNeutrality },
   { name: "test layout", run: checkTestLayout },
   { name: "e2e layout", run: checkE2eLayout },
   { name: "web test layout", run: checkWebTestLayout },
@@ -939,17 +1054,22 @@ const checks: GuardCheck[] = [
   { name: "design system component manifest extraction", run: checkComponentsManifestExtraction },
 ];
 
-const results: boolean[] = [];
-for (const check of checks) {
-  try {
-    results.push(await check.run());
-  } catch (error) {
-    console.error(`Guard check failed unexpectedly: ${check.name}`);
-    console.error(error);
-    results.push(false);
+async function runChecks(): Promise<boolean> {
+  const results: boolean[] = [];
+  for (const check of checks) {
+    try {
+      results.push(await check.run());
+    } catch (error) {
+      console.error(`Guard check failed unexpectedly: ${check.name}`);
+      console.error(error);
+      results.push(false);
+    }
   }
+
+  return results.every(Boolean);
 }
 
-if (results.some((passed) => !passed)) {
+const isMain = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+if (isMain && !(await runChecks())) {
   process.exitCode = 1;
 }

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -511,6 +511,7 @@ const productNeutralitySkippedDirectories = new Set([
 // add stricter local terms through OD_PRODUCT_NEUTRALITY_FORBIDDEN_TERMS.
 const productNeutralityCheckedPathPrefixes = [
   "apps/daemon/src/",
+  "apps/web/app/",
   "apps/web/src/",
   "craft/",
   "design-systems/",

--- a/scripts/product-neutrality.test.ts
+++ b/scripts/product-neutrality.test.ts
@@ -17,6 +17,18 @@ test("product-neutrality check rejects named orchestrator examples on public sur
   assert.equal(violations[0]?.lineNumber, 1);
 });
 
+test("product-neutrality check covers web App Router public copy", () => {
+  assert.equal(isProductNeutralityCheckedPath("apps/web/app/page.tsx"), true);
+
+  const violations = collectProductNeutralityViolationsFromSource(
+    "apps/web/app/page.tsx",
+    "This page mentions an orchestrator such as Acme.",
+    [],
+  );
+
+  assert.equal(violations.length, 1);
+});
+
 test("product-neutrality check supports local forbidden terms without committing them", () => {
   const violations = collectProductNeutralityViolationsFromSource(
     "docs/example.md",

--- a/scripts/product-neutrality.test.ts
+++ b/scripts/product-neutrality.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  collectProductNeutralityViolationsFromSource,
+  isProductNeutralityCheckedPath,
+} from "./guard.ts";
+
+test("product-neutrality check rejects named orchestrator examples on public surfaces", () => {
+  const violations = collectProductNeutralityViolationsFromSource(
+    "packages/contracts/src/api/chat.ts",
+    "Run-scoped tool bundle supplied by an orchestrator such as Acme.",
+    [],
+  );
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0]?.lineNumber, 1);
+});
+
+test("product-neutrality check supports local forbidden terms without committing them", () => {
+  const violations = collectProductNeutralityViolationsFromSource(
+    "docs/example.md",
+    "This private deployment name should not ship.",
+    ["private deployment"],
+  );
+
+  assert.equal(violations.length, 1);
+});
+
+test("product-neutrality check ignores out-of-scope paths", () => {
+  assert.equal(isProductNeutralityCheckedPath("tmp/scratch.md"), false);
+  assert.deepEqual(
+    collectProductNeutralityViolationsFromSource(
+      "tmp/scratch.md",
+      "A scratch note can mention an orchestrator such as Acme.",
+      [],
+    ),
+    [],
+  );
+});


### PR DESCRIPTION
Refs #3416

## Why

This is PR1 of the reduced three-PR follow-up stack from #3416. The use case is embedding Open Design under an external orchestrator while keeping the upstream project neutral and reviewable.

The pain being addressed is that some sandbox runtime guarantees were still convention-based: public text could drift into deployment-specific naming, sensitive extracted routes still had dead shadow handlers later in `server.ts`, and `POST /api/runs/:id/tool-result` wrote to child stdin before proving the `toolUseId` belonged to the run.

## What users will see

No UI changes. Normal local Open Design behavior should stay the same for valid calls.

Contributors will see `pnpm guard` fail if public contracts/docs/prompts use named orchestrator examples instead of generic external-orchestrator phrasing. Invalid or replayed `tool_result` submissions now fail before they can write to a live child process.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A; no UI surface changed.

## Bug fix verification

- Not a user-visible bug fix. This is hardening work with regression coverage for the new invariants.
- Test paths:
  - `apps/daemon/tests/route-registration-guard.test.ts`
  - `apps/daemon/tests/run-tool-results.test.ts`
  - `apps/daemon/tests/chat-tool-result-route.test.ts`

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/route-registration-guard.test.ts tests/run-tool-results.test.ts tests/chat-tool-result-route.test.ts tests/media-policy-routes.test.ts tests/pdf-export.test.ts`
- `pnpm --filter @open-design/daemon exec vitest run tests/route-registration-guard.test.ts tests/run-tool-results.test.ts tests/chat-tool-result-route.test.ts`
- `pnpm guard`
- `pnpm typecheck`

Local note: this shell is on Node v26.0.0, so pnpm printed the repo's expected engine warning (`node: ~24`), but the listed commands passed.
