### PR TITLE
feat(plugins): add WebGPU hero example plugin

### DIFF
--- a/plugins/_official/examples/example-webgpu-hero/SKILL.md
+++ b/plugins/_official/examples/example-webgpu-hero/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: example-webgpu-hero
+zh_name: "WebGPU 英雄区"
+en_name: "WebGPU Hero"
+emoji: "🍜"
+description: "Full-bleed WebGPU three.js hero/splash: a flock of mouse-reactive tube 'noodles' animated entirely on the GPU behind an editorial title block and minimal chrome."
+zh_description: "全屏 WebGPU three.js 英雄区 / splash：GPU 计算驱动的鼠标交互「面条」管束动画，叠在编辑风标题与极简框架之上。"
+en_description: "Full-bleed WebGPU three.js hero/splash: a flock of mouse-reactive tube 'noodles' animated entirely on the GPU behind an editorial title block and minimal chrome."
+category: prototype
+scenario: design
+featured: 60
+tags: ["webgpu", "three.js", "hero", "splash", "shader", "generative", "background"]
+example_id: sample-webgpu-hero
+example_name: "WebGPU 英雄区 · OMMA"
+example_format: html
+example_tagline: "GPU 面条流"
+example_desc: "TSL 计算着色器驱动的管束 + 3D 标题淡入 + 鼠标视差"
+od:
+  mode: prototype
+  surface: prototype
+  scenario: design
+  platform: desktop
+  preview:
+    type: html
+    entry: index.html
+    reload: debounce-100
+  design_system:
+    requires: false
+  example_prompt: "Use the WebGPU Hero template to turn my content into a full-bleed splash page with a live three.js GPU-animated background behind an editorial title block. Preserve the template's visual signature and WebGPU pipeline, use real copy, and avoid lorem ipsum or placeholder images."
+  example_prompt_i18n:
+    zh-CN: "用「WebGPU 英雄区」模板把我的内容做成一个全屏 splash：实时 three.js GPU 动画背景 + 编辑风标题。保持模板的视觉签名和 WebGPU 管线，使用真实文案，避免 lorem ipsum 和占位图片。"
+---
+
+# WebGPU Hero Skill
+
+Produce a single, self-contained HTML splash page: a full-viewport WebGPU
+three.js animation rendered behind an editorial title block and thin chrome.
+Start from the bundled `example.html` and **edit** it — do not rewrite the
+shader pipeline from scratch.
+
+## What ships
+
+```
+example-webgpu-hero/
+├── SKILL.md          ← you're reading this
+├── open-design.json  ← marketplace manifest
+└── example.html      ← baked seed: full WebGPU pipeline + chrome (READ FIRST)
+```
+
+## How it works (so you know what is safe to touch)
+
+The seed is one HTML file with three layers:
+
+1. **Chrome (HTML + CSS)** — the title block (`.title-block h1` / `.tagline`),
+   top nav (`.logo` / `.nav-links`), `.badge`, side labels, `.bottom-bar`,
+   corner frames, and the radial-gradient `body` background. Plain markup you
+   can freely rewrite.
+2. **The 3D background (`<script type="module">`)** — a three.js WebGPU renderer
+   driving a flock of tube "noodles" along Catmull-Rom flight paths, animated
+   entirely on the GPU via TSL compute passes (spine → centroids → boids
+   repulsion → parallel-transport frames → tube vertices). A `params` object at
+   the top is the single source of truth for every tunable value; a `lil-gui`
+   panel (toggle with the `P` key) exposes them live.
+3. **3D title text** — the `<h1>` is mirrored as extruded `TextGeometry` that
+   fades/slides in once the Space Grotesk font loads, kept aligned to the DOM
+   `<h1>` via `updateTextScale()`.
+
+Dependencies load from a CDN `importmap` (three.js 0.183, stats-gl, lil-gui).
+Keep the script inline and keep the importmap — the preview runs in a
+null-origin sandbox, so a separate `/index.js` or bare relative import would
+not resolve.
+
+## Workflow
+
+1. **Read the seed** end to end. Note the `params` block, `PALETTE`, and the
+   chrome class names above.
+2. **Rebrand the chrome** — replace `<title>`, `.logo`, `.nav-links`, `.badge`,
+   `.title-block h1`, `.tagline`, side labels, and `.bottom-bar` with the user's
+   real copy. No filler — every slot carries a real word.
+3. **Match the 3D title** — update the `TextGeometry('OMMA', …)` string to the
+   new headline so the extruded text matches the DOM `<h1>`. For a long
+   headline, delete the `textMesh` block + font-load `.then` and rely on the CSS
+   `<h1>` alone.
+4. **Tune the look via `params` only** — palette via `PALETTE`; background via
+   `bgColorCenter` / `bgColorEdge` (mirror in the CSS `body` gradient);
+   density/shape via `noodleCount` / `tubeRadius` / `pathFraction`; material via
+   `roughness` / `metalness` / `clearcoat` / `colorGradientMix`; feel via
+   `mouseForce` / `separationAmplitude` / `parallaxAmountX/Y`. Leave the
+   compute-shader bodies alone unless changing the motion model itself.
+5. **Self-check** — single HTML file; module stays inline; importmap intact;
+   `navigator.gpu` guard + `.gpu-fallback` present; CSS gradient matches the
+   `bg*` params; 3D-text string equals the `<h1>` (or both 3D-text blocks
+   removed); no filler; one clear accent.
+6. **Emit the artifact** — wrap the final HTML in `<artifact>` with a kebab-case
+   `identifier`. One sentence before; nothing after.
+
+## Hard rules
+
+- **WebGPU only.** Keep the `navigator.gpu` guard and `.gpu-fallback` message —
+  never ship a blank screen on unsupported browsers.
+- **Single inline module + CDN importmap.** No external `.js`, no bundler.
+- **`params` is the only knob surface.** Tune visuals there, not deep in the GPU
+  passes.
+- **Chrome stays minimal.** Thin nav, one badge, editorial title — the 3D layer
+  is the hero; don't crowd it.
+- **Keep first paint dark.** The CSS gradient must match the WebGPU clear so
+  there's no flash before the canvas initializes.

--- a/plugins/_official/examples/example-webgpu-hero/example.html
+++ b/plugins/_official/examples/example-webgpu-hero/example.html
@@ -387,9 +387,9 @@ import {
   deltaTime,
   Return,
 } from 'three/tsl'
-import { TTFLoader } from 'three/examples/jsm/loaders/TTFLoader.js'
-import { Font } from 'three/examples/jsm/loaders/FontLoader.js'
-import { TextGeometry } from 'three/examples/jsm/geometries/TextGeometry.js'
+import { TTFLoader } from 'three/addons/loaders/TTFLoader.js'
+import { Font } from 'three/addons/loaders/FontLoader.js'
+import { TextGeometry } from 'three/addons/geometries/TextGeometry.js'
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 import Stats from 'stats-gl'
 import GUI from 'lil-gui'

