### PR TITLE
feat(web): validate BYOK API keys in the field

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -3287,6 +3287,7 @@ export function SettingsDialog({
                 labels={{
                   apiHint: t('settings.apiHint'),
                   apiKey: t('settings.apiKey'),
+                  apiKeyCleaned: t('settings.apiKeyCleaned'),
                   apiKeyGetLink: t('settings.apiKeyGetLink', {
                     host: apiKeyConsoleLink.host,
                   }),
@@ -3302,6 +3303,7 @@ export function SettingsDialog({
                   testTitle: t('settings.testTitle'),
                 }}
                 providerTestState={providerTestState}
+                draftValidation={byokDraftValidation}
                 renderTestMessage={(result) => renderTestMessage(result, 'api')}
                 requiresApiKey={byokRequiresApiKey}
                 showApiKey={showApiKey}

--- a/apps/web/src/components/byok/ByokKeyField.tsx
+++ b/apps/web/src/components/byok/ByokKeyField.tsx
@@ -1,7 +1,12 @@
-import type { Ref } from 'react';
+import { useMemo, useState, type Ref } from 'react';
 import { API_KEY_PLACEHOLDERS } from '../../state/apiProtocols';
 import type { ApiProtocol, ConnectionTestResponse } from '../../types';
 import { Icon } from '../Icon';
+import {
+  cleanByokApiKey,
+  type ByokDraftIssue,
+  type ByokDraftValidation,
+} from './validation';
 
 type ByokProviderTestState =
   | { status: 'idle' }
@@ -18,6 +23,7 @@ interface ByokKeyFieldProps {
   inputRef: Ref<HTMLInputElement>;
   labels: {
     apiHint: string;
+    apiKeyCleaned: string;
     apiKey: string;
     apiKeyGetLink: string;
     apiKeyInvalid: string;
@@ -32,6 +38,7 @@ interface ByokKeyFieldProps {
     testTitle: string;
   };
   providerTestState: ByokProviderTestState;
+  draftValidation: ByokDraftValidation;
   renderTestMessage: (result: ConnectionTestResponse) => string;
   requiresApiKey: boolean;
   showApiKey: boolean;
@@ -52,6 +59,7 @@ export function ByokKeyField({
   inputRef,
   labels,
   providerTestState,
+  draftValidation,
   renderTestMessage,
   requiresApiKey,
   showApiKey,
@@ -61,6 +69,29 @@ export function ByokKeyField({
   onTestProvider,
   onToggleShowApiKey,
 }: ByokKeyFieldProps) {
+  const [apiKeyCleanedNotice, setApiKeyCleanedNotice] = useState(false);
+  const apiKeyDraftIssue = useMemo(
+    () => firstApiKeyDraftIssue(draftValidation),
+    [draftValidation],
+  );
+  const apiKeyErrorMessage = apiKeyDraftIssue
+    ? apiKeyDraftIssue.message || labels.apiKeyInvalid
+    : apiKeyAuthFailed && providerTestState.status === 'idle'
+      ? labels.apiKeyInvalid
+      : null;
+  const handleChange = (value: string) => {
+    setApiKeyCleanedNotice(false);
+    onChange(value);
+  };
+  const handleBlur = () => {
+    const cleaned = cleanByokApiKey(apiKey);
+    if (cleaned !== apiKey) {
+      setApiKeyCleanedNotice(Boolean(cleaned));
+      onChange(cleaned);
+    }
+    onBlur();
+  };
+
   return (
     <label className="field">
       <span className="field-label-row">
@@ -90,8 +121,9 @@ export function ByokKeyField({
           type={showApiKey ? 'text' : 'password'}
           placeholder={API_KEY_PLACEHOLDERS[apiProtocol]}
           value={apiKey}
-          onChange={(e) => onChange(e.target.value)}
-          onBlur={onBlur}
+          aria-invalid={apiKeyDraftIssue ? 'true' : undefined}
+          onChange={(e) => handleChange(e.target.value)}
+          onBlur={handleBlur}
           onFocus={onFocus}
           autoFocus
         />
@@ -106,9 +138,14 @@ export function ByokKeyField({
           {showApiKey ? labels.hide : labels.show}
         </button>
       </div>
-      {apiKeyAuthFailed && providerTestState.status === 'idle' ? (
+      {apiKeyErrorMessage ? (
         <span className="field-error" role="alert">
-          {labels.apiKeyInvalid}
+          {apiKeyErrorMessage}
+        </span>
+      ) : null}
+      {apiKeyCleanedNotice && !apiKeyErrorMessage ? (
+        <span className="field-inline-status success" role="status">
+          {labels.apiKeyCleaned}
         </span>
       ) : null}
       {providerTestState.status === 'running' ? (
@@ -167,4 +204,18 @@ export function ByokKeyField({
       ) : null}
     </label>
   );
+}
+
+function firstApiKeyDraftIssue(
+  draftValidation: ByokDraftValidation,
+): ByokDraftIssue | null {
+  return draftValidation.issues.find(
+    (issue) =>
+      issue.field === 'api_key' &&
+      issue.level === 'error' &&
+      (
+        issue.code === 'api_key_malformed' ||
+        issue.code === 'api_key_wrong_protocol'
+      ),
+  ) ?? null;
 }

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -276,6 +276,7 @@ export const en: Dict = {
   'settings.hide': 'Hide',
   'settings.model': 'Model',
   'settings.apiKeyInvalid': 'Invalid API key.',
+  'settings.apiKeyCleaned': 'Removed extra whitespace from the API key.',
   'settings.modelsLoadedFromAccount': '✓ Loaded {count} models from your account.',
   'settings.fetchModels': 'Fetch models',
   'settings.fetchModelsTitle': 'Fetch available models from this provider',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -276,6 +276,7 @@ export const zhCN: Dict = {
   'settings.hide': '隐藏',
   'settings.model': '模型',
   'settings.apiKeyInvalid': 'API key 无效。',
+  'settings.apiKeyCleaned': '已移除 API key 中多余的空白字符。',
   'settings.modelsLoadedFromAccount': '✓ 已从你的账号加载 {count} 个模型。',
   'settings.fetchModels': '拉取模型',
   'settings.fetchModelsTitle': '从当前提供方拉取可用模型',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -288,6 +288,7 @@ export interface Dict {
   'settings.hide': string;
   'settings.model': string;
   'settings.apiKeyInvalid': string;
+  'settings.apiKeyCleaned': string;
   'settings.modelsLoadedFromAccount': string;
   'settings.fetchModels': string;
   'settings.fetchModelsTitle': string;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1085,7 +1085,9 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Test' }));
 
-    expect(screen.getByRole('alert').textContent).toContain('Invalid API key.');
+    expect(
+      screen.getByText('This looks like an OpenAI key, not an Anthropic key.'),
+    ).toBeTruthy();
     await waitFor(() => {
       const testConnectionCalls = fetchMock.mock.calls.filter(
         ([input]) => input.toString() === '/api/test/connection',
@@ -1137,6 +1139,47 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect(testConnectionCalls).toHaveLength(1);
     // The malformed value must never reach the wire.
     expect(sentApiKey).toBe('sk-ant-test-provider');
+  });
+
+  it('shows a BYOK API key cleaned notice after blur cleanup', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      expect(url).toBe('/api/test/connection');
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          kind: 'ok',
+          latencyMs: 7,
+          model: 'claude-sonnet-4-5',
+          sample: 'pong',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSettingsDialog();
+
+    const apiKeyInput = screen.getByLabelText('API key') as HTMLInputElement;
+    fireEvent.change(apiKeyInput, {
+      target: { value: ' \u200Bsk-ant-test-provider\n' },
+    });
+    fireEvent.blur(apiKeyInput);
+
+    await waitFor(() => {
+      expect(apiKeyInput.value).toBe('sk-ant-test-provider');
+    });
+    expect(screen.getByText(en['settings.apiKeyCleaned'])).toBeTruthy();
+    const testConnectionCalls = fetchMock.mock.calls.filter(
+      ([input]) => input.toString() === '/api/test/connection',
+    );
+    expect(testConnectionCalls).toHaveLength(1);
   });
 
   it('lets users retry a failed BYOK connection test without editing the API key', async () => {


### PR DESCRIPTION
## Why

This is BYOK PR-B. The BYOK failure data shows a large chunk of provider setup failures come from API keys being pasted dirty or pasted into the wrong provider tab. PR-A added the shared validation ground; this PR moves the highest-signal API key feedback into the field itself so users see the problem before sending a doomed provider request.

## What users will see

In Settings → Execution → BYOK, the API key field now trims pasted whitespace / zero-width characters on blur, shows a small “removed extra spaces” confirmation, and displays first-party provider key-shape errors inline when the key clearly belongs to another provider or does not match the expected first-party shape.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: this is a field-level inline status/error change in the existing Settings → Execution BYOK form. The behavior is covered by focused SettingsDialog tests for dirty paste cleanup, inline cleaned status, wrong-provider key errors, and preserving the PR-A auto-test/model-fetch flow after cleanup.

## Bug fix verification

N/A — not a bug fix.

## Validation

- `git diff --check origin/main...HEAD`
- `NODE_OPTIONS=--localstorage-file=/tmp/open-design-vitest-localstorage-pr-b pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx`
- `pnpm i18n:check`
- `pnpm i18n:coverage`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`

Note: local validation emitted the existing engine warning because this environment is running Node v26 while the repo expects Node ~24.
