### PR TITLE
fix(landing): keep auth redirects on AMR wallet (forward #3415 to main)

### DIFF
--- a/apps/landing-page/public/_redirects
+++ b/apps/landing-page/public/_redirects
@@ -10,6 +10,52 @@
 
 /sitemap.xml /sitemap-index.xml 301
 
+# AMR wallet lives under `/amr`. Social auth callbacks from the wallet can
+# return to locale-prefixed `/wallet` paths (for example `/zh/wallet`) after a
+# logout/register flow; keep those callbacks on the wallet surface instead of
+# falling through to the marketing site.
+# Keep locale-prefixed entries in sync with `app/i18n.ts:LANDING_LOCALES`.
+# Do not replace them with `/:locale/wallet`: that would also match
+# `/amr/wallet` and redirect the wallet URL to itself.
+/wallet          /amr/wallet  302
+/wallet/         /amr/wallet  302
+/en/wallet       /amr/wallet  302
+/en/wallet/      /amr/wallet  302
+/zh/wallet       /amr/wallet  302
+/zh/wallet/      /amr/wallet  302
+/zh-tw/wallet    /amr/wallet  302
+/zh-tw/wallet/   /amr/wallet  302
+/ja/wallet       /amr/wallet  302
+/ja/wallet/      /amr/wallet  302
+/ko/wallet       /amr/wallet  302
+/ko/wallet/      /amr/wallet  302
+/de/wallet       /amr/wallet  302
+/de/wallet/      /amr/wallet  302
+/fr/wallet       /amr/wallet  302
+/fr/wallet/      /amr/wallet  302
+/ru/wallet       /amr/wallet  302
+/ru/wallet/      /amr/wallet  302
+/es/wallet       /amr/wallet  302
+/es/wallet/      /amr/wallet  302
+/pt-br/wallet    /amr/wallet  302
+/pt-br/wallet/   /amr/wallet  302
+/it/wallet       /amr/wallet  302
+/it/wallet/      /amr/wallet  302
+/vi/wallet       /amr/wallet  302
+/vi/wallet/      /amr/wallet  302
+/pl/wallet       /amr/wallet  302
+/pl/wallet/      /amr/wallet  302
+/id/wallet       /amr/wallet  302
+/id/wallet/      /amr/wallet  302
+/nl/wallet       /amr/wallet  302
+/nl/wallet/      /amr/wallet  302
+/ar/wallet       /amr/wallet  302
+/ar/wallet/      /amr/wallet  302
+/tr/wallet       /amr/wallet  302
+/tr/wallet/      /amr/wallet  302
+/uk/wallet       /amr/wallet  302
+/uk/wallet/      /amr/wallet  302
+
 # Locale-code migration: the previous OD landing-page stack used BCP-47
 # region-qualified codes (zh-CN, zh-TW, pt-BR, es-ES) whereas the
 # current bundle adopts the simpler codes the @astrojs/sitemap plugin


### PR DESCRIPTION
## Why

#3415 fixed the AMR wallet social-auth callback by keeping locale-prefixed `/wallet` paths on the wallet surface (`/amr/wallet`) instead of falling through to the marketing site. That PR merged into `release/v0.9.0` only, so the fix is **not on `main`** and the landing-page deploy workflow (`landing-page-deploy.yml`, triggered on push to `main`) has never shipped it to production (`open-design.ai`). This forwards the same `_redirects` change to `main` so it actually deploys.

**Author's use case:** wanted the wallet redirect live on production now, but it was stranded on the release branch.
**Pain addressed:** without this, wallet social-auth logout/register callbacks to `/zh/wallet` etc. fall through to the marketing 404/home instead of returning to the wallet.

## What users will see

No visible UI change on the marketing site itself. Users hitting `/wallet` or any locale-prefixed `/<locale>/wallet` (e.g. `/zh/wallet`) — including AMR wallet social-auth callbacks — get a 302 to `/amr/wallet` instead of falling through to the marketing site.

## What changed

Cherry-pick of `9144c3c` (#3415): adds locale-prefixed `/wallet -> /amr/wallet 302` redirect entries to `apps/landing-page/public/_redirects`. Single-file change, identical to the merged release-branch fix.

## Surface area

- [x] Landing page (`apps/landing-page`)

## Notes

Forward-port to `main` of an already-reviewed-and-merged release fix. Once merged, `landing-page-deploy.yml` deploys to Cloudflare Pages production automatically.