### PR TITLE
[codex] Add same-run retry runtime

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11275,7 +11275,14 @@ export async function startServer({
           'error',
           createSseErrorPayload('AGENT_EXECUTION_FAILED', message),
         );
-        design.runs.finish(run, 'failed', 1, null);
+        // Route the retried-start failure through the same finalizer as child
+        // close/error so it emits terminal retry telemetry (run_retry_finished
+        // with retry_result: 'failed') and sets run.retryFinalResult, instead
+        // of finishing directly and leaving run_finished to report the fallback
+        // retry_final_result: 'not_attempted'. retryAttemptCount is already 1
+        // here, so decideSafeRunRetry suppresses with attempt_limit_reached and
+        // cannot trigger another restart loop.
+        finishWithRetryDecision('failed', 1, null);
       });
     };
     const finalizeRetryTelemetry = (status, decision, failure, errorCode) => {
@@ -11354,10 +11361,11 @@ export async function startServer({
           retry_reason: decision.retryReason,
         });
         restartSameRunAfterRetry();
-        return;
+        return true;
       }
       finalizeRetryTelemetry(status, decision, failure, errorCode);
       design.runs.finish(run, status, code, signal);
+      return false;
     };
     const mcpServers = buildLiveArtifactsMcpServersForAgent(def, {
       enabled: Boolean(toolTokenGrant?.token),
@@ -11771,6 +11779,14 @@ export async function startServer({
     // they just terminated the process. Set strictly inside
     // `failForInactivity`'s quiet-period branch.
     let artifactQuietShutdownRequested = false;
+    // Set when the no-output inactivity watchdog routed this attempt through
+    // the same-run retry finalizer AND that finalizer restarted the run on a
+    // fresh child. The stalled child is then SIGTERM'd, so its later `close`
+    // must NOT finalize the run a second time or unregister the new attempt's
+    // event sink / run handle (both keyed by the shared runId). The close
+    // handler bails early when this is true, revoking only this attempt's own
+    // tool token.
+    let watchdogRetryRestarted = false;
     const summarizeAgentEventForInactivity = (payload) => {
       const type = payload?.type ? String(payload.type) : 'unknown';
       if (type === 'tool_result') {
@@ -11862,7 +11878,17 @@ export async function startServer({
         stallPayload = createSseErrorPayload('AGENT_EXECUTION_FAILED', message, { retryable: true });
       }
       send('error', stallPayload);
-      design.runs.finish(run, 'failed', 1, null);
+      // A silent first-token hang is one of the safe transient failure shapes
+      // this run is allowed to recover: classifyRunFailure maps the stall text
+      // to a retryable `timeout` at `first_token_wait`, and decideSafeRunRetry
+      // permits the same-run retry when no output/tools/artifacts were seen.
+      // Route through the shared finalizer (after surfacing stallPayload) so
+      // the watchdog path gets the same run_retry_attempted/run_retry_finished
+      // telemetry as child close/error — not a bare terminal failure.
+      const retried = finishWithRetryDecision('failed', 1, null);
+      if (retried) {
+        watchdogRetryRestarted = true;
+      }
       if (acpSession?.abort) {
         acpSession.abort();
       }
@@ -12748,6 +12774,17 @@ export async function startServer({
     child.on('close', async (code, signal) => {
       try {
       clearInactivityWatchdog();
+      if (watchdogRetryRestarted) {
+        // The inactivity watchdog already failed this attempt and the same-run
+        // retry restarted on a fresh child. Finalization and event-sink / run-
+        // handle ownership (keyed by the shared runId) now belong to the new
+        // attempt, so this stalled child's close must not re-run them — doing
+        // so would re-finalize the run and delete the new attempt's sink.
+        // Revoke only THIS attempt's tool token (idempotent, keyed by its own
+        // token string) and bail; the `finally` block still cleans up logs.
+        revokeToolToken('child_exit');
+        return;
+      }
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
       if (acpSession?.hasFatalError()) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -245,6 +245,7 @@ import { renderDesignSystemShowcase } from './design-system-showcase.js';
 import { createChatRunService } from './runs.js';
 import { deriveRunErrorCode, runResultFromStatus } from './run-result.js';
 import { classifyRunFailure } from './run-failure-classification.js';
+import { decideSafeRunRetry } from './run-retry-policy.js';
 import {
   hasExplicitRequestedModelForAnalytics,
   scanRunEventsForUsageAnalytics,
@@ -2043,6 +2044,70 @@ function scanRunEventsForFinishedProps(events, reqBodyModel) {
 
 export function __forTestScanRunEventsForFinishedProps(events, reqBodyModel) {
   return scanRunEventsForFinishedProps(events, reqBodyModel);
+}
+
+function scanRunEventsForRetrySideEffects(events) {
+  const sideEffects = {
+    userVisibleOutputSeen: false,
+    toolCallSeen: false,
+    artifactWriteSeen: false,
+    liveArtifactSeen: false,
+  };
+  for (const rec of Array.isArray(events) ? events : []) {
+    if (rec?.event === 'stdout') {
+      const chunk = rec.data?.chunk;
+      if (typeof chunk === 'string' ? chunk.length > 0 : chunk !== undefined) {
+        sideEffects.userVisibleOutputSeen = true;
+      }
+    }
+    const data = rec?.data;
+    if (!data || typeof data !== 'object') continue;
+    if (data.type === 'text_delta' || data.type === 'thinking_delta') {
+      const delta = typeof data.delta === 'string' ? data.delta : '';
+      if (delta.length > 0) sideEffects.userVisibleOutputSeen = true;
+    }
+    if (data.type === 'tool_use') sideEffects.toolCallSeen = true;
+    if (data.type === 'artifact') sideEffects.artifactWriteSeen = true;
+    if (data.type === 'live_artifact' || rec.event === 'live_artifact') {
+      sideEffects.liveArtifactSeen = true;
+    }
+  }
+  if (
+    countNewHtmlArtifacts(events) > 0 ||
+    didRunCreateDesignSystemFile(events) ||
+    countDesignSystemPreviewModules(events) > 0
+  ) {
+    sideEffects.artifactWriteSeen = true;
+  }
+  return sideEffects;
+}
+
+export function __forTestScanRunEventsForRetrySideEffects(events) {
+  return scanRunEventsForRetrySideEffects(events);
+}
+
+function retryFinalResultForRunStatus(status, retryAttemptCount) {
+  const result = runResultFromStatus(status);
+  if ((retryAttemptCount ?? 0) <= 0) {
+    return result === 'failed' ? 'suppressed' : 'not_attempted';
+  }
+  if (result === 'success') return 'success';
+  if (result === 'failed') return 'failed';
+  return 'suppressed';
+}
+
+export function __forTestRetryFinalResultForRunStatus(status, retryAttemptCount) {
+  return retryFinalResultForRunStatus(status, retryAttemptCount);
+}
+
+function runRetryEventsForAnalytics(events) {
+  return (Array.isArray(events) ? events : []).filter((rec) =>
+    rec?.event === 'run_retry_attempted' || rec?.event === 'run_retry_finished'
+  );
+}
+
+export function __forTestRunRetryEventsForAnalytics(events) {
+  return runRetryEventsForAnalytics(events);
 }
 
 function githubRepoNameFromPluginName(name) {
@@ -10768,7 +10833,11 @@ export async function startServer({
     // disk and a marker inside this turn's message is reflected in this
     // turn's prompt. Failures are swallowed — memory is best-effort and
     // must never block the agent run.
-    if (typeof message === 'string' && message.trim().length > 0) {
+    if (
+      (run.retryAttemptCount ?? 0) === 0 &&
+      typeof message === 'string' &&
+      message.trim().length > 0
+    ) {
       try {
         await extractFromMessage(RUNTIME_DATA_DIR, message);
       } catch (err) {
@@ -11157,6 +11226,138 @@ export async function startServer({
     const send = (event, data) => {
       persistRunEventToAssistantMessage(db, run, event, data);
       design.runs.emit(run, event, data);
+    };
+    const retryAnalyticsBase = (decision, failure, errorCode) => {
+      const runProjectKind = resolveRunProjectKindForAnalytics({
+        hintProjectKind: null,
+        projectMetadata: projectRecord?.metadata,
+      });
+      const isDesignSystemRun =
+        runProjectKind === 'design_system' ||
+        (typeof designSystemId === 'string' && designSystemId.length > 0);
+      return {
+        page_name: isDesignSystemRun ? 'design_system_project' : 'chat_panel',
+        area: isDesignSystemRun ? 'design_system_generation' : 'chat_panel',
+        project_id: typeof projectId === 'string' ? projectId : run.projectId,
+        conversation_id:
+          typeof conversationId === 'string' ? conversationId : run.conversationId ?? null,
+        run_id: run.id,
+        retry_of_run_id: run.id,
+        retry_attempt_index: decision.retryAttemptIndex,
+        retry_max_attempts: decision.retryMaxAttempts,
+        retry_strategy: decision.retryStrategy,
+        agent_provider_id: agentIdToTracking(agentId),
+        model_id: modelIdForTracking(safeModel ?? model),
+        ...(failure?.failure_category ? { failure_category: failure.failure_category } : {}),
+        ...(failure?.failure_detail ? { failure_detail: failure.failure_detail } : {}),
+        ...(failure?.failure_stage ? { failure_stage: failure.failure_stage } : {}),
+        ...(errorCode ? { error_code: errorCode } : {}),
+      };
+    };
+    const restartSameRunAfterRetry = () => {
+      run.status = 'queued';
+      run.updatedAt = Date.now();
+      run.child = null;
+      run.acpSession = null;
+      run.exitCode = null;
+      run.signal = null;
+      run.error = null;
+      run.errorCode = null;
+      run.stdinOpen = false;
+      run.pendingHostAnswers?.clear?.();
+      run.analyticsTelemetry = {
+        startRequestedAt: run.analyticsTelemetry?.startRequestedAt ?? run.createdAt,
+      };
+      void startChatRun(chatBody, run).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        design.runs.emit(
+          run,
+          'error',
+          createSseErrorPayload('AGENT_EXECUTION_FAILED', message),
+        );
+        design.runs.finish(run, 'failed', 1, null);
+      });
+    };
+    const finalizeRetryTelemetry = (status, decision, failure, errorCode) => {
+      const attemptCount = run.retryAttemptCount ?? 0;
+      const result = runResultFromStatus(status);
+      if (attemptCount <= 0 && result !== 'failed') {
+        run.retryFinalResult = 'not_attempted';
+        run.retrySuppressedReason = undefined;
+        return;
+      }
+      const retryResult =
+        attemptCount > 0
+          ? result === 'success'
+            ? 'success'
+            : result === 'failed'
+              ? 'failed'
+              : 'suppressed'
+          : 'suppressed';
+      const retrySuppressedReason =
+        retryResult === 'suppressed'
+          ? run.cancelRequested
+            ? 'cancel_requested'
+            : decision?.retrySuppressedReason
+          : undefined;
+      const eventDecision =
+        attemptCount > 0
+          ? { ...decision, retryAttemptIndex: attemptCount }
+          : decision;
+      run.retryFinalResult = retryResult;
+      run.retrySuppressedReason = retrySuppressedReason;
+      design.runs.emit(run, 'run_retry_finished', {
+        ...retryAnalyticsBase(eventDecision, failure, errorCode),
+        retry_result: retryResult,
+        ...(retrySuppressedReason
+          ? { retry_suppressed_reason: retrySuppressedReason }
+          : {}),
+      });
+    };
+    const finishWithRetryDecision = (status, code = null, signal = null) => {
+      const result = runResultFromStatus(status);
+      const errorCode = deriveRunErrorCode({
+        status,
+        error: run.error,
+        errorCode: run.errorCode,
+        exitCode: code,
+        signal,
+      });
+      const failure = classifyRunFailure({
+        result,
+        status: {
+          status,
+          error: run.error,
+          errorCode: run.errorCode,
+          exitCode: code,
+          signal,
+        },
+        ...(errorCode ? { errorCode } : {}),
+        agentId: run.agentId,
+        events: run.events,
+      });
+      const decision = decideSafeRunRetry({
+        result,
+        failure,
+        attemptCount: run.retryAttemptCount ?? 0,
+        sideEffects: {
+          ...scanRunEventsForRetrySideEffects(run.events),
+          cancelRequested: !!run.cancelRequested,
+        },
+      });
+      if (decision.shouldRetry && !design.runs.isTerminal(run.status)) {
+        run.retryAttemptCount = decision.retryAttemptIndex;
+        run.retryFinalResult = undefined;
+        run.retrySuppressedReason = undefined;
+        design.runs.emit(run, 'run_retry_attempted', {
+          ...retryAnalyticsBase(decision, failure, errorCode),
+          retry_reason: decision.retryReason,
+        });
+        restartSameRunAfterRetry();
+        return;
+      }
+      finalizeRetryTelemetry(status, decision, failure, errorCode);
+      design.runs.finish(run, status, code, signal);
     };
     const mcpServers = buildLiveArtifactsMcpServersForAgent(def, {
       enabled: Boolean(toolTokenGrant?.token),
@@ -12542,7 +12743,7 @@ export async function startServer({
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
       send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err.message));
-      design.runs.finish(run, 'failed', 1, null);
+      finishWithRetryDecision('failed', 1, null);
     });
     child.on('close', async (code, signal) => {
       try {
@@ -12550,10 +12751,10 @@ export async function startServer({
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
       if (acpSession?.hasFatalError()) {
-        return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
+        return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
       }
       if (agentStreamError) {
-        return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
+        return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
       }
       if (
         code !== 0 &&
@@ -12565,7 +12766,7 @@ export async function startServer({
           );
           if (amrFailure) {
             sendAmrAccountFailure(amrFailure);
-            return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
+            return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
           }
         }
         const authFailure = classifyAgentAuthFailure(
@@ -12578,7 +12779,7 @@ export async function startServer({
             authFailure.message ?? cursorAuthGuidance(),
             { retryable: true },
           ));
-          return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
+          return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
         }
       }
       // Empty-output guard: a clean `code === 0` exit with no visible
@@ -12595,7 +12796,7 @@ export async function startServer({
           'Agent completed without producing any output. The model or provider may have returned an empty response — check the agent logs for upstream errors.',
           { retryable: true },
         ));
-        return design.runs.finish(run, 'failed', code, signal);
+        return finishWithRetryDecision('failed', code, signal);
       }
       if (
         code === 0 &&
@@ -12608,7 +12809,7 @@ export async function startServer({
           'Plugin authoring ended before generating the required generated-plugin artifacts.',
           { retryable: true },
         ));
-        return design.runs.finish(run, 'failed', code, signal);
+        return finishWithRetryDecision('failed', code, signal);
       }
       // Plain-stream auth-failure guard: plain adapters (today
       // antigravity, deepseek's TUI variants) may exit cleanly with
@@ -12636,7 +12837,7 @@ export async function startServer({
             authFailure.message ?? `${def.name} authentication required. Please re-authenticate and retry.`,
             { retryable: true },
           ));
-          return design.runs.finish(run, 'failed', 0, signal);
+          return finishWithRetryDecision('failed', 0, signal);
         }
       }
       // Plain-stream empty-output guard: plain agents send raw stdout
@@ -12698,7 +12899,7 @@ export async function startServer({
           msg,
           { retryable: true },
         ));
-        return design.runs.finish(run, 'failed', 0, signal);
+        return finishWithRetryDecision('failed', 0, signal);
       }
       // ACP agents that don't shut down on stdin.end() (e.g. Devin for
       // Terminal) are forced to exit via SIGTERM from attachAcpSession after
@@ -12839,7 +13040,7 @@ export async function startServer({
       for (const chunk of plaintextStdoutBuffer) {
         send('stdout', { chunk });
       }
-      design.runs.finish(run, status, code, signal);
+      finishWithRetryDecision(status, code, signal);
       } finally {
         // Best-effort cleanup of the per-run agy log file on every close
         // path — successful, failed, cancelled, or non-zero exit — so
@@ -13575,6 +13776,15 @@ export async function startServer({
         const finishedModelId = hasExplicitRequestedModelForAnalytics(reqBody.model)
           ? modelIdForTracking(reqBody.model)
           : modelIdForTracking(usageAnalytics.agent_reported_model);
+        for (const [index, retryEvent] of runRetryEventsForAnalytics(run.events).entries()) {
+          design.analytics.capture({
+            eventName: retryEvent.event,
+            context: analyticsContext,
+            appVersion: design.getAppVersion(),
+            properties: retryEvent.data,
+            insertId: `${runInsertId}-${retryEvent.event}-${index}`,
+          });
+        }
         design.analytics.capture({
           eventName: 'run_finished',
           context: analyticsContext,
@@ -13603,6 +13813,11 @@ export async function startServer({
             // artifact" funnel instead of counting them as failures. See
             // `run-artifacts.ts`; tested in `tests/run-artifacts.test.ts`.
             asked_user_question: runAskedUserQuestion(run.events),
+            retry_attempt_count: run.retryAttemptCount ?? 0,
+            retry_final_result: run.retryFinalResult ?? 'not_attempted',
+            ...(run.retrySuppressedReason
+              ? { retry_suppressed_reason: run.retrySuppressedReason }
+              : {}),
             ...(isDesignSystemRun ? {
               // DS runs land a `DESIGN.md` write when generation
               // succeeded; the run-artifacts inspector reuses the

--- a/apps/daemon/tests/run-lifecycle-analytics.test.ts
+++ b/apps/daemon/tests/run-lifecycle-analytics.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  __forTestRetryFinalResultForRunStatus,
+  __forTestRunRetryEventsForAnalytics,
   __forTestResolveRunProjectKindForAnalytics,
+  __forTestScanRunEventsForRetrySideEffects,
   __forTestScanRunEventsForFinishedProps,
 } from '../src/server.js';
 import { hasExplicitRequestedModelForAnalytics } from '../src/run-analytics-observability.js';
@@ -139,5 +142,49 @@ describe('hasExplicitRequestedModelForAnalytics', () => {
     expect(hasExplicitRequestedModelForAnalytics('')).toBe(false);
     expect(hasExplicitRequestedModelForAnalytics(' default ')).toBe(false);
     expect(hasExplicitRequestedModelForAnalytics('claude-opus-4-7')).toBe(true);
+  });
+});
+
+describe('run retry analytics helpers', () => {
+  it('detects retry-blocking side effects from run events', () => {
+    expect(__forTestScanRunEventsForRetrySideEffects([
+      { event: 'stderr', data: { chunk: 'HTTP 503' } },
+    ])).toEqual({
+      userVisibleOutputSeen: false,
+      toolCallSeen: false,
+      artifactWriteSeen: false,
+      liveArtifactSeen: false,
+    });
+
+    expect(__forTestScanRunEventsForRetrySideEffects([
+      { event: 'agent', data: { type: 'text_delta', delta: 'hello' } },
+      { event: 'agent', data: { type: 'tool_use', id: 't1', name: 'Read', input: {} } },
+      { event: 'agent', data: { type: 'live_artifact' } },
+    ])).toMatchObject({
+      userVisibleOutputSeen: true,
+      toolCallSeen: true,
+      liveArtifactSeen: true,
+    });
+  });
+
+  it('derives retry final result from terminal status and attempt count', () => {
+    expect(__forTestRetryFinalResultForRunStatus('succeeded', 0)).toBe('not_attempted');
+    expect(__forTestRetryFinalResultForRunStatus('failed', 0)).toBe('suppressed');
+    expect(__forTestRetryFinalResultForRunStatus('succeeded', 1)).toBe('success');
+    expect(__forTestRetryFinalResultForRunStatus('failed', 1)).toBe('failed');
+    expect(__forTestRetryFinalResultForRunStatus('canceled', 1)).toBe('suppressed');
+  });
+
+  it('selects retry events for daemon-side analytics replay', () => {
+    const events = [
+      { event: 'start', data: {} },
+      { event: 'run_retry_attempted', data: { retry_attempt_index: 1 } },
+      { event: 'run_retry_finished', data: { retry_result: 'success' } },
+      { event: 'end', data: {} },
+    ];
+    expect(__forTestRunRetryEventsForAnalytics(events).map((event) => event.event)).toEqual([
+      'run_retry_attempted',
+      'run_retry_finished',
+    ]);
   });
 });

--- a/apps/daemon/tests/run-retry-runtime.test.ts
+++ b/apps/daemon/tests/run-retry-runtime.test.ts
@@ -100,6 +100,63 @@ describe('same-run retry runtime', () => {
       retry_result: 'success',
     });
   });
+
+  it('retries a silent first-token stall caught by the inactivity watchdog', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-retry-stall-bin-'));
+    const fakeClaude = await writeStallingClaude(binDir, 'claude-stall');
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    // Trip the no-output inactivity watchdog quickly so the first (silent)
+    // attempt stalls at first_token_wait and the same-run retry can fire. Kept
+    // comfortably above node cold-start so the recovered retry attempt's own
+    // watchdog does not also trip before it emits its first token.
+    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = '400';
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: fakeClaude } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const run = await createAndWaitForRun(started.url);
+    expect(run.status).toBe('succeeded');
+    expect(run.id).toBeTruthy();
+
+    const events = await readRunEvents(run.eventsLogPath);
+    // Two spawns (silent stall + recovered retry), one terminal end.
+    expect(events.filter((event) => event.event === 'start')).toHaveLength(2);
+    expect(events.filter((event) => event.event === 'end')).toHaveLength(1);
+
+    const retryAttempted = events.filter((event) => event.event === 'run_retry_attempted');
+    expect(retryAttempted).toHaveLength(1);
+    expect(retryAttempted[0]?.data).toMatchObject({
+      run_id: run.id,
+      retry_of_run_id: run.id,
+      retry_attempt_index: 1,
+      retry_max_attempts: 1,
+      retry_strategy: 'same_run_transient',
+      retry_reason: 'transient_failure',
+      failure_category: 'timeout',
+      failure_detail: 'inactivity_timeout',
+      failure_stage: 'first_token_wait',
+    });
+
+    const retryFinished = events.filter((event) => event.event === 'run_retry_finished');
+    expect(retryFinished).toHaveLength(1);
+    expect(retryFinished[0]?.data).toMatchObject({
+      run_id: run.id,
+      retry_of_run_id: run.id,
+      retry_attempt_index: 1,
+      retry_result: 'success',
+    });
+  });
 });
 
 function snapshotEnv(): Record<string, string | undefined> {
@@ -110,6 +167,7 @@ function snapshotEnv(): Record<string, string | undefined> {
     OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
     POSTHOG_KEY: process.env.POSTHOG_KEY,
     POSTHOG_HOST: process.env.POSTHOG_HOST,
+    OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS: process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS,
   };
 }
 
@@ -147,6 +205,46 @@ if (attempts === 0) {
     message: {
       id: 'msg-retry-success',
       content: [{ type: 'text', text: 'Recovered after retry.' }],
+      stop_reason: 'end_turn'
+    }
+  }));
+  setTimeout(() => process.exit(0), 20);
+}
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function writeStallingClaude(dir: string, name: string): Promise<string> {
+  const bin = path.join(dir, name);
+  const counterPath = path.join(dir, `${name}-attempts`);
+  await writeFile(bin, `#!/usr/bin/env node
+const fs = require('node:fs');
+const counterPath = ${JSON.stringify(counterPath)};
+if (process.argv.includes('--version')) {
+  console.log('claude-code 1.0.0-retry-stall');
+  process.exit(0);
+}
+if (process.argv.includes('--help')) {
+  console.log('Usage: claude -p [--include-partial-messages] [--add-dir DIR]');
+  process.exit(0);
+}
+let attempts = 0;
+try { attempts = Number(fs.readFileSync(counterPath, 'utf8')) || 0; } catch {}
+fs.writeFileSync(counterPath, String(attempts + 1));
+if (attempts === 0) {
+  // First attempt: emit nothing on stdout/stderr and hang well past the
+  // inactivity watchdog window so the daemon classifies a silent first-token
+  // stall. Exit cleanly when the watchdog SIGTERMs us (default Node behavior),
+  // and keep a long fallback timer so we never self-exit before the watchdog.
+  setTimeout(() => process.exit(0), 60000);
+} else {
+  console.log(JSON.stringify({ type: 'system', subtype: 'init', model: 'claude-retry-test' }));
+  console.log(JSON.stringify({
+    type: 'assistant',
+    message: {
+      id: 'msg-retry-stall-success',
+      content: [{ type: 'text', text: 'Recovered after watchdog retry.' }],
       stop_reason: 'end_turn'
     }
   }));

--- a/apps/daemon/tests/run-retry-runtime.test.ts
+++ b/apps/daemon/tests/run-retry-runtime.test.ts
@@ -1,0 +1,232 @@
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = {
+  id: string;
+  projectId: string;
+  conversationId: string;
+  assistantMessageId: string;
+  agentId: string;
+  status: string;
+  createdAt: number;
+  updatedAt: number;
+  exitCode: number | null;
+  signal: string | null;
+  error: string | null;
+  errorCode: string | null;
+  eventsLogPath: string;
+};
+
+type RunEvent = {
+  event: string;
+  data: Record<string, unknown>;
+};
+
+describe('same-run retry runtime', () => {
+  const originalEnv = snapshotEnv();
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (binDir) await rm(binDir, { recursive: true, force: true });
+    binDir = null;
+    restoreEnv(originalEnv);
+  });
+
+  it('retries a transient first-token failure inside the same run and logs retry events', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-retry-runtime-bin-'));
+    const fakeClaude = await writeFlakyClaude(binDir, 'claude-flaky');
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: fakeClaude } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const run = await createAndWaitForRun(started.url);
+    expect(run.status).toBe('succeeded');
+    expect(run.id).toBeTruthy();
+
+    const events = await readRunEvents(run.eventsLogPath);
+    expect(events.filter((event) => event.event === 'start')).toHaveLength(2);
+    expect(events.filter((event) => event.event === 'end')).toHaveLength(1);
+
+    const retryAttempted = events.filter((event) => event.event === 'run_retry_attempted');
+    expect(retryAttempted).toHaveLength(1);
+    expect(retryAttempted[0]?.data).toMatchObject({
+      run_id: run.id,
+      retry_of_run_id: run.id,
+      retry_attempt_index: 1,
+      retry_max_attempts: 1,
+      retry_strategy: 'same_run_transient',
+      retry_reason: 'transient_failure',
+      failure_category: 'upstream_unavailable',
+      failure_detail: 'upstream_5xx',
+      failure_stage: 'first_token_wait',
+    });
+
+    const retryFinished = events.filter((event) => event.event === 'run_retry_finished');
+    expect(retryFinished).toHaveLength(1);
+    expect(retryFinished[0]?.data).toMatchObject({
+      run_id: run.id,
+      retry_of_run_id: run.id,
+      retry_attempt_index: 1,
+      retry_result: 'success',
+    });
+  });
+});
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return {
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+  };
+}
+
+function restoreEnv(env: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+async function writeFlakyClaude(dir: string, name: string): Promise<string> {
+  const bin = path.join(dir, name);
+  const counterPath = path.join(dir, `${name}-attempts`);
+  await writeFile(bin, `#!/usr/bin/env node
+const fs = require('node:fs');
+const counterPath = ${JSON.stringify(counterPath)};
+if (process.argv.includes('--version')) {
+  console.log('claude-code 1.0.0-retry-runtime');
+  process.exit(0);
+}
+if (process.argv.includes('--help')) {
+  console.log('Usage: claude -p [--include-partial-messages] [--add-dir DIR]');
+  process.exit(0);
+}
+let attempts = 0;
+try { attempts = Number(fs.readFileSync(counterPath, 'utf8')) || 0; } catch {}
+fs.writeFileSync(counterPath, String(attempts + 1));
+if (attempts === 0) {
+  process.stderr.write('HTTP 503 Service Unavailable: upstream provider unavailable before first token.\\n');
+  setTimeout(() => process.exit(1), 20);
+} else {
+  console.log(JSON.stringify({ type: 'system', subtype: 'init', model: 'claude-retry-test' }));
+  console.log(JSON.stringify({
+    type: 'assistant',
+    message: {
+      id: 'msg-retry-success',
+      content: [{ type: 'text', text: 'Recovered after retry.' }],
+      stop_reason: 'end_turn'
+    }
+  }));
+  setTimeout(() => process.exit(0), 20);
+}
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function createAndWaitForRun(url: string): Promise<RunStatus> {
+  const projectId = `retry_runtime_${randomUUID()}`;
+  const projectResponse = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'Retry runtime smoke',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(projectResponse.status).toBe(200);
+  const projectBody = await projectResponse.json() as { conversationId: string };
+  const assistantMessageId = `assistant_retry_${randomUUID()}`;
+  const runResponse = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'retry-runtime-test',
+      'x-od-analytics-session-id': 'retry-runtime-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId,
+      conversationId: projectBody.conversationId,
+      assistantMessageId,
+      clientRequestId: `client_retry_${randomUUID()}`,
+      agentId: 'claude',
+      message: 'please retry a transient runtime failure',
+      currentPrompt: 'please retry a transient runtime failure',
+    }),
+  });
+  expect(runResponse.status).toBe(202);
+  const body = await runResponse.json() as { runId: string };
+  return await waitForRun(url, body.runId);
+}
+
+async function waitForRun(url: string, runId: string): Promise<RunStatus> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
+    expect(response.status).toBe(200);
+    const run = await response.json() as RunStatus;
+    if (run.status === 'failed' || run.status === 'succeeded' || run.status === 'canceled') {
+      return run;
+    }
+    await delay(100);
+  }
+  throw new Error(`run ${runId} did not finish`);
+}
+
+async function readRunEvents(file: string): Promise<RunEvent[]> {
+  const raw = await readFile(file, 'utf8');
+  return raw
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as RunEvent);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Refs #3543

## Why

Issue #3543 tracks safe automatic retry for chat runs. PR #3569 landed the deterministic retry policy and analytics contracts; this PR wires that already-reviewed policy into the daemon runtime so transient first-token failures can recover without turning into a final user-visible failure.

The pain being addressed is that retryable upstream/service blips currently end a chat run even when the run has not emitted output, tools, artifacts, or live artifacts. This keeps the retry semantics centralized in the policy layer while adding the runtime path and observability needed for the next slice.

## What users will see

A chat run that fails once with a safe transient provider/runtime failure before side effects can automatically retry inside the same run and finish successfully. Retry attempts and final retry outcomes are logged for analytics.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — daemon runtime behavior only.

## Bug fix verification

N/A — this is the PR2C runtime slice for #3543, not a standalone bug fix.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/run-lifecycle-analytics.test.ts tests/run-retry-runtime.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`