### PR TITLE
fix: remove bottom-right overlay icon from media fallback cards

### DIFF
--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -81,13 +81,9 @@ function MediaFallback({
 }) {
   const trimmed = pluginTitle.trim();
   const glyph = String.fromCodePoint(trimmed.codePointAt(0) ?? 0x2022).toUpperCase();
-  const icon = mediaType === 'video' ? 'play' : mediaType === 'audio' ? 'mic' : 'image';
   return (
     <div className="plugins-home__media-fallback" aria-hidden>
       <span className="plugins-home__media-fallback-glyph">{glyph}</span>
-      <span className="plugins-home__media-fallback-icon">
-        <Icon name={icon} size={15} />
-      </span>
     </div>
   );
 }

--- a/apps/web/src/styles/home/plugins-home.css
+++ b/apps/web/src/styles/home/plugins-home.css
@@ -494,21 +494,6 @@
   line-height: 1;
   opacity: 0.86;
 }
-.plugins-home__media-fallback-icon {
-  position: absolute;
-  right: 10px;
-  bottom: 10px;
-  width: 28px;
-  height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--bg-panel) 74%, transparent);
-  color: var(--accent);
-  box-shadow: var(--shadow-xs);
-}
 @keyframes plugins-home-shimmer {
   to {
     background-position: -200% 0, 0 0;


### PR DESCRIPTION
## Summary

Removes the absolutely-positioned icon badge from MediaFallback component that was obscuring the overlay description text on hover.

## Problem

The icon (play/mic/image) was rendered at bottom: 10px; right: 10px and overlapped with the card overlay's description text when users hovered over media plugin cards without poster images.

## Solution

- Remove icon span and Icon import logic from MediaFallback in MediaSurface.tsx
- Delete .plugins-home__media-fallback-icon CSS rule (~15 lines)

The centered glyph (first character of plugin title) remains as the visual fallback, which is sufficient. The icon was aria-hidden so no a11y impact.

## Testing

- Visual inspection: media fallback cards no longer have bottom-right icon
- Hover behavior: overlay description text is no longer obscured

Fixes #3203
