### PR TITLE
ci(feishu): linkify PR refs and commit hashes in the daily build card

### DIFF
--- a/.github/scripts/release/feishu/notify.ts
+++ b/.github/scripts/release/feishu/notify.ts
@@ -86,6 +86,18 @@ function readChangelog() {
   return { lines: truncated ? all.slice(0, MAX_CHANGELOG_LINES) : all, truncated, total: all.length };
 }
 
+// Turn the plain-text `git log` line into clickable Feishu links: every PR
+// reference (`#1234`, typically the `(#1234)` suffix a squash-merge leaves on
+// the subject) jumps to the pull request, and the trailing short hash appended
+// by `git log %s (%h)` jumps to the commit. Lines without a PR ref (direct
+// pushes to the release branch) still get their commit linked.
+function linkifyChangelogLine(line) {
+  if (repo.length === 0) return line;
+  return line
+    .replace(/#(\d+)/g, (_match, num) => `[#${num}](https://github.com/${repo}/pull/${num})`)
+    .replace(/\(([0-9a-f]{7,40})\)\s*$/i, (_match, hash) => `([\`${hash}\`](https://github.com/${repo}/commit/${hash}))`);
+}
+
 function changelogMarkdown() {
   const { lines, truncated, total } = readChangelog();
   if (previousCommit.length === 0) {
@@ -94,7 +106,7 @@ function changelogMarkdown() {
   if (lines.length === 0) {
     return `与上个 ${channelLabel} 包之间没有新增提交。`;
   }
-  const body = lines.map((line) => `- ${line}`).join("\n");
+  const body = lines.map((line) => `- ${linkifyChangelogLine(line)}`).join("\n");
   if (truncated) {
     return `${body}\n- …还有 ${total - lines.length} 条提交(共 ${total} 条)`;
   }


### PR DESCRIPTION
## Why

The daily Feishu build card (and the per-push release card) lists the changelog as plain text — `git log %s (%h)` — so the `(#1234)` PR refs and the trailing short hash are just unclickable strings. When the morning Beta card lands in the group, you can see *that* PRs went in but can't jump to any of them; you have to hand-copy the number into the URL bar. This makes the "what's new since yesterday's build" list links you can actually click.

Pairs with wiring the daily group's `FEISHU_DAILY_WEBHOOK` secret (configured separately), which is what makes the 09:00 Asia/Shanghai card actually post.

## What users will see

In the Feishu build card, under **自上个 … 新增提交**, every PR reference renders as a clickable `#1234` that opens the pull request, and each line's commit hash is a clickable link to the commit. Lines from direct pushes (no PR ref) still get their commit linked. No change to which builds post or when.

## Surface area

- [x] **None** — internal CI/notification script change only (`.github/scripts/release/feishu/notify.ts`); affects both the daily-beta and release-push Feishu cards.

## Bug fix verification

Not a bug fix. Verified the rendering locally by running the script's `changelogMarkdown()` against a sample `git log` file mixing squash-merged PR lines and a direct-push line — PR refs and hashes both render as Feishu `lark_md` links, the no-PR line keeps its commit link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
