### PR TITLE
[codex] Preserve Settings dialog rounded corners

### DIFF
--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -472,6 +472,7 @@
   height: min(720px, calc(100vh - 64px));
   padding: 0;
   gap: 0;
+  overflow: hidden;
   /* Anchor for the absolutely-positioned `.settings-chrome` strip
      (close button + autosave indicator). Without this the chrome
      would escape to the viewport on long-scrolling sections. */


### PR DESCRIPTION
## Summary

- Preserves rounded corners on the Settings dialog by clipping child panels to the modal radius.
- Keeps the existing sidebar/content internal scrolling behavior unchanged.
- Avoids adding separate competing corner radii to the Settings header/sidebar/content.

## Root Cause

Settings reused the shared `.modal` border radius, but `.modal-settings` left `overflow` visible. Its header, sidebar, and content panels paint directly to the dialog edges, so their square backgrounds can visually flatten the modal corners instead of respecting the outer rounded surface.

## Why This Fix

The dialog already owns the correct radius. The missing piece is clipping: the outer modal should define the shape, and inner Settings panels should scroll/paint inside that shape. Adding `overflow: hidden` to `.modal-settings` matches the New project modal pattern without duplicating radius rules on each child panel.

## How It Was Fixed

- Added `overflow: hidden` to `.modal-settings`.
- Left `.settings-sidebar` and `.settings-content` as their own scroll containers.

## Surface area

- [x] UI
- [ ] CLI
- [ ] API
- [ ] Data model
- [ ] Default behavior change
- [ ] Accessibility
- [ ] Performance
- [ ] Security/privacy
- [ ] None

## Validation

- Playwright opened Settings on `http://localhost:3001` and confirmed `.modal-settings` has `overflow: hidden` with the existing `16px` radius.
- Local screenshot inspection showed the Settings dialog clipping to rounded corners after the change.
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`

## Notes

- CSS-only change.
- No dependencies added.
- `@open-design/web` does not define a separate `lint` script, so lint was not run separately.
