### PR TITLE
[codex] Fix landing download release metadata

### DIFF
--- a/apps/landing-page/app/_components/header-enhancer.astro
+++ b/apps/landing-page/app/_components/header-enhancer.astro
@@ -1,13 +1,10 @@
 ---
-import { getStableReleaseMetadata } from '../_lib/release-metadata';
-
-const stableReleaseMetadata = await getStableReleaseMetadata();
+import { RELEASE_METADATA_URL } from '../_lib/release-metadata';
 ---
 
-<script is:inline define:vars={{ stableReleaseMetadata }}>
+<script is:inline define:vars={{ RELEASE_METADATA_URL }}>
   (() => {
     const REPO_API = 'https://api.github.com/repos/nexu-io/open-design';
-    const RELEASE_METADATA = stableReleaseMetadata;
 
     const formatStars = (count) => {
       if (!Number.isFinite(count) || count <= 0) return null;
@@ -168,11 +165,18 @@ const stableReleaseMetadata = await getStableReleaseMetadata();
     const versionSlots = document.querySelectorAll('[data-github-version]');
     const hasDownloadCtas = document.querySelector('[data-download-cta]') !== null;
     if (versionSlots.length > 0 || hasDownloadCtas) {
-      enhanceDownloadCtas(RELEASE_METADATA);
-      const label = formatVersion(RELEASE_METADATA);
-      if (label) {
-        for (const slot of versionSlots) slot.textContent = label;
-      }
+      fetch(RELEASE_METADATA_URL, {
+        headers: { Accept: 'application/json' },
+      })
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error('http error'))))
+        .then((metadata) => {
+          enhanceDownloadCtas(metadata);
+          const label = formatVersion(metadata);
+          if (label) {
+            for (const slot of versionSlots) slot.textContent = label;
+          }
+        })
+        .catch(() => {});
     }
 
     // Helper used by every clipboard-write button (link copy, share

