### PR TITLE
fix(app): refresh and cache AMR agent catalog

### DIFF
--- a/apps/daemon/src/static-resource-routes.ts
+++ b/apps/daemon/src/static-resource-routes.ts
@@ -2,6 +2,7 @@ import type { Express } from 'express';
 import path from 'node:path';
 import fs from 'node:fs';
 import { detectAgents } from './agents.js';
+import type { DetectedAgent } from './runtimes/types.js';
 import {
   SkillImportError,
   deleteUserSkill,
@@ -27,6 +28,88 @@ import { installFromTarget, uninstallById } from './library-install.js';
 import type { RouteDeps } from './server-context.js';
 
 export interface RegisterStaticResourceRoutesDeps extends RouteDeps<'http' | 'paths' | 'resources'> {}
+
+export const AGENT_DETECTION_CACHE_TTL_MS = 30_000;
+
+let cachedAgentDetection:
+  | { envKey: string; agents: DetectedAgent[]; expiresAtMs: number }
+  | null = null;
+let inflightAgentDetection:
+  | { envKey: string; force: boolean; promise: Promise<DetectedAgent[]> }
+  | null = null;
+
+export function resetAgentDetectionCacheForTests() {
+  cachedAgentDetection = null;
+  inflightAgentDetection = null;
+}
+
+export async function detectAgentsForApi(
+  configuredEnvByAgent: Record<string, Record<string, string>> = {},
+  options: {
+    force?: boolean;
+    nowMs?: number;
+    ttlMs?: number;
+    detect?: typeof detectAgents;
+  } = {},
+): Promise<DetectedAgent[]> {
+  const envKey = stableJson(configuredEnvByAgent);
+  const nowMs = options.nowMs ?? Date.now();
+  const ttlMs = options.ttlMs ?? AGENT_DETECTION_CACHE_TTL_MS;
+  const force = options.force === true;
+  if (
+    !force &&
+    cachedAgentDetection &&
+    cachedAgentDetection.envKey === envKey &&
+    cachedAgentDetection.expiresAtMs > nowMs
+  ) {
+    return cachedAgentDetection.agents;
+  }
+  if (
+    inflightAgentDetection &&
+    inflightAgentDetection.envKey === envKey &&
+    (!force || inflightAgentDetection.force)
+  ) {
+    return inflightAgentDetection.promise;
+  }
+  const detect = options.detect ?? detectAgents;
+  const promise = detect(configuredEnvByAgent).then((agents) => {
+    cachedAgentDetection = {
+      envKey,
+      agents,
+      expiresAtMs: (options.nowMs ?? Date.now()) + ttlMs,
+    };
+    return agents;
+  });
+  inflightAgentDetection = { envKey, force, promise };
+  promise.finally(() => {
+    if (inflightAgentDetection?.promise === promise) {
+      inflightAgentDetection = null;
+    }
+  }).catch(() => undefined);
+  return promise;
+}
+
+function stableJson(value: unknown): string {
+  if (!value || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .join(',')}}`;
+}
+
+function shouldForceAgentDetection(query: Record<string, unknown>): boolean {
+  return ['refresh', 'force', 'rescan'].some((key) => {
+    const value = query[key];
+    if (Array.isArray(value)) return value.some(isForceQueryValue);
+    return isForceQueryValue(value);
+  });
+}
+
+function isForceQueryValue(value: unknown): boolean {
+  return value === true || value === 'true' || value === '1' || value === '';
+}
 
 export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticResourceRoutesDeps) {
   const {
@@ -56,10 +139,12 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
     return false;
   };
 
-  app.get('/api/agents', async (_req, res) => {
+  app.get('/api/agents', async (req, res) => {
     try {
       const config = await readAppConfig(RUNTIME_DATA_DIR);
-      const list = await detectAgents(config.agentCliEnv ?? {});
+      const list = await detectAgentsForApi(config.agentCliEnv ?? {}, {
+        force: shouldForceAgentDetection(req.query),
+      });
       res.json({ agents: list });
     } catch (err: any) {
       res.status(500).json({ error: String(err) });

--- a/apps/daemon/tests/static-resource-routes.test.ts
+++ b/apps/daemon/tests/static-resource-routes.test.ts
@@ -3,11 +3,56 @@ import http from 'node:http';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { isLocalSameOrigin } from '../src/origin-validation.js';
 import { listDesignSystems } from '../src/design-systems.js';
-import { registerStaticResourceRoutes } from '../src/static-resource-routes.js';
+import {
+  detectAgentsForApi,
+  registerStaticResourceRoutes,
+  resetAgentDetectionCacheForTests,
+} from '../src/static-resource-routes.js';
+
+afterEach(() => {
+  resetAgentDetectionCacheForTests();
+});
+
+describe('agent detection API cache', () => {
+  it('serves repeated scans from the short-lived cache until forced', async () => {
+    const agents = [{ id: 'amr', name: 'AMR', available: true, models: [] }] as any;
+    const detect = vi.fn(async () => agents);
+
+    await expect(
+      detectAgentsForApi({}, { detect, nowMs: 100, ttlMs: 10_000 }),
+    ).resolves.toBe(agents);
+    await expect(
+      detectAgentsForApi({}, { detect, nowMs: 200, ttlMs: 10_000 }),
+    ).resolves.toBe(agents);
+    expect(detect).toHaveBeenCalledTimes(1);
+
+    await expect(
+      detectAgentsForApi({}, { detect, force: true, nowMs: 300, ttlMs: 10_000 }),
+    ).resolves.toBe(agents);
+    expect(detect).toHaveBeenCalledTimes(2);
+  });
+
+  it('dedupes concurrent ordinary scans', async () => {
+    const agents = [{ id: 'amr', name: 'AMR', available: true, models: [] }] as any;
+    let resolveScan: (value: any) => void = () => undefined;
+    const detect = vi.fn(
+      () => new Promise<any>((resolve) => {
+        resolveScan = resolve;
+      }),
+    );
+
+    const first = detectAgentsForApi({}, { detect, nowMs: 100, ttlMs: 10_000 });
+    const second = detectAgentsForApi({}, { detect, nowMs: 100, ttlMs: 10_000 });
+
+    expect(detect).toHaveBeenCalledTimes(1);
+    resolveScan(agents);
+    await expect(Promise.all([first, second])).resolves.toEqual([agents, agents]);
+  });
+});
 
 describe('static resource mutation routes', () => {
   let server: http.Server;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -18,6 +18,10 @@ import { MarketplaceView } from './components/MarketplaceView';
 import { PluginDetailView } from './components/PluginDetailView';
 import type { CreateInput, ImportClaudeDesignOutcome } from './components/NewProjectPanel';
 import { MemoryToast } from './components/MemoryToast';
+import {
+  AMR_LOGIN_STATUS_EVENT,
+  amrLoginStatusEventReason,
+} from './components/amrLoginPolling';
 import { PetOverlay, type PetTaskCenter } from './components/pet/PetOverlay';
 import { buildPetTaskCenter } from './components/pet/taskCenter';
 import { migrateCustomPetAtlas } from './components/pet/pets';
@@ -198,6 +202,7 @@ export function App() {
   const [integrationInitialTab, setIntegrationInitialTab] = useState<IntegrationTab>('mcp');
   const [daemonLive, setDaemonLive] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
+  const amrAuthAgentRefreshRunningRef = useRef(false);
   // Functional skills (capabilities the agent invokes mid-task) — stays
   // small and lives under the Settings → Skills surface.
   const [skills, setSkills] = useState<SkillSummary[]>([]);
@@ -804,6 +809,23 @@ export function App() {
     },
     [config],
   );
+
+  useEffect(() => {
+    const refreshAfterAmrAuthChange = (event: Event) => {
+      if (amrLoginStatusEventReason(event) !== 'status-changed') return;
+      if (amrAuthAgentRefreshRunningRef.current) return;
+      amrAuthAgentRefreshRunningRef.current = true;
+      void refreshAgents()
+        .catch(() => undefined)
+        .finally(() => {
+          amrAuthAgentRefreshRunningRef.current = false;
+        });
+    };
+    window.addEventListener(AMR_LOGIN_STATUS_EVENT, refreshAfterAmrAuthChange);
+    return () => {
+      window.removeEventListener(AMR_LOGIN_STATUS_EVENT, refreshAfterAmrAuthChange);
+    };
+  }, [refreshAgents]);
 
   const handleCreateProject = useCallback(
     async (

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -796,14 +796,21 @@ export function App() {
   );
 
   const refreshAgents = useCallback(
-    async (options?: { throwOnError?: boolean; agentCliEnv?: AppConfig['agentCliEnv'] }) => {
+    async (options?: {
+      throwOnError?: boolean;
+      agentCliEnv?: AppConfig['agentCliEnv'];
+      force?: boolean;
+    }) => {
       if (options && Object.prototype.hasOwnProperty.call(options, 'agentCliEnv')) {
         const nextConfig = { ...config, agentCliEnv: options.agentCliEnv ?? {} };
         saveConfig(nextConfig);
         await syncConfigToDaemon(nextConfig);
         setConfig(nextConfig);
       }
-      const next = await fetchAgents({ throwOnError: options?.throwOnError });
+      const next = await fetchAgents({
+        throwOnError: options?.throwOnError,
+        force: options?.force,
+      });
       setAgents(next);
       return next;
     },
@@ -815,7 +822,7 @@ export function App() {
       if (amrLoginStatusEventReason(event) !== 'status-changed') return;
       if (amrAuthAgentRefreshRunningRef.current) return;
       amrAuthAgentRefreshRunningRef.current = true;
-      void refreshAgents()
+      void refreshAgents({ force: true })
         .catch(() => undefined)
         .finally(() => {
           amrAuthAgentRefreshRunningRef.current = false;

--- a/apps/web/src/components/AmrLoginPill.tsx
+++ b/apps/web/src/components/AmrLoginPill.tsx
@@ -246,6 +246,7 @@ export function AmrLoginPill({
         loginStartedAtRef.current = null;
         loginPendingRef.current = false;
         setPending(null);
+        notifyAmrLoginStatusChanged('status-changed');
         return;
       }
       if (outcome === 'stopped' || outcome === 'timed-out') {

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -113,6 +113,7 @@ import { AmrAccountControl } from './AmrLoginPill';
 import {
   AMR_LOGIN_POLL_INTERVAL_MS,
   amrLoginPollOutcome,
+  notifyAmrLoginStatusChanged,
 } from './amrLoginPolling';
 
 // The topbar chips (GitHub star, model switcher, Use everywhere)
@@ -1338,6 +1339,7 @@ function OnboardingView({
         return;
       }
       if (await pollAmrLoginCompletion()) {
+        notifyAmrLoginStatusChanged('status-changed');
         setStep((current) => current + 1);
       }
     } finally {

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -159,6 +159,7 @@ export function InlineModelSwitcher({
         stopAmrPolling();
         amrLoginStartedAtRef.current = null;
         setAmrLoginPending(false);
+        notifyAmrLoginStatusChanged('status-changed');
         return;
       }
       if (outcome === 'stopped' || outcome === 'timed-out') {

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -199,6 +199,7 @@ interface Props {
 export interface AgentRefreshOptions {
   throwOnError?: boolean;
   agentCliEnv?: AppConfig['agentCliEnv'];
+  force?: boolean;
 }
 
 function codexPathStrings(locale: Locale) {
@@ -1142,7 +1143,10 @@ export function SettingsDialog({
     setAgentRescanRunning(true);
     setAgentRescanNotice(null);
     try {
-      const refreshed = await onRefreshAgents(agentRefreshOptionsForConfig(cfg));
+      const refreshed = await onRefreshAgents({
+        ...agentRefreshOptionsForConfig(cfg),
+        force: true,
+      });
       const nextAgents = Array.isArray(refreshed) ? refreshed : agents;
       setAgentRescanNotice({
         kind: 'success',

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -85,9 +85,14 @@ function deployProviderQuery(providerId?: WebDeployProviderId): string {
   return providerId ? `?providerId=${encodeURIComponent(providerId)}` : '';
 }
 
-export async function fetchAgents(options?: { throwOnError?: boolean }): Promise<AgentInfo[]> {
+export async function fetchAgents(options?: {
+  throwOnError?: boolean;
+  force?: boolean;
+}): Promise<AgentInfo[]> {
   try {
-    const resp = await fetch('/api/agents', { cache: 'no-store' });
+    const resp = await fetch(options?.force ? '/api/agents?refresh=1' : '/api/agents', {
+      cache: 'no-store',
+    });
     if (!resp.ok) {
       if (options?.throwOnError) throw new Error(`agents ${resp.status}`);
       return [];

--- a/apps/web/tests/components/App.mediaProviders.test.tsx
+++ b/apps/web/tests/components/App.mediaProviders.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App } from '../../src/App';
+import { notifyAmrLoginStatusChanged } from '../../src/components/amrLoginPolling';
 import type { AppConfig } from '../../src/types';
 import {
   fetchComposioConfigFromDaemon,
@@ -268,5 +269,19 @@ describe('App media provider sync flows', () => {
         },
       }),
     );
+  });
+
+  it('refreshes the agent catalog after AMR auth state settles', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedFetchAgents).toHaveBeenCalledTimes(1);
+    });
+
+    notifyAmrLoginStatusChanged('status-changed');
+
+    await waitFor(() => {
+      expect(mockedFetchAgents).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/apps/web/tests/components/App.mediaProviders.test.tsx
+++ b/apps/web/tests/components/App.mediaProviders.test.tsx
@@ -283,5 +283,8 @@ describe('App media provider sync flows', () => {
     await waitFor(() => {
       expect(mockedFetchAgents).toHaveBeenCalledTimes(2);
     });
+    expect(mockedFetchAgents).toHaveBeenLastCalledWith(
+      expect.objectContaining({ force: true }),
+    );
   });
 });

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1256,6 +1256,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(onRefreshAgents).toHaveBeenCalledWith({
       throwOnError: true,
       agentCliEnv: {},
+      force: true,
     });
     expect(rescanButton.disabled).toBe(true);
     expect(screen.getByText('Scanning...')).toBeTruthy();
@@ -1317,6 +1318,7 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
       expect(onRefreshAgents).toHaveBeenCalledWith({
         throwOnError: true,
         agentCliEnv: {},
+        force: true,
       });
     });
   });


### PR DESCRIPTION
## Summary
- Refresh the agent catalog when AMR auth status settles after sign-in.
- Emit the shared AMR auth-status event from onboarding, the AMR login pill, and the inline model switcher successful sign-in paths.
- Add a daemon-side short TTL + inflight cache for ordinary `/api/agents` requests so the model-list UI does not rerun every CLI/model probe on each render/refresh.
- Keep explicit forced refresh for Settings Rescan and AMR auth-settled refresh so login still pulls fresh AMR models instead of serving stale cached state.
- Add regression coverage for AMR auth refresh and the daemon agent-detection cache.

## Verification
- `pnpm --filter @open-design/daemon test -- static-resource-routes.test.ts`
- `pnpm --filter @open-design/web test -- App.mediaProviders.test.tsx SettingsDialog.execution.test.tsx AmrLoginPill.test.tsx InlineModelSwitcher.test.tsx EntryShell.onboarding.test.tsx`

## Notes
- This intentionally excludes the Vela CLI dependency bump, Windows packaging changes, and handoff doc changes. The Windows permission root fix belongs to Vela CLI: https://github.com/powerformer/vela/pull/176