### PR TITLE
feat(daemon): per-agent MCP installer with source-deploy fallback

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -13,6 +13,13 @@ import { splitResearchSubcommand } from './research/cli-args.js';
 import { resolveDaemonUrl } from './daemon-url.js';
 import { requestJsonIpc } from '@open-design/sidecar';
 import { SIDECAR_ENV, SIDECAR_MESSAGES } from '@open-design/sidecar-proto';
+import {
+  AGENT_SLUGS,
+  isAgentSlug,
+  planAgentInstall,
+  applyJsonInstall,
+  removeJsonInstall,
+} from './mcp-agent-install.js';
 
 const argv = process.argv.slice(2);
 
@@ -67,6 +74,25 @@ const MCP_STRING_FLAGS = new Set([
 const MCP_BOOLEAN_FLAGS = new Set([
   'help',
   'h',
+]);
+
+// Hoisted next to MCP_*_FLAGS for the same TDZ reason as the MEDIA flags
+// above: `od mcp install <agent>` dispatches through SUBCOMMAND_MAP during
+// top-level module evaluation, and runMcpInstall references these `const`
+// Sets — defining them next to runMcpInstall lower in the file would hit
+// the TDZ.
+const MCP_INSTALL_STRING_FLAGS = new Set([
+  'daemon-url',
+  'name',
+]);
+const MCP_INSTALL_BOOLEAN_FLAGS = new Set([
+  'help',
+  'h',
+  'json',
+  'print',
+  'dry-run',
+  'uninstall',
+  'remove',
 ]);
 
 const RESEARCH_SEARCH_STRING_FLAGS = new Set([
@@ -826,6 +852,9 @@ files folder so the FileViewer can preview them immediately.`);
 // ---------------------------------------------------------------------------
 
 async function runMcp(args) {
+  if (args[0] === 'install') {
+    return runMcpInstall(args.slice(1));
+  }
   let flags;
   try {
     flags = parseFlags(args, {
@@ -887,7 +916,254 @@ callers can see which project/file got resolved.
 For the copy-paste, per-client snippet (with absolute paths resolved
 for your machine, plus a one-click deeplink for Cursor), open Settings
 → MCP server in the Open Design app. The daemon must be running locally
-for tool calls to succeed.`);
+for tool calls to succeed.
+
+To register this server into a coding agent's own config automatically:
+  od mcp install <agent> [--uninstall] [--print] [--json] [--daemon-url <url>]
+  Agents: ${AGENT_SLUGS.join(' ')}`);
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: od mcp install <agent>
+//
+// Wires this daemon's stdio MCP server into a coding agent's own config.
+// The pure planner (mcp-agent-install.ts) maps a resolved launch spec onto
+// one of three strategies — drive the agent's own `mcp add/remove` CLI,
+// deep-merge a JSON config file, or (for unverified formats) print a
+// ready-to-paste snippet. This executor performs the IO the planner avoids.
+// ---------------------------------------------------------------------------
+
+// Resolve the canonical launch spec from the running daemon's
+// /api/mcp/install-info (the same payload the Settings → MCP panel and the
+// Codex one-click install use), so every install path configures byte-for-
+// byte the same command. Falls back to a minimal `od mcp --daemon-url`
+// spec when the daemon is unreachable.
+async function resolveMcpLaunchSpec(flags) {
+  const base = await cliDaemonBaseUrl(flags);
+  try {
+    const resp = await fetch(`${base}/api/mcp/install-info`);
+    if (resp.ok) {
+      const info = await resp.json();
+      if (info && typeof info.command === 'string' && Array.isArray(info.args)) {
+        return {
+          command: info.command,
+          args: info.args,
+          env: info.env && typeof info.env === 'object' ? info.env : {},
+        };
+      }
+    }
+  } catch {
+    // daemon not running / unreachable — fall through to the minimal spec
+  }
+  return {
+    command: 'od',
+    args: ['mcp', '--daemon-url', base],
+    env: {},
+  };
+}
+
+function emitInstallResult(useJson, result) {
+  if (useJson) {
+    console.log(JSON.stringify(result));
+    return;
+  }
+  if (result.ok) {
+    console.log(`✓ ${result.message}`);
+  } else {
+    console.error(`✗ ${result.message}`);
+  }
+}
+
+async function runMcpInstall(args) {
+  let flags;
+  try {
+    flags = parseFlags(args, {
+      string: MCP_INSTALL_STRING_FLAGS,
+      boolean: MCP_INSTALL_BOOLEAN_FLAGS,
+    });
+  } catch (err) {
+    console.error(err.message);
+    printMcpInstallHelp();
+    process.exit(2);
+  }
+  if (flags.help || flags.h) {
+    printMcpInstallHelp();
+    return;
+  }
+
+  const slug = positionalArgs(args, MCP_INSTALL_STRING_FLAGS)[0];
+  const useJson = Boolean(flags.json);
+  if (!slug) {
+    console.error('missing agent slug');
+    printMcpInstallHelp();
+    process.exit(2);
+  }
+  if (!isAgentSlug(slug)) {
+    const msg = `unknown agent: ${slug} (expected one of: ${AGENT_SLUGS.join(' ')})`;
+    emitInstallResult(useJson, { ok: false, agent: slug, message: msg });
+    process.exit(2);
+  }
+
+  const uninstall = Boolean(flags.uninstall || flags.remove);
+  const dryRun = Boolean(flags.print || flags['dry-run']);
+  const serverName = flags.name || 'open-design';
+
+  const os = await import('node:os');
+  const spec = await resolveMcpLaunchSpec(flags);
+  const plan = planAgentInstall(slug, spec, {
+    home: os.homedir(),
+    platform: process.platform,
+    serverName,
+  });
+
+  if (plan.kind === 'manual') {
+    const result = {
+      ok: false,
+      agent: slug,
+      kind: 'manual',
+      configPath: plan.configPath,
+      format: plan.format,
+      snippet: plan.snippet,
+      message: `${slug}: manual setup required. ${plan.reason}`,
+    };
+    if (useJson) {
+      console.log(JSON.stringify(result));
+    } else {
+      console.error(`› ${result.message}`);
+      if (plan.configPath) console.error(`  Config: ${plan.configPath}`);
+      console.error(`  Add this ${plan.format} block:\n`);
+      console.log(plan.snippet);
+    }
+    return;
+  }
+
+  if (plan.kind === 'cli') {
+    const argv = uninstall ? plan.removeArgv : plan.addArgv;
+    if (dryRun) {
+      emitInstallResult(useJson, {
+        ok: true,
+        agent: slug,
+        kind: 'cli',
+        command: `${plan.bin} ${argv.join(' ')}`,
+        message: `would run: ${plan.bin} ${argv.join(' ')}`,
+      });
+      return;
+    }
+    const { spawn } = await import('node:child_process');
+    const code = await new Promise((resolve) => {
+      const child = spawn(plan.bin, argv, { stdio: 'inherit' });
+      child.on('error', (err) => {
+        console.error(`✗ failed to run ${plan.bin}: ${err.message}`);
+        resolve(127);
+      });
+      child.on('exit', (c) => resolve(c ?? 0));
+    });
+    if (code !== 0) {
+      emitInstallResult(useJson, {
+        ok: false,
+        agent: slug,
+        kind: 'cli',
+        message: `${plan.bin} exited with code ${code}`,
+      });
+      process.exit(code || 1);
+    }
+    emitInstallResult(useJson, {
+      ok: true,
+      agent: slug,
+      kind: 'cli',
+      message: uninstall
+        ? `removed ${serverName} from ${slug}`
+        : `installed ${serverName} into ${slug}`,
+    });
+    return;
+  }
+
+  // plan.kind === 'json'
+  const fs = await import('node:fs/promises');
+  const path = await import('node:path');
+  let existing = null;
+  try {
+    existing = await fs.readFile(plan.configPath, 'utf8');
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') throw err;
+  }
+
+  if (uninstall) {
+    const next = removeJsonInstall(existing, plan);
+    if (next == null) {
+      emitInstallResult(useJson, {
+        ok: true,
+        agent: slug,
+        kind: 'json',
+        configPath: plan.configPath,
+        message: `${serverName} not present in ${plan.configPath} — nothing to remove`,
+      });
+      return;
+    }
+    if (dryRun) {
+      emitInstallResult(useJson, {
+        ok: true,
+        agent: slug,
+        kind: 'json',
+        configPath: plan.configPath,
+        preview: next,
+        message: `would update ${plan.configPath}`,
+      });
+      return;
+    }
+    await fs.writeFile(plan.configPath, next, 'utf8');
+    emitInstallResult(useJson, {
+      ok: true,
+      agent: slug,
+      kind: 'json',
+      configPath: plan.configPath,
+      message: `removed ${serverName} from ${plan.configPath}`,
+    });
+    return;
+  }
+
+  const next = applyJsonInstall(existing, plan);
+  if (dryRun) {
+    emitInstallResult(useJson, {
+      ok: true,
+      agent: slug,
+      kind: 'json',
+      configPath: plan.configPath,
+      preview: next,
+      message: `would write ${plan.configPath}`,
+    });
+    return;
+  }
+  await fs.mkdir(path.dirname(plan.configPath), { recursive: true });
+  await fs.writeFile(plan.configPath, next, 'utf8');
+  emitInstallResult(useJson, {
+    ok: true,
+    agent: slug,
+    kind: 'json',
+    configPath: plan.configPath,
+    message: `installed ${serverName} into ${plan.configPath}`,
+  });
+}
+
+function printMcpInstallHelp() {
+  console.log(`Usage: od mcp install <agent> [options]
+
+Register Open Design's stdio MCP server into a coding agent's own config.
+
+Agents:
+  ${AGENT_SLUGS.join(' ')}
+
+Options:
+  --uninstall, --remove   Remove the Open Design MCP server instead.
+  --print, --dry-run      Show what would change; write nothing.
+  --json                  Machine-readable result.
+  --name <name>           MCP server name in the agent config (default: open-design).
+  --daemon-url <url>      Daemon URL used to resolve the launch command.
+
+The launch command is resolved from the running daemon's
+/api/mcp/install-info, so the installed entry matches the Settings → MCP
+panel snippet byte-for-byte. Start the daemon first for an exact match;
+otherwise a minimal \`od mcp --daemon-url <url>\` command is used.`);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/daemon/src/mcp-agent-install.ts
+++ b/apps/daemon/src/mcp-agent-install.ts
@@ -154,8 +154,9 @@ export function planAgentInstall(
         bin: 'claude',
         addArgv: [
           'mcp', 'add', '--scope', 'user',
+          serverName,
           ...envFlags(spec.env, '-e'),
-          serverName, '--', spec.command, ...spec.args,
+          '--', spec.command, ...spec.args,
         ],
         removeArgv: ['mcp', 'remove', '--scope', 'user', serverName],
         getArgv: ['mcp', 'get', serverName],

--- a/apps/daemon/src/mcp-agent-install.ts
+++ b/apps/daemon/src/mcp-agent-install.ts
@@ -1,0 +1,447 @@
+// Per-agent MCP registration planner.
+//
+// `od mcp install <agent>` (and the hosted `install.sh | sh -s <agent>`
+// bootstrap that calls it) wires Open Design's stdio MCP server into a
+// coding agent's own configuration. Each agent stores MCP servers
+// differently, so this module maps a single resolved launch spec
+// (command/args/env — the same shape buildMcpInstallPayload produces and
+// the Settings → MCP panel pastes) onto one of three registration
+// strategies:
+//
+//   - 'cli'    : the agent ships its own `<bin> mcp add/remove/get`. We
+//                shell out to it (like codex-cli.ts) so we inherit the
+//                agent's merge/validation rules instead of editing its
+//                config by hand. Used for claude / codex / gemini / kimi.
+//   - 'json'   : the agent reads a JSON config file with a known schema.
+//                We deep-merge one server entry, never clobbering the
+//                rest of the file. Used for cursor / copilot / cline /
+//                opencode / openclaw / antigravity / trae.
+//   - 'manual' : we could not verify the agent's config path/format
+//                authoritatively (pi / hermes / vibe). We refuse to write
+//                a guessed path and instead print a ready-to-paste
+//                snippet plus the best-known location. Writing a wrong
+//                path risks corrupting a user-owned config, so this stays
+//                a print-only path until the format is confirmed.
+//
+// The planning functions are pure (no fs / spawn) so they unit-test
+// against fixed launch specs + a fake home dir; the executor in cli.ts
+// performs the IO.
+
+import path from 'node:path';
+
+export const AGENT_SLUGS = [
+  'claude',
+  'codex',
+  'cursor',
+  'copilot',
+  'openclaw',
+  'antigravity',
+  'gemini',
+  'pi',
+  'vibe',
+  'hermes',
+  'cline',
+  'kimi',
+  'trae',
+  'opencode',
+] as const;
+
+export type AgentSlug = (typeof AGENT_SLUGS)[number];
+
+export function isAgentSlug(value: string): value is AgentSlug {
+  return (AGENT_SLUGS as readonly string[]).includes(value);
+}
+
+/** The resolved stdio launch spec — mirrors the relevant fields of
+ *  McpInstallPayload (command/args/env). */
+export interface McpLaunchSpec {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+}
+
+export interface PlanContext {
+  /** Absolute home directory (os.homedir()). Injected for testability. */
+  home: string;
+  /** Node platform — selects per-OS config paths (cline / trae). */
+  platform: NodeJS.Platform;
+  /** MCP server name as it appears in the agent config. */
+  serverName: string;
+}
+
+/** Agent owns a `<bin> mcp add/remove/get`; we drive it. */
+export interface CliInstallPlan {
+  kind: 'cli';
+  slug: AgentSlug;
+  bin: string;
+  addArgv: string[];
+  removeArgv: string[];
+  /** Argv that exits 0 iff the server is already registered. */
+  getArgv: string[];
+}
+
+/** Agent reads a JSON config file with a known schema. */
+export interface JsonInstallPlan {
+  kind: 'json';
+  slug: AgentSlug;
+  /** Absolute path to the config file we merge into. */
+  configPath: string;
+  /** Nested object path to the server map, e.g. ['mcpServers'] or
+   *  ['mcp', 'servers'] or ['mcp']. */
+  keyPath: string[];
+  serverKey: string;
+  /** Value stored under keyPath → serverKey. */
+  entry: unknown;
+}
+
+/** Unverified format — print a snippet, never write. */
+export interface ManualInstallPlan {
+  kind: 'manual';
+  slug: AgentSlug;
+  format: 'json' | 'yaml' | 'toml';
+  /** Best-known config location, or null when even that is unknown. */
+  configPath: string | null;
+  snippet: string;
+  reason: string;
+}
+
+export type InstallPlan = CliInstallPlan | JsonInstallPlan | ManualInstallPlan;
+
+function envFlags(env: Record<string, string>, flag: string): string[] {
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(env)) {
+    out.push(flag, `${k}=${v}`);
+  }
+  return out;
+}
+
+/** JSON server entry shared by the `env`-style agents (cursor / copilot /
+ *  cline / openclaw / antigravity / trae). `extra` carries per-agent
+ *  fields; env is only attached when non-empty so configs stay clean. */
+function jsonEntry(
+  spec: McpLaunchSpec,
+  extra: Record<string, unknown> = {},
+  envKey: 'env' | 'environment' = 'env',
+): Record<string, unknown> {
+  const entry: Record<string, unknown> = {
+    command: spec.command,
+    args: spec.args,
+    ...extra,
+  };
+  if (Object.keys(spec.env).length > 0) {
+    entry[envKey] = spec.env;
+  }
+  return entry;
+}
+
+/**
+ * Build the registration plan for one agent. Pure — all IO happens in the
+ * executor. Throws on an unknown slug so callers surface a clear error.
+ */
+export function planAgentInstall(
+  slug: AgentSlug,
+  spec: McpLaunchSpec,
+  ctx: PlanContext,
+): InstallPlan {
+  const { home, platform, serverName } = ctx;
+
+  switch (slug) {
+    // ----- CLI-driven agents (idempotent via the agent's own tool) -----
+    case 'claude':
+      return {
+        kind: 'cli',
+        slug,
+        bin: 'claude',
+        addArgv: [
+          'mcp', 'add', '--scope', 'user',
+          ...envFlags(spec.env, '-e'),
+          serverName, '--', spec.command, ...spec.args,
+        ],
+        removeArgv: ['mcp', 'remove', '--scope', 'user', serverName],
+        getArgv: ['mcp', 'get', serverName],
+      };
+    case 'codex':
+      return {
+        kind: 'cli',
+        slug,
+        bin: 'codex',
+        addArgv: [
+          'mcp', 'add', serverName,
+          ...envFlags(spec.env, '--env'),
+          '--', spec.command, ...spec.args,
+        ],
+        removeArgv: ['mcp', 'remove', serverName],
+        getArgv: ['mcp', 'get', serverName],
+      };
+    case 'gemini':
+      return {
+        kind: 'cli',
+        slug,
+        bin: 'gemini',
+        addArgv: [
+          'mcp', 'add', '-s', 'user', '-t', 'stdio',
+          ...envFlags(spec.env, '-e'),
+          serverName, spec.command, ...spec.args,
+        ],
+        removeArgv: ['mcp', 'remove', serverName],
+        getArgv: ['mcp', 'list'],
+      };
+    case 'kimi':
+      return {
+        kind: 'cli',
+        slug,
+        bin: 'kimi',
+        addArgv: [
+          'mcp', 'add', '--transport', 'stdio',
+          ...envFlags(spec.env, '--env'),
+          serverName, '--', spec.command, ...spec.args,
+        ],
+        removeArgv: ['mcp', 'remove', serverName],
+        getArgv: ['mcp', 'get', serverName],
+      };
+
+    // ----- JSON config-file agents (safe deep-merge) -----
+    case 'cursor':
+      return {
+        kind: 'json',
+        slug,
+        configPath: path.join(home, '.cursor', 'mcp.json'),
+        keyPath: ['mcpServers'],
+        serverKey: serverName,
+        entry: jsonEntry(spec, { type: 'stdio' }),
+      };
+    case 'copilot':
+      // GitHub Copilot CLI: ~/.copilot/mcp-config.json, type "local".
+      // (VS Code Copilot uses a different `servers` key in
+      // .vscode/mcp.json; the terminal installer targets the CLI.)
+      return {
+        kind: 'json',
+        slug,
+        configPath: path.join(home, '.copilot', 'mcp-config.json'),
+        keyPath: ['mcpServers'],
+        serverKey: serverName,
+        entry: jsonEntry(spec, { type: 'local', tools: ['*'] }),
+      };
+    case 'cline':
+      return {
+        kind: 'json',
+        slug,
+        configPath: clineConfigPath(home, platform),
+        keyPath: ['mcpServers'],
+        serverKey: serverName,
+        entry: jsonEntry(spec, { disabled: false, autoApprove: [] }),
+      };
+    case 'opencode':
+      // OpenCode nests under `mcp`, folds command+args into one array,
+      // and gates the server with `enabled`.
+      return {
+        kind: 'json',
+        slug,
+        configPath: path.join(home, '.config', 'opencode', 'opencode.json'),
+        keyPath: ['mcp'],
+        serverKey: serverName,
+        entry: (() => {
+          const e: Record<string, unknown> = {
+            type: 'local',
+            command: [spec.command, ...spec.args],
+            enabled: true,
+          };
+          if (Object.keys(spec.env).length > 0) e.environment = spec.env;
+          return e;
+        })(),
+      };
+    case 'openclaw':
+      return {
+        kind: 'json',
+        slug,
+        configPath: path.join(home, '.openclaw', 'openclaw.json'),
+        keyPath: ['mcp', 'servers'],
+        serverKey: serverName,
+        entry: jsonEntry(spec),
+      };
+    case 'antigravity':
+      return {
+        kind: 'json',
+        slug,
+        configPath: path.join(home, '.gemini', 'antigravity', 'mcp_config.json'),
+        keyPath: ['mcpServers'],
+        serverKey: serverName,
+        entry: jsonEntry(spec),
+      };
+    case 'trae':
+      return {
+        kind: 'json',
+        slug,
+        configPath: traeConfigPath(home, platform),
+        keyPath: ['mcpServers'],
+        serverKey: serverName,
+        entry: jsonEntry(spec),
+      };
+
+    // ----- Unverified formats: print-only, never write -----
+    case 'vibe':
+      return {
+        kind: 'manual',
+        slug,
+        format: 'toml',
+        configPath: path.join(home, '.vibe', 'config.toml'),
+        snippet: vibeTomlSnippet(spec, serverName),
+        reason:
+          'Mistral Vibe uses a TOML array-of-tables ([[mcp_servers]]); ' +
+          'its exact schema is unverified, so append this block by hand ' +
+          'to avoid corrupting an existing config.',
+      };
+    case 'pi':
+      return {
+        kind: 'manual',
+        slug,
+        format: 'json',
+        configPath: path.join(home, '.pi', 'agent', 'mcp.json'),
+        snippet: genericMcpServersSnippet(spec, serverName),
+        reason:
+          'The pi coding agent exposes MCP, but its config path/schema is ' +
+          'not authoritatively documented. Paste this into pi’s MCP ' +
+          'config (check `pi --help` for the exact location).',
+      };
+    case 'hermes':
+      return {
+        kind: 'manual',
+        slug,
+        format: 'yaml',
+        configPath: path.join(home, '.hermes', 'config.yaml'),
+        snippet: hermesYamlSnippet(spec, serverName),
+        reason:
+          'Hermes config format is unverified. Add this under your Hermes ' +
+          'MCP server configuration by hand.',
+      };
+    default: {
+      const exhaustive: never = slug;
+      throw new Error(`unknown agent slug: ${String(exhaustive)}`);
+    }
+  }
+}
+
+function clineConfigPath(home: string, platform: NodeJS.Platform): string {
+  const rel = path.join(
+    'globalStorage',
+    'saoudrizwan.claude-dev',
+    'settings',
+    'cline_mcp_settings.json',
+  );
+  if (platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'Code', 'User', rel);
+  }
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming');
+    return path.join(appData, 'Code', 'User', rel);
+  }
+  return path.join(home, '.config', 'Code', 'User', rel);
+}
+
+function traeConfigPath(home: string, platform: NodeJS.Platform): string {
+  if (platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'Trae', 'User', 'mcp.json');
+  }
+  if (platform === 'win32') {
+    const appData = process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming');
+    return path.join(appData, 'Trae', 'User', 'mcp.json');
+  }
+  return path.join(home, '.config', 'Trae', 'User', 'mcp.json');
+}
+
+// --- Pure JSON merge / removal (the heart of the 'json' strategy) -------
+
+/**
+ * Merge one server entry into existing config text without disturbing the
+ * rest. Missing intermediate objects are created. Returns pretty JSON with
+ * a trailing newline. Throws if existing text is non-empty but unparseable
+ * (caller decides whether to bail or back up).
+ */
+export function applyJsonInstall(existingText: string | null, plan: JsonInstallPlan): string {
+  const root = parseJsonObject(existingText, plan.configPath);
+  let cursor: Record<string, unknown> = root;
+  for (const key of plan.keyPath) {
+    const next = cursor[key];
+    if (next == null || typeof next !== 'object' || Array.isArray(next)) {
+      cursor[key] = {};
+    }
+    cursor = cursor[key] as Record<string, unknown>;
+  }
+  cursor[plan.serverKey] = plan.entry;
+  return `${JSON.stringify(root, null, 2)}\n`;
+}
+
+/**
+ * Remove the server entry. Returns the new text, or null when the file did
+ * not exist / had nothing to remove (caller treats null as a no-op).
+ */
+export function removeJsonInstall(existingText: string | null, plan: JsonInstallPlan): string | null {
+  if (existingText == null || existingText.trim() === '') return null;
+  const root = parseJsonObject(existingText, plan.configPath);
+  let cursor: Record<string, unknown> = root;
+  for (const key of plan.keyPath) {
+    const next = cursor[key];
+    if (next == null || typeof next !== 'object' || Array.isArray(next)) {
+      return null;
+    }
+    cursor = next as Record<string, unknown>;
+  }
+  if (!(plan.serverKey in cursor)) return null;
+  delete cursor[plan.serverKey];
+  return `${JSON.stringify(root, null, 2)}\n`;
+}
+
+function parseJsonObject(text: string | null, where: string): Record<string, unknown> {
+  if (text == null || text.trim() === '') return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      `existing config at ${where} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`existing config at ${where} is not a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+// --- Snippets for the manual (print-only) strategy ----------------------
+
+function genericMcpServersSnippet(spec: McpLaunchSpec, name: string): string {
+  const server: Record<string, unknown> = {
+    command: spec.command,
+    args: spec.args,
+  };
+  if (Object.keys(spec.env).length > 0) server.env = spec.env;
+  return JSON.stringify({ mcpServers: { [name]: server } }, null, 2);
+}
+
+function hermesYamlSnippet(spec: McpLaunchSpec, name: string): string {
+  const lines = [
+    'mcp_servers:',
+    `  ${name}:`,
+    `    command: ${JSON.stringify(spec.command)}`,
+    `    args: ${JSON.stringify(spec.args)}`,
+  ];
+  if (Object.keys(spec.env).length > 0) {
+    lines.push('    env:');
+    for (const [k, v] of Object.entries(spec.env)) {
+      lines.push(`      ${k}: ${JSON.stringify(v)}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function vibeTomlSnippet(spec: McpLaunchSpec, name: string): string {
+  const argsToml = `[${spec.args.map((a) => JSON.stringify(a)).join(', ')}]`;
+  const lines = [
+    '[[mcp_servers]]',
+    `name = ${JSON.stringify(name)}`,
+    'transport = "stdio"',
+    `command = ${JSON.stringify(spec.command)}`,
+    `args = ${argsToml}`,
+  ];
+  return lines.join('\n');
+}

--- a/apps/daemon/tests/mcp-agent-install.test.ts
+++ b/apps/daemon/tests/mcp-agent-install.test.ts
@@ -40,8 +40,9 @@ describe('CLI-driven agents', () => {
     expect(plan.bin).toBe('claude');
     expect(plan.addArgv).toEqual([
       'mcp', 'add', '--scope', 'user',
+      'open-design',
       '-e', 'OD_DATA_DIR=/home/u/.open-design',
-      'open-design', '--',
+      '--',
       SPEC.command, ...SPEC.args,
     ]);
     expect(plan.removeArgv).toEqual(['mcp', 'remove', '--scope', 'user', 'open-design']);

--- a/apps/daemon/tests/mcp-agent-install.test.ts
+++ b/apps/daemon/tests/mcp-agent-install.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AGENT_SLUGS,
+  applyJsonInstall,
+  isAgentSlug,
+  planAgentInstall,
+  removeJsonInstall,
+  type JsonInstallPlan,
+  type McpLaunchSpec,
+} from '../src/mcp-agent-install.js';
+
+const SPEC: McpLaunchSpec = {
+  command: '/usr/local/bin/node',
+  args: ['/opt/open-design/cli.js', 'mcp', '--daemon-url', 'http://127.0.0.1:7456'],
+  env: { OD_DATA_DIR: '/home/u/.open-design' },
+};
+
+const SPEC_NO_ENV: McpLaunchSpec = { ...SPEC, env: {} };
+
+const ctx = (platform: NodeJS.Platform = 'linux') => ({
+  home: '/home/u',
+  platform,
+  serverName: 'open-design',
+});
+
+describe('agent slug guard', () => {
+  it('accepts every documented slug and rejects others', () => {
+    for (const s of AGENT_SLUGS) expect(isAgentSlug(s)).toBe(true);
+    expect(isAgentSlug('not-an-agent')).toBe(false);
+    expect(AGENT_SLUGS).toHaveLength(14);
+  });
+});
+
+describe('CLI-driven agents', () => {
+  it('claude registers via `claude mcp add --scope user` with env flags', () => {
+    const plan = planAgentInstall('claude', SPEC, ctx());
+    expect(plan.kind).toBe('cli');
+    if (plan.kind !== 'cli') throw new Error('expected cli');
+    expect(plan.bin).toBe('claude');
+    expect(plan.addArgv).toEqual([
+      'mcp', 'add', '--scope', 'user',
+      '-e', 'OD_DATA_DIR=/home/u/.open-design',
+      'open-design', '--',
+      SPEC.command, ...SPEC.args,
+    ]);
+    expect(plan.removeArgv).toEqual(['mcp', 'remove', '--scope', 'user', 'open-design']);
+  });
+
+  it('codex uses --env and a -- separator', () => {
+    const plan = planAgentInstall('codex', SPEC, ctx());
+    if (plan.kind !== 'cli') throw new Error('expected cli');
+    expect(plan.addArgv).toContain('--env');
+    expect(plan.addArgv).toContain('OD_DATA_DIR=/home/u/.open-design');
+    expect(plan.addArgv.slice(-SPEC.args.length - 2)).toEqual(['--', SPEC.command, ...SPEC.args]);
+  });
+
+  it('gemini omits the -- separator (positional command)', () => {
+    const plan = planAgentInstall('gemini', SPEC_NO_ENV, ctx());
+    if (plan.kind !== 'cli') throw new Error('expected cli');
+    expect(plan.addArgv).toEqual([
+      'mcp', 'add', '-s', 'user', '-t', 'stdio',
+      'open-design', SPEC.command, ...SPEC.args,
+    ]);
+  });
+});
+
+describe('JSON-config agents', () => {
+  it('cursor merges a stdio entry under mcpServers', () => {
+    const plan = planAgentInstall('cursor', SPEC, ctx());
+    if (plan.kind !== 'json') throw new Error('expected json');
+    expect(plan.configPath).toBe('/home/u/.cursor/mcp.json');
+    expect(plan.keyPath).toEqual(['mcpServers']);
+    expect(plan.entry).toEqual({
+      command: SPEC.command,
+      args: SPEC.args,
+      type: 'stdio',
+      env: SPEC.env,
+    });
+  });
+
+  it('opencode folds command+args into one array under `mcp` and uses `environment`', () => {
+    const plan = planAgentInstall('opencode', SPEC, ctx());
+    if (plan.kind !== 'json') throw new Error('expected json');
+    expect(plan.keyPath).toEqual(['mcp']);
+    expect(plan.entry).toEqual({
+      type: 'local',
+      command: [SPEC.command, ...SPEC.args],
+      enabled: true,
+      environment: SPEC.env,
+    });
+  });
+
+  it('openclaw nests under mcp.servers', () => {
+    const plan = planAgentInstall('openclaw', SPEC_NO_ENV, ctx());
+    if (plan.kind !== 'json') throw new Error('expected json');
+    expect(plan.keyPath).toEqual(['mcp', 'servers']);
+    expect(plan.entry).toEqual({ command: SPEC.command, args: SPEC.args });
+  });
+
+  it('omits env entirely when the launch spec has no env', () => {
+    const plan = planAgentInstall('cursor', SPEC_NO_ENV, ctx());
+    if (plan.kind !== 'json') throw new Error('expected json');
+    expect(plan.entry).not.toHaveProperty('env');
+  });
+
+  it('cline path is OS-specific', () => {
+    const mac = planAgentInstall('cline', SPEC, ctx('darwin'));
+    const linux = planAgentInstall('cline', SPEC, ctx('linux'));
+    if (mac.kind !== 'json' || linux.kind !== 'json') throw new Error('expected json');
+    expect(mac.configPath).toContain('Library/Application Support/Code/User');
+    expect(linux.configPath).toContain('.config/Code/User');
+    expect(mac.configPath).toContain('saoudrizwan.claude-dev');
+  });
+});
+
+describe('manual (unverified) agents', () => {
+  it('pi / vibe / hermes never produce a writable plan', () => {
+    for (const slug of ['pi', 'vibe', 'hermes'] as const) {
+      const plan = planAgentInstall(slug, SPEC, ctx());
+      expect(plan.kind).toBe('manual');
+      if (plan.kind !== 'manual') throw new Error('expected manual');
+      expect(plan.snippet.length).toBeGreaterThan(0);
+      expect(plan.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('vibe snippet is TOML array-of-tables', () => {
+    const plan = planAgentInstall('vibe', SPEC, ctx());
+    if (plan.kind !== 'manual') throw new Error('expected manual');
+    expect(plan.format).toBe('toml');
+    expect(plan.snippet).toContain('[[mcp_servers]]');
+    expect(plan.snippet).toContain('transport = "stdio"');
+  });
+});
+
+describe('applyJsonInstall', () => {
+  const plan = planAgentInstall('cursor', SPEC, ctx()) as JsonInstallPlan;
+
+  it('creates the file structure from empty input', () => {
+    const out = applyJsonInstall(null, plan);
+    const parsed = JSON.parse(out);
+    expect(parsed.mcpServers['open-design'].command).toBe(SPEC.command);
+    expect(out.endsWith('\n')).toBe(true);
+  });
+
+  it('preserves unrelated keys and sibling servers', () => {
+    const existing = JSON.stringify({
+      editor: { theme: 'dark' },
+      mcpServers: { 'other-server': { command: 'foo' } },
+    });
+    const out = JSON.parse(applyJsonInstall(existing, plan));
+    expect(out.editor).toEqual({ theme: 'dark' });
+    expect(out.mcpServers['other-server']).toEqual({ command: 'foo' });
+    expect(out.mcpServers['open-design'].type).toBe('stdio');
+  });
+
+  it('is idempotent — re-applying yields the same content', () => {
+    const once = applyJsonInstall(null, plan);
+    const twice = applyJsonInstall(once, plan);
+    expect(twice).toBe(once);
+  });
+
+  it('throws on an unparseable existing config rather than clobbering it', () => {
+    expect(() => applyJsonInstall('{not json', plan)).toThrow(/not valid JSON/);
+  });
+});
+
+describe('removeJsonInstall', () => {
+  const plan = planAgentInstall('cursor', SPEC, ctx()) as JsonInstallPlan;
+
+  it('removes only the open-design entry', () => {
+    const existing = applyJsonInstall(
+      JSON.stringify({ mcpServers: { other: { command: 'x' } } }),
+      plan,
+    );
+    const out = JSON.parse(removeJsonInstall(existing, plan)!);
+    expect(out.mcpServers).not.toHaveProperty('open-design');
+    expect(out.mcpServers.other).toEqual({ command: 'x' });
+  });
+
+  it('returns null when there is nothing to remove', () => {
+    expect(removeJsonInstall(null, plan)).toBeNull();
+    expect(removeJsonInstall('{}', plan)).toBeNull();
+    expect(removeJsonInstall(JSON.stringify({ mcpServers: {} }), plan)).toBeNull();
+  });
+});

--- a/deploy/scripts/install-agent.sh
+++ b/deploy/scripts/install-agent.sh
@@ -1,0 +1,226 @@
+#!/bin/sh
+# Open Design — per-agent MCP installer (POSIX sh; safe under `curl ... | sh -s <agent>`)
+#
+# One command, handed to a coding agent, that ends with Open Design wired into
+# that agent over MCP. Two paths, chosen automatically:
+#
+#   Path 1 — Open Design is already installed locally.
+#     We locate a runnable `od` (PATH, packaged app, or a previous source
+#     build) and forward to `od mcp install <agent>`.
+#
+#   Path 2 — Open Design is NOT installed.
+#     We deploy it from source: clone the repo, `pnpm install` (compiles
+#     better-sqlite3), build the daemon, link `od` onto PATH, start the
+#     daemon in the background, then forward to `od mcp install <agent>`.
+#
+# Either way the agent ends up talking to Open Design's stdio MCP server, so
+# it can pull projects/files and create artifacts without exporting a zip
+# each iteration. The real per-agent logic lives in `od mcp install`
+# (TypeScript); this script only bootstraps a runnable `od`.
+#
+# Usage:
+#   curl -fsSL https://open-design.ai/install.sh | sh -s <agent>
+#   ./install-agent.sh <agent> [--uninstall] [--print] [--json] [--daemon-url URL]
+#
+# Environment overrides (Path 2):
+#   OD_HOME        Checkout + runtime dir   (default: $HOME/.open-design)
+#   OD_REPO        Git clone source         (default: nexu-io/open-design)
+#   OD_BIN_DIR     Where `od` is linked     (default: $HOME/.local/bin)
+#   OD_DAEMON_URL  Daemon base URL          (default: http://127.0.0.1:7456)
+#
+# Agents: claude codex cursor copilot openclaw antigravity gemini pi vibe
+#         hermes cline kimi trae opencode
+set -eu
+
+AGENTS="claude codex cursor copilot openclaw antigravity gemini pi vibe hermes cline kimi trae opencode"
+
+OD_HOME="${OD_HOME:-$HOME/.open-design}"
+OD_REPO="${OD_REPO:-https://github.com/nexu-io/open-design.git}"
+OD_BIN_DIR="${OD_BIN_DIR:-$HOME/.local/bin}"
+DAEMON_URL="${OD_DAEMON_URL:-http://127.0.0.1:7456}"
+HEALTH_TIMEOUT=60
+
+# ---- formatting ------------------------------------------------------------
+if [ -t 1 ]; then
+  BOLD=$(printf '\033[1m'); RED=$(printf '\033[31m'); GREEN=$(printf '\033[32m')
+  YELLOW=$(printf '\033[33m'); RESET=$(printf '\033[0m')
+else
+  BOLD=''; RED=''; GREEN=''; YELLOW=''; RESET=''
+fi
+err()  { printf '%s✗%s %s\n' "$RED" "$RESET" "$1" >&2; }
+ok()   { printf '%s✓%s %s\n' "$GREEN" "$RESET" "$1"; }
+note() { printf '%s›%s %s\n' "$YELLOW" "$RESET" "$1" >&2; }
+
+usage() {
+  cat >&2 <<EOF
+${BOLD}Open Design — install MCP into a coding agent${RESET}
+
+Usage: install-agent.sh <agent> [options]
+
+Agents:
+  $AGENTS
+
+Options:
+  --uninstall, --remove   Remove the Open Design MCP server instead.
+  --print, --dry-run      Show what would change; write nothing.
+  --json                  Machine-readable result.
+  --daemon-url <url>      Daemon URL used to resolve the launch command.
+
+If Open Design is not installed locally, it is deployed from source first
+(clone + pnpm install + build). Requires git, Node.js >= 24, and pnpm
+(enable via \`corepack enable\`).
+EOF
+}
+
+is_agent() {
+  for a in $AGENTS; do [ "$1" = "$a" ] && return 0; done
+  return 1
+}
+
+need_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+# ---- parse the leading agent slug ------------------------------------------
+if [ $# -eq 0 ]; then usage; exit 2; fi
+case "$1" in
+  -h|--help) usage; exit 0 ;;
+esac
+AGENT="$1"; shift
+if ! is_agent "$AGENT"; then
+  err "unknown agent: $AGENT"
+  note "expected one of: $AGENTS"
+  exit 2
+fi
+
+# ---- locate a runnable Open Design `od` ------------------------------------
+# CAUTION: `od` is also the standard Unix octal-dump utility (/usr/bin/od),
+# so `command -v od` alone is not enough — we must confirm the binary is
+# Open Design's CLI before forwarding to it. The probe runs the agent
+# installer's own --help and checks for the Open Design banner; the
+# octal-dump `od` errors out / prints unrelated text and is rejected.
+is_open_design_od() {
+  "$1" mcp install --help 2>/dev/null | grep -q 'Open Design' 2>/dev/null
+}
+
+locate_od() {
+  # `od` on PATH first, then known install locations.
+  _candidates=$(command -v od 2>/dev/null || true)
+  _candidates="$_candidates
+$OD_BIN_DIR/od
+$HOME/.local/bin/od
+/usr/local/bin/od
+/opt/open-design/bin/od
+/Applications/Open Design.app/Contents/Resources/bin/od
+/Applications/Open Design Preview.app/Contents/Resources/bin/od"
+
+  OD_BIN=""
+  _oldifs=$IFS
+  IFS='
+'
+  for cand in $_candidates; do
+    [ -n "$cand" ] || continue
+    { command -v "$cand" >/dev/null 2>&1 || [ -x "$cand" ]; } || continue
+    if is_open_design_od "$cand"; then OD_BIN="$cand"; break; fi
+  done
+  IFS=$_oldifs
+  [ -n "$OD_BIN" ]
+}
+
+# ---- Path 2: deploy Open Design from source --------------------------------
+check_node() {
+  need_cmd node || return 1
+  _major=$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)
+  [ "$_major" -ge 24 ]
+}
+
+deploy_from_source() {
+  note "Open Design not found locally — deploying from source."
+
+  if ! need_cmd git; then
+    err "git is required to deploy Open Design."
+    note "Install git, then re-run."
+    exit 1
+  fi
+  if ! check_node; then
+    err "Node.js >= 24 is required (found: $(node --version 2>/dev/null || echo 'none'))."
+    note "Install from https://nodejs.org (or via nvm/winget/brew), then re-run."
+    exit 1
+  fi
+  if ! need_cmd pnpm && need_cmd corepack; then
+    corepack enable >/dev/null 2>&1 || true
+  fi
+  if ! need_cmd pnpm; then
+    err "pnpm is required."
+    note "Enable it with: corepack enable   (or: npm install -g pnpm)"
+    exit 1
+  fi
+
+  if [ -d "$OD_HOME/.git" ]; then
+    ok "Updating existing checkout at $OD_HOME"
+    git -C "$OD_HOME" pull --ff-only || note "git pull failed; using existing checkout"
+  else
+    ok "Cloning $OD_REPO"
+    git clone --depth 1 "$OD_REPO" "$OD_HOME"
+  fi
+
+  (
+    cd "$OD_HOME"
+    ok "Installing dependencies (compiles better-sqlite3; ~2 min)…"
+    pnpm install
+    ok "Building the daemon…"
+    pnpm --filter @open-design/daemon build
+  )
+
+  mkdir -p "$OD_BIN_DIR"
+  ln -sf "$OD_HOME/apps/daemon/bin/od.mjs" "$OD_BIN_DIR/od"
+  OD_BIN="$OD_BIN_DIR/od"
+  ok "Linked od -> $OD_BIN"
+
+  case ":$PATH:" in
+    *":$OD_BIN_DIR:"*) ;;
+    *) note "Add to your shell profile: export PATH=\"$OD_BIN_DIR:\$PATH\"" ;;
+  esac
+}
+
+# ---- ensure a daemon is reachable (Path 2) ---------------------------------
+daemon_healthy() {
+  if need_cmd curl; then
+    [ "$(curl -s -o /dev/null -w '%{http_code}' "$DAEMON_URL/api/health" 2>/dev/null || echo 000)" = "200" ]
+  elif need_cmd wget; then
+    wget -q -O /dev/null "$DAEMON_URL/api/health" 2>/dev/null
+  else
+    return 1
+  fi
+}
+
+ensure_daemon() {
+  if daemon_healthy; then
+    ok "Daemon already running at $DAEMON_URL"
+    return 0
+  fi
+  note "Starting the Open Design daemon in the background…"
+  mkdir -p "$OD_HOME"
+  nohup "$OD_BIN" --no-open >"$OD_HOME/daemon.log" 2>&1 &
+  _elapsed=0
+  while [ "$_elapsed" -lt "$HEALTH_TIMEOUT" ]; do
+    if daemon_healthy; then
+      ok "Daemon healthy at $DAEMON_URL"
+      return 0
+    fi
+    sleep 2
+    _elapsed=$((_elapsed + 2))
+  done
+  err "Daemon did not become healthy within ${HEALTH_TIMEOUT}s."
+  note "Check the log: $OD_HOME/daemon.log"
+  exit 1
+}
+
+# ---- choose a path ---------------------------------------------------------
+if ! locate_od; then
+  deploy_from_source
+  ensure_daemon
+fi
+
+# ---- forward to the real engine --------------------------------------------
+# `od mcp install` resolves the exact launch command from the running daemon
+# (GET /api/mcp/install-info) and performs the per-agent registration.
+exec "$OD_BIN" mcp install "$AGENT" "$@"

--- a/deploy/scripts/install-agent.sh
+++ b/deploy/scripts/install-agent.sh
@@ -25,6 +25,7 @@
 # Environment overrides (Path 2):
 #   OD_HOME        Checkout + runtime dir   (default: $HOME/.open-design)
 #   OD_REPO        Git clone source         (default: nexu-io/open-design)
+#   OD_REF         Git branch/tag to clone  (default: repo's default branch)
 #   OD_BIN_DIR     Where `od` is linked     (default: $HOME/.local/bin)
 #   OD_DAEMON_URL  Daemon base URL          (default: http://127.0.0.1:7456)
 #
@@ -36,6 +37,7 @@ AGENTS="claude codex cursor copilot openclaw antigravity gemini pi vibe hermes c
 
 OD_HOME="${OD_HOME:-$HOME/.open-design}"
 OD_REPO="${OD_REPO:-https://github.com/nexu-io/open-design.git}"
+OD_REF="${OD_REF:-}"
 OD_BIN_DIR="${OD_BIN_DIR:-$HOME/.local/bin}"
 DAEMON_URL="${OD_DAEMON_URL:-http://127.0.0.1:7456}"
 HEALTH_TIMEOUT=60
@@ -157,6 +159,9 @@ deploy_from_source() {
   if [ -d "$OD_HOME/.git" ]; then
     ok "Updating existing checkout at $OD_HOME"
     git -C "$OD_HOME" pull --ff-only || note "git pull failed; using existing checkout"
+  elif [ -n "$OD_REF" ]; then
+    ok "Cloning $OD_REPO ($OD_REF)"
+    git clone --depth 1 --branch "$OD_REF" "$OD_REPO" "$OD_HOME"
   else
     ok "Cloning $OD_REPO"
     git clone --depth 1 "$OD_REPO" "$OD_HOME"

--- a/deploy/scripts/install-agent.sh
+++ b/deploy/scripts/install-agent.sh
@@ -159,12 +159,22 @@ deploy_from_source() {
   if [ -d "$OD_HOME/.git" ]; then
     ok "Updating existing checkout at $OD_HOME"
     git -C "$OD_HOME" pull --ff-only || note "git pull failed; using existing checkout"
-  elif [ -n "$OD_REF" ]; then
-    ok "Cloning $OD_REPO ($OD_REF)"
-    git clone --depth 1 --branch "$OD_REF" "$OD_REPO" "$OD_HOME"
   else
-    ok "Cloning $OD_REPO"
-    git clone --depth 1 "$OD_REPO" "$OD_HOME"
+    # Refuse to clone into a non-empty dir that isn't our checkout: it may hold
+    # unrelated user data (git clone would fatal anyway). Never delete it.
+    if [ -d "$OD_HOME" ] && [ -n "$(ls -A "$OD_HOME" 2>/dev/null)" ]; then
+      err "$OD_HOME exists and is not an Open Design checkout."
+      note "It contains other files. Re-run with a different OD_HOME, e.g.:"
+      note "  OD_HOME=\"\$HOME/.open-design-src\" $0 $AGENT"
+      exit 1
+    fi
+    if [ -n "$OD_REF" ]; then
+      ok "Cloning $OD_REPO ($OD_REF)"
+      git clone --depth 1 --branch "$OD_REF" "$OD_REPO" "$OD_HOME"
+    else
+      ok "Cloning $OD_REPO"
+      git clone --depth 1 "$OD_REPO" "$OD_HOME"
+    fi
   fi
 
   (


### PR DESCRIPTION
Closes #3430

## Why

**Use case:** I was handing Open Design to coding agents (Claude Code, Codex, Cursor) and hit the per-agent MCP wiring chore myself every time — open Settings, copy the snippet, hand-edit that agent's config. Each agent's config shape differs, so the steps never transfer. I wanted one command I could paste (or hand to the agent) that ends with Open Design wired in.

**Pain:** MCP registration was UI-only (Settings → MCP snippet) with no CLI path. That breaks the UI/CLI dual-track contract: external agents (hermes-agent, openclaw, packaged runtimes driven from another shell) drive Open Design through `od` subcommands and can't render the web UI, so a UI-only affordance can't be composed into them.

## What users will see

- A new `od mcp install <agent>` subcommand that registers Open Design's stdio MCP server into a coding agent's config, with `--uninstall`, `--print` (dry-run), and `--json`.
- A `curl -fsSL https://open-design.ai/install.sh | sh -s <agent>` one-liner. If Open Design isn't installed locally, it deploys from source first (clone + `pnpm install` + build daemon + link `od` + start daemon in background), then registers.
- Supported agents: claude codex cursor copilot openclaw antigravity gemini pi vibe hermes cline kimi trae opencode.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — new `od mcp install <agent>` subcommand (`--uninstall`, `--print`, `--json`); new `OD_HOME` / `OD_REPO` / `OD_REF` / `OD_BIN_DIR` / `OD_DAEMON_URL` env vars consumed by the bootstrap script.
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — installer is opt-in (user runs the command); it does not change existing users' experience.
- [ ] **None**

## Bug fix verification

This PR is feature-first but includes one bug fix in the claude path:

- `claude mcp add`'s `-e/--env` is variadic (`<env...>`). Emitting `mcp add --scope user -e KEY=val open-design -- <cmd>` made the CLI swallow the server name `open-design` as a second env value (`Invalid environment variable format: open-design`), so claude exited 1.
- Fix: place the server name before the env flags — `mcp add --scope user open-design -e KEY=val -- <cmd>` — matching the documented `claude mcp add <name> -e K=v -- <cmd>` form.
- Test: \`apps/daemon/tests/mcp-agent-install.test.ts\` asserts the corrected argv order (the planner test goes green on the fix, would fail on the pre-fix order). Real-world verification: ran the full \`curl | sh\` flow on a clean machine — \`claude mcp list\` reports \`open-design: ... - ✓ Connected\`.

## Validation

- \`pnpm guard\` — 36/36 pass.
- \`pnpm typecheck\` — all packages pass, 0 errors.
- \`pnpm --filter @open-design/daemon exec vitest run tests/mcp-agent-install.test.ts\` — 17/17 pass.
- End-to-end clean-machine run of the bare \`curl | sh -s claude\` one-liner: clone → install → build → background daemon → \`od mcp install claude\` → \`✓ Connected\`.
- Note: \`apps/daemon/tests/connection-test.test.ts\` has 4 pre-existing failures unrelated to this change (Claude profile guidance text assertions) present on \`main\`.