### PR TITLE
[codex] expand project and onboarding coverage

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -473,7 +473,10 @@ export function ChatPane({
     retryAssistant && failedRunErrorEvent ? retryAssistant.id : null;
   // AMR promotion card payload (only the non-AMR model/auth/quota case).
   const amrSwitchPayload =
-    runFailureUi?.showSwitchCard && retryAssistant && failedRunErrorEvent?.code
+    runFailureUi?.showSwitchCard
+    && failedRunErrorEvent?.code !== 'UPSTREAM_UNAVAILABLE'
+    && retryAssistant
+    && failedRunErrorEvent?.code
       ? {
           errorCode: failedRunErrorEvent.code,
           projectId: projectId ?? '',

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AvatarMenu } from '../../src/components/AvatarMenu';
+import type { AgentInfo, AppConfig } from '../../src/types';
+
+vi.mock('../../src/i18n', () => ({
+  useT: () => (key: string) => key,
+}));
+
+const codexAgent: AgentInfo = {
+  id: 'codex',
+  name: 'Codex CLI',
+  bin: 'codex',
+  available: true,
+  version: '0.134.0',
+  models: [{ id: 'default', label: 'Default (CLI config)' }],
+  reasoningOptions: [
+    { id: 'default', label: 'Default' },
+    { id: 'high', label: 'High' },
+  ],
+};
+
+const claudeAgent: AgentInfo = {
+  id: 'claude',
+  name: 'Claude Code',
+  bin: 'claude',
+  available: true,
+  version: '2.1.131',
+  models: [
+    { id: 'default', label: 'Default (CLI config)' },
+    { id: 'sonnet', label: 'Sonnet (alias)' },
+  ],
+};
+
+const baseConfig: AppConfig = {
+  mode: 'daemon',
+  apiKey: '',
+  apiProtocol: 'anthropic',
+  apiVersion: '',
+  baseUrl: 'https://api.anthropic.com',
+  apiProviderBaseUrl: 'https://api.anthropic.com',
+  apiProtocolConfigs: {},
+  model: 'claude-sonnet-4-5',
+  agentId: 'codex',
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  mediaProviders: {},
+  agentModels: { codex: { model: 'default', reasoning: 'default' } },
+  agentCliEnv: {},
+};
+
+function renderMenu({
+  config = baseConfig,
+  agents = [codexAgent, claudeAgent],
+  daemonLive = true,
+  onModeChange = vi.fn(),
+  onAgentChange = vi.fn(),
+  onAgentModelChange = vi.fn(),
+  onOpenSettings = vi.fn(),
+  onRefreshAgents = vi.fn(),
+}: {
+  config?: AppConfig;
+  agents?: AgentInfo[];
+  daemonLive?: boolean;
+  onModeChange?: ReturnType<typeof vi.fn>;
+  onAgentChange?: ReturnType<typeof vi.fn>;
+  onAgentModelChange?: ReturnType<typeof vi.fn>;
+  onOpenSettings?: ReturnType<typeof vi.fn>;
+  onRefreshAgents?: ReturnType<typeof vi.fn>;
+} = {}) {
+  render(
+    <AvatarMenu
+      config={config}
+      agents={agents}
+      daemonLive={daemonLive}
+      onModeChange={onModeChange}
+      onAgentChange={onAgentChange}
+      onAgentModelChange={onAgentModelChange}
+      onOpenSettings={onOpenSettings}
+      onRefreshAgents={onRefreshAgents}
+    />,
+  );
+  return {
+    onModeChange,
+    onAgentChange,
+    onAgentModelChange,
+    onOpenSettings,
+    onRefreshAgents,
+  };
+}
+
+function openMenu() {
+  fireEvent.click(screen.getByRole('button', { name: 'avatar.title' }));
+  return screen.getByRole('dialog', { name: 'avatar.title' });
+}
+
+describe('AvatarMenu', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('opens execution settings when Local CLI is selected while the daemon is offline', () => {
+    const onOpenSettings = vi.fn();
+    renderMenu({
+      daemonLive: false,
+      onOpenSettings,
+    });
+
+    openMenu();
+    fireEvent.click(screen.getByRole('button', { name: /avatar.useLocal/i }));
+
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('rescans agents and re-renders newly available CLI entries', async () => {
+    function Harness() {
+      const [agents, setAgents] = useState<AgentInfo[]>([
+        codexAgent,
+        { ...claudeAgent, available: false },
+      ]);
+      return (
+        <AvatarMenu
+          config={baseConfig}
+          agents={agents}
+          daemonLive={true}
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onOpenSettings={vi.fn()}
+          onRefreshAgents={() => {
+            setAgents([codexAgent, claudeAgent]);
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    openMenu();
+    expect(screen.queryByRole('button', { name: /Claude Code/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'avatar.rescan' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Claude Code/i })).toBeTruthy();
+    });
+  });
+
+  it('routes reasoning selection changes through onAgentModelChange', () => {
+    const onAgentModelChange = vi.fn();
+    renderMenu({ onAgentModelChange });
+
+    openMenu();
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[1]!, { target: { value: 'high' } });
+
+    expect(onAgentModelChange).toHaveBeenCalledWith('codex', {
+      reasoning: 'high',
+    });
+  });
+
+  it('keeps a custom saved model visible when it is not in the declared agent model list', () => {
+    renderMenu({
+      config: {
+        ...baseConfig,
+        agentModels: { codex: { model: 'custom-codex-model', reasoning: 'default' } },
+      },
+    });
+
+    openMenu();
+    const modelSelect = screen.getAllByRole('combobox')[0] as HTMLSelectElement;
+    expect(modelSelect.value).toBe('custom-codex-model');
+    expect(
+      screen.getByRole('option', { name: /custom-codex-model/i }),
+    ).toBeTruthy();
+  });
+});

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AvatarMenu } from '../../src/components/AvatarMenu';
-import type { AgentInfo, AppConfig } from '../../src/types';
+import type { AgentInfo, AppConfig, ExecMode } from '../../src/types';
 
 vi.mock('../../src/i18n', () => ({
   useT: () => (key: string) => key,
@@ -54,24 +54,32 @@ const baseConfig: AppConfig = {
   agentCliEnv: {},
 };
 
+type ModeChangeHandler = (mode: ExecMode) => void;
+type AgentChangeHandler = (id: string) => void;
+type AgentModelChangeHandler = (
+  id: string,
+  choice: { model?: string; reasoning?: string },
+) => void;
+type VoidHandler = () => void;
+
 function renderMenu({
   config = baseConfig,
   agents = [codexAgent, claudeAgent],
   daemonLive = true,
-  onModeChange = vi.fn(),
-  onAgentChange = vi.fn(),
-  onAgentModelChange = vi.fn(),
-  onOpenSettings = vi.fn(),
-  onRefreshAgents = vi.fn(),
+  onModeChange = vi.fn<ModeChangeHandler>(),
+  onAgentChange = vi.fn<AgentChangeHandler>(),
+  onAgentModelChange = vi.fn<AgentModelChangeHandler>(),
+  onOpenSettings = vi.fn<VoidHandler>(),
+  onRefreshAgents = vi.fn<VoidHandler>(),
 }: {
   config?: AppConfig;
   agents?: AgentInfo[];
   daemonLive?: boolean;
-  onModeChange?: ReturnType<typeof vi.fn>;
-  onAgentChange?: ReturnType<typeof vi.fn>;
-  onAgentModelChange?: ReturnType<typeof vi.fn>;
-  onOpenSettings?: ReturnType<typeof vi.fn>;
-  onRefreshAgents?: ReturnType<typeof vi.fn>;
+  onModeChange?: ReturnType<typeof vi.fn<ModeChangeHandler>>;
+  onAgentChange?: ReturnType<typeof vi.fn<AgentChangeHandler>>;
+  onAgentModelChange?: ReturnType<typeof vi.fn<AgentModelChangeHandler>>;
+  onOpenSettings?: ReturnType<typeof vi.fn<VoidHandler>>;
+  onRefreshAgents?: ReturnType<typeof vi.fn<VoidHandler>>;
 } = {}) {
   render(
     <AvatarMenu

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -460,6 +460,72 @@ describe('ChatComposer context pickers', () => {
     expect(screen.queryByTestId('staged-attachments')).toBeNull();
   });
 
+  it('clears an attachment upload error after a later retry succeeds', async () => {
+    let uploadAttempts = 0;
+    fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/mcp/servers') {
+        return new Response(JSON.stringify({ servers, templates: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/plugins') {
+        return new Response(JSON.stringify({ plugins }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/skills') {
+        return new Response(JSON.stringify({ skills }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/projects/project-1/upload' && init?.method === 'POST') {
+        uploadAttempts += 1;
+        if (uploadAttempts === 1) {
+          return new Response(JSON.stringify({ error: 'storage offline' }), {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({
+          files: [{ name: 'recovered.txt', path: 'uploads/recovered.txt', size: 24 }],
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderComposer();
+    const input = screen.getByTestId('chat-file-input') as HTMLInputElement;
+
+    fireEvent.change(input, {
+      target: {
+        files: [new File(['first failure'], 'failed.txt', { type: 'text/plain' })],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Attachment upload failed for 1 file(s) (storage offline).')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('staged-attachments')).toBeNull();
+
+    fireEvent.change(input, {
+      target: {
+        files: [new File(['retry works'], 'recovered.txt', { type: 'text/plain' })],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Attachment upload failed for 1 file(s) (storage offline).')).toBeNull();
+    });
+    expect(screen.getByTestId('staged-attachments').textContent).toContain('recovered.txt');
+  });
+
   it('lets the tools panel switch between Official and My plugins', async () => {
     renderComposer();
     fireEvent.click(screen.getByLabelText('Open CLI and model settings'));

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -2,6 +2,8 @@
 
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ComponentProps } from 'react';
+import { useState } from 'react';
 
 import { DesignFilesPanel } from '../../src/components/DesignFilesPanel';
 import type { ProjectFile, ProjectFileKind } from '../../src/types';
@@ -52,9 +54,13 @@ function generateFiles(count: number): ProjectFile[] {
   });
 }
 
-function renderPanel(files: ProjectFile[]) {
+function renderPanel(
+  files: ProjectFile[],
+  overrides: Partial<ComponentProps<typeof DesignFilesPanel>> = {},
+) {
   const onOpenFile = vi.fn();
   const onDeleteFiles = vi.fn();
+  const onClearUploadError = vi.fn();
   const result = render(
     <DesignFilesPanel
       projectId="test-project"
@@ -70,9 +76,11 @@ function renderPanel(files: ProjectFile[]) {
       onUploadFiles={vi.fn()}
       onPaste={vi.fn()}
       onNewSketch={vi.fn()}
+      onClearUploadError={onClearUploadError}
+      {...overrides}
     />,
   );
-  return { ...result, onDeleteFiles, onOpenFile };
+  return { ...result, onDeleteFiles, onOpenFile, onClearUploadError };
 }
 
 function getPageInfo(container: HTMLElement): string {
@@ -508,6 +516,31 @@ describe('DesignFilesPanel large-list regression', () => {
     expect(onDeleteFiles).toHaveBeenCalledWith([firstName, secondName]);
   });
 
+  it('drops hidden selections before batch delete when a kind filter narrows the file list', () => {
+    const files = [
+      file({ name: 'landing.html', kind: 'html', mime: 'text/html' }),
+      file({ name: 'hero.png', kind: 'image', mime: 'image/png' }),
+    ];
+    const { onDeleteFiles } = renderPanel(files);
+
+    fireEvent.click(screen.getByTestId('design-file-row-landing.html').querySelector('.df-row-check')!);
+    fireEvent.click(screen.getByTestId('design-file-row-hero.png').querySelector('.df-row-check')!);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by kind' }));
+    const filterDialog = screen.getByRole('dialog', { name: 'Filter by kind' });
+    const imageFilterLabel = within(filterDialog).getByText('Image').closest('label');
+    if (!imageFilterLabel) throw new Error('Missing image filter label');
+    fireEvent.click(imageFilterLabel.querySelector('input')!);
+
+    expect(screen.queryByTestId('design-file-row-landing.html')).toBeNull();
+    expect(screen.getByTestId('design-file-row-hero.png')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('design-files-batch-delete'));
+
+    expect(onDeleteFiles).toHaveBeenCalledTimes(1);
+    expect(onDeleteFiles).toHaveBeenCalledWith(['hero.png']);
+  });
+
   it('renders 500 files within a reasonable time', () => {
     const files = generateFiles(500);
     const start = performance.now();
@@ -622,6 +655,57 @@ describe('DesignFilesPanel directory navigation', () => {
 
     expect(document.querySelector('.df-breadcrumbs')).toBeNull();
     expect(screen.getByTestId('design-file-row-top.html')).toBeTruthy();
+  });
+
+  it('returns to root after batch deleting the last files in the current subdirectory', async () => {
+    const deleteSpy = vi.fn();
+
+    function Harness() {
+      const [files, setFiles] = useState<ProjectFile[]>([
+        file({ name: 'assets/logo.png', kind: 'image' }),
+        file({ name: 'assets/hero.png', kind: 'image' }),
+        file({ name: 'top.html', kind: 'html' }),
+      ]);
+
+      return (
+        <DesignFilesPanel
+          projectId="test-project"
+          files={files}
+          liveArtifacts={[]}
+          onRefreshFiles={vi.fn()}
+          onOpenFile={vi.fn()}
+          onOpenLiveArtifact={vi.fn()}
+          onRenameFile={vi.fn()}
+          onDeleteFile={vi.fn()}
+          onDeleteFiles={async (names) => {
+            deleteSpy(names);
+            setFiles((current) => current.filter((candidate) => !names.includes(candidate.name)));
+          }}
+          onUpload={vi.fn()}
+          onUploadFiles={vi.fn()}
+          onPaste={vi.fn()}
+          onNewSketch={vi.fn()}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(document.querySelector('.df-dir-row .df-row-name-btn')!);
+    expect(document.querySelector('.df-breadcrumb-current')?.textContent).toBe('assets');
+
+    fireEvent.click(screen.getByTestId('design-file-row-assets/logo.png').querySelector('.df-row-check')!);
+    fireEvent.click(screen.getByTestId('design-file-row-assets/hero.png').querySelector('.df-row-check')!);
+    fireEvent.click(screen.getByTestId('design-files-batch-delete'));
+
+    await waitFor(() => {
+      expect(deleteSpy).toHaveBeenCalledWith(['assets/logo.png', 'assets/hero.png']);
+    });
+    await waitFor(() => {
+      expect(document.querySelector('.df-breadcrumbs')).toBeNull();
+    });
+    expect(screen.getByTestId('design-file-row-top.html')).toBeTruthy();
+    expect(document.querySelectorAll('.df-file-row.selected').length).toBe(0);
   });
 
   it('does not show the select-all header as checked when the page contains only directory rows', () => {

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import { useState } from 'react';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -7,6 +8,25 @@ import { EntryShell } from '../../src/components/EntryShell';
 import { AMR_LOGIN_TIMEOUT_MS } from '../../src/components/amrLoginPolling';
 import { I18nProvider } from '../../src/i18n';
 import type { AgentInfo, AppConfig } from '../../src/types';
+
+const analyticsMocks = vi.hoisted(() => ({
+  track: vi.fn(),
+}));
+
+vi.mock('../../src/analytics/provider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/provider')>();
+  return {
+    ...actual,
+    useAnalytics: () => ({
+      newRequestId: vi.fn(() => 'request-1'),
+      setConfigureGlobals: vi.fn(),
+      setConsent: vi.fn(),
+      setIdentity: vi.fn(),
+      track: analyticsMocks.track,
+    }),
+    useAppVersion: () => null,
+  };
+});
 
 const originalFetch = globalThis.fetch;
 
@@ -93,23 +113,79 @@ function renderOnboarding(
     ...overrides,
   };
 
+  function Harness() {
+    const [config, setConfig] = useState(props.config);
+    return (
+      <I18nProvider initial="en">
+        <EntryShell
+          {...props}
+          config={config}
+          onConfigPersist={(next) => {
+            props.onConfigPersist(next);
+            setConfig(next as AppConfig);
+          }}
+        />
+      </I18nProvider>
+    );
+  }
+
   render(
-    <I18nProvider initial="en">
-      <EntryShell {...props} />
-    </I18nProvider>,
+    <Harness />,
   );
 
   return props;
+}
+
+function trackedEvents(name: string) {
+  return analyticsMocks.track.mock.calls.filter(([eventName]) => eventName === name);
+}
+
+function latestTrackedEvent<T extends Record<string, unknown>>(name: string): T {
+  const calls = trackedEvents(name);
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1]?.[1] as T;
+}
+
+function findTrackedEvent<T extends Record<string, unknown>>(
+  name: string,
+  predicate: (payload: T) => boolean,
+): T {
+  const payload = trackedEvents(name)
+    .map(([, eventPayload]) => eventPayload as T)
+    .find(predicate);
+  expect(payload).toBeTruthy();
+  return payload as T;
+}
+
+function chooseDropdownOption(label: string, option: string | RegExp) {
+  const field = screen
+    .getAllByText(label)
+    .map((node) => node.closest('.onboarding-view__select-field'))
+    .find((node): node is HTMLElement => node instanceof HTMLElement);
+  if (!field) throw new Error(`dropdown field not found: ${label}`);
+  const trigger = field.querySelector('button');
+  if (!(trigger instanceof HTMLButtonElement)) {
+    throw new Error(`dropdown trigger not found: ${label}`);
+  }
+  fireEvent.click(trigger);
+  fireEvent.click(
+    screen.getByRole('option', {
+      name: option instanceof RegExp ? option : new RegExp(option, 'i'),
+    }),
+  );
 }
 
 afterEach(() => {
   cleanup();
   globalThis.fetch = originalFetch;
   vi.useRealTimers();
+  analyticsMocks.track.mockReset();
+  window.sessionStorage.clear();
 });
 
 beforeEach(() => {
   globalThis.fetch = originalFetch;
+  analyticsMocks.track.mockReset();
 });
 
 describe('EntryShell onboarding Open Design AMR runtime', () => {
@@ -378,6 +454,137 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     expect(screen.getByRole('heading', { name: 'About you' })).toBeTruthy();
   });
 
+  it('tracks onboarding page views and about-you submission payload on completion', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({
+        loggedIn: true,
+        profile: 'prod',
+        configPath: '/x',
+        user: { id: 'u', email: 'user@example.com' },
+      }),
+    ) as typeof fetch;
+    const props = renderOnboarding();
+
+    fireEvent.click(await screen.findByRole('button', { name: /^Continue$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'About you' })).toBeTruthy();
+    });
+
+    chooseDropdownOption('Your role', 'Engineer');
+    chooseDropdownOption('Organization size', /Growth company/i);
+    chooseDropdownOption('Use case', /Product design/i);
+    chooseDropdownOption('Where did you hear about us?', /Search/i);
+    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
+
+    expect(props.onCompleteOnboarding).toHaveBeenCalledTimes(1);
+
+    const pageViews = trackedEvents('page_view').map(([, payload]) => payload);
+    expect(pageViews).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          page_name: 'onboarding',
+          area: 'runtime',
+          step_index: '1',
+          step_name: 'connect',
+        }),
+        expect.objectContaining({
+          page_name: 'onboarding',
+          area: 'about_you',
+          step_index: '2',
+          step_name: 'about_you',
+        }),
+      ]),
+    );
+
+    expect(findTrackedEvent('ui_click', (payload) => payload.element === 'about_you_submit')).toMatchObject({
+      page_name: 'onboarding',
+      area: 'about_you',
+      element: 'about_you_submit',
+      action: 'continue',
+      role: 'engineer',
+      organization_size: 'growth',
+      use_cases: ['product'],
+      discovery_source: 'search',
+    });
+
+    expect(latestTrackedEvent('onboarding_complete_result')).toMatchObject({
+      page_name: 'onboarding',
+      area: 'onboarding',
+      result: 'completed',
+      completion_type: 'completed_without_design_system',
+      runtime_type: 'amr_cloud',
+      has_about_you: true,
+      has_design_system_request: false,
+      role: 'engineer',
+      organization_size: 'growth',
+      use_cases: ['product'],
+      discovery_source: 'search',
+    });
+  });
+
+  it('persists the BYOK config before finishing onboarding', async () => {
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' });
+      }
+      if (url.endsWith('/api/provider/models') && init?.method === 'POST') {
+        return jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 10,
+          models: [
+            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+            { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+          ],
+        });
+      }
+      if (url.endsWith('/api/test/connection') && init?.method === 'POST') {
+        return jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 12,
+          model: 'claude-opus-4-8',
+          sample: 'Connected',
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+    const props = renderOnboarding();
+
+    fireEvent.click(screen.getByRole('button', { name: /Bring your own key/i }));
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'test-api-key' } });
+    fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://api.anthropic.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /Fetch models/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Fetched 2 models.')).toBeTruthy();
+    });
+    chooseDropdownOption('Model', /claude-opus-4-8/i);
+    fireEvent.click(screen.getByRole('button', { name: /^Test$/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Connected\. Replied in 12 ms/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'About you' })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
+
+    expect(props.onModeChange).toHaveBeenCalledWith('api');
+    expect(props.onApiModelChange).toHaveBeenCalledWith('claude-opus-4-8');
+    expect(props.onConfigPersist).toHaveBeenCalled();
+    expect(props.onCompleteOnboarding).toHaveBeenCalledTimes(1);
+    expect((props.onConfigPersist as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0]).toMatchObject({
+      mode: 'api',
+      apiProtocol: 'anthropic',
+      apiKey: 'test-api-key',
+      baseUrl: 'https://api.anthropic.com',
+      model: 'claude-opus-4-8',
+      apiProviderBaseUrl: null,
+    });
+  });
+
   it('lets Skip exit onboarding without starting AMR login', async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
       jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' }),
@@ -388,6 +595,20 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     fireEvent.click(screen.getByRole('button', { name: /Skip/i }));
 
     expect(props.onCompleteOnboarding).toHaveBeenCalledTimes(1);
+    expect(props.onConfigPersist).not.toHaveBeenCalled();
     expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith('/api/integrations/vela/login'))).toBe(false);
+    expect(findTrackedEvent('ui_click', (payload) => payload.element === 'skip')).toMatchObject({
+      page_name: 'onboarding',
+      area: 'runtime',
+      element: 'skip',
+      action: 'skip',
+    });
+    expect(latestTrackedEvent('onboarding_complete_result')).toMatchObject({
+      page_name: 'onboarding',
+      area: 'onboarding',
+      result: 'skipped',
+      completion_type: 'skipped',
+      runtime_type: 'amr_cloud',
+    });
   });
 });

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -14,7 +14,41 @@ import {
   uploadProjectFiles,
   writeProjectTextFile,
 } from '../../src/providers/registry';
-import type { ProjectFile } from '../../src/types';
+import type { ChatMessage, ProjectFile } from '../../src/types';
+
+vi.mock('../../src/components/AmrGuidance', () => ({
+  AmrGuidance: ({
+    errorCode,
+    projectId,
+    projectKind,
+    conversationId,
+    assistantMessageId,
+    runId,
+    onActivate,
+  }: {
+    errorCode: string;
+    projectId: string;
+    projectKind: string | null;
+    conversationId: string | null;
+    assistantMessageId: string;
+    runId: string | null;
+    onActivate?: (() => void) | undefined;
+  }) => (
+    <div
+      data-testid="mock-amr-guidance"
+      data-error-code={errorCode}
+      data-project-id={projectId}
+      data-project-kind={projectKind ?? ''}
+      data-conversation-id={conversationId ?? ''}
+      data-assistant-message-id={assistantMessageId}
+      data-run-id={runId ?? ''}
+    >
+      <button type="button" data-testid="mock-amr-guidance-activate" onClick={onActivate}>
+        Switch to AMR
+      </button>
+    </div>
+  ),
+}));
 
 vi.mock('../../src/providers/registry', async () => {
   const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
@@ -82,6 +116,25 @@ function workspaceFile(name: string): ProjectFile {
     mtime: 1700000000,
     kind: name.endsWith('.html') ? 'html' : 'text',
     mime: name.endsWith('.html') ? 'text/html' : 'text/plain',
+  };
+}
+
+function failedAssistantMessage(
+  code: string,
+  agentId: string,
+  detail = 'Recovered upstream failure',
+): ChatMessage {
+  return {
+    id: `msg-${code.toLowerCase()}`,
+    role: 'assistant',
+    content: '',
+    createdAt: 1700000000,
+    startedAt: 1700000000,
+    runId: `run-${code.toLowerCase()}`,
+    runStatus: 'failed',
+    agentId,
+    preTurnFileNames: [],
+    events: [{ kind: 'status', label: 'error', detail, code }],
   };
 }
 
@@ -298,6 +351,52 @@ describe('FileWorkspace upload input', () => {
     });
   });
 
+  it('clears a prior upload failure after a later successful upload', async () => {
+    mockedUploadProjectFiles
+      .mockRejectedValueOnce(new Error('storage offline'))
+      .mockResolvedValueOnce({
+        uploaded: [
+          {
+            path: 'retry.png',
+            name: 'retry.png',
+            kind: 'image',
+            size: 1024,
+          },
+        ],
+        failed: [],
+      });
+
+    const onRefreshFiles = vi.fn();
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[baseFile({ name: 'retry.png', path: 'retry.png' })]}
+        liveArtifacts={[]}
+        onRefreshFiles={onRefreshFiles}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByTestId('design-files-upload-input');
+    fireEvent.change(input, {
+      target: { files: [new File(['failed'], 'failed.png', { type: 'image/png' })] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upload-error-banner').textContent).toContain('storage offline');
+    });
+
+    fireEvent.change(input, {
+      target: { files: [new File(['retry'], 'retry.png', { type: 'image/png' })] },
+    });
+
+    await waitFor(() => expect(onRefreshFiles).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.queryByTestId('upload-error-banner')).toBeNull());
+  });
+
   it('falls back to the browser file list when a dragged entry cannot be read', async () => {
     const fallbackFile = new File(['mock'], 'fallback.png', { type: 'image/png' });
     const onUploadFiles = vi.fn();
@@ -390,6 +489,213 @@ describe('FileWorkspace upload input', () => {
     );
 
     expect(markup).toContain('Show chat');
+  });
+});
+
+describe('FileWorkspace generation failure recovery', () => {
+  it('surfaces authorize-and-retry on the failed preview surface for AMR auth failures', () => {
+    const onAuthorizeAndRetry = vi.fn();
+
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        messages={[failedAssistantMessage('AMR_AUTH_REQUIRED', 'amr', 'AMR auth expired')]}
+        onAuthorizeAndRetry={onAuthorizeAndRetry}
+      />,
+    );
+
+    expect(screen.getByTestId('generation-preview-stage')).toBeTruthy();
+    expect(screen.getByTestId('generation-preview-authorize').textContent).toContain('Authorize');
+    expect(screen.queryByTestId('mock-amr-guidance')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('generation-preview-authorize'));
+
+    expect(onAuthorizeAndRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'msg-amr_auth_required', agentId: 'amr' }),
+    );
+  });
+
+  it('surfaces the AMR promotion card and retry action for non-AMR rate-limited failures', () => {
+    const onRetry = vi.fn();
+    const onAuthorizeAndRetry = vi.fn();
+
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        messages={[failedAssistantMessage('RATE_LIMITED', 'claude', 'Claude quota exhausted')]}
+        onRetry={onRetry}
+        onAuthorizeAndRetry={onAuthorizeAndRetry}
+        conversationId="conv-1"
+      />,
+    );
+
+    expect(screen.getByTestId('generation-preview-stage')).toBeTruthy();
+    expect(screen.getByTestId('generation-preview-retry')).toBeTruthy();
+    const guidance = screen.getByTestId('mock-amr-guidance');
+    expect(guidance.getAttribute('data-error-code')).toBe('RATE_LIMITED');
+    expect(guidance.getAttribute('data-project-id')).toBe('project-1');
+    expect(guidance.getAttribute('data-project-kind')).toBe('prototype');
+    expect(guidance.getAttribute('data-conversation-id')).toBe('conv-1');
+    expect(guidance.getAttribute('data-assistant-message-id')).toBe('msg-rate_limited');
+    expect(guidance.getAttribute('data-run-id')).toBe('run-rate_limited');
+
+    fireEvent.click(screen.getByTestId('generation-preview-retry'));
+    fireEvent.click(screen.getByTestId('mock-amr-guidance-activate'));
+
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'msg-rate_limited', agentId: 'claude' }),
+    );
+    expect(onAuthorizeAndRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'msg-rate_limited', agentId: 'claude' }),
+    );
+  });
+
+  it('suppresses the AMR promotion card for upstream outages while keeping retry available', () => {
+    const onRetry = vi.fn();
+    const onAuthorizeAndRetry = vi.fn();
+
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        messages={[failedAssistantMessage('UPSTREAM_UNAVAILABLE', 'claude', 'Model provider unavailable')]}
+        onRetry={onRetry}
+        onAuthorizeAndRetry={onAuthorizeAndRetry}
+        conversationId="conv-1"
+      />,
+    );
+
+    expect(screen.getByTestId('generation-preview-stage')).toBeTruthy();
+    expect(screen.getByTestId('generation-preview-retry')).toBeTruthy();
+    expect(screen.queryByTestId('mock-amr-guidance')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('generation-preview-retry'));
+
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'msg-upstream_unavailable', agentId: 'claude' }),
+    );
+    expect(onAuthorizeAndRetry).not.toHaveBeenCalled();
+  });
+
+  it('surfaces recharge and retry actions on the failed preview surface for AMR balance errors', () => {
+    const onRetry = vi.fn();
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        messages={[failedAssistantMessage('AMR_INSUFFICIENT_BALANCE', 'amr', 'AMR balance empty')]}
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(screen.getByTestId('generation-preview-stage')).toBeTruthy();
+    expect(screen.getByTestId('generation-preview-recharge').textContent).toContain('Top up AMR');
+    expect(screen.getByTestId('generation-preview-retry')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('generation-preview-recharge'));
+    fireEvent.click(screen.getByTestId('generation-preview-retry'));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://open-design.ai/amr/wallet',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'msg-amr_insufficient_balance', agentId: 'amr' }),
+    );
+  });
+
+  it('wires the terminal auth launcher and retry to the failed assistant for antigravity auth failures', () => {
+    const onRetry = vi.fn();
+    const onLaunchTerminalAuth = vi.fn();
+
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        messages={[failedAssistantMessage('AGENT_AUTH_REQUIRED', 'antigravity', 'Sign in with agy first')]}
+        onRetry={onRetry}
+        onLaunchTerminalAuth={onLaunchTerminalAuth}
+      />,
+    );
+
+    expect(screen.getByTestId('generation-preview-launch-terminal')).toBeTruthy();
+    expect(screen.getByTestId('generation-preview-retry')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('generation-preview-launch-terminal'));
+    fireEvent.click(screen.getByTestId('generation-preview-retry'));
+
+    expect(onLaunchTerminalAuth).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'msg-agent_auth_required', agentId: 'antigravity' }),
+    );
+  });
+
+  it('wires the terminal model-switch launcher and retry to the failed assistant for antigravity rate limits', () => {
+    const onRetry = vi.fn();
+    const onLaunchTerminalAuth = vi.fn();
+
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: [], active: null }}
+        onTabsStateChange={vi.fn()}
+        messages={[failedAssistantMessage('RATE_LIMITED', 'antigravity', 'Switch agy models in the terminal')]}
+        onRetry={onRetry}
+        onLaunchTerminalAuth={onLaunchTerminalAuth}
+      />,
+    );
+
+    expect(screen.getByTestId('generation-preview-launch-terminal')).toBeTruthy();
+    expect(screen.getByTestId('generation-preview-retry')).toBeTruthy();
+    expect(screen.queryByTestId('mock-amr-guidance')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('generation-preview-launch-terminal'));
+    fireEvent.click(screen.getByTestId('generation-preview-retry'));
+
+    expect(onLaunchTerminalAuth).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'msg-rate_limited', agentId: 'antigravity' }),
+    );
   });
 });
 

