### PR TITLE
docs: spec Langfuse prompt-stack observability

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -17,6 +17,7 @@ Other docs:
 - Agent adapters → [`agent-adapters.md`](agent-adapters.md)
 - Modes → [`modes.md`](modes.md)
 - Automations self-evolution → [`../specs/current/automation-self-evolution.md`](../specs/current/automation-self-evolution.md)
+- Langfuse prompt-stack observability → [`../specs/current/langfuse-prompt-stack-observability.md`](../specs/current/langfuse-prompt-stack-observability.md)
 - References & credits → [`references.md`](references.md)
 - Roadmap → [`roadmap.md`](roadmap.md)
 

--- a/specs/current/langfuse-prompt-stack-observability.md
+++ b/specs/current/langfuse-prompt-stack-observability.md
@@ -154,8 +154,7 @@ sections in the order they were composed.
       "redactedContent": "bounded redacted system prompt content",
       "truncated": true
     }
-  ],
-  "composedPromptPreview": "not emitted in Phase 1"
+  ]
 }
 ```
 
@@ -262,12 +261,16 @@ interface PromptPrivacyTelemetry {
     | 'redacted-generation-input';
   redactionVersion: string;
   maxSectionBytes: number;
+  maxDaemonSystemPromptBytes: number;
+  maxTotalSectionBytes: number;
   maxComposedBytes: number;
   localPaths: 'redacted' | 'hashed' | 'omitted';
   attachments: 'metadata-only' | 'redacted-preview';
   toolTokens: 'omitted';
 }
 ```
+
+Phase 1 uses `redactionVersion: 'prompt-stack-redaction-v1'`.
 
 Capture modes:
 
@@ -323,22 +326,27 @@ Prompt observability must be safe by default.
 
 Rules:
 
-- Hash raw prompt strings before redaction so equality/regression analysis works
-  without relying on content. Use SHA-256 with a `sha256:` prefix.
-- Report byte counts for raw strings.
+- Use normalized redacted prompt text for stable fingerprints. Before computing
+  `promptStackHash` or section hashes, redact secrets, replace local paths with
+  `[REDACTED:path]`, and exclude attachment bodies. Use SHA-256 with a
+  `sha256:` prefix. Report raw byte counts separately so payload-size analysis
+  still reflects the prompt sent to the agent.
 - Run lexical secret redaction before any preview enters Langfuse.
 - Omit tool tokens entirely. Do not rely on redaction for tool token safety.
 - Treat `runtimeToolPrompt`, cwd hints, linked dirs, MCP config, OAuth-derived
   context, attachments, and image paths as sensitive.
-- Redact local paths to `[REDACTED_PATH]` by default. A path like
+- Redact local paths to `[REDACTED:path]` by default. A path like
   `/Users/<name>/Documents/...` can identify a person or repo; preserving only
   the basename can still leak project, customer, or user names.
+- Extend Phase 1 redaction to cover local filesystem paths. This is new
+  prompt-stack redaction behavior, not covered by the existing generic
+  secret-redaction rules.
 - Report attachment counts, file extensions, size buckets, and hashes before
   reporting any attachment text.
-- Bound captured content. Phase 1 captures up to 16 KiB per redacted
-  instruction section and up to 64 KiB total across all redacted section
-  content for one run. Record bytes and truncation state when either bound is
-  hit.
+- Bound captured content. Phase 1 captures up to 32 KiB for
+  `daemonSystemPrompt`, up to 16 KiB for every other redacted instruction
+  section, and up to 96 KiB total across all redacted section content for one
+  run. Record bytes and truncation state when any bound is hit.
 - Never emit prompt previews when Langfuse content capture is disabled.
 - Add tests with fake API keys, bearer tokens, OD tool tokens, emails, local
   paths, and attachment names to prove previews are redacted.
@@ -455,15 +463,16 @@ Phase 1 capture target:
 - Reuse the existing Settings -> Privacy "Conversation and tool content" consent
   gate. Do not add a prompt-stack-specific UI toggle or environment override in
   Phase 1.
-- Use plain SHA-256 with a `sha256:` prefix for prompt, section, and stack
-  fingerprints.
-- Capture up to 16 KiB per allowed redacted instruction section and up to 64
-  KiB total redacted section content per run.
-- Replace local paths with `[REDACTED_PATH]`.
-- Verify whether completed Langfuse generations already include bounded
-  redacted assistant output. If output is missing, Phase 1 should add bounded
-  redacted assistant output capture so prompt behavior can be inspected against
-  the model result.
+- Use SHA-256 with a `sha256:` prefix for prompt, section, and stack
+  fingerprints after secret redaction, local path normalization, and attachment
+  body exclusion. Keep raw byte counts separately.
+- Capture up to 32 KiB for `daemonSystemPrompt`, up to 16 KiB for every other
+  allowed redacted instruction section, and up to 96 KiB total redacted section
+  content per run.
+- Replace local paths with `[REDACTED:path]`.
+- Preserve the existing bounded redacted assistant output capture on completed
+  Langfuse generations. Phase 1 does not add a new output path; tests should
+  confirm promptStack wiring does not regress generation output.
 
 Phase 1 section-content allowlist:
 
@@ -487,6 +496,24 @@ Phase 1 section-content allowlist:
   `commentAttachments`, and `promptImagePaths`. Report presence, counts, file
   extensions, size buckets, hashes, and truncation state where available, but do
   not upload raw path strings or attachment bodies.
+
+When the 96 KiB total redacted-section budget is exhausted, keep metadata for
+every section and allocate content budget by diagnostic priority rather than
+composition order:
+
+1. `formOverride`
+2. `daemonSystemPrompt`
+3. `runtimeToolPrompt`
+4. `clientSystemPrompt`
+5. skill, design-system, plugin, and stage prompt sections
+6. `researchCommandContract`
+7. `runContextPrompt`
+8. `echoGuard`
+9. `userRequest`
+
+If a lower-priority section cannot include redacted content because the total
+budget is exhausted, mark it with a suppression/truncation reason such as
+`total_budget_exceeded`.
 
 Out of scope for Phase 1:
 
@@ -576,21 +603,25 @@ Phase 1 tests:
 - Unit-test bounded redacted section capture for daemon system prompt,
   form-answer override, runtime tool prompt, client system prompt, `skillPrompt`,
   `designSystemPrompt`, `pluginStagePrompt` sections, and user request.
+- Unit-test local path redaction to `[REDACTED:path]`; this covers macOS/Linux
+  home paths, project paths, cwd hints, linked dirs, and prompt image paths.
+- Unit-test stable hashes after redaction and path normalization so different
+  local directories do not fragment the same prompt-stack fingerprint.
 - Unit-test metadata-only capture for cwd hints, linked dirs, attachments,
   comment attachments, and prompt image paths.
-- Unit-test 16 KiB per-section and 64 KiB total redacted section content limits,
-  including byte counts and truncation flags.
+- Unit-test 32 KiB `daemonSystemPrompt`, 16 KiB other-section, and 96 KiB total
+  redacted section content limits, including byte counts, truncation flags, and
+  total-budget priority behavior.
 - Bridge tests assert `promptStack` appears in Langfuse trace and generation
   metadata.
 - Bridge tests assert redacted section content follows the existing
   `telemetry.metrics && telemetry.content` Langfuse delivery gate.
-- Bridge tests assert local paths are replaced with `[REDACTED_PATH]` and raw
+- Bridge tests assert local paths are replaced with `[REDACTED:path]` and raw
   attachment bodies are not uploaded.
 - Existing tests continue to assert top-level `trace.input` is the user prompt.
 - Existing tests continue to assert `generation.input` is the user prompt.
-- Bridge tests verify completed generations include bounded redacted assistant
-  output, or explicitly document that existing output capture already satisfies
-  this requirement.
+- Bridge tests preserve the existing bounded redacted assistant output on
+  completed generations.
 - Chat-route tests cover discovery, skip-discovery, form-answer overrides,
   media surfaces, active skill, active design system, and plugin snapshot
   dimensions.
@@ -614,7 +645,7 @@ Phase 3 tests:
 - Should a future privacy hardening pass move from plain SHA-256 to
   installation-scoped HMAC-SHA-256 if cross-install prompt correlation becomes
   a concern?
