### PR TITLE
[codex] Fix integrations CLI guide flow

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // @ts-nocheck
-import { runDaemonCliStartup } from './daemon-startup.js';
+import { runDaemonCliStartup, startDaemonRuntime } from './daemon-startup.js';
 import { runLiveArtifactsMcpServer } from './mcp-live-artifacts-server.js';
 import { runArtifactsCli } from './artifacts-cli.js';
 import { runProjectHandoff } from './handoff-cli.js';
@@ -137,9 +137,7 @@ const UI_BOOLEAN_FLAGS = new Set([
 // during module load; any const declared further down the file is
 // still in TDZ when the handler executes, so `od status` /
 // `od atoms list` / etc. would crash with `Cannot access X before
-// initialization`. The actual definitions stay further down (next
-// to their handlers); we just export the bindings up here so the
-// dispatch path always sees an initialized value.
+// initialization`.
 const DAEMON_STRING_FLAGS = new Set([
   'daemon-url', 'port', 'host',
 ]);
@@ -148,6 +146,10 @@ const DAEMON_BOOLEAN_FLAGS = new Set([
 ]);
 const LIBRARY_STRING_FLAGS = new Set(['daemon-url', 'query', 'tag']);
 const LIBRARY_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
+const DIAGNOSTICS_STRING_FLAGS = new Set(['daemon-url', 'output']);
+const DIAGNOSTICS_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
+const CONFIG_STRING_FLAGS = new Set(['daemon-url', 'value', 'value-json']);
+const CONFIG_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
 const PROJECT_STRING_FLAGS = new Set([
   'daemon-url', 'name', 'skill', 'design-system', 'plugin', 'metadata-json',
   'pending-prompt', 'project', 'conversation', 'message', 'path', 'as',
@@ -5196,50 +5198,34 @@ function formatBytes(n) {
 }
 
 async function runDaemonStart(flags) {
-  // The headless flag implies --no-open AND auto-applies any other
-  // headless-only env defaults. Because the existing default-mode boot
-  // already handles port / host / no-open, we forward into it by
-  // mutating process.argv before re-entering the boot path.
-  // Simpler path: re-implement the boot inline, mirroring the default.
   const port = Number(flags.port ?? process.env.OD_PORT ?? 7456);
   const host = String(flags.host ?? process.env.OD_BIND_HOST ?? '127.0.0.1');
   const headless = Boolean(flags.headless || flags['no-open'] || flags['serve-web']);
-  process.env.OD_BIND_HOST = host;
-  process.env.OD_PORT = String(port);
-  const { startServer: startHeadless } = await import('./server.js');
-  const started = await startHeadless({ port, host, returnServer: true });
-  const url = started.url;
-  const server = started.server;
-  const shutdown = started.shutdown;
-  const closeServer = () => new Promise((resolve) => {
-    let resolved = false;
-    const resolveOnce = () => { if (!resolved) { resolved = true; resolve(); } };
-    const idleTimer = setTimeout(() => server.closeIdleConnections?.(), 1_000);
-    const hardTimer = setTimeout(() => { server.closeAllConnections?.(); resolveOnce(); }, 5_000);
-    idleTimer.unref?.();
-    hardTimer.unref?.();
-    server.close(() => resolveOnce());
+  const runtime = await startDaemonRuntime({
+    host,
+    logListening: false,
+    openBrowser: !headless,
+    port,
   });
-  let shuttingDown = false;
-  const stop = () => {
-    if (shuttingDown) process.exit(0);
-    shuttingDown = true;
-    void Promise.allSettled([
-      Promise.resolve().then(() => shutdown?.()),
-      closeServer(),
-    ]).finally(() => process.exit(0));
-  };
-  process.on('SIGINT', stop);
-  process.on('SIGTERM', stop);
-  console.log(`[od] listening on ${url} (${headless ? 'headless' : 'desktop'})`);
-  if (!headless) {
-    const opener = process.platform === 'darwin' ? 'open'
-      : process.platform === 'win32' ? 'start'
-      : 'xdg-open';
-    import('node:child_process').then(({ spawn }) => {
-      spawn(opener, [url], { detached: true, stdio: 'ignore' }).unref();
-    });
-  }
+  console.log(`[od] listening on ${runtime.url} (${headless ? 'headless' : 'desktop'})`);
+
+  await new Promise((resolve) => {
+    let shuttingDown = false;
+    const stop = () => {
+      if (shuttingDown) process.exit(0);
+      shuttingDown = true;
+      void runtime.stop().finally(() => {
+        cleanup();
+        resolve();
+      });
+    };
+    const cleanup = () => {
+      process.off('SIGINT', stop);
+      process.off('SIGTERM', stop);
+    };
+    process.on('SIGINT', stop);
+    process.on('SIGTERM', stop);
+  });
 }
 
 async function runDaemonStatus(flags) {
@@ -5471,9 +5457,6 @@ async function runStatus(args) {
 // without driving the web UI.
 // ---------------------------------------------------------------------------
 
-const DIAGNOSTICS_STRING_FLAGS = new Set(['daemon-url', 'output']);
-const DIAGNOSTICS_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
-
 async function runDiagnostics(args) {
   const sub = args[0];
   if (!sub || sub === 'help' || args.includes('--help') || args.includes('-h')) {
@@ -5574,9 +5557,6 @@ async function runVersion(args) {
 // without leaving the terminal. JSON values pass through unchanged;
 // scalar strings/numbers/booleans are coerced.
 // ---------------------------------------------------------------------------
-
-const CONFIG_STRING_FLAGS = new Set(['daemon-url', 'value', 'value-json']);
-const CONFIG_BOOLEAN_FLAGS = new Set(['help', 'h', 'json']);
 
 async function runDoctor(args) {
   const flags = parseFlags(args, { string: CONFIG_STRING_FLAGS, boolean: CONFIG_BOOLEAN_FLAGS });

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4517,8 +4517,8 @@ export async function startServer({
     res.json({
       ok: true,
       version: versionInfo.version,
-      bindHost: process.env.OD_BIND_HOST ?? '127.0.0.1',
-      port: Number(process.env.OD_PORT ?? 7456),
+      bindHost: host,
+      port: resolvedPort,
       dataDir: RUNTIME_DATA_DIR,
       mediaConfigDir: process.env.OD_MEDIA_CONFIG_DIR ?? null,
       sandboxMode: SANDBOX_RUNTIME.enabled,

--- a/apps/daemon/tests/cli-startup.test.ts
+++ b/apps/daemon/tests/cli-startup.test.ts
@@ -3,7 +3,7 @@ import http from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execFile } from 'node:child_process';
+import { execFile, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { promisify } from 'node:util';
 import { describe, expect, it } from 'vitest';
 
@@ -12,6 +12,82 @@ const daemonRoot = fileURLToPath(new URL('..', import.meta.url));
 const cliEntry = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
 
 describe('CLI startup boundaries', () => {
+  it.each([
+    ['doctor', ['doctor', '--help']],
+    ['config', ['config', 'get', 'apiProtocol', '--daemon-url', 'http://127.0.0.1:9']],
+    ['diagnostics', ['diagnostics', 'export', '--daemon-url', 'http://127.0.0.1:9']],
+  ])('initializes flag constants before dispatching od %s', async (_name, args) => {
+    let output = '';
+    try {
+      const result = await execFileAsync(
+        process.execPath,
+        ['--import', 'tsx', cliEntry, ...args],
+        {
+          cwd: daemonRoot,
+          env: { ...process.env },
+        },
+      );
+      output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+    } catch (error: unknown) {
+      const failed = error as { stdout?: string; stderr?: string };
+      output = `${failed.stdout ?? ''}${failed.stderr ?? ''}`;
+    }
+
+    expect(output).not.toContain('ReferenceError');
+    expect(output).not.toContain('before initialization');
+    expect(output).not.toContain('CONFIG_STRING_FLAGS');
+    expect(output).not.toContain('DIAGNOSTICS_STRING_FLAGS');
+  });
+
+  it('keeps od daemon start alive until SIGTERM and reports the actual listening port', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'od-cli-daemon-start-'));
+    const dataDir = join(root, 'data');
+    await mkdir(dataDir);
+    const child = spawn(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        cliEntry,
+        'daemon',
+        'start',
+        '--headless',
+        '--port',
+        '0',
+      ],
+      {
+        cwd: daemonRoot,
+        env: {
+          ...process.env,
+          OD_BIND_HOST: '127.0.0.1',
+          OD_DATA_DIR: dataDir,
+        },
+      },
+    );
+
+    try {
+      const line = await waitForStdoutLine(child, /\[od\] listening on (http:\/\/[^\s]+) \(headless\)/u);
+      const match = line.match(/(http:\/\/[^\s]+)/u);
+      const daemonUrl = match?.[1];
+      expect(daemonUrl).toBeTruthy();
+      const parsed = new URL(daemonUrl!);
+      expect(Number(parsed.port)).toBeGreaterThan(0);
+
+      const healthResp = await fetch(`${daemonUrl}/api/health`);
+      expect(healthResp.status).toBe(200);
+
+      const statusResp = await fetch(`${daemonUrl}/api/daemon/status`);
+      expect(statusResp.status).toBe(200);
+      const status = await statusResp.json() as { bindHost: string; port: number };
+      expect(status.bindHost).toBe('127.0.0.1');
+      expect(status.port).toBe(Number(parsed.port));
+      expect(child.exitCode).toBeNull();
+    } finally {
+      await terminateChild(child);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('does not import daemon startup code for media client commands', async () => {
     const root = await mkdtemp(join(tmpdir(), 'od-cli-media-'));
     const dataDir = join(root, 'data');
@@ -130,3 +206,60 @@ describe('CLI startup boundaries', () => {
     ]);
   });
 });
+
+function waitForStdoutLine(
+  child: ChildProcessWithoutNullStreams,
+  pattern: RegExp,
+  timeoutMs = 15_000,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`timed out waiting for stdout ${pattern}; output:\n${output}`));
+    }, timeoutMs);
+    const onData = (chunk: Buffer) => {
+      output += chunk.toString('utf8');
+      const line = output.split(/\r?\n/u).find((candidate) => pattern.test(candidate));
+      if (line) {
+        cleanup();
+        resolve(line);
+      }
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(`child exited before stdout matched ${pattern}: code=${code} signal=${signal}; output:\n${output}`));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.stdout.off('data', onData);
+      child.stderr.off('data', onData);
+      child.off('error', onError);
+      child.off('exit', onExit);
+    };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    child.on('error', onError);
+    child.on('exit', onExit);
+  });
+}
+
+async function terminateChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>((resolve) => {
+    child.once('exit', () => resolve());
+  });
+  child.kill('SIGTERM');
+  const timeout = new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      resolve();
+    }, 5_000);
+    timer.unref?.();
+  });
+  await Promise.race([exited, timeout]);
+}

--- a/apps/daemon/tests/daemon-lifecycle.test.ts
+++ b/apps/daemon/tests/daemon-lifecycle.test.ts
@@ -49,6 +49,7 @@ describe('GET /api/daemon/status', () => {
     expect(typeof body.version === 'string' || typeof body.version === 'object').toBe(true);
     expect(typeof body.bindHost).toBe('string');
     expect(typeof body.port).toBe('number');
+    expect(body.port).toBe(Number(new URL(baseUrl).port));
     expect(typeof body.pid).toBe('number');
     expect(typeof body.installedPlugins).toBe('number');
     expect(body.sandboxMode).toBe(false);

--- a/apps/web/src/components/use-everywhere/sections.ts
+++ b/apps/web/src/components/use-everywhere/sections.ts
@@ -92,7 +92,7 @@ export const GUIDE_SECTIONS: GuideSection[] = [
     bullets: [
       '`od` (no args) — boots the daemon and opens the web UI.',
       '`od media generate ...` — produce image / video / audio bytes through the unified media protocol.',
-      '`od run ...` — start a project run from a prompt + skill.',
+      '`od project create` + `od run start` — create a project, send a message, and stream the run.',
       '`od plugin install <source>` / `od plugin apply <id>` — install and apply community plugins.',
       '`od skills list` / `od design-systems list` — inspect what is available locally.',
       '`od status` / `od doctor` — verify daemon health and detect agent CLIs on your PATH.',
@@ -110,13 +110,62 @@ export const GUIDE_SECTIONS: GuideSection[] = [
           '  --output ./out/hero.png',
       },
       {
-        label: 'Run a scenario plugin headlessly and stream events as JSON lines',
+        label: 'Use the CLI from a source checkout',
         language: 'bash',
         body:
-          'od run \\\n' +
+          'corepack enable\n' +
+          'pnpm install\n' +
+          'pnpm --filter @open-design/daemon build\n' +
+          '\n' +
+          'export OD_NODE_BIN="${OD_NODE_BIN:-/opt/homebrew/opt/node@24/bin/node}"\n' +
+          'export OD_BIN="$PWD/apps/daemon/dist/cli.js"\n' +
+          '"$OD_NODE_BIN" "$OD_BIN" daemon start --headless --serve-web --port 7456',
+      },
+      {
+        label: 'Run a design project headlessly and stream events',
+        language: 'bash',
+        body:
+          'DAEMON_URL=${DAEMON_URL:-http://127.0.0.1:7456}\n' +
+          'PROJECT_JSON=$(od project create \\\n' +
+          '  --name "Investor pitch" \\\n' +
+          '  --skill frontend-design \\\n' +
+          '  --design-system clean \\\n' +
+          '  --json \\\n' +
+          '  --daemon-url "$DAEMON_URL")\n' +
+          'PROJECT_ID=$(jq -r \'.project.id\' <<<"$PROJECT_JSON")\n' +
+          'CONVERSATION_ID=$(jq -r \'.conversationId\' <<<"$PROJECT_JSON")\n' +
+          '\n' +
+          'od run start \\\n' +
+          '  --project "$PROJECT_ID" \\\n' +
+          '  --conversation "$CONVERSATION_ID" \\\n' +
           '  --plugin od-new-generation \\\n' +
-          "  --prompt 'A 10-slide investor pitch for a SaaS for design teams' \\\n" +
-          '  --json --follow',
+          '  --agent codex \\\n' +
+          "  --message 'A 10-slide investor pitch for a SaaS for design teams' \\\n" +
+          '  --daemon-url "$DAEMON_URL" \\\n' +
+          '  --follow',
+      },
+      {
+        label: 'Answer a discovery question form from the CLI',
+        language: 'bash',
+        body:
+          'od run start \\\n' +
+          '  --project "$PROJECT_ID" \\\n' +
+          '  --conversation "$CONVERSATION_ID" \\\n' +
+          '  --agent codex \\\n' +
+          '  --message "[form answers - discovery]\n' +
+          '- Audience: Seed-stage investors\n' +
+          '- Format: 10-slide pitch deck\n' +
+          '- Tone: Confident, concise, product-led\n' +
+          '- Constraints: Use clean visuals and include traction placeholders" \\\n' +
+          '  --daemon-url "$DAEMON_URL" \\\n' +
+          '  --follow',
+      },
+      {
+        label: 'Verify generated files after the stream completes',
+        language: 'bash',
+        body:
+          'od files list "$PROJECT_ID" --daemon-url "$DAEMON_URL" --json\n' +
+          'od files read "$PROJECT_ID" index.html --daemon-url "$DAEMON_URL" | head',
       },
       {
         label: 'Inventory locally available skills and design systems',
@@ -140,7 +189,8 @@ export const GUIDE_SECTIONS: GuideSection[] = [
     footer:
       'All subcommands accept `--daemon-url http://127.0.0.1:<port>` to ' +
       'target a specific running daemon — useful when running a sandboxed ' +
-      'second instance for tests.',
+      'second instance for tests. From a source checkout, replace `od` with ' +
+      '`"$OD_NODE_BIN" "$OD_BIN"` after exporting those variables.',
   },
   {
     id: 'mcp',

--- a/apps/web/tests/components/use-everywhere-agent-guide.test.ts
+++ b/apps/web/tests/components/use-everywhere-agent-guide.test.ts
@@ -42,6 +42,17 @@ describe('buildAgentGuideMarkdown', () => {
     expect(md).toContain('```yaml');
   });
 
+  it('documents the current project create plus run start CLI flow', () => {
+    const md = buildAgentGuideMarkdown();
+    expect(md).toContain('od project create');
+    expect(md).toContain('od run start');
+    expect(md).toContain('--conversation "$CONVERSATION_ID"');
+    expect(md).toContain('[form answers - discovery]');
+    expect(md).toContain('od files list "$PROJECT_ID"');
+    expect(md).not.toContain('od run \\\n  --plugin');
+    expect(md).not.toContain("--prompt 'A 10-slide investor pitch");
+  });
+
   it('surfaces version and CLI hints in the checklist when supplied', () => {
     const md = buildAgentGuideMarkdown({
       versionHint: '0.42.0',


### PR DESCRIPTION
## Context

Fixes #3454.

The Integrations CLI guide had drifted from the current `od` command flow. It still described an older one-shot `od run --plugin ... --prompt ...` path, but the current CLI flow is project-first:

1. start or target a daemon,
2. create a project with `od project create`,
3. keep the returned `conversationId`,
4. stream work with `od run start`,
5. verify generated files with `od files list` / `od files read`.

That mismatch made the guide hard to follow for source-checkout and headless agent usage. While validating the corrected flow, two daemon-side problems also surfaced: `od daemon start` had its own duplicated startup lifecycle and could let the top-level CLI dispatcher return after startup, and `/api/daemon/status` reported env-derived port data instead of the actual resolved runtime port for dynamic-port starts.

## Why This Fix

The guide is used as the operator-facing reference for connecting agents and running Open Design from a local daemon. If the command sequence is stale, users can copy a flow that no longer matches the CLI surface. Fixing the docs alone was not enough because the documented source-checkout/headless path also depends on `od daemon start` staying alive and status reporting the real port it bound to.

## What users will see

Operators following the Integrations CLI guide now get a copyable source-checkout flow that matches the current CLI: start the daemon, create a project, stream a run, answer form prompts, and inspect generated files.

The daemon source-start path also stays running until shutdown, and daemon status now reports the actual bind host and resolved port, including dynamic-port starts.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [x] CLI / env var - `od daemon start` behavior and the documented CLI flow changed
- [x] API / contract - `/api/daemon/status` now reports the actual resolved bind host and port
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] Default behavior change - source-checkout daemon start no longer returns immediately after startup, and dynamic-port status is accurate
- [ ] None

## What Changed

- Updated the Integrations CLI guide to document the current source-checkout startup flow, `od project create`, `od run start`, form-answer messages, and generated-file verification commands.
- Routed `od daemon start` through the shared daemon startup runtime instead of duplicating server lifecycle code, so it stays alive until SIGINT/SIGTERM.
- Made `/api/daemon/status` return the actual bind host and resolved port from the running server, including `--port 0` dynamic-port starts.
- Hoisted `doctor`, `config`, and `diagnostics` flag constants above the top-level dispatcher so those subcommands cannot trip temporal-dead-zone `ReferenceError`s during module-load dispatch.
- Added regression tests for the CLI dispatch boundary, daemon start lifecycle, dynamic status port reporting, and guide markdown content.

## How It Was Implemented

The daemon CLI now uses `startDaemonRuntime()` for `od daemon start`, then installs signal handlers and awaits shutdown. This keeps startup behavior aligned with the existing shared daemon path and removes the duplicated server close/open-browser handling from the CLI command.

The status endpoint now closes over the actual `host` and `resolvedPort` values produced by `startServer()`, instead of reading `OD_BIND_HOST` / `OD_PORT` back from the environment. That keeps status accurate for both normal fixed-port starts and ephemeral port starts used in tests.

The guide snippets were rewritten to show a complete copyable path: build the daemon from source, start it headlessly, create a project, extract `PROJECT_ID` and `CONVERSATION_ID`, run `od run start`, answer discovery questions with the expected message format, and inspect generated files.

## Verification

Local verification run before opening the PR:

- `pnpm exec vitest run -c vitest.config.ts tests/cli-startup.test.ts tests/daemon-lifecycle.test.ts`
- `pnpm exec vitest run -c vitest.config.ts tests/components/use-everywhere-agent-guide.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- `git diff --check`

GitHub CI on #3465 is green:

- `Preflight`
- `Validate Nix flake`
- `Workspace unit tests`
- `Daemon workspace tests`
- `Web workspace tests`
- `Browser tests`
- `Build workspaces`
- `Validate workspace`
- fork PR `approve`
- `Capture PR visual screenshots`
- `Strict PR visual tests`

## Review Notes

The visual regression bot reported `1 changed · 16 unchanged · 0 missing baseline · 0 failed`. The changed case is `visual-design-systems`; I inspected the main, PR, and diff screenshots. The bot comment is advisory-only, strict visual tests passed, and there is no actionable visual failure.

`lint` was not run locally because `@open-design/daemon` and `@open-design/web` do not define a `lint` script.

