### PR TITLE
ci(release): split Feishu streams on release/v0.9.0 (backport #3474)

### DIFF
--- a/.github/scripts/release/feishu/notify.ts
+++ b/.github/scripts/release/feishu/notify.ts
@@ -1,20 +1,24 @@
-// Posts a beta ("nightly") build notification to a Feishu (Lark) custom-bot
-// webhook as an interactive card: version, branch, commit, per-platform download
-// buttons, and the changelog since the previously published beta.
+// Posts a packaged build notification to a Feishu (Lark) custom-bot webhook as
+// an interactive card: version, branch, commit, per-platform download buttons,
+// and the changelog since the previously published build of the same channel.
 //
 // Inputs (all via env):
 //   FEISHU_WEBHOOK        (required) custom-bot webhook URL
 //   FEISHU_SIGN_SECRET    (optional) signing secret when the bot enables 签名校验
-//   VERSION_METADATA_URL  (required) public R2 URL of this build's version metadata.json
-//   BETA_VERSION          (required) x.y.z-beta.N
+//   CHANNEL_LABEL         display channel name, e.g. "Nightly" (default "Nightly")
+//   VERSION               (required) build version, e.g. 0.9.0.nightly.1
 //   BRANCH                git branch that was built
 //   COMMIT                commit SHA that was built
-//   PREVIOUS_COMMIT       changelog baseline (last published beta); empty on cold start
+//   PREVIOUS_COMMIT       changelog baseline (last published build); empty on cold start
 //   CHANGELOG_FILE        path to a file holding `git log` output (one commit per line)
-//   RELEASE_STATE         complete | partial | failed
+//   BUILD_STATE           build result (success | ...) — drives header color
 //   STREAM_LABEL          human label for the trigger (e.g. "release 分支推送" / "每日定时")
 //   REPO                  owner/name
 //   RUN_URL               link back to the GitHub Actions run
+//   MAC_ARM64_URL         macOS arm64 download URL (optional)
+//   MAC_INTEL_URL         macOS x64 (Intel) download URL (optional)
+//   WIN_URL               Windows x64 download URL (optional)
+//   LINUX_URL             Linux x64 download URL (optional)
 
 import { createHmac } from "node:crypto";
 import { readFileSync } from "node:fs";
@@ -34,75 +38,45 @@ function optional(name, fallback = "") {
 
 const webhook = required("FEISHU_WEBHOOK");
 const signSecret = optional("FEISHU_SIGN_SECRET");
-const versionMetadataUrl = optional("VERSION_METADATA_URL");
-const betaVersion = required("BETA_VERSION");
+const channelLabel = optional("CHANNEL_LABEL", "Nightly");
+const version = required("VERSION");
 const branch = optional("BRANCH");
 const commit = optional("COMMIT");
 const previousCommit = optional("PREVIOUS_COMMIT");
 const changelogFile = optional("CHANGELOG_FILE");
-const releaseState = optional("RELEASE_STATE", "unknown");
+const buildState = optional("BUILD_STATE", "success");
 const streamLabel = optional("STREAM_LABEL", "构建");
 const repo = optional("REPO");
 const runUrl = optional("RUN_URL");
 
 const MAX_CHANGELOG_LINES = 30;
 
-// Primary downloadable artifact per platform key, in preference order.
-const PRIMARY_ARTIFACT = {
-  mac: ["dmg", "zip"],
-  win: ["installer"],
-  linux: ["appImage"],
-  macIntel: ["dmg", "zip"],
-};
+// Download buttons, in display order. Empty URLs are skipped, so the set of
+// buttons reflects exactly the platforms this build published.
+const DOWNLOADS = [
+  { label: "macOS (Apple Silicon)", url: optional("MAC_ARM64_URL") },
+  { label: "macOS (Intel)", url: optional("MAC_INTEL_URL") },
+  { label: "Windows", url: optional("WIN_URL") },
+  { label: "Linux", url: optional("LINUX_URL") },
+];
 
-async function fetchMetadata(url) {
-  if (url.length === 0) return null;
-  try {
-    const res = await fetch(url, { redirect: "follow" });
-    if (!res.ok) {
-      console.warn(`[feishu] metadata fetch ${url} returned HTTP ${res.status}`);
-      return null;
-    }
-    return await res.json();
-  } catch (error) {
-    console.warn(`[feishu] metadata fetch failed: ${error instanceof Error ? error.message : String(error)}`);
-    return null;
-  }
-}
-
-function downloadButtons(metadata) {
-  if (metadata == null || typeof metadata.platforms !== "object") return [];
-  const buttons = [];
-  for (const [key, platform] of Object.entries(metadata.platforms)) {
-    if (platform == null || platform.status !== "published") continue;
-    const artifacts = platform.artifacts ?? {};
-    const order = PRIMARY_ARTIFACT[key] ?? Object.keys(artifacts);
-    let chosen = null;
-    for (const name of order) {
-      if (artifacts[name]?.url) {
-        chosen = artifacts[name].url;
-        break;
-      }
-    }
-    if (chosen == null) continue;
-    const label = platform.label ?? key;
-    buttons.push({
-      tag: "button",
-      text: { tag: "plain_text", content: `下载 ${label}` },
-      type: buttons.length === 0 ? "primary" : "default",
-      url: chosen,
-    });
-  }
-  return buttons;
+function downloadButtons() {
+  const present = DOWNLOADS.filter((d) => d.url.length > 0);
+  return present.map((d, index) => ({
+    tag: "button",
+    text: { tag: "plain_text", content: `下载 ${d.label}` },
+    type: index === 0 ? "primary" : "default",
+    url: d.url,
+  }));
 }
 
 function readChangelog() {
-  if (changelogFile.length === 0) return { lines: [], truncated: false };
+  if (changelogFile.length === 0) return { lines: [], truncated: false, total: 0 };
   let raw = "";
   try {
     raw = readFileSync(changelogFile, "utf8");
   } catch {
-    return { lines: [], truncated: false };
+    return { lines: [], truncated: false, total: 0 };
   }
   const all = raw
     .split("\n")
@@ -115,10 +89,10 @@ function readChangelog() {
 function changelogMarkdown() {
   const { lines, truncated, total } = readChangelog();
   if (previousCommit.length === 0) {
-    return "首个 beta 包,无上个版本可对比。";
+    return `首个 ${channelLabel} 包,无上个版本可对比。`;
   }
   if (lines.length === 0) {
-    return "与上个 beta 包之间没有新增提交。";
+    return `与上个 ${channelLabel} 包之间没有新增提交。`;
   }
   const body = lines.map((line) => `- ${line}`).join("\n");
   if (truncated) {
@@ -128,9 +102,7 @@ function changelogMarkdown() {
 }
 
 function headerTemplate() {
-  if (releaseState === "complete") return "blue";
-  if (releaseState === "partial") return "orange";
-  return "red";
+  return buildState === "success" ? "blue" : "red";
 }
 
 function buildCard() {
@@ -143,16 +115,16 @@ function buildCard() {
     const link = repo.length > 0 ? `[\`${shortCommit}\`](https://github.com/${repo}/commit/${commit})` : `\`${shortCommit}\``;
     fields.push({ is_short: true, text: { tag: "lark_md", content: `**提交**\n${link}` } });
   }
-  fields.push({ is_short: true, text: { tag: "lark_md", content: `**状态**\n${releaseState}` } });
+  fields.push({ is_short: true, text: { tag: "lark_md", content: `**渠道**\n${channelLabel}` } });
   fields.push({ is_short: true, text: { tag: "lark_md", content: `**触发**\n${streamLabel}` } });
 
   const elements = [{ tag: "div", fields }];
   elements.push({
     tag: "div",
-    text: { tag: "lark_md", content: `**自上个 beta 新增提交**\n${changelogMarkdown()}` },
+    text: { tag: "lark_md", content: `**自上个 ${channelLabel} 新增提交**\n${changelogMarkdown()}` },
   });
 
-  const buttons = downloadButtons(currentMetadata);
+  const buttons = downloadButtons();
   if (buttons.length > 0) {
     elements.push({ tag: "hr" });
     elements.push({ tag: "action", actions: buttons });
@@ -169,7 +141,7 @@ function buildCard() {
     config: { wide_screen_mode: true },
     header: {
       template: headerTemplate(),
-      title: { tag: "plain_text", content: `🚀 Open Design Beta ${betaVersion}` },
+      title: { tag: "plain_text", content: `🚀 Open Design ${channelLabel} ${version}` },
     },
     elements,
   };
@@ -183,6 +155,11 @@ function signedEnvelope(card) {
   const stringToSign = `${timestamp}\n${signSecret}`;
   const sign = createHmac("sha256", stringToSign).update("").digest("base64");
   return { timestamp, sign, ...body };
+}
+
+function sleep(attempt) {
+  const ms = Math.min(1000 * 2 ** (attempt - 1), 15000);
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function post(body) {
@@ -223,11 +200,4 @@ async function post(body) {
   }
 }
 
-function sleep(attempt) {
-  const ms = Math.min(1000 * 2 ** (attempt - 1), 15000);
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-const currentMetadata = await fetchMetadata(versionMetadataUrl);
-const card = buildCard();
-await post(signedEnvelope(card));
+await post(signedEnvelope(buildCard()));

--- a/.github/workflows/notify-daily-feishu.yml
+++ b/.github/workflows/notify-daily-feishu.yml
@@ -1,10 +1,10 @@
 name: notify-daily-feishu
 
-# Every morning (09:00 Asia/Shanghai) build a full beta ("nightly") package off
-# the currently active release branch (highest-semver release/vX.Y.Z) by reusing
-# release-beta, then post a Feishu card with download links and the changelog
-# since the previously published beta — to a separate Feishu group from the
-# per-push release stream.
+# Every morning (09:00 Asia/Shanghai) build a beta package off the currently
+# active release branch (highest-semver release/vX.Y.Z) by reusing release-beta,
+# then post a Feishu card with download links and the changelog since the
+# previously published beta — to a separate Feishu group from the per-push
+# release stream (which builds the heavier nightly channel).
 #
 # NOTE: schedule triggers only fire from the default branch (main), so this file
 # must live on main to run on its cron.
@@ -110,13 +110,15 @@ jobs:
         env:
           FEISHU_WEBHOOK: ${{ secrets.FEISHU_DAILY_WEBHOOK }}
           FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_DAILY_SIGN_SECRET }}
-          VERSION_METADATA_URL: ${{ needs.build.outputs.version_metadata_url }}
-          BETA_VERSION: ${{ needs.build.outputs.beta_version }}
+          CHANNEL_LABEL: "Beta"
+          VERSION: ${{ needs.build.outputs.beta_version }}
           BRANCH: ${{ needs.build.outputs.branch }}
           COMMIT: ${{ needs.build.outputs.commit }}
           PREVIOUS_COMMIT: ${{ needs.build.outputs.previous_commit }}
           CHANGELOG_FILE: ${{ steps.changelog.outputs.file }}
-          RELEASE_STATE: ${{ needs.build.outputs.release_state }}
+          BUILD_STATE: ${{ needs.build.result }}
+          MAC_ARM64_URL: ${{ needs.build.outputs.mac_arm64_url }}
+          WIN_URL: ${{ needs.build.outputs.win_url }}
           STREAM_LABEL: "每日定时"
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/notify-release-feishu.yml
+++ b/.github/workflows/notify-release-feishu.yml
@@ -1,9 +1,10 @@
 name: notify-release-feishu
 
-# On every push to a release/** branch, build a full beta ("nightly") package by
-# reusing release-beta, then post a Feishu card with the download links and the
-# changelog since the previously published beta. Consecutive pushes to the same
-# branch are debounced: a newer push cancels the in-flight build.
+# On every push to a release/** branch, build a full nightly package by reusing
+# release-stable (channel=nightly), then post a Feishu card with the download
+# links (macOS arm64 + Intel, Windows, and Linux when enabled) and the changelog
+# since the previously published nightly. Consecutive pushes to the same branch
+# are debounced: a newer push cancels the in-flight build.
 
 on:
   push:
@@ -11,7 +12,7 @@ on:
       - "release/**"
 
 permissions:
-  contents: read
+  contents: write
   actions: write
 
 concurrency:
@@ -20,18 +21,17 @@ concurrency:
 
 jobs:
   build:
-    name: Build beta from release branch
+    name: Build nightly from release branch
     if: github.repository == 'nexu-io/open-design'
-    uses: ./.github/workflows/release-beta.yml
+    uses: ./.github/workflows/release-stable.yml
     secrets: inherit
     with:
-      enable_mac: true
-      enable_win: true
+      channel: nightly
 
   notify:
     name: Notify Feishu (release)
     needs: build
-    if: ${{ !cancelled() && needs.build.outputs.beta_version != '' }}
+    if: ${{ !cancelled() && needs.build.outputs.release_version != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout built ref
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
 
-      - name: Compute changelog since last beta
+      - name: Compute changelog since last nightly
         id: changelog
         env:
           PREV: ${{ needs.build.outputs.previous_commit }}
@@ -63,13 +63,17 @@ jobs:
         env:
           FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
           FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}
-          VERSION_METADATA_URL: ${{ needs.build.outputs.version_metadata_url }}
-          BETA_VERSION: ${{ needs.build.outputs.beta_version }}
+          CHANNEL_LABEL: "Nightly"
+          VERSION: ${{ needs.build.outputs.release_version }}
           BRANCH: ${{ needs.build.outputs.branch }}
           COMMIT: ${{ needs.build.outputs.commit }}
           PREVIOUS_COMMIT: ${{ needs.build.outputs.previous_commit }}
           CHANGELOG_FILE: ${{ steps.changelog.outputs.file }}
-          RELEASE_STATE: ${{ needs.build.outputs.release_state }}
+          BUILD_STATE: ${{ needs.build.result }}
+          MAC_ARM64_URL: ${{ needs.build.outputs.mac_arm64_url }}
+          MAC_INTEL_URL: ${{ needs.build.outputs.mac_intel_url }}
+          WIN_URL: ${{ needs.build.outputs.win_url }}
+          LINUX_URL: ${{ needs.build.outputs.linux_url }}
           STREAM_LABEL: "release 分支推送"
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -74,6 +74,12 @@ on:
       version_metadata_url:
         description: "Public R2 URL of this build's version metadata.json."
         value: ${{ jobs.publish.outputs.version_metadata_url }}
+      mac_arm64_url:
+        description: "macOS arm64 dmg download URL."
+        value: ${{ jobs.publish.outputs.mac_arm64_url }}
+      win_url:
+        description: "Windows x64 installer download URL."
+        value: ${{ jobs.publish.outputs.win_url }}
 
 permissions:
   actions: write
@@ -787,6 +793,8 @@ jobs:
     outputs:
       version_metadata_url: ${{ steps.r2.outputs.version_metadata_url }}
       release_state: ${{ steps.r2.outputs.release_state }}
+      mac_arm64_url: ${{ steps.r2.outputs.mac_dmg_url }}
+      win_url: ${{ steps.r2.outputs.win_installer_url }}
     env:
       GH_TOKEN: ${{ github.token }}
       # Record the real built commit in metadata.json. Under workflow_call the

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -15,6 +15,59 @@ on:
         description: "Required when channel=stable: exact validated nightly version to promote, for example 0.5.1.nightly.3."
         required: false
         type: string
+      ref:
+        description: "Optional git ref (branch/tag/SHA) to build. Empty builds the ref this workflow was dispatched on."
+        required: false
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      channel:
+        description: "Release channel (nightly or stable)."
+        required: false
+        type: string
+        default: nightly
+      nightly_version:
+        description: "Required when channel=stable: exact validated nightly version to promote."
+        required: false
+        type: string
+        default: ""
+      ref:
+        description: "Optional git ref (branch/tag/SHA) to build. Empty builds the caller's ref."
+        required: false
+        type: string
+        default: ""
+    outputs:
+      release_version:
+        description: "The version that was built (x.y.z.nightly.N for nightly)."
+        value: ${{ jobs.metadata.outputs.release_version }}
+      channel:
+        description: "The channel that was built."
+        value: ${{ jobs.metadata.outputs.channel }}
+      branch:
+        description: "The branch that was built."
+        value: ${{ jobs.metadata.outputs.branch }}
+      commit:
+        description: "The commit SHA that was built."
+        value: ${{ jobs.metadata.outputs.commit }}
+      previous_commit:
+        description: "Commit SHA of the previously published nightly (changelog baseline); empty on cold start."
+        value: ${{ jobs.metadata.outputs.previous_commit }}
+      version_metadata_url:
+        description: "Public R2 URL of this build's version metadata.json."
+        value: ${{ jobs.publish.outputs.version_metadata_url }}
+      mac_arm64_url:
+        description: "macOS arm64 dmg download URL."
+        value: ${{ jobs.publish.outputs.mac_arm64_url }}
+      mac_intel_url:
+        description: "macOS x64 (Intel) dmg download URL."
+        value: ${{ jobs.publish.outputs.mac_intel_url }}
+      win_url:
+        description: "Windows x64 installer download URL."
+        value: ${{ jobs.publish.outputs.win_url }}
+      linux_url:
+        description: "Linux x64 AppImage download URL (empty if linux disabled)."
+        value: ${{ jobs.publish.outputs.linux_url }}
 
 permissions:
   actions: write
@@ -63,6 +116,7 @@ jobs:
       namespace: ${{ steps.stable.outputs.namespace }}
       nightly_number: ${{ steps.stable.outputs.nightly_number }}
       previous_stable: ${{ steps.stable.outputs.previous_stable }}
+      previous_commit: ${{ steps.prev.outputs.previous_commit }}
       release_name: ${{ steps.stable.outputs.release_name }}
       release_version: ${{ steps.stable.outputs.release_version }}
       stable_version: ${{ steps.stable.outputs.stable_version }}
@@ -73,6 +127,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -80,8 +135,29 @@ jobs:
         with:
           node-version: 24
 
+      # Under workflow_call the runner's GITHUB_SHA/GITHUB_REF_NAME describe the
+      # caller's ref (e.g. main for the scheduled daily build), not the ref we
+      # actually checked out. Resolve the real built HEAD so the published
+      # metadata.json records the branch we built, not the caller.
+      - name: Resolve built commit
+        run: echo "BUILT_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      # Capture the previously published nightly commit BEFORE this run overwrites
+      # nightly/latest/metadata.json, so the notification can diff the changelog
+      # against the last package. Empty on cold start (HTTP 404).
+      - name: Capture previous nightly commit
+        id: prev
+        run: |
+          set -euo pipefail
+          prev="$(curl -fsSL "$OPEN_DESIGN_NIGHTLY_METADATA_URL" | jq -r '.github.commit // ""' 2>/dev/null || true)"
+          echo "previous nightly commit: ${prev:-<none>}"
+          echo "previous_commit=$prev" >> "$GITHUB_OUTPUT"
+
       - name: Prepare release metadata
         id: stable
+        env:
+          GITHUB_SHA: ${{ env.BUILT_SHA }}
+          GITHUB_REF_NAME: ${{ inputs.ref != '' && inputs.ref || github.ref_name }}
         run: node --experimental-strip-types ./scripts/release-stable.ts
 
       - name: Validate R2 release access
@@ -105,6 +181,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -158,6 +235,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -372,6 +450,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -445,6 +524,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -637,6 +717,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -755,8 +836,18 @@ jobs:
         (needs.build_linux.result == 'success' || needs.build_linux.result == 'skipped')
       }}
     runs-on: ubuntu-latest
+    outputs:
+      version_metadata_url: ${{ steps.r2.outputs.version_metadata_url }}
+      mac_arm64_url: ${{ steps.r2.outputs.mac_dmg_url }}
+      mac_intel_url: ${{ steps.r2.outputs.mac_intel_dmg_url }}
+      win_url: ${{ steps.r2.outputs.win_installer_url }}
+      linux_url: ${{ steps.r2.outputs.linux_appimage_url }}
     env:
       GH_TOKEN: ${{ github.token }}
+      # Record the real built commit in metadata.json. Under workflow_call the
+      # runner's GITHUB_SHA is the caller's ref, so pin it to the resolved build
+      # commit; the next run reads this back as its changelog baseline.
+      GITHUB_SHA: ${{ needs.metadata.outputs.commit }}
       AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_RELEASES_SK }}
       AWS_DEFAULT_REGION: auto
@@ -784,6 +875,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -952,6 +1044,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Delete unpublished release asset artifacts
         env:


### PR DESCRIPTION
## Why

Backport of #3474 (squash \`2305a3576\`, cherry-picked with \`-x\`) onto the current release branch.

A \`push\`-triggered workflow runs the version of the workflow file **on the pushed branch**, so to activate the corrected per-push stream on \`release/v0.9.0\` the workflows must live on this branch. #3469 previously put the (wrong, beta-only) version here; this aligns it with the split landed on main.

## What users will see

After this merges, every push to \`release/v0.9.0\`:
- builds the **nightly** channel via release-stable (strong checks; macOS arm64 + Intel + Windows) and posts a card to the release Feishu group;
- the daily 09:00 job (on main) builds **beta** off the active release branch to the daily group.

⚠️ **Merging this PR is itself a push to \`release/v0.9.0\`**, so it triggers the first real nightly build (~20 min) + Feishu card — intended live validation.

## Surface area

- [x] **None** — release/CI infra only; identical to #3474 (already reviewed on main). Clean cherry-pick (release-stable.yml auto-merged, no conflicts).

## Validation

\`actionlint 1.7.12\` clean on all four touched workflows. Full static + dry-run validation done on #3474.

## Note

Channel renaming (beta+nightly on main, nightly→prerelease) is intentionally **out of scope** here and tracked separately — it touches packaged identity and the stable promotion gate.