### PR TITLE
[codex] Hide placeholder assistant cost values

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -810,6 +810,13 @@ function AssistantFooter({
 }: AssistantFooterProps) {
   const t = useT();
   const elapsed = useLiveElapsed(streaming, startedAt, endedAt, usage?.durationMs);
+  const formattedCost =
+    typeof usage?.costUsd === "number" &&
+    Number.isFinite(usage.costUsd) &&
+    usage.costUsd > 0
+      ? usage.costUsd.toFixed(4)
+      : "";
+  const costLabel = formattedCost && formattedCost !== "0.0000" ? ` · $${formattedCost}` : "";
   if (
     !forceVisible &&
     !streaming &&
@@ -839,9 +846,7 @@ function AssistantFooter({
         {usage?.outputTokens != null
           ? ` · ${t("assistant.outTokens", { n: usage.outputTokens })}`
           : ""}
-        {typeof usage?.costUsd === "number"
-          ? ` · $${usage.costUsd.toFixed(4)}`
-          : ""}
+        {costLabel}
       </span>
       {feedbackControls}
     </div>

--- a/apps/web/tests/components/assistant-message-unfinished-todos.test.tsx
+++ b/apps/web/tests/components/assistant-message-unfinished-todos.test.tsx
@@ -145,6 +145,68 @@ describe('AssistantMessage unfinished todo state', () => {
     expect(screen.getByText(/1439 out/)).toBeTruthy();
   });
 
+  it('hides zero cost because it is not reliable billing data', () => {
+    render(
+      <AssistantMessage
+        message={{
+          id: 'assistant-zero-cost',
+          role: 'assistant',
+          content: 'Done',
+          startedAt: 1_000,
+          runStatus: 'succeeded',
+          events: [{ kind: 'usage', outputTokens: 1439, durationMs: 32_000, costUsd: 0 }],
+        }}
+        streaming={false}
+        projectId="project-1"
+        isLast
+      />,
+    );
+
+    expect(screen.getByText(/1439 out/)).toBeTruthy();
+    expect(screen.queryByText(/\$0\.0000/)).toBeNull();
+  });
+
+  it('hides costs that round to zero in the current display precision', () => {
+    render(
+      <AssistantMessage
+        message={{
+          id: 'assistant-rounded-zero-cost',
+          role: 'assistant',
+          content: 'Done',
+          startedAt: 1_000,
+          runStatus: 'succeeded',
+          events: [{ kind: 'usage', outputTokens: 1439, durationMs: 32_000, costUsd: 0.00001 }],
+        }}
+        streaming={false}
+        projectId="project-1"
+        isLast
+      />,
+    );
+
+    expect(screen.getByText(/1439 out/)).toBeTruthy();
+    expect(screen.queryByText(/\$0\.0000/)).toBeNull();
+  });
+
+  it('shows positive usage cost when billing data is present', () => {
+    render(
+      <AssistantMessage
+        message={{
+          id: 'assistant-positive-cost',
+          role: 'assistant',
+          content: 'Done',
+          startedAt: 1_000,
+          runStatus: 'succeeded',
+          events: [{ kind: 'usage', outputTokens: 1439, durationMs: 32_000, costUsd: 0.0123 }],
+        }}
+        streaming={false}
+        projectId="project-1"
+        isLast
+      />,
+    );
+
+    expect(screen.getByText(/\$0\.0123/)).toBeTruthy();
+  });
+
   it('does not synthesize a growing elapsed time for completed messages without endedAt', () => {
     render(
       <AssistantMessage


### PR DESCRIPTION
## Summary

- Fixes #3493 by hiding placeholder-looking run cost values from the assistant footer when real billing data is not meaningful.
- Keeps duration and output-token usage stats visible when present.
- Keeps positive provider-reported costs visible, while suppressing `$0.0000` values including tiny costs that round to zero at the current display precision.

## Root Cause

`AssistantFooter` rendered the cost label for any numeric `usage.costUsd`. Some providers or run paths can surface unavailable cost data as `0`, which the UI formatted as `$0.0000`. That makes the status area look like it has authoritative billing data when it does not.

## Why This Fix

Billing/cost values are trust-sensitive. Until the event stream has an explicit flag that says a zero-cost value is verified billing data, showing `$0.0000` is more misleading than helpful. The narrower fix is to hide only values that are missing, non-finite, non-positive, or round to `$0.0000`, while preserving real positive costs.

## How It Was Fixed

- Added a formatted-cost gate in `AssistantFooter`.
- Render cost only when `costUsd` is finite, positive, and formats to a non-zero four-decimal value.
- Added regression coverage for `costUsd: 0`, tiny positive values that round to zero, and a normal positive cost.

## What users will see

The running/completed status footer no longer shows `$0.0000` when billing data is unavailable. If real positive cost data is present, the footer still shows it next to duration and output-token stats.

## Surface area

- [x] UI
- [ ] CLI
- [ ] API
- [ ] Data model
- [x] Default behavior change
- [ ] Accessibility
- [ ] Performance
- [ ] Security/privacy
- [ ] None

## Validation

- Red check before fix: the new zero-cost regression test would fail because `$0.0000` was rendered.
- `pnpm exec vitest run -c vitest.config.ts tests/components/assistant-message-unfinished-todos.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`

## Notes

- No dependencies added.
- `@open-design/web` does not define a separate `lint` script, so lint was not run separately.

Fixes #3493
