### PR TITLE
fix: trust compositionEnd over isComposing for IME Enter key

### DIFF
--- a/apps/web/src/utils/imeComposing.ts
+++ b/apps/web/src/utils/imeComposing.ts
@@ -1,10 +1,20 @@
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
-/** True while an IME composition is active or this key is part of confirming it. */
+/**
+ * True while an IME composition is active.
+ * 
+ * We trust the composing ref (driven by onCompositionStart/End) over
+ * nativeEvent.isComposing because on some browser/IME combinations
+ * (e.g. Chrome/macOS Pinyin), the Enter keydown that confirms a candidate
+ * can still carry isComposing=true even after compositionEnd has fired.
+ * 
+ * Relying on the stale nativeEvent.isComposing causes the Enter key to
+ * insert a newline instead of sending the message.
+ */
 export function isImeComposing(
   event: ReactKeyboardEvent<HTMLInputElement | HTMLTextAreaElement>,
   composing: boolean,
 ): boolean {
-  const nativeEvent = event.nativeEvent as KeyboardEvent & { keyCode?: number };
-  return composing || nativeEvent.isComposing || nativeEvent.keyCode === 229;
+  // Trust the composition ref first
+  return composing;
 }


### PR DESCRIPTION
Fixes #3426

## Problem

When composing a chat message with a Chinese/CJK IME, pressing Enter after the text is committed inserts a newline into the composer instead of sending the message.

## Root Cause

On Chrome/macOS Pinyin (and potentially other browser/IME combinations), the Enter keydown event that confirms a candidate can still carry `nativeEvent.isComposing=true` even after `compositionEnd` has fired and cleared the `composingRef`.

The previous logic checked `composing || nativeEvent.isComposing`, which meant the stale `isComposing` flag would prevent the Enter key from sending the message, causing it to insert a newline instead.

## Solution

Now we trust only the `composing` ref (driven by `onCompositionStart`/`onCompositionEnd`), which accurately reflects the IME state and allows Enter to send after composition is complete.

## Testing

- Manually tested with macOS Pinyin IME in Chrome
- Type checking passes
- No behavior change for non-IME input