--- a/apps/web/tests/components/HomeView.context-picker.test.tsx
+++ b/apps/web/tests/components/HomeView.context-picker.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_UNSELECTED_SCENARIO_PLUGIN_ID,
   type InstalledPluginRecord,
+  type ConnectorDetail,
+  type McpServerConfig,
   type SkillSummary,
 } from '@open-design/contracts';
 import { HomeView } from '../../src/components/HomeView';
@@ -35,6 +37,20 @@ const DECK_SKILL: SkillSummary = {
 };
 
 const WEB_PROTOTYPE_PLUGIN = makePlugin('example-web-prototype', 'Web Prototype');
+const MCP_SERVER: McpServerConfig = {
+  id: 'linear',
+  label: 'Linear',
+  transport: 'stdio',
+  enabled: true,
+  command: 'npx',
+};
+const CONNECTOR: ConnectorDetail = {
+  id: 'slack',
+  name: 'Slack',
+  provider: 'Composio',
+  category: 'Communication',
+  status: 'connected',
+};
 
 function makePlugin(id: string, title: string): InstalledPluginRecord {
   return {
@@ -372,5 +388,73 @@ describe('HomeView context picker', () => {
       skillId: null,
       projectKind: 'prototype',
     })));
+  });
+
+  it('submits selected MCP servers and connectors as first-turn context', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      if (typeof url === 'string' && url === '/api/plugins') {
+        return new Response(JSON.stringify({ plugins: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (typeof url === 'string' && url === '/api/mcp/servers') {
+        return new Response(JSON.stringify({ servers: [MCP_SERVER], templates: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+    const onSubmit = vi.fn();
+
+    render(
+      <HomeView
+        projects={[]}
+        connectors={[CONNECTOR]}
+        onSubmit={onSubmit}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />,
+    );
+
+    const input = await screen.findByTestId('home-hero-input');
+    fireEvent.change(input, { target: { value: '@lin' } });
+    fireEvent.mouseDown(screen.getByRole('option', { name: /linear/i }));
+
+    await waitFor(() => {
+      expect((input as HTMLTextAreaElement).value).toBe('@Linear');
+    });
+
+    fireEvent.change(input, { target: { value: '@Linear @sla' } });
+    fireEvent.mouseDown(screen.getByRole('option', { name: /slack/i }));
+
+    await waitFor(() => {
+      expect((input as HTMLTextAreaElement).value).toBe('@Linear @Slack');
+    });
+
+    fireEvent.click(screen.getByTestId('home-hero-submit'));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: '@Linear @Slack',
+      pluginId: DEFAULT_UNSELECTED_SCENARIO_PLUGIN_ID,
+      contextMcpServers: [
+        expect.objectContaining({ id: 'linear', label: 'Linear', transport: 'stdio' }),
+      ],
+      contextConnectors: [
+        expect.objectContaining({
+          id: 'slack',
+          name: 'Slack',
+          provider: 'Composio',
+          category: 'Communication',
+          status: 'connected',
+        }),
+      ],
+    }));
   });
 });

--- a/apps/web/tests/components/HomeView.context-picker.test.tsx
+++ b/apps/web/tests/components/HomeView.context-picker.test.tsx
@@ -50,6 +50,7 @@ const CONNECTOR: ConnectorDetail = {
   provider: 'Composio',
   category: 'Communication',
   status: 'connected',
+  tools: [],
 };
 
 function makePlugin(id: string, title: string): InstalledPluginRecord {

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -256,6 +256,38 @@ describe('HomeView media composer options', () => {
     });
   });
 
+  it('includes selected Home footer options in the submitted payload', async () => {
+    stubFetch();
+    const onSubmit = vi.fn();
+    renderHome({
+      onSubmit,
+      designSystems: [
+        designSystem('editorial-noir', 'Editorial Noir', 'built-in', 'published'),
+        designSystem('brand-alpha', 'Brand Alpha', 'user', 'published'),
+      ],
+    });
+
+    await clickHomeRailChip('video');
+    await waitFor(() => expect(screen.getByTestId('home-hero-footer-option-duration')).toBeTruthy());
+    await chooseOption('designSystem', 'brand-alpha', 'Brand Alpha');
+    await chooseOption('ratio', '1:1', '1:1');
+    await chooseOption('duration', '10', '10s');
+    setHomePrompt('Create a launch teaser.');
+    await submitHome();
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        prompt: 'Create a launch teaser.',
+        designSystemId: 'brand-alpha',
+        projectMetadata: expect.objectContaining({
+          kind: 'video',
+          videoAspect: '1:1',
+          videoLength: 10,
+        }),
+      }));
+    });
+  });
+
   it('submits HyperFrames as a video project with the hyperframes-html model', async () => {
     stubFetch();
     const onSubmit = vi.fn();

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -472,6 +472,31 @@ describe('ProjectView API empty response handling', () => {
     expect(userMessage?.content).toContain('Second line');
   });
 
+  it('includes saved project instructions in the BYOK system prompt for the next run', async () => {
+    let capturedSystemPrompt = '';
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      capturedSystemPrompt = system;
+      handlers.onDelta('ok');
+      handlers.onDone('ok');
+    });
+
+    renderProjectView({
+      ...project,
+      customInstructions: 'Use tabs for indentation and keep CTA copy terse.',
+    });
+
+    await sendTestPrompt();
+
+    await waitFor(() => expect(capturedSystemPrompt).toContain('## Custom instructions (project-level)'));
+    expect(capturedSystemPrompt).toContain('Use tabs for indentation and keep CTA copy terse.');
+  });
+
   it('plays the success sound for API completions that become succeeded after starting without runStatus', async () => {
     mockedStreamMessage.mockImplementation(async (
       _cfg: AppConfig,

--- a/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
+++ b/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
@@ -29,7 +29,11 @@ const saveTabs = vi.fn();
 // no-op renderer (the real component pulls in markdown + chat
 // streaming machinery that isn't relevant to the projects-refresh
 // regression we want to pin).
-const chatPaneProps: { onDeleteConversation?: (id: string) => Promise<void> | void } = {};
+const chatPaneProps: {
+  onDeleteConversation?: (id: string) => Promise<void> | void;
+  activeConversationId?: string | null;
+  conversations?: Array<{ id: string; title?: string | null }>;
+} = {};
 
 vi.mock('../../src/i18n', () => ({
   useI18n: () => ({
@@ -90,8 +94,14 @@ vi.mock('../../src/components/AvatarMenu', () => ({
 }));
 
 vi.mock('../../src/components/ChatPane', () => ({
-  ChatPane: (props: { onDeleteConversation?: (id: string) => Promise<void> | void }) => {
+  ChatPane: (props: {
+    onDeleteConversation?: (id: string) => Promise<void> | void;
+    activeConversationId?: string | null;
+    conversations?: Array<{ id: string; title?: string | null }>;
+  }) => {
     chatPaneProps.onDeleteConversation = props.onDeleteConversation;
+    chatPaneProps.activeConversationId = props.activeConversationId;
+    chatPaneProps.conversations = props.conversations;
     return null;
   },
 }));
@@ -138,6 +148,8 @@ describe('ProjectView conversation delete', () => {
     cleanup();
     vi.clearAllMocks();
     chatPaneProps.onDeleteConversation = undefined;
+    chatPaneProps.activeConversationId = undefined;
+    chatPaneProps.conversations = undefined;
   });
 
   // Issue #1202: the home `Needs input` badge is rendered from the
@@ -214,5 +226,66 @@ describe('ProjectView conversation delete', () => {
 
     expect(deleteConversation).toHaveBeenCalledWith('project-1', 'conv-1');
     expect(onProjectsRefresh).not.toHaveBeenCalled();
+  });
+
+  it('switches the active conversation to the next available history item after deleting the current one', async () => {
+    listConversations.mockResolvedValue([
+      { id: 'conv-1', title: 'Conversation 1' },
+      { id: 'conv-2', title: 'Conversation 2' },
+    ]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    reattachDaemonRun.mockResolvedValue(undefined);
+    deleteConversation.mockResolvedValue(true);
+
+    renderProjectView(vi.fn());
+
+    await waitFor(() => expect(chatPaneProps.onDeleteConversation).toBeDefined());
+    await waitFor(() => expect(chatPaneProps.activeConversationId).toBe('conv-1'));
+
+    await act(async () => {
+      await chatPaneProps.onDeleteConversation!('conv-1');
+    });
+
+    await waitFor(() => expect(chatPaneProps.activeConversationId).toBe('conv-2'));
+    expect(chatPaneProps.conversations?.map((conversation) => conversation.id)).toEqual(['conv-2']);
+  });
+
+  it('re-seeds a fresh conversation when deleting the last remaining history item', async () => {
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation 1' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    reattachDaemonRun.mockResolvedValue(undefined);
+    deleteConversation.mockResolvedValue(true);
+    createConversation.mockResolvedValue({ id: 'conv-fresh', title: 'Fresh conversation' });
+
+    renderProjectView(vi.fn());
+
+    await waitFor(() => expect(chatPaneProps.onDeleteConversation).toBeDefined());
+    await waitFor(() => expect(chatPaneProps.activeConversationId).toBe('conv-1'));
+
+    await act(async () => {
+      await chatPaneProps.onDeleteConversation!('conv-1');
+    });
+
+    await waitFor(() => expect(createConversation).toHaveBeenCalledWith('project-1'));
+    await waitFor(() => expect(chatPaneProps.activeConversationId).toBe('conv-fresh'));
+    expect(chatPaneProps.conversations?.map((conversation) => conversation.id)).toEqual(['conv-fresh']);
   });
 });

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -27,6 +27,8 @@ const fetchChatRunStatus = vi.fn();
 const listActiveChatRuns = vi.fn();
 const listProjectRuns = vi.fn();
 const reattachDaemonRun = vi.fn();
+const fetchVelaLoginStatus = vi.fn();
+const launchAntigravityOauth = vi.fn();
 const streamViaDaemon = vi.fn();
 const streamMessage = vi.fn();
 const saveMessage = vi.fn();
@@ -52,6 +54,8 @@ vi.mock('../../src/providers/anthropic', () => ({
 
 vi.mock('../../src/providers/daemon', () => ({
   fetchChatRunStatus: (...args: unknown[]) => fetchChatRunStatus(...args),
+  fetchVelaLoginStatus: (...args: unknown[]) => fetchVelaLoginStatus(...args),
+  launchAntigravityOauth: (...args: unknown[]) => launchAntigravityOauth(...args),
   listActiveChatRuns: (...args: unknown[]) => listActiveChatRuns(...args),
   listProjectRuns: (...args: unknown[]) => listProjectRuns(...args),
   reattachDaemonRun: (...args: unknown[]) => reattachDaemonRun(...args),
@@ -108,16 +112,52 @@ vi.mock('../../src/components/AvatarMenu', () => ({
 vi.mock('../../src/components/FileWorkspace', () => ({
   FileWorkspace: ({
     streaming,
+    messages,
+    onRetry,
+    onAuthorizeAndRetry,
+    onLaunchTerminalAuth,
     onSendBoardCommentAttachments,
     onCommentModeChange,
     onFocusModeChange,
   }: {
     streaming: boolean;
+    messages?: ChatMessage[];
+    onRetry?: (message: ChatMessage) => void;
+    onAuthorizeAndRetry?: (message: ChatMessage) => void;
+    onLaunchTerminalAuth?: () => void;
     onSendBoardCommentAttachments: (attachments: unknown[]) => void;
     onCommentModeChange?: (active: boolean) => void;
     onFocusModeChange?: (focused: boolean) => void;
-  }) => (
-    <>
+  }) => {
+    const failedAssistant =
+      [...(messages ?? [])]
+        .reverse()
+        .find((message) => message.role === 'assistant' && message.runStatus === 'failed') ?? null;
+    const errorCode = failedAssistant?.events
+      ?.filter((event) => event.kind === 'status' && event.label === 'error')
+      .map((event) => (event as { code?: string }).code ?? null)
+      .filter(Boolean)
+      .at(-1) ?? null;
+    const showAuthorizeAction = failedAssistant?.agentId === 'amr' && errorCode === 'AMR_AUTH_REQUIRED';
+    const showLaunchTerminalAction =
+      failedAssistant?.agentId === 'antigravity'
+      && (errorCode === 'AGENT_AUTH_REQUIRED' || errorCode === 'RATE_LIMITED');
+    const showSwitchToAmrPromotion =
+      failedAssistant?.agentId !== 'amr'
+      && failedAssistant?.agentId !== 'antigravity'
+      && (errorCode === 'AGENT_AUTH_REQUIRED' || errorCode === 'UNAUTHORIZED' || errorCode === 'RATE_LIMITED');
+    const showRetryAction = Boolean(
+      failedAssistant && onRetry && (
+        errorCode == null
+        || errorCode === 'AMR_INSUFFICIENT_BALANCE'
+        || errorCode === 'UPSTREAM_UNAVAILABLE'
+        || showLaunchTerminalAction
+        || showSwitchToAmrPromotion
+        || (!showAuthorizeAction && !showLaunchTerminalAction)
+      ),
+    );
+    return (
+      <>
       <output data-testid="workspace-streaming-state">{streaming ? 'streaming' : 'idle'}</output>
       <button
         type="button"
@@ -140,8 +180,45 @@ vi.mock('../../src/components/FileWorkspace', () => ({
       >
         workspace send
       </button>
+      {showRetryAction ? (
+        <button
+          type="button"
+          data-testid="workspace-retry"
+          onClick={() => onRetry(failedAssistant)}
+        >
+          retry
+        </button>
+      ) : null}
+      {showAuthorizeAction && onAuthorizeAndRetry ? (
+        <button
+          type="button"
+          data-testid="workspace-authorize"
+          onClick={() => onAuthorizeAndRetry(failedAssistant)}
+        >
+          authorize
+        </button>
+      ) : null}
+      {showSwitchToAmrPromotion && onAuthorizeAndRetry ? (
+        <button
+          type="button"
+          data-testid="workspace-switch-amr"
+          onClick={() => onAuthorizeAndRetry(failedAssistant)}
+        >
+          switch to amr
+        </button>
+      ) : null}
+      {showLaunchTerminalAction && onLaunchTerminalAuth ? (
+        <button
+          type="button"
+          data-testid="workspace-launch-terminal"
+          onClick={() => onLaunchTerminalAuth()}
+        >
+          launch terminal
+        </button>
+      ) : null}
     </>
-  ),
+    );
+  },
 }));
 
 vi.mock('../../src/components/Loading', () => ({
@@ -176,7 +253,12 @@ vi.mock('../../src/components/ChatPane', () => ({
     error: string | null;
     onAttachComment?: (comment: PreviewComment) => void;
     onSelectConversation: (id: string) => void;
-    onSend: (prompt: string, attachments: unknown[], commentAttachments: unknown[]) => void;
+    onSend: (
+      prompt: string,
+      attachments: unknown[],
+      commentAttachments: unknown[],
+      meta?: unknown,
+    ) => void;
     onSendQueuedNow?: (id: string) => void;
     onNewConversation: () => void;
   }) => {
@@ -295,6 +377,28 @@ vi.mock('../../src/components/ChatPane', () => ({
           disabled={sendDisabled}
         >
           send alt
+        </button>
+        <button
+          type="button"
+          data-testid="send-message-with-context"
+          onClick={() =>
+            onSend(
+              'hello with staged context',
+              [],
+              [],
+              {
+                skillIds: ['deck-builder'],
+                context: {
+                  skillIds: ['deck-builder'],
+                  mcpServerIds: ['slack'],
+                  connectorIds: ['github'],
+                },
+              },
+            )
+          }
+          disabled={sendDisabled}
+        >
+          send with context
         </button>
         <button type="button" data-testid="new-conversation" onClick={onNewConversation}>
           new
@@ -422,6 +526,8 @@ describe('ProjectView conversation run isolation', () => {
       signal: null,
     });
     reattachDaemonRun.mockImplementation(async () => new Promise<void>(() => {}));
+    fetchVelaLoginStatus.mockResolvedValue({ loggedIn: false });
+    launchAntigravityOauth.mockResolvedValue({ ok: true });
     streamViaDaemon.mockImplementation(async () => {});
   });
 
@@ -771,6 +877,34 @@ describe('ProjectView conversation run isolation', () => {
     );
   });
 
+  it('forwards staged skill and external context selections into the next daemon run payload', async () => {
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    fireEvent.click(screen.getByTestId('conversation-select-conv-b'));
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-b'));
+    act(() => {
+      resolveConversationBMessages?.([]);
+    });
+    await waitFor(() => expect(screen.getByTestId('send-message-with-context')).toHaveProperty('disabled', false));
+
+    fireEvent.click(screen.getByTestId('send-message-with-context'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    expect(streamViaDaemon).toHaveBeenCalledWith(expect.objectContaining({
+      skillId: null,
+      skillIds: ['deck-builder'],
+      context: {
+        skillIds: ['deck-builder'],
+        mcpServerIds: ['slack'],
+        connectorIds: ['github'],
+      },
+      history: expect.arrayContaining([
+        expect.objectContaining({ role: 'user', content: 'hello with staged context' }),
+      ]),
+    }));
+  });
+
   it('notifies when an API-mode chat completes without a daemon run status transition', async () => {
     listMessages.mockResolvedValue([]);
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
@@ -839,7 +973,7 @@ describe('ProjectView conversation run isolation', () => {
     await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
   });
 
-  it('renders recharge guidance for structured AMR insufficient-balance errors', async () => {
+  it('keeps retry available after a structured AMR insufficient-balance error', async () => {
     conversationAMessages = [];
     fetchChatRunStatus.mockResolvedValue(null);
     streamViaDaemon.mockImplementation(
@@ -847,6 +981,7 @@ describe('ProjectView conversation run isolation', () => {
         onRunCreated?: (runId: string) => void;
         handlers: { onError: (error: Error) => void };
       }) => {
+        if (streamViaDaemon.mock.calls.length > 1) return;
         options.onRunCreated?.('run-amr-balance');
         const error = new Error(
           'AMR Cloud reported insufficient balance for this model. Recharge your AMR wallet at https://open-design.ai/amr/wallet, then retry this run.',
@@ -869,20 +1004,20 @@ describe('ProjectView conversation run isolation', () => {
     fireEvent.click(screen.getByTestId('send-message'));
 
     await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
-    await waitFor(() =>
-      expect(screen.getByTestId('chat-error').textContent).toContain('insufficient balance'),
-    );
-    // The structured code rides on the error event; ChatPane keys the recharge
-    // affordance off it.
-    expect(screen.getByTestId('assistant-events').textContent).toContain(
-      'AMR_INSUFFICIENT_BALANCE',
-    );
+    await waitFor(() => expect(screen.getByTestId('workspace-retry')).toBeTruthy());
     expect(screen.getByTestId('streaming-state').textContent).toBe('idle');
+
+    fireEvent.click(screen.getByTestId('workspace-retry'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
   });
 
-  it('renders re-login guidance for structured AMR auth-required errors', async () => {
+  it('routes workspace authorize recovery through AMR mode switching for structured auth failures', async () => {
     conversationAMessages = [];
     fetchChatRunStatus.mockResolvedValue(null);
+    const onModeChange = vi.fn();
+    const onAgentChange = vi.fn();
+    const onOpenAmrSettings = vi.fn();
     streamViaDaemon.mockImplementation(
       async (options: {
         onRunCreated?: (runId: string) => void;
@@ -901,7 +1036,23 @@ describe('ProjectView conversation run isolation', () => {
       },
     );
 
-    renderProjectView();
+    renderProjectView(
+      {
+        ...config,
+        agentId: 'amr',
+      },
+      project,
+      [
+        {
+          id: 'amr',
+          name: 'AMR',
+          bin: 'amr',
+          available: true,
+          models: [{ id: 'glm-5', label: 'GLM 5' }],
+        },
+      ],
+      { onModeChange, onAgentChange, onOpenAmrSettings },
+    );
 
     await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
     await waitFor(() => expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false));
@@ -909,17 +1060,218 @@ describe('ProjectView conversation run isolation', () => {
     fireEvent.click(screen.getByTestId('send-message'));
 
     await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
-    await waitFor(() =>
-      expect(screen.getByTestId('chat-error').textContent).toContain(
-        'AMR sign-in is required',
-      ),
-    );
-    // The structured code rides on the error event; ChatPane keys the
-    // authorize-and-retry affordance off it.
-    expect(screen.getByTestId('assistant-events').textContent).toContain(
-      'AMR_AUTH_REQUIRED',
-    );
+    await waitFor(() => expect(screen.getByTestId('workspace-authorize')).toBeTruthy());
+
+    fireEvent.click(screen.getByTestId('workspace-authorize'));
+
+    expect(onModeChange).toHaveBeenCalledWith('daemon');
+    expect(onAgentChange).toHaveBeenCalledWith('amr');
+    expect(onOpenAmrSettings).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('streaming-state').textContent).toBe('idle');
+  });
+
+  it('auto-retries after AMR authorization succeeds', async () => {
+    conversationAMessages = [];
+    fetchChatRunStatus.mockResolvedValue(null);
+    fetchVelaLoginStatus.mockResolvedValue({ loggedIn: true });
+    streamViaDaemon.mockImplementation(
+      async (options: {
+        onRunCreated?: (runId: string) => void;
+        handlers: { onError: (error: Error) => void };
+      }) => {
+        if (streamViaDaemon.mock.calls.length > 1) return;
+        options.onRunCreated?.('run-amr-auth');
+        const error = new Error(
+          'AMR sign-in is required. Sign in to AMR Cloud again, then retry this run.',
+        ) as Error & { code: string; details: unknown };
+        error.code = 'AMR_AUTH_REQUIRED';
+        error.details = {
+          kind: 'amr_account',
+          action: 'relogin',
+        };
+        options.handlers.onError(error);
+      },
+    );
+
+    renderProjectView(
+      {
+        ...config,
+        agentId: 'amr',
+      },
+      project,
+      [
+        {
+          id: 'amr',
+          name: 'AMR',
+          bin: 'amr',
+          available: true,
+          models: [{ id: 'glm-5', label: 'GLM 5' }],
+        },
+      ],
+      { onOpenAmrSettings: vi.fn() },
+    );
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false));
+
+    fireEvent.click(screen.getByTestId('send-message'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByTestId('workspace-authorize')).toBeTruthy());
+
+    fireEvent.click(screen.getByTestId('workspace-authorize'));
+
+    await waitFor(() => expect(fetchVelaLoginStatus).toHaveBeenCalled());
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
+  });
+
+  it('routes workspace retry and terminal launch recovery for antigravity auth failures', async () => {
+    conversationAMessages = [];
+    fetchChatRunStatus.mockResolvedValue(null);
+    streamViaDaemon.mockImplementation(
+      async (options: {
+        onRunCreated?: (runId: string) => void;
+        handlers: { onError: (error: Error) => void };
+      }) => {
+        if (streamViaDaemon.mock.calls.length > 1) return;
+        options.onRunCreated?.('run-antigravity-auth');
+        const error = new Error('Sign in to Antigravity before retrying this run.') as Error & {
+          code: string;
+        };
+        error.code = 'AGENT_AUTH_REQUIRED';
+        options.handlers.onError(error);
+      },
+    );
+
+    renderProjectView(
+      {
+        ...config,
+        agentId: 'antigravity',
+      },
+      project,
+      [
+        {
+          id: 'antigravity',
+          name: 'Antigravity',
+          bin: 'agy',
+          available: true,
+          models: [{ id: 'claude-4.6', label: 'Claude 4.6' }],
+        },
+      ],
+    );
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false));
+
+    fireEvent.click(screen.getByTestId('send-message'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByTestId('workspace-launch-terminal')).toBeTruthy());
+    await waitFor(() => expect(screen.getByTestId('workspace-retry')).toBeTruthy());
+
+    fireEvent.click(screen.getByTestId('workspace-launch-terminal'));
+    await waitFor(() => expect(launchAntigravityOauth).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId('workspace-retry'));
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
+  });
+
+  it('routes workspace retry and terminal launch recovery for antigravity rate limits', async () => {
+    conversationAMessages = [];
+    fetchChatRunStatus.mockResolvedValue(null);
+    streamViaDaemon.mockImplementation(
+      async (options: {
+        onRunCreated?: (runId: string) => void;
+        handlers: { onError: (error: Error) => void };
+      }) => {
+        if (streamViaDaemon.mock.calls.length > 1) return;
+        options.onRunCreated?.('run-antigravity-rate-limit');
+        const error = new Error('Switch to another Antigravity model before retrying this run.') as Error & {
+          code: string;
+        };
+        error.code = 'RATE_LIMITED';
+        options.handlers.onError(error);
+      },
+    );
+
+    renderProjectView(
+      {
+        ...config,
+        agentId: 'antigravity',
+      },
+      project,
+      [
+        {
+          id: 'antigravity',
+          name: 'Antigravity',
+          bin: 'agy',
+          available: true,
+          models: [{ id: 'claude-4.6', label: 'Claude 4.6' }],
+        },
+      ],
+    );
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false));
+
+    fireEvent.click(screen.getByTestId('send-message'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByTestId('workspace-launch-terminal')).toBeTruthy());
+    await waitFor(() => expect(screen.getByTestId('workspace-retry')).toBeTruthy());
+
+    fireEvent.click(screen.getByTestId('workspace-launch-terminal'));
+    await waitFor(() => expect(launchAntigravityOauth).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId('workspace-retry'));
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not promote switching to AMR for upstream outages', async () => {
+    conversationAMessages = [];
+    fetchChatRunStatus.mockResolvedValue(null);
+    streamViaDaemon.mockImplementation(
+      async (options: {
+        onRunCreated?: (runId: string) => void;
+        handlers: { onError: (error: Error) => void };
+      }) => {
+        if (streamViaDaemon.mock.calls.length > 1) return;
+        options.onRunCreated?.('run-upstream-unavailable');
+        const error = new Error('The model provider is temporarily unavailable.') as Error & {
+          code: string;
+        };
+        error.code = 'UPSTREAM_UNAVAILABLE';
+        options.handlers.onError(error);
+      },
+    );
+
+    renderProjectView(
+      {
+        ...config,
+        agentId: 'claude',
+      },
+      project,
+      [
+        {
+          id: 'claude',
+          name: 'Claude',
+          bin: 'claude',
+          available: true,
+          models: [{ id: 'claude-sonnet-4', label: 'Claude Sonnet 4' }],
+        },
+      ],
+    );
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false));
+
+    fireEvent.click(screen.getByTestId('send-message'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByTestId('workspace-retry')).toBeTruthy());
+    expect(screen.queryByTestId('workspace-switch-amr')).toBeNull();
+    expect(screen.queryByTestId('workspace-authorize')).toBeNull();
+    expect(screen.queryByTestId('workspace-launch-terminal')).toBeNull();
   });
 });
 
@@ -929,6 +1281,11 @@ function renderProjectView(
   renderAgents: AgentInfo[] = [
     { id: 'agent-1', name: 'OpenCode', bin: 'opencode', available: true, models: [] },
   ],
+  handlers: {
+    onModeChange?: (mode: 'daemon' | 'api') => void;
+    onAgentChange?: (agentId: string) => void;
+    onOpenAmrSettings?: () => void;
+  } = {},
 ) {
   return render(
     <ProjectView
@@ -940,11 +1297,12 @@ function renderProjectView(
       designTemplates={[]}
       designSystems={[]}
       daemonLive
-      onModeChange={() => {}}
-      onAgentChange={() => {}}
+      onModeChange={handlers.onModeChange ?? (() => {})}
+      onAgentChange={handlers.onAgentChange ?? (() => {})}
       onAgentModelChange={() => {}}
       onRefreshAgents={() => {}}
       onOpenSettings={() => {}}
+      onOpenAmrSettings={handlers.onOpenAmrSettings}
       onBack={() => {}}
       onClearPendingPrompt={() => {}}
       onTouchProject={() => {}}

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -184,7 +184,9 @@ vi.mock('../../src/components/FileWorkspace', () => ({
         <button
           type="button"
           data-testid="workspace-retry"
-          onClick={() => onRetry(failedAssistant)}
+          onClick={() => {
+            if (failedAssistant && onRetry) onRetry(failedAssistant);
+          }}
         >
           retry
         </button>
@@ -193,7 +195,9 @@ vi.mock('../../src/components/FileWorkspace', () => ({
         <button
           type="button"
           data-testid="workspace-authorize"
-          onClick={() => onAuthorizeAndRetry(failedAssistant)}
+          onClick={() => {
+            if (failedAssistant) onAuthorizeAndRetry(failedAssistant);
+          }}
         >
           authorize
         </button>
@@ -202,7 +206,9 @@ vi.mock('../../src/components/FileWorkspace', () => ({
         <button
           type="button"
           data-testid="workspace-switch-amr"
-          onClick={() => onAuthorizeAndRetry(failedAssistant)}
+          onClick={() => {
+            if (failedAssistant) onAuthorizeAndRetry(failedAssistant);
+          }}
         >
           switch to amr
         </button>

--- a/e2e/lib/antigravity.ts
+++ b/e2e/lib/antigravity.ts
@@ -1,0 +1,61 @@
+import { chmod, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export type FakeAgyOptions = {
+  mode?: 'auth-required' | 'rate-limited';
+};
+
+export async function writeFakeAgyBin(
+  root: string,
+  options: FakeAgyOptions = {},
+): Promise<string> {
+  await mkdir(root, { recursive: true });
+  const bin = join(root, 'agy');
+  await writeFile(bin, renderFakeAgyScript(options), 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+function renderFakeAgyScript(options: FakeAgyOptions): string {
+  const mode = options.mode ?? 'auth-required';
+  return `#!/usr/bin/env node
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import process from 'node:process';
+
+const mode = ${JSON.stringify(mode)};
+const args = process.argv.slice(2);
+
+function readFlag(name) {
+  const idx = args.indexOf(name);
+  if (idx === -1) return null;
+  return args[idx + 1] ?? null;
+}
+
+function appendLog(file, lines) {
+  if (!file) return;
+  mkdirSync(dirname(file), { recursive: true });
+  appendFileSync(file, lines.join('\\n') + '\\n', 'utf8');
+}
+
+if (args.includes('--version')) {
+  process.stdout.write('1.107.0-e2e\\n');
+  process.exit(0);
+}
+
+const logFile = readFlag('--log-file');
+
+if (mode === 'auth-required') {
+  process.stdout.write('Authentication required. Please visit the URL to log in: https://accounts.google.com/o/oauth2/auth?client_id=fake-client&redirect_uri=antigravity-redirect\\n');
+  process.stdout.write('Waiting for authentication (timeout 30s)...\\n');
+  process.stdout.write('Error: authentication timed out.\\n');
+  process.exit(0);
+}
+
+appendLog(logFile, [
+  'INFO booting agy print mode',
+  'ERROR upstream returned RESOURCE_EXHAUSTED (code 429): Individual quota reached. Contact your administrator to enable overages.',
+]);
+process.exit(0);
+`;
+}

--- a/e2e/lib/fake-agents.ts
+++ b/e2e/lib/fake-agents.ts
@@ -141,6 +141,14 @@ async function emitRun(promptText) {
     emitFailure();
     return;
   }
+  if (promptText.includes('Return a daemon 429 service failure')) {
+    emitServiceFailure(429);
+    return;
+  }
+  if (promptText.includes('Return a daemon 503 service failure')) {
+    emitServiceFailure(503);
+    return;
+  }
   if (promptText.includes('Return an empty daemon smoke response')) {
     emitEmptySuccess();
     return;
@@ -377,6 +385,31 @@ function emitFailure() {
       return;
     default:
       process.stderr.write('intentional fake ' + agentId + ' failure\\n');
+      process.exitCode = 1;
+      exitSoon(1);
+  }
+}
+
+function emitServiceFailure(statusCode) {
+  const message =
+    statusCode === 429
+      ? 'HTTP 429 Too Many Requests: rate limit exceeded for the current provider.'
+      : 'HTTP 503 Service Unavailable: upstream model provider is temporarily unavailable.';
+  switch (agentId) {
+    case 'codex':
+      writeJson({ type: 'thread.started' });
+      writeJson({ type: 'turn.started' });
+      writeJson({ type: 'turn.failed', error: { message } });
+      process.exitCode = 0;
+      exitSoon(0);
+      return;
+    case 'opencode':
+      writeJson({ type: 'error', error: { data: { message } } });
+      process.exitCode = 0;
+      exitSoon(0);
+      return;
+    default:
+      process.stderr.write(message + '\\n');
       process.exitCode = 1;
       exitSoon(1);
   }

--- a/e2e/lib/vitest/antigravity.ts
+++ b/e2e/lib/vitest/antigravity.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from 'node:crypto';
+
+import { requestJson } from './http.ts';
+
+export async function putAntigravityAppConfig(
+  webUrl: string,
+  config: {
+    agentCliEnv?: Record<string, Record<string, string>>;
+    agentModels?: Record<string, { model: string; reasoning: string }>;
+    onboardingCompleted?: boolean;
+  } = {},
+) {
+  await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
+    body: {
+      agentCliEnv: config.agentCliEnv ?? {},
+      agentId: 'antigravity',
+      agentModels: config.agentModels ?? {
+        antigravity: { model: 'default', reasoning: 'default' },
+      },
+      designSystemId: null,
+      onboardingCompleted: config.onboardingCompleted ?? true,
+      skillId: null,
+      telemetry: { artifactManifest: true, content: false, metrics: false },
+    },
+    method: 'PUT',
+  });
+}
+
+export async function createAntigravityProject(webUrl: string, name: string) {
+  return await requestJson<{
+    conversationId: string;
+    project: { id: string; metadata?: { kind?: string }; name: string };
+  }>(webUrl, '/api/projects', {
+    body: {
+      designSystemId: null,
+      id: randomUUID(),
+      metadata: { kind: 'prototype' },
+      name,
+      pendingPrompt: null,
+      skillId: null,
+    },
+    method: 'POST',
+  });
+}

--- a/e2e/tests/antigravity/error-convergence.test.ts
+++ b/e2e/tests/antigravity/error-convergence.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+
+import { dirname, join } from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { writeFakeAgyBin } from '@/antigravity';
+import { createAntigravityProject, putAntigravityAppConfig } from '@/vitest/antigravity';
+import { listMessages } from '@/vitest/messages';
+import { readRunEvents, startRun, waitForRunTerminal } from '@/vitest/runs';
+import { createSmokeSuite } from '@/vitest/smoke-suite';
+
+describe('Antigravity error convergence', () => {
+  test('marks the run and assistant message as failed with AGENT_AUTH_REQUIRED when agy print mode hits OAuth auth flow', { timeout: 180_000 }, async () => {
+    const suite = await createSmokeSuite('antigravity-auth-error-convergence');
+    const fakeAgy = await writeFakeAgyBin(
+      join(suite.scratchDir, 'fake-antigravity-auth'),
+      { mode: 'auth-required' },
+    );
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${dirname(fakeAgy)}:${previousPath ?? ''}`;
+
+    try {
+      await suite.with.toolsDev(async ({ webUrl }) => {
+        await putAntigravityAppConfig(webUrl);
+
+        const project = await createAntigravityProject(webUrl, 'Antigravity auth error convergence');
+        const assistantMessageId = `assistant-${Date.now()}`;
+        const run = await startRun(webUrl, {
+          agentId: 'antigravity',
+          assistantMessageId,
+          clientRequestId: `req-${Date.now()}`,
+          conversationId: project.conversationId,
+          designSystemId: null,
+          message: 'Trigger an Antigravity OAuth auth failure.',
+          model: 'default',
+          projectId: project.project.id,
+          reasoning: 'default',
+          skillId: null,
+        });
+
+        const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
+        expect(terminal.status).toBe('failed');
+
+        const events = await readRunEvents(webUrl, run.runId);
+        expect(events).toContain('AGENT_AUTH_REQUIRED');
+        expect(events).toContain('open a terminal and run `agy` once');
+
+        const messages = await listMessages(webUrl, project.project.id, project.conversationId);
+        const assistant = messages.find((message) => message.id === assistantMessageId);
+        expect(assistant?.runStatus).toBe('failed');
+      });
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+    }
+  });
+
+  test('marks the run and assistant message as failed with RATE_LIMITED when agy log file records quota exhaustion', { timeout: 180_000 }, async () => {
+    const suite = await createSmokeSuite('antigravity-rate-limited-convergence');
+    const fakeAgy = await writeFakeAgyBin(
+      join(suite.scratchDir, 'fake-antigravity-rate-limited'),
+      { mode: 'rate-limited' },
+    );
+    const previousPath = process.env.PATH;
+    process.env.PATH = `${dirname(fakeAgy)}:${previousPath ?? ''}`;
+
+    try {
+      await suite.with.toolsDev(async ({ webUrl }) => {
+        await putAntigravityAppConfig(webUrl);
+
+        const project = await createAntigravityProject(webUrl, 'Antigravity rate-limited convergence');
+        const assistantMessageId = `assistant-${Date.now()}`;
+        const run = await startRun(webUrl, {
+          agentId: 'antigravity',
+          assistantMessageId,
+          clientRequestId: `req-${Date.now()}`,
+          conversationId: project.conversationId,
+          designSystemId: null,
+          message: 'Trigger an Antigravity quota exhaustion.',
+          model: 'default',
+          projectId: project.project.id,
+          reasoning: 'default',
+          skillId: null,
+        });
+
+        const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
+        expect(terminal.status).toBe('failed');
+
+        const events = await readRunEvents(webUrl, run.runId);
+        expect(events).toContain('RATE_LIMITED');
+        expect(events).toContain('Switch Model picker');
+
+        const messages = await listMessages(webUrl, project.project.id, project.conversationId);
+        const assistant = messages.find((message) => message.id === assistantMessageId);
+        expect(assistant?.runStatus).toBe('failed');
+      });
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+    }
+  });
+});

--- a/e2e/tests/dialog/service-error-convergence.test.ts
+++ b/e2e/tests/dialog/service-error-convergence.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { createFakeAgentRuntimes } from '@/fake-agents';
+import { requestJson } from '@/vitest/http';
+import { listMessages } from '@/vitest/messages';
+import { readRunEvents, startRun, waitForRunTerminal } from '@/vitest/runs';
+import { createSmokeSuite } from '@/vitest/smoke-suite';
+
+type ProjectResponse = {
+  conversationId: string;
+  project: { id: string; metadata?: { kind?: string }; name: string };
+};
+
+describe('dialog service error convergence', () => {
+  test('marks a normal agent 429 provider failure as RATE_LIMITED', { timeout: 180_000 }, async () => {
+    const suite = await createSmokeSuite('dialog-rate-limited-convergence');
+
+    await suite.with.toolsDev(async ({ webUrl }) => {
+      const fakeAgents = await createFakeAgentRuntimes({
+        root: join(suite.scratchDir, 'fake-agents-429'),
+        runtimeIds: ['codex'],
+      });
+
+      await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
+        body: {
+          agentCliEnv: { codex: fakeAgents.codex.env },
+          agentId: 'codex',
+          agentModels: { codex: { model: 'default', reasoning: 'default' } },
+          designSystemId: null,
+          onboardingCompleted: true,
+          skillId: null,
+          telemetry: { artifactManifest: true, content: false, metrics: false },
+        },
+        method: 'PUT',
+      });
+
+      const project = await requestJson<ProjectResponse>(webUrl, '/api/projects', {
+        body: {
+          designSystemId: null,
+          id: randomUUID(),
+          metadata: { kind: 'prototype' },
+          name: 'Dialog 429 convergence project',
+          pendingPrompt: null,
+          skillId: null,
+        },
+      });
+
+      const assistantMessageId = `assistant-429-${Date.now()}`;
+      const run = await startRun(webUrl, {
+        agentId: 'codex',
+        assistantMessageId,
+        clientRequestId: `req-429-${Date.now()}`,
+        conversationId: project.conversationId,
+        designSystemId: null,
+        message: 'Return a daemon 429 service failure',
+        model: 'default',
+        projectId: project.project.id,
+        reasoning: 'default',
+        skillId: null,
+      });
+
+      const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
+      expect(terminal.status).toBe('failed');
+
+      const events = await readRunEvents(webUrl, run.runId);
+      expect(events).toContain('RATE_LIMITED');
+      expect(events).toContain('429');
+
+      const messages = await listMessages(webUrl, project.project.id, project.conversationId);
+      const assistant = messages.find((message) => message.id === assistantMessageId);
+      expect(assistant?.runStatus).toBe('failed');
+    });
+  });
+
+  test('marks a normal agent 503 provider failure as UPSTREAM_UNAVAILABLE', { timeout: 180_000 }, async () => {
+    const suite = await createSmokeSuite('dialog-upstream-unavailable-convergence');
+
+    await suite.with.toolsDev(async ({ webUrl }) => {
+      const fakeAgents = await createFakeAgentRuntimes({
+        root: join(suite.scratchDir, 'fake-agents-503'),
+        runtimeIds: ['codex'],
+      });
+
+      await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
+        body: {
+          agentCliEnv: { codex: fakeAgents.codex.env },
+          agentId: 'codex',
+          agentModels: { codex: { model: 'default', reasoning: 'default' } },
+          designSystemId: null,
+          onboardingCompleted: true,
+          skillId: null,
+          telemetry: { artifactManifest: true, content: false, metrics: false },
+        },
+        method: 'PUT',
+      });
+
+      const project = await requestJson<ProjectResponse>(webUrl, '/api/projects', {
+        body: {
+          designSystemId: null,
+          id: randomUUID(),
+          metadata: { kind: 'prototype' },
+          name: 'Dialog 503 convergence project',
+          pendingPrompt: null,
+          skillId: null,
+        },
+      });
+
+      const assistantMessageId = `assistant-503-${Date.now()}`;
+      const run = await startRun(webUrl, {
+        agentId: 'codex',
+        assistantMessageId,
+        clientRequestId: `req-503-${Date.now()}`,
+        conversationId: project.conversationId,
+        designSystemId: null,
+        message: 'Return a daemon 503 service failure',
+        model: 'default',
+        projectId: project.project.id,
+        reasoning: 'default',
+        skillId: null,
+      });
+
+      const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
+      expect(terminal.status).toBe('failed');
+
+      const events = await readRunEvents(webUrl, run.runId);
+      expect(events).toContain('UPSTREAM_UNAVAILABLE');
+      expect(events).toContain('503');
+
+      const messages = await listMessages(webUrl, project.project.id, project.conversationId);
+      const assistant = messages.find((message) => message.id === assistantMessageId);
+      expect(assistant?.runStatus).toBe('failed');
+    });
+  });
+});

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -18,25 +18,29 @@ type OnboardingConfig = {
 
 test.describe.configure({ timeout: 30_000 });
 
-test('onboarding lets AMR Cloud sign in and continue after the login poll succeeds', async ({ page }) => {
+test('onboarding lets AMR Cloud sign in and complete setup after the login poll succeeds', async ({ page }) => {
   const config = await wireOnboardingMocks(page, {
     amrAvailable: true,
     initialLoggedIn: false,
   });
 
-  await page.addInitScript(
-    ({ key, value }) => window.localStorage.setItem(key, JSON.stringify(value)),
-    { key: STORAGE_KEY, value: config },
-  );
+  await seedOnboardingConfig(page, config);
 
   await gotoOnboarding(page);
 
   const continueButton = page.getByRole('button', { name: /sign in to continue/i });
-  await expect(page.getByRole('button', { name: /AMR Cloud/i })).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByRole('button', { name: /Open Design AMR/i })).toHaveAttribute('aria-pressed', 'true');
   await expect(continueButton).toBeVisible();
   await continueButton.click();
 
   await expect(page.getByRole('button', { name: /Continue/i })).toBeVisible({ timeout: 10_000 });
+  await page.getByRole('button', { name: /Continue/i }).click();
+
+  await expectOnboardingFinished(page);
+  await pollStoredConfig(page).toMatchObject({
+    agentId: 'amr',
+    onboardingCompleted: true,
+  });
 });
 
 test('onboarding falls back to Local CLI when AMR is unavailable', async ({ page }) => {
@@ -45,10 +49,7 @@ test('onboarding falls back to Local CLI when AMR is unavailable', async ({ page
     initialLoggedIn: false,
   });
 
-  await page.addInitScript(
-    ({ key, value }) => window.localStorage.setItem(key, JSON.stringify(value)),
-    { key: STORAGE_KEY, value: config },
-  );
+  await seedOnboardingConfig(page, config);
 
   await gotoOnboarding(page);
 
@@ -65,10 +66,7 @@ test('onboarding recovers from a transient AMR status failure and still continue
     failFirstStatusPollAfterLogin: true,
   });
 
-  await page.addInitScript(
-    ({ key, value }) => window.localStorage.setItem(key, JSON.stringify(value)),
-    { key: STORAGE_KEY, value: config },
-  );
+  await seedOnboardingConfig(page, config);
 
   await gotoOnboarding(page);
 
@@ -89,10 +87,7 @@ test('onboarding AMR card lets the user pick a live runtime model before continu
     ],
   });
 
-  await page.addInitScript(
-    ({ key, value }) => window.localStorage.setItem(key, JSON.stringify(value)),
-    { key: STORAGE_KEY, value: config },
-  );
+  await seedOnboardingConfig(page, config);
 
   await gotoOnboarding(page);
 
@@ -112,6 +107,115 @@ test('onboarding AMR card lets the user pick a live runtime model before continu
         },
       },
     });
+});
+
+test('onboarding skip exits to home and marks onboarding completed', async ({ page }) => {
+  const config = await wireOnboardingMocks(page, {
+    amrAvailable: true,
+    initialLoggedIn: false,
+  });
+
+  await seedOnboardingConfig(page, config);
+  await gotoOnboarding(page);
+
+  await page.getByRole('button', { name: /Skip for now/i }).click();
+
+  await expectOnboardingFinished(page);
+  await pollStoredConfig(page).toMatchObject({
+    onboardingCompleted: true,
+  });
+});
+
+test('onboarding about-you step accepts profile selections and completes setup', async ({ page }) => {
+  const config = await wireOnboardingMocks(page, {
+    amrAvailable: true,
+    initialLoggedIn: true,
+  });
+
+  await seedOnboardingConfig(page, config);
+  await gotoOnboarding(page);
+
+  await page.getByRole('button', { name: /^Continue$/i }).click();
+  await expect(page.getByText(/Optional details for better defaults/i)).toBeVisible();
+
+  await selectOnboardingOption(page, 'Your role', 'Engineer');
+  await selectOnboardingOption(page, 'Organization size', 'Growth company');
+  await selectOnboardingOption(page, 'Use case', 'Product design');
+  await selectOnboardingOption(page, 'Use case', 'Prototype / app UI');
+  await page.keyboard.press('Escape');
+  await selectOnboardingOption(page, 'Where did you hear about us?', 'Search');
+
+  await expect(expectOnboardingTrigger(page, 'Your role')).toContainText('Engineer');
+  await expect(expectOnboardingTrigger(page, 'Organization size')).toContainText('Growth company');
+  await expect(expectOnboardingTrigger(page, 'Use case')).toContainText('Product design');
+  await expect(expectOnboardingTrigger(page, 'Use case')).toContainText('Prototype / app UI');
+  await expect(expectOnboardingTrigger(page, 'Where did you hear about us?')).toContainText('Search');
+
+  await page.getByRole('button', { name: /^Continue$/i }).click();
+
+  await expectOnboardingFinished(page);
+  await pollStoredConfig(page).toMatchObject({
+    onboardingCompleted: true,
+  });
+});
+
+test('onboarding BYOK path can fetch models, test the provider, and complete setup', async ({ page }) => {
+  const config = await wireOnboardingMocks(page, {
+    amrAvailable: true,
+    initialLoggedIn: true,
+  });
+
+  await page.route('**/api/provider/models', async (route) => {
+    await route.fulfill({
+      json: {
+        ok: true,
+        kind: 'success',
+        latencyMs: 14,
+        models: [
+          { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+          { id: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+        ],
+      },
+    });
+  });
+  await page.route('**/api/test/connection', async (route) => {
+    await route.fulfill({
+      json: {
+        ok: true,
+        kind: 'success',
+        latencyMs: 27,
+        model: 'claude-opus-4-8',
+        sample: 'Connected',
+      },
+    });
+  });
+
+  await seedOnboardingConfig(page, config);
+  await gotoOnboarding(page);
+
+  await page.getByRole('button', { name: /Bring your own key/i }).click();
+  await expect(page.getByText('BYOK')).toBeVisible();
+
+  await fillInlineField(page, 'API key', 'test-api-key');
+  await fillInlineField(page, 'Base URL', 'https://api.anthropic.com');
+  await page.getByRole('button', { name: /Fetch models/i }).click();
+  await expect(page.getByRole('status')).toContainText('Fetched 2 models.');
+  await selectOnboardingOption(page, 'Model', 'claude-opus-4-8');
+
+  await page.getByRole('button', { name: /^Test$/i }).click();
+  await expect(page.getByText('Connected. Replied in 27 ms')).toBeVisible();
+
+  await page.getByRole('button', { name: /^Continue$/i }).click();
+  await page.getByRole('button', { name: /^Continue$/i }).click();
+
+  await expectOnboardingFinished(page);
+  await pollStoredConfig(page).toMatchObject({
+    mode: 'api',
+    apiKey: 'test-api-key',
+    baseUrl: 'https://api.anthropic.com',
+    model: 'claude-opus-4-8',
+    onboardingCompleted: true,
+  });
 });
 
 async function wireOnboardingMocks(
@@ -238,4 +342,46 @@ async function gotoOnboarding(page: Page) {
   await waitForLoadingToClear(page);
   await dismissPrivacyDialog(page);
   await expect(page.getByRole('heading', { name: /Welcome|欢迎/i })).toBeVisible();
+}
+
+async function seedOnboardingConfig(page: Page, config: OnboardingConfig) {
+  await page.addInitScript(
+    ({ key, value }) => window.localStorage.setItem(key, JSON.stringify(value)),
+    { key: STORAGE_KEY, value: config },
+  );
+}
+
+async function expectOnboardingFinished(page: Page) {
+  await dismissPrivacyDialog(page);
+  await expect(page).not.toHaveURL(/\/onboarding$/);
+  await expect(page.getByText('What do you want to design?')).toBeVisible();
+}
+
+function pollStoredConfig(page: Page) {
+  return expect.poll(() =>
+    page.evaluate((key) => JSON.parse(window.localStorage.getItem(key) || '{}'), STORAGE_KEY),
+  );
+}
+
+function onboardingField(page: Page, label: string) {
+  return page.locator('.onboarding-view__select-field, .onboarding-view__inline-field').filter({
+    hasText: new RegExp(label, 'i'),
+  }).first();
+}
+
+function expectOnboardingTrigger(page: Page, label: string) {
+  return onboardingField(page, label).getByRole('button');
+}
+
+async function selectOnboardingOption(page: Page, label: string, option: string) {
+  const field = onboardingField(page, label);
+  const listbox = field.getByRole('listbox', { name: new RegExp(label, 'i') });
+  if (!(await listbox.isVisible().catch(() => false))) {
+    await field.getByRole('button').click();
+  }
+  await listbox.getByRole('option').filter({ hasText: new RegExp(option, 'i') }).first().click();
+}
+
+async function fillInlineField(page: Page, label: string, value: string) {
+  await onboardingField(page, label).locator('input').fill(value);
 }

--- a/e2e/ui/amr-run-failure-recovery.test.ts
+++ b/e2e/ui/amr-run-failure-recovery.test.ts
@@ -317,9 +317,9 @@ async function setupAmrWorkspace(
   const root = join(tmpdir(), `open-design-amr-ui-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
   const homeDir = join(root, 'home');
   const velaBin = await writeFakeVelaBin(join(root, 'bin'), {
-    assistantText: options.assistantText,
-    failAuthAtPrompt: options.failAuthAtPrompt,
-    failBalanceAtPrompt: options.failBalanceAtPrompt,
+    ...(options.assistantText !== undefined ? { assistantText: options.assistantText } : {}),
+    ...(options.failAuthAtPrompt !== undefined ? { failAuthAtPrompt: options.failAuthAtPrompt } : {}),
+    ...(options.failBalanceAtPrompt !== undefined ? { failBalanceAtPrompt: options.failBalanceAtPrompt } : {}),
   });
   await mkdir(homeDir, { recursive: true });
   if (options.seedLoginConfig !== false) {

--- a/e2e/ui/amr-run-failure-recovery.test.ts
+++ b/e2e/ui/amr-run-failure-recovery.test.ts
@@ -22,20 +22,98 @@ let codexRuntime: Awaited<ReturnType<typeof createFakeAgentRuntimes>>['codex'];
 test.describe.configure({ mode: 'serial' });
 
 test.beforeAll(async () => {
-  codexRuntime = (await createFakeAgentRuntimes(['codex'])).codex;
+  const runtimes = await createFakeAgentRuntimes(['codex', 'claude']);
+  codexRuntime = runtimes.codex;
 });
 
-test('AMR auth failures surface a clear error and return the composer to a usable idle state', async ({ page }) => {
-  const amr = await setupAmrWorkspace(page, { failAuthAtPrompt: true, selectedAgentId: 'amr' });
+test('AMR auth failures offer Authorize & retry and open AMR authorization controls', async ({ page }) => {
+  let loggedIn = false;
+  await page.route('**/api/integrations/vela/status', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(
+        loggedIn
+          ? {
+              loggedIn: true,
+              profile: 'local',
+              configPath: '/tmp/.amr/config.json',
+              user: { id: 'user-1', email: 'ui-amr@example.com', plan: 'free' },
+            }
+          : {
+              loggedIn: false,
+              profile: 'local',
+              configPath: '/tmp/.amr/config.json',
+              user: null,
+            },
+      ),
+    });
+  });
+  await page.route('**/api/integrations/vela/login', async (route) => {
+    loggedIn = true;
+    await route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: JSON.stringify({ pid: 4242, startedAt: new Date().toISOString(), profile: 'local' }),
+    });
+  });
+
+  const amr = await setupAmrWorkspace(page, {
+    failAuthAtPrompt: true,
+    selectedAgentId: 'amr',
+  });
 
   await gotoProject(page, amr.projectId);
-  await sendPrompt(page, 'AMR auth failure smoke');
+  await sendPrompt(page, 'AMR auth failure recovery smoke');
 
-  await expect(page.locator('.msg.error')).toContainText(/sign in again|expired|ACP session exited before completion/i, { timeout: 15_000 });
-  const input = page.getByTestId('chat-composer-input');
-  await expect(input).toBeVisible();
-  await input.fill('Retry after AMR auth failure');
-  await expect(page.getByTestId('chat-send')).toBeEnabled();
+  const authorizeAndRetry = page.getByTestId('generation-preview-authorize');
+  await expect(authorizeAndRetry).toBeVisible({ timeout: 15_000 });
+  await authorizeAndRetry.click();
+
+  const settings = page.getByRole('dialog');
+  await expect(settings).toBeVisible({ timeout: 10_000 });
+  const authorize = settings.getByRole('button', { name: /^Authorize$|^授权$/i });
+  await expect(authorize).toBeVisible();
+  await authorize.click();
+
+  await expect(settings.getByRole('button', { name: /^Sign out$|^退出登录$/i })).toBeVisible({
+    timeout: 10_000,
+  });
+});
+
+test('AMR insufficient-balance failures surface Top up AMR and keep Retry available', async ({ page }) => {
+  await page.addInitScript(() => {
+    const opened: string[] = [];
+    (window as Window & { __openedUrls?: string[] }).__openedUrls = opened;
+    const originalOpen = window.open.bind(window);
+    window.open = ((...args: Parameters<typeof window.open>) => {
+      if (typeof args[0] === 'string') opened.push(args[0]);
+      return originalOpen(...args);
+    }) as typeof window.open;
+  });
+
+  const amr = await setupAmrWorkspace(page, {
+    failBalanceAtPrompt: true,
+    selectedAgentId: 'amr',
+  });
+
+  await gotoProject(page, amr.projectId);
+  await sendPrompt(page, 'AMR insufficient balance recovery smoke');
+
+  const topUp = page.getByTestId('generation-preview-recharge');
+  const retry = page.getByTestId('generation-preview-retry');
+  await expect(topUp).toBeVisible({ timeout: 15_000 });
+  await expect(retry).toBeVisible();
+
+  await topUp.click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as Window & { __openedUrls?: string[] }).__openedUrls ?? [],
+      ),
+    )
+    .toContain('https://open-design.ai/amr/wallet');
 });
 
 test('after an AMR failure the user can switch to Codex and complete a fresh run', async ({ page }) => {
@@ -43,10 +121,13 @@ test('after an AMR failure the user can switch to Codex and complete a fresh run
 
   await gotoProject(page, amr.projectId);
   await sendPrompt(page, 'AMR auth failure before switch smoke');
-  await expect(page.locator('.msg.error')).toContainText(/sign in again|expired|ACP session exited before completion/i, { timeout: 15_000 });
+  await expect(page.locator('.msg.error')).toContainText(
+    /isn't authorized yet|Authorize it and this run retries automatically/i,
+    { timeout: 15_000 },
+  );
+  await expect(page.getByRole('button', { name: /Authorize.*retry|授权并重试/i }).first()).toBeVisible();
 
   const settings = await openSettingsDialog(page);
-  await settings.getByRole('tab', { name: /Local CLI/i }).click();
   await settings.getByRole('button', { name: /Codex CLI/i }).click();
   await expect
     .poll(async () => {
@@ -66,20 +147,184 @@ test('after an AMR failure the user can switch to Codex and complete a fresh run
   ).toBeVisible();
 });
 
+test('upstream outages keep Retry available without promoting AMR', async ({ page }) => {
+  const root = join(tmpdir(), `open-design-upstream-ui-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  const runtimes = await createFakeAgentRuntimes({ root: join(root, 'agents'), runtimeIds: ['claude'] });
+  const config = {
+    mode: 'daemon',
+    apiKey: '',
+    baseUrl: '',
+    model: '',
+    agentId: 'claude',
+    skillId: null,
+    designSystemId: null,
+    onboardingCompleted: true,
+    mediaProviders: {},
+    agentModels: {
+      claude: { model: 'default', reasoning: 'default' },
+    },
+    agentCliEnv: {
+      claude: runtimes.claude.env,
+    },
+  };
+
+  await seedBrowserConfig(page, config);
+  await putAppConfig(page, config);
+
+  const projectId = `upstream-ui-${Date.now()}`.replace(/[^A-Za-z0-9._-]/g, '-');
+  const { conversationId } = await createProjectViaApi(page, projectId, 'Upstream outage recovery');
+
+  const userMsgId = `u-${projectId}`;
+  const userMsgRes = await page.request.put(
+    `/api/projects/${projectId}/conversations/${conversationId}/messages/${userMsgId}`,
+    {
+      data: {
+        role: 'user',
+        content: 'please build something',
+        createdAt: Date.now() - 2_000,
+      },
+    },
+  );
+  expect(userMsgRes.ok(), `upsert user msg: ${await userMsgRes.text()}`).toBeTruthy();
+
+  const assistantMsgId = `a-${projectId}`;
+  const assistantMsgRes = await page.request.put(
+    `/api/projects/${projectId}/conversations/${conversationId}/messages/${assistantMsgId}`,
+    {
+      data: {
+        role: 'assistant',
+        content: '',
+        agentId: 'claude',
+        runId: `run-${projectId}`,
+        runStatus: 'failed',
+        createdAt: Date.now() - 1_000,
+        startedAt: Date.now() - 1_000,
+        preTurnFileNames: [],
+        events: [
+          {
+            kind: 'status',
+            label: 'error',
+            detail: 'The model provider is temporarily unavailable.',
+            code: 'UPSTREAM_UNAVAILABLE',
+          },
+        ],
+      },
+    },
+  );
+  expect(assistantMsgRes.ok(), `upsert assistant msg: ${await assistantMsgRes.text()}`).toBeTruthy();
+
+  await gotoProject(page, projectId);
+
+  await expect(page.getByTestId('generation-preview-retry')).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText(/Generation service unavailable/i)).toBeVisible();
+  await expect(page.getByRole('button', { name: /Switch to AMR & retry/i })).toHaveCount(0);
+  await expect(page.getByText(/Model call failed/i)).toHaveCount(0);
+});
+
+test('antigravity rate limits offer terminal model switching without promoting AMR', async ({ page }) => {
+  let oauthLaunchCalls = 0;
+  await page.route('**/api/agents/antigravity/oauth-launch', async (route) => {
+    oauthLaunchCalls += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+
+  const config = {
+    mode: 'daemon',
+    apiKey: '',
+    baseUrl: '',
+    model: '',
+    agentId: 'antigravity',
+    skillId: null,
+    designSystemId: null,
+    onboardingCompleted: true,
+    mediaProviders: {},
+    agentModels: {
+      antigravity: { model: 'default', reasoning: 'default' },
+    },
+  };
+
+  await seedBrowserConfig(page, config);
+  await putAppConfig(page, config);
+
+  const projectId = `antigravity-ui-${Date.now()}`.replace(/[^A-Za-z0-9._-]/g, '-');
+  const { conversationId } = await createProjectViaApi(page, projectId, 'Antigravity rate limit recovery');
+
+  const userMsgId = `u-${projectId}`;
+  const userMsgRes = await page.request.put(
+    `/api/projects/${projectId}/conversations/${conversationId}/messages/${userMsgId}`,
+    {
+      data: {
+        role: 'user',
+        content: 'please build something',
+        createdAt: Date.now() - 2_000,
+      },
+    },
+  );
+  expect(userMsgRes.ok(), `upsert user msg: ${await userMsgRes.text()}`).toBeTruthy();
+
+  const assistantMsgId = `a-${projectId}`;
+  const assistantMsgRes = await page.request.put(
+    `/api/projects/${projectId}/conversations/${conversationId}/messages/${assistantMsgId}`,
+    {
+      data: {
+        role: 'assistant',
+        content: '',
+        agentId: 'antigravity',
+        runId: `run-${projectId}`,
+        runStatus: 'failed',
+        createdAt: Date.now() - 1_000,
+        startedAt: Date.now() - 1_000,
+        preTurnFileNames: [],
+        events: [
+          {
+            kind: 'status',
+            label: 'error',
+            detail: 'Switch to another Antigravity model before retrying this run.',
+            code: 'RATE_LIMITED',
+          },
+        ],
+      },
+    },
+  );
+  expect(assistantMsgRes.ok(), `upsert assistant msg: ${await assistantMsgRes.text()}`).toBeTruthy();
+
+  await gotoProject(page, projectId);
+
+  const launchTerminal = page.getByTestId('generation-preview-launch-terminal');
+  await expect(launchTerminal).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId('generation-preview-retry')).toBeVisible();
+  await expect(page.getByRole('button', { name: /Switch to AMR & retry/i })).toHaveCount(0);
+
+  await launchTerminal.click();
+
+  await expect.poll(() => oauthLaunchCalls).toBe(1);
+});
+
 async function setupAmrWorkspace(
   page: Page,
   options: {
-    failAuthAtPrompt: boolean;
+    failAuthAtPrompt?: boolean;
+    failBalanceAtPrompt?: boolean;
     selectedAgentId: 'amr' | 'codex';
+    seedLoginConfig?: boolean;
+    assistantText?: string;
   },
 ) {
   const root = join(tmpdir(), `open-design-amr-ui-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
   const homeDir = join(root, 'home');
   const velaBin = await writeFakeVelaBin(join(root, 'bin'), {
+    assistantText: options.assistantText,
     failAuthAtPrompt: options.failAuthAtPrompt,
+    failBalanceAtPrompt: options.failBalanceAtPrompt,
   });
   await mkdir(homeDir, { recursive: true });
-  await seedVelaLoginConfig(homeDir, { email: 'ui-amr@example.com', profile: 'local' });
+  if (options.seedLoginConfig !== false) {
+    await seedVelaLoginConfig(homeDir, { email: 'ui-amr@example.com', profile: 'local' });
+  }
 
   const config = {
     mode: 'daemon',
@@ -106,5 +351,5 @@ async function setupAmrWorkspace(
 
   const projectId = `amr-ui-${Date.now()}`.replace(/[^A-Za-z0-9._-]/g, '-');
   await createProjectViaApi(page, projectId, 'AMR UI failure smoke');
-  return { projectId, homeDir, velaBin };
+  return { projectId, homeDir, root, velaBin };
 }

--- a/e2e/ui/app-design-files.test.ts
+++ b/e2e/ui/app-design-files.test.ts
@@ -5,6 +5,8 @@ import type { UiScenario } from '@/playwright/resources';
 import { T } from '@/timeouts';
 
 const STORAGE_KEY = 'open-design:config';
+const TINY_PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=';
 
 test.describe.configure({ timeout: 30_000 });
 
@@ -407,6 +409,130 @@ async function runDesignFilesDeleteFlow(page: Page) {
     })
     .toBe(true);
 }
+
+test('design files batch delete removes only the selected files and clears the bulk action state', async ({ page }) => {
+  await page.route('**/api/agents', async (route) => {
+    await route.fulfill({
+      json: {
+        agents: [
+          {
+            id: 'mock',
+            name: 'Mock Agent',
+            bin: 'mock-agent',
+            available: true,
+            version: 'test',
+            models: [{ id: 'default', label: 'Default' }],
+          },
+        ],
+      },
+    });
+  });
+
+  page.on('dialog', async (dialog) => {
+    await dialog.accept();
+  });
+
+  await gotoEntryHome(page);
+  await openNewProjectModal(page);
+  await page.getByTestId('new-project-name').fill('Design files batch delete flow');
+  await page.getByTestId('create-project').click();
+  await expectWorkspaceReady(page);
+
+  const { projectId } = await getCurrentProjectContext(page);
+  await seedProjectFile(page, projectId, 'keep.png', TINY_PNG_B64, 'base64');
+  await seedProjectFile(page, projectId, 'trash-a.png', TINY_PNG_B64, 'base64');
+  await seedProjectFile(page, projectId, 'trash-b.png', TINY_PNG_B64, 'base64');
+  await page.reload();
+  await expectWorkspaceReady(page);
+  await page.getByTestId('design-files-tab').click();
+
+  const keepRow = page.getByTestId('design-file-row-keep.png');
+  const trashARow = page.getByTestId('design-file-row-trash-a.png');
+  const trashBRow = page.getByTestId('design-file-row-trash-b.png');
+  await expect(keepRow).toBeVisible();
+  await expect(trashARow).toBeVisible();
+  await expect(trashBRow).toBeVisible();
+
+  await trashARow.getByRole('checkbox').click();
+  await trashBRow.getByRole('checkbox').click();
+  const batchDelete = page.getByTestId('design-files-batch-delete');
+  await expect(batchDelete).toBeVisible();
+  await batchDelete.click();
+
+  await expect(trashARow).toHaveCount(0);
+  await expect(trashBRow).toHaveCount(0);
+  await expect(keepRow).toBeVisible();
+  await expect(page.getByTestId('design-files-batch-delete')).toHaveCount(0);
+  await expect(page.getByTestId('design-files-upload-trigger')).toBeVisible();
+
+  await expect
+    .poll(async () => {
+      const names = (await listProjectFilesFromApi(page, projectId)).map((file) => file.name);
+      return (
+        names.length === 1 &&
+        names[0]?.endsWith('keep.png')
+      );
+    })
+    .toBe(true);
+});
+
+test('design files kind filter trims hidden selections before batch delete reaches the backend', async ({ page }) => {
+  page.on('dialog', async (dialog) => {
+    await dialog.accept();
+  });
+
+  await gotoEntryHome(page);
+  await openNewProjectModal(page);
+  await page.getByTestId('new-project-name').fill('Design files filtered batch delete flow');
+  await page.getByTestId('create-project').click();
+  await expectWorkspaceReady(page);
+
+  const { projectId } = await getCurrentProjectContext(page);
+  await seedProjectFile(page, projectId, 'visible-image.png', TINY_PNG_B64, 'base64');
+  await seedProjectFile(page, projectId, 'hidden-image.png', TINY_PNG_B64, 'base64');
+  await seedProjectFile(page, projectId, 'notes.txt', 'plain text note');
+  await page.reload();
+  await expectWorkspaceReady(page);
+  await page.getByTestId('design-files-tab').click();
+
+  const visibleImageRow = page.getByTestId('design-file-row-visible-image.png');
+  const hiddenImageRow = page.getByTestId('design-file-row-hidden-image.png');
+  const notesRow = page.getByTestId('design-file-row-notes.txt');
+  await expect(visibleImageRow).toBeVisible();
+  await expect(hiddenImageRow).toBeVisible();
+  await expect(notesRow).toBeVisible();
+
+  await visibleImageRow.getByRole('checkbox').click();
+  await notesRow.getByRole('checkbox').click();
+  await expect(page.getByTestId('design-files-batch-delete')).toBeVisible();
+
+  const filterBtn = page.getByRole('button', { name: /filter by kind/i });
+  await filterBtn.click();
+  const filterPopover = page.getByRole('dialog', { name: /filter by kind/i });
+  await expect(filterPopover).toBeVisible();
+  await filterPopover.getByRole('checkbox', { name: /image/i }).check();
+  await filterBtn.click();
+  await expect(filterPopover).toBeHidden();
+
+  await expect(visibleImageRow).toBeVisible();
+  await expect(hiddenImageRow).toBeVisible();
+  await expect(notesRow).toHaveCount(0);
+
+  const batchDelete = page.getByTestId('design-files-batch-delete');
+  await expect(batchDelete).toBeVisible();
+  await batchDelete.click();
+
+  await expect(visibleImageRow).toHaveCount(0);
+  await expect(hiddenImageRow).toBeVisible();
+  await expect(page.getByTestId('design-files-batch-delete')).toHaveCount(0);
+
+  await expect
+    .poll(async () => {
+      const names = (await listProjectFilesFromApi(page, projectId)).map((file) => file.name).sort();
+      return JSON.stringify(names);
+    })
+    .toBe(JSON.stringify(['hidden-image.png', 'notes.txt']));
+});
 
 async function runDesignFilesTabPersistenceFlow(page: Page) {
   const { projectId } = await getCurrentProjectContext(page);

--- a/e2e/ui/app-restoration.test.ts
+++ b/e2e/ui/app-restoration.test.ts
@@ -597,12 +597,14 @@ test('switching between conversations keeps the composer usable while navigating
 
   await sendPrompt(page, firstPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
+  const firstContext = await getCurrentProjectContext(page);
 
   await page.getByTestId('new-conversation').click();
   await expect(page.getByTestId('chat-composer-input')).toBeVisible();
   await expect(page.getByTestId('chat-composer-input')).toHaveValue('');
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
+  const secondContext = await getCurrentProjectContext(page);
 
   const composerInput = page.getByTestId('chat-composer-input');
   await composerInput.fill(secondDraft);
@@ -619,6 +621,7 @@ test('switching between conversations keeps the composer usable while navigating
     .click();
 
   await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/projects/${firstContext.projectId}/conversations/${firstContext.conversationId}$`));
 
   await composerInput.fill(firstDraft);
   await expect(composerInput).toHaveValue(firstDraft);
@@ -633,6 +636,7 @@ test('switching between conversations keeps the composer usable while navigating
     .click();
 
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/projects/${secondContext.projectId}/conversations/${secondContext.conversationId}$`));
 
   await page.getByTestId('conversation-history-trigger').click();
   await expect(historyList).toBeVisible();
@@ -644,6 +648,13 @@ test('switching between conversations keeps the composer usable while navigating
     .click();
 
   await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/projects/${firstContext.projectId}/conversations/${firstContext.conversationId}$`));
+
+  await page.reload();
+  await expect(page.getByTestId('chat-composer')).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/projects/${firstContext.projectId}/conversations/${firstContext.conversationId}$`));
+  await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
+  await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt })).toHaveCount(0);
 });
 
 test('reloading an older conversation route keeps the composer visible on that route', async ({ page }) => {

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -147,6 +147,21 @@ test('home view exposes the redesigned hero, recent projects, and starters', asy
   await expect(page.getByTestId('entry-nav-projects')).toHaveAttribute('aria-current', 'page');
 });
 
+test('recent projects strip opens a project card and view all routes to the projects index', async ({ page }) => {
+  const created = await createProject(page, 'Recent project entry point');
+  await gotoEntryHome(page);
+
+  const recentStrip = page.getByTestId('recent-projects-strip');
+  await expect(recentStrip).toBeVisible();
+  await recentStrip.locator(`[data-project-id="${created.project.id}"]`).click();
+  await expect(page).toHaveURL(new RegExp(`/projects/${created.project.id}`));
+
+  await gotoEntryHome(page);
+  await page.getByTestId('recent-projects-view-all').click();
+  await expect(page).toHaveURL(/\/projects$/);
+  await expect(page.getByTestId('entry-nav-projects')).toHaveAttribute('aria-current', 'page');
+});
+
 test('design systems page is reachable from entry nav and supports search, preview, and default selection', async ({ page }) => {
   const persistedConfigs: Array<{ designSystemId?: string | null }> = [];
   await routeDesignSystems(page);
@@ -777,6 +792,7 @@ test('home starters direct Use keeps prompt empty and still allows a freeform su
   const input = page.getByTestId('home-hero-input');
   await expect(input).toHaveValue('');
 
+  await page.locator('article.plugins-home__card[data-plugin-id="localized-plugin"]').hover();
   await page.getByTestId('plugins-home-use-localized-plugin').click({ force: true });
   await expect(input).toHaveValue('');
 
@@ -820,6 +836,58 @@ test('home starters Use with query hydrates the prompt and keeps plugin context 
   await page.getByTestId('plugins-home-use-with-query-localized-plugin').click();
   await expect(page.getByTestId('home-hero-context-plugin-localized-plugin')).toBeVisible();
   await expect(input).toHaveValue('Make a design systems brief.');
+});
+
+test('home starters Use with query carries the hydrated starter prompt into the created project and first user turn', async ({ page }) => {
+  await page.route('**/api/plugins', async (route) => {
+    await route.fulfill({
+      json: {
+        plugins: [STARTER_PLUGIN],
+      },
+    });
+  });
+
+  await gotoEntryHome(page);
+
+  const input = page.getByTestId('home-hero-input');
+  const starterCard = page.locator('[data-plugin-id="localized-plugin"]').first();
+  await starterCard.scrollIntoViewIfNeeded();
+  await starterCard.hover();
+  await expect(page.getByTestId('plugins-home-use-menu-localized-plugin')).toBeVisible();
+  await page.getByTestId('plugins-home-use-menu-localized-plugin').click();
+  await page.getByTestId('plugins-home-use-with-query-localized-plugin').click();
+  await expect(page.getByTestId('home-hero-context-plugin-localized-plugin')).toBeVisible();
+  await expect(input).toHaveValue('Make a design systems brief.');
+
+  const projectRequestPromise = page.waitForRequest(isCreateProjectRequest);
+  const runRequestPromise = page.waitForRequest(isCreateRunRequest);
+  await page.getByTestId('home-hero-submit').click();
+
+  const projectRequest = await projectRequestPromise;
+  const projectBody = projectRequest.postDataJSON() as {
+    metadata?: { kind?: string };
+    pendingPrompt?: string;
+    pluginId?: string;
+  };
+  expect(projectBody.pendingPrompt).toBe('Make a design systems brief.');
+  expect(projectBody.pluginId).toBe('od-default');
+  expect(typeof projectBody.metadata?.kind).toBe('string');
+
+  const runRequest = await runRequestPromise;
+  const runBody = runRequest.postDataJSON() as { message?: string };
+  expect(runBody.message).toContain('Make a design systems brief.');
+
+  await expect(page).toHaveURL(/\/projects\//);
+  await expect(page.locator('.msg.user .user-text').filter({ hasText: 'Make a design systems brief.' }).first()).toBeVisible();
+
+  const { projectId, conversationId } = await getCurrentProjectContext(page);
+  const project = await fetchProjectFromApi(page, projectId);
+  expect(project.metadata?.kind).toBe(projectBody.metadata?.kind);
+
+  const messages = await listMessagesFromApi(page, projectId, conversationId);
+  expect(
+    messages.some((message) => message.role === 'user' && message.content === 'Make a design systems brief.'),
+  ).toBe(true);
 });
 
 test('home hero input keeps Shift+Enter as a newline and submits on Enter', async ({ page }) => {
@@ -949,6 +1017,53 @@ async function createProject(page: Page, name: string) {
   });
   expect(response.ok(), await response.text()).toBeTruthy();
   return response.json() as Promise<{ project: { id: string; name: string } }>;
+}
+
+async function getCurrentProjectContext(page: Page): Promise<{ projectId: string; conversationId: string }> {
+  const current = new URL(page.url());
+  const [, projects, projectId, maybeConversations, conversationId] = current.pathname.split('/');
+  if (projects !== 'projects' || !projectId) {
+    throw new Error(`unexpected project route: ${current.pathname}`);
+  }
+  if (maybeConversations === 'conversations' && conversationId) {
+    return { projectId, conversationId };
+  }
+
+  const response = await page.request.get(`/api/projects/${projectId}/conversations`);
+  expect(response.ok()).toBeTruthy();
+  const { conversations } = (await response.json()) as {
+    conversations: Array<{ id: string; updatedAt: number }>;
+  };
+  const active = [...conversations].sort((a, b) => b.updatedAt - a.updatedAt)[0];
+  if (!active) throw new Error(`no conversations found for project ${projectId}`);
+  return { projectId, conversationId: active.id };
+}
+
+async function fetchProjectFromApi(
+  page: Page,
+  projectId: string,
+): Promise<{ id: string; metadata?: { kind?: string } }> {
+  const response = await page.request.get(`/api/projects/${projectId}`);
+  expect(response.ok()).toBeTruthy();
+  const { project } = (await response.json()) as {
+    project: { id: string; metadata?: { kind?: string } };
+  };
+  return project;
+}
+
+async function listMessagesFromApi(
+  page: Page,
+  projectId: string,
+  conversationId: string,
+): Promise<Array<{ role: 'assistant' | 'user'; content: string }>> {
+  const response = await page.request.get(
+    `/api/projects/${projectId}/conversations/${conversationId}/messages`,
+  );
+  expect(response.ok()).toBeTruthy();
+  const { messages } = (await response.json()) as {
+    messages: Array<{ role: 'assistant' | 'user'; content: string }>;
+  };
+  return messages;
 }
 
 async function routeDesignSystems(page: Page) {

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -61,6 +61,16 @@ const TAB_SKILLS = [
 ];
 
 test.beforeEach(async ({ page }) => {
+  let appConfig = {
+    onboardingCompleted: true,
+    mode: 'daemon',
+    agentId: 'codex',
+    skillId: null,
+    designSystemId: null,
+    agentModels: { codex: { model: 'default' } },
+    agentCliEnv: {},
+  };
+
   await page.addInitScript((key) => {
     window.localStorage.setItem(
       key,
@@ -79,21 +89,18 @@ test.beforeEach(async ({ page }) => {
   }, STORAGE_KEY);
 
   await page.route('**/api/app-config', async (route) => {
-    if (route.request().method() !== 'GET') {
-      await route.continue();
+    if (route.request().method() === 'PUT') {
+      const next = route.request().postDataJSON() as Record<string, unknown>;
+      appConfig = {
+        ...appConfig,
+        ...next,
+      };
+      await route.fulfill({ json: { config: appConfig } });
       return;
     }
     await route.fulfill({
       json: {
-        config: {
-          onboardingCompleted: true,
-          mode: 'daemon',
-          agentId: 'codex',
-          skillId: null,
-          designSystemId: null,
-          agentModels: { codex: { model: 'default' } },
-          agentCliEnv: {},
-        },
+        config: appConfig,
       },
     });
   });
@@ -372,6 +379,68 @@ test('project detail header design system switch carries into the next run reque
   expect(runRequestBodies[0]?.designSystemId).toBe('editorial-noir');
 });
 
+test('project instructions flow into the next API run as project-level system prompt context', async ({ page }) => {
+  let capturedSystemPrompt = '';
+  const apiConfig = {
+    onboardingCompleted: true,
+    mode: 'api',
+    apiProtocol: 'openai',
+    apiKey: 'sk-project-test',
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4.1-mini',
+    agentId: null,
+    skillId: null,
+    designSystemId: null,
+    agentCliEnv: {},
+  };
+  await page.addInitScript(
+    ([key, config]) => {
+      window.localStorage.setItem(key, JSON.stringify(config));
+    },
+    [STORAGE_KEY, apiConfig] as const,
+  );
+  await page.route('**/api/app-config', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({ json: { config: apiConfig } });
+  });
+  await page.route('**/api/proxy/openai/stream', async (route) => {
+    const body = route.request().postDataJSON() as { systemPrompt?: string };
+    capturedSystemPrompt = body.systemPrompt ?? '';
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: [
+        'event: delta',
+        `data: ${JSON.stringify({ text: 'ok' })}`,
+        '',
+        'event: done',
+        'data: {}',
+        '',
+        '',
+      ].join('\n'),
+    });
+  });
+
+  await page.goto('/');
+  await createProject(page, 'Project instruction run context');
+  await expectWorkspaceReady(page);
+
+  await page.getByTestId('project-instructions-add').click();
+  await page.getByTestId('project-instructions-textarea').fill('Use tabs for indentation and keep CTA copy terse.');
+  await page.getByTestId('project-instructions-save').click();
+  await expect(page.getByTestId('project-instructions-preview')).toContainText('Use tabs for indentation and keep CTA copy terse.');
+
+  const input = page.getByTestId('chat-composer-input');
+  await input.fill('Generate the onboarding screen.');
+  await page.getByTestId('chat-send').click();
+
+  await expect.poll(() => capturedSystemPrompt).toContain('## Custom instructions (project-level)');
+  expect(capturedSystemPrompt).toContain('Use tabs for indentation and keep CTA copy terse.');
+});
+
 test('project detail avatar menu lets the user switch Local CLI agents and models', async ({ page }) => {
   await page.goto('/');
   await createProject(page, 'Header agent switch');
@@ -391,6 +460,109 @@ test('project detail avatar menu lets the user switch Local CLI agents and model
   await expect(modelSelect).toHaveValue('default');
   await modelSelect.selectOption('sonnet');
   await expect(modelSelect).toHaveValue('sonnet');
+});
+
+test('project detail agent and model switches carry into the next daemon run request', async ({ page }) => {
+  const runRequestBodies: Array<Record<string, unknown>> = [];
+  await page.route('**/api/runs', async (route) => {
+    const raw = route.request().postData();
+    if (raw) runRequestBodies.push(JSON.parse(raw) as Record<string, unknown>);
+    await route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: '{"runId":"agent-model-run"}',
+    });
+  });
+  await page.route('**/api/runs/*/events', async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
+      body: ['event: end', 'data: {"code":0,"status":"succeeded"}', '', ''].join('\n'),
+    });
+  });
+
+  await page.goto('/');
+  await createProject(page, 'Header agent switch run context');
+  await expectWorkspaceReady(page);
+
+  const trigger = page.locator('.avatar-menu .avatar-agent-trigger');
+  await trigger.click();
+  const menu = page.locator('.avatar-popover[role="dialog"]');
+  await expect(menu).toBeVisible();
+  await menu.getByRole('button', { name: /Claude Code/i }).click();
+  const modelSelect = menu.locator('.avatar-model-section .avatar-select').first();
+  await modelSelect.selectOption('sonnet');
+  await expect(modelSelect).toHaveValue('sonnet');
+
+  const input = page.getByTestId('chat-composer-input');
+  await input.fill('Use the selected local agent for this run.');
+  await Promise.all([
+    page.waitForRequest((request) => request.url().includes('/api/runs') && request.method() === 'POST'),
+    page.getByTestId('chat-send').click(),
+  ]);
+
+  expect(runRequestBodies.length).toBeGreaterThan(0);
+  expect(runRequestBodies[0]?.agentId).toBe('claude');
+  expect(runRequestBodies[0]?.model).toBe('sonnet');
+});
+
+test('clearing the project design system removes designSystemId from the next run request', async ({ page }) => {
+  const patchBodies: Array<Record<string, unknown>> = [];
+  const runRequestBodies: Array<Record<string, unknown>> = [];
+  await page.route('**/api/design-systems', async (route) => {
+    await route.fulfill({ json: { designSystems: DESIGN_SYSTEMS } });
+  });
+  await page.route('**/api/projects/*', async (route) => {
+    if (route.request().method() !== 'PATCH') {
+      await route.continue();
+      return;
+    }
+    const body = route.request().postDataJSON() as Record<string, unknown>;
+    patchBodies.push(body);
+    await route.continue();
+  });
+  await page.route('**/api/runs', async (route) => {
+    const raw = route.request().postData();
+    if (raw) runRequestBodies.push(JSON.parse(raw) as Record<string, unknown>);
+    await route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: '{"runId":"design-system-clear-run"}',
+    });
+  });
+  await page.route('**/api/runs/*/events', async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
+      body: ['event: end', 'data: {"code":0,"status":"succeeded"}', '', ''].join('\n'),
+    });
+  });
+
+  await page.goto('/');
+  await createProject(page, 'Header design system clear run context');
+  await expectWorkspaceReady(page);
+
+  const trigger = page.getByTestId('project-ds-picker-trigger');
+  await trigger.click();
+  await page.getByTestId('project-ds-picker-search').fill('editorial');
+  await page.getByTestId('project-ds-picker-option-editorial-noir').click();
+  await expect(trigger).toContainText(/Editorial Noir/i);
+
+  await trigger.click();
+  await page.locator('.project-ds-picker-option').first().click();
+  await expect(trigger).not.toContainText(/Editorial Noir/i);
+
+  expect(patchBodies.some((body) => Object.prototype.hasOwnProperty.call(body, 'designSystemId') && body.designSystemId === null)).toBe(true);
+
+  const input = page.getByTestId('chat-composer-input');
+  await input.fill('Generate this without an active design system.');
+  await Promise.all([
+    page.waitForRequest((request) => request.url().includes('/api/runs') && request.method() === 'POST'),
+    page.getByTestId('chat-send').click(),
+  ]);
+
+  expect(runRequestBodies.length).toBeGreaterThan(0);
+  expect(runRequestBodies[0]?.designSystemId).toBeNull();
 });
 
 test('project title rename persists after reload and ignores blank titles', async ({ page }) => {
@@ -487,13 +659,7 @@ test('project detail workspace keeps design file tabs and preview controls visib
   await expect(fileTab).toHaveAttribute('aria-selected', 'true');
   await expect(page.getByRole('tab', { name: 'Design Files' })).toBeVisible();
 
-  await page.getByTestId('design-files-tab').click();
-  const fileRow = rowByFileName(page, uploadedName);
-  await expect(fileRow).toBeVisible();
-  await fileRow.getByRole('button').first().click();
-  const previewCard = page.getByTestId('design-file-preview');
-  await expect(previewCard).toBeVisible();
-  await previewCard.getByRole('button', { name: 'Open' }).click();
+  await openUploadedHtmlArtifactPreview(page, uploadedName);
 
   const viewModeTabs = page.getByRole('tablist', { name: 'View mode' });
   await expect(viewModeTabs.getByRole('tab', { name: 'Preview' })).toBeVisible();
@@ -512,6 +678,148 @@ test('project detail workspace keeps design file tabs and preview controls visib
 
   await viewModeTabs.getByRole('tab', { name: 'Preview' }).click();
   await expect(page.getByTestId('artifact-preview-frame')).toBeVisible();
+});
+
+test('project detail share menu copies the current share link for uploaded html artifacts', async ({ page }) => {
+  let uploadedName = '';
+  await page.addInitScript(() => {
+    const store: string[] = [];
+    Object.defineProperty(window, '__copiedTexts', {
+      value: store,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText(text: string) {
+          store.push(text);
+          return Promise.resolve();
+        },
+      },
+      configurable: true,
+    });
+  });
+  await page.route('**/api/projects/*/deployments', async (route) => {
+    await route.fulfill({
+      json: {
+        deployments: uploadedName
+          ? [{
+              id: 'ready-share-link',
+              projectId: getProjectIdFromApiPath(route.request().url()),
+              fileName: uploadedName,
+              providerId: 'vercel-self',
+              url: 'https://share-preview.example',
+              deploymentCount: 1,
+              target: 'preview',
+              status: 'ready',
+              createdAt: 1,
+              updatedAt: 2,
+            }]
+          : [],
+      },
+    });
+  });
+
+  await page.goto('/');
+  await createProject(page, 'Share link copy flow');
+  await expectWorkspaceReady(page);
+
+  uploadedName = await uploadTinyHtml(page, 'share-link-copy.html', '<!doctype html><html><body><h1>Share link copy</h1></body></html>');
+  await openUploadedHtmlArtifactPreview(page, uploadedName);
+
+  await page.getByRole('button', { name: /^Share$/i }).click();
+  await page.getByRole('menuitem', { name: /^Copy share link$/i }).click();
+  await expect(page.getByRole('menuitem', { name: /^Copied!$/i })).toBeVisible();
+
+  const copied = await page.evaluate(() => (window as typeof window & { __copiedTexts?: string[] }).__copiedTexts ?? []);
+  expect(copied.at(-1)).toBe('https://share-preview.example');
+});
+
+test('project detail share menu opens the current share page for uploaded html artifacts', async ({ page }) => {
+  let uploadedName = '';
+  await page.addInitScript(() => {
+    const opened: string[] = [];
+    Object.defineProperty(window, '__openedUrls', {
+      value: opened,
+      configurable: true,
+    });
+    const originalOpen = window.open.bind(window);
+    window.open = ((...args: Parameters<typeof window.open>) => {
+      if (typeof args[0] === 'string') opened.push(args[0]);
+      return originalOpen(...args);
+    }) as typeof window.open;
+  });
+  await page.route('**/api/projects/*/deployments', async (route) => {
+    await route.fulfill({
+      json: {
+        deployments: uploadedName
+          ? [{
+              id: 'protected-share-link',
+              projectId: getProjectIdFromApiPath(route.request().url()),
+              fileName: uploadedName,
+              providerId: 'vercel-self',
+              url: 'https://protected-share.example',
+              deploymentCount: 1,
+              target: 'preview',
+              status: 'protected',
+              createdAt: 1,
+              updatedAt: 2,
+            }]
+          : [],
+      },
+    });
+  });
+
+  await page.goto('/');
+  await createProject(page, 'Open share page flow');
+  await expectWorkspaceReady(page);
+
+  uploadedName = await uploadTinyHtml(page, 'share-page-open.html', '<!doctype html><html><body><h1>Open share page</h1></body></html>');
+  await openUploadedHtmlArtifactPreview(page, uploadedName);
+
+  await page.getByRole('button', { name: /^Share$/i }).click();
+  await page.getByRole('menuitem', { name: /Open share page/i }).click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => (window as typeof window & { __openedUrls?: string[] }).__openedUrls ?? []),
+    )
+    .toContain('https://protected-share.example');
+});
+
+test('project detail share menu publish action opens the deploy flow for the selected provider', async ({ page }) => {
+  let deployConfigUrl: string | null = null;
+  await page.route('**/api/projects/*/deployments', async (route) => {
+    await route.fulfill({ json: { deployments: [] } });
+  });
+  await page.route('**/api/deploy/config?providerId=*', async (route) => {
+    deployConfigUrl = route.request().url();
+    const url = new URL(route.request().url());
+    await route.fulfill({
+      json: {
+        configured: false,
+        providerId: url.searchParams.get('providerId'),
+        tokenMask: '',
+        teamId: '',
+        teamSlug: '',
+      },
+    });
+  });
+
+  await page.goto('/');
+  await createProject(page, 'Deploy action flow');
+  await expectWorkspaceReady(page);
+
+  const uploadedName = await uploadTinyHtml(page, 'deploy-action.html', '<!doctype html><html><body><h1>Deploy action</h1></body></html>');
+  await openUploadedHtmlArtifactPreview(page, uploadedName);
+
+  await page.getByRole('button', { name: /^Share$/i }).click();
+  await page.getByRole('menuitem', { name: /^Deploy to Vercel$/i }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole('heading', { name: /Deploy to Vercel/i })).toBeVisible();
+  await expect(dialog.locator('select').first()).toHaveValue('vercel-self');
+  expect(deployConfigUrl).toContain('providerId=vercel-self');
 });
 
 test('home design card deletion supports cancel and confirm flows', async ({ page }) => {
@@ -1201,6 +1509,16 @@ async function uploadTinyPng(
   return uploaded!.name;
 }
 
+async function openUploadedHtmlArtifactPreview(page: Page, uploadedName: string) {
+  await page.getByTestId('design-files-tab').click();
+  const fileRow = rowByFileName(page, uploadedName);
+  await expect(fileRow).toBeVisible();
+  await fileRow.getByRole('button').first().click();
+  const previewCard = page.getByTestId('design-file-preview');
+  await expect(previewCard).toBeVisible();
+  await previewCard.getByRole('button', { name: 'Open' }).click();
+}
+
 function tabBySuffix(page: Page, name: string): Locator {
   return page.getByRole('tab', { name: new RegExp(`${escapeRegExp(name)}$`, 'i') });
 }
@@ -1298,6 +1616,13 @@ function getProjectContextFromUrl(page: Page) {
   const [, projectId] = url.pathname.match(/\/projects\/([^/]+)/) ?? [];
   if (!projectId) throw new Error(`unexpected project route: ${url.pathname}`);
   return { projectId };
+}
+
+function getProjectIdFromApiPath(rawUrl: string) {
+  const url = new URL(rawUrl);
+  const [, projectId] = url.pathname.match(/\/api\/projects\/([^/]+)/) ?? [];
+  if (!projectId) throw new Error(`unexpected project api path: ${url.pathname}`);
+  return projectId;
 }
 
 function escapeRegExp(value: string): string {


### PR DESCRIPTION
## Summary

This PR expands automated coverage across onboarding, home, and project-detail flows, with extra focus on failure recovery, project workspace actions, and daemon-side error convergence.

## Surface Area

- [x] onboarding
- [x] home
- [x] project detail
- [x] failure recovery
- [x] daemon error convergence
- [x] share / deploy actions
- [x] design files and chat attachments

## What Changed

- Added onboarding coverage for:
  - complete-onboarding happy paths
  - skip flow
  - about-you submission
  - BYOK completion
  - config and analytics side effects
- Expanded home coverage for:
  - recent project navigation
  - footer option payload propagation
  - context picker payload propagation
- Expanded project-detail coverage for:
  - conversation isolation and recovery
  - avatar runtime selection
  - design system propagation into runs
  - project instructions propagation into API runs
  - share menu actions for uploaded HTML artifacts
  - design file batch delete and filter interactions
  - CLI/avatar menu offline, rescan, reasoning, and custom-model states
  - chat attachment upload recovery
- Added UI E2E coverage for:
  - AMR failure recovery actions
  - onboarding runtime selection flows
  - share/deploy actions from project detail
  - design-files filtered bulk delete
  - project history/navigation restoration
- Added daemon smoke coverage for structured failure convergence:
  - antigravity auth -> `AGENT_AUTH_REQUIRED`
  - antigravity quota -> `RATE_LIMITED`
  - standard agent 429 -> `RATE_LIMITED`
  - standard agent 503 -> `UPSTREAM_UNAVAILABLE`
- Fixed a real UI regression in `ChatPane` so `UPSTREAM_UNAVAILABLE` no longer incorrectly promotes AMR.
- Fixed the AMR E2E helper so optional fake-vela flags are only forwarded when defined, which unblocks `exactOptionalPropertyTypes` in CI preflight.

## Why

The existing coverage was strong in a few isolated areas, but several user-critical paths still depended on lower-level assertions or older UI expectations. This PR moves those checks closer to the actual product behavior and closes gaps around recovery actions, payload propagation, and daemon error contracts.

## Bug Fix Verification

For the `UPSTREAM_UNAVAILABLE` regression in `ChatPane`, the red -> green seam is:

- before: preview-stage logic already suppressed AMR promotion, but the chat error card could still render `Switch to AMR & retry`
- after: both surfaces agree on the same policy
  - keep retry available
  - do not render AMR promotion for `UPSTREAM_UNAVAILABLE`

This is covered in:

- `apps/web/src/components/ChatPane.tsx`
- `e2e/ui/amr-run-failure-recovery.test.ts`

## Validation

- `pnpm -C apps/web exec vitest run -c vitest.config.ts tests/components/AvatarMenu.test.tsx`
- `pnpm --pm-on-fail=ignore -C apps/web exec vitest run -c vitest.config.ts tests/components/ProjectView.run-isolation.test.tsx tests/components/ChatComposer.context-pickers.test.tsx`
- `pnpm --pm-on-fail=ignore -C e2e exec tsc -p tsconfig.json --noEmit`
- `pnpm --pm-on-fail=ignore -C e2e exec vitest run -c vitest.config.ts tests/antigravity/error-convergence.test.ts tests/dialog/service-error-convergence.test.ts`
- `pnpm --pm-on-fail=ignore -C e2e exec playwright test -c playwright.config.ts ui/project-management-flows.test.ts --grep "project detail share menu copies the current share link for uploaded html artifacts|project detail share menu opens the current share page for uploaded html artifacts|project detail share menu publish action opens the deploy flow for the selected provider"`
