### PR TITLE
[codex] Reduce chat composer input lag

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -2,7 +2,6 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -389,6 +388,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     const [toolsTab, setToolsTab] = useState<ToolsTab>('plugins');
     const fileInputRef = useRef<HTMLInputElement | null>(null);
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+    const textareaResizeFrameRef = useRef<number | null>(null);
     const composingRef = useRef(false);
     const toolsMenuRef = useRef<HTMLDivElement | null>(null);
     const toolsTriggerRef = useRef<HTMLButtonElement | null>(null);
@@ -579,16 +579,37 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       if (!ta) return;
       const maxHeight = composerTextareaMaxHeight();
       ta.style.height = 'auto';
+      const scrollHeight = ta.scrollHeight;
       const nextHeight = Math.min(
-        Math.max(ta.scrollHeight, COMPOSER_TEXTAREA_MIN_HEIGHT),
+        Math.max(scrollHeight, COMPOSER_TEXTAREA_MIN_HEIGHT),
         maxHeight,
       );
       ta.style.height = `${nextHeight}px`;
-      ta.style.overflowY = ta.scrollHeight > maxHeight ? 'auto' : 'hidden';
+      ta.style.overflowY = scrollHeight > maxHeight ? 'auto' : 'hidden';
     }
 
-    useLayoutEffect(() => {
-      resizeTextarea();
+    useEffect(() => {
+      if (
+        typeof window === 'undefined' ||
+        typeof window.requestAnimationFrame !== 'function' ||
+        typeof window.cancelAnimationFrame !== 'function'
+      ) {
+        resizeTextarea();
+        return;
+      }
+      if (textareaResizeFrameRef.current !== null) {
+        window.cancelAnimationFrame(textareaResizeFrameRef.current);
+      }
+      textareaResizeFrameRef.current = window.requestAnimationFrame(() => {
+        textareaResizeFrameRef.current = null;
+        resizeTextarea();
+      });
+      return () => {
+        if (textareaResizeFrameRef.current !== null) {
+          window.cancelAnimationFrame(textareaResizeFrameRef.current);
+          textareaResizeFrameRef.current = null;
+        }
+      };
     }, [draft, composerMentionParts, staged.length, stagedSkills.length]);
 
     useEffect(() => {

--- a/apps/web/src/utils/inlineMentions.ts
+++ b/apps/web/src/utils/inlineMentions.ts
@@ -35,6 +35,7 @@ export function buildInlineMentionParts(
   options: { highlightUnknown?: boolean } = {},
 ): InlineMentionPart[] | null {
   if (!text) return null;
+  if (!text.includes('@')) return null;
   const highlightUnknown = options.highlightUnknown ?? true;
   const known = normalizeEntities(entities);
   const parts: InlineMentionPart[] = [];

--- a/apps/web/tests/components/ChatComposer.infinite-render.test.tsx
+++ b/apps/web/tests/components/ChatComposer.infinite-render.test.tsx
@@ -144,4 +144,56 @@ describe('ChatComposer infinite re-render regression (#2097)', () => {
       }
     }
   });
+
+  it('coalesces textarea auto-resize work behind animation frames', () => {
+    const scrollHeightGetter = vi.fn(() => 96);
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'scrollHeight',
+    );
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    const frameCallbacks = new Map<number, FrameRequestCallback>();
+    let nextFrameId = 1;
+
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: scrollHeightGetter,
+    });
+    window.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) => {
+      const id = nextFrameId++;
+      frameCallbacks.set(id, cb);
+      return id;
+    });
+    window.cancelAnimationFrame = vi.fn((id: number) => {
+      frameCallbacks.delete(id);
+    });
+
+    try {
+      renderComposer();
+      const textarea = screen.getByTestId('chat-composer-input') as HTMLTextAreaElement;
+      scrollHeightGetter.mockClear();
+
+      for (const value of ['h', 'he', 'hel', 'hello Open Design']) {
+        fireEvent.change(textarea, { target: { value, selectionStart: value.length } });
+      }
+
+      expect(scrollHeightGetter).not.toHaveBeenCalled();
+      expect(frameCallbacks.size).toBe(1);
+
+      const callbacks = Array.from(frameCallbacks.entries());
+      frameCallbacks.clear();
+      for (const [id, cb] of callbacks) cb(id);
+
+      expect(scrollHeightGetter).toHaveBeenCalledTimes(1);
+    } finally {
+      if (originalScrollHeight) {
+        Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', originalScrollHeight);
+      } else {
+        delete (HTMLTextAreaElement.prototype as { scrollHeight?: number }).scrollHeight;
+      }
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
 });

