### PR TITLE
fix(app): refresh AMR agents after auth

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -463,6 +463,7 @@ jobs:
             "--cache-dir", $cacheDir,
             "--namespace", "release-beta-win",
             "--portable",
+            "--require-vela-cli",
             "--app-version", "${{ needs.metadata.outputs.beta_version }}",
             "--to", "all",
             "--json"
@@ -481,6 +482,7 @@ jobs:
               --dir $toolsPackDir `
               --namespace release-beta-win `
               --portable `
+              --require-vela-cli `
               --app-version "${{ needs.metadata.outputs.beta_version }}" `
               --to all `
               --json

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -18,6 +18,10 @@ import { MarketplaceView } from './components/MarketplaceView';
 import { PluginDetailView } from './components/PluginDetailView';
 import type { CreateInput, ImportClaudeDesignOutcome } from './components/NewProjectPanel';
 import { MemoryToast } from './components/MemoryToast';
+import {
+  AMR_LOGIN_STATUS_EVENT,
+  amrLoginStatusEventReason,
+} from './components/amrLoginPolling';
 import { PetOverlay, type PetTaskCenter } from './components/pet/PetOverlay';
 import { buildPetTaskCenter } from './components/pet/taskCenter';
 import { migrateCustomPetAtlas } from './components/pet/pets';
@@ -198,6 +202,7 @@ export function App() {
   const [integrationInitialTab, setIntegrationInitialTab] = useState<IntegrationTab>('mcp');
   const [daemonLive, setDaemonLive] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
+  const amrAuthAgentRefreshRunningRef = useRef(false);
   // Functional skills (capabilities the agent invokes mid-task) — stays
   // small and lives under the Settings → Skills surface.
   const [skills, setSkills] = useState<SkillSummary[]>([]);
@@ -804,6 +809,23 @@ export function App() {
     },
     [config],
   );