--- a/plugins/_official/examples/example-webgpu-hero/example.html
+++ b/plugins/_official/examples/example-webgpu-hero/example.html
@@ -1,0 +1,1320 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OMMA — a visual experiment in motion</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Inter:wght@300;400;500" rel="stylesheet">
+  <style>
+    *, *::before, *::after {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      background: radial-gradient(ellipse at center, #212f78 0%, #0d122b 55%);
+      font-family: 'Inter', sans-serif;
+      overflow-x: hidden;
+      color: #fff;
+    }
+
+    canvas {
+      position: fixed !important;
+      top: 0;
+      left: 0;
+      z-index: -1;
+    }
+
+    /* ── Splash ── */
+    .splash {
+      height: 100lvh;
+      position: relative;
+      overflow: clip;
+    }
+
+    /* ── Title ── */
+    .title-block {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      z-index: 2;
+      opacity: 0;
+    }
+
+    .title-block h1 {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: clamp(64px, 14vw, 200px);
+      font-weight: 700;
+      letter-spacing: -0.04em;
+      line-height: 0.9;
+      color: #e0e0ff;
+      opacity: 0;
+      width: max-content;
+      margin: 0 auto;
+    }
+
+    .title-block .divider {
+      width: 40px;
+      height: 1px;
+      background: #ccc;
+      margin: 20px auto;
+    }
+
+    .title-block .tagline {
+      font-size: clamp(11px, 1.1vw, 15px);
+      font-weight: 300;
+      letter-spacing: 0.35em;
+      text-transform: uppercase;
+      color: #999;
+    }
+
+    /* ── Top bar ── */
+    .top-bar {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 32px 48px;
+      z-index: 2;
+      animation: fadeIn 0.8s ease-out 0.5s both;
+    }
+
+    .logo {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .logo .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: #fff;
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 32px;
+    }
+
+    .nav-links a {
+      font-size: 11px;
+      font-weight: 400;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: #fff;
+      text-decoration: none;
+      transition: color 0.3s;
+    }
+
+    .nav-links a:hover {
+      color: #fff;
+    }
+
+    /* ── Badge ── */
+    .badge {
+      position: absolute;
+      top: 96px;
+      right: 48px;
+      padding: 6px 16px;
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: #fff;
+      border: 1px solid #ddd;
+      border-radius: 100px;
+      z-index: 2;
+      animation: fadeIn 0.8s ease-out 0.8s both;
+    }
+
+    /* ── Side labels ── */
+    .side-label-left {
+      position: absolute;
+      left: 48px;
+      top: 50%;
+      transform: translateY(-50%);
+      z-index: 2;
+      animation: fadeIn 0.8s ease-out 0.6s both;
+    }
+
+    .side-label-left .num {
+      font-family: 'Space Grotesk', sans-serif;
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.3em;
+      color: #bbb;
+      writing-mode: vertical-lr;
+    }
+
+    .side-label-right {
+      position: absolute;
+      right: 48px;
+      top: 50%;
+      transform: translateY(-50%);
+      z-index: 2;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 6px;
+      animation: fadeIn 0.8s ease-out 0.6s both;
+    }
+
+    .side-label-right span {
+      font-size: 10px;
+      font-weight: 400;
+      letter-spacing: 0.25em;
+      text-transform: uppercase;
+      color: #fff;
+    }
+
+    /* ── Bottom bar ── */
+    .bottom-bar {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
+      padding: 32px 48px;
+      z-index: 2;
+      animation: fadeIn 0.8s ease-out 0.7s both;
+    }
+
+    .bottom-left,
+    .bottom-center,
+    .bottom-right {
+      font-size: 11px;
+      font-weight: 400;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: #bbb;
+    }
+
+    /* ── Corner frames ── */
+    .frame-tl {
+      position: absolute;
+      top: 24px;
+      left: 32px;
+      width: 40px;
+      height: 40px;
+      border-top: 1px solid #ddd;
+      border-left: 1px solid #ddd;
+      z-index: 2;
+      pointer-events: none;
+    }
+
+    .frame-br {
+      position: absolute;
+      bottom: 24px;
+      right: 32px;
+      width: 40px;
+      height: 40px;
+      border-bottom: 1px solid #ddd;
+      border-right: 1px solid #ddd;
+      z-index: 2;
+      pointer-events: none;
+    }
+
+    /* ── Horizontal rule ── */
+    .h-rule {
+      position: absolute;
+      bottom: 100px;
+      left: 48px;
+      right: 48px;
+      height: 1px;
+      background: linear-gradient(90deg, #ddd 0%, transparent 30%, transparent 70%, #ddd 100%);
+      z-index: 2;
+      pointer-events: none;
+      opacity: 0.5;
+    }
+
+    /* ── Animations ── */
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translate(-50%, -45%);
+      }
+      to {
+        opacity: 1;
+        transform: translate(-50%, -50%);
+      }
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    /* ── Responsive ── */
+    @media (max-width: 768px) {
+      .top-bar { padding: 24px 24px; }
+      .bottom-bar { padding: 24px 24px; }
+      .side-label-left,
+      .side-label-right { display: none; }
+      .badge { right: 24px; top: 80px; }
+      .nav-links { gap: 20px; }
+      .frame-tl { left: 16px; top: 16px; }
+      .frame-br { right: 16px; bottom: 16px; }
+      .h-rule { left: 24px; right: 24px; }
+    }
+
+    /* ── WebGPU fallback notice (shown if navigator.gpu is unavailable) ── */
+    .gpu-fallback {
+      position: fixed;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 32px;
+      z-index: 3;
+      font-size: 13px;
+      letter-spacing: 0.1em;
+      color: #bbb;
+    }
+    .gpu-fallback.show { display: flex; }
+  </style>
+
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://cdn.jsdelivr.net/npm/three@0.183.2/build/three.webgpu.js",
+      "three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.183.2/build/three.webgpu.js",
+      "three/tsl": "https://cdn.jsdelivr.net/npm/three@0.183.2/build/three.tsl.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.183.2/examples/jsm/",
+      "stats-gl": "https://cdn.jsdelivr.net/npm/stats-gl@4.0.2/dist/main.js",
+      "lil-gui": "https://cdn.jsdelivr.net/npm/lil-gui@0.21.0/dist/lil-gui.esm.js"
+    }
+  }
+  </script>
+
+</head>
+<body>
+
+  <section class="splash">
+    <div class="frame-tl"></div>
+    <div class="frame-br"></div>
+
+    <nav class="top-bar">
+      <div class="logo">
+        <span class="dot"></span>
+        NOODLES
+      </div>
+      <div class="nav-links">
+        <a href="#">Work</a>
+        <a href="#">About</a>
+        <a href="#">Contact</a>
+      </div>
+    </nav>
+
+    <div class="badge">WebGPU</div>
+
+    <div class="side-label-left">
+      <span class="num">N&ordm; 001</span>
+    </div>
+
+    <div class="title-block">
+      <h1>OMMA</h1>
+      <div class="divider"></div>
+      <p class="tagline">A visual experiment in motion</p>
+    </div>
+
+    <div class="side-label-right">
+      <span>Est.</span>
+      <span>2026</span>
+    </div>
+
+    <div class="h-rule"></div>
+
+    <div class="bottom-bar">
+      <div class="bottom-left">Tokyo / Milano / NYC</div>
+      <div class="bottom-center">Always al dente</div>
+      <div class="bottom-right">&infin; flavours</div>
+    </div>
+  </section>
+
+  <div class="gpu-fallback" id="gpuFallback">
+    This prototype needs WebGPU. Try the latest Chrome, Edge, or Safari&nbsp;Technology&nbsp;Preview.
+  </div>
+
+  <script type="module">
+import * as THREE from 'three/webgpu'
+import {
+  Fn,
+  If,
+  Loop,
+  float,
+  int,
+  uint,
+  vec3,
+  uniform,
+  select,
+  mix,
+  uv,
+  attribute,
+  instancedArray,
+  instanceIndex,
+  vertexIndex,
+  dot,
+  length,
+  sin,
+  cos,
+  floor,
+  fract,
+  normalize,
+  cross,
+  max,
+  min,
+  positionLocal,
+  cameraViewMatrix,
+  TWO_PI,
+  smoothstep,
+  deltaTime,
+  Return,
+} from 'three/tsl'
+import { TTFLoader } from 'three/examples/jsm/loaders/TTFLoader.js'
+import { Font } from 'three/examples/jsm/loaders/FontLoader.js'
+import { TextGeometry } from 'three/examples/jsm/geometries/TextGeometry.js'
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
+import Stats from 'stats-gl'
+import GUI from 'lil-gui'
+
+// WebGPU is required. Surface a friendly notice instead of a blank screen
+// when the browser cannot provide an adapter.
+if (!navigator.gpu) {
+  document.getElementById('gpuFallback').classList.add('show')
+  throw new Error('WebGPU not available')
+}
+
+// ── Params (single source of truth for configurable values) ─────────────────
+const params = {
+  debug: false,
+  showPaths: false,
+
+  noodleCount: 100,
+  pathFraction: 0.08, // fraction of flight path each noodle occupies
+  tubeRadius: 0.5,
+
+  // Mouse interaction (boids repulsion)
+  mouseAttract: false,
+  mouseZ: -5,
+  mouseRadius: 12,
+  mouseForce: 80,
+  returnSpring: 6,
+  damping: 2,
+  mouseBodyForce: 3,
+  mouseBodyDecay: 2,
+  separationRadius: 5,
+  separationAmplitude: 2,
+
+  // Camera
+  cameraFov: 50,
+  cameraDistance: 25,
+
+  // Parallax
+  parallaxAmountX: 2,
+  parallaxAmountY: 1.5,
+  parallaxSmoothing: 0.05,
+
+  // Material
+  roughness: 0.2,
+  metalness: 0.0,
+  clearcoat: 0.6,
+  clearcoatRoughness: 0.1,
+  colorGradientMix: 0.3,
+
+  // Tonemapping
+  toneMapping: 'ACES',
+
+  // Text
+  textColor: '#fff',
+
+  // Background gradient
+  bgColorCenter: '#212f78',
+  bgColorEdge: '#0d122b',
+
+  // Lighting
+  ambientIntensity: 0.7,
+  dirLight1Intensity: 1.5,
+  dirLight1X: 10,
+  dirLight1Y: 15,
+  dirLight1Z: 10,
+  dirLight2Intensity: 0.4,
+  dirLight2X: -8,
+  dirLight2Y: -5,
+  dirLight2Z: 8,
+  shadowLightIntensity: 1.2,
+  shadowLightX: 5,
+  shadowLightY: 20,
+  shadowLightZ: 10,
+}
+
+const PALETTE = [
+  0xff6b6b, 0xffd93d, 0x6bcb77, 0x4d96ff, 0xff6eb4, 0xffa726, 0xab47bc, 0x26c6da, 0x7e57c2, 0x66bb6a, 0xff7043,
+  0x42a5f5, 0xec407a, 0xffca28, 0x26a69a,
+]
+
+const TUBE_SEGMENTS = 60
+const RADIAL_SEGMENTS = 10
+const PATH_SAMPLES = 256
+const VERTS_PER_NOODLE = (TUBE_SEGMENTS + 1) * (RADIAL_SEGMENTS + 1)
+const SPINE_POINTS = TUBE_SEGMENTS + 1
+const TOTAL_VERTICES = params.noodleCount * VERTS_PER_NOODLE
+const TOTAL_SPINE = params.noodleCount * SPINE_POINTS
+
+// ── Curve generator ────────────────────────────────────────────────────────
+function generateFlightPath() {
+  const points = []
+  const numPoints = 5 + Math.floor(Math.random() * 4)
+  const radiusX = 10 + Math.random() * 12
+  const radiusY = 7 + Math.random() * 8
+  const centerX = (Math.random() - 0.5) * 6
+  const centerY = (Math.random() - 0.5) * 4
+  const centerZ = -5 + Math.random() * 8
+
+  for (let i = 0; i < numPoints; i++) {
+    const angle = (i / numPoints) * Math.PI * 2
+    points.push(
+      new THREE.Vector3(
+        Math.cos(angle) * radiusX + centerX + (Math.random() - 0.5) * 5,
+        Math.sin(angle) * radiusY + centerY + (Math.random() - 0.5) * 4,
+        Math.sin(angle * 1.5) * 4 + centerZ,
+      ),
+    )
+  }
+
+  return new THREE.CatmullRomCurve3(points, true)
+}
+
+// ── Pre-sample flight paths into GPU storage buffers ────────────────────────
+const flightPaths = Array.from({ length: params.noodleCount }, generateFlightPath)
+
+const pathSamplesData = new Float32Array(params.noodleCount * PATH_SAMPLES * 3)
+const _v = new THREE.Vector3()
+for (let n = 0; n < params.noodleCount; n++) {
+  for (let s = 0; s < PATH_SAMPLES; s++) {
+    flightPaths[n].getPointAt(s / PATH_SAMPLES, _v)
+    const base = (n * PATH_SAMPLES + s) * 3
+    pathSamplesData[base] = _v.x
+    pathSamplesData[base + 1] = _v.y
+    pathSamplesData[base + 2] = _v.z
+  }
+}
+const pathSamples = instancedArray(pathSamplesData, 'vec3')
+
+// Per-noodle params: (speed, timeOffset, pathFractionScale, mouseInfluenceFactor)
+const noodleParamsData = new Float32Array(params.noodleCount * 4)
+for (let i = 0; i < params.noodleCount; i++) {
+  const base = i * 4
+  noodleParamsData[base] = 0.02 + Math.random() * 0.06
+  noodleParamsData[base + 1] = Math.random()
+  noodleParamsData[base + 2] = 0.8 + Math.random() * 0.4
+  noodleParamsData[base + 3] = 0.3 + Math.random() * 1.0
+}
+const noodleParams = instancedArray(noodleParamsData, 'vec4')
+
+// Per-noodle colors
+const noodleColorsData = new Float32Array(params.noodleCount * 3)
+const _c = new THREE.Color()
+for (let i = 0; i < params.noodleCount; i++) {
+  _c.set(PALETTE[i % PALETTE.length])
+  const base = i * 3
+  noodleColorsData[base] = _c.r
+  noodleColorsData[base + 1] = _c.g
+  noodleColorsData[base + 2] = _c.b
+}
+const noodleColors = instancedArray(noodleColorsData, 'vec3')
+
+// Spine positions (compute pass 1 → pass 2/3 + cap materials)
+const spinePositions = instancedArray(TOTAL_SPINE, 'vec3')
+
+// Parallel-transport frames (compute pass 2 → pass 3)
+const frameNormals = instancedArray(TOTAL_SPINE, 'vec3')
+const frameBinormals = instancedArray(TOTAL_SPINE, 'vec3')
+
+// Vertex positions and normals (compute pass 3 → tube material)
+const vertexPositions = instancedArray(TOTAL_VERTICES, 'vec3')
+const vertexNormals = instancedArray(TOTAL_VERTICES, 'vec3')
+
+// Per-spine-point persistent path offsets (for gradual path bending + decay)
+const spineOffsets = instancedArray(TOTAL_SPINE, 'vec3')
+
+// Per-noodle boids state (persistent across frames)
+const noodleOffsets = instancedArray(params.noodleCount, 'vec3')
+const noodleVelocities = instancedArray(params.noodleCount, 'vec3')
+const noodleCentroids = instancedArray(params.noodleCount, 'vec3')
+
+// ── Shared uniforms ─────────────────────────────────────────────────────────
+const elapsedU = uniform(0)
+const mouseWorldPosU = uniform(new THREE.Vector3(0, 0, params.mouseZ))
+const mouseSignU = uniform(params.mouseAttract ? -1 : 1)
+const mouseRadiusU = uniform(params.mouseRadius)
+const mouseForceU = uniform(params.mouseForce)
+const mouseBodyForceU = uniform(params.mouseBodyForce)
+const mouseBodyDecayU = uniform(params.mouseBodyDecay)
+const returnSpringU = uniform(params.returnSpring)
+const dampingU = uniform(params.damping)
+const separationRadiusU = uniform(params.separationRadius)
+const separationAmplitudeU = uniform(params.separationAmplitude)
+const pathFractionU = uniform(params.pathFraction)
+const tubeRadiusU = uniform(params.tubeRadius)
+const roughnessU = uniform(params.roughness)
+const metalnessU = uniform(params.metalness)
+const clearcoatU = uniform(params.clearcoat)
+const clearcoatRoughnessU = uniform(params.clearcoatRoughness)
+const colorGradientMixU = uniform(params.colorGradientMix)
+
+// ── Compute Pass 1: Spine positions (raw path sampling, no interaction) ─────
+const computeSpine = Fn(() => {
+  If(instanceIndex.greaterThanEqual(uint(TOTAL_SPINE)), () => { Return() })
+
+  const idx = instanceIndex
+  const noodleIdx = idx.div(uint(SPINE_POINTS))
+  const segIdx = idx.mod(uint(SPINE_POINTS))
+
+  const np = noodleParams.element(noodleIdx)
+  const pathFrac = pathFractionU.mul(np.z)
+  const tStart = fract(elapsedU.mul(np.x).add(np.y))
+  const t = fract(tStart.add(segIdx.toFloat().div(float(TUBE_SEGMENTS)).mul(pathFrac)))
+
+  // Linear interpolation between pre-sampled path points (wrapping)
+  const sF = t.mul(float(PATH_SAMPLES))
+  const sI = floor(sF).toUint()
+  const sFrac = fract(sF)
+  const base = noodleIdx.mul(uint(PATH_SAMPLES))
+  const i0 = base.add(sI.mod(uint(PATH_SAMPLES)))
+  const i1 = base.add(sI.add(uint(1)).mod(uint(PATH_SAMPLES)))
+
+  spinePositions.element(idx).assign(mix(pathSamples.element(i0), pathSamples.element(i1), sFrac))
+})().compute(TOTAL_SPINE)
+
+// ── Compute Pass 1.5: Noodle centroids (1 thread/noodle) ──────────────────
+const computeCentroids = Fn(() => {
+  If(instanceIndex.greaterThanEqual(uint(params.noodleCount)), () => { Return() })
+
+  const noodleIdx = instanceIndex
+  const spineBase = noodleIdx.mul(uint(SPINE_POINTS))
+
+  const centroid = vec3(0, 0, 0).toVar()
+  Loop(int(SPINE_POINTS), ({ i }) => {
+    centroid.addAssign(spinePositions.element(spineBase.add(uint(i))))
+  })
+  centroid.divAssign(float(SPINE_POINTS))
+  centroid.addAssign(noodleOffsets.element(noodleIdx))
+
+  noodleCentroids.element(noodleIdx).assign(centroid)
+})().compute(params.noodleCount)
+
+// ── Compute Pass 1.75: Boids-like repulsion (1 thread/noodle) ─────────────
+const computeRepulsion = Fn(() => {
+  If(instanceIndex.greaterThanEqual(uint(params.noodleCount)), () => { Return() })
+
+  const noodleIdx = instanceIndex
+
+  const offset = noodleOffsets.element(noodleIdx)
+  const vel = noodleVelocities.element(noodleIdx)
+  const dt = min(deltaTime, float(0.05))
+
+  const centroid = noodleCentroids.element(noodleIdx)
+  const force = vec3(0, 0, 0).toVar()
+
+  // ── Mouse repulsion ──
+  const toMouse = centroid.sub(mouseWorldPosU)
+  const mouseDist = length(toMouse)
+  If(mouseDist.greaterThan(0.001).and(mouseDist.lessThan(mouseRadiusU)), () => {
+    const repelDir = toMouse.div(mouseDist)
+    const falloff = smoothstep(mouseRadiusU, float(0), mouseDist)
+    const np = noodleParams.element(noodleIdx)
+    force.addAssign(repelDir.mul(mouseSignU).mul(mouseForceU.mul(np.w).mul(falloff)))
+  })
+
+  // ── Noodle-to-noodle separation ──
+  Loop(int(params.noodleCount), ({ i }) => {
+    If(i.notEqual(int(noodleIdx)), () => {
+      const otherCentroid = noodleCentroids.element(uint(i))
+      const away = centroid.sub(otherCentroid)
+      const dist = length(away)
+      If(dist.greaterThan(0.001).and(dist.lessThan(separationRadiusU)), () => {
+        const sepDir = away.div(dist)
+        const sepFalloff = smoothstep(separationRadiusU, float(0), dist)
+        force.addAssign(sepDir.mul(separationAmplitudeU.mul(sepFalloff)))
+      })
+    })
+  })
+
+  // ── Return-to-origin spring ──
+  force.subAssign(offset.mul(returnSpringU))
+
+  // ── Velocity damping ──
+  force.subAssign(vel.mul(dampingU))
+
+  // ── Integrate (semi-implicit Euler) ──
+  vel.addAssign(force.mul(dt))
+  offset.addAssign(vel.mul(dt))
+})().compute(params.noodleCount)
+
+// ── Compute Pass 2: Apply offset + parallel-transport frames (1 thread/noodle)
+const computeFrames = Fn(() => {
+  If(instanceIndex.greaterThanEqual(uint(params.noodleCount)), () => { Return() })
+
+  const noodleIdx = instanceIndex
+  const spineBase = noodleIdx.mul(uint(SPINE_POINTS))
+
+  // Apply boids offset + persistent path deflection with decay
+  const offset = noodleOffsets.element(noodleIdx)
+  const dt = min(deltaTime, float(0.05))
+  const accumForce = vec3(0, 0, 0).toVar()
+
+  Loop(int(SPINE_POINTS), ({ i }) => {
+    const idx = spineBase.add(uint(i))
+    const pos = spinePositions.element(idx)
+    pos.addAssign(offset)
+
+    // Accumulate deflection along spine for smooth path bending
+    const toMouse = pos.sub(mouseWorldPosU)
+    const dist = length(toMouse)
+    If(dist.greaterThan(0.001).and(dist.lessThan(mouseRadiusU)), () => {
+      const dir = toMouse.div(dist)
+      const falloff = smoothstep(mouseRadiusU, float(0), dist)
+      accumForce.addAssign(dir.mul(mouseSignU).mul(mouseBodyForceU.mul(falloff).div(float(TUBE_SEGMENTS))))
+    })
+
+    // Persistent offset: lerp toward deflection target (fast), decay to zero (slow)
+    const stored = spineOffsets.element(idx)
+    const hasTarget = smoothstep(float(0), float(0.001), length(accumForce))
+    const rate = mix(mouseBodyDecayU, float(10), hasTarget).mul(dt).saturate()
+    stored.assign(mix(stored, accumForce, rate))
+
+    pos.addAssign(stored)
+  })
+
+  // ── Parallel-transport frames from displaced positions ──
+  const p0 = spinePositions.element(spineBase)
+  const p1 = spinePositions.element(spineBase.add(uint(1)))
+  const diff0 = p1.sub(p0)
+  const diff0Len = length(diff0)
+  const T = select(diff0Len.greaterThan(0.0001), diff0.div(diff0Len), vec3(0, 0, 1)).toVar()
+
+  // Initial frame via branchless ONB (Duff et al. 2017)
+  const s = select(T.z.greaterThanEqual(0), float(1), float(-1))
+  const a = float(-1).div(s.add(T.z))
+  const bv = T.x.mul(T.y).mul(a)
+  const N = vec3(float(1).add(s.mul(T.x).mul(T.x).mul(a)), s.mul(bv), s.negate().mul(T.x)).toVar()
+
+  frameNormals.element(spineBase).assign(N)
+  frameBinormals.element(spineBase).assign(normalize(cross(T, N)))
+
+  // Propagate frames along spine via parallel transport
+  Loop(int(TUBE_SEGMENTS), ({ i }) => {
+    const segIdx = i.add(1).toUint()
+
+    // Central-difference tangent (clamped at boundary)
+    const prevSeg = max(int(segIdx).sub(1), int(0)).toUint()
+    const nextSeg = min(segIdx.add(uint(1)), uint(TUBE_SEGMENTS))
+    const pPrev = spinePositions.element(spineBase.add(prevSeg))
+    const pNext = spinePositions.element(spineBase.add(nextSeg))
+    const diff = pNext.sub(pPrev)
+    const diffLen = length(diff)
+    const T2 = select(diffLen.greaterThan(0.0001), diff.div(diffLen), T).toVar()
+
+    // Project previous normal onto plane perpendicular to new tangent
+    const projected = N.sub(T2.mul(dot(N, T2))).toVar()
+    const projLen = length(projected)
+
+    If(projLen.greaterThan(0.001), () => {
+      N.assign(projected.div(projLen))
+    })
+
+    T.assign(T2)
+
+    frameNormals.element(spineBase.add(segIdx)).assign(N)
+    frameBinormals.element(spineBase.add(segIdx)).assign(normalize(cross(T2, N)))
+  })
+})().compute(params.noodleCount)
+
+// ── Compute Pass 3: Tube vertices from frames ──────────────────────────────
+const computeVertices = Fn(() => {
+  If(instanceIndex.greaterThanEqual(uint(TOTAL_VERTICES)), () => { Return() })
+
+  const idx = instanceIndex
+  const noodleIdx = idx.div(uint(VERTS_PER_NOODLE))
+  const localIdx = idx.mod(uint(VERTS_PER_NOODLE))
+  const segIdx = localIdx.div(uint(RADIAL_SEGMENTS + 1))
+  const radIdx = localIdx.mod(uint(RADIAL_SEGMENTS + 1))
+
+  const frameIdx = noodleIdx.mul(uint(SPINE_POINTS)).add(segIdx)
+  const P = spinePositions.element(frameIdx)
+  const N = frameNormals.element(frameIdx)
+  const B = frameBinormals.element(frameIdx)
+
+  // Tube cross-section vertex
+  const angle = radIdx.toFloat().div(float(RADIAL_SEGMENTS)).mul(TWO_PI)
+  const cx = tubeRadiusU.negate().mul(cos(angle))
+  const cy = tubeRadiusU.mul(sin(angle))
+
+  vertexPositions.element(idx).assign(P.add(N.mul(cx)).add(B.mul(cy)))
+  vertexNormals.element(idx).assign(normalize(N.mul(cx).add(B.mul(cy))))
+})().compute(TOTAL_VERTICES)
+
+// ── Renderer ────────────────────────────────────────────────────────────────
+const renderer = new THREE.WebGPURenderer({ antialias: true, alpha: true })
+renderer.setSize(window.innerWidth, window.innerHeight)
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+renderer.toneMapping = THREE.ACESFilmicToneMapping
+renderer.setClearColor(0x000000, 0)
+renderer.shadowMap.enabled = true
+document.body.appendChild(renderer.domElement)
+await renderer.init()
+
+// ── Camera ──────────────────────────────────────────────────────────────────
+const camera = new THREE.PerspectiveCamera(params.cameraFov, window.innerWidth / window.innerHeight, 0.1, 200)
+camera.position.z = params.cameraDistance
+
+// Invisible overlay to capture pointer events for dragging in debug mode
+const debugOverlay = document.createElement('div')
+debugOverlay.style.cssText = 'position:fixed;inset:0;z-index:100;display:none;'
+document.body.appendChild(debugOverlay)
+
+const controls = new OrbitControls(camera, debugOverlay)
+controls.enableDamping = true
+controls.enabled = params.debug
+
+// ── Scene ───────────────────────────────────────────────────────────────────
+const scene = new THREE.Scene()
+
+const ambientLight = new THREE.AmbientLight(0xffffff, params.ambientIntensity)
+scene.add(ambientLight)
+
+const dir1 = new THREE.DirectionalLight(0xffffff, params.dirLight1Intensity)
+dir1.position.set(params.dirLight1X, params.dirLight1Y, params.dirLight1Z)
+scene.add(dir1)
+
+const dir2 = new THREE.DirectionalLight(0xffffff, params.dirLight2Intensity)
+dir2.position.set(params.dirLight2X, params.dirLight2Y, params.dirLight2Z)
+scene.add(dir2)
+
+const shadowLight = new THREE.DirectionalLight(0xffffff, params.shadowLightIntensity)
+shadowLight.position.set(params.shadowLightX, params.shadowLightY, params.shadowLightZ)
+shadowLight.castShadow = true
+shadowLight.shadow.mapSize.set(2048, 2048)
+shadowLight.shadow.camera.left = -30
+shadowLight.shadow.camera.right = 30
+shadowLight.shadow.camera.top = 20
+shadowLight.shadow.camera.bottom = -20
+shadowLight.shadow.camera.near = 0.1
+shadowLight.shadow.camera.far = 60
+shadowLight.shadow.bias = -0.001
+scene.add(shadowLight)
+
+// ── Debug mouse sphere ──────────────────────────────────────────────────────
+const debugSphere = new THREE.Mesh(
+  new THREE.SphereGeometry(1, 24, 16),
+  new THREE.MeshBasicMaterial({ color: 0xffffff, wireframe: true, transparent: true, opacity: 0.3 }),
+)
+debugSphere.visible = false
+scene.add(debugSphere)
+
+// ── Tube geometry (single merged mesh for all noodles) ──────────────────────
+const tubeGeometry = new THREE.BufferGeometry()
+
+// Dummy position attribute (actual positions come via positionNode from compute)
+tubeGeometry.setAttribute('position', new THREE.Float32BufferAttribute(new Float32Array(TOTAL_VERTICES * 3), 3))
+
+// Pre-computed UVs: x = along tube length, y = around tube
+const uvArray = new Float32Array(TOTAL_VERTICES * 2)
+for (let n = 0; n < params.noodleCount; n++) {
+  for (let seg = 0; seg <= TUBE_SEGMENTS; seg++) {
+    for (let rad = 0; rad <= RADIAL_SEGMENTS; rad++) {
+      const vi = n * VERTS_PER_NOODLE + seg * (RADIAL_SEGMENTS + 1) + rad
+      uvArray[vi * 2] = seg / TUBE_SEGMENTS
+      uvArray[vi * 2 + 1] = rad / RADIAL_SEGMENTS
+    }
+  }
+}
+tubeGeometry.setAttribute('uv', new THREE.BufferAttribute(uvArray, 2))
+
+// Per-vertex noodle index (for color lookup in material)
+const noodleIndexArray = new Float32Array(TOTAL_VERTICES)
+for (let n = 0; n < params.noodleCount; n++) {
+  for (let v = 0; v < VERTS_PER_NOODLE; v++) {
+    noodleIndexArray[n * VERTS_PER_NOODLE + v] = n
+  }
+}
+tubeGeometry.setAttribute('noodleIndex', new THREE.BufferAttribute(noodleIndexArray, 1))
+
+// Index buffer (tube topology repeated for each noodle)
+const tubeIndices = new Uint32Array(params.noodleCount * TUBE_SEGMENTS * RADIAL_SEGMENTS * 6)
+let ti = 0
+for (let n = 0; n < params.noodleCount; n++) {
+  const vo = n * VERTS_PER_NOODLE
+  for (let seg = 0; seg < TUBE_SEGMENTS; seg++) {
+    for (let rad = 0; rad < RADIAL_SEGMENTS; rad++) {
+      const a = vo + seg * (RADIAL_SEGMENTS + 1) + rad
+      const b = vo + (seg + 1) * (RADIAL_SEGMENTS + 1) + rad
+      const c = vo + (seg + 1) * (RADIAL_SEGMENTS + 1) + (rad + 1)
+      const d = vo + seg * (RADIAL_SEGMENTS + 1) + (rad + 1)
+      tubeIndices[ti++] = a
+      tubeIndices[ti++] = b
+      tubeIndices[ti++] = d
+      tubeIndices[ti++] = b
+      tubeIndices[ti++] = c
+      tubeIndices[ti++] = d
+    }
+  }
+}
+tubeGeometry.setIndex(new THREE.BufferAttribute(tubeIndices, 1))
+
+// ── Tube material ───────────────────────────────────────────────────────────
+const tubeMaterial = new THREE.MeshPhysicalNodeMaterial()
+
+tubeMaterial.positionNode = Fn(() => {
+  return vertexPositions.element(vertexIndex)
+})()
+
+// Pass computed normals as varying, then transform to view space for lighting
+const vNormal = vertexNormals.element(vertexIndex).toVarying('v_computedNormal')
+const computedNormalView = Fn(() => {
+  return cameraViewMatrix.transformDirection(vNormal).normalize()
+})()
+tubeMaterial.normalNode = computedNormalView
+tubeMaterial.clearcoatNormalNode = computedNormalView
+
+tubeMaterial.colorNode = Fn(() => {
+  const nIdx = attribute('noodleIndex').toUint()
+  const baseColor = noodleColors.element(nIdx)
+  const lightCol = mix(baseColor, vec3(1, 1, 1), colorGradientMixU)
+  return mix(baseColor, lightCol, uv().x)
+})()
+
+tubeMaterial.roughnessNode = roughnessU
+tubeMaterial.metalnessNode = metalnessU
+tubeMaterial.clearcoatNode = clearcoatU
+tubeMaterial.clearcoatRoughnessNode = clearcoatRoughnessU
+
+const tubeMesh = new THREE.Mesh(tubeGeometry, tubeMaterial)
+tubeMesh.castShadow = true
+tubeMesh.receiveShadow = true
+tubeMesh.frustumCulled = false
+scene.add(tubeMesh)
+
+// ── Cap meshes (InstancedMesh: start and end caps) ──────────────────────────
+const capGeometry = new THREE.SphereGeometry(1, 10, 8)
+
+const startCapMaterial = new THREE.MeshPhysicalNodeMaterial()
+startCapMaterial.positionNode = Fn(() => {
+  const spineIdx = instanceIndex.mul(uint(SPINE_POINTS))
+  return spinePositions.element(spineIdx).add(positionLocal.mul(tubeRadiusU))
+})()
+startCapMaterial.colorNode = Fn(() => {
+  return noodleColors.element(instanceIndex)
+})()
+startCapMaterial.roughnessNode = roughnessU
+startCapMaterial.metalnessNode = metalnessU
+startCapMaterial.clearcoatNode = clearcoatU
+startCapMaterial.clearcoatRoughnessNode = clearcoatRoughnessU
+
+const startCaps = new THREE.InstancedMesh(capGeometry, startCapMaterial, params.noodleCount)
+startCaps.castShadow = true
+startCaps.receiveShadow = true
+startCaps.frustumCulled = false
+scene.add(startCaps)
+
+const endCapMaterial = new THREE.MeshPhysicalNodeMaterial()
+endCapMaterial.positionNode = Fn(() => {
+  const spineIdx = instanceIndex.mul(uint(SPINE_POINTS)).add(uint(TUBE_SEGMENTS))
+  return spinePositions.element(spineIdx).add(positionLocal.mul(tubeRadiusU))
+})()
+endCapMaterial.colorNode = Fn(() => {
+  const baseColor = noodleColors.element(instanceIndex)
+  return mix(baseColor, vec3(1, 1, 1), colorGradientMixU)
+})()
+endCapMaterial.roughnessNode = roughnessU
+endCapMaterial.metalnessNode = metalnessU
+endCapMaterial.clearcoatNode = clearcoatU
+endCapMaterial.clearcoatRoughnessNode = clearcoatRoughnessU
+
+const endCaps = new THREE.InstancedMesh(capGeometry, endCapMaterial, params.noodleCount)
+endCaps.castShadow = true
+endCaps.receiveShadow = true
+endCaps.frustumCulled = false
+scene.add(endCaps)
+
+// ── 3D Text ────────────────────────────────────────────────────────────────
+const h1Element = document.querySelector('.title-block h1')
+const titleBlockElement = document.querySelector('.title-block')
+const textColorU = uniform(new THREE.Color(params.textColor))
+const textOpacityU = uniform(0)
+
+const textMaterial = new THREE.MeshStandardNodeMaterial({ transparent: true })
+textMaterial.colorNode = textColorU
+textMaterial.opacityNode = textOpacityU
+textMaterial.roughness = 1
+textMaterial.metalness = 0
+
+// Placeholder mesh so the text shader is compiled first
+const textMesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), textMaterial)
+textMesh.visible = false
+textMesh.receiveShadow = true
+scene.add(textMesh)
+
+let textGeometry = null
+let textAnimStart = -Infinity
+
+const TEXT_ANIM_DELAY = 0 // seconds
+const TEXT_ANIM_DURATION = 1 // seconds
+const TEXT_SLIDE_DISTANCE = 0.5 // world units upward
+
+function easeOutCubic(t) {
+  return 1 - (1 - t) ** 3
+}
+
+function updateTextScale() {
+  if (!textGeometry) return
+
+  const h1Width = h1Element.getBoundingClientRect().width
+
+  const vFov = (camera.fov * Math.PI) / 180
+  const visibleHeight = 2 * Math.tan(vFov / 2) * params.cameraDistance
+  const pixelToWorld = visibleHeight / window.innerHeight
+
+  const targetWidth = h1Width * pixelToWorld
+  const bb = textGeometry.boundingBox
+  const geoWidth = bb.max.x - bb.min.x
+  textMesh.scale.setScalar(targetWidth / geoWidth)
+
+  const h1CenterInBlock = h1Element.offsetTop + h1Element.offsetHeight / 2
+  const blockCenter = titleBlockElement.offsetHeight / 2
+  textMesh.position.x = 0
+  textMesh.userData.baseY = -(h1CenterInBlock - blockCenter) * pixelToWorld
+}
+
+// Load font asynchronously — fade in 3D text when ready
+new TTFLoader()
+  .loadAsync('https://fonts.gstatic.com/s/spacegrotesk/v22/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj4PVksj.ttf')
+  .then((fontData) => {
+    const font = new Font(fontData)
+
+    textGeometry = new TextGeometry('OMMA', {
+      font,
+      size: 1,
+      depth: 0,
+      curveSegments: 12,
+    })
+    textGeometry.computeBoundingBox()
+    const bbox = textGeometry.boundingBox
+    textGeometry.translate(-(bbox.max.x + bbox.min.x) / 2, -(bbox.max.y + bbox.min.y) / 2, 0)
+    textGeometry.computeBoundingBox()
+
+    // Swap placeholder geometry for the real text
+    textMesh.geometry.dispose()
+    textMesh.geometry = textGeometry
+    textMesh.visible = true
+
+    updateTextScale()
+
+    // Start both CSS and 3D text animations together
+    titleBlockElement.style.animation = 'fadeInUp 1s ease-out both'
+    textAnimStart = performance.now()
+  })
+
+// ── GUI & Stats ─────────────────────────────────────────────────────────────
+const gui = new GUI({ closeFolders: true })
+
+const toneMappingOptions = { AGX: THREE.AgXToneMapping, ACES: THREE.ACESFilmicToneMapping, None: THREE.NoToneMapping }
+
+gui
+  .add(params, 'toneMapping', Object.keys(toneMappingOptions))
+  .name('Tone Mapping')
+  .onChange((v) => {
+    renderer.toneMapping = toneMappingOptions[v]
+  })
+
+gui
+  .addColor(params, 'textColor')
+  .name('Text Color')
+  .onChange((v) => {
+    textColorU.value.set(v)
+  })
+
+function updateBackground() {
+  document.body.style.background = `radial-gradient(ellipse at center, ${params.bgColorCenter} 0%, ${params.bgColorEdge} 55%)`
+}
+
+updateBackground()
+
+gui.addColor(params, 'bgColorCenter').name('BG Center').onChange(updateBackground)
+
+gui.addColor(params, 'bgColorEdge').name('BG Edge').onChange(updateBackground)
+
+const cameraFolder = gui.addFolder('Camera')
+cameraFolder
+  .add(params, 'cameraFov', 10, 120, 1)
+  .name('FOV')
+  .onChange((v) => {
+    camera.fov = v
+    camera.updateProjectionMatrix()
+  })
+
+gui
+  .add(params, 'showPaths')
+  .name('Show Paths')
+  .onChange((v) => {
+    for (const line of pathLines) line.visible = v
+  })
+
+const tubeFolder = gui.addFolder('Tube')
+tubeFolder
+  .add(params, 'tubeRadius', 0.02, 0.8, 0.01)
+  .name('Radius')
+  .onChange((v) => (tubeRadiusU.value = v))
+tubeFolder
+  .add(params, 'pathFraction', 0.01, 1, 0.001)
+  .name('Length')
+  .onChange((v) => (pathFractionU.value = v))
+const mouseFolder = gui.addFolder('Mouse Interaction')
+mouseFolder
+  .add(params, 'mouseAttract')
+  .name('Attract')
+  .onChange((v) => (mouseSignU.value = v ? -1 : 1))
+mouseFolder.add(params, 'mouseZ', -20, 10, 0.5).name('Z Plane')
+mouseFolder
+  .add(params, 'mouseRadius', 1, 30, 0.5)
+  .name('Repulsion Radius')
+  .onChange((v) => {
+    mouseRadiusU.value = v
+    debugSphere.scale.setScalar(v)
+  })
+mouseFolder
+  .add(params, 'mouseForce', 0, 100, 0.5)
+  .name('Repulsion Amplitude')
+  .onChange((v) => (mouseForceU.value = v))
+mouseFolder
+  .add(params, 'returnSpring', 0, 10, 0.1)
+  .name('Return Spring')
+  .onChange((v) => (returnSpringU.value = v))
+mouseFolder
+  .add(params, 'damping', 0, 10, 0.1)
+  .name('Damping')
+  .onChange((v) => (dampingU.value = v))
+mouseFolder
+  .add(params, 'mouseBodyForce', 0, 15, 0.1)
+  .name('Body Force')
+  .onChange((v) => (mouseBodyForceU.value = v))
+mouseFolder
+  .add(params, 'mouseBodyDecay', 0.1, 10, 0.1)
+  .name('Body Decay')
+  .onChange((v) => (mouseBodyDecayU.value = v))
+mouseFolder
+  .add(params, 'separationRadius', 0, 15, 0.5)
+  .name('Separation Radius')
+  .onChange((v) => (separationRadiusU.value = v))
+mouseFolder
+  .add(params, 'separationAmplitude', 0, 10, 0.1)
+  .name('Separation Amplitude')
+  .onChange((v) => (separationAmplitudeU.value = v))
+
+const lightingFolder = gui.addFolder('Lighting')
+lightingFolder
+  .add(params, 'ambientIntensity', 0, 3, 0.01)
+  .name('Ambient')
+  .onChange((v) => (ambientLight.intensity = v))
+
+const dir1Folder = lightingFolder.addFolder('Dir Light 1')
+dir1Folder
+  .add(params, 'dirLight1Intensity', 0, 5, 0.01)
+  .name('Intensity')
+  .onChange((v) => (dir1.intensity = v))
+dir1Folder
+  .add(params, 'dirLight1X', -30, 30, 0.1)
+  .name('X')
+  .onChange((v) => (dir1.position.x = v))
+dir1Folder
+  .add(params, 'dirLight1Y', -30, 30, 0.1)
+  .name('Y')
+  .onChange((v) => (dir1.position.y = v))
+dir1Folder
+  .add(params, 'dirLight1Z', -30, 30, 0.1)
+  .name('Z')
+  .onChange((v) => (dir1.position.z = v))
+
+const dir2Folder = lightingFolder.addFolder('Dir Light 2')
+dir2Folder
+  .add(params, 'dirLight2Intensity', 0, 5, 0.01)
+  .name('Intensity')
+  .onChange((v) => (dir2.intensity = v))
+dir2Folder
+  .add(params, 'dirLight2X', -30, 30, 0.1)
+  .name('X')
+  .onChange((v) => (dir2.position.x = v))
+dir2Folder
+  .add(params, 'dirLight2Y', -30, 30, 0.1)
+  .name('Y')
+  .onChange((v) => (dir2.position.y = v))
+dir2Folder
+  .add(params, 'dirLight2Z', -30, 30, 0.1)
+  .name('Z')
+  .onChange((v) => (dir2.position.z = v))
+
+const shadowFolder = lightingFolder.addFolder('Shadow Light')
+shadowFolder
+  .add(params, 'shadowLightIntensity', 0, 5, 0.01)
+  .name('Intensity')
+  .onChange((v) => (shadowLight.intensity = v))
+shadowFolder
+  .add(params, 'shadowLightX', -30, 30, 0.1)
+  .name('X')
+  .onChange((v) => (shadowLight.position.x = v))
+shadowFolder
+  .add(params, 'shadowLightY', -30, 30, 0.1)
+  .name('Y')
+  .onChange((v) => (shadowLight.position.y = v))
+shadowFolder
+  .add(params, 'shadowLightZ', -30, 30, 0.1)
+  .name('Z')
+  .onChange((v) => (shadowLight.position.z = v))
+
+const materialFolder = gui.addFolder('Noodle Material')
+materialFolder
+  .add(params, 'roughness', 0, 1, 0.01)
+  .name('Roughness')
+  .onChange((v) => (roughnessU.value = v))
+materialFolder
+  .add(params, 'metalness', 0, 1, 0.01)
+  .name('Metalness')
+  .onChange((v) => (metalnessU.value = v))
+materialFolder
+  .add(params, 'clearcoat', 0, 1, 0.01)
+  .name('Clearcoat')
+  .onChange((v) => (clearcoatU.value = v))
+materialFolder
+  .add(params, 'clearcoatRoughness', 0, 1, 0.01)
+  .name('Clearcoat roughness')
+  .onChange((v) => (clearcoatRoughnessU.value = v))
+materialFolder
+  .add(params, 'colorGradientMix', 0, 1, 0.01)
+  .name('Color gradient mix')
+  .onChange((v) => (colorGradientMixU.value = v))
+
+const stats = new Stats({ trackGPU: true, trackCPT: true })
+document.body.appendChild(stats.dom)
+stats.init(renderer)
+
+// Debug flight path lines
+const pathLineMaterial = new THREE.LineBasicMaterial({ color: 0xbbbbbb })
+const pathLines = flightPaths.map((path) => {
+  const points = path.getPoints(100)
+  const line = new THREE.Line(new THREE.BufferGeometry().setFromPoints(points), pathLineMaterial)
+  line.visible = false
+  scene.add(line)
+  return line
+})
+
+function setDebugMode(enabled) {
+  params.debug = enabled
+  controls.enabled = enabled
+  debugOverlay.style.display = enabled ? 'block' : 'none'
+  debugSphere.visible = enabled
+  stats.dom.style.display = enabled ? '' : 'none'
+  gui.domElement.style.display = enabled ? '' : 'none'
+}
+
+setDebugMode(params.debug)
+
+window.addEventListener('keydown', (e) => {
+  if (e.key === 'p' || e.key === 'P') {
+    setDebugMode(!params.debug)
+  }
+})
+
+// ── Events ──────────────────────────────────────────────────────────────────
+let mouseNdcX = 0
+let mouseNdcY = 0
+const _mouseNdc = new THREE.Vector2()
+const _raycaster = new THREE.Raycaster()
+const _mousePlane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0)
+const _mouseWorld = new THREE.Vector3()
+
+document.addEventListener('mousemove', (e) => {
+  mouseNdcX = (e.clientX / window.innerWidth) * 2 - 1
+  mouseNdcY = -(e.clientY / window.innerHeight) * 2 + 1
+})
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight
+  camera.updateProjectionMatrix()
+  renderer.setSize(window.innerWidth, window.innerHeight)
+  updateTextScale()
+})
+
+// ── Animation ───────────────────────────────────────────────────────────────
+renderer.setAnimationLoop(async () => {
+  // Project mouse onto z = mouseZ plane in world space
+  _mouseNdc.set(mouseNdcX, mouseNdcY)
+  _raycaster.setFromCamera(_mouseNdc, camera)
+  _mousePlane.constant = -params.mouseZ
+  if (_raycaster.ray.intersectPlane(_mousePlane, _mouseWorld)) {
+    mouseWorldPosU.value.copy(_mouseWorld)
+    debugSphere.position.copy(_mouseWorld)
+  }
+  debugSphere.scale.setScalar(params.mouseRadius)
+
+  // Update compute uniforms
+  elapsedU.value = performance.now() / 1000
+
+  // GPU compute: spine → centroids → boids repulsion → frames → tube vertices
+  renderer.compute(computeSpine)
+  renderer.compute(computeCentroids)
+  renderer.compute(computeRepulsion)
+  renderer.compute(computeFrames)
+  renderer.compute(computeVertices)
+
+  // Text fade-in + slide-up
+  if (textGeometry) {
+    const baseY = textMesh.userData.baseY || 0
+    const textAnimElapsed = (performance.now() - textAnimStart) / 1000 - TEXT_ANIM_DELAY
+    if (textAnimElapsed < 0) {
+      textOpacityU.value = 0
+      textMesh.position.y = baseY - TEXT_SLIDE_DISTANCE
+    } else if (textAnimElapsed < TEXT_ANIM_DURATION) {
+      const t = easeOutCubic(textAnimElapsed / TEXT_ANIM_DURATION)
+      textOpacityU.value = t
+      textMesh.position.y = baseY - TEXT_SLIDE_DISTANCE * (1 - t)
+    } else {
+      textOpacityU.value = 1
+      textMesh.position.y = baseY
+    }
+  }
+
+  // Camera follows mouse for depth parallax (skip when orbit controls are active)
+  if (!params.debug) {
+    camera.position.x += (mouseNdcX * params.parallaxAmountX - camera.position.x) * params.parallaxSmoothing
+    camera.position.y += (mouseNdcY * params.parallaxAmountY - camera.position.y) * params.parallaxSmoothing
+    camera.lookAt(0, 0, 0)
+  }
+
+  controls.update()
+
+  renderer.render(scene, camera)
+
+  stats.update()
+  await renderer.resolveTimestampsAsync('render')
+  await renderer.resolveTimestampsAsync('compute')
+})
+  </script>
+</body>
+</html>

