### PR TITLE
fix: harden local CLI prompt routing

### DIFF
--- a/mocks/scripts/contract-check.sh
+++ b/mocks/scripts/contract-check.sh
@@ -52,10 +52,10 @@ case "$AGENT" in
   claude)   real_bin="$(PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "$MOCKS_DIR/bin" | paste -sd: -) command -v claude || true)" ;;
   codex)    real_bin="$(PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "$MOCKS_DIR/bin" | paste -sd: -) command -v codex  || true)" ;;
   opencode) real_bin="$(PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "$MOCKS_DIR/bin" | paste -sd: -) command -v opencode || true)" ;;
-  *) echo "✗ unsupported agent for contract check: $AGENT" >&2; exit 2 ;;
+  *) echo "x unsupported agent for contract check: $AGENT" >&2; exit 2 ;;
 esac
 if [ -z "$real_bin" ]; then
-  echo "✗ real '$AGENT' CLI not on PATH. Install + login, then re-run." >&2
+  echo "x real '$AGENT' CLI not on PATH. Install + login, then re-run." >&2
   exit 1
 fi
 echo "real CLI:  $real_bin"
@@ -63,7 +63,7 @@ echo "prompt:    $PROMPT"
 echo
 
 # 1. Real CLI
-echo "→ invoking real $AGENT…"
+echo "-> invoking real $AGENT..."
 case "$AGENT" in
   claude)
     printf '%s' "$PROMPT" | "$real_bin" -p --output-format=stream-json --verbose >"$real_out" 2>&1 || true ;;
@@ -78,7 +78,7 @@ esac
 # and silently send an empty string to the mock — defeating the
 # "same input on both sides" property the rest of the script relies on.
 # A subshell scopes the PATH override locally, no var-passing dance.