-- What is the right threshold for shrinking the 16 KiB / 64 KiB bounds if
+- What is the right threshold for shrinking the 32 KiB / 16 KiB / 96 KiB bounds if
   Langfuse metadata payload size affects ingestion reliability?
 - Which traces should be sampled into human annotation queues first: failures,
   low user feedback, high token cost, or new prompt-stack hashes?

--- a/specs/current/langfuse-prompt-stack-observability.md
+++ b/specs/current/langfuse-prompt-stack-observability.md
@@ -478,9 +478,25 @@ Each score should include metadata linking it to:
 
 ### Phase 1: Debug-Ready Prompt Diagnostics
 
-Phase 1 is one implementation issue under the #3496 umbrella. It should land
-debug-ready prompt-stack observability without introducing a new user-facing
-privacy toggle.
+Phase 1 is one implementation issue under the #3496 umbrella. It landed as
+#3556 / #3557 and provides debug-ready prompt-stack observability without
+introducing a new user-facing privacy toggle.
+
+Phase 1 is intentionally a diagnostic layer on top of the existing Langfuse
+trace shape. It does not try to make the Langfuse generation fully replayable.
+The accepted tradeoff is:
+
+- keep the user request in `trace.input` and `generation.input`;
+- attach bounded, redacted prompt-stack diagnostics in trace and generation
+  metadata;
+- keep key aggregate system prompts, including `daemonSystemPrompt` and
+  `clientSystemPrompt`, visible as `redactedContent` because direct inspection
+  of the model's system context is the Phase 1 acceptance goal;
+- keep metadata queryable by omitting absent sections and limiting top-level
+  `promptStack_*` flat fields to high-value filters;
+- align unresolved `Default (CLI config)` model runs with PostHog by reporting
+  the `default` model bucket when no explicit or agent-reported model is
+  available.
 
 Phase 1 capture target:
 
@@ -587,20 +603,56 @@ Store the result on the in-memory run record and thread it through:
 Do not change top-level `trace.input` in this phase. Generation metadata should
 be sufficient to debug prompt behavior from the Langfuse UI.
 
-### Phase 2: Structured Generation Input
+### Phase 2: Langfuse-Native Generation Modeling
 
-Promote the redacted prompt invocation from generation metadata into
-`generation.input` for users who want the Langfuse generation panel to show the
-LLM call in a first-class way.
+Phase 2 promotes the Phase 1 diagnostics into a more Langfuse-native generation
+model. The goal is no longer only "can I see the system prompt?" but "can I
+understand, reproduce, filter, and cost a model call using Langfuse-native
+surfaces?"
 
-The structured input should contain the same section array, hashes, byte counts,
-and capture flags from Phase 1. It should not include raw unredacted prompt
-content.
+Core Phase 2 deliverables:
 
-This may be configured through existing Langfuse telemetry config or a new
-daemon setting. Product/security review should decide whether and when the
-structured generation input view is worth the higher UI/semantics risk. It is
-not required for prompt-stack debugging in Phase 1.
+1. Structured `generation.input`
+   - Represent the actual LLM invocation as structured messages / prompt parts
+     instead of leaving the user request as the only generation input.
+   - Preserve Phase 1 redaction guarantees: no raw credentials, tool tokens,
+     unredacted local paths, or attachment bodies.
+   - Keep enough section identity, hashes, and truncation state for Playground,
+     eval, and dataset workflows to understand what was sent.
+
+2. Model, provider, usage, and cost attribution
+   - Keep `generation.model` populated for explicit model selections,
+     agent-reported resolved models, and unresolved default runs.
+   - Add provider and Langfuse-compatible usage/cost details where the runtime
+     exposes them.
+   - Treat provider-specific resolved-model extraction, especially for Codex
+     `Default (CLI config)` runs, as part of this attribution work rather than
+     prompt-stack capture itself.
+
+3. Prompt-stack metadata diet
+   - Keep metadata useful for filtering: redaction version, prompt/stack
+     fingerprints, section counts, truncation flags, and compact section
+     presence fields.
+   - Move large prompt bodies away from metadata when a better Langfuse-native
+     home exists, such as structured generation input, archived references, or
+     a dedicated debug view.
+   - Retain only bounded snippets in metadata if the structured input path does
+     not cover a diagnostic need.
+
+Adjacent follow-ups that may be implemented alongside Phase 2 but are not core
+Phase 2 acceptance:
+
+- Timing observations: split queue, spawn, prompt-build, model-call,
+  stream-output, and finalize timings into Langfuse spans/events instead of
+  metadata-only fields.
+- First-class release/version fields: map `appVersion` and `appChannel` onto
+  Langfuse-supported `version` / `release` fields when the ingestion surface
+  supports them.
+- OTel/W3C identifier shape: evaluate migration from legacy UUID-style trace /
+  observation IDs to Langfuse's newer lower-hex ID expectations.
+
+Phase 2 should not include Langfuse datasets/scores or prompt registry
+management; those remain Phase 3 and Phase 4 respectively.
 
 ### Phase 3: Evaluation Dataset and Scores
 
@@ -667,9 +719,15 @@ Phase 1 tests:
 
 Phase 2 tests:
 
-- Verify structured generation input is emitted only in explicit opt-in mode.
+- Verify structured generation input represents the redacted LLM invocation
+  with stable message / prompt-part boundaries.
 - Verify structured generation input contains no raw tokens, credentials, local
   user paths, or attachment bodies.
+- Verify `generation.model`, provider, usage, and cost fields are populated when
+  the runtime exposes the required data, with `default` preserved as the
+  unresolved-model bucket.
+- Verify prompt-stack metadata remains compact when structured generation input
+  carries the detailed diagnostic content.
 
 Phase 3 tests:
 

