### PR TITLE
[codex] Exclude manual sketches from turn output inference

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -54,6 +54,7 @@ import {
   messageTime,
   relativeTimeLong,
 } from "../utils/chatTime";
+import { filterImplicitProducedFiles } from "../produced-files";
 import type {
   AgentEvent,
   ChatMessage,
@@ -698,14 +699,14 @@ function inferProducedFilesFromTurn({
   if (fileOps.length > 0) return [];
   const start = message.startedAt - 1_000;
   const end = message.endedAt + 60_000;
-  return projectFiles
-    .filter((file) => {
+  return filterImplicitProducedFiles(
+    projectFiles.filter((file) => {
       if (file.type === "dir") return false;
       if (!file.name || file.name.startsWith(".")) return false;
       if (file.name.includes("/.")) return false;
       return file.mtime >= start && file.mtime <= end;
-    })
-    .sort((a, b) => b.mtime - a.mtime);
+    }),
+  ).sort((a, b) => b.mtime - a.mtime);
 }
 
 function isFeedbackEligible({

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -137,6 +137,7 @@ import {
   mergeAttachedComments,
   removeAttachedComment,
 } from '../comments';
+import { filterImplicitProducedFiles } from '../produced-files';
 import { buildPptxExportPrompt } from '../lib/build-pptx-export-prompt';
 import { AppChromeHeader } from './AppChromeHeader';
 import { AvatarMenu } from './AvatarMenu';
@@ -2110,7 +2111,7 @@ export function ProjectView({
                     nextFiles = await refreshProjectFiles();
                   }
                 }
-                const diff = nextFiles.filter((f) => !beforeFileNames.has(f.name));
+                const diff = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
                 const produced = mergeRecoveredArtifact(diff, recoveredExistingArtifact);
                 if (produced.length > 0) {
                   updateMessageById(
@@ -2669,7 +2670,7 @@ export function ProjectView({
               await persistArtifact(parsedArtifact, nextFiles);
               nextFiles = await refreshProjectFiles();
             }
-            const produced = nextFiles.filter((f) => !beforeFileNames.has(f.name));
+            const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
             setMessages((curr) => {
               const updated = curr.map((m) =>
                 m.id === assistantId
@@ -4949,7 +4950,7 @@ export function computeProducedFiles(
 ): ProjectFile[] | undefined {
   if (!beforeNames) return undefined;
   const set = beforeNames instanceof Set ? beforeNames : new Set(beforeNames);
-  return next.filter((f) => !set.has(f.name));
+  return filterImplicitProducedFiles(next.filter((f) => !set.has(f.name)));
 }
 
 // Reattach with a recovered (on-disk) artifact must still include any

--- a/apps/web/src/produced-files.ts
+++ b/apps/web/src/produced-files.ts
@@ -4,7 +4,8 @@ import type { ProjectFile } from './types';
 // diffs. User-created sketches can change during a run, but that does not make
 // them assistant output files unless a run records them explicitly.
 export function isImplicitProducedFileCandidate(file: ProjectFile): boolean {
-  return file.kind !== 'sketch';
+  const lowerPath = (file.path ?? file.name).toLowerCase();
+  return !lowerPath.endsWith('.sketch.json');
 }
 
 export function filterImplicitProducedFiles(files: readonly ProjectFile[]): ProjectFile[] {

--- a/apps/web/src/produced-files.ts
+++ b/apps/web/src/produced-files.ts
@@ -1,0 +1,12 @@
+import type { ProjectFile } from './types';
+
+// Implicit attribution is based on project-file timing or pre/post file-list
+// diffs. User-created sketches can change during a run, but that does not make
+// them assistant output files unless a run records them explicitly.
+export function isImplicitProducedFileCandidate(file: ProjectFile): boolean {
+  return file.kind !== 'sketch';
+}
+
+export function filterImplicitProducedFiles(files: readonly ProjectFile[]): ProjectFile[] {
+  return files.filter(isImplicitProducedFileCandidate);
+}

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -331,6 +331,44 @@ describe('AssistantMessage recovered produced files', () => {
     expect(screen.queryByText('board.sketch.json')).toBeNull();
   });
 
+  it('still infers generated svg files classified as sketches', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          content: '',
+          events: [
+            { kind: 'status', label: 'starting', detail: 'Claude' } as ChatMessage['events'][number],
+            { kind: 'status', label: 'initializing', detail: 'claude-opus' } as ChatMessage['events'][number],
+          ],
+          producedFiles: [],
+        })}
+        streaming={false}
+        projectId="proj-1"
+        projectFiles={[
+          {
+            name: 'diagram.svg',
+            path: 'diagram.svg',
+            size: 2048,
+            mtime: 1700000004,
+            kind: 'sketch',
+            mime: 'image/svg+xml',
+          } as ProjectFile,
+          {
+            name: 'board.sketch.json',
+            path: 'board.sketch.json',
+            size: 2048,
+            mtime: 1700000004,
+            kind: 'sketch',
+            mime: 'application/json',
+          } as ProjectFile,
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('diagram.svg')).toBeTruthy();
+    expect(screen.queryByText('board.sketch.json')).toBeNull();
+  });
+
   it('keeps explicitly recorded sketch outputs visible', () => {
     render(
       <AssistantMessage

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -301,4 +301,56 @@ describe('AssistantMessage recovered produced files', () => {
 
     expect(screen.getByText('iphone-device-reveal.mp4')).toBeTruthy();
   });
+
+  it('does not infer user sketches as turn output files', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          content: '',
+          events: [
+            { kind: 'status', label: 'starting', detail: 'Claude' } as ChatMessage['events'][number],
+            { kind: 'status', label: 'initializing', detail: 'claude-opus' } as ChatMessage['events'][number],
+          ],
+          producedFiles: [],
+        })}
+        streaming={false}
+        projectId="proj-1"
+        projectFiles={[
+          {
+            name: 'board.sketch.json',
+            path: 'board.sketch.json',
+            size: 2048,
+            mtime: 1700000004,
+            kind: 'sketch',
+            mime: 'application/json',
+          } as ProjectFile,
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText('board.sketch.json')).toBeNull();
+  });
+
+  it('keeps explicitly recorded sketch outputs visible', () => {
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          producedFiles: [
+            {
+              name: 'agent-sketch.sketch.json',
+              path: 'agent-sketch.sketch.json',
+              size: 2048,
+              mtime: 1700000004,
+              kind: 'sketch',
+              mime: 'application/json',
+            } as ProjectFile,
+          ],
+        })}
+        streaming={false}
+        projectId="proj-1"
+      />,
+    );
+
+    expect(screen.getByText('agent-sketch.sketch.json')).toBeTruthy();
+  });
 });

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -162,6 +162,17 @@ describe('computeProducedFiles', () => {
     expect(produced?.map((f) => f.name)).toEqual(['new.pptx']);
   });
 
+  it('keeps generated svg files even when they are classified as sketches', () => {
+    const before = ['existing.html'];
+    const next = [
+      { name: 'existing.html', path: '/p/existing.html', size: 1, mtime: 1, kind: 'html', mime: 'text/html' },
+      { name: 'diagram.svg', path: '/p/diagram.svg', size: 2, mtime: 2, kind: 'sketch', mime: 'image/svg+xml' },
+      { name: 'board.sketch.json', path: '/p/board.sketch.json', size: 3, mtime: 3, kind: 'sketch', mime: 'application/json' },
+    ];
+    const produced = computeProducedFiles(before, next as never);
+    expect(produced?.map((f) => f.name)).toEqual(['diagram.svg']);
+  });
+
   it('returns undefined when no baseline is provided', () => {
     expect(computeProducedFiles(undefined, [] as never)).toBeUndefined();
   });

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -151,6 +151,17 @@ describe('computeProducedFiles', () => {
     expect(produced?.map((f) => f.name)).toEqual(['new.pptx']);
   });
 
+  it('excludes user sketch files from turn output attribution', () => {
+    const before = ['existing.html'];
+    const next = [
+      { name: 'existing.html', path: '/p/existing.html', size: 1, mtime: 1, kind: 'html', mime: 'text/html' },
+      { name: 'board.sketch.json', path: '/p/board.sketch.json', size: 2, mtime: 2, kind: 'sketch', mime: 'application/json' },
+      { name: 'new.pptx', path: '/p/new.pptx', size: 3, mtime: 3, kind: 'pdf', mime: 'application/pdf' },
+    ];
+    const produced = computeProducedFiles(before, next as never);
+    expect(produced?.map((f) => f.name)).toEqual(['new.pptx']);
+  });
+
   it('returns undefined when no baseline is provided', () => {
     expect(computeProducedFiles(undefined, [] as never)).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- Fixes #3089 by excluding saved workspace sketch JSON files from implicit "Files from this turn" attribution.
- Keeps explicitly recorded `producedFiles` visible, including sketch files, so intentional run outputs are not hidden.
- Preserves generated `.svg` artifacts even when existing file-kind inference classifies them as `sketch`.
- Shares the filter between the chat mtime fallback and ProjectView pre/post file-list diff paths.

## Root Cause

The web UI has two fallback attribution paths for assistant turn output files: one infers candidates from project files modified inside the assistant turn window, and another diffs the project file list before and after a run. Manual `.sketch.json` files can be created or saved during the same time window, so those implicit paths treated a user-created workspace sketch as if it were emitted by the assistant.

A first pass filtered every `kind: sketch` candidate, but this repo also classifies ordinary `.svg` files as `sketch` for viewer routing. That broader predicate would hide real generated SVG outputs such as `icon.svg` or `diagram.svg`.

## Why This Fix

The issue is provenance, not the broad sketch kind. A saved workspace sketch should not be classified as assistant output just because it was present or modified during a run, while generated SVG artifacts should still appear as assistant outputs. Filtering only implicit `.sketch.json` candidates fixes the false attribution without suppressing SVG outputs or explicit `producedFiles`.

## How It Was Fixed

- Added `filterImplicitProducedFiles` for file-attribution candidates and narrowed it to saved workspace sketch JSON paths.
- Applied it to `AssistantMessage` mtime inference.
- Applied it to `ProjectView.computeProducedFiles`, including reattach and send-completion paths that compare pre/post file lists.
- Added regression coverage for both implicit paths, including generated `.svg` files classified as `sketch`, plus a guard test showing explicit sketch outputs still render.

## User Impact

Manual `.sketch.json` canvases created in the workspace should no longer appear under "Files from this turn" unless the run explicitly records them as produced files. Generated SVG files still appear when the assistant produced them, keeping the conversation output area aligned with actual assistant output.

## Surface area

- [x] UI
- [ ] CLI
- [ ] API
- [ ] Data model
- [x] Default behavior change
- [ ] Accessibility
- [ ] Performance
- [ ] Security/privacy
- [ ] None

## Bug fix verification

- Repro: create or save `board.sketch.json` during an assistant run, then inspect the assistant turn's "Files from this turn" list.
- Before: implicit mtime and pre/post file-list fallback paths could attribute `board.sketch.json` to the assistant even though it was a manual workspace sketch.
- After: implicit `.sketch.json` candidates are filtered unless the run explicitly records them in `producedFiles`; generated `.svg` artifacts still remain visible.

## Validation

- Red checks before fixes: new regression tests failed because `board.sketch.json` was shown/returned as a produced file, and the review-requested SVG guard would fail if `kind: sketch` SVGs were filtered out.
- `pnpm exec vitest run -c vitest.config.ts tests/components/AssistantMessage.test.tsx tests/components/ProjectView.reattach-restore.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`

## Notes

- No dependencies added.
- Browser manual reproduction was not run; behavior is covered at the renderer attribution and pre/post diff helper boundaries.
- `@open-design/web` does not define a `lint` script, so lint was not run separately.

Fixes #3089