### PR TITLE
docs(readme): uniform `od mcp install <agent>` install column (zh + en)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,26 +82,27 @@ It is also the **Figma alternative for the agent era** — instead of pixel-push
 
 ## Platform Compatibility
 
-> Open Design ships as **Skills, CLIs, and an MCP server** that mainstream coding agents consume natively. Install once, then invoke `open-design` (or `od`) from inside any of the agents below — same loop, no UI re-tooling.
+> Open Design ships as **Skills, CLIs, and an MCP server** that mainstream coding agents consume natively. Once Open Design is installed, a single `od mcp install <agent>` wires the MCP server into that agent's config — same loop, no UI re-tooling.
 
 | Platform | Status | Install method |
 |---|---|---|
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ **Native** | Plugin marketplace · `claude plugin install open-design` |
-| [Cursor](https://www.cursor.com/cli) | ✅ Supported | Auto-discovery from `PATH` · Cursor deeplink in **Settings → MCP server** |
-| [VS Code + GitHub Copilot](https://github.com/features/copilot) | ✅ Supported | Auto-discovery from `PATH` |
-| [GitHub Copilot CLI](https://github.com/features/copilot/cli) | ✅ Supported | `od plugin install copilot` |
-| [Codex CLI](https://github.com/openai/codex) | ✅ Supported | `curl -fsSL https://open-design.ai/install.sh \| sh -s codex` |
-| [OpenCode](https://opencode.ai/) | ✅ Supported | `curl -fsSL https://open-design.ai/install.sh \| sh -s opencode` |
-| [OpenClaw](https://github.com/openclaw/openclaw) | ✅ Supported | `curl -fsSL https://open-design.ai/install.sh \| sh -s openclaw` |
-| [Antigravity](https://antigravity.google) | ✅ Supported | `curl -fsSL https://open-design.ai/install.sh \| sh -s antigravity` |
-| Gemini CLI | ✅ Supported | `curl -fsSL https://open-design.ai/install.sh \| sh -s gemini` |
-| [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Supported | `curl -fsSL https://open-design.ai/install.sh \| sh -s pi` |
-| [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Supported | `curl -fsSL https://open-design.ai/install.sh \| sh -s vibe` |
-| [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Supported | `curl -fsSL https://open-design.ai/install.sh \| sh -s hermes` |
-| [Cline](https://github.com/cline/cline) | ✅ Supported | `curl -fsSL https://open-design.ai/install.sh \| sh -s cline` |
-| Kimi CLI | ✅ Supported | `curl -fsSL https://open-design.ai/install.sh \| sh -s kimi` |
-| [Trae](https://www.trae.ai/) | ✅ Supported | `curl -fsSL https://open-design.ai/install.sh \| sh -s trae` |
-| Devin for Terminal · Qwen Code · Qoder CLI · Kiro · Kilo · DeepSeek TUI | ✅ Supported | auto-detected on `PATH`, no setup |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ Supported | `od mcp install claude` |
+| [Codex CLI](https://github.com/openai/codex) | ✅ Supported | `od mcp install codex` |
+| [Cursor](https://www.cursor.com/cli) | ✅ Supported | `od mcp install cursor` |
+| [VS Code + GitHub Copilot](https://github.com/features/copilot) | ✅ Supported | `od mcp install copilot` |
+| [GitHub Copilot CLI](https://github.com/features/copilot/cli) | ✅ Supported | `od mcp install copilot` |
+| Gemini CLI | ✅ Supported | `od mcp install gemini` |
+| [OpenCode](https://opencode.ai/) | ✅ Supported | `od mcp install opencode` |
+| [OpenClaw](https://github.com/openclaw/openclaw) | ✅ Supported | `od mcp install openclaw` |
+| [Antigravity](https://antigravity.google) | ✅ Supported | `od mcp install antigravity` |
+| [Cline](https://github.com/cline/cline) | ✅ Supported | `od mcp install cline` |
+| [Trae](https://www.trae.ai/) | ✅ Supported | `od mcp install trae` |
+| Kimi CLI | ✅ Supported | `od mcp install kimi` |
+| [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Supported | `od mcp install pi` |
+| [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Supported | `od mcp install vibe` |
+| [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Supported | `od mcp install hermes` |
+
+`od mcp install <agent> --print` to preview the change · `--uninstall` to remove · `od mcp install --help` for the full list.
 
 **No CLI installed?** The BYOK proxy at `POST /api/proxy/{anthropic,openai,azure,google,ollama,senseaudio}/stream` is the same loop minus the spawn — paste a `baseUrl` + `apiKey` + `model` for OpenAI, Anthropic, Azure OpenAI, Google Gemini, Ollama, LM Studio, vLLM, or any OpenAI-compatible endpoint. Per-target SSRF guard blocks internal IPs / link-local / CGNAT at the daemon edge.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -118,26 +118,27 @@ Open Design 是这样一种产物：Anthropic 随 Claude Design 推出的 **Agen
 
 ## 平台兼容性
 
-> Open Design 以 **技能、CLI 和 MCP 服务器**的形式交付，主流编码 Agent 可原生消费。安装一次，然后在下方任一 Agent 内调用 `open-design`（或 `od`）——相同的循环，无需重新适配 UI。
+> Open Design 以 **技能、CLI 和 MCP 服务器**的形式交付，主流编码 Agent 可原生消费。装好 OD 后，一行 `od mcp install <agent>` 把 MCP 服务器 wire 进对应 Agent 的配置，任何 Agent 内调用相同工具。
 
 | 平台 | 状态 | 安装方式 |
 |---|---|---|
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ **原生** | `curl -fsSL https://open-design.ai/install.sh \| sh -s claude` |
-| [Cursor](https://www.cursor.com/cli) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s cursor` |
-| [VS Code + GitHub Copilot](https://github.com/features/copilot) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s copilot` |
-| [GitHub Copilot CLI](https://github.com/features/copilot/cli) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s copilot` |
-| [Codex CLI](https://github.com/openai/codex) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s codex` |
-| [OpenCode](https://opencode.ai/) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s opencode` |
-| [OpenClaw](https://github.com/openclaw/openclaw) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s openclaw` |
-| [Antigravity](https://antigravity.google) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s antigravity` |
-| Gemini CLI | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s gemini` |
-| [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s pi` |
-| [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s vibe` |
-| [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s hermes` |
-| [Cline](https://github.com/cline/cline) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s cline` |
-| Kimi CLI | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s kimi` |
-| [Trae](https://www.trae.ai/) | ✅ 支持 | `curl -fsSL https://open-design.ai/install.sh \| sh -s trae` |
-| Devin for Terminal · Qwen Code · Qoder CLI · Kiro · Kilo · DeepSeek TUI | ✅ 支持 | 在 `PATH` 上自动检测，无需配置 |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ 支持 | `od mcp install claude` |
+| [Codex CLI](https://github.com/openai/codex) | ✅ 支持 | `od mcp install codex` |
+| [Cursor](https://www.cursor.com/cli) | ✅ 支持 | `od mcp install cursor` |
+| [VS Code + GitHub Copilot](https://github.com/features/copilot) | ✅ 支持 | `od mcp install copilot` |
+| [GitHub Copilot CLI](https://github.com/features/copilot/cli) | ✅ 支持 | `od mcp install copilot` |
+| Gemini CLI | ✅ 支持 | `od mcp install gemini` |
+| [OpenCode](https://opencode.ai/) | ✅ 支持 | `od mcp install opencode` |
+| [OpenClaw](https://github.com/openclaw/openclaw) | ✅ 支持 | `od mcp install openclaw` |
+| [Antigravity](https://antigravity.google) | ✅ 支持 | `od mcp install antigravity` |
+| [Cline](https://github.com/cline/cline) | ✅ 支持 | `od mcp install cline` |
+| [Trae](https://www.trae.ai/) | ✅ 支持 | `od mcp install trae` |
+| Kimi CLI | ✅ 支持 | `od mcp install kimi` |
+| [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ 支持 | `od mcp install pi` |
+| [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ 支持 | `od mcp install vibe` |
+| [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ 支持 | `od mcp install hermes` |
+
+`od mcp install <agent> --print` 干跑预览 · `--uninstall` 卸载 · 完整清单 `od mcp install --help`。
 
 **未安装任何 CLI？** `POST /api/proxy/{anthropic,openai,azure,google,ollama,senseaudio}/stream` 的 BYOK 代理提供同样的循环（无需 spawn 进程）——粘贴 `baseUrl` + `apiKey` + `model`，支持 OpenAI、Anthropic、Azure OpenAI、Google Gemini、Ollama、LM Studio、vLLM 或任何 OpenAI 兼容端点。每个目标的 SSRF 防护在守护进程边缘拦截内网 IP / link-local / CGNAT。
 


### PR DESCRIPTION
Companion to #3442 (which ships `od mcp install <agent>`).

## What this PR does

Replaces every cell in the **平台兼容性 / Platform Compatibility** table — in both `README.md` and `README.zh-CN.md` — with the same canonical command form: `od mcp install <agent>`.

Before this PR the table mixed four install patterns:

1. `claude plugin install open-design` — claude only, and missing the `@open-design` marketplace qualifier so it wouldn't have actually worked.
2. `od plugin install copilot` — wrong subcommand. The daemon ships `od mcp install`, not `od plugin install`.
3. "Auto-discovery from `PATH`" — cursor / VS Code Copilot. MCP doesn't auto-discover; something has to write the agent's config.
4. `curl -fsSL https://open-design.ai/install.sh \| sh -s <agent>` — 11 agents. But `install.sh` is the bootstrap-source-deploy path being dropped in #3442, and the URL it pointed at served the Next.js index page anyway (Vercel serves `apps/web/out`, not `deploy/scripts/install-agent.sh`).

All 15 supported agents now share the same command form. The dispatch (which agents shell out to a CLI vs deep-merge JSON vs print a manual snippet) is the daemon's business — the readme doesn't need to surface it.

## Other adjustments in the same pass

- Drop the **✅ Native** emphasis from Claude Code. Everything is equally well-supported; no need to single one out.
- Drop the catch-all row **"Devin · Qwen Code · Qoder · Kiro · Kilo · DeepSeek TUI — auto-detected on PATH, no setup"**. None of these are in the `od mcp install` planner's 14-entry `AGENT_SLUGS` — promising "auto-detected on PATH" without a config-writer behind it would mislead readers. When these get planner entries, we add them back honestly.
- Add a trailing one-liner with the `--print` (dry-run) and `--uninstall` flags so readers know they can preview / reverse.
- Reorder so claude / codex / cursor / copilot lead (highest-traffic agents first), then gemini / opencode / openclaw / antigravity, then cline / trae / kimi, then pi / vibe / hermes.

Edits applied to both READMEs so the two stay in sync.

## Verified locally (already in #3442's PR body too)

- `claude plugin marketplace add /path` + `claude plugin install open-design@open-design` against #3442's manifest → plugin enabled, `claude mcp list` shows the entry registered.
- `codex plugin marketplace add /path` + `codex plugin add open-design@open-design` → cache + config wired.
- The `od mcp install` planner has 17/17 vitest pass for the 14-agent routing (existing on #3431/#3442 base).

## Why base `preview/zh-cn-readme-0.8.0`

That's the in-flight readme refresh branch the install-column lives on (commit `f5586e6b4 docs: unify compatibility table install column to sh script format`). This PR stacks on top so the install-column edit goes out with the rest of the preview content; if you'd rather it land on `main` directly, change the base before merge.

## Depends on

- #3442 — `od mcp install <agent>` daemon command. README references it as the canonical install method, so this PR should land at the same time as or after #3442.