### PR TITLE
[codex] Add safe retry policy contracts

### DIFF
--- a/apps/daemon/src/run-retry-policy.ts
+++ b/apps/daemon/src/run-retry-policy.ts
@@ -7,7 +7,11 @@ import type {
   TrackingRunResult,
 } from '@open-design/contracts/analytics';
 
-export const DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS = 2;
+// Counts automatic same-run retry attempts, not the initial run. Issue #3543
+// scopes the first implementation to at most one automatic same-run retry, so
+// the default caps retries at a single attempt (attemptCount >= 1 suppresses
+// with attempt_limit_reached).
+export const DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS = 1;
 export const SAFE_RUN_RETRY_STRATEGY: TrackingRunRetryStrategy = 'same_run_transient';
 
 export interface RunRetryFailureSignal {

--- a/apps/daemon/src/run-retry-policy.ts
+++ b/apps/daemon/src/run-retry-policy.ts
@@ -1,0 +1,132 @@
+import type {
+  TrackingRunFailureCategory,
+  TrackingRunFailureDetail,
+  TrackingRunFailureStage,
+  TrackingRunRetryStrategy,
+  TrackingRunRetrySuppressedReason,
+  TrackingRunResult,
+} from '@open-design/contracts/analytics';
+
+export const DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS = 2;
+export const SAFE_RUN_RETRY_STRATEGY: TrackingRunRetryStrategy = 'same_run_transient';
+
+export interface RunRetryFailureSignal {
+  failure_category?: TrackingRunFailureCategory;
+  failure_detail?: TrackingRunFailureDetail;
+  failure_stage?: TrackingRunFailureStage;
+  retryable?: boolean;
+}
+
+export interface RunRetrySideEffectState {
+  cancelRequested?: boolean;
+  userVisibleOutputSeen?: boolean;
+  toolCallSeen?: boolean;
+  artifactWriteSeen?: boolean;
+  liveArtifactSeen?: boolean;
+}
+
+export interface RunRetryPolicyInput {
+  result: TrackingRunResult;
+  failure?: RunRetryFailureSignal;
+  attemptCount: number;
+  maxAttempts?: number;
+  sideEffects?: RunRetrySideEffectState;
+}
+
+export type RunRetryPolicyDecision =
+  | {
+      shouldRetry: true;
+      retryAttemptIndex: number;
+      retryMaxAttempts: number;
+      retryStrategy: TrackingRunRetryStrategy;
+      retryReason: 'transient_failure';
+    }
+  | {
+      shouldRetry: false;
+      retryAttemptIndex: number;
+      retryMaxAttempts: number;
+      retryStrategy: TrackingRunRetryStrategy;
+      retrySuppressedReason: TrackingRunRetrySuppressedReason;
+    };
+
+function normalizeAttemptCount(attemptCount: number): number {
+  if (!Number.isFinite(attemptCount) || attemptCount < 0) return 0;
+  return Math.floor(attemptCount);
+}
+
+function normalizeMaxAttempts(maxAttempts: number | undefined): number {
+  if (maxAttempts === undefined) return DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS;
+  if (!Number.isFinite(maxAttempts) || maxAttempts < 0) return 0;
+  return Math.floor(maxAttempts);
+}
+
+function isTransientRetryCategory(
+  category: TrackingRunFailureCategory | undefined,
+  detail: TrackingRunFailureDetail | undefined,
+  stage: TrackingRunFailureStage | undefined,
+): boolean {
+  if (category === 'rate_limit') return detail !== 'hard_quota';
+  if (category === 'upstream_unavailable') return true;
+  if (category === 'empty_output') return stage === undefined || stage === 'first_token_wait';
+  if (category === 'timeout') return stage === 'first_token_wait';
+  return false;
+}
+
+export function decideSafeRunRetry(
+  input: RunRetryPolicyInput,
+): RunRetryPolicyDecision {
+  const attemptCount = normalizeAttemptCount(input.attemptCount);
+  const retryMaxAttempts = normalizeMaxAttempts(input.maxAttempts);
+  const retryAttemptIndex = attemptCount + 1;
+  const base = {
+    retryAttemptIndex,
+    retryMaxAttempts,
+    retryStrategy: SAFE_RUN_RETRY_STRATEGY,
+  };
+  const suppress = (
+    retrySuppressedReason: TrackingRunRetrySuppressedReason,
+  ): RunRetryPolicyDecision => ({
+    ...base,
+    shouldRetry: false,
+    retrySuppressedReason,
+  });
+
+  if (input.result !== 'failed') return suppress('not_failed');
+
+  const sideEffects = input.sideEffects ?? {};
+  if (sideEffects.cancelRequested) return suppress('cancel_requested');
+
+  const failure = input.failure;
+  if (failure?.failure_detail === 'hard_quota') return suppress('hard_quota');
+  if (
+    failure?.failure_category !== undefined &&
+    !isTransientRetryCategory(
+      failure.failure_category,
+      failure.failure_detail,
+      failure.failure_stage,
+    )
+  ) {
+    return suppress('unsupported_category');
+  }
+  if (!failure?.retryable) return suppress('not_retryable');
+  if (
+    !isTransientRetryCategory(
+      failure.failure_category,
+      failure.failure_detail,
+      failure.failure_stage,
+    )
+  ) {
+    return suppress('unsupported_category');
+  }
+  if (attemptCount >= retryMaxAttempts) return suppress('attempt_limit_reached');
+  if (sideEffects.userVisibleOutputSeen) return suppress('user_visible_output_seen');
+  if (sideEffects.toolCallSeen) return suppress('tool_call_seen');
+  if (sideEffects.artifactWriteSeen) return suppress('artifact_write_seen');
+  if (sideEffects.liveArtifactSeen) return suppress('live_artifact_seen');
+
+  return {
+    ...base,
+    shouldRetry: true,
+    retryReason: 'transient_failure',
+  };
+}

--- a/apps/daemon/tests/run-retry-policy.test.ts
+++ b/apps/daemon/tests/run-retry-policy.test.ts
@@ -134,6 +134,20 @@ describe('decideSafeRunRetry', () => {
     }
   });
 
