### PR TITLE
[codex] Align workspace tabs with shell edge

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type DragEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useT } from '../i18n';
 import { navigate, type EntryHomeView, type Route } from '../router';
@@ -210,6 +210,23 @@ function normalizeTabsState(state: WorkspaceTabsState): WorkspaceTabsState {
   };
 }
 
+function reorderTabsById(
+  tabs: WorkspaceChromeTab[],
+  sourceId: string,
+  targetId: string,
+): WorkspaceChromeTab[] {
+  if (sourceId === targetId) return tabs;
+  const sourceIndex = tabs.findIndex((tab) => tab.id === sourceId);
+  const targetIndex = tabs.findIndex((tab) => tab.id === targetId);
+  if (sourceIndex < 0 || targetIndex < 0) return tabs;
+
+  const nextTabs = tabs.slice();
+  const [movedTab] = nextTabs.splice(sourceIndex, 1);
+  if (!movedTab) return tabs;
+  nextTabs.splice(targetIndex, 0, movedTab);
+  return nextTabs;
+}
+
 function initialTabsState(route: Route): WorkspaceTabsState {
   const fallback = tabFromRoute(route);
   if (typeof window === 'undefined') {
@@ -342,6 +359,9 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const hoverTimerRef = useRef<number | null>(null);
+  const dragSuppressClickRef = useRef(false);
+  const draggingTabIdRef = useRef<string | null>(null);
+  const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
 
   function clearHoverTimer() {
     if (hoverTimerRef.current !== null) {
@@ -482,6 +502,10 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
   }, [tabsMenuOpen]);
 
   function openTab(tab: WorkspaceChromeTab) {
+    if (dragSuppressClickRef.current) {
+      dragSuppressClickRef.current = false;
+      return;
+    }
     setState((current) => ({
       tabs: normalizeTabsState(current).tabs.map((item) =>
         item.id === tab.id ? { ...item, lastActiveAt: Date.now() } : item,
@@ -538,6 +562,58 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
     if (nextRoute) navigate(nextRoute);
   }
 
+  function reorderTab(sourceId: string, targetId: string) {
+    dismissHoverPreview();
+    setTabsMenuOpen(false);
+    setState((current) => {
+      const normalized = normalizeTabsState(current);
+      const tabs = reorderTabsById(normalized.tabs, sourceId, targetId);
+      return tabs === normalized.tabs ? normalized : { ...normalized, tabs };
+    });
+  }
+
+  function handleTabDragStart(tabId: string, event: DragEvent<HTMLDivElement>) {
+    const target = event.target;
+    if (target instanceof HTMLElement && target.closest('.workspace-tab__close')) {
+      event.preventDefault();
+      return;
+    }
+    dismissHoverPreview();
+    dragSuppressClickRef.current = true;
+    draggingTabIdRef.current = tabId;
+    setDraggingTabId(tabId);
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', tabId);
+  }
+
+  function handleTabDragOver(tabId: string, event: DragEvent<HTMLDivElement>) {
+    const sourceId = draggingTabIdRef.current ?? event.dataTransfer.getData('text/plain');
+    if (!sourceId || sourceId === tabId) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }
+
+  function handleTabDrop(tabId: string, event: DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    const sourceId = draggingTabIdRef.current ?? event.dataTransfer.getData('text/plain');
+    if (sourceId && sourceId !== tabId) {
+      reorderTab(sourceId, tabId);
+    }
+    draggingTabIdRef.current = null;
+    setDraggingTabId(null);
+    window.setTimeout(() => {
+      dragSuppressClickRef.current = false;
+    }, 0);
+  }
+
+  function handleTabDragEnd() {
+    draggingTabIdRef.current = null;
+    setDraggingTabId(null);
+    window.setTimeout(() => {
+      dragSuppressClickRef.current = false;
+    }, 0);
+  }
+
   return (
     <header className="app-chrome-header workspace-tabs-chrome" aria-label="Workspace tabs">
       <div className="app-chrome-traffic-space workspace-tabs-traffic" aria-hidden />
@@ -560,10 +636,15 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
           return (
             <div
               key={tab.id}
-              className={`workspace-tab${active ? ' is-active' : ''}`}
+              className={`workspace-tab${active ? ' is-active' : ''}${draggingTabId === tab.id ? ' is-dragging' : ''}`}
               role="tab"
               aria-selected={active}
               aria-describedby={hoverPreview?.tabId === tab.id ? 'workspace-tab-preview' : undefined}
+              draggable={state.tabs.length > 1}
+              onDragStart={(event) => handleTabDragStart(tab.id, event)}
+              onDragOver={(event) => handleTabDragOver(tab.id, event)}
+              onDrop={(event) => handleTabDrop(tab.id, event)}
+              onDragEnd={handleTabDragEnd}
               onMouseEnter={(event) => scheduleHoverPreview(tab.id, event.currentTarget)}
               onMouseLeave={dismissHoverPreview}
             >

--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -43,6 +43,13 @@ interface DisplayTab {
   tab: WorkspaceChromeTab;
 }
 
+type TabDropEdge = 'before' | 'after';
+
+interface TabDragTarget {
+  tabId: string;
+  edge: TabDropEdge;
+}
+
 interface Props {
   route: Route;
   projects: Project[];
@@ -51,6 +58,8 @@ interface Props {
 const STORAGE_KEY = 'open-design:workspace-tabs:v1';
 const OPEN_WORKSPACE_TAB_EVENT = 'open-design:workspace-tabs:open';
 const MAX_SEARCH_RESULTS = 80;
+const TAB_DRAG_HAPTIC_MS = 8;
+const TAB_DROP_HAPTIC_MS = 12;
 
 export function openWorkspaceTab(route: Route): void {
   window.dispatchEvent(
@@ -214,17 +223,36 @@ function reorderTabsById(
   tabs: WorkspaceChromeTab[],
   sourceId: string,
   targetId: string,
+  edge: TabDropEdge,
 ): WorkspaceChromeTab[] {
   if (sourceId === targetId) return tabs;
-  const sourceIndex = tabs.findIndex((tab) => tab.id === sourceId);
-  const targetIndex = tabs.findIndex((tab) => tab.id === targetId);
-  if (sourceIndex < 0 || targetIndex < 0) return tabs;
-
-  const nextTabs = tabs.slice();
-  const [movedTab] = nextTabs.splice(sourceIndex, 1);
+  const movedTab = tabs.find((tab) => tab.id === sourceId);
   if (!movedTab) return tabs;
-  nextTabs.splice(targetIndex, 0, movedTab);
+
+  const nextTabs = tabs.filter((tab) => tab.id !== sourceId);
+  const targetIndex = nextTabs.findIndex((tab) => tab.id === targetId);
+  if (targetIndex < 0) return tabs;
+  nextTabs.splice(edge === 'after' ? targetIndex + 1 : targetIndex, 0, movedTab);
+  if (nextTabs.every((tab, index) => tab.id === tabs[index]?.id)) return tabs;
   return nextTabs;
+}
+
+function tabDragTargetKey(target: TabDragTarget): string {
+  return `${target.tabId}:${target.edge}`;
+}
+
+function tabDropEdgeFromElement(event: DragEvent<HTMLElement>, element: HTMLElement): TabDropEdge {
+  const rect = element.getBoundingClientRect();
+  return event.clientX > rect.left + rect.width / 2 ? 'after' : 'before';
+}
+
+function pulseTabDragHaptic(durationMs = TAB_DRAG_HAPTIC_MS) {
+  if (typeof navigator === 'undefined' || typeof navigator.vibrate !== 'function') return;
+  try {
+    navigator.vibrate(durationMs);
+  } catch {
+    // Haptics are opportunistic; unsupported environments should keep dragging normally.
+  }
 }
 
 function initialTabsState(route: Route): WorkspaceTabsState {
@@ -344,6 +372,7 @@ interface HoverPreviewState {
   anchorLeft: number;
   anchorRight: number;
   anchorBottom: number;
+  anchorWidth: number;
 }
 
 const HOVER_PREVIEW_DELAY_MS = 380;
@@ -361,7 +390,9 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
   const hoverTimerRef = useRef<number | null>(null);
   const dragSuppressClickRef = useRef(false);
   const draggingTabIdRef = useRef<string | null>(null);
+  const dragHapticTargetRef = useRef<string | null>(null);
   const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
+  const [dragOverTarget, setDragOverTarget] = useState<TabDragTarget | null>(null);
 
   function clearHoverTimer() {
     if (hoverTimerRef.current !== null) {
@@ -379,6 +410,7 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
         anchorLeft: rect.left,
         anchorRight: rect.right,
         anchorBottom: rect.bottom,
+        anchorWidth: rect.width,
       });
     }, HOVER_PREVIEW_DELAY_MS);
   }
@@ -562,14 +594,41 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
     if (nextRoute) navigate(nextRoute);
   }
 
-  function reorderTab(sourceId: string, targetId: string) {
+  function reorderTab(sourceId: string, targetId: string, edge: TabDropEdge) {
     dismissHoverPreview();
     setTabsMenuOpen(false);
     setState((current) => {
       const normalized = normalizeTabsState(current);
-      const tabs = reorderTabsById(normalized.tabs, sourceId, targetId);
+      const tabs = reorderTabsById(normalized.tabs, sourceId, targetId, edge);
       return tabs === normalized.tabs ? normalized : { ...normalized, tabs };
     });
+  }
+
+  function findTabDropTarget(event: DragEvent<HTMLElement>, sourceId: string): TabDragTarget | null {
+    const strip = stripRef.current;
+    if (!strip) return null;
+
+    const eventTarget = event.target;
+    if (eventTarget instanceof HTMLElement) {
+      const tabElement = eventTarget.closest<HTMLElement>('[data-workspace-tab-id]');
+      if (tabElement && strip.contains(tabElement)) {
+        const tabId = tabElement.dataset.workspaceTabId;
+        if (tabId && tabId !== sourceId) {
+          return { tabId, edge: tabDropEdgeFromElement(event, tabElement) };
+        }
+      }
+    }
+
+    let lastTarget: TabDragTarget | null = null;
+    for (const tabElement of strip.querySelectorAll<HTMLElement>('[data-workspace-tab-id]')) {
+      const tabId = tabElement.dataset.workspaceTabId;
+      if (!tabId || tabId === sourceId) continue;
+      const rect = tabElement.getBoundingClientRect();
+      if (event.clientX <= rect.left + rect.width / 2) return { tabId, edge: 'before' };
+      if (event.clientX <= rect.right) return { tabId, edge: 'after' };
+      lastTarget = { tabId, edge: 'after' };
+    }
+    return lastTarget;
   }
 
   function handleTabDragStart(tabId: string, event: DragEvent<HTMLDivElement>) {
@@ -581,33 +640,61 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
     dismissHoverPreview();
     dragSuppressClickRef.current = true;
     draggingTabIdRef.current = tabId;
+    dragHapticTargetRef.current = `${tabId}:self`;
+    setDragOverTarget(null);
     setDraggingTabId(tabId);
     event.dataTransfer.effectAllowed = 'move';
     event.dataTransfer.setData('text/plain', tabId);
+    pulseTabDragHaptic();
   }
 
-  function handleTabDragOver(tabId: string, event: DragEvent<HTMLDivElement>) {
+  function handleStripDragOver(event: DragEvent<HTMLDivElement>) {
     const sourceId = draggingTabIdRef.current ?? event.dataTransfer.getData('text/plain');
-    if (!sourceId || sourceId === tabId) return;
+    if (!sourceId) return;
+    const target = findTabDropTarget(event, sourceId);
+    if (!target) return;
     event.preventDefault();
     event.dataTransfer.dropEffect = 'move';
+    const targetKey = tabDragTargetKey(target);
+    setDragOverTarget((current) =>
+      current && tabDragTargetKey(current) === targetKey ? current : target,
+    );
+    if (dragHapticTargetRef.current !== targetKey) {
+      dragHapticTargetRef.current = targetKey;
+      pulseTabDragHaptic();
+    }
+    reorderTab(sourceId, target.tabId, target.edge);
   }
 
-  function handleTabDrop(tabId: string, event: DragEvent<HTMLDivElement>) {
-    event.preventDefault();
+  function handleStripDrop(event: DragEvent<HTMLDivElement>) {
     const sourceId = draggingTabIdRef.current ?? event.dataTransfer.getData('text/plain');
-    if (sourceId && sourceId !== tabId) {
-      reorderTab(sourceId, tabId);
+    if (sourceId) {
+      event.preventDefault();
+    }
+    const target = sourceId ? findTabDropTarget(event, sourceId) : null;
+    if (sourceId && target) {
+      reorderTab(sourceId, target.tabId, target.edge);
+      pulseTabDragHaptic(TAB_DROP_HAPTIC_MS);
     }
     draggingTabIdRef.current = null;
+    dragHapticTargetRef.current = null;
+    setDragOverTarget(null);
     setDraggingTabId(null);
     window.setTimeout(() => {
       dragSuppressClickRef.current = false;
     }, 0);
   }
 
+  function handleStripDragLeave(event: DragEvent<HTMLDivElement>) {
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+    setDragOverTarget(null);
+  }
+
   function handleTabDragEnd() {
     draggingTabIdRef.current = null;
+    dragHapticTargetRef.current = null;
+    setDragOverTarget(null);
     setDraggingTabId(null);
     window.setTimeout(() => {
       dragSuppressClickRef.current = false;
@@ -622,6 +709,9 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
         role="tablist"
         aria-label="Open workspaces"
         ref={stripRef}
+        onDragOver={handleStripDragOver}
+        onDrop={handleStripDrop}
+        onDragLeave={handleStripDragLeave}
       >
         {/* Render every open tab — the strip itself scrolls horizontally
             when the tabs exceed the available chrome width. Previous
@@ -633,17 +723,20 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
         {state.tabs.map((tab) => {
           const display = displayTabById.get(tab.id) ?? displayTabFor(tab, projectById, t);
           const active = tab.id === state.activeTabId;
+          const dragOverClass =
+            dragOverTarget?.tabId === tab.id && draggingTabId !== tab.id
+              ? ` is-drag-over-${dragOverTarget.edge}`
+              : '';
           return (
             <div
               key={tab.id}
-              className={`workspace-tab${active ? ' is-active' : ''}${draggingTabId === tab.id ? ' is-dragging' : ''}`}
+              className={`workspace-tab${active ? ' is-active' : ''}${draggingTabId === tab.id ? ' is-dragging' : ''}${dragOverClass}`}
+              data-workspace-tab-id={tab.id}
               role="tab"
               aria-selected={active}
               aria-describedby={hoverPreview?.tabId === tab.id ? 'workspace-tab-preview' : undefined}
               draggable={state.tabs.length > 1}
               onDragStart={(event) => handleTabDragStart(tab.id, event)}
-              onDragOver={(event) => handleTabDragOver(tab.id, event)}
-              onDrop={(event) => handleTabDrop(tab.id, event)}
               onDragEnd={handleTabDragEnd}
               onMouseEnter={(event) => scheduleHoverPreview(tab.id, event.currentTarget)}
               onMouseLeave={dismissHoverPreview}
@@ -768,12 +861,11 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
               const previewDisplay = displayTabById.get(previewTab.id)
                 ?? displayTabFor(previewTab, projectById, t);
               const previewDetail = describePreviewDetail(previewTab, projectById);
-              const previewWidth = 240;
-              const anchorCenter = (hoverPreview.anchorLeft + hoverPreview.anchorRight) / 2;
+              const previewWidth = Math.max(1, Math.round(hoverPreview.anchorWidth));
               const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1024;
               const left = Math.max(
-                10,
-                Math.min(viewportWidth - previewWidth - 10, anchorCenter - previewWidth / 2),
+                0,
+                Math.min(viewportWidth - previewWidth, hoverPreview.anchorLeft),
               );
               return (
                 <div

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -34,7 +34,7 @@
 /* Left rail */
 .entry-nav-rail {
   width: var(--entry-rail-width, 64px);
-  border-right: 1px solid var(--border);
+  border-right: 0;
   background: var(--bg-panel);
   padding: 8px 0 10px;
   display: flex;
@@ -54,6 +54,18 @@
      area lets those floats appear over the scroll surface. */
   position: relative;
   z-index: 30;
+}
+.entry-nav-rail::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 1px;
+  background: color-mix(in srgb, var(--border) 64%, transparent);
+  transform: scaleX(0.5);
+  transform-origin: right center;
+  pointer-events: none;
 }
 .entry-nav-rail__group {
   display: flex;

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -263,7 +263,7 @@
   background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-sm);
+  box-shadow: none;
   padding: 14px 14px 10px;
   display: flex;
   flex-direction: column;
@@ -277,11 +277,11 @@
 }
 .home-hero__input-card:focus-within {
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
-  box-shadow: var(--shadow-md);
+  box-shadow: none;
 }
 .home-hero__input-card.is-drag-active {
   border-color: color-mix(in srgb, var(--accent) 56%, var(--border));
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent), var(--shadow-md);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent);
 }
 .home-hero__active {
   display: flex;
@@ -871,7 +871,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  border-top: 1px dashed var(--border-soft);
+  border-top: 0;
   padding-top: 8px;
 }
 .home-hero__attachments {

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -53,7 +53,7 @@
   max-width: 100%;
   min-height: 38px;
   height: 38px;
-  padding: 0 8px 0 0;
+  padding: 0 8px 0 6px;
   gap: 0;
   background: color-mix(in srgb, var(--bg-panel) 88%, var(--bg-subtle));
   border-bottom: 1px solid color-mix(in srgb, var(--border) 74%, transparent);

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -75,6 +75,7 @@
   transform: scaleY(0.5);
   transform-origin: center bottom;
   pointer-events: none;
+  z-index: 0;
 }
 .workspace-tabs-chrome .workspace-tabs-traffic {
   margin-right: var(--app-chrome-traffic-margin);
@@ -126,6 +127,8 @@
   align-items: center;
   gap: 0;
   padding-left: 0;
+  position: relative;
+  z-index: 1;
   /* Horizontal scroll inside the strip — tabs keep their natural width
      and the strip itself scrolls when it overflows the chrome. This
      replaces the previous "slice to N visible + overflow chip" model
@@ -159,26 +162,37 @@
   border-radius: 6px;
   background: transparent;
   color: var(--text-muted);
-  overflow: hidden;
+  overflow: visible;
   contain: layout style;
-  transition: background 100ms ease, border-color 100ms ease, color 100ms ease;
+  transition-property: background, border-color, color, opacity, transform, box-shadow;
+  transition-duration: 100ms, 100ms, 100ms, 120ms, 150ms, 150ms;
+  transition-timing-function: ease, ease, ease, ease, cubic-bezier(0.2, 0.8, 0.2, 1), ease;
   -webkit-app-region: no-drag;
-  cursor: grab;
+  cursor: default;
+  z-index: 1;
+  will-change: transform;
 }
 .workspace-tab.is-dragging {
-  opacity: 0.7;
-  cursor: grabbing;
+  opacity: 0.88;
+  transform: translateY(-2px) scale(1.015);
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--text) 14%, transparent);
+  cursor: default;
+  z-index: 3;
+}
+.workspace-tab.is-drag-over-before,
+.workspace-tab.is-drag-over-after {
+  background: color-mix(in srgb, var(--bg-panel) 84%, var(--bg-subtle));
+  border-color: color-mix(in srgb, var(--border-strong) 42%, transparent);
+  color: var(--text);
+}
+.workspace-tab.is-drag-over-before {
+  transform: translateX(6px);
+}
+.workspace-tab.is-drag-over-after {
+  transform: translateX(-6px);
 }
 .workspace-tab + .workspace-tab::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 50%;
-  width: 1px;
-  height: 14px;
-  background: color-mix(in srgb, var(--border) 70%, transparent);
-  transform: translateY(-50%);
-  pointer-events: none;
+  display: none;
 }
 .workspace-tab:hover {
   background: color-mix(in srgb, var(--bg-panel) 64%, transparent);
@@ -444,6 +458,7 @@
 .workspace-tab-preview {
   position: fixed;
   z-index: 140;
+  box-sizing: border-box;
   display: flex;
   align-items: flex-start;
   gap: 9px;

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -56,13 +56,25 @@
   padding: 0 8px 0 6px;
   gap: 0;
   background: color-mix(in srgb, var(--bg-panel) 88%, var(--bg-subtle));
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
+  border-bottom: 0;
   box-shadow: 0 1px 0 color-mix(in srgb, var(--bg-panel) 80%, transparent) inset;
   user-select: none;
   -webkit-app-region: drag;
   overflow: hidden;
   position: relative;
   z-index: 120;
+}
+.workspace-tabs-chrome.app-chrome-header::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background: color-mix(in srgb, var(--border) 64%, transparent);
+  transform: scaleY(0.5);
+  transform-origin: center bottom;
+  pointer-events: none;
 }
 .workspace-tabs-chrome .workspace-tabs-traffic {
   margin-right: var(--app-chrome-traffic-margin);
@@ -151,6 +163,11 @@
   contain: layout style;
   transition: background 100ms ease, border-color 100ms ease, color 100ms ease;
   -webkit-app-region: no-drag;
+  cursor: grab;
+}
+.workspace-tab.is-dragging {
+  opacity: 0.7;
+  cursor: grabbing;
 }
 .workspace-tab + .workspace-tab::before {
   content: '';
@@ -195,6 +212,7 @@
   justify-content: flex-start;
   gap: 6px;
   text-align: left;
+  cursor: inherit;
 }
 .workspace-tab__main:hover:not(:disabled) {
   background: transparent;
@@ -240,6 +258,7 @@
   justify-content: center;
   opacity: 0;
   flex: 0 0 auto;
+  cursor: pointer;
 }
 .workspace-tab:hover .workspace-tab__close,
 .workspace-tab.is-active .workspace-tab__close {

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -53,7 +53,7 @@
   max-width: 100%;
   min-height: 38px;
   height: 38px;
-  padding: 0 8px 0 12px;
+  padding: 0 8px 0 0;
   gap: 0;
   background: color-mix(in srgb, var(--bg-panel) 88%, var(--bg-subtle));
   border-bottom: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
@@ -65,7 +65,7 @@
   z-index: 120;
 }
 .workspace-tabs-chrome .workspace-tabs-traffic {
-  margin-right: calc(var(--app-chrome-traffic-margin) + 8px);
+  margin-right: var(--app-chrome-traffic-margin);
 }
 .workspace-tabs-new-btn {
   width: 24px;

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -693,13 +693,11 @@
   background: var(--workspace-tab-bar-bg);
   border-bottom: 0;
   box-shadow: none;
-  overflow: visible;
 }
 .workspace-shell .workspace-tabs-strip {
   gap: 4px;
   align-items: flex-end;
   padding-top: 3px;
-  overflow: visible;
 }
 .workspace-shell .workspace-tab {
   height: 32px;

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -685,38 +685,76 @@
    Keep the outer panes flat; only controls and repeated items get radius. */
 .workspace-shell .workspace-tabs-chrome.app-chrome-header {
   --workspace-tabs-chrome-height: 36px;
+  --workspace-tab-bar-bg: color-mix(in srgb, var(--bg-panel) 82%, var(--bg-subtle));
+  --workspace-active-tab-border: color-mix(in srgb, var(--border-strong) 42%, transparent);
   height: 36px;
   min-height: 36px;
-  padding: 0 10px 0 6px;
-  background: var(--bg-panel);
+  padding: 0 10px 0 0;
+  background: var(--workspace-tab-bar-bg);
   border-bottom: 0;
   box-shadow: none;
+  overflow: visible;
 }
 .workspace-shell .workspace-tabs-strip {
   gap: 4px;
+  align-items: flex-end;
+  padding-top: 3px;
+  overflow: visible;
 }
 .workspace-shell .workspace-tab {
-  height: 24px;
-  min-height: 24px;
+  height: 32px;
+  min-height: 32px;
   min-width: 96px;
   max-width: 168px;
   flex: 1 1 148px;
   grid-template-columns: minmax(0, 1fr) 24px;
-  border-radius: 6px;
+  align-self: flex-end;
+  border-radius: 10px 10px 0 0;
   border: 1px solid transparent;
+  border-bottom: 0;
   background: transparent;
   box-shadow: none;
 }
 .workspace-shell .workspace-tab + .workspace-tab::before {
-  height: 12px;
+  display: none;
 }
 .workspace-shell .workspace-tab.is-active {
-  background: var(--bg-subtle);
-  border-color: var(--border);
+  background: var(--bg-panel);
+  border-color: var(--workspace-active-tab-border);
+  border-bottom-color: transparent;
+  box-shadow:
+    0 1px 0 var(--bg-panel),
+    0 -1px 0 color-mix(in srgb, var(--bg-panel) 86%, transparent) inset;
+  z-index: 2;
+}
+.workspace-shell .workspace-tab:not(.is-active):hover,
+.workspace-shell .workspace-tab:not(.is-active):focus-within {
+  border-radius: 10px;
+  background:
+    linear-gradient(
+      color-mix(in srgb, var(--bg-panel) 78%, transparent),
+      color-mix(in srgb, var(--bg-panel) 78%, transparent)
+    )
+    0 0 / 100% calc(100% - 2px) no-repeat;
+  border-color: transparent;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--border) 58%, transparent),
+    0 1px 2px color-mix(in srgb, var(--text) 5%, transparent);
+}
+.workspace-shell .workspace-tab.is-dragging {
+  background: var(--bg-panel);
+  box-shadow: 0 14px 30px color-mix(in srgb, var(--text) 16%, transparent);
+  z-index: 4;
 }
 .workspace-shell .workspace-tab__main {
+  position: relative;
+  z-index: 2;
   gap: 6px;
-  padding-inline: 9px 4px;
+  padding-inline: 10px 4px;
+}
+.workspace-shell .workspace-tab__close {
+  position: relative;
+  z-index: 2;
 }
 .workspace-shell .workspace-tab__label {
   font-size: 12px;

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -689,7 +689,7 @@
   min-height: 36px;
   padding: 0 10px 0 6px;
   background: var(--bg-panel);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 0;
   box-shadow: none;
 }
 .workspace-shell .workspace-tabs-strip {

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -687,7 +687,7 @@
   --workspace-tabs-chrome-height: 36px;
   height: 36px;
   min-height: 36px;
-  padding: 0 10px;
+  padding: 0 10px 0 0;
   background: var(--bg-panel);
   border-bottom: 1px solid var(--border);
   box-shadow: none;

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -687,7 +687,7 @@
   --workspace-tabs-chrome-height: 36px;
   height: 36px;
   min-height: 36px;
-  padding: 0 10px 0 0;
+  padding: 0 10px 0 6px;
   background: var(--bg-panel);
   border-bottom: 1px solid var(--border);
   box-shadow: none;

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -56,6 +56,27 @@ const project: Project = {
   updatedAt: 1,
 };
 
+const projectBeta: Project = {
+  id: 'project-beta',
+  name: 'Project Beta',
+  skillId: null,
+  designSystemId: null,
+  createdAt: 2,
+  updatedAt: 2,
+};
+
+function createDataTransfer(): DataTransfer {
+  const store = new Map<string, string>();
+  return {
+    dropEffect: 'move',
+    effectAllowed: 'move',
+    getData: vi.fn((key: string) => store.get(key) ?? ''),
+    setData: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+  } as unknown as DataTransfer;
+}
+
 describe('WorkspaceTabsBar navigation semantics', () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -223,5 +244,80 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog', { name: 'Search tabs' })).toBeNull();
     });
+  });
+
+  it('reorders tabs with drag and drop without changing the active route', async () => {
+    window.localStorage.setItem(
+      'open-design:workspace-tabs:v1',
+      JSON.stringify({
+        activeTabId: 'project:project-alpha',
+        tabs: [
+          {
+            id: 'entry:home:seed',
+            kind: 'entry',
+            view: 'home',
+            createdAt: 1,
+            lastActiveAt: 1,
+          },
+          {
+            id: 'project:project-alpha',
+            kind: 'project',
+            projectId: 'project-alpha',
+            conversationId: null,
+            fileName: null,
+            createdAt: 2,
+            lastActiveAt: 2,
+          },
+          {
+            id: 'project:project-beta',
+            kind: 'project',
+            projectId: 'project-beta',
+            conversationId: null,
+            fileName: null,
+            createdAt: 3,
+            lastActiveAt: 3,
+          },
+        ],
+      }),
+    );
+
+    render(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project, projectBeta]} />);
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      expect(labels).toEqual([
+        expect.stringContaining('Home'),
+        expect.stringContaining('Project Alpha'),
+        expect.stringContaining('Project Beta'),
+      ]);
+    });
+
+    const [homeTab, alphaTab] = screen.getAllByRole('tab');
+    const dataTransfer = createDataTransfer();
+    fireEvent.dragStart(homeTab!, { dataTransfer });
+    fireEvent.dragOver(alphaTab!, { dataTransfer });
+    fireEvent.drop(alphaTab!, { dataTransfer });
+    fireEvent.dragEnd(homeTab!, { dataTransfer });
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      expect(labels).toEqual([
+        expect.stringContaining('Project Alpha'),
+        expect.stringContaining('Home'),
+        expect.stringContaining('Project Beta'),
+      ]);
+    });
+
+    expect(navigate).not.toHaveBeenCalled();
+    const stored = JSON.parse(window.localStorage.getItem('open-design:workspace-tabs:v1') ?? '{}') as {
+      activeTabId?: string;
+      tabs?: Array<{ id?: string }>;
+    };
+    expect(stored.activeTabId).toBe('project:project-alpha');
+    expect(stored.tabs?.map((tab) => tab.id)).toEqual([
+      'project:project-alpha',
+      'entry:home:seed',
+      'project:project-beta',
+    ]);
   });
 });

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -77,6 +77,36 @@ function createDataTransfer(): DataTransfer {
   } as unknown as DataTransfer;
 }
 
+function mockTabRect(element: HTMLElement, left: number, width = 100) {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () =>
+      ({
+        x: left,
+        y: 0,
+        left,
+        right: left + width,
+        top: 0,
+        bottom: 32,
+        width,
+        height: 32,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  });
+}
+
+function dispatchDragEvent(
+  element: HTMLElement,
+  type: 'dragover' | 'drop',
+  dataTransfer: DataTransfer,
+  clientX: number,
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'dataTransfer', { configurable: true, value: dataTransfer });
+  Object.defineProperty(event, 'clientX', { configurable: true, value: clientX });
+  fireEvent(element, event);
+}
+
 describe('WorkspaceTabsBar navigation semantics', () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -246,7 +276,58 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     });
   });
 