--- a/apps/web/tests/utils/inlineMentions.test.ts
+++ b/apps/web/tests/utils/inlineMentions.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildInlineMentionParts, type InlineMentionEntity } from '../../src/utils/inlineMentions';
+
+describe('buildInlineMentionParts', () => {
+  it('skips entity matching when plain text has no mention marker', () => {
+    const entities: InlineMentionEntity[] = Array.from({ length: 1_000 }, (_, index) => ({
+      id: `file-${index}`,
+      kind: 'file',
+      label: `file-${index}.html`,
+      token: `@file-${index}.html`,
+    }));
+
+    expect(buildInlineMentionParts('typing ordinary Chinese text without mentions', entities)).toBeNull();
+  });
+
+  it('does not normalize entities on plain text drafts', () => {
+    const entity = {
+      id: 'index.html',
+      kind: 'file',
+      label: 'index.html',
+      get token() {
+        throw new Error('token should not be read for plain text');
+      },
+    } as InlineMentionEntity;
+
+    expect(buildInlineMentionParts('plain text only', [entity])).toBeNull();
+  });
+
+  it('still highlights known mentions when the draft contains a marker', () => {
+    const parts = buildInlineMentionParts('Review @index.html', [
+      { id: 'index.html', kind: 'file', label: 'index.html' },
+    ]);
+
+    expect(parts).toEqual([
+      { kind: 'text', text: 'Review ' },
+      {
+        kind: 'mention',
+        text: '@index.html',
+        entity: {
+          id: 'index.html',
+          kind: 'file',
+          label: 'index.html',
+          token: '@index.html',
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Context

Fixes #3461.

A macOS desktop user reported that typing in the chat composer becomes noticeably laggy once the conversation has a few historical messages. The reported symptom points at work happening on the input path: every keystroke needs to stay cheap even when the chat DOM behind it is large.

## Root Cause

Two composer paths were still doing unnecessary work for ordinary plain-text typing:

1. `ChatComposer` resized the textarea in a `useLayoutEffect`, resetting height and reading `scrollHeight` synchronously on every draft change. That forces layout before paint, and the cost grows with the surrounding chat DOM.
2. `buildInlineMentionParts()` normalized and sorted all mention entities on every draft change even when the draft did not contain `@`, so normal typing paid the full mention-overlay setup cost without needing the overlay.

## What Changed

- Moved textarea auto-resize from synchronous layout effect work to a `requestAnimationFrame`-coalesced effect.
- Cancelled superseded resize frames so rapid typing only performs the latest resize work.
- Reduced textarea resize layout reads from two `scrollHeight` reads to one.
- Added a fast path in `buildInlineMentionParts()` that returns immediately when the draft has no `@` marker.
- Added regression tests for the coalesced resize path and the no-mention parser fast path.

## Why This Shape

This keeps the existing controlled textarea, auto-grow behavior, and inline mention overlay behavior intact. It avoids a broader chat virtualization or message rendering rewrite, because the immediate input-lag path can be improved without changing chat history rendering semantics.

## What users will see

No visible UI or workflow change. Typing in long chat histories should stay responsive, including ordinary drafts without mentions.

## Surface area

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] Data model
- [ ] Default behavior change
- [ ] Accessibility
- [ ] Performance
- [ ] Security/privacy
- [x] None

## Verification

Local verification:

- `pnpm exec vitest run -c vitest.config.ts tests/components/ChatComposer.infinite-render.test.tsx tests/utils/inlineMentions.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `git diff --check`

## Notes

`lint` was not run locally because `@open-design/web` does not define a `lint` script.
