### PR TITLE
Implement Langfuse prompt-stack diagnostics

### DIFF
--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -10,6 +10,8 @@
 
 import os from 'node:os';
 
+import { modelIdForTracking } from '@open-design/contracts/analytics';
+
 import { readAppConfig } from './app-config.js';
 import type { AppVersionInfo } from './app-version.js';
 import { listMessages } from './db.js';
@@ -118,13 +120,11 @@ function turnInfoFromRun(
     turn.model = run.model;
   } else if (agentReportedModel && agentReportedModel.trim().length > 0) {
     turn.model = agentReportedModel.trim();
+  } else {
+    // Keep Langfuse aligned with PostHog's model bucket when the user selected
+    // "Default (CLI config)" and the runtime did not emit a resolved model.
+    turn.model = modelIdForTracking(agentReportedModel);
   }
-  // No fallback to a non-explicit `run.model` here. When the request never
-  // pinned a concrete model and the agent never reported one, forwarding the
-  // request-side `default` placeholder would label the generation
-  // `model: "default"` — and Langfuse treats `generation.model` as a
-  // first-class grouping/cost dimension, so that creates a fake model bucket
-  // instead of leaving the model unknown.
   if (run.reasoning) turn.reasoning = run.reasoning;
   if (run.skillId) turn.skillId = run.skillId;
   if (run.designSystemId) turn.designSystemId = run.designSystemId;

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -26,6 +26,7 @@ import {
   type ToolCallSummary,
   type TurnInfo,
 } from './langfuse-trace.js';
+import type { PromptStackTelemetry } from './prompt-telemetry.js';
 import { redactSecrets } from './redact.js';
 import {
   hasExplicitRequestedModelForAnalytics,
@@ -67,6 +68,7 @@ interface DaemonRunRecord {
   skillId?: string;
   designSystemId?: string;
   clientType?: 'desktop' | 'web' | 'unknown';
+  promptTelemetry?: PromptStackTelemetry;
 }
 
 export interface ReportRunCompletedFromDaemonOpts {
@@ -444,6 +446,7 @@ export async function reportRunCompletedFromDaemon(
       prefs,
       ...(turn ? { turn } : {}),
       runtime,
+      ...(run.promptTelemetry ? { promptTelemetry: run.promptTelemetry } : {}),
     };
 
     await reportRunCompleted(

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -19,6 +19,11 @@
 import { randomUUID } from 'node:crypto';
 
 import type { TelemetryPrefs } from './app-config.js';
+import {
+  buildPromptStackFlatMetadata,
+  promptStackWithoutContent,
+  type PromptStackTelemetry,
+} from './prompt-telemetry.js';
 import type { RunTimingAnalytics } from './run-analytics-observability.js';
 import type { RunFailureClassification } from './run-failure-classification.js';
 
@@ -186,6 +191,8 @@ export interface ReportContext {
   turn?: TurnInfo;
   /** Process- / build-level info collected once per daemon process. */
   runtime?: RuntimeInfo;
+  /** Redacted section-level prompt diagnostics captured before agent spawn. */
+  promptTelemetry?: PromptStackTelemetry;
   extraTags?: string[];
 }
 
@@ -343,7 +350,7 @@ function buildTagList(ctx: ReportContext): string[] {
 }
 
 export function buildTracePayload(ctx: ReportContext): unknown[] {
-  const wantsContent = ctx.prefs.content === true;
+  const wantsContent = ctx.prefs.metrics === true && ctx.prefs.content === true;
   const wantsArtifacts = ctx.prefs.artifactManifest === true;
 
   const sessionId =
@@ -399,6 +406,14 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
     ctx.langfuse ?? deriveLangfuseDeliveryState(ctx.prefs, readTelemetrySinkConfig());
   const agentSpanId = `${ctx.run.runId}-agent`;
   const generationId = `${ctx.run.runId}-gen`;
+  const promptStack = ctx.promptTelemetry
+    ? wantsContent
+      ? ctx.promptTelemetry
+      : promptStackWithoutContent(ctx.promptTelemetry)
+    : undefined;
+  const promptStackFlatMetadata = promptStack
+    ? buildPromptStackFlatMetadata(promptStack)
+    : {};
 
   // Trace metadata is the queryable + exportable fact-sheet for each turn.
   // Anything we want to slice on for evals or dataset construction lives
@@ -432,6 +447,8 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
     osRelease: ctx.runtime?.osRelease,
     arch: ctx.runtime?.arch,
     clientType: ctx.runtime?.clientType,
+    promptStack,
+    ...promptStackFlatMetadata,
   };
 
   // Generation-level model parameters mirror the Langfuse schema so the UI
@@ -502,6 +519,8 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
         usage,
         metadata: {
           durationMs: ctx.eventsSummary.durationMs,
+          promptStack,
+          ...promptStackFlatMetadata,
         },
       },
     },

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -95,7 +95,8 @@ const SECTION_PRIORITY = new Map<PromptTelemetrySectionKind, number>([
 
 const FILE_LOCAL_PATH =
   /(^|[\s([{"'`])file:\/\/(?:localhost)?\/[^\s)\]}"'`,;<>]+/gi;
-const POSIX_LOCAL_PATH = /(^|[\s([{"'`])\/(?!\/)[^\s)\]}"'`,;<>]+/g;
+const POSIX_LOCAL_PATH =
+  /(^|[\s([{"'`])\/(?:Users|home|root|tmp|private\/tmp|private\/var\/folders|var\/folders|Volumes|mnt|workspace|workspaces|app)\/[^\s)\]}"'`,;<>]+/g;
 const WINDOWS_LOCAL_PATH =
   /(^|[\s([{"'`])(?:[A-Za-z]:\\|\\\\)[^\s)\]}"'`,;<>]+/g;
 

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -96,7 +96,7 @@ const SECTION_PRIORITY = new Map<PromptTelemetrySectionKind, number>([
 const FILE_LOCAL_PATH =
   /(^|[\s([{"'`@])file:\/\/(?:localhost)?\/[^\s)\]}"'`,;<>]+/gi;
 const POSIX_LOCAL_PATH =
-  /(^|[\s([{"'`@])\/(?:Users|home|root|tmp|private\/tmp|private\/var\/folders|var\/folders|var\/tmp|usr\/local|opt|Volumes|mnt|media|srv|workspace|workspaces|app)\/[^\s)\]}"'`,;<>]+/g;
+  /(^|[\s([{"'`@])\/(?:Users|home|root|tmp|private\/tmp|private\/var\/folders|private\/var\/tmp|var\/folders|var\/tmp|usr\/local|opt|Volumes|mnt|media|srv|workspace|workspaces|app)\/[^\s)\]}"'`,;<>]+/g;
 const WINDOWS_LOCAL_PATH =
   /(^|[\s([{"'`@])(?:[A-Za-z]:\\|\\\\)[^\s)\]}"'`,;<>]+/g;
 

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -1,0 +1,364 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+import { redactSecrets } from './redact.js';
+
+export const PROMPT_STACK_REDACTION_VERSION = 'prompt-stack-redaction-v1';
+export const PROMPT_STACK_PATH_MARKER = '[REDACTED:path]';
+
+const KIB = 1024;
+const DAEMON_SYSTEM_PROMPT_MAX_BYTES = 32 * KIB;
+const SECTION_MAX_BYTES = 16 * KIB;
+const TOTAL_REDACTED_CONTENT_MAX_BYTES = 96 * KIB;
+
+export type PromptTelemetrySectionKind =
+  | 'formOverride'
+  | 'daemonSystemPrompt'
+  | 'runtimeToolPrompt'
+  | 'researchCommandContract'
+  | 'runContextPrompt'
+  | 'clientSystemPrompt'
+  | 'echoGuard'
+  | 'userRequest'
+  | 'skillPrompt'
+  | 'designSystemPrompt'
+  | 'pluginStagePrompt'
+  | 'cwdHint'
+  | 'linkedDirsHint'
+  | 'attachments'
+  | 'commentAttachments'
+  | 'promptImagePaths';
+
+export interface PromptTelemetryInputSection {
+  kind: PromptTelemetrySectionKind;
+  content?: string | null;
+  metadata?: unknown;
+}
+
+export interface PromptTelemetrySection {
+  kind: PromptTelemetrySectionKind;
+  ordinal: number;
+  present: boolean;
+  contentMode: 'redacted-section-content' | 'metadata-only';
+  rawBytes: number;
+  redactedBytes: number;
+  fingerprint: string;
+  truncated: boolean;
+  truncationReason?: 'section_byte_limit' | 'total_budget_exceeded';
+  redactedContent?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PromptStackTelemetry {
+  redactionVersion: typeof PROMPT_STACK_REDACTION_VERSION;
+  promptFingerprint: string;
+  stackFingerprint: string;
+  rawBytes: number;
+  redactedBytes: number;
+  sectionCount: number;
+  redactedContentBytes: number;
+  redactedContentBudgetBytes: number;
+  sections: PromptTelemetrySection[];
+}
+
+interface MutablePromptTelemetrySection extends PromptTelemetrySection {
+  redactedSource: string;
+}
+
+const REDACTED_CONTENT_KINDS = new Set<PromptTelemetrySectionKind>([
+  'formOverride',
+  'daemonSystemPrompt',
+  'runtimeToolPrompt',
+  'researchCommandContract',
+  'runContextPrompt',
+  'clientSystemPrompt',
+  'echoGuard',
+  'userRequest',
+  'skillPrompt',
+  'designSystemPrompt',
+  'pluginStagePrompt',
+]);
+
+const SECTION_PRIORITY = new Map<PromptTelemetrySectionKind, number>([
+  ['formOverride', 1],
+  ['daemonSystemPrompt', 2],
+  ['runtimeToolPrompt', 3],
+  ['clientSystemPrompt', 4],
+  ['skillPrompt', 5],
+  ['designSystemPrompt', 5],
+  ['pluginStagePrompt', 5],
+  ['researchCommandContract', 6],
+  ['runContextPrompt', 7],
+  ['echoGuard', 8],
+  ['userRequest', 9],
+]);
+
+const POSIX_LOCAL_PATH =
+  /(^|[\s([{"'`])\/(?:Users|home|tmp|private\/tmp|var\/folders|Volumes|mnt|workspace)\/[^\s)\]}"'`,;<>]+/g;
+const WINDOWS_LOCAL_PATH =
+  /(^|[\s([{"'`])(?:[A-Za-z]:\\|\\\\)[^\s)\]}"'`,;<>]+/g;
+
+function sha256(value: string): string {
+  return `sha256:${createHash('sha256').update(value, 'utf8').digest('hex')}`;
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  const buf = Buffer.from(value, 'utf8');
+  if (buf.length <= maxBytes) return value;
+  let cut = maxBytes;
+  while (cut > 0 && (buf[cut]! & 0xc0) === 0x80) cut -= 1;
+  return buf.subarray(0, cut).toString('utf8');
+}
+
+export function redactLocalPaths(input: string): string {
+  if (!input) return input;
+  return input
+    .replace(POSIX_LOCAL_PATH, (_match, prefix: string) => {
+      return `${prefix}${PROMPT_STACK_PATH_MARKER}`;
+    })
+    .replace(WINDOWS_LOCAL_PATH, (_match, prefix: string) => {
+      return `${prefix}${PROMPT_STACK_PATH_MARKER}`;
+    });
+}
+
+function redactPromptText(input: string): string {
+  return redactLocalPaths(redactSecrets(input));
+}
+
+function stripRuntimeToolPromptTokens(input: string): string {
+  return input
+    .split(/\r?\n/)
+    .filter((line) => !line.includes('OD_TOOL_TOKEN'))
+    .join('\n');
+}
+
+function sanitizeSectionContent(kind: PromptTelemetrySectionKind, content: string): string {
+  const structurallySafe =
+    kind === 'runtimeToolPrompt' ? stripRuntimeToolPromptTokens(content) : content;
+  return redactPromptText(structurallySafe);
+}
+
+function extensionFromPath(value: string): string | null {
+  const ext = path.extname(value).replace(/^\./, '').toLowerCase();
+  return ext || null;
+}
+
+function sizeBucket(value: number): string {
+  if (value <= 0) return 'unknown';
+  if (value <= 10 * KIB) return '0-10KiB';
+  if (value <= 100 * KIB) return '10-100KiB';
+  if (value <= 1024 * KIB) return '100KiB-1MiB';
+  return '1MiB+';
+}
+
+function summarizeMetadataValue(value: unknown): Record<string, unknown> {
+  if (Array.isArray(value)) {
+    const extensions = new Set<string>();
+    const sizeBuckets = new Map<string, number>();
+    const selectionKinds = new Map<string, number>();
+    let knownSizeCount = 0;
+    for (const item of value) {
+      if (typeof item === 'string') {
+        const ext = extensionFromPath(item);
+        if (ext) extensions.add(ext);
+        continue;
+      }
+      if (!item || typeof item !== 'object') continue;
+      const obj = item as Record<string, unknown>;
+      const fileLike =
+        typeof obj.filePath === 'string'
+          ? obj.filePath
+          : typeof obj.screenshotPath === 'string'
+            ? obj.screenshotPath
+            : typeof obj.path === 'string'
+              ? obj.path
+              : typeof obj.name === 'string'
+                ? obj.name
+                : '';
+      const ext = fileLike ? extensionFromPath(fileLike) : null;
+      if (ext) extensions.add(ext);
+      const size = typeof obj.size === 'number' ? obj.size : undefined;
+      if (size !== undefined && Number.isFinite(size)) {
+        knownSizeCount += 1;
+        const bucket = sizeBucket(size);
+        sizeBuckets.set(bucket, (sizeBuckets.get(bucket) ?? 0) + 1);
+      }
+      if (typeof obj.selectionKind === 'string') {
+        selectionKinds.set(
+          obj.selectionKind,
+          (selectionKinds.get(obj.selectionKind) ?? 0) + 1,
+        );
+      }
+    }
+    return {
+      count: value.length,
+      extensions: Array.from(extensions).sort(),
+      sizeBuckets: Object.fromEntries([...sizeBuckets].sort()),
+      knownSizeCount,
+      selectionKinds: Object.fromEntries([...selectionKinds].sort()),
+    };
+  }
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value as Record<string, unknown>).sort();
+    return { keyCount: keys.length, keys };
+  }
+  if (typeof value === 'string') {
+    return {
+      count: value.length > 0 ? 1 : 0,
+      extensions: extensionFromPath(value) ? [extensionFromPath(value)] : [],
+    };
+  }
+  return {};
+}
+
+function metadataFingerprintSource(
+  section: PromptTelemetryInputSection,
+): Record<string, unknown> {
+  if (section.metadata !== undefined) {
+    return summarizeMetadataValue(section.metadata);
+  }
+  return summarizeMetadataValue(section.content ?? '');
+}
+
+function perSectionLimit(kind: PromptTelemetrySectionKind): number {
+  return kind === 'daemonSystemPrompt'
+    ? DAEMON_SYSTEM_PROMPT_MAX_BYTES
+    : SECTION_MAX_BYTES;
+}
+
+export function buildPromptStackTelemetry({
+  composedPrompt,
+  sections,
+}: {
+  composedPrompt: string;
+  sections: PromptTelemetryInputSection[];
+}): PromptStackTelemetry {
+  const normalizedComposed = redactPromptText(composedPrompt);
+  const rawBytes = byteLength(composedPrompt);
+  const redactedBytes = byteLength(normalizedComposed);
+  const built: MutablePromptTelemetrySection[] = sections.map((section, index) => {
+    const rawContent = typeof section.content === 'string' ? section.content : '';
+    const present =
+      rawContent.length > 0 ||
+      (Array.isArray(section.metadata)
+        ? section.metadata.length > 0
+        : section.metadata !== undefined && section.metadata !== null);
+    const canCaptureContent = REDACTED_CONTENT_KINDS.has(section.kind);
+    const redacted = canCaptureContent
+      ? sanitizeSectionContent(section.kind, rawContent)
+      : JSON.stringify(metadataFingerprintSource(section));
+    const metadata = canCaptureContent
+      ? section.metadata && typeof section.metadata === 'object'
+        ? summarizeMetadataValue(section.metadata)
+        : undefined
+      : metadataFingerprintSource(section);
+    return {
+      kind: section.kind,
+      ordinal: index,
+      present,
+      contentMode: (canCaptureContent
+        ? 'redacted-section-content'
+        : 'metadata-only') as PromptTelemetrySection['contentMode'],
+      rawBytes: byteLength(rawContent),
+      redactedBytes: byteLength(redacted),
+      fingerprint: sha256(redacted),
+      truncated: false,
+      redactedSource: redacted,
+      ...(metadata && Object.keys(metadata).length > 0 ? { metadata } : {}),
+    };
+  });
+
+  let remaining = TOTAL_REDACTED_CONTENT_MAX_BYTES;
+  const allocationOrder = [...built]
+    .filter((section) => section.present && section.contentMode === 'redacted-section-content')
+    .sort((a, b) => {
+      const priorityA = SECTION_PRIORITY.get(a.kind) ?? 99;
+      const priorityB = SECTION_PRIORITY.get(b.kind) ?? 99;
+      return priorityA - priorityB || a.ordinal - b.ordinal;
+    });
+  for (const section of allocationOrder) {
+    if (remaining <= 0) {
+      section.truncated = true;
+      section.truncationReason = 'total_budget_exceeded';
+      continue;
+    }
+    const limit = Math.min(perSectionLimit(section.kind), remaining);
+    const redactedContent = truncateUtf8(section.redactedSource, limit);
+    const contentBytes = byteLength(redactedContent);
+    if (contentBytes > 0) section.redactedContent = redactedContent;
+    remaining -= contentBytes;
+    const sourceBytes = byteLength(section.redactedSource);
+    if (contentBytes < sourceBytes) {
+      section.truncated = true;
+      section.truncationReason =
+        limit < perSectionLimit(section.kind)
+          ? 'total_budget_exceeded'
+          : 'section_byte_limit';
+    }
+  }
+
+  const outputSections: PromptTelemetrySection[] = built.map(
+    ({ redactedSource: _redactedSource, ...section }) => section,
+  );
+  const stackFingerprintSource = outputSections.map((section) => ({
+    kind: section.kind,
+    ordinal: section.ordinal,
+    fingerprint: section.fingerprint,
+  }));
+  const redactedContentBytes = outputSections.reduce(
+    (total, section) => total + byteLength(section.redactedContent ?? ''),
+    0,
+  );
+  return {
+    redactionVersion: PROMPT_STACK_REDACTION_VERSION,
+    promptFingerprint: sha256(normalizedComposed),
+    stackFingerprint: sha256(JSON.stringify(stackFingerprintSource)),
+    rawBytes,
+    redactedBytes,
+    sectionCount: outputSections.length,
+    redactedContentBytes,
+    redactedContentBudgetBytes: TOTAL_REDACTED_CONTENT_MAX_BYTES,
+    sections: outputSections,
+  };
+}
+
+export function promptStackWithoutContent(
+  telemetry: PromptStackTelemetry,
+): PromptStackTelemetry {
+  return {
+    ...telemetry,
+    redactedContentBytes: 0,
+    sections: telemetry.sections.map(({ redactedContent: _content, ...section }) => section),
+  };
+}
+
+export function buildPromptStackFlatMetadata(
+  telemetry: PromptStackTelemetry,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    promptStack_redactionVersion: telemetry.redactionVersion,
+    promptStack_promptFingerprint: telemetry.promptFingerprint,
+    promptStack_stackFingerprint: telemetry.stackFingerprint,
+    promptStack_rawBytes: telemetry.rawBytes,
+    promptStack_redactedBytes: telemetry.redactedBytes,
+    promptStack_sectionCount: telemetry.sectionCount,
+    promptStack_redactedContentBytes: telemetry.redactedContentBytes,
+    promptStack_redactedContentBudgetBytes: telemetry.redactedContentBudgetBytes,
+  };
+  for (const section of telemetry.sections) {
+    const prefix = `promptStack_section_${section.kind}`;
+    out[`${prefix}_present`] = section.present;
+    out[`${prefix}_rawBytes`] = section.rawBytes;
+    out[`${prefix}_redactedBytes`] = section.redactedBytes;
+    out[`${prefix}_fingerprint`] = section.fingerprint;
+    out[`${prefix}_truncated`] = section.truncated;
+    if (section.truncationReason) {
+      out[`${prefix}_truncationReason`] = section.truncationReason;
+    }
+  }
+  return out;
+}

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -94,11 +94,11 @@ const SECTION_PRIORITY = new Map<PromptTelemetrySectionKind, number>([
 ]);
 
 const FILE_LOCAL_PATH =
-  /(^|[\s([{"'`])file:\/\/(?:localhost)?\/[^\s)\]}"'`,;<>]+/gi;
+  /(^|[\s([{"'`@])file:\/\/(?:localhost)?\/[^\s)\]}"'`,;<>]+/gi;
 const POSIX_LOCAL_PATH =
-  /(^|[\s([{"'`])\/(?:Users|home|root|tmp|private\/tmp|private\/var\/folders|var\/folders|Volumes|mnt|workspace|workspaces|app)\/[^\s)\]}"'`,;<>]+/g;
+  /(^|[\s([{"'`@])\/(?:Users|home|root|tmp|private\/tmp|private\/var\/folders|var\/folders|Volumes|mnt|media|srv|workspace|workspaces|app)\/[^\s)\]}"'`,;<>]+/g;
 const WINDOWS_LOCAL_PATH =
-  /(^|[\s([{"'`])(?:[A-Za-z]:\\|\\\\)[^\s)\]}"'`,;<>]+/g;
+  /(^|[\s([{"'`@])(?:[A-Za-z]:\\|\\\\)[^\s)\]}"'`,;<>]+/g;
 
 function sha256(value: string): string {
   return `sha256:${createHash('sha256').update(value, 'utf8').digest('hex')}`;

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -93,8 +93,9 @@ const SECTION_PRIORITY = new Map<PromptTelemetrySectionKind, number>([
   ['userRequest', 9],
 ]);
 
-const POSIX_LOCAL_PATH =
-  /(^|[\s([{"'`])\/(?:Users|home|root|tmp|private\/tmp|private\/var\/folders|var\/folders|Volumes|mnt|workspace|workspaces)\/[^\s)\]}"'`,;<>]+/g;
+const FILE_LOCAL_PATH =
+  /(^|[\s([{"'`])file:\/\/(?:localhost)?\/[^\s)\]}"'`,;<>]+/gi;
+const POSIX_LOCAL_PATH = /(^|[\s([{"'`])\/(?!\/)[^\s)\]}"'`,;<>]+/g;
 const WINDOWS_LOCAL_PATH =
   /(^|[\s([{"'`])(?:[A-Za-z]:\\|\\\\)[^\s)\]}"'`,;<>]+/g;
 
@@ -117,6 +118,9 @@ function truncateUtf8(value: string, maxBytes: number): string {
 export function redactLocalPaths(input: string): string {
   if (!input) return input;
   return input
+    .replace(FILE_LOCAL_PATH, (_match, prefix: string) => {
+      return `${prefix}${PROMPT_STACK_PATH_MARKER}`;
+    })
     .replace(POSIX_LOCAL_PATH, (_match, prefix: string) => {
       return `${prefix}${PROMPT_STACK_PATH_MARKER}`;
     })

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -32,6 +32,7 @@ export type PromptTelemetrySectionKind =
 export interface PromptTelemetryInputSection {
   kind: PromptTelemetrySectionKind;
   content?: string | null;
+  captureContent?: boolean;
   metadata?: unknown;
 }
 
@@ -252,11 +253,12 @@ export function buildPromptStackTelemetry({
       (Array.isArray(section.metadata)
         ? section.metadata.length > 0
         : section.metadata !== undefined && section.metadata !== null);
-    const canCaptureContent = REDACTED_CONTENT_KINDS.has(section.kind);
-    const redacted = canCaptureContent
+    const isContentKind = REDACTED_CONTENT_KINDS.has(section.kind);
+    const canCaptureContent = isContentKind && section.captureContent !== false;
+    const redacted = isContentKind
       ? sanitizeSectionContent(section.kind, rawContent)
       : JSON.stringify(metadataFingerprintSource(section));
-    const metadata = canCaptureContent
+    const metadata = isContentKind
       ? section.metadata && typeof section.metadata === 'object'
         ? summarizeMetadataValue(section.metadata)
         : undefined

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -94,7 +94,7 @@ const SECTION_PRIORITY = new Map<PromptTelemetrySectionKind, number>([
 ]);
 
 const POSIX_LOCAL_PATH =
-  /(^|[\s([{"'`])\/(?:Users|home|root|tmp|private\/tmp|private\/var\/folders|var\/folders|Volumes|mnt|workspace)\/[^\s)\]}"'`,;<>]+/g;
+  /(^|[\s([{"'`])\/(?:Users|home|root|tmp|private\/tmp|private\/var\/folders|var\/folders|Volumes|mnt|workspace|workspaces)\/[^\s)\]}"'`,;<>]+/g;
 const WINDOWS_LOCAL_PATH =
   /(^|[\s([{"'`])(?:[A-Za-z]:\\|\\\\)[^\s)\]}"'`,;<>]+/g;
 

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -96,7 +96,7 @@ const SECTION_PRIORITY = new Map<PromptTelemetrySectionKind, number>([
 const FILE_LOCAL_PATH =
   /(^|[\s([{"'`@])file:\/\/(?:localhost)?\/[^\s)\]}"'`,;<>]+/gi;
 const POSIX_LOCAL_PATH =
-  /(^|[\s([{"'`@])\/(?:Users|home|root|tmp|private\/tmp|private\/var\/folders|var\/folders|Volumes|mnt|media|srv|workspace|workspaces|app)\/[^\s)\]}"'`,;<>]+/g;
+  /(^|[\s([{"'`@])\/(?:Users|home|root|tmp|private\/tmp|private\/var\/folders|var\/folders|var\/tmp|usr\/local|opt|Volumes|mnt|media|srv|workspace|workspaces|app)\/[^\s)\]}"'`,;<>]+/g;
 const WINDOWS_LOCAL_PATH =
   /(^|[\s([{"'`@])(?:[A-Za-z]:\\|\\\\)[^\s)\]}"'`,;<>]+/g;
 

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -94,7 +94,7 @@ const SECTION_PRIORITY = new Map<PromptTelemetrySectionKind, number>([
 ]);
 
 const POSIX_LOCAL_PATH =
-  /(^|[\s([{"'`])\/(?:Users|home|tmp|private\/tmp|var\/folders|Volumes|mnt|workspace)\/[^\s)\]}"'`,;<>]+/g;
+  /(^|[\s([{"'`])\/(?:Users|home|root|tmp|private\/tmp|private\/var\/folders|var\/folders|Volumes|mnt|workspace)\/[^\s)\]}"'`,;<>]+/g;
 const WINDOWS_LOCAL_PATH =
   /(^|[\s([{"'`])(?:[A-Za-z]:\\|\\\\)[^\s)\]}"'`,;<>]+/g;
 

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -301,9 +301,9 @@ export function buildPromptStackTelemetry({
     }
   }
 
-  const outputSections: PromptTelemetrySection[] = built.map(
-    ({ redactedSource: _redactedSource, ...section }) => section,
-  );
+  const outputSections: PromptTelemetrySection[] = built
+    .filter((section) => section.present)
+    .map(({ redactedSource: _redactedSource, ...section }) => section);
   const stackFingerprintSource = outputSections.map((section) => ({
     kind: section.kind,
     ordinal: section.ordinal,
@@ -343,22 +343,30 @@ export function buildPromptStackFlatMetadata(
     promptStack_redactionVersion: telemetry.redactionVersion,
     promptStack_promptFingerprint: telemetry.promptFingerprint,
     promptStack_stackFingerprint: telemetry.stackFingerprint,
-    promptStack_rawBytes: telemetry.rawBytes,
-    promptStack_redactedBytes: telemetry.redactedBytes,
     promptStack_sectionCount: telemetry.sectionCount,
     promptStack_redactedContentBytes: telemetry.redactedContentBytes,
     promptStack_redactedContentBudgetBytes: telemetry.redactedContentBudgetBytes,
   };
-  for (const section of telemetry.sections) {
-    const prefix = `promptStack_section_${section.kind}`;
-    out[`${prefix}_present`] = section.present;
-    out[`${prefix}_rawBytes`] = section.rawBytes;
-    out[`${prefix}_redactedBytes`] = section.redactedBytes;
-    out[`${prefix}_fingerprint`] = section.fingerprint;
-    out[`${prefix}_truncated`] = section.truncated;
-    if (section.truncationReason) {
-      out[`${prefix}_truncationReason`] = section.truncationReason;
-    }
+
+  const daemonSystemPrompt = telemetry.sections.find(
+    (section) => section.kind === 'daemonSystemPrompt',
+  );
+  const runtimeToolPrompt = telemetry.sections.find(
+    (section) => section.kind === 'runtimeToolPrompt',
+  );
+  const pluginStagePrompt = telemetry.sections.find(
+    (section) => section.kind === 'pluginStagePrompt',
+  );
+
+  out.promptStack_section_daemonSystemPrompt_present = Boolean(daemonSystemPrompt);
+  out.promptStack_section_daemonSystemPrompt_truncated =
+    daemonSystemPrompt?.truncated ?? false;
+  out.promptStack_section_runtimeToolPrompt_present = Boolean(runtimeToolPrompt);
+  out.promptStack_section_pluginStagePrompt_present = Boolean(pluginStagePrompt);
+
+  if (daemonSystemPrompt?.truncationReason) {
+    out.promptStack_section_daemonSystemPrompt_truncationReason =
+      daemonSystemPrompt.truncationReason;
   }
   return out;
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11091,11 +11091,19 @@ export async function startServer({
       composedPrompt: composed,
       sections: [
         { kind: 'formOverride', content: formOverride },
-        { kind: 'daemonSystemPrompt', content: daemonSystemPrompt },
+        {
+          kind: 'daemonSystemPrompt',
+          content: daemonSystemPrompt,
+          captureContent: false,
+        },
         { kind: 'runtimeToolPrompt', content: runtimeToolPrompt },
         { kind: 'researchCommandContract', content: researchCommandContract },
         { kind: 'runContextPrompt', content: runContextPrompt },
-        { kind: 'clientSystemPrompt', content: clientInstructionPrompt },
+        {
+          kind: 'clientSystemPrompt',
+          content: clientInstructionPrompt,
+          captureContent: false,
+        },
         { kind: 'echoGuard', content: ECHO_GUARD },
         { kind: 'userRequest', content: userRequestPrompt },
         { kind: 'skillPrompt', content: promptTelemetryParts?.skillPrompt },

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11091,19 +11091,14 @@ export async function startServer({
       composedPrompt: composed,
       sections: [
         { kind: 'formOverride', content: formOverride },
-        {
-          kind: 'daemonSystemPrompt',
-          content: daemonSystemPrompt,
-          captureContent: false,
-        },
+        // Phase 1 explicitly needs redactedContent for these aggregate prompts:
+        // they are the quickest way to inspect the system context sent to the
+        // model when diagnosing Langfuse traces.
+        { kind: 'daemonSystemPrompt', content: daemonSystemPrompt },
         { kind: 'runtimeToolPrompt', content: runtimeToolPrompt },
         { kind: 'researchCommandContract', content: researchCommandContract },
         { kind: 'runContextPrompt', content: runContextPrompt },
-        {
-          kind: 'clientSystemPrompt',
-          content: clientInstructionPrompt,
-          captureContent: false,
-        },
+        { kind: 'clientSystemPrompt', content: clientInstructionPrompt },
         { kind: 'echoGuard', content: ECHO_GUARD },
         { kind: 'userRequest', content: userRequestPrompt },
         { kind: 'skillPrompt', content: promptTelemetryParts?.skillPrompt },

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -259,6 +259,7 @@ import {
   deriveLangfuseDeliveryState,
   readTelemetrySinkConfig,
 } from './langfuse-trace.js';
+import { buildPromptStackTelemetry } from './prompt-telemetry.js';
 import {
   createAnalyticsService,
   newInsertId,
@@ -10555,7 +10556,19 @@ export async function startServer({
     // `listSkills()` scan in `startChatRun`. critiqueShouldRun threads
     // the same panel-eligibility decision down to the spawn-path
     // orchestrator gate so prompt and orchestrator stay in lockstep.
-    return { prompt, activeSkillDir, activeSkillDirs, critiqueShouldRun };
+    return {
+      prompt,
+      activeSkillDir,
+      activeSkillDirs,
+      critiqueShouldRun,
+      promptTelemetryParts: {
+        skillPrompt: skillBody ?? '',
+        designSystemPrompt: designSystemBody ?? '',
+        pluginStagePrompt: [pluginBlock, ...(activeStageBlocks ?? [])]
+          .filter((part) => typeof part === 'string' && part.trim().length > 0)
+          .join('\n\n---\n\n'),
+      },
+    };
   };
 
   // Plan §3.I1 / §3.D / spec §10.1: fire the pipeline schedule on a
@@ -10917,6 +10930,7 @@ export async function startServer({
       prompt: daemonSystemPrompt,
       activeSkillDirs,
       critiqueShouldRun,
+      promptTelemetryParts,
     } =
       await composeDaemonSystemPrompt({
         agentId,
@@ -11073,6 +11087,49 @@ export async function startServer({
         ? `\n\n${promptImagePaths.map((p) => `@${p}`).join(' ')}`
         : '',
     ].join('');
+    run.promptTelemetry = buildPromptStackTelemetry({
+      composedPrompt: composed,
+      sections: [
+        { kind: 'formOverride', content: formOverride },
+        { kind: 'daemonSystemPrompt', content: daemonSystemPrompt },
+        { kind: 'runtimeToolPrompt', content: runtimeToolPrompt },
+        { kind: 'researchCommandContract', content: researchCommandContract },
+        { kind: 'runContextPrompt', content: runContextPrompt },
+        { kind: 'clientSystemPrompt', content: clientInstructionPrompt },
+        { kind: 'echoGuard', content: ECHO_GUARD },
+        { kind: 'userRequest', content: userRequestPrompt },
+        { kind: 'skillPrompt', content: promptTelemetryParts?.skillPrompt },
+        {
+          kind: 'designSystemPrompt',
+          content: promptTelemetryParts?.designSystemPrompt,
+        },
+        {
+          kind: 'pluginStagePrompt',
+          content: promptTelemetryParts?.pluginStagePrompt,
+        },
+        { kind: 'cwdHint', content: cwdHint, metadata: cwd ? [cwd] : [] },
+        {
+          kind: 'linkedDirsHint',
+          content: linkedDirsHint,
+          metadata: linkedDirs,
+        },
+        {
+          kind: 'attachments',
+          content: attachmentHint,
+          metadata: safeAttachments,
+        },
+        {
+          kind: 'commentAttachments',
+          content: commentHint,
+          metadata: safeCommentAttachments,
+        },
+        {
+          kind: 'promptImagePaths',
+          content: promptImagePaths.join('\n'),
+          metadata: promptImagePaths,
+        },
+      ],
+    });
     // Per-agent model + reasoning the user picked in the model menu.
     // Trust the value when it matches the most recent /api/agents listing
     // (live or fallback). Otherwise allow it through if it passes a

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { reportRunCompletedFromDaemon } from '../src/langfuse-bridge.js';
+import { buildPromptStackTelemetry } from '../src/prompt-telemetry.js';
 
 interface FakeMessage {
   id: string;
@@ -269,6 +270,51 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
       { slug: 'style.css', type: 'code', sizeBytes: 800 },
     ]);
     expect(trace.metadata.success).toBe(true);
+  });
+
+  it('forwards run prompt telemetry into trace and generation metadata', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true, artifactManifest: false },
+    });
+    const promptTelemetry = buildPromptStackTelemetry({
+      composedPrompt:
+        '# Instructions\n\nUse /Users/alice/project\n\n---\n# User request\n\ndesign a coffee landing page',
+      sections: [
+        { kind: 'daemonSystemPrompt', content: 'Use /Users/alice/project' },
+        { kind: 'userRequest', content: 'design a coffee landing page' },
+      ],
+    });
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 207 }));
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    try {
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({
+          'conv-1': [{ id: 'msg-1', role: 'assistant', content: 'Here is a draft …' }],
+        }),
+        dataDir,
+        run: makeRun({ promptTelemetry } as any) as any,
+        fetchImpl: fetchSpy as any,
+      });
+    } finally {
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
+
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const batch = JSON.parse(init.body as string).batch as any[];
+    const trace = batch[0].body;
+    const generation = bodyOf(batch, 'generation-create', 'llm');
+    expect(trace.input).toBe('design a coffee landing page');
+    expect(generation.input).toBe('design a coffee landing page');
+    expect(trace.metadata.promptStack.sections[0].redactedContent).toContain(
+      '[REDACTED:path]',
+    );
+    expect(generation.metadata.promptStack).toEqual(trace.metadata.promptStack);
+    expect(trace.metadata.promptStack_section_userRequest_present).toBe(true);
   });
 
   it('attaches turn-level config (model / reasoning / skill / DS) to trace + generation', async () => {

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -481,7 +481,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     expect(generation.usage.total).toBe(512);
   });
 
-  it('leaves model unknown for a default-model run with no status/model event', async () => {
+  it('uses the default model bucket for a default-model run with no status/model event', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-4',
       telemetry: { metrics: true, content: true, artifactManifest: false },
@@ -493,8 +493,8 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     process.env.LANGFUSE_SECRET_KEY = 'sk';
     try {
       // Request never pinned a concrete model (the `default` placeholder) and
-      // the agent never reported one, so the resolved model is genuinely
-      // unknown. Forwarding `default` would manufacture a fake model bucket.
+      // the agent never reported one. Keep this aligned with PostHog's
+      // model_id bucket so Langfuse traces remain filterable by model state.
       await reportRunCompletedFromDaemon({
         db: makeDbWithListMessages({ 'conv-1': [] }),
         dataDir,
@@ -509,11 +509,9 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     const batch = JSON.parse(init.body as string).batch as any[];
     const trace = batch[0].body;
     const generation = bodyOf(batch, 'generation-create', 'llm');
-    expect(trace.metadata.model).toBeUndefined();
-    expect((trace.tags as string[]).some((t) => t.startsWith('model:'))).toBe(
-      false,
-    );
-    expect(generation.model).toBeUndefined();
+    expect(trace.metadata.model).toBe('default');
+    expect(trace.tags).toEqual(expect.arrayContaining(['model:default']));
+    expect(generation.model).toBe('default');
   });
 
   it('omits artifacts when that gate is off', async () => {

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -314,7 +314,12 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
       '[REDACTED:path]',
     );
     expect(generation.metadata.promptStack).toEqual(trace.metadata.promptStack);
-    expect(trace.metadata.promptStack_section_userRequest_present).toBe(true);
+    expect(
+      trace.metadata.promptStack.sections.some(
+        (section: { kind: string }) => section.kind === 'userRequest',
+      ),
+    ).toBe(true);
+    expect(trace.metadata.promptStack_section_userRequest_present).toBeUndefined();
   });
 
   it('attaches turn-level config (model / reasoning / skill / DS) to trace + generation', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -13,6 +13,7 @@ import {
   type ReportContext,
   type TelemetrySinkConfig,
 } from '../src/langfuse-trace.js';
+import { buildPromptStackTelemetry } from '../src/prompt-telemetry.js';
 
 function makeCtx(overrides: Partial<ReportContext> = {}): ReportContext {
   const base: ReportContext = {
@@ -304,6 +305,59 @@ describe('buildTracePayload', () => {
     expect(trace.output).toMatch(/landing page draft/);
     expect(tool.input).toMatch(/ls -la/);
     expect(tool.output).toBe('total 0');
+  });
+
+  it('adds prompt-stack metadata to trace and generation without replacing user prompt input', () => {
+    const promptTelemetry = buildPromptStackTelemetry({
+      composedPrompt:
+        '# Instructions\n\nWork in /Users/alice/project\n\n---\n# User request\n\nBuild a card',
+      sections: [
+        { kind: 'daemonSystemPrompt', content: 'Work in /Users/alice/project' },
+        { kind: 'userRequest', content: 'Build a card' },
+        { kind: 'attachments', metadata: ['src/App.tsx'] },
+      ],
+    });
+    const batch = buildTracePayload(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+        promptTelemetry,
+      }),
+    );
+
+    const trace = bodyOf(batch, 'trace-create');
+    const generation = bodyOf(batch, 'generation-create', 'llm');
+    expect(trace.input).toBe('Make a landing page for a coffee shop.');
+    expect(generation.input).toBe('Make a landing page for a coffee shop.');
+    expect(trace.metadata.promptStack).toMatchObject({
+      redactionVersion: 'prompt-stack-redaction-v1',
+      sectionCount: 3,
+    });
+    expect(generation.metadata.promptStack).toEqual(trace.metadata.promptStack);
+    expect(trace.metadata.promptStack.sections[0].redactedContent).toContain(
+      '[REDACTED:path]',
+    );
+    expect(trace.metadata.promptStack.sections[2].redactedContent).toBeUndefined();
+    expect(trace.metadata.promptStack_section_daemonSystemPrompt_present).toBe(true);
+    expect(trace.metadata.promptStack_section_attachments_present).toBe(true);
+    expect(trace.metadata.promptStack_promptFingerprint).toMatch(/^sha256:/);
+  });
+
+  it('omits prompt-stack redactedContent when metrics or content consent is off', () => {
+    const promptTelemetry = buildPromptStackTelemetry({
+      composedPrompt: '# User request\n\nBuild a card',
+      sections: [{ kind: 'userRequest', content: 'Build a card' }],
+    });
+
+    for (const prefs of [
+      { metrics: true, content: false, artifactManifest: false },
+      { metrics: false, content: true, artifactManifest: false },
+    ]) {
+      const batch = buildTracePayload(makeCtx({ prefs, promptTelemetry }));
+      const trace = bodyOf(batch, 'trace-create');
+      expect(trace.input).toBeUndefined();
+      expect(trace.metadata.promptStack.sections[0].redactedContent).toBeUndefined();
+      expect(trace.metadata.promptStack.redactedContentBytes).toBe(0);
+    }
   });
 
   it('truncates ASCII prompt at 8 KB and output at 16 KB (bytes == chars)', () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -338,7 +338,8 @@ describe('buildTracePayload', () => {
     );
     expect(trace.metadata.promptStack.sections[2].redactedContent).toBeUndefined();
     expect(trace.metadata.promptStack_section_daemonSystemPrompt_present).toBe(true);
-    expect(trace.metadata.promptStack_section_attachments_present).toBe(true);
+    expect(trace.metadata.promptStack_section_attachments_present).toBeUndefined();
+    expect(trace.metadata.promptStack_section_daemonSystemPrompt_rawBytes).toBeUndefined();
     expect(trace.metadata.promptStack_promptFingerprint).toMatch(/^sha256:/);
   });
 

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -99,7 +99,7 @@ describe('prompt telemetry builder', () => {
     expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
   });
 
-  it('normalizes arbitrary absolute project roots before fingerprinting', () => {
+  it('normalizes app project roots before fingerprinting', () => {
     const first = buildPromptStackTelemetry({
       composedPrompt: 'Your working directory: /app/project',
       sections: [
@@ -123,6 +123,29 @@ describe('prompt telemetry builder', () => {
     expect(second.sections[0]!.redactedContent).not.toContain('/app/other');
     expect(first.promptFingerprint).toBe(second.promptFingerprint);
     expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
+  });
+
+  it('preserves semantic slash-prefixed prompt tokens', () => {
+    const telemetry = buildPromptStackTelemetry({
+      composedPrompt:
+        'POST /api/runs/:id/tool-result, match /foo/bar, cwd /app/project',
+      sections: [
+        {
+          kind: 'daemonSystemPrompt',
+          content:
+            'POST /api/runs/:id/tool-result, match /foo/bar, cwd /app/project',
+        },
+      ],
+    });
+
+    expect(telemetry.sections[0]!.redactedContent).toBe(
+      `POST /api/runs/:id/tool-result, match /foo/bar, cwd ${PROMPT_STACK_PATH_MARKER}`,
+    );
+    expect(telemetry.sections[0]!.redactedContent).toContain(
+      '/api/runs/:id/tool-result',
+    );
+    expect(telemetry.sections[0]!.redactedContent).toContain('/foo/bar');
+    expect(telemetry.sections[0]!.redactedContent).not.toContain('/app/project');
   });
 
   it('normalizes file URL local paths before fingerprinting', () => {

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -158,36 +158,39 @@ describe('prompt telemetry builder', () => {
     expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
   });
 
-  it('redacts opt, usr-local, and var-tmp project roots before fingerprinting', () => {
+  it('redacts opt, usr-local, and macOS var-tmp project roots before fingerprinting', () => {
     const first = buildPromptStackTelemetry({
       composedPrompt:
-        'cwd /opt/project, src /usr/local/src/app, temp /var/tmp/project, route /foo/bar',
+        'cwd /opt/project, src /usr/local/src/app, temp /var/tmp/project, private temp /private/var/tmp/open-design, route /foo/bar',
       sections: [
         {
           kind: 'daemonSystemPrompt',
           content:
-            'cwd /opt/project, src /usr/local/src/app, temp /var/tmp/project, route /foo/bar',
+            'cwd /opt/project, src /usr/local/src/app, temp /var/tmp/project, private temp /private/var/tmp/open-design, route /foo/bar',
         },
       ],
     });
     const second = buildPromptStackTelemetry({
       composedPrompt:
-        'cwd /opt/other, src /usr/local/src/other, temp /var/tmp/other, route /foo/bar',
+        'cwd /opt/other, src /usr/local/src/other, temp /var/tmp/other, private temp /private/var/tmp/other, route /foo/bar',
       sections: [
         {
           kind: 'daemonSystemPrompt',
           content:
-            'cwd /opt/other, src /usr/local/src/other, temp /var/tmp/other, route /foo/bar',
+            'cwd /opt/other, src /usr/local/src/other, temp /var/tmp/other, private temp /private/var/tmp/other, route /foo/bar',
         },
       ],
     });
 
     expect(first.sections[0]!.redactedContent).toBe(
-      `cwd ${PROMPT_STACK_PATH_MARKER}, src ${PROMPT_STACK_PATH_MARKER}, temp ${PROMPT_STACK_PATH_MARKER}, route /foo/bar`,
+      `cwd ${PROMPT_STACK_PATH_MARKER}, src ${PROMPT_STACK_PATH_MARKER}, temp ${PROMPT_STACK_PATH_MARKER}, private temp ${PROMPT_STACK_PATH_MARKER}, route /foo/bar`,
     );
     expect(first.sections[0]!.redactedContent).not.toContain('/opt/project');
     expect(first.sections[0]!.redactedContent).not.toContain('/usr/local/src/app');
     expect(first.sections[0]!.redactedContent).not.toContain('/var/tmp/project');
+    expect(first.sections[0]!.redactedContent).not.toContain(
+      '/private/var/tmp/open-design',
+    );
     expect(first.sections[0]!.redactedContent).toContain('/foo/bar');
     expect(first.promptFingerprint).toBe(second.promptFingerprint);
     expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -99,6 +99,55 @@ describe('prompt telemetry builder', () => {
     expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
   });
 
+  it('normalizes arbitrary absolute project roots before fingerprinting', () => {
+    const first = buildPromptStackTelemetry({
+      composedPrompt: 'Your working directory: /app/project',
+      sections: [
+        { kind: 'daemonSystemPrompt', content: 'Your working directory: /app/project' },
+      ],
+    });
+    const second = buildPromptStackTelemetry({
+      composedPrompt: 'Your working directory: /app/other',
+      sections: [
+        { kind: 'daemonSystemPrompt', content: 'Your working directory: /app/other' },
+      ],
+    });
+
+    expect(first.sections[0]!.redactedContent).toBe(
+      `Your working directory: ${PROMPT_STACK_PATH_MARKER}`,
+    );
+    expect(second.sections[0]!.redactedContent).toBe(
+      `Your working directory: ${PROMPT_STACK_PATH_MARKER}`,
+    );
+    expect(first.sections[0]!.redactedContent).not.toContain('/app/project');
+    expect(second.sections[0]!.redactedContent).not.toContain('/app/other');
+    expect(first.promptFingerprint).toBe(second.promptFingerprint);
+    expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
+  });
+
+  it('normalizes file URL local paths before fingerprinting', () => {
+    const first = buildPromptStackTelemetry({
+      composedPrompt: 'Preview file:///app/project/index.html',
+      sections: [
+        { kind: 'userRequest', content: 'Preview file:///app/project/index.html' },
+      ],
+    });
+    const second = buildPromptStackTelemetry({
+      composedPrompt: 'Preview file://localhost/app/other/index.html',
+      sections: [
+        {
+          kind: 'userRequest',
+          content: 'Preview file://localhost/app/other/index.html',
+        },
+      ],
+    });
+
+    expect(first.sections[0]!.redactedContent).toBe(`Preview ${PROMPT_STACK_PATH_MARKER}`);
+    expect(second.sections[0]!.redactedContent).toBe(`Preview ${PROMPT_STACK_PATH_MARKER}`);
+    expect(first.promptFingerprint).toBe(second.promptFingerprint);
+    expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
+  });
+
   it('strips runtime tool token-bearing lines before capture', () => {
     const telemetry = buildPromptStackTelemetry({
       composedPrompt: 'tools',

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -366,6 +366,58 @@ describe('prompt telemetry builder', () => {
     expect(userRequest.truncationReason).toBe('total_budget_exceeded');
   });
 
+  it('keeps aggregate prompt fingerprints metadata-only without spending content budget', () => {
+    const huge = 'x'.repeat(120 * 1024);
+    const telemetry = buildPromptStackTelemetry({
+      composedPrompt: huge,
+      sections: [
+        {
+          kind: 'daemonSystemPrompt',
+          content: huge,
+          captureContent: false,
+        },
+        {
+          kind: 'clientSystemPrompt',
+          content: huge,
+          captureContent: false,
+        },
+        { kind: 'skillPrompt', content: huge },
+        { kind: 'designSystemPrompt', content: huge },
+        { kind: 'pluginStagePrompt', content: huge },
+        { kind: 'researchCommandContract', content: huge },
+        { kind: 'runContextPrompt', content: huge },
+      ],
+    });
+
+    const daemonSystemPrompt = telemetry.sections.find(
+      (s) => s.kind === 'daemonSystemPrompt',
+    )!;
+    const clientSystemPrompt = telemetry.sections.find(
+      (s) => s.kind === 'clientSystemPrompt',
+    )!;
+    expect(daemonSystemPrompt.contentMode).toBe('metadata-only');
+    expect(daemonSystemPrompt.redactedContent).toBeUndefined();
+    expect(daemonSystemPrompt.fingerprint).toMatch(/^sha256:/);
+    expect(clientSystemPrompt.contentMode).toBe('metadata-only');
+    expect(clientSystemPrompt.redactedContent).toBeUndefined();
+    expect(clientSystemPrompt.fingerprint).toMatch(/^sha256:/);
+    expect(telemetry.sections.find((s) => s.kind === 'skillPrompt')?.redactedContent)
+      .toHaveLength(16 * 1024);
+    expect(
+      telemetry.sections.find((s) => s.kind === 'designSystemPrompt')?.redactedContent,
+    ).toHaveLength(16 * 1024);
+    expect(
+      telemetry.sections.find((s) => s.kind === 'pluginStagePrompt')?.redactedContent,
+    ).toHaveLength(16 * 1024);
+    expect(
+      telemetry.sections.find((s) => s.kind === 'researchCommandContract')
+        ?.redactedContent,
+    ).toHaveLength(16 * 1024);
+    expect(telemetry.sections.find((s) => s.kind === 'runContextPrompt')?.redactedContent)
+      .toHaveLength(16 * 1024);
+    expect(telemetry.redactedContentBytes).toBe(80 * 1024);
+  });
+
   it('removes redactedContent when content consent is unavailable', () => {
     const telemetry = buildPromptStackTelemetry({
       composedPrompt: 'hello',

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -158,6 +158,41 @@ describe('prompt telemetry builder', () => {
     expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
   });
 
+  it('redacts opt, usr-local, and var-tmp project roots before fingerprinting', () => {
+    const first = buildPromptStackTelemetry({
+      composedPrompt:
+        'cwd /opt/project, src /usr/local/src/app, temp /var/tmp/project, route /foo/bar',
+      sections: [
+        {
+          kind: 'daemonSystemPrompt',
+          content:
+            'cwd /opt/project, src /usr/local/src/app, temp /var/tmp/project, route /foo/bar',
+        },
+      ],
+    });
+    const second = buildPromptStackTelemetry({
+      composedPrompt:
+        'cwd /opt/other, src /usr/local/src/other, temp /var/tmp/other, route /foo/bar',
+      sections: [
+        {
+          kind: 'daemonSystemPrompt',
+          content:
+            'cwd /opt/other, src /usr/local/src/other, temp /var/tmp/other, route /foo/bar',
+        },
+      ],
+    });
+
+    expect(first.sections[0]!.redactedContent).toBe(
+      `cwd ${PROMPT_STACK_PATH_MARKER}, src ${PROMPT_STACK_PATH_MARKER}, temp ${PROMPT_STACK_PATH_MARKER}, route /foo/bar`,
+    );
+    expect(first.sections[0]!.redactedContent).not.toContain('/opt/project');
+    expect(first.sections[0]!.redactedContent).not.toContain('/usr/local/src/app');
+    expect(first.sections[0]!.redactedContent).not.toContain('/var/tmp/project');
+    expect(first.sections[0]!.redactedContent).toContain('/foo/bar');
+    expect(first.promptFingerprint).toBe(second.promptFingerprint);
+    expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
+  });
+
   it('preserves semantic slash-prefixed prompt tokens', () => {
     const telemetry = buildPromptStackTelemetry({
       composedPrompt:

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -77,6 +77,27 @@ describe('prompt telemetry builder', () => {
     expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
   });
 
+  it('normalizes dev-container workspace roots before fingerprinting', () => {
+    const first = buildPromptStackTelemetry({
+      composedPrompt: 'open /workspace/open-design/src/App.tsx',
+      sections: [
+        { kind: 'userRequest', content: 'open /workspace/open-design/src/App.tsx' },
+      ],
+    });
+    const second = buildPromptStackTelemetry({
+      composedPrompt: 'open /workspaces/open-design/src/App.tsx',
+      sections: [
+        { kind: 'userRequest', content: 'open /workspaces/open-design/src/App.tsx' },
+      ],
+    });
+
+    expect(first.sections[0]!.redactedContent).toBe(`open ${PROMPT_STACK_PATH_MARKER}`);
+    expect(second.sections[0]!.redactedContent).toBe(`open ${PROMPT_STACK_PATH_MARKER}`);
+    expect(second.sections[0]!.redactedContent).not.toContain('/workspaces');
+    expect(first.promptFingerprint).toBe(second.promptFingerprint);
+    expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
+  });
+
   it('strips runtime tool token-bearing lines before capture', () => {
     const telemetry = buildPromptStackTelemetry({
       composedPrompt: 'tools',

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PROMPT_STACK_PATH_MARKER,
+  buildPromptStackTelemetry,
+  promptStackWithoutContent,
+  redactLocalPaths,
+} from '../src/prompt-telemetry.js';
+
+describe('prompt telemetry builder', () => {
+  it('redacts local paths and secrets before hashing or content capture', () => {
+    const telemetry = buildPromptStackTelemetry({
+      composedPrompt:
+        'Use /Users/alice/work/repo/index.html with sk-test-1234567890123456789012.',
+      sections: [
+        {
+          kind: 'daemonSystemPrompt',
+          content:
+            'Read /Users/alice/work/repo/index.html and token sk-test-1234567890123456789012.',
+        },
+      ],
+    });
+
+    const section = telemetry.sections[0]!;
+    expect(section.redactedContent).toContain(PROMPT_STACK_PATH_MARKER);
+    expect(section.redactedContent).toContain('[REDACTED:sk_key]');
+    expect(section.redactedContent).not.toContain('/Users/alice');
+    expect(section.redactedContent).not.toContain('sk-test-');
+    expect(section.fingerprint).toMatch(/^sha256:/);
+    expect(telemetry.promptFingerprint).toMatch(/^sha256:/);
+  });
+
+  it('normalizes different local paths to the same prompt fingerprint', () => {
+    const first = buildPromptStackTelemetry({
+      composedPrompt: 'Open /Users/alice/project/src/App.tsx',
+      sections: [{ kind: 'userRequest', content: 'Open /Users/alice/project/src/App.tsx' }],
+    });
+    const second = buildPromptStackTelemetry({
+      composedPrompt: 'Open /Users/bob/other/src/App.tsx',
+      sections: [{ kind: 'userRequest', content: 'Open /Users/bob/other/src/App.tsx' }],
+    });
+
+    expect(first.promptFingerprint).toBe(second.promptFingerprint);
+    expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
+  });
+
+  it('strips runtime tool token-bearing lines before capture', () => {
+    const telemetry = buildPromptStackTelemetry({
+      composedPrompt: 'tools',
+      sections: [
+        {
+          kind: 'runtimeToolPrompt',
+          content: [
+            '## Runtime tool environment',
+            '- `OD_TOOL_TOKEN` is available in your environment for this run.',
+            '- Daemon URL: `http://127.0.0.1:1234`.',
+          ].join('\n'),
+        },
+      ],
+    });
+
+    expect(telemetry.sections[0]!.redactedContent).not.toContain('OD_TOOL_TOKEN');
+    expect(telemetry.sections[0]!.redactedContent).toContain('Daemon URL');
+  });
+
+  it('keeps metadata-only sections free of raw paths and attachment bodies', () => {
+    const telemetry = buildPromptStackTelemetry({
+      composedPrompt: 'attached',
+      sections: [
+        {
+          kind: 'commentAttachments',
+          content:
+            'file: /Users/alice/project/index.html\ncomment: make the hero blue\nscreenshot: /tmp/mark.png',
+          metadata: [
+            {
+              filePath: '/Users/alice/project/index.html',
+              screenshotPath: '/tmp/mark.png',
+              selectionKind: 'visual',
+              comment: 'make the hero blue',
+            },
+          ],
+        },
+      ],
+    });
+
+    const section = telemetry.sections[0]!;
+    expect(section.contentMode).toBe('metadata-only');
+    expect(section.redactedContent).toBeUndefined();
+    expect(section.metadata).toEqual({
+      count: 1,
+      extensions: ['html'],
+      knownSizeCount: 0,
+      selectionKinds: { visual: 1 },
+      sizeBuckets: {},
+    });
+    expect(JSON.stringify(section)).not.toContain('/Users/alice');
+    expect(JSON.stringify(section)).not.toContain('make the hero blue');
+  });
+
+  it('applies per-section limits and total budget in diagnostic priority order', () => {
+    const huge = 'x'.repeat(120 * 1024);
+    const telemetry = buildPromptStackTelemetry({
+      composedPrompt: huge,
+      sections: [
+        { kind: 'userRequest', content: huge },
+        { kind: 'formOverride', content: huge },
+        { kind: 'daemonSystemPrompt', content: huge },
+        { kind: 'runtimeToolPrompt', content: huge },
+        { kind: 'clientSystemPrompt', content: huge },
+        { kind: 'skillPrompt', content: huge },
+        { kind: 'designSystemPrompt', content: huge },
+        { kind: 'pluginStagePrompt', content: huge },
+        { kind: 'researchCommandContract', content: huge },
+        { kind: 'runContextPrompt', content: huge },
+        { kind: 'echoGuard', content: huge },
+      ],
+    });
+
+    expect(telemetry.redactedContentBytes).toBe(96 * 1024);
+    expect(telemetry.sections.find((s) => s.kind === 'formOverride')?.redactedContent)
+      .toHaveLength(16 * 1024);
+    expect(
+      telemetry.sections.find((s) => s.kind === 'daemonSystemPrompt')?.redactedContent,
+    ).toHaveLength(32 * 1024);
+    expect(telemetry.sections.find((s) => s.kind === 'clientSystemPrompt')?.redactedContent)
+      .toHaveLength(16 * 1024);
+    expect(telemetry.sections.find((s) => s.kind === 'skillPrompt')?.redactedContent)
+      .toHaveLength(16 * 1024);
+    const userRequest = telemetry.sections.find((s) => s.kind === 'userRequest')!;
+    expect(userRequest.redactedContent).toBeUndefined();
+    expect(userRequest.truncationReason).toBe('total_budget_exceeded');
+  });
+
+  it('removes redactedContent when content consent is unavailable', () => {
+    const telemetry = buildPromptStackTelemetry({
+      composedPrompt: 'hello',
+      sections: [{ kind: 'userRequest', content: 'hello' }],
+    });
+
+    const metadataOnly = promptStackWithoutContent(telemetry);
+    expect(metadataOnly.redactedContentBytes).toBe(0);
+    expect(metadataOnly.sections[0]!.redactedContent).toBeUndefined();
+    expect(metadataOnly.sections[0]!.fingerprint).toBe(telemetry.sections[0]!.fingerprint);
+  });
+
+  it('redacts Windows local paths', () => {
+    expect(redactLocalPaths('Open C:\\Users\\alice\\repo\\index.html')).toBe(
+      `Open ${PROMPT_STACK_PATH_MARKER}`,
+    );
+  });
+});

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -366,41 +366,30 @@ describe('prompt telemetry builder', () => {
     expect(userRequest.truncationReason).toBe('total_budget_exceeded');
   });
 
-  it('keeps aggregate prompt fingerprints metadata-only without spending content budget', () => {
+  it('supports explicit metadata-only content sections without spending content budget', () => {
     const huge = 'x'.repeat(120 * 1024);
     const telemetry = buildPromptStackTelemetry({
       composedPrompt: huge,
       sections: [
         {
-          kind: 'daemonSystemPrompt',
-          content: huge,
-          captureContent: false,
-        },
-        {
-          kind: 'clientSystemPrompt',
+          kind: 'researchCommandContract',
           content: huge,
           captureContent: false,
         },
         { kind: 'skillPrompt', content: huge },
         { kind: 'designSystemPrompt', content: huge },
         { kind: 'pluginStagePrompt', content: huge },
-        { kind: 'researchCommandContract', content: huge },
         { kind: 'runContextPrompt', content: huge },
+        { kind: 'echoGuard', content: huge },
       ],
     });
 
-    const daemonSystemPrompt = telemetry.sections.find(
-      (s) => s.kind === 'daemonSystemPrompt',
+    const metadataOnlySection = telemetry.sections.find(
+      (s) => s.kind === 'researchCommandContract',
     )!;
-    const clientSystemPrompt = telemetry.sections.find(
-      (s) => s.kind === 'clientSystemPrompt',
-    )!;
-    expect(daemonSystemPrompt.contentMode).toBe('metadata-only');
-    expect(daemonSystemPrompt.redactedContent).toBeUndefined();
-    expect(daemonSystemPrompt.fingerprint).toMatch(/^sha256:/);
-    expect(clientSystemPrompt.contentMode).toBe('metadata-only');
-    expect(clientSystemPrompt.redactedContent).toBeUndefined();
-    expect(clientSystemPrompt.fingerprint).toMatch(/^sha256:/);
+    expect(metadataOnlySection.contentMode).toBe('metadata-only');
+    expect(metadataOnlySection.redactedContent).toBeUndefined();
+    expect(metadataOnlySection.fingerprint).toMatch(/^sha256:/);
     expect(telemetry.sections.find((s) => s.kind === 'skillPrompt')?.redactedContent)
       .toHaveLength(16 * 1024);
     expect(
@@ -410,10 +399,9 @@ describe('prompt telemetry builder', () => {
       telemetry.sections.find((s) => s.kind === 'pluginStagePrompt')?.redactedContent,
     ).toHaveLength(16 * 1024);
     expect(
-      telemetry.sections.find((s) => s.kind === 'researchCommandContract')
-        ?.redactedContent,
+      telemetry.sections.find((s) => s.kind === 'runContextPrompt')?.redactedContent,
     ).toHaveLength(16 * 1024);
-    expect(telemetry.sections.find((s) => s.kind === 'runContextPrompt')?.redactedContent)
+    expect(telemetry.sections.find((s) => s.kind === 'echoGuard')?.redactedContent)
       .toHaveLength(16 * 1024);
     expect(telemetry.redactedContentBytes).toBe(80 * 1024);
   });

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -125,6 +125,39 @@ describe('prompt telemetry builder', () => {
     expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
   });
 
+  it('redacts non-home Linux project and attachment roots before fingerprinting', () => {
+    const first = buildPromptStackTelemetry({
+      composedPrompt:
+        'cwd /media/william/disk/project, service /srv/open-design, image @/media/william/disk/screenshot.png',
+      sections: [
+        {
+          kind: 'daemonSystemPrompt',
+          content:
+            'cwd /media/william/disk/project, service /srv/open-design, image @/media/william/disk/screenshot.png',
+        },
+      ],
+    });
+    const second = buildPromptStackTelemetry({
+      composedPrompt:
+        'cwd /media/other/disk/project, service /srv/other-design, image @/media/other/disk/screenshot.png',
+      sections: [
+        {
+          kind: 'daemonSystemPrompt',
+          content:
+            'cwd /media/other/disk/project, service /srv/other-design, image @/media/other/disk/screenshot.png',
+        },
+      ],
+    });
+
+    expect(first.sections[0]!.redactedContent).toBe(
+      `cwd ${PROMPT_STACK_PATH_MARKER}, service ${PROMPT_STACK_PATH_MARKER}, image @${PROMPT_STACK_PATH_MARKER}`,
+    );
+    expect(first.sections[0]!.redactedContent).not.toContain('/media/william');
+    expect(first.sections[0]!.redactedContent).not.toContain('/srv/open-design');
+    expect(first.promptFingerprint).toBe(second.promptFingerprint);
+    expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
+  });
+
   it('preserves semantic slash-prefixed prompt tokens', () => {
     const telemetry = buildPromptStackTelemetry({
       composedPrompt:

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   PROMPT_STACK_PATH_MARKER,
+  buildPromptStackFlatMetadata,
   buildPromptStackTelemetry,
   promptStackWithoutContent,
   redactLocalPaths,
@@ -149,6 +150,43 @@ describe('prompt telemetry builder', () => {
     });
     expect(JSON.stringify(section)).not.toContain('/Users/alice');
     expect(JSON.stringify(section)).not.toContain('make the hero blue');
+  });
+
+  it('omits absent sections from the emitted prompt stack', () => {
+    const telemetry = buildPromptStackTelemetry({
+      composedPrompt: 'Build a card',
+      sections: [
+        { kind: 'formOverride', content: '' },
+        { kind: 'daemonSystemPrompt', content: 'system prompt' },
+        { kind: 'attachments', metadata: [] },
+      ],
+    });
+
+    expect(telemetry.sections.map((section) => section.kind)).toEqual([
+      'daemonSystemPrompt',
+    ]);
+    expect(telemetry.sectionCount).toBe(1);
+  });
+
+  it('keeps only high-value flat metadata fields', () => {
+    const telemetry = buildPromptStackTelemetry({
+      composedPrompt: 'Build a card',
+      sections: [
+        { kind: 'daemonSystemPrompt', content: 'system prompt' },
+        { kind: 'runtimeToolPrompt', content: 'runtime tools' },
+        { kind: 'pluginStagePrompt', content: 'plugin stage' },
+        { kind: 'userRequest', content: 'Build a card' },
+      ],
+    });
+
+    const flat = buildPromptStackFlatMetadata(telemetry);
+    expect(flat.promptStack_promptFingerprint).toMatch(/^sha256:/);
+    expect(flat.promptStack_section_daemonSystemPrompt_present).toBe(true);
+    expect(flat.promptStack_section_runtimeToolPrompt_present).toBe(true);
+    expect(flat.promptStack_section_pluginStagePrompt_present).toBe(true);
+    expect(flat.promptStack_section_userRequest_present).toBeUndefined();
+    expect(flat.promptStack_section_daemonSystemPrompt_rawBytes).toBeUndefined();
+    expect(flat.promptStack_rawBytes).toBeUndefined();
   });
 
   it('applies per-section limits and total budget in diagnostic priority order', () => {

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -44,6 +44,39 @@ describe('prompt telemetry builder', () => {
     expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
   });
 
+  it('redacts macOS private var folders and root session paths before fingerprinting', () => {
+    const first = buildPromptStackTelemetry({
+      composedPrompt:
+        'open /private/var/folders/aa/token/T/render.png and /root/project/file.ts',
+      sections: [
+        {
+          kind: 'userRequest',
+          content:
+            'open /private/var/folders/aa/token/T/render.png and /root/project/file.ts',
+        },
+      ],
+    });
+    const second = buildPromptStackTelemetry({
+      composedPrompt:
+        'open /private/var/folders/bb/other/T/render.png and /root/other/file.ts',
+      sections: [
+        {
+          kind: 'userRequest',
+          content:
+            'open /private/var/folders/bb/other/T/render.png and /root/other/file.ts',
+        },
+      ],
+    });
+
+    expect(first.sections[0]!.redactedContent).toBe(
+      `open ${PROMPT_STACK_PATH_MARKER} and ${PROMPT_STACK_PATH_MARKER}`,
+    );
+    expect(first.sections[0]!.redactedContent).not.toContain('/private/var/folders');
+    expect(first.sections[0]!.redactedContent).not.toContain('/root/project');
+    expect(first.promptFingerprint).toBe(second.promptFingerprint);
+    expect(first.sections[0]!.fingerprint).toBe(second.sections[0]!.fingerprint);
+  });
+
   it('strips runtime tool token-bearing lines before capture', () => {
     const telemetry = buildPromptStackTelemetry({
       composedPrompt: 'tools',


### PR DESCRIPTION
Closes #3556

## Why

This implements the Phase 1 prompt-stack observability work requested in #3556, following the prior Langfuse trace plumbing. The pain addressed is that Langfuse traces currently show the user prompt and bounded output, but not enough redacted section-level prompt context to diagnose prompt composition issues across daemon, runtime, skill, design-system, plugin, attachment, and request sections.

## What users will see

No UI or browsing behavior changes. For runs that already qualify for Langfuse content delivery through telemetry metrics plus conversation/tool content consent, Langfuse trace and generation metadata now include redacted prompt-stack diagnostics and flat prompt-stack dimensions for filtering and dashboards. Trace and generation inputs remain the user prompt.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A; no UI changes.

## Bug fix verification

N/A; feature implementation with focused coverage for the new telemetry behavior.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/prompt-telemetry.test.ts tests/langfuse-trace.test.ts tests/langfuse-bridge.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>