### PR TITLE
fix(runtime): handle Gemini stream-json tool events

### DIFF
--- a/apps/daemon/src/diagnostics-export.ts
+++ b/apps/daemon/src/diagnostics-export.ts
@@ -1,5 +1,6 @@
 import { homedir, userInfo } from 'node:os';
-import { dirname } from 'node:path';
+import { readdir, stat } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 
 import type { RequestHandler } from 'express';
 
@@ -29,9 +30,13 @@ export interface DiagnosticsHandlerOptions {
   runtime: SidecarRuntimeContext<SidecarStamp> | null;
   /** Project root used to derive crash-report match strings. */
   projectRoot: string;
+  /** Directory containing per-run event logs at <runsDir>/<runId>/events.jsonl. */
+  runsDir?: string | null;
 }
 
 const TAIL_BYTES_PER_LOG = 4 * 1024 * 1024;
+const TAIL_BYTES_PER_RUN_EVENT_LOG = 2 * 1024 * 1024;
+const MAX_RUN_EVENT_LOGS = 20;
 
 function safeUsername(): string | undefined {
   try {
@@ -88,11 +93,46 @@ function buildSidecarLogSources(runtime: SidecarRuntimeContext<SidecarStamp> | n
   return sources;
 }
 
+async function buildRunEventLogSources(runsDir: string | null | undefined): Promise<LogSource[]> {
+  if (!runsDir) return [];
+  let entries;
+  try {
+    entries = await readdir(runsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const candidates: Array<{ runId: string; absolutePath: string; mtimeMs: number }> = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!/^[A-Za-z0-9._-]+$/u.test(entry.name)) continue;
+    const absolutePath = join(runsDir, entry.name, 'events.jsonl');
+    try {
+      const info = await stat(absolutePath);
+      if (!info.isFile()) continue;
+      candidates.push({ runId: entry.name, absolutePath, mtimeMs: info.mtimeMs });
+    } catch {
+      continue;
+    }
+  }
+
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return candidates.slice(0, MAX_RUN_EVENT_LOGS).map(({ runId, absolutePath }) => ({
+    name: `runs/${runId}/events.jsonl`,
+    absolutePath,
+    kind: 'text',
+    tailBytes: TAIL_BYTES_PER_RUN_EVENT_LOG,
+  }));
+}
+
 export function createDiagnosticsExportHandler(options: DiagnosticsHandlerOptions): RequestHandler {
   return async (_req, res) => {
     try {
       const versionInfo = await readCurrentAppVersionInfo().catch(() => null);
-      const sources = buildSidecarLogSources(options.runtime);
+      const sources = [
+        ...buildSidecarLogSources(options.runtime),
+        ...(await buildRunEventLogSources(options.runsDir)),
+      ];
       const username = safeUsername();
       const home = homedir();
 

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -226,6 +226,10 @@ function handleGeminiEvent(obj: unknown, onEvent: StreamEventHandler): boolean {
     return true;
   }
 
+  if (obj.type === 'message' && obj.role === 'user') {
+    return true;
+  }
+
   if (
     obj.type === 'message' &&
     obj.role === 'assistant' &&
@@ -236,7 +240,54 @@ function handleGeminiEvent(obj: unknown, onEvent: StreamEventHandler): boolean {
     return true;
   }
 
-  if (obj.type === 'result' && isRecord(obj.stats)) {
+  if (
+    obj.type === 'tool_use' &&
+    typeof obj.tool_id === 'string' &&
+    typeof obj.tool_name === 'string'
+  ) {
+    onEvent({
+      type: 'tool_use',
+      id: obj.tool_id,
+      name: obj.tool_name,
+      input: safeParseJson(obj.parameters) ?? obj.parameters ?? null,
+    });
+    return true;
+  }
+
+  if (obj.type === 'tool_result' && typeof obj.tool_id === 'string') {
+    const error = isRecord(obj.error) ? obj.error : null;
+    const errorMessage = error ? extractErrorMessage(error, '') : '';
+    const output = typeof obj.output === 'string'
+      ? obj.output
+      : errorMessage || stringifyContent(obj.output);
+    onEvent({
+      type: 'tool_result',
+      toolUseId: obj.tool_id,
+      content: output,
+      isError: obj.status === 'error' || Boolean(error),
+    });
+    return true;
+  }
+
+  if (obj.type === 'error') {
+    onEvent({
+      type: 'status',
+      label: typeof obj.severity === 'string' && obj.severity ? obj.severity : 'warning',
+      detail: extractErrorMessage(obj.message ?? obj.error, 'Gemini CLI warning'),
+    });
+    return true;
+  }
+
+  if (obj.type === 'result') {
+    if (obj.status === 'error' || isRecord(obj.error)) {
+      onEvent({
+        type: 'error',
+        message: extractErrorMessage(obj.error, 'Gemini CLI error'),
+        raw: stringifyContent(obj),
+      });
+      return true;
+    }
+    if (!isRecord(obj.stats)) return true;
     const usage: Usage = {};
     if (typeof obj.stats.input_tokens === 'number') usage.input_tokens = obj.stats.input_tokens;
     if (typeof obj.stats.output_tokens === 'number') usage.output_tokens = obj.stats.output_tokens;

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -270,11 +270,16 @@ function handleGeminiEvent(obj: unknown, onEvent: StreamEventHandler): boolean {
   }
 
   if (obj.type === 'error') {
-    onEvent({
-      type: 'status',
-      label: typeof obj.severity === 'string' && obj.severity ? obj.severity : 'warning',
-      detail: extractErrorMessage(obj.message ?? obj.error, 'Gemini CLI warning'),
-    });
+    const severity = typeof obj.severity === 'string' ? obj.severity.toLowerCase() : '';
+    const message = extractErrorMessage(
+      obj.message ?? obj.error,
+      severity === 'warning' ? 'Gemini CLI warning' : 'Gemini CLI error',
+    );
+    if (severity === 'warning') {
+      onEvent({ type: 'status', label: 'warning', detail: message });
+    } else {
+      onEvent({ type: 'error', message, raw: stringifyContent(obj) });
+    }
     return true;
   }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4783,7 +4783,11 @@ export async function startServer({
   app.get(
     DIAGNOSTICS_EXPORT_PATH,
     requireLocalDaemonRequest,
-    createDiagnosticsExportHandler({ runtime, projectRoot: PROJECT_ROOT }),
+    createDiagnosticsExportHandler({
+      runtime,
+      projectRoot: PROJECT_ROOT,
+      runsDir: path.join(RUNTIME_DATA_DIR, 'runs'),
+    }),
   );
 
   // ---- Projects (DB-backed) -------------------------------------------------
@@ -11635,7 +11639,11 @@ export async function startServer({
         return `tool_use:${name}`;
       }
       if (type === 'text_delta' || type === 'thinking_delta') {
-        const text = typeof payload.text === 'string' ? payload.text : '';
+        const text = typeof payload.delta === 'string'
+          ? payload.delta
+          : typeof payload.text === 'string'
+            ? payload.text
+            : '';
         return `${type}:${text.length} chars`;
       }
       return type;

--- a/apps/daemon/tests/diagnostics-export.test.ts
+++ b/apps/daemon/tests/diagnostics-export.test.ts
@@ -170,3 +170,46 @@ describe('diagnostics export handler — packaged (runtime) layout', () => {
   });
 
 });
+
+describe('diagnostics export handler — run event logs', () => {
+  it('bundles recent per-run events.jsonl logs for agent stream forensics', async () => {
+    const root = join(tmpdir(), `od-diag-runs-${randomUUID()}`);
+    const runsDir = join(root, 'runs');
+    const runLogPath = join(runsDir, 'run-3165', 'events.jsonl');
+    const marker = 'Agent stalled without emitting any new output for 600s';
+    try {
+      await mkdir(dirname(runLogPath), { recursive: true });
+      await writeFile(
+        runLogPath,
+        JSON.stringify({
+          event: 'agent',
+          data: { type: 'raw', line: marker },
+        }) + '\n',
+        'utf8',
+      );
+
+      const handler = createDiagnosticsExportHandler({
+        runtime: null,
+        projectRoot: '/tmp/test-project',
+        runsDir,
+      });
+      const res = mockResponse();
+      await handler({} as never, res as never, () => undefined);
+
+      expect(res.capturedStatus).toBe(200);
+      const zip = await JSZip.loadAsync(res.capturedPayload!);
+      const runEntry = zip.file('runs/run-3165/events.jsonl');
+      expect(runEntry).not.toBeNull();
+      expect(await runEntry!.async('string')).toContain(marker);
+
+      const manifest = JSON.parse(await zip.file('summary/manifest.json')!.async('string')) as {
+        files: { name: string; bytes: number; error?: string }[];
+      };
+      const runFile = manifest.files.find((file) => file.name === 'runs/run-3165/events.jsonl');
+      expect(runFile?.error).toBeUndefined();
+      expect(runFile?.bytes ?? 0).toBeGreaterThan(0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -197,6 +197,50 @@ test('gemini stream emits init text and usage events', () => {
   ]);
 });
 
+test('gemini stream handles real stream-json user, tool, and error frames', () => {
+  const { events, handler } = collectEvents('gemini');
+
+  const fatalResult = {
+    type: 'result',
+    status: 'error',
+    error: { type: 'FatalAuthenticationError', message: 'Authentication failed' },
+    stats: { input_tokens: 11, output_tokens: 0, cached: 0, duration_ms: 42 },
+  };
+
+  handler.feed(
+    JSON.stringify({ type: 'message', role: 'user', content: 'make a video' }) + '\n' +
+    JSON.stringify({
+      type: 'tool_use',
+      tool_name: 'write_file',
+      tool_id: 'tool-1',
+      parameters: { path: 'timeline.json' },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'tool_result',
+      tool_id: 'tool-1',
+      status: 'success',
+      output: 'wrote timeline.json',
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'error',
+      severity: 'warning',
+      message: 'Agent execution blocked: retrying without shell',
+    }) +
+    '\n' +
+    JSON.stringify(fatalResult) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'tool_use', id: 'tool-1', name: 'write_file', input: { path: 'timeline.json' } },
+    { type: 'tool_result', toolUseId: 'tool-1', content: 'wrote timeline.json', isError: false },
+    { type: 'status', label: 'warning', detail: 'Agent execution blocked: retrying without shell' },
+    { type: 'error', message: 'Authentication failed', raw: JSON.stringify(fatalResult) },
+  ]);
+});
+
 test('cursor stream emits partial text once and usage events', () => {
   const { events, handler } = collectEvents('cursor-agent');
 

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -241,6 +241,39 @@ test('gemini stream handles real stream-json user, tool, and error frames', () =
   ]);
 });
 
+test('gemini stream treats terminal error frames as fatal error events', () => {
+  const { events, handler } = collectEvents('gemini');
+
+  const terminalError = {
+    type: 'error',
+    severity: 'error',
+    message: 'Maximum session turns exceeded',
+  };
+  const unknownSeverityError = {
+    type: 'error',
+    severity: 'critical',
+    error: { message: 'Invalid stream: malformed tool call' },
+  };
+
+  handler.feed(
+    JSON.stringify(terminalError) + '\n' +
+    JSON.stringify(unknownSeverityError) + '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'error',
+      message: 'Maximum session turns exceeded',
+      raw: JSON.stringify(terminalError),
+    },
+    {
+      type: 'error',
+      message: 'Invalid stream: malformed tool call',
+      raw: JSON.stringify(unknownSeverityError),
+    },
+  ]);
+});
+
 test('cursor stream emits partial text once and usage events', () => {
   const { events, handler } = collectEvents('cursor-agent');
 

--- a/mocks/README.md
+++ b/mocks/README.md
@@ -157,12 +157,12 @@ verified line-by-line against the parsers in `apps/daemon/src/`:
 | `devin` `hermes` `kilo` `kimi` `kiro` `vibe` | `acp-json-rpc` | `acp.ts:attachAcpSession`                       |
 | `vela` (AMR) | `acp-json-rpc` + `login` / `models` subcommands | `runtimes/defs/amr.ts` + `apps/daemon/tests/fixtures/fake-vela.mjs` (sibling stub) |
 
-> **Note on `gemini` and `cursor-agent`**: OD's parsers for these two
-> agents do NOT recognize tool-call events — only init / assistant text /
-> usage. The renderers therefore emit ONLY the final assistant text wrapped
-> in the expected init/text/usage envelope. Tool calls present in the
-> source recording are silently dropped (which matches the real CLI's UI
-> behavior — these agents don't surface tools in OD's chat view).
+> **Note on `cursor-agent`**: OD's parser does NOT recognize tool-call
+> events — only init / assistant text / usage. The renderer therefore emits
+> only the final assistant text wrapped in the expected init/text/usage
+> envelope. Tool calls present in the source recording are silently dropped.
+> `gemini` recognizes the current Gemini CLI `stream-json` tool_use /
+> tool_result frames and replays recorded tool calls through that envelope.
 
 > **Note on ACP agents** (`devin` / `hermes` / `kilo` / `kimi` / `kiro` /
 > `vibe`): These do NOT stream stdout — they speak JSON-RPC v2 over stdio.

--- a/mocks/lib/format-gemini.mjs
+++ b/mocks/lib/format-gemini.mjs
@@ -1,15 +1,12 @@
 // OD-faithful gemini renderer.
 //
 // Matches the JSONL shape OD's `json-event-stream.ts:handleGeminiEvent`
-// parser accepts. The parser only recognizes THREE event types:
-//   {"type":"init","model":"..."}                        → status:initializing
-//   {"type":"message","role":"assistant","content":"…"}  → text_delta
-//   {"type":"result","stats":{...}}                      → usage
-//
-// Notably ABSENT: any tool-call event shape. OD's gemini surface doesn't
-// render tool calls in the UI — they're stripped at the parser layer.
-// So our renderer only emits the final assistant text wrapped in the
-// init/message/result envelope. Tool calls in the recording are ignored.
+// parser accepts:
+//   {"type":"init","model":"..."}                         → status:initializing
+//   {"type":"message","role":"assistant","content":"..."}  → text_delta
+//   {"type":"tool_use","tool_name":"...","tool_id":"..."}  → tool_use
+//   {"type":"tool_result","tool_id":"...","output":"..."}  → tool_result
+//   {"type":"result","stats":{...}}                       → usage
 
 import { writeFile } from 'node:fs/promises';
 
@@ -19,6 +16,8 @@ export async function renderAsGemini(events, opts = {}) {
   const emit = opts.emit ?? (s => process.stdout.write(s));
   const maxSleep = opts.maxSleepMs ?? 2000;
   const meta = events.find(e => e.type === 'meta');
+  const results = new Map();
+  for (const e of events) if (e.type === 'tool_result') results.set(e.obs_id, e);
 
   emit(JSON.stringify({
     type: 'init',
@@ -30,7 +29,21 @@ export async function renderAsGemini(events, opts = {}) {
   // gemini parser accepts multi-chunk too (each emits as text_delta).
   if (!opts.noDelay) await sleep(Math.min(maxSleep, 200));
   for (const e of events) {
-    if (e.type === 'report') {
+    if (e.type === 'tool_call') {
+      const result = results.get(e.obs_id);
+      emit(JSON.stringify({
+        type: 'tool_use',
+        tool_name: e.name,
+        tool_id: e.obs_id,
+        parameters: e.input ?? null,
+      }) + '\n');
+      emit(JSON.stringify({
+        type: 'tool_result',
+        tool_id: e.obs_id,
+        status: result?.status === 'error' ? 'error' : 'success',
+        output: result?.output ?? '',
+      }) + '\n');
+    } else if (e.type === 'report') {
       emit(JSON.stringify({
         type: 'message',
         role: 'assistant',


### PR DESCRIPTION
Fixes #3165

## Why

I picked this up because #3165 is a P1 Windows/Gemini runtime bug: HyperFrames stalls after the setup form, the daemon reports stdout arrived, but the last agent event is only `raw` and the run eventually hits the 600s inactivity watchdog.

The concrete pain is twofold: current Gemini CLI `stream-json` emits user/tool/error/result frames that OD was downgrading to raw, so tool progress was invisible to the run lifecycle; and diagnostics exports did not include per-run `events.jsonl`, which left maintainers without the raw Gemini frames needed for follow-up debugging.

## What users will see

Gemini-backed runs can now surface Gemini CLI `tool_use` / `tool_result` frames as normal run events instead of opaque raw frames. Diagnostics exports now include recent per-run event logs under `runs/<runId>/events.jsonl`, so failed agent streams are available in support bundles.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/daemon/tests/json-event-stream.test.ts` (`gemini stream handles real stream-json user, tool, and error frames`)
  - `apps/daemon/tests/diagnostics-export.test.ts` (`bundles recent per-run events.jsonl logs for agent stream forensics`)
- Did the test go red on `main` and green on this branch? yes. The Gemini parser spec failed with raw user/tool/error frames before the fix; the diagnostics spec failed because `runs/<runId>/events.jsonl` was absent from the zip.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/json-event-stream.test.ts`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/diagnostics-export.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/json-event-stream.test.ts tests/diagnostics-export.test.ts tests/mocks-golden.test.ts`
- `node --check mocks/lib/format-gemini.mjs`
- `pnpm guard`
- `pnpm typecheck`

Note: local validation ran on Node v22.14.0, so pnpm emitted the repo's expected engine warning (`node: ~24`), but the listed commands exited 0 after the fix.
