### PR TITLE
fix(daemon): don't fail AMR runs that do tool work but emit no text (v0.9.0)

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -457,6 +457,7 @@ export function attachAcpSession({
   let emittedThinkingStart = false;
   let emittedFirstTokenStatus = false;
   let emittedTextChunk = false;
+  let emittedToolCall = false;
   let finished = false;
   let fatal = false;
   let aborted = false;
@@ -631,6 +632,16 @@ export function attachAcpSession({
         }
         return;
       }
+      if (
+        update.sessionUpdate === 'tool_call' ||
+        update.sessionUpdate === 'tool_call_update'
+      ) {
+        // The turn did real work (a tool call / file edit), which is valid output even
+        // when the model emits no closing assistant text. Track it so the prompt-complete
+        // handler does not misreport such a turn as "no output / model unavailable".
+        emittedToolCall = true;
+        return;
+      }
       return;
     }
     if (obj.id !== expectedId || !result) {
@@ -682,7 +693,7 @@ export function attachAcpSession({
       return;
     }
     if (promptRequestId !== null && obj.id === promptRequestId) {
-      if (!emittedTextChunk && modelUnavailableErrorCode) {
+      if (!emittedTextChunk && !emittedToolCall && modelUnavailableErrorCode) {
         fail(
           'ACP session completed without producing any assistant text. Refresh the AMR model list, choose a supported model, and retry this run.',
           { forceModelUnavailable: true },

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -237,6 +237,57 @@ test('attachAcpSession includes image attachments as ACP resource links', () => 
   });
 });
 
+test('attachAcpSession does not fail a tool-only AMR turn that emits no assistant text', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'change all card backgrounds to gray',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  // The model does real work via a tool/file edit but emits no closing assistant text.
+  writeAcpUpdate(child, { sessionUpdate: 'tool_call', toolCallId: 'tc-1', title: 'edit', status: 'pending' });
+  writeAcpUpdate(child, { sessionUpdate: 'tool_call_update', toolCallId: 'tc-1', status: 'completed' });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const errorEvents = events.filter((entry) => entry.event === 'error');
+  assert.deepEqual(errorEvents, [], 'a turn that produced tool calls must not be reported as model-unavailable');
+});
+
+test('attachAcpSession still fails an AMR turn that produces no text and no tool calls', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'do something',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpResult(child, 3, {}); // empty turn: no updates at all
+
+  const errorEvents = events.filter((entry) => entry.event === 'error');
+  assert.equal(errorEvents.length, 1, 'a genuinely empty turn must still fail');
+  assert.match(
+    (errorEvents[0]?.payload as { message?: string }).message ?? '',
+    /without producing any assistant text/,
+  );
+});
+
 test('attachAcpSession exposes abort and sends session cancel after session creation', () => {
   const child = new FakeAcpChild();
   const writes: string[] = [];
@@ -326,6 +377,9 @@ function parseRpcWrites(writes: string[]): Array<Record<string, unknown>> {
 
 function writeAcpResult(child: FakeAcpChild, id: number, result: unknown): void {
   child.stdout.write(`${JSON.stringify({ id, result })}\n`);
+}
+function writeAcpUpdate(child: FakeAcpChild, update: unknown): void {
+  child.stdout.write(`${JSON.stringify({ method: 'session/update', params: { update } })}\n`);
 }
 
 function agentModelStatuses(events: Array<{ event: string; payload: unknown }>): unknown[] {


### PR DESCRIPTION
Backport to `release/v0.9.0`.

## Why

A teammate's AMR run on **0.9.0-nightly** (gemini-3-flash-preview, editing an existing artifact) showed **"ACP session completed without producing any output / Refresh the AMR model list, choose a supported model, and retry this run"** — even though the model had actually done the edit.

In `acp.ts`, the prompt-complete handler fails the run when `!emittedTextChunk && modelUnavailableErrorCode`. But `modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE'` is set **unconditionally for every AMR run**, so the check is effectively just "no assistant text". And `emittedTextChunk` is only set by `agent_message_chunk`; `tool_call` / `tool_call_update` session updates are ignored. So a turn that does its work via a tool/file edit and ends **without a closing text message** (common with gemini on edit tasks) is misreported as a model-unavailable failure.

**Proof:** drove a gemini-3-flash-preview AMR run told to "only do the tool call, output no text" → it created the file (work succeeded) yet the run was marked **failed** with the exact error. Captured the real ACP stream: opencode emits `tool_call` + `tool_call_update`, no `agent_message_chunk`.

## What changed

Track tool-call activity (`tool_call` / `tool_call_update`) in a new `emittedToolCall` flag, and only emit the no-output failure when the turn produced **neither assistant text nor any tool call**. A genuinely empty turn — the real unsupported-model signal this guard exists for — still fails.

## Risk: low

The change only makes the fail condition **stricter** (fails in fewer cases) — it never introduces a new failure path. AMR/ACP-only. A `tool_call` means opencode actually ran a tool = real work, so not failing is correct; an unsupported model produces no tool calls and still fails.

## Tests (`apps/daemon/tests/acp.test.ts`)

- a tool-only turn (`tool_call` + `tool_call_update`, no `agent_message_chunk`) no longer produces an `error` event;
- an empty turn (no text, no tool calls) still fails with `…without producing any assistant text`.

Red/green verified; full `acp.test.ts` (20 tests) green; daemon `typecheck` passes.

Note: this is the release-line equivalent of the same fix; `release/v0.9.0`'s `acp.ts` differs slightly from `main` so it was applied directly rather than cherry-picked.