### PR TITLE
feat(web): add BYOK draft validation

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -963,6 +963,7 @@ export function SettingsDialog({
   const providerTestRevisionRef = useRef(0);
   const providerModelsRevisionRef = useRef(0);
   const providerModelsFirstResetRef = useRef(true);
+  const recommitModelsAfterCleanRef = useRef(false);
   const providerAutoTestKeyRef = useRef<string | null>(null);
   const apiKeyInputRef = useRef<HTMLInputElement | null>(null);
   const baseUrlInputRef = useRef<HTMLInputElement | null>(null);
@@ -1905,11 +1906,27 @@ export function SettingsDialog({
     // non-blocking warning yet still go out malformed over the wire.
     const cleanedApiKey = cleanByokApiKey(cfg.apiKey);
     if (cleanedApiKey !== cfg.apiKey) {
+      // Writing the cleaned key changes cfg.apiKey, which re-runs the effect
+      // that nulls providerModelsCommittedKey on any apiKey change — so a
+      // commit here would be clobbered before the auto-fetch effect reads it.
+      // Defer the model commit until the cleaned value lands (recommit effect
+      // below), otherwise account models never auto-load after a dirty paste.
+      recommitModelsAfterCleanRef.current = true;
       updateApiConfig({ apiKey: cleanedApiKey });
+    } else {
+      commitProviderModelsInputs();
     }
-    commitProviderModelsInputs();
     handleAutoTestProvider();
   };
+  useEffect(() => {
+    if (!recommitModelsAfterCleanRef.current) return;
+    recommitModelsAfterCleanRef.current = false;
+    if (blockingByokDraftIssues(byokModelFetchDraftValidation).length > 0) {
+      setProviderModelsCommittedKey(null);
+      return;
+    }
+    setProviderModelsCommittedKey(providerModelsKey);
+  }, [cfg.apiKey, byokModelFetchDraftValidation, providerModelsKey]);
   useEffect(() => {
     if (cfg.mode !== 'api') return;
     if (apiProtocol === 'azure' || apiProtocol === 'ollama') return;

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -112,6 +112,14 @@ import { ByokModelField } from './byok/ByokModelField';
 import { ByokProviderBaseUrl } from './byok/ByokProviderBaseUrl';
 import { ByokProviderPicker } from './byok/ByokProviderPicker';
 import {
+  blockingByokDraftFields,
+  blockingByokDraftIssues,
+  validateByokDraft,
+  type ByokDraftField,
+  type ByokDraftIssue,
+  type ByokDraftValidation,
+} from './byok/validation';
+import {
   setCritiqueTheaterEnabled,
   useCritiqueTheaterEnabled,
 } from './Theater';
@@ -290,7 +298,7 @@ type ProviderModelsState =
   | { status: 'running'; cacheKey: string }
   | { status: 'done'; cacheKey: string; result: ProviderModelsResponse };
 
-type ByokRequiredField = 'api_key' | 'base_url' | 'model';
+type ByokRequiredField = ByokDraftField;
 type ByokPreconditionAction = 'test';
 
 // Map a test result to the visual severity of its inline status node so
@@ -1263,14 +1271,12 @@ export function SettingsDialog({
     if (providerTestState.status === 'running') {
       return;
     }
-    const missing = missingByokConnectionFields(cfg, {
-      requiresApiKey: byokRequiresApiKey,
-    });
-    if (missing.length > 0) {
+    const blockingIssues = blockingByokDraftIssues(byokDraftValidation);
+    if (blockingIssues.length > 0) {
       if (options.silentPreconditions) {
         return;
       }
-      showByokPreconditionNotice('test', missing);
+      showByokDraftValidationNotice('test', byokDraftValidation);
       const byokProviderId = byokProtocolToTracking(apiProtocol);
       if (byokProviderId) {
         trackSettingsByokTestResult(analytics.track, {
@@ -1362,12 +1368,7 @@ export function SettingsDialog({
     if (providerTestState.status === 'running') {
       return;
     }
-    if (
-      missingByokConnectionFields(cfg, {
-        requiresApiKey: byokRequiresApiKey,
-      }).length > 0 ||
-      !baseUrlValid
-    ) {
+    if (blockingByokDraftIssues(byokDraftValidation).length > 0) {
       return;
     }
     const key = providerConnectionTestKey(apiProtocol, cfg);
@@ -1402,20 +1403,12 @@ export function SettingsDialog({
       }
       return;
     }
-    const missing = missingByokModelFetchFields(cfg);
-    if (missing.length > 0) {
+    const modelFetchBlockingIssues = blockingByokDraftIssues(
+      byokModelFetchDraftValidation,
+    );
+    if (modelFetchBlockingIssues.length > 0) {
       if (!options.silent) {
-        showByokPreconditionNotice('test', missing);
-      }
-      return;
-    }
-    if (!baseUrlValid) {
-      if (!options.silent) {
-        setByokPreconditionNotice({
-          action: 'test',
-          message: t('settings.fetchModelsInvalidBaseUrl'),
-        });
-        focusByokRequiredField('base_url');
+        showByokDraftValidationNotice('test', byokModelFetchDraftValidation);
       }
       return;
     }
@@ -1628,6 +1621,52 @@ export function SettingsDialog({
     });
     focusByokRequiredField(fields[0]);
   };
+  const byokDraftIssueMessage = (issue: ByokDraftIssue): string => {
+    switch (issue.code) {
+      case 'api_key_required':
+      case 'base_url_required':
+      case 'model_required':
+        return t('settings.testMissingFields', {
+          fields: byokRequiredLabel(issue.field),
+        });
+      case 'api_key_extra_whitespace':
+      case 'api_key_malformed':
+      case 'api_key_wrong_protocol':
+        return t('settings.apiKeyInvalid');
+      case 'base_url_invalid':
+        return t('settings.baseUrlInvalid');
+      default: {
+        const exhaustive: never = issue.code;
+        return exhaustive;
+      }
+    }
+  };
+  const showByokDraftValidationNotice = (
+    action: ByokPreconditionAction,
+    validation: ByokDraftValidation,
+  ) => {
+    const blockingFields = blockingByokDraftFields(validation);
+    if (blockingFields.length === 0) return;
+    const blockingIssues = blockingByokDraftIssues(validation);
+    const missingFields = blockingIssues
+      .filter((issue) =>
+        issue.code === 'api_key_required' ||
+        issue.code === 'base_url_required' ||
+        issue.code === 'model_required'
+      )
+      .map((issue) => issue.field);
+    if (missingFields.length > 0) {
+      showByokPreconditionNotice(action, missingFields);
+      return;
+    }
+    const firstIssue = blockingIssues[0];
+    if (!firstIssue) return;
+    setByokPreconditionNotice({
+      action,
+      message: byokDraftIssueMessage(firstIssue),
+    });
+    focusByokRequiredField(firstIssue.field);
+  };
   // Autosave loop. Every committed edit to `cfg` schedules a debounced
   // sync to localStorage + the daemon. We keep a 400ms debounce so rapid
   // typing in text fields doesn't flood the daemon with PUTs while still
@@ -1815,6 +1854,30 @@ export function SettingsDialog({
     selectedProvider,
     cfg.baseUrl,
   );
+  const byokDraftValidation = useMemo(
+    () => validateByokDraft(
+      apiProtocol,
+      {
+        apiKey: cfg.apiKey,
+        baseUrl: cfg.baseUrl,
+        model: cfg.model,
+      },
+      { requiresApiKey: byokRequiresApiKey },
+    ),
+    [apiProtocol, byokRequiresApiKey, cfg.apiKey, cfg.baseUrl, cfg.model],
+  );
+  const byokModelFetchDraftValidation = useMemo(
+    () => validateByokDraft(
+      apiProtocol,
+      {
+        apiKey: cfg.apiKey,
+        baseUrl: cfg.baseUrl,
+        model: cfg.model,
+      },
+      { requiresApiKey: byokRequiresApiKey, requireModel: false },
+    ),
+    [apiProtocol, byokRequiresApiKey, cfg.apiKey, cfg.baseUrl, cfg.model],
+  );
   const providerModelsKey = useMemo(
     () => providerModelsCacheKey(
       apiProtocol,
@@ -1827,17 +1890,20 @@ export function SettingsDialog({
   const fetchedApiModelOptions =
     activeProviderModelsCache[providerModelsKey] ?? [];
   const commitProviderModelsInputs = () => {
-    if (missingByokModelFetchFields(cfg).length > 0 || !baseUrlValid) {
+    if (blockingByokDraftIssues(byokModelFetchDraftValidation).length > 0) {
       setProviderModelsCommittedKey(null);
       return;
     }
     setProviderModelsCommittedKey(providerModelsKey);
   };
+  const onByokKeyCommit = () => {
+    commitProviderModelsInputs();
+    handleAutoTestProvider();
+  };
   useEffect(() => {
     if (cfg.mode !== 'api') return;
     if (apiProtocol === 'azure' || apiProtocol === 'ollama') return;
-    if (missingByokModelFetchFields(cfg).length > 0) return;
-    if (!baseUrlValid) return;
+    if (blockingByokDraftIssues(byokModelFetchDraftValidation).length > 0) return;
     if (providerModelsCommittedKey !== providerModelsKey) return;
     const timer = window.setTimeout(() => {
       void handleFetchProviderModels({ silent: true });
@@ -1845,11 +1911,11 @@ export function SettingsDialog({
     return () => window.clearTimeout(timer);
   }, [
     apiProtocol,
-    baseUrlValid,
     cfg.apiKey,
     cfg.baseUrl,
     cfg.mode,
     cfg.apiVersion,
+    byokModelFetchDraftValidation,
     providerModelsCommittedKey,
     providerModelsKey,
   ]);
@@ -3205,10 +3271,7 @@ export function SettingsDialog({
                 renderTestMessage={(result) => renderTestMessage(result, 'api')}
                 requiresApiKey={byokRequiresApiKey}
                 showApiKey={showApiKey}
-                onBlur={() => {
-                  commitProviderModelsInputs();
-                  handleAutoTestProvider();
-                }}
+                onBlur={onByokKeyCommit}
                 onChange={(value) => updateApiConfig({ apiKey: value })}
                 onFocus={() => {
                   const byokProviderId = byokProtocolToTracking(apiProtocol);

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -963,7 +963,7 @@ export function SettingsDialog({
   const providerTestRevisionRef = useRef(0);
   const providerModelsRevisionRef = useRef(0);
   const providerModelsFirstResetRef = useRef(true);
-  const recommitModelsAfterCleanRef = useRef(false);
+  const deferAfterKeyCleanRef = useRef(false);
   const providerAutoTestKeyRef = useRef<string | null>(null);
   const apiKeyInputRef = useRef<HTMLInputElement | null>(null);
   const baseUrlInputRef = useRef<HTMLInputElement | null>(null);
@@ -1906,26 +1906,33 @@ export function SettingsDialog({
     // non-blocking warning yet still go out malformed over the wire.
     const cleanedApiKey = cleanByokApiKey(cfg.apiKey);
     if (cleanedApiKey !== cfg.apiKey) {
-      // Writing the cleaned key changes cfg.apiKey, which re-runs the effect
-      // that nulls providerModelsCommittedKey on any apiKey change — so a
-      // commit here would be clobbered before the auto-fetch effect reads it.
-      // Defer the model commit until the cleaned value lands (recommit effect
-      // below), otherwise account models never auto-load after a dirty paste.
-      recommitModelsAfterCleanRef.current = true;
+      // Writing the cleaned key changes cfg.apiKey, which re-runs the reset
+      // effects above: one nulls providerModelsCommittedKey, the other bumps
+      // providerTestRevisionRef / clears providerAutoTestKeyRef. So committing
+      // the model key or starting the auto-test here would be clobbered — the
+      // model commit before the auto-fetch effect reads it, and the auto-test
+      // result dropped by the stale-revision guard. Defer both until the
+      // cleaned value has landed (effect below), otherwise account models
+      // never auto-load and the auto-test success/error never reaches the UI
+      // for the exact dirty-paste case this handles.
+      deferAfterKeyCleanRef.current = true;
       updateApiConfig({ apiKey: cleanedApiKey });
-    } else {
-      commitProviderModelsInputs();
+      return;
     }
+    commitProviderModelsInputs();
     handleAutoTestProvider();
   };
   useEffect(() => {
-    if (!recommitModelsAfterCleanRef.current) return;
-    recommitModelsAfterCleanRef.current = false;
+    if (!deferAfterKeyCleanRef.current) return;
+    deferAfterKeyCleanRef.current = false;
     if (blockingByokDraftIssues(byokModelFetchDraftValidation).length > 0) {
       setProviderModelsCommittedKey(null);
-      return;
+    } else {
+      setProviderModelsCommittedKey(providerModelsKey);
     }
-    setProviderModelsCommittedKey(providerModelsKey);
+    // Runs after the provider-test reset effect (declaration order) bumped the
+    // revision for the cleaned key, so this auto-test is not flagged stale.
+    handleAutoTestProvider();
   }, [cfg.apiKey, byokModelFetchDraftValidation, providerModelsKey]);
   useEffect(() => {
     if (cfg.mode !== 'api') return;

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -114,6 +114,7 @@ import { ByokProviderPicker } from './byok/ByokProviderPicker';
 import {
   blockingByokDraftFields,
   blockingByokDraftIssues,
+  cleanByokApiKey,
   validateByokDraft,
   type ByokDraftField,
   type ByokDraftIssue,
@@ -1304,7 +1305,7 @@ export function SettingsDialog({
         {
           protocol: apiProtocol,
           baseUrl: cfg.baseUrl,
-          apiKey: cfg.apiKey,
+          apiKey: cleanByokApiKey(cfg.apiKey),
           model: cfg.model,
           apiVersion:
             apiProtocol === 'azure'
@@ -1446,7 +1447,7 @@ export function SettingsDialog({
         {
           protocol: apiProtocol,
           baseUrl: cfg.baseUrl,
-          apiKey: cfg.apiKey,
+          apiKey: cleanByokApiKey(cfg.apiKey),
         },
         controller.signal,
       );
@@ -1897,6 +1898,15 @@ export function SettingsDialog({
     setProviderModelsCommittedKey(providerModelsKey);
   };
   const onByokKeyCommit = () => {
+    // Normalize the stored key on blur so the value that flows into the
+    // connection-test / model-fetch requests below (and back to the daemon
+    // via autosave) is already free of pasted whitespace / zero-width
+    // characters — otherwise a key like "sk-ant-...\n" would only raise a
+    // non-blocking warning yet still go out malformed over the wire.
+    const cleanedApiKey = cleanByokApiKey(cfg.apiKey);
+    if (cleanedApiKey !== cfg.apiKey) {
+      updateApiConfig({ apiKey: cleanedApiKey });
+    }
     commitProviderModelsInputs();
     handleAutoTestProvider();
   };

--- a/apps/web/src/components/byok/validation.ts
+++ b/apps/web/src/components/byok/validation.ts
@@ -1,0 +1,308 @@
+import { validateBaseUrl } from '@open-design/contracts/api/connectionTest';
+import type { ApiProtocol, ProviderModelOption } from '../../types';
+
+export type ByokDraftField = 'api_key' | 'base_url' | 'model';
+
+export type ByokDraftIssueLevel = 'error' | 'warn';
+
+export type ByokDraftIssueCode =
+  | 'api_key_required'
+  | 'api_key_extra_whitespace'
+  | 'api_key_malformed'
+  | 'api_key_wrong_protocol'
+  | 'base_url_required'
+  | 'base_url_invalid'
+  | 'model_required';
+
+export type ByokDraftAction =
+  | 'focus_api_key'
+  | 'focus_base_url'
+  | 'focus_model'
+  | 'select_provider';
+
+export interface ByokDraftIssue {
+  field: ByokDraftField;
+  level: ByokDraftIssueLevel;
+  code: ByokDraftIssueCode;
+  message: string;
+  action?: ByokDraftAction;
+  detectedProtocol?: ApiProtocol;
+}
+
+export interface ByokDraftValidation {
+  ok: boolean;
+  issues: ByokDraftIssue[];
+}
+
+interface ValidateByokDraftOptions {
+  requiresApiKey?: boolean;
+  requireModel?: boolean;
+}
+
+interface ByokDraftConfig {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+}
+
+export interface NormalizedByokBaseUrl {
+  value: string;
+  changed: boolean;
+  addedProtocol: boolean;
+  addedOpenAiVersionPath: boolean;
+}
+
+export type ByokModelPreferenceSource =
+  | 'explicit'
+  | 'account'
+  | 'provider_default'
+  | 'empty';
+
+export interface ByokModelPreference {
+  model: string;
+  source: ByokModelPreferenceSource;
+}
+
+const ZERO_WIDTH_CHARS = /[\u200B-\u200D\uFEFF]/g;
+
+export function cleanByokApiKey(value: string): string {
+  return value
+    .replace(ZERO_WIDTH_CHARS, '')
+    .replace(/[\r\n\t]+/g, '')
+    .trim();
+}
+
+export function normalizeByokBaseUrl(
+  value: string,
+  protocol: ApiProtocol,
+): NormalizedByokBaseUrl {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return {
+      value: '',
+      changed: value !== '',
+      addedProtocol: false,
+      addedOpenAiVersionPath: false,
+    };
+  }
+
+  const addedProtocol = !/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed);
+  const withProtocol = addedProtocol ? `https://${trimmed}` : trimmed;
+  const withoutTrailingSlash = withProtocol.replace(/\/+$/, '');
+
+  let normalized = withoutTrailingSlash;
+  let addedOpenAiVersionPath = false;
+  try {
+    const parsed = new URL(withoutTrailingSlash);
+    if (
+      protocol === 'openai' &&
+      parsed.hostname.toLowerCase() === 'api.openai.com' &&
+      (parsed.pathname === '' || parsed.pathname === '/')
+    ) {
+      parsed.pathname = '/v1';
+      normalized = parsed.toString().replace(/\/+$/, '');
+      addedOpenAiVersionPath = true;
+    }
+  } catch {
+    normalized = withoutTrailingSlash;
+  }
+
+  return {
+    value: normalized,
+    changed: normalized !== value,
+    addedProtocol,
+    addedOpenAiVersionPath,
+  };
+}
+
+export function validateByokDraft(
+  protocol: ApiProtocol,
+  config: ByokDraftConfig,
+  options: ValidateByokDraftOptions = {},
+): ByokDraftValidation {
+  const requiresApiKey = options.requiresApiKey ?? true;
+  const requireModel = options.requireModel ?? true;
+  const issues: ByokDraftIssue[] = [];
+  const cleanedApiKey = cleanByokApiKey(config.apiKey);
+  const baseUrl = config.baseUrl.trim();
+  const model = config.model.trim();
+
+  if (requiresApiKey && !cleanedApiKey) {
+    issues.push({
+      field: 'api_key',
+      level: 'error',
+      code: 'api_key_required',
+      message: 'API key is required.',
+      action: 'focus_api_key',
+    });
+  } else if (requiresApiKey) {
+    if (cleanedApiKey !== config.apiKey) {
+      issues.push({
+        field: 'api_key',
+        level: 'warn',
+        code: 'api_key_extra_whitespace',
+        message: 'API key contains extra whitespace.',
+        action: 'focus_api_key',
+      });
+    }
+    const keyIssue = validateApiKeyShape(protocol, cleanedApiKey, baseUrl);
+    if (keyIssue) issues.push(keyIssue);
+  }
+
+  if (!baseUrl) {
+    issues.push({
+      field: 'base_url',
+      level: 'error',
+      code: 'base_url_required',
+      message: 'Base URL is required.',
+      action: 'focus_base_url',
+    });
+  } else if (validateBaseUrl(baseUrl).error) {
+    issues.push({
+      field: 'base_url',
+      level: 'error',
+      code: 'base_url_invalid',
+      message: 'Base URL must be a valid public http:// or https:// URL.',
+      action: 'focus_base_url',
+    });
+  }
+
+  if (requireModel && !model) {
+    issues.push({
+      field: 'model',
+      level: 'error',
+      code: 'model_required',
+      message: 'Model is required.',
+      action: 'focus_model',
+    });
+  }
+
+  return {
+    ok: !issues.some((issue) => issue.level === 'error'),
+    issues,
+  };
+}
+
+export function blockingByokDraftIssues(
+  validation: ByokDraftValidation,
+): ByokDraftIssue[] {
+  return validation.issues.filter((issue) => issue.level === 'error');
+}
+
+export function blockingByokDraftFields(
+  validation: ByokDraftValidation,
+): ByokDraftField[] {
+  return Array.from(
+    new Set(blockingByokDraftIssues(validation).map((issue) => issue.field)),
+  );
+}
+
+export function resolveByokModelPreference({
+  currentModel,
+  accountModels,
+  providerDefaultModel,
+}: {
+  currentModel: string;
+  accountModels: readonly ProviderModelOption[];
+  providerDefaultModel?: string;
+}): ByokModelPreference {
+  const explicit = currentModel.trim();
+  if (explicit) return { model: explicit, source: 'explicit' };
+  const account = accountModels.find((model) => model.id.trim());
+  if (account) return { model: account.id, source: 'account' };
+  const providerDefault = providerDefaultModel?.trim() ?? '';
+  if (providerDefault) {
+    return { model: providerDefault, source: 'provider_default' };
+  }
+  return { model: '', source: 'empty' };
+}
+
+function validateApiKeyShape(
+  protocol: ApiProtocol,
+  apiKey: string,
+  baseUrl: string,
+): ByokDraftIssue | null {
+  if (!apiKey) return null;
+  const detectedProtocol = detectByokApiKeyProtocol(apiKey);
+
+  if (protocol === 'anthropic' && isAnthropicFirstPartyBaseUrl(baseUrl)) {
+    if (apiKey.startsWith('sk-ant-')) return null;
+    return {
+      field: 'api_key',
+      level: 'error',
+      code: detectedProtocol === 'openai'
+        ? 'api_key_wrong_protocol'
+        : 'api_key_malformed',
+      message: detectedProtocol === 'openai'
+        ? 'This looks like an OpenAI key, not an Anthropic key.'
+        : 'This API key does not match the expected Anthropic format.',
+      action: 'focus_api_key',
+      ...(detectedProtocol ? { detectedProtocol } : {}),
+    };
+  }
+
+  if (protocol === 'openai' && isOpenAiFirstPartyBaseUrl(baseUrl)) {
+    if (apiKey.startsWith('sk-') && !apiKey.startsWith('sk-ant-')) return null;
+    return {
+      field: 'api_key',
+      level: 'error',
+      code: detectedProtocol === 'anthropic'
+        ? 'api_key_wrong_protocol'
+        : 'api_key_malformed',
+      message: detectedProtocol === 'anthropic'
+        ? 'This looks like an Anthropic key, not an OpenAI-compatible key.'
+        : 'This API key does not match the expected OpenAI-compatible format.',
+      action: 'focus_api_key',
+      ...(detectedProtocol ? { detectedProtocol } : {}),
+    };
+  }
+
+  if (protocol === 'google' && isGoogleFirstPartyBaseUrl(baseUrl)) {
+    if (apiKey.startsWith('AIza')) return null;
+    return {
+      field: 'api_key',
+      level: 'error',
+      code: detectedProtocol
+        ? 'api_key_wrong_protocol'
+        : 'api_key_malformed',
+      message: detectedProtocol
+        ? 'This key does not look like a Google Gemini API key.'
+        : 'This API key does not match the expected Google Gemini format.',
+      action: 'focus_api_key',
+      ...(detectedProtocol ? { detectedProtocol } : {}),
+    };
+  }
+
+  return null;
+}
+
+function detectByokApiKeyProtocol(apiKey: string): ApiProtocol | null {
+  if (apiKey.startsWith('sk-ant-')) return 'anthropic';
+  if (apiKey.startsWith('AIza')) return 'google';
+  if (apiKey.startsWith('sk-')) return 'openai';
+  return null;
+}
+
+function isAnthropicFirstPartyBaseUrl(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === 'api.anthropic.com';
+  } catch {
+    return false;
+  }
+}
+
+function isOpenAiFirstPartyBaseUrl(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === 'api.openai.com';
+  } catch {
+    return false;
+  }
+}
+
+function isGoogleFirstPartyBaseUrl(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === 'generativelanguage.googleapis.com';
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -789,6 +789,43 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect(screen.getByText('Model discovery is not available for this protocol.')).toBeTruthy();
   });
 
+  it('auto-loads provider models after a pasted dirty key is cleaned on blur', async () => {
+    fetchProviderModelsMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      models: [{ id: 'gpt-account', label: 'Account Model' }],
+    });
+    renderSettingsDialog({
+      apiProtocol: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+    expect(fetchProviderModelsMock).not.toHaveBeenCalled();
+
+    // Paste a key with a leading zero-width char + trailing newline/tab.
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: '\u200Bsk-openai\n\t' },
+    });
+    fireEvent.blur(screen.getByLabelText('API key'));
+
+    // If onByokKeyCommit committed the dirty-key cache key, the auto-fetch
+    // effect would bail on providerModelsCommittedKey !== providerModelsKey
+    // and this text would never appear.
+    expect(await screen.findByText('✓ Loaded 1 models from your account.')).toBeTruthy();
+    expect(fetchProviderModelsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        protocol: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-openai',
+      }),
+      expect.any(AbortSignal),
+    );
+  });
+
   it('does not show a BYOK Test button or nag when the API key is still missing', () => {
     renderSettingsDialog({
       apiProtocol: 'anthropic',

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -997,7 +997,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
       expect(JSON.parse(String(init?.body))).toMatchObject({
         mode: 'provider',
         protocol: 'anthropic',
-        apiKey: 'sk-test-provider',
+        apiKey: 'sk-ant-test-provider',
         baseUrl: 'https://api.anthropic.com',
         model: 'claude-sonnet-4-5',
       });
@@ -1014,7 +1014,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    renderSettingsDialog({ apiKey: 'sk-test-provider' });
+    renderSettingsDialog({ apiKey: 'sk-ant-test-provider' });
 
     expect(screen.getByRole('button', { name: 'Test' })).toBeTruthy();
 
@@ -1030,6 +1030,31 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
       ([input]) => input.toString() === '/api/test/connection',
     );
     expect(testConnectionCalls).toHaveLength(1);
+  });
+
+  it('blocks an obvious OpenAI key in the Anthropic tab before testing', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (input.toString() === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`unexpected request: ${input.toString()}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSettingsDialog({ apiKey: 'sk-openai-provider' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+
+    expect(screen.getByRole('alert').textContent).toContain('Invalid API key.');
+    await waitFor(() => {
+      const testConnectionCalls = fetchMock.mock.calls.filter(
+        ([input]) => input.toString() === '/api/test/connection',
+      );
+      expect(testConnectionCalls).toHaveLength(0);
+    });
   });
 
   it('lets users retry a failed BYOK connection test without editing the API key', async () => {
@@ -1065,7 +1090,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    renderSettingsDialog({ apiKey: 'sk-test-provider' });
+    renderSettingsDialog({ apiKey: 'sk-ant-test-provider' });
 
     fireEvent.click(screen.getByRole('button', { name: 'Test' }));
     expect(await screen.findByRole('button', { name: 'Retry test' })).toBeTruthy();

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1125,12 +1125,16 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
 
     fireEvent.blur(screen.getByLabelText('API key'));
 
+    // The auto-test must survive the apiKey-cleanup re-render: if it fired in
+    // the blur tick it would be dropped by the stale-revision guard and the
+    // success state would never reach the UI.
     await waitFor(() => {
-      const testConnectionCalls = fetchMock.mock.calls.filter(
-        ([input]) => input.toString() === '/api/test/connection',
-      );
-      expect(testConnectionCalls).toHaveLength(1);
+      expect(screen.getByText(/Connected\. Replied in 7 ms/)).toBeTruthy();
     });
+    const testConnectionCalls = fetchMock.mock.calls.filter(
+      ([input]) => input.toString() === '/api/test/connection',
+    );
+    expect(testConnectionCalls).toHaveLength(1);
     // The malformed value must never reach the wire.
     expect(sentApiKey).toBe('sk-ant-test-provider');
   });

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1057,6 +1057,47 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     });
   });
 
+  it('sends a cleaned API key when the pasted value has trailing newline/zero-width characters', async () => {
+    let sentApiKey: unknown;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      expect(url).toBe('/api/test/connection');
+      sentApiKey = JSON.parse(String(init?.body)).apiKey;
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          kind: 'ok',
+          latencyMs: 7,
+          model: 'claude-sonnet-4-5',
+          sample: 'pong',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Leading zero-width char + trailing newline/tab — the exact shape a
+    // pasted key picks up from a docs code block or a terminal copy.
+    renderSettingsDialog({ apiKey: '\u200Bsk-ant-test-provider\n\t' });
+
+    fireEvent.blur(screen.getByLabelText('API key'));
+
+    await waitFor(() => {
+      const testConnectionCalls = fetchMock.mock.calls.filter(
+        ([input]) => input.toString() === '/api/test/connection',
+      );
+      expect(testConnectionCalls).toHaveLength(1);
+    });
+    // The malformed value must never reach the wire.
+    expect(sentApiKey).toBe('sk-ant-test-provider');
+  });
+
   it('lets users retry a failed BYOK connection test without editing the API key', async () => {
     let attempt = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {

--- a/apps/web/tests/components/byok-validation.test.ts
+++ b/apps/web/tests/components/byok-validation.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import {
+  blockingByokDraftFields,
+  cleanByokApiKey,
+  normalizeByokBaseUrl,
+  resolveByokModelPreference,
+  validateByokDraft,
+} from '../../src/components/byok/validation';
+
+describe('BYOK draft validation', () => {
+  it('cleans pasted API keys without changing the stored value itself', () => {
+    expect(cleanByokApiKey(' \u200Bsk-ant-test\n\t')).toBe('sk-ant-test');
+  });
+
+  it('normalizes base URL drafts for future field commits', () => {
+    expect(normalizeByokBaseUrl('api.openai.com/', 'openai')).toEqual({
+      value: 'https://api.openai.com/v1',
+      changed: true,
+      addedProtocol: true,
+      addedOpenAiVersionPath: true,
+    });
+    expect(normalizeByokBaseUrl('https://api.anthropic.com/', 'anthropic')).toEqual({
+      value: 'https://api.anthropic.com',
+      changed: true,
+      addedProtocol: false,
+      addedOpenAiVersionPath: false,
+    });
+  });
+
+  it('blocks missing required fields before a provider connection test', () => {
+    const validation = validateByokDraft('anthropic', {
+      apiKey: '',
+      baseUrl: '',
+      model: '',
+    });
+
+    expect(validation.ok).toBe(false);
+    expect(blockingByokDraftFields(validation)).toEqual([
+      'api_key',
+      'base_url',
+      'model',
+    ]);
+  });
+
+  it('detects obvious API keys pasted into the wrong first-party tab', () => {
+    const anthropic = validateByokDraft('anthropic', {
+      apiKey: 'sk-openai-key',
+      baseUrl: 'https://api.anthropic.com',
+      model: 'claude-sonnet-4-5',
+    });
+    expect(anthropic.ok).toBe(false);
+    expect(anthropic.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'api_key',
+          level: 'error',
+          code: 'api_key_wrong_protocol',
+          detectedProtocol: 'openai',
+        }),
+      ]),
+    );
+
+    const openai = validateByokDraft('openai', {
+      apiKey: 'sk-ant-key',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+    });
+    expect(openai.ok).toBe(false);
+    expect(openai.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'api_key',
+          level: 'error',
+          code: 'api_key_wrong_protocol',
+          detectedProtocol: 'anthropic',
+        }),
+      ]),
+    );
+  });
+
+  it('does not over-block third-party compatible gateways', () => {
+    expect(
+      validateByokDraft('anthropic', {
+        apiKey: 'sk-deepseek-key',
+        baseUrl: 'https://api.deepseek.com/anthropic',
+        model: 'deepseek-chat',
+      }).ok,
+    ).toBe(true);
+    expect(
+      validateByokDraft('openai', {
+        apiKey: 'minimax-enterprise-key',
+        baseUrl: 'https://api.minimax.io/v1',
+        model: 'MiniMax-M1',
+      }).ok,
+    ).toBe(true);
+    expect(
+      validateByokDraft('google', {
+        apiKey: 'enterprise-gemini-key',
+        baseUrl: 'https://gemini.internal.example.com/v1beta',
+        model: 'gemini-2.0-flash',
+      }).ok,
+    ).toBe(true);
+  });
+
+  it('still enforces key shape on first-party OpenAI and Google endpoints', () => {
+    const openai = validateByokDraft('openai', {
+      apiKey: 'enterprise-openai-key',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+    });
+    expect(openai.ok).toBe(false);
+    expect(openai.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'api_key',
+          level: 'error',
+          code: 'api_key_malformed',
+        }),
+      ]),
+    );
+
+    const google = validateByokDraft('google', {
+      apiKey: 'sk-openai-key',
+      baseUrl: 'https://generativelanguage.googleapis.com',
+      model: 'gemini-2.0-flash',
+    });
+    expect(google.ok).toBe(false);
+    expect(google.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'api_key',
+          level: 'error',
+          code: 'api_key_wrong_protocol',
+          detectedProtocol: 'openai',
+        }),
+      ]),
+    );
+  });
+
+  it('blocks invalid base URLs and can validate model-fetch drafts without a model', () => {
+    const invalid = validateByokDraft('openai', {
+      apiKey: 'sk-openai-key',
+      baseUrl: 'api.openai.com/v1',
+      model: 'gpt-4o',
+    });
+    expect(invalid.ok).toBe(false);
+    expect(blockingByokDraftFields(invalid)).toEqual(['base_url']);
+
+    const modelFetchDraft = validateByokDraft(
+      'openai',
+      {
+        apiKey: 'sk-openai-key',
+        baseUrl: 'https://api.openai.com/v1',
+        model: '',
+      },
+      { requireModel: false },
+    );
+    expect(modelFetchDraft.ok).toBe(true);
+  });
+
+  it('defines the model preference order for later model-fetch PRs', () => {
+    expect(
+      resolveByokModelPreference({
+        currentModel: 'custom-model',
+        accountModels: [{ id: 'account-model', label: 'Account model' }],
+        providerDefaultModel: 'provider-model',
+      }),
+    ).toEqual({ model: 'custom-model', source: 'explicit' });
+
+    expect(
+      resolveByokModelPreference({
+        currentModel: '',
+        accountModels: [{ id: 'account-model', label: 'Account model' }],
+        providerDefaultModel: 'provider-model',
+      }),
+    ).toEqual({ model: 'account-model', source: 'account' });
+
+    expect(
+      resolveByokModelPreference({
+        currentModel: '',
+        accountModels: [],
+        providerDefaultModel: 'provider-model',
+      }),
+    ).toEqual({ model: 'provider-model', source: 'provider_default' });
+  });
+});


### PR DESCRIPTION
## Why

This is PR-A in the BYOK shift-left series. I wrote it to turn the configuration mistakes we saw in BYOK setup into a shared local validation layer before the UI sends doomed connection-test or model-fetch requests.

The pain being addressed is that Settings → Execution currently knows whether BYOK is incomplete only through scattered button/precondition logic. Follow-up PRs need one stable selector and one key-commit seam so API key cleanup, model discovery, and Base URL IA can land without each PR rewriting the same handlers.

## What users will see

Settings → Execution → BYOK now refuses obvious local draft failures before sending a provider test or model-fetch request. Missing fields, invalid Base URL values, and obvious wrong-provider API key shapes use the existing inline notice/focus behavior instead of waiting for a network round trip.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this PR reuses the existing Settings → Execution BYOK notice and focus surfaces, with no new page, panel, or visual layout.

## Bug fix verification

-

## Validation

- `NODE_OPTIONS=--localstorage-file=/tmp/open-design-vitest-localstorage-pr-a-rebase pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/byok-validation.test.ts tests/components/SettingsDialog.execution.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`

Note: this local environment is running Node v26.0.0, so pnpm emits the repo engine warning (`node ~24` expected), but all commands above completed successfully.
