### PR TITLE
Harden sandbox-mode media and tools-dev smoke

### DIFF
--- a/apps/daemon/src/media-routes.ts
+++ b/apps/daemon/src/media-routes.ts
@@ -3,17 +3,60 @@ import type { MediaExecutionPolicy } from '@open-design/contracts';
 import { defaultMediaExecutionPolicy, mediaPolicyDenial } from './media-policy.js';
 import type { RouteDeps } from './server-context.js';
 import { proxyDispatcherRequestInit } from './connectionTest.js';
+import { isSandboxModeEnabled } from './sandbox-mode.js';
 import type { ToolTokenGrant } from './tool-tokens.js';
 
 const LONG_MEDIA_PROXY_TIMEOUT_MS = 10 * 60 * 1000;
 
 export interface RegisterMediaRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'ids' | 'auth' | 'media' | 'appConfig' | 'orbit' | 'nativeDialogs' | 'projectStore' | 'projectFiles' | 'conversations' | 'research'> {}
 
+export type LegacyMediaRouteGrantDecision =
+  | { ok: true; grant: ToolTokenGrant | null }
+  | {
+      ok: false;
+      code: string;
+      details?: Record<string, unknown>;
+      message: string;
+      status: number;
+    };
+
+export function resolveLegacyMediaRouteGrant(input: {
+  grant: ToolTokenGrant | null;
+  projectId: string;
+  requestProjectOverride: (projectId: string, tokenProjectId: string) => boolean;
+  sandboxMode: boolean;
+}): LegacyMediaRouteGrantDecision {
+  if (
+    input.sandboxMode &&
+    input.grant &&
+    input.requestProjectOverride(input.projectId, input.grant.projectId)
+  ) {
+    return {
+      ok: false,
+      code: 'FORBIDDEN',
+      details: { suppliedProjectId: input.projectId },
+      message: 'projectId is derived from the tool token',
+      status: 403,
+    };
+  }
+
+  if (!input.grant && input.sandboxMode) {
+    return {
+      ok: false,
+      code: 'TOOL_TOKEN_MISSING',
+      message: 'tool token is required for media generation in sandbox mode',
+      status: 401,
+    };
+  }
+
+  return { ok: true, grant: input.grant };
+}
+
 export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) {
   const { db, design } = ctx;
   const { sendApiError, requireLocalDaemonRequest, isLocalSameOrigin, resolvedPortRef } = ctx.http;
   const { PROJECT_ROOT, PROJECTS_DIR, RUNTIME_DATA_DIR } = ctx.paths;
-  const { authorizeToolRequest, optionalToolGrantFromRequest } = ctx.auth;
+  const { authorizeToolRequest, optionalToolGrantFromRequest, requestProjectOverride } = ctx.auth;
   const { randomUUID } = ctx.ids;
   const { MEDIA_PROVIDERS, IMAGE_MODELS, VIDEO_MODELS, AUDIO_MODELS_BY_KIND, MEDIA_ASPECTS, VIDEO_LENGTHS_SEC, AUDIO_DURATIONS_SEC, readMaskedConfig, writeConfig, generateMedia, createMediaTask, persistMediaTask, appendTaskProgress, notifyTaskWaiters, getLiveMediaTask, mediaTaskSnapshot, listMediaTasksByProject, listElevenLabsVoiceOptions } = ctx.media;
   const { readAppConfig, writeAppConfig } = ctx.appConfig;
@@ -24,10 +67,19 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
   const { searchResearch, ResearchError } = ctx.research;
   const getResolvedPort = () => resolvedPortRef.current;
 
-  const mediaPolicyForGrant = (grant: ToolTokenGrant | null): MediaExecutionPolicy => {
-    if (!grant?.runId) return defaultMediaExecutionPolicy();
+  const mediaPolicyForGrant = (grant: ToolTokenGrant | null):
+    | { ok: true; policy: MediaExecutionPolicy }
+    | { ok: false; code: string; message: string } => {
+    if (!grant?.runId) return { ok: true, policy: defaultMediaExecutionPolicy() };
     const run = design.runs.get(grant.runId);
-    return run?.mediaExecution ?? defaultMediaExecutionPolicy();
+    if (!run) {
+      return {
+        ok: false,
+        code: 'MEDIA_POLICY_UNAVAILABLE',
+        message: 'media generation policy is unavailable for this run',
+      };
+    }
+    return { ok: true, policy: run.mediaExecution ?? defaultMediaExecutionPolicy() };
   };
 
   const handleGenerate = async (
@@ -49,7 +101,10 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
     }
 
     const policy = mediaPolicyForGrant(options.grant);
-    const denial = mediaPolicyDenial(policy, { surface, model });
+    if (!policy.ok) {
+      return sendApiError(res, 403, policy.code, policy.message);
+    }
+    const denial = mediaPolicyDenial(policy.policy, { surface, model });
     if (denial) {
       return sendApiError(res, 403, denial.code, denial.message);
     }
@@ -289,9 +344,23 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
     }
 
     try {
-      // #3199: valid run tokens enforce media policy here; no-token local calls remain a known v1 gap.
-      const grant = optionalToolGrantFromRequest(req);
-      await handleGenerate(req, res, { projectId: req.params.id, grant });
+      const grant = optionalToolGrantFromRequest(req, { operation: 'media:generate' });
+      const grantDecision = resolveLegacyMediaRouteGrant({
+        grant,
+        projectId: req.params.id,
+        requestProjectOverride,
+        sandboxMode: isSandboxModeEnabled(process.env),
+      });
+      if (!grantDecision.ok) {
+        return sendApiError(
+          res,
+          grantDecision.status,
+          grantDecision.code,
+          grantDecision.message,
+          grantDecision.details ? { details: grantDecision.details } : {},
+        );
+      }
+      await handleGenerate(req, res, { projectId: req.params.id, grant: grantDecision.grant });
     } catch (err: any) {
       const status = typeof err?.status === 'number' ? err.status : 400;
       const code = err?.code;

--- a/apps/daemon/src/run-tool-results.ts
+++ b/apps/daemon/src/run-tool-results.ts
@@ -12,7 +12,6 @@ export type SubmitToolResultResult =
 interface WritableStdin {
   destroyed?: boolean;
   write(chunk: string, encoding?: BufferEncoding): unknown;
-  end(): unknown;
 }
 
 interface ToolResultRunState {
@@ -76,14 +75,6 @@ export function submitToolResultToRunState(
   }
 
   run.pendingHostAnswers.delete(input.toolUseId);
-  if (run.pendingHostAnswers.size === 0 && run.stdinOpen) {
-    if (!run.child.stdin.destroyed) {
-      try {
-        run.child.stdin.end();
-      } catch {}
-    }
-    run.stdinOpen = false;
-  }
 
   return { ok: true };
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -93,7 +93,7 @@ import { installFromTarget, uninstallById, sanitizeRepoName } from './library-in
 import { buildWindowsFolderDialogCommand, parseFolderDialogStdout } from './native-folder-dialog.js';
 import { listCodexPets, readCodexPetSpritesheet } from './codex-pets.js';
 import { syncCommunityPets } from './community-pets-sync.js';
-import { parseMediaExecutionPolicyInput } from './media-policy.js';
+import { defaultMediaExecutionPolicy, parseMediaExecutionPolicyInput } from './media-policy.js';
 import {
   applySandboxRuntimeEnv,
   ensureSandboxRuntimeDirs,
@@ -3209,8 +3209,8 @@ function authorizeToolRequest(req, res, operation) {
   return validation.grant;
 }
 
-function optionalToolGrantFromRequest(req) {
-  const validation = toolTokenRegistry.validate(bearerTokenFromRequest(req));
+function optionalToolGrantFromRequest(req, options = {}) {
+  const validation = toolTokenRegistry.validate(bearerTokenFromRequest(req), options);
   return validation.ok ? validation.grant : null;
 }
 
@@ -12844,6 +12844,7 @@ export async function startServer({
       assistantMessageId,
       clientRequestId: `orbit-${trigger}-${randomUUID()}`,
       agentId,
+      mediaExecution: defaultMediaExecutionPolicy(),
     });
     upsertMessage(db, conversationId, {
       id: `orbit-user-${run.id}`,
@@ -13778,6 +13779,7 @@ export async function startServer({
       assistantMessageId,
       clientRequestId: `routine-${trigger}-${randomUUID()}`,
       agentId,
+      mediaExecution: defaultMediaExecutionPolicy(),
       ...(resolvedRoutineSnapshot?.ok
         ? {
             appliedPluginSnapshotId: resolvedRoutineSnapshot.snapshotId,

--- a/apps/daemon/tests/media-policy-routes.test.ts
+++ b/apps/daemon/tests/media-policy-routes.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
 import { memoryDir, writeMemoryConfig } from '../src/memory.js';
+import { resolveLegacyMediaRouteGrant } from '../src/media-routes.js';
 
 type FakeMediaEndpoint = 'tool' | 'legacy';
 
@@ -443,6 +444,76 @@ describe('run-scoped media policy routes', () => {
     expect(response.status).toBe(401);
     const body = await response.json() as { error?: { code?: string } };
     expect(body.error).toMatchObject({ code: 'TOOL_TOKEN_INVALID' });
+  });
+
+  it('requires a run token for the legacy media route only in sandbox mode', () => {
+    const requestProjectOverride = (projectId: string, tokenProjectId: string) =>
+      projectId !== tokenProjectId;
+
+    expect(
+      resolveLegacyMediaRouteGrant({
+        grant: null,
+        projectId: 'project-1',
+        requestProjectOverride,
+        sandboxMode: false,
+      }),
+    ).toEqual({ ok: true, grant: null });
+
+    expect(
+      resolveLegacyMediaRouteGrant({
+        grant: null,
+        projectId: 'project-1',
+        requestProjectOverride,
+        sandboxMode: true,
+      }),
+    ).toMatchObject({
+      code: 'TOOL_TOKEN_MISSING',
+      ok: false,
+      status: 401,
+    });
+  });
+
+  it('rejects project overrides on token-bearing legacy media requests in sandbox mode', () => {
+    const decision = resolveLegacyMediaRouteGrant({
+      grant: {
+        allowedEndpoints: ['/api/tools/media/generate'],
+        allowedOperations: ['media:generate'],
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        issuedAt: new Date().toISOString(),
+        projectId: 'token-project',
+        runId: 'run-1',
+        token: 'token',
+      },
+      projectId: 'other-project',
+      requestProjectOverride: (projectId, tokenProjectId) => projectId !== tokenProjectId,
+      sandboxMode: true,
+    });
+
+    expect(decision).toMatchObject({
+      code: 'FORBIDDEN',
+      details: { suppliedProjectId: 'other-project' },
+      ok: false,
+      status: 403,
+    });
+  });
+
+  it('preserves token-bearing legacy project overrides outside sandbox mode', () => {
+    const decision = resolveLegacyMediaRouteGrant({
+      grant: {
+        allowedEndpoints: ['/api/tools/media/generate'],
+        allowedOperations: ['media:generate'],
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        issuedAt: new Date().toISOString(),
+        projectId: 'token-project',
+        runId: 'run-1',
+        token: 'token',
+      },
+      projectId: 'other-project',
+      requestProjectOverride: (projectId, tokenProjectId) => projectId !== tokenProjectId,
+      sandboxMode: false,
+    });
+
+    expect(decision).toMatchObject({ ok: true });
   });
 
   async function startProjectServer(name: string): Promise<{

--- a/apps/daemon/tests/run-tool-results.test.ts
+++ b/apps/daemon/tests/run-tool-results.test.ts
@@ -31,7 +31,7 @@ describe('submitToolResultToRunState', () => {
     expect(run.stdinOpen).toBe(true);
   });
 
-  it('writes valid tool results and closes stdin after the final pending answer', () => {
+  it('writes valid tool results and leaves stdin open after the final pending answer', () => {
     const { run, stdin, writes } = makeRun(['tool-1']);
 
     const result = submitToolResultToRunState(run, {
@@ -43,8 +43,8 @@ describe('submitToolResultToRunState', () => {
 
     expect(result).toEqual({ ok: true });
     expect(run.pendingHostAnswers.has('tool-1')).toBe(false);
-    expect(run.stdinOpen).toBe(false);
-    expect(stdin.destroyed || stdin.writableEnded).toBe(true);
+    expect(run.stdinOpen).toBe(true);
+    expect(stdin.destroyed || stdin.writableEnded).toBe(false);
     expect(writes).toHaveLength(1);
     const [write] = writes;
     expect(JSON.parse(write!)).toMatchObject({

--- a/e2e/lib/vitest/runs.ts
+++ b/e2e/lib/vitest/runs.ts
@@ -13,6 +13,9 @@ export type ChatRunCreateBody = {
   projectId: string;
   reasoning?: string | null;
   skillId?: string | null;
+  toolBundle?: {
+    mcpServers?: Array<Record<string, unknown>>;
+  };
 };
 
 export type ChatRunStatusBody = {

--- a/e2e/lib/vitest/smoke-suite.ts
+++ b/e2e/lib/vitest/smoke-suite.ts
@@ -49,6 +49,7 @@ export type ToolsDevSuiteContext = {
 };
 
 export type ToolsDevSuiteOptions = {
+  env?: Record<string, string | undefined>;
   onFailure?: (input: {
     context: ToolsDevSuiteContext | null;
     error: unknown;
@@ -138,23 +139,23 @@ async function runToolsDevSuite(
     let start: ToolsDevStartResult | null = null;
     for (let attempt = 1; attempt <= 3; attempt++) {
       try {
-        start = await toolsDev.startToolsDevWeb(suite, runtime);
+        start = await toolsDev.startToolsDevWeb(suite, runtime, options.env);
         break;
       } catch (error) {
         if (attempt === 3 || !toolsDev.isToolsDevPortConflict(error)) throw error;
         await runtime.release().catch(() => {});
-        await toolsDev.stopToolsDevWeb(suite).catch(() => {});
+        await toolsDev.stopToolsDevWeb(suite, options.env).catch(() => {});
         runtime = await toolsDev.allocateToolsDevRuntime();
       }
     }
     if (start == null) throw new Error('tools-dev start did not return a result');
     const webUrl = assertRuntimeUrl(start.web?.status.url, 'web');
-    const status = await toolsDev.inspectToolsDevStatus(suite);
+    const status = await toolsDev.inspectToolsDevStatus(suite, options.env);
     assertToolsDevStatus(suite, status);
 
     context = {
-      check: () => toolsDev.inspectToolsDevCheck(suite),
-      logs: () => toolsDev.readToolsDevLogs(suite),
+      check: () => toolsDev.inspectToolsDevCheck(suite, options.env),
+      logs: () => toolsDev.readToolsDevLogs(suite, options.env),
       runtime,
       start,
       status,
@@ -168,7 +169,7 @@ async function runToolsDevSuite(
     success = true;
   } catch (error) {
     caughtError = error;
-    diagnostics = await toolsDev.inspectToolsDevCheck(suite).catch((diagnosticError: unknown) => ({
+    diagnostics = await toolsDev.inspectToolsDevCheck(suite, options.env).catch((diagnosticError: unknown) => ({
       error: diagnosticError instanceof Error ? diagnosticError.message : String(diagnosticError),
     }));
     await options.onFailure?.({ context, error, suite }).catch((failureHookError: unknown) => {
@@ -184,7 +185,7 @@ async function runToolsDevSuite(
     // next smoke run on a shared CI runner.
     let stopError: unknown = null;
     try {
-      await toolsDev.stopToolsDevWeb(suite);
+      await toolsDev.stopToolsDevWeb(suite, options.env);
     } catch (error) {
       stopError = error;
     }

--- a/e2e/lib/vitest/tools-dev.ts
+++ b/e2e/lib/vitest/tools-dev.ts
@@ -78,7 +78,11 @@ export async function allocateToolsDevRuntime(): Promise<ToolsDevRuntime> {
   };
 }
 
-export async function startToolsDevWeb(suite: SmokeSuite, runtime: ToolsDevRuntime): Promise<ToolsDevStartResult> {
+export async function startToolsDevWeb(
+  suite: SmokeSuite,
+  runtime: ToolsDevRuntime,
+  env: Record<string, string | undefined> = {},
+): Promise<ToolsDevStartResult> {
   // Keep both ports reserved until immediately before tools-dev starts so
   // parallel Vitest workers do not race each other for the same "free" port.
   await runtime.release();
@@ -97,10 +101,14 @@ export async function startToolsDevWeb(suite: SmokeSuite, runtime: ToolsDevRunti
       String(runtime.webPort),
       '--json',
     ],
+    env,
   );
 }
 
-export async function stopToolsDevWeb(suite: SmokeSuite): Promise<unknown> {
+export async function stopToolsDevWeb(
+  suite: SmokeSuite,
+  env: Record<string, string | undefined> = {},
+): Promise<unknown> {
   return await runToolsDevJson<unknown>(
     suite,
     [
@@ -112,10 +120,14 @@ export async function stopToolsDevWeb(suite: SmokeSuite): Promise<unknown> {
       suite.toolsDevRoot,
       '--json',
     ],
+    env,
   );
 }
 
-export async function inspectToolsDevStatus(suite: SmokeSuite): Promise<ToolsDevStatusResult> {
+export async function inspectToolsDevStatus(
+  suite: SmokeSuite,
+  env: Record<string, string | undefined> = {},
+): Promise<ToolsDevStatusResult> {
   return await runToolsDevJson<ToolsDevStatusResult>(
     suite,
     [
@@ -126,10 +138,14 @@ export async function inspectToolsDevStatus(suite: SmokeSuite): Promise<ToolsDev
       suite.toolsDevRoot,
       '--json',
     ],
+    env,
   );
 }
 
-export async function inspectToolsDevCheck(suite: SmokeSuite): Promise<ToolsDevCheckResult> {
+export async function inspectToolsDevCheck(
+  suite: SmokeSuite,
+  env: Record<string, string | undefined> = {},
+): Promise<ToolsDevCheckResult> {
   return await runToolsDevJson<ToolsDevCheckResult>(
     suite,
     [
@@ -140,10 +156,14 @@ export async function inspectToolsDevCheck(suite: SmokeSuite): Promise<ToolsDevC
       suite.toolsDevRoot,
       '--json',
     ],
+    env,
   );
 }
 
-export async function readToolsDevLogs(suite: SmokeSuite): Promise<Record<string, ToolsDevLogResult>> {
+export async function readToolsDevLogs(
+  suite: SmokeSuite,
+  env: Record<string, string | undefined> = {},
+): Promise<Record<string, ToolsDevLogResult>> {
   return await runToolsDevJson<Record<string, ToolsDevLogResult>>(
     suite,
     [
@@ -154,6 +174,7 @@ export async function readToolsDevLogs(suite: SmokeSuite): Promise<Record<string
       suite.toolsDevRoot,
       '--json',
     ],
+    env,
   );
 }
 
@@ -165,7 +186,11 @@ export function isToolsDevPortConflict(error: unknown): boolean {
     (text.includes('is already running in namespace') && text.includes('stop it or choose another namespace'));
 }
 
-async function runToolsDevJson<T>(suite: SmokeSuite, args: string[]): Promise<T> {
+async function runToolsDevJson<T>(
+  suite: SmokeSuite,
+  args: string[],
+  extraEnv: Record<string, string | undefined> = {},
+): Promise<T> {
   const useNpmExecPathWithNode = process.env.OD_E2E_PNPM_COMMAND == null
     && pnpmExecPath != null
     && nodeLoadablePackageManagerExtensions.has(extname(pnpmExecPath).toLowerCase());
@@ -179,6 +204,7 @@ async function runToolsDevJson<T>(suite: SmokeSuite, args: string[]): Promise<T>
     cwd: e2eWorkspaceRoot(),
     env: {
       ...process.env,
+      ...extraEnv,
       CODEX_HOME: suite.codexHomeDir,
       OD_DATA_DIR: suite.dataDir,
       OD_MEDIA_CONFIG_DIR: suite.dataDir,

--- a/e2e/tests/tools-dev/sandbox-mode.test.ts
+++ b/e2e/tests/tools-dev/sandbox-mode.test.ts
@@ -1,0 +1,288 @@
+// @vitest-environment node
+
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { requestJson } from '@/vitest/http';
+import { startRun, waitForRunStatus } from '@/vitest/runs';
+import { createSmokeSuite } from '@/vitest/smoke-suite';
+
+type DaemonStatusResponse = {
+  dataDir?: string;
+  sandbox?: {
+    enabled?: boolean;
+    roots?: Record<string, string>;
+  };
+  sandboxMode?: boolean;
+};
+
+type ProjectResponse = {
+  conversationId: string;
+  project: { id: string };
+};
+
+type CapturedOpenCodeRun = {
+  argv: string[];
+  cwd: string;
+  env: Record<string, string | null>;
+  hasToolToken: boolean;
+  promptLength: number;
+};
+
+const CAPTURE_ENV_KEYS = [
+  'CODEX_HOME',
+  'HOME',
+  'OD_AGENT_HOME',
+  'OD_DATA_DIR',
+  'OD_PROJECT_DIR',
+  'OD_PROJECT_ID',
+  'OD_SANDBOX_MODE',
+  'OPENCODE_CONFIG_CONTENT',
+  'OPENCODE_TEST_HOME',
+  'TEMP',
+  'TMP',
+  'TMPDIR',
+  'USERPROFILE',
+  'XDG_CACHE_HOME',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_STATE_HOME',
+];
+
+describe('tools-dev sandbox mode smoke', () => {
+  test('launches web/daemon with OD_SANDBOX_MODE=1 and a sandboxed agent spawn', async () => {
+    const suite = await createSmokeSuite('tools-dev-sandbox-mode');
+    const capturePath = join(suite.scratchDir, 'captures', 'opencode-run.json');
+    const opencodeBin = await writeFakeOpenCodeBin(
+      join(suite.scratchDir, 'fake-opencode'),
+    );
+
+    await suite.with.toolsDev(
+      async ({ status, webUrl }) => {
+        expect(status.namespace).toBe(suite.namespace);
+
+        const daemonStatus = await requestJson<DaemonStatusResponse>(
+          webUrl,
+          '/api/daemon/status',
+        );
+
+        expect(daemonStatus.dataDir).toBe(suite.dataDir);
+        expect(daemonStatus.sandboxMode).toBe(true);
+        expect(daemonStatus.sandbox?.enabled).toBe(true);
+        expect(daemonStatus.sandbox?.roots).toEqual(expect.any(Object));
+        for (const root of Object.values(daemonStatus.sandbox?.roots ?? {})) {
+          expect(root.startsWith(suite.dataDir)).toBe(true);
+        }
+
+        await requestJson(webUrl, '/api/app-config', {
+          body: {
+            agentCliEnv: { opencode: { OPENCODE_BIN: opencodeBin } },
+            agentId: 'opencode',
+            agentModels: { opencode: { model: 'default', reasoning: 'default' } },
+            designSystemId: null,
+            onboardingCompleted: true,
+            skillId: null,
+            telemetry: { artifactManifest: true, content: false, metrics: false },
+          },
+          method: 'PUT',
+        });
+        await requestJson(webUrl, '/api/mcp/servers', {
+          body: {
+            servers: [
+              {
+                args: ['persisted.js'],
+                command: 'node',
+                enabled: true,
+                id: 'persisted-mcp',
+                label: 'Persisted MCP',
+                transport: 'stdio',
+              },
+            ],
+          },
+          method: 'PUT',
+        });
+
+        const project = await requestJson<ProjectResponse>(webUrl, '/api/projects', {
+          body: {
+            designSystemId: null,
+            id: randomUUID(),
+            metadata: { kind: 'prototype' },
+            name: 'Sandbox mode smoke',
+            pendingPrompt: null,
+            skillId: null,
+          },
+        });
+        const run = await startRun(webUrl, {
+          agentId: 'opencode',
+          assistantMessageId: `assistant-sandbox-smoke-${Date.now()}`,
+          clientRequestId: `sandbox-smoke-${Date.now()}`,
+          conversationId: project.conversationId,
+          designSystemId: null,
+          message: 'Create a deterministic sandbox mode smoke artifact',
+          model: 'default',
+          projectId: project.project.id,
+          reasoning: 'default',
+          skillId: null,
+          toolBundle: {
+            mcpServers: [
+              {
+                args: ['run-scoped.js'],
+                command: 'node',
+                enabled: true,
+                env: { RUN_SCOPED: '1' },
+                id: 'run-scoped-mcp',
+                label: 'Run-scoped MCP',
+                transport: 'stdio',
+              },
+            ],
+          },
+        });
+
+        await waitForRunStatus(webUrl, run.runId, 'succeeded', {
+          timeoutMs: 30_000,
+        });
+
+        const capture = JSON.parse(
+          await readFile(capturePath, 'utf8'),
+        ) as CapturedOpenCodeRun;
+        const roots = daemonStatus.sandbox?.roots ?? {};
+        expect(capture.argv).toEqual(expect.arrayContaining(['run', '--format', 'json']));
+        expect(capture.cwd.startsWith(`${suite.dataDir}/projects/`)).toBe(true);
+        expect(capture.hasToolToken).toBe(true);
+        expect(capture.promptLength).toBeGreaterThan(0);
+        expect(capture.env.OD_SANDBOX_MODE).toBe('1');
+        expect(capture.env.OD_DATA_DIR).toBe(suite.dataDir);
+        expect(capture.env.OD_PROJECT_ID).toBe(project.project.id);
+        expectPathUnder(capture.env.OD_AGENT_HOME, roots.agentHomeDir, 'OD_AGENT_HOME');
+        expectPathUnder(capture.env.HOME, roots.agentHomeDir, 'HOME');
+        expectPathUnder(capture.env.USERPROFILE, roots.agentHomeDir, 'USERPROFILE');
+        expectPathUnder(capture.env.CODEX_HOME, roots.agentHomeDir, 'CODEX_HOME');
+        expectPathUnder(capture.env.OPENCODE_TEST_HOME, roots.agentHomeDir, 'OPENCODE_TEST_HOME');
+        expectPathUnder(capture.env.TMPDIR, roots.tempDir, 'TMPDIR');
+        expectPathUnder(capture.env.TEMP, roots.tempDir, 'TEMP');
+        expectPathUnder(capture.env.TMP, roots.tempDir, 'TMP');
+        expectPathUnder(capture.env.XDG_CONFIG_HOME, roots.configDir, 'XDG_CONFIG_HOME');
+        expectPathUnder(capture.env.XDG_CACHE_HOME, roots.cacheDir, 'XDG_CACHE_HOME');
+        expectPathUnder(capture.env.XDG_DATA_HOME, roots.configDir, 'XDG_DATA_HOME');
+        expectPathUnder(capture.env.XDG_STATE_HOME, roots.configDir, 'XDG_STATE_HOME');
+
+        const opencodeConfig = JSON.parse(
+          capture.env.OPENCODE_CONFIG_CONTENT ?? '{}',
+        ) as { mcp?: Record<string, unknown> };
+        expect(opencodeConfig.mcp).toHaveProperty('run-scoped-mcp');
+        expect(opencodeConfig.mcp).not.toHaveProperty('persisted-mcp');
+
+        await suite.report.json('summary.json', {
+          capture,
+          dataDir: daemonStatus.dataDir,
+          namespace: suite.namespace,
+          opencodeMcpServerIds: Object.keys(opencodeConfig.mcp ?? {}),
+          sandbox: daemonStatus.sandbox,
+          sandboxMode: daemonStatus.sandboxMode,
+        });
+      },
+      {
+        env: {
+          OD_E2E_SANDBOX_CAPTURE_PATH: capturePath,
+          OD_SANDBOX_MODE: '1',
+        },
+      },
+    );
+  }, 180_000);
+});
+
+async function writeFakeOpenCodeBin(root: string): Promise<string> {
+  await mkdir(root, { recursive: true });
+  const bin = join(root, 'opencode-sandbox-smoke.cjs');
+  await writeFile(bin, renderFakeOpenCodeScript(), 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+function renderFakeOpenCodeScript(): string {
+  return `#!/usr/bin/env node
+const { mkdirSync, writeFileSync } = require('node:fs');
+const { dirname } = require('node:path');
+
+const args = process.argv.slice(2);
+const captureEnvKeys = ${JSON.stringify(CAPTURE_ENV_KEYS)};
+
+if (args.includes('--version')) {
+  process.stdout.write('opencode-sandbox-smoke 0.0.0\\n');
+  process.exit(0);
+}
+
+if (args[0] === 'models') {
+  process.stdout.write('fake/default\\n');
+  process.exit(0);
+}
+
+if (args[0] !== 'run') {
+  process.exit(0);
+}
+
+let emitted = false;
+let prompt = '';
+let emitTimer = null;
+process.stdin.setEncoding('utf8');
+process.stdin.resume();
+process.stdin.on('data', (chunk) => {
+  prompt += chunk;
+  if (emitTimer) clearTimeout(emitTimer);
+  emitTimer = setTimeout(() => emitRun(prompt), 25);
+});
+process.stdin.on('end', () => emitRun(prompt));
+setTimeout(() => emitRun(prompt), 500);
+
+function emitRun(promptText) {
+  if (emitted) return;
+  emitted = true;
+  const capturePath = process.env.OD_E2E_SANDBOX_CAPTURE_PATH;
+  if (capturePath && process.env.OD_TOOL_TOKEN) {
+    const env = {};
+    for (const key of captureEnvKeys) {
+      env[key] = typeof process.env[key] === 'string' ? process.env[key] : null;
+    }
+    mkdirSync(dirname(capturePath), { recursive: true });
+    writeFileSync(
+      capturePath,
+      JSON.stringify({
+        argv: args,
+        cwd: process.cwd(),
+        env,
+        hasToolToken: Boolean(process.env.OD_TOOL_TOKEN),
+        promptLength: promptText.length,
+      }, null, 2) + '\\n',
+      'utf8',
+    );
+  }
+  const artifact = '<artifact identifier="sandbox-mode-smoke" type="text/html" title="Sandbox Mode Smoke"><!doctype html><html><body><main><h1>Sandbox Mode Smoke</h1></main></body></html></artifact>';
+  writeJson({ type: 'step_start', sessionID: 'sandbox-smoke', part: { type: 'step-start' } });
+  writeJson({ type: 'text', sessionID: 'sandbox-smoke', part: { type: 'text', text: artifact } });
+  writeJson({ type: 'step_finish', sessionID: 'sandbox-smoke', part: { type: 'step-finish', tokens: { input: 1, output: 1 }, cost: 0 } });
+  setTimeout(() => process.exit(0), 10);
+}
+
+function writeJson(value) {
+  process.stdout.write(JSON.stringify(value) + '\\n');
+}
+`;
+}
+
+function expectPathUnder(
+  actual: string | null | undefined,
+  root: string | undefined,
+  label: string,
+): void {
+  expect(root, `${label} root`).toEqual(expect.any(String));
+  expect(actual, label).toEqual(expect.any(String));
+  const actualPath = actual as string;
+  const rootPath = root as string;
+  expect(
+    actualPath === rootPath || actualPath.startsWith(`${rootPath}/`),
+    `${label}=${actualPath} should be under ${rootPath}`,
+  ).toBe(true);
+}


### PR DESCRIPTION
Refs #3416.
Depends on #3420 and should not merge before it. This branch is built directly on `sandbox-orchestration-hardening`; GitHub requires upstream PR bases to be branches on `nexu-io/open-design`, so this PR targets `main` until #3420 lands. Reviewers who want the narrow follow-up diff can compare `dredozubov:sandbox-orchestration-hardening...dredozubov:sandbox-orchestration-media-smoke`.

## Why

This is the second follow-up slice from the sandbox runtime hardening discussion. The author use case is embedding OD behind an external orchestrator while keeping OD's public repo generic and safe for normal local use.

The pain being addressed is that sandbox-mode containment was partly conventional: future media callers and tools-dev smoke coverage could accidentally bypass run-scoped policy, persisted MCP isolation, or sandboxed agent home/cache/temp roots without an obvious failing test.

## What users will see

Normal local OD behavior is unchanged. When `OD_SANDBOX_MODE=1` is enabled, legacy project media generation now requires a valid run token and rejects token/project mismatches instead of silently falling back to local behavior.

Orbit and routine runs now carry explicit default media-execution policy, so downstream media checks do not depend on omitted-policy behavior. The e2e suite also gains a tools-dev sandbox smoke that starts web/daemon with isolated data, launches a fake OpenCode run, and proves the child process sees sandboxed HOME/CODEX/XDG/TMP roots plus only the run-scoped MCP server.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI changes.

## Bug fix verification

This is hardening work, not a user-visible bug fix. The new regression coverage is `e2e/tests/tools-dev/sandbox-mode.test.ts`, plus focused daemon unit coverage in `apps/daemon/tests/media-policy-routes.test.ts`.

## Validation

- `PATH="$HOME/.nvm/versions/node/v24.12.0/bin:$PATH" pnpm --filter @open-design/daemon exec vitest run tests/media-policy-routes.test.ts`
- `PATH="$HOME/.nvm/versions/node/v24.12.0/bin:$PATH" pnpm test tests/tools-dev/sandbox-mode.test.ts` from `e2e/`
- `PATH="$HOME/.nvm/versions/node/v24.12.0/bin:$PATH" pnpm guard`
- `PATH="$HOME/.nvm/versions/node/v24.12.0/bin:$PATH" pnpm typecheck`