--- a/apps/landing-page/app/_components/header-enhancer.astro
+++ b/apps/landing-page/app/_components/header-enhancer.astro
@@ -1,6 +1,13 @@
-<script is:inline>
+---
+import { getStableReleaseMetadata } from '../_lib/release-metadata';
+
+const stableReleaseMetadata = await getStableReleaseMetadata();
+---
+
+<script is:inline define:vars={{ stableReleaseMetadata }}>
   (() => {
     const REPO_API = 'https://api.github.com/repos/nexu-io/open-design';
+    const RELEASE_METADATA = stableReleaseMetadata;
 
     const formatStars = (count) => {
       if (!Number.isFinite(count) || count <= 0) return null;
@@ -8,18 +15,24 @@
       return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}K`;
     };
 
-    const formatVersion = (release) => {
+    const formatVersion = (metadata) => {
+      const fromVersion = (version) => {
+        if (typeof version !== 'string') return null;
+        const m = version.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
+        return m ? `v${m[1]}` : null;
+      };
       const fromTag = (tag) => {
         if (typeof tag !== 'string') return null;
         const cleaned = tag.replace(/^open-design[-_]?v?/i, '').trim();
         return cleaned ? `v${cleaned.replace(/^v/, '')}` : null;
       };
-      const fromName = (name) => {
-        if (typeof name !== 'string') return null;
-        const m = name.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
-        return m ? `v${m[1]}` : null;
-      };
-      return fromName(release?.name) ?? fromTag(release?.tag_name) ?? null;
+      return (
+        fromVersion(metadata?.releaseVersion) ??
+        fromVersion(metadata?.stableVersion) ??
+        fromVersion(metadata?.baseVersion) ??
+        fromTag(metadata?.versionTag) ??
+        null
+      );
     };
 
     // Best-effort OS + arch detection so the header download CTA points
@@ -37,7 +50,7 @@
       const isWindows = /win/.test(uaPlatform) || /windows/.test(ua);
       const isMac = /mac/.test(uaPlatform) || (/mac os x/.test(ua) && !/iphone|ipad|ipod/.test(ua));
       const isLinux = /linux/.test(uaPlatform) || (/linux/.test(ua) && !/android/.test(ua));
-      if (isWindows) return { os: 'Windows', arch: 'Windows', match: (n) => /win.*setup\.exe$/.test(n) };
+      if (isWindows) return { os: 'Windows', arch: 'Windows', artifact: (m) => m?.platforms?.win?.artifacts?.installer?.url };
       if (isMac) {
         const isIntel = (() => {
           try {
@@ -49,15 +62,15 @@
             return false;
           }
         })();
-        const suffix = isIntel ? 'mac-x64.dmg' : 'mac-arm64.dmg';
         const arch = isIntel ? 'Apple Intel' : 'Apple Silicon';
-        return { os: 'macOS', arch, match: (n) => n.endsWith(suffix) };
+        const key = isIntel ? 'macIntel' : 'mac';
+        return { os: 'macOS', arch, artifact: (m) => m?.platforms?.[key]?.artifacts?.dmg?.url };
       }
-      if (isLinux) return { os: 'Linux', arch: '', match: () => false };
+      if (isLinux) return { os: 'Linux', arch: '', artifact: () => null };
       return null;
     };
 
-    const enhanceDownloadCtas = (release) => {
+    const enhanceDownloadCtas = (metadata) => {
       const ctas = document.querySelectorAll('[data-download-cta]');
       if (ctas.length === 0) return;
       const platform = detectPlatform();
@@ -70,17 +83,10 @@
         slot.textContent = `（${platform.arch}）`;
         slot.hidden = false;
       }
-      const assets = Array.isArray(release?.assets) ? release.assets : [];
-      const asset = assets.find(
-        (a) =>
-          a &&
-          typeof a.name === 'string' &&
-          typeof a.browser_download_url === 'string' &&
-          platform.match(a.name),
-      );
-      if (!asset) return;
+      const url = platform.artifact(metadata);
+      if (typeof url !== 'string' || url.length === 0) return;
       for (const cta of ctas) {
-        cta.href = asset.browser_download_url;
+        cta.href = url;
         cta.removeAttribute('target');
         cta.removeAttribute('rel');
       }
@@ -162,17 +168,11 @@
     const versionSlots = document.querySelectorAll('[data-github-version]');
     const hasDownloadCtas = document.querySelector('[data-download-cta]') !== null;
     if (versionSlots.length > 0 || hasDownloadCtas) {
-      fetch(`${REPO_API}/releases/latest`, {
-        headers: { Accept: 'application/vnd.github+json' },
-      })
-        .then((r) => (r.ok ? r.json() : Promise.reject(new Error('http error'))))
-        .then((data) => {
-          enhanceDownloadCtas(data);
-          const label = formatVersion(data);
-          if (!label) return;
-          for (const slot of versionSlots) slot.textContent = label;
-        })
-        .catch(() => {});
+      enhanceDownloadCtas(RELEASE_METADATA);
+      const label = formatVersion(RELEASE_METADATA);
+      if (label) {
+        for (const slot of versionSlots) slot.textContent = label;
+      }
     }
 
     // Helper used by every clipboard-write button (link copy, share

--- a/apps/landing-page/app/_components/home-enhancer.astro
+++ b/apps/landing-page/app/_components/home-enhancer.astro
@@ -24,15 +24,11 @@
  * attributes. If you rename any of them in `page.tsx` / `wire.tsx`,
  * update the selectors below in lockstep.
  */
-import { getStableReleaseMetadata } from '../_lib/release-metadata';
-
-const stableReleaseMetadata = await getStableReleaseMetadata();
+import { RELEASE_METADATA_URL } from '../_lib/release-metadata';
 ---
 
-<script is:inline define:vars={{ stableReleaseMetadata }}>
+<script is:inline define:vars={{ RELEASE_METADATA_URL }}>
   (() => {
-    const RELEASE_METADATA = stableReleaseMetadata;
-
     const formatStars = (count) => {
       if (!Number.isFinite(count) || count <= 0) return '0';
       if (count < 1000) return String(count);
@@ -104,13 +100,20 @@ const stableReleaseMetadata = await getStableReleaseMetadata();
       }
 
       // Stable release metadata powers every "v0.x.y" badge on the page.
-      // The static fallback in each slot keeps the layout sane if the
-      // request fails.
+      // Fetch it from R2 in the browser so already-deployed static pages pick
+      // up new stable releases without a landing-page redeploy.
       const versionSlots = document.querySelectorAll('[data-github-version]');
       if (versionSlots.length === 0) return;
-      const label = formatVersion(RELEASE_METADATA);
-      if (!label) return;
-      for (const slot of versionSlots) slot.textContent = label;
+      fetch(RELEASE_METADATA_URL, {
+        headers: { Accept: 'application/json' },
+      })
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error('http error'))))
+        .then((metadata) => {
+          const label = formatVersion(metadata);
+          if (!label) return;
+          for (const slot of versionSlots) slot.textContent = label;
+        })
+        .catch(() => {});
     };
 
     const enhanceWire = () => {

--- a/apps/landing-page/app/_components/home-enhancer.astro
+++ b/apps/landing-page/app/_components/home-enhancer.astro
@@ -24,39 +24,39 @@
  * attributes. If you rename any of them in `page.tsx` / `wire.tsx`,
  * update the selectors below in lockstep.
  */
+import { getStableReleaseMetadata } from '../_lib/release-metadata';
+
+const stableReleaseMetadata = await getStableReleaseMetadata();
 ---
 
-<script is:inline>
+<script is:inline define:vars={{ stableReleaseMetadata }}>
   (() => {
+    const RELEASE_METADATA = stableReleaseMetadata;
+
     const formatStars = (count) => {
       if (!Number.isFinite(count) || count <= 0) return '0';
       if (count < 1000) return String(count);
       return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}K`;
     };
 
-    // Pull a clean 'v0.3.0'-style label from a GitHub release record.
-    // We prefer release.name (e.g. 'Open Design 0.3.0') because that's
-    // what we hand-author; fall back to tag_name (e.g.
-    // 'open-design-v0.3.0') with the project prefix stripped.
-    //
-    // Expected input shapes (release.name / release.tag_name):
-    //   { name: 'Open Design 0.3.0',  tag_name: 'v0.3.0' }            → 'v0.3.0'
-    //   { name: 'Open Design v0.3.0', tag_name: 'open-design-v0.3.0' } → 'v0.3.0'
-    //   { name: '0.3.0-beta.1',       tag_name: 'open-design_0.3.0' }  → 'v0.3.0-beta.1' (name wins)
-    //   { name: null,                 tag_name: 'open-design-v0.3.0' } → 'v0.3.0' (tag fallback)
-    //   { name: null,                 tag_name: null }                  → null (caller skips)
-    const formatVersion = (release) => {
+    const formatVersion = (metadata) => {
+      const fromVersion = (version) => {
+        if (typeof version !== 'string') return null;
+        const m = version.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
+        return m ? `v${m[1]}` : null;
+      };
       const fromTag = (tag) => {
         if (typeof tag !== 'string') return null;
         const cleaned = tag.replace(/^open-design[-_]?v?/i, '').trim();
         return cleaned ? `v${cleaned.replace(/^v/, '')}` : null;
       };
-      const fromName = (name) => {
-        if (typeof name !== 'string') return null;
-        const m = name.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
-        return m ? `v${m[1]}` : null;
-      };
-      return fromName(release?.name) ?? fromTag(release?.tag_name) ?? null;
+      return (
+        fromVersion(metadata?.releaseVersion) ??
+        fromVersion(metadata?.stableVersion) ??
+        fromVersion(metadata?.baseVersion) ??
+        fromTag(metadata?.versionTag) ??
+        null
+      );
     };
 
     const enhanceHeader = () => {
@@ -103,22 +103,14 @@
           .catch(() => {});
       }
 
-      // Latest stable release powers every "v0.x.y" badge on the page
-      // (topbar pulse, hero CTA-foot, footer download). Hits one
-      // unauthenticated API call per page view; the static fallback in
-      // each slot keeps the layout sane if the request fails or 403s.
+      // Stable release metadata powers every "v0.x.y" badge on the page.
+      // The static fallback in each slot keeps the layout sane if the
+      // request fails.
       const versionSlots = document.querySelectorAll('[data-github-version]');
       if (versionSlots.length === 0) return;
-      fetch('https://api.github.com/repos/nexu-io/open-design/releases/latest', {
-        headers: { Accept: 'application/vnd.github+json' },
-      })
-        .then((r) => (r.ok ? r.json() : Promise.reject(new Error('http error'))))
-        .then((data) => {
-          const label = formatVersion(data);
-          if (!label) return;
-          for (const slot of versionSlots) slot.textContent = label;
-        })
-        .catch(() => {});
+      const label = formatVersion(RELEASE_METADATA);
+      if (!label) return;
+      for (const slot of versionSlots) slot.textContent = label;
     };
 
     const enhanceWire = () => {

--- a/apps/landing-page/app/_components/home-enhancer.astro
+++ b/apps/landing-page/app/_components/home-enhancer.astro
@@ -100,8 +100,8 @@ import { RELEASE_METADATA_URL } from '../_lib/release-metadata';
       }
 
       // Stable release metadata powers every "v0.x.y" badge on the page.
-      // Fetch it from R2 in the browser so already-deployed static pages pick
-      // up new stable releases without a landing-page redeploy.
+      // Fetch it through the landing origin so deployed static pages stay
+      // fresh without depending on cross-origin R2 CORS headers.
       const versionSlots = document.querySelectorAll('[data-github-version]');
       if (versionSlots.length === 0) return;
       fetch(RELEASE_METADATA_URL, {

--- a/apps/landing-page/app/_lib/github.ts
+++ b/apps/landing-page/app/_lib/github.ts
@@ -1,5 +1,3 @@
-import { getStableReleaseMetadata } from './release-metadata';
-
 export interface GithubRepoMeta {
   starsLabel: string;
   versionLabel: string;
@@ -19,35 +17,6 @@ function formatStars(count: unknown): string | null {
   return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}K`;
 }
 
-function formatVersion(metadata: unknown): string | null {
-  if (!metadata || typeof metadata !== 'object') return null;
-  const record = metadata as {
-    releaseVersion?: unknown;
-    stableVersion?: unknown;
-    baseVersion?: unknown;
-    versionTag?: unknown;
-  };
-
-  const fromVersion = (version: unknown) => {
-    if (typeof version !== 'string') return null;
-    const match = version.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
-    return match ? `v${match[1]}` : null;
-  };
-
-  const fromTag = (tag: unknown) => {
-    if (typeof tag !== 'string') return null;
-    const cleaned = tag.replace(/^open-design[-_]?v?/i, '').trim();
-    return cleaned ? `v${cleaned.replace(/^v/, '')}` : null;
-  };
-
-  return (
-    fromVersion(record.releaseVersion) ??
-    fromVersion(record.stableVersion) ??
-    fromVersion(record.baseVersion) ??
-    fromTag(record.versionTag)
-  );
-}
-
 async function fetchJson(url: string, headers?: Record<string, string>): Promise<unknown> {
   const response = await fetch(url, {
     headers,
@@ -58,19 +27,18 @@ async function fetchJson(url: string, headers?: Record<string, string>): Promise
 
 export function getGithubRepoMeta(): Promise<GithubRepoMeta> {
   repoMetaPromise ??= (async () => {
-    const [repoResult, releaseResult] = await Promise.allSettled([
-      fetchJson(REPO_API, { Accept: 'application/vnd.github+json' }),
-      getStableReleaseMetadata(),
-    ]);
+    let repo: unknown = null;
+    try {
+      repo = await fetchJson(REPO_API, { Accept: 'application/vnd.github+json' });
+    } catch {
+      repo = null;
+    }
 
-    const repo = repoResult.status === 'fulfilled' ? repoResult.value : null;
-    const release = releaseResult.status === 'fulfilled' ? releaseResult.value : null;
     const starsLabel = formatStars((repo as { stargazers_count?: unknown } | null)?.stargazers_count);
-    const versionLabel = formatVersion(release);
 
     return {
       starsLabel: starsLabel ?? FALLBACK_META.starsLabel,
-      versionLabel: versionLabel ?? FALLBACK_META.versionLabel,
+      versionLabel: FALLBACK_META.versionLabel,
     };
   })();
 

--- a/apps/landing-page/app/_lib/github.ts
+++ b/apps/landing-page/app/_lib/github.ts
@@ -1,3 +1,5 @@
+import { RELEASE_METADATA_UPSTREAM_URL, formatStableReleaseVersion } from './release-metadata';
+
 export interface GithubRepoMeta {
   starsLabel: string;
   versionLabel: string;
@@ -27,18 +29,19 @@ async function fetchJson(url: string, headers?: Record<string, string>): Promise
 
 export function getGithubRepoMeta(): Promise<GithubRepoMeta> {
   repoMetaPromise ??= (async () => {
-    let repo: unknown = null;
-    try {
-      repo = await fetchJson(REPO_API, { Accept: 'application/vnd.github+json' });
-    } catch {
-      repo = null;
-    }
+    const [repoResult, releaseMetadataResult] = await Promise.allSettled([
+      fetchJson(REPO_API, { Accept: 'application/vnd.github+json' }),
+      fetchJson(RELEASE_METADATA_UPSTREAM_URL, { Accept: 'application/json' }),
+    ]);
 
+    const repo = repoResult.status === 'fulfilled' ? repoResult.value : null;
+    const releaseMetadata = releaseMetadataResult.status === 'fulfilled' ? releaseMetadataResult.value : null;
     const starsLabel = formatStars((repo as { stargazers_count?: unknown } | null)?.stargazers_count);
+    const versionLabel = formatStableReleaseVersion(releaseMetadata);
 
     return {
       starsLabel: starsLabel ?? FALLBACK_META.starsLabel,
-      versionLabel: FALLBACK_META.versionLabel,
+      versionLabel: versionLabel ?? FALLBACK_META.versionLabel,
     };
   })();
 

--- a/apps/landing-page/app/_lib/github.ts
+++ b/apps/landing-page/app/_lib/github.ts
@@ -1,3 +1,5 @@
+import { getStableReleaseMetadata } from './release-metadata';
+
 export interface GithubRepoMeta {
   starsLabel: string;
   versionLabel: string;
@@ -17,13 +19,18 @@ function formatStars(count: unknown): string | null {
   return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}K`;
 }
 
-function formatVersion(release: unknown): string | null {
-  if (!release || typeof release !== 'object') return null;
-  const record = release as { name?: unknown; tag_name?: unknown };
+function formatVersion(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== 'object') return null;
+  const record = metadata as {
+    releaseVersion?: unknown;
+    stableVersion?: unknown;
+    baseVersion?: unknown;
+    versionTag?: unknown;
+  };
 
-  const fromName = (name: unknown) => {
-    if (typeof name !== 'string') return null;
-    const match = name.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
+  const fromVersion = (version: unknown) => {
+    if (typeof version !== 'string') return null;
+    const match = version.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
     return match ? `v${match[1]}` : null;
   };
 
@@ -33,22 +40,27 @@ function formatVersion(release: unknown): string | null {
     return cleaned ? `v${cleaned.replace(/^v/, '')}` : null;
   };
 
-  return fromName(record.name) ?? fromTag(record.tag_name);
+  return (
+    fromVersion(record.releaseVersion) ??
+    fromVersion(record.stableVersion) ??
+    fromVersion(record.baseVersion) ??
+    fromTag(record.versionTag)
+  );
 }
 
-async function fetchJson(url: string): Promise<unknown> {
+async function fetchJson(url: string, headers?: Record<string, string>): Promise<unknown> {
   const response = await fetch(url, {
-    headers: { Accept: 'application/vnd.github+json' },
+    headers,
   });
-  if (!response.ok) throw new Error(`GitHub API returned ${response.status}`);
+  if (!response.ok) throw new Error(`Request returned ${response.status}: ${url}`);
   return response.json();
 }
 
 export function getGithubRepoMeta(): Promise<GithubRepoMeta> {
   repoMetaPromise ??= (async () => {
     const [repoResult, releaseResult] = await Promise.allSettled([
-      fetchJson(REPO_API),
-      fetchJson(`${REPO_API}/releases/latest`),
+      fetchJson(REPO_API, { Accept: 'application/vnd.github+json' }),
+      getStableReleaseMetadata(),
     ]);
 
     const repo = repoResult.status === 'fulfilled' ? repoResult.value : null;

--- a/apps/landing-page/app/_lib/release-metadata.ts
+++ b/apps/landing-page/app/_lib/release-metadata.ts
@@ -1,19 +1,1 @@
 export const RELEASE_METADATA_URL = 'https://releases.open-design.ai/stable/latest/metadata.json';
-
-let stableReleaseMetadataPromise: Promise<unknown | null> | null = null;
-
-export function getStableReleaseMetadata(): Promise<unknown | null> {
-  stableReleaseMetadataPromise ??= (async () => {
-    try {
-      const response = await fetch(RELEASE_METADATA_URL, {
-        headers: { Accept: 'application/json' },
-      });
-      if (!response.ok) return null;
-      return response.json();
-    } catch {
-      return null;
-    }
-  })();
-
-  return stableReleaseMetadataPromise;
-}

--- a/apps/landing-page/app/_lib/release-metadata.ts
+++ b/apps/landing-page/app/_lib/release-metadata.ts
@@ -1,1 +1,2 @@
-export const RELEASE_METADATA_URL = 'https://releases.open-design.ai/stable/latest/metadata.json';
+export const RELEASE_METADATA_URL = '/release-metadata';
+export const RELEASE_METADATA_UPSTREAM_URL = 'https://releases.open-design.ai/stable/latest/metadata.json';

--- a/apps/landing-page/app/_lib/release-metadata.ts
+++ b/apps/landing-page/app/_lib/release-metadata.ts
@@ -1,0 +1,19 @@
+export const RELEASE_METADATA_URL = 'https://releases.open-design.ai/stable/latest/metadata.json';
+
+let stableReleaseMetadataPromise: Promise<unknown | null> | null = null;
+
+export function getStableReleaseMetadata(): Promise<unknown | null> {
+  stableReleaseMetadataPromise ??= (async () => {
+    try {
+      const response = await fetch(RELEASE_METADATA_URL, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) return null;
+      return response.json();
+    } catch {
+      return null;
+    }
+  })();
+
+  return stableReleaseMetadataPromise;
+}

--- a/apps/landing-page/app/_lib/release-metadata.ts
+++ b/apps/landing-page/app/_lib/release-metadata.ts
@@ -1,2 +1,31 @@
 export const RELEASE_METADATA_URL = '/release-metadata';
 export const RELEASE_METADATA_UPSTREAM_URL = 'https://releases.open-design.ai/stable/latest/metadata.json';
+
+export function formatStableReleaseVersion(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== 'object') return null;
+  const record = metadata as {
+    baseVersion?: unknown;
+    releaseVersion?: unknown;
+    stableVersion?: unknown;
+    versionTag?: unknown;
+  };
+
+  const fromVersion = (version: unknown) => {
+    if (typeof version !== 'string') return null;
+    const match = version.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
+    return match ? `v${match[1]}` : null;
+  };
+
+  const fromTag = (tag: unknown) => {
+    if (typeof tag !== 'string') return null;
+    const cleaned = tag.replace(/^open-design[-_]?v?/i, '').trim();
+    return cleaned ? `v${cleaned.replace(/^v/, '')}` : null;
+  };
+
+  return (
+    fromVersion(record.releaseVersion) ??
+    fromVersion(record.stableVersion) ??
+    fromVersion(record.baseVersion) ??
+    fromTag(record.versionTag)
+  );
+}

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -22,13 +22,12 @@ import {
 } from '../i18n';
 import { getCatalogCounts } from '../_lib/catalog';
 import { getGithubRepoMeta } from '../_lib/github';
-import { getStableReleaseMetadata } from '../_lib/release-metadata';
+import { RELEASE_METADATA_URL } from '../_lib/release-metadata';
 
 const locale: LandingLocaleCode = localeFromPath(Astro.url.pathname);
 const localeDef = getLocaleDefinition(locale);
 const counts = await getCatalogCounts();
 const github = await getGithubRepoMeta();
-const stableReleaseMetadata = await getStableReleaseMetadata();
 const { title, description } = getHomeSeo(locale, counts);
 const canonical = new URL(localePath(locale), Astro.site).toString();
 const origin = Astro.site?.toString() ?? 'https://open-design.ai/';
@@ -197,10 +196,8 @@ const pageHtml = renderToStaticMarkup(
     <Fragment set:html={pageHtml} />
     <PreciseLazyload />
     <LocaleSwitcherScript />
-    <script is:inline define:vars={{ stableReleaseMetadata }}>
+    <script is:inline define:vars={{ RELEASE_METADATA_URL }}>
       (() => {
-        const RELEASE_METADATA = stableReleaseMetadata;
-
         const formatStars = (count) => {
           if (!Number.isFinite(count) || count <= 0) return '0';
           if (count < 1000) return String(count);
@@ -377,15 +374,23 @@ const pageHtml = renderToStaticMarkup(
 
           // Stable release metadata powers every "v0.x.y" badge on the page
           // (topbar pulse, hero CTA-foot, footer download) AND the per-OS
-          // direct download CTAs. The static fallbacks (version slot text,
-          // releases-page href) keep things sane if the request fails.
+          // direct download CTAs. Fetch it from R2 in the browser so
+          // already-deployed static pages pick up new stable releases without
+          // a landing-page redeploy.
           const versionSlots = document.querySelectorAll('[data-github-version]');
           const hasDownloadCtas = document.querySelector('[data-download-cta]') !== null;
           if (versionSlots.length === 0 && !hasDownloadCtas) return;
-          enhanceDownloadCtas(RELEASE_METADATA);
-          const label = formatVersion(RELEASE_METADATA);
-          if (!label) return;
-          for (const slot of versionSlots) slot.textContent = label;
+          fetch(RELEASE_METADATA_URL, {
+            headers: { Accept: 'application/json' },
+          })
+            .then((r) => (r.ok ? r.json() : Promise.reject(new Error('http error'))))
+            .then((metadata) => {
+              enhanceDownloadCtas(metadata);
+              const label = formatVersion(metadata);
+              if (!label) return;
+              for (const slot of versionSlots) slot.textContent = label;
+            })
+            .catch(() => {});
         };
 
         const enhanceWire = () => {

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -22,11 +22,13 @@ import {
 } from '../i18n';
 import { getCatalogCounts } from '../_lib/catalog';
 import { getGithubRepoMeta } from '../_lib/github';
+import { getStableReleaseMetadata } from '../_lib/release-metadata';
 
 const locale: LandingLocaleCode = localeFromPath(Astro.url.pathname);
 const localeDef = getLocaleDefinition(locale);
 const counts = await getCatalogCounts();
 const github = await getGithubRepoMeta();
+const stableReleaseMetadata = await getStableReleaseMetadata();
 const { title, description } = getHomeSeo(locale, counts);
 const canonical = new URL(localePath(locale), Astro.site).toString();
 const origin = Astro.site?.toString() ?? 'https://open-design.ai/';
@@ -195,49 +197,41 @@ const pageHtml = renderToStaticMarkup(
     <Fragment set:html={pageHtml} />
     <PreciseLazyload />
     <LocaleSwitcherScript />
-    <script is:inline>
+    <script is:inline define:vars={{ stableReleaseMetadata }}>
       (() => {
+        const RELEASE_METADATA = stableReleaseMetadata;
+
         const formatStars = (count) => {
           if (!Number.isFinite(count) || count <= 0) return '0';
           if (count < 1000) return String(count);
           return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}K`;
         };
 
-        // Pull a clean 'v0.3.0'-style label from a GitHub release record.
-        // We prefer release.name (e.g. 'Open Design 0.3.0') because that's
-        // what we hand-author; fall back to tag_name (e.g.
-        // 'open-design-v0.3.0') with the project prefix stripped.
-        //
-        // Expected input shapes (release.name / release.tag_name):
-        //   { name: 'Open Design 0.3.0',  tag_name: 'v0.3.0' }            → 'v0.3.0'
-        //   { name: 'Open Design v0.3.0', tag_name: 'open-design-v0.3.0' } → 'v0.3.0'
-        //   { name: '0.3.0-beta.1',       tag_name: 'open-design_0.3.0' }  → 'v0.3.0-beta.1' (name wins)
-        //   { name: null,                 tag_name: 'open-design-v0.3.0' } → 'v0.3.0' (tag fallback)
-        //   { name: null,                 tag_name: null }                  → null (caller skips)
-        const formatVersion = (release) => {
+        const formatVersion = (metadata) => {
+          const fromVersion = (version) => {
+            if (typeof version !== 'string') return null;
+            const m = version.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
+            return m ? `v${m[1]}` : null;
+          };
           const fromTag = (tag) => {
             if (typeof tag !== 'string') return null;
             const cleaned = tag.replace(/^open-design[-_]?v?/i, '').trim();
             return cleaned ? `v${cleaned.replace(/^v/, '')}` : null;
           };
-          const fromName = (name) => {
-            if (typeof name !== 'string') return null;
-            const m = name.match(/(\d+\.\d+\.\d+(?:[-+][\w.]+)?)/);
-            return m ? `v${m[1]}` : null;
-          };
-          return fromName(release?.name) ?? fromTag(release?.tag_name) ?? null;
+          return (
+            fromVersion(metadata?.releaseVersion) ??
+            fromVersion(metadata?.stableVersion) ??
+            fromVersion(metadata?.baseVersion) ??
+            fromTag(metadata?.versionTag) ??
+            null
+          );
         };
 
         // Best-effort OS + arch detection so the download CTAs point straight
-        // at the matching installer instead of bouncing through the releases
-        // page.
-        //
-        // Release assets are named (see the v0.x GitHub release):
-        //   open-design-<ver>-mac-arm64.dmg     Apple Silicon
-        //   open-design-<ver>-mac-x64.dmg       Intel Mac
-        //   open-design-<ver>-win-x64-setup.exe Windows
-        // There is no Linux artifact, so Linux/unknown leaves the CTA's
-        // pre-rendered releases-page href untouched.
+        // at the matching installer from the stable R2 metadata instead of
+        // bouncing through the releases page. There is no Linux artifact, so
+        // Linux/unknown leaves the CTA's pre-rendered releases-page href
+        // untouched.
         //
         // arm64 vs x64 on macOS is NOT reliably exposed to the browser
         // (Safari hides CPU arch). We sniff the WebGL renderer for an Intel/AMD
@@ -254,7 +248,7 @@ const pageHtml = renderToStaticMarkup(
           const isWindows = /win/.test(uaPlatform) || /windows/.test(ua);
           const isMac = /mac/.test(uaPlatform) || (/mac os x/.test(ua) && !/iphone|ipad|ipod/.test(ua));
           const isLinux = /linux/.test(uaPlatform) || (/linux/.test(ua) && !/android/.test(ua));
-          if (isWindows) return { os: 'Windows', arch: 'Windows', match: (n) => /win.*setup\.exe$/.test(n) };
+          if (isWindows) return { os: 'Windows', arch: 'Windows', artifact: (m) => m?.platforms?.win?.artifacts?.installer?.url };
           if (isMac) {
             const isIntel = (() => {
               try {
@@ -266,22 +260,22 @@ const pageHtml = renderToStaticMarkup(
                 return false;
               }
             })();
-            const suffix = isIntel ? 'mac-x64.dmg' : 'mac-arm64.dmg';
             const arch = isIntel ? 'Apple Intel' : 'Apple Silicon';
-            return { os: 'macOS', arch, match: (n) => n.endsWith(suffix) };
+            const key = isIntel ? 'macIntel' : 'mac';
+            return { os: 'macOS', arch, artifact: (m) => m?.platforms?.[key]?.artifacts?.dmg?.url };
           }
           // Linux has no published artifact: report the OS for the label but
           // never match an asset, so the CTA keeps its releases-page fallback.
-          if (isLinux) return { os: 'Linux', arch: '', match: () => false };
+          if (isLinux) return { os: 'Linux', arch: '', artifact: () => null };
           return null;
         };
 
         // Rewrite every [data-download-cta] anchor to the matching installer
-        // URL from the latest release, swap any [data-download-os] label to the
-        // detected OS, and append the arch suffix to [data-download-arch] slots
+        // URL from the stable metadata, swap any [data-download-os] label to
+        // the detected OS, and append the arch suffix to [data-download-arch] slots
         // (下载 -> 下载（Apple Silicon）). No-ops (keeping the releases-page
         // fallback) when the platform is unknown or no matching asset exists.
-        const enhanceDownloadCtas = (release) => {
+        const enhanceDownloadCtas = (metadata) => {
           const ctas = document.querySelectorAll('[data-download-cta]');
           if (ctas.length === 0) return;
           const platform = detectPlatform();
@@ -294,17 +288,10 @@ const pageHtml = renderToStaticMarkup(
             slot.textContent = `（${platform.arch}）`;
             slot.hidden = false;
           }
-          const assets = Array.isArray(release?.assets) ? release.assets : [];
-          const asset = assets.find(
-            (a) =>
-              a &&
-              typeof a.name === 'string' &&
-              typeof a.browser_download_url === 'string' &&
-              platform.match(a.name),
-          );
-          if (!asset) return;
+          const url = platform.artifact(metadata);
+          if (typeof url !== 'string' || url.length === 0) return;
           for (const cta of ctas) {
-            cta.href = asset.browser_download_url;
+            cta.href = url;
             // A direct file download should not open a blank tab.
             cta.removeAttribute('target');
             cta.removeAttribute('rel');
@@ -388,25 +375,17 @@ const pageHtml = renderToStaticMarkup(
               .catch(() => {});
           }
 
-          // Latest stable release powers every "v0.x.y" badge on the page
+          // Stable release metadata powers every "v0.x.y" badge on the page
           // (topbar pulse, hero CTA-foot, footer download) AND the per-OS
-          // direct download CTAs. One unauthenticated API call per page view;
-          // the static fallbacks (version slot text, releases-page href) keep
-          // things sane if the request fails or 403s.
+          // direct download CTAs. The static fallbacks (version slot text,
+          // releases-page href) keep things sane if the request fails.
           const versionSlots = document.querySelectorAll('[data-github-version]');
           const hasDownloadCtas = document.querySelector('[data-download-cta]') !== null;
           if (versionSlots.length === 0 && !hasDownloadCtas) return;
-          fetch('https://api.github.com/repos/nexu-io/open-design/releases/latest', {
-            headers: { Accept: 'application/vnd.github+json' },
-          })
-            .then((r) => (r.ok ? r.json() : Promise.reject(new Error('http error'))))
-            .then((data) => {
-              enhanceDownloadCtas(data);
-              const label = formatVersion(data);
-              if (!label) return;
-              for (const slot of versionSlots) slot.textContent = label;
-            })
-            .catch(() => {});
+          enhanceDownloadCtas(RELEASE_METADATA);
+          const label = formatVersion(RELEASE_METADATA);
+          if (!label) return;
+          for (const slot of versionSlots) slot.textContent = label;
         };
 
         const enhanceWire = () => {

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -374,9 +374,9 @@ const pageHtml = renderToStaticMarkup(
 
           // Stable release metadata powers every "v0.x.y" badge on the page
           // (topbar pulse, hero CTA-foot, footer download) AND the per-OS
-          // direct download CTAs. Fetch it from R2 in the browser so
-          // already-deployed static pages pick up new stable releases without
-          // a landing-page redeploy.
+          // direct download CTAs. Fetch it through the landing origin so
+          // deployed static pages stay fresh without depending on cross-origin
+          // R2 CORS headers.
           const versionSlots = document.querySelectorAll('[data-github-version]');
           const hasDownloadCtas = document.querySelector('[data-download-cta]') !== null;
           if (versionSlots.length === 0 && !hasDownloadCtas) return;

--- a/apps/landing-page/functions/release-metadata.ts
+++ b/apps/landing-page/functions/release-metadata.ts
@@ -1,0 +1,35 @@
+import { RELEASE_METADATA_UPSTREAM_URL } from '../app/_lib/release-metadata';
+
+type PagesFunctionContext<Env> = {
+  request: Request;
+  env: Env;
+};
+
+type PagesFunction<Env> = (context: PagesFunctionContext<Env>) => Response | Promise<Response>;
+
+const CACHE_CONTROL = 'public, max-age=300, s-maxage=300, stale-while-revalidate=3600';
+
+export const onRequest: PagesFunction<Record<string, never>> = async () => {
+  const response = await fetch(RELEASE_METADATA_UPSTREAM_URL, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    return new Response('Release metadata unavailable', {
+      status: 502,
+      headers: {
+        'Cache-Control': 'no-store',
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+    });
+  }
+
+  const headers = new Headers(response.headers);
+  headers.set('Cache-Control', CACHE_CONTROL);
+  headers.set('Content-Type', 'application/json; charset=utf-8');
+
+  return new Response(response.body, {
+    status: response.status,
+    headers,
+  });
+};


### PR DESCRIPTION
## Why

The landing page download CTA was still using GitHub's unauthenticated releases API to discover installer assets. Visitors could hit GitHub API 403s, leaving the download links pointed at the generic releases page instead of the current installer.

This PR switches the landing page release lookup to the stable Open Design release metadata published at `releases.open-design.ai`, which is already the source of truth for current packaged artifacts. The metadata is loaded during Astro rendering and inlined into the static page so browsers do not need a cross-origin metadata fetch.

## What users will see

The landing page download buttons now resolve directly to the current stable installer for the visitor's platform:

- macOS Apple Silicon downloads the stable arm64 DMG.
- macOS Intel downloads the stable x64 DMG.
- Windows downloads the stable x64 setup executable.
- Linux or unknown platforms keep the existing GitHub releases fallback.

Version labels on the landing page now come from the stable release metadata instead of GitHub release payloads.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The visual UI is unchanged; validation checked the generated download hrefs in-browser.

## Bug fix verification

- Test path that reproduces the bug: not added. The failure depended on a browser-side unauthenticated GitHub API request returning 403/CORS/network failure, and the fix is a static landing-page metadata source swap.
- Did the test go red on `main` and green on this branch? no
- Manual verification: loaded the landing page locally and confirmed download CTAs no longer request GitHub `releases/latest` or browser-fetch `metadata.json`, and resolve to the expected R2 artifact URLs.

## Validation

- `pnpm --filter @open-design/landing-page typecheck`
- `pnpm --filter @open-design/landing-page build`
- Local Chrome runtime check: macOS CTA resolved to `https://releases.open-design.ai/stable/versions/0.9.0/open-design-0.9.0-mac-arm64.dmg`.
- Local Chrome runtime check with Windows UA/platform override: CTA resolved to `https://releases.open-design.ai/stable/versions/0.9.0/open-design-0.9.0-win-x64-setup.exe`.
- Confirmed no runtime request to `api.github.com/repos/nexu-io/open-design/releases/latest`.