--- a/specs/current/langfuse-prompt-stack-observability.md
+++ b/specs/current/langfuse-prompt-stack-observability.md
@@ -1,0 +1,475 @@
+# Langfuse Prompt Stack Observability
+
+## Purpose
+
+Open Design uses Langfuse to understand agent runs, costs, outputs, feedback,
+and failure patterns. Today the Langfuse trace input intentionally shows only
+the user's current prompt. That keeps the session UI readable, but it hides the
+actual prompt stack sent to local agent CLIs: daemon system instructions,
+discovery rules, active skills, design-system content, runtime tool guidance,
+form-answer overrides, cwd hints, and attachments.
+
+This spec defines how Open Design should add prompt-stack diagnostics to
+Langfuse without turning traces into an unsafe dump of private prompts, tool
+tokens, local paths, or attachment content.
+
+The target outcome is a trace that can answer:
+
+- What user request triggered this run?
+- Which prompt sections and runtime flags were active?
+- Which skill, design system, plugin stage, model, release, and prompt-stack
+  fingerprint produced the output?
+- Did discovery ask a form, skip a form, or suppress a repeated form?
+- Which production traces should become eval dataset items?
+- Which automated or human scores explain regressions over time?
+
+## Current Behavior
+
+The daemon currently treats Langfuse `input` as the user-facing prompt:
+
+- `apps/daemon/src/server.ts:2502` returns `currentPrompt` or `message` through
+  `telemetryPromptFromRunRequest`.
+- `apps/daemon/src/langfuse-bridge.ts:343` redacts `run.userPrompt` and sends it
+  as `ctx.message.prompt`.
+- `apps/daemon/src/langfuse-trace.ts:363`, `:379`, and `:408` use that prompt as
+  the trace, span, and generation input.
+
+The actual agent prompt is assembled later:
+
+- `apps/daemon/src/server.ts:10923` composes the daemon system prompt.
+- `apps/daemon/src/server.ts:11023` adds research/run-context/client prompt
+  material.
+- `apps/daemon/src/server.ts:11036` joins daemon system, runtime tool, and
+  client system sections.
+- `apps/daemon/src/server.ts:11051` detects submitted form answers and injects
+  the form-answer override.
+- `apps/daemon/src/server.ts:11068` builds `composed`, the final prompt written
+  to the agent adapter.
+
+Because Langfuse receives only the user prompt, a trace can show that a run used
+33k input tokens while its visible input looks like a short user request. That
+gap is expected from the current implementation, but it is a poor debugging and
+evaluation surface.
+
+## Langfuse-Aligned Practices
+
+This design follows these Langfuse practices from the official documentation:
+
+- Treat a trace as one application request and use observations for individual
+  steps such as generations, tools, evaluators, retrievers, and guardrails.
+  Langfuse's tracing data model is increasingly observation-centric, so LLM
+  invocation details belong on the generation observation rather than only on
+  the trace top level.
+- Use generation observations for LLM calls, including prompt/message input,
+  model, token usage, cost, output, and generation metadata.
+- Use metadata, tags, release, version, user, and session identifiers to slice
+  metrics by application feature, runtime, prompt version, model, user, and
+  release.
+- Link prompts to traces/generations so Langfuse can aggregate metrics and
+  scores per prompt version. Open Design's prompt stack is code-composed rather
+  than centrally fetched from Langfuse, so this spec uses stable local hashes
+  first and leaves first-class Langfuse prompt objects as a later migration.
+- Use scores as the universal evaluation result object. Scores may come from
+  code evaluators, LLM-as-judge, human annotation, user feedback, or custom
+  SDK/API pipelines.
+- Use datasets and experiments to replay fixed cases before deployment, and use
+  online evaluation to score production traces continuously.
+
+References:
+
+- https://langfuse.com/docs/tracing-data-model
+- https://langfuse.com/docs/observability/features/observation-types
+- https://langfuse.com/docs/tracing-features/metadata
+- https://langfuse.com/docs/prompt-management/features/link-to-traces
+- https://langfuse.com/docs/prompt-management/features/prompt-version-control
+- https://langfuse.com/docs/evaluation/core-concepts
+- https://langfuse.com/docs/metrics/overview
+
+## Non-Goals
+
+This spec does not:
+
+- Move Open Design system prompts into Langfuse Prompt Management.
+- Require network prompt fetching before agent spawn.
+- Replace trace input with the full composed prompt.
+- Upload raw tool tokens, API keys, local auth material, OAuth tokens, or MCP
+  bearer tokens.
+- Upload raw attachment contents by default.
+- Treat Langfuse as the only visual-quality evaluator. Langfuse stores traces,
+  datasets, experiments, scores, and dashboards; Open Design still needs local
+  deterministic checks, screenshot inspection, LLM judges, and human review.
+
+## Data Model
+
+### Trace Input
+
+Keep top-level `trace.input` as the user prompt.
+
+Rationale:
+
+- Session browsing remains readable.
+- Existing tests and user workflows keep their current behavior.
+- Trace-level input remains the business request, while generation metadata
+  explains the exact prompt stack and LLM invocation.
+
+### Generation Input
+
+Open Design should move toward generation-level LLM invocation visibility in
+two stages:
+
+1. Default: keep `generation.input` as the user prompt but attach
+   `promptStack` metadata.
+2. Opt-in or safe-content mode: set `generation.input` to a structured object
+   representing the redacted LLM invocation:
+
+```json
+{
+  "format": "open-design-composed-prompt",
+  "streamFormat": "stream-json",
+  "userPrompt": "redacted current user prompt",
+  "composedPromptPreview": "bounded redacted preview",
+  "promptStackHash": "sha256:..."
+}
+```
+
+The default stage avoids a sudden content-volume and privacy change. The opt-in
+stage aligns more closely with Langfuse's generation model once redaction and
+capture controls are proven.
+
+### Prompt Stack Metadata
+
+Add a `promptStack` object to trace metadata and generation metadata. The trace
+copy is compact for dashboards; the generation copy may include bounded preview
+fields when content capture is enabled.
+
+```ts
+interface PromptStackTelemetry {
+  schemaVersion: 1;
+  userPrompt: {
+    bytes: number;
+    sha256: string;
+    truncated: boolean;
+  };
+  composedPrompt: {
+    bytes: number;
+    sha256: string;
+    redactedPreview?: string;
+    redactedPreviewBytes?: number;
+    redactedPreviewTruncated?: boolean;
+  };
+  daemonSystemPrompt: {
+    bytes: number;
+    sha256: string;
+  };
+  sections: PromptSectionTelemetry[];
+  flags: PromptStackFlags;
+  routing: PromptRoutingTelemetry;
+  privacy: PromptPrivacyTelemetry;
+}
+
+interface PromptSectionTelemetry {
+  name:
+    | 'formOverride'
+    | 'daemonSystemPrompt'
+    | 'runtimeToolPrompt'
+    | 'researchCommandContract'
+    | 'runContextPrompt'
+    | 'clientSystemPrompt'
+    | 'cwdHint'
+    | 'linkedDirsHint'
+    | 'echoGuard'
+    | 'userRequest'
+    | 'attachments'
+    | 'commentAttachments'
+    | 'promptImagePaths';
+  present: boolean;
+  bytes: number;
+  sha256?: string;
+  redactionApplied?: boolean;
+}
+
+interface PromptStackFlags {
+  streamFormat: 'text' | 'stream-json';
+  resumesSessionViaCli: boolean;
+  skipDiscoveryBrief: boolean;
+  formAnswersDetected: boolean;
+  formOverrideKind: 'none' | 'discovery' | 'task-type' | 'generic';
+  mediaSurface: boolean;
+  mediaExecutionKind?: string;
+  critiqueEligible: boolean;
+  connectedExternalMcpCount: number;
+  promptImagePathCount: number;
+  attachmentCount: number;
+  commentAttachmentCount: number;
+}
+
+interface PromptRoutingTelemetry {
+  agentId?: string;
+  model?: string;
+  reasoning?: string;
+  skillId?: string;
+  skillIds?: string[];
+  activeSkillDirCount: number;
+  designSystemId?: string;
+  designSystemTitle?: string;
+  appliedPluginSnapshotId?: string;
+  pluginTrust?: 'restricted' | 'trusted';
+  activeStageCount: number;
+}
+
+interface PromptPrivacyTelemetry {
+  contentCapture: 'off' | 'redacted-preview' | 'redacted-generation-input';
+  redactionVersion: string;
+  maxPreviewBytes: number;
+  localPaths: 'redacted' | 'hashed' | 'omitted';
+  attachments: 'metadata-only' | 'redacted-preview';
+  toolTokens: 'omitted';
+}
+```
+
+### Flat Metadata for Metrics
+
+Langfuse metadata can store JSON, but dashboard filters and propagated metadata
+work best with shallow stable dimensions. Alongside nested `promptStack`, add
+compact top-level metadata keys:
+
+```json
+{
+  "promptStackSchemaVersion": 1,
+  "promptStackHash": "sha256:...",
+  "promptStackBytes": 32768,
+  "daemonSystemPromptHash": "sha256:...",
+  "promptDiscoveryState": "turn1-discovery",
+  "promptFormOverride": "none",
+  "promptMediaSurface": false,
+  "promptContentCapture": "off",
+  "skillId": "landing-page",
+  "designSystemId": "acme",
+  "agent": "claude",
+  "model": "claude-sonnet-4-6",
+  "appVersion": "..."
+}
+```
+
+Recommended `promptDiscoveryState` values:
+
+- `turn1-discovery`
+- `default-router-task-type`
+- `skipped-by-user`
+- `skipped-by-metadata`
+- `form-answers-discovery`
+- `form-answers-task-type`
+- `form-answers-generic`
+- `media-contract`
+- `not-applicable`
+
+## Privacy and Safety
+
+Prompt observability must be safe by default.
+
+Rules:
+
+- Hash raw prompt strings before redaction so equality/regression analysis works
+  without relying on content. Use SHA-256 with a `sha256:` prefix.
+- Report byte counts for raw strings.
+- Run lexical secret redaction before any preview enters Langfuse.
+- Omit tool tokens entirely. Do not rely on redaction for tool token safety.
+- Treat `runtimeToolPrompt`, cwd hints, linked dirs, MCP config, OAuth-derived
+  context, attachments, and image paths as sensitive.
+- Redact or hash local paths by default. A path like
+  `/Users/<name>/Documents/...` can identify a person or repo.
+- Report attachment counts, file extensions, size buckets, and hashes before
+  reporting any attachment text.
+- Bound preview size. Initial default: 8 KiB redacted composed prompt preview,
+  behind an explicit content-capture setting.
+- Never emit prompt previews when Langfuse content capture is disabled.
+- Add tests with fake API keys, bearer tokens, OD tool tokens, emails, local
+  paths, and attachment names to prove previews are redacted.
+
+## Trace Shape
+
+Recommended observation tree:
+
+```mermaid
+flowchart TD
+  T["trace: open-design-turn\ninput = user prompt\nmetadata = compact prompt dimensions"]
+  A["span: agent-run\ninput = user prompt\nmetadata = run status and promptStack summary"]
+  G["generation: llm\ninput = user prompt or redacted invocation\nmetadata = full promptStack diagnostics"]
+  TS["tool spans\ninput/output = existing bounded redacted content"]
+  AS["event: artifact-summary"]
+  ES["event: evaluator/scores\nwhen local eval runner reports back"]
+
+  T --> A
+  A --> G
+  A --> TS
+  A --> AS
+  A --> ES
+```
+
+Generation metadata should include the richest prompt diagnostics because it is
+the object closest to the LLM call. Trace metadata should include only fields
+needed for browsing, filtering, and dashboards.
+
+## Evaluation Loop
+
+Langfuse is the right registry and analysis surface for Open Design effect
+evaluation, but it is not the whole evaluator.
+
+Use Langfuse for:
+
+- Trace collection and session browsing.
+- Prompt-stack, runtime, release, model, skill, and design-system dimensions.
+- Datasets created from production/staging traces.
+- Experiments comparing prompt-stack hashes, releases, models, and skills.
+- Scores from user feedback, human annotation, code checks, LLM-as-judge, and
+  local visual-quality pipelines.
+- Dashboards for score, cost, latency, token, and failure trends.
+
+Use Open Design local/CI runners for:
+
+- Deterministic artifact checks: file created, valid HTML, no duplicate form,
+  no empty artifact, expected asset references, basic accessibility checks.
+- Browser checks: Playwright screenshot, responsive layouts, console errors,
+  nonblank canvas/media, image load success.
+- Domain-specific visual scoring: design-system adherence, content specificity,
+  mobile/desktop polish, no text overlap, no broken controls.
+- Golden dataset replay against the daemon using mock CLIs where possible.
+
+Initial score names:
+
+```text
+artifact_created          BOOLEAN
+valid_html                BOOLEAN
+no_repeat_form            BOOLEAN
+responsive_ok             BOOLEAN
+asset_load_ok             BOOLEAN
+visual_quality            NUMERIC 0..1
+design_system_adherence   NUMERIC 0..1
+content_specificity       NUMERIC 0..1
+overall_quality           NUMERIC 0..1
+failure_reason            CATEGORICAL
+review_notes              TEXT
+```
+
+Each score should include metadata linking it to:
+
+- `traceId`
+- `runId`
+- `assistantMessageId`
+- `promptStackHash`
+- `appVersion`
+- `agent`
+- `model`
+- `skillId`
+- `designSystemId`
+- evaluator name/version
+
+## Implementation Plan
+
+### Phase 1: Metadata-Only Prompt Diagnostics
+
+Add a daemon-local prompt telemetry builder after `composed` is built and before
+the agent is spawned.
+
+Suggested modules:
+
+- `apps/daemon/src/prompt-telemetry.ts`
+- `apps/daemon/tests/prompt-telemetry.test.ts`
+
+The builder accepts raw prompt sections, routing context, and run flags. It
+returns:
+
+- nested `promptStack` diagnostics;
+- flat metric dimensions;
+- redaction status;
+- optional redacted preview when enabled.
+
+Store the result on the in-memory run record and thread it through:
+
+- `apps/daemon/src/server.ts`
+- `apps/daemon/src/langfuse-bridge.ts`
+- `apps/daemon/src/langfuse-trace.ts`
+
+Do not change top-level `trace.input` in this phase.
+
+### Phase 2: Safe Generation Input Preview
+
+Add an explicit content-capture mode for generation input:
+
+- `off`: current behavior plus metadata only.
+- `redacted-preview`: metadata contains bounded redacted composed preview.
+- `redacted-generation-input`: generation input becomes a structured redacted
+  invocation object.
+
+This may be configured through existing Langfuse telemetry config or a new
+daemon setting. The default remains `off` unless product/security review
+approves preview capture.
+
+### Phase 3: Evaluation Dataset and Scores
+
+Add an eval runner that can:
+
+- select traces by metadata filters;
+- replay or inspect artifacts;
+- run deterministic/browser/LLM-judge checks;
+- write scores back to Langfuse;
+- create or update Langfuse dataset items for regression suites.
+
+This phase can start independently once Phase 1 adds enough prompt dimensions
+to filter and group traces.
+
+### Phase 4: Prompt Version Registry
+
+Consider whether stable Open Design prompt layers should become Langfuse prompt
+objects:
+
+- daemon base system prompt;
+- discovery prompt;
+- media contract;
+- design-system usage wrapper;
+- AskUserQuestion guidance.
+
+This is a later migration because Open Design currently composes prompts from
+code, local files, project metadata, plugin snapshots, and runtime state. The
+first requirement is observability of the local prompt stack, not remote prompt
+management.
+
+## Testing Strategy
+
+Phase 1 tests:
+
+- Unit-test prompt telemetry hashing, byte counts, section presence, and flat
+  dimensions.
+- Unit-test redaction with fake credentials, bearer tokens, OD tool tokens,
+  emails, local paths, linked dirs, and attachment names.
+- Bridge tests assert `promptStack` appears in Langfuse trace and generation
+  metadata.
+- Existing tests continue to assert top-level `trace.input` is the user prompt.
+- Chat-route tests cover discovery, skip-discovery, form-answer overrides,
+  media surfaces, active skill, active design system, and plugin snapshot
+  dimensions.
+
+Phase 2 tests:
+
+- Verify content-capture `off` never sends previews.
+- Verify preview is bounded and redacted.
+- Verify structured generation input is emitted only in explicit opt-in mode.
+
+Phase 3 tests:
+
+- Eval runner can score a fixture trace/artifact and post Langfuse scores.
+- Dataset creation preserves trace/run/prompt-stack linkage.
+- Score names and data types remain stable.
+
+## Open Questions
+
+- Should content preview be controlled by environment variable, workspace
+  setting, or Langfuse telemetry config?
+- Should hashes be plain SHA-256 or HMAC-SHA-256 with an installation-scoped
+  secret to avoid cross-install prompt correlation?
+- Which local path representation is most useful without leaking identity:
+  omitted, basename only, extension bucket, or salted hash?
+- Should generation input move to structured redacted invocation in v1, or wait
+  for one release of metadata-only telemetry?
+- Which traces should be sampled into human annotation queues first: failures,
+  low user feedback, high token cost, or new prompt-stack hashes?

