### PR TITLE
fix: persist dismissed todo card state across tab switches

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -438,7 +438,30 @@ export function ChatPane({
   // We key the dismissal on the snapshot (serialized TodoWrite input) so
   // the next time the agent emits a different snapshot the card returns,
   // but the same snapshot stays hidden across renders / streaming ticks.
-  const [dismissedPinnedTodoKey, setDismissedPinnedTodoKey] = useState<string | null>(null);
+  // Persisted to sessionStorage so the dismissal survives tab switches and
+  // component remounts (the ChatPane key includes conversationId, so switching
+  // conversations unmounts and remounts the component).
+  const dismissedStorageKey = `dismissedTodo:${activeConversationId ?? 'none'}`;
+  const [dismissedPinnedTodoKey, setDismissedPinnedTodoKey] = useState<string | null>(() => {
+    try {
+      return sessionStorage.getItem(dismissedStorageKey);
+    } catch {
+      return null;
+    }
+  });
+  
+  // Sync dismissed state when conversationId changes (e.g., tab switching).
+  // The parent key includes conversationId so unmount/remount resets this,
+  // but if conversationId changes without unmounting or the storage key
+  // changes, re-read to keep the dismissed state in sync.
+  useEffect(() => {
+    try {
+      const stored = sessionStorage.getItem(dismissedStorageKey);
+      setDismissedPinnedTodoKey(stored);
+    } catch {
+      // sessionStorage access can fail in private browsing
+    }
+  }, [dismissedStorageKey]);
   const lastAssistantId = [...messages].reverse().find((m) => m.role === 'assistant')?.id;
   const hasActiveRunMessage = messages.some(
     (m) => m.role === 'assistant' && isActiveRunStatus(m.runStatus),
@@ -1285,7 +1308,18 @@ export function ChatPane({
             messages={messages}
             streaming={streaming}
             dismissedKey={dismissedPinnedTodoKey}
-            onDismiss={setDismissedPinnedTodoKey}
+            onDismiss={(key) => {
+              setDismissedPinnedTodoKey(key);
+              try {
+                if (key) {
+                  sessionStorage.setItem(dismissedStorageKey, key);
+                } else {
+                  sessionStorage.removeItem(dismissedStorageKey);
+                }
+              } catch {
+                // sessionStorage access can fail in private browsing / sandboxed contexts
+              }
+            }}
             containerRef={pinnedTodoRef}
           />
           <QueuedSendStrip


### PR DESCRIPTION
Fixes #3494

## Problem
Done task cards reappear after switching tabs. When users dismiss a task card by clicking Done, switching to another project tab and returning causes the dismissed card to reappear, even though the user already closed it.

## Root Cause
The `dismissedPinnedTodoKey` state is stored only in React component memory, without persistence. When switching tabs, ProjectView unmounts and remounts with `key={project.id}`, resetting all internal state to initial values. The dismissed state is lost because it was never synchronized to sessionStorage.

## Solution
Persist the dismissed state to `sessionStorage` with key `dismissedTodo:${conversationId}`:
1. Read from storage on component initialization
2. Add a `useEffect` to sync state when `activeConversationId` changes
3. Write to storage when user clicks Done
4. Guard all storage access with try/catch for private browsing / sandboxed contexts

This ensures dismissed state survives tab switches and conversation navigation.

## Surface area

- [x] **UI** — ChatPane pinned todo card dismissal behavior (now persisted across tab switches)
- [ ] API / contract / Keyboard shortcut / CLI / env var / Extension point / i18n / dependency / Default behavior change

## Testing
- Type checking passes: `pnpm --filter @open-design/web typecheck`
- Verified dismissed state persists across tab switches
- Storage access is guarded against private browsing mode failures

## Changes
- `apps/web/src/components/ChatPane.tsx`: Add sessionStorage persistence for dismissed todo state