--- a/plugins/_official/examples/example-webgpu-hero/open-design.json
+++ b/plugins/_official/examples/example-webgpu-hero/open-design.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "example-webgpu-hero",
+  "title": "WebGPU Hero",
+  "title_i18n": {
+    "en": "WebGPU Hero",
+    "zh-CN": "WebGPU 英雄区",
+    "zh-TW": "WebGPU 主視覺",
+    "ja": "WebGPU ヒーロー",
+    "ko": "WebGPU 히어로",
+    "de": "WebGPU-Hero",
+    "fr": "Hero WebGPU",
+    "ru": "WebGPU-герой",
+    "es": "Hero WebGPU",
+    "pt-BR": "Hero WebGPU",
+    "it": "Hero WebGPU",
+    "vi": "Hero WebGPU",
+    "pl": "Hero WebGPU",
+    "id": "Hero WebGPU",
+    "nl": "WebGPU-hero",
+    "ar": "بطل WebGPU",
+    "tr": "WebGPU Hero",
+    "uk": "WebGPU-герой"
+  },
+  "version": "0.1.0",
+  "description": "Full-bleed WebGPU three.js hero/splash: a flock of mouse-reactive tube 'noodles' animated entirely on the GPU behind an editorial title block and minimal chrome.",
+  "description_i18n": {
+    "en": "Full-bleed WebGPU three.js hero/splash: a flock of mouse-reactive tube 'noodles' animated entirely on the GPU behind an editorial title block and minimal chrome.",
+    "zh-CN": "全屏 WebGPU three.js 英雄区 / splash：GPU 计算驱动的鼠标交互「面条」管束动画，叠在编辑风标题与极简框架之上。",
+    "zh-TW": "全螢幕 WebGPU three.js 主視覺／splash：GPU 運算驅動、可隨滑鼠互動的「麵條」管束動畫，疊在編輯風標題與極簡框架之上。",
+    "ja": "全画面 WebGPU three.js のヒーロー／スプラッシュ。GPU 計算で動くマウス反応型のチューブ「ヌードル」群を、エディトリアルなタイトルと最小限の装飾の背後に配置。",
+    "ko": "전체 화면 WebGPU three.js 히어로/스플래시. GPU 연산으로 움직이는 마우스 반응형 튜브 '누들' 무리를 편집형 타이틀과 미니멀한 프레임 뒤에 배치합니다.",
+    "de": "Vollflächiger WebGPU-three.js-Hero/Splash: ein Schwarm mausreaktiver Röhren-„Noodles\", vollständig auf der GPU animiert, hinter einem redaktionellen Titelblock und minimalem Rahmen.",
+    "fr": "Hero/splash WebGPU three.js plein écran : une nuée de tubes « nouilles » réactifs à la souris, animés entièrement sur le GPU, derrière un bloc-titre éditorial et un habillage minimal.",
+    "ru": "Полноэкранный WebGPU three.js герой/сплэш: стая трубчатых «лапшинок», реагирующих на мышь и анимированных полностью на GPU, за редакционным заголовком и минимальным оформлением.",
+    "es": "Hero/splash WebGPU three.js a pantalla completa: un enjambre de tubos «fideos» reactivos al ratón, animados completamente en la GPU, tras un bloque de título editorial y un marco minimalista.",
+    "pt-BR": "Hero/splash WebGPU three.js de tela cheia: um enxame de tubos \"macarrões\" reativos ao mouse, animados inteiramente na GPU, atrás de um bloco de título editorial e moldura minimalista.",
+    "it": "Hero/splash WebGPU three.js a tutto schermo: uno sciame di tubi \"spaghetti\" reattivi al mouse, animati interamente sulla GPU, dietro un blocco titolo editoriale e una cornice minimale.",
+    "vi": "Hero/splash WebGPU three.js toàn màn hình: một bầy ống \"mì\" phản ứng theo chuột, được tạo chuyển động hoàn toàn trên GPU, phía sau khối tiêu đề kiểu biên tập và khung tối giản.",
+    "pl": "Pełnoekranowy hero/splash WebGPU three.js: rój rurkowych „kluseczek\" reagujących na mysz, animowanych w całości na GPU, za redakcyjnym blokiem tytułowym i minimalistyczną ramą.",
+    "id": "Hero/splash WebGPU three.js layar penuh: kawanan tabung \"mi\" yang reaktif terhadap mouse, dianimasikan sepenuhnya di GPU, di belakang blok judul editorial dan bingkai minimal.",
+    "nl": "Schermvullende WebGPU-three.js-hero/splash: een zwerm muis-reactieve buis-'noodles', volledig op de GPU geanimeerd, achter een redactioneel titelblok en minimale opmaak.",
+    "ar": "قسم بطل/شاشة افتتاحية بملء الشاشة بتقنية WebGPU وthree.js: سرب من الأنابيب \"النودلز\" المتفاعلة مع الماوس، متحركة بالكامل على وحدة معالجة الرسومات، خلف كتلة عنوان تحريرية وإطار بسيط.",
+    "tr": "Tam ekran WebGPU three.js hero/splash: fareye tepki veren ve tamamen GPU üzerinde canlandırılan bir tüp \"erişte\" sürüsü; editöryel bir başlık bloğu ve sade çerçevenin arkasında.",
+    "uk": "Повноекранний WebGPU three.js герой/сплеш: рій трубчастих «локшинок», що реагують на мишу й анімуються повністю на GPU, за редакційним заголовком і мінімальним оформленням."
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Open Design",
+    "url": "https://github.com/nexu-io"
+  },
+  "homepage": "https://github.com/nexu-io/open-design/tree/main/plugins/_official/examples/example-webgpu-hero",
+  "tags": [
+    "example",
+    "first-party",
+    "prototype",
+    "webgpu",
+    "three.js",
+    "hero",
+    "splash",
+    "shader",
+    "generative",
+    "background"
+  ],
+  "compat": {
+    "agentSkills": [
+      {
+        "path": "./SKILL.md"
+      }
+    ]
+  },
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "prototype",
+    "scenario": "design",
+    "surface": "prototype",
+    "preview": {
+      "type": "html",
+      "entry": "./example.html"
+    },
+    "useCase": {
+      "query": {
+        "en": "Use the WebGPU Hero template to turn my content into a full-bleed splash page with a live three.js GPU-animated background behind an editorial title block. Preserve the template's visual signature and WebGPU pipeline, use real copy, and avoid lorem ipsum or placeholder images.",
+        "zh-CN": "用「WebGPU 英雄区」模板把我的内容做成一个全屏 splash：实时 three.js GPU 动画背景 + 编辑风标题。保持模板的视觉签名和 WebGPU 管线，使用真实文案，避免 lorem ipsum 和占位图片。"
+      },
+      "exampleOutputs": [
+        {
+          "path": "./example.html",
+          "title": "WebGPU Hero",
+          "title_i18n": {
+            "en": "WebGPU Hero",
+            "zh-CN": "WebGPU 英雄区"
+          }
+        }
+      ]
+    },
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ],
+      "assets": [
+        "./example.html"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}

--- a/plugins/_official/examples/example-webgpu-hero/open-design.json
+++ b/plugins/_official/examples/example-webgpu-hero/open-design.json
@@ -75,7 +75,7 @@
     "taskKind": "new-generation",
     "mode": "prototype",
     "scenario": "design",
-    "surface": "prototype",
+    "surface": "web",
     "preview": {
       "type": "html",
       "entry": "./example.html"

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -12,7 +12,7 @@
     "description": "Official Open Design plugin registry seed. The generated public catalog is served from open-design.ai/marketplace.",
     "version": "0.1.0",
     "generatedFrom": "plugins/_official",
-    "bundledPreinstallCount": 401
+    "bundledPreinstallCount": 402
   },
   "plugins": [
     {

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -4565,6 +4565,45 @@
       }
     },
     {
+      "name": "open-design/example-webgpu-hero",
+      "title": "WebGPU Hero",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/_official/examples/example-webgpu-hero",
+      "publisher": {
+        "id": "open-design",
+        "url": "https://open-design.ai"
+      },
+      "capabilitiesSummary": [
+        "prompt:inject",
+        "fs:write"
+      ],
+      "description": "Full-bleed WebGPU three.js hero/splash: a flock of mouse-reactive tube 'noodles' animated entirely on the GPU behind an editorial title block and minimal chrome.",
+      "tags": [
+        "example",
+        "first-party",
+        "prototype",
+        "webgpu",
+        "three.js",
+        "hero",
+        "splash",
+        "shader",
+        "generative",
+        "background"
+      ],
+      "homepage": "https://github.com/nexu-io/open-design/tree/main/plugins/_official/examples/example-webgpu-hero",
+      "license": "MIT",
+      "mode": "prototype",
+      "taskKind": "new-generation",
+      "title_i18n": {
+        "en": "WebGPU Hero",
+        "zh-CN": "WebGPU 英雄区"
+      },
+      "description_i18n": {
+        "en": "Full-bleed WebGPU three.js hero/splash: a flock of mouse-reactive tube 'noodles' animated entirely on the GPU behind an editorial title block and minimal chrome.",
+        "zh-CN": "全屏 WebGPU three.js 英雄区 / splash：GPU 计算驱动的鼠标交互「面条」管束动画，叠在编辑风标题与极简框架之上。"
+      }
+    },
+    {
       "name": "open-design/example-frame-logo-outro",
       "title": "Logo Outro Frame",
       "version": "0.1.0",


### PR DESCRIPTION
## Summary
- Adds a new first-party example plugin `example-webgpu-hero` under `plugins/_official/examples/`: a full-bleed WebGPU three.js hero/splash with a GPU-animated flock of mouse-reactive tube "noodles" (TSL compute pipeline: spine → centroids → boids repulsion → parallel-transport frames → tube vertices) behind an editorial title block and minimal chrome.
- Ships `SKILL.md` (rebrand/tune workflow), `open-design.json` (manifest, `od.mode: prototype`, 17-language title/description), and a self-contained `example.html` with the module **inlined** (the preview iframe is a null-origin sandbox, so a separate `/index.js` would not resolve) and a `navigator.gpu` fallback notice.
- Registers a matching entry in `plugins/registry/official/open-design-marketplace.json`.

## Notes
- WebGPU only — renders the 3D background in Chrome/Edge or Safari Technology Preview; unsupported browsers see a friendly fallback message instead of a blank screen.
- Dependencies load from a CDN importmap (three.js 0.183, stats-gl, lil-gui), matching the inline-module pattern used by sibling example plugins.

## Test plan
- [x] `pnpm guard` — 40 tests pass, 0 fail
- [x] `pnpm --filter @open-design/daemon build` — exit 0
- [x] `od plugin validate ./plugins/_official/examples/example-webgpu-hero` — `ok=true`
- [x] Booted the daemon: plugin registers and appears in `/api/plugins` alongside `example-frame-liquid-bg-hero`
- [x] `POST /api/plugins/example-webgpu-hero/doctor` — `ok:true`, 0 errors, 0 warnings
- [x] `GET /api/plugins/example-webgpu-hero/preview` — HTTP 200, full self-contained HTML (WebGPU pipeline, importmap, gpu fallback present; no external `/index.js` ref)
- [ ] Visual check of the rendered 3D preview in a WebGPU browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)