-  it('reorders tabs with drag and drop without changing the active route', async () => {
+  it('sizes the hover preview to the hovered tab width', async () => {
+    window.localStorage.setItem(
+      'open-design:workspace-tabs:v1',
+      JSON.stringify({
+        activeTabId: 'entry:home:seed',
+        tabs: [
+          {
+            id: 'entry:home:seed',
+            kind: 'entry',
+            view: 'home',
+            createdAt: 1,
+            lastActiveAt: 2,
+          },
+          {
+            id: 'project:project-alpha',
+            kind: 'project',
+            projectId: 'project-alpha',
+            conversationId: null,
+            fileName: null,
+            createdAt: 2,
+            lastActiveAt: 1,
+          },
+        ],
+      }),
+    );
+
+    render(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('tab')).toHaveLength(2);
+    });
+
+    const projectTab = screen.getAllByRole('tab').find((tab) =>
+      (tab.textContent ?? '').includes('Project Alpha'),
+    ) as HTMLElement;
+    mockTabRect(projectTab, 32, 148);
+    fireEvent.mouseEnter(projectTab);
+
+    await new Promise((resolve) => window.setTimeout(resolve, 430));
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip.style.width).toBe('148px');
+    expect(tooltip.style.left).toBe('32px');
+  });
+
+  it('reorders tabs live from left to right while dragging without changing the active route', async () => {
+    const vibrate = vi.fn();
+    Object.defineProperty(window.navigator, 'vibrate', {
+      configurable: true,
+      value: vibrate,
+    });
+
     window.localStorage.setItem(
       'open-design:workspace-tabs:v1',
       JSON.stringify({
@@ -293,10 +374,21 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     });
 
     const [homeTab, alphaTab] = screen.getAllByRole('tab');
+    mockTabRect(alphaTab! as HTMLElement, 100);
     const dataTransfer = createDataTransfer();
     fireEvent.dragStart(homeTab!, { dataTransfer });
-    fireEvent.dragOver(alphaTab!, { dataTransfer });
-    fireEvent.drop(alphaTab!, { dataTransfer });
+    dispatchDragEvent(alphaTab! as HTMLElement, 'dragover', dataTransfer, 160);
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      expect(labels).toEqual([
+        expect.stringContaining('Project Alpha'),
+        expect.stringContaining('Home'),
+        expect.stringContaining('Project Beta'),
+      ]);
+    });
+
+    dispatchDragEvent(alphaTab! as HTMLElement, 'drop', dataTransfer, 160);
     fireEvent.dragEnd(homeTab!, { dataTransfer });
 
     await waitFor(() => {
@@ -309,6 +401,8 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     });
 
     expect(navigate).not.toHaveBeenCalled();
+    expect(vibrate).toHaveBeenCalledWith(8);
+    expect(vibrate).toHaveBeenCalledWith(12);
     const stored = JSON.parse(window.localStorage.getItem('open-design:workspace-tabs:v1') ?? '{}') as {
       activeTabId?: string;
       tabs?: Array<{ id?: string }>;
@@ -319,5 +413,67 @@ describe('WorkspaceTabsBar navigation semantics', () => {
       'entry:home:seed',
       'project:project-beta',
     ]);
+  });
+
+  it('reorders tabs live from right to left while dragging', async () => {
+    window.localStorage.setItem(
+      'open-design:workspace-tabs:v1',
+      JSON.stringify({
+        activeTabId: 'project:project-alpha',
+        tabs: [
+          {
+            id: 'entry:home:seed',
+            kind: 'entry',
+            view: 'home',
+            createdAt: 1,
+            lastActiveAt: 1,
+          },
+          {
+            id: 'project:project-alpha',
+            kind: 'project',
+            projectId: 'project-alpha',
+            conversationId: null,
+            fileName: null,
+            createdAt: 2,
+            lastActiveAt: 2,
+          },
+          {
+            id: 'project:project-beta',
+            kind: 'project',
+            projectId: 'project-beta',
+            conversationId: null,
+            fileName: null,
+            createdAt: 3,
+            lastActiveAt: 3,
+          },
+        ],
+      }),
+    );
+
+    render(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project, projectBeta]} />);
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      expect(labels).toEqual([
+        expect.stringContaining('Home'),
+        expect.stringContaining('Project Alpha'),
+        expect.stringContaining('Project Beta'),
+      ]);
+    });
+
+    const [, alphaTab, betaTab] = screen.getAllByRole('tab');
+    mockTabRect(alphaTab! as HTMLElement, 100);
+    const dataTransfer = createDataTransfer();
+    fireEvent.dragStart(betaTab!, { dataTransfer });
+    dispatchDragEvent(alphaTab! as HTMLElement, 'dragover', dataTransfer, 110);
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      expect(labels).toEqual([
+        expect.stringContaining('Home'),
+        expect.stringContaining('Project Beta'),
+        expect.stringContaining('Project Alpha'),
+      ]);
+    });
   });
 });

