### PR TITLE
fix(web): stop AMR Sign out flicker and resync sign-in on window focus

### DIFF
--- a/apps/web/src/components/AmrLoginPill.tsx
+++ b/apps/web/src/components/AmrLoginPill.tsx
@@ -221,7 +221,20 @@ export function AmrLoginPill({
 
   useEffect(() => {
     setStatus(initialStatus);
-  }, [initialStatus]);
+    // A signed-in status pushed in from the host (e.g. the Settings card
+    // refetching on window focus after an out-of-band login) is authoritative:
+    // clear any stale login error/pending the early-stopped poll left behind so
+    // `accountStatus`, which ranks `errorMessage` above `loggedIn`, doesn't keep
+    // the pill stuck on Authorize.
+    if (initialStatus?.loggedIn) {
+      stopPolling();
+      loginStartedAtRef.current = null;
+      loginPendingRef.current = false;
+      setErrorMessage(null);
+      setPending(null);
+      setCanceledVisible(false);
+    }
+  }, [initialStatus, stopPolling]);
 
   useEffect(() => {
     if (!canceledVisible) return;

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -28,7 +28,6 @@ import type { Locale } from '../i18n';
 import type { Dict } from '../i18n/types';
 import { AgentIcon } from './AgentIcon';
 import { AmrLoginPill } from './AmrLoginPill';
-import { notifyAmrLoginStatusChanged } from './amrLoginPolling';
 import {
   fetchVelaLoginStatus,
   type VelaLoginStatus,
@@ -950,17 +949,14 @@ export function SettingsDialog({
     const hasAmrAgent = agents.some((agent) => agent.id === 'amr' && agent.available);
     if (!hasAmrAgent) return;
     let cancelled = false;
+    // Passive read only. Push the daemon's current status down into the card;
+    // the pill mirrors it via `initialStatus` (and clears any stale login error
+    // when it sees a signed-in status). Do NOT republish the login-state-change
+    // event here — that restarts the pill's poll/pending machine on every focus
+    // and, while the external browser is stealing and returning focus during a
+    // login, ping-pongs the action between "Signing in…" and "Authorize".
     const resyncAmrStatus = () => {
       if (document.visibilityState === 'hidden') return;
-      // Drive any mounted AMR pill to reconcile through its own listener. This
-      // is the only path that clears a stale `errorMessage` left behind when
-      // the in-pill poll gave up early (the `loginInFlight:false` "stopped"
-      // outcome of vela's redirect/wallet hand-off) — the pill ranks
-      // `errorMessage` above `loggedIn`, so pushing a fresh signed-in status in
-      // alone would leave it stuck on Authorize.
-      notifyAmrLoginStatusChanged('status-changed');
-      // Also refresh card-level status directly so the parent stays fresh when
-      // the AMR card isn't the active selection and its pill is unmounted.
       void fetchVelaLoginStatus().then((next) => {
         if (cancelled || !next) return;
         setAmrCardStatus(next);

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -28,6 +28,7 @@ import type { Locale } from '../i18n';
 import type { Dict } from '../i18n/types';
 import { AgentIcon } from './AgentIcon';
 import { AmrLoginPill } from './AmrLoginPill';
+import { notifyAmrLoginStatusChanged } from './amrLoginPolling';
 import {
   fetchVelaLoginStatus,
   type VelaLoginStatus,
@@ -951,6 +952,15 @@ export function SettingsDialog({
     let cancelled = false;
     const resyncAmrStatus = () => {
       if (document.visibilityState === 'hidden') return;
+      // Drive any mounted AMR pill to reconcile through its own listener. This
+      // is the only path that clears a stale `errorMessage` left behind when
+      // the in-pill poll gave up early (the `loginInFlight:false` "stopped"
+      // outcome of vela's redirect/wallet hand-off) — the pill ranks
+      // `errorMessage` above `loggedIn`, so pushing a fresh signed-in status in
+      // alone would leave it stuck on Authorize.
+      notifyAmrLoginStatusChanged('status-changed');
+      // Also refresh card-level status directly so the parent stays fresh when
+      // the AMR card isn't the active selection and its pill is unmounted.
       void fetchVelaLoginStatus().then((next) => {
         if (cancelled || !next) return;
         setAmrCardStatus(next);

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -921,7 +921,13 @@ export function SettingsDialog({
       return;
     }
     let cancelled = false;
-    setAmrCardStatusReady(false);
+    // Refetch in place on every agents refresh, but do NOT flip
+    // `amrCardStatusReady` back to false here. The post-sign-in model-catalog
+    // rescan loop hands down a fresh `agents` array on each retry; tearing the
+    // pill down to the hidden `--placeholder` between the reset and the async
+    // status read made the Sign out action blink out and back on every tick.
+    // Readiness latches true after the first read and only resets when AMR
+    // becomes unavailable (handled above).
     void fetchVelaLoginStatus().then((next) => {
       if (!cancelled) {
         setAmrCardStatus(next);
@@ -930,6 +936,32 @@ export function SettingsDialog({
     });
     return () => {
       cancelled = true;
+    };
+  }, [agents]);
+
+  // Reconcile AMR sign-in state whenever the user returns to the window. The
+  // vela device-login flow completes in an external browser / AMR console; if
+  // the in-pill poll has already timed out (or the login finished fully
+  // out-of-band), the card would otherwise keep showing the stale signed-out
+  // state until Settings is closed and reopened. Refetching on focus /
+  // visibility keeps the signed-in state, email, and Sign out action live.
+  useEffect(() => {
+    const hasAmrAgent = agents.some((agent) => agent.id === 'amr' && agent.available);
+    if (!hasAmrAgent) return;
+    let cancelled = false;
+    const resyncAmrStatus = () => {
+      if (document.visibilityState === 'hidden') return;
+      void fetchVelaLoginStatus().then((next) => {
+        if (cancelled || !next) return;
+        setAmrCardStatus(next);
+      });
+    };
+    window.addEventListener('focus', resyncAmrStatus);
+    document.addEventListener('visibilitychange', resyncAmrStatus);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('focus', resyncAmrStatus);
+      document.removeEventListener('visibilitychange', resyncAmrStatus);
     };
   }, [agents]);
   const [byokPreconditionNotice, setByokPreconditionNotice] = useState<{

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1999,6 +1999,65 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     });
   });
 
+  // Ping-pong regression: an earlier fix resynced on focus by re-publishing the
+  // `od:amr-login-status-change` event, which restarts the pill's poll/pending
+  // machine. While the external browser steals and returns focus during a
+  // login, that kicked the action back and forth between "Signing in…" and
+  // "Authorize". Focus must do a passive status read only — never re-emit the
+  // login-state event.
+  it('does not re-publish the AMR login-state event on window focus', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn: true,
+            loginInFlight: false,
+            profile: 'local',
+            user: { id: 'u1', email: 'amr@example.com' },
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'amr' },
+      { agents: [amrAgent] },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+    expect(await screen.findByRole('button', { name: 'Sign out' })).toBeTruthy();
+
+    const loginEventSpy = vi.fn();
+    window.addEventListener('od:amr-login-status-change', loginEventSpy);
+    const statusReadsBefore = fetchMock.mock.calls.filter(
+      ([input]) => input?.toString() === '/api/integrations/vela/status',
+    ).length;
+
+    window.dispatchEvent(new Event('focus'));
+
+    // The focus handler does a passive status read…
+    await waitFor(() => {
+      const statusReadsAfter = fetchMock.mock.calls.filter(
+        ([input]) => input?.toString() === '/api/integrations/vela/status',
+      ).length;
+      expect(statusReadsAfter).toBeGreaterThan(statusReadsBefore);
+    });
+    // …but must NOT re-publish the login-state machine event.
+    expect(loginEventSpy).not.toHaveBeenCalled();
+    window.removeEventListener('od:amr-login-status-change', loginEventSpy);
+  });
+
   // First-install repro: the agent list is last detected while signed out, so
   // AMR comes back with an empty (fail-closed) model list. The live `vela
   // models` catalog only becomes fetchable AFTER the credential lands, so when

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1932,6 +1932,73 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(screen.getByText('amr@example.com')).toBeTruthy();
   });
 
+  // Error-recovery regression: the in-pill poll gives up early on the
+  // `loginInFlight:false` "stopped" path (vela's redirect/wallet flow hands the
+  // browser off and the spawned child exits before the credential lands),
+  // leaving the pill holding an internal `errorMessage`. Because the pill ranks
+  // `errorMessage` above `loggedIn`, simply pushing a fresh signed-in status
+  // into the card is NOT enough — focus must drive the pill through its own
+  // reconcile listener so the stale error clears and the card flips from
+  // Authorize back to Sign out. A failed launch reproduces the same stuck
+  // error state without waiting on the poll timers.
+  it('reconciles the AMR card to Signed in on focus even after the pill showed a login error', async () => {
+    let loggedIn = false;
+    let startCalls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn,
+            loginInFlight: false,
+            profile: 'local',
+            user: loggedIn ? { id: 'u1', email: 'amr@example.com' } : null,
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/login' && init?.method === 'POST') {
+        startCalls += 1;
+        // Launch fails -> the pill surfaces its compact error state.
+        return new Response(JSON.stringify({ error: 'spawn failed' }), {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'amr' },
+      { agents: [amrAgent] },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Authorize' }));
+
+    // The failed launch leaves the pill in its error state: still Authorize,
+    // no Sign out.
+    await waitFor(() => expect(startCalls).toBe(1));
+    expect(screen.queryByRole('button', { name: 'Sign out' })).toBeNull();
+
+    // Login is finished out-of-band; returning focus must reconcile the card
+    // despite the lingering pill error.
+    loggedIn = true;
+    window.dispatchEvent(new Event('focus'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Sign out' })).toBeTruthy();
+    });
+  });
+
   // First-install repro: the agent list is last detected while signed out, so
   // AMR comes back with an empty (fail-closed) model list. The live `vela
   // models` catalog only becomes fetchable AFTER the credential lands, so when

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1812,6 +1812,126 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(screen.getByText('late@example.com')).toBeTruthy();
   });
 
+  // Flicker regression: the AMR card re-reads `/vela/status` every time the
+  // `agents` prop identity changes (the post-sign-in model-catalog rescan loop
+  // hands down a fresh array on each retry). Resetting `amrCardStatusReady` to
+  // false on each of those refreshes swapped the live pill for the hidden
+  // `--placeholder`, so the Sign out action blinked out and back on every
+  // rescan tick. The card must keep the pill mounted and update status in place.
+  it('keeps the AMR Sign out action mounted across agents-list refreshes (no flicker)', async () => {
+    let statusCalls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/status') {
+        statusCalls += 1;
+        // The first read resolves signed-in. A later read (triggered by an
+        // agents-list refresh) hangs — mimicking vela lagging behind the
+        // credential write — so the card is forced to hold the last known
+        // pill instead of falling back to the placeholder while it waits.
+        if (statusCalls === 1) {
+          return new Response(
+            JSON.stringify({
+              loggedIn: true,
+              loginInFlight: false,
+              profile: 'local',
+              user: { id: 'u1', email: 'amr@example.com' },
+              configPath: '/Users/test/.amr/config.json',
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        }
+        return new Promise<Response>(() => {});
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const sharedProps = {
+      initial: { ...baseConfig, mode: 'daemon' as const, agentId: 'amr' },
+      daemonLive: true,
+      appVersionInfo: null,
+      initialSection: 'execution' as const,
+      onPersist: vi.fn(),
+      onPersistComposioKey: vi.fn(),
+      onClose: vi.fn(),
+      onRefreshAgents: vi.fn<OnRefreshAgents>(),
+    };
+    const { rerender } = render(
+      <SettingsDialog {...sharedProps} agents={[{ ...amrAgent }]} />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+    expect(await screen.findByRole('button', { name: 'Sign out' })).toBeTruthy();
+
+    // A background agents refresh hands down a new array reference. Under the
+    // bug this synchronously tore the pill down to the hidden placeholder.
+    rerender(<SettingsDialog {...sharedProps} agents={[{ ...amrAgent }]} />);
+
+    // No await: the regression is a synchronous swap to `--placeholder` during
+    // the refetch window.
+    expect(screen.getByRole('button', { name: 'Sign out' })).toBeTruthy();
+    expect(
+      document.querySelector('.agent-card-amr-auth--placeholder'),
+    ).toBeNull();
+  });
+
+  // Out-of-band sign-in regression: the vela device-login flow completes in an
+  // external browser / AMR console. If the in-pill poll has already timed out
+  // (or the login was finished fully out-of-band), the card kept showing the
+  // stale signed-out state until Settings was closed and reopened. Returning
+  // focus to the window must reconcile the card without a reopen.
+  it('refreshes AMR sign-in state when the window regains focus after an external login', async () => {
+    let loggedIn = false;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn,
+            loginInFlight: false,
+            profile: 'local',
+            user: loggedIn ? { id: 'u1', email: 'amr@example.com' } : null,
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'amr' },
+      { agents: [amrAgent] },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+    expect(await screen.findByRole('button', { name: 'Authorize' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Sign out' })).toBeNull();
+
+    // The user finishes the login in the external console and returns to Open
+    // Design. Focus alone must reconcile the card.
+    loggedIn = true;
+    window.dispatchEvent(new Event('focus'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Sign out' })).toBeTruthy();
+    });
+    expect(screen.getByText('amr@example.com')).toBeTruthy();
+  });
+
   // First-install repro: the agent list is last detected while signed out, so
   // AMR comes back with an empty (fail-closed) model list. The live `vela
   // models` catalog only becomes fetchable AFTER the credential lands, so when


### PR DESCRIPTION
## Why

- **Use case:** scratching an itch hit while using the AMR (Open Design AMR) local CLI in Settings → Execution mode. Several papercuts on the AMR card surfaced back to back.
- **Pain:**
  1. With AMR selected and signed in, the **Sign out** action constantly flickers. Root cause is web-side, not vela: the `[agents]` effect in `SettingsDialog` reset `amrCardStatusReady` to `false` on *every* `agents` prop change and only restored it after an async `/vela/status` read. The post-sign-in model-catalog rescan loop hands down a fresh `agents` array on each retry, so the live login pill kept being swapped for the hidden `--placeholder` and back — the Sign out button blinked on every tick.
  2. After signing out and re-authorizing, the vela device-login completes in an **external browser / AMR console**. When the in-pill poll has already given up early (the `loginInFlight:false` "stopped" outcome of vela's redirect/wallet hand-off) — or the login finished fully out-of-band — the Settings card stayed on the stale signed-out state until you **closed and reopened Settings**.

## What users will see

- The **Sign out** button on the AMR card no longer flickers while the model catalog is settling after sign-in.
- After finishing AMR login in the external console and returning to Open Design, the Settings card updates to the signed-in state (email + Sign out) on window focus — no need to reopen Settings — and recovers even if the in-pill poll had already surfaced a login error.
- The action no longer ping-pongs between **Signing in…** and **Authorize** while the external browser steals/returns focus during login.

## How it works

- `SettingsDialog`: `amrCardStatusReady` latches `true` after the first `/vela/status` read and only resets when AMR becomes unavailable — refreshes happen in place so the pill never unmounts.
- `SettingsDialog`: a focus / visibilitychange listener does a **passive** `/vela/status` read and pushes it into the card. It deliberately does NOT re-publish the `od:amr-login-status-change` event — doing so restarts the pill's poll/pending machine on every focus and caused the Signing in ⇄ Authorize ping-pong.
- `AmrLoginPill`: when it receives an authoritative signed-in `initialStatus`, it clears any stale `errorMessage`/`pending` left behind by an early-stopped poll, so a focus-driven status push flips it from Authorize back to Sign out without driving the login state machine.

## Surface area

- [x] **UI** — AMR card in Settings → Execution mode → Local CLI
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

No new capability and no API/contract change — this is a pure rendering/reconciliation fix in `apps/web`, so there is no CLI surface to mirror. vela CLI, daemon, and contracts are untouched.

## Bug fix verification

- Test file: `apps/web/tests/components/SettingsDialog.execution.test.tsx`
  - `keeps the AMR Sign out action mounted across agents-list refreshes (no flicker)`
  - `refreshes AMR sign-in state when the window regains focus after an external login`
  - `reconciles the AMR card to Signed in on focus even after the pill showed a login error`
  - `does not re-publish the AMR login-state event on window focus` (ping-pong guard)
- Did the specs go red before each fix and green after? **yes** — each was confirmed red on the unfixed code and green after the change.
- Full `SettingsDialog.execution` + `AmrLoginPill` suites: **122 passed**. `pnpm --filter @open-design/web typecheck` passes; `pnpm guard` passes.
- **Human verification:** ran a local `tools-dev` instance off this branch against a real AMR account and drove sign-out → authorize → external-console completion → return to window. No Sign out flicker, no Signing in ⇄ Authorize ping-pong, and the card reconciled to signed-in on focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)