+
+  useEffect(() => {
+    const refreshAfterAmrAuthChange = (event: Event) => {
+      if (amrLoginStatusEventReason(event) !== 'status-changed') return;
+      if (amrAuthAgentRefreshRunningRef.current) return;
+      amrAuthAgentRefreshRunningRef.current = true;
+      void refreshAgents()
+        .catch(() => undefined)
+        .finally(() => {
+          amrAuthAgentRefreshRunningRef.current = false;
+        });
+    };
+    window.addEventListener(AMR_LOGIN_STATUS_EVENT, refreshAfterAmrAuthChange);
+    return () => {
+      window.removeEventListener(AMR_LOGIN_STATUS_EVENT, refreshAfterAmrAuthChange);
+    };
+  }, [refreshAgents]);
 
   const handleCreateProject = useCallback(
     async (

--- a/apps/web/src/components/AmrLoginPill.tsx
+++ b/apps/web/src/components/AmrLoginPill.tsx
@@ -246,6 +246,7 @@ export function AmrLoginPill({
         loginStartedAtRef.current = null;
         loginPendingRef.current = false;
         setPending(null);
+        notifyAmrLoginStatusChanged('status-changed');
         return;
       }
       if (outcome === 'stopped' || outcome === 'timed-out') {

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -113,6 +113,7 @@ import { AmrAccountControl } from './AmrLoginPill';
 import {
   AMR_LOGIN_POLL_INTERVAL_MS,
   amrLoginPollOutcome,
+  notifyAmrLoginStatusChanged,
 } from './amrLoginPolling';
 
 // The topbar chips (GitHub star, model switcher, Use everywhere)
@@ -1338,6 +1339,7 @@ function OnboardingView({
         return;
       }
       if (await pollAmrLoginCompletion()) {
+        notifyAmrLoginStatusChanged('status-changed');
         setStep((current) => current + 1);
       }
     } finally {

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -159,6 +159,7 @@ export function InlineModelSwitcher({
         stopAmrPolling();
         amrLoginStartedAtRef.current = null;
         setAmrLoginPending(false);
+        notifyAmrLoginStatusChanged('status-changed');
         return;
       }
       if (outcome === 'stopped' || outcome === 'timed-out') {

--- a/apps/web/tests/components/App.mediaProviders.test.tsx
+++ b/apps/web/tests/components/App.mediaProviders.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App } from '../../src/App';
+import { notifyAmrLoginStatusChanged } from '../../src/components/amrLoginPolling';
 import type { AppConfig } from '../../src/types';
 import {
   fetchComposioConfigFromDaemon,
@@ -268,5 +269,19 @@ describe('App media provider sync flows', () => {
         },
       }),
     );
+  });
+
+  it('refreshes the agent catalog after AMR auth state settles', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedFetchAgents).toHaveBeenCalledTimes(1);
+    });
+
+    notifyAmrLoginStatusChanged('status-changed');
+
+    await waitFor(() => {
+      expect(mockedFetchAgents).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/docs/plans/amr-windows-vela-permission-conclusion.md
+++ b/docs/plans/amr-windows-vela-permission-conclusion.md
@@ -1,0 +1,31 @@
+# AMR Windows Vela Config Permission Conclusion
+
+Date: 2026-06-01
+
+## Finding
+
+On Windows, `vela.exe` rejects `C:\Users\<user>\.amr\config.json` before `vela login` or `vela models` can proceed when it applies the POSIX `0600 or stricter` permission check.
+
+Tightening the Windows ACL to only the current user does not satisfy the check because POSIX-style stat still reports modes such as `0666` or `0444` on Windows. This blocks:
+
+- the AMR `Authorize` button, because `/api/integrations/vela/login` spawns `vela login`
+- the AMR model picker, because daemon discovery runs `vela models`
+
+## Preferred Root Fix
+
+Fix this in `vela-cli`, not Open Design:
+
+- keep the strict `0600` check on macOS/Linux
+- skip the POSIX permission check on Windows, or replace it with a Windows ACL-aware check later
+
+Recommended minimal Vela fix:
+
+```go
+if runtime.GOOS == "windows" {
+    return nil
+}
+```
+
+inside the config permission validation function.
+
+After publishing the fixed Vela package, bump `@powerformer/vela-cli` in Open Design and rebuild the Windows installer.

--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-nSMVyVSHfcXV5fLMXM3tfdQxZRb+FNF6P4iuJw/Z8Mo=";
-  webHash = "sha256-QOufFb3Hb5js3jK6QEl3WfnxNAa4DdZfMKoALTHY4hI=";
+  daemonHash = "sha256-Igx7hFM1okbUNNJIz6n4sEpkEq6BKF3Kj97WnNIeEws=";
+  webHash = "sha256-euLiJ/t0zqzV3hxIlo5xcNsWDiqIkzw52HRTHYDbDVM=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,8 +601,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.4
-        version: 0.0.4
+        specifier: 0.0.6
+        version: 0.0.6
 
   tools/serve:
     dependencies:
@@ -1642,13 +1642,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.4':
-    resolution: {integrity: sha512-PleB0cl42Iv7s+TrhsBFu1KZ0p3tQa+Qpm5PAS21p0INUU6kQ9H45DJ6bKB/CAoGuhq5lPL1XT3NdkLPe+V46A==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.6':
+    resolution: {integrity: sha512-NhZOudkaGGNPeTSrA2BubzXl8xKs74HQuTn3zRMqlVrxVc6LkGgtzhRkHHebeuEVvv66fNtme3hfxiKqPQ396A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli@0.0.4':
-    resolution: {integrity: sha512-63QzbvQ3JRkFwHf9cETAn4WTkbIjYc48Z4Et+pYFRyIwu3CtUUBxsPy93k/L9I1AcXOGjyJT7vFMm1gfs8amew==}
+  '@powerformer/vela-cli-darwin-x64@0.0.6':
+    resolution: {integrity: sha512-5urixFfgNHR4b0mZ2NLQeQyv2Ze3XPtvwpt4oHcSxxvE4E/4C/+YO9owwV6KzVnEY0i+/RocZnAbFusgwy7a8Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@powerformer/vela-cli-linux-arm64@0.0.6':
+    resolution: {integrity: sha512-nujuvebyoZhkfLDrWVVFC5WM5KaClHEMgX7GX+yfvLSd7zcfrH1zu4aBvd3vA62jKSYpSKRTH3vqei5Avo56sg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@powerformer/vela-cli-linux-x64@0.0.6':
+    resolution: {integrity: sha512-qX1VHfFVjiNNllzftBnuJ/k32gvc6J4yk/L8soVyfJQUadjO+YCL6GZ3S+h5jDkPD5Ao/l++YBXHFB07aXPwew==}
+    cpu: [x64]
+    os: [linux]
+
+  '@powerformer/vela-cli-win32-x64@0.0.6':
+    resolution: {integrity: sha512-LCTNtYO3jAw8Z5TQHoeckaHHDlMpj581ZluiOgV4Z103ZRAI3wOxZxSLJWgCV4ayvgfiNOp4vwR0Nnechphtlw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@powerformer/vela-cli@0.0.6':
+    resolution: {integrity: sha512-jBUf7//UQ5o+9ZrUPXv/jFsJhObw78m0wBCuxD2EM+6gF7YzsLbe7x9Xn8Y3jTvPxeEgHySzfeHEUDJdvJtnOQ==}
     hasBin: true
 
   '@rollup/pluginutils@5.3.0':
@@ -6043,12 +6063,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.4':
+  '@powerformer/vela-cli-darwin-arm64@0.0.6':
     optional: true
 
-  '@powerformer/vela-cli@0.0.4':
+  '@powerformer/vela-cli-darwin-x64@0.0.6':
+    optional: true
+
+  '@powerformer/vela-cli-linux-arm64@0.0.6':
+    optional: true
+
+  '@powerformer/vela-cli-linux-x64@0.0.6':
+    optional: true
+
+  '@powerformer/vela-cli-win32-x64@0.0.6':
+    optional: true
+
+  '@powerformer/vela-cli@0.0.6':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.4
+      '@powerformer/vela-cli-darwin-arm64': 0.0.6
+      '@powerformer/vela-cli-darwin-x64': 0.0.6
+      '@powerformer/vela-cli-linux-arm64': 0.0.6
+      '@powerformer/vela-cli-linux-x64': 0.0.6
+      '@powerformer/vela-cli-win32-x64': 0.0.6
     optional: true
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -22,7 +22,7 @@
     "electron-builder": "26.8.1"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.4"
+    "@powerformer/vela-cli": "0.0.6"
   },
   "devDependencies": {
     "@types/node": "24.12.2",

--- a/tools/pack/src/workspace-build.ts
+++ b/tools/pack/src/workspace-build.ts
@@ -212,7 +212,12 @@ async function hoistStandaloneNextPeerDeps(standaloneRoot: string): Promise<void
     // from a previous build with different react/react-dom versions)
     // before recreating, so repeated invocations don't EEXIST.
     if (existing) await unlink(linkPath).catch(() => undefined);
-    await symlink(relativeTarget, linkPath);
+    try {
+      await symlink(relativeTarget, linkPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EPERM" || process.platform !== "win32") throw error;
+      await cp(target, linkPath, { recursive: true });
+    }
   }
 }
 

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -11,7 +11,7 @@ function sectionBetween(content: string, start: string, end: string): string {
 }
 
 describe("release workflows", () => {
-  it("requires Vela CLI only for beta mac arm64 packaging", async () => {
+  it("requires Vela CLI for beta mac arm64 and Windows packaging", async () => {
     const beta = await readFile(new URL("../../../.github/workflows/release-beta.yml", import.meta.url), "utf8");
     const mac = sectionBetween(beta, "  build_mac:", "  build_mac_intel:");
     const macIntel = sectionBetween(beta, "  build_mac_intel:", "  build_win:");
@@ -20,8 +20,8 @@ describe("release workflows", () => {
 
     expect(mac).toContain("--require-vela-cli");
     expect(macIntel).not.toContain("--require-vela-cli");
-    expect(win).not.toContain("--require-vela-cli");
+    expect(win).toContain("--require-vela-cli");
     expect(linux).not.toContain("--require-vela-cli");
-    expect(beta.match(/--require-vela-cli/g)?.length).toBe(1);
+    expect(beta.match(/--require-vela-cli/g)?.length).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary
- Refresh the app agent catalog when AMR auth status settles so the AMR model picker appears after sign-in across platforms.
- Bump bundled `@powerformer/vela-cli` to `0.0.6` and require Vela CLI for Windows beta packaging.
- Add a Windows symlink fallback for packaging Next peer dependencies when symlink creation hits `EPERM`.
- Save the Windows Vela config permission conclusion for the launch-contract verification handoff.

## Verification
- `pnpm --filter @open-design/web test -- App.mediaProviders.test.tsx SettingsDialog.execution.test.tsx InlineModelSwitcher.test.tsx AmrLoginPill.test.tsx EntryShell.onboarding.test.tsx`
- `pnpm --filter @open-design/tools-pack build`

## Related
- Vela root fix PR: https://github.com/powerformer/vela/pull/176