### PR TITLE
[codex] Center home wordmark text

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -25,13 +25,18 @@
   padding: 32px 0 8px;
 }
 .home-hero__brand {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
   color: var(--text-muted);
   font-size: 13px;
 }
 .home-hero__brand-mark {
+  position: absolute;
+  top: 50%;
+  right: calc(100% + 8px);
+  transform: translateY(-50%);
   width: 26px;
   height: 26px;
   border-radius: 50%;


### PR DESCRIPTION
## Summary

- Centers the `Open Design` wordmark text on the same axis as the home hero title/subtitle.
- Keeps the app icon attached to the left of the wordmark without letting the icon shift the text right.
- Leaves the home composer and gallery layout untouched.

## Root Cause

The home hero brand row used a normal inline-flex layout and centered the icon + wordmark as one combined lockup. That made the combined group centered, but the `Open Design` text itself sat to the right of the hero heading axis because the icon occupied space on the left. This is why the wordmark looked visually off-center in the homepage header.

## Why This Fix

Moving the entire hero left would compensate for the left nav rail, but it would also shift the composer and gallery rhythm. The visible problem is the wordmark text alignment, so the narrower fix is to keep the wordmark centered and position the icon as an attached mark to its left.

## How It Was Fixed

- Made `.home-hero__brand` a relative centered text container.
- Removed the flex `gap` layout that let the icon participate in the centered width.
- Absolutely positioned `.home-hero__brand-mark` to the left of the centered wordmark.

## Surface area

- [x] UI
- [ ] CLI
- [ ] API
- [ ] Data model
- [ ] Default behavior change
- [ ] Accessibility
- [ ] Performance
- [ ] Security/privacy
- [ ] None

## Validation

- Playwright bounding-box measurement on `http://localhost:3001` showed `.home-hero__brand-name` center aligned with `.home-hero__title` center after the change.
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`

## Notes

- CSS-only change.
- No dependencies added.
- `@open-design/web` does not define a separate `lint` script, so lint was not run separately.
