### PR TITLE
refactor(web): extract BYOK settings fields

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -53,7 +53,6 @@ import {
 import type { KnownProvider } from '../state/config';
 import { navigate as navigateRoute, useRoute } from '../router';
 import {
-  API_KEY_PLACEHOLDERS,
   API_PROTOCOL_LABELS,
   API_PROTOCOL_TABS,
   SUGGESTED_MODELS_BY_PROTOCOL,
@@ -99,6 +98,10 @@ import { RoutinesSection } from './RoutinesSection';
 import { ConnectorsBrowser } from './ConnectorsBrowser';
 import { MemoryModelInline } from './MemoryModelInline';
 import { MemorySection } from './MemorySection';
+import { ByokKeyField } from './byok/ByokKeyField';
+import { ByokModelField } from './byok/ByokModelField';
+import { ByokProviderBaseUrl } from './byok/ByokProviderBaseUrl';
+import { ByokProviderPicker } from './byok/ByokProviderPicker';
 import {
   setCritiqueTheaterEnabled,
   useCritiqueTheaterEnabled,
@@ -1909,9 +1912,6 @@ export function SettingsDialog({
       apiModelIds,
       apiModelCustomEditing,
     );
-  const apiModelSelectValue = apiModelCustomActive
-    ? CUSTOM_MODEL_SENTINEL
-    : cfg.model;
   const baseUrlReadOnly =
     (apiProtocol === 'anthropic' || apiProtocol === 'google') &&
     cfg.apiProviderBaseUrl !== null &&
@@ -1923,76 +1923,6 @@ export function SettingsDialog({
       : apiProtocol === 'ollama'
         ? 'http://localhost:11434'
         : undefined;
-  const renderByokBaseUrlField = () => (
-    <label className={'field' + (baseUrlReadOnly ? ' settings-base-url-readonly' : '')}>
-      <span className="field-label">
-        {t('settings.baseUrl')}
-        <span className="field-required" aria-label={t('settings.required')}>
-          *
-        </span>
-      </span>
-      <div className="field-row">
-        <input
-          ref={baseUrlInputRef}
-          aria-label={t('settings.baseUrl')}
-          type="url"
-          inputMode="url"
-          value={cfg.baseUrl}
-          placeholder={baseUrlPlaceholder}
-          readOnly={baseUrlReadOnly || undefined}
-          aria-invalid={baseUrlInvalid || undefined}
-          aria-describedby={
-            baseUrlInvalid ? 'settings-base-url-error' : undefined
-          }
-          onFocus={() => {
-            const byokProviderId = byokProtocolToTracking(apiProtocol);
-            if (byokProviderId) {
-              trackSettingsByokFieldClick(analytics.track, {
-                page_name: 'settings',
-                area: 'configure_execution_mode_byok',
-                element: 'base_url',
-                provider_id: byokProviderId,
-                has_value: Boolean(cfg.baseUrl?.trim()),
-              });
-            }
-          }}
-          onBlur={commitProviderModelsInputs}
-          onChange={(e) => updateApiConfig({ baseUrl: e.target.value, apiProviderBaseUrl: null })}
-        />
-        {baseUrlReadOnly ? (
-          <button
-            type="button"
-            className="ghost icon-btn settings-base-url-customize"
-            onClick={() => {
-              updateApiConfig({ apiProviderBaseUrl: null });
-              window.setTimeout(() => baseUrlInputRef.current?.focus(), 0);
-            }}
-          >
-            {t('settings.baseUrlCustomize')}
-          </button>
-        ) : null}
-      </div>
-      {baseUrlInvalid ? (
-        <span
-          id="settings-base-url-error"
-          className="settings-field-error"
-          role="alert"
-        >
-          {t('settings.baseUrlInvalid')}
-        </span>
-      ) : null}
-      {baseUrlReadOnly ? (
-        <span className="field-inline-status">
-          {t('settings.baseUrlDefaultHint')}
-        </span>
-      ) : null}
-      {apiProtocol === 'azure' ? (
-        <span className="field-inline-status">
-          {t('settings.azureBaseUrlHint')}
-        </span>
-      ) : null}
-    </label>
-  );
   useEffect(() => {
     if (!focusByokRequiredFieldAfterProtocolSwitchRef.current) return;
     focusByokRequiredFieldAfterProtocolSwitchRef.current = false;
@@ -3235,255 +3165,169 @@ export function SettingsDialog({
                 </p>
               ) : null}
               {showQuickFillProvider ? (
-                <label className="field">
-                  <span className="field-label">{t('settings.quickFillProvider')}</span>
-                  <select
-                    value={selectedProviderIndex >= 0 ? String(selectedProviderIndex) : ''}
-                    onChange={(e) => {
-                      if (e.target.value === '') {
-                        setApiModelCustomEditing(false);
-                        updateApiConfig({
-                          baseUrl: '',
-                          model: '',
-                          apiProviderBaseUrl: null,
-                        });
-                        return;
-                      }
-                      const idx = Number(e.target.value);
-                      if (!isNaN(idx) && protocolProviders[idx]) {
-                        const p = protocolProviders[idx]!;
-                        setApiModelCustomEditing(false);
-                        updateApiConfig({
-                          baseUrl: p.baseUrl,
-                          model: p.model,
-                          apiProviderBaseUrl: p.baseUrl,
-                        });
-                      }
-                    }}
-                  >
-                    <option value="">{t('settings.customProvider')}</option>
-                    {protocolProviders.map((p, i) => (
-                      <option key={p.label} value={i}>{p.label}</option>
-                    ))}
-                  </select>
-                </label>
-              ) : null}
-              <label className="field">
-                <span className="field-label-row">
-                  <span className="field-label">
-                    {t('settings.apiKey')}
-                    {byokRequiresApiKey ? (
-                      <span className="field-required" aria-label={t('settings.required')}>
-                        *
-                      </span>
-                    ) : null}
-                  </span>
-                  {byokRequiresApiKey ? (
-                    <a
-                      className="field-label-link"
-                      href={apiKeyConsoleLink.url}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      {t('settings.apiKeyGetLink', {
-                        host: apiKeyConsoleLink.host,
-                      })}
-                    </a>
-                  ) : null}
-                </span>
-                <div className="field-row">
-                  <input
-                    ref={apiKeyInputRef}
-                    aria-label={t('settings.apiKey')}
-                    type={showApiKey ? 'text' : 'password'}
-                    placeholder={API_KEY_PLACEHOLDERS[apiProtocol]}
-                    value={cfg.apiKey}
-                    onChange={(e) => updateApiConfig({ apiKey: e.target.value })}
-                    onBlur={() => {
-                      commitProviderModelsInputs();
-                      handleAutoTestProvider();
-                    }}
-                    onFocus={() => {
-                      const byokProviderId = byokProtocolToTracking(apiProtocol);
-                      if (byokProviderId) {
-                        trackSettingsByokFieldClick(analytics.track, {
-                          page_name: 'settings',
-                          area: 'configure_execution_mode_byok',
-                          element: 'api_key',
-                          provider_id: byokProviderId,
-                          has_value: Boolean(cfg.apiKey?.trim()),
-                        });
-                      }
-                    }}
-                    autoFocus
-                  />
-                  <button
-                    type="button"
-                    className="ghost icon-btn"
-                    onClick={() => setShowApiKey((v) => !v)}
-                    title={
-                      showApiKey ? t('settings.hideKey') : t('settings.showKey')
-                    }
-                  >
-                    {showApiKey ? t('settings.hide') : t('settings.show')}
-                  </button>
-                </div>
-                {apiKeyAuthFailed && providerTestState.status === 'idle' ? (
-                  <span className="field-error" role="alert">
-                    {t('settings.apiKeyInvalid')}
-                  </span>
-                ) : null}
-                {providerTestState.status === 'running' ? (
-                  <span
-                    className="field-inline-status running"
-                    role="status"
-                    aria-live="polite"
-                  >
-                    {t('settings.testRunning')}
-                  </span>
-                ) : providerTestState.status === 'done' ? (
-                  <span
-                    className={
-                      providerTestState.result.ok
-                        ? 'field-inline-status success'
-                        : 'field-error'
-                    }
-                    role={providerTestState.result.ok ? 'status' : 'alert'}
-                  >
-                    {renderTestMessage(providerTestState.result, 'api')}
-                  </span>
-                ) : null}
-                <span className="field-inline-status">
-                  {t('settings.apiHint')}
-                </span>
-                {canRunProviderConnectionTest(cfg, {
-                  requiresApiKey: byokRequiresApiKey,
-                }) && baseUrlValid ? (
-                  <button
-                    type="button"
-                    className={
-                      'ghost icon-btn settings-test-btn' +
-                      (providerTestState.status === 'running' ? ' loading' : '')
-                    }
-                    onClick={() => void handleTestProvider()}
-                    disabled={providerTestState.status === 'running'}
-                    title={t('settings.testTitle')}
-                  >
-                    {providerTestState.status === 'running' ? (
-                      <>
-                        <Icon
-                          name="spinner"
-                          size={13}
-                          className="icon-spin"
-                        />
-                        <span>{t('settings.test')}</span>
-                      </>
-                    ) : providerTestState.status === 'done' &&
-                      !providerTestState.result.ok ? (
-                      <>
-                        <Icon name="reload" size={13} />
-                        <span>{t('settings.testRetry')}</span>
-                      </>
-                    ) : (
-                      t('settings.test')
-                    )}
-                  </button>
-                ) : null}
-              </label>
-              <label className="field">
-                <span className="field-label">
-                  {apiProtocol === 'azure'
-                    ? t('settings.azureDeploymentModel')
-                    : t('settings.model')}
-                  <span className="field-required" aria-label={t('settings.required')}>
-                    *
-                  </span>
-                </span>
-                <SearchableModelSelect
-                  ref={modelSelectRef}
-                  className="inline-switcher__select settings-model-select settings-model-select--byok"
-                  aria-label={
-                    apiProtocol === 'azure'
-                      ? t('settings.azureDeploymentModel')
-                      : t('settings.model')
-                  }
-                  searchPlaceholder={t('designs.searchPlaceholder')}
-                  searchInputTestId="settings-byok-model-search"
-                  popoverTestId="settings-byok-model-popover"
-                  models={apiModelOptions.map((m) => ({
-                    id: m.id,
-                    label: apiModelOptionLabel(m),
-                  }))}
-                  value={apiModelSelectValue}
-                  onFocus={() => {
-                    const byokProviderId = byokProtocolToTracking(apiProtocol);
-                    if (byokProviderId) {
-                      trackSettingsByokFieldClick(analytics.track, {
-                        page_name: 'settings',
-                        area: 'configure_execution_mode_byok',
-                        element: 'model',
-                        provider_id: byokProviderId,
-                        has_value: Boolean(cfg.model?.trim()),
-                      });
-                    }
+                <ByokProviderPicker
+                  label={t('settings.quickFillProvider')}
+                  customProviderLabel={t('settings.customProvider')}
+                  providers={protocolProviders}
+                  selectedProviderIndex={selectedProviderIndex}
+                  onCustomProviderSelect={() => {
+                    setApiModelCustomEditing(false);
+                    updateApiConfig({
+                      baseUrl: '',
+                      model: '',
+                      apiProviderBaseUrl: null,
+                    });
                   }}
-                  onChange={(nextValue) => {
-                    if (nextValue === CUSTOM_MODEL_SENTINEL) {
-                      setApiModelCustomEditing(true);
-                      updateApiConfig({ model: '' });
-                    } else {
-                      setApiModelCustomEditing(false);
-                      updateApiConfig({ model: nextValue });
-                    }
+                  onProviderSelect={(p) => {
+                    setApiModelCustomEditing(false);
+                    updateApiConfig({
+                      baseUrl: p.baseUrl,
+                      model: p.model,
+                      apiProviderBaseUrl: p.baseUrl,
+                    });
                   }}
-                  additionalOptions={[
-                    {
-                      value: CUSTOM_MODEL_SENTINEL,
-                      label: t('settings.modelCustom'),
-                    },
-                  ]}
                 />
-                {loadedAccountModelCount > 0 ? (
-                  <span className="field-inline-status success" role="status">
-                    {t('settings.modelsLoadedFromAccount', {
-                      count: loadedAccountModelCount,
-                    })}
-                  </span>
-                ) : null}
-                {providerModelsFailureMessage ? (
-                  <span className="field-error" role="alert">
-                    {providerModelsFailureMessage}
-                  </span>
-                ) : null}
-              </label>
-              {!selectedProvider ? (
-                <p className="hint">{t('settings.suggestedModelsHint')}</p>
               ) : null}
-              {apiProtocol === 'azure' ? (
-                <p className="hint">{t('settings.azureModelFetchHint')}</p>
-              ) : null}
-              {apiProtocol === 'ollama' ? (
-                <p className="hint">{t('settings.fetchModelsUnsupported')}</p>
-              ) : null}
-              {apiModelCustomActive ? (
-                <label className="field">
-                  <span className="field-label">
-                    {t('settings.modelCustomLabel')}
-                    <span className="field-required" aria-label={t('settings.required')}>
-                      *
-                    </span>
-                  </span>
-                  <input
-                    ref={customModelInputRef}
-                    aria-label={t('settings.modelCustomLabel')}
-                    type="text"
-                    value={cfg.model}
-                    placeholder={t('settings.modelCustomPlaceholder')}
-                    onChange={(e) => updateApiConfig({ model: e.target.value.trim() })}
-                  />
-                </label>
-              ) : null}
-              {renderByokBaseUrlField()}
+              <ByokKeyField
+                apiKey={cfg.apiKey}
+                apiKeyAuthFailed={apiKeyAuthFailed}
+                apiKeyConsoleLink={apiKeyConsoleLink}
+                apiProtocol={apiProtocol}
+                baseUrlValid={baseUrlValid}
+                canRunConnectionTest={canRunProviderConnectionTest(cfg, {
+                  requiresApiKey: byokRequiresApiKey,
+                })}
+                inputRef={apiKeyInputRef}
+                labels={{
+                  apiHint: t('settings.apiHint'),
+                  apiKey: t('settings.apiKey'),
+                  apiKeyGetLink: t('settings.apiKeyGetLink', {
+                    host: apiKeyConsoleLink.host,
+                  }),
+                  apiKeyInvalid: t('settings.apiKeyInvalid'),
+                  hide: t('settings.hide'),
+                  hideKey: t('settings.hideKey'),
+                  required: t('settings.required'),
+                  show: t('settings.show'),
+                  showKey: t('settings.showKey'),
+                  test: t('settings.test'),
+                  testRetry: t('settings.testRetry'),
+                  testRunning: t('settings.testRunning'),
+                  testTitle: t('settings.testTitle'),
+                }}
+                providerTestState={providerTestState}
+                renderTestMessage={(result) => renderTestMessage(result, 'api')}
+                requiresApiKey={byokRequiresApiKey}
+                showApiKey={showApiKey}
+                onBlur={() => {
+                  commitProviderModelsInputs();
+                  handleAutoTestProvider();
+                }}
+                onChange={(value) => updateApiConfig({ apiKey: value })}
+                onFocus={() => {
+                  const byokProviderId = byokProtocolToTracking(apiProtocol);
+                  if (byokProviderId) {
+                    trackSettingsByokFieldClick(analytics.track, {
+                      page_name: 'settings',
+                      area: 'configure_execution_mode_byok',
+                      element: 'api_key',
+                      provider_id: byokProviderId,
+                      has_value: Boolean(cfg.apiKey?.trim()),
+                    });
+                  }
+                }}
+                onTestProvider={() => handleTestProvider()}
+                onToggleShowApiKey={() => setShowApiKey((v) => !v)}
+              />
+              <ByokModelField
+                customActive={apiModelCustomActive}
+                customInputRef={customModelInputRef}
+                labels={{
+                  customModel: t('settings.modelCustom'),
+                  customModelLabel: t('settings.modelCustomLabel'),
+                  customModelPlaceholder: t('settings.modelCustomPlaceholder'),
+                  fetchModelsUnsupported: t('settings.fetchModelsUnsupported'),
+                  model: apiProtocol === 'azure'
+                    ? t('settings.azureDeploymentModel')
+                    : t('settings.model'),
+                  required: t('settings.required'),
+                  searchPlaceholder: t('designs.searchPlaceholder'),
+                  suggestedModelsHint: t('settings.suggestedModelsHint'),
+                }}
+                model={cfg.model}
+                modelSelectRef={modelSelectRef}
+                models={apiModelOptions.map((m) => ({
+                  id: m.id,
+                  label: apiModelOptionLabel(m),
+                }))}
+                modelsLoadedFromAccountMessage={
+                  loadedAccountModelCount > 0
+                    ? t('settings.modelsLoadedFromAccount', {
+                        count: loadedAccountModelCount,
+                      })
+                    : null
+                }
+                providerModelsFailureMessage={providerModelsFailureMessage}
+                showAzureModelFetchHint={apiProtocol === 'azure'}
+                showFetchModelsUnsupportedHint={apiProtocol === 'ollama'}
+                showSuggestedModelsHint={!selectedProvider}
+                azureModelFetchHint={t('settings.azureModelFetchHint')}
+                onCustomModelChange={(value) => updateApiConfig({ model: value })}
+                onCustomModelSelect={() => {
+                  setApiModelCustomEditing(true);
+                  updateApiConfig({ model: '' });
+                }}
+                onFocus={() => {
+                  const byokProviderId = byokProtocolToTracking(apiProtocol);
+                  if (byokProviderId) {
+                    trackSettingsByokFieldClick(analytics.track, {
+                      page_name: 'settings',
+                      area: 'configure_execution_mode_byok',
+                      element: 'model',
+                      provider_id: byokProviderId,
+                      has_value: Boolean(cfg.model?.trim()),
+                    });
+                  }
+                }}
+                onModelSelect={(nextValue) => {
+                  setApiModelCustomEditing(false);
+                  updateApiConfig({ model: nextValue });
+                }}
+              />
+              <ByokProviderBaseUrl
+                apiProtocol={apiProtocol}
+                inputRef={baseUrlInputRef}
+                baseUrl={cfg.baseUrl}
+                baseUrlInvalid={baseUrlInvalid}
+                baseUrlPlaceholder={baseUrlPlaceholder}
+                baseUrlReadOnly={baseUrlReadOnly}
+                labels={{
+                  baseUrl: t('settings.baseUrl'),
+                  required: t('settings.required'),
+                  customize: t('settings.baseUrlCustomize'),
+                  invalid: t('settings.baseUrlInvalid'),
+                  defaultHint: t('settings.baseUrlDefaultHint'),
+                  azureHint: t('settings.azureBaseUrlHint'),
+                }}
+                onBlur={commitProviderModelsInputs}
+                onChange={(value) => updateApiConfig({ baseUrl: value, apiProviderBaseUrl: null })}
+                onCustomize={() => {
+                  updateApiConfig({ apiProviderBaseUrl: null });
+                  window.setTimeout(() => baseUrlInputRef.current?.focus(), 0);
+                }}
+                onFocus={() => {
+                  const byokProviderId = byokProtocolToTracking(apiProtocol);
+                  if (byokProviderId) {
+                    trackSettingsByokFieldClick(analytics.track, {
+                      page_name: 'settings',
+                      area: 'configure_execution_mode_byok',
+                      element: 'base_url',
+                      provider_id: byokProviderId,
+                      has_value: Boolean(cfg.baseUrl?.trim()),
+                    });
+                  }
+                }}
+              />
               <details className="agent-cli-env settings-memory-advanced">
                 <summary className="agent-cli-env-summary">
                   <span className="agent-cli-env-summary-title">

--- a/apps/web/src/components/byok/ByokKeyField.tsx
+++ b/apps/web/src/components/byok/ByokKeyField.tsx
@@ -1,0 +1,170 @@
+import type { Ref } from 'react';
+import { API_KEY_PLACEHOLDERS } from '../../state/apiProtocols';
+import type { ApiProtocol, ConnectionTestResponse } from '../../types';
+import { Icon } from '../Icon';
+
+type ByokProviderTestState =
+  | { status: 'idle' }
+  | { status: 'running' }
+  | { status: 'done'; result: ConnectionTestResponse };
+
+interface ByokKeyFieldProps {
+  apiKey: string;
+  apiKeyAuthFailed: boolean;
+  apiKeyConsoleLink: { host: string; url: string };
+  apiProtocol: ApiProtocol;
+  baseUrlValid: boolean;
+  canRunConnectionTest: boolean;
+  inputRef: Ref<HTMLInputElement>;
+  labels: {
+    apiHint: string;
+    apiKey: string;
+    apiKeyGetLink: string;
+    apiKeyInvalid: string;
+    hide: string;
+    hideKey: string;
+    required: string;
+    show: string;
+    showKey: string;
+    test: string;
+    testRetry: string;
+    testRunning: string;
+    testTitle: string;
+  };
+  providerTestState: ByokProviderTestState;
+  renderTestMessage: (result: ConnectionTestResponse) => string;
+  requiresApiKey: boolean;
+  showApiKey: boolean;
+  onBlur: () => void;
+  onChange: (value: string) => void;
+  onFocus: () => void;
+  onTestProvider: () => void | Promise<void>;
+  onToggleShowApiKey: () => void;
+}
+
+export function ByokKeyField({
+  apiKey,
+  apiKeyAuthFailed,
+  apiKeyConsoleLink,
+  apiProtocol,
+  baseUrlValid,
+  canRunConnectionTest,
+  inputRef,
+  labels,
+  providerTestState,
+  renderTestMessage,
+  requiresApiKey,
+  showApiKey,
+  onBlur,
+  onChange,
+  onFocus,
+  onTestProvider,
+  onToggleShowApiKey,
+}: ByokKeyFieldProps) {
+  return (
+    <label className="field">
+      <span className="field-label-row">
+        <span className="field-label">
+          {labels.apiKey}
+          {requiresApiKey ? (
+            <span className="field-required" aria-label={labels.required}>
+              *
+            </span>
+          ) : null}
+        </span>
+        {requiresApiKey ? (
+          <a
+            className="field-label-link"
+            href={apiKeyConsoleLink.url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {labels.apiKeyGetLink}
+          </a>
+        ) : null}
+      </span>
+      <div className="field-row">
+        <input
+          ref={inputRef}
+          aria-label={labels.apiKey}
+          type={showApiKey ? 'text' : 'password'}
+          placeholder={API_KEY_PLACEHOLDERS[apiProtocol]}
+          value={apiKey}
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          autoFocus
+        />
+        <button
+          type="button"
+          className="ghost icon-btn"
+          onClick={onToggleShowApiKey}
+          title={
+            showApiKey ? labels.hideKey : labels.showKey
+          }
+        >
+          {showApiKey ? labels.hide : labels.show}
+        </button>
+      </div>
+      {apiKeyAuthFailed && providerTestState.status === 'idle' ? (
+        <span className="field-error" role="alert">
+          {labels.apiKeyInvalid}
+        </span>
+      ) : null}
+      {providerTestState.status === 'running' ? (
+        <span
+          className="field-inline-status running"
+          role="status"
+          aria-live="polite"
+        >
+          {labels.testRunning}
+        </span>
+      ) : providerTestState.status === 'done' ? (
+        <span
+          className={
+            providerTestState.result.ok
+              ? 'field-inline-status success'
+              : 'field-error'
+          }
+          role={providerTestState.result.ok ? 'status' : 'alert'}
+        >
+          {renderTestMessage(providerTestState.result)}
+        </span>
+      ) : null}
+      <span className="field-inline-status">
+        {labels.apiHint}
+      </span>
+      {canRunConnectionTest && baseUrlValid ? (
+        <button
+          type="button"
+          className={
+            'ghost icon-btn settings-test-btn' +
+            (providerTestState.status === 'running' ? ' loading' : '')
+          }
+          onClick={() => void onTestProvider()}
+          disabled={providerTestState.status === 'running'}
+          title={labels.testTitle}
+        >
+          {providerTestState.status === 'running' ? (
+            <>
+              <Icon
+                name="spinner"
+                size={13}
+                className="icon-spin"
+              />
+              <span>{labels.test}</span>
+            </>
+          ) : providerTestState.status === 'done' &&
+            !providerTestState.result.ok ? (
+            <>
+              <Icon name="reload" size={13} />
+              <span>{labels.testRetry}</span>
+            </>
+          ) : (
+            labels.test
+          )}
+        </button>
+      ) : null}
+    </label>
+  );
+}

--- a/apps/web/src/components/byok/ByokModelField.tsx
+++ b/apps/web/src/components/byok/ByokModelField.tsx
@@ -1,0 +1,131 @@
+import type { Ref } from 'react';
+import type { AgentModelOption } from '../../types';
+import {
+  CUSTOM_MODEL_SENTINEL,
+  SearchableModelSelect,
+} from '../modelOptions';
+
+interface ByokModelFieldProps {
+  customActive: boolean;
+  customInputRef: Ref<HTMLInputElement>;
+  labels: {
+    customModel: string;
+    customModelLabel: string;
+    customModelPlaceholder: string;
+    fetchModelsUnsupported: string;
+    model: string;
+    required: string;
+    searchPlaceholder: string;
+    suggestedModelsHint: string;
+  };
+  model: string;
+  modelSelectRef: Ref<HTMLButtonElement>;
+  models: AgentModelOption[];
+  modelsLoadedFromAccountMessage: string | null;
+  providerModelsFailureMessage: string | null;
+  showAzureModelFetchHint: boolean;
+  showFetchModelsUnsupportedHint: boolean;
+  showSuggestedModelsHint: boolean;
+  azureModelFetchHint: string;
+  onCustomModelChange: (value: string) => void;
+  onCustomModelSelect: () => void;
+  onFocus: () => void;
+  onModelSelect: (value: string) => void;
+}
+
+export function ByokModelField({
+  customActive,
+  customInputRef,
+  labels,
+  model,
+  modelSelectRef,
+  models,
+  modelsLoadedFromAccountMessage,
+  providerModelsFailureMessage,
+  showAzureModelFetchHint,
+  showFetchModelsUnsupportedHint,
+  showSuggestedModelsHint,
+  azureModelFetchHint,
+  onCustomModelChange,
+  onCustomModelSelect,
+  onFocus,
+  onModelSelect,
+}: ByokModelFieldProps) {
+  const selectValue = customActive
+    ? CUSTOM_MODEL_SENTINEL
+    : model;
+
+  return (
+    <>
+      <label className="field">
+        <span className="field-label">
+          {labels.model}
+          <span className="field-required" aria-label={labels.required}>
+            *
+          </span>
+        </span>
+        <SearchableModelSelect
+          ref={modelSelectRef}
+          className="inline-switcher__select settings-model-select settings-model-select--byok"
+          aria-label={labels.model}
+          searchPlaceholder={labels.searchPlaceholder}
+          searchInputTestId="settings-byok-model-search"
+          popoverTestId="settings-byok-model-popover"
+          models={models}
+          value={selectValue}
+          onFocus={onFocus}
+          onChange={(nextValue) => {
+            if (nextValue === CUSTOM_MODEL_SENTINEL) {
+              onCustomModelSelect();
+            } else {
+              onModelSelect(nextValue);
+            }
+          }}
+          additionalOptions={[
+            {
+              value: CUSTOM_MODEL_SENTINEL,
+              label: labels.customModel,
+            },
+          ]}
+        />
+        {modelsLoadedFromAccountMessage ? (
+          <span className="field-inline-status success" role="status">
+            {modelsLoadedFromAccountMessage}
+          </span>
+        ) : null}
+        {providerModelsFailureMessage ? (
+          <span className="field-error" role="alert">
+            {providerModelsFailureMessage}
+          </span>
+        ) : null}
+      </label>
+      {showSuggestedModelsHint ? (
+        <p className="hint">{labels.suggestedModelsHint}</p>
+      ) : null}
+      {showAzureModelFetchHint ? (
+        <p className="hint">{azureModelFetchHint}</p>
+      ) : null}
+      {showFetchModelsUnsupportedHint ? (
+        <p className="hint">{labels.fetchModelsUnsupported}</p>
+      ) : null}
+      {customActive ? (
+        <label className="field">
+          <span className="field-label">
+            {labels.customModelLabel}
+            <span className="field-required" aria-label={labels.required}>
+              *
+            </span>
+          </span>
+          <input
+            ref={customInputRef}
+            aria-label={labels.customModelLabel}
+            type="text"
+            value={model}
+            placeholder={labels.customModelPlaceholder}
+            onChange={(e) => onCustomModelChange(e.target.value.trim())}
+          />
+        </label>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/components/byok/ByokProviderBaseUrl.tsx
+++ b/apps/web/src/components/byok/ByokProviderBaseUrl.tsx
@@ -1,0 +1,94 @@
+import type { Ref } from 'react';
+import type { ApiProtocol } from '../../types';
+
+interface ByokProviderBaseUrlProps {
+  apiProtocol: ApiProtocol;
+  inputRef: Ref<HTMLInputElement>;
+  baseUrl: string;
+  baseUrlInvalid: boolean;
+  baseUrlPlaceholder?: string;
+  baseUrlReadOnly: boolean;
+  labels: {
+    baseUrl: string;
+    required: string;
+    customize: string;
+    invalid: string;
+    defaultHint: string;
+    azureHint: string;
+  };
+  onBlur: () => void;
+  onChange: (value: string) => void;
+  onCustomize: () => void;
+  onFocus: () => void;
+}
+
+export function ByokProviderBaseUrl({
+  apiProtocol,
+  inputRef,
+  baseUrl,
+  baseUrlInvalid,
+  baseUrlPlaceholder,
+  baseUrlReadOnly,
+  labels,
+  onBlur,
+  onChange,
+  onCustomize,
+  onFocus,
+}: ByokProviderBaseUrlProps) {
+  return (
+    <label className={'field' + (baseUrlReadOnly ? ' settings-base-url-readonly' : '')}>
+      <span className="field-label">
+        {labels.baseUrl}
+        <span className="field-required" aria-label={labels.required}>
+          *
+        </span>
+      </span>
+      <div className="field-row">
+        <input
+          ref={inputRef}
+          aria-label={labels.baseUrl}
+          type="url"
+          inputMode="url"
+          value={baseUrl}
+          placeholder={baseUrlPlaceholder}
+          readOnly={baseUrlReadOnly || undefined}
+          aria-invalid={baseUrlInvalid || undefined}
+          aria-describedby={
+            baseUrlInvalid ? 'settings-base-url-error' : undefined
+          }
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onChange={(e) => onChange(e.target.value)}
+        />
+        {baseUrlReadOnly ? (
+          <button
+            type="button"
+            className="ghost icon-btn settings-base-url-customize"
+            onClick={onCustomize}
+          >
+            {labels.customize}
+          </button>
+        ) : null}
+      </div>
+      {baseUrlInvalid ? (
+        <span
+          id="settings-base-url-error"
+          className="settings-field-error"
+          role="alert"
+        >
+          {labels.invalid}
+        </span>
+      ) : null}
+      {baseUrlReadOnly ? (
+        <span className="field-inline-status">
+          {labels.defaultHint}
+        </span>
+      ) : null}
+      {apiProtocol === 'azure' ? (
+        <span className="field-inline-status">
+          {labels.azureHint}
+        </span>
+      ) : null}
+    </label>
+  );
+}

--- a/apps/web/src/components/byok/ByokProviderPicker.tsx
+++ b/apps/web/src/components/byok/ByokProviderPicker.tsx
@@ -1,0 +1,43 @@
+import type { KnownProvider } from '../../state/config';
+
+interface ByokProviderPickerProps {
+  label: string;
+  customProviderLabel: string;
+  providers: KnownProvider[];
+  selectedProviderIndex: number;
+  onCustomProviderSelect: () => void;
+  onProviderSelect: (provider: KnownProvider) => void;
+}
+
+export function ByokProviderPicker({
+  label,
+  customProviderLabel,
+  providers,
+  selectedProviderIndex,
+  onCustomProviderSelect,
+  onProviderSelect,
+}: ByokProviderPickerProps) {
+  return (
+    <label className="field">
+      <span className="field-label">{label}</span>
+      <select
+        value={selectedProviderIndex >= 0 ? String(selectedProviderIndex) : ''}
+        onChange={(e) => {
+          if (e.target.value === '') {
+            onCustomProviderSelect();
+            return;
+          }
+          const idx = Number(e.target.value);
+          if (!isNaN(idx) && providers[idx]) {
+            onProviderSelect(providers[idx]!);
+          }
+        }}
+      >
+        <option value="">{customProviderLabel}</option>
+        {providers.map((p, i) => (
+          <option key={p.label} value={i}>{p.label}</option>
+        ))}
+      </select>
+    </label>
+  );
+}


### PR DESCRIPTION
## Why

This is PR-0 for the BYOK shift-left work. I need the later API key, model, and provider/base URL PRs to land without all of them editing the same large `SettingsDialog` BYOK block.

The pain addressed here is merge risk and reviewability: today the BYOK key field, model picker, provider picker, and base URL field all live inline inside `SettingsDialog.tsx`, so future field-level changes would collide on the same JSX region. This PR extracts those fields while preserving the existing parent-owned state, callbacks, analytics, and validation behavior.

## What users will see

No user-visible change. Settings → Execution → BYOK should render the same provider picker, API key field, model picker, base URL field, test button, and inline statuses as before.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — this is a zero-behavior structural extraction.

## Bug fix verification

N/A — this is not a bug fix.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/host build`
- `pnpm --filter @open-design/platform build`
- `pnpm --filter @open-design/sidecar-proto build`
- `pnpm --filter @open-design/sidecar build`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `NODE_OPTIONS=--localstorage-file=/tmp/open-design-vitest-localstorage pnpm --filter @open-design/web test -- tests/components/SettingsDialog.execution.test.tsx`

Note: local validation emitted engine warnings because this shell is Node `v26.0.0` while the repo expects Node `~24`. The focused web test command uses `--localstorage-file` because Node 26 does not expose `localStorage` by default.
