### PR TITLE
fix: reuse ACP sessions per conversation

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -939,6 +939,7 @@ export function attachAcpSession({
   let promptRequestId: JsonRpcId | null = null;
   let setModelRequestId: JsonRpcId | null = null;
   let sessionId: string | null = null;
+  let sessionStartMethod: 'session/load' | 'session/new' | null = null;
   // The durable upstream session handle reported by the agent on session/new or
   // session/load (vela's `openCodeSessionId`). The caller stores it per
   // conversation to resume next turn. Distinct from `sessionId`, which is the
@@ -1312,6 +1313,9 @@ export function attachAcpSession({
     }
     const update = asObject(params?.update);
     if (obj.method === 'session/update' && update) {
+      if (sessionStartMethod === 'session/load' && promptRequestId === null) {
+        return;
+      }
       if (update.sessionUpdate !== 'agent_message_chunk' && update.sessionUpdate !== 'agent_thought_chunk') {
         send('agent', {
           type: 'status',
@@ -1484,13 +1488,24 @@ export function attachAcpSession({
       }
       return;
     }
-    if (obj.id !== expectedId || !result) {
+    if (obj.id !== expectedId) {
+      return;
+    }
+    const responseResult: JsonObject | null =
+      result ??
+      (
+        expectedId === 2 && sessionStartMethod === 'session/load'
+          ? {}
+          : null
+      );
+    if (!responseResult) {
       return;
     }
     if (expectedId === 1) {
       expectedId = nextId;
       if (resumeSessionId) {
         // Resume the prior upstream session instead of creating a fresh one.
+        sessionStartMethod = 'session/load';
         writeRpc(
           nextId,
           'session/load',
@@ -1498,6 +1513,7 @@ export function attachAcpSession({
           'session/load',
         );
       } else {
+        sessionStartMethod = 'session/new';
         writeRpc(
           nextId,
           'session/new',
@@ -1512,15 +1528,19 @@ export function attachAcpSession({
       return;
     }
     if (expectedId === 2) {
-      sessionId = typeof result.sessionId === 'string' ? result.sessionId : null;
+      const restoredSessionId =
+        sessionStartMethod === 'session/load' && typeof resumeSessionId === 'string' && resumeSessionId.trim()
+          ? resumeSessionId
+          : null;
+      sessionId = typeof responseResult.sessionId === 'string' ? responseResult.sessionId : restoredSessionId;
       // The durable handle for resuming this session on the next turn.
       durableSessionId =
-        typeof result.openCodeSessionId === 'string' ? result.openCodeSessionId : null;
+        typeof responseResult.openCodeSessionId === 'string' ? responseResult.openCodeSessionId : restoredSessionId;
       // session/new acknowledged with a session id = handshake done (#3408 §4).
       if (sessionId) onSessionInit?.();
-      const modelConfig = findModelConfigOption(result.configOptions);
+      const modelConfig = findModelConfigOption(responseResult.configOptions);
       modelConfigId = modelConfig?.configId ?? null;
-      activeModel = currentModelFromSessionResult(result);
+      activeModel = currentModelFromSessionResult(responseResult);
       if (sessionId && activeModel) {
         send('agent', { type: 'status', label: 'model', model: activeModel });
       }
@@ -1541,14 +1561,14 @@ export function attachAcpSession({
         return;
       }
       if (!sessionId) {
-        fail(`invalid session/new response: ${rawLine}`);
+        fail(`invalid ${sessionStartMethod ?? 'session/new'} response: ${rawLine}`);
         return;
       }
       sendPrompt();
       return;
     }
     if (promptRequestId !== null && obj.id === promptRequestId) {
-      const usage = formatUsage(result.usage);
+      const usage = formatUsage(responseResult.usage);
       if (!emittedVisibleTextChunk && !emittedConcreteToolEvent && modelUnavailableErrorCode) {
         const outputTokens = usage?.output_tokens;
         const hadCompletionTokens = typeof outputTokens === 'number' && outputTokens > 0;
@@ -1573,11 +1593,11 @@ export function attachAcpSession({
         }
         return;
       }
-      finishCleanPrompt(result.usage);
+      finishCleanPrompt(responseResult.usage);
       return;
     }
     if (sessionId && model && model !== 'default' && obj.id === expectedId) {
-      activeModel = currentModelFromSessionResult(result) ?? model;
+      activeModel = currentModelFromSessionResult(responseResult) ?? model;
       send('agent', { type: 'status', label: 'model', model: activeModel });
       sendPrompt();
     }

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -1451,6 +1451,94 @@ test('attachAcpSession resumes via session/load when resumeSessionId is set', ()
   assert.equal(requests.some((entry) => entry.method === 'session/new'), false);
 });
 
+test('attachAcpSession accepts id-less session/load completions', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  const events: Array<{ event: string; payload: unknown }> = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'continue',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'oc-prev',
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, null);
+  writeAcpResult(child, 3, {});
+
+  const requests = parseRpcWrites(writes);
+  assert.deepEqual(requests.map((entry) => entry.method).filter(Boolean), [
+    'initialize',
+    'session/load',
+    'session/prompt',
+  ]);
+  assert.deepEqual(requests[2]?.params, {
+    sessionId: 'oc-prev',
+    prompt: [{ type: 'text', text: 'continue' }],
+  });
+  assert.equal(session.getDurableSessionId(), 'oc-prev');
+  assert.equal(events.some((entry) => entry.event === 'error'), false);
+});
+
+test('attachAcpSession keeps the stored durable handle when session/load omits it', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'continue',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'oc-prev',
+    send: () => {},
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'vela-wrapper-1' });
+  writeAcpResult(child, 3, {});
+
+  const promptRequest = parseRpcWrites(writes).find((entry) => entry.method === 'session/prompt');
+  assert.deepEqual(promptRequest?.params, {
+    sessionId: 'vela-wrapper-1',
+    prompt: [{ type: 'text', text: 'continue' }],
+  });
+  assert.equal(session.getDurableSessionId(), 'oc-prev');
+});
+
+test('attachAcpSession ignores restored ACP history before the resumed prompt starts', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'continue',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'oc-prev',
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'old restored answer' },
+  });
+  writeAcpResult(child, 2, {});
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'new answer' },
+  });
+  writeAcpResult(child, 3, {});
+
+  const textDeltas = events
+    .filter((entry) => entry.event === 'agent' && (entry.payload as { type?: unknown }).type === 'text_delta')
+    .map((entry) => (entry.payload as { delta?: unknown }).delta);
+
+  assert.deepEqual(textDeltas, ['new answer']);
+});
+
 test('attachAcpSession captures the durable session handle from the result', () => {
   const child = new FakeAcpChild();
   const session = attachAcpSession({


### PR DESCRIPTION
## Summary
- accept successful ACP `session/load` responses that omit a fresh `sessionId` by continuing with the stored resume handle
- keep the stored durable resume handle when a restored load response omits `openCodeSessionId`
- suppress restored ACP history emitted before the next resumed prompt starts

Fixes #730

## Why
`main` now owns session persistence through `agent_sessions` and routes AMR ACP resumes through `resumesSessionViaAcpLoad`. This follow-up keeps the ACP adapter robust around minimal successful `session/load` response shapes without adding a second session store.

## What users will see
No new UI. Resumed ACP turns avoid a false protocol failure and avoid showing restored history as fresh output before the new prompt runs.

## Surface area

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** - adding any new entry to the root `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [ ] **Default behavior change** - changes what existing users experience without opting in
- [x] **None** - daemon/runtime session handling bug fix with tests only

## Screenshots
Not applicable; this is daemon/runtime session handling only.

## Bug fix verification
- Added focused regressions in `apps/daemon/tests/acp.test.ts` for id-less `session/load`, missing durable handle fallback, and restored-history suppression before the resumed prompt starts.
- The tests exercise the ACP adapter seam that previously required an object-shaped start response and could forward restored history before the new turn's prompt.

## Validation
- `pnpm -r --filter @open-design/daemon... run build`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/acp.test.ts --reporter=dot --maxWorkers=1 --pool=forks` (47 tests passed)
- `pnpm --filter @open-design/daemon typecheck`
- `git diff --check`