### PR TITLE
feat(web): prefer fetched BYOK account models

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -116,6 +116,7 @@ import {
   blockingByokDraftFields,
   blockingByokDraftIssues,
   cleanByokApiKey,
+  resolveByokModelPreference,
   validateByokDraft,
   type ByokDraftField,
   type ByokDraftIssue,
@@ -713,10 +714,14 @@ export function agentRefreshOptionsForConfig(cfg: AppConfig): AgentRefreshOption
   };
 }
 
-function apiModelOptionLabel(model: ProviderModelOption): string {
-  return model.label && model.label !== model.id
+function apiModelOptionLabel(
+  model: ProviderModelOption,
+  sourceLabel?: string,
+): string {
+  const baseLabel = model.label && model.label !== model.id
     ? `${model.label} (${model.id})`
     : model.id;
+  return sourceLabel ? `${baseLabel} · ${sourceLabel}` : baseLabel;
 }
 
 function codexPathRepairState(
@@ -1359,6 +1364,9 @@ export function SettingsDialog({
         return;
       }
       setProviderTestState({ status: 'done', result });
+      if (!result.ok && result.kind === 'not_found_model') {
+        focusByokRequiredField('model');
+      }
       const byokProviderId = byokProtocolToTracking(apiProtocol);
       if (byokProviderId) {
         trackSettingsByokTestResult(analytics.track, {
@@ -2097,10 +2105,40 @@ export function SettingsDialog({
     ),
     [fetchedApiModelOptions, suggestedApiModelIds],
   );
+  const fetchedApiModelIds = useMemo(
+    () => new Set(fetchedApiModelOptions.map((model) => model.id.trim())),
+    [fetchedApiModelOptions],
+  );
   const apiModelIds = useMemo(
     () => apiModelOptions.map((m) => m.id),
     [apiModelOptions],
   );
+  const providerDefaultModel =
+    selectedProvider?.model.trim() || suggestedApiModelIds[0] || '';
+  useEffect(() => {
+    if (cfg.mode !== 'api') return;
+    if (apiModelCustomEditing) return;
+    if (fetchedApiModelOptions.length === 0) return;
+    const currentModel = cfg.model.trim();
+    if (currentModel && fetchedApiModelIds.has(currentModel)) return;
+    if (currentModel && currentModel !== providerDefaultModel) return;
+
+    const preference = resolveByokModelPreference({
+      currentModel: '',
+      accountModels: fetchedApiModelOptions,
+      providerDefaultModel,
+    });
+    if (preference.source !== 'account') return;
+    if (preference.model === currentModel) return;
+    updateApiConfig({ model: preference.model });
+  }, [
+    apiModelCustomEditing,
+    cfg.mode,
+    cfg.model,
+    fetchedApiModelIds,
+    fetchedApiModelOptions,
+    providerDefaultModel,
+  ]);
   const apiModelCustomActive =
     shouldShowCustomModelInput(
       cfg.model,
@@ -3450,7 +3488,14 @@ export function SettingsDialog({
                 modelSelectRef={modelSelectRef}
                 models={apiModelOptions.map((m) => ({
                   id: m.id,
-                  label: apiModelOptionLabel(m),
+                  label: apiModelOptionLabel(
+                    m,
+                    loadedAccountModelCount > 0
+                      ? fetchedApiModelIds.has(m.id)
+                        ? t('settings.modelSourceAccount')
+                        : t('settings.modelSourceSuggested')
+                      : undefined,
+                  ),
                 }))}
                 modelsLoadedFromAccountMessage={
                   loadedAccountModelCount > 0

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1003,6 +1003,11 @@ export function SettingsDialog({
   const modelSelectRef = useRef<HTMLButtonElement | null>(null);
   const customModelInputRef = useRef<HTMLInputElement | null>(null);
   const focusByokRequiredFieldAfterProtocolSwitchRef = useRef(false);
+  // Tracks whether the current BYOK model value came from an explicit user
+  // pick (combobox selection or custom entry) rather than an auto-populated
+  // provider preset. The account-model auto-switch must never overwrite a
+  // deliberate choice, even when that choice equals the provider preset id.
+  const apiModelUserSelectedRef = useRef(false);
   const [apiModelCustomEditing, setApiModelCustomEditing] = useState(false);
   const [agentCustomModelIds, setAgentCustomModelIds] = useState<
     ReadonlySet<string>
@@ -1182,6 +1187,7 @@ export function SettingsDialog({
   };
   const setApiProtocol = (protocol: ApiProtocol) => {
     setApiModelCustomEditing(false);
+    apiModelUserSelectedRef.current = false;
     focusByokRequiredFieldAfterProtocolSwitchRef.current = true;
     setCfg((c) => switchApiProtocolConfig(c, protocol));
   };
@@ -2118,6 +2124,9 @@ export function SettingsDialog({
   useEffect(() => {
     if (cfg.mode !== 'api') return;
     if (apiModelCustomEditing) return;
+    // Respect an explicit user pick — even when it equals the provider preset
+    // id, the user deliberately chose it and discovery must not rewrite it.
+    if (apiModelUserSelectedRef.current) return;
     if (fetchedApiModelOptions.length === 0) return;
     const currentModel = cfg.model.trim();
     if (currentModel && fetchedApiModelIds.has(currentModel)) return;
@@ -3511,6 +3520,7 @@ export function SettingsDialog({
                 azureModelFetchHint={t('settings.azureModelFetchHint')}
                 onCustomModelChange={(value) => updateApiConfig({ model: value })}
                 onCustomModelSelect={() => {
+                  apiModelUserSelectedRef.current = true;
                   setApiModelCustomEditing(true);
                   updateApiConfig({ model: '' });
                 }}
@@ -3527,6 +3537,7 @@ export function SettingsDialog({
                   }
                 }}
                 onModelSelect={(nextValue) => {
+                  apiModelUserSelectedRef.current = true;
                   setApiModelCustomEditing(false);
                   updateApiConfig({ model: nextValue });
                 }}

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -277,6 +277,8 @@ export const en: Dict = {
   'settings.model': 'Model',
   'settings.apiKeyInvalid': 'Invalid API key.',
   'settings.modelsLoadedFromAccount': '✓ Loaded {count} models from your account.',
+  'settings.modelSourceAccount': 'From your account',
+  'settings.modelSourceSuggested': 'Suggested',
   'settings.fetchModels': 'Fetch models',
   'settings.fetchModelsTitle': 'Fetch available models from this provider',
   'settings.fetchModelsRunning': 'Fetching models…',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -277,6 +277,8 @@ export const zhCN: Dict = {
   'settings.model': '模型',
   'settings.apiKeyInvalid': 'API key 无效。',
   'settings.modelsLoadedFromAccount': '✓ 已从你的账号加载 {count} 个模型。',
+  'settings.modelSourceAccount': '来自你的账号',
+  'settings.modelSourceSuggested': '建议',
   'settings.fetchModels': '拉取模型',
   'settings.fetchModelsTitle': '从当前提供方拉取可用模型',
   'settings.fetchModelsRunning': '正在拉取模型…',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -289,6 +289,8 @@ export interface Dict {
   'settings.model': string;
   'settings.apiKeyInvalid': string;
   'settings.modelsLoadedFromAccount': string;
+  'settings.modelSourceAccount': string;
+  'settings.modelSourceSuggested': string;
   'settings.fetchModels': string;
   'settings.fetchModelsTitle': string;
   'settings.fetchModelsRunning': string;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -889,6 +889,52 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     );
   });
 
+  it('keeps a suggested model the user explicitly re-picked after discovery resolves', async () => {
+    fetchProviderModelsMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      models: [{ id: 'account-ready-model', label: 'Account Ready' }],
+    });
+    const { onPersist } = renderSettingsDialog({
+      apiProtocol: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+    expect(fetchProviderModelsMock).not.toHaveBeenCalled();
+
+    // The user deliberately re-picks the suggested model that equals the
+    // provider preset id before discovery runs.
+    fireEvent.click(screen.getByRole('combobox', { name: 'Model' }));
+    const modelPopover = screen.getByTestId('settings-byok-model-popover');
+    fireEvent.click(within(modelPopover).getByRole('option', { name: 'gpt-4o' }));
+
+    // Supplying the key triggers account-model discovery.
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'sk-openai' },
+    });
+    fireEvent.blur(screen.getByLabelText('API key'));
+
+    expect(await screen.findByText('✓ Loaded 1 models from your account.')).toBeTruthy();
+
+    // The explicit pick must survive discovery — no silent rewrite to the
+    // first fetched account model.
+    const modelCombobox = screen.getByRole('combobox', { name: 'Model' });
+    expect(modelCombobox.textContent).toContain('gpt-4o');
+    expect(modelCombobox.textContent).not.toContain('account-ready-model');
+    await waitForPersist(
+      onPersist,
+      expect.objectContaining({
+        apiProtocol: 'openai',
+        model: 'gpt-4o',
+      }),
+      {},
+    );
+  });
+
   it('does not show a BYOK Test button or nag when the API key is still missing', () => {
     renderSettingsDialog({
       apiProtocol: 'anthropic',

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -793,7 +793,11 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     const modelPopover = screen.getByTestId('settings-byok-model-popover');
     expect(
       within(modelPopover).getAllByRole('option').map((option) => option.textContent?.trim()),
-    ).toEqual(expect.arrayContaining(['Account Model (gpt-account)', 'gpt-4o', 'Custom (type below)…']));
+    ).toEqual(expect.arrayContaining([
+      'Account Model (gpt-account) · From your account',
+      'gpt-4o · Suggested',
+      'Custom (type below)…',
+    ]));
     expect(analyticsTrackMock).toHaveBeenCalledWith(
       'settings_byok_models_fetch_result',
       expect.objectContaining({
@@ -854,6 +858,37 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     );
   });
 
+  it('defaults to an account model when discovery replaces a provider preset', async () => {
+    fetchProviderModelsMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      models: [{ id: 'account-ready-model', label: 'Account Ready' }],
+    });
+    const { onPersist } = renderSettingsDialog({
+      apiProtocol: 'openai',
+      apiKey: 'sk-openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+
+    expect(await screen.findByText('✓ Loaded 1 models from your account.')).toBeTruthy();
+    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain(
+      'Account Ready (account-ready-model) · From your account',
+    );
+    await waitForPersist(
+      onPersist,
+      expect.objectContaining({
+        apiProtocol: 'openai',
+        model: 'account-ready-model',
+      }),
+      {},
+    );
+  });
+
   it('does not show a BYOK Test button or nag when the API key is still missing', () => {
     renderSettingsDialog({
       apiProtocol: 'anthropic',
@@ -905,7 +940,11 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     const modelPopover = screen.getByTestId('settings-byok-model-popover');
     expect(
       within(modelPopover).getAllByRole('option').map((option) => option.textContent?.trim()),
-    ).toEqual(['gpt-4.1-mini', 'gpt-5.5', 'Custom (type below)…']);
+    ).toEqual([
+      'gpt-4.1-mini · From your account',
+      'gpt-5.5 · From your account',
+      'Custom (type below)…',
+    ]);
   });
 
   it('fetches provider models, merges them into the picker, and preserves a custom current model', async () => {
@@ -943,7 +982,11 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     const modelPopover = screen.getByTestId('settings-byok-model-popover');
     expect(
       within(modelPopover).getAllByRole('option').map((option) => option.textContent?.trim()),
-    ).toEqual(expect.arrayContaining(['Remote Alpha (remote-alpha)', 'gpt-4o', 'Custom (type below)…']));
+    ).toEqual(expect.arrayContaining([
+      'Remote Alpha (remote-alpha) · From your account',
+      'gpt-4o · From your account',
+      'Custom (type below)…',
+    ]));
     expect((screen.getByLabelText('Custom model id') as HTMLInputElement).value).toBe('custom-still-here');
   });
 
@@ -1287,6 +1330,45 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
       }),
       undefined,
     );
+  });
+
+  it('focuses the model field when the BYOK test returns model not found', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      expect(url).toBe('/api/test/connection');
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          kind: 'not_found_model',
+          latencyMs: 18,
+          model: 'missing-model',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSettingsDialog({
+      apiProtocol: 'openai',
+      apiKey: 'sk-openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'missing-model',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+
+    expect(await screen.findByText("Model 'missing-model' not found on this endpoint.")).toBeTruthy();
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByLabelText('Custom model id'));
+    });
   });
 });
 


### PR DESCRIPTION
## Why

BYOK model failures are largely caused by users relying on static suggestions or hand-typed model IDs that their endpoint does not actually expose. PR-A already added the validation and automatic provider-model discovery plumbing; this PR uses that discovered account list as the safer model source.

This addresses the model-name part of the BYOK shift-left plan: reduce not_found_model failures before the user has to interpret a failed connection test.

## What users will see

In Settings → Execution → BYOK, when provider model discovery returns models from the user's account, the Model picker labels those entries as “From your account” and static fallback entries as “Suggested”.

If the current model is empty or still sitting on a provider preset that is not in the returned account list, Settings automatically switches to the first account model. Explicit user selections and custom model entry are preserved.

If a BYOK connection test returns model_not_found, focus moves back to the model field so the user can correct it immediately.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: the changed UI is inline text/state in the existing Settings BYOK model picker. Covered by focused component tests that open the picker and assert the visible labels and focus behavior.

## Bug fix verification

- Test path that reproduces the issue: `apps/web/tests/components/SettingsDialog.execution.test.tsx`
- Did the test go red on `main` and green on this branch? Not checked separately; this is the PR-C feature step on top of PR-A rather than a single bug fix.

## Validation

- `NODE_OPTIONS=--localstorage-file=/tmp/open-design-vitest-localstorage-pr-c pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx`
- `pnpm i18n:check`
- `pnpm i18n:coverage`
- `pnpm --filter @open-design/web typecheck`
- `git diff --check`
- `pnpm guard`

Note: local validation emitted the repo engine warning because this shell is on Node v26.0.0 while the repo wants Node ~24; the commands completed successfully.
