### PR TITLE
fix(web): preserve bulk edit file paths

### DIFF
--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -23,7 +23,13 @@ import { createRoleMarkerGuard, type RoleMarkerGuard } from './role-marker-guard
 
 type StreamEvent = Record<string, unknown>;
 type EventSink = (event: StreamEvent) => void;
-type BlockState = { type?: unknown; name?: unknown; id?: unknown; input: string };
+type BlockState = {
+  type?: unknown;
+  name?: unknown;
+  id?: unknown;
+  input: string;
+  inputValue?: unknown;
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -257,7 +263,13 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
     if (ev.type === 'content_block_start' && isRecord(ev.content_block)) {
       const key = blockKey(ev.index);
       const block = ev.content_block;
-      blocks.set(key, { type: block.type, name: block.name, id: block.id, input: '' });
+      blocks.set(key, {
+        type: block.type,
+        name: block.name,
+        id: block.id,
+        input: '',
+        inputValue: 'input' in block ? block.input : undefined,
+      });
       if (block.type === 'thinking') {
         onEvent({ type: 'thinking_start' });
       }
@@ -304,6 +316,19 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
           // Fall through to the final assistant wrapper's input if the
           // streamed JSON is malformed or incomplete.
         }
+      } else if (
+        state &&
+        state.type === 'tool_use' &&
+        typeof state.id === 'string' &&
+        state.inputValue !== undefined
+      ) {
+        onEvent({
+          type: 'tool_use',
+          id: state.id,
+          name: state.name,
+          input: state.inputValue,
+        });
+        streamedToolUseIds.add(state.id);
       }
       blocks.delete(key);
       return;

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -89,6 +89,57 @@ describe('structured agent stream fixtures', () => {
     });
   });
 
+  it('preserves Claude Code tool input from content_block_start when no delta arrives', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+
+    handler.feed(`${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'message_start', message: { id: 'msg-1' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: {
+          type: 'tool_use',
+          id: 'toolu-edit-1',
+          name: 'Edit',
+          input: {
+            file_path: 'C:\\Users\\Tetsu\\project\\canvas2-nodes.jsx',
+            old_string: 'const nodes = []',
+            new_string: 'const nodes = computeNodes()',
+          },
+        },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_stop', index: 0 },
+    })}\n${JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg-1',
+        content: [{ type: 'tool_use', id: 'toolu-edit-1', name: 'Edit', input: {} }],
+      },
+    })}\n`);
+    handler.flush();
+
+    const toolUses = events.filter((event) => typeof event === 'object' && event !== null && (event as { type?: string }).type === 'tool_use');
+
+    expect(toolUses).toEqual([
+      {
+        type: 'tool_use',
+        id: 'toolu-edit-1',
+        name: 'Edit',
+        input: {
+          file_path: 'C:\\Users\\Tetsu\\project\\canvas2-nodes.jsx',
+          old_string: 'const nodes = []',
+          new_string: 'const nodes = computeNodes()',
+        },
+      },
+    ]);
+  });
+
   it('does not duplicate streamed Claude Code text or thinking when final assistant wrapper has no id', () => {
     const events: unknown[] = [];
     const handler = createClaudeStreamHandler((event: unknown) => events.push(event));

--- a/apps/web/src/components/ToolCard.tsx
+++ b/apps/web/src/components/ToolCard.tsx
@@ -498,6 +498,7 @@ function FileWriteCard({
         <ResultBadge result={result} runStreaming={runStreaming} runSucceeded={runSucceeded} />
         <OpenInTabButton filePath={file} ctx={ctx} />
       </div>
+      <FileErrorDetail result={result} />
     </div>
   );
 }
@@ -538,6 +539,7 @@ function FileEditCard({
         <ResultBadge result={result} runStreaming={runStreaming} runSucceeded={runSucceeded} />
         <OpenInTabButton filePath={file} ctx={ctx} />
       </div>
+      <FileErrorDetail result={result} />
     </div>
   );
 }
@@ -567,6 +569,7 @@ function FileReadCard({
         <ResultBadge result={result} runStreaming={runStreaming} runSucceeded={runSucceeded} />
         <OpenInTabButton filePath={file} ctx={ctx} />
       </div>
+      <FileErrorDetail result={result} />
     </div>
   );
 }
@@ -696,8 +699,13 @@ function ResultBadge({ result, runStreaming, runSucceeded }: { result?: Props['r
   const t = useT();
   if (!result && runStreaming) return <span className="op-status op-status-running">{t('tool.running')}</span>;
   if (!result && !runSucceeded) return <span className="op-status op-status-error">{t('tool.error')}</span>;
-  if (result?.isError) return <span className="op-status op-status-error">{t('tool.error')}</span>;
+  if (result?.isError) return <span className="op-status op-status-error" title={result.content}>{t('tool.error')}</span>;
   return <span className="op-status op-status-ok">{t('tool.done')}</span>;
+}
+
+function FileErrorDetail({ result }: { result?: Props['result'] }) {
+  if (!result?.isError || !result.content.trim()) return null;
+  return <pre className="op-output">{truncate(result.content, 1200)}</pre>;
 }
 
 function describeInput(input: unknown): string {

--- a/apps/web/tests/runtime/tool-renderers.test.tsx
+++ b/apps/web/tests/runtime/tool-renderers.test.tsx
@@ -211,4 +211,17 @@ describe('ToolCard dispatch', () => {
     expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
   });
+
+  it('shows file edit error details alongside the target path', () => {
+    const markup = renderToStaticMarkup(
+      <ToolCard
+        use={use({ file_path: 'C:\\repo\\canvas2-nodes.jsx', old_string: 'a', new_string: 'b' }, 'Edit')}
+        result={err('String to replace was not found in C:\\repo\\canvas2-nodes.jsx')}
+        runStreaming={false}
+      />,
+    );
+
+    expect(markup).toContain('C:\\repo\\canvas2-nodes.jsx');
+    expect(markup).toContain('String to replace was not found');
+  });
 });


### PR DESCRIPTION
Closes #1914

## Why

Claude Code stream events can carry a complete tool_use input on content_block_start without later input_json_delta chunks. Open Design was ignoring that start-block input, so when Claude repeated a failed Edit call in the final assistant wrapper with an empty input object, the chat UI rendered the failed file operation as `(unnamed)`. That made Windows bulk-edit failures impossible to diagnose from the edit panel.

This fixes the issue for users hitting multi-edit failures in desktop with Claude Code by preserving the original file path and surfacing the upstream error text on file operation cards.

## What users will see

Failed Read/Write/Edit cards keep the file path that Claude Code provided, including Windows-style paths such as `C:\...\canvas2-nodes.jsx`. File-operation error cards also show the error detail below the row instead of only a red error badge.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: this runner does not have Node/pnpm available to start the web app or capture the desktop UI.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/structured-streams.test.ts` (`preserves Claude Code tool input from content_block_start when no delta arrives`)
- Additional UI coverage: `apps/web/tests/runtime/tool-renderers.test.tsx` (`shows file edit error details alongside the target path`)
- Did the test go red on `main` and green on this branch? Not run locally; this runner is missing Node, Corepack, npm, and pnpm.

## Validation

- `git diff --check`
- Not run: `pnpm --filter @open-design/daemon test -- structured-streams.test.ts`, `pnpm --filter @open-design/web test -- tool-renderers.test.tsx`, `pnpm guard`, and `pnpm typecheck` because Node/Corepack/npm/pnpm are not installed on PATH in this runner.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>