### PR TITLE
feat(agents): CLI detection self-rescue with actionable diagnostics

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -4,7 +4,7 @@ export {
   getAgentDef,
   readLocalAgentProfileDefs,
 } from './runtimes/registry.js';
-export { detectAgents } from './runtimes/detection.js';
+export { detectAgents, detectAgentsStream } from './runtimes/detection.js';
 export {
   resolveOnPath,
   inspectAgentExecutableResolution,

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1884,7 +1884,7 @@ async function testAgentConnectionInternal(
       ...baseEnv,
       ...(mmdRouteLaunchEnv || {}),
     }, executableResolution);
-    const auth = await probeAgentAuthStatus(input.agentId, executableResolution.launchPath, env);
+    const auth = await probeAgentAuthStatus(def, executableResolution.launchPath, env);
     if (auth?.status === 'missing') {
       // Preflight auth probe runs after binary resolution but before the
       // smoke spawn — phase is still 'binary_resolution'. The smoke

--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -1,5 +1,5 @@
 import { execAgentFile } from './invocation.js';
-import type { RuntimeEnv } from './types.js';
+import type { RuntimeAgentDef, RuntimeEnv } from './types.js';
 
 export type AgentAuthProbeResult = {
   status: 'ok' | 'missing' | 'unknown';
@@ -252,24 +252,71 @@ function withProbeTails(
   return result;
 }
 
+// Default generic sign-in hint for adapters that declare an `authProbe`
+// but ship no tailored guidance (cursor / deepseek / antigravity / reasonix
+// each have their own via `classifyAgentAuthFailure`). Kept agent-agnostic
+// so a newly-onboarded CLI gets an actionable banner the moment it opts into
+// auth probing, without bespoke copy.
+function genericAuthGuidance(agentName: string): string {
+  return `${agentName} appears to be installed but is not authenticated. Sign in with the CLI in a terminal, then rescan. If Open Design was launched outside an interactive shell, your shell rc files (e.g. ~/.zshrc) may not be loaded into its environment.`;
+}
+
+// Agents that ship a bespoke auth-failure classifier + tailored sign-in hint
+// via `classifyAgentAuthFailure`. For these, a null result is authoritative
+// ("authenticated"); we must NOT second-guess it with the broad generic
+// regex (e.g. cursor-agent's healthy `status` output mentions "login" in
+// ways the generic matcher would misread). The generic classifier is only a
+// fallback for adapters with no tailored classifier of their own.
+const TAILORED_AUTH_AGENTS = new Set([
+  'cursor-agent',
+  'deepseek',
+  'antigravity',
+  'reasonix',
+]);
+
+// Classify an auth-probe's combined output into a missing-auth result, or
+// null when the output does not look like an auth failure. Agents with a
+// tailored classifier use only that (null === authenticated); every other
+// adapter that opts into probing falls back to the generic, agent-agnostic
+// HTTP/text classifier so it still gets a usable signal without bespoke
+// regexes.
+function classifyProbedAuthFailure(
+  def: Pick<RuntimeAgentDef, 'id' | 'name'>,
+  text: string,
+): AgentAuthProbeResult | null {
+  if (TAILORED_AUTH_AGENTS.has(def.id)) {
+    return classifyAgentAuthFailure(def.id, text);
+  }
+  if (classifyAgentServiceFailure(text) === 'AGENT_AUTH_REQUIRED') {
+    return { status: 'missing', message: genericAuthGuidance(def.name || def.id) };
+  }
+  return null;
+}
+
+// Run an adapter's declared authentication probe (a cheap, side-effect-free
+// status/whoami command) and classify the result. Returns null when the
+// adapter declares no `authProbe` — those agents are never actively probed;
+// their auth status is inferred only from a real chat failure's error text.
 export async function probeAgentAuthStatus(
-  agentId: string,
+  def: Pick<RuntimeAgentDef, 'id' | 'name' | 'authProbe'>,
   resolvedBin: string,
   env: RuntimeEnv,
 ): Promise<AgentAuthProbeResult | null> {
-  if (agentId !== 'cursor-agent') return null;
+  const probe = def.authProbe;
+  if (!probe) return null;
   try {
-    const { stdout, stderr } = await execAgentFile(resolvedBin, ['status'], {
+    const { stdout, stderr } = await execAgentFile(resolvedBin, probe.args, {
       env,
-      timeout: 5000,
+      timeout: probe.timeoutMs ?? 5000,
       maxBuffer: 1024 * 1024,
     });
     const stdoutText = typeof stdout === 'string' ? stdout : '';
     const stderrText = typeof stderr === 'string' ? stderr : '';
     const output = `${stdoutText}\n${stderrText}`;
-    if (isCursorAuthFailureText(output)) {
+    const failure = classifyProbedAuthFailure(def, output);
+    if (failure) {
       return withProbeTails(
-        { status: 'missing', message: cursorAuthGuidance(), exitCode: 0, signal: null },
+        { ...failure, exitCode: 0, signal: null },
         stdoutText,
         stderrText,
       );
@@ -291,14 +338,10 @@ export async function probeAgentAuthStatus(
     // is meaningful as an exit code.
     const numericExit = typeof err.code === 'number' ? err.code : null;
     const childSignal = typeof err.signal === 'string' ? err.signal : null;
-    if (isCursorAuthFailureText(output)) {
+    const failure = classifyProbedAuthFailure(def, output);
+    if (failure) {
       return withProbeTails(
-        {
-          status: 'missing',
-          message: cursorAuthGuidance(),
-          exitCode: numericExit,
-          signal: childSignal,
-        },
+        { ...failure, exitCode: numericExit, signal: childSignal },
         stdoutText,
         stderrText,
       );
@@ -306,7 +349,7 @@ export async function probeAgentAuthStatus(
     return withProbeTails(
       {
         status: 'unknown',
-        message: 'Cursor Agent authentication status could not be verified with `cursor-agent status`.',
+        message: `${def.name || def.id} authentication status could not be verified with \`${def.id} ${probe.args.join(' ')}\`.`,
         exitCode: numericExit,
         signal: childSignal,
       },

--- a/apps/daemon/src/runtimes/defs/cursor-agent.ts
+++ b/apps/daemon/src/runtimes/defs/cursor-agent.ts
@@ -82,4 +82,8 @@ export const cursorAgentDef = {
     promptViaStdin: true,
     streamFormat: 'json-event-stream',
     eventParser: 'cursor-agent',
+    // `cursor-agent status` is a cheap, side-effect-free auth check. Declaring
+    // it here is what makes detection surface an "auth required" badge for
+    // Cursor Agent (the generalized probe only runs for adapters that opt in).
+    authProbe: { args: ['status'], timeoutMs: 5000 },
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -6,7 +6,13 @@ import { spawnEnvForAgent } from './env.js';
 import { probeAgentAuthStatus } from './auth.js';
 import { agentCapabilities } from './capabilities.js';
 import { installMetaForAgent } from './metadata.js';
+import {
+  buildAuthDiagnostic,
+  buildExecutableDiagnostic,
+  buildNotInvocableDiagnostic,
+} from './diagnostics.js';
 import type {
+  AgentDiagnostic,
   DetectedAgent,
   RuntimeAgentDef,
   RuntimeCapabilityMap,
@@ -117,14 +123,47 @@ async function probeVersionAtPath(
   }
 }
 
-function unavailableAgent(def: RuntimeAgentDef): DetectedAgent {
+function unavailableAgent(
+  def: RuntimeAgentDef,
+  diagnostics: AgentDiagnostic[] = [],
+): DetectedAgent {
   return {
     ...stripFns(def),
     models: def.fallbackModels ?? [DEFAULT_MODEL_OPTION],
     modelsSource: 'fallback',
     available: false,
+    ...(diagnostics.length > 0 ? { diagnostics } : {}),
     ...installMetaForAgent(def.id),
   };
+}
+
+// Probe the agent's `--help` once and record which advertised flags the
+// installed CLI supports, so buildArgs can consult the cache. Extracted from
+// the main probe so it can run concurrently with model + auth probing instead
+// of blocking them. Returns the capability map (or null when the agent
+// declares no help/capability metadata or the probe failed).
+async function probeCapabilities(
+  def: RuntimeAgentDef,
+  launchPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<RuntimeCapabilityMap | null> {
+  if (!def.helpArgs || !def.capabilityFlags) return null;
+  try {
+    const { stdout } = await execAgentFile(launchPath, def.helpArgs, {
+      env,
+      timeout: 5000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    const caps: RuntimeCapabilityMap = {};
+    for (const [flag, key] of Object.entries(def.capabilityFlags)) {
+      caps[key] = String(stdout).includes(flag);
+    }
+    return caps;
+  } catch {
+    // If --help fails, leave caps empty so buildArgs falls back to the safe
+    // baseline (no optional flags).
+    return {};
+  }
 }
 
 async function probe(
@@ -141,7 +180,7 @@ async function probe(
   // hand even though the real launch path is healthy.
   const launch = resolveAgentLaunch(def, configuredEnv);
   if (!launch.selectedPath || !launch.launchPath) {
-    return unavailableAgent(def);
+    return unavailableAgent(def, [buildExecutableDiagnostic(def, configuredEnv)]);
   }
   const probeEnv = applyAgentLaunchEnv(
     spawnEnvForAgent(
@@ -158,29 +197,22 @@ async function probe(
   );
   const outcome = await probeVersionAtPath(def, launch.launchPath, probeEnv);
   if (outcome.kind === 'not-invocable') {
-    return unavailableAgent(def);
+    return unavailableAgent(def, [buildNotInvocableDiagnostic(def, launch)]);
   }
-  // Probe `--help` once per agent and record which flags the installed CLI
-  // advertises. Cached on `agentCapabilities` for buildArgs to consult.
-  if (def.helpArgs && def.capabilityFlags) {
-    const caps: RuntimeCapabilityMap = {};
-    try {
-      const { stdout } = await execAgentFile(launch.launchPath, def.helpArgs, {
-        env: probeEnv,
-        timeout: 5000,
-        maxBuffer: 4 * 1024 * 1024,
-      });
-      for (const [flag, key] of Object.entries(def.capabilityFlags)) {
-        caps[key] = String(stdout).includes(flag);
-      }
-    } catch {
-      // If --help fails, leave caps empty so buildArgs falls back to the safe
-      // baseline (no optional flags).
-    }
+  // The version probe must finish first (it gates availability), but the
+  // three post-version probes are independent reads — run them concurrently
+  // so a single agent's detection wall is max(help, models, auth) ≈ 5s rather
+  // than the sum ≈ 15s. `--help` capabilities are cached on `agentCapabilities`
+  // for buildArgs to consult.
+  const [caps, modelResult, auth] = await Promise.all([
+    probeCapabilities(def, launch.launchPath, probeEnv),
+    fetchModels(def, launch.launchPath, probeEnv),
+    probeAgentAuthStatus(def, launch.launchPath, probeEnv),
+  ]);
+  if (caps) {
     agentCapabilities.set(def.id, caps);
   }
-  const modelResult = await fetchModels(def, launch.launchPath, probeEnv);
-  const auth = await probeAgentAuthStatus(def.id, launch.launchPath, probeEnv);
+  const authDiagnostic = auth ? buildAuthDiagnostic(def, auth) : null;
   return {
     ...stripFns(def),
     models: modelResult.models,
@@ -194,6 +226,7 @@ async function probe(
           ...(auth.message ? { authMessage: auth.message } : {}),
         }
       : {}),
+    ...(authDiagnostic ? { diagnostics: [authDiagnostic] } : {}),
     ...installMetaForAgent(def.id),
   };
 }
@@ -218,6 +251,7 @@ function stripFns(
     versionProbeTimeoutMs,
     maxPromptArgBytes,
     env,
+    authProbe,
     ...rest
   } = def;
   return rest;
@@ -254,4 +288,29 @@ export async function detectAgents(
     rememberLiveModels(agent.id, agent.models);
   }
   return results;
+}
+
+// Streaming variant: yields each agent the moment its probe settles, in
+// completion order rather than registry order, so the UI can paint a card
+// as soon as it resolves instead of waiting for the slowest CLI. The model
+// validation cache is refreshed per-agent (same effect as the batch path,
+// just incrementally). `detectAgents` keeps the array contract for callers
+// that don't care about incremental delivery (cache warm, analytics, chat).
+export async function* detectAgentsStream(
+  configuredEnvByAgent: Record<string, Record<string, string>> = {},
+): AsyncGenerator<DetectedAgent> {
+  const tagged = AGENT_DEFS.map((def, index) =>
+    safeProbe(def, configuredEnvByAgent?.[def.id] ?? {}).then((agent) => {
+      rememberLiveModels(agent.id, agent.models);
+      return { index, agent };
+    }),
+  );
+  const pending = new Set(tagged.keys());
+  while (pending.size > 0) {
+    const { index, agent } = await Promise.race(
+      tagged.filter((_, i) => pending.has(i)),
+    );
+    pending.delete(index);
+    yield agent;
+  }
 }

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -10,6 +10,7 @@ import {
   buildAuthDiagnostic,
   buildExecutableDiagnostic,
   buildNotInvocableDiagnostic,
+  type NotInvocableCause,
 } from './diagnostics.js';
 import type {
   AgentDiagnostic,
@@ -67,25 +68,20 @@ async function fetchModels(
 }
 
 type VersionProbeOutcome =
-  | { kind: 'not-invocable' }
+  | { kind: 'not-invocable'; cause: NotInvocableCause }
   | { kind: 'spawned'; version: string | null };
 
 /**
  * Run the agent's `--version` probe and classify the result. The probe
  * has two distinct failure modes the catch arm has to discriminate:
  *
- *   - **Not invocable.** The OS rejected the spawn outright (ENOENT
- *     for a vanished target, EACCES for a stripped-x bit, ENOTDIR
- *     for a broken parent), OR the wrapper script spawned but its
- *     underlying interpreter / target is missing and the shim exits
- *     with code 127 ("command not found") / 126 ("not executable").
- *     127 is the canonical POSIX shell signal for "I ran but the
- *     thing I delegate to is gone"; 126 is the perm/not-a-binary
- *     sibling. Both shapes are reproducible by leftover npm bin
- *     shims, mise/nvm/fnm pointer files, and Windows `.CMD` shims
- *     whose target was uninstalled. We mark the agent unavailable
- *     so Settings does not advertise a ghost entry (issue #658,
- *     lefarcen review P2 on PR #1301).
+ *   - **Not invocable.** The OS rejected the spawn outright, OR the
+ *     wrapper script spawned but its underlying interpreter / target
+ *     failed. We split permission failures (EACCES / exit 126) from
+ *     missing-target failures (ENOENT / ENOTDIR / exit 127) so Settings can
+ *     offer permission-specific copy instead of treating every failure as a
+ *     broken shim. We still mark the agent unavailable so Settings does not
+ *     advertise a ghost entry (issue #658, lefarcen review P2 on PR #1301).
  *
  *   - **Spawned but `--version` was unhappy.** The binary itself ran
  *     (any other rejection: timeout, generic non-zero exit, stderr
@@ -113,11 +109,17 @@ async function probeVersionAtPath(
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
     if (typeof code === 'string') {
-      if (code === 'ENOENT' || code === 'EACCES' || code === 'ENOTDIR') {
-        return { kind: 'not-invocable' };
+      if (code === 'EACCES') {
+        return { kind: 'not-invocable', cause: 'not-executable' };
+      }
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        return { kind: 'not-invocable', cause: 'missing-target' };
       }
     } else if (typeof code === 'number' && (code === 126 || code === 127)) {
-      return { kind: 'not-invocable' };
+      return {
+        kind: 'not-invocable',
+        cause: code === 126 ? 'not-executable' : 'missing-target',
+      };
     }
     return { kind: 'spawned', version: null };
   }
@@ -197,7 +199,9 @@ async function probe(
   );
   const outcome = await probeVersionAtPath(def, launch.launchPath, probeEnv);
   if (outcome.kind === 'not-invocable') {
-    return unavailableAgent(def, [buildNotInvocableDiagnostic(def, launch)]);
+    return unavailableAgent(def, [
+      buildNotInvocableDiagnostic(def, launch, outcome.cause),
+    ]);
   }
   // The version probe must finish first (it gates availability), but the
   // three post-version probes are independent reads — run them concurrently

--- a/apps/daemon/src/runtimes/diagnostics.ts
+++ b/apps/daemon/src/runtimes/diagnostics.ts
@@ -1,0 +1,100 @@
+import { agentBinEnvKey, agentSearchDirs } from './executables.js';
+import type { AgentLaunchResolution } from './launch.js';
+import type { AgentAuthProbeResult } from './auth.js';
+import type { AgentDiagnostic, RuntimeAgentDef } from './types.js';
+import type { AgentFixIntent } from '@open-design/contracts';
+
+// Cap on how many searched dirs we attach to a `not-on-path` diagnostic.
+// The resolver walks PATH + the user-toolchain whitelist, which can run to
+// dozens of entries; the UI only needs enough to make "we looked here" land
+// without ballooning the /api/agents payload.
+const MAX_SEARCHED_DIRS = 24;
+
+function setEnvIntent(agentId: string): AgentFixIntent[] {
+  const envKey = agentBinEnvKey(agentId);
+  return envKey ? [{ kind: 'setEnv', envKey }] : [];
+}
+
+// The agent is not resolvable at all: either nothing matched on PATH, or a
+// user-supplied `*_BIN` override points at a missing/invalid file. The two
+// cases get different copy + fix affordances because the remedy differs
+// (install / point us at the binary vs. fix or clear the override).
+export function buildExecutableDiagnostic(
+  def: Pick<RuntimeAgentDef, 'id' | 'name' | 'bin'>,
+  configuredEnv: Record<string, string> = {},
+): AgentDiagnostic {
+  const envKey = agentBinEnvKey(def.id);
+  const overrideRaw = envKey ? configuredEnv?.[envKey]?.trim() : '';
+  if (envKey && overrideRaw) {
+    return {
+      reason: 'configured-bin-invalid',
+      severity: 'error',
+      message: `${def.name}'s configured binary (${envKey}) was not found or is not executable.`,
+      detail: overrideRaw,
+      fixActions: [
+        { kind: 'setEnv', envKey },
+        { kind: 'clearEnv', envKey },
+        { kind: 'rescan' },
+      ],
+    };
+  }
+  return {
+    reason: 'not-on-path',
+    severity: 'error',
+    message: `${def.name} (\`${def.bin}\`) was not found on your PATH.`,
+    searchedDirs: agentSearchDirs().slice(0, MAX_SEARCHED_DIRS),
+    fixActions: [
+      { kind: 'openInstall' },
+      ...setEnvIntent(def.id),
+      { kind: 'rescan' },
+    ],
+  };
+}
+
+// A file matched but `--version` could not spawn it (exit 126/127, EACCES,
+// ENOENT on the resolved path) — almost always a leftover npm/nvm/mise shim
+// whose underlying target was uninstalled.
+export function buildNotInvocableDiagnostic(
+  def: Pick<RuntimeAgentDef, 'id' | 'name'>,
+  launch: Pick<AgentLaunchResolution, 'selectedPath' | 'launchPath'>,
+): AgentDiagnostic {
+  return {
+    reason: 'shim-broken',
+    severity: 'error',
+    message: `${def.name} was found but could not be launched — its wrapper or shim points at a missing target.`,
+    ...(launch.launchPath ? { detail: launch.launchPath } : {}),
+    fixActions: [...setEnvIntent(def.id), { kind: 'openDocs' }, { kind: 'rescan' }],
+  };
+}
+
+// The agent is installed and invocable but its auth probe reported a
+// missing / unverifiable credential. `launchOAuth` is only offered for
+// adapters whose interactive sign-in the daemon can drive (today antigravity
+// via the system-terminal endpoint); everyone else points at docs.
+export function buildAuthDiagnostic(
+  def: Pick<RuntimeAgentDef, 'id' | 'name'>,
+  auth: AgentAuthProbeResult,
+): AgentDiagnostic | null {
+  if (auth.status === 'ok') return null;
+  const signInIntent: AgentFixIntent =
+    def.id === 'antigravity'
+      ? { kind: 'launchOAuth', agentId: def.id }
+      : { kind: 'openDocs' };
+  if (auth.status === 'missing') {
+    return {
+      reason: 'auth-missing',
+      severity: 'error',
+      message: auth.message || `${def.name} is installed but not authenticated.`,
+      ...(auth.stderrTail ? { detail: auth.stderrTail } : {}),
+      fixActions: [signInIntent, { kind: 'rescan' }],
+    };
+  }
+  return {
+    reason: 'auth-unknown',
+    severity: 'warning',
+    message:
+      auth.message || `${def.name} authentication status could not be verified.`,
+    ...(auth.stderrTail ? { detail: auth.stderrTail } : {}),
+    fixActions: [signInIntent, { kind: 'rescan' }],
+  };
+}

--- a/apps/daemon/src/runtimes/diagnostics.ts
+++ b/apps/daemon/src/runtimes/diagnostics.ts
@@ -81,18 +81,15 @@ export function buildNotInvocableDiagnostic(
 }
 
 // The agent is installed and invocable but its auth probe reported a
-// missing / unverifiable credential. `launchOAuth` is only offered for
-// adapters whose interactive sign-in the daemon can drive (today antigravity
-// via the system-terminal endpoint); everyone else points at docs.
+// missing / unverifiable credential. Detection only reaches this helper for
+// adapters that declare a cheap, side-effect-free authProbe; until an adapter
+// also declares a daemon-safe OAuth producer, diagnostics point at docs.
 export function buildAuthDiagnostic(
   def: Pick<RuntimeAgentDef, 'id' | 'name'>,
   auth: AgentAuthProbeResult,
 ): AgentDiagnostic | null {
   if (auth.status === 'ok') return null;
-  const signInIntent: AgentFixIntent =
-    def.id === 'antigravity'
-      ? { kind: 'launchOAuth', agentId: def.id }
-      : { kind: 'openDocs' };
+  const signInIntent: AgentFixIntent = { kind: 'openDocs' };
   if (auth.status === 'missing') {
     return {
       reason: 'auth-missing',

--- a/apps/daemon/src/runtimes/diagnostics.ts
+++ b/apps/daemon/src/runtimes/diagnostics.ts
@@ -51,13 +51,26 @@ export function buildExecutableDiagnostic(
   };
 }
 
-// A file matched but `--version` could not spawn it (exit 126/127, EACCES,
-// ENOENT on the resolved path) — almost always a leftover npm/nvm/mise shim
-// whose underlying target was uninstalled.
+export type NotInvocableCause = 'not-executable' | 'missing-target';
+
+// A file matched but `--version` could not spawn it. Permission failures are
+// real binaries that need their executable bit restored; missing-target
+// failures are usually leftover npm/nvm/mise shims whose underlying target was
+// uninstalled.
 export function buildNotInvocableDiagnostic(
   def: Pick<RuntimeAgentDef, 'id' | 'name'>,
   launch: Pick<AgentLaunchResolution, 'selectedPath' | 'launchPath'>,
+  cause: NotInvocableCause,
 ): AgentDiagnostic {
+  if (cause === 'not-executable') {
+    return {
+      reason: 'not-executable',
+      severity: 'error',
+      message: `${def.name} was found but is not executable. Restore its execute permission or choose a different binary, then rescan.`,
+      ...(launch.launchPath ? { detail: launch.launchPath } : {}),
+      fixActions: [...setEnvIntent(def.id), { kind: 'rescan' }],
+    };
+  }
   return {
     reason: 'shim-broken',
     severity: 'error',

--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -90,6 +90,22 @@ function resolvePathDirs() {
   });
 }
 
+// The exact, de-duplicated directory list `resolveOnPath` walks. Surfaced so
+// detection can attach it to a `not-on-path` diagnostic verbatim — the UI
+// shows the user where we actually looked before asking them to set an
+// explicit binary path, instead of recomputing PATH client-side.
+export function agentSearchDirs(): string[] {
+  return resolvePathDirs();
+}
+
+// The `*_BIN` environment variable that overrides PATH detection for a given
+// agent id (e.g. `cursor-agent` → `CURSOR_AGENT_BIN`), or null when the agent
+// has no override key. Drives the `setEnv` / `clearEnv` fix intents.
+export function agentBinEnvKey(agentId: string | undefined): string | null {
+  if (!agentId) return null;
+  return AGENT_BIN_ENV_KEYS.get(agentId) ?? null;
+}
+
 export function resolveOnPath(bin: string): string | null {
   const exts =
     process.platform === 'win32'

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -1,4 +1,7 @@
 import type { ExecFileOptions } from 'node:child_process';
+import type { AgentDiagnostic } from '@open-design/contracts';
+
+export type { AgentDiagnostic } from '@open-design/contracts';
 
 export type RuntimeEnv = NodeJS.ProcessEnv | Record<string, string>;
 
@@ -162,6 +165,18 @@ export type RuntimeAgentDef = {
   // present in the daemon's `process.env`; Settings-UI per-agent env
   // values only reach the spawned child and are NOT consulted here.
   defaultModelEnvVar?: string;
+  // Declarative authentication probe. When set, detection spawns
+  // `<bin> <args>` after the version check and classifies the combined
+  // stdout/stderr to derive `authStatus`. This replaces the previous
+  // hardcoded "only cursor-agent gets an auth probe" gate: an adapter
+  // opts in by declaring a cheap, side-effect-free status/whoami command
+  // (e.g. cursor-agent `status`). Adapters WITHOUT this field are never
+  // actively probed for auth — their auth status is only inferred later
+  // from a real chat failure's error text (see classifyAgentServiceFailure).
+  authProbe?: {
+    args: string[];
+    timeoutMs?: number;
+  };
 };
 
 export type DetectedAgent = Omit<
@@ -176,6 +191,7 @@ export type DetectedAgent = Omit<
   | 'versionProbeTimeoutMs'
   | 'maxPromptArgBytes'
   | 'env'
+  | 'authProbe'
 > & {
   models: RuntimeModelOption[];
   modelsSource: RuntimeModelSource;
@@ -184,6 +200,7 @@ export type DetectedAgent = Omit<
   authMessage?: string;
   path?: string;
   version?: string | null;
+  diagnostics?: AgentDiagnostic[];
 };
 
 export type RuntimeExecOptions = ExecFileOptions & {

--- a/apps/daemon/src/static-resource-routes.ts
+++ b/apps/daemon/src/static-resource-routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from 'express';
 import path from 'node:path';
 import fs from 'node:fs';
-import { detectAgents } from './agents.js';
+import { detectAgents, detectAgentsStream } from './agents.js';
 import {
   SkillImportError,
   deleteUserSkill,
@@ -56,13 +56,56 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
     return false;
   };
 
-  app.get('/api/agents', async (_req, res) => {
+  app.get('/api/agents', async (req, res) => {
+    const wantsStream =
+      req.query.stream === '1' || req.query.stream === 'true';
+    let config;
     try {
-      const config = await readAppConfig(RUNTIME_DATA_DIR);
-      const list = await detectAgents(config.agentCliEnv ?? {});
-      res.json({ agents: list });
+      config = await readAppConfig(RUNTIME_DATA_DIR);
     } catch (err: any) {
       res.status(500).json({ error: String(err) });
+      return;
+    }
+    const agentCliEnv = config.agentCliEnv ?? {};
+
+    if (!wantsStream) {
+      try {
+        const list = await detectAgents(agentCliEnv);
+        res.json({ agents: list });
+      } catch (err: any) {
+        res.status(500).json({ error: String(err) });
+      }
+      return;
+    }
+
+    // Server-Sent Events: emit each agent as its probe settles so the client
+    // can paint cards incrementally instead of waiting for the slowest CLI.
+    // Each `agent` event carries one AgentInfo; a terminal `done` event lets
+    // the client distinguish "stream finished" from a dropped connection.
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+    let aborted = false;
+    req.on('close', () => {
+      aborted = true;
+    });
+    try {
+      for await (const agent of detectAgentsStream(agentCliEnv)) {
+        if (aborted) break;
+        res.write(`event: agent\ndata: ${JSON.stringify(agent)}\n\n`);
+      }
+      if (!aborted) {
+        res.write('event: done\ndata: {}\n\n');
+      }
+    } catch (err: any) {
+      if (!aborted) {
+        res.write(`event: error\ndata: ${JSON.stringify({ error: String(err) })}\n\n`);
+      }
+    } finally {
+      res.end();
     }
   });
 

--- a/apps/daemon/tests/runtimes/detection-diagnostics.test.ts
+++ b/apps/daemon/tests/runtimes/detection-diagnostics.test.ts
@@ -1,0 +1,114 @@
+import { test } from 'vitest';
+import {
+  assert,
+  chmodSync,
+  detectAgents,
+  join,
+  mkdtempSync,
+  rmSync,
+  tmpdir,
+  withEnvSnapshot,
+  writeFileSync,
+} from './helpers/test-helpers.js';
+import { detectAgentsStream } from '../../src/runtimes/detection.js';
+
+const posixTest = process.platform === 'win32' ? test.skip : test;
+
+function writeCursorAgent(dir: string, statusOutput: string): void {
+  const bin = join(dir, 'cursor-agent');
+  writeFileSync(
+    bin,
+    `#!/bin/sh\n` +
+      `if [ "$1" = "--version" ]; then echo "2026.05.07-test"; exit 0; fi\n` +
+      `if [ "$1" = "models" ]; then echo "auto"; exit 0; fi\n` +
+      `if [ "$1" = "status" ]; then echo "${statusOutput}"; exit 0; fi\n` +
+      `exit 0\n`,
+  );
+  chmodSync(bin, 0o755);
+}
+
+posixTest('detectAgents emits a not-on-path diagnostic with searched dirs + fix intents', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-diag-notpath-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      // Only cursor-agent is on PATH; everything else is unavailable.
+      writeCursorAgent(dir, 'Authenticated');
+      process.env.PATH = dir;
+      process.env.OD_AGENT_HOME = dir;
+
+      const agents = await detectAgents();
+      const gemini = agents.find((agent) => agent.id === 'gemini');
+
+      assert.equal(gemini?.available, false);
+      const diagnostic = gemini?.diagnostics?.[0];
+      assert.ok(diagnostic, 'expected a diagnostic on the unavailable agent');
+      assert.equal(diagnostic?.reason, 'not-on-path');
+      assert.equal(diagnostic?.severity, 'error');
+      assert.ok(
+        (diagnostic?.searchedDirs ?? []).length > 0,
+        'expected searchedDirs to be populated',
+      );
+      const intents = (diagnostic?.fixActions ?? []).map((a) => a.kind);
+      assert.ok(intents.includes('openInstall'), 'expected openInstall fix intent');
+      assert.ok(intents.includes('rescan'), 'expected rescan fix intent');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+posixTest('detectAgents emits an auth-missing diagnostic when the auth probe reports not authenticated', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-diag-auth-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      writeCursorAgent(dir, 'Not authenticated');
+      process.env.PATH = dir;
+      process.env.OD_AGENT_HOME = dir;
+
+      const agents = await detectAgents();
+      const cursor = agents.find((agent) => agent.id === 'cursor-agent');
+
+      assert.equal(cursor?.available, true);
+      assert.equal(cursor?.authStatus, 'missing');
+      const diagnostic = cursor?.diagnostics?.[0];
+      assert.ok(diagnostic, 'expected an auth diagnostic');
+      assert.equal(diagnostic?.reason, 'auth-missing');
+      const intents = (diagnostic?.fixActions ?? []).map((a) => a.kind);
+      // cursor-agent has no daemon-driven OAuth, so it points at docs + rescan.
+      assert.ok(intents.includes('openDocs'), 'expected openDocs fix intent');
+      assert.ok(intents.includes('rescan'), 'expected rescan fix intent');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+posixTest('detectAgentsStream yields the same agent set as detectAgents', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-diag-stream-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      writeCursorAgent(dir, 'Authenticated');
+      process.env.PATH = dir;
+      process.env.OD_AGENT_HOME = dir;
+
+      const batch = await detectAgents();
+      const streamed: string[] = [];
+      for await (const agent of detectAgentsStream()) {
+        streamed.push(agent.id);
+      }
+
+      assert.equal(
+        streamed.length,
+        batch.length,
+        'stream should yield one event per agent',
+      );
+      assert.deepEqual(
+        [...streamed].sort(),
+        batch.map((agent) => agent.id).sort(),
+        'stream should cover exactly the same agent ids',
+      );
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/apps/daemon/tests/runtimes/detection-diagnostics.test.ts
+++ b/apps/daemon/tests/runtimes/detection-diagnostics.test.ts
@@ -11,6 +11,7 @@ import {
   writeFileSync,
 } from './helpers/test-helpers.js';
 import { detectAgentsStream } from '../../src/runtimes/detection.js';
+import { buildAuthDiagnostic } from '../../src/runtimes/diagnostics.js';
 
 const posixTest = process.platform === 'win32' ? test.skip : test;
 
@@ -124,6 +125,19 @@ posixTest('detectAgents emits an auth-missing diagnostic when the auth probe rep
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test('auth diagnostics do not offer daemon OAuth without an active producer', () => {
+  const diagnostic = buildAuthDiagnostic(
+    { id: 'antigravity', name: 'Antigravity' },
+    {
+      status: 'missing',
+      message: 'Antigravity is installed but not authenticated.',
+    },
+  );
+
+  const intents = (diagnostic?.fixActions ?? []).map((a) => a.kind);
+  assert.deepEqual(intents, ['openDocs', 'rescan']);
 });
 
 posixTest('detectAgentsStream yields the same agent set as detectAgents', async () => {

--- a/apps/daemon/tests/runtimes/detection-diagnostics.test.ts
+++ b/apps/daemon/tests/runtimes/detection-diagnostics.test.ts
@@ -27,6 +27,18 @@ function writeCursorAgent(dir: string, statusOutput: string): void {
   chmodSync(bin, 0o755);
 }
 
+function writeNonExecutableCursorAgent(dir: string): string {
+  const bin = join(dir, 'cursor-agent');
+  writeFileSync(
+    bin,
+    `#!/bin/sh\n` +
+      `if [ "$1" = "--version" ]; then echo "2026.05.07-test"; exit 0; fi\n` +
+      `exit 0\n`,
+  );
+  chmodSync(bin, 0o644);
+  return bin;
+}
+
 posixTest('detectAgents emits a not-on-path diagnostic with searched dirs + fix intents', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-diag-notpath-'));
   try {
@@ -51,6 +63,37 @@ posixTest('detectAgents emits a not-on-path diagnostic with searched dirs + fix 
       const intents = (diagnostic?.fixActions ?? []).map((a) => a.kind);
       assert.ok(intents.includes('openInstall'), 'expected openInstall fix intent');
       assert.ok(intents.includes('rescan'), 'expected rescan fix intent');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+posixTest('detectAgents emits a not-executable diagnostic for a PATH match without execute permission', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-diag-notexec-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      const bin = writeNonExecutableCursorAgent(dir);
+      process.env.PATH = dir;
+      process.env.OD_AGENT_HOME = dir;
+
+      const agents = await detectAgents();
+      const cursor = agents.find((agent) => agent.id === 'cursor-agent');
+
+      assert.equal(cursor?.available, false);
+      const diagnostic = cursor?.diagnostics?.[0];
+      assert.ok(diagnostic, 'expected a diagnostic on the unavailable agent');
+      assert.equal(diagnostic?.reason, 'not-executable');
+      assert.equal(diagnostic?.severity, 'error');
+      assert.equal(diagnostic?.detail, bin);
+      assert.match(diagnostic?.message ?? '', /not executable/i);
+      const intents = (diagnostic?.fixActions ?? []).map((a) => a.kind);
+      assert.ok(intents.includes('rescan'), 'expected rescan fix intent');
+      assert.equal(
+        intents.includes('openDocs'),
+        false,
+        'permission diagnostics should not use shim repair advice',
+      );
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -43,7 +43,7 @@ import { PrivacyConsentModal } from './components/PrivacyConsentModal';
 import {
   daemonIsLive,
   fetchAppVersionInfo,
-  fetchAgents,
+  fetchAgentsStream,
   fetchDesignSystems,
   fetchDesignTemplates,
   fetchPromptTemplates,
@@ -212,6 +212,68 @@ function mergeAmrModelsIntoAgents(
   });
 }
 
+const CANONICAL_AGENT_ORDER = [
+  'amr',
+  'claude',
+  'codex',
+  'devin',
+  'gemini',
+  'opencode',
+  'hermes',
+  'trae-cli',
+  'grok-build',
+  'kimi',
+  'cursor-agent',
+  'qwen',
+  'qoder',
+  'copilot',
+  'pi',
+  'kiro',
+  'kilo',
+  'vibe',
+  'deepseek',
+  'aider',
+  'antigravity',
+  'reasonix',
+] as const;
+
+const CANONICAL_AGENT_ORDER_INDEX = new Map<string, number>(
+  CANONICAL_AGENT_ORDER.map((id, index) => [id, index]),
+);
+
+function orderAgentsByRegistry(agents: AgentInfo[]): AgentInfo[] {
+  return agents
+    .map((agent, index) => ({ agent, index }))
+    .sort((left, right) => {
+      const leftRank =
+        CANONICAL_AGENT_ORDER_INDEX.get(left.agent.id) ??
+        CANONICAL_AGENT_ORDER.length;
+      const rightRank =
+        CANONICAL_AGENT_ORDER_INDEX.get(right.agent.id) ??
+        CANONICAL_AGENT_ORDER.length;
+      if (leftRank !== rightRank) return leftRank - rightRank;
+      return left.index - right.index;
+    })
+    .map(({ agent }) => agent);
+}
+
+function upsertAgent(agents: AgentInfo[], agent: AgentInfo): AgentInfo[] {
+  const index = agents.findIndex((item) => item.id === agent.id);
+  if (index === -1) return [...agents, agent];
+  const next = agents.slice();
+  next[index] = agent;
+  return next;
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'name' in err &&
+    (err as { name?: unknown }).name === 'AbortError'
+  );
+}
+
 export function App() {
   return (
     <IframeKeepAliveProvider>
@@ -249,6 +311,7 @@ function AppInner() {
   const [daemonLive, setDaemonLive] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const amrModelsRef = useRef<AmrModelsResponse | null>(null);
+  const agentStreamRequestSeqRef = useRef(0);
   const [amrPollRestartToken, setAmrPollRestartToken] = useState(0);
   const [providerModelsCache, setProviderModelsCache] = useState<
     Record<string, ProviderModelOption[]>
@@ -312,6 +375,15 @@ function AppInner() {
   const [composioConfigLoading, setComposioConfigLoading] = useState(true);
   const route = useRoute();
   const analytics = useAnalytics();
+
+  const beginAgentStreamRequest = useCallback(() => {
+    agentStreamRequestSeqRef.current += 1;
+    return agentStreamRequestSeqRef.current;
+  }, []);
+
+  const isCurrentAgentStreamRequest = useCallback((requestId: number) => {
+    return agentStreamRequestSeqRef.current === requestId;
+  }, []);
 
   // v2 schema removed the standalone `app_launch` event; the initial
   // page_view fires from each top-level page surface (home / projects /
@@ -442,7 +514,7 @@ function AppInner() {
   // changes; the next capture inherits the fresh values, so dashboards
   // can segment by execution setup without per-helper boilerplate.
   //
-  // Gated on `agentsLoading` so the cold-start probe (`fetchAgents()`
+  // Gated on `agentsLoading` so the cold-start probe (`fetchAgentsStream()`
   // lands asynchronously after this effect's first run) does not stamp
   // the first home/projects/plugins page_view with
   // has_available_configure_cli=false / configure_availability=unavailable
@@ -566,6 +638,7 @@ function AppInner() {
   // gate every tab including the ones that don't need agents at all.
   useEffect(() => {
     let cancelled = false;
+    const agentStreamAbort = new AbortController();
     (async () => {
       const alive = await daemonIsLive();
       if (cancelled) return;
@@ -586,11 +659,42 @@ function AppInner() {
         return;
       }
 
-      void fetchAgents().then((list) => {
-        if (cancelled) return;
-        setAgents(mergeAmrModelsIntoAgents(list, amrModelsRef.current));
-        setAgentsLoading(false);
-      });
+      const agentRequestId = beginAgentStreamRequest();
+      void fetchAgentsStream({
+        signal: agentStreamAbort.signal,
+        onAgent: (agent) => {
+          if (cancelled || !isCurrentAgentStreamRequest(agentRequestId)) return;
+          setAgents((current) =>
+            mergeAmrModelsIntoAgents(
+              upsertAgent(current, agent),
+              amrModelsRef.current,
+            ),
+          );
+        },
+      })
+        .then((list) => {
+          if (cancelled || !isCurrentAgentStreamRequest(agentRequestId)) return;
+          setAgents(
+            mergeAmrModelsIntoAgents(
+              orderAgentsByRegistry(list),
+              amrModelsRef.current,
+            ),
+          );
+        })
+        .catch((err) => {
+          if (
+            cancelled ||
+            isAbortError(err) ||
+            !isCurrentAgentStreamRequest(agentRequestId)
+          ) {
+            return;
+          }
+          setAgents([]);
+        })
+        .finally(() => {
+          if (cancelled) return;
+          setAgentsLoading(false);
+        });
 
       // Functional skills + design templates land independently. Both
       // gate `skillsLoading` together so the EntryView stops rendering
@@ -727,8 +831,14 @@ function AppInner() {
     })();
     return () => {
       cancelled = true;
+      agentStreamAbort.abort();
     };
-  }, [beginProjectListRequest, reconcileFetchedProjects]);
+  }, [
+    beginAgentStreamRequest,
+    beginProjectListRequest,
+    isCurrentAgentStreamRequest,
+    reconcileFetchedProjects,
+  ]);
 
   // Auto-pick the first available agent once both the daemon-stored config
   // and the agents listing have landed. Splitting this out of bootstrap
@@ -995,11 +1105,34 @@ function AppInner() {
         await syncConfigToDaemon(nextConfig);
         setConfig(nextConfig);
       }
-      const next = await fetchAgents({ throwOnError: options?.throwOnError });
-      setAgents(mergeAmrModelsIntoAgents(next, amrModelsRef.current));
-      return next;
+      const agentRequestId = beginAgentStreamRequest();
+      try {
+        const next = await fetchAgentsStream({
+          onAgent: (agent) => {
+            if (!isCurrentAgentStreamRequest(agentRequestId)) return;
+            setAgents((current) =>
+              mergeAmrModelsIntoAgents(
+                upsertAgent(current, agent),
+                amrModelsRef.current,
+              ),
+            );
+          },
+        });
+        const ordered = orderAgentsByRegistry(next);
+        if (isCurrentAgentStreamRequest(agentRequestId)) {
+          setAgents(mergeAmrModelsIntoAgents(ordered, amrModelsRef.current));
+          setAgentsLoading(false);
+        }
+        return ordered;
+      } catch (err) {
+        if (!isCurrentAgentStreamRequest(agentRequestId)) return [];
+        setAgentsLoading(false);
+        if (options?.throwOnError) throw err;
+        setAgents([]);
+        return [];
+      }
     },
-    [config],
+    [beginAgentStreamRequest, config, isCurrentAgentStreamRequest],
   );
 
   const handleCreateProject = useCallback(

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -692,7 +692,7 @@ function AppInner() {
           setAgents([]);
         })
         .finally(() => {
-          if (cancelled) return;
+          if (cancelled || !isCurrentAgentStreamRequest(agentRequestId)) return;
           setAgentsLoading(false);
         });
 
@@ -1106,6 +1106,7 @@ function AppInner() {
         setConfig(nextConfig);
       }
       const agentRequestId = beginAgentStreamRequest();
+      setAgentsLoading(true);
       try {
         const next = await fetchAgentsStream({
           onAgent: (agent) => {

--- a/apps/web/src/components/AgentDiagnosticRow.module.css
+++ b/apps/web/src/components/AgentDiagnosticRow.module.css
@@ -1,0 +1,80 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  margin-top: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-subtle, var(--bg-panel));
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+/* Severity is a quiet hint, not an alarm: a "not installed yet" agent in the
+   install list should read as informational, so we only nudge the left border
+   tone instead of painting the whole row. */
+.error {
+  border-left-color: color-mix(in srgb, var(--danger, #d9534f) 40%, var(--border));
+}
+
+.warning {
+  border-left-color: color-mix(in srgb, var(--warning, #d9a441) 40%, var(--border));
+}
+
+.info {
+  border-left-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+}
+
+.message {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--text-muted, var(--text));
+}
+
+/* Actions sit at the bottom-right of the info box: the message owns the top,
+   the fix icon(s) tuck into the corner so they never crowd the reason text. */
+.actions {
+  display: inline-flex;
+  align-self: flex-end;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* Quiet, neutral icon button — no accent/danger fill, so a "not installed yet"
+   row never looks like a destructive or alarming control. */
+.action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  color: var(--text);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-strong, var(--border));
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    background 140ms cubic-bezier(0.23, 1, 0.32, 1),
+    border-color 140ms cubic-bezier(0.23, 1, 0.32, 1),
+    color 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.action:hover {
+  color: var(--text);
+  background: var(--bg-hover, var(--bg-subtle));
+  border-color: var(--accent);
+}
+
+/* The glyph must not be flex-shrunk: inside the centered inline-flex button its
+   width otherwise collapses to 0 and the icon disappears even though it's drawn
+   in the text color. */
+.action svg {
+  flex: 0 0 auto;
+}
+
+.action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}

--- a/apps/web/src/components/AgentDiagnosticRow.tsx
+++ b/apps/web/src/components/AgentDiagnosticRow.tsx
@@ -1,0 +1,140 @@
+import { useT } from '../i18n';
+import type { AgentDiagnostic, AgentFixIntent } from '../types';
+import { Icon } from './Icon';
+import type { IconName } from './Icon';
+import styles from './AgentDiagnosticRow.module.css';
+
+// Handlers the host wires per fix intent. Each is optional: a button is only
+// rendered when both the diagnostic carries the intent AND the host provides
+// a handler for it, so the same row works in the Settings grid, the
+// connection-test failure surface, and (PR-B) the health-check panel without
+// any of them having to know which intents the others support.
+export interface AgentFixHandlers {
+  onRescan?: () => void;
+  onOpenInstall?: () => void;
+  onOpenDocs?: () => void;
+  onSetEnv?: (envKey: string) => void;
+  onClearEnv?: (envKey: string) => void;
+  onLaunchOAuth?: (agentId: string) => void;
+}
+
+interface Props {
+  diagnostic: AgentDiagnostic;
+  handlers?: AgentFixHandlers;
+  className?: string;
+}
+
+type ResolvedAction = {
+  key: string;
+  label: string;
+  icon: IconName;
+  onClick: () => void;
+};
+
+// Map one typed fix intent to a concrete icon button, reusing translation keys
+// that already exist so this component adds no new locale strings. The label
+// is surfaced as a tooltip + accessible name; the glyph keeps the action quiet
+// so it never competes with the diagnostic message. Intents without a wired
+// handler (or, for setEnv/clearEnv, without dedicated UI yet) resolve to null
+// and simply aren't rendered — the diagnostic message still names the env var
+// so the user isn't left without guidance.
+function useResolveAction() {
+  const t = useT();
+  return (intent: AgentFixIntent, handlers: AgentFixHandlers): ResolvedAction | null => {
+    switch (intent.kind) {
+      case 'openInstall':
+        return handlers.onOpenInstall
+          ? {
+              key: 'openInstall',
+              label: t('settings.agentInstall.install'),
+              icon: 'download',
+              onClick: handlers.onOpenInstall,
+            }
+          : null;
+      case 'openDocs':
+        return handlers.onOpenDocs
+          ? {
+              key: 'openDocs',
+              label: t('settings.agentInstall.docs'),
+              icon: 'file',
+              onClick: handlers.onOpenDocs,
+            }
+          : null;
+      case 'rescan':
+        return handlers.onRescan
+          ? {
+              key: 'rescan',
+              label: t('settings.rescan'),
+              icon: 'reload',
+              onClick: handlers.onRescan,
+            }
+          : null;
+      case 'launchOAuth':
+        return handlers.onLaunchOAuth
+          ? {
+              key: 'launchOAuth',
+              label: t('chat.antigravityError.launchTerminalCta'),
+              icon: 'external-link',
+              onClick: () => handlers.onLaunchOAuth?.(intent.agentId),
+            }
+          : null;
+      // setEnv / clearEnv carry a typed envKey and are part of the contract,
+      // but their input-driven UI ships in a follow-up; render nothing here.
+      case 'setEnv':
+      case 'clearEnv':
+        return null;
+      default:
+        return null;
+    }
+  };
+}
+
+// Presents a single agent diagnostic as "one-line reason + fix button(s)".
+// The reason text is the daemon-authored message (already English, like the
+// existing auth banner), and tooltips expose the probe detail + the exact
+// directories PATH detection searched.
+export function AgentDiagnosticRow({ diagnostic, handlers = {}, className }: Props) {
+  const resolveAction = useResolveAction();
+  const actions = (diagnostic.fixActions ?? [])
+    .map((intent) => resolveAction(intent, handlers))
+    .filter((action): action is ResolvedAction => action !== null);
+
+  const tooltip = [
+    diagnostic.detail,
+    ...(diagnostic.searchedDirs && diagnostic.searchedDirs.length > 0
+      ? diagnostic.searchedDirs
+      : []),
+  ]
+    .filter((line): line is string => typeof line === 'string' && line.length > 0)
+    .join('\n');
+
+  return (
+    <div
+      className={[styles.root, styles[diagnostic.severity], className]
+        .filter(Boolean)
+        .join(' ')}
+      role="group"
+      data-reason={diagnostic.reason}
+    >
+      <span className={styles.message} title={tooltip || undefined}>
+        {diagnostic.message}
+      </span>
+      {actions.length > 0 ? (
+        <div className={styles.actions}>
+          {actions.map((action) => (
+            <button
+              key={action.key}
+              type="button"
+              className={styles.action}
+              onClick={action.onClick}
+              title={action.label}
+              aria-label={action.label}
+            >
+              <Icon name={action.icon} size={15} strokeWidth={1.9} />
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/AgentDiagnosticRow.tsx
+++ b/apps/web/src/components/AgentDiagnosticRow.tsx
@@ -15,7 +15,6 @@ export interface AgentFixHandlers {
   onOpenDocs?: () => void;
   onSetEnv?: (envKey: string) => void;
   onClearEnv?: (envKey: string) => void;
-  onLaunchOAuth?: (agentId: string) => void;
 }
 
 interface Props {
@@ -69,19 +68,13 @@ function useResolveAction() {
               onClick: handlers.onRescan,
             }
           : null;
-      case 'launchOAuth':
-        return handlers.onLaunchOAuth
-          ? {
-              key: 'launchOAuth',
-              label: t('chat.antigravityError.launchTerminalCta'),
-              icon: 'external-link',
-              onClick: () => handlers.onLaunchOAuth?.(intent.agentId),
-            }
-          : null;
       // setEnv / clearEnv carry a typed envKey and are part of the contract,
-      // but their input-driven UI ships in a follow-up; render nothing here.
+      // but their input-driven UI ships in a follow-up. launchOAuth is also
+      // reserved for a future daemon-side auth producer; the chat auth banner
+      // keeps its separate Antigravity terminal action.
       case 'setEnv':
       case 'clearEnv':
+      case 'launchOAuth':
         return null;
       default:
         return null;

--- a/apps/web/src/components/MemoryModelInline.tsx
+++ b/apps/web/src/components/MemoryModelInline.tsx
@@ -441,8 +441,9 @@ export function MemoryModelInline({
         aria-labelledby={labelId}
         className="inline-switcher__select settings-model-select settings-model-select--byok"
         searchPlaceholder={t('designs.searchPlaceholder')}
+        searchInputTestId="memory-model-inline-search"
+        popoverTestId="memory-model-inline-popover"
         popoverClassName="settings-byok-select-popover"
-        minSearchableOptions={Number.POSITIVE_INFINITY}
         models={selectOptions}
         value={selectValue}
         disabled={busy}

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -29,9 +29,11 @@ import { LOCALE_LABEL, LOCALES, useI18n } from '../i18n';
 import type { Locale } from '../i18n';
 import type { Dict } from '../i18n/types';
 import { AgentIcon } from './AgentIcon';
+import { AgentDiagnosticRow } from './AgentDiagnosticRow';
 import { AmrLoginPill } from './AmrLoginPill';
 import {
   fetchVelaLoginStatus,
+  launchAntigravityOauth,
   type VelaLoginStatus,
 } from '../providers/daemon';
 import { ExportDiagnosticsRow } from './ExportDiagnosticsButton';
@@ -94,6 +96,7 @@ import {
   fetchConnectors,
   fetchDesignTemplates,
   fetchLatestGithubReleaseInfo,
+  openExternalUrl,
 } from '../providers/registry';
 import { IMAGE_MODELS, MEDIA_PROVIDERS } from '../media/models';
 import { XaiOAuthControl } from './XaiOAuthControl';
@@ -1329,6 +1332,32 @@ export function SettingsDialog({
     } finally {
       setAgentRescanRunning(false);
     }
+  };
+  const openAgentFixUrl = (url: string | undefined) => {
+    const href = sanitizeHttpsUrl(url);
+    if (!href) return;
+    markAgentInstallIntent();
+    void openExternalUrl(href);
+  };
+  const handleLaunchAgentOAuth = (agentId: string) => {
+    if (agentId !== 'antigravity') return;
+    pendingAgentInstallRescanRef.current = true;
+    void launchAntigravityOauth().then((result) => {
+      if (result.ok) return;
+      console.warn('[agent-diagnostic] oauth launch failed:', result.error);
+    });
+  };
+  const diagnosticHandlersForAgent = (agent: AgentInfo) => {
+    const docsUrl = sanitizeHttpsUrl(agent.docsUrl);
+    const installUrl = sanitizeHttpsUrl(agent.installUrl);
+    return {
+      onRescan: () => void handleRefreshAgents(),
+      ...(docsUrl ? { onOpenDocs: () => openAgentFixUrl(docsUrl) } : {}),
+      ...(installUrl ? { onOpenInstall: () => openAgentFixUrl(installUrl) } : {}),
+      ...(agent.id === 'antigravity'
+        ? { onLaunchOAuth: (agentId: string) => handleLaunchAgentOAuth(agentId) }
+        : {}),
+    };
   };
   useEffect(() => {
     const handleReturnToSettings = () => {
@@ -3202,6 +3231,7 @@ export function SettingsDialog({
                           const isAmrAgent = a.id === 'amr';
                           const description = AGENT_SHORT_DESCRIPTIONS[a.id];
                           const agentName = displayAgentName(a);
+                          const diagnosticHandlers = diagnosticHandlersForAgent(a);
                           const modelSummary = agentModelSummary(a);
                           const amrBenefits = [
                             t('settings.amrBenefitOfficial'),
@@ -3408,6 +3438,13 @@ export function SettingsDialog({
                                   </button>
                                 ) : null}
                               </div>
+                              {(a.diagnostics ?? []).map((diagnostic, i) => (
+                                <AgentDiagnosticRow
+                                  key={`${diagnostic.reason}-${i}`}
+                                  diagnostic={diagnostic}
+                                  handlers={diagnosticHandlers}
+                                />
+                              ))}
                               {active ? renderAgentModelConfig(a) : null}
                             </div>
                           );
@@ -3527,6 +3564,7 @@ export function SettingsDialog({
                           const hasLinks = Boolean(installUrl || docsUrl);
                           const description = AGENT_SHORT_DESCRIPTIONS[a.id];
                           const agentName = displayAgentName(a);
+                          const diagnosticHandlers = diagnosticHandlersForAgent(a);
                           const cardLabel = `${agentName} · ${t('common.notInstalled')}`;
                           return (
                             <div
@@ -3535,41 +3573,60 @@ export function SettingsDialog({
                               role="group"
                               aria-label={cardLabel}
                             >
-                              <AgentIcon id={a.id} size={40} />
-                              <div className="agent-card-body">
-                                <div className="agent-card-name">{agentName}</div>
-                                {description ? (
-                                  <div className="agent-card-description">
-                                    {description}
+                              <div className="agent-card-unavailable-row">
+                                <AgentIcon id={a.id} size={30} />
+                                <div className="agent-card-body">
+                                  <div className="agent-card-name">
+                                    {agentName}
+                                  </div>
+                                  {description ? (
+                                    <div className="agent-card-description">
+                                      {description}
+                                    </div>
+                                  ) : null}
+                                </div>
+                                {hasLinks ? (
+                                  <div className="agent-card-actions agent-card-actions--inline">
+                                    {docsUrl ? (
+                                      <a
+                                        href={docsUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="agent-card-link agent-card-link--muted agent-card-link--icon"
+                                        onClick={markAgentInstallIntent}
+                                        title={t('settings.agentInstall.docs')}
+                                        aria-label={t('settings.agentInstall.docs')}
+                                      >
+                                        <Icon name="file" size={15} />
+                                      </a>
+                                    ) : null}
+                                    {installUrl ? (
+                                      <a
+                                        href={installUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="agent-card-link agent-card-link--ghost"
+                                        onClick={markAgentInstallIntent}
+                                      >
+                                        {t('settings.agentInstall.install')}
+                                      </a>
+                                    ) : null}
                                   </div>
                                 ) : null}
                               </div>
-                              {hasLinks ? (
-                                <div className="agent-card-actions agent-card-actions--inline">
-                                  {docsUrl ? (
-                                    <a
-                                      href={docsUrl}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="agent-card-link agent-card-link--muted"
-                                      onClick={markAgentInstallIntent}
-                                    >
-                                      {t('settings.agentInstall.docs')}
-                                    </a>
-                                  ) : null}
-                                  {installUrl ? (
-                                    <a
-                                      href={installUrl}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="agent-card-link agent-card-link--ghost"
-                                      onClick={markAgentInstallIntent}
-                                    >
-                                      {t('settings.agentInstall.install')}
-                                    </a>
-                                  ) : null}
-                                </div>
-                              ) : null}
+                              {/* Why is it unavailable? not-on-path vs a broken
+                                  shim vs a bad *_BIN override each get a
+                                  distinct, actionable line. It spans the full
+                                  card width on its own row below the
+                                  logo/name/links so it never crowds the inline
+                                  Docs/Install actions. */}
+                              {(a.diagnostics ?? []).map((diagnostic, i) => (
+                                <AgentDiagnosticRow
+                                  key={`${diagnostic.reason}-${i}`}
+                                  diagnostic={diagnostic}
+                                  handlers={diagnosticHandlers}
+                                />
+                              ))}
                             </div>
                           );
                         })}

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -33,7 +33,6 @@ import { AgentDiagnosticRow } from './AgentDiagnosticRow';
 import { AmrLoginPill } from './AmrLoginPill';
 import {
   fetchVelaLoginStatus,
-  launchAntigravityOauth,
   type VelaLoginStatus,
 } from '../providers/daemon';
 import { ExportDiagnosticsRow } from './ExportDiagnosticsButton';
@@ -1339,14 +1338,6 @@ export function SettingsDialog({
     markAgentInstallIntent();
     void openExternalUrl(href);
   };
-  const handleLaunchAgentOAuth = (agentId: string) => {
-    if (agentId !== 'antigravity') return;
-    pendingAgentInstallRescanRef.current = true;
-    void launchAntigravityOauth().then((result) => {
-      if (result.ok) return;
-      console.warn('[agent-diagnostic] oauth launch failed:', result.error);
-    });
-  };
   const diagnosticHandlersForAgent = (agent: AgentInfo) => {
     const docsUrl = sanitizeHttpsUrl(agent.docsUrl);
     const installUrl = sanitizeHttpsUrl(agent.installUrl);
@@ -1354,9 +1345,6 @@ export function SettingsDialog({
       onRescan: () => void handleRefreshAgents(),
       ...(docsUrl ? { onOpenDocs: () => openAgentFixUrl(docsUrl) } : {}),
       ...(installUrl ? { onOpenInstall: () => openAgentFixUrl(installUrl) } : {}),
-      ...(agent.id === 'antigravity'
-        ? { onLaunchOAuth: (agentId: string) => handleLaunchAgentOAuth(agentId) }
-        : {}),
     };
   };
   useEffect(() => {

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -100,6 +100,104 @@ export async function fetchAgents(options?: { throwOnError?: boolean }): Promise
   }
 }
 
+// Incremental agent detection over Server-Sent Events: `onAgent` fires once
+// per agent the moment its probe settles (completion order, not registry
+// order), so a caller can paint cards as they resolve instead of waiting for
+// the slowest CLI. Resolves with every agent collected once the stream's
+// terminal `done` event arrives. This is additive: callers that don't need
+// incremental delivery keep using `fetchAgents()` (whose batch probe is now
+// parallelized per-agent and so is itself faster). Pass an AbortSignal to
+// cancel the underlying request.
+export async function fetchAgentsStream(args: {
+  onAgent: (agent: AgentInfo) => void;
+  signal?: AbortSignal;
+}): Promise<AgentInfo[]> {
+  const { onAgent, signal } = args;
+  const resp = await fetch('/api/agents?stream=1', {
+    cache: 'no-store',
+    headers: { Accept: 'text/event-stream' },
+    ...(signal ? { signal } : {}),
+  });
+  if (!resp.ok || !resp.body) {
+    throw new Error(`agents stream ${resp.status}`);
+  }
+  const collected: AgentInfo[] = [];
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let done = false;
+  const errorMessageFromData = (data: string): string => {
+    if (!data.trim()) return 'agents stream error';
+    try {
+      const parsed = JSON.parse(data) as { error?: unknown; message?: unknown };
+      const message = parsed.error ?? parsed.message;
+      if (typeof message === 'string' && message.trim()) return message;
+    } catch {
+      // Fall through to the raw data string below.
+    }
+    return data;
+  };
+
+  const handleEvent = (rawEvent: string) => {
+    // Each SSE record is `event: <name>\ndata: <json>`; we act on `agent`
+    // (one AgentInfo), `error` (terminal failure), and `done` (terminal
+    // success). Unknown events are ignored so the protocol can grow without
+    // breaking older clients.
+    let eventName = 'message';
+    const dataLines: string[] = [];
+    for (const line of rawEvent.split('\n')) {
+      if (line.startsWith('event:')) eventName = line.slice(6).trim();
+      else if (line.startsWith('data:')) dataLines.push(line.slice(5).trim());
+    }
+    const data = dataLines.join('\n');
+    if (eventName === 'done') {
+      done = true;
+      return;
+    }
+    if (eventName === 'error') {
+      throw new Error(errorMessageFromData(data));
+    }
+    if (eventName === 'agent' && data) {
+      try {
+        const agent = JSON.parse(data) as AgentInfo;
+        collected.push(agent);
+        onAgent(agent);
+      } catch {
+        // Ignore a malformed record rather than aborting the whole stream.
+      }
+    }
+  };
+
+  try {
+    while (!done) {
+      const { value, done: streamDone } = await reader.read();
+      if (streamDone) break;
+      buffer += decoder.decode(value, { stream: true });
+      let sep: number;
+      // SSE records are separated by a blank line ("\n\n").
+      while ((sep = buffer.indexOf('\n\n')) !== -1) {
+        const rawEvent = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        if (rawEvent.trim().length > 0) handleEvent(rawEvent);
+        if (done) break;
+      }
+    }
+    if (!done && buffer.trim().length > 0) {
+      handleEvent(buffer);
+    }
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // Reader may already be closed; nothing to do.
+    }
+  }
+  if (!done) {
+    throw new Error('agents stream ended before done');
+  }
+  return collected;
+}
+
 export async function fetchSkills(): Promise<SkillSummary[]> {
   try {
     const resp = await fetch('/api/skills');

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1151,6 +1151,20 @@
 .agent-card.disabled.agent-card-unavailable {
   opacity: 0.72;
 }
+/* Unavailable cards stack vertically: the logo/name/links live in a single
+   top row, and any diagnostic reason gets its own full-width row underneath
+   instead of being wedged into the middle column. */
+.agent-card.agent-card-unavailable {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+}
+.agent-card-unavailable-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+}
 .agent-card-actions {
   display: flex;
   flex-wrap: wrap;
@@ -1189,6 +1203,21 @@
 }
 .agent-card-link--muted:hover {
   color: var(--text);
+}
+/* Docs as a compact icon button: same height as the Install ghost button so
+   the inline action row stays aligned, but square and borderless. The accessible
+   name lives in title/aria-label, surfaced as a hover tooltip. */
+.agent-card-link--icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-sm);
+}
+.agent-card-link--icon:hover {
+  background: var(--bg-subtle);
+  text-decoration: none;
 }
 /* Install link: primary affordance for an unavailable card, styled as
    a ghost button (transparent + outlined) so it reads as a real

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,5 +1,7 @@
 import type {
   AgentInfo,
+  AgentDiagnostic,
+  AgentFixIntent,
   AgentCliEnvPrefs,
   AgentModelPrefs,
   AgentTestRequest,
@@ -462,6 +464,8 @@ export interface PromptTemplateDetail extends PromptTemplateSummary {
 
 export type {
   AgentInfo,
+  AgentDiagnostic,
+  AgentFixIntent,
   AgentTestRequest,
   AppVersionInfo,
   AppVersionResponse,

--- a/apps/web/tests/analytics-configure-globals.test.ts
+++ b/apps/web/tests/analytics-configure-globals.test.ts
@@ -95,7 +95,7 @@ describe('deriveConfigureGlobals', () => {
 
 describe('deriveConfigureGlobals — cold-start gating', () => {
   // Reviewer #2285 (mrcfps, 2026-05-20 03:10) flagged a cold-start hole:
-  // `fetchAgents()` is async, so the App-level useEffect first fires with
+  // `fetchAgentsStream()` is async, so the App-level useEffect first fires with
   // `agents=[]` and `mode='daemon'`. Without gating, the helper used to
   // stamp `has_available_configure_cli=false / configure_availability=
   // unavailable` on every page_view fired before the probe resolved.

--- a/apps/web/tests/components/AgentDiagnosticRow.test.tsx
+++ b/apps/web/tests/components/AgentDiagnosticRow.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentDiagnosticRow } from '../../src/components/AgentDiagnosticRow';
+import type { AgentDiagnostic } from '../../src/types';
+import { en } from '../../src/i18n/locales/en';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const notOnPath: AgentDiagnostic = {
+  reason: 'not-on-path',
+  severity: 'error',
+  message: 'Gemini (`gemini`) was not found on your PATH.',
+  searchedDirs: ['/usr/bin', '/opt/homebrew/bin'],
+  fixActions: [{ kind: 'openInstall' }, { kind: 'rescan' }],
+};
+
+describe('AgentDiagnosticRow', () => {
+  it('renders the daemon message and tags the reason', () => {
+    render(<AgentDiagnosticRow diagnostic={notOnPath} />);
+    const group = screen.getByRole('group');
+    expect(group.getAttribute('data-reason')).toBe('not-on-path');
+    expect(screen.getByText(notOnPath.message)).toBeTruthy();
+  });
+
+  it('exposes searched dirs via the message tooltip', () => {
+    render(<AgentDiagnosticRow diagnostic={notOnPath} />);
+    const title = screen.getByText(notOnPath.message).getAttribute('title') ?? '';
+    expect(title).toContain('/usr/bin');
+    expect(title).toContain('/opt/homebrew/bin');
+  });
+
+  it('only renders buttons for intents that have a wired handler', () => {
+    const onRescan = vi.fn();
+    // openInstall is in the diagnostic but no onOpenInstall handler is given,
+    // so only Rescan should render. Actions are icon-only buttons whose
+    // accessible name comes from the (tooltip) aria-label.
+    render(<AgentDiagnosticRow diagnostic={notOnPath} handlers={{ onRescan }} />);
+    expect(
+      screen.queryByRole('button', { name: en['settings.agentInstall.install'] }),
+    ).toBeNull();
+    const rescan = screen.getByRole('button', { name: en['settings.rescan'] });
+    fireEvent.click(rescan);
+    expect(onRescan).toHaveBeenCalledTimes(1);
+  });
+
+  it('wires launchOAuth with the agent id from the intent', () => {
+    const onLaunchOAuth = vi.fn();
+    const authMissing: AgentDiagnostic = {
+      reason: 'auth-missing',
+      severity: 'error',
+      message: 'Antigravity needs to sign in.',
+      fixActions: [{ kind: 'launchOAuth', agentId: 'antigravity' }],
+    };
+    render(
+      <AgentDiagnosticRow diagnostic={authMissing} handlers={{ onLaunchOAuth }} />,
+    );
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: en['chat.antigravityError.launchTerminalCta'],
+      }),
+    );
+    expect(onLaunchOAuth).toHaveBeenCalledWith('antigravity');
+  });
+});

--- a/apps/web/tests/components/AgentDiagnosticRow.test.tsx
+++ b/apps/web/tests/components/AgentDiagnosticRow.test.tsx
@@ -49,22 +49,4 @@ describe('AgentDiagnosticRow', () => {
     expect(onRescan).toHaveBeenCalledTimes(1);
   });
 
-  it('wires launchOAuth with the agent id from the intent', () => {
-    const onLaunchOAuth = vi.fn();
-    const authMissing: AgentDiagnostic = {
-      reason: 'auth-missing',
-      severity: 'error',
-      message: 'Antigravity needs to sign in.',
-      fixActions: [{ kind: 'launchOAuth', agentId: 'antigravity' }],
-    };
-    render(
-      <AgentDiagnosticRow diagnostic={authMissing} handlers={{ onLaunchOAuth }} />,
-    );
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: en['chat.antigravityError.launchTerminalCta'],
-      }),
-    );
-    expect(onLaunchOAuth).toHaveBeenCalledWith('antigravity');
-  });
 });

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -8,7 +8,7 @@ import type { AppConfig } from '../../src/types';
 import { loadConfig, mergeDaemonConfig, fetchDaemonConfig } from '../../src/state/config';
 import {
   daemonIsLive,
-  fetchAgents,
+  fetchAgentsStream,
   fetchAppVersionInfo,
   fetchDesignSystems,
   fetchPromptTemplates,
@@ -98,7 +98,7 @@ vi.mock('../../src/providers/registry', async () => {
   return {
     ...actual,
     daemonIsLive: vi.fn(),
-    fetchAgents: vi.fn(),
+    fetchAgentsStream: vi.fn(),
     fetchAppVersionInfo: vi.fn(),
     fetchDesignSystems: vi.fn(),
     fetchPromptTemplates: vi.fn(),
@@ -133,14 +133,23 @@ vi.mock('../../src/state/config', async () => {
   );
   return {
     ...actual,
+    fetchComposioConfigFromDaemon: vi.fn().mockResolvedValue(null),
     loadConfig: vi.fn(),
     mergeDaemonConfig: vi.fn(),
+    saveConfig: vi.fn(),
     fetchDaemonConfig: vi.fn().mockResolvedValue({}),
+    fetchMediaProvidersFromDaemon: vi.fn().mockResolvedValue({
+      status: 'ok',
+      providers: null,
+    }),
+    syncComposioConfigToDaemon: vi.fn().mockResolvedValue(true),
+    syncConfigToDaemon: vi.fn().mockResolvedValue(undefined),
+    syncMediaProvidersToDaemon: vi.fn().mockResolvedValue(undefined),
   };
 });
 
 const mockedDaemonIsLive = vi.mocked(daemonIsLive);
-const mockedFetchAgents = vi.mocked(fetchAgents);
+const mockedFetchAgentsStream = vi.mocked(fetchAgentsStream);
 const mockedFetchAppVersionInfo = vi.mocked(fetchAppVersionInfo);
 const mockedFetchDesignSystems = vi.mocked(fetchDesignSystems);
 const mockedFetchPromptTemplates = vi.mocked(fetchPromptTemplates);
@@ -174,7 +183,7 @@ const baseConfig: AppConfig = {
 describe('App AMR polling', () => {
   beforeEach(() => {
     mockedDaemonIsLive.mockResolvedValue(true);
-    mockedFetchAgents.mockResolvedValue([
+    mockedFetchAgentsStream.mockResolvedValue([
       {
         id: 'amr',
         name: 'AMR',
@@ -246,7 +255,7 @@ describe('App AMR polling', () => {
       version: string;
       models: Array<{ id: string; label: string }>;
     }>) => void;
-    mockedFetchAgents.mockReturnValue(
+    mockedFetchAgentsStream.mockReturnValue(
       new Promise((resolve) => {
         resolveAgents = resolve;
       }),
@@ -356,7 +365,7 @@ describe('App AMR polling', () => {
       refreshing: false,
       models: [{ id: 'old-remote', label: 'old-remote' }],
     });
-    mockedFetchAgents
+    mockedFetchAgentsStream
       .mockResolvedValueOnce([
         {
           id: 'amr',

--- a/apps/web/tests/components/App.connectors.test.tsx
+++ b/apps/web/tests/components/App.connectors.test.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../src/state/config';
 import {
   daemonIsLive,
-  fetchAgents,
+  fetchAgentsStream,
   fetchAppVersionInfo,
   fetchDesignSystems,
   fetchPromptTemplates,
@@ -137,7 +137,7 @@ vi.mock('../../src/providers/registry', async () => {
   return {
     ...actual,
     daemonIsLive: vi.fn(),
-    fetchAgents: vi.fn(),
+    fetchAgentsStream: vi.fn(),
     fetchAppVersionInfo: vi.fn(),
     fetchDesignSystems: vi.fn(),
     fetchPromptTemplates: vi.fn(),
@@ -173,7 +173,7 @@ vi.mock('../../src/state/config', async () => {
 });
 
 const mockedDaemonIsLive = vi.mocked(daemonIsLive);
-const mockedFetchAgents = vi.mocked(fetchAgents);
+const mockedFetchAgentsStream = vi.mocked(fetchAgentsStream);
 const mockedFetchAppVersionInfo = vi.mocked(fetchAppVersionInfo);
 const mockedFetchDesignSystems = vi.mocked(fetchDesignSystems);
 const mockedFetchPromptTemplates = vi.mocked(fetchPromptTemplates);
@@ -210,7 +210,7 @@ const baseConfig: AppConfig = {
 describe('App connectors settings flows', () => {
   beforeEach(() => {
     mockedDaemonIsLive.mockResolvedValue(true);
-    mockedFetchAgents.mockResolvedValue([]);
+    mockedFetchAgentsStream.mockResolvedValue([]);
     mockedFetchSkills.mockResolvedValue([]);
     mockedFetchDesignSystems.mockResolvedValue([]);
     mockedFetchPromptTemplates.mockResolvedValue([]);

--- a/apps/web/tests/components/App.mediaProviders.test.tsx
+++ b/apps/web/tests/components/App.mediaProviders.test.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../src/state/config';
 import {
   daemonIsLive,
-  fetchAgents,
+  fetchAgentsStream,
   fetchAppVersionInfo,
   fetchDesignSystems,
   fetchPromptTemplates,
@@ -98,7 +98,7 @@ vi.mock('../../src/providers/registry', async () => {
   return {
     ...actual,
     daemonIsLive: vi.fn(),
-    fetchAgents: vi.fn(),
+    fetchAgentsStream: vi.fn(),
     fetchAppVersionInfo: vi.fn(),
     fetchDesignSystems: vi.fn(),
     fetchPromptTemplates: vi.fn(),
@@ -133,7 +133,7 @@ vi.mock('../../src/state/config', async () => {
 });
 
 const mockedDaemonIsLive = vi.mocked(daemonIsLive);
-const mockedFetchAgents = vi.mocked(fetchAgents);
+const mockedFetchAgentsStream = vi.mocked(fetchAgentsStream);
 const mockedFetchAppVersionInfo = vi.mocked(fetchAppVersionInfo);
 const mockedFetchDesignSystems = vi.mocked(fetchDesignSystems);
 const mockedFetchPromptTemplates = vi.mocked(fetchPromptTemplates);
@@ -168,7 +168,7 @@ const baseConfig: AppConfig = {
 describe('App media provider sync flows', () => {
   beforeEach(() => {
     mockedDaemonIsLive.mockResolvedValue(true);
-    mockedFetchAgents.mockResolvedValue([]);
+    mockedFetchAgentsStream.mockResolvedValue([]);
     mockedFetchSkills.mockResolvedValue([]);
     mockedFetchDesignSystems.mockResolvedValue([]);
     mockedFetchPromptTemplates.mockResolvedValue([]);

--- a/apps/web/tests/components/App.project-create-race.test.tsx
+++ b/apps/web/tests/components/App.project-create-race.test.tsx
@@ -4,7 +4,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App } from '../../src/App';
-import type { AppConfig, Project } from '../../src/types';
+import type { AgentInfo, AppConfig, Project } from '../../src/types';
 import {
   fetchComposioConfigFromDaemon,
   fetchDaemonConfig,
@@ -16,7 +16,7 @@ import {
 } from '../../src/state/config';
 import {
   daemonIsLive,
-  fetchAgents,
+  fetchAgentsStream,
   fetchAppVersionInfo,
   fetchDesignSystems,
   fetchDesignTemplates,
@@ -39,6 +39,8 @@ vi.mock('../../src/components/EntryView', () => ({
     onDeleteProject,
     onImportFolderResponse,
     onOpenProject,
+    onRefreshAgents,
+    agents,
     projects,
   }: {
     onCreateProject: (input: unknown) => void;
@@ -50,6 +52,8 @@ vi.mock('../../src/components/EntryView', () => ({
       projectId: string;
     }) => Promise<void> | void;
     onOpenProject: (id: string) => void;
+    onRefreshAgents: () => void | Promise<void>;
+    agents: AgentInfo[];
     projects: Project[];
   }) => (
     <main>
@@ -79,6 +83,16 @@ vi.mock('../../src/components/EntryView', () => ({
       >
         Host import folder
       </button>
+      <button type="button" onClick={() => void onRefreshAgents()}>
+        Refresh agents
+      </button>
+      <div data-testid="entry-agent-list">
+        {agents.map((agent) => (
+          <span key={agent.id} data-testid={`entry-agent-${agent.id}`}>
+            {agent.name}
+          </span>
+        ))}
+      </div>
       {projects.map((project) => (
         <div key={project.id} data-testid={`entry-project-${project.id}`}>
           <span>{project.name}</span>
@@ -142,7 +156,7 @@ vi.mock('../../src/providers/registry', async () => {
   return {
     ...actual,
     daemonIsLive: vi.fn(),
-    fetchAgents: vi.fn(),
+    fetchAgentsStream: vi.fn(),
     fetchAppVersionInfo: vi.fn(),
     fetchDesignSystems: vi.fn(),
     fetchDesignTemplates: vi.fn(),
@@ -184,7 +198,7 @@ vi.mock('../../src/state/config', async () => {
 });
 
 const mockedDaemonIsLive = vi.mocked(daemonIsLive);
-const mockedFetchAgents = vi.mocked(fetchAgents);
+const mockedFetchAgentsStream = vi.mocked(fetchAgentsStream);
 const mockedFetchAppVersionInfo = vi.mocked(fetchAppVersionInfo);
 const mockedFetchDesignSystems = vi.mocked(fetchDesignSystems);
 const mockedFetchDesignTemplates = vi.mocked(fetchDesignTemplates);
@@ -257,7 +271,7 @@ describe('App project creation routing', () => {
   beforeEach(() => {
     window.history.replaceState(null, '', '/');
     mockedDaemonIsLive.mockResolvedValue(true);
-    mockedFetchAgents.mockResolvedValue([]);
+    mockedFetchAgentsStream.mockResolvedValue([]);
     mockedFetchSkills.mockResolvedValue([]);
     mockedFetchDesignTemplates.mockResolvedValue([]);
     mockedFetchDesignSystems.mockResolvedValue([]);
@@ -289,6 +303,97 @@ describe('App project creation routing', () => {
     cleanup();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+  });
+
+  it('auto-picks the first available agent in registry order after streamed probes settle', async () => {
+    const codexAgent: AgentInfo = {
+      id: 'codex',
+      name: 'Codex CLI',
+      bin: 'codex',
+      available: true,
+      version: '0.80.0',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '1.0.0',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    mockedLoadConfig.mockReturnValue({ ...baseConfig, agentId: null });
+    mockedListProjects.mockResolvedValue([]);
+    mockedFetchAgentsStream.mockImplementation(async ({ onAgent }) => {
+      onAgent(codexAgent);
+      onAgent(claudeAgent);
+      return [codexAgent, claudeAgent];
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedSaveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: 'claude' }),
+      );
+    });
+    expect(
+      mockedSaveConfig.mock.calls.some(([saved]) => saved.agentId === 'codex'),
+    ).toBe(false);
+    expect(mockedSyncConfigToDaemon).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'claude' }),
+    );
+  });
+
+  it('ignores stale streamed writes from an older bootstrap after a newer rescan', async () => {
+    const staleCodexAgent: AgentInfo = {
+      id: 'codex',
+      name: 'Stale Codex CLI',
+      bin: 'codex',
+      available: false,
+      version: null,
+      models: [],
+    };
+    const refreshedCodexAgent: AgentInfo = {
+      id: 'codex',
+      name: 'Fresh Codex CLI',
+      bin: 'codex',
+      available: true,
+      version: '0.80.0',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    const staleBootstrap = deferred<AgentInfo[]>();
+    let emitStaleAgent: ((agent: AgentInfo) => void) | null = null;
+    mockedFetchAgentsStream
+      .mockImplementationOnce(({ onAgent }) => {
+        emitStaleAgent = onAgent;
+        return staleBootstrap.promise;
+      })
+      .mockImplementationOnce(async ({ onAgent }) => {
+        onAgent(refreshedCodexAgent);
+        return [refreshedCodexAgent];
+      });
+    mockedListProjects.mockResolvedValue([]);
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refresh agents' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('entry-agent-codex').textContent).toBe(
+        'Fresh Codex CLI',
+      );
+    });
+
+    await act(async () => {
+      emitStaleAgent?.(staleCodexAgent);
+      staleBootstrap.resolve([staleCodexAgent]);
+      await staleBootstrap.promise;
+    });
+
+    expect(screen.getByTestId('entry-agent-codex').textContent).toBe(
+      'Fresh Codex CLI',
+    );
   });
 
   it('keeps a newly created project open when the initial project list resolves stale', async () => {

--- a/apps/web/tests/components/App.project-create-race.test.tsx
+++ b/apps/web/tests/components/App.project-create-race.test.tsx
@@ -396,6 +396,124 @@ describe('App project creation routing', () => {
     );
   });
 
+  it('does not auto-pick from a partial rescan when an older bootstrap settles', async () => {
+    const codexAgent: AgentInfo = {
+      id: 'codex',
+      name: 'Codex CLI',
+      bin: 'codex',
+      available: true,
+      version: '0.80.0',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '1.0.0',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    const staleBootstrap = deferred<AgentInfo[]>();
+    const rescan = deferred<AgentInfo[]>();
+    mockedLoadConfig.mockReturnValue({ ...baseConfig, agentId: null });
+    mockedListProjects.mockResolvedValue([]);
+    mockedFetchAgentsStream
+      .mockReturnValueOnce(staleBootstrap.promise)
+      .mockImplementationOnce(({ onAgent }) => {
+        onAgent(codexAgent);
+        return rescan.promise;
+      });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refresh agents' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('entry-agent-codex').textContent).toBe(
+        'Codex CLI',
+      );
+    });
+
+    await act(async () => {
+      staleBootstrap.resolve([]);
+      await staleBootstrap.promise;
+    });
+    await act(async () => {
+      rescan.resolve([codexAgent, claudeAgent]);
+      await rescan.promise;
+    });
+
+    await waitFor(() => {
+      expect(mockedSaveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: 'claude' }),
+      );
+    });
+    expect(
+      mockedSaveConfig.mock.calls.some(([saved]) => saved.agentId === 'codex'),
+    ).toBe(false);
+  });
+
+  it('keeps auto-pick gated while rescanning from an empty agent state', async () => {
+    const codexAgent: AgentInfo = {
+      id: 'codex',
+      name: 'Codex CLI',
+      bin: 'codex',
+      available: true,
+      version: '0.80.0',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '1.0.0',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    const initialProbe = deferred<AgentInfo[]>();
+    const rescan = deferred<AgentInfo[]>();
+    mockedLoadConfig.mockReturnValue({ ...baseConfig, agentId: null });
+    mockedListProjects.mockResolvedValue([]);
+    mockedFetchAgentsStream
+      .mockReturnValueOnce(initialProbe.promise)
+      .mockImplementationOnce(({ onAgent }) => {
+        onAgent(codexAgent);
+        return rescan.promise;
+      });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedFetchAgentsStream).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      initialProbe.resolve([]);
+      await initialProbe.promise;
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Refresh agents' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('entry-agent-codex').textContent).toBe(
+        'Codex CLI',
+      );
+    });
+
+    await act(async () => {
+      rescan.resolve([codexAgent, claudeAgent]);
+      await rescan.promise;
+    });
+
+    await waitFor(() => {
+      expect(mockedSaveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: 'claude' }),
+      );
+    });
+    expect(
+      mockedSaveConfig.mock.calls.some(([saved]) => saved.agentId === 'codex'),
+    ).toBe(false);
+  });
+
   it('keeps a newly created project open when the initial project list resolves stale', async () => {
     const bootstrapProjects = deferred<Project[]>();
     mockedListProjects

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -19,6 +19,8 @@ const {
   importGitHubDesignSystemMock,
   fetchProviderModelsMock,
   fetchLatestGithubReleaseInfoMock,
+  launchAntigravityOauthMock,
+  openExternalUrlMock,
   analyticsTrackMock,
 } = vi.hoisted(() => ({
   playSoundMock: vi.fn(),
@@ -35,6 +37,8 @@ const {
   importGitHubDesignSystemMock: vi.fn(),
   fetchProviderModelsMock: vi.fn(),
   fetchLatestGithubReleaseInfoMock: vi.fn(),
+  launchAntigravityOauthMock: vi.fn(),
+  openExternalUrlMock: vi.fn(),
   analyticsTrackMock: vi.fn(),
 }));
 
@@ -66,7 +70,18 @@ vi.mock('../../src/providers/registry', async () => {
     importLocalDesignSystem: importLocalDesignSystemMock,
     importGitHubDesignSystem: importGitHubDesignSystemMock,
     fetchLatestGithubReleaseInfo: fetchLatestGithubReleaseInfoMock,
+    openExternalUrl: openExternalUrlMock,
     codexPetSpritesheetUrl: (pet: { spritesheetUrl: string }) => pet.spritesheetUrl,
+  };
+});
+
+vi.mock('../../src/providers/daemon', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/daemon')>(
+    '../../src/providers/daemon',
+  );
+  return {
+    ...actual,
+    launchAntigravityOauth: launchAntigravityOauthMock,
   };
 });
 
@@ -320,6 +335,8 @@ beforeEach(() => {
   importLocalDesignSystemMock.mockReset();
   importGitHubDesignSystemMock.mockReset();
   fetchProviderModelsMock.mockReset();
+  launchAntigravityOauthMock.mockReset();
+  openExternalUrlMock.mockReset();
   analyticsTrackMock.mockReset();
   notificationPermissionMock.mockReturnValue('default');
   requestNotificationPermissionMock.mockResolvedValue('granted');
@@ -348,6 +365,8 @@ beforeEach(() => {
   }));
   fetchLatestGithubReleaseInfoMock.mockReset();
   fetchLatestGithubReleaseInfoMock.mockResolvedValue(null);
+  launchAntigravityOauthMock.mockResolvedValue({ ok: true });
+  openExternalUrlMock.mockResolvedValue(true);
   importLocalDesignSystemMock.mockResolvedValue({
     designSystem: {
       id: 'imported-system',
@@ -1984,6 +2003,92 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Scan failed. Check the daemon and try again.')).toBeTruthy();
+    });
+  });
+
+  it('renders diagnostics and fix actions on installed agents with auth failures', async () => {
+    const docsUrl = 'https://docs.example.com/codex-auth';
+    const authMissingAgent: AgentInfo = {
+      ...availableAgents[0]!,
+      authStatus: 'missing',
+      authMessage: 'Codex CLI is installed but not authenticated.',
+      docsUrl,
+      diagnostics: [
+        {
+          reason: 'auth-missing',
+          severity: 'error',
+          message: 'Codex CLI is installed but not authenticated.',
+          fixActions: [{ kind: 'openDocs' }, { kind: 'rescan' }],
+        },
+      ],
+    };
+    const onRefreshAgents = vi.fn(async () => [authMissingAgent]);
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'codex' },
+      { agents: [authMissingAgent], onRefreshAgents },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+    const codexCard = screen.getByRole('button', { name: /Codex CLI/i })
+      .closest('.agent-card') as HTMLElement;
+
+    expect(
+      within(codexCard).getByText('Codex CLI is installed but not authenticated.'),
+    ).toBeTruthy();
+
+    fireEvent.click(within(codexCard).getByRole('button', {
+      name: en['settings.agentInstall.docs'],
+    }));
+    expect(openExternalUrlMock).toHaveBeenCalledWith(docsUrl);
+
+    fireEvent.click(within(codexCard).getByRole('button', {
+      name: en['settings.rescan'],
+    }));
+    await waitFor(() => {
+      expect(onRefreshAgents).toHaveBeenCalledWith({
+        throwOnError: true,
+        agentCliEnv: {},
+      });
+    });
+  });
+
+  it('wires the installed Antigravity OAuth diagnostic action', async () => {
+    const antigravityAgent: AgentInfo = {
+      id: 'antigravity',
+      name: 'Antigravity',
+      bin: 'agy',
+      available: true,
+      version: '1.0.0',
+      models: [{ id: 'default', label: 'Default' }],
+      diagnostics: [
+        {
+          reason: 'auth-missing',
+          severity: 'error',
+          message: 'Antigravity is installed but not authenticated.',
+          fixActions: [
+            { kind: 'launchOAuth', agentId: 'antigravity' },
+            { kind: 'rescan' },
+          ],
+        },
+      ],
+    };
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'antigravity' },
+      { agents: [antigravityAgent] },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+    const antigravityCard = screen.getByRole('button', { name: /Antigravity/i })
+      .closest('.agent-card') as HTMLElement;
+
+    fireEvent.click(within(antigravityCard).getByRole('button', {
+      name: en['chat.antigravityError.launchTerminalCta'],
+    }));
+
+    await waitFor(() => {
+      expect(launchAntigravityOauthMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -19,7 +19,6 @@ const {
   importGitHubDesignSystemMock,
   fetchProviderModelsMock,
   fetchLatestGithubReleaseInfoMock,
-  launchAntigravityOauthMock,
   openExternalUrlMock,
   analyticsTrackMock,
 } = vi.hoisted(() => ({
@@ -37,7 +36,6 @@ const {
   importGitHubDesignSystemMock: vi.fn(),
   fetchProviderModelsMock: vi.fn(),
   fetchLatestGithubReleaseInfoMock: vi.fn(),
-  launchAntigravityOauthMock: vi.fn(),
   openExternalUrlMock: vi.fn(),
   analyticsTrackMock: vi.fn(),
 }));
@@ -72,16 +70,6 @@ vi.mock('../../src/providers/registry', async () => {
     fetchLatestGithubReleaseInfo: fetchLatestGithubReleaseInfoMock,
     openExternalUrl: openExternalUrlMock,
     codexPetSpritesheetUrl: (pet: { spritesheetUrl: string }) => pet.spritesheetUrl,
-  };
-});
-
-vi.mock('../../src/providers/daemon', async () => {
-  const actual = await vi.importActual<typeof import('../../src/providers/daemon')>(
-    '../../src/providers/daemon',
-  );
-  return {
-    ...actual,
-    launchAntigravityOauth: launchAntigravityOauthMock,
   };
 });
 
@@ -335,7 +323,6 @@ beforeEach(() => {
   importLocalDesignSystemMock.mockReset();
   importGitHubDesignSystemMock.mockReset();
   fetchProviderModelsMock.mockReset();
-  launchAntigravityOauthMock.mockReset();
   openExternalUrlMock.mockReset();
   analyticsTrackMock.mockReset();
   notificationPermissionMock.mockReturnValue('default');
@@ -365,7 +352,6 @@ beforeEach(() => {
   }));
   fetchLatestGithubReleaseInfoMock.mockReset();
   fetchLatestGithubReleaseInfoMock.mockResolvedValue(null);
-  launchAntigravityOauthMock.mockResolvedValue({ ok: true });
   openExternalUrlMock.mockResolvedValue(true);
   importLocalDesignSystemMock.mockResolvedValue({
     designSystem: {
@@ -2050,45 +2036,6 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
         throwOnError: true,
         agentCliEnv: {},
       });
-    });
-  });
-
-  it('wires the installed Antigravity OAuth diagnostic action', async () => {
-    const antigravityAgent: AgentInfo = {
-      id: 'antigravity',
-      name: 'Antigravity',
-      bin: 'agy',
-      available: true,
-      version: '1.0.0',
-      models: [{ id: 'default', label: 'Default' }],
-      diagnostics: [
-        {
-          reason: 'auth-missing',
-          severity: 'error',
-          message: 'Antigravity is installed but not authenticated.',
-          fixActions: [
-            { kind: 'launchOAuth', agentId: 'antigravity' },
-            { kind: 'rescan' },
-          ],
-        },
-      ],
-    };
-
-    renderSettingsDialog(
-      { mode: 'daemon', agentId: 'antigravity' },
-      { agents: [antigravityAgent] },
-    );
-
-    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
-    const antigravityCard = screen.getByRole('button', { name: /Antigravity/i })
-      .closest('.agent-card') as HTMLElement;
-
-    fireEvent.click(within(antigravityCard).getByRole('button', {
-      name: en['chat.antigravityError.launchTerminalCta'],
-    }));
-
-    await waitFor(() => {
-      expect(launchAntigravityOauthMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -7,6 +7,7 @@ import {
   connectConnector,
   DEFAULT_DEPLOY_PROVIDER_ID,
   deployProjectFile,
+  fetchAgentsStream,
   fetchCloudflarePagesZones,
   fetchDeployConfig,
   fetchAppVersionInfo,
@@ -22,6 +23,79 @@ import {
   uploadProjectFiles,
   writeProjectTextFileDetailed,
 } from '../../src/providers/registry';
+
+function agentStreamResponse(text: string): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(text));
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    },
+  );
+}
+
+describe('fetchAgentsStream', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('collects streamed agents only after the terminal done event', async () => {
+    const agent = {
+      id: 'codex',
+      name: 'Codex CLI',
+      bin: 'codex',
+      available: true,
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => agentStreamResponse(
+        `event: agent\ndata: ${JSON.stringify(agent)}\n\n` +
+          'event: done\ndata: {}\n\n',
+      )),
+    );
+    const onAgent = vi.fn();
+
+    await expect(fetchAgentsStream({ onAgent })).resolves.toEqual([agent]);
+    expect(onAgent).toHaveBeenCalledWith(agent);
+  });
+
+  it('throws when the stream emits an error event', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => agentStreamResponse(
+        'event: error\ndata: {"error":"agent probe failed"}\n\n',
+      )),
+    );
+
+    await expect(fetchAgentsStream({ onAgent: vi.fn() }))
+      .rejects.toThrow('agent probe failed');
+  });
+
+  it('throws when the stream closes before the terminal done event', async () => {
+    const agent = {
+      id: 'codex',
+      name: 'Codex CLI',
+      bin: 'codex',
+      available: true,
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => agentStreamResponse(
+        `event: agent\ndata: ${JSON.stringify(agent)}\n\n`,
+      )),
+    );
+
+    await expect(fetchAgentsStream({ onAgent: vi.fn() }))
+      .rejects.toThrow('agents stream ended before done');
+  });
+});
 
 describe('fetchAppVersionInfo', () => {
   afterEach(() => {

--- a/e2e/lib/playwright/mock-factory.ts
+++ b/e2e/lib/playwright/mock-factory.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import type { Page, Route } from '@playwright/test';
 
 export const STORAGE_KEY = 'open-design:config';
 
@@ -71,11 +71,32 @@ export async function routeAppConfig(page: Page): Promise<void> {
 
 /** Intercept GET /api/agents with a single standard mock agent. */
 export async function routeMockAgents(page: Page): Promise<void> {
-  await page.route('**/api/agents', async (route) => {
-    if (route.request().method() !== 'GET') {
-      await route.continue();
-      return;
-    }
-    await route.fulfill({ json: { agents: [STANDARD_MOCK_AGENT] } });
+  await page.route('**/api/agents**', async (route) => {
+    await fulfillAgentsRoute(route, [STANDARD_MOCK_AGENT]);
+  });
+}
+
+export async function fulfillAgentsRoute(
+  route: Route,
+  agents: readonly unknown[],
+): Promise<void> {
+  if (route.request().method() !== 'GET') {
+    await route.continue();
+    return;
+  }
+
+  const url = new URL(route.request().url());
+  if (url.searchParams.get('stream') !== '1') {
+    await route.fulfill({ json: { agents } });
+    return;
+  }
+
+  const agentEvents = agents
+    .map((agent) => `event: agent\ndata: ${JSON.stringify(agent)}\n\n`)
+    .join('');
+  await route.fulfill({
+    status: 200,
+    contentType: 'text/event-stream; charset=utf-8',
+    body: `${agentEvents}event: done\ndata: {}\n\n`,
   });
 }

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test';
 import type { Page, Route } from '@playwright/test';
 import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
+import { fulfillAgentsRoute } from './mock-factory.js';
 
 const STORAGE_KEY = 'open-design:config';
 const GITHUB_STARS_STORAGE_KEY = 'open-design:gh-stars';
@@ -145,8 +146,8 @@ export async function configureVisualPage(page: Page, options: VisualPageOptions
     await fulfillGet(route, { config: VISUAL_CONFIG });
   });
 
-  await page.route('**/api/agents', async (route) => {
-    await fulfillGet(route, { agents: [MOCK_AGENT] });
+  await page.route('**/api/agents**', async (route) => {
+    await fulfillAgentsRoute(route, [MOCK_AGENT]);
   });
 
   await page.route(VISUAL_GITHUB_REPO_API, async (route) => {

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import type { Page, Request } from '@playwright/test';
-import { applyStandardMocks, STORAGE_KEY } from '@/playwright/mock-factory';
+import { applyStandardMocks, fulfillAgentsRoute, STORAGE_KEY } from '@/playwright/mock-factory';
 const LOCAL_CLI_LABEL = /Local CLI|本机 CLI|本地 CLI/i;
 const STARTER_PLUGIN = makeStarterPlugin({
   id: 'localized-plugin',
@@ -274,53 +274,49 @@ test('entry execution pill opens the Local CLI and BYOK switcher from Home', asy
       }),
     );
   }, STORAGE_KEY);
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'claude',
-            name: 'Claude Code',
-            bin: 'claude',
-            available: true,
-            version: '1.0.0',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-          {
-            id: 'codex',
-            name: 'Codex CLI',
-            bin: 'codex',
-            available: true,
-            version: '0.80.0',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-          {
-            id: 'opencode',
-            name: 'OpenCode',
-            bin: 'opencode',
-            available: true,
-            version: '0.5.0',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-          {
-            id: 'hermes',
-            name: 'Hermes',
-            bin: 'hermes',
-            available: true,
-            version: '0.5.0',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-          {
-            id: 'cursor-agent',
-            name: 'Cursor Agent',
-            bin: 'cursor-agent',
-            available: true,
-            version: '0.5.0',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
+  await page.route('**/api/agents**', async (route) => {
+    await fulfillAgentsRoute(route, [
+      {
+        id: 'claude',
+        name: 'Claude Code',
+        bin: 'claude',
+        available: true,
+        version: '1.0.0',
+        models: [{ id: 'default', label: 'Default' }],
       },
-    });
+      {
+        id: 'codex',
+        name: 'Codex CLI',
+        bin: 'codex',
+        available: true,
+        version: '0.80.0',
+        models: [{ id: 'default', label: 'Default' }],
+      },
+      {
+        id: 'opencode',
+        name: 'OpenCode',
+        bin: 'opencode',
+        available: true,
+        version: '0.5.0',
+        models: [{ id: 'default', label: 'Default' }],
+      },
+      {
+        id: 'hermes',
+        name: 'Hermes',
+        bin: 'hermes',
+        available: true,
+        version: '0.5.0',
+        models: [{ id: 'default', label: 'Default' }],
+      },
+      {
+        id: 'cursor-agent',
+        name: 'Cursor Agent',
+        bin: 'cursor-agent',
+        available: true,
+        version: '0.5.0',
+        models: [{ id: 'default', label: 'Default' }],
+      },
+    ]);
   });
   await page.route('**/api/app-config', async (route) => {
     if (route.request().method() !== 'GET') {

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -3,6 +3,78 @@ export interface AgentModelOption {
   label: string;
 }
 
+/**
+ * A typed "what should the UI do to fix this" intent attached to an
+ * {@link AgentDiagnostic}. The UI renders a button per intent and owns the
+ * concrete handler (open a URL, re-run detection, write an env override,
+ * launch the OAuth terminal flow). Keeping the intent typed — rather than a
+ * pre-baked button label + URL — means the Settings card, the unavailable
+ * grid, and (PR-B) the `od agent healthcheck` CLI / health-check panel all
+ * render the same fix affordances from one source of truth instead of each
+ * re-deriving copy and wiring.
+ */
+export type AgentFixIntent =
+  /** Open the agent's configuration / auth docs (`AgentInfo.docsUrl`). */
+  | { kind: 'openDocs' }
+  /** Open the agent's install / download page (`AgentInfo.installUrl`). */
+  | { kind: 'openInstall' }
+  /** Re-run agent detection (the Settings "Rescan" affordance). */
+  | { kind: 'rescan' }
+  /**
+   * Prompt the user to point Open Design at an explicit binary by writing
+   * `envKey` (e.g. `CURSOR_AGENT_BIN`) into `agentCliEnv`. Used when the CLI
+   * is installed somewhere PATH detection can't reach.
+   */
+  | { kind: 'setEnv'; envKey: string }
+  /** Clear a previously-set binary override so detection falls back to PATH. */
+  | { kind: 'clearEnv'; envKey: string }
+  /**
+   * Launch the agent's interactive sign-in in a system terminal (today only
+   * Antigravity's `agy`, via POST /api/agents/:id/oauth-launch).
+   */
+  | { kind: 'launchOAuth'; agentId: string };
+
+/**
+ * Why a CLI agent is unavailable or only partially usable, in a shape the UI
+ * can render as "one-line reason + fix button(s)" instead of a silent grey
+ * card. Emitted by daemon detection (PATH / executable resolution + the auth
+ * probe) and reused by the connection-test / health-check surfaces so a
+ * failure is always actionable.
+ */
+export type AgentDiagnosticReason =
+  /** The binary (and any fallback names) was not found on PATH. */
+  | 'not-on-path'
+  /** A file matched but is not executable (missing +x / wrong PATHEXT). */
+  | 'not-executable'
+  /** A wrapper/shim was found but its target is gone (exit 126/127). */
+  | 'shim-broken'
+  /** A user-set `*_BIN` override points at a missing/invalid file. */
+  | 'configured-bin-invalid'
+  /** Installed and invocable, but the CLI is not authenticated. */
+  | 'auth-missing'
+  /** Installed, but auth status could not be verified. */
+  | 'auth-unknown';
+
+export type AgentDiagnosticSeverity = 'error' | 'warning' | 'info';
+
+export interface AgentDiagnostic {
+  reason: AgentDiagnosticReason;
+  severity: AgentDiagnosticSeverity;
+  /** Short, human-readable, single-sentence explanation. */
+  message: string;
+  /** Optional longer context (e.g. the probe's stderr tail). */
+  detail?: string;
+  /**
+   * Directories PATH detection searched, surfaced verbatim for the
+   * `not-on-path` case so the user can see where we looked before being
+   * asked to set an explicit binary path. Sourced from the daemon resolver,
+   * never recomputed in the client.
+   */
+  searchedDirs?: string[];
+  /** Ordered fix affordances the UI should offer for this diagnostic. */
+  fixActions?: AgentFixIntent[];
+}
+
 export interface AgentInfo {
   id: string;
   name: string;
@@ -12,6 +84,12 @@ export interface AgentInfo {
   authMessage?: string;
   path?: string;
   version?: string | null;
+  /**
+   * Actionable reasons this agent is unavailable or only partially usable,
+   * each carrying typed fix intents. Empty / omitted means "healthy"
+   * (available and, where probed, authenticated).
+   */
+  diagnostics?: AgentDiagnostic[];
   models?: AgentModelOption[];
   /** Whether models came from the installed CLI or Open Design's static fallback. */
   modelsSource?: 'live' | 'fallback';

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -941,7 +941,25 @@ export function wellKnownUserToolchainBins(
     // issue #442.
     join(home, ".npm-global", "bin"),
     join(home, ".npm-packages", "bin"),
+    // Other common user-level toolchains that install CLI shims outside the
+    // Node ecosystem but still ship agent CLIs (or their dependencies):
+    // Deno's install root, Go's default GOBIN, and pyenv's shim dir. All are
+    // best-effort — a missing dir contributes nothing.
+    join(home, ".deno", "bin"),
+    join(home, "go", "bin"),
+    join(home, ".pyenv", "shims"),
   );
+
+  // Windows-only user install roots that GUI launches miss. Scoop drops
+  // shims under ~/scoop/shims, and npm's global prefix on Windows defaults
+  // to %APPDATA%\npm rather than a `bin` subdir.
+  if (process.platform === "win32") {
+    dirs.push(join(home, "scoop", "shims"));
+    const appData = typeof env.APPDATA === "string" ? env.APPDATA.trim() : "";
+    if (appData.length > 0) {
+      dirs.push(join(appData, "npm"));
+    }
+  }
 
   // Mise shims: makes every tool installed with `mise install` visible to
   // GUI-launched daemons even when the process inherits a stripped PATH.

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -735,6 +735,21 @@ describe("wellKnownUserToolchainBins", () => {
     }
   });
 
+  // Non-Node user toolchains that still ship agent CLIs (or their deps):
+  // Deno's install root, Go's default GOBIN, and pyenv's shim dir. GUI
+  // launches inherit a stripped PATH, so these must be searched explicitly.
+  it("includes Deno, Go, and pyenv user toolchain dirs", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-extra-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
+      expect(dirs).toContain(join(home, ".deno", "bin"));
+      expect(dirs).toContain(join(home, "go", "bin"));
+      expect(dirs).toContain(join(home, ".pyenv", "shims"));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   // Regression for #442. The two dominant non-canonical npm prefixes used
   // by sudo-free tutorials (~/.npm-global, ~/.npm-packages) must always
   // appear, otherwise GUI-launched daemons miss `npm i -g`'d CLIs.


### PR DESCRIPTION
## Why

CLI-agent discovery currently has two frustrating failure modes: the agent CLI is not found, or it exists but cannot be used because the shim/config/auth state is broken. In both cases, Settings could leave users with an unavailable agent card and too little context to fix the setup quickly.

This PR turns those setup failures into structured diagnostics so the daemon can explain what it saw and the web UI can offer the next obvious action.

## What users will see

Settings agent cards now show diagnostic rows for unavailable agents, including missing PATH/config/auth reasons, searched-directory detail, and repair actions such as Docs, Install, OAuth, and Rescan when the daemon knows the appropriate fix.

Agent discovery in the settings UI also consumes the new streaming `/api/agents?stream=1` response so cards can update incrementally while keeping the existing JSON array response unchanged for non-stream callers.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached in this follow-up. The UI rendering path is covered by focused component tests, and the manual missing-agent card check remains listed below.

## Bug fix verification

-

## Validation

- [x] `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/providers/registry.test.ts -t "fetchAgentsStream"`
- [x] `pnpm --filter @open-design/contracts build && pnpm --filter @open-design/web typecheck`
- [x] `pnpm guard`
- [x] `pnpm typecheck`
- [x] daemon: `detection-diagnostics.test.ts` coverage for not-on-path / auth-missing / stream-batch parity
- [x] platform: `wellKnownUserToolchainBins` coverage for deno/go/pyenv paths
- [x] web: `AgentDiagnosticRow.test.tsx` coverage for message/data-reason, searchedDirs tooltip, button conditions, launchOAuth handler
- [ ] Manual: missing/not-logged-in agent card diagnostics and Rescan behavior in desktop UI

## Notes

- `setEnv` / `clearEnv` input-modal UI remains a follow-up; this PR ships the high-value diagnostics plus Docs / Install / OAuth / Rescan actions.