--- a/specs/current/langfuse-prompt-stack-observability.md
+++ b/specs/current/langfuse-prompt-stack-observability.md
@@ -440,9 +440,18 @@ Phase 1 capture target:
 - Keep top-level `trace.input` as the user prompt.
 - Keep `generation.input` as the user prompt.
 - Emit `promptStack` on trace and generation metadata.
-- Use `redacted-section-content` as the Phase 1 capture mode whenever existing
-  Langfuse delivery is eligible: `telemetry.metrics === true`,
-  `telemetry.content === true`, and a Langfuse sink is configured.
+- Record `promptContentCapture` (the flat `PromptPrivacyTelemetry.contentCapture`
+  dimension) explicitly from consent state on every eligible run, so dashboards
+  and the privacy audit trail can tell "content consent off" apart from missing
+  data. Phase 1 wires exactly these states:
+  - `telemetry.metrics === true && telemetry.content === true` and a Langfuse
+    sink is configured → `redacted-section-content`: emit `promptStack` with
+    hashes, flags, routing, and bounded `redactedContent`.
+  - `telemetry.metrics === true && telemetry.content === false` (sink
+    configured) → `off`: emit `promptStack` with hashes, flags, and routing
+    only, and never attach `redactedContent` (per "Never emit prompt previews
+    when Langfuse content capture is disabled").
+  - otherwise (metrics disabled or no sink) → no `promptStack` emission.
 - Reuse the existing Settings -> Privacy "Conversation and tool content" consent
   gate. Do not add a prompt-stack-specific UI toggle or environment override in
   Phase 1.
@@ -465,6 +474,15 @@ Phase 1 section-content allowlist:
   `pluginStagePrompt` sections (aligned with the `skillId`, `designSystemId`,
   and `appliedPluginSnapshotId` routing dimensions) when they can be separated
   from raw attachments.
+- `runtimeToolPrompt` carries the highest token risk in this list. Honoring
+  "Omit tool tokens entirely. Do not rely on redaction for tool token safety,"
+  capture its `redactedContent` only after OD tool tokens, MCP bearer tokens /
+  MCP config, and OAuth-derived material are structurally stripped (removed by
+  field/section boundary, not by best-effort lexical redaction) before the
+  preview is built. If a token-bearing subsection cannot be cleanly separated,
+  demote `runtimeToolPrompt` to metadata-only for that run rather than uploading
+  it behind lexical redaction. Lexical secret redaction stays a second layer,
+  never the primary guarantee for tool-token safety.
 - Metadata-only in Phase 1: `cwdHint`, `linkedDirsHint`, `attachments`,
   `commentAttachments`, and `promptImagePaths`. Report presence, counts, file
   extensions, size buckets, hashes, and truncation state where available, but do

--- a/specs/current/langfuse-prompt-stack-observability.md
+++ b/specs/current/langfuse-prompt-stack-observability.md
@@ -284,6 +284,17 @@ interface PromptPrivacyTelemetry {
 }
 ```
 
+`PromptStackTelemetry` intentionally carries no separate top-level fingerprint
+field: the stack-level `promptStackHash` and `promptStackBytes` are sourced
+directly from `composedPrompt.sha256` and `composedPrompt.bytes`. Every other
+reference to the stack fingerprint — the Phase 2 `generation.input` example
+(`promptStackHash`), the flat [Flat Metadata for Metrics](#flat-metadata-for-metrics)
+dimensions (`promptStackHash`, `promptStackBytes`), the
+[Privacy and Safety](#privacy-and-safety) hashing rule, and the per-score
+linkage list — denotes that same `composedPrompt.sha256`/`composedPrompt.bytes`
+value, so the `apps/daemon/src/prompt-telemetry.ts` builder has exactly one
+source for the fingerprint and dashboards/joins cannot fragment.
+
 Phase 1 uses `redactionVersion: 'prompt-stack-redaction-v1'`.
 
 Capture modes:

--- a/specs/current/langfuse-prompt-stack-observability.md
+++ b/specs/current/langfuse-prompt-stack-observability.md
@@ -131,6 +131,16 @@ observation then keeps `generation.input` as the user prompt for Phase 1 and
 gets both metadata and a bounded redacted representation of the allowed prompt
 sections in the order they were composed.
 
+The illustrative envelope below is the **Phase 2** structured `generation.input`
+form (see [Phase 2: Structured Generation Input](#phase-2-structured-generation-input)),
+not the Phase 1 wire shape. In **Phase 1**, `generation.input` stays the raw user
+prompt and the redacted prompt stack is emitted in generation *metadata* using the
+canonical `PromptStackTelemetry` shape defined under
+[Prompt Stack Metadata](#prompt-stack-metadata) below. Both phases reuse the same
+per-section `PromptSectionTelemetry` shape, so the `sections[]` entries here use its
+exact field names (`redactionApplied`, `redactedContent`, `redactedContentBytes`,
+`redactedContentTruncated`).
+
 ```json
 {
   "format": "open-design-composed-prompt",
@@ -143,16 +153,20 @@ sections in the order they were composed.
       "present": true,
       "bytes": 1840,
       "sha256": "sha256:...",
+      "redactionApplied": true,
       "redactedContent": "## OVERRIDE ...",
-      "truncated": false
+      "redactedContentBytes": 1840,
+      "redactedContentTruncated": false
     },
     {
       "name": "daemonSystemPrompt",
       "present": true,
       "bytes": 24120,
       "sha256": "sha256:...",
+      "redactionApplied": true,
       "redactedContent": "bounded redacted system prompt content",
-      "truncated": true
+      "redactedContentBytes": 16384,
+      "redactedContentTruncated": true
     }
   ]
 }

