### PR TITLE
feat(web): track BYOK configuration outcomes

### DIFF
--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -86,6 +86,7 @@ import type {
   FeedbackSubmitResultProps,
   SettingsViewProps,
   SettingsCliTestResultProps,
+  SettingsByokModelsFetchResultProps,
   SettingsByokTestResultProps,
   SettingsConnectorAuthResultProps,
   OnboardingClickProps,
@@ -671,6 +672,13 @@ export function trackSettingsByokTestResult(
   props: SettingsByokTestResultProps,
 ): void {
   send(track, 'settings_byok_test_result', props);
+}
+
+export function trackSettingsByokModelsFetchResult(
+  track: Track,
+  props: SettingsByokModelsFetchResultProps,
+): void {
+  send(track, 'settings_byok_models_fetch_result', props);
 }
 
 export function trackSettingsConnectorAuthResult(

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { useAnalytics } from '../analytics/provider';
 import {
   trackSettingsAppearanceClick,
+  trackSettingsByokModelsFetchResult,
   trackSettingsByokTestResult,
   trackSettingsCliTestResult,
   trackSettingsByokFieldClick,
@@ -301,6 +302,32 @@ type ProviderModelsState =
 
 type ByokRequiredField = ByokDraftField;
 type ByokPreconditionAction = 'test';
+type ByokFieldMissing = 'api_key' | 'base_url' | 'model' | 'multiple' | 'none';
+
+function byokFieldMissingFromIssues(issues: readonly ByokDraftIssue[]): ByokFieldMissing {
+  const missingFields = new Set<ByokRequiredField>();
+  for (const issue of issues) {
+    if (
+      issue.code === 'api_key_required' ||
+      issue.code === 'base_url_required' ||
+      issue.code === 'model_required'
+    ) {
+      missingFields.add(issue.field);
+    }
+  }
+  if (missingFields.size === 0) return 'none';
+  if (missingFields.size > 1) return 'multiple';
+  return Array.from(missingFields)[0] ?? 'none';
+}
+
+function byokErrorKindFromIssues(issues: readonly ByokDraftIssue[]): string | undefined {
+  return issues[0]?.code;
+}
+
+function byokTrackingTestResult(result: ConnectionTestResponse): 'success' | 'failed' | 'timeout' {
+  if (result.ok) return 'success';
+  return result.kind === 'timeout' ? 'timeout' : 'failed';
+}
 
 // Map a test result to the visual severity of its inline status node so
 // the same green/red/amber palette as the Rescan status applies.
@@ -965,6 +992,7 @@ export function SettingsDialog({
   const providerModelsFirstResetRef = useRef(true);
   const deferAfterKeyCleanRef = useRef(false);
   const providerAutoTestKeyRef = useRef<string | null>(null);
+  const byokLastUnsuccessfulTestKeyRef = useRef<string | null>(null);
   const apiKeyInputRef = useRef<HTMLInputElement | null>(null);
   const baseUrlInputRef = useRef<HTMLInputElement | null>(null);
   const modelSelectRef = useRef<HTMLButtonElement | null>(null);
@@ -1274,6 +1302,10 @@ export function SettingsDialog({
       return;
     }
     const blockingIssues = blockingByokDraftIssues(byokDraftValidation);
+    const currentConfigKey = providerConnectionTestKey(apiProtocol, cfg);
+    const lastUnsuccessfulConfigKey = byokLastUnsuccessfulTestKeyRef.current;
+    const configKeyChanged = lastUnsuccessfulConfigKey !== null &&
+      lastUnsuccessfulConfigKey !== currentConfigKey;
     if (blockingIssues.length > 0) {
       if (options.silentPreconditions) {
         return;
@@ -1285,10 +1317,16 @@ export function SettingsDialog({
           page_name: 'settings',
           area: 'execution_model',
           provider_id: byokProviderId,
-          result: 'not_ready',
+          result: 'failed',
+          error_code: byokErrorKindFromIssues(blockingIssues),
+          error_kind: byokErrorKindFromIssues(blockingIssues),
+          field_missing: byokFieldMissingFromIssues(blockingIssues),
+          config_key_changed: configKeyChanged,
+          success_after_action: false,
           duration_ms: 0,
         });
       }
+      byokLastUnsuccessfulTestKeyRef.current = currentConfigKey;
       return;
     }
     const controller = new AbortController();
@@ -1327,11 +1365,16 @@ export function SettingsDialog({
           page_name: 'settings',
           area: 'execution_model',
           provider_id: byokProviderId,
-          result: result.ok ? 'success' : 'failed',
+          result: byokTrackingTestResult(result),
           ...(result.ok ? {} : { error_code: result.kind || 'UNKNOWN' }),
+          ...(result.ok ? {} : { error_kind: result.kind || 'UNKNOWN' }),
+          field_missing: 'none',
+          config_key_changed: configKeyChanged,
+          success_after_action: result.ok && configKeyChanged,
           duration_ms: Math.round(performance.now() - startedAt),
         });
       }
+      byokLastUnsuccessfulTestKeyRef.current = result.ok ? null : currentConfigKey;
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;
       if (providerTestRevisionRef.current !== revision) {
@@ -1356,9 +1399,14 @@ export function SettingsDialog({
           provider_id: byokProviderId,
           result: 'failed',
           error_code: err instanceof Error ? err.name : 'UNKNOWN',
+          error_kind: err instanceof Error ? err.name : 'UNKNOWN',
+          field_missing: 'none',
+          config_key_changed: configKeyChanged,
+          success_after_action: false,
           duration_ms: Math.round(performance.now() - startedAt),
         });
       }
+      byokLastUnsuccessfulTestKeyRef.current = currentConfigKey;
     } finally {
       if (providerTestAbortRef.current === controller) {
         providerTestAbortRef.current = null;
@@ -1382,12 +1430,37 @@ export function SettingsDialog({
   };
 
   const handleFetchProviderModels = async (
-    options: { silent?: boolean } = {},
+    options: { silent?: boolean; trigger?: 'auto' | 'manual' } = {},
   ) => {
+    const trigger = options.trigger ?? (options.silent ? 'auto' : 'manual');
+    const byokProviderId = byokProtocolToTracking(apiProtocol);
+    const trackModelsFetchResult = (
+      props: Omit<
+        Parameters<typeof trackSettingsByokModelsFetchResult>[1],
+        'page_name' | 'area' | 'provider_id' | 'trigger' | 'source'
+      >,
+      source: 'network' | 'cache' = 'network',
+    ) => {
+      if (!byokProviderId) return;
+      trackSettingsByokModelsFetchResult(analytics.track, {
+        page_name: 'settings',
+        area: 'configure_execution_mode_byok',
+        provider_id: byokProviderId,
+        trigger,
+        source,
+        ...props,
+      });
+    };
     if (providerModelsState.status === 'running') {
       return;
     }
     if (apiProtocol === 'azure') {
+      trackModelsFetchResult({
+        result: 'failed',
+        error_code: 'unsupported_azure',
+        error_kind: 'unsupported_azure',
+        duration_ms: 0,
+      });
       if (!options.silent) {
         setByokPreconditionNotice({
           action: 'test',
@@ -1397,6 +1470,12 @@ export function SettingsDialog({
       return;
     }
     if (apiProtocol === 'ollama') {
+      trackModelsFetchResult({
+        result: 'failed',
+        error_code: 'unsupported_ollama',
+        error_kind: 'unsupported_ollama',
+        duration_ms: 0,
+      });
       if (!options.silent) {
         setByokPreconditionNotice({
           action: 'test',
@@ -1409,6 +1488,13 @@ export function SettingsDialog({
       byokModelFetchDraftValidation,
     );
     if (modelFetchBlockingIssues.length > 0) {
+      trackModelsFetchResult({
+        result: 'failed',
+        error_code: byokErrorKindFromIssues(modelFetchBlockingIssues),
+        error_kind: byokErrorKindFromIssues(modelFetchBlockingIssues),
+        field_missing: byokFieldMissingFromIssues(modelFetchBlockingIssues),
+        duration_ms: 0,
+      });
       if (!options.silent) {
         showByokDraftValidationNotice('test', byokModelFetchDraftValidation);
       }
@@ -1422,6 +1508,14 @@ export function SettingsDialog({
     );
     const cachedModels = activeProviderModelsCache[cacheKey];
     if (cachedModels) {
+      trackModelsFetchResult(
+        {
+          result: 'success',
+          model_count: cachedModels.length,
+          duration_ms: 0,
+        },
+        'cache',
+      );
       setProviderModelsState({
         status: 'done',
         cacheKey,
@@ -1438,6 +1532,7 @@ export function SettingsDialog({
     const revision = providerModelsRevisionRef.current;
     providerModelsAbortRef.current = controller;
     setProviderModelsState({ status: 'running', cacheKey });
+    const startedAt = performance.now();
     const clearIfStale = () => {
       if (providerModelsAbortRef.current === controller) {
         setProviderModelsState({ status: 'idle' });
@@ -1463,6 +1558,13 @@ export function SettingsDialog({
           [cacheKey]: result.models ?? [],
         }));
       }
+      trackModelsFetchResult({
+        result: result.ok ? 'success' : 'failed',
+        ...(result.ok ? {} : { error_code: result.kind || 'UNKNOWN' }),
+        ...(result.ok ? {} : { error_kind: result.kind || 'UNKNOWN' }),
+        model_count: result.ok ? result.models?.length ?? 0 : 0,
+        duration_ms: Math.round(performance.now() - startedAt),
+      });
       setProviderModelsState({ status: 'done', cacheKey, result });
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;
@@ -1479,6 +1581,13 @@ export function SettingsDialog({
           latencyMs: 0,
           detail: err instanceof Error ? err.message : 'Model list request failed',
         },
+      });
+      trackModelsFetchResult({
+        result: 'failed',
+        error_code: err instanceof Error ? err.name : 'UNKNOWN',
+        error_kind: err instanceof Error ? err.name : 'UNKNOWN',
+        model_count: 0,
+        duration_ms: Math.round(performance.now() - startedAt),
       });
     } finally {
       if (providerModelsAbortRef.current === controller) {

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -19,6 +19,7 @@ const {
   importGitHubDesignSystemMock,
   fetchProviderModelsMock,
   fetchLatestGithubReleaseInfoMock,
+  analyticsTrackMock,
 } = vi.hoisted(() => ({
   playSoundMock: vi.fn(),
   requestNotificationPermissionMock: vi.fn(),
@@ -34,6 +35,7 @@ const {
   importGitHubDesignSystemMock: vi.fn(),
   fetchProviderModelsMock: vi.fn(),
   fetchLatestGithubReleaseInfoMock: vi.fn(),
+  analyticsTrackMock: vi.fn(),
 }));
 
 vi.mock('../../src/utils/notifications', async () => {
@@ -70,6 +72,18 @@ vi.mock('../../src/providers/registry', async () => {
 
 vi.mock('../../src/providers/provider-models', () => ({
   fetchProviderModels: fetchProviderModelsMock,
+}));
+
+vi.mock('../../src/analytics/provider', () => ({
+  useAnalytics: () => ({
+    track: analyticsTrackMock,
+    setConsent: () => undefined,
+    setIdentity: () => undefined,
+    setConfigureGlobals: () => undefined,
+    anonymousId: 'test-anonymous',
+    sessionId: 'test-session',
+    newRequestId: () => 'test-request',
+  }),
 }));
 
 import { SettingsDialog } from '../../src/components/SettingsDialog';
@@ -296,6 +310,7 @@ beforeEach(() => {
   importLocalDesignSystemMock.mockReset();
   importGitHubDesignSystemMock.mockReset();
   fetchProviderModelsMock.mockReset();
+  analyticsTrackMock.mockReset();
   notificationPermissionMock.mockReturnValue('default');
   requestNotificationPermissionMock.mockResolvedValue('granted');
   showCompletionNotificationMock.mockResolvedValue('shown');
@@ -779,6 +794,19 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect(
       within(modelPopover).getAllByRole('option').map((option) => option.textContent?.trim()),
     ).toEqual(expect.arrayContaining(['Account Model (gpt-account)', 'gpt-4o', 'Custom (type below)…']));
+    expect(analyticsTrackMock).toHaveBeenCalledWith(
+      'settings_byok_models_fetch_result',
+      expect.objectContaining({
+        page_name: 'settings',
+        area: 'configure_execution_mode_byok',
+        provider_id: 'openai',
+        result: 'success',
+        trigger: 'auto',
+        source: 'network',
+        model_count: 1,
+      }),
+      undefined,
+    );
 
     fireEvent.click(screen.getByRole('tab', { name: 'Azure OpenAI' }));
     expect(screen.queryByRole('button', { name: 'Fetch models' })).toBeNull();
@@ -1092,6 +1120,22 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
       );
       expect(testConnectionCalls).toHaveLength(0);
     });
+    expect(analyticsTrackMock).toHaveBeenCalledWith(
+      'settings_byok_test_result',
+      expect.objectContaining({
+        page_name: 'settings',
+        area: 'execution_model',
+        provider_id: 'anthropic',
+        result: 'failed',
+        error_code: 'api_key_wrong_protocol',
+        error_kind: 'api_key_wrong_protocol',
+        field_missing: 'none',
+        config_key_changed: false,
+        success_after_action: false,
+        duration_ms: 0,
+      }),
+      undefined,
+    );
   });
 
   it('sends a cleaned API key when the pasted value has trailing newline/zero-width characters', async () => {
@@ -1184,6 +1228,65 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
       ([input]) => input.toString() === '/api/test/connection',
     );
     expect(testConnectionCalls).toHaveLength(2);
+  });
+
+  it('marks a successful BYOK test after a config edit as success after action', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      expect(url).toBe('/api/test/connection');
+      const body = JSON.parse(String(init?.body)) as { apiKey?: string };
+      return new Response(
+        JSON.stringify(
+          body.apiKey === 'sk-ant-fixed'
+            ? {
+                ok: true,
+                kind: 'ok',
+                latencyMs: 20,
+                model: 'claude-sonnet-4-5',
+                sample: 'pong',
+              }
+            : {
+                ok: false,
+                kind: 'auth_failed',
+                latencyMs: 18,
+                model: 'claude-sonnet-4-5',
+              },
+        ),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSettingsDialog({ apiKey: 'sk-ant-stale' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+    expect(await screen.findByRole('button', { name: 'Retry test' })).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk-ant-fixed' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+
+    expect(await screen.findByText(/Connected\. Replied in 20 ms/)).toBeTruthy();
+    expect(analyticsTrackMock).toHaveBeenCalledWith(
+      'settings_byok_test_result',
+      expect.objectContaining({
+        page_name: 'settings',
+        area: 'execution_model',
+        provider_id: 'anthropic',
+        result: 'success',
+        field_missing: 'none',
+        config_key_changed: true,
+        success_after_action: true,
+      }),
+      undefined,
+    );
   });
 });
 

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -42,6 +42,7 @@ export type AnalyticsEventName =
   | 'settings_view'
   | 'settings_cli_test_result'
   | 'settings_byok_test_result'
+  | 'settings_byok_models_fetch_result'
   | 'settings_connector_auth_result'
   // Onboarding-only result events. UI clicks + page_views inside the
   // onboarding flow reuse the generic `ui_click` / `page_view` shapes
@@ -1979,8 +1980,26 @@ export interface SettingsByokTestResultProps {
   // wire format matches the doc.
   area: 'execution_model';
   provider_id: TrackingByokProviderId;
-  result: TrackingTestResult | 'not_ready';
+  result: TrackingTestResult;
   error_code?: string;
+  error_kind?: string;
+  field_missing?: 'api_key' | 'base_url' | 'model' | 'multiple' | 'none';
+  config_key_changed?: boolean;
+  success_after_action?: boolean;
+  duration_ms: number;
+}
+
+export interface SettingsByokModelsFetchResultProps {
+  page_name: TrackingSettingsPage;
+  area: 'configure_execution_mode_byok';
+  provider_id: TrackingByokProviderId;
+  result: TrackingResult;
+  trigger: 'auto' | 'manual';
+  source: 'network' | 'cache';
+  error_code?: string;
+  error_kind?: string;
+  field_missing?: 'api_key' | 'base_url' | 'model' | 'multiple' | 'none';
+  model_count?: number;
   duration_ms: number;
 }
 
@@ -2024,6 +2043,10 @@ export type AnalyticsEventPayload =
   | { event: 'settings_view'; props: SettingsViewProps }
   | { event: 'settings_cli_test_result'; props: SettingsCliTestResultProps }
   | { event: 'settings_byok_test_result'; props: SettingsByokTestResultProps }
+  | {
+      event: 'settings_byok_models_fetch_result';
+      props: SettingsByokModelsFetchResultProps;
+    }
   | { event: 'settings_connector_auth_result'; props: SettingsConnectorAuthResultProps }
   | { event: 'onboarding_runtime_scan_result'; props: OnboardingRuntimeScanResultProps }
   | { event: 'onboarding_complete_result'; props: OnboardingCompleteResultProps }


### PR DESCRIPTION
## Why

BYOK configuration failures are currently hard to diagnose from analytics: we can see whether the connection test passed, but not whether the user was blocked by a missing/invalid field, changed the config after a failure, or recovered after taking an action. This PR adds the attribution needed to measure the BYOK shift-left work without waiting for failures to show up only at generation time.

## What users will see

No visible UI changes. Settings → Execution continues to behave the same, but BYOK connection tests and model-list fetches now emit more structured analytics.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — analytics-only change.

## Bug fix verification

N/A — not a bug fix.

## Validation

- `git diff --check`
- `NODE_OPTIONS=--localstorage-file=/tmp/open-design-vitest-localstorage-metrics pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm guard`

Note: local validation emitted the existing engine warning because this environment is running Node v26 while the repo expects Node ~24.
