### PR TITLE
[codex] Add inline color swatches for hex chat output

### DIFF
--- a/apps/web/src/runtime/markdown.tsx
+++ b/apps/web/src/runtime/markdown.tsx
@@ -431,6 +431,48 @@ function isSafeMarkdownImageSrc(src: string): boolean {
   );
 }
 
+const INLINE_CODE_HEX_COLOR_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+const PROSE_HEX_COLOR_RE = /(^|[^\w#])(#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}))(?![\w-])/g;
+
+function isInlineCodeHexColor(value: string): boolean {
+  return INLINE_CODE_HEX_COLOR_RE.test(value);
+}
+
+function ColorSwatch({ color }: { color: string }) {
+  return (
+    <span
+      className="md-color-swatch"
+      aria-hidden="true"
+      style={{ backgroundColor: color }}
+    />
+  );
+}
+
+function renderInlineCodeSpan(value: string, key: number): ReactNode {
+  if (!isInlineCodeHexColor(value)) {
+    return (
+      <code key={key} className="md-inline-code">
+        {value}
+      </code>
+    );
+  }
+  return (
+    <code key={key} className="md-inline-code md-color-token">
+      <ColorSwatch color={value} />
+      {value}
+    </code>
+  );
+}
+
+function renderColorToken(value: string, key: string): ReactNode {
+  return (
+    <span key={key} className="md-color-token">
+      <ColorSwatch color={value} />
+      {value}
+    </span>
+  );
+}
+
 // Inline pass: tokenize into runs of `code`, **bold**, *italic*, links,
 // and plain text. We walk the string with a regex that matches whichever
 // delimiter shows up next; everything between delimiters becomes a text
@@ -464,11 +506,7 @@ function renderInline(text: string, options?: RenderMarkdownOptions): ReactNode 
       pushText(out, text.slice(lastIndex, m.index), key++, options);
     }
     if (m[1]) {
-      out.push(
-        <code key={key++} className="md-inline-code">
-          {m[1].slice(1, -1)}
-        </code>,
-      );
+      out.push(renderInlineCodeSpan(m[1].slice(1, -1), key++));
     } else if (m[3] !== undefined) {
       // Image: m[2] = alt (may be empty), m[3] = src
       const src = m[3];
@@ -552,7 +590,7 @@ function pushText(out: ReactNode[], text: string, baseKey: number, options?: Ren
   let k = 0;
   while ((m = urlRe.exec(text))) {
     if (m.index > lastIndex) {
-      segments.push(...withBreaks(text.slice(lastIndex, m.index), `${baseKey}-${k++}`));
+      segments.push(...withBreaksAndColorSwatches(text.slice(lastIndex, m.index), `${baseKey}-${k++}`));
     }
     const [href, suffix] = splitTrailingAutolinkPunctuation(m[1]!);
     segments.push(
@@ -568,12 +606,12 @@ function pushText(out: ReactNode[], text: string, baseKey: number, options?: Ren
       </a>,
     );
     if (suffix) {
-      segments.push(...withBreaks(suffix, `${baseKey}-${k++}`));
+      segments.push(...withBreaksAndColorSwatches(suffix, `${baseKey}-${k++}`));
     }
     lastIndex = urlRe.lastIndex;
   }
   if (lastIndex < text.length) {
-    segments.push(...withBreaks(text.slice(lastIndex), `${baseKey}-${k++}`));
+    segments.push(...withBreaksAndColorSwatches(text.slice(lastIndex), `${baseKey}-${k++}`));
   }
   out.push(<Fragment key={baseKey}>{segments}</Fragment>);
 }
@@ -585,12 +623,34 @@ function splitTrailingAutolinkPunctuation(url: string): [string, string] {
   return trimmed ? [trimmed, match[1]] : [url, ''];
 }
 
-function withBreaks(text: string, baseKey: string): ReactNode[] {
+function withBreaksAndColorSwatches(text: string, baseKey: string): ReactNode[] {
   const parts = text.split('\n');
   const out: ReactNode[] = [];
   parts.forEach((part, i) => {
     if (i > 0) out.push(<br key={`${baseKey}-br-${i}`} />);
-    if (part) out.push(<Fragment key={`${baseKey}-t-${i}`}>{part}</Fragment>);
+    if (part) out.push(...withProseColorSwatches(part, `${baseKey}-t-${i}`));
   });
+  return out;
+}
+
+function withProseColorSwatches(text: string, baseKey: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+  PROSE_HEX_COLOR_RE.lastIndex = 0;
+  while ((match = PROSE_HEX_COLOR_RE.exec(text))) {
+    const prefix = match[1] ?? '';
+    const color = match[2] ?? '';
+    const colorIndex = match.index + prefix.length;
+    if (colorIndex > lastIndex) {
+      out.push(<Fragment key={`${baseKey}-${key++}`}>{text.slice(lastIndex, colorIndex)}</Fragment>);
+    }
+    out.push(renderColorToken(color, `${baseKey}-${key++}`));
+    lastIndex = colorIndex + color.length;
+  }
+  if (lastIndex < text.length) {
+    out.push(<Fragment key={`${baseKey}-${key++}`}>{text.slice(lastIndex)}</Fragment>);
+  }
   return out;
 }

--- a/apps/web/src/styles/viewer/code.css
+++ b/apps/web/src/styles/viewer/code.css
@@ -538,6 +538,28 @@
   font-family: var(--mono);
   font-size: 0.92em;
 }
+.prose-block .md-color-token {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  vertical-align: -0.08em;
+  white-space: nowrap;
+}
+.prose-block .md-color-swatch {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 0.85em;
+  height: 0.85em;
+  border-radius: 2px;
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.24),
+    0 0 0 1px rgba(255, 255, 255, 0.55);
+}
+[data-theme="dark"] .prose-block .md-color-swatch {
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.28),
+    0 0 0 1px rgba(0, 0, 0, 0.45);
+}
 .prose-block .md-code {
   background: var(--bg-subtle);
   border: 1px solid var(--border);

--- a/apps/web/tests/runtime/markdown.test.tsx
+++ b/apps/web/tests/runtime/markdown.test.tsx
@@ -129,6 +129,30 @@ describe('renderMarkdown', () => {
     expect(out).toContain('<code class="md-inline-code">https://example.com/x</code>');
   });
 
+  it('renders color swatches for valid hex tokens inside inline code spans', () => {
+    const out = html('Palette: `#475569`, `#fff`, `#ffff`, `#11223344`, and `npm install`.');
+
+    expect(out).toContain('<code class="md-inline-code md-color-token">');
+    expect(out).toContain('style="background-color:#475569"');
+    expect(out).toContain('style="background-color:#fff"');
+    expect(out).toContain('style="background-color:#ffff"');
+    expect(out).toContain('style="background-color:#11223344"');
+    expect(out).toContain('<code class="md-inline-code">npm install</code>');
+    expect(out.match(/class="md-color-swatch"/g)?.length).toBe(4);
+  });
+
+  it('renders prose color swatches only for 6 and 8 digit hex values', () => {
+    const out = html('Use #475569, #11223344, #1672, and #498 in the notes.');
+
+    expect(out).toContain('style="background-color:#475569"');
+    expect(out).toContain('style="background-color:#11223344"');
+    expect(out).not.toContain('style="background-color:#1672"');
+    expect(out).not.toContain('style="background-color:#498"');
+    expect(out).toContain('#1672');
+    expect(out).toContain('#498');
+    expect(out.match(/class="md-color-swatch"/g)?.length).toBe(2);
+  });
+
   it('adds copy controls to fenced code blocks', () => {
     const out = html('```tsx\nexport const ok = true;\n```');
     expect(out).toContain('class="md-code-block"');


### PR DESCRIPTION
Fixes #3427

## Why

Assistant answers often include design-system palettes and color tokens as raw hex values. In the chat UI those values were previously rendered as plain text, so users had to mentally translate `#475569` or paste it into a picker to understand the color.

This PR adds the small readability affordance requested in #3427: validated hex colors render with an inline swatch while the original token remains visible and copyable.

## What users will see

- Assistant markdown now shows a compact swatch next to hex colors in inline code spans such as `#475569`, `#fff`, `#ffff`, and `#11223344`.
- Plain prose gets swatches only for 6/8 digit hex colors such as `#475569` and `#11223344`.
- Short issue/PR-like references such as `#1672` and `#498` stay plain text in prose.
- Non-color inline code such as `npm install` is unchanged.

## Surface area

- [x] **UI** — assistant chat markdown rendering now decorates hex color tokens with a swatch
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`)
- [x] **Default behavior change** — existing assistant hex output now includes a visual swatch by default
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No screenshot attached. The change is an inline markdown decoration; the PR includes renderer regression tests for the produced markup, and the repository visual regression workflow will capture UI drift for review.

## Implementation Notes

- Added conservative hex detection inside `apps/web/src/runtime/markdown.tsx`.
- Kept inline code permissive for valid `#rgb`, `#rgba`, `#rrggbb`, and `#rrggbbaa` tokens because code spans are explicit color-like tokens.
- Kept prose detection limited to 6/8 digit hex values to avoid turning short GitHub refs into colors.
- Added `.md-color-token` / `.md-color-swatch` styling with light/dark inset borders so near-white colors remain visible.
- Added focused markdown renderer tests for the color behavior and the short-ref guard.

## Bug fix verification

- Test path that reproduces the missing behavior: `apps/web/tests/runtime/markdown.test.tsx`
- Red on `main`: yes. Before the source change, the new markdown tests failed because no color swatch markup was emitted.
- Green on this branch: yes.

## Validation

- `PATH=/Users/sidqin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm exec vitest run -c vitest.config.ts tests/runtime/markdown.test.tsx tests/runtime/markdown.linkClick.test.tsx`
- `PATH=/Users/sidqin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --filter @open-design/web typecheck`
- `PATH=/Users/sidqin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm guard`
- `git diff --check`

## Notes

- No dependencies were added.
- `@open-design/web` does not define a `lint` script, so lint was not run separately.