--- a/apps/web/tests/styles/home-hero-prompt-metrics.test.ts
+++ b/apps/web/tests/styles/home-hero-prompt-metrics.test.ts
@@ -65,4 +65,16 @@ describe('HomeHero prompt overlay metrics', () => {
     expect(optionalRuleValue(inner, 'transform')).toBeNull();
     expect(ruleValue(inner, 'top')).toBe('calc(-1 * var(--home-hero-prompt-scroll, 0px))');
   });
+
+  it('keeps the prompt input chrome clean on focus', () => {
+    const card = cssDeclarations('.home-hero__input-card');
+    const focusedCard = cssDeclarations('.home-hero__input-card:focus-within');
+    const dragCard = cssDeclarations('.home-hero__input-card.is-drag-active');
+    const foot = cssDeclarations('.home-hero__input-foot');
+
+    expect(ruleValue(card, 'box-shadow')).toBe('none');
+    expect(ruleValue(focusedCard, 'box-shadow')).toBe('none');
+    expect(ruleValue(dragCard, 'box-shadow')).not.toContain('var(--shadow-md)');
+    expect(ruleValue(foot, 'border-top')).toBe('0');
+  });
 });

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -74,6 +74,7 @@ describe('workspace tabs chrome styles', () => {
       '.workspace-shell .workspace-tabs-chrome.app-chrome-header',
     );
     const projectStrip = cssDeclarations(routinesCss, '.workspace-shell .workspace-tabs-strip');
+    const sharedStrip = cssDeclarations(shellCss, '.workspace-tabs-strip');
 
     expect(ruleValue(projectTab, 'height')).toBe('32px');
     expect(ruleValue(projectTab, 'align-self')).toBe('flex-end');
@@ -84,8 +85,11 @@ describe('workspace tabs chrome styles', () => {
     expect(ruleValue(activeProjectTab, 'border-bottom-color')).toBe('transparent');
     expect(ruleValue(activeProjectTab, 'box-shadow')).toContain('0 1px 0 var(--bg-panel)');
     expect(ruleValue(activeProjectTab, 'box-shadow')).toContain('inset');
-    expect(ruleValue(projectChrome, 'overflow')).toBe('visible');
-    expect(ruleValue(projectStrip, 'overflow')).toBe('visible');
+    expect(projectChrome).not.toContain('overflow:');
+    expect(projectStrip).not.toContain('overflow:');
+    expect(projectStrip).not.toContain('overflow-x:');
+    expect(ruleValue(sharedStrip, 'overflow-x')).toBe('auto');
+    expect(ruleValue(sharedStrip, 'overflow-y')).toBe('hidden');
     expect(ruleValue(tabSeparator, 'display')).toBe('none');
     expect(ruleValue(main, 'z-index')).toBe('2');
     expect(ruleValue(preview, 'box-sizing')).toBe('border-box');

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const shellCss = readFileSync(new URL('../../src/styles/shell.css', import.meta.url), 'utf8');
+const routinesCss = readFileSync(new URL('../../src/styles/viewer/routines.css', import.meta.url), 'utf8');
+
+function cssDeclarations(css: string, selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g'))];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('workspace tabs chrome styles', () => {
+  it('does not reserve hidden traffic-button space before the first tab', () => {
+    const chrome = cssDeclarations(shellCss, '.workspace-tabs-chrome.app-chrome-header');
+    const traffic = cssDeclarations(shellCss, '.workspace-tabs-chrome .workspace-tabs-traffic');
+    const projectChrome = cssDeclarations(
+      routinesCss,
+      '.workspace-shell .workspace-tabs-chrome.app-chrome-header',
+    );
+
+    expect(ruleValue(chrome, 'padding')).toBe('0 8px 0 0');
+    expect(ruleValue(traffic, 'margin-right')).toBe('var(--app-chrome-traffic-margin)');
+    expect(ruleValue(projectChrome, 'padding')).toBe('0 10px 0 0');
+  });
+});

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -33,10 +33,12 @@ describe('workspace tabs chrome styles', () => {
       routinesCss,
       '.workspace-shell .workspace-tabs-chrome.app-chrome-header',
     );
+    const projectStrip = cssDeclarations(routinesCss, '.workspace-shell .workspace-tabs-strip');
 
     expect(ruleValue(chrome, 'padding')).toBe('0 8px 0 6px');
     expect(ruleValue(traffic, 'margin-right')).toBe('var(--app-chrome-traffic-margin)');
-    expect(ruleValue(projectChrome, 'padding')).toBe('0 10px 0 6px');
+    expect(ruleValue(projectChrome, 'padding')).toBe('0 10px 0 0');
+    expect(ruleValue(projectStrip, 'align-items')).toBe('flex-end');
   });
 
   it('uses hairline dividers for the tab chrome and entry rail', () => {
@@ -59,5 +61,63 @@ describe('workspace tabs chrome styles', () => {
     expect(ruleValue(railDivider, 'width')).toBe('1px');
     expect(ruleValue(railDivider, 'background')).toBe(hairlineColor);
     expect(ruleValue(railDivider, 'transform')).toBe('scaleX(0.5)');
+  });
+
+  it('connects the active workspace tab to the top chrome surface', () => {
+    const projectTab = cssDeclarations(routinesCss, '.workspace-shell .workspace-tab');
+    const activeProjectTab = cssDeclarations(routinesCss, '.workspace-shell .workspace-tab.is-active');
+    const tabSeparator = cssDeclarations(routinesCss, '.workspace-shell .workspace-tab + .workspace-tab::before');
+    const main = cssDeclarations(routinesCss, '.workspace-shell .workspace-tab__main');
+    const preview = cssDeclarations(shellCss, '.workspace-tab-preview');
+    const projectChrome = cssDeclarations(
+      routinesCss,
+      '.workspace-shell .workspace-tabs-chrome.app-chrome-header',
+    );
+    const projectStrip = cssDeclarations(routinesCss, '.workspace-shell .workspace-tabs-strip');
+
+    expect(ruleValue(projectTab, 'height')).toBe('32px');
+    expect(ruleValue(projectTab, 'align-self')).toBe('flex-end');
+    expect(ruleValue(projectTab, 'border-radius')).toBe('10px 10px 0 0');
+    expect(ruleValue(projectTab, 'border-bottom')).toBe('0');
+    expect(ruleValue(activeProjectTab, 'background')).toBe('var(--bg-panel)');
+    expect(ruleValue(activeProjectTab, 'border-color')).toBe('var(--workspace-active-tab-border)');
+    expect(ruleValue(activeProjectTab, 'border-bottom-color')).toBe('transparent');
+    expect(ruleValue(activeProjectTab, 'box-shadow')).toContain('0 1px 0 var(--bg-panel)');
+    expect(ruleValue(activeProjectTab, 'box-shadow')).toContain('inset');
+    expect(ruleValue(projectChrome, 'overflow')).toBe('visible');
+    expect(ruleValue(projectStrip, 'overflow')).toBe('visible');
+    expect(ruleValue(tabSeparator, 'display')).toBe('none');
+    expect(ruleValue(main, 'z-index')).toBe('2');
+    expect(ruleValue(preview, 'box-sizing')).toBe('border-box');
+    expect(routinesCss).not.toContain('.workspace-shell .workspace-tab.is-active::before');
+    expect(routinesCss).not.toContain('.workspace-shell .workspace-tab.is-active::after');
+  });
+
+  it('uses a rounded highlight for inactive workspace tab hover', () => {
+    const hoverTab = cssDeclarations(routinesCss, '.workspace-shell .workspace-tab:not(.is-active):hover');
+
+    expect(ruleValue(hoverTab, 'border-radius')).toBe('10px');
+    expect(ruleValue(hoverTab, 'background')).toContain('calc(100% - 2px)');
+    expect(ruleValue(hoverTab, 'border-color')).toBe('transparent');
+    expect(ruleValue(hoverTab, 'box-shadow')).toContain('inset 0 0 0 1px');
+  });
+
+  it('gives dragged tabs physical collision feedback', () => {
+    const tab = cssDeclarations(shellCss, '.workspace-tab');
+    const dragging = cssDeclarations(shellCss, '.workspace-tab.is-dragging');
+    const dragOverBefore = cssDeclarations(shellCss, '.workspace-tab.is-drag-over-before');
+    const dragOverAfter = cssDeclarations(shellCss, '.workspace-tab.is-drag-over-after');
+    const projectDragging = cssDeclarations(routinesCss, '.workspace-shell .workspace-tab.is-dragging');
+
+    expect(ruleValue(tab, 'cursor')).toBe('default');
+    expect(ruleValue(tab, 'transition-property')).toContain('transform');
+    expect(ruleValue(dragging, 'transform')).toBe('translateY(-2px) scale(1.015)');
+    expect(ruleValue(dragging, 'z-index')).toBe('3');
+    expect(ruleValue(dragOverBefore, 'border-color')).not.toContain('var(--accent)');
+    expect(ruleValue(dragOverBefore, 'transform')).toBe('translateX(6px)');
+    expect(ruleValue(dragOverAfter, 'transform')).toBe('translateX(-6px)');
+    expect(ruleValue(projectDragging, 'box-shadow')).toContain('0 14px 30px');
+    expect(shellCss).not.toContain('.workspace-tab.is-drag-over-before::after');
+    expect(shellCss).not.toContain('.workspace-tab.is-drag-over-after::after');
   });
 });

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 const shellCss = readFileSync(new URL('../../src/styles/shell.css', import.meta.url), 'utf8');
 const routinesCss = readFileSync(new URL('../../src/styles/viewer/routines.css', import.meta.url), 'utf8');
+const entryLayoutCss = readFileSync(new URL('../../src/styles/home/entry-layout.css', import.meta.url), 'utf8');
 
 function cssDeclarations(css: string, selector: string): string {
   const blocks: string[] = [];
@@ -36,5 +37,27 @@ describe('workspace tabs chrome styles', () => {
     expect(ruleValue(chrome, 'padding')).toBe('0 8px 0 6px');
     expect(ruleValue(traffic, 'margin-right')).toBe('var(--app-chrome-traffic-margin)');
     expect(ruleValue(projectChrome, 'padding')).toBe('0 10px 0 6px');
+  });
+
+  it('uses hairline dividers for the tab chrome and entry rail', () => {
+    const chrome = cssDeclarations(shellCss, '.workspace-tabs-chrome.app-chrome-header');
+    const chromeDivider = cssDeclarations(shellCss, '.workspace-tabs-chrome.app-chrome-header::after');
+    const projectChrome = cssDeclarations(
+      routinesCss,
+      '.workspace-shell .workspace-tabs-chrome.app-chrome-header',
+    );
+    const rail = cssDeclarations(entryLayoutCss, '.entry-nav-rail');
+    const railDivider = cssDeclarations(entryLayoutCss, '.entry-nav-rail::after');
+
+    const hairlineColor = 'color-mix(in srgb, var(--border) 64%, transparent)';
+    expect(ruleValue(chrome, 'border-bottom')).toBe('0');
+    expect(ruleValue(projectChrome, 'border-bottom')).toBe('0');
+    expect(ruleValue(rail, 'border-right')).toBe('0');
+    expect(ruleValue(chromeDivider, 'height')).toBe('1px');
+    expect(ruleValue(chromeDivider, 'background')).toBe(hairlineColor);
+    expect(ruleValue(chromeDivider, 'transform')).toBe('scaleY(0.5)');
+    expect(ruleValue(railDivider, 'width')).toBe('1px');
+    expect(ruleValue(railDivider, 'background')).toBe(hairlineColor);
+    expect(ruleValue(railDivider, 'transform')).toBe('scaleX(0.5)');
   });
 });

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -25,7 +25,7 @@ function ruleValue(block: string, property: string): string {
 }
 
 describe('workspace tabs chrome styles', () => {
-  it('does not reserve hidden traffic-button space before the first tab', () => {
+  it('keeps only a small intentional inset before the first tab', () => {
     const chrome = cssDeclarations(shellCss, '.workspace-tabs-chrome.app-chrome-header');
     const traffic = cssDeclarations(shellCss, '.workspace-tabs-chrome .workspace-tabs-traffic');
     const projectChrome = cssDeclarations(
@@ -33,8 +33,8 @@ describe('workspace tabs chrome styles', () => {
       '.workspace-shell .workspace-tabs-chrome.app-chrome-header',
     );
 
-    expect(ruleValue(chrome, 'padding')).toBe('0 8px 0 0');
+    expect(ruleValue(chrome, 'padding')).toBe('0 8px 0 6px');
     expect(ruleValue(traffic, 'margin-right')).toBe('var(--app-chrome-traffic-margin)');
-    expect(ruleValue(projectChrome, 'padding')).toBe('0 10px 0 0');
+    expect(ruleValue(projectChrome, 'padding')).toBe('0 10px 0 6px');
   });
 });


### PR DESCRIPTION
## Summary

- Refines the workspace shell top tabs so the first project-shell tab is flush with the left sidebar edge and the active tab reads as connected to the top chrome instead of floating away from it.
- Removes heavy/visible divider artifacts from the top chrome, sidebar split, tab separators, and drag insertion state.
- Cleans the home prompt input focus state by removing the focus shadow and the internal divider line.
- Adds drag-and-drop tab reordering with live physical feedback in both directions, before/after placement based on pointer position, and opportunistic haptic pulses through `navigator.vibrate` when supported.
- Adds a rounded inactive-tab hover highlight with a small bottom gap and makes the hover preview match the hovered tab width.
- Preserves the shared `overflow-x: auto` tab-strip scrolling contract for project-shell overflow cases while keeping the visual tab polish.


## Surface area

- [x] UI
- [ ] CLI / daemon
- [ ] Docs
- [ ] Tests only

## Root Cause

The original shell tab chrome had several small layout/style mismatches:

- The project-shell top chrome kept a leading inset that made the first tab feel detached from the left sidebar.
- Active tabs were styled like isolated pills, while the desired interaction is closer to a connected browser tab sitting on the chrome edge.
- The drag implementation only inserted the source tab before the drop target, so left-to-right moves were hard to perceive and could appear ineffective.
- Drag feedback relied on drop timing and insertion affordances rather than live reorder/physical movement.
- Hover previews used a fixed width, which made the tooltip wider than the triggering tab.
- Divider and focus treatments were visually heavier than the surrounding chrome.

## What Changed

- Set the project-shell tab chrome left padding to `0` so the first tab aligns flush with the shell/sidebar edge.
- Kept the shared non-project chrome's small leading inset intact for the earlier spacing request.
- Converted the top and side dividers into lighter hairline pseudo-elements.
- Removed workspace tab separator lines and colored drag insertion bars.
- Added inactive-tab hover styling as an inset rounded highlight with a 2px bottom gap.
- Changed the tab cursor back to the default arrow instead of a hand/grab cursor.
- Reworked tab reorder logic to:
  - detect `before` / `after` from the pointer's position inside the target tab,
  - reorder live during `dragover`,
  - support both left-to-right and right-to-left moves,
  - avoid route changes during drag reorder,
  - add best-effort haptic pulses for drag start, target changes, and drop.
- Resized the tab hover preview from a fixed `240px` to the hovered tab's actual width and aligned it to the tab's left edge.

## Impact

Users get a cleaner, more precise top chrome:

- first tab visually connects to the left sidebar,
- active tabs stay attached to the top chrome surface,
- inactive hover states are visible without touching the bottom divider,
- drag reorder provides immediate movement feedback and works in both directions,
- previews no longer look wider than their source tab.

## Verification

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/WorkspaceTabsBar.test.tsx tests/styles/workspace-tabs-chrome.test.ts tests/styles/home-hero-prompt-metrics.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`
- Playwright on `http://localhost:3001` verified:
  - hover tab width `168px`, tooltip width `168px`, `box-sizing: border-box`, and matching left edge,
  - inactive hover background uses `calc(100% - 2px)` so it keeps a bottom gap,
  - tab cursor is `default`,
  - active tab bottom border is `0px`,
  - project-shell left padding is `0px` and the first tab left gap is `0`.
  - project tab overflow keeps `overflowX: auto`, `overflowY: hidden`, `scrollWidth 1196 > clientWidth 746`, and the strip stays before trailing actions.

## Notes

- Browser haptics are best-effort: unsupported `navigator.vibrate` environments continue dragging normally.
- Earlier active-tab side-curve experiments were removed because they read as white patch artifacts in this shell.


