### PR TITLE
docs(zh-CN): 顶部公告升级到 0.9.0，主打 Open Design AMR（装好即用）

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <h1 align="center">Open Design：The open-source Claude Design alternative</h1>
 
-> 🔥 **Open Design 0.8.0 已发布。** 这一版重点上线两件事：Plugin 体系，让模板和工作流像文件夹一样添加、复制、分享；Design System，支持导入品牌规范并沉淀为可复用的 [`DESIGN.md`](design-systems/)。[下载 0.8.0](https://github.com/nexu-io/open-design/releases) · [参与讨论](https://github.com/nexu-io/open-design/discussions/1727)
+> 🔥 **Open Design 0.9.0 已发布——装好即用。** 这一版重磅上线 **[Open Design AMR](https://open-design.ai/amr)**：官方 Model Router 内置在应用里，**无需任何配置、不用装 CLI、不用找 API Key**——打开应用，一键登录，选个模型，立刻开始创作。[下载 0.9.0](https://github.com/nexu-io/open-design/releases) · [参与讨论](https://github.com/nexu-io/open-design/discussions/1727)
 >
 > 🏅 **Open Design Fellow 计划正式开放。** 如果你也相信设计应该是开放的，欢迎成为 Open Design Fellow，和核心团队一起打磨产品，让更多人参与并定义设计的未来。详情 → [`MAINTAINERS.md`](MAINTAINERS.md) 与 [Discord](https://discord.gg/qhbcCH8Am4)。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <h1 align="center">Open Design：The open-source Claude Design alternative</h1>
 
-> 🔥 **Open Design 0.9.0 已发布——装好即用。** 这一版重磅上线 **[Open Design AMR](https://open-design.ai/amr)**：官方 Model Router 内置在应用里，**无需任何配置、不用装 CLI、不用找 API Key**——打开应用，一键登录，选个模型，立刻开始创作。[下载 0.9.0](https://github.com/nexu-io/open-design/releases) · [参与讨论](https://github.com/nexu-io/open-design/discussions/1727)
+> 🔥 **Open Design 0.9.0 正式发布：创作，从此无需准备。** [官方 Model Router](https://open-design.ai/amr) 直接内置于应用，无需额外配置、不用安装 CLI，也不必准备 API Key。只需打开应用，登录账号，就能立刻开始设计与创作。[下载 0.9.0](https://github.com/nexu-io/open-design/releases) · [参与讨论](https://github.com/nexu-io/open-design/discussions/1727)
 >
 > 🏅 **Open Design Fellow 计划正式开放。** 如果你也相信设计应该是开放的，欢迎成为 Open Design Fellow，和核心团队一起打磨产品，让更多人参与并定义设计的未来。详情 → [`MAINTAINERS.md`](MAINTAINERS.md) 与 [Discord](https://discord.gg/qhbcCH8Am4)。
 


### PR DESCRIPTION
## Why

0.9.0 已发布，头号能力是 **Open Design AMR**（官方 Model Router 内置在应用里）——零配置、不用装 CLI、不用找 API Key，一键登录即可用。README 顶部公告仍停留在 0.8.0 的 Plugin/Design System 主题，需要升级并主打 AMR 这个「装好即用」的体验。

## What users will see

顶部 0.8.0 公告替换为 0.9.0 公告：

> 🔥 **Open Design 0.9.0 已发布——装好即用。** 这一版重磅上线 **Open Design AMR**：官方 Model Router 内置在应用里，无需任何配置、不用装 CLI、不用找 API Key——打开应用，一键登录，选个模型，立刻开始创作。

## 范围

- 仅改中文 `README.zh-CN.md` 顶部公告一行（按惯例多语言先改中文确认）。
- 英文 README.md 及其余 11 个语言版本待此文案确认后再同步。

## 事实核对

AMR（内部代号 vela）在 0.9.0 release notes 中为头号 Highlight，代码见 `apps/daemon/src/runtimes/defs/amr.ts`、`integrations/vela.ts`、`apps/web/src/components/AmrLoginPill.tsx`；官方页 https://open-design.ai/amr。

## Surface area

- [x] 文档（README.zh-CN.md）