-echo "→ invoking mock $AGENT…"
+echo "-> invoking mock $AGENT..."
 (
   export PATH="$MOCKS_DIR/bin:$PATH"
   export OD_MOCKS_NO_DELAY=1
@@ -94,7 +94,7 @@ echo "→ invoking mock $AGENT…"
 
 # 3. Compare top-level event `type` distributions (skip content)
 summarize() {
-  jq -r 'try .type catch empty' "$1" 2>/dev/null | sort | uniq -c | sort -rn || true
+  awk '/^[[:space:]]*\{/' "$1" | jq -r 'try .type catch empty' 2>/dev/null | sort | uniq -c | sort -rn || true
 }
 real_summary=$(summarize "$real_out")
 mock_summary=$(summarize "$mock_out")
@@ -109,5 +109,5 @@ echo
 echo "raw outputs kept at:"
 echo "  real: $real_out"
 echo "  mock: $mock_out"
-echo "(diff manually — `diff <(jq -r .type $real_out|sort -u) <(jq -r .type $mock_out|sort -u)`)"
+echo "(diff manually — `diff <(awk '/^[[:space:]]*\\{/' "$real_out" | jq -r .type | sort -u) <(awk '/^[[:space:]]*\\{/' "$mock_out" | jq -r .type | sort -u)`)"
 trap - EXIT   # leave the tmpfiles for the maintainer to inspect

--- a/packages/contracts/src/prompts/discovery.ts
+++ b/packages/contracts/src/prompts/discovery.ts
@@ -13,7 +13,7 @@
  *                · brand value "brand_spec" / "reference_match"
  *                                              →  brand-spec extraction (Bash + Read), then TodoWrite
  *                · otherwise                   →  TodoWrite directly
- *   Turn 3+ →  work the plan, show progress live, build, self-check, emit <artifact>.
+ *   Turn 3+ →  work the plan, show progress live, build, self-check, emit <artifact> if a new canonical HTML was written this turn (skip on edits-only).
  *
  * Distilled from alchaincyf/huashu-design (Junior-Designer mode,
  * variations-not-answers, anti-AI-slop, embody-the-specialist) and
@@ -42,12 +42,12 @@ Active design system exception: if a later section in this same system prompt is
 When the user opens a new project or sends a fresh design brief, your **very first output** is one short prose line + a \`<question-form>\` block. Nothing else. No file reads. No Bash. No TodoWrite. No extended thinking. The form is your time-to-first-byte.
 Match the user's chat language. When the user is writing in non-English, every label, title, placeholder, and option label in the form must be in their language. The example form below uses English text for reference; replace each user-facing string with its localized equivalent before emitting.
 
-Default-router exception: when the Active plugin / Active skill is \`od-default\` or "Default design router", replace the generic \`discovery\` form with the exact \`<question-form id="task-type">\` form below on turn 1. Do not rename, tailor, drop, reorder, or rewrite these task type options; the user did not choose a Home chip yet, so this form is the missing chip selection. After the user answers \`[form answers — task-type]\`, treat the chosen task type as the route, then continue with the normal discovery / plan / generate / critique flow for that type.
+Default-router exception: when the Active plugin / Active skill is \`od-default\` or "Default design router", replace the generic \`discovery\` form with the exact \`<question-form id="task-type">\` form below on turn 1. Do not rename, tailor, drop, reorder, or rewrite the \`taskType\` options; the user did not choose a Home chip yet, so this form is the missing chip selection. This form is intentionally a **single-shot brief** — it asks the routing question (\`taskType\`) and the core discovery fields (audience, brand, scale, constraints) in one batch so the user only sees one clarification card. After the user answers \`[form answers — task-type]\`, treat the chosen task type as the route and **do NOT emit a second \`<question-form id="discovery">\` / "Quick brief — 30 seconds" form** for that turn — the brief is already locked. Proceed directly to RULE 2 (treating the submitted \`brand\` value the same way as a \`discovery\` answer) and then RULE 3.
 
 \`\`\`
 <question-form id="task-type" title="Choose the task type">
 {
-  "description": "I will route the free-form prompt through the right Open Design workflow.",
+  "description": "I'll route this through the right Open Design workflow and lock the brief in one shot. Skip what doesn't apply — I'll fill defaults.",
   "questions": [
     {
       "id": "taskType",
@@ -64,6 +64,28 @@ Default-router exception: when the Active plugin / Active skill is \`od-default\
         "Audio",
         "Other"
       ]
+    },
+    {
+      "id": "audience",
+      "label": "Who is this for?",
+      "type": "text",
+      "placeholder": "Target user, buyer, viewer, or audience..."
+    },
+    {
+      "id": "brand",
+      "label": "Brand context",
+      "type": "radio",
+      "options": [
+        { "label": "Pick a direction for me", "value": "pick_direction" },
+        { "label": "I have a brand spec — I'll share it", "value": "brand_spec" },
+        { "label": "Match a reference site / screenshot — I'll attach it", "value": "reference_match" }
+      ]
+    },
+    {
+      "id": "scale",
+      "label": "Roughly how much?",
+      "type": "text",
+      "placeholder": "e.g. 8 slides, 1 landing + 3 sub-pages, 4 mobile screens, 30s video"
     },
     {
       "id": "constraints",
@@ -84,7 +106,7 @@ Default-router exception: when the Active plugin / Active skill is \`od-default\
     { "id": "output", "label": "What are we making?", "type": "radio", "required": true,
       "options": ["Slide deck / pitch", "Single web prototype / landing", "Multi-screen app prototype", "Dashboard / tool UI", "Editorial / marketing page", "Other — I'll describe"] },
     { "id": "platform", "label": "Target platform", "type": "checkbox", "maxSelections": 4,
-      "options": ["Responsive web", "Desktop web", "iOS app", "Android app", "Tablet", "Desktop app", "Fixed canvas (1920×1080)"] },
+      "options": ["Responsive web", "Desktop web", "iOS app", "Android app", "Tablet app", "Desktop app", "Fixed canvas (1920×1080)"] },
     { "id": "audience", "label": "Who is this for?", "type": "text",
       "placeholder": "e.g. early-stage investors, dev-tools buyers, internal exec review" },
     { "id": "tone", "label": "Visual tone", "type": "checkbox", "maxSelections": 2,
@@ -131,7 +153,7 @@ When skipping the form, do not skip brand-source handling: if the current messag
 
 ## RULE 2 — turn 2 branches on the \`brand\` answer, but never asks for visual direction again
 
-Once the user submits the discovery form (their next message starts with \`[form answers — discovery]\`) or the initial brief already answered the brand question, resolve the branch in this order:
+Once the user submits the discovery form (their next message starts with \`[form answers — discovery]\` or \`[form answers — task-type]\`) or the initial brief already answered the brand question, resolve the branch in this order:
 
 1. If the current message, attachments, prior brief, or URL already contains an actual brand spec / brand guide / reference site / screenshot source, use Branch A.
 2. Otherwise, look at the submitted \`brand\` value. When the answer line includes \`[value: ...]\`, use that stable value instead of the visible label.
@@ -161,6 +183,12 @@ Skip directly to RULE 3. Do **not** emit any second direction-picking form and d
 
 ---
 
+## Artifact emission is conditional (dominant-layer invariant)
+
+Emit \`<artifact>\` **only when this turn wrote a new canonical HTML file**. If this turn only edited an existing HTML file — or the body would be prose / summary / file-path / bash-output rather than a complete \`<!doctype html>\` document — do **not** emit \`<artifact>\`; summarize the changed file instead. This invariant overrides any \`emit <artifact>\` step that appears later in this prompt; see "Artifact handoff" in the base charter for the full no-emit rationale and rules.
+
+---
+
 ## RULE 3 — TodoWrite the plan, then live updates
 
 Once the design-system / inferred direction / brand-spec is locked, your **first tool call** is TodoWrite with a plan of short imperative items covering the work, in the order you'll do them. The chat renders this as a live "Todos" card — it is the user's primary way to see your plan and redirect cheaply. (No numeric cap — the TodoWrite schema is unbounded and complex briefs legitimately need more than ten steps.)
@@ -178,7 +206,7 @@ The standard plan template (adapt the middle steps to the brief):
 - 6.  Replace [REPLACE] placeholders with real, specific copy from the brief
 - 7.  Self-check: run references/checklist.md (P0 must all pass)
 - 8.  Critique: 5-dim radar (philosophy / hierarchy / execution / specificity / restraint), fix any < 3/5
-- 9.  Emit single <artifact>
+- 9.  Emit single <artifact> if a new canonical HTML file was written this turn; otherwise summarize the edits
 \`\`\`
 
 **Decks especially — framework first, content second.** For \`kind=deck\` projects, step 4 is the load-bearing one: copy the deck framework HTML (the active skill's \`assets/template.html\`, or, if no skill is bound, the canonical skeleton in the deck-mode directive at the bottom of this prompt) **verbatim** before authoring any slide content. Do NOT write your own scale-to-fit logic, keyboard handler, slide visibility toggle, counter, or print stylesheet — every freeform attempt at this re-introduces the same iframe positioning / scaling bugs we have already fixed in the framework. Your job is to drop the framework in, bind the palette, then fill the \`<section class="slide">\` slots. That's it.

--- a/packages/contracts/src/prompts/system.ts
+++ b/packages/contracts/src/prompts/system.ts
@@ -226,6 +226,13 @@ export function composeSystemPrompt({
   // wording later in the official base prompt.
   const parts: string[] = [];
   const activeDesignSystemBody = designSystemBody?.trim();
+  const isMediaSurfaceEarly =
+    skillMode === 'image' ||
+    skillMode === 'video' ||
+    skillMode === 'audio' ||
+    metadata?.kind === 'image' ||
+    metadata?.kind === 'video' ||
+    metadata?.kind === 'audio';
 
   // API/BYOK mode (streamFormat === 'plain'): no tools are wired through
   // to the model, but the discovery layer + base prompt below still tell
@@ -251,11 +258,11 @@ export function composeSystemPrompt({
     parts.push('\n\n---\n\n');
   }
 
-  parts.push(
-    DISCOVERY_AND_PHILOSOPHY,
-    '\n\n---\n\n# Identity and workflow charter (background)\n\n',
-    BASE_SYSTEM_PROMPT,
-  );
+  if (!isMediaSurfaceEarly) {
+    parts.push(DISCOVERY_AND_PHILOSOPHY, '\n\n---\n\n');
+  }
+
+  parts.push('# Identity and workflow charter (background)\n\n', BASE_SYSTEM_PROMPT);
 
   // Mirrors the daemon-side composer in apps/daemon/src/prompts/system.ts —
   // keep both copies of this preamble in sync so a CLI chat and a BYOK
@@ -347,14 +354,7 @@ export function composeSystemPrompt({
     );
   }
 
-  const isMediaSurface =
-    skillMode === 'image' ||
-    skillMode === 'video' ||
-    skillMode === 'audio' ||
-    metadata?.kind === 'image' ||
-    metadata?.kind === 'video' ||
-    metadata?.kind === 'audio';
-  if (isMediaSurface) {
+  if (isMediaSurfaceEarly) {
     parts.push(MEDIA_GENERATION_CONTRACT);
   }
 

--- a/packages/contracts/tests/system-prompt.test.ts
+++ b/packages/contracts/tests/system-prompt.test.ts
@@ -33,6 +33,40 @@ describe('DISCOVERY_AND_PHILOSOPHY (contracts copy) — TodoWrite plan item coun
   });
 });
 
+describe('DISCOVERY_AND_PHILOSOPHY (contracts copy) — prompt routing parity', () => {
+  it('uses the single-shot task-type form shape from the daemon prompt', () => {
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('<question-form id="task-type"');
+    for (const id of ['taskType', 'audience', 'brand', 'scale', 'constraints']) {
+      expect(DISCOVERY_AND_PHILOSOPHY).toContain(`"id": "${id}"`);
+    }
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain(
+      'This form is intentionally a **single-shot brief**',
+    );
+    expect(DISCOVERY_AND_PHILOSOPHY).toMatch(
+      /do NOT emit a second `<question-form id="discovery">` \/ "Quick brief — 30 seconds" form/,
+    );
+  });
+
+  it('routes task-type form answers through the same RULE 2 / RULE 3 path as discovery answers', () => {
+    expect(DISCOVERY_AND_PHILOSOPHY).toMatch(
+      /\[form answers — discovery\][^.]*\[form answers — task-type\]/,
+    );
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain(
+      'Proceed directly to RULE 2 (treating the submitted `brand` value the same way as a `discovery` answer) and then RULE 3.',
+    );
+  });
+
+  it('keeps artifact emission conditional on writing a new canonical HTML file', () => {
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain('## Artifact emission is conditional');
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain(
+      'only when this turn wrote a new canonical HTML file',
+    );
+    expect(DISCOVERY_AND_PHILOSOPHY).toContain(
+      'If this turn only edited an existing HTML file',
+    );
+  });
+});
+
 describe('composeSystemPrompt', () => {
   it('injects Chinese quick brief guidance when the UI locale is zh-CN', () => {
     const prompt = composeSystemPrompt({ locale: 'zh-CN' });
@@ -113,5 +147,19 @@ describe('composeSystemPrompt', () => {
     expect(prompt.indexOf('## Active design system visual direction')).toBeGreaterThan(
       prompt.indexOf('### direction-picker'),
     );
+  });
+
+  it('does not include the HTML discovery layer for media surfaces', () => {
+    const prompt = composeSystemPrompt({
+      metadata: {
+        kind: 'image',
+        imageModel: 'fal/imagen4',
+        imageAspect: '16:9',
+      } as any,
+    });
+
+    expect(prompt).not.toContain('# OD core directives');
+    expect(prompt).not.toContain('<question-form id="discovery"');
+    expect(prompt).toContain('## Media generation contract');
   });
 });


### PR DESCRIPTION
Refs #3390

## Why

I opened this as the follow-up to the Antigravity log-order work because the remaining issue is broader than one adapter: same-chat runs can still be steered back toward the generic default discovery path when the user already selected a Home chip/plugin/scenario or answered the default task-type router.

The pain being addressed is prompt-routing drift. The daemon prompt had the newer invariants for task-type answers, media-surface discovery skipping, and conditional artifact emission, while the contracts composer used by web/BYOK paths still carried older wording. That split makes follow-up turns easier to regress because the same user intent can be composed differently depending on the entrypoint.

## What users will see

Users who start from the default Home router should get one task-type brief that also captures audience, brand, scale, and constraints, then the next turn proceeds from that route instead of asking the generic Quick brief again. Media projects created as image/video/audio avoid the HTML discovery layer and stay on the media generation contract.

Existing HTML edit/tweak turns should be less likely to re-emit artifact wrappers when the turn only edits or summarizes an existing file.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `packages/contracts/tests/system-prompt.test.ts`
- Did the test go red on `main` and green on this branch? yes. The new prompt-routing parity specs failed before the contracts prompt alignment and pass after it.
- Additional verification: daemon prompt/runtime tests and mock CLI smoke coverage below.

## Validation

- `pnpm --filter @open-design/contracts test tests/system-prompt.test.ts`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/daemon test tests/prompts tests/telemetry-message-finalization.test.ts tests/runtimes/agent-args.test.ts`
- `pnpm --filter @open-design/daemon test tests/mocks-golden.test.ts tests/structured-streams.test.ts tests/json-event-stream.test.ts`
- `pnpm --filter @open-design/daemon test tests/prompts tests/telemetry-message-finalization.test.ts tests/runtimes/agent-args.test.ts tests/mocks-golden.test.ts tests/structured-streams.test.ts tests/json-event-stream.test.ts`
- `pnpm --filter @open-design/daemon build`
- `bash mocks/scripts/fetch-recordings.sh`
- `bash mocks/scripts/smoke-test.sh`
- `bash mocks/scripts/contract-check.sh claude`
- `bash mocks/scripts/contract-check.sh codex`
- `bash mocks/scripts/contract-check.sh opencode`
- `pnpm guard`
- `pnpm typecheck`

Notes: this machine is currently on Node v26.0.0, so pnpm prints the repo engine warning (`node: ~24`) on every command. The commands above still completed successfully. Direct `contract-check` summaries show Claude as JSON stream-compatible with a live-only `rate_limit_event`; direct Codex/OpenCode invocations are plain text in that script mode, while their replay protocol surfaces are covered by the mock smoke and daemon stream tests.
