### PR TITLE
fix(analytics): map AMR runtime to its own provider id

### DIFF
--- a/apps/web/src/components/MemoryModelInline.tsx
+++ b/apps/web/src/components/MemoryModelInline.tsx
@@ -128,6 +128,7 @@ function cliAgentLabel(agentId: string | null | undefined): string | null {
     codex: 'Codex CLI',
     gemini: 'Gemini CLI',
     opencode: 'OpenCode',
+    amr: 'AMR',
     qwen: 'Qwen Code',
     qoder: 'Qoder CLI',
     copilot: 'GitHub Copilot CLI',

--- a/apps/web/src/utils/agentLabels.ts
+++ b/apps/web/src/utils/agentLabels.ts
@@ -5,6 +5,7 @@ const AGENT_LABELS: Record<string, string> = {
   devin: 'Devin',
   gemini: 'Gemini',
   opencode: 'OpenCode',
+  amr: 'AMR',
   'cursor-agent': 'Cursor',
   cursor: 'Cursor',
   qwen: 'Qwen',

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -140,7 +140,8 @@ export type TrackingByokProviderId =
   | 'senseaudio';
 
 // v2 CLI provider catalogue (CSV row 63 + image 59). Adds `qoder_cli` and
-// `kilo` over v1.
+// `kilo` over v1, plus `amr` (the vela CLI runtime) so AMR runs no longer
+// fold into the `other` catch-all bucket.
 export type TrackingCliProviderId =
   | 'claude_code'
   | 'codex_cli'
@@ -155,6 +156,7 @@ export type TrackingCliProviderId =
   | 'github_copilot_cli'
   | 'pi'
   | 'kilo'
+  | 'amr'
   | 'other';
 
 export type TrackingFeedbackProviderId =
@@ -2134,6 +2136,8 @@ export function agentIdToTracking(agentId: string | null | undefined): TrackingC
       return 'pi';
     case 'kilo':
       return 'kilo';
+    case 'amr':
+      return 'amr';
     default:
       return 'other';
   }

--- a/packages/contracts/tests/analytics-agent-provider.test.ts
+++ b/packages/contracts/tests/analytics-agent-provider.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  agentIdToTracking,
+  feedbackAgentProviderIdToTracking,
+} from '../src/analytics/events.js';
+
+describe('agentIdToTracking', () => {
+  it('maps the AMR (vela CLI) runtime to its own provider id', () => {
+    // Regression: AMR's daemon agentId is `amr` (apps/daemon/src/runtimes
+    // /defs/amr.ts), but the mapping had no `amr` case, so every AMR run
+    // landed in the `other` catch-all and could not be told apart from
+    // unmapped agents in PostHog. It must report `amr`, not `other`.
+    expect(agentIdToTracking('amr')).toBe('amr');
+  });
+
+  it('keeps mapping known CLI agents and falls back to other for unknowns', () => {
+    expect(agentIdToTracking('claude')).toBe('claude_code');
+    expect(agentIdToTracking('opencode')).toBe('opencode');
+    expect(agentIdToTracking('totally-unknown-agent')).toBe('other');
+    expect(agentIdToTracking(null)).toBe('other');
+    expect(agentIdToTracking(undefined)).toBe('other');
+  });
+
+  it('routes AMR feedback through the same provider id', () => {
+    // feedbackAgentProviderIdToTracking falls through to agentIdToTracking
+    // for non-BYOK agents, so AMR assistant feedback must also be `amr`.
+    expect(feedbackAgentProviderIdToTracking('amr')).toBe('amr');
+  });
+});


### PR DESCRIPTION
## Why

While measuring the client-side failure rate of AMR (the vela CLI runtime) in PostHog, AMR runs were impossible to isolate: they were all bucketed into `agent_provider_id='other'`, mixed in with every other unmapped agent. Root cause is a one-case gap in the analytics mapping — AMR's daemon `agentId` is `'amr'` (`apps/daemon/src/runtimes/defs/amr.ts`, `bin: 'vela'`), but `agentIdToTracking()` had no `'amr'` arm, so it fell through to `default → 'other'`. The AMR runtime branch added the agent everywhere (runtime def, icon, executables, env) **except** the analytics catalogue, so AMR is the only first-class UI agent whose runs can't be told apart in product analytics.

This blocks any AMR-specific dashboard (success/failure rate, model mix, latency) for the v0.9.0 release that ships AMR.

## What users will see

No user-facing behavior change. Going forward, AMR runs report `agent_provider_id='amr'` (and `cli_provider_id`/`selected_cli_id` likewise, since they share the type), so AMR can be filtered as its own value in PostHog instead of hiding inside `other`. The agent also now renders as **AMR** in two web label maps that previously fell back to the lowercase id `amr`.

Note: this is not retroactive — events already sent as `other` stay `other`; the clean signal starts at merge.

## Surface area

- [x] **API / contract** — changed `TrackingCliProviderId` in `packages/contracts/src/analytics/events.ts` (added `'amr'`)
- [ ] UI / Keyboard shortcut / CLI / env var / Extension point / i18n / dependency / Default behavior change

(The two web label-map edits are display-string lookups, not new UI surfaces.)

## Bug fix verification

- Test: `packages/contracts/tests/analytics-agent-provider.test.ts`
- Red on `release/v0.9.0` (base): `agentIdToTracking('amr')` returns `'other'`, so `expect(...).toBe('amr')` fails. Green on this branch.

## Validation

- `pnpm --filter @open-design/contracts typecheck` — pass
- `pnpm --filter @open-design/contracts test` (new spec) — 3/3 pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web exec vitest run tests/utils/apiProtocol.test.ts` — 5/5 pass
- `pnpm guard` — pass

## Adjacent (not in this PR)

`MemoryModelInline.chatProtocolFromAgent()` does not list `'amr'` either, so AMR conversations currently get no memory-extraction protocol. That's a functional routing decision (AMR's link is OpenAI-compatible, so it would likely return `'openai'`) rather than an analytics/label gap — left for the AMR owners to confirm rather than guessed here.
