### PR TITLE
fix(web): stop repeated AMR settings rescans

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -214,14 +214,6 @@ export interface AgentRefreshOptions {
   agentCliEnv?: AppConfig['agentCliEnv'];
 }
 
-// When AMR sign-in completes, vela's live `models` catalog can lag the
-// credential write by a beat (the link backend has to register the freshly
-// authorized device). Re-detect a few times so a momentarily-empty catalog
-// doesn't leave the model picker hidden — the symptom that previously needed
-// an app restart / reinstall to clear.
-const AMR_SIGN_IN_RESCAN_ATTEMPTS = 4;
-const AMR_SIGN_IN_RESCAN_RETRY_MS = 1500;
-
 function codexPathStrings(locale: Locale) {
   if (locale === 'zh-CN') {
     return {
@@ -972,9 +964,9 @@ export function SettingsDialog({
   const providerTestAbortRef = useRef<AbortController | null>(null);
   const providerModelsAbortRef = useRef<AbortController | null>(null);
   const pendingAgentInstallRescanRef = useRef(false);
-  // Guards the AMR catalog-chase loop so concurrent renders can't start it
-  // twice (see the re-detect effect below).
-  const amrRescanInFlightRef = useRef(false);
+  // Settings only nudges agent detection once after AMR signs in. App-level
+  // AMR model polling owns the catalog retry loop.
+  const amrRescanRequestedRef = useRef(false);
   const agentTestRevisionRef = useRef(0);
   const providerTestRevisionRef = useRef(0);
   const providerModelsRevisionRef = useRef(0);
@@ -1209,66 +1201,17 @@ export function SettingsDialog({
     };
   }, [agentRescanRunning, handleRefreshAgents]);
 
-  // Chase AMR's live model catalog whenever the user is signed in but the
-  // model list hasn't arrived yet. AMR is detected at app start (often while
-  // signed out, so it comes back with an empty, fail-closed list), and the
-  // live `vela models` catalog only becomes fetchable once the credential
-  // lands — and can lag the credential write by a beat. We must cover every
-  // way Settings ends up "signed in + empty", not just an in-Settings
-  // sign-in edge: onboarding signs in and re-detects exactly once, so if that
-  // single call lands during the propagation window Settings later mounts
-  // already signed in with an empty list. Keying on `loggedIn === true` +
-  // "AMR has no models" handles both; the picker shows its loading state
-  // (see renderAgentModelConfig) until the catalog fills in.
-  //
-  // `onRefreshAgents` / `agents` are read through refs so re-detecting (which
-  // changes their identity) can't tear the retry loop down mid-flight — that
-  // is what made the loading row flash and vanish before the catalog arrived.
-  // The in-flight ref keeps a single loop running across renders.
-  const onRefreshAgentsRef = useRef(onRefreshAgents);
-  onRefreshAgentsRef.current = onRefreshAgents;
-  const agentsRef = useRef(agents);
-  agentsRef.current = agents;
   useEffect(() => {
-    if (amrCardStatus?.loggedIn !== true) return;
-    const amr = agentsRef.current.find((agent) => agent.id === 'amr');
+    if (amrCardStatus?.loggedIn !== true) {
+      amrRescanRequestedRef.current = false;
+      return;
+    }
+    const amr = agents.find((agent) => agent.id === 'amr');
     if (!amr || (amr.models?.length ?? 0) > 0) return;
-    if (amrRescanInFlightRef.current) return;
-    amrRescanInFlightRef.current = true;
-    let cancelled = false;
-    void (async () => {
-      try {
-        for (
-          let attempt = 0;
-          attempt < AMR_SIGN_IN_RESCAN_ATTEMPTS && !cancelled;
-          attempt += 1
-        ) {
-          let next: void | AgentInfo[];
-          try {
-            next = await onRefreshAgentsRef.current();
-          } catch {
-            return;
-          }
-          if (cancelled) return;
-          const detected = Array.isArray(next) ? next : [];
-          const refreshed = detected.find((agent) => agent.id === 'amr');
-          // Stop once the live catalog has caught up (or AMR vanished); a
-          // still-empty list means vela hasn't published the catalog yet, so
-          // retry.
-          if (!refreshed || (refreshed.models?.length ?? 0) > 0) return;
-          await new Promise((resolve) => {
-            setTimeout(resolve, AMR_SIGN_IN_RESCAN_RETRY_MS);
-          });
-        }
-      } finally {
-        amrRescanInFlightRef.current = false;
-      }
-    })();
-    return () => {
-      cancelled = true;
-      amrRescanInFlightRef.current = false;
-    };
-  }, [amrCardStatus?.loggedIn]);
+    if (amrRescanRequestedRef.current) return;
+    amrRescanRequestedRef.current = true;
+    void Promise.resolve(onRefreshAgents()).catch(() => undefined);
+  }, [agents, amrCardStatus?.loggedIn, onRefreshAgents]);
 
   const handleTestAgent = async () => {
     if (agentTestState.status === 'running') {

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1378,13 +1378,13 @@
   font-size: 13px;
   font-weight: 680;
   cursor: pointer;
-  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease, transform 120ms ease;
+  transition: none;
 }
 .agent-card-amr-auth .amr-account-control__action:hover:not(:disabled) {
   border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
   background: color-mix(in srgb, var(--accent-tint) 76%, var(--bg-panel));
   color: var(--accent-strong);
-  transform: translateY(-1px);
+  transform: none;
 }
 .agent-card-amr-auth .amr-account-control__action:disabled {
   cursor: default;
@@ -1393,6 +1393,10 @@
 .agent-card-amr-auth .amr-account-control__error,
 .agent-card-amr-auth .amr-login-pill-badge {
   display: none;
+}
+.amr-auth-anchor .amr-coachmark,
+.amr-auth-anchor .amr-coachmark__ring {
+  animation: none;
 }
 .agent-model-row-head {
   font-size: 12px;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1923,6 +1923,50 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     });
   });
 
+  it('does not repeatedly re-detect agents while signed-in AMR models stay empty', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn: true,
+            loginInFlight: false,
+            profile: 'local',
+            user: { id: 'u1', email: 'amr@example.com' },
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const signedInEmptyAmr: AgentInfo = { ...amrAgent, models: [] };
+    const onRefreshAgents = vi.fn<OnRefreshAgents>(async () => [
+      { ...amrAgent, models: [] },
+    ]);
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'amr' },
+      { agents: [signedInEmptyAmr], onRefreshAgents },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+
+    await waitFor(() => {
+      expect(onRefreshAgents).toHaveBeenCalledTimes(1);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1700));
+    expect(onRefreshAgents).toHaveBeenCalledTimes(1);
+  });
+
   // The live `vela models` catalog lands a beat after sign-in. Rather than
   // leave the picker blank until then (the "appears seconds later" complaint),
   // the row renders immediately in a loading state.


### PR DESCRIPTION
## Summary
- replace the Settings AMR catalog chase loop with a single re-detect nudge after signed-in empty state
- leave AMR model retry ownership with the app-level polling flow added on the release branch
- add a regression test that the Settings dialog does not keep re-detecting when AMR models remain empty

## Tests
- `pnpm --filter @open-design/web test -- tests/components/SettingsDialog.execution.test.tsx tests/components/App.amr-polling.test.tsx`