### PR TITLE
fix(web,landing): remove overlay icons from all card variants (#3203)

### DIFF
--- a/apps/landing-page/app/_components/template-card.astro
+++ b/apps/landing-page/app/_components/template-card.astro
@@ -161,22 +161,5 @@ const isVideoPreview = record.previewType === 'video' && record.previewVideo;
 
   <div class="tpl-actions">
     <a class="tpl-cta" href={detailHref}>{pcopy.cardUseTemplate}</a>
-    <button
-      type="button"
-      class="tpl-share"
-      data-tpl-card-share
-      data-share-text={shareText}
-      data-share-url={shareUrl}
-      data-share-title={name}
-      aria-label={pcopy.cardShareAria(name)}
-    >
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <circle cx="18" cy="5" r="3" />
-        <circle cx="6" cy="12" r="3" />
-        <circle cx="18" cy="19" r="3" />
-        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-        <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
-      </svg>
-    </button>
   </div>
 </article>

--- a/apps/landing-page/app/sub-pages.css
+++ b/apps/landing-page/app/sub-pages.css
@@ -1972,9 +1972,7 @@ body.sub-page {
 }
 
 .tpl-actions {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 10px;
+  display: block;
 }
 .tpl-cta {
   display: flex;
@@ -1992,19 +1990,6 @@ body.sub-page {
   transition: background 0.16s ease;
 }
 .tpl-cta:hover { background: var(--coral); border-color: var(--coral); }
-.tpl-share {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
-  background: var(--bone);
-  color: var(--ink);
-  border: 1.5px solid var(--ink);
-  cursor: pointer;
-  transition: background 0.16s ease;
-}
-.tpl-share:hover { background: var(--paper-warm); }
 
 /*
  * ─── FAQ section (YouMind-style accordion) ─────────────────────

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1168,7 +1168,6 @@ export const HomeHero = forwardRef<HTMLTextAreaElement, Props>(function HomeHero
                 onClick={() => usePromptExample(example)}
               >
                 <span>{example}</span>
-                <Icon name="external-link" size={14} aria-hidden />
               </button>
             ))}
           </div>

--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -8,7 +8,6 @@
 
 import { useEffect, useState } from 'react';
 import type { MediaPreviewSpec } from '../preview';
-import { Icon } from '../../Icon';
 
 interface Props {
   preview: MediaPreviewSpec;
@@ -50,7 +49,7 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
           onError={() => setPosterLoadFailed(true)}
         />
       ) : useFallback ? (
-        <MediaFallback pluginTitle={pluginTitle} mediaType={preview.mediaType} />
+        <MediaFallback pluginTitle={pluginTitle} />
       ) : (
         <div
           className={`plugins-home__media-skeleton${inView ? ' is-active' : ''}`}
@@ -73,21 +72,15 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
 }
 
 function MediaFallback({
-  mediaType,
   pluginTitle,
 }: {
-  mediaType: MediaPreviewSpec['mediaType'];
   pluginTitle: string;
 }) {
   const trimmed = pluginTitle.trim();
   const glyph = String.fromCodePoint(trimmed.codePointAt(0) ?? 0x2022).toUpperCase();
-  const icon = mediaType === 'video' ? 'play' : mediaType === 'audio' ? 'mic' : 'image';
   return (
     <div className="plugins-home__media-fallback" aria-hidden>
       <span className="plugins-home__media-fallback-glyph">{glyph}</span>
-      <span className="plugins-home__media-fallback-icon">
-        <Icon name={icon} size={15} />
-      </span>
     </div>
   );
 }

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -1845,11 +1845,8 @@
   appearance: none;
   min-width: 0;
   min-height: 112px;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  grid-template-rows: minmax(0, 1fr) auto;
-  align-items: start;
-  gap: 8px;
+  display: flex;
+  align-items: flex-start;
   padding: 12px;
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -1869,18 +1866,8 @@
     box-shadow 140ms ease;
 }
 .home-hero__prompt-example span {
-  grid-column: 1 / -1;
-  align-self: start;
   min-width: 0;
   overflow-wrap: anywhere;
-}
-.home-hero__prompt-example svg {
-  grid-column: 2;
-  grid-row: 2;
-  align-self: end;
-  justify-self: end;
-  color: var(--text-faint);
-  transition: color 140ms ease, transform 140ms ease;
 }
 .home-hero__prompt-example:hover,
 .home-hero__prompt-example:focus-visible {
@@ -1890,11 +1877,6 @@
   color: var(--text-strong);
   transform: translateY(-1px);
   box-shadow: var(--shadow-sm);
-}
-.home-hero__prompt-example:hover svg,
-.home-hero__prompt-example:focus-visible svg {
-  color: var(--accent);
-  transform: translate(1px, -1px);
 }
 
 .home-hero__plugin-presets-wrap {

--- a/apps/web/src/styles/home/plugins-home.css
+++ b/apps/web/src/styles/home/plugins-home.css
@@ -494,21 +494,6 @@
   line-height: 1;
   opacity: 0.86;
 }
-.plugins-home__media-fallback-icon {
-  position: absolute;
-  right: 10px;
-  bottom: 10px;
-  width: 28px;
-  height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--bg-panel) 74%, transparent);
-  color: var(--accent);
-  box-shadow: var(--shadow-xs);
-}
 @keyframes plugins-home-shimmer {
   to {
     background-position: -200% 0, 0 0;


### PR DESCRIPTION
Fixes #3203

## Summary

Fixes #3203 — three separate card surfaces all had an absolutely-positioned icon in the bottom-right corner that obscured the card's text content. This PR removes all three in one shot.

### Surface 1 — Landing-page template cards (`apps/landing-page`)
- **Removed** the `<button class="tpl-share">` element from `template-card.astro`
- **Simplified** `.tpl-actions` from `display:grid; grid-template-columns: 1fr auto` → `display:block`
- **Deleted** the now-dead `.tpl-share` and `.tpl-share:hover` CSS rules from `sub-pages.css`

### Surface 2 — Plugin-home media-fallback cards (`apps/web`)
- **Removed** the `<span class="plugins-home__media-fallback-icon">` overlay from `MediaSurface.tsx`
- **Deleted** the `.plugins-home__media-fallback-icon { position:absolute; right:10px; bottom:10px … }` rule from `plugins-home.css`
- **Cleaned up** unused `icon` variable, `mediaType` prop, and the now-unreferenced `Icon` import

### Surface 3 — HomeHero prompt-example cards (`apps/web`)
- **Removed** `<Icon name="external-link" size={14} aria-hidden />` from `HomeHero.tsx`
- **Converted** `.home-hero__prompt-example` layout from `display:grid` (2-col, 2-row) → `display:flex; align-items:flex-start`
- **Deleted** orphaned `.home-hero__prompt-example svg` and `:hover svg` / `:focus-visible svg` rules from `home-hero.css`

## Why

Three card surfaces across `apps/web` and `apps/landing-page` had absolutely-positioned icons rendered in the bottom-right corner that overlapped card text content. Three independent PRs (#3211, #3369, #3433) each address one surface; this PR bundles all three so #3203 can be fully resolved in a single merge without cross-branch coordination.

## What users will see

- Home page prompt-example cards display their full text without an external-link icon overlaid in the bottom-right corner
- Plugin gallery media-fallback tiles no longer show a corner badge icon
- Landing-page template cards show only the CTA button — no share icon in the corner

## Surface area

- [x] **UI** — changes to `apps/web` components (`HomeHero.tsx`, `MediaSurface.tsx`) and `apps/landing-page` (`template-card.astro`) plus associated CSS
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, etc.
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before/after screenshots not attached — the change is removal of a DOM element; the "after" state is cards without the corner icon. Visual verification was done manually against all three surfaces (see Bug fix verification below).

## Bug fix verification

These are pure CSS layout / DOM-presence fixes with no branching logic, so a failing unit test is not the cheapest verification path.

- Reproduced the overlapping icon on `main` on all three surfaces in a standard 1280 px viewport — the icon sat over the card text in the bottom-right corner in each case
- Applied this branch and confirmed the icon is absent on Home prompt-example cards, plugin gallery media-fallback tiles, and landing-page template cards
- Confirmed hover and focus-visible states still apply correctly with no visual regression

## Validation

- `pnpm typecheck` — exit 0, no type errors (verified locally)
- Manual visual check across all three surfaces: Home page (`/`), plugin gallery (`/plugins`), landing-page template gallery

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] Visit Home page → prompt example cards show text without any SVG icon overlay
- [ ] Visit plugin gallery → media-fallback tiles show centered glyph only, no corner badge
- [ ] Visit landing-page template gallery → template cards show CTA button only, no share icon overlay
- [ ] Hover states on all three card types still work correctly