+  it('allows at most one automatic same-run retry by default', () => {
+    expect(decide({ attemptCount: 0 })).toMatchObject({
+      shouldRetry: true,
+      retryAttemptIndex: 1,
+      retryMaxAttempts: DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS,
+    });
+    expect(decide({ attemptCount: 1 })).toMatchObject({
+      shouldRetry: false,
+      retryAttemptIndex: 2,
+      retryMaxAttempts: DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS,
+      retrySuppressedReason: 'attempt_limit_reached',
+    });
+  });
+
   it('stops at the configured attempt limit', () => {
     expect(decide({ attemptCount: 1, maxAttempts: 2 })).toMatchObject({
       shouldRetry: true,

--- a/apps/daemon/tests/run-retry-policy.test.ts
+++ b/apps/daemon/tests/run-retry-policy.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS,
+  SAFE_RUN_RETRY_STRATEGY,
+  decideSafeRunRetry,
+  type RunRetryPolicyInput,
+} from '../src/run-retry-policy.js';
+
+function decide(input: Partial<RunRetryPolicyInput> = {}) {
+  return decideSafeRunRetry({
+    result: 'failed',
+    attemptCount: 0,
+    failure: {
+      failure_category: 'upstream_unavailable',
+      failure_detail: 'upstream_5xx',
+      failure_stage: 'first_token_wait',
+      retryable: true,
+    },
+    ...input,
+  });
+}
+
+describe('decideSafeRunRetry', () => {
+  it('allows retryable transient upstream failures before side effects', () => {
+    expect(decide()).toEqual({
+      shouldRetry: true,
+      retryAttemptIndex: 1,
+      retryMaxAttempts: DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS,
+      retryStrategy: SAFE_RUN_RETRY_STRATEGY,
+      retryReason: 'transient_failure',
+    });
+  });
+
+  it('allows ordinary retryable 429 rate limits but suppresses hard quota', () => {
+    expect(
+      decide({
+        failure: {
+          failure_category: 'rate_limit',
+          failure_detail: 'rate_limit_429',
+          failure_stage: 'session_init',
+          retryable: true,
+        },
+      }).shouldRetry,
+    ).toBe(true);
+
+    expect(
+      decide({
+        failure: {
+          failure_category: 'rate_limit',
+          failure_detail: 'hard_quota',
+          failure_stage: 'session_init',
+          retryable: false,
+        },
+      }),
+    ).toMatchObject({
+      shouldRetry: false,
+      retrySuppressedReason: 'hard_quota',
+    });
+  });
+
+  it('allows empty output and first-token timeout failures', () => {
+    expect(
+      decide({
+        failure: {
+          failure_category: 'empty_output',
+          failure_detail: 'empty_output',
+          failure_stage: 'first_token_wait',
+          retryable: true,
+        },
+      }).shouldRetry,
+    ).toBe(true);
+
+    expect(
+      decide({
+        failure: {
+          failure_category: 'timeout',
+          failure_detail: 'inactivity_timeout',
+          failure_stage: 'first_token_wait',
+          retryable: true,
+        },
+      }).shouldRetry,
+    ).toBe(true);
+  });
+
+  it('does not retry successful or cancelled terminal results', () => {
+    expect(decide({ result: 'success' })).toMatchObject({
+      shouldRetry: false,
+      retrySuppressedReason: 'not_failed',
+    });
+    expect(decide({ result: 'cancelled' })).toMatchObject({
+      shouldRetry: false,
+      retrySuppressedReason: 'not_failed',
+    });
+  });
+
+  it('requires the classifier retryable signal', () => {
+    expect(
+      decide({
+        failure: {
+          failure_category: 'upstream_unavailable',
+          failure_detail: 'upstream_5xx',
+          failure_stage: 'first_token_wait',
+          retryable: false,
+        },
+      }),
+    ).toMatchObject({
+      shouldRetry: false,
+      retrySuppressedReason: 'not_retryable',
+    });
+  });
+
+  it('suppresses non-transient categories even when the classifier marks them retryable', () => {
+    for (const failure_category of [
+      'auth',
+      'prompt_too_large',
+      'model_unavailable',
+      'tool_error',
+      'process_exit',
+      'unknown',
+    ] as const) {
+      expect(
+        decide({
+          failure: {
+            failure_category,
+            failure_stage: 'tool_execution',
+            retryable: true,
+          },
+        }),
+      ).toMatchObject({
+        shouldRetry: false,
+        retrySuppressedReason: 'unsupported_category',
+      });
+    }
+  });
+
+  it('stops at the configured attempt limit', () => {
+    expect(decide({ attemptCount: 1, maxAttempts: 2 })).toMatchObject({
+      shouldRetry: true,
+      retryAttemptIndex: 2,
+      retryMaxAttempts: 2,
+    });
+    expect(decide({ attemptCount: 2, maxAttempts: 2 })).toMatchObject({
+      shouldRetry: false,
+      retryAttemptIndex: 3,
+      retryMaxAttempts: 2,
+      retrySuppressedReason: 'attempt_limit_reached',
+    });
+  });
+
+  it('suppresses retries after user-visible output, tools, artifact writes, or live artifacts', () => {
+    expect(decide({ sideEffects: { userVisibleOutputSeen: true } })).toMatchObject({
+      shouldRetry: false,
+      retrySuppressedReason: 'user_visible_output_seen',
+    });
+    expect(decide({ sideEffects: { toolCallSeen: true } })).toMatchObject({
+      shouldRetry: false,
+      retrySuppressedReason: 'tool_call_seen',
+    });
+    expect(decide({ sideEffects: { artifactWriteSeen: true } })).toMatchObject({
+      shouldRetry: false,
+      retrySuppressedReason: 'artifact_write_seen',
+    });
+    expect(decide({ sideEffects: { liveArtifactSeen: true } })).toMatchObject({
+      shouldRetry: false,
+      retrySuppressedReason: 'live_artifact_seen',
+    });
+  });
+
+  it('suppresses retries when cancellation was requested', () => {
+    expect(decide({ sideEffects: { cancelRequested: true } })).toMatchObject({
+      shouldRetry: false,
+      retrySuppressedReason: 'cancel_requested',
+    });
+  });
+});

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -25,6 +25,8 @@ export type AnalyticsEventName =
   // Run lifecycle (daemon authoritative)
   | 'run_created'
   | 'run_finished'
+  | 'run_retry_attempted'
+  | 'run_retry_finished'
   // Packaged updater lifecycle
   | 'update_install_result'
   | 'update_apply_observed'
@@ -256,6 +258,23 @@ export type TrackingRunFailureUserAction =
   | 'reduce_context'
   | 'install_cli'
   | 'none';
+export type TrackingRunRetryStrategy = 'same_run_transient';
+export type TrackingRunRetryFinalResult =
+  | 'not_attempted'
+  | 'success'
+  | 'failed'
+  | 'suppressed';
+export type TrackingRunRetrySuppressedReason =
+  | 'not_failed'
+  | 'not_retryable'
+  | 'unsupported_category'
+  | 'hard_quota'
+  | 'attempt_limit_reached'
+  | 'cancel_requested'
+  | 'user_visible_output_seen'
+  | 'tool_call_seen'
+  | 'artifact_write_seen'
+  | 'live_artifact_seen';
 export type TrackingRunDiagnosticSource =
   | 'error_event'
   | 'stderr'
@@ -1903,6 +1922,36 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   design_system_created?: boolean;
   preview_module_count?: number;
   missing_font_count?: number;
+  retry_attempt_count?: number;
+  retry_final_result?: TrackingRunRetryFinalResult;
+  retry_suppressed_reason?: TrackingRunRetrySuppressedReason;
+}
+
+export interface RunRetryBaseProps {
+  page_name: 'chat_panel' | 'design_system_project';
+  area: 'chat_panel' | 'design_system_generation';
+  project_id: string;
+  conversation_id: string | null;
+  run_id: string;
+  retry_of_run_id: string;
+  retry_attempt_index: number;
+  retry_max_attempts: number;
+  retry_strategy: TrackingRunRetryStrategy;
+  agent_provider_id: TrackingCliProviderId;
+  model_id: string;
+  failure_category?: TrackingRunFailureCategory;
+  failure_detail?: TrackingRunFailureDetail;
+  failure_stage?: TrackingRunFailureStage;
+  error_code?: string;
+}
+
+export interface RunRetryAttemptedProps extends RunRetryBaseProps {
+  retry_reason: 'transient_failure';
+}
+
+export interface RunRetryFinishedProps extends RunRetryBaseProps {
+  retry_result: 'success' | 'failed' | 'suppressed';
+  retry_suppressed_reason?: TrackingRunRetrySuppressedReason;
 }
 
 export type TrackingUpdateApplyResult = 'success' | 'not_applied' | 'unknown';
@@ -2145,6 +2194,8 @@ export type AnalyticsEventPayload =
   | { event: 'plugin_replacement_result'; props: PluginReplacementResultProps }
   | { event: 'run_created'; props: RunCreatedProps }
   | { event: 'run_finished'; props: RunFinishedProps }
+  | { event: 'run_retry_attempted'; props: RunRetryAttemptedProps }
+  | { event: 'run_retry_finished'; props: RunRetryFinishedProps }
   | { event: 'update_install_result'; props: UpdateInstallResultProps }
   | { event: 'update_apply_observed'; props: UpdateApplyObservedProps }
   | { event: 'file_upload_result'; props: FileUploadResultProps }

--- a/packages/contracts/tests/analytics-run-finished-contract.test.ts
+++ b/packages/contracts/tests/analytics-run-finished-contract.test.ts
@@ -76,6 +76,8 @@ describe('analytics run_finished contract', () => {
         tool_call_count: 2,
         tool_duration_ms: 350,
         finalize_duration_ms: 30,
+        retry_attempt_count: 1,
+        retry_final_result: 'success',
       },
     } satisfies Extract<AnalyticsEventPayload, { event: 'run_finished' }>;
 
@@ -87,5 +89,43 @@ describe('analytics run_finished contract', () => {
     expect(payload.props.cache_token_source).toBe('anthropic');
     expect(payload.props.total_duration_ms).toBe(1234);
     expect(payload.props.tool_call_count).toBe(2);
+    expect(payload.props.retry_attempt_count).toBe(1);
+    expect(payload.props.retry_final_result).toBe('success');
+  });
+
+  it('accepts retry attempted and finished lifecycle events', () => {
+    const attempted = {
+      event: 'run_retry_attempted',
+      props: {
+        page_name: 'chat_panel',
+        area: 'chat_panel',
+        project_id: 'proj-1',
+        conversation_id: 'conv-1',
+        run_id: 'run-1',
+        retry_of_run_id: 'run-1',
+        retry_attempt_index: 1,
+        retry_max_attempts: 2,
+        retry_strategy: 'same_run_transient',
+        agent_provider_id: 'claude_code',
+        model_id: 'claude-sonnet-4-5',
+        failure_category: 'upstream_unavailable',
+        failure_detail: 'upstream_5xx',
+        failure_stage: 'first_token_wait',
+        error_code: 'UPSTREAM_UNAVAILABLE',
+        retry_reason: 'transient_failure',
+      },
+    } satisfies Extract<AnalyticsEventPayload, { event: 'run_retry_attempted' }>;
+
+    const finished = {
+      event: 'run_retry_finished',
+      props: {
+        ...attempted.props,
+        retry_result: 'suppressed',
+        retry_suppressed_reason: 'tool_call_seen',
+      },
+    } satisfies Extract<AnalyticsEventPayload, { event: 'run_retry_finished' }>;
+
+    expect(attempted.props.retry_strategy).toBe('same_run_transient');
+    expect(finished.props.retry_suppressed_reason).toBe('tool_call_seen');
   });
 });


### PR DESCRIPTION
Refs #3408
Refs #3526

## Why

Issue 1 starts the run reliability follow-up work agreed in #3526. The immediate need is to lock the safe same-run retry contract before wiring runtime behavior, so the retry implementation can emit stable PostHog fields and make suppression reasons reviewable instead of implicit.

This addresses the reliability gap where transient failures are classified as retryable but there is not yet a bounded policy or analytics contract for retry attempts, retry results, and final run aggregates.

## What users will see

No direct user-facing behavior change. This PR adds typed contracts and daemon policy groundwork only; runtime retry wiring is left for the next implementation PR.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface.

## Bug fix verification

N/A — this is contract and policy groundwork for the safe retry implementation.

## Validation

- `pnpm --filter @open-design/contracts test -- analytics-run-finished-contract.test.ts`
- `pnpm exec vitest run -c vitest.config.ts tests/run-retry-policy.test.ts` from `apps/daemon`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
