### PR TITLE
feat(web): enable privacy-masked PostHog session replay

### DIFF
--- a/apps/web/src/analytics/client.ts
+++ b/apps/web/src/analytics/client.ts
@@ -212,13 +212,42 @@ export async function getAnalyticsClient(
         //    on scrub.ts.
         before_send: scrubBeforeSend,
 
-        // --- Explicitly disabled --------------------------------------
+        // --- Session replay (privacy-masked) --------------------------
         // Session replay captures the user's entire screen. For a tool
         // where prompts, generated artifacts, and provider API keys are
-        // all visible in DOM, this needs an extensive mask catalogue
-        // before we can satisfy the CSV's no-prompt-content rule. Off
-        // until a dedicated consent surface ships.
-        disable_session_recording: true,
+        // all visible in DOM, recording the raw screen would violate the
+        // CSV's no-prompt-content rule. Rather than gate replay behind a
+        // separate consent surface, we record only layout + interaction
+        // and over-redact every content surface — the same
+        // "redact-by-default, single audit point" philosophy scrub.ts
+        // uses for events (see scrub.ts header). Replay stays gated by the
+        // existing Privacy → "Share usage data" consent: posthog-js's
+        // global opt_out_capturing() halts replay too (see applyConsent()).
+        //
+        // The three redaction layers, in order of how much they cover:
+        //   1. maskTextSelector '*' masks EVERY text node into asterisks,
+        //      so prompts, generated artifact text, provider/model names,
+        //      project titles, and any future text surface never appear in
+        //      a replay. A new sensitive surface is covered automatically.
+        //   2. maskAllInputs masks every <input>/<textarea> value, so the
+        //      prompt composer and BYOK provider-key fields are blanked
+        //      even though only the composer carries `ph-no-capture`.
+        //   3. blockSelector 'iframe' fully blocks every embedded frame.
+        //      The artifact/preview FileViewer iframes (and plugin embeds)
+        //      render generated HTML that can contain anything; rrweb would
+        //      otherwise serialize same-origin/srcDoc frame DOM into the
+        //      recording. They render as an inert placeholder instead.
+        // `ph-no-capture` remains posthog-js's default replay block class,
+        // so the composer subtree stays blocked as defense in depth.
+        disable_session_recording: false,
+        session_recording: {
+          maskAllInputs: true,
+          maskTextSelector: '*',
+          blockSelector: 'iframe',
+          // Don't reach into cross-origin frames either — belt and braces
+          // alongside blockSelector for the URL-load artifact iframe.
+          recordCrossOriginIframes: false,
+        },
 
         loaded: (instance) => {
           lastRegisterPayload = {

--- a/apps/web/tests/analytics-session-replay.test.ts
+++ b/apps/web/tests/analytics-session-replay.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+//
+// Regression test for "PostHog session replay is enabled but privacy-masked".
+//
+// Session replay was previously off (`disable_session_recording: true`)
+// because Open Design's DOM is full of sensitive content — prompts, generated
+// artifacts, and BYOK provider keys. Turning replay on without masking would
+// violate the no-prompt-content rule.
+//
+// The contract this test pins: when the daemon reports analytics enabled,
+// `posthog.init` must be called with replay ENABLED and the three redaction
+// layers in place, so a raw screen recording can never leak prompt content:
+//   1. maskTextSelector '*'      — every text node masked
+//   2. maskAllInputs true        — every input/textarea value masked
+//   3. blockSelector 'iframe'    — artifact/preview iframes fully blocked
+//
+// Goes red on the `disable_session_recording: true` version (replay off, no
+// session_recording config) and green once replay ships masked.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface InitConfig {
+  disable_session_recording?: boolean;
+  session_recording?: {
+    maskAllInputs?: boolean;
+    maskTextSelector?: string | null;
+    blockSelector?: string | null;
+    recordCrossOriginIframes?: boolean;
+  };
+}
+
+let lastInitConfig: InitConfig | null = null;
+
+vi.mock('posthog-js', () => {
+  const stub = {
+    init: (_key: string, config: InitConfig) => {
+      lastInitConfig = config;
+      // posthog-js's loaded() callback fires synchronously enough for the
+      // test; invoke it so the register payload path runs too.
+      const loaded = (config as unknown as { loaded?: (i: unknown) => void }).loaded;
+      loaded?.(stub);
+      return stub;
+    },
+    register: () => undefined,
+    opt_in_capturing: () => undefined,
+    opt_out_capturing: () => undefined,
+    reset: () => undefined,
+    identify: () => undefined,
+  };
+  return { default: stub };
+});
+
+describe('PostHog session replay configuration', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    lastInitConfig = null;
+    vi.resetModules();
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      if (url.endsWith('/api/analytics/config')) {
+        return new Response(
+          JSON.stringify({
+            enabled: true,
+            key: 'phc_test_key',
+            host: 'https://us.i.posthog.com',
+            installationId: 'install-123',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  async function initClient() {
+    const { getAnalyticsClient } = await import('../src/analytics/client');
+    await getAnalyticsClient({
+      anonymousId: 'anon-1',
+      sessionId: 'sess-1',
+      clientType: 'web',
+      locale: 'en',
+      appVersion: '1.2.3',
+    });
+    return lastInitConfig;
+  }
+
+  it('enables session replay (replay off would leak prompt content)', async () => {
+    const config = await initClient();
+    expect(config).not.toBeNull();
+    expect(config?.disable_session_recording).toBe(false);
+    expect(config?.session_recording).toBeDefined();
+  });
+
+  it('masks every text node so prompts and artifact text never render', async () => {
+    const config = await initClient();
+    expect(config?.session_recording?.maskTextSelector).toBe('*');
+  });
+
+  it('masks every input value so BYOK provider keys are blanked', async () => {
+    const config = await initClient();
+    expect(config?.session_recording?.maskAllInputs).toBe(true);
+  });
+
+  it('blocks all iframes so generated artifact frames are never serialized', async () => {
+    const config = await initClient();
+    expect(config?.session_recording?.blockSelector).toBe('iframe');
+    expect(config?.session_recording?.recordCrossOriginIframes).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

I was checking why PostHog showed **zero session recordings** for the OpenDesign project (420348) despite the server-side `session_recording_opt_in` toggle being on and frontend events (`$autocapture`, `$pageview`, `$rageclick`, `$dead_click`) flowing normally. The trail led to `apps/web/src/analytics/client.ts`, where replay was deliberately turned off with `disable_session_recording: true` — the comment said it was waiting on "an extensive mask catalogue" and "a dedicated consent surface" before it could satisfy the no-prompt-content rule.

The pain: we have rich path/funnel data but no behavioral replay at all, so we can't see *how* users get stuck — only the aggregate click stream. The blocker was real (prompts, generated artifacts, and BYOK provider keys are all in the DOM), but it doesn't actually require a whole new consent surface to unblock — it requires aggressive masking. This PR ships that masking.

## What users will see

No new UI. For users who have already opted into **Privacy → "Share usage data"**, PostHog now records session replays — but **fully redacted**: every text node is masked to asterisks, every input value is blanked, and all embedded artifact/preview iframes render as inert placeholders. The replay shows layout, clicks, scrolls, rage-clicks, and navigation, but never any prompt text, generated content, or API keys. Users who have *not* opted in record nothing — replay is gated by the same single consent toggle as all other capture (`opt_out_capturing()` halts replay too).

This is a default-behavior change for already-opted-in users, so it's flagged below.

## Surface area

- [x] **Default behavior change** — opted-in users now produce (privacy-masked) session recordings; nothing changes for opted-out users.

## Screenshots

No UI surface. The change is the PostHog `posthog.init` config; behavior is observable only in the PostHog replay dashboard.

## Bug fix verification

Not a bug fix per se, but the change is pinned with a falsifiable red/green spec following the repo's red-spec convention.

- Test path: `apps/web/tests/analytics-session-replay.test.ts`
- Red on `main` / green on branch? **yes** — reverting `client.ts` to `disable_session_recording: true` fails all 4 cases (`expected true to be false`, `expected undefined to be '*'`, etc.); the masked-replay config makes them green.

## Validation

- `pnpm --filter @open-design/web test` — 2635 passed (incl. the 4 new cases)
- `pnpm exec vitest run tests/analytics-session-replay.test.ts` — 4 passed; reverted-fix run — 4 failed (red-on-main confirmed)
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm guard` — 40/40

## Note for reviewers

The masking strategy intentionally over-redacts (mask **all** text, **all** inputs, block **all** iframes) to match `scrub.ts`'s stated "redact-by-default, single audit point" philosophy — a new sensitive surface is covered automatically rather than needing a new `ph-no-capture` mark. The trade-off is that replays read as "wireframe + interactions" rather than pixel-accurate screens. Selectively unmasking safe chrome text (so replays are more legible) is a deliberate follow-up with its own risk surface, not part of this PR.

One operational gate: the PostHog project's Session Recording master switch must also be enabled for ingestion. Project 420348 already reports `session_recording_opt_in: True`, so recordings will begin flowing once this merges and ships.
