### PR TITLE
chore(tools-pack): bump @powerformer/vela-cli to 0.0.8

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-DBUyzKxuMS9HlS5E/d6GY67Qs50FOkALso6REdefdGY=";
-  webHash = "sha256-932IeZAwiGNPBwer8evwVKNbEmz6v05roOz9/aGEpg4=";
+  daemonHash = "sha256-Pk1lUxbg6e+7DaXROLG79RKRhrXT6fwtXu7X+WxUZjk=";
+  webHash = "sha256-Sb1DzpiiuTc20zOUNCUpoSiWVr8uB10uNfk2Tk+3rpU=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,8 +601,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: 0.0.8
+        version: 0.0.8
 
   tools/serve:
     dependencies:
@@ -1642,33 +1642,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.7':
-    resolution: {integrity: sha512-jDQxCdKD97jNVmihAGKXl3qJwTx8L5AxyB90Ka4JQ5sDnZ7kcATPny1BqGf+tCbqgP2LqUoKzP0bt83B4Fnhcw==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.8':
+    resolution: {integrity: sha512-w9r+1IubeCkChCCIXxdz/Wlnq5qTNQ4fklXlMiict5AAH+3OzEjRKD8Ka8snky/XkwECg/tM0WkO4M0tMClUCA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.7':
-    resolution: {integrity: sha512-rQdPD/lyZFdBL3TawXFV20ppI+CSVZ8fQNXvoNB2M9DezdHKBzMzo1Rq7b5JbnF0ZrG7DOTrT2A5yFvMfrzfzQ==}
+  '@powerformer/vela-cli-darwin-x64@0.0.8':
+    resolution: {integrity: sha512-NYsrCqIAvUH0Ms7Yc8J/WH2FUqsOu3Eg0g7g4Q1aGgO62iSidAuDblUGPx9x+OSoktvX8Z7cZsAJ387OKrWqtg==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.7':
-    resolution: {integrity: sha512-Lpz/+7dgWRIzWhAua9NhhX54YAS/T/xr103OcJ4QgMpHC6HdeJ1p9EyefcE40Z9ucfQapylF4FV2FTWOmMkBpA==}
+  '@powerformer/vela-cli-linux-arm64@0.0.8':
+    resolution: {integrity: sha512-XeiDvJJOoQJPXLVos9gwwvTPV9Yq79PQ6gvXNqQpIUZSOFzdZMIldLo/1D2cS55fx41O0dyEZVITN2NwfsjP9A==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.7':
-    resolution: {integrity: sha512-9Q9fWNGCV3LJnca3vBqN+DsTKUwUn8vYx4iBTP64zyX3vW3SRf473GvlGIB3wIUkTamaibTUv/CP5w/NOZchdw==}
+  '@powerformer/vela-cli-linux-x64@0.0.8':
+    resolution: {integrity: sha512-mPwjJSEMup0VWp+VNzVo4xKYn2ueUaGogujshLPyuZ08kkeZKCMuGg9PBp2XKz8VQvWDYnQE3TFoY5mW1/Sc+Q==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.7':
-    resolution: {integrity: sha512-G49FmEKSFLwP/aNgJr9xFmeqMBj23oKmVpVMWS9YWurF4jaKD3Px8+bEEQF6fbGyVY44A6Ww6UBSzt1WO7VmYQ==}
+  '@powerformer/vela-cli-win32-x64@0.0.8':
+    resolution: {integrity: sha512-x91rBmOjoFaca/cOnpMzU3NpS72poxdMWBUj9vJkci5jat/D+o6SEutuVldqxBMjMHCUtxTQDP/GT21o0SiiBw==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.7':
-    resolution: {integrity: sha512-kKXnhGR0Xs1uF2aNvrkD4zyps2GQ9gQz7O0aVAvqlCdOyuu9HFokozVlyqDHbxGG31NNyhkyxXAktsimb1dteQ==}
+  '@powerformer/vela-cli@0.0.8':
+    resolution: {integrity: sha512-XtG+0MmAM99R1hZg8EpPv2Pkbgl0QWXuuKaA1wrSgY+P8DXe6ivjc5u1Gy7RDtIp4gKpEpLbv5lrIKxPuciwvw==}
     hasBin: true
 
   '@rollup/pluginutils@5.3.0':
@@ -6063,28 +6063,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.7':
+  '@powerformer/vela-cli-darwin-arm64@0.0.8':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.7':
+  '@powerformer/vela-cli-darwin-x64@0.0.8':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.7':
+  '@powerformer/vela-cli-linux-arm64@0.0.8':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.7':
+  '@powerformer/vela-cli-linux-x64@0.0.8':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.7':
+  '@powerformer/vela-cli-win32-x64@0.0.8':
     optional: true
 
-  '@powerformer/vela-cli@0.0.7':
+  '@powerformer/vela-cli@0.0.8':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.7
-      '@powerformer/vela-cli-darwin-x64': 0.0.7
-      '@powerformer/vela-cli-linux-arm64': 0.0.7
-      '@powerformer/vela-cli-linux-x64': 0.0.7
-      '@powerformer/vela-cli-win32-x64': 0.0.7
+      '@powerformer/vela-cli-darwin-arm64': 0.0.8
+      '@powerformer/vela-cli-darwin-x64': 0.0.8
+      '@powerformer/vela-cli-linux-arm64': 0.0.8
+      '@powerformer/vela-cli-linux-x64': 0.0.8
+      '@powerformer/vela-cli-win32-x64': 0.0.8
     optional: true
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -22,7 +22,7 @@
     "electron-builder": "26.8.1"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.7"
+    "@powerformer/vela-cli": "0.0.8"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

The packaged build bundles the `@powerformer/vela-cli` (AMR runtime) binary via `tools/pack`. release/v0.9.0 was pinned to `0.0.7`; `0.0.8` is now the `latest` published version. Bumping keeps the packaged AMR runtime on the current CLI so v0.9.0 ships the up-to-date vela binary rather than a stale one.

## What users will see

No visible UI change. Packaged Open Design builds will embed vela CLI `0.0.8` instead of `0.0.7`; users relying on AMR get the latest CLI behavior/fixes from that release.

## How

- `tools/pack/package.json`: `@powerformer/vela-cli` optionalDependency `0.0.7` → `0.0.8`.
- `pnpm-lock.yaml`: regenerated (`pnpm install --lockfile-only`) — only the vela-cli main + per-platform optional packages and their integrity hashes changed.

## Surface area

- [x] Dependencies (root/package `package.json`)
- [x] Packaging / release tooling (`tools/pack`)

## Validation

- `pnpm install --lockfile-only` succeeds; lockfile resolves vela-cli `0.0.8` for all 5 platform binaries (darwin arm64/x64, linux arm64/x64, win32 x64).
- No residual `vela-cli@0.0.7` references remain in the lockfile.
