### PR TITLE
fix(web): surface plugin apply input errors

### DIFF
--- a/apps/web/src/components/InlinePluginsRail.tsx
+++ b/apps/web/src/components/InlinePluginsRail.tsx
@@ -11,7 +11,7 @@ import type {
   ApplyResult,
   InstalledPluginRecord,
 } from '@open-design/contracts';
-import { applyPlugin, listPlugins } from '../state/projects';
+import { applyPluginRequest, listPlugins } from '../state/projects';
 import { useI18n } from '../i18n';
 
 interface Props {
@@ -68,18 +68,16 @@ export function InlinePluginsRail(props: Props) {
   const onClick = async (record: InstalledPluginRecord) => {
     setPendingId(record.id);
     setError(null);
-    const result = await applyPlugin(record.id, {
+    const outcome = await applyPluginRequest(record.id, {
       ...(props.projectId ? { projectId: props.projectId } : {}),
       locale,
     });
     setPendingId(null);
-    if (!result) {
-      setError(
-        `Failed to apply ${record.title}. Make sure the daemon is reachable.`,
-      );
+    if (!outcome.ok) {
+      setError(`Failed to apply ${record.title}: ${outcome.message}`);
       return;
     }
-    props.onApplied(record, result);
+    props.onApplied(record, outcome.result);
   };
 
   if (plugins.length === 0) {

--- a/apps/web/src/components/PluginsSection.tsx
+++ b/apps/web/src/components/PluginsSection.tsx
@@ -36,8 +36,9 @@ import type {
   InstalledPluginRecord,
 } from '@open-design/contracts';
 import {
-  applyPlugin,
+  applyPluginRequest,
   renderPluginBriefTemplate,
+  type ApplyPluginFailure,
 } from '../state/projects';
 import { useI18n } from '../i18n';
 import { ContextChipStrip } from './ContextChipStrip';
@@ -96,9 +97,11 @@ export const PluginsSection = forwardRef<PluginsSectionHandle, Props>(
     const [applied, setApplied] = useState<ApplyResult | null>(null);
     const [activeRecord, setActiveRecord] = useState<InstalledPluginRecord | null>(null);
     const [pluginInputs, setPluginInputs] = useState<Record<string, unknown>>({});
+    const [applyError, setApplyError] = useState<string | null>(null);
 
     const handleApplied = useCallback(
       (record: InstalledPluginRecord | null, result: ApplyResult) => {
+        setApplyError(null);
         setActiveRecord(record);
         setApplied(result);
         const initialInputs: Record<string, unknown> = {};
@@ -127,6 +130,7 @@ export const PluginsSection = forwardRef<PluginsSectionHandle, Props>(
       setApplied(null);
       setActiveRecord(null);
       setPluginInputs({});
+      setApplyError(null);
       props.onCleared?.();
     }, [props]);
 
@@ -141,13 +145,17 @@ export const PluginsSection = forwardRef<PluginsSectionHandle, Props>(
       ref,
       () => ({
         applyById: async (pluginId, record = null) => {
-          const result = await applyPlugin(pluginId, {
+          setApplyError(null);
+          const outcome = await applyPluginRequest(pluginId, {
             ...(props.projectId ? { projectId: props.projectId } : {}),
             locale,
           });
-          if (!result) return null;
-          handleApplied(record, result);
-          return result;
+          if (!outcome.ok) {
+            setApplyError(formatApplyPluginFailure(pluginId, record, outcome));
+            return null;
+          }
+          handleApplied(record, outcome.result);
+          return outcome.result;
         },
         clear,
         getActiveRecord: () => activeRecord,
@@ -185,6 +193,11 @@ export const PluginsSection = forwardRef<PluginsSectionHandle, Props>(
 
     return (
       <div className="plugins-section" data-testid="plugins-section">
+        {applyError ? (
+          <div role="alert" className="plugins-section__error">
+            {applyError}
+          </div>
+        ) : null}
         {applied ? (
           <div className="plugins-section__active" data-active-plugin-id={activeRecord?.id}>
             <ContextChipStrip
@@ -214,3 +227,20 @@ export const PluginsSection = forwardRef<PluginsSectionHandle, Props>(
     );
   },
 );
+
+function formatApplyPluginFailure(
+  pluginId: string,
+  record: InstalledPluginRecord | null,
+  failure: ApplyPluginFailure,
+): string {
+  const title = record?.title ?? pluginId;
+  if (failure.error === 'missing_inputs') {
+    const labels = failure.missingInputFields.map((name) => {
+      const field = record?.manifest?.od?.inputs?.find((input) => input.name === name);
+      return field?.label ?? name;
+    });
+    const suffix = labels.length > 0 ? `: ${labels.join(', ')}` : '';
+    return `${title} needs required inputs before it can be applied${suffix}.`;
+  }
+  return `Failed to apply ${title}: ${failure.message}`;
+}

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -1258,15 +1258,29 @@ async function readPluginMarketplaceOutcome(
   };
 }
 
-export async function applyPlugin(
+interface ApplyPluginOptions {
+  inputs?: Record<string, unknown>;
+  projectId?: string;
+  grantCaps?: string[];
+  locale?: string;
+}
+
+export interface ApplyPluginFailure {
+  ok: false;
+  status?: number;
+  error?: string;
+  message: string;
+  missingInputFields: string[];
+}
+
+export type ApplyPluginOutcome =
+  | { ok: true; result: ApplyResult }
+  | ApplyPluginFailure;
+
+export async function applyPluginRequest(
   pluginId: string,
-  options: {
-    inputs?: Record<string, unknown>;
-    projectId?: string;
-    grantCaps?: string[];
-    locale?: string;
-  } = {},
-): Promise<ApplyResult | null> {
+  options: ApplyPluginOptions = {},
+): Promise<ApplyPluginOutcome> {
   try {
     const resp = await fetch(
       `/api/plugins/${encodeURIComponent(pluginId)}/apply`,
@@ -1281,12 +1295,81 @@ export async function applyPlugin(
         }),
       },
     );
-    if (!resp.ok) return null;
+    if (!resp.ok) return readApplyPluginFailure(resp);
     const json = (await resp.json()) as ApplyResult & { ok?: boolean };
-    return json;
-  } catch {
+    return { ok: true, result: json };
+  } catch (err) {
+    return {
+      ok: false,
+      message: (err as Error).message,
+      missingInputFields: [],
+    };
+  }
+}
+
+export async function applyPlugin(
+  pluginId: string,
+  options: ApplyPluginOptions = {},
+): Promise<ApplyResult | null> {
+  const outcome = await applyPluginRequest(pluginId, options);
+  if (!outcome.ok) {
     return null;
   }
+  return outcome.result;
+}
+
+async function readApplyPluginFailure(resp: Response): Promise<ApplyPluginFailure> {
+  let payload: Record<string, unknown> | null = null;
+  try {
+    const json = (await resp.json()) as unknown;
+    if (json && typeof json === 'object') {
+      payload = json as Record<string, unknown>;
+    }
+  } catch {
+    // Use the HTTP status text below.
+  }
+
+  const rawError = payload?.error;
+  const objectError =
+    rawError && typeof rawError === 'object'
+      ? (rawError as { message?: unknown; data?: { errors?: unknown } })
+      : null;
+  const error =
+    typeof rawError === 'string'
+      ? rawError
+      : typeof objectError?.message === 'string'
+        ? objectError.message
+        : undefined;
+  const fields = Array.isArray(payload?.fields)
+    ? payload.fields.filter(
+      (field): field is string => typeof field === 'string' && field.length > 0,
+    )
+    : [];
+  const payloadMessage =
+    typeof payload?.message === 'string'
+      ? payload.message
+      : typeof objectError?.message === 'string'
+        ? objectError.message
+        : undefined;
+  const details = extractErrorDetails(objectError?.data?.errors, payload?.errors);
+  let message =
+    payloadMessage ??
+    (error === 'missing_inputs' ? 'Missing required plugin inputs' : error) ??
+    resp.statusText ??
+    `HTTP ${resp.status}`;
+  if (error === 'missing_inputs' && fields.length > 0) {
+    message = `Missing required plugin inputs: ${fields.join(', ')}`;
+  } else if (details.length > 0) {
+    message = `${message}: ${details.join('; ')}`;
+  }
+
+  return {
+    ok: false,
+    status: resp.status,
+    ...(error ? { error } : {}),
+    message,
+    missingInputFields: fields,
+  };
 }
 
 async function readErrorMessage(resp: Response): Promise<string> {

--- a/apps/web/src/styles/viewer/plugin-rail.css
+++ b/apps/web/src/styles/viewer/plugin-rail.css
@@ -225,6 +225,15 @@
   background: var(--bg-subtle);
   border: 1px solid var(--border);
 }
+.plugins-section__error {
+  font-size: 12px;
+  line-height: 1.35;
+  color: var(--danger, #c33);
+  padding: 7px 9px;
+  border-radius: var(--radius-sm, 6px);
+  background: color-mix(in srgb, var(--danger, #c33) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger, #c33) 28%, transparent);
+}
 
 /* Strip rail — single-row horizontal scroller, intended for the
    ChatComposer mount where vertical space is precious. Cards collapse

--- a/apps/web/tests/components/PluginsSection.test.tsx
+++ b/apps/web/tests/components/PluginsSection.test.tsx
@@ -12,9 +12,14 @@
 //   3. Editing an input field re-fires onApplied with the new brief.
 //   4. Removing a chip clears the active plugin and invokes onCleared.
 
+import { useRef } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { PluginsSection } from '../../src/components/PluginsSection';
+import type { InstalledPluginRecord } from '@open-design/contracts';
+import {
+  PluginsSection,
+  type PluginsSectionHandle,
+} from '../../src/components/PluginsSection';
 
 const PLUGIN_ROW = {
   id: 'sample-plugin',
@@ -23,13 +28,18 @@ const PLUGIN_ROW = {
   trust: 'restricted' as const,
   sourceKind: 'local' as const,
   source: '/tmp/sample',
+  capabilitiesGranted: [],
+  fsPath: '/tmp/sample',
+  installedAt: 0,
+  updatedAt: 0,
   manifest: {
     name: 'sample-plugin',
+    version: '1.0.0',
     title: 'Sample Plugin',
     description: 'A fixture',
-    od: { taskKind: 'new-generation', mode: 'deck' },
+    od: { taskKind: 'new-generation' as const, mode: 'deck' },
   },
-};
+} satisfies InstalledPluginRecord;
 
 const APPLY_RESULT = {
   ok: true,
@@ -62,6 +72,23 @@ const APPLY_RESULT = {
   },
   projectMetadata: {},
 };
+
+function RefApplyHarness({ record = PLUGIN_ROW }: { record?: InstalledPluginRecord }) {
+  const sectionRef = useRef<PluginsSectionHandle | null>(null);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          void sectionRef.current?.applyById(record.id, record);
+        }}
+      >
+        Apply via composer
+      </button>
+      <PluginsSection ref={sectionRef} showRail={false} projectId="project-1" />
+    </>
+  );
+}
 
 let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -138,5 +165,32 @@ describe('PluginsSection', () => {
     await waitFor(() => expect(onCleared).toHaveBeenCalled());
     expect(screen.queryByTestId('context-chip-strip')).toBeNull();
     expect(screen.queryByTestId('plugin-inputs-form')).toBeNull();
+  });
+
+  it('surfaces missing required inputs from imperative composer applies', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (typeof url === 'string' && url.includes('/apply')) {
+        return new Response(
+          JSON.stringify({
+            error: 'missing_inputs',
+            fields: ['product_name', 'tagline'],
+          }),
+          {
+            status: 422,
+            headers: { 'content-type': 'application/json' },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+
+    render(<RefApplyHarness />);
+    fireEvent.click(screen.getByText('Apply via composer'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('Sample Plugin');
+    expect(alert.textContent).toContain('product_name');
+    expect(alert.textContent).toContain('tagline');
+    expect(screen.queryByTestId('context-chip-strip')).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #3540

## Why

I picked this up from the high-priority issue queue. The SaaS Landing plugin could be selected from the Live Artifact / ChatComposer plugin picker, but `/api/plugins/example-saas-landing/apply` returned `422 missing_inputs` for required fields and the web client collapsed that response to `null`.

That made the click look completely unresponsive instead of telling the user what blocked the plugin apply.

## What users will see

When a plugin apply fails because required inputs are missing, the composer now closes the plugin picker and shows an alert above the composer naming the plugin and the missing fields. Inline plugin rail applies also show the server-provided apply error details instead of the generic daemon-reachable message.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is an error state on failed plugin apply; the covered entry point is the ChatComposer imperative apply path, locked by the component regression test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/PluginsSection.test.tsx`
- Did the test go red on `main` and green on this branch? yes — the new test first failed with `Unable to find role="alert"`, then passed after the fix.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/PluginsSection.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `git diff --check`
