### PR TITLE
feat(web): pin the manual-edit inspector instead of switching on hover

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -713,13 +713,42 @@ function manualEditFloatingPanelStyle(
     pad,
     Math.min(targetTop, Math.max(pad, canvasHeight - panelHeight - pad)),
   );
+  // Height is left to the content (auto): a short inspector (e.g. typography
+  // only) should be a compact card, not a tall half-empty panel. The cap only
+  // engages for long inspectors, at which point the scroll body takes over.
   return {
     left,
     top,
     width: panelWidth,
-    height: panelHeight,
-    maxHeight: `calc(100% - ${pad * 2}px)`,
+    maxHeight: panelHeight,
   };
+}
+
+// Anchors the hover "edit params" affordance to the top-right corner of the
+// hovered element, just inside its bounds so moving the cursor from the
+// element onto the icon does not drop the hover. Uses the same iframe→canvas
+// coordinate basis as the floating inspector panel.
+function manualEditHoverIconStyle(
+  target: ManualEditTarget,
+  previewScale: number,
+  canvasSize: PreviewCanvasSize | undefined,
+): CSSProperties {
+  const scale = Number.isFinite(previewScale) && previewScale > 0 ? previewScale : 1;
+  const iconSize = 26;
+  const inset = 4;
+  const canvasWidth = canvasSize?.width ?? 1200;
+  const canvasHeight = canvasSize?.height ?? 800;
+  const targetTop = target.rect.y * scale;
+  const targetRight = (target.rect.x + target.rect.width) * scale;
+  const left = Math.max(
+    inset,
+    Math.min(targetRight - iconSize - inset, canvasWidth - iconSize - inset),
+  );
+  const top = Math.max(
+    inset,
+    Math.min(targetTop + inset, canvasHeight - iconSize - inset),
+  );
+  return { left, top, width: iconSize, height: iconSize };
 }
 
 export function cancelManualEditPendingStyleSnapshot(
@@ -4461,6 +4490,8 @@ function HtmlViewer({
   }, []);
 const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([]);
   const [selectedManualEditTarget, setSelectedManualEditTarget] = useState<ManualEditTarget | null>(null);
+  const [manualEditHoverTarget, setManualEditHoverTarget] = useState<ManualEditTarget | null>(null);
+  const [manualEditPageStylesOpen, setManualEditPageStylesOpen] = useState(false);
   const [manualEditPanelPosition, setManualEditPanelPosition] = useState<{ left: number; top: number } | null>(null);
   const selectedManualEditTargetIdRef = useRef<string | null>(null);
   const [manualEditDraft, setManualEditDraft] = useState<ManualEditDraft>(() => emptyManualEditDraft());
@@ -5445,6 +5476,8 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     if (!manualEditMode) {
       setManualEditTargets([]);
       setSelectedManualEditTarget(null);
+      setManualEditHoverTarget(null);
+      setManualEditPageStylesOpen(false);
       setManualEditPanelPosition(null);
       setManualEditError(null);
       manualEditPendingStyleRef.current = null;
@@ -5471,12 +5504,27 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         return;
       }
       if (data.type === 'od-edit-select') {
+        setManualEditHoverTarget(null);
         void selectManualEditTarget(data.target);
         return;
       }
       if (data.type === 'od-edit-hover') {
-        if (data.target.id !== selectedManualEditTargetIdRef.current) {
-          void selectManualEditTarget(data.target);
+        // Hover only surfaces a lightweight "edit params" affordance; it must
+        // NOT switch the pinned inspector. The panel changes only when the
+        // user clicks that affordance (or a container/image body), so moving
+        // the cursor across the canvas never yanks the panel away mid-edit.
+        setManualEditHoverTarget(
+          data.target.id === selectedManualEditTargetIdRef.current ? null : data.target,
+        );
+        return;
+      }
+      if (data.type === 'od-edit-background') {
+        // Clicking empty canvas deselects and opens the compact page-styles
+        // card — only meaningful for full HTML documents.
+        setManualEditHoverTarget(null);
+        if (typeof source === 'string' && isManualEditFullHtmlDocument(source)) {
+          void clearManualEditTargetSelection();
+          setManualEditPageStylesOpen(true);
         }
         return;
       }
@@ -5616,19 +5664,19 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     return true;
   }
 
-  function cancelManualEditModeAndExit() {
-    cancelManualEditStyleDraft();
-    selectedManualEditTargetIdRef.current = null;
-    setSelectedManualEditTarget(null);
-    setManualEditPanelPosition(null);
-    setManualEditDraft(emptyManualEditDraft(sourceRef.current ?? ''));
-    setManualEditError(null);
-    setManualEditMode(false);
-    refreshSrcDocPreviewAfterManualEditExit();
-    postSelectedManualEditTargetToIframe(null);
+  // Clears the hover affordance and re-arms the iframe's per-element hover
+  // dedupe so re-entering the same element re-announces it. Called from the
+  // workspace's own mouseleave (host-side), NOT the iframe's mouseleave — the
+  // affordance overlays the iframe, so reacting to the iframe leaving would
+  // yank it out from under the cursor and strobe on/off.
+  function clearManualEditHover() {
+    setManualEditHoverTarget(null);
+    const win = iframeRef.current?.contentWindow;
+    if (win) win.postMessage({ type: 'od-edit-hover-reset' }, '*');
   }
 
   async function selectManualEditTarget(target: ManualEditTarget) {
+    setManualEditPageStylesOpen(false);
     if (manualEditPendingStyleRef.current?.id !== target.id) cancelManualEditStyleDraft();
     const base = sourceRef.current ?? '';
     const fields = readManualEditFields(base, target.id);
@@ -5652,6 +5700,26 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     setManualEditPanelPosition(null);
     setManualEditDraft(emptyManualEditDraft(sourceRef.current ?? ''));
     setManualEditError(null);
+  }
+
+  // The inspector is scoped to one element (or the page). Closing it should
+  // only collapse the panel and keep the user in edit mode — exiting edit is
+  // the toolbar toggle's job. Dismiss flushes any in-flight tweak first so
+  // nothing is lost; cancel reverts the in-flight unsaved tweak instead.
+  async function dismissManualEditPanel() {
+    const ok = await flushManualEditStyleSave();
+    if (!ok) return;
+    if (selectedManualEditTarget) void clearManualEditTargetSelection();
+    else setManualEditPageStylesOpen(false);
+  }
+
+  function cancelManualEditPanel() {
+    if (selectedManualEditTarget) {
+      void clearManualEditTargetSelection();
+    } else {
+      cancelManualEditStyleDraft();
+      setManualEditPageStylesOpen(false);
+    }
   }
 
   async function applyManualEdit(patch: ManualEditPatch, label: string): Promise<boolean> {
@@ -6856,7 +6924,14 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
     localCommentSideDockActive && commentSidePanelCollapsed ? 'comment-preview-layer-dock-collapsed' : '',
     boardSideDockStacked ? 'comment-preview-layer-side-dock-stacked' : '',
   ].filter(Boolean).join(' ');
-  const manualEditPanel = manualEditMode ? (
+  // Edit mode opens clean: the inspector only appears once the user pins an
+  // element (click its hover affordance / a container) or opens page styles by
+  // clicking the empty canvas. No more full-height panel popping on toggle.
+  const manualEditPageCardActive =
+    manualEditMode && !selectedManualEditTarget && manualEditPageStylesOpen;
+  const manualEditPanelActive =
+    manualEditMode && (!!selectedManualEditTarget || manualEditPageCardActive);
+  const manualEditPanel = manualEditPanelActive ? (
     <ManualEditPanel
       targets={manualEditTargets}
       selectedTarget={selectedManualEditTarget}
@@ -6881,13 +6956,13 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         void clearManualEditTargetSelection();
       }}
       onExit={() => {
-        void exitManualEditModeAfterFlush();
+        void dismissManualEditPanel();
       }}
       onCancelDraft={() => {
-        cancelManualEditModeAndExit();
+        cancelManualEditPanel();
       }}
       onSaveDraft={() => {
-        void exitManualEditModeAfterFlush();
+        void dismissManualEditPanel();
       }}
       onUndo={() => {
         void undoManualEdit();
@@ -6895,6 +6970,7 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
       onRedo={() => {
         void redoManualEdit();
       }}
+      floatingClassName={manualEditPageCardActive ? 'manual-edit-page-card' : undefined}
       floatingStyle={selectedManualEditTarget
         ? {
             ...manualEditFloatingPanelStyle(
@@ -6904,8 +6980,8 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
             ),
             ...(manualEditPanelPosition ?? {}),
           }
-        : undefined}
-      onFloatingPositionChange={setManualEditPanelPosition}
+        : { top: 12, right: 12, width: 320 }}
+      onFloatingPositionChange={selectedManualEditTarget ? setManualEditPanelPosition : undefined}
       onPickImage={async (pickedFile) => {
         const result = await uploadProjectFiles(projectId, [pickedFile]);
         const uploaded = result.uploaded[0];
@@ -6918,6 +6994,30 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
       }}
     />
   ) : null;
+  const manualEditHoverAffordance =
+    manualEditMode &&
+    manualEditHoverTarget &&
+    manualEditHoverTarget.id !== selectedManualEditTarget?.id ? (
+      <button
+        type="button"
+        className="manual-edit-hover-action"
+        data-testid="manual-edit-hover-open"
+        aria-label={t('manualEdit.editParams')}
+        title={t('manualEdit.editParams')}
+        style={manualEditHoverIconStyle(
+          manualEditHoverTarget,
+          overlayPreviewScale,
+          previewBodySize,
+        )}
+        onClick={() => {
+          const target = manualEditHoverTarget;
+          setManualEditHoverTarget(null);
+          void selectManualEditTarget(target);
+        }}
+      >
+        <Icon name="sliders" size={15} />
+      </button>
+    ) : null;
   const activeComposerComment = activePreviewCommentId
     ? visibleSideComments.find((comment) => comment.id === activePreviewCommentId) ?? null
     : null;
@@ -7538,8 +7638,10 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
             className={`${manualEditMode ? 'manual-edit-workspace' : commentPreviewLayoutClass} preview-viewport preview-viewport-${previewViewport}`}
             data-testid={manualEditMode ? undefined : 'comment-preview-layout'}
             style={previewViewportStyle(previewViewport, previewScale, boardPreviewCanvasSize, boardPreviewScaleOptions)}
+            onMouseLeave={manualEditMode ? clearManualEditHover : undefined}
           >
             {manualEditPanel}
+            {manualEditHoverAffordance}
             <div
               className={manualEditMode ? 'manual-edit-canvas' : 'comment-preview-canvas'}
               data-testid={manualEditMode ? undefined : 'comment-preview-canvas'}

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -39,6 +39,7 @@ export function ManualEditPanel({
   onPickImage,
   pageStylesEnabled = true,
   floatingStyle,
+  floatingClassName,
   onFloatingPositionChange,
 }: {
   targets: ManualEditTarget[];
@@ -57,6 +58,7 @@ export function ManualEditPanel({
   onApplyPatch: (patch: ManualEditPatch, label: string) => void;
   onPickImage?: (file: File) => Promise<string | null>;
   floatingStyle?: CSSProperties;
+  floatingClassName?: string;
   onFloatingPositionChange?: (position: { left: number; top: number }) => void;
   onError: (message: string) => void;
   onClearSelection: () => void;
@@ -128,7 +130,7 @@ export function ManualEditPanel({
 
   return (
     <aside
-      className={`manual-edit-right${floatingStyle ? ' manual-edit-floating' : ''}`}
+      className={`manual-edit-right${floatingStyle ? ' manual-edit-floating' : ''}${floatingClassName ? ` ${floatingClassName}` : ''}`}
       style={floatingStyle}
     >
       <section className="manual-edit-modal cc-panel">

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -333,6 +333,12 @@ export function buildManualEditBridge(enabled: boolean): string {
       setSelectedTarget(ev.data.id || null);
       return;
     }
+    if (ev.data.type === 'od-edit-hover-reset') {
+      // Host signals the cursor truly left the canvas, so the next pointerover
+      // re-announces the hovered element (defeats the per-element dedupe).
+      lastHoverId = null;
+      return;
+    }
     if (ev.data.type === 'od-edit-preview-style') {
       applyPreviewStyles(ev.data.id, ev.data.styles || {}, ev.data.version);
       return;
@@ -344,7 +350,12 @@ export function buildManualEditBridge(enabled: boolean): string {
     ev.preventDefault();
     ev.stopPropagation();
     var el = closestTarget(ev);
-    if (!el) return;
+    if (!el) {
+      // Clicking empty canvas (no source-mapped ancestor) is the gesture for
+      // page-level styles; the host decides whether to surface the card.
+      window.parent.postMessage({ type: 'od-edit-background' }, '*');
+      return;
+    }
     var kind = inferKind(el);
     if (kind === 'text' || kind === 'link') {
       makeEditable(el, ev);

--- a/apps/web/src/edit-mode/types.ts
+++ b/apps/web/src/edit-mode/types.ts
@@ -102,6 +102,10 @@ export interface ManualEditHoverMessage {
   target: ManualEditTarget;
 }
 
+export interface ManualEditBackgroundMessage {
+  type: 'od-edit-background';
+}
+
 export interface ManualEditPreviewAppliedMessage {
   type: 'od-edit-preview-style-applied';
   id: string;
@@ -120,6 +124,7 @@ export type ManualEditBridgeMessage =
   | ManualEditTargetMessage
   | ManualEditSelectMessage
   | ManualEditHoverMessage
+  | ManualEditBackgroundMessage
   | ManualEditPreviewAppliedMessage
   | ManualEditTextCommitMessage;
 

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1103,6 +1103,7 @@ export const ar: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'تعديل المعلمات',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -991,6 +991,7 @@ export const de: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Parameter bearbeiten',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1749,6 +1749,7 @@ export const en: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Edit parameters',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -992,6 +992,7 @@ export const esES: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Editar parámetros',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1127,6 +1127,7 @@ export const fa: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'ویرایش پارامترها',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1636,6 +1636,7 @@ export const fr: Dict = {
   'manualEdit.title': 'Éditeur manuel',
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Modifier les paramètres',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': 'Sélectionnez un calque',
   'manualEdit.empty': 'Cliquez sur un élément dans l’aperçu ou choisissez un calque.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1103,6 +1103,7 @@ export const hu: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Paraméterek szerkesztése',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1220,6 +1220,7 @@ export const id: Dict = {
   'manualEdit.title': 'Editor manual',
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Edit parameter',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': 'Pilih lapisan',
   'manualEdit.empty': 'Klik elemen di pratinjau atau pilih lapisan.',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1008,6 +1008,7 @@ export const it: Dict = {
   'manualEdit.title': 'Editor manuale',
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Modifica parametri',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': 'Seleziona un livello',
   'manualEdit.empty': 'Clicca un elemento nell\'anteprima o scegli un livello.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -990,6 +990,7 @@ export const ja: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'パラメーターを編集',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1103,6 +1103,7 @@ export const ko: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': '매개변수 편집',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1103,6 +1103,7 @@ export const pl: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Edytuj parametry',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1126,6 +1126,7 @@ export const ptBR: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Editar parâmetros',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1126,6 +1126,7 @@ export const ru: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Изменить параметры',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1040,6 +1040,7 @@ export const th: Dict = {
   'manualEdit.title': "กล่องควบคุม",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'แก้ไขพารามิเตอร์',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "เลือกเลเยอร์ขึ้นมา",
   'manualEdit.empty': "เลือกกล่องด้านบนเพื่อเปิดดู",

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1090,6 +1090,7 @@ export const tr: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Parametreleri düzenle',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1145,6 +1145,7 @@ export const uk: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': 'Edit',
   'manualEdit.movePanel': 'Move edit panel',
+  'manualEdit.editParams': 'Редагувати параметри',
   'manualEdit.closePanel': 'Close edit panel',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1722,6 +1722,7 @@ export const zhCN: Dict = {
   'manualEdit.title': '手动编辑器',
   'manualEdit.fallbackTitle': '编辑',
   'manualEdit.movePanel': '移动编辑面板',
+  'manualEdit.editParams': '编辑参数',
   'manualEdit.closePanel': '关闭编辑面板',
   'manualEdit.selectLayer': '选择图层',
   'manualEdit.empty': '在预览中点击元素,或选择一个图层。',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1319,6 +1319,7 @@ export const zhTW: Dict = {
   'manualEdit.title': "Manual editor",
   'manualEdit.fallbackTitle': '編輯',
   'manualEdit.movePanel': '移動編輯面板',
+  'manualEdit.editParams': '編輯參數',
   'manualEdit.closePanel': '關閉編輯面板',
   'manualEdit.selectLayer': "Select a layer",
   'manualEdit.empty': "Click an element in the preview or choose a layer.",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2083,6 +2083,7 @@ export interface Dict {
   'manualEdit.title': string;
   'manualEdit.fallbackTitle': string;
   'manualEdit.movePanel': string;
+  'manualEdit.editParams': string;
   'manualEdit.closePanel': string;
   'manualEdit.selectLayer': string;
   'manualEdit.empty': string;

--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -663,6 +663,49 @@
   pointer-events: auto;
 }
 
+/* Page-styles card: a compact, content-height variant of the floating panel
+   anchored top-right. Opened by clicking the empty canvas so edit mode itself
+   stays clean instead of docking a full-height panel on open. */
+.manual-edit-workspace > .manual-edit-right.manual-edit-page-card {
+  right: 12px;
+  height: auto;
+  max-height: calc(100% - 24px);
+}
+.manual-edit-page-card .manual-edit-modal.cc-panel {
+  height: auto;
+}
+
+/* Hover affordance: a small "edit params" handle pinned to the hovered
+   element so click-to-pin selection stays discoverable without the panel
+   chasing the cursor. */
+.manual-edit-workspace > .manual-edit-hover-action {
+  position: absolute;
+  z-index: 31;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, #2563eb 55%, transparent);
+  border-radius: 7px;
+  background: var(--bg-panel);
+  color: #2563eb;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(15, 23, 42, 0.22);
+  opacity: 0;
+  transform: scale(0.9);
+  animation: manual-edit-hover-action-in 160ms cubic-bezier(0.23, 1, 0.32, 1) forwards;
+  pointer-events: auto;
+}
+.manual-edit-workspace > .manual-edit-hover-action:hover {
+  background: color-mix(in srgb, #2563eb 12%, var(--bg-panel));
+}
+@keyframes manual-edit-hover-action-in {
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 /* Claude Code-style edit inspector panel. */
 .cc-panel { display: flex; flex-direction: column; gap: 0; padding: 8px 0; overflow: hidden; background: var(--bg-panel); }
 .cc-inspector { display: flex; flex-direction: column; gap: 12px; padding: 6px 12px; }
@@ -922,7 +965,11 @@
   scrollbar-gutter: stable;
 }
 .manual-edit-floating .manual-edit-modal.cc-panel {
-  height: 100%;
+  /* Fit content; the aside's max-height caps it and the scroll body engages
+     only when the inspector is taller than the cap. No fixed height so short
+     inspectors render as compact cards. */
+  height: auto;
+  max-height: 100%;
   padding-bottom: 10px;
   border-radius: 12px;
   box-shadow: 0 18px 48px rgba(15, 23, 42, 0.18);

--- a/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
@@ -36,7 +36,10 @@ function clickAgentTool(testId: string) {
   fireEvent.click(screen.getByTestId(testId));
 }
 
-async function hoverManualEditTarget(target = heroTarget()) {
+// Pins the inspector to a target. Hover no longer auto-selects, so selection
+// rides the explicit click path (od-edit-select), matching the bridge sending
+// it when the user clicks the hover affordance or a container/image body.
+async function selectManualEditTarget(target = heroTarget()) {
   const frame = await waitFor(() => {
     const node = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     if (!node.contentWindow) throw new Error('Preview frame not ready');
@@ -44,7 +47,7 @@ async function hoverManualEditTarget(target = heroTarget()) {
   });
   act(() => {
     window.dispatchEvent(new MessageEvent('message', {
-      data: { type: 'od-edit-hover', target },
+      data: { type: 'od-edit-select', target },
       source: frame.contentWindow,
     }));
   });
@@ -93,7 +96,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
 
     act(() => {
       panelState.props?.onStyleChange?.('hero', { color: '#ef4444' }, 'Style: Hero');
@@ -121,7 +124,7 @@ describe('FileViewer manual edit history regressions', () => {
     expect(screen.getByTestId('draw-overlay-toggle').getAttribute('aria-pressed')).toBe('true');
   });
 
-  it('remounts the srcDoc iframe when closing manual edit on a srcDoc-only preview', async () => {
+  it('remounts the srcDoc iframe when exiting manual edit on a srcDoc-only preview', async () => {
     const source = '<!doctype html><html><body><script>localStorage.getItem("od");</script><main data-od-id="hero">Hero</main></body></html>';
 
     render(
@@ -131,15 +134,15 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
 
     const editFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     expect(editFrame.getAttribute('data-od-render-mode')).toBe('srcdoc');
     expect(editFrame.srcdoc).toContain('data-od-edit-bridge');
 
-    act(() => {
-      panelState.props?.onExit?.();
-    });
+    // Exiting edit mode is the toolbar toggle's job — the panel's own close
+    // button only collapses the inspector and stays in edit.
+    clickManualTool('manual-edit-mode-toggle');
 
     await waitFor(() => {
       const previewFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
@@ -185,7 +188,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
 
     act(() => {
       panelState.props?.onApplyPatch(
@@ -247,7 +250,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const getActivePreviewFrame = () => screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
 
     await waitFor(() => {
@@ -305,7 +308,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     const postMessageSpy = vi.spyOn(frame.contentWindow!, 'postMessage');
 
@@ -322,8 +325,9 @@ describe('FileViewer manual edit history regressions', () => {
     await waitFor(() => expect(savedSources).toHaveLength(1));
     expect(savedSources[0]).not.toContain('data-od-id="hero"');
     expect(savedSources[0]).toContain('data-od-id="body"');
-    await waitFor(() => expect(panelState.props?.selectedTarget).toBeNull());
-    expect(screen.getByTestId('mock-manual-edit-panel')).toBeTruthy();
+    // Clearing the selection closes the inspector: edit mode returns to a clean
+    // canvas (no docked/pinned panel) and the iframe selection marker is reset.
+    await waitFor(() => expect(screen.queryByTestId('mock-manual-edit-panel')).toBeNull());
     expect(postMessageSpy).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'od-edit-selected-target', id: null }),
       '*',

--- a/apps/web/tests/components/FileViewer.manual-edit.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit.test.tsx
@@ -20,15 +20,50 @@ describe('FileViewer manual edit regressions', () => {
     fireEvent.click(screen.getByTestId(testId));
   }
 
-  async function hoverManualEditTarget(target = heroTarget()) {
-    const frame = await waitFor(() => {
+  async function previewFrame() {
+    return waitFor(() => {
       const node = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
       if (!node.contentWindow) throw new Error('Preview frame not ready');
       return node;
     });
+  }
+
+  async function hoverManualEditTarget(target = heroTarget()) {
+    const frame = await previewFrame();
     act(() => {
       window.dispatchEvent(new MessageEvent('message', {
         data: { type: 'od-edit-hover', target },
+        source: frame.contentWindow,
+      }));
+    });
+    // Hover only surfaces the affordance; it must not open any panel.
+    await waitFor(() => {
+      expect(screen.getByTestId('manual-edit-hover-open')).toBeTruthy();
+    });
+  }
+
+  // Clicking the empty canvas is the gesture that opens the compact page card.
+  async function clickManualEditBackground() {
+    const frame = await previewFrame();
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'od-edit-background' },
+        source: frame.contentWindow,
+      }));
+    });
+    await waitFor(() => {
+      expect(document.querySelector('.manual-edit-right')).not.toBeNull();
+    });
+  }
+
+  // Hover only surfaces the "edit params" affordance; pinning the inspector to
+  // a target now requires an explicit click (mirrors clicking that affordance
+  // or a container/image body in the bridge).
+  async function selectManualEditTarget(target = heroTarget()) {
+    const frame = await previewFrame();
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'od-edit-select', target },
         source: frame.contentWindow,
       }));
     });
@@ -76,7 +111,7 @@ describe('FileViewer manual edit regressions', () => {
     expect(cancelManualEditPendingStyleSnapshot(otherTargetPending, 'cta', ['fontSize'])).toBe(otherTargetPending);
   });
 
-  it('opens the page edit panel before a target is hovered or selected', async () => {
+  it('opens edit mode with a clean canvas and no docked panel', async () => {
     const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>';
     vi.stubGlobal('fetch', vi.fn(async () =>
       new Response(source, { status: 200, headers: { 'Content-Type': 'text/html' } }),
@@ -89,11 +124,60 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    expect(document.querySelector('.manual-edit-right')).not.toBeNull();
-    expect(screen.getByText('PAGE')).toBeTruthy();
+    // No panel auto-pops; the canvas stays clean.
+    expect(document.querySelector('.manual-edit-right')).toBeNull();
+    expect(screen.queryByText('PAGE')).toBeNull();
 
+    // Hovering surfaces only the click affordance, still no panel.
     await hoverManualEditTarget();
-    expect(document.querySelector('.manual-edit-right')).not.toBeNull();
+    expect(document.querySelector('.manual-edit-right')).toBeNull();
+    expect(screen.queryByText('PAGE')).toBeNull();
+    expect(screen.getByTestId('manual-edit-hover-open')).toBeTruthy();
+  });
+
+  it('opens the compact page-styles card when the empty canvas is clicked', async () => {
+    const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>';
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(source, { status: 200, headers: { 'Content-Type': 'text/html' } }),
+    ));
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={source}
+      />,
+    );
+
+    clickManualTool('manual-edit-mode-toggle');
+    await clickManualEditBackground();
+
+    expect(screen.getByText('PAGE')).toBeTruthy();
+    expect(document.querySelector('.manual-edit-page-card')).not.toBeNull();
+  });
+
+  it('pins the inspector to a target only after clicking the hover affordance', async () => {
+    const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>';
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(source, { status: 200, headers: { 'Content-Type': 'text/html' } }),
+    ));
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={source}
+      />,
+    );
+
+    clickManualTool('manual-edit-mode-toggle');
+    await hoverManualEditTarget();
+    // No panel until the affordance is clicked.
+    expect(document.querySelector('.manual-edit-right')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('manual-edit-hover-open'));
+
+    // Selected target inspector exposes the typography "Size" control.
+    await findStyleInput('Size');
+    expect(screen.queryByText('PAGE')).toBeNull();
+    // Affordance hides once its element is the pinned selection.
+    expect(screen.queryByTestId('manual-edit-hover-open')).toBeNull();
   });
 
   it('does not let a pending manual edit style save survive a file switch', async () => {
@@ -117,7 +201,7 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const baseSizeInput = await findStyleInput('Size');
     fireEvent.change(baseSizeInput, { target: { value: '18' } });
 
@@ -162,7 +246,7 @@ describe('FileViewer manual edit regressions', () => {
         {},
       ));
       fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-      await hoverManualEditTarget();
+      await selectManualEditTarget();
       const baseSizeInput = await findStyleInput('Size');
       fireEvent.change(baseSizeInput, { target: { value: '18' } });
 
@@ -213,7 +297,7 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const baseSizeInput = await findStyleInput('Size');
 
     fireEvent.change(baseSizeInput, { target: { value: '18' } });
@@ -229,7 +313,7 @@ describe('FileViewer manual edit regressions', () => {
     });
   });
 
-  it('closes manual edit without saving when footer cancel is clicked', async () => {
+  it('closes the inspector without saving on cancel, staying in edit mode', async () => {
     const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>';
     const fetchMock = vi.fn(async () =>
       new Response(source, { status: 200, headers: { 'Content-Type': 'text/html' } }),
@@ -243,7 +327,7 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const baseSizeInput = await findStyleInput('Size');
 
     fireEvent.change(baseSizeInput, { target: { value: '18' } });
@@ -252,13 +336,14 @@ describe('FileViewer manual edit regressions', () => {
     await waitFor(() => {
       expect(document.querySelector('.manual-edit-right')).toBeNull();
     });
+    expect(document.querySelector('.manual-edit-workspace')).not.toBeNull();
     expect(fetchMock).not.toHaveBeenCalledWith(
       '/api/projects/project-1/files',
       expect.objectContaining({ method: 'POST' }),
     );
   });
 
-  it('closes manual edit after footer save succeeds', async () => {
+  it('closes the inspector after save succeeds, staying in edit mode', async () => {
     const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>';
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
@@ -279,7 +364,7 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const baseSizeInput = await findStyleInput('Size');
 
     fireEvent.change(baseSizeInput, { target: { value: '18' } });
@@ -292,6 +377,7 @@ describe('FileViewer manual edit regressions', () => {
       );
       expect(document.querySelector('.manual-edit-right')).toBeNull();
     });
+    expect(document.querySelector('.manual-edit-workspace')).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Why

Self-inflicted while editing prototypes with the manual-edit tool: the parameter
panel followed the cursor, so the panel kept swapping under the mouse on every
hover and there was no way to keep one element's settings open long enough to
actually change them. The interaction felt "too loose" — you could see params
but couldn't reliably land on them. This reworks the model to a Figma-like
hover-highlight + click-to-pin flow, and fixes the related oddity that the
panel's close/cancel/save buttons all kicked you out of edit mode entirely.

## What users will see

In an HTML/prototype preview's **Edit** mode:

- **Hovering** an element now only highlights it and fades in a small "edit
  parameters" affordance in its top-right corner — it no longer swaps the
  parameter panel.
- **Clicking** that affordance (or a container/image) **pins** the inspector to
  that element; it stays put until you pick another element or close it.
- **Single-click on text/links** still enters inline text editing as before.
- **Clicking the empty canvas** opens a compact **page styles** card (auto-sized
  to its content) instead of a full-height panel.
- Edit mode now **opens clean** — no panel pops open on toggle.
- The inspector's own buttons are **panel-scoped and never exit edit mode**:
  **close (X)** and **Save** flush the in-flight tweak then collapse the panel,
  **Cancel** reverts the in-flight tweak then collapses it. Leaving edit mode is
  only the toolbar Edit toggle's job (it already flushes on exit).

## Surface area

- [x] **UI** — manual-edit inspector interaction model in `apps/web` (hover affordance, click-to-pin, page-styles card, panel-scoped close/cancel/save)
- [x] **i18n keys** — added `manualEdit.editParams` across all 19 locales
- [ ] **None**

This is a refinement of the existing manual-edit UI surface, not a new
capability, so there is no new `/api/*` endpoint or `od` subcommand to mirror.

## Screenshots

_To attach: Edit mode showing the hover affordance on an element, the pinned
inspector after clicking it, and the page-styles card after clicking the empty
canvas._

## Bug fix verification

Not a single-bug fix, but the new behavior is locked by unit specs:

- `apps/web/tests/components/FileViewer.manual-edit.test.tsx` — edit opens clean, hover only shows the affordance, background click opens the page-styles card, the affordance pins the inspector, and **close/cancel/save collapse the inspector while staying in edit mode**.
- `apps/web/tests/components/FileViewer.manual-edit-history.test.tsx` — exiting edit (via the toolbar toggle) still remounts the srcDoc iframe and drops the edit bridge.

## Validation

- `pnpm guard` — pass (36/36)
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web test tests/components/FileViewer.manual-edit.test.tsx tests/components/FileViewer.manual-edit-history.test.tsx` — 14 passed

Made with [Cursor](https://cursor.com)