### PR TITLE
fix(platform): read Windows user proxy env for agent launches

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -939,7 +939,12 @@ export function SettingsDialog({
     const hasAmrAgent = agents.some((agent) => agent.id === 'amr' && agent.available);
     if (!hasAmrAgent) return;
     const onAmrStatusChange = (event: Event) => {
-      if (amrLoginStatusEventReason(event) === 'login-canceled') return;
+      if (amrLoginStatusEventReason(event) === 'login-canceled') {
+        setAmrCardStatus((current) => (
+          current ? { ...current, loginInFlight: false } : current
+        ));
+        return;
+      }
       refreshAmrCardStatus();
     };
     window.addEventListener(AMR_LOGIN_STATUS_EVENT, onAmrStatusChange);

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -29,6 +29,10 @@ import type { Dict } from '../i18n/types';
 import { AgentIcon } from './AgentIcon';
 import { AmrLoginPill } from './AmrLoginPill';
 import {
+  AMR_LOGIN_STATUS_EVENT,
+  amrLoginStatusEventReason,
+} from './amrLoginPolling';
+import {
   fetchVelaLoginStatus,
   type VelaLoginStatus,
 } from '../providers/daemon';
@@ -903,31 +907,46 @@ export function SettingsDialog({
   });
   const [amrCardStatus, setAmrCardStatus] = useState<VelaLoginStatus | null>(null);
   const [amrCardStatusReady, setAmrCardStatusReady] = useState(false);
+  const amrCardStatusRequestRef = useRef(0);
   const [hoveredAgentCardId, setHoveredAgentCardId] = useState<string | null>(null);
   const [providerTestState, setProviderTestState] = useState<TestState>({
     status: 'idle',
   });
 
+  const refreshAmrCardStatus = useCallback((options?: { markPending?: boolean }) => {
+    const requestId = ++amrCardStatusRequestRef.current;
+    if (options?.markPending) setAmrCardStatusReady(false);
+    void fetchVelaLoginStatus().then((next) => {
+      if (requestId !== amrCardStatusRequestRef.current) return;
+      setAmrCardStatus(next);
+      setAmrCardStatusReady(true);
+    });
+  }, []);
+
   useEffect(() => {
     const hasAmrAgent = agents.some((agent) => agent.id === 'amr' && agent.available);
     if (!hasAmrAgent) {
+      amrCardStatusRequestRef.current += 1;
       setAmrCardStatus(null);
       setAmrCardStatusReady(false);
       setHoveredAgentCardId(null);
       return;
     }
-    let cancelled = false;
-    setAmrCardStatusReady(false);
-    void fetchVelaLoginStatus().then((next) => {
-      if (!cancelled) {
-        setAmrCardStatus(next);
-        setAmrCardStatusReady(true);
-      }
-    });
-    return () => {
-      cancelled = true;
+    refreshAmrCardStatus({ markPending: true });
+  }, [agents, refreshAmrCardStatus]);
+
+  useEffect(() => {
+    const hasAmrAgent = agents.some((agent) => agent.id === 'amr' && agent.available);
+    if (!hasAmrAgent) return;
+    const onAmrStatusChange = (event: Event) => {
+      if (amrLoginStatusEventReason(event) === 'login-canceled') return;
+      refreshAmrCardStatus();
     };
-  }, [agents]);
+    window.addEventListener(AMR_LOGIN_STATUS_EVENT, onAmrStatusChange);
+    return () => {
+      window.removeEventListener(AMR_LOGIN_STATUS_EVENT, onAmrStatusChange);
+    };
+  }, [agents, refreshAmrCardStatus]);
   const [byokPreconditionNotice, setByokPreconditionNotice] = useState<{
     action: ByokPreconditionAction;
     message: string;

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -347,15 +347,25 @@ export function parseMacosScutilProxyOutput(
   );
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+type RegistryEntry = {
+  name: string;
+  type: string;
+  value: string;
+};
+
+function parseRegistryEntries(stdout: string): RegistryEntry[] {
+  return Array.from(stdout.matchAll(/^\s*(\S+)\s+(REG_\w+)\s+(.+)$/gim), (match) => ({
+    name: match[1].trim(),
+    type: match[2].trim().toUpperCase(),
+    value: match[3].trim(),
+  }));
 }
 
-function parseRegistryEntry(stdout: string, valueName: string): { type: string; value: string } | null {
-  const match = stdout.match(
-    new RegExp(`^\\s*${escapeRegExp(valueName)}\\s+(REG_\\w+)\\s+(.+)$`, "im"),
+function parseRegistryEntry(stdout: string, valueName: string): Omit<RegistryEntry, "name"> | null {
+  const entry = parseRegistryEntries(stdout).find(
+    (candidate) => candidate.name.toLowerCase() === valueName.toLowerCase(),
   );
-  return match ? { type: match[1].trim().toUpperCase(), value: match[2].trim() } : null;
+  return entry ? { type: entry.type, value: entry.value } : null;
 }
 
 function parseRegistryValue(stdout: string, valueName: string): string | null {
@@ -367,6 +377,14 @@ function expandWindowsEnvironmentValue(value: string, env: NodeJS.ProcessEnv): s
     const match = Object.entries(env).find(([key]) => key.toLowerCase() === name.toLowerCase());
     return match?.[1] ?? placeholder;
   });
+}
+
+function parseWindowsUserEnvironmentExpansionEnv(stdout: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const entry of parseRegistryEntries(stdout)) {
+    env[entry.name] = entry.value;
+  }
+  return env;
 }
 
 export function parseWindowsInternetSettingsProxyOutput(
@@ -450,6 +468,9 @@ export function resolveSystemProxyEnv(options: ResolveSystemProxyEnvOptions = {}
       return parseMacosScutilProxyOutput(tryRun("scutil", ["--proxy"]), platform);
     }
     if (platform === "win32") {
+      const userEnvironmentOutput = tryRun("reg", ["query", "HKCU\\Environment"]);
+      const userEnvironmentExpansionEnv =
+        parseWindowsUserEnvironmentExpansionEnv(userEnvironmentOutput);
       return mergeProxyAwareEnv(
         platform,
         parseWindowsInternetSettingsProxyOutput(
@@ -477,38 +498,14 @@ export function resolveSystemProxyEnv(options: ResolveSystemProxyEnvOptions = {}
         ),
         parseWindowsUserEnvironmentProxyOutput(
           {
-            HTTP_PROXY: tryRun("reg", [
-              "query",
-              "HKCU\\Environment",
-              "/v",
-              "HTTP_PROXY",
-            ]),
-            HTTPS_PROXY: tryRun("reg", [
-              "query",
-              "HKCU\\Environment",
-              "/v",
-              "HTTPS_PROXY",
-            ]),
-            ALL_PROXY: tryRun("reg", [
-              "query",
-              "HKCU\\Environment",
-              "/v",
-              "ALL_PROXY",
-            ]),
-            NO_PROXY: tryRun("reg", [
-              "query",
-              "HKCU\\Environment",
-              "/v",
-              "NO_PROXY",
-            ]),
-            NODE_USE_ENV_PROXY: tryRun("reg", [
-              "query",
-              "HKCU\\Environment",
-              "/v",
-              "NODE_USE_ENV_PROXY",
-            ]),
+            ALL_PROXY: userEnvironmentOutput,
+            HTTP_PROXY: userEnvironmentOutput,
+            HTTPS_PROXY: userEnvironmentOutput,
+            NODE_USE_ENV_PROXY: userEnvironmentOutput,
+            NO_PROXY: userEnvironmentOutput,
           },
           platform,
+          userEnvironmentExpansionEnv,
         ),
       );
     }

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -469,8 +469,10 @@ export function resolveSystemProxyEnv(options: ResolveSystemProxyEnvOptions = {}
     }
     if (platform === "win32") {
       const userEnvironmentOutput = tryRun("reg", ["query", "HKCU\\Environment"]);
-      const userEnvironmentExpansionEnv =
-        parseWindowsUserEnvironmentExpansionEnv(userEnvironmentOutput);
+      const userEnvironmentExpansionEnv = {
+        ...process.env,
+        ...parseWindowsUserEnvironmentExpansionEnv(userEnvironmentOutput),
+      };
       return mergeProxyAwareEnv(
         platform,
         parseWindowsInternetSettingsProxyOutput(

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -92,7 +92,14 @@ type WindowsProcessRecord = {
   ProcessId?: number | string | null;
 };
 
-const CANONICAL_PROXY_ENV_KEYS = new Map<string, "ALL_PROXY" | "HTTP_PROXY" | "HTTPS_PROXY" | "NODE_USE_ENV_PROXY" | "NO_PROXY">([
+type ProxyEnvKey =
+  | "ALL_PROXY"
+  | "HTTP_PROXY"
+  | "HTTPS_PROXY"
+  | "NODE_USE_ENV_PROXY"
+  | "NO_PROXY";
+
+const CANONICAL_PROXY_ENV_KEYS = new Map<string, ProxyEnvKey>([
   ["all_proxy", "ALL_PROXY"],
   ["http_proxy", "HTTP_PROXY"],
   ["https_proxy", "HTTPS_PROXY"],
@@ -109,9 +116,7 @@ function defaultSystemProxyCommandRunner(command: string, args: string[]): strin
   });
 }
 
-function canonicalProxyEnvKey(
-  key: string,
-): "ALL_PROXY" | "HTTP_PROXY" | "HTTPS_PROXY" | "NODE_USE_ENV_PROXY" | "NO_PROXY" | null {
+function canonicalProxyEnvKey(key: string): ProxyEnvKey | null {
   return CANONICAL_PROXY_ENV_KEYS.get(key.toLowerCase()) ?? null;
 }
 
@@ -123,7 +128,7 @@ function deleteProxyEnvVariants(env: NodeJS.ProcessEnv, canonicalKey: string): v
 
 function setCanonicalProxyEnvValue(
   env: NodeJS.ProcessEnv,
-  canonicalKey: "ALL_PROXY" | "HTTP_PROXY" | "HTTPS_PROXY" | "NODE_USE_ENV_PROXY" | "NO_PROXY",
+  canonicalKey: ProxyEnvKey,
   value: string,
   platform: NodeJS.Platform,
 ): void {
@@ -142,7 +147,7 @@ export function mergeProxyAwareEnv(
   const merged: NodeJS.ProcessEnv = {};
   for (const source of sources) {
     const proxyEntries = new Map<
-      "ALL_PROXY" | "HTTP_PROXY" | "HTTPS_PROXY" | "NODE_USE_ENV_PROXY" | "NO_PROXY",
+      ProxyEnvKey,
       { preferLowercase: boolean; value: string }
     >();
     for (const [key, value] of Object.entries(source)) {
@@ -170,7 +175,7 @@ export function mergeProxyAwareEnv(
 
 function hasCanonicalProxyEnv(
   env: NodeJS.ProcessEnv,
-  canonicalKey: "ALL_PROXY" | "HTTP_PROXY" | "HTTPS_PROXY" | "NODE_USE_ENV_PROXY" | "NO_PROXY",
+  canonicalKey: ProxyEnvKey,
 ): boolean {
   return Object.keys(env).some((key) => key.toLowerCase() === canonicalKey.toLowerCase());
 }
@@ -342,8 +347,14 @@ export function parseMacosScutilProxyOutput(
   );
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function parseRegistryValue(stdout: string, valueName: string): string | null {
-  const match = stdout.match(new RegExp(`^\\s*${valueName}\\s+REG_\\w+\\s+(.+)$`, "m"));
+  const match = stdout.match(
+    new RegExp(`^\\s*${escapeRegExp(valueName)}\\s+REG_\\w+\\s+(.+)$`, "im"),
+  );
   return match ? match[1].trim() : null;
 }
 
@@ -386,6 +397,28 @@ export function parseWindowsInternetSettingsProxyOutput(
   );
 }
 
+export function parseWindowsUserEnvironmentProxyOutput(
+  input: Partial<Record<ProxyEnvKey, string>>,
+  platform: NodeJS.Platform = "win32",
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, stdout] of Object.entries(input)) {
+    if (!stdout) continue;
+    const value = parseRegistryValue(stdout, key);
+    if (!value) continue;
+    setCanonicalProxyEnvValue(
+      env,
+      key as ProxyEnvKey,
+      value,
+      platform,
+    );
+  }
+  if (hasProxyEndpointEnv(env) && !hasCanonicalProxyEnv(env, "NODE_USE_ENV_PROXY")) {
+    env.NODE_USE_ENV_PROXY = "1";
+  }
+  return env;
+}
+
 export function resolveSystemProxyEnv(options: ResolveSystemProxyEnvOptions = {}): NodeJS.ProcessEnv {
   const platform = options.platform ?? process.platform;
   const runCommand = options.runCommand ?? defaultSystemProxyCommandRunner;
@@ -401,28 +434,66 @@ export function resolveSystemProxyEnv(options: ResolveSystemProxyEnvOptions = {}
       return parseMacosScutilProxyOutput(tryRun("scutil", ["--proxy"]), platform);
     }
     if (platform === "win32") {
-      return parseWindowsInternetSettingsProxyOutput(
-        {
-          proxyEnable: tryRun("reg", [
-            "query",
-            "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings",
-            "/v",
-            "ProxyEnable",
-          ]),
-          proxyOverride: tryRun("reg", [
-            "query",
-            "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings",
-            "/v",
-            "ProxyOverride",
-          ]),
-          proxyServer: tryRun("reg", [
-            "query",
-            "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings",
-            "/v",
-            "ProxyServer",
-          ]),
-        },
+      return mergeProxyAwareEnv(
         platform,
+        parseWindowsInternetSettingsProxyOutput(
+          {
+            proxyEnable: tryRun("reg", [
+              "query",
+              "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings",
+              "/v",
+              "ProxyEnable",
+            ]),
+            proxyOverride: tryRun("reg", [
+              "query",
+              "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings",
+              "/v",
+              "ProxyOverride",
+            ]),
+            proxyServer: tryRun("reg", [
+              "query",
+              "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings",
+              "/v",
+              "ProxyServer",
+            ]),
+          },
+          platform,
+        ),
+        parseWindowsUserEnvironmentProxyOutput(
+          {
+            HTTP_PROXY: tryRun("reg", [
+              "query",
+              "HKCU\\Environment",
+              "/v",
+              "HTTP_PROXY",
+            ]),
+            HTTPS_PROXY: tryRun("reg", [
+              "query",
+              "HKCU\\Environment",
+              "/v",
+              "HTTPS_PROXY",
+            ]),
+            ALL_PROXY: tryRun("reg", [
+              "query",
+              "HKCU\\Environment",
+              "/v",
+              "ALL_PROXY",
+            ]),
+            NO_PROXY: tryRun("reg", [
+              "query",
+              "HKCU\\Environment",
+              "/v",
+              "NO_PROXY",
+            ]),
+            NODE_USE_ENV_PROXY: tryRun("reg", [
+              "query",
+              "HKCU\\Environment",
+              "/v",
+              "NODE_USE_ENV_PROXY",
+            ]),
+          },
+          platform,
+        ),
       );
     }
   } catch {

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -351,11 +351,22 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function parseRegistryValue(stdout: string, valueName: string): string | null {
+function parseRegistryEntry(stdout: string, valueName: string): { type: string; value: string } | null {
   const match = stdout.match(
-    new RegExp(`^\\s*${escapeRegExp(valueName)}\\s+REG_\\w+\\s+(.+)$`, "im"),
+    new RegExp(`^\\s*${escapeRegExp(valueName)}\\s+(REG_\\w+)\\s+(.+)$`, "im"),
   );
-  return match ? match[1].trim() : null;
+  return match ? { type: match[1].trim().toUpperCase(), value: match[2].trim() } : null;
+}
+
+function parseRegistryValue(stdout: string, valueName: string): string | null {
+  return parseRegistryEntry(stdout, valueName)?.value ?? null;
+}
+
+function expandWindowsEnvironmentValue(value: string, env: NodeJS.ProcessEnv): string {
+  return value.replace(/%([^%]+)%/g, (placeholder, name: string) => {
+    const match = Object.entries(env).find(([key]) => key.toLowerCase() === name.toLowerCase());
+    return match?.[1] ?? placeholder;
+  });
 }
 
 export function parseWindowsInternetSettingsProxyOutput(
@@ -400,12 +411,17 @@ export function parseWindowsInternetSettingsProxyOutput(
 export function parseWindowsUserEnvironmentProxyOutput(
   input: Partial<Record<ProxyEnvKey, string>>,
   platform: NodeJS.Platform = "win32",
+  expansionEnv: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   for (const [key, stdout] of Object.entries(input)) {
     if (!stdout) continue;
-    const value = parseRegistryValue(stdout, key);
-    if (!value) continue;
+    const registryEntry = parseRegistryEntry(stdout, key);
+    if (!registryEntry?.value) continue;
+    const value =
+      registryEntry.type === "REG_EXPAND_SZ"
+        ? expandWindowsEnvironmentValue(registryEntry.value, expansionEnv)
+        : registryEntry.value;
     setCanonicalProxyEnvValue(
       env,
       key as ProxyEnvKey,

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -494,6 +494,31 @@ HKEY_CURRENT_USER\\Environment
     expect(userEnvironmentQueryCount).toBe(1);
   });
 
+  it("resolves Windows REG_EXPAND_SZ proxy values from inherited env", () => {
+    const original = process.env.SYSTEM_PROXY_ROOT;
+    process.env.SYSTEM_PROXY_ROOT = "system-proxy";
+    try {
+      const env = resolveSystemProxyEnv({
+        platform: "win32",
+        runCommand(_command, args) {
+          if (args.includes("HKCU\\Environment")) {
+            return `
+HKEY_CURRENT_USER\\Environment
+    HTTPS_PROXY    REG_EXPAND_SZ    http://%SYSTEM_PROXY_ROOT%:7890
+`;
+          }
+          return "";
+        },
+      });
+
+      expect(env.HTTPS_PROXY).toBe("http://system-proxy:7890");
+      expect(env.NODE_USE_ENV_PROXY).toBe("1");
+    } finally {
+      if (original == null) delete process.env.SYSTEM_PROXY_ROOT;
+      else process.env.SYSTEM_PROXY_ROOT = original;
+    }
+  });
+
   it("lets Windows user-level proxy env override Internet Settings proxy values", () => {
     const env = resolveSystemProxyEnv({
       platform: "win32",

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -452,16 +452,11 @@ HKEY_CURRENT_USER\\Environment
       platform: "win32",
       runCommand(command, args) {
         expect(command).toBe("reg");
-        const valueName = args.at(-1);
-        if (args.includes("HKCU\\Environment") && valueName === "HTTP_PROXY") {
+        if (args.includes("HKCU\\Environment")) {
+          expect(args).toEqual(["query", "HKCU\\Environment"]);
           return `
 HKEY_CURRENT_USER\\Environment
     HTTP_PROXY    REG_SZ    http://127.0.0.1:7890
-`;
-        }
-        if (args.includes("HKCU\\Environment") && valueName === "HTTPS_PROXY") {
-          return `
-HKEY_CURRENT_USER\\Environment
     HTTPS_PROXY    REG_SZ    http://127.0.0.1:7890
 `;
         }
@@ -474,12 +469,31 @@ HKEY_CURRENT_USER\\Environment
     expect(env.NODE_USE_ENV_PROXY).toBe("1");
   });
 
+  it("resolves Windows REG_EXPAND_SZ proxy values from registry-backed user env", () => {
+    const env = resolveSystemProxyEnv({
+      platform: "win32",
+      runCommand(_command, args) {
+        if (args.includes("HKCU\\Environment")) {
+          return `
+HKEY_CURRENT_USER\\Environment
+    CORP_PROXY_URL    REG_SZ    http://registry-proxy:7890
+    HTTPS_PROXY    REG_EXPAND_SZ    %CORP_PROXY_URL%
+`;
+        }
+        return "";
+      },
+    });
+
+    expect(env.HTTPS_PROXY).toBe("http://registry-proxy:7890");
+    expect(env.NODE_USE_ENV_PROXY).toBe("1");
+  });
+
   it("lets Windows user-level proxy env override Internet Settings proxy values", () => {
     const env = resolveSystemProxyEnv({
       platform: "win32",
       runCommand(_command, args) {
         const valueName = args.at(-1);
-        if (args.includes("HKCU\\Environment") && valueName === "HTTP_PROXY") {
+        if (args.includes("HKCU\\Environment")) {
           return `
 HKEY_CURRENT_USER\\Environment
     HTTP_PROXY    REG_SZ    http://env-proxy:7890

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -13,6 +13,7 @@ import {
   matchesStampedProcess,
   parseMacosScutilProxyOutput,
   parseWindowsInternetSettingsProxyOutput,
+  parseWindowsUserEnvironmentProxyOutput,
   pathContains,
   readProcessStampFromCommand,
   removePathBestEffort,
@@ -395,6 +396,30 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
     expect(env.NO_PROXY).toBe("*");
   });
 
+  it("parses Windows user-level proxy env values from HKCU Environment", () => {
+    const env = parseWindowsUserEnvironmentProxyOutput({
+      HTTP_PROXY: `
+HKEY_CURRENT_USER\\Environment
+    http_proxy    REG_SZ    http://127.0.0.1:7890
+`,
+      HTTPS_PROXY: `
+HKEY_CURRENT_USER\\Environment
+    HTTPS_PROXY    REG_EXPAND_SZ    http://127.0.0.1:7890
+`,
+      NO_PROXY: `
+HKEY_CURRENT_USER\\Environment
+    NO_PROXY    REG_SZ    localhost,127.0.0.1
+`,
+    });
+
+    expect(env).toEqual({
+      HTTP_PROXY: "http://127.0.0.1:7890",
+      HTTPS_PROXY: "http://127.0.0.1:7890",
+      NO_PROXY: "localhost,127.0.0.1",
+      NODE_USE_ENV_PROXY: "1",
+    });
+  });
+
   it("resolves macOS system proxy env through the command runner", () => {
     const env = resolveSystemProxyEnv({
       platform: "darwin",
@@ -412,6 +437,68 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
     });
 
     expect(env.HTTP_PROXY).toBe("http://127.0.0.1:8888");
+    expect(env.NODE_USE_ENV_PROXY).toBe("1");
+  });
+
+  it("resolves Windows user-level proxy env through the command runner", () => {
+    const env = resolveSystemProxyEnv({
+      platform: "win32",
+      runCommand(command, args) {
+        expect(command).toBe("reg");
+        const valueName = args.at(-1);
+        if (args.includes("HKCU\\Environment") && valueName === "HTTP_PROXY") {
+          return `
+HKEY_CURRENT_USER\\Environment
+    HTTP_PROXY    REG_SZ    http://127.0.0.1:7890
+`;
+        }
+        if (args.includes("HKCU\\Environment") && valueName === "HTTPS_PROXY") {
+          return `
+HKEY_CURRENT_USER\\Environment
+    HTTPS_PROXY    REG_SZ    http://127.0.0.1:7890
+`;
+        }
+        return "";
+      },
+    });
+
+    expect(env.HTTP_PROXY).toBe("http://127.0.0.1:7890");
+    expect(env.HTTPS_PROXY).toBe("http://127.0.0.1:7890");
+    expect(env.NODE_USE_ENV_PROXY).toBe("1");
+  });
+
+  it("lets Windows user-level proxy env override Internet Settings proxy values", () => {
+    const env = resolveSystemProxyEnv({
+      platform: "win32",
+      runCommand(_command, args) {
+        const valueName = args.at(-1);
+        if (args.includes("HKCU\\Environment") && valueName === "HTTP_PROXY") {
+          return `
+HKEY_CURRENT_USER\\Environment
+    HTTP_PROXY    REG_SZ    http://env-proxy:7890
+`;
+        }
+        const isInternetSettings = args.includes(
+          "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings",
+        );
+        if (isInternetSettings && valueName === "ProxyEnable") {
+          return `
+HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings
+    ProxyEnable    REG_DWORD    0x1
+`;
+        }
+        if (isInternetSettings && valueName === "ProxyServer") {
+          return `
+HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings
+    ProxyServer    REG_SZ    http://internet-settings:8080
+`;
+        }
+        return "";
+      },
+    });
+
+    expect(env.HTTP_PROXY).toBe("http://env-proxy:7890");
+    expect(env.HTTPS_PROXY).toBe("http://internet-settings:8080");
     expect(env.NODE_USE_ENV_PROXY).toBe("1");
   });
 

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -489,7 +489,7 @@ HKEY_CURRENT_USER\\Environment
     });
 
     expect(env.HTTPS_PROXY).toBe("http://registry-proxy:7890");
-    expect(env.NO_PROXY).toBe("BUILD-WIN-01,localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("BUILD-WIN-01,localhost");
     expect(env.NODE_USE_ENV_PROXY).toBe("1");
     expect(userEnvironmentQueryCount).toBe(1);
   });

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -470,14 +470,18 @@ HKEY_CURRENT_USER\\Environment
   });
 
   it("resolves Windows REG_EXPAND_SZ proxy values from registry-backed user env", () => {
+    let userEnvironmentQueryCount = 0;
     const env = resolveSystemProxyEnv({
       platform: "win32",
       runCommand(_command, args) {
         if (args.includes("HKCU\\Environment")) {
+          userEnvironmentQueryCount += 1;
           return `
 HKEY_CURRENT_USER\\Environment
+    COMPUTERNAME    REG_SZ    BUILD-WIN-01
     CORP_PROXY_URL    REG_SZ    http://registry-proxy:7890
     HTTPS_PROXY    REG_EXPAND_SZ    %CORP_PROXY_URL%
+    NO_PROXY    REG_EXPAND_SZ    %COMPUTERNAME%,localhost
 `;
         }
         return "";
@@ -485,7 +489,9 @@ HKEY_CURRENT_USER\\Environment
     });
 
     expect(env.HTTPS_PROXY).toBe("http://registry-proxy:7890");
+    expect(env.NO_PROXY).toBe("BUILD-WIN-01,localhost,127.0.0.1");
     expect(env.NODE_USE_ENV_PROXY).toBe("1");
+    expect(userEnvironmentQueryCount).toBe(1);
   });
 
   it("lets Windows user-level proxy env override Internet Settings proxy values", () => {

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -397,25 +397,32 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
   });
 
   it("parses Windows user-level proxy env values from HKCU Environment", () => {
-    const env = parseWindowsUserEnvironmentProxyOutput({
-      HTTP_PROXY: `
+    const env = parseWindowsUserEnvironmentProxyOutput(
+      {
+        HTTP_PROXY: `
 HKEY_CURRENT_USER\\Environment
     http_proxy    REG_SZ    http://127.0.0.1:7890
 `,
-      HTTPS_PROXY: `
+        HTTPS_PROXY: `
 HKEY_CURRENT_USER\\Environment
-    HTTPS_PROXY    REG_EXPAND_SZ    http://127.0.0.1:7890
+    HTTPS_PROXY    REG_EXPAND_SZ    %CORP_PROXY_URL%
 `,
-      NO_PROXY: `
+        NO_PROXY: `
 HKEY_CURRENT_USER\\Environment
-    NO_PROXY    REG_SZ    localhost,127.0.0.1
+    NO_PROXY    REG_EXPAND_SZ    %COMPUTERNAME%,localhost,127.0.0.1
 `,
-    });
+      },
+      "win32",
+      {
+        COMPUTERNAME: "BUILD-WIN-01",
+        CORP_PROXY_URL: "http://127.0.0.1:7890",
+      },
+    );
 
     expect(env).toEqual({
       HTTP_PROXY: "http://127.0.0.1:7890",
       HTTPS_PROXY: "http://127.0.0.1:7890",
-      NO_PROXY: "localhost,127.0.0.1",
+      NO_PROXY: "BUILD-WIN-01,localhost,127.0.0.1",
       NODE_USE_ENV_PROXY: "1",
     });
   });


### PR DESCRIPTION
Closes #2197

## Why

Windows packaged users can configure Codex correctly and still see Settings → Codex CLI connection tests time out when the app was launched outside a shell that already contains `HTTP_PROXY` / `HTTPS_PROXY`.

The reported machine had working user-level Windows proxy environment variables, but the packaged runtime only reconstructed Windows Internet Settings proxy values. That left Codex child processes without the same effective proxy environment as a successful manual `codex.cmd exec ...` run.

## What users will see

On Windows, packaged Open Design now carries user-level proxy environment values from `HKCU\Environment` into agent CLI launches. Codex connection tests should use the same `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, and `NODE_USE_ENV_PROXY` values that a newly opened PowerShell/cmd session sees.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI changes.

## Bug fix verification

- Test path that reproduces the bug: `packages/platform/tests/index.test.ts` now covers parsing Windows user-level proxy env values from `HKCU\Environment`, resolving them through `resolveSystemProxyEnv`, and letting explicit user env proxy values override Internet Settings proxy values.
- Did the test go red on `main` and green on this branch? Not run here; this worker does not have Node, npm, Corepack, or pnpm installed.

## Validation

- `git diff --check`
- Attempted `pnpm --filter @open-design/platform test` but `pnpm` was not available in this worker. `node`, `npm`, and `corepack` were also unavailable, so package tests/typecheck could not be executed locally.
