### PR TITLE
fix: update anthropics/skills upstream URLs to use skills/ subdirectory

### DIFF
--- a/scripts/seed-curated-design-skills.ts
+++ b/scripts/seed-curated-design-skills.ts
@@ -66,7 +66,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['canvas design', 'visual art', 'poster design', 'create poster', 'illustration', '海报', '插画'],
     mode: 'image',
     category: 'image-generation',
-    upstream: 'https://github.com/anthropics/skills/tree/main/canvas-design',
+    upstream: 'https://github.com/anthropics/skills/tree/main/skills/canvas-design',
     attribution: 'Curated from Anthropic\'s official skills repository.',
   },
   {
@@ -76,7 +76,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['algorithmic art', 'generative art', 'p5js', 'procedural art', 'seeded randomness', '生成艺术'],
     mode: 'image',
     category: 'image-generation',
-    upstream: 'https://github.com/anthropics/skills/tree/main/algorithmic-art',
+    upstream: 'https://github.com/anthropics/skills/tree/main/skills/algorithmic-art',
     attribution: 'Curated from Anthropic\'s official skills repository.',
   },
   {
@@ -126,7 +126,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['slack gif', 'animated gif', 'reaction gif', 'tiny gif'],
     mode: 'image',
     category: 'image-generation',
-    upstream: 'https://github.com/anthropics/skills/tree/main/slack-gif-creator',
+    upstream: 'https://github.com/anthropics/skills/tree/main/skills/slack-gif-creator',
     attribution: 'Curated from Anthropic\'s official skills repository.',
   },
   {
@@ -432,7 +432,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['pptx', 'powerpoint', 'slide deck', 'create slides', 'edit pptx'],
     mode: 'deck',
     category: 'slides',
-    upstream: 'https://github.com/anthropics/skills/tree/main/pptx',
+    upstream: 'https://github.com/anthropics/skills/tree/main/skills/pptx',
     attribution: 'Curated from Anthropic\'s official skills repository.',
   },
   {
@@ -476,7 +476,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['docx', 'word document', 'tracked changes', 'design brief doc', 'copy doc'],
     mode: 'prototype',
     category: 'documents',
-    upstream: 'https://github.com/anthropics/skills/tree/main/docx',
+    upstream: 'https://github.com/anthropics/skills/tree/main/skills/docx',
     attribution: 'Curated from Anthropic\'s official skills repository.',
   },
   {
@@ -486,7 +486,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['pdf', 'create pdf', 'pdf form', 'branded pdf', 'one pager'],
     mode: 'prototype',
     category: 'documents',
-    upstream: 'https://github.com/anthropics/skills/tree/main/pdf',
+    upstream: 'https://github.com/anthropics/skills/tree/main/skills/pdf',
     attribution: 'Curated from Anthropic\'s official skills repository.',
   },
   {
@@ -530,7 +530,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['brand guidelines', 'brand colors', 'brand typography', 'visual identity'],
     mode: 'design-system',
     category: 'design-systems',
-    upstream: 'https://github.com/anthropics/skills/tree/main/brand-guidelines',
+    upstream: 'https://github.com/anthropics/skills/tree/main/skills/brand-guidelines',
     attribution: 'Curated from Anthropic\'s official skills repository.',
   },
   {
@@ -540,7 +540,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['theme factory', 'apply theme', 'design theme', 'theme generator', 'preset theme'],
     mode: 'design-system',
     category: 'design-systems',
-    upstream: 'https://github.com/anthropics/skills/tree/main/theme-factory',
+    upstream: 'https://github.com/anthropics/skills/tree/main/skills/theme-factory',
     attribution: 'Curated from Anthropic\'s official skills repository.',
   },
   {
@@ -550,7 +550,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['frontend design', 'ui design', 'ux design', 'web design', 'production ui'],
     mode: 'design-system',
     category: 'design-systems',
-    upstream: 'https://github.com/anthropics/skills/tree/main/frontend-design',
+    upstream: 'https://github.com/anthropics/skills/tree/main/skills/frontend-design',
     attribution: 'Curated from Anthropic\'s official skills repository.',
   },
   {
@@ -1020,7 +1020,7 @@ const CATALOGUE: CuratedSkill[] = [
     triggers: ['web artifacts', 'tailwind artifact', 'react artifact', 'anthropic artifact'],
     mode: 'prototype',
     category: 'web-artifacts',
-    upstream: 'https://github.com/anthropics/skills/tree/main/web-artifacts-builder',
+    upstream: 'https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder',
     attribution: 'Curated from Anthropic\'s official skills repository.',
   },
   {

--- a/skills/algorithmic-art/SKILL.md
+++ b/skills/algorithmic-art/SKILL.md
@@ -12,7 +12,7 @@ triggers:
 od:
   mode: image
   category: image-generation
-  upstream: "https://github.com/anthropics/skills/tree/main/algorithmic-art"
+  upstream: "https://github.com/anthropics/skills/tree/main/skills/algorithmic-art"
 ---
 
 # algorithmic-art
@@ -25,7 +25,7 @@ Create generative art using p5.js with seeded randomness so every render is repr
 
 ## Source
 
-- Upstream: https://github.com/anthropics/skills/tree/main/algorithmic-art
+- Upstream: https://github.com/anthropics/skills/tree/main/skills/algorithmic-art
 - Category: `image-generation`
 
 ## How to use
@@ -37,7 +37,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/anthropics/skills/tree/main/algorithmic-art
+open https://github.com/anthropics/skills/tree/main/skills/algorithmic-art
 ```
 
 Then ask the agent to invoke this skill by name (`algorithmic-art`) or with

--- a/skills/brand-guidelines/SKILL.md
+++ b/skills/brand-guidelines/SKILL.md
@@ -10,7 +10,7 @@ triggers:
 od:
   mode: design-system
   category: design-systems
-  upstream: "https://github.com/anthropics/skills/tree/main/brand-guidelines"
+  upstream: "https://github.com/anthropics/skills/tree/main/skills/brand-guidelines"
 ---
 
 # brand-guidelines
@@ -23,7 +23,7 @@ Apply Anthropic's official brand colors and typography to artifacts for consiste
 
 ## Source
 
-- Upstream: https://github.com/anthropics/skills/tree/main/brand-guidelines
+- Upstream: https://github.com/anthropics/skills/tree/main/skills/brand-guidelines
 - Category: `design-systems`
 
 ## How to use
@@ -35,7 +35,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/anthropics/skills/tree/main/brand-guidelines
+open https://github.com/anthropics/skills/tree/main/skills/brand-guidelines
 ```
 
 Then ask the agent to invoke this skill by name (`brand-guidelines`) or with

--- a/skills/canvas-design/SKILL.md
+++ b/skills/canvas-design/SKILL.md
@@ -13,7 +13,7 @@ triggers:
 od:
   mode: image
   category: image-generation
-  upstream: "https://github.com/anthropics/skills/tree/main/canvas-design"
+  upstream: "https://github.com/anthropics/skills/tree/main/skills/canvas-design"
 ---
 
 # canvas-design
@@ -26,7 +26,7 @@ Create beautiful visual art in PNG and PDF documents using design philosophy and
 
 ## Source
 
-- Upstream: https://github.com/anthropics/skills/tree/main/canvas-design
+- Upstream: https://github.com/anthropics/skills/tree/main/skills/canvas-design
 - Category: `image-generation`
 
 ## How to use
@@ -38,7 +38,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/anthropics/skills/tree/main/canvas-design
+open https://github.com/anthropics/skills/tree/main/skills/canvas-design
 ```
 
 Then ask the agent to invoke this skill by name (`canvas-design`) or with

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -11,7 +11,7 @@ triggers:
 od:
   mode: prototype
   category: documents
-  upstream: "https://github.com/anthropics/skills/tree/main/docx"
+  upstream: "https://github.com/anthropics/skills/tree/main/skills/docx"
 ---
 
 # docx
@@ -24,7 +24,7 @@ Create, edit, and analyze Word documents with tracked changes, comments, and for
 
 ## Source
 
-- Upstream: https://github.com/anthropics/skills/tree/main/docx
+- Upstream: https://github.com/anthropics/skills/tree/main/skills/docx
 - Category: `documents`
 
 ## How to use
@@ -36,7 +36,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/anthropics/skills/tree/main/docx
+open https://github.com/anthropics/skills/tree/main/skills/docx
 ```
 
 Then ask the agent to invoke this skill by name (`docx`) or with

--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -11,7 +11,7 @@ triggers:
 od:
   mode: prototype
   category: documents
-  upstream: "https://github.com/anthropics/skills/tree/main/pdf"
+  upstream: "https://github.com/anthropics/skills/tree/main/skills/pdf"
 ---
 
 # pdf
@@ -24,7 +24,7 @@ Extract text, create PDFs, and handle forms. Useful for press releases, branded 
 
 ## Source
 
-- Upstream: https://github.com/anthropics/skills/tree/main/pdf
+- Upstream: https://github.com/anthropics/skills/tree/main/skills/pdf
 - Category: `documents`
 
 ## How to use
@@ -36,7 +36,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/anthropics/skills/tree/main/pdf
+open https://github.com/anthropics/skills/tree/main/skills/pdf
 ```
 
 Then ask the agent to invoke this skill by name (`pdf`) or with

--- a/skills/pptx/SKILL.md
+++ b/skills/pptx/SKILL.md
@@ -11,7 +11,7 @@ triggers:
 od:
   mode: deck
   category: slides
-  upstream: "https://github.com/anthropics/skills/tree/main/pptx"
+  upstream: "https://github.com/anthropics/skills/tree/main/skills/pptx"
 ---
 
 # pptx
@@ -24,7 +24,7 @@ Read, generate, and adjust PowerPoint slides, layouts, and templates. Useful for
 
 ## Source
 
-- Upstream: https://github.com/anthropics/skills/tree/main/pptx
+- Upstream: https://github.com/anthropics/skills/tree/main/skills/pptx
 - Category: `slides`
 
 ## How to use
@@ -36,7 +36,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/anthropics/skills/tree/main/pptx
+open https://github.com/anthropics/skills/tree/main/skills/pptx
 ```
 
 Then ask the agent to invoke this skill by name (`pptx`) or with

--- a/skills/slack-gif-creator/SKILL.md
+++ b/skills/slack-gif-creator/SKILL.md
@@ -10,7 +10,7 @@ triggers:
 od:
   mode: image
   category: image-generation
-  upstream: "https://github.com/anthropics/skills/tree/main/slack-gif-creator"
+  upstream: "https://github.com/anthropics/skills/tree/main/skills/slack-gif-creator"
 ---
 
 # slack-gif-creator
@@ -23,7 +23,7 @@ Create animated GIFs optimized for Slack with validators for size constraints an
 
 ## Source
 
-- Upstream: https://github.com/anthropics/skills/tree/main/slack-gif-creator
+- Upstream: https://github.com/anthropics/skills/tree/main/skills/slack-gif-creator
 - Category: `image-generation`
 
 ## How to use
@@ -35,7 +35,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/anthropics/skills/tree/main/slack-gif-creator
+open https://github.com/anthropics/skills/tree/main/skills/slack-gif-creator
 ```
 
 Then ask the agent to invoke this skill by name (`slack-gif-creator`) or with

--- a/skills/theme-factory/SKILL.md
+++ b/skills/theme-factory/SKILL.md
@@ -11,7 +11,7 @@ triggers:
 od:
   mode: design-system
   category: design-systems
-  upstream: "https://github.com/anthropics/skills/tree/main/theme-factory"
+  upstream: "https://github.com/anthropics/skills/tree/main/skills/theme-factory"
 ---
 
 # theme-factory
@@ -24,7 +24,7 @@ Apply professional font and color themes to artifacts including slides, docs, re
 
 ## Source
 
-- Upstream: https://github.com/anthropics/skills/tree/main/theme-factory
+- Upstream: https://github.com/anthropics/skills/tree/main/skills/theme-factory
 - Category: `design-systems`
 
 ## How to use
@@ -36,7 +36,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/anthropics/skills/tree/main/theme-factory
+open https://github.com/anthropics/skills/tree/main/skills/theme-factory
 ```
 
 Then ask the agent to invoke this skill by name (`theme-factory`) or with

--- a/skills/web-artifacts-builder/SKILL.md
+++ b/skills/web-artifacts-builder/SKILL.md
@@ -10,7 +10,7 @@ triggers:
 od:
   mode: prototype
   category: web-artifacts
-  upstream: "https://github.com/anthropics/skills/tree/main/web-artifacts-builder"
+  upstream: "https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder"
 ---
 
 # web-artifacts-builder
@@ -23,7 +23,7 @@ Build complex claude.ai HTML artifacts with React and Tailwind. Anthropic's refe
 
 ## Source
 
-- Upstream: https://github.com/anthropics/skills/tree/main/web-artifacts-builder
+- Upstream: https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder
 - Category: `web-artifacts`
 
 ## How to use
@@ -35,7 +35,7 @@ bundle into your active agent's skills directory:
 
 ```bash
 # Inspect the upstream README for exact paths
-open https://github.com/anthropics/skills/tree/main/web-artifacts-builder
+open https://github.com/anthropics/skills/tree/main/skills/web-artifacts-builder
 ```
 
 Then ask the agent to invoke this skill by name (`web-artifacts-builder`) or with


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

I was browsing the curated skills catalogue in Settings → Skills and noticed the "Upstream" links for every Anthropic-sourced skill 404. The `anthropics/skills` repo recently restructured — all skill directories moved from root into a `skills/` subfolder, so `tree/main/canvas-design` is now `tree/main/skills/canvas-design`. This PR fixes all 19 broken URLs across the 9 SKILL.md stubs and the seed script.


## What users will see

No visual change. Users clicking an "Upstream" link in Settings → Skills for any Anthropic-sourced skill will land on the correct GitHub page instead of a 404.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

- This is a URL correctness fix — no behaviour change to test via specs.
- Verified by grep that zero occurrences of `anthropics/skills/tree/main/` without a `skills/` suffix remain.


## Validation

```bash
pnpm guard
pnpm typecheck