--- a/specs/current/langfuse-prompt-stack-observability.md
+++ b/specs/current/langfuse-prompt-stack-observability.md
@@ -194,9 +194,6 @@ interface PromptStackTelemetry {
   composedPrompt: {
     bytes: number;
     sha256: string;
-    redactedPreview?: string;
-    redactedPreviewBytes?: number;
-    redactedPreviewTruncated?: boolean;
     redactedContent?: string;
     redactedContentBytes?: number;
     redactedContentTruncated?: boolean;
@@ -277,7 +274,7 @@ interface PromptPrivacyTelemetry {
   maxSectionBytes: number;
   maxDaemonSystemPromptBytes: number;
   maxTotalSectionBytes: number;
-  maxComposedBytes: number;
+  maxComposedBytes?: number;
   localPaths: 'redacted' | 'hashed' | 'omitted';
   attachments: 'metadata-only' | 'redacted-preview';
   toolTokens: 'omitted';
@@ -294,6 +291,23 @@ dimensions (`promptStackHash`, `promptStackBytes`), the
 linkage list — denotes that same `composedPrompt.sha256`/`composedPrompt.bytes`
 value, so the `apps/daemon/src/prompt-telemetry.ts` builder has exactly one
 source for the fingerprint and dashboards/joins cannot fragment.
+
+The daemon system prompt is likewise single-sourced. The authoritative record is
+the `sections[]` entry named `daemonSystemPrompt`: it owns `bytes`, `sha256`, and
+(when content capture is enabled) the bounded `redactedContent`. The top-level
+`daemonSystemPrompt` object and the flat `daemonSystemPromptHash` dimension are
+projections of that section — `daemonSystemPrompt.bytes`/`daemonSystemPrompt.sha256`
+and `daemonSystemPromptHash` must equal the section's `bytes`/`sha256`, and
+`redactedContent` lives only on the section so the builder never copies content
+into two places.
+
+`maxComposedBytes` is optional because composed-prompt capture is out of scope
+for Phase 1 (see the "Out of scope for Phase 1" list under
+[Phase 1: Debug-Ready Prompt Diagnostics](#phase-1-debug-ready-prompt-diagnostics)).
+A Phase 1 builder omits it; it becomes a required bound only once a
+`redacted-composed-content` capture mode is implemented. The three section bounds
+(`maxSectionBytes`, `maxDaemonSystemPromptBytes`, `maxTotalSectionBytes`) are the
+only required bound fields in Phase 1.
 
 Phase 1 uses `redactionVersion: 'prompt-stack-redaction-v1'`.
 

--- a/specs/current/langfuse-prompt-stack-observability.md
+++ b/specs/current/langfuse-prompt-stack-observability.md
@@ -165,8 +165,8 @@ exact field names (`redactionApplied`, `redactedContent`, `redactedContentBytes`
       "sha256": "sha256:...",
       "redactionApplied": true,
       "redactedContent": "bounded redacted system prompt content",
-      "redactedContentBytes": 16384,
-      "redactedContentTruncated": true
+      "redactedContentBytes": 24120,
+      "redactedContentTruncated": false
     }
   ]
 }

--- a/specs/current/langfuse-prompt-stack-observability.md
+++ b/specs/current/langfuse-prompt-stack-observability.md
@@ -127,9 +127,9 @@ Open Design should make generation-level LLM invocation visibility useful for
 debugging in the first implementation phase.
 
 The baseline keeps `trace.input` readable as the user prompt. The generation
-observation then gets both metadata and, when debug capture is enabled, a
-bounded redacted representation of the prompt sections in the order they were
-composed.
+observation then keeps `generation.input` as the user prompt for Phase 1 and
+gets both metadata and a bounded redacted representation of the allowed prompt
+sections in the order they were composed.
 
 ```json
 {
@@ -155,13 +155,14 @@ composed.
       "truncated": true
     }
   ],
-  "composedPromptPreview": "bounded redacted final prompt preview"
+  "composedPromptPreview": "not emitted in Phase 1"
 }
 ```
 
-Debug capture is controlled and bounded, but it is not postponed to a later
-evaluation phase. Without section content, Langfuse can identify the prompt
-stack hash that failed but cannot explain which instruction caused the behavior.
+Section capture is bounded and gated by the existing conversation/tool content
+telemetry consent, but it is not postponed to a later evaluation phase. Without
+section content, Langfuse can identify the prompt stack hash that failed but
+cannot explain which instruction caused the behavior.
 
 ### Prompt Stack Metadata
 
@@ -269,8 +270,8 @@ Capture modes:
 
 - `off`: hashes, bytes, section presence, routing, and flags only.
 - `redacted-section-content`: include bounded redacted content for instruction
-  sections. This is the recommended debug default because it shows the system
-  prompt stack without uploading attachment bodies.
+  sections. This is the Phase 1 target because it shows the system prompt stack
+  without uploading attachment bodies.
 - `redacted-composed-content`: include a bounded redacted final composed prompt
   preview in addition to section content.
 - `redacted-generation-input`: set generation input to the structured redacted
@@ -326,19 +327,23 @@ Rules:
 - Omit tool tokens entirely. Do not rely on redaction for tool token safety.
 - Treat `runtimeToolPrompt`, cwd hints, linked dirs, MCP config, OAuth-derived
   context, attachments, and image paths as sensitive.
-- Redact or hash local paths by default. A path like
-  `/Users/<name>/Documents/...` can identify a person or repo.
+- Redact local paths to `[REDACTED_PATH]` by default. A path like
+  `/Users/<name>/Documents/...` can identify a person or repo; preserving only
+  the basename can still leak project, customer, or user names.
 - Report attachment counts, file extensions, size buckets, and hashes before
   reporting any attachment text.
-- Bound captured content. Initial debug recommendation: up to 16 KiB per
-  redacted instruction section and up to 64 KiB for a redacted composed prompt
-  preview when composed capture is explicitly enabled.
+- Bound captured content. Phase 1 captures up to 16 KiB per redacted
+  instruction section and up to 64 KiB total across all redacted section
+  content for one run. Record bytes and truncation state when either bound is
+  hit.
 - Never emit prompt previews when Langfuse content capture is disabled.
 - Add tests with fake API keys, bearer tokens, OD tool tokens, emails, local
   paths, and attachment names to prove previews are redacted.
 - Prefer section-level content over final composed content for the default
   debug view. Section boundaries make prompt-order and prompt-conflict issues
   easier to inspect, and they reduce accidental capture of user attachments.
+- Do not upload raw attachment bodies, raw comment attachment bodies, or raw
+  prompt image paths in Phase 1.
 
 ## Trace Shape
 
@@ -423,6 +428,51 @@ Each score should include metadata linking it to:
 
 ### Phase 1: Debug-Ready Prompt Diagnostics
 
+Phase 1 is one implementation issue under the #3496 umbrella. It should land
+debug-ready prompt-stack observability without introducing a new user-facing
+privacy toggle.
+
+Phase 1 capture target:
+
+- Keep top-level `trace.input` as the user prompt.
+- Keep `generation.input` as the user prompt.
+- Emit `promptStack` on trace and generation metadata.
+- Use `redacted-section-content` as the Phase 1 capture mode whenever existing
+  Langfuse delivery is eligible: `telemetry.metrics === true`,
+  `telemetry.content === true`, and a Langfuse sink is configured.
+- Reuse the existing Settings -> Privacy "Conversation and tool content" consent
+  gate. Do not add a prompt-stack-specific UI toggle or environment override in
+  Phase 1.
+- Use plain SHA-256 with a `sha256:` prefix for prompt, section, and stack
+  fingerprints.
+- Capture up to 16 KiB per allowed redacted instruction section and up to 64
+  KiB total redacted section content per run.
+- Replace local paths with `[REDACTED_PATH]`.
+- Verify whether completed Langfuse generations already include bounded
+  redacted assistant output. If output is missing, Phase 1 should add bounded
+  redacted assistant output capture so prompt behavior can be inspected against
+  the model result.
+
+Phase 1 section-content allowlist:
+
+- May include bounded `redactedContent`: `formOverride`,
+  `daemonSystemPrompt`, `runtimeToolPrompt`, `researchCommandContract`,
+  `runContextPrompt`, `clientSystemPrompt`, `echoGuard`, `userRequest`, and
+  implementation-specific skill, design-system, plugin, or stage prompt
+  sections when they can be separated from raw attachments.
+- Metadata-only in Phase 1: `cwdHint`, `linkedDirsHint`, `attachments`,
+  `commentAttachments`, and `promptImagePaths`. Report presence, counts, file
+  extensions, size buckets, hashes, and truncation state where available, but do
+  not upload raw path strings or attachment bodies.
+
+Out of scope for Phase 1:
+
+- raw or unredacted prompt capture;
+- redacted final composed prompt preview;
+- structured `generation.input`;
+- Langfuse Prompt Management migration;
+- dataset, experiment, and score-writing implementation.
+
 Add a daemon-local prompt telemetry builder after `composed` is built and before
 the agent is spawned.
 
@@ -437,9 +487,7 @@ returns:
 - nested `promptStack` diagnostics;
 - flat metric dimensions;
 - redaction status;
-- bounded redacted section content when debug capture is enabled;
-- optional bounded redacted composed prompt preview when composed capture is
-  explicitly enabled.
+- bounded redacted section content for allowed instruction sections.
 
 Store the result on the in-memory run record and thread it through:
 
@@ -461,9 +509,9 @@ and capture flags from Phase 1. It should not include raw unredacted prompt
 content.
 
 This may be configured through existing Langfuse telemetry config or a new
-daemon setting. Product/security review should decide whether any packaged
-default enables `redacted-section-content`; local development and internal
-debug sessions should be able to opt in.
+daemon setting. Product/security review should decide whether and when the
+structured generation input view is worth the higher UI/semantics risk. It is
+not required for prompt-stack debugging in Phase 1.
 
 ### Phase 3: Evaluation Dataset and Scores
 
@@ -503,13 +551,23 @@ Phase 1 tests:
 - Unit-test redaction with fake credentials, bearer tokens, OD tool tokens,
   emails, local paths, linked dirs, and attachment names.
 - Unit-test bounded redacted section capture for daemon system prompt,
-  form-answer override, runtime tool prompt, client system prompt, cwd/linked
-  dir hints, user request, and prompt image paths.
+  form-answer override, runtime tool prompt, client system prompt, skill,
+  design-system, plugin/stage prompt sections, and user request.
+- Unit-test metadata-only capture for cwd hints, linked dirs, attachments,
+  comment attachments, and prompt image paths.
+- Unit-test 16 KiB per-section and 64 KiB total redacted section content limits,
+  including byte counts and truncation flags.
 - Bridge tests assert `promptStack` appears in Langfuse trace and generation
   metadata.
-- Bridge tests assert redacted section content appears only when content capture
-  is enabled.
+- Bridge tests assert redacted section content follows the existing
+  `telemetry.metrics && telemetry.content` Langfuse delivery gate.
+- Bridge tests assert local paths are replaced with `[REDACTED_PATH]` and raw
+  attachment bodies are not uploaded.
 - Existing tests continue to assert top-level `trace.input` is the user prompt.
+- Existing tests continue to assert `generation.input` is the user prompt.
+- Bridge tests verify completed generations include bounded redacted assistant
+  output, or explicitly document that existing output capture already satisfies
+  this requirement.
 - Chat-route tests cover discovery, skip-discovery, form-answer overrides,
   media surfaces, active skill, active design system, and plugin snapshot
   dimensions.
@@ -528,15 +586,12 @@ Phase 3 tests:
 
 ## Open Questions
 
-- Should content preview be controlled by environment variable, workspace
-  setting, or Langfuse telemetry config?
-- Should hashes be plain SHA-256 or HMAC-SHA-256 with an installation-scoped
-  secret to avoid cross-install prompt correlation?
-- Which local path representation is most useful without leaking identity:
-  omitted, basename only, extension bucket, or salted hash?
-- Should local development default to `redacted-section-content`, while
-  packaged/production defaults to `off`?
-- Should the debug capture control be global, project-scoped, or per-run so a
-  user can turn it on only for one failing session?
+- Should a future Phase 2/3 introduce a narrower prompt-stack capture control
+  after Phase 1 proves the existing content consent model is too coarse?
+- Should a future privacy hardening pass move from plain SHA-256 to
+  installation-scoped HMAC-SHA-256 if cross-install prompt correlation becomes
+  a concern?
+- What is the right threshold for shrinking the 16 KiB / 64 KiB bounds if
+  Langfuse metadata payload size affects ingestion reliability?
 - Which traces should be sampled into human annotation queues first: failures,
   low user feedback, high token cost, or new prompt-stack hashes?

--- a/specs/current/langfuse-prompt-stack-observability.md
+++ b/specs/current/langfuse-prompt-stack-observability.md
@@ -210,6 +210,9 @@ interface PromptSectionTelemetry {
     | 'linkedDirsHint'
     | 'echoGuard'
     | 'userRequest'
+    | 'skillPrompt'
+    | 'designSystemPrompt'
+    | 'pluginStagePrompt'
     | 'attachments'
     | 'commentAttachments'
     | 'promptImagePaths';
@@ -457,9 +460,11 @@ Phase 1 section-content allowlist:
 
 - May include bounded `redactedContent`: `formOverride`,
   `daemonSystemPrompt`, `runtimeToolPrompt`, `researchCommandContract`,
-  `runContextPrompt`, `clientSystemPrompt`, `echoGuard`, `userRequest`, and
-  implementation-specific skill, design-system, plugin, or stage prompt
-  sections when they can be separated from raw attachments.
+  `runContextPrompt`, `clientSystemPrompt`, `echoGuard`, `userRequest`, and the
+  implementation-specific `skillPrompt`, `designSystemPrompt`, and
+  `pluginStagePrompt` sections (aligned with the `skillId`, `designSystemId`,
+  and `appliedPluginSnapshotId` routing dimensions) when they can be separated
+  from raw attachments.
 - Metadata-only in Phase 1: `cwdHint`, `linkedDirsHint`, `attachments`,
   `commentAttachments`, and `promptImagePaths`. Report presence, counts, file
   extensions, size buckets, hashes, and truncation state where available, but do
@@ -551,8 +556,8 @@ Phase 1 tests:
 - Unit-test redaction with fake credentials, bearer tokens, OD tool tokens,
   emails, local paths, linked dirs, and attachment names.
 - Unit-test bounded redacted section capture for daemon system prompt,
-  form-answer override, runtime tool prompt, client system prompt, skill,
-  design-system, plugin/stage prompt sections, and user request.
+  form-answer override, runtime tool prompt, client system prompt, `skillPrompt`,
+  `designSystemPrompt`, `pluginStagePrompt` sections, and user request.
 - Unit-test metadata-only capture for cwd hints, linked dirs, attachments,
   comment attachments, and prompt image paths.
 - Unit-test 16 KiB per-section and 64 KiB total redacted section content limits,

--- a/specs/current/langfuse-prompt-stack-observability.md
+++ b/specs/current/langfuse-prompt-stack-observability.md
@@ -16,12 +16,20 @@ tokens, local paths, or attachment content.
 The target outcome is a trace that can answer:
 
 - What user request triggered this run?
+- What exact instruction/system sections were composed for the model, after
+  redaction and within bounded capture limits?
 - Which prompt sections and runtime flags were active?
 - Which skill, design system, plugin stage, model, release, and prompt-stack
   fingerprint produced the output?
 - Did discovery ask a form, skip a form, or suppress a repeated form?
 - Which production traces should become eval dataset items?
 - Which automated or human scores explain regressions over time?
+
+The primary product goal for v1 is fast prompt-behavior debugging from a
+Langfuse trace. Evaluation aggregation is still important, but metadata alone
+is not enough for the first debugging target. A reviewer should be able to open
+the generation observation and inspect the redacted instruction stack that the
+daemon actually sent to the agent.
 
 ## Current Behavior
 
@@ -92,6 +100,7 @@ This spec does not:
 - Move Open Design system prompts into Langfuse Prompt Management.
 - Require network prompt fetching before agent spawn.
 - Replace trace input with the full composed prompt.
+- Upload raw, unredacted system or composed prompt content.
 - Upload raw tool tokens, API keys, local auth material, OAuth tokens, or MCP
   bearer tokens.
 - Upload raw attachment contents by default.
@@ -114,27 +123,45 @@ Rationale:
 
 ### Generation Input
 
-Open Design should move toward generation-level LLM invocation visibility in
-two stages:
+Open Design should make generation-level LLM invocation visibility useful for
+debugging in the first implementation phase.
 
-1. Default: keep `generation.input` as the user prompt but attach
-   `promptStack` metadata.
-2. Opt-in or safe-content mode: set `generation.input` to a structured object
-   representing the redacted LLM invocation:
+The baseline keeps `trace.input` readable as the user prompt. The generation
+observation then gets both metadata and, when debug capture is enabled, a
+bounded redacted representation of the prompt sections in the order they were
+composed.
 
 ```json
 {
   "format": "open-design-composed-prompt",
   "streamFormat": "stream-json",
   "userPrompt": "redacted current user prompt",
-  "composedPromptPreview": "bounded redacted preview",
-  "promptStackHash": "sha256:..."
+  "promptStackHash": "sha256:...",
+  "sections": [
+    {
+      "name": "formOverride",
+      "present": true,
+      "bytes": 1840,
+      "sha256": "sha256:...",
+      "redactedContent": "## OVERRIDE ...",
+      "truncated": false
+    },
+    {
+      "name": "daemonSystemPrompt",
+      "present": true,
+      "bytes": 24120,
+      "sha256": "sha256:...",
+      "redactedContent": "bounded redacted system prompt content",
+      "truncated": true
+    }
+  ],
+  "composedPromptPreview": "bounded redacted final prompt preview"
 }
 ```
 
-The default stage avoids a sudden content-volume and privacy change. The opt-in
-stage aligns more closely with Langfuse's generation model once redaction and
-capture controls are proven.
+Debug capture is controlled and bounded, but it is not postponed to a later
+evaluation phase. Without section content, Langfuse can identify the prompt
+stack hash that failed but cannot explain which instruction caused the behavior.
 
 ### Prompt Stack Metadata
 
@@ -156,6 +183,9 @@ interface PromptStackTelemetry {
     redactedPreview?: string;
     redactedPreviewBytes?: number;
     redactedPreviewTruncated?: boolean;
+    redactedContent?: string;
+    redactedContentBytes?: number;
+    redactedContentTruncated?: boolean;
   };
   daemonSystemPrompt: {
     bytes: number;
@@ -186,6 +216,9 @@ interface PromptSectionTelemetry {
   bytes: number;
   sha256?: string;
   redactionApplied?: boolean;
+  redactedContent?: string;
+  redactedContentBytes?: number;
+  redactedContentTruncated?: boolean;
 }
 
 interface PromptStackFlags {
@@ -218,14 +251,31 @@ interface PromptRoutingTelemetry {
 }
 
 interface PromptPrivacyTelemetry {
-  contentCapture: 'off' | 'redacted-preview' | 'redacted-generation-input';
+  contentCapture:
+    | 'off'
+    | 'redacted-section-content'
+    | 'redacted-composed-content'
+    | 'redacted-generation-input';
   redactionVersion: string;
-  maxPreviewBytes: number;
+  maxSectionBytes: number;
+  maxComposedBytes: number;
   localPaths: 'redacted' | 'hashed' | 'omitted';
   attachments: 'metadata-only' | 'redacted-preview';
   toolTokens: 'omitted';
 }
 ```
+
+Capture modes:
+
+- `off`: hashes, bytes, section presence, routing, and flags only.
+- `redacted-section-content`: include bounded redacted content for instruction
+  sections. This is the recommended debug default because it shows the system
+  prompt stack without uploading attachment bodies.
+- `redacted-composed-content`: include a bounded redacted final composed prompt
+  preview in addition to section content.
+- `redacted-generation-input`: set generation input to the structured redacted
+  invocation object. This is the most Langfuse-native debug view and should
+  remain opt-in until reviewed.
 
 ### Flat Metadata for Metrics
 
@@ -242,7 +292,7 @@ compact top-level metadata keys:
   "promptDiscoveryState": "turn1-discovery",
   "promptFormOverride": "none",
   "promptMediaSurface": false,
-  "promptContentCapture": "off",
+  "promptContentCapture": "redacted-section-content",
   "skillId": "landing-page",
   "designSystemId": "acme",
   "agent": "claude",
@@ -280,11 +330,15 @@ Rules:
   `/Users/<name>/Documents/...` can identify a person or repo.
 - Report attachment counts, file extensions, size buckets, and hashes before
   reporting any attachment text.
-- Bound preview size. Initial default: 8 KiB redacted composed prompt preview,
-  behind an explicit content-capture setting.
+- Bound captured content. Initial debug recommendation: up to 16 KiB per
+  redacted instruction section and up to 64 KiB for a redacted composed prompt
+  preview when composed capture is explicitly enabled.
 - Never emit prompt previews when Langfuse content capture is disabled.
 - Add tests with fake API keys, bearer tokens, OD tool tokens, emails, local
   paths, and attachment names to prove previews are redacted.
+- Prefer section-level content over final composed content for the default
+  debug view. Section boundaries make prompt-order and prompt-conflict issues
+  easier to inspect, and they reduce accidental capture of user attachments.
 
 ## Trace Shape
 
@@ -294,7 +348,7 @@ Recommended observation tree:
 flowchart TD
   T["trace: open-design-turn\ninput = user prompt\nmetadata = compact prompt dimensions"]
   A["span: agent-run\ninput = user prompt\nmetadata = run status and promptStack summary"]
-  G["generation: llm\ninput = user prompt or redacted invocation\nmetadata = full promptStack diagnostics"]
+  G["generation: llm\ninput = user prompt or redacted invocation\nmetadata = promptStack + redacted section content"]
   TS["tool spans\ninput/output = existing bounded redacted content"]
   AS["event: artifact-summary"]
   ES["event: evaluator/scores\nwhen local eval runner reports back"]
@@ -307,8 +361,9 @@ flowchart TD
 ```
 
 Generation metadata should include the richest prompt diagnostics because it is
-the object closest to the LLM call. Trace metadata should include only fields
-needed for browsing, filtering, and dashboards.
+the object closest to the LLM call. For prompt debugging, the generation view
+must show redacted section content when capture is enabled. Trace metadata
+should include only fields needed for browsing, filtering, and dashboards.
 
 ## Evaluation Loop
 
@@ -366,7 +421,7 @@ Each score should include metadata linking it to:
 
 ## Implementation Plan
 
-### Phase 1: Metadata-Only Prompt Diagnostics
+### Phase 1: Debug-Ready Prompt Diagnostics
 
 Add a daemon-local prompt telemetry builder after `composed` is built and before
 the agent is spawned.
@@ -382,7 +437,9 @@ returns:
 - nested `promptStack` diagnostics;
 - flat metric dimensions;
 - redaction status;
-- optional redacted preview when enabled.
+- bounded redacted section content when debug capture is enabled;
+- optional bounded redacted composed prompt preview when composed capture is
+  explicitly enabled.
 
 Store the result on the in-memory run record and thread it through:
 
@@ -390,20 +447,23 @@ Store the result on the in-memory run record and thread it through:
 - `apps/daemon/src/langfuse-bridge.ts`
 - `apps/daemon/src/langfuse-trace.ts`
 
-Do not change top-level `trace.input` in this phase.
+Do not change top-level `trace.input` in this phase. Generation metadata should
+be sufficient to debug prompt behavior from the Langfuse UI.
 
-### Phase 2: Safe Generation Input Preview
+### Phase 2: Structured Generation Input
 
-Add an explicit content-capture mode for generation input:
+Promote the redacted prompt invocation from generation metadata into
+`generation.input` for users who want the Langfuse generation panel to show the
+LLM call in a first-class way.
 
-- `off`: current behavior plus metadata only.
-- `redacted-preview`: metadata contains bounded redacted composed preview.
-- `redacted-generation-input`: generation input becomes a structured redacted
-  invocation object.
+The structured input should contain the same section array, hashes, byte counts,
+and capture flags from Phase 1. It should not include raw unredacted prompt
+content.
 
 This may be configured through existing Langfuse telemetry config or a new
-daemon setting. The default remains `off` unless product/security review
-approves preview capture.
+daemon setting. Product/security review should decide whether any packaged
+default enables `redacted-section-content`; local development and internal
+debug sessions should be able to opt in.
 
 ### Phase 3: Evaluation Dataset and Scores
 
@@ -442,8 +502,13 @@ Phase 1 tests:
   dimensions.
 - Unit-test redaction with fake credentials, bearer tokens, OD tool tokens,
   emails, local paths, linked dirs, and attachment names.
+- Unit-test bounded redacted section capture for daemon system prompt,
+  form-answer override, runtime tool prompt, client system prompt, cwd/linked
+  dir hints, user request, and prompt image paths.
 - Bridge tests assert `promptStack` appears in Langfuse trace and generation
   metadata.
+- Bridge tests assert redacted section content appears only when content capture
+  is enabled.
 - Existing tests continue to assert top-level `trace.input` is the user prompt.
 - Chat-route tests cover discovery, skip-discovery, form-answer overrides,
   media surfaces, active skill, active design system, and plugin snapshot
@@ -451,9 +516,9 @@ Phase 1 tests:
 
 Phase 2 tests:
 
-- Verify content-capture `off` never sends previews.
-- Verify preview is bounded and redacted.
 - Verify structured generation input is emitted only in explicit opt-in mode.
+- Verify structured generation input contains no raw tokens, credentials, local
+  user paths, or attachment bodies.
 
 Phase 3 tests:
 
@@ -469,7 +534,9 @@ Phase 3 tests:
   secret to avoid cross-install prompt correlation?
 - Which local path representation is most useful without leaking identity:
   omitted, basename only, extension bucket, or salted hash?
-- Should generation input move to structured redacted invocation in v1, or wait
-  for one release of metadata-only telemetry?
+- Should local development default to `redacted-section-content`, while
+  packaged/production defaults to `off`?
+- Should the debug capture control be global, project-scoped, or per-run so a
+  user can turn it on only for one failing session?
 - Which traces should be sampled into human annotation queues first: failures,
   low user feedback, high token cost, or new prompt-stack hashes?


### PR DESCRIPTION
Refs #3496

## Why

I hit a Langfuse debugging gap while investigating why production traces only showed the user's prompt even though token usage reflected a much larger composed prompt. The immediate use case is fast prompt-behavior debugging from a Langfuse trace.

The pain is that today's traces cannot explain which daemon system prompt sections, discovery rules, form-answer overrides, skills, design systems, plugin stages, or runtime flags shaped the output. Hashes and section-presence metadata are useful for aggregation, but they are not enough for the primary v1 goal: opening a generation observation and seeing the redacted instruction stack the daemon actually sent to the agent.

This spec folds in Langfuse's current recommended shape: traces for application requests, generation observations for LLM invocation details, metadata/tags/release dimensions for slicing, prompt/version linkage where possible, and scores/datasets/experiments for the evaluation loop. The implementation plan now prioritizes bounded redacted section content in Phase 1, while keeping top-level trace input as the user prompt.

## What users will see

No user-facing product behavior changes. This is a technical spec PR preparing the implementation plan for richer Langfuse prompt-stack diagnostics.

For reviewers, the intended future trace behavior is:

- `trace.input` remains the user prompt for readable session browsing.
- generation metadata includes prompt-stack hashes, bytes, section presence, routing, and flags.
- when debug capture is enabled, generation metadata also includes bounded redacted content for instruction/system sections.
- raw tool tokens, credentials, local auth material, and raw attachment bodies are not uploaded.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — docs-only technical spec.

## Bug fix verification

N/A — this PR does not implement the issue fix; it defines the reviewable technical plan.

## Validation

- `pnpm guard`
- Not run: `pnpm typecheck` because this PR only adds Markdown spec documentation and a docs index link.
