### PR TITLE
docs(zh-CN): 顶部标题补全为完整定位语

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<h1 align="center">Open Design</h1>
+<h1 align="center">Open Design：The open-source Claude Design alternative</h1>
 
 > 🔥 Open Design 0.8.0 已发布。这一版重点上线两件事：Plugin 体系，让模板和工作流像文件夹一样添加、复制、分享；Design System，支持导入品牌规范并沉淀为可复用的 [`DESIGN.md`](design-systems/)。[下载 0.8.0](https://github.com/nexu-io/open-design/releases) · [参与讨论](https://github.com/nexu-io/open-design/discussions/1727)
 


### PR DESCRIPTION
## Why

中文 README 顶部 H1 只有「Open Design」，没有传达定位。补全为与 banner 一致的完整 tagline，进站第一眼就说清产品是什么。

## What users will see

README 顶部大标题由「Open Design」改为「Open Design：The open-source Claude Design alternative」。

## What changed

- `README.zh-CN.md` 第 1 行 H1 文案。仅一行。

## Surface area

- [x] 文档（README.zh-CN.md）