### PR TITLE
feat(daemon): load AMR model presets before remote catalog

### DIFF
--- a/apps/daemon/src/integrations/vela.ts
+++ b/apps/daemon/src/integrations/vela.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
 
@@ -26,6 +26,15 @@ export interface VelaLoginStatus {
   profile: string;
   user: VelaUser | null;
   configPath: string;
+}
+
+export interface VelaCredentialRevision {
+  authSource: 'env' | 'file' | 'none';
+  profile: string;
+  loggedIn: boolean;
+  userId: string;
+  userEmail: string;
+  configMtimeMs: number | null;
 }
 
 interface VelaProfileShape {
@@ -101,6 +110,28 @@ export function readVelaLoginStatus(
       }
     : null;
   return { loggedIn: true, loginInFlight, profile, user, configPath };
+}
+
+export function readVelaCredentialRevision(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): VelaCredentialRevision {
+  const mergedEnv = mergeVelaEnv(env, configuredEnv);
+  const status = readVelaLoginStatus(env, configuredEnv);
+  const hasEnvCredentials =
+    (mergedEnv.VELA_RUNTIME_KEY?.trim() ?? '').length > 0 &&
+    (mergedEnv.VELA_LINK_URL?.trim() ?? '').length > 0;
+  return {
+    authSource: hasEnvCredentials ? 'env' : status.loggedIn ? 'file' : 'none',
+    profile: status.profile,
+    loggedIn: status.loggedIn,
+    userId: status.user?.id ?? '',
+    userEmail: status.user?.email ?? '',
+    configMtimeMs:
+      hasEnvCredentials || !existsSync(status.configPath)
+        ? null
+        : statSync(status.configPath).mtimeMs,
+  };
 }
 
 export function forgetVelaLogin(env: NodeJS.ProcessEnv = process.env): void {

--- a/apps/daemon/src/runtimes/amr-model-cache.ts
+++ b/apps/daemon/src/runtimes/amr-model-cache.ts
@@ -11,6 +11,12 @@ type Fetchers = {
   fetchRemote: () => Promise<RuntimeModelOption[]>;
 };
 
+type CacheState = {
+  remote: RemoteCacheEntry | null;
+  inFlight: Promise<void> | null;
+  lastRemoteError: string | null;
+};
+
 const DEFAULT_REMOTE_REFRESH_INTERVAL_MS = 60_000;
 
 function errorMessage(error: unknown): string {
@@ -18,60 +24,69 @@ function errorMessage(error: unknown): string {
 }
 
 export class AmrModelLoadingCache {
-  private remote: RemoteCacheEntry | null = null;
-  private inFlight: Promise<void> | null = null;
-  private lastRemoteError: string | null = null;
+  private readonly states = new Map<string, CacheState>();
 
   constructor(private readonly refreshIntervalMs = DEFAULT_REMOTE_REFRESH_INTERVAL_MS) {}
 
-  async get(fetchers: Fetchers): Promise<AmrModelsResponse> {
+  async get(cacheKey: string, fetchers: Fetchers): Promise<AmrModelsResponse> {
+    const state = this.stateFor(cacheKey);
     const now = Date.now();
-    if (this.remote) {
-      const staleByAge = now - this.remote.fetchedAt >= this.refreshIntervalMs;
-      if (staleByAge) this.startRefresh(fetchers.fetchRemote);
+    if (state.remote) {
+      const staleByAge = now - state.remote.fetchedAt >= this.refreshIntervalMs;
+      if (staleByAge) this.startRefresh(state, fetchers.fetchRemote);
       return {
         source: 'remote',
-        models: this.remote.models,
-        refreshing: this.inFlight !== null,
-        ...(this.inFlight || this.lastRemoteError ? { stale: true } : {}),
-        ...(this.lastRemoteError ? { remoteError: this.lastRemoteError } : {}),
+        models: state.remote.models,
+        refreshing: state.inFlight !== null,
+        ...(state.inFlight || state.lastRemoteError ? { stale: true } : {}),
+        ...(state.lastRemoteError ? { remoteError: state.lastRemoteError } : {}),
       };
     }
 
     const preset = await fetchers.fetchPreset();
-    this.startRefresh(fetchers.fetchRemote);
+    this.startRefresh(state, fetchers.fetchRemote);
     return {
       source: 'preset',
       models: preset,
-      refreshing: this.inFlight !== null,
-      ...(this.lastRemoteError ? { remoteError: this.lastRemoteError } : {}),
+      refreshing: state.inFlight !== null,
+      ...(state.lastRemoteError ? { remoteError: state.lastRemoteError } : {}),
     };
   }
 
-  warm(fetchRemote: () => Promise<RuntimeModelOption[]>): void {
-    this.startRefresh(fetchRemote);
+  warm(cacheKey: string, fetchRemote: () => Promise<RuntimeModelOption[]>): void {
+    this.startRefresh(this.stateFor(cacheKey), fetchRemote);
   }
 
   resetForTests(): void {
-    this.remote = null;
-    this.inFlight = null;
-    this.lastRemoteError = null;
+    this.states.clear();
   }
 
-  private startRefresh(fetchRemote: () => Promise<RuntimeModelOption[]>): void {
-    if (this.inFlight) return;
-    this.inFlight = (async () => {
+  private stateFor(cacheKey: string): CacheState {
+    const existing = this.states.get(cacheKey);
+    if (existing) return existing;
+    const created: CacheState = {
+      remote: null,
+      inFlight: null,
+      lastRemoteError: null,
+    };
+    this.states.set(cacheKey, created);
+    return created;
+  }
+
+  private startRefresh(state: CacheState, fetchRemote: () => Promise<RuntimeModelOption[]>): void {
+    if (state.inFlight) return;
+    state.inFlight = (async () => {
       try {
         const models = await fetchRemote();
         if (models.length === 0) {
           throw new Error('AMR remote model list returned no chat models');
         }
-        this.remote = { models, fetchedAt: Date.now() };
-        this.lastRemoteError = null;
+        state.remote = { models, fetchedAt: Date.now() };
+        state.lastRemoteError = null;
       } catch (error) {
-        this.lastRemoteError = errorMessage(error);
+        state.lastRemoteError = errorMessage(error);
       } finally {
-        this.inFlight = null;
+        state.inFlight = null;
       }
     })();
   }

--- a/apps/daemon/src/runtimes/amr-model-cache.ts
+++ b/apps/daemon/src/runtimes/amr-model-cache.ts
@@ -1,0 +1,80 @@
+import type { AmrModelsResponse } from '@open-design/contracts';
+import type { RuntimeModelOption } from './types.js';
+
+type RemoteCacheEntry = {
+  models: RuntimeModelOption[];
+  fetchedAt: number;
+};
+
+type Fetchers = {
+  fetchPreset: () => Promise<RuntimeModelOption[]>;
+  fetchRemote: () => Promise<RuntimeModelOption[]>;
+};
+
+const DEFAULT_REMOTE_REFRESH_INTERVAL_MS = 60_000;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error ?? 'unknown error');
+}
+
+export class AmrModelLoadingCache {
+  private remote: RemoteCacheEntry | null = null;
+  private inFlight: Promise<void> | null = null;
+  private lastRemoteError: string | null = null;
+
+  constructor(private readonly refreshIntervalMs = DEFAULT_REMOTE_REFRESH_INTERVAL_MS) {}
+
+  async get(fetchers: Fetchers): Promise<AmrModelsResponse> {
+    const now = Date.now();
+    if (this.remote) {
+      const staleByAge = now - this.remote.fetchedAt >= this.refreshIntervalMs;
+      if (staleByAge) this.startRefresh(fetchers.fetchRemote);
+      return {
+        source: 'remote',
+        models: this.remote.models,
+        refreshing: this.inFlight !== null,
+        ...(this.inFlight || this.lastRemoteError ? { stale: true } : {}),
+        ...(this.lastRemoteError ? { remoteError: this.lastRemoteError } : {}),
+      };
+    }
+
+    const preset = await fetchers.fetchPreset();
+    this.startRefresh(fetchers.fetchRemote);
+    return {
+      source: 'preset',
+      models: preset,
+      refreshing: this.inFlight !== null,
+      ...(this.lastRemoteError ? { remoteError: this.lastRemoteError } : {}),
+    };
+  }
+
+  warm(fetchRemote: () => Promise<RuntimeModelOption[]>): void {
+    this.startRefresh(fetchRemote);
+  }
+
+  resetForTests(): void {
+    this.remote = null;
+    this.inFlight = null;
+    this.lastRemoteError = null;
+  }
+
+  private startRefresh(fetchRemote: () => Promise<RuntimeModelOption[]>): void {
+    if (this.inFlight) return;
+    this.inFlight = (async () => {
+      try {
+        const models = await fetchRemote();
+        if (models.length === 0) {
+          throw new Error('AMR remote model list returned no chat models');
+        }
+        this.remote = { models, fetchedAt: Date.now() };
+        this.lastRemoteError = null;
+      } catch (error) {
+        this.lastRemoteError = errorMessage(error);
+      } finally {
+        this.inFlight = null;
+      }
+    })();
+  }
+}
+
+export const amrModelLoadingCache = new AmrModelLoadingCache();

--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -3,6 +3,7 @@ import type { RuntimeAgentDef, RuntimeModelOption } from '../types.js';
 
 const AMR_MODELS_TIMEOUT_MS = 10_000;
 const AMR_MODELS_RETRY_DELAYS_MS = [250, 750] as const;
+export type VelaModelJsonSource = 'preset' | 'remote';
 
 const PREFERRED_AMR_CHAT_MODEL_ORDER = [
   'deepseek-v4-flash',
@@ -117,6 +118,41 @@ export function parseVelaModels(stdout: string): RuntimeModelOption[] {
   return orderAmrChatModels(models);
 }
 
+export function parseVelaModelJson(
+  stdout: string,
+  expectedSource: VelaModelJsonSource,
+): RuntimeModelOption[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`Invalid vela model JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Invalid vela model JSON: expected object');
+  }
+  const source = (parsed as { source?: unknown }).source;
+  if (source !== expectedSource) {
+    throw new Error(`Invalid vela model JSON source: expected ${expectedSource}, got ${String(source)}`);
+  }
+  const data = (parsed as { data?: unknown }).data;
+  if (!Array.isArray(data)) {
+    throw new Error('Invalid vela model JSON: expected data array');
+  }
+  const seen = new Set<string>();
+  const models: RuntimeModelOption[] = [];
+  for (const item of data) {
+    const rawId = item && typeof item === 'object'
+      ? (item as { id?: unknown }).id
+      : null;
+    const id = typeof rawId === 'string' ? rawId.trim() : '';
+    if (!id || seen.has(id) || !isVelaChatModelId(id)) continue;
+    seen.add(id);
+    models.push({ id, label: id });
+  }
+  return orderAmrChatModels(models);
+}
+
 function orderAmrChatModels(
   models: RuntimeModelOption[],
 ): RuntimeModelOption[] {
@@ -185,12 +221,51 @@ async function fetchVelaModelsWithRetry(
   throw lastError instanceof Error ? lastError : new Error(velaModelsErrorMessage(lastError));
 }
 
+export async function fetchVelaPresetModels(
+  resolvedBin: string,
+  env: NodeJS.ProcessEnv,
+): Promise<RuntimeModelOption[]> {
+  const { stdout } = await execAgentFile(resolvedBin, ['model', 'preset', '--format', 'json'], {
+    env,
+    timeout: AMR_MODELS_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+  });
+  return parseVelaModelJson(String(stdout), 'preset');
+}
+
+export async function fetchVelaRemoteModelsWithRetry(
+  resolvedBin: string,
+  env: NodeJS.ProcessEnv,
+): Promise<RuntimeModelOption[]> {
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt <= AMR_MODELS_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      const { stdout } = await execAgentFile(resolvedBin, ['model', 'list', '--format', 'json'], {
+        env,
+        timeout: AMR_MODELS_TIMEOUT_MS,
+        maxBuffer: 1024 * 1024,
+      });
+      return parseVelaModelJson(String(stdout), 'remote');
+    } catch (error) {
+      lastError = error;
+      if (
+        attempt === AMR_MODELS_RETRY_DELAYS_MS.length ||
+        !isRetriableVelaModelsError(error)
+      ) {
+        throw error;
+      }
+      await sleep(AMR_MODELS_RETRY_DELAYS_MS[attempt] ?? 0);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(velaModelsErrorMessage(lastError));
+}
+
 export const amrAgentDef = {
   id: 'amr',
   name: 'AMR',
   bin: 'vela',
   versionArgs: ['--version'],
-  fetchModels: fetchVelaModelsWithRetry,
+  fetchModels: fetchVelaRemoteModelsWithRetry,
   // Fail closed when Vela's live catalog is unavailable. Stale static
   // fallbacks let users select models that link/opencode no longer accepts.
   fallbackModels: [] as RuntimeModelOption[],

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6093,7 +6093,6 @@ export async function startServer({
         },
         configuredEnv,
         undefined,
-        { resolvedBin: agentLaunch.selectedPath },
       ),
       agentLaunch,
     );

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -51,6 +51,7 @@ import {
   cancelVelaLogin,
   forgetVelaLogin,
   mergeVelaEnv,
+  readVelaCredentialRevision,
   readVelaLoginStatus,
   spawnVelaLogin,
 } from './integrations/vela.js';
@@ -6096,6 +6097,7 @@ export async function startServer({
       ),
       agentLaunch,
     );
+    const credentialRevision = readVelaCredentialRevision(process.env, configuredEnv);
     const cacheKey = JSON.stringify({
       launchPath,
       home: env.HOME ?? env.USERPROFILE ?? '',
@@ -6104,6 +6106,7 @@ export async function startServer({
       velaLinkUrl: env.VELA_LINK_URL ?? '',
       velaRuntimeKey: env.VELA_RUNTIME_KEY ?? '',
       velaOpencodeBin: env.VELA_OPENCODE_BIN ?? '',
+      credentialRevision,
     });
     return { launchPath, env, configuredEnv, cacheKey };
   }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -58,6 +58,11 @@ import {
   amrAccountFailureDetails,
   classifyAmrAccountFailure,
 } from './integrations/vela-errors.js';
+import { amrModelLoadingCache } from './runtimes/amr-model-cache.js';
+import {
+  fetchVelaPresetModels,
+  fetchVelaRemoteModelsWithRetry,
+} from './runtimes/defs/amr.js';
 import { migrateLegacyDataDirSync } from './legacy-data-migrator.js';
 import {
   consumedImportNonces,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6096,13 +6096,22 @@ export async function startServer({
       ),
       agentLaunch,
     );
-    return { launchPath, env, configuredEnv };
+    const cacheKey = JSON.stringify({
+      launchPath,
+      home: env.HOME ?? env.USERPROFILE ?? '',
+      openDesignAmrProfile: env.OPEN_DESIGN_AMR_PROFILE ?? '',
+      velaProfile: env.VELA_PROFILE ?? '',
+      velaLinkUrl: env.VELA_LINK_URL ?? '',
+      velaRuntimeKey: env.VELA_RUNTIME_KEY ?? '',
+      velaOpencodeBin: env.VELA_OPENCODE_BIN ?? '',
+    });
+    return { launchPath, env, configuredEnv, cacheKey };
   }
 
   app.get('/api/amr/models', async (_req, res) => {
     try {
       const probe = await resolveAmrModelProbe();
-      const response = await amrModelLoadingCache.get({
+      const response = await amrModelLoadingCache.get(probe.cacheKey, {
         fetchPreset: () => fetchVelaPresetModels(probe.launchPath, probe.env),
         fetchRemote: () => fetchVelaRemoteModelsWithRetry(probe.launchPath, probe.env),
       });
@@ -6120,7 +6129,7 @@ export async function startServer({
       if (status.loggedIn) {
         void resolveAmrModelProbe()
           .then((probe) => {
-            amrModelLoadingCache.warm(() =>
+            amrModelLoadingCache.warm(probe.cacheKey, () =>
               fetchVelaRemoteModelsWithRetry(probe.launchPath, probe.env),
             );
           })

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6070,11 +6070,58 @@ export async function startServer({
   // The vela CLI owns the device-authorization UX (URL + code + browser open);
   // these routes only surface enough state for Open Design's Settings card to
   // show login status and trigger a login from a button.
+  async function resolveAmrModelProbe() {
+    const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+    const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
+    const def = getAgentDef('amr');
+    if (!def) throw new Error('AMR runtime definition is missing');
+    const agentLaunch = resolveAgentLaunch(def, configuredEnv);
+    const launchPath = agentLaunch.launchPath ?? agentLaunch.selectedPath;
+    if (!launchPath) throw new Error('AMR vela binary could not be resolved');
+    const env = applyAgentLaunchEnv(
+      spawnEnvForAgent(
+        def.id,
+        {
+          ...process.env,
+          ...(def.env || {}),
+        },
+        configuredEnv,
+        undefined,
+        { resolvedBin: agentLaunch.selectedPath },
+      ),
+      agentLaunch,
+    );
+    return { launchPath, env, configuredEnv };
+  }
+
+  app.get('/api/amr/models', async (_req, res) => {
+    try {
+      const probe = await resolveAmrModelProbe();
+      const response = await amrModelLoadingCache.get({
+        fetchPreset: () => fetchVelaPresetModels(probe.launchPath, probe.env),
+        fetchRemote: () => fetchVelaRemoteModelsWithRetry(probe.launchPath, probe.env),
+      });
+      res.json(response);
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
   app.get('/api/integrations/vela/status', async (_req, res) => {
     try {
       const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
       const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
-      res.json(readVelaLoginStatus(mergeVelaEnv(process.env, configuredEnv)));
+      const status = readVelaLoginStatus(mergeVelaEnv(process.env, configuredEnv));
+      if (status.loggedIn) {
+        void resolveAmrModelProbe()
+          .then((probe) => {
+            amrModelLoadingCache.warm(() =>
+              fetchVelaRemoteModelsWithRetry(probe.launchPath, probe.env),
+            );
+          })
+          .catch((err) => console.warn('[amr] model cache warm failed', err));
+      }
+      res.json(status);
     } catch (err) {
       res.status(500).json({ error: String(err) });
     }

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -11,7 +11,7 @@
  * data record, so this test also pins the contract the def declares:
  *   - id, bin, streamFormat are stable for downstream consumers
  *   - buildArgs() emits the vela invocation shape the docs describe
- *   - AMR picker models come from `vela models`, not stale static ids.
+ *   - AMR authoritative models come from `vela model list --format json`, not stale static ids.
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
@@ -23,9 +23,12 @@ import { describe, expect, it } from 'vitest';
 
 import { attachAcpSession, detectAcpModels } from '../src/acp.js';
 import { classifyAmrAccountFailure } from '../src/integrations/vela-errors.js';
+import { AmrModelLoadingCache } from '../src/runtimes/amr-model-cache.js';
 import {
   amrAgentDef,
+  fetchVelaPresetModels,
   normalizeVelaModelId,
+  parseVelaModelJson,
   parseVelaModels,
 } from '../src/runtimes/defs/amr.js';
 import { getAgentDef } from '../src/runtimes/registry.js';
@@ -135,7 +138,35 @@ describe('AMR runtime def', () => {
     expect(models.map((model) => model.id)).not.toContain('seedance-2');
   });
 
-  it('fetches AMR picker models from `vela models`', async () => {
+  it('parses Vela preset and remote JSON without legacy id normalization', () => {
+    const models = parseVelaModelJson(JSON.stringify({
+      source: 'remote',
+      data: [
+        { id: 'public_model_deepseek_v3_2' },
+        { id: 'deepseek-v4-flash' },
+        { id: 'gpt-image-2' },
+        { id: 'deepseek-v4-flash' },
+      ],
+    }), 'remote');
+    expect(models).toEqual([
+      { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
+      { id: 'public_model_deepseek_v3_2', label: 'public_model_deepseek_v3_2' },
+    ]);
+    expect(() => parseVelaModelJson(JSON.stringify({ source: 'preset', data: [] }), 'remote'))
+      .toThrow(/expected remote/);
+  });
+
+  it('fetches AMR preset models from `vela model preset --format json`', async () => {
+    const models = await fetchVelaPresetModels(FAKE_VELA, process.env);
+    expect(models).toEqual([
+      { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
+      { id: 'deepseek-v3.2', label: 'deepseek-v3.2' },
+      { id: 'glm-5.1', label: 'glm-5.1' },
+      { id: 'gemini-2.5-flash', label: 'gemini-2.5-flash' },
+    ]);
+  });
+
+  it('fetches AMR authoritative models from `vela model list --format json`', async () => {
     const models = await amrAgentDef.fetchModels?.(FAKE_VELA, process.env);
     expect(models).toEqual([
       { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
@@ -154,7 +185,7 @@ describe('AMR runtime def', () => {
     ]);
   });
 
-  it('retries transient `vela models` failures before succeeding', async () => {
+  it('retries transient `vela model list --format json` failures before succeeding', async () => {
     const tempDir = mkdtempSync(path.join(tmpdir(), 'od-amr-retry-'));
     const stateFile = path.join(tempDir, 'retry-state.json');
     const wrapperPath = path.join(tempDir, 'vela-wrapper');
@@ -164,7 +195,7 @@ const { spawn } = require('node:child_process');
 const stateFile = process.env.RETRY_STATE_FILE;
 const fakeVela = process.env.FAKE_VELA_PATH;
 const args = process.argv.slice(2);
-if (args[0] === 'models') {
+if (args[0] === 'model' && args[1] === 'list') {
   const state = stateFile && existsSync(stateFile)
     ? JSON.parse(readFileSync(stateFile, 'utf8'))
     : { attempts: 0 };
@@ -207,6 +238,75 @@ child.on('exit', (code) => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('AMR model loading cache', () => {
+  it('returns preset immediately, coalesces remote refreshes, then serves remote', async () => {
+    const cache = new AmrModelLoadingCache(1_000);
+    let remoteCalls = 0;
+    const releaseRemote: Array<() => void> = [];
+    const fetchRemote = async () => {
+      remoteCalls += 1;
+      await new Promise<void>((resolve) => {
+        releaseRemote.push(resolve);
+      });
+      return [{ id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' }];
+    };
+
+    const first = await cache.get({
+      fetchPreset: async () => [{ id: 'preset-a', label: 'preset-a' }],
+      fetchRemote,
+    });
+    const second = await cache.get({
+      fetchPreset: async () => [{ id: 'preset-b', label: 'preset-b' }],
+      fetchRemote,
+    });
+    expect(first).toMatchObject({ source: 'preset', refreshing: true });
+    expect(second).toMatchObject({ source: 'preset', refreshing: true });
+    expect(remoteCalls).toBe(1);
+
+    releaseRemote[0]?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const remote = await cache.get({
+      fetchPreset: async () => {
+        throw new Error('preset should not be required after remote cache exists');
+      },
+      fetchRemote,
+    });
+    expect(remote).toMatchObject({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' }],
+    });
+  });
+
+  it('keeps stale remote rows when a later refresh fails', async () => {
+    const cache = new AmrModelLoadingCache(0);
+    cache.warm(async () => [{ id: 'deepseek-v3.2', label: 'deepseek-v3.2' }]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const stale = await cache.get({
+      fetchPreset: async () => [{ id: 'preset-a', label: 'preset-a' }],
+      fetchRemote: async () => {
+        throw new Error('remote unavailable');
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const afterFailure = await cache.get({
+      fetchPreset: async () => [{ id: 'preset-a', label: 'preset-a' }],
+      fetchRemote: async () => {
+        throw new Error('remote unavailable');
+      },
+    });
+    expect(stale.source).toBe('remote');
+    expect(afterFailure).toMatchObject({
+      source: 'remote',
+      stale: true,
+      remoteError: 'remote unavailable',
+      models: [{ id: 'deepseek-v3.2', label: 'deepseek-v3.2' }],
+    });
   });
 });
 

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -254,11 +254,11 @@ describe('AMR model loading cache', () => {
       return [{ id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' }];
     };
 
-    const first = await cache.get({
+    const first = await cache.get('vela:local', {
       fetchPreset: async () => [{ id: 'preset-a', label: 'preset-a' }],
       fetchRemote,
     });
-    const second = await cache.get({
+    const second = await cache.get('vela:local', {
       fetchPreset: async () => [{ id: 'preset-b', label: 'preset-b' }],
       fetchRemote,
     });
@@ -269,7 +269,7 @@ describe('AMR model loading cache', () => {
     releaseRemote[0]?.();
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    const remote = await cache.get({
+    const remote = await cache.get('vela:local', {
       fetchPreset: async () => {
         throw new Error('preset should not be required after remote cache exists');
       },
@@ -284,17 +284,17 @@ describe('AMR model loading cache', () => {
 
   it('keeps stale remote rows when a later refresh fails', async () => {
     const cache = new AmrModelLoadingCache(0);
-    cache.warm(async () => [{ id: 'deepseek-v3.2', label: 'deepseek-v3.2' }]);
+    cache.warm('vela:local', async () => [{ id: 'deepseek-v3.2', label: 'deepseek-v3.2' }]);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    const stale = await cache.get({
+    const stale = await cache.get('vela:local', {
       fetchPreset: async () => [{ id: 'preset-a', label: 'preset-a' }],
       fetchRemote: async () => {
         throw new Error('remote unavailable');
       },
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
-    const afterFailure = await cache.get({
+    const afterFailure = await cache.get('vela:local', {
       fetchPreset: async () => [{ id: 'preset-a', label: 'preset-a' }],
       fetchRemote: async () => {
         throw new Error('remote unavailable');
@@ -306,6 +306,23 @@ describe('AMR model loading cache', () => {
       stale: true,
       remoteError: 'remote unavailable',
       models: [{ id: 'deepseek-v3.2', label: 'deepseek-v3.2' }],
+    });
+  });
+
+  it('keeps remote catalogs isolated per resolved Vela environment', async () => {
+    const cache = new AmrModelLoadingCache(60_000);
+    cache.warm('vela:local', async () => [{ id: 'remote-local', label: 'remote-local' }]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const otherEnv = await cache.get('vela:prod', {
+      fetchPreset: async () => [{ id: 'preset-prod', label: 'preset-prod' }],
+      fetchRemote: async () => [{ id: 'remote-prod', label: 'remote-prod' }],
+    });
+
+    expect(otherEnv).toMatchObject({
+      source: 'preset',
+      models: [{ id: 'preset-prod', label: 'preset-prod' }],
+      refreshing: true,
     });
   });
 });

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -262,7 +262,7 @@ const { spawn } = require('node:child_process');
 const fixture = ${JSON.stringify(FAKE_VELA_FIXTURE)};
 const stateFile = ${JSON.stringify(stateFile)};
 const args = process.argv.slice(2);
-if (args[0] === 'models') {
+if (args[0] === 'model' && args[1] === 'list') {
   const state = existsSync(stateFile)
     ? JSON.parse(readFileSync(stateFile, 'utf8'))
     : { attempts: 0 };

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -2,9 +2,9 @@
 /**
  * Fake vela CLI used by AMR integration tests. Routes by the first argv:
  *
- *   `vela models`                       → prints the live link model catalog
- *                                         in the same tabular shape as Vela
- *                                         0.0.1.
+ *   `vela model preset --format json`   → prints the local AMR picker seed.
+ *   `vela model list --format json`     → prints the authoritative remote
+ *                                         AMR model catalog.
  *
  *   `vela login`                        → writes ~/.amr/config.json (the
  *                                         active VELA_PROFILE only) and
@@ -43,6 +43,8 @@
  *   FAKE_VELA_SET_MODEL_ERROR    – when set, session/set_model returns a JSON-RPC error
  *   FAKE_VELA_PROMPT_ERROR       – when set, session/prompt returns a JSON-RPC error
  *   FAKE_VELA_MODELS             – newline-separated `vela models` stdout
+ *   FAKE_VELA_MODEL_PRESET_JSON  – JSON stdout for `model preset --format json`
+ *   FAKE_VELA_MODEL_LIST_JSON    – JSON stdout for `model list --format json`
  *   FAKE_VELA_REQUIRE_SET_MODEL  – strict gate (default on); set to '0' to
  *                                   accept session/prompt without prior
  *                                   session/set_model (legacy behaviour)
@@ -82,6 +84,35 @@ const DEFAULT_MODELS_STDOUT = [
   'public_model_qwen3_235b_a22b  vela',
   'public_model_seedance_2    vela',
 ].join('\n');
+const DEFAULT_MODEL_PRESET_JSON = JSON.stringify({
+  source: 'preset',
+  data: [
+    { id: 'deepseek-v4-flash' },
+    { id: 'deepseek-v3.2' },
+    { id: 'glm-5.1' },
+    { id: 'gemini-2.5-flash' },
+  ],
+});
+const DEFAULT_MODEL_LIST_JSON = JSON.stringify({
+  source: 'remote',
+  data: [
+    { id: 'deepseek-v3.2' },
+    { id: 'deepseek-v4-flash' },
+    { id: 'deepseek-v4-pro' },
+    { id: 'gemini-2.5-flash' },
+    { id: 'gemini-3.1-flash-lite-preview' },
+    { id: 'gemini-3.1-pro-preview' },
+    { id: 'gpt-5.4' },
+    { id: 'gpt-5.4-mini' },
+    { id: 'glm-5' },
+    { id: 'glm-5.1' },
+    { id: 'gpt-image-2' },
+    { id: 'kimi-k2.6' },
+    { id: 'minimax-m2.7' },
+    { id: 'qwen3-235b-a22b' },
+    { id: 'seedance-2' },
+  ],
+});
 
 // Real `vela agent run --runtime opencode` rejects session/prompt until
 // session/set_model has been called for the current session — see the
@@ -303,4 +334,15 @@ if (argv[2] === 'login') {
 if (argv[2] === 'models') {
   stdout.write(`${env.FAKE_VELA_MODELS || DEFAULT_MODELS_STDOUT}\n`);
   exit(0);
+}
+
+if (argv[2] === 'model' && argv[4] === '--format' && argv[5] === 'json') {
+  if (argv[3] === 'preset') {
+    stdout.write(`${env.FAKE_VELA_MODEL_PRESET_JSON || DEFAULT_MODEL_PRESET_JSON}\n`);
+    exit(0);
+  }
+  if (argv[3] === 'list') {
+    stdout.write(`${env.FAKE_VELA_MODEL_LIST_JSON || DEFAULT_MODEL_LIST_JSON}\n`);
+    exit(0);
+  }
 }

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -48,6 +48,24 @@ async function postJson<T = unknown>(url: string): Promise<{ status: number; bod
   return { status: resp.status, body };
 }
 
+async function waitForAmrModels(
+  expectedSource: 'preset' | 'remote',
+  timeoutMs = 5_000,
+): Promise<{ status: number; body: { source: 'preset' | 'remote'; models: Array<{ id: string }> } }> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const response = await getJson<{
+      source: 'preset' | 'remote';
+      models: Array<{ id: string }>;
+    }>(`${baseUrl}/api/amr/models`);
+    if (response.body.source === expectedSource) return response;
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for /api/amr/models source=${expectedSource}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
 function configPath(): string {
   return path.join(tmpHome, '.amr', 'config.json');
 }
@@ -443,6 +461,55 @@ describe('POST /api/integrations/vela/login', () => {
 });
 
 describe('POST /api/integrations/vela/logout', () => {
+  it('drops back to preset AMR models after file-backed logout invalidates the cached remote catalog', async () => {
+    seedLogin('local');
+
+    const first = await getJson<{
+      source: 'preset' | 'remote';
+      refreshing?: boolean;
+      models: Array<{ id: string }>;
+    }>(`${baseUrl}/api/amr/models`);
+    expect(first.status).toBe(200);
+    expect(first.body).toMatchObject({
+      source: 'preset',
+      refreshing: true,
+    });
+    expect(first.body.models.map((model) => model.id)).toEqual([
+      'deepseek-v4-flash',
+      'deepseek-v3.2',
+      'glm-5.1',
+      'gemini-2.5-flash',
+    ]);
+
+    const warmed = await waitForAmrModels('remote');
+    expect(warmed.status).toBe(200);
+    expect(warmed.body.source).toBe('remote');
+    expect(warmed.body.models.map((model) => model.id)).toContain('deepseek-v4-flash');
+    expect(warmed.body.models.map((model) => model.id)).toContain('gpt-5.4');
+
+    const logout = await postJson<{ ok?: boolean }>(`${baseUrl}/api/integrations/vela/logout`);
+    expect(logout.status).toBe(200);
+    expect(logout.body.ok).toBe(true);
+
+    const afterLogout = await getJson<{
+      source: 'preset' | 'remote';
+      refreshing?: boolean;
+      remoteError?: string;
+      models: Array<{ id: string }>;
+    }>(`${baseUrl}/api/amr/models`);
+    expect(afterLogout.status).toBe(200);
+    expect(afterLogout.body).toMatchObject({
+      source: 'preset',
+      refreshing: true,
+    });
+    expect(afterLogout.body.models.map((model) => model.id)).toEqual([
+      'deepseek-v4-flash',
+      'deepseek-v3.2',
+      'glm-5.1',
+      'gemini-2.5-flash',
+    ]);
+  });
+
   it('removes only resolved profile credentials so the next login can reuse endpoint config', async () => {
     seedLogin('local');
     const cfg = JSON.parse(readFileSync(configPath(), 'utf8'));

--- a/apps/daemon/tests/integrations/vela.test.ts
+++ b/apps/daemon/tests/integrations/vela.test.ts
@@ -17,6 +17,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   forgetVelaLogin,
+  readVelaCredentialRevision,
   readVelaLoginStatus,
   resolveAmrProfile,
   spawnVelaLogin,
@@ -279,6 +280,38 @@ describe('readVelaLoginStatus', () => {
     expect(status.user?.id).toBe('');
     expect(status.user?.email).toBe('');
     expect(status.user?.plan).toBeUndefined();
+  });
+});
+
+describe('readVelaCredentialRevision', () => {
+  it('changes when file-backed logout clears the active profile credentials', async () => {
+    writeConfig({
+      profiles: {
+        local: {
+          runtimeKey: 'rt-local',
+          user: { id: 'u-local', email: 'local@example.com' },
+        },
+      },
+    });
+    const before = readVelaCredentialRevision({ OPEN_DESIGN_AMR_PROFILE: 'local' });
+    expect(before).toMatchObject({
+      authSource: 'file',
+      loggedIn: true,
+      userId: 'u-local',
+      userEmail: 'local@example.com',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    forgetVelaLogin({ OPEN_DESIGN_AMR_PROFILE: 'local' });
+
+    const after = readVelaCredentialRevision({ OPEN_DESIGN_AMR_PROFILE: 'local' });
+    expect(after).toMatchObject({
+      authSource: 'none',
+      loggedIn: false,
+      userId: '',
+      userEmail: '',
+    });
+    expect(after.configMtimeMs).not.toBe(before.configMtimeMs);
   });
 });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -861,6 +861,7 @@ function AppInner() {
     async (options?: { throwOnError?: boolean; agentCliEnv?: AppConfig['agentCliEnv'] }) => {
       if (options && Object.prototype.hasOwnProperty.call(options, 'agentCliEnv')) {
         const nextConfig = { ...config, agentCliEnv: options.agentCliEnv ?? {} };
+        amrModelsRef.current = null;
         saveConfig(nextConfig);
         await syncConfigToDaemon(nextConfig);
         setConfig(nextConfig);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import {
   projectKindToTracking,
   fidelityToTracking,
 } from '@open-design/contracts/analytics';
+import type { AmrModelsResponse } from '@open-design/contracts';
 import { EntryView } from './components/EntryView';
 import type { IntegrationTab } from './components/IntegrationsView';
 import { MarketplaceView } from './components/MarketplaceView';
@@ -176,6 +177,22 @@ export function resolveSettingsCloseConfig(
   return base.onboardingCompleted ? base : { ...base, onboardingCompleted: true };
 }
 
+function mergeAmrModelsIntoAgents(
+  agents: AgentInfo[],
+  amrModels: AmrModelsResponse | null,
+): AgentInfo[] {
+  if (!amrModels || amrModels.models.length === 0) return agents;
+  return agents.map((agent) => {
+    if (agent.id !== 'amr') return agent;
+    const shouldPreferAgentModels =
+      amrModels.source === 'preset' &&
+      Array.isArray(agent.models) &&
+      agent.models.length > 0;
+    if (shouldPreferAgentModels) return agent;
+    return { ...agent, models: amrModels.models, modelsSource: 'live' };
+  });
+}
+
 export function App() {
   return (
     <IframeKeepAliveProvider>
@@ -212,7 +229,7 @@ function AppInner() {
   const [integrationInitialTab, setIntegrationInitialTab] = useState<IntegrationTab>('mcp');
   const [daemonLive, setDaemonLive] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
-  const amrAgentAvailable = agents.some((agent) => agent.id === 'amr' && agent.available);
+  const amrModelsRef = useRef<AmrModelsResponse | null>(null);
   // Functional skills (capabilities the agent invokes mid-task) — stays
   // small and lives under the Settings → Skills surface.
   const [skills, setSkills] = useState<SkillSummary[]>([]);
@@ -384,7 +401,7 @@ function AppInner() {
   }, [activeProjectId, activeFileName]);
 
   useEffect(() => {
-    if (!daemonLive || !amrAgentAvailable) return;
+    if (!daemonLive) return;
     let cancelled = false;
     let timer: number | null = null;
     const pollDelayMs = 1_000;
@@ -393,12 +410,9 @@ function AppInner() {
 
     const applyAmrModels = async () => {
       const result = await fetchAmrModels();
-      if (cancelled || !result || result.models.length === 0) return;
-      setAgents((current) => current.map((agent) =>
-        agent.id === 'amr'
-          ? { ...agent, models: result.models, modelsSource: 'live' }
-          : agent,
-      ));
+      if (cancelled || !result || !Array.isArray(result.models) || result.models.length === 0) return;
+      amrModelsRef.current = result;
+      setAgents((current) => mergeAmrModelsIntoAgents(current, result));
       const shouldPollPreset =
         result.source === 'preset' &&
         !result.remoteError &&
@@ -416,7 +430,7 @@ function AppInner() {
       cancelled = true;
       if (timer !== null) window.clearTimeout(timer);
     };
-  }, [amrAgentAvailable, daemonLive]);
+  }, [daemonLive]);
 
   // Bootstrap — detect daemon, then fan out independent fetches so each
   // entry-view tab can render the moment its own data lands. Earlier this
@@ -447,7 +461,7 @@ function AppInner() {
 
       void fetchAgents().then((list) => {
         if (cancelled) return;
-        setAgents(list);
+        setAgents(mergeAmrModelsIntoAgents(list, amrModelsRef.current));
         setAgentsLoading(false);
       });
 
@@ -852,7 +866,7 @@ function AppInner() {
         setConfig(nextConfig);
       }
       const next = await fetchAgents({ throwOnError: options?.throwOnError });
-      setAgents(next);
+      setAgents(mergeAmrModelsIntoAgents(next, amrModelsRef.current));
       return next;
     },
     [config],

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -388,6 +388,8 @@ function AppInner() {
     let cancelled = false;
     let timer: number | null = null;
     const pollDelayMs = 1_000;
+    const maxPresetPolls = 10;
+    let presetPolls = 0;
 
     const applyAmrModels = async () => {
       const result = await fetchAmrModels();
@@ -397,7 +399,12 @@ function AppInner() {
           ? { ...agent, models: result.models, modelsSource: 'live' }
           : agent,
       ));
-      if (result.source === 'preset' || result.refreshing) {
+      const shouldPollPreset =
+        result.source === 'preset' &&
+        !result.remoteError &&
+        presetPolls < maxPresetPolls;
+      if (shouldPollPreset) {
+        presetPolls += 1;
         timer = window.setTimeout(() => {
           void applyAmrModels();
         }, pollDelayMs);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -50,7 +50,12 @@ import {
   fetchSkills,
   uploadProjectFiles,
 } from './providers/registry';
-import { RUNS_CHANGED_EVENT, fetchAmrModels, listProjectRuns } from './providers/daemon';
+import {
+  RUNS_CHANGED_EVENT,
+  fetchAmrModels,
+  listProjectRuns,
+  type VelaLoginStatus,
+} from './providers/daemon';
 import { navigate, useRoute } from './router';
 import {
   fetchDaemonConfig,
@@ -230,6 +235,7 @@ function AppInner() {
   const [daemonLive, setDaemonLive] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const amrModelsRef = useRef<AmrModelsResponse | null>(null);
+  const [amrPollRestartToken, setAmrPollRestartToken] = useState(0);
   // Functional skills (capabilities the agent invokes mid-task) — stays
   // small and lives under the Settings → Skills surface.
   const [skills, setSkills] = useState<SkillSummary[]>([]);
@@ -430,7 +436,12 @@ function AppInner() {
       cancelled = true;
       if (timer !== null) window.clearTimeout(timer);
     };
-  }, [daemonLive]);
+  }, [amrPollRestartToken, daemonLive]);
+
+  const handleAmrLoginStatusChange = useCallback((status: VelaLoginStatus | null) => {
+    if (status?.loggedIn !== true) return;
+    setAmrPollRestartToken((current) => current + 1);
+  }, []);
 
   // Bootstrap — detect daemon, then fan out independent fetches so each
   // entry-view tab can render the moment its own data lands. Earlier this
@@ -1670,6 +1681,7 @@ function AppInner() {
             setSettingsHighlight(null);
           }}
           onRefreshAgents={refreshAgents}
+          onAmrLoginStatusChange={handleAmrLoginStatusChange}
           onSkillsRefresh={refreshSkills}
           daemonMediaProviders={daemonMediaProviders}
           daemonMediaProvidersFetchState={daemonMediaProvidersFetchState}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -386,9 +386,7 @@ function AppInner() {
   useEffect(() => {
     if (!daemonLive || !amrAgentAvailable) return;
     let cancelled = false;
-    let attempts = 0;
     let timer: number | null = null;
-    const maxPresetPolls = 8;
     const pollDelayMs = 1_000;
 
     const applyAmrModels = async () => {
@@ -399,8 +397,7 @@ function AppInner() {
           ? { ...agent, models: result.models, modelsSource: 'live' }
           : agent,
       ));
-      if (result.source === 'preset' && attempts < maxPresetPolls) {
-        attempts += 1;
+      if (result.source === 'preset' || result.refreshing) {
         timer = window.setTimeout(() => {
           void applyAmrModels();
         }, pollDelayMs);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -49,7 +49,7 @@ import {
   fetchSkills,
   uploadProjectFiles,
 } from './providers/registry';
-import { RUNS_CHANGED_EVENT, listProjectRuns } from './providers/daemon';
+import { RUNS_CHANGED_EVENT, fetchAmrModels, listProjectRuns } from './providers/daemon';
 import { navigate, useRoute } from './router';
 import {
   fetchDaemonConfig,
@@ -212,6 +212,7 @@ function AppInner() {
   const [integrationInitialTab, setIntegrationInitialTab] = useState<IntegrationTab>('mcp');
   const [daemonLive, setDaemonLive] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
+  const amrAgentAvailable = agents.some((agent) => agent.id === 'amr' && agent.available);
   // Functional skills (capabilities the agent invokes mid-task) — stays
   // small and lives under the Settings → Skills surface.
   const [skills, setSkills] = useState<SkillSummary[]>([]);
@@ -381,6 +382,37 @@ function AppInner() {
       // Daemon down or transient network — not worth surfacing.
     });
   }, [activeProjectId, activeFileName]);
+
+  useEffect(() => {
+    if (!daemonLive || !amrAgentAvailable) return;
+    let cancelled = false;
+    let attempts = 0;
+    let timer: number | null = null;
+    const maxPresetPolls = 8;
+    const pollDelayMs = 1_000;
+
+    const applyAmrModels = async () => {
+      const result = await fetchAmrModels();
+      if (cancelled || !result || result.models.length === 0) return;
+      setAgents((current) => current.map((agent) =>
+        agent.id === 'amr'
+          ? { ...agent, models: result.models, modelsSource: 'live' }
+          : agent,
+      ));
+      if (result.source === 'preset' && attempts < maxPresetPolls) {
+        attempts += 1;
+        timer = window.setTimeout(() => {
+          void applyAmrModels();
+        }, pollDelayMs);
+      }
+    };
+
+    void applyAmrModels();
+    return () => {
+      cancelled = true;
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [amrAgentAvailable, daemonLive]);
 
   // Bootstrap — detect daemon, then fan out independent fetches so each
   // entry-view tab can render the moment its own data lands. Earlier this

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2235,7 +2235,9 @@ export function SettingsDialog({
         : t('settings.modelSourceFallback');
     const modelSourceHint =
       modelSource === 'live'
-        ? t('settings.modelPickerLiveHint')
+        ? selected.supportsCustomModel === false
+          ? t('settings.modelPickerLiveCatalogOnlyHint')
+          : t('settings.modelPickerLiveHint')
         : t('settings.modelPickerFallbackHint');
     return (
       <div className="agent-card-config">

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -188,6 +188,7 @@ interface Props {
   onRefreshAgents: (
     options?: AgentRefreshOptions,
   ) => AgentInfo[] | Promise<AgentInfo[] | void> | void;
+  onAmrLoginStatusChange?: (status: VelaLoginStatus | null) => void;
   /** Re-fetch functional skills into App state after Settings mutations. */
   onSkillsRefresh?: () => Promise<void> | void;
   daemonMediaProviders?: AppConfig['mediaProviders'] | null;
@@ -838,6 +839,7 @@ export function SettingsDialog({
   composioConfigLoading = false,
   onClose,
   onRefreshAgents,
+  onAmrLoginStatusChange,
   onSkillsRefresh,
   daemonMediaProviders,
   daemonMediaProvidersFetchState = 'idle',
@@ -911,6 +913,10 @@ export function SettingsDialog({
   const [providerTestState, setProviderTestState] = useState<TestState>({
     status: 'idle',
   });
+
+  useEffect(() => {
+    onAmrLoginStatusChange?.(amrCardStatus);
+  }, [amrCardStatus, onAmrLoginStatusChange]);
 
   useEffect(() => {
     const hasAmrAgent = agents.some((agent) => agent.id === 'amr' && agent.available);

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -318,6 +318,8 @@ export const ar: Dict = {
     'يتم جلبه من CLI عندما يعرض أمر `models`. "الافتراضي" يترك الخيار لإعدادات CLI؛ "مخصص..." يسمح لك بكتابة أي معرف نموذج يقبله CLI.',
   'settings.modelPickerLiveHint':
     'تم تحديث النماذج من CLI المثبت. لا يزال الخيار الافتراضي يستخدم إعدادات CLI.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'تم تحديث النماذج من CLI المثبت.',
   'settings.modelPickerFallbackHint':
     'يتم عرض الإعدادات الافتراضية المضمنة. انقر على إعادة المسح لجلب النماذج المباشرة من CLI.',
   'settings.cliEnvTitle': 'CLI config locations',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -318,6 +318,8 @@ export const de: Dict = {
     'Wird aus der CLI geladen, wenn sie einen `models`-Befehl anbietet. „Standard“ überlässt die Auswahl der CLI-Konfiguration; mit „Benutzerdefiniert…“ können Sie jede von der CLI akzeptierte Modell-ID eingeben.',
   'settings.modelPickerLiveHint':
     'Modelle wurden aus der installierten CLI aktualisiert. Standard verwendet weiterhin die CLI-Konfiguration.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'Modelle wurden aus der installierten CLI aktualisiert.',
   'settings.modelPickerFallbackHint':
     'Integrierte Standardwerte werden angezeigt. Klicken Sie auf Neu scannen, um Live-Modelle aus der CLI abzurufen.',
   'settings.cliEnvTitle': 'CLI config locations',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -329,6 +329,8 @@ export const en: Dict = {
     'Default uses the CLI’s own config. Custom… lets you type any model id.',
   'settings.modelPickerLiveHint':
     "Model list comes from this CLI. Default uses the CLI's own config.",
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'Model list comes from this CLI.',
   'settings.modelPickerFallbackHint':
     'Showing built-in defaults. Click Rescan to pull live models from the CLI.',
   'settings.cliEnvTitle': 'Advanced: proxy & custom paths',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -318,6 +318,8 @@ export const esES: Dict = {
     'Se obtiene de la CLI cuando expone un comando `models`. «Predeterminado» deja la elección a la propia configuración de la CLI; «Personalizado…» permite escribir cualquier id de modelo aceptado por la CLI.',
   'settings.modelPickerLiveHint':
     'Los modelos se actualizaron desde la CLI instalada. Predeterminado sigue usando la configuración de la CLI.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'Los modelos se actualizaron desde la CLI instalada.',
   'settings.modelPickerFallbackHint':
     'Mostrando valores predeterminados integrados. Pulsa Reescanear para obtener modelos en vivo desde la CLI.',
   'settings.cliEnvTitle': 'CLI config locations',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -318,6 +318,8 @@ export const fa: Dict = {
     'هنگامی که CLI یک دستور `models` را ارائه می‌دهد از آن دریافت می‌شود. «پیش‌فرض» انتخاب را به پیکربندی خود CLI واگذار می‌کند؛ «سفارشی…» به شما امکان می‌دهد هر شناسه مدلی را که CLI می‌پذیرد تایپ کنید.',
   'settings.modelPickerLiveHint':
     'مدل‌ها از CLI نصب‌شده به‌روزرسانی شدند. گزینه پیش‌فرض همچنان از تنظیمات CLI استفاده می‌کند.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'مدل‌ها از CLI نصب‌شده به‌روزرسانی شدند.',
   'settings.modelPickerFallbackHint':
     'پیش‌فرض‌های داخلی نمایش داده می‌شوند. برای دریافت مدل‌های زنده از CLI روی اسکن مجدد کلیک کنید.',
   'settings.cliEnvTitle': 'CLI config locations',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -312,6 +312,7 @@ export const fr: Dict = {
   'settings.reasoningPicker': 'Effort de raisonnement',
   'settings.modelPickerHint': 'Par défaut utilise la configuration propre de la CLI. Personnalisé… vous permet de saisir n’importe quel identifiant de modèle.',
   'settings.modelPickerLiveHint': 'Les modèles ont été actualisés depuis la CLI installée. Par défaut utilise toujours la configuration propre de la CLI.',
+  'settings.modelPickerLiveCatalogOnlyHint': 'Les modèles ont été actualisés depuis la CLI installée.',
   'settings.modelPickerFallbackHint': 'Valeurs par défaut intégrées affichées. Cliquez sur Réanalyser pour récupérer les modèles en direct depuis la CLI.',
   'settings.cliEnvTitle': 'Avancé : proxy et chemins personnalisés',
   'settings.cliEnvHint': 'Utilisez ces réglages uniquement si vous routez le trafic CLI via votre propre proxy ou si le binaire est installé à un emplacement non standard. Les secrets restent dans la configuration locale de l’app et seule la CLI sélectionnée les voit.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -318,6 +318,8 @@ export const hu: Dict = {
     'A CLI-tól kérdezi le, ha az közzéteszi a `models` parancsot. Az „Alapértelmezett" a CLI saját konfigjára bízza a választást; az „Egyedi…" tetszőleges, a CLI által elfogadott modell-id-t enged megadni.',
   'settings.modelPickerLiveHint':
     'A modellek frissültek a telepített CLI-ből. Az Alapértelmezett továbbra is a CLI konfigurációját használja.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'A modellek frissültek a telepített CLI-ből.',
   'settings.modelPickerFallbackHint':
     'A beépített alapértékek láthatók. Kattints az Újraellenőrzésre az élő CLI-modellek lekéréséhez.',
   'settings.cliEnvTitle': 'CLI config locations',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -315,6 +315,8 @@ export const id: Dict = {
     'Diambil dari CLI jika tersedia. "Default" mengikuti konfigurasi CLI; "Custom..." untuk mengetik model id sendiri.',
   'settings.modelPickerLiveHint':
     'Model diperbarui dari CLI yang terpasang. Default tetap memakai konfigurasi CLI.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'Model diperbarui dari CLI yang terpasang.',
   'settings.modelPickerFallbackHint':
     'Menampilkan default bawaan. Klik Pindai ulang untuk mengambil model langsung dari CLI.',
   'settings.cliEnvTitle': 'Lokasi konfigurasi CLI',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -314,6 +314,8 @@ export const it: Dict = {
     'Recuperato dalla CLI quando espone un comando `models`. "Predefinito" lascia la scelta alla configurazione della CLI; "Personalizzato…" ti permette di inserire qualsiasi identificatore di modello accettato dalla CLI.',
   'settings.modelPickerLiveHint':
     'I modelli sono stati aggiornati dalla CLI installata. Predefinito usa ancora la configurazione della CLI.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'I modelli sono stati aggiornati dalla CLI installata.',
   'settings.modelPickerFallbackHint':
     'Mostra i valori predefiniti integrati. Clicca su Rianalizza per recuperare i modelli live dalla CLI.',
   'settings.cliEnvTitle': 'Posizioni di configurazione CLI',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -318,6 +318,8 @@ export const ja: Dict = {
     'CLI が `models` コマンドを公開している場合に取得されます。「デフォルト」は CLI 自身の設定に委ね、「カスタム…」は CLI が受け付ける任意のモデル ID を入力できます。',
   'settings.modelPickerLiveHint':
     'インストール済みの CLI からモデルを更新しました。デフォルトは引き続き CLI 設定を使用します。',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'インストール済みの CLI からモデルを更新しました。',
   'settings.modelPickerFallbackHint':
     '組み込みのデフォルトを表示しています。再スキャンをクリックすると CLI から最新モデルを取得します。',
   'settings.cliEnvTitle': 'CLI config locations',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -318,6 +318,8 @@ export const ko: Dict = {
     'CLI가 `models` 명령어를 지원할 때 가져옵니다. "Default"는 CLI 자체 설정을 따르며, "직접 입력…"을 선택하면 CLI가 허용하는 모델 ID를 입력할 수 있습니다.',
   'settings.modelPickerLiveHint':
     '설치된 CLI에서 모델을 새로 고쳤습니다. 기본값은 계속 CLI 구성을 사용합니다.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    '설치된 CLI에서 모델을 새로 고쳤습니다.',
   'settings.modelPickerFallbackHint':
     '내장 기본값을 표시 중입니다. CLI에서 실시간 모델을 가져오려면 다시 스캔을 클릭하세요.',
   'settings.cliEnvTitle': 'CLI config locations',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -318,6 +318,8 @@ export const pl: Dict = {
       'Pobierane z CLI, gdy obsługuje ono polecenie `models`. „Domyślne” pozostawia wybór konfiguracji CLI; „Własne…” pozwala wpisać dowolne ID modelu akceptowane przez CLI.',
   'settings.modelPickerLiveHint':
     'Modele zostały odświeżone z zainstalowanego CLI. Domyślny wybór nadal używa konfiguracji CLI.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'Modele zostały odświeżone z zainstalowanego CLI.',
   'settings.modelPickerFallbackHint':
     'Wyświetlane są wbudowane wartości domyślne. Kliknij Ponów skanowanie, aby pobrać modele na żywo z CLI.',
   'settings.cliEnvTitle': 'CLI config locations',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -318,6 +318,8 @@ export const ptBR: Dict = {
     'Buscado na CLI quando ela expõe um comando `models`. "Padrão" deixa a escolha para a configuração da própria CLI; "Personalizado…" permite digitar qualquer id de modelo aceito pela CLI.',
   'settings.modelPickerLiveHint':
     'Os modelos foram atualizados a partir da CLI instalada. O padrão ainda usa a configuração da CLI.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'Os modelos foram atualizados a partir da CLI instalada.',
   'settings.modelPickerFallbackHint':
     'Mostrando padrões integrados. Clique em Reescanear para buscar modelos ao vivo da CLI.',
   'settings.cliEnvTitle': 'CLI config locations',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -318,6 +318,8 @@ export const ru: Dict = {
     'Получается из CLI, если он поддерживает команду `models`. «По умолчанию» оставляет выбор конфигурации CLI, а «Пользовательская…» позволяет ввести любой ID модели, который CLI принимает.',
   'settings.modelPickerLiveHint':
     'Модели обновлены из установленного CLI. Вариант по умолчанию по-прежнему использует конфигурацию CLI.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'Модели обновлены из установленного CLI.',
   'settings.modelPickerFallbackHint':
     'Показаны встроенные значения по умолчанию. Нажмите «Пересканировать», чтобы получить актуальные модели из CLI.',
   'settings.cliEnvTitle': 'CLI config locations',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -312,6 +312,8 @@ export const th: Dict = {
   'settings.modelPickerHint': 'ดึงข้อมูลจาก CLI เมื่อมีคำสั่ง `models`',
   'settings.modelPickerLiveHint':
     'รีเฟรชโมเดลจาก CLI ที่ติดตั้งแล้ว ค่าเริ่มต้นยังใช้การตั้งค่าของ CLI',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'รีเฟรชโมเดลจาก CLI ที่ติดตั้งแล้ว',
   'settings.modelPickerFallbackHint':
     'กำลังแสดงค่าเริ่มต้นในตัว คลิกสแกนอีกครั้งเพื่อดึงโมเดลสดจาก CLI',
   'settings.cliEnvTitle': 'ตำแหน่งการตั้งค่า CLI',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -318,6 +318,8 @@ export const tr: Dict = {
     'Bir `models` komutu açığa çıkaran CLI’lardan getirilir. "Varsayılan" seçimi CLI’ın kendi ayarına bırakır; "Özel…" CLI’ın kabul edeceği herhangi bir model kimliği seçmenize izin verir.',
   'settings.modelPickerLiveHint':
     'Modeller kurulu CLI\'dan yenilendi. Varsayılan seçenek hâlâ CLI yapılandırmasını kullanır.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'Modeller kurulu CLI\'dan yenilendi.',
   'settings.modelPickerFallbackHint':
     'Yerleşik varsayılanlar gösteriliyor. CLI\'dan canlı modelleri almak için Yeniden tara\'ya tıklayın.',
   'settings.modelCustom': 'Özel (aşağıya yazın)…',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -319,6 +319,8 @@ export const uk: Dict = {
     'Отримується з CLI, коли він виявляє команду `models`. «За замовчуванням» залишає вибір конфігурації CLI; «Власна…» дозволяє ввести будь-яке ID моделі, яке приймає CLI.',
   'settings.modelPickerLiveHint':
     'Моделі оновлено з установленого CLI. Типовий варіант і далі використовує конфігурацію CLI.',
+  'settings.modelPickerLiveCatalogOnlyHint':
+    'Моделі оновлено з установленого CLI.',
   'settings.modelPickerFallbackHint':
     'Показано вбудовані типові значення. Натисніть Переканувати, щоб отримати актуальні моделі з CLI.',
   'settings.cliEnvTitle': 'CLI config locations',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -329,6 +329,7 @@ export const zhCN: Dict = {
     '当 CLI 提供 `models` 命令时会自动拉取。选择「默认」则沿用 CLI 自身的配置；选择「自定义」可手动输入任何 CLI 支持的模型 id。',
   'settings.modelPickerLiveHint':
     '模型列表来自这个 CLI；选“默认”会沿用 CLI 自己的设置。',
+  'settings.modelPickerLiveCatalogOnlyHint': '模型列表来自这个 CLI。',
   'settings.modelPickerFallbackHint':
     '正在显示内置默认值。点击“重新扫描”可从 CLI 拉取实时模型。',
   'settings.cliEnvTitle': 'CLI 配置位置',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -321,6 +321,7 @@ export const zhTW: Dict = {
     '當 CLI 提供 `models` 命令時會自動拉取。選擇「預設」則沿用 CLI 自身的設定；選擇「自訂」可手動輸入任何 CLI 支援的模型 id。',
   'settings.modelPickerLiveHint':
     '模型列表來自這個 CLI；選「預設」會沿用 CLI 自己的設定。',
+  'settings.modelPickerLiveCatalogOnlyHint': '模型列表來自這個 CLI。',
   'settings.modelPickerFallbackHint':
     '正在顯示內建預設值。點擊「重新掃描」可從 CLI 拉取即時模型。',
   'settings.cliEnvTitle': 'CLI 設定位置',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -333,6 +333,7 @@ export interface Dict {
   'settings.reasoningPicker': string;
   'settings.modelPickerHint': string;
   'settings.modelPickerLiveHint': string;
+  'settings.modelPickerLiveCatalogOnlyHint': string;
   'settings.modelPickerFallbackHint': string;
   'settings.cliEnvTitle': string;
   'settings.cliEnvHint': string;

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -20,6 +20,8 @@ import type {
   ChatSseEvent,
   ChatSseStartPayload,
   DaemonAgentPayload,
+  AmrModelsResponse,
+  MediaExecutionPolicy,
   ResearchOptions,
   RunContextSelection,
   SseErrorPayload,
@@ -509,6 +511,16 @@ export async function fetchVelaLoginStatus(): Promise<VelaLoginStatus | null> {
     const resp = await fetch('/api/integrations/vela/status');
     if (!resp.ok) return null;
     return (await resp.json()) as VelaLoginStatus;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchAmrModels(): Promise<AmrModelsResponse | null> {
+  try {
+    const resp = await fetch('/api/amr/models', { cache: 'no-store' });
+    if (!resp.ok) return null;
+    return (await resp.json()) as AmrModelsResponse;
   } catch {
     return null;
   }

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -192,6 +192,48 @@ describe('App AMR polling', () => {
     expect(mockedFetchAmrModels).toHaveBeenCalledTimes(3);
   });
 
+  it('starts AMR preset polling before the agent probe resolves', { timeout: 10_000 }, async () => {
+    let resolveAgents!: (value: Array<{
+      id: string;
+      name: string;
+      bin: string;
+      available: boolean;
+      version: string;
+      models: Array<{ id: string; label: string }>;
+    }>) => void;
+    mockedFetchAgents.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAgents = resolve;
+      }),
+    );
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'preset',
+      refreshing: true,
+      models: [{ id: 'preset-a', label: 'preset-a' }],
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
+    });
+    resolveAgents([
+      {
+        id: 'amr',
+        name: 'AMR',
+        bin: 'vela',
+        available: true,
+        version: '1.0.0',
+        models: [],
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('preset-a');
+    });
+  });
+
   it('stops polling after the remote refresh reports a preset-side error', { timeout: 10_000 }, async () => {
     mockedFetchAmrModels.mockReset();
     mockedFetchAmrModels

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -191,4 +191,34 @@ describe('App AMR polling', () => {
     }, { timeout: 4_000 });
     expect(mockedFetchAmrModels).toHaveBeenCalledTimes(3);
   });
+
+  it('stops polling after the remote refresh reports a preset-side error', { timeout: 10_000 }, async () => {
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels
+      .mockResolvedValueOnce({
+        source: 'preset',
+        refreshing: true,
+        models: [{ id: 'preset-a', label: 'preset-a' }],
+      })
+      .mockResolvedValueOnce({
+        source: 'preset',
+        refreshing: true,
+        remoteError: 'remote unavailable',
+        models: [{ id: 'preset-a', label: 'preset-a' }],
+      });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+    }, { timeout: 4_000 });
+
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+
+    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App } from '../../src/App';
@@ -23,10 +23,19 @@ vi.mock('../../src/router', () => ({
 }));
 
 vi.mock('../../src/components/EntryView', () => ({
-  EntryView: ({ agents }: { agents: Array<{ id: string; models?: Array<{ id: string }> }> }) => (
-    <div data-testid="amr-model">
-      {agents.find((agent) => agent.id === 'amr')?.models?.[0]?.id ?? 'none'}
-    </div>
+  EntryView: ({
+    agents,
+    onOpenSettings,
+  }: {
+    agents: Array<{ id: string; models?: Array<{ id: string }> }>;
+    onOpenSettings: () => void;
+  }) => (
+    <>
+      <div data-testid="amr-model">
+        {agents.find((agent) => agent.id === 'amr')?.models?.[0]?.id ?? 'none'}
+      </div>
+      <button onClick={() => onOpenSettings()}>open settings</button>
+    </>
   ),
 }));
 
@@ -43,7 +52,22 @@ vi.mock('../../src/components/pet/pets', () => ({
 }));
 
 vi.mock('../../src/components/SettingsDialog', () => ({
-  SettingsDialog: () => null,
+  SettingsDialog: ({
+    onRefreshAgents,
+  }: {
+    onRefreshAgents: (options?: { agentCliEnv?: AppConfig['agentCliEnv'] }) => void | Promise<void>;
+  }) => (
+    <button
+      onClick={() =>
+        void onRefreshAgents({
+          agentCliEnv: {
+            amr: { VELA_PROFILE: 'next-profile' },
+          },
+        })}
+    >
+      rescan agents
+    </button>
+  ),
 }));
 
 vi.mock('../../src/providers/registry', async () => {
@@ -284,5 +308,53 @@ describe('App AMR polling', () => {
 
     expect(mockedFetchAmrModels).toHaveBeenCalledTimes(11);
     expect(screen.getByTestId('amr-model').textContent).toBe('preset-a');
+  });
+
+  it('does not merge stale AMR remote models over a rescan with new agent env', async () => {
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'old-remote', label: 'old-remote' }],
+    });
+    mockedFetchAgents
+      .mockResolvedValueOnce([
+        {
+          id: 'amr',
+          name: 'AMR',
+          bin: 'vela',
+          available: true,
+          version: '1.0.0',
+          models: [],
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'amr',
+          name: 'AMR',
+          bin: 'vela',
+          available: true,
+          version: '1.0.0',
+          models: [{ id: 'new-probe', label: 'new-probe' }],
+        },
+      ]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('old-remote');
+    });
+
+    fireEvent.click(screen.getByText('open settings'));
+
+    await waitFor(() => {
+      expect(screen.getByText('rescan agents')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText('rescan agents'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('new-probe');
+    });
+    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -54,19 +54,40 @@ vi.mock('../../src/components/pet/pets', () => ({
 vi.mock('../../src/components/SettingsDialog', () => ({
   SettingsDialog: ({
     onRefreshAgents,
+    onAmrLoginStatusChange,
   }: {
     onRefreshAgents: (options?: { agentCliEnv?: AppConfig['agentCliEnv'] }) => void | Promise<void>;
+    onAmrLoginStatusChange?: (status: {
+      loggedIn: boolean;
+      loginInFlight?: boolean;
+      profile: string;
+      user: null;
+      configPath: string;
+    } | null) => void;
   }) => (
-    <button
-      onClick={() =>
-        void onRefreshAgents({
-          agentCliEnv: {
-            amr: { VELA_PROFILE: 'next-profile' },
-          },
-        })}
-    >
-      rescan agents
-    </button>
+    <>
+      <button
+        onClick={() =>
+          void onRefreshAgents({
+            agentCliEnv: {
+              amr: { VELA_PROFILE: 'next-profile' },
+            },
+          })}
+      >
+        rescan agents
+      </button>
+      <button
+        onClick={() =>
+          onAmrLoginStatusChange?.({
+            loggedIn: true,
+            profile: 'default',
+            user: null,
+            configPath: '/tmp/amr-config.json',
+          })}
+      >
+        mark amr signed in
+      </button>
+    </>
   ),
 }));
 
@@ -258,7 +279,9 @@ describe('App AMR polling', () => {
     });
   });
 
-  it('stops polling after the remote refresh reports a preset-side error', { timeout: 10_000 }, async () => {
+  it('restarts AMR polling after sign-in when preset refresh previously stopped on a remote error', {
+    timeout: 10_000,
+  }, async () => {
     mockedFetchAmrModels.mockReset();
     mockedFetchAmrModels
       .mockResolvedValueOnce({
@@ -271,6 +294,11 @@ describe('App AMR polling', () => {
         refreshing: true,
         remoteError: 'remote unavailable',
         models: [{ id: 'preset-a', label: 'preset-a' }],
+      })
+      .mockResolvedValueOnce({
+        source: 'remote',
+        refreshing: false,
+        models: [{ id: 'remote-a', label: 'remote-a' }],
       });
 
     render(<App />);
@@ -286,6 +314,17 @@ describe('App AMR polling', () => {
     await new Promise((resolve) => setTimeout(resolve, 1_500));
 
     expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByText('open settings'));
+    await waitFor(() => {
+      expect(screen.getByText('mark amr signed in')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText('mark amr signed in'));
+
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(3);
+      expect(screen.getByTestId('amr-model').textContent).toBe('remote-a');
+    }, { timeout: 4_000 });
   });
 
   it('stops polling after the preset retry budget is exhausted when remote never arrives', {

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { App } from '../../src/App';
+import type { AppConfig } from '../../src/types';
+import { loadConfig, mergeDaemonConfig, fetchDaemonConfig } from '../../src/state/config';
+import {
+  daemonIsLive,
+  fetchAgents,
+  fetchAppVersionInfo,
+  fetchDesignSystems,
+  fetchPromptTemplates,
+  fetchSkills,
+} from '../../src/providers/registry';
+import { fetchAmrModels } from '../../src/providers/daemon';
+import { listProjects, listTemplates } from '../../src/state/projects';
+
+vi.mock('../../src/router', () => ({
+  navigate: vi.fn(),
+  useRoute: () => ({ kind: 'home' as const, view: 'home' as const }),
+}));
+
+vi.mock('../../src/components/EntryView', () => ({
+  EntryView: ({ agents }: { agents: Array<{ id: string; models?: Array<{ id: string }> }> }) => (
+    <div data-testid="amr-model">
+      {agents.find((agent) => agent.id === 'amr')?.models?.[0]?.id ?? 'none'}
+    </div>
+  ),
+}));
+
+vi.mock('../../src/components/ProjectView', () => ({
+  ProjectView: () => <div>Project view</div>,
+}));
+
+vi.mock('../../src/components/pet/PetOverlay', () => ({
+  PetOverlay: () => null,
+}));
+
+vi.mock('../../src/components/pet/pets', () => ({
+  migrateCustomPetAtlas: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/components/SettingsDialog', () => ({
+  SettingsDialog: () => null,
+}));
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    daemonIsLive: vi.fn(),
+    fetchAgents: vi.fn(),
+    fetchAppVersionInfo: vi.fn(),
+    fetchDesignSystems: vi.fn(),
+    fetchPromptTemplates: vi.fn(),
+    fetchSkills: vi.fn(),
+  };
+});
+
+vi.mock('../../src/providers/daemon', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/daemon')>(
+    '../../src/providers/daemon',
+  );
+  return {
+    ...actual,
+    fetchAmrModels: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/projects')>(
+    '../../src/state/projects',
+  );
+  return {
+    ...actual,
+    listProjects: vi.fn(),
+    listTemplates: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/config', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/config')>(
+    '../../src/state/config',
+  );
+  return {
+    ...actual,
+    loadConfig: vi.fn(),
+    mergeDaemonConfig: vi.fn(),
+    fetchDaemonConfig: vi.fn().mockResolvedValue({}),
+  };
+});
+
+const mockedDaemonIsLive = vi.mocked(daemonIsLive);
+const mockedFetchAgents = vi.mocked(fetchAgents);
+const mockedFetchAppVersionInfo = vi.mocked(fetchAppVersionInfo);
+const mockedFetchDesignSystems = vi.mocked(fetchDesignSystems);
+const mockedFetchPromptTemplates = vi.mocked(fetchPromptTemplates);
+const mockedFetchSkills = vi.mocked(fetchSkills);
+const mockedFetchAmrModels = vi.mocked(fetchAmrModels);
+const mockedListProjects = vi.mocked(listProjects);
+const mockedListTemplates = vi.mocked(listTemplates);
+const mockedLoadConfig = vi.mocked(loadConfig);
+const mockedMergeDaemonConfig = vi.mocked(mergeDaemonConfig);
+const mockedFetchDaemonConfig = vi.mocked(fetchDaemonConfig);
+
+const baseConfig: AppConfig = {
+  mode: 'api',
+  apiKey: '',
+  apiProtocol: 'anthropic',
+  apiVersion: '',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  apiProviderBaseUrl: 'https://api.anthropic.com',
+  apiProtocolConfigs: {},
+  agentId: null,
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  mediaProviders: {},
+  composio: {},
+  agentModels: {},
+  agentCliEnv: {},
+};
+
+describe('App AMR polling', () => {
+  beforeEach(() => {
+    mockedDaemonIsLive.mockResolvedValue(true);
+    mockedFetchAgents.mockResolvedValue([
+      {
+        id: 'amr',
+        name: 'AMR',
+        bin: 'vela',
+        available: true,
+        version: '1.0.0',
+        models: [],
+      },
+    ]);
+    mockedFetchSkills.mockResolvedValue([]);
+    mockedFetchDesignSystems.mockResolvedValue([]);
+    mockedFetchPromptTemplates.mockResolvedValue([]);
+    mockedFetchAppVersionInfo.mockResolvedValue(null);
+    mockedListProjects.mockResolvedValue([]);
+    mockedListTemplates.mockResolvedValue([]);
+    mockedLoadConfig.mockReturnValue({ ...baseConfig });
+    mockedMergeDaemonConfig.mockImplementation((local) => local);
+    mockedFetchDaemonConfig.mockResolvedValue({});
+    mockedFetchAmrModels
+      .mockResolvedValueOnce({
+        source: 'preset',
+        refreshing: true,
+        models: [{ id: 'preset-a', label: 'preset-a' }],
+      })
+      .mockResolvedValueOnce({
+        source: 'preset',
+        refreshing: true,
+        models: [{ id: 'preset-a', label: 'preset-a' }],
+      })
+      .mockResolvedValueOnce({
+        source: 'remote',
+        refreshing: false,
+        models: [{ id: 'remote-a', label: 'remote-a' }],
+      });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('keeps polling AMR models until the remote catalog replaces the preset list', { timeout: 10_000 }, async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('preset-a');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('remote-a');
+    }, { timeout: 4_000 });
+    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -221,4 +221,26 @@ describe('App AMR polling', () => {
 
     expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
   });
+
+  it('stops polling after the preset retry budget is exhausted when remote never arrives', {
+    timeout: 20_000,
+  }, async () => {
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockImplementation(async () => ({
+      source: 'preset',
+      refreshing: true,
+      models: [{ id: 'preset-a', label: 'preset-a' }],
+    }));
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(11);
+    }, { timeout: 12_000 });
+
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+
+    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(11);
+    expect(screen.getByTestId('amr-model').textContent).toBe('preset-a');
+  });
 });

--- a/apps/web/tests/providers/daemon-amr-models.test.ts
+++ b/apps/web/tests/providers/daemon-amr-models.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchAmrModels } from '../../src/providers/daemon';
+
+describe('fetchAmrModels', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns AMR model cache payloads from the daemon', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({
+        source: 'preset',
+        models: [{ id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' }],
+        refreshing: true,
+      }), { status: 200 })),
+    );
+
+    await expect(fetchAmrModels()).resolves.toEqual({
+      source: 'preset',
+      models: [{ id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' }],
+      refreshing: true,
+    });
+    expect(fetch).toHaveBeenCalledWith('/api/amr/models', { cache: 'no-store' });
+  });
+
+  it('returns null when the daemon does not return AMR models', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status: 500 })),
+    );
+
+    await expect(fetchAmrModels()).resolves.toBeNull();
+  });
+});

--- a/e2e/lib/amr.ts
+++ b/e2e/lib/amr.ts
@@ -9,6 +9,18 @@ export type FakeVelaOptions = {
 };
 
 const DEFAULT_ASSISTANT_TEXT = 'Hello from the e2e fake vela.';
+const PRESET_MODELS_JSON = JSON.stringify({
+  source: 'preset',
+  data: [
+    { id: 'glm-5' },
+  ],
+});
+const REMOTE_MODELS_JSON = JSON.stringify({
+  source: 'remote',
+  data: [
+    { id: 'glm-5' },
+  ],
+});
 
 export async function writeFakeVelaBin(root: string, options: FakeVelaOptions = {}): Promise<string> {
   await mkdir(root, { recursive: true });
@@ -124,6 +136,16 @@ if (argv[2] === 'login') {
 
 if (argv[2] === 'models') {
   stdout.write('public_model_glm_5    vela\\n');
+  exit(0);
+}
+
+if (argv[2] === 'model' && argv[3] === 'preset' && argv[4] === '--format' && argv[5] === 'json') {
+  stdout.write(${JSON.stringify(PRESET_MODELS_JSON)} + '\\n');
+  exit(0);
+}
+
+if (argv[2] === 'model' && argv[3] === 'list' && argv[4] === '--format' && argv[5] === 'json') {
+  stdout.write(${JSON.stringify(REMOTE_MODELS_JSON)} + '\\n');
   exit(0);
 }
 

--- a/e2e/tests/amr/turn.test.ts
+++ b/e2e/tests/amr/turn.test.ts
@@ -46,7 +46,9 @@ type ProjectResponse = {
 // Inline fake `vela` binary. Handles the two argv shapes Open Design's
 // daemon ever spawns:
 //
-//   `vela models`                       — print the live link model catalog.
+//   `vela models`                       — legacy catalog probe compatibility.
+//   `vela model preset --format json`   — print the fast preset catalog.
+//   `vela model list --format json`     — print the live link model catalog.
 //   `vela login`                        — write ~/.amr/config.json and exit 0.
 //   `vela agent run --runtime opencode` — ACP stdio runtime (initialize →
 //                                          session/new → session/set_model →
@@ -64,6 +66,8 @@ import { argv, stdin, stdout, env, exit } from 'node:process';
 const ASSISTANT_TEXT = env.FAKE_VELA_TEXT || 'Hello from the e2e fake vela.';
 const SESSION_ID = 'fake-amr-session-1';
 const LIVE_MODEL_ID = 'glm-5';
+const PRESET_MODELS_JSON = JSON.stringify({ source: 'preset', data: [{ id: LIVE_MODEL_ID }] });
+const REMOTE_MODELS_JSON = JSON.stringify({ source: 'remote', data: [{ id: LIVE_MODEL_ID }] });
 
 function writeMessage(obj) {
   stdout.write(JSON.stringify(obj) + '\\n');
@@ -95,6 +99,16 @@ if (argv[2] === 'login') {
 
 if (argv[2] === 'models') {
   stdout.write('public_model_glm_5    vela\\n');
+  exit(0);
+}
+
+if (argv[2] === 'model' && argv[3] === 'preset' && argv[4] === '--format' && argv[5] === 'json') {
+  stdout.write(PRESET_MODELS_JSON + '\\n');
+  exit(0);
+}
+
+if (argv[2] === 'model' && argv[3] === 'list' && argv[4] === '--format' && argv[5] === 'json') {
+  stdout.write(REMOTE_MODELS_JSON + '\\n');
   exit(0);
 }
 

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -46,6 +46,16 @@ export interface AgentsResponse {
   agents: AgentInfo[];
 }
 
+export type AmrModelsSource = 'preset' | 'remote';
+
+export interface AmrModelsResponse {
+  source: AmrModelsSource;
+  models: AgentModelOption[];
+  refreshing: boolean;
+  stale?: boolean;
+  remoteError?: string;
+}
+
 export type SkillSource = 'built-in' | 'user';
 
 export interface SkillSummary {

--- a/specs/change/20260601-amr-model-loading-cache/spec.md
+++ b/specs/change/20260601-amr-model-loading-cache/spec.md
@@ -1,0 +1,344 @@
+---
+id: 20260601-amr-model-loading-cache
+name: Amr Model Loading Cache
+status: designed
+created: '2026-06-01'
+---
+
+## Overview
+
+### Problem Statement
+
+AMR model discovery currently rides on the general agent probing path. The
+Open Design AMR runtime still calls legacy `vela models`, waits for that
+catalog before `/api/agents` can return AMR model data, and parses
+production-shaped text ids that the new Vela model discovery contract no
+longer wants Open Design to treat as primary.
+
+The Vela CLI now exposes a split contract:
+
+- `vela model preset --format json`: fast local picker seed.
+- `vela model list --format json`: authoritative remote AMR catalog.
+
+Open Design should use the fast preset to occupy AMR model pickers while a
+background remote catalog refresh fills a loading cache. `/api/agents` can
+keep its existing compatibility payload, but AMR UI surfaces should not rely
+on `/api/agents` for the AMR model list.
+
+### Goals
+
+- Add an AMR-specific `GET /api/amr/models` endpoint.
+- Return Vela `source: "preset" | "remote"` semantics from that endpoint.
+- Keep the latest successful remote catalog in daemon memory and refresh it
+  in the background without clearing it.
+- Warm the remote model cache when AMR login status reports `loggedIn: true`.
+- Update AMR model pickers to use `/api/amr/models` with bounded polling.
+- Migrate new AMR model discovery from legacy `vela models` to
+  `vela model list --format json`.
+
+### Non-Goals
+
+- Do not remove the existing generic `fallback` model mechanism.
+- Do not remove `/api/agents` AMR model fields in this change.
+- Do not add new glossary terms to `CONTEXT.md`.
+- Do not implement a broader generic runtime model endpoint.
+- Do not change AMR execution away from `vela agent run --runtime opencode`.
+
+### Success Criteria
+
+- AMR model UI can show preset rows quickly while remote model list loads.
+- A successful remote list replaces preset rows and is cached for later loads.
+- Remote cache refreshes do not make the UI fall back to preset when stale
+  remote data exists.
+- AMR run preflight still validates against authoritative remote list data,
+  not preset rows.
+- Existing non-AMR runtime probing and fallback behavior remains unchanged.
+
+## Research
+
+### Existing System
+
+- AMR runtime discovery currently uses `fetchVelaModelsWithRetry`, which
+  executes `vela models`, parses stdout, and retries transient text errors.
+  Source: `apps/daemon/src/runtimes/defs/amr.ts:4-5,161-185`.
+- The current AMR parser normalizes legacy `public_model_*` and `vela/` ids,
+  filters media model prefixes, deduplicates, and orders preferred chat
+  models. Source: `apps/daemon/src/runtimes/defs/amr.ts:39-117,120-132`.
+- AMR declares `fallbackModels: []`, disables custom model ids, and keeps
+  execution on `vela agent run --runtime opencode`. Source:
+  `apps/daemon/src/runtimes/defs/amr.ts:188-208`.
+- Generic runtime probing calls each runtime's `fetchModels` during
+  `detectAgents`, maps successful results to `modelsSource: "live"`, and
+  falls back to static fallback models on empty/error results. Source:
+  `apps/daemon/src/runtimes/detection.ts:22-60,182-188`.
+- `detectAgents` probes all registered agent defs with `Promise.all` and then
+  records the surfaced model ids in the run-time validation cache. Source:
+  `apps/daemon/src/runtimes/detection.ts:244-256`.
+- The shared `AgentInfo` contract currently models agent model provenance as
+  `modelsSource?: "live" | "fallback"`. Source:
+  `packages/contracts/src/api/registry.ts:1-18`.
+- AMR login status is already exposed through
+  `GET /api/integrations/vela/status`, and login/logout use separate Vela
+  integration endpoints. Source: `apps/daemon/src/server.ts:6156-6214`;
+  `apps/web/src/providers/daemon.ts:505-566`.
+- Chat-run AMR preflight currently calls `def.fetchModels`, updates remembered
+  live models on success, falls back to remembered live models when the fresh
+  fetch fails, and blocks when the selected model is absent. Source:
+  `apps/daemon/src/server.ts:11328-11414`.
+- Onboarding has an AMR-specific hardcoded model list used when the AMR agent
+  payload does not include models. Source:
+  `apps/web/src/components/EntryShell.tsx:132-137,904-911`.
+- Onboarding renders the AMR picker from its selected `amrModels` and
+  `amrModelsSource`. Source:
+  `apps/web/src/components/EntryShell.tsx:1651-1659,2051-2085`.
+- The current fake Vela test fixture only implements `vela models` for model
+  listing. Source: `apps/daemon/tests/fixtures/fake-vela.mjs:1-20,68-84`.
+- AMR integration tests pin the current behavior: no static fallback, legacy
+  normalization, parsing/filtering, `fetchModels` through `vela models`, and
+  transient retry. Source:
+  `apps/daemon/tests/amr-acp-integration.test.ts:77-155,157-207`.
+
+### Design Inputs
+
+- Vela's new contract separates model discovery into `vela model preset`,
+  `vela model list`, and legacy `vela models`. Source:
+  `/private/tmp/open-design-amr-model-catalog-handoff.md:7-21`.
+- Vela preset is a fast local picker seed, does not require login/config or
+  network, is not authoritative, and must not be used as execution fallback.
+  Source: `/private/tmp/open-design-amr-model-catalog-handoff.md:50-61`.
+- Vela preset JSON is requested with `vela model preset --format json` and
+  returns `source: "preset"` plus `data[].id`. Source:
+  `/private/tmp/open-design-amr-model-catalog-handoff.md:77-100`.
+- Vela remote list is authoritative, requires a valid profile/control key,
+  calls `GET /api/v1/models`, returns requestable model names in `data[].id`,
+  and does not fall back to preset. Source:
+  `/private/tmp/open-design-amr-model-catalog-handoff.md:102-150`.
+- Legacy `vela models` is text-only compatibility output and should not be
+  used by new picker/preflight paths. Source:
+  `/private/tmp/open-design-amr-model-catalog-handoff.md:152-164`.
+- New `vela model list` ids are already requestable AMR model names, so Open
+  Design should not apply `public_model_*` normalization to new list results.
+  Source: `/private/tmp/open-design-amr-model-catalog-handoff.md:166-180`.
+- Recommended picker flow is preset first, remote list in parallel or
+  immediately after, then remote replaces preset when it succeeds. Source:
+  `/private/tmp/open-design-amr-model-catalog-handoff.md:182-189`.
+
+### Constraints & Dependencies
+
+- Project command boundaries require new user-facing capabilities to have both
+  HTTP and CLI surfaces unless genuinely not applicable; this change is an AMR
+  UI/daemon support endpoint rather than a new `od` user command. Source:
+  `AGENTS.md` "Capability exposure (UI/CLI dual-track)".
+- Root validation for regular work is at least `pnpm guard` and
+  `pnpm typecheck`, plus package-scoped tests/builds matching touched files.
+  Source: `AGENTS.md` "Validation strategy".
+- New i18n keys must be added to `apps/web/src/i18n/types.ts` and all 18
+  locale files. Source: `AGENTS.md` "i18n keys".
+
+## Design
+
+### Design Summary
+
+Introduce an AMR-only model catalog endpoint backed by a daemon memory
+loading cache. The endpoint returns preset rows immediately when no remote
+catalog is cached, starts or joins a background remote `vela model list`
+refresh, and returns the last successful remote catalog whenever one exists.
+Remote refreshes are stale-while-refresh: stale remote data remains visible
+while the daemon refreshes in the background.
+
+The frontend AMR pickers call `/api/amr/models` directly. If the endpoint
+returns `source: "preset"`, the frontend polls a bounded number of times for
+the remote result. If polling reaches the limit, the UI keeps showing preset
+rows. `/api/agents` remains compatible and may still include AMR model data,
+but AMR picker freshness no longer depends on general agent probing.
+
+### Design Decisions
+
+- Decision: Add `GET /api/amr/models` instead of making `/api/agents` carry
+  AMR's staged picker behavior. `/api/agents` currently probes all runtimes
+  and awaits model discovery inside `detectAgents`, so an AMR remote catalog
+  wait is coupled to all agent detection. Source:
+  `apps/daemon/src/runtimes/detection.ts:22-60,244-256`.
+- Decision: Use endpoint `source` values `"preset"` and `"remote"`, matching
+  Vela's JSON contract, instead of extending generic `modelsSource` for this
+  AMR-only endpoint. Source:
+  `/private/tmp/open-design-amr-model-catalog-handoff.md:77-100,127-150`;
+  `packages/contracts/src/api/registry.ts:15-18`.
+- Decision: Keep generic `fallback` behavior unchanged. Non-AMR runtime
+  probing uses `"fallback"` for static runtime lists, while Vela preset is a
+  CLI-provided local seed, not an Open Design static fallback. Source:
+  `apps/daemon/src/runtimes/detection.ts:27-60`;
+  `/private/tmp/open-design-amr-model-catalog-handoff.md:50-61`.
+- Decision: Parse new Vela JSON by `data[].id` directly and do not apply
+  legacy `public_model_*` normalization to `vela model list` results. Source:
+  `/private/tmp/open-design-amr-model-catalog-handoff.md:166-180`;
+  `apps/daemon/src/runtimes/defs/amr.ts:39-117`.
+- Decision: Preserve chat-model filtering and preferred ordering for AMR model
+  options after JSON parsing, because AMR currently drives chat completions
+  and existing tests pin media filtering/order. Source:
+  `apps/daemon/src/runtimes/defs/amr.ts:91-132`;
+  `apps/daemon/tests/amr-acp-integration.test.ts:113-155`.
+- Decision: Keep AMR execution preflight authoritative by using remote
+  `vela model list --format json`; preset rows must not populate the execution
+  allowlist. Source:
+  `/private/tmp/open-design-amr-model-catalog-handoff.md:56-60,102-112`;
+  `apps/daemon/src/server.ts:11328-11414`.
+- Decision: Warm the remote model loading cache when
+  `/api/integrations/vela/status` reads `loggedIn: true`, without awaiting the
+  refresh before responding. Source:
+  `apps/daemon/src/server.ts:6160-6165`;
+  `/private/tmp/open-design-amr-model-catalog-handoff.md:106-112`.
+- Decision: Keep `/api/agents` AMR payload compatibility for now, and make
+  frontend AMR model pickers prefer `/api/amr/models` instead. Source:
+  `apps/web/src/components/EntryShell.tsx:904-911,1651-1659`;
+  `apps/daemon/src/runtimes/detection.ts:182-188`.
+
+### System Procedure
+
+Flow:
+
+1. Frontend requests `GET /api/amr/models` when an AMR model picker mounts or
+   needs refresh.
+2. Daemon resolves AMR's Vela launch path and environment using existing agent
+   launch/config helpers.
+3. Daemon reads or fetches preset rows via
+   `vela model preset --format json`.
+4. If a remote catalog cache exists, daemon returns it with
+   `source: "remote"`, and starts a background refresh when the refresh
+   interval says it is stale.
+5. If no remote catalog cache exists, daemon returns preset rows with
+   `source: "preset"` and starts or joins a background remote refresh.
+6. Frontend polls while `source === "preset"` until remote arrives or the
+   poll limit is reached.
+7. Chat-run preflight fetches the remote list directly, updates remembered
+   live models only from remote results, and blocks unavailable selections.
+
+### Interfaces / APIs
+
+`GET /api/amr/models`
+
+```ts
+type AmrModelsResponse = {
+  source: 'preset' | 'remote';
+  models: Array<{ id: string; label: string }>;
+  refreshing: boolean;
+  stale?: boolean;
+  remoteError?: string;
+};
+```
+
+Response semantics:
+
+- `source: "preset"` means no successful remote catalog is cached yet.
+- `source: "remote"` means rows came from the latest successful
+  `vela model list --format json`.
+- `refreshing: true` means a remote refresh is currently running.
+- `stale: true` means the returned remote rows are from a previous successful
+  fetch and a later refresh attempt failed or is in progress.
+- `remoteError` is diagnostic only; UI can keep showing current rows.
+
+### Change Scope
+
+Impact Areas:
+
+- Daemon AMR runtime model discovery: replace legacy primary `vela models`
+  integration for new AMR model flows with JSON preset/list helpers.
+- Daemon HTTP routes: add AMR-specific model endpoint and warm cache from Vela
+  login status reads.
+- Contracts: add AMR model response types without changing generic
+  `AgentInfo.modelsSource`.
+- Web AMR picker data flow: fetch `/api/amr/models`, poll with an upper bound,
+  and keep `/api/agents` as compatibility/fallback input only.
+- Tests and fixtures: teach fake Vela about `model preset/list --format json`
+  and add coverage for cache, parsing, and UI replacement behavior.
+
+Planned File Changes:
+
+- `packages/contracts/src/api/registry.ts` - add AMR model endpoint response
+  type or a nearby exported contract type.
+- `apps/daemon/src/runtimes/defs/amr.ts` - add JSON model response parsing,
+  preset fetch, remote list fetch, and remote-only preflight helper.
+- `apps/daemon/src/runtimes/amr-model-cache.ts` or equivalent - implement
+  process-local loading cache with in-flight refresh coalescing.
+- `apps/daemon/src/server.ts` - register `GET /api/amr/models` and warm the
+  cache from the Vela status endpoint when logged in.
+- `apps/daemon/tests/fixtures/fake-vela.mjs` - support
+  `model preset --format json` and `model list --format json`.
+- `apps/daemon/tests/amr-acp-integration.test.ts` or focused daemon route
+  tests - update legacy expectations and add new model cache cases.
+- `apps/web/src/providers/daemon.ts` - add `fetchAmrModels`.
+- `apps/web/src/components/EntryShell.tsx`,
+  `apps/web/src/components/SettingsDialog.tsx`, and
+  `apps/web/src/components/InlineModelSwitcher.tsx` - use `/api/amr/models`
+  for AMR model options where those surfaces render AMR pickers.
+- `apps/web/tests/**` - cover bounded polling and AMR model replacement where
+  practical.
+
+### Edge Cases
+
+- If remote cache exists and refresh fails, keep returning the stale remote
+  cache rather than falling back to preset.
+- If no remote cache exists, return preset and keep attempting remote refresh
+  on later requests; frontend stops polling after its upper bound.
+- If AMR binary resolution fails, return a clear endpoint failure instead of
+  fabricating model rows.
+- If Vela JSON is malformed or has the wrong `source`, fail the required
+  step visibly in daemon tests and endpoint responses.
+- If remote list returns media models, preserve the existing chat-only filter.
+
+### Verification Strategy
+
+- Daemon parser tests: validate preset/remote JSON parsing, source checks,
+  direct `data[].id` use, media filtering, de-dupe, and ordering. Source:
+  `apps/daemon/tests/amr-acp-integration.test.ts:88-155`.
+- Daemon cache tests: validate first preset response starts refresh, concurrent
+  requests coalesce one remote call, remote replaces preset, stale remote
+  survives failed refresh, and login status warm starts refresh. Source:
+  `apps/daemon/src/server.ts:6160-6165`.
+- Chat preflight tests: validate AMR execution allowlist is populated only
+  from remote list results, not preset. Source:
+  `apps/daemon/src/server.ts:11328-11414`.
+- Web tests: validate AMR pickers call `/api/amr/models`, poll only while
+  `source === "preset"`, stop after remote or after the poll cap, and keep
+  existing `/api/agents` compatibility. Source:
+  `apps/web/src/components/EntryShell.tsx:904-911,1651-1659`.
+- Final validation: run `pnpm guard`, `pnpm typecheck`,
+  `pnpm --filter @open-design/daemon test -- amr-acp-integration`, and
+  focused web tests touched by the implementation. Source:
+  `AGENTS.md` "Validation strategy".
+
+## Plan
+
+- [ ] Step 1: Daemon AMR model contract and cache
+  - [ ] Substep 1.1 Implement: Add AMR preset/remote JSON parsers and fetch
+    helpers in the AMR runtime area.
+  - [ ] Substep 1.2 Implement: Add process-local loading cache with in-flight
+    remote refresh coalescing and stale-while-refresh behavior.
+  - [ ] Substep 1.3 Implement: Add `GET /api/amr/models` and Vela status warm
+    trigger.
+  - [ ] Substep 1.4 Verify: Add fake Vela support for new commands.
+  - [ ] Substep 1.5 Verify: Add daemon tests for parser, endpoint/cache, and
+    remote-only execution preflight.
+- [ ] Step 2: Frontend AMR picker integration
+  - [ ] Substep 2.1 Implement: Add web provider helper for `/api/amr/models`.
+  - [ ] Substep 2.2 Implement: Wire AMR model pickers to endpoint results while
+    preserving `/api/agents` compatibility.
+  - [ ] Substep 2.3 Implement: Add bounded polling while `source === "preset"`.
+  - [ ] Substep 2.4 Verify: Add focused web tests for preset-to-remote
+    replacement and polling cap.
+- [ ] Step 3: Regression validation
+  - [ ] Substep 3.1 Verify: Run daemon AMR tests.
+  - [ ] Substep 3.2 Verify: Run focused web tests.
+  - [ ] Substep 3.3 Verify: Run `pnpm guard` and `pnpm typecheck`.
+
+## Notes
+
+<!-- Optional sections — add what's relevant. -->
+
+### Implementation
+
+<!-- Files created/modified, decisions made during coding, deviations from design -->
+
+### Verification
+
+<!-- How the feature was verified: tests written, manual testing steps, results -->

--- a/specs/change/20260601-amr-model-loading-cache/spec.md
+++ b/specs/change/20260601-amr-model-loading-cache/spec.md
@@ -359,6 +359,7 @@ Planned File Changes:
 ### Verification
 
 - Passed: `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/amr-acp-integration.test.ts`.
+- Passed after log-check import fix: `pnpm --filter @open-design/daemon typecheck`.
 - Passed: `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/chat-route.test.ts -t "retries transient AMR Link catalog failures"`.
 - Passed: `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/providers/daemon-amr-models.test.ts`.
 - Passed: `pnpm --filter @open-design/daemon typecheck && pnpm --filter @open-design/web typecheck && pnpm --filter @open-design/contracts typecheck`.

--- a/specs/change/20260601-amr-model-loading-cache/spec.md
+++ b/specs/change/20260601-amr-model-loading-cache/spec.md
@@ -309,26 +309,26 @@ Planned File Changes:
 
 ## Plan
 
-- [ ] Step 1: Daemon AMR model contract and cache
-  - [ ] Substep 1.1 Implement: Add AMR preset/remote JSON parsers and fetch
+- [x] Step 1: Daemon AMR model contract and cache
+  - [x] Substep 1.1 Implement: Add AMR preset/remote JSON parsers and fetch
     helpers in the AMR runtime area.
-  - [ ] Substep 1.2 Implement: Add process-local loading cache with in-flight
+  - [x] Substep 1.2 Implement: Add process-local loading cache with in-flight
     remote refresh coalescing and stale-while-refresh behavior.
-  - [ ] Substep 1.3 Implement: Add `GET /api/amr/models` and Vela status warm
+  - [x] Substep 1.3 Implement: Add `GET /api/amr/models` and Vela status warm
     trigger.
-  - [ ] Substep 1.4 Verify: Add fake Vela support for new commands.
-  - [ ] Substep 1.5 Verify: Add daemon tests for parser, endpoint/cache, and
+  - [x] Substep 1.4 Verify: Add fake Vela support for new commands.
+  - [x] Substep 1.5 Verify: Add daemon tests for parser, endpoint/cache, and
     remote-only execution preflight.
-- [ ] Step 2: Frontend AMR picker integration
-  - [ ] Substep 2.1 Implement: Add web provider helper for `/api/amr/models`.
-  - [ ] Substep 2.2 Implement: Wire AMR model pickers to endpoint results while
+- [x] Step 2: Frontend AMR picker integration
+  - [x] Substep 2.1 Implement: Add web provider helper for `/api/amr/models`.
+  - [x] Substep 2.2 Implement: Wire AMR model pickers to endpoint results while
     preserving `/api/agents` compatibility.
-  - [ ] Substep 2.3 Implement: Add bounded polling while `source === "preset"`.
-  - [ ] Substep 2.4 Verify: Add focused web tests for preset-to-remote
+  - [x] Substep 2.3 Implement: Add bounded polling while `source === "preset"`.
+  - [x] Substep 2.4 Verify: Add focused web tests for preset-to-remote
     replacement and polling cap.
 - [ ] Step 3: Regression validation
-  - [ ] Substep 3.1 Verify: Run daemon AMR tests.
-  - [ ] Substep 3.2 Verify: Run focused web tests.
+  - [x] Substep 3.1 Verify: Run daemon AMR tests.
+  - [x] Substep 3.2 Verify: Run focused web tests.
   - [ ] Substep 3.3 Verify: Run `pnpm guard` and `pnpm typecheck`.
 
 ## Notes
@@ -337,8 +337,32 @@ Planned File Changes:
 
 ### Implementation
 
-<!-- Files created/modified, decisions made during coding, deviations from design -->
+- `packages/contracts/src/api/registry.ts` - added `AmrModelsResponse` and
+  `source: "preset" | "remote"` contract types.
+- `apps/daemon/src/runtimes/defs/amr.ts` - added Vela preset/list JSON parsing
+  and fetch helpers; AMR authoritative `fetchModels` now uses
+  `vela model list --format json`.
+- `apps/daemon/src/runtimes/amr-model-cache.ts` - added process-local AMR
+  loading cache with in-flight remote coalescing and stale-while-refresh
+  behavior.
+- `apps/daemon/src/server.ts` - added `GET /api/amr/models` and status-route
+  remote cache warming when Vela reports `loggedIn: true`.
+- `apps/daemon/tests/fixtures/fake-vela.mjs` - added `model preset/list
+  --format json` fixture support.
+- `apps/web/src/providers/daemon.ts` and `apps/web/src/App.tsx` - added
+  `/api/amr/models` fetching and app-level bounded polling that updates AMR
+  models for onboarding, Settings, and inline switcher surfaces while keeping
+  `/api/agents` compatibility.
+- Deviation: focused web coverage verifies the provider helper. The polling is
+  implemented at the app-level merge point so all AMR picker surfaces share it.
 
 ### Verification
 
-<!-- How the feature was verified: tests written, manual testing steps, results -->
+- Passed: `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/amr-acp-integration.test.ts`.
+- Passed: `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/chat-route.test.ts -t "retries transient AMR Link catalog failures"`.
+- Passed: `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/providers/daemon-amr-models.test.ts`.
+- Passed: `pnpm --filter @open-design/daemon typecheck && pnpm --filter @open-design/web typecheck && pnpm --filter @open-design/contracts typecheck`.
+- Passed: `pnpm typecheck`.
+- Failed: `pnpm guard` due an existing tools layout violation:
+  `tools/pr/ -> tools/ top-level entries are allowlisted; expected only
+  AGENTS.md, dev/, pack/, and serve/`.


### PR DESCRIPTION
## Why

AMR model selection currently depends on the remote Vela catalog path before users can get usable model choices. This PR makes the picker responsive by returning the local Vela preset catalog immediately, then warming and serving the authoritative remote catalog when it is available.

This is the release/v0.9.0-targeted replacement for #3419, which was opened against main by mistake. The commits were cherry-picked onto a branch based on `release/v0.9.0`.

## What users will see

Settings → Local CLI → AMR shows available preset models quickly, then updates to the live CLI-backed catalog after Vela finishes loading remote models. The AMR picker remains catalog-only rather than offering free-form custom model ids.

## Surface area

- [x] **UI** — model picker hint/update behavior in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/amr/models` endpoint and contract response shape
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation key
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — AMR model list now initially uses Vela presets and refreshes to remote catalog
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; change is a Settings model-picker data-loading behavior and hint text update.

## Bug fix verification

- Not a bug-fix PR.

## Validation

- `pnpm typecheck` — passed. Existing landing-page Astro/TypeScript deprecation and unused-value hints were reported, with 0 errors.
- `pnpm --filter @open-design/daemon test` — passed: 293 files passed, 1 skipped; 3544 tests passed, 4 skipped, 4 todo.
- `pnpm --filter @open-design/web test` — passed: 252 files passed; 2407 tests passed. jsdom reported the existing `HTMLCanvasElement.getContext()` not-implemented warnings.
- `pnpm test tests/amr/turn.test.ts` from `e2e/` — passed: 1 file passed; 1 test passed.
- `pnpm guard` — failed on existing repository guard violation: `tools/pr/ -> tools/ top-level entries are allowlisted; expected only AGENTS.md, dev/, pack/, and serve/`. Other guard sections shown before/after that violation passed.
- Cherry-picked #3419 commits onto `release/v0.9.0`; resolved one import conflict in `apps/web/src/providers/daemon.ts`.
