### PR TITLE
feat(analytics): attribute AMR entry conversions

### DIFF
--- a/apps/daemon/src/integrations/vela.ts
+++ b/apps/daemon/src/integrations/vela.ts
@@ -4,6 +4,11 @@ import { homedir } from 'node:os';
 import path from 'node:path';
 
 import { createCommandInvocation } from '@open-design/platform';
+import type {
+  AmrEntryAttribution,
+  TrackingAmrEntrySource,
+  TrackingPageName,
+} from '@open-design/contracts/analytics';
 
 import { resolveAgentLaunch } from '../runtimes/launch.js';
 import { spawnEnvForAgent } from '../runtimes/env.js';
@@ -11,6 +16,108 @@ import { getAgentDef } from '../runtimes/registry.js';
 import { resolveAmrProfile } from './vela-profile.js';
 
 export { resolveAmrProfile } from './vela-profile.js';
+
+const AMR_ENTRY_SOURCES: ReadonlySet<TrackingAmrEntrySource> = new Set([
+  'onboarding_amr_card',
+  'onboarding_amr_sign_in_continue',
+  'inline_model_switcher_amr_row',
+  'settings_amr_agent_card',
+  'settings_amr_authorize',
+  'chat_error_authorize_retry',
+  'chat_error_recharge',
+  'chat_error_switch_retry_card',
+  'generation_preview_authorize_retry',
+  'generation_preview_recharge',
+  'generation_preview_switch_retry_card',
+]);
+
+type AmrEntrySourcePageName = Extract<
+  TrackingPageName,
+  'onboarding' | 'chat_panel' | 'settings' | 'file_manager'
+>;
+
+const AMR_ENTRY_SOURCE_PAGES: ReadonlySet<AmrEntrySourcePageName> = new Set([
+  'onboarding',
+  'chat_panel',
+  'settings',
+  'file_manager',
+]);
+
+const AMR_ENTRY_SOURCE_PAGE_BY_SOURCE: Record<
+  TrackingAmrEntrySource,
+  AmrEntrySourcePageName
+> = {
+  onboarding_amr_card: 'onboarding',
+  onboarding_amr_sign_in_continue: 'onboarding',
+  inline_model_switcher_amr_row: 'chat_panel',
+  settings_amr_agent_card: 'settings',
+  settings_amr_authorize: 'settings',
+  chat_error_authorize_retry: 'chat_panel',
+  chat_error_recharge: 'chat_panel',
+  chat_error_switch_retry_card: 'chat_panel',
+  generation_preview_authorize_retry: 'file_manager',
+  generation_preview_recharge: 'file_manager',
+  generation_preview_switch_retry_card: 'file_manager',
+};
+
+const AMR_ANALYTICS_EVENTS_URL =
+  'https://amr-api.open-design.ai/api/v1/analytics/events';
+const AMR_ANALYTICS_TIMEOUT_MS = 1500;
+
+type AmrAnalyticsEnv = 'local' | 'test' | 'staging' | 'production';
+
+const AMR_ANALYTICS_ENVS: ReadonlySet<AmrAnalyticsEnv> = new Set([
+  'local',
+  'test',
+  'staging',
+  'production',
+]);
+
+export interface AmrEntryAnalyticsPayload {
+  pageName: 'open_design';
+  sourcePageName: AmrEntrySourcePageName;
+  area: 'amr_entry';
+  element: TrackingAmrEntrySource;
+  action: 'click_amr_entry';
+  entryId: string;
+  sourceProduct: 'open_design';
+  sourceDetail: TrackingAmrEntrySource;
+  entryOccurredAt: string;
+}
+
+export interface AmrEntryAnalyticsContext {
+  deviceId?: string | null;
+  sessionId?: string | null;
+  locale?: string | null;
+}
+
+interface FetchResponseLike {
+  ok: boolean;
+  status: number;
+}
+
+type FetchLike = (
+  input: string,
+  init: {
+    method: 'POST';
+    headers: Record<string, string>;
+    body: string;
+    signal?: AbortSignal;
+  },
+) => Promise<FetchResponseLike>;
+
+export interface MirrorAmrEntryAnalyticsDeps {
+  analyticsContext?: AmrEntryAnalyticsContext | null;
+  appVersion?: string | null;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: FetchLike;
+}
+
+export interface MirrorAmrEntryAnalyticsResult {
+  mirrored: boolean;
+  status?: number;
+  error?: string;
+}
 
 export interface VelaUser {
   id: string;
@@ -210,6 +317,7 @@ export function cancelVelaLogin(): CancelVelaLoginResult {
 export interface SpawnVelaLoginDeps {
   configuredEnv?: Record<string, string>;
   baseEnv?: NodeJS.ProcessEnv;
+  attribution?: AmrEntryAttribution | null;
 }
 
 async function waitForImmediateLoginFailure(child: ChildProcess): Promise<void> {
@@ -276,7 +384,10 @@ export async function spawnVelaLogin(
   if (!bin) {
     throw new Error('vela binary not found; install vela or configure VELA_BIN');
   }
-  const env = spawnEnvForAgent('amr', baseEnv, configuredEnv);
+  const env = {
+    ...spawnEnvForAgent('amr', baseEnv, configuredEnv),
+    ...velaLoginAttributionEnv(deps.attribution),
+  };
   // Route through createCommandInvocation so an npm/Node-style `vela.cmd` or
   // `vela.bat` shim on Windows gets wrapped under `cmd.exe /d /s /c …` with
   // verbatim args, matching what `execAgentFile` / chat-run spawning do. A
@@ -307,4 +418,176 @@ export async function spawnVelaLogin(
     startedAt: new Date().toISOString(),
     profile: resolveAmrProfile(env),
   };
+}
+
+export function parseVelaLoginAttribution(input: unknown): AmrEntryAttribution | null {
+  const raw = input && typeof input === 'object' && 'attribution' in input
+    ? (input as { attribution?: unknown }).attribution
+    : null;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const value = raw as Partial<AmrEntryAttribution>;
+  if (
+    typeof value.entryId !== 'string'
+    || value.entryId.length === 0
+    || value.sourceProduct !== 'open_design'
+    || typeof value.sourceDetail !== 'string'
+    || !AMR_ENTRY_SOURCES.has(value.sourceDetail as TrackingAmrEntrySource)
+    || typeof value.occurredAt !== 'string'
+    || !Number.isFinite(Date.parse(value.occurredAt))
+  ) {
+    return null;
+  }
+  return {
+    entryId: value.entryId,
+    sourceProduct: value.sourceProduct,
+    sourceDetail: value.sourceDetail as TrackingAmrEntrySource,
+    occurredAt: value.occurredAt,
+  };
+}
+
+export function parseAmrEntryAnalyticsPayload(
+  input: unknown,
+): AmrEntryAnalyticsPayload | null {
+  const raw = isRecord(input) && 'payload' in input ? input.payload : input;
+  if (!isRecord(raw)) return null;
+  const pageName = raw.pageName;
+  const sourcePageName = raw.sourcePageName;
+  const area = raw.area;
+  const element = raw.element;
+  const action = raw.action;
+  const entryId = raw.entryId;
+  const sourceProduct = raw.sourceProduct;
+  const sourceDetail = raw.sourceDetail;
+  const entryOccurredAt = raw.entryOccurredAt;
+  if (
+    pageName !== 'open_design'
+    || typeof sourcePageName !== 'string'
+    || !AMR_ENTRY_SOURCE_PAGES.has(sourcePageName as AmrEntrySourcePageName)
+    || area !== 'amr_entry'
+    || typeof element !== 'string'
+    || !AMR_ENTRY_SOURCES.has(element as TrackingAmrEntrySource)
+    || action !== 'click_amr_entry'
+    || typeof entryId !== 'string'
+    || entryId.length === 0
+    || sourceProduct !== 'open_design'
+    || typeof sourceDetail !== 'string'
+    || !AMR_ENTRY_SOURCES.has(sourceDetail as TrackingAmrEntrySource)
+    || sourceDetail !== element
+    || sourcePageName
+      !== AMR_ENTRY_SOURCE_PAGE_BY_SOURCE[sourceDetail as TrackingAmrEntrySource]
+    || typeof entryOccurredAt !== 'string'
+    || !Number.isFinite(Date.parse(entryOccurredAt))
+  ) {
+    return null;
+  }
+  return {
+    pageName,
+    sourcePageName: sourcePageName as AmrEntrySourcePageName,
+    area,
+    element: element as TrackingAmrEntrySource,
+    action,
+    entryId,
+    sourceProduct,
+    sourceDetail: sourceDetail as TrackingAmrEntrySource,
+    entryOccurredAt,
+  };
+}
+
+export async function mirrorAmrEntryAnalytics(
+  payload: AmrEntryAnalyticsPayload,
+  deps: MirrorAmrEntryAnalyticsDeps = {},
+): Promise<MirrorAmrEntryAnalyticsResult> {
+  const fetchImpl = deps.fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined);
+  if (!fetchImpl) return { mirrored: false };
+  const env = deps.env ?? process.env;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), AMR_ANALYTICS_TIMEOUT_MS);
+  timeout.unref?.();
+  try {
+    const response = await fetchImpl(resolveAmrAnalyticsEventsUrl(env), {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      signal: controller.signal,
+      body: JSON.stringify({
+        events: [
+          {
+            common: buildAmrEntryAnalyticsCommon(payload, deps),
+            payload,
+          },
+        ],
+      }),
+    });
+    return { mirrored: response.ok, status: response.status };
+  } catch (err) {
+    return {
+      mirrored: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function velaLoginAttributionEnv(
+  attribution: AmrEntryAttribution | null | undefined,
+): Record<string, string> {
+  if (!attribution) return {};
+  return {
+    OPEN_DESIGN_AMR_ENTRY_ID: attribution.entryId,
+    OPEN_DESIGN_AMR_ENTRY_SOURCE: attribution.sourceDetail,
+    OPEN_DESIGN_AMR_ENTRY_AT: attribution.occurredAt,
+    OPEN_DESIGN_AMR_ORIGIN: attribution.sourceProduct,
+  };
+}
+
+function buildAmrEntryAnalyticsCommon(
+  payload: AmrEntryAnalyticsPayload,
+  deps: MirrorAmrEntryAnalyticsDeps,
+) {
+  const context = deps.analyticsContext ?? null;
+  const anonymousId = context?.deviceId?.trim() || payload.entryId;
+  const sessionId = context?.sessionId?.trim() || payload.entryId;
+  return {
+    eventId: `od-amr-entry-${payload.entryId}`,
+    eventTime: payload.entryOccurredAt,
+    registryKey: 'open_design_amr_entry',
+    eventName: 'amr_entry',
+    eventType: 'click',
+    platform: 'web',
+    env: resolveAmrAnalyticsEnv(deps.env ?? process.env),
+    userId: null,
+    anonymousId,
+    sessionId,
+    appVersion: deps.appVersion ?? null,
+    locale: context?.locale?.trim() || null,
+    timezone: null,
+    deviceType: null,
+    browser: null,
+    os: null,
+    arch: null,
+    cliVersion: null,
+    traceId: payload.entryId,
+    walletBalance: null,
+  };
+}
+
+function resolveAmrAnalyticsEventsUrl(env: NodeJS.ProcessEnv): string {
+  return env.OPEN_DESIGN_AMR_ANALYTICS_URL?.trim() || AMR_ANALYTICS_EVENTS_URL;
+}
+
+function resolveAmrAnalyticsEnv(env: NodeJS.ProcessEnv): AmrAnalyticsEnv {
+  const raw = env.OPEN_DESIGN_AMR_ANALYTICS_ENV?.trim();
+  if (raw && AMR_ANALYTICS_ENVS.has(raw as AmrAnalyticsEnv)) {
+    return raw as AmrAnalyticsEnv;
+  }
+  if (env.NODE_ENV === 'production') return 'production';
+  if (env.NODE_ENV === 'test') return 'test';
+  return 'local';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -55,6 +55,9 @@ import {
   cancelVelaLogin,
   forgetVelaLogin,
   mergeVelaEnv,
+  mirrorAmrEntryAnalytics,
+  parseAmrEntryAnalyticsPayload,
+  parseVelaLoginAttribution,
   readVelaCredentialRevision,
   readVelaLoginStatus,
   spawnVelaLogin,
@@ -6287,11 +6290,12 @@ export async function startServer({
     }
   });
 
-  app.post('/api/integrations/vela/login', async (_req, res) => {
+  app.post('/api/integrations/vela/login', async (req, res) => {
     try {
       const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
       const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
-      const spawned = await spawnVelaLogin({ configuredEnv });
+      const attribution = parseVelaLoginAttribution(req.body);
+      const spawned = await spawnVelaLogin({ configuredEnv, attribution });
       res.status(202).json(spawned);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -6308,6 +6312,19 @@ export async function startServer({
     } catch (err) {
       res.status(500).json({ error: String(err) });
     }
+  });
+
+  app.post('/api/integrations/vela/analytics-entry', async (req, res) => {
+    const payload = parseAmrEntryAnalyticsPayload(req.body);
+    if (!payload) {
+      res.status(400).json({ error: 'invalid_amr_entry_analytics' });
+      return;
+    }
+    const result = await mirrorAmrEntryAnalytics(payload, {
+      analyticsContext: readAnalyticsContext(req),
+      env: process.env,
+    });
+    res.status(202).json(result);
   });
 
   app.post('/api/integrations/vela/logout', async (_req, res) => {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6320,8 +6320,25 @@ export async function startServer({
       res.status(400).json({ error: 'invalid_amr_entry_analytics' });
       return;
     }
+    // Consent gate. The web fetch wrapper attaches `x-od-analytics-*` headers
+    // only when Privacy → metrics is on (apps/web/src/analytics/provider.tsx),
+    // so a null context means the user is opted out — never forward the click
+    // to the external AMR endpoint. Mirrors the analytics-capture invariant.
+    const analyticsContext = readAnalyticsContext(req);
+    if (!analyticsContext) {
+      res.status(202).json({ mirrored: false });
+      return;
+    }
+    // Defense in depth: re-read telemetry.metrics from app-config so a stale
+    // header leak after opt-out still cannot ship behavior to AMR, matching
+    // createAnalyticsService.capture (apps/daemon/src/analytics.ts).
+    const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+    if (appConfig.telemetry?.metrics !== true) {
+      res.status(202).json({ mirrored: false });
+      return;
+    }
     const result = await mirrorAmrEntryAnalytics(payload, {
-      analyticsContext: readAnalyticsContext(req),
+      analyticsContext,
       env: process.env,
     });
     res.status(202).json(result);

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -13,6 +13,8 @@
 // mirroring real vela's on-disk side-effect without the device-auth loop.
 
 import { mkdtempSync, existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type http from 'node:http';
@@ -38,14 +40,23 @@ let tmpHome: string;
 
 async function getJson<T = unknown>(url: string): Promise<{ status: number; body: T }> {
   const resp = await fetch(url);
-  const body = (await resp.json()) as T;
-  return { status: resp.status, body };
+  const parsedBody = (await resp.json()) as T;
+  return { status: resp.status, body: parsedBody };
 }
 
-async function postJson<T = unknown>(url: string): Promise<{ status: number; body: T }> {
-  const resp = await fetch(url, { method: 'POST' });
-  const body = (await resp.json()) as T;
-  return { status: resp.status, body };
+async function postJson<T = unknown>(
+  url: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: T }> {
+  const init: RequestInit = {
+    method: 'POST',
+    headers: body === undefined ? headers : { 'Content-Type': 'application/json', ...headers },
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  const resp = await fetch(url, init);
+  const parsedBody = (await resp.json()) as T;
+  return { status: resp.status, body: parsedBody };
 }
 
 async function waitForAmrModels(
@@ -141,6 +152,8 @@ afterEach(() => {
   delete process.env.FAKE_VELA_LOGIN_USER_PLAN;
   delete process.env.VELA_RUNTIME_KEY;
   delete process.env.VELA_LINK_URL;
+  delete process.env.OPEN_DESIGN_AMR_ANALYTICS_URL;
+  delete process.env.OPEN_DESIGN_AMR_ANALYTICS_ENV;
   rmSync(tmpHome, { recursive: true, force: true });
 });
 
@@ -512,6 +525,95 @@ describe('POST /api/integrations/vela/login', () => {
     expect(after.body.loggedIn).toBe(false);
     expect(after.body.loginInFlight).toBe(false);
     expect(existsSync(configPath())).toBe(false);
+  });
+});
+
+describe('POST /api/integrations/vela/analytics-entry', () => {
+  it('mirrors Open Design AMR entry clicks to the AMR analytics ingest shape', async () => {
+    const requests: unknown[] = [];
+    const captureServer = createServer((req, res) => {
+      let raw = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        raw += chunk;
+      });
+      req.on('end', () => {
+        requests.push(JSON.parse(raw));
+        res.writeHead(202, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ accepted: 1 }));
+      });
+    });
+    await new Promise<void>((resolve) => {
+      captureServer.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = captureServer.address() as AddressInfo;
+    process.env.OPEN_DESIGN_AMR_ANALYTICS_URL =
+      `http://127.0.0.1:${address.port}/api/v1/analytics/events`;
+    process.env.OPEN_DESIGN_AMR_ANALYTICS_ENV = 'test';
+
+    const payload = {
+      pageName: 'open_design',
+      sourcePageName: 'chat_panel',
+      area: 'amr_entry',
+      element: 'chat_error_recharge',
+      action: 'click_amr_entry',
+      entryId: 'od-amr-entry-123',
+      sourceProduct: 'open_design',
+      sourceDetail: 'chat_error_recharge',
+      entryOccurredAt: '2026-06-03T12:00:00.000Z',
+    };
+
+    try {
+      const { status, body } = await postJson<{ mirrored: boolean; status: number }>(
+        `${baseUrl}/api/integrations/vela/analytics-entry`,
+        { payload },
+        {
+          'x-od-analytics-device-id': 'od-device-1',
+          'x-od-analytics-session-id': 'od-session-1',
+          'x-od-analytics-locale': 'zh-CN',
+        },
+      );
+
+      expect(status).toBe(202);
+      expect(body).toEqual({ mirrored: true, status: 202 });
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toMatchObject({
+        events: [
+          {
+            common: {
+              eventId: 'od-amr-entry-od-amr-entry-123',
+              eventTime: '2026-06-03T12:00:00.000Z',
+              registryKey: 'open_design_amr_entry',
+              eventName: 'amr_entry',
+              eventType: 'click',
+              platform: 'web',
+              env: 'test',
+              userId: null,
+              anonymousId: 'od-device-1',
+              sessionId: 'od-session-1',
+              appVersion: null,
+              locale: 'zh-CN',
+              traceId: 'od-amr-entry-123',
+            },
+            payload,
+          },
+        ],
+      });
+    } finally {
+      await new Promise<void>((resolve) => {
+        captureServer.close(() => resolve());
+      });
+    }
+  });
+
+  it('rejects malformed AMR entry analytics payloads', async () => {
+    const { status, body } = await postJson<{ error: string }>(
+      `${baseUrl}/api/integrations/vela/analytics-entry`,
+      { payload: { pageName: 'open_design' } },
+    );
+
+    expect(status).toBe(400);
+    expect(body).toEqual({ error: 'invalid_amr_entry_analytics' });
   });
 });
 

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -615,6 +615,123 @@ describe('POST /api/integrations/vela/analytics-entry', () => {
     expect(status).toBe(400);
     expect(body).toEqual({ error: 'invalid_amr_entry_analytics' });
   });
+
+  it('does not mirror to AMR when the request carries no analytics-consent headers', async () => {
+    const requests: unknown[] = [];
+    const captureServer = createServer((req, res) => {
+      let raw = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        raw += chunk;
+      });
+      req.on('end', () => {
+        requests.push(JSON.parse(raw));
+        res.writeHead(202, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ accepted: 1 }));
+      });
+    });
+    await new Promise<void>((resolve) => {
+      captureServer.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = captureServer.address() as AddressInfo;
+    process.env.OPEN_DESIGN_AMR_ANALYTICS_URL =
+      `http://127.0.0.1:${address.port}/api/v1/analytics/events`;
+    process.env.OPEN_DESIGN_AMR_ANALYTICS_ENV = 'test';
+
+    const payload = {
+      pageName: 'open_design',
+      sourcePageName: 'chat_panel',
+      area: 'amr_entry',
+      element: 'chat_error_recharge',
+      action: 'click_amr_entry',
+      entryId: 'od-amr-entry-no-consent',
+      sourceProduct: 'open_design',
+      sourceDetail: 'chat_error_recharge',
+      entryOccurredAt: '2026-06-03T12:00:00.000Z',
+    };
+
+    try {
+      // No x-od-analytics-* headers => readAnalyticsContext returns null =>
+      // opted out. The route must short-circuit before any external fetch.
+      const { status, body } = await postJson<{ mirrored: boolean }>(
+        `${baseUrl}/api/integrations/vela/analytics-entry`,
+        { payload },
+      );
+
+      expect(status).toBe(202);
+      expect(body).toEqual({ mirrored: false });
+      expect(requests).toHaveLength(0);
+    } finally {
+      await new Promise<void>((resolve) => {
+        captureServer.close(() => resolve());
+      });
+    }
+  });
+
+  it('does not mirror to AMR when telemetry.metrics consent is off', async () => {
+    const dataDir = process.env.OD_DATA_DIR as string;
+    const previous = await readAppConfig(dataDir);
+    await writeAppConfig(dataDir, {
+      ...previous,
+      telemetry: { ...(previous.telemetry ?? {}), metrics: false },
+    });
+
+    const requests: unknown[] = [];
+    const captureServer = createServer((req, res) => {
+      let raw = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        raw += chunk;
+      });
+      req.on('end', () => {
+        requests.push(JSON.parse(raw));
+        res.writeHead(202, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ accepted: 1 }));
+      });
+    });
+    await new Promise<void>((resolve) => {
+      captureServer.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = captureServer.address() as AddressInfo;
+    process.env.OPEN_DESIGN_AMR_ANALYTICS_URL =
+      `http://127.0.0.1:${address.port}/api/v1/analytics/events`;
+    process.env.OPEN_DESIGN_AMR_ANALYTICS_ENV = 'test';
+
+    const payload = {
+      pageName: 'open_design',
+      sourcePageName: 'chat_panel',
+      area: 'amr_entry',
+      element: 'chat_error_recharge',
+      action: 'click_amr_entry',
+      entryId: 'od-amr-entry-metrics-off',
+      sourceProduct: 'open_design',
+      sourceDetail: 'chat_error_recharge',
+      entryOccurredAt: '2026-06-03T12:00:00.000Z',
+    };
+
+    try {
+      // Consent headers are present, but app-config opt-out must still win as
+      // defense in depth against a stale header leak after the user opts out.
+      const { status, body } = await postJson<{ mirrored: boolean }>(
+        `${baseUrl}/api/integrations/vela/analytics-entry`,
+        { payload },
+        {
+          'x-od-analytics-device-id': 'od-device-1',
+          'x-od-analytics-session-id': 'od-session-1',
+          'x-od-analytics-locale': 'zh-CN',
+        },
+      );
+
+      expect(status).toBe(202);
+      expect(body).toEqual({ mirrored: false });
+      expect(requests).toHaveLength(0);
+    } finally {
+      await writeAppConfig(dataDir, previous as unknown as Record<string, unknown>);
+      await new Promise<void>((resolve) => {
+        captureServer.close(() => resolve());
+      });
+    }
+  });
 });
 
 describe('POST /api/integrations/vela/logout', () => {

--- a/apps/web/src/analytics/amr-attribution.ts
+++ b/apps/web/src/analytics/amr-attribution.ts
@@ -1,0 +1,165 @@
+import type {
+  AmrEntryAttribution,
+  TrackingAmrEntrySource,
+  TrackingPageName,
+} from '@open-design/contracts/analytics';
+import { trackAmrEntryClick } from './events';
+
+type Track = (
+  event: string,
+  properties: Record<string, unknown>,
+  options?: { requestId?: string; insertId?: string },
+) => void;
+
+interface RecordAmrEntryOptions {
+  reuseExistingFrom?: readonly TrackingAmrEntrySource[];
+}
+
+const AMR_ATTRIBUTION_STORAGE_KEY = 'open-design:amr-entry-attribution:v1';
+const AMR_ATTRIBUTION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+const ENTRY_PAGE_BY_SOURCE: Record<TrackingAmrEntrySource, TrackingPageName> = {
+  onboarding_amr_card: 'onboarding',
+  onboarding_amr_sign_in_continue: 'onboarding',
+  inline_model_switcher_amr_row: 'chat_panel',
+  settings_amr_agent_card: 'settings',
+  settings_amr_authorize: 'settings',
+  chat_error_authorize_retry: 'chat_panel',
+  chat_error_recharge: 'chat_panel',
+  chat_error_switch_retry_card: 'chat_panel',
+  generation_preview_authorize_retry: 'file_manager',
+  generation_preview_recharge: 'file_manager',
+  generation_preview_switch_retry_card: 'file_manager',
+};
+
+export type { AmrEntryAttribution, TrackingAmrEntrySource };
+
+export function recordAmrEntry(
+  track: Track,
+  sourceDetail: TrackingAmrEntrySource,
+  now: Date = new Date(),
+  options: RecordAmrEntryOptions = {},
+): AmrEntryAttribution {
+  const existing = readReusableAmrAttribution(now, options.reuseExistingFrom);
+  if (existing) return existing;
+
+  const attribution: AmrEntryAttribution = {
+    entryId: `od-amr-${randomId()}`,
+    sourceProduct: 'open_design',
+    sourceDetail,
+    occurredAt: now.toISOString(),
+  };
+  writeAmrAttribution(attribution);
+  trackAmrEntryClick(track, {
+    page_name: ENTRY_PAGE_BY_SOURCE[sourceDetail],
+    area: 'amr_entry',
+    element: sourceDetail,
+    action: 'click_amr_entry',
+    entry_id: attribution.entryId,
+    source_product: attribution.sourceProduct,
+    source_detail: attribution.sourceDetail,
+    entry_occurred_at: attribution.occurredAt,
+  });
+  void mirrorAmrEntryToAmrAnalytics(attribution);
+  return attribution;
+}
+
+export function readAmrAttribution(now: Date = new Date()): AmrEntryAttribution | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(AMR_ATTRIBUTION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<AmrEntryAttribution>;
+    if (!isValidAmrAttribution(parsed)) return null;
+    if (now.getTime() - Date.parse(parsed.occurredAt) > AMR_ATTRIBUTION_TTL_MS) {
+      window.localStorage.removeItem(AMR_ATTRIBUTION_STORAGE_KEY);
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function attributedAmrUrl(baseUrl: string, attribution: AmrEntryAttribution): string {
+  try {
+    const url = new URL(baseUrl);
+    url.searchParams.set('od_origin', attribution.sourceProduct);
+    url.searchParams.set('od_entry_id', attribution.entryId);
+    url.searchParams.set('od_entry_source', attribution.sourceDetail);
+    url.searchParams.set('od_entry_at', attribution.occurredAt);
+    return url.toString();
+  } catch {
+    const separator = baseUrl.includes('?') ? '&' : '?';
+    return `${baseUrl}${separator}${new URLSearchParams({
+      od_origin: attribution.sourceProduct,
+      od_entry_id: attribution.entryId,
+      od_entry_source: attribution.sourceDetail,
+      od_entry_at: attribution.occurredAt,
+    }).toString()}`;
+  }
+}
+
+function writeAmrAttribution(attribution: AmrEntryAttribution): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(AMR_ATTRIBUTION_STORAGE_KEY, JSON.stringify(attribution));
+  } catch {
+    // Analytics persistence must never block the primary action.
+  }
+}
+
+function readReusableAmrAttribution(
+  now: Date,
+  reuseExistingFrom: readonly TrackingAmrEntrySource[] | undefined,
+): AmrEntryAttribution | null {
+  if (!reuseExistingFrom || reuseExistingFrom.length === 0) return null;
+  const existing = readAmrAttribution(now);
+  if (!existing) return null;
+  return reuseExistingFrom.includes(existing.sourceDetail) ? existing : null;
+}
+
+async function mirrorAmrEntryToAmrAnalytics(
+  attribution: AmrEntryAttribution,
+): Promise<void> {
+  if (typeof fetch !== 'function') return;
+  const sourcePageName = ENTRY_PAGE_BY_SOURCE[attribution.sourceDetail];
+  try {
+    await fetch('/api/integrations/vela/analytics-entry', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        payload: {
+          pageName: 'open_design',
+          sourcePageName,
+          area: 'amr_entry',
+          element: attribution.sourceDetail,
+          action: 'click_amr_entry',
+          entryId: attribution.entryId,
+          sourceProduct: attribution.sourceProduct,
+          sourceDetail: attribution.sourceDetail,
+          entryOccurredAt: attribution.occurredAt,
+        },
+      }),
+    });
+  } catch {
+    // AMR analytics mirroring must never block the primary Open Design action.
+  }
+}
+
+function isValidAmrAttribution(value: Partial<AmrEntryAttribution>): value is AmrEntryAttribution {
+  return value.sourceProduct === 'open_design'
+    && typeof value.entryId === 'string'
+    && value.entryId.length > 0
+    && typeof value.sourceDetail === 'string'
+    && value.sourceDetail in ENTRY_PAGE_BY_SOURCE
+    && typeof value.occurredAt === 'string'
+    && Number.isFinite(Date.parse(value.occurredAt));
+}
+
+function randomId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}

--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -49,6 +49,7 @@ import type {
   IntegrationsUseEverywhereTabClickProps,
   ChatPanelClickProps,
   RunFailedToastClickProps,
+  AmrEntryClickProps,
   RunFailedToastSurfaceViewProps,
   ChatPanelResourcesPopoverClickProps,
   FileManagerClickProps,
@@ -173,6 +174,13 @@ export function trackRunFailedToastSurfaceView(
 export function trackRunFailedToastGoAmrClick(
   track: Track,
   props: RunFailedToastClickProps,
+): void {
+  send(track, 'ui_click', props);
+}
+
+export function trackAmrEntryClick(
+  track: Track,
+  props: AmrEntryClickProps,
 ): void {
   send(track, 'ui_click', props);
 }

--- a/apps/web/src/components/AmrGuidance.tsx
+++ b/apps/web/src/components/AmrGuidance.tsx
@@ -6,6 +6,7 @@ import {
   trackRunFailedToastSurfaceView,
 } from '../analytics/events';
 import type { TrackingProjectKind } from '@open-design/contracts/analytics';
+import { recordAmrEntry, type TrackingAmrEntrySource } from '../analytics/amr-attribution';
 
 export interface AmrGuidanceProps {
   errorCode: string;
@@ -14,6 +15,7 @@ export interface AmrGuidanceProps {
   conversationId: string | null;
   assistantMessageId: string;
   runId: string | null;
+  sourceDetail: TrackingAmrEntrySource;
   // Switch the run to AMR and retry. The `ui_click` analytics event is fired
   // here first; the host performs the switch + arms the auto-retry.
   onActivate: () => void;
@@ -32,6 +34,7 @@ export function AmrGuidance({
   conversationId,
   assistantMessageId,
   runId,
+  sourceDetail,
   onActivate,
 }: AmrGuidanceProps) {
   const t = useT();
@@ -85,6 +88,7 @@ export function AmrGuidance({
               area: 'chat_panel',
               element: 'go_amr',
             });
+            recordAmrEntry(analytics.track, sourceDetail);
             onActivate();
           }}
         >

--- a/apps/web/src/components/AmrLoginPill.tsx
+++ b/apps/web/src/components/AmrLoginPill.tsx
@@ -6,6 +6,11 @@ import {
   velaLogout,
   type VelaLoginStatus,
 } from '../providers/daemon';
+import { useAnalytics } from '../analytics/provider';
+import {
+  recordAmrEntry,
+  type TrackingAmrEntrySource,
+} from '../analytics/amr-attribution';
 import { useI18n } from '../i18n';
 import {
   AMR_LOGIN_STATUS_EVENT,
@@ -24,10 +29,17 @@ interface AmrLoginPillProps {
   initialStatus?: VelaLoginStatus | null;
   skipInitialRefresh?: boolean;
   signInLabel?: string;
+  amrEntrySourceDetail?: TrackingAmrEntrySource;
   revealPendingCancelAction?: boolean;
   showConsoleAction?: boolean;
   onStatusChange?: (status: VelaLoginStatus | null) => void;
 }
+
+const AMR_LOGIN_REUSE_ENTRY_SOURCES: readonly TrackingAmrEntrySource[] = [
+  'settings_amr_agent_card',
+  'chat_error_authorize_retry',
+  'generation_preview_authorize_retry',
+];
 
 export type AmrAccountControlStatus =
   | 'signed-out'
@@ -202,11 +214,13 @@ export function AmrLoginPill({
   initialStatus = null,
   skipInitialRefresh = false,
   signInLabel,
+  amrEntrySourceDetail,
   revealPendingCancelAction = false,
   showConsoleAction = false,
   onStatusChange,
 }: AmrLoginPillProps) {
   const { t } = useI18n();
+  const analytics = useAnalytics();
   const [status, setStatus] = useState<VelaLoginStatus | null>(initialStatus);
   const [pending, setPending] = useState<null | 'login' | 'logout' | 'cancel'>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -370,7 +384,12 @@ export function AmrLoginPill({
       loginStartedAtRef.current = startedAt;
       setErrorMessage(null);
       setPending('login');
-      const result = await startVelaLogin();
+      const attribution = amrEntrySourceDetail
+        ? recordAmrEntry(analytics.track, amrEntrySourceDetail, new Date(), {
+            reuseExistingFrom: AMR_LOGIN_REUSE_ENTRY_SOURCES,
+          })
+        : null;
+      const result = await startVelaLogin(attribution);
       if (!result.ok && !result.alreadyRunning) {
         loginStartedAtRef.current = null;
         loginPendingRef.current = false;
@@ -381,7 +400,7 @@ export function AmrLoginPill({
       notifyAmrLoginStatusChanged('login-started');
       startPolling(startedAt);
     },
-    [startPolling, t],
+    [amrEntrySourceDetail, analytics.track, startPolling, t],
   );
 
   const handleCancelLogin = useCallback(

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useRef, useState, type MutableRefObject, type ReactNode } from 'react';
 import { useAnalytics } from '../analytics/provider';
-import { trackChatPanelClick } from '../analytics/events';
+import { trackChatPanelClick, trackRunFailedToastSurfaceView } from '../analytics/events';
+import { attributedAmrUrl, recordAmrEntry } from '../analytics/amr-attribution';
 import { useT } from '../i18n';
 import type { Dict } from '../i18n/types';
 import { copyToClipboard } from '../lib/copy-to-clipboard';
@@ -431,6 +432,7 @@ export function ChatPane({
   const pinnedTodoRef = useRef<HTMLDivElement | null>(null);
   const queuedSendStripRef = useRef<HTMLDivElement | null>(null);
   const didInitialScrollRef = useRef(false);
+  const runFailedToastSurfaceKeysRef = useRef<Set<string>>(new Set());
   // Tracks whether the user is glued close enough to the bottom that
   // streamed content should auto-follow. Distinct from the jump-button
   // state below, which uses a wider threshold (120px) so the affordance
@@ -517,6 +519,45 @@ export function ChatPane({
           runId: retryAssistant.runId ?? null,
         }
       : null;
+  useEffect(() => {
+    if (!displayError || !failedRunErrorEvent?.code || !retryAssistant) return;
+    // The hosted-AMR nudge owns this same surface_view when it renders below
+    // the error card. For all other failed-run guidance (AMR auth/balance,
+    // Antigravity auth/quota, upstream outage, generic retry), the chat error
+    // card itself is the visible run_failed_toast surface.
+    if (amrSwitchPayload) return;
+
+    const key = [
+      projectId ?? '',
+      activeConversationId ?? '',
+      retryAssistant.id,
+      retryAssistant.runId ?? '',
+      failedRunErrorEvent.code,
+    ].join(':');
+    if (runFailedToastSurfaceKeysRef.current.has(key)) return;
+    runFailedToastSurfaceKeysRef.current.add(key);
+
+    trackRunFailedToastSurfaceView(analytics.track, {
+      page_name: 'chat_panel',
+      area: 'chat_panel',
+      element: 'run_failed_toast',
+      error_code: failedRunErrorEvent.code,
+      project_id: projectId ?? '',
+      project_kind: projectKindForTracking,
+      conversation_id: activeConversationId,
+      assistant_message_id: retryAssistant.id,
+      run_id: retryAssistant.runId ?? null,
+    });
+  }, [
+    activeConversationId,
+    analytics.track,
+    amrSwitchPayload,
+    displayError,
+    failedRunErrorEvent?.code,
+    projectId,
+    projectKindForTracking,
+    retryAssistant,
+  ]);
   const composerDraftStorageKey = projectId && activeConversationId
     ? `od:chat-composer:draft:${projectId}:${activeConversationId}`
     : undefined;
@@ -1109,6 +1150,7 @@ export function ChatPane({
                           type="button"
                           className="chat-error-action"
                           onClick={() => {
+                            recordAmrEntry(analytics.track, 'chat_error_authorize_retry');
                             if (onSwitchToAmrAndRetry) {
                               onSwitchToAmrAndRetry(retryAssistant);
                             } else {
@@ -1142,9 +1184,17 @@ export function ChatPane({
                         <button
                           type="button"
                           className="chat-error-action"
-                          onClick={() =>
-                            window.open(AMR_RECHARGE_URL, '_blank', 'noopener,noreferrer')
-                          }
+                          onClick={() => {
+                            const attribution = recordAmrEntry(
+                              analytics.track,
+                              'chat_error_recharge',
+                            );
+                            window.open(
+                              attributedAmrUrl(AMR_RECHARGE_URL, attribution),
+                              '_blank',
+                              'noopener,noreferrer',
+                            );
+                          }}
                         >
                           {t('chat.amrError.rechargeCta')}
                         </button>
@@ -1165,6 +1215,7 @@ export function ChatPane({
               {amrSwitchPayload ? (
                 <AmrGuidance
                   {...amrSwitchPayload}
+                  sourceDetail="chat_error_switch_retry_card"
                   onActivate={() => {
                     if (retryAssistant && onSwitchToAmrAndRetry) {
                       onSwitchToAmrAndRetry(retryAssistant);

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -34,6 +34,7 @@ import {
   trackOnboardingRuntimeScanResult,
   trackPageView,
 } from '../analytics/events';
+import { recordAmrEntry, type AmrEntryAttribution } from '../analytics/amr-attribution';
 import {
   clearOnboardingSessionId,
   getOrCreateOnboardingSessionId,
@@ -1361,7 +1362,13 @@ function OnboardingView({
   }
   function handlePrimaryAction() {
     if (step === 0 && amrSelectedAndSignedOut) {
-      void handleAmrSignInToContinue();
+      const attribution = recordAmrEntry(
+        analytics.track,
+        'onboarding_amr_sign_in_continue',
+        new Date(),
+        { reuseExistingFrom: ['onboarding_amr_card'] },
+      );
+      void handleAmrSignInToContinue(attribution);
       return;
     }
     if (isLastStep) {
@@ -1390,7 +1397,9 @@ function OnboardingView({
     setStep((current) => current + 1);
   }
 
-  async function handleAmrSignInToContinue() {
+  async function handleAmrSignInToContinue(
+    attribution?: AmrEntryAttribution | null,
+  ) {
     if (amrLoginPending) return;
     amrLoginPollCancelledRef.current = false;
     setAmrLoginError(false);
@@ -1402,7 +1411,7 @@ function OnboardingView({
         setStep((current) => current + 1);
         return;
       }
-      const loginResult = await startVelaLogin();
+      const loginResult = await startVelaLogin(attribution);
       if (!loginResult.ok && !loginResult.alreadyRunning) {
         setAmrLoginError(true);
         return;
@@ -1694,6 +1703,7 @@ function OnboardingView({
                       featured
                       selected={runtime === 'amr'}
                       onClick={() => {
+                        recordAmrEntry(analytics.track, 'onboarding_amr_card');
                         setRuntime('amr');
                         onModeChange('daemon');
                         onAgentChange('amr');

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -1056,6 +1056,8 @@ export function FileWorkspace({
                 : undefined
             }
             onLaunchTerminalAuth={onLaunchTerminalAuth}
+            amrAuthorizeSourceDetail="generation_preview_authorize_retry"
+            amrRechargeSourceDetail="generation_preview_recharge"
             amrGuidance={
               generationPreview.promoteAmrSwitch
                 && generationPreview.errorCode
@@ -1068,6 +1070,7 @@ export function FileWorkspace({
                   conversationId={conversationId ?? null}
                   assistantMessageId={generationPreview.retryTarget.id}
                   runId={generationPreview.retryTarget.runId ?? null}
+                  sourceDetail="generation_preview_switch_retry_card"
                   onActivate={() => onAuthorizeAndRetry(generationPreview.retryTarget!)}
                 />
               ) : undefined

--- a/apps/web/src/components/GenerationPreviewStage.tsx
+++ b/apps/web/src/components/GenerationPreviewStage.tsx
@@ -1,5 +1,11 @@
 import type { ReactNode } from 'react';
 import { useT } from '../i18n';
+import { useAnalytics } from '../analytics/provider';
+import {
+  attributedAmrUrl,
+  recordAmrEntry,
+  type TrackingAmrEntrySource,
+} from '../analytics/amr-attribution';
 import type { Dict } from '../i18n/types';
 import { AMR_RECHARGE_URL } from '../runtime/amr-guidance';
 import type { GenerationPreviewModel } from '../runtime/generation-preview';
@@ -13,6 +19,8 @@ type Props = {
   // Each is pre-bound to the failed run in the parent so the stage stays dumb.
   onAuthorizeAndRetry?: (() => void) | undefined;
   onLaunchTerminalAuth?: (() => void) | undefined;
+  amrAuthorizeSourceDetail?: TrackingAmrEntrySource;
+  amrRechargeSourceDetail?: TrackingAmrEntrySource;
   // "Switch to AMR" promotion card, pre-built by the parent and rendered under
   // the actions for the non-AMR auth/quota cases (see model.promoteAmrSwitch).
   amrGuidance?: ReactNode;
@@ -44,9 +52,12 @@ export function GenerationPreviewStage({
   onRetry,
   onAuthorizeAndRetry,
   onLaunchTerminalAuth,
+  amrAuthorizeSourceDetail,
+  amrRechargeSourceDetail,
   amrGuidance,
 }: Props) {
   const t = useT();
+  const analytics = useAnalytics();
 
   const generating = model.phase === 'generating';
 
@@ -147,7 +158,12 @@ export function GenerationPreviewStage({
               type="button"
               className={styles.action}
               data-testid="generation-preview-authorize"
-              onClick={onAuthorizeAndRetry}
+              onClick={() => {
+                if (amrAuthorizeSourceDetail) {
+                  recordAmrEntry(analytics.track, amrAuthorizeSourceDetail);
+                }
+                onAuthorizeAndRetry();
+              }}
             >
               {t('chat.amrError.authorizeCta')}
             </button>
@@ -171,7 +187,17 @@ export function GenerationPreviewStage({
               type="button"
               className={styles.action}
               data-testid="generation-preview-recharge"
-              onClick={() => window.open(AMR_RECHARGE_URL, '_blank', 'noopener,noreferrer')}
+              onClick={() => {
+                const attribution = recordAmrEntry(
+                  analytics.track,
+                  amrRechargeSourceDetail ?? 'generation_preview_recharge',
+                );
+                window.open(
+                  attributedAmrUrl(AMR_RECHARGE_URL, attribution),
+                  '_blank',
+                  'noopener,noreferrer',
+                );
+              }}
             >
               {t('chat.amrError.rechargeCta')}
             </button>

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -10,6 +10,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useT } from '../i18n';
+import { useAnalytics } from '../analytics/provider';
+import { recordAmrEntry, type AmrEntryAttribution } from '../analytics/amr-attribution';
 import { KNOWN_PROVIDERS } from '../state/config';
 import { SUGGESTED_MODELS_BY_PROTOCOL } from '../state/apiProtocols';
 import {
@@ -119,6 +121,7 @@ export function InlineModelSwitcher({
   onOpenSettings,
 }: Props) {
   const t = useT();
+  const analytics = useAnalytics();
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const [amrStatus, setAmrStatus] = useState<VelaLoginStatus | null>(null);
@@ -186,12 +189,14 @@ export function InlineModelSwitcher({
     }, AMR_LOGIN_POLL_INTERVAL_MS);
   }, [refreshAmrStatus, stopAmrPolling]);
 
-  const handleAmrSignIn = useCallback(async () => {
+  const handleAmrSignIn = useCallback(async (
+    attribution?: AmrEntryAttribution | null,
+  ) => {
     const startedAt = Date.now();
     amrLoginStartedAtRef.current = startedAt;
     setAmrLoginError(false);
     setAmrLoginPending(true);
-    const result = await startVelaLogin();
+    const result = await startVelaLogin(attribution);
     if (!result.ok && !result.alreadyRunning) {
       amrLoginStartedAtRef.current = null;
       setAmrLoginPending(false);
@@ -220,12 +225,17 @@ export function InlineModelSwitcher({
         await handleAmrCancelLogin();
         return;
       }
+      const attribution = recordAmrEntry(
+        analytics.track,
+        'inline_model_switcher_amr_row',
+      );
       const latest = await refreshAmrStatus();
       if (latest?.loggedIn) return;
-      await handleAmrSignIn();
+      await handleAmrSignIn(attribution);
     },
     [
       amrLoginPending,
+      analytics.track,
       handleAmrCancelLogin,
       handleAmrSignIn,
       onAgentChange,

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -9,6 +9,7 @@ import {
   settingsSectionToTracking,
 } from '@open-design/contracts/analytics';
 import { useAnalytics } from '../analytics/provider';
+import { recordAmrEntry } from '../analytics/amr-attribution';
 import {
   trackSettingsAppearanceClick,
   trackSettingsByokModelsFetchResult,
@@ -3268,6 +3269,9 @@ export function SettingsDialog({
                                       cli_provider_id: agentIdToTracking(a.id),
                                       install_status: 'installed',
                                     });
+                                    if (isAmrAgent) {
+                                      recordAmrEntry(analytics.track, 'settings_amr_agent_card');
+                                    }
                                     setCfg((c) => ({ ...c, agentId: a.id }));
                                   }}
                                   aria-pressed={active}
@@ -3371,6 +3375,7 @@ export function SettingsDialog({
                                         skipInitialRefresh
                                         signInLabel={t('settings.amrAuthorize')}
                                         showConsoleAction={amrCardStatus?.loggedIn === true}
+                                        amrEntrySourceDetail="settings_amr_authorize"
                                         revealPendingCancelAction={amrRevealPendingCancelAction}
                                         onStatusChange={setAmrCardStatus}
                                       />

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -10,6 +10,7 @@
  *                 non-zero (tail appended to the error message).
  */
 import type { AgentEvent, ChatCommentAttachment, ChatMessage } from '../types';
+import type { AmrEntryAttribution } from '../analytics/amr-attribution';
 import type {
   ChatAnalyticsHints,
   ChatRunCreateResponse,
@@ -537,9 +538,15 @@ export interface StartVelaLoginResult {
   error?: string;
 }
 
-export async function startVelaLogin(): Promise<StartVelaLoginResult> {
+export async function startVelaLogin(
+  attribution?: AmrEntryAttribution | null,
+): Promise<StartVelaLoginResult> {
   try {
-    const resp = await fetch('/api/integrations/vela/login', { method: 'POST' });
+    const resp = await fetch('/api/integrations/vela/login', {
+      method: 'POST',
+      headers: attribution ? { 'Content-Type': 'application/json' } : undefined,
+      body: attribution ? JSON.stringify({ attribution }) : undefined,
+    });
     if (resp.ok) {
       const body = (await resp.json()) as { pid?: number };
       return { ok: true, status: resp.status, pid: body.pid };

--- a/apps/web/tests/analytics/amr-attribution.test.ts
+++ b/apps/web/tests/analytics/amr-attribution.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  attributedAmrUrl,
+  readAmrAttribution,
+  recordAmrEntry,
+} from '../../src/analytics/amr-attribution';
+
+describe('AMR attribution helper', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    fetchMock = vi.fn(async () => new Response('{}', { status: 202 }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('accepts every AMR entry source defined for Open Design entry points', () => {
+    const track = vi.fn();
+    const sources = [
+      'onboarding_amr_card',
+      'onboarding_amr_sign_in_continue',
+      'inline_model_switcher_amr_row',
+      'settings_amr_agent_card',
+      'settings_amr_authorize',
+      'chat_error_authorize_retry',
+      'chat_error_recharge',
+      'chat_error_switch_retry_card',
+      'generation_preview_authorize_retry',
+      'generation_preview_recharge',
+      'generation_preview_switch_retry_card',
+    ] as const;
+
+    for (const [index, source] of sources.entries()) {
+      recordAmrEntry(
+        track,
+        source,
+        new Date(`2026-06-03T12:00:${index.toString().padStart(2, '0')}.000Z`),
+      );
+    }
+
+    expect(track).toHaveBeenCalledTimes(sources.length);
+    expect(track.mock.calls.map(([, props]) => props.element)).toEqual(sources);
+  });
+
+  it('records a last-touch AMR entry and emits the matching ui_click event', () => {
+    const track = vi.fn();
+    const now = new Date('2026-06-03T12:00:00.000Z');
+
+    const attribution = recordAmrEntry(track, 'chat_error_recharge', now);
+
+    expect(attribution).toMatchObject({
+      sourceProduct: 'open_design',
+      sourceDetail: 'chat_error_recharge',
+      occurredAt: '2026-06-03T12:00:00.000Z',
+    });
+    expect(attribution.entryId).toMatch(/^od-amr-/u);
+    expect(readAmrAttribution(now)).toEqual(attribution);
+    expect(track).toHaveBeenCalledWith(
+      'ui_click',
+      expect.objectContaining({
+        page_name: 'chat_panel',
+        area: 'amr_entry',
+        element: 'chat_error_recharge',
+        action: 'click_amr_entry',
+        entry_id: attribution.entryId,
+        source_product: 'open_design',
+        source_detail: 'chat_error_recharge',
+        entry_occurred_at: '2026-06-03T12:00:00.000Z',
+      }),
+      undefined,
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/integrations/vela/analytics-entry',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toEqual({
+      payload: {
+        pageName: 'open_design',
+        sourcePageName: 'chat_panel',
+        area: 'amr_entry',
+        element: 'chat_error_recharge',
+        action: 'click_amr_entry',
+        entryId: attribution.entryId,
+        sourceProduct: 'open_design',
+        sourceDetail: 'chat_error_recharge',
+        entryOccurredAt: '2026-06-03T12:00:00.000Z',
+      },
+    });
+  });
+
+  it('reuses a previous entry id for follow-up actions in the same source path', () => {
+    const track = vi.fn();
+    const first = recordAmrEntry(
+      track,
+      'onboarding_amr_card',
+      new Date('2026-06-03T12:00:00.000Z'),
+    );
+
+    const second = recordAmrEntry(
+      track,
+      'onboarding_amr_sign_in_continue',
+      new Date('2026-06-03T12:00:05.000Z'),
+      { reuseExistingFrom: ['onboarding_amr_card'] },
+    );
+
+    expect(second).toEqual(first);
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(readAmrAttribution(new Date('2026-06-03T12:00:05.000Z'))).toEqual(
+      first,
+    );
+  });
+
+  it('expires stored attribution after seven days', () => {
+    const track = vi.fn();
+    const attribution = recordAmrEntry(
+      track,
+      'settings_amr_authorize',
+      new Date('2026-06-03T12:00:00.000Z'),
+    );
+
+    expect(readAmrAttribution(new Date('2026-06-10T11:59:59.000Z'))).toEqual(
+      attribution,
+    );
+    expect(readAmrAttribution(new Date('2026-06-10T12:00:01.000Z'))).toBeNull();
+  });
+
+  it('adds Open Design attribution params to AMR wallet URLs', () => {
+    expect(
+      attributedAmrUrl('https://open-design.ai/amr/wallet?tab=recharge', {
+        entryId: 'od-amr-entry-123',
+        sourceProduct: 'open_design',
+        sourceDetail: 'generation_preview_recharge',
+        occurredAt: '2026-06-03T12:00:00.000Z',
+      }),
+    ).toBe(
+      'https://open-design.ai/amr/wallet?tab=recharge&od_origin=open_design&od_entry_id=od-amr-entry-123&od_entry_source=generation_preview_recharge&od_entry_at=2026-06-03T12%3A00%3A00.000Z',
+    );
+  });
+});

--- a/apps/web/tests/components/AmrGuidance.test.tsx
+++ b/apps/web/tests/components/AmrGuidance.test.tsx
@@ -57,6 +57,7 @@ function renderGuidance(onActivate = vi.fn()) {
       conversationId="conv-1"
       assistantMessageId="msg-amr"
       runId="run-9"
+      sourceDetail="chat_error_switch_retry_card"
       onActivate={onActivate}
     />,
   );

--- a/apps/web/tests/components/ChatPane.conversation-title.test.tsx
+++ b/apps/web/tests/components/ChatPane.conversation-title.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { forwardRef } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatPane } from '../../src/components/ChatPane';
+import { trackRunFailedToastSurfaceView } from '../../src/analytics/events';
 import type { ChatMessage, Conversation } from '../../src/types';
 
 vi.mock('../../src/i18n', () => ({
@@ -26,8 +27,18 @@ vi.mock('../../src/components/ChatComposer', () => ({
   ChatComposer: forwardRef((_props, _ref) => <div data-testid="composer" />),
 }));
 
+vi.mock('../../src/analytics/events', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/events')>();
+  return {
+    ...actual,
+    trackChatPanelClick: vi.fn(),
+    trackRunFailedToastSurfaceView: vi.fn(),
+  };
+});
+
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
 });
 
 // Session rename was removed by design — chats are not renamed. These tests
@@ -90,6 +101,47 @@ describe('ChatPane session switcher', () => {
     expect(screen.queryByTestId('chat-active-conversation-rename-input')).toBeNull();
     expect(screen.queryByDisplayValue('Contract review draft')).toBeNull();
   });
+
+  it('tracks run_failed_toast exposure for AMR balance guidance', async () => {
+    render(
+      <ChatPane
+        messages={[
+          failedAssistantMessage({
+            id: 'msg-amr-balance',
+            runId: 'run-amr-balance',
+            code: 'AMR_INSUFFICIENT_BALANCE',
+            agentId: 'amr',
+          }),
+        ]}
+        streaming={false}
+        error={null}
+        projectId="project-1"
+        projectKindForTracking="prototype"
+        projectFiles={[]}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onRetry={vi.fn()}
+        conversations={[conversation({ id: 'conv-1', title: 'Current' })]}
+        activeConversationId="conv-1"
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(trackRunFailedToastSurfaceView).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(trackRunFailedToastSurfaceView).mock.calls[0]![1]).toMatchObject({
+      page_name: 'chat_panel',
+      area: 'chat_panel',
+      element: 'run_failed_toast',
+      error_code: 'AMR_INSUFFICIENT_BALANCE',
+      project_id: 'project-1',
+      project_kind: 'prototype',
+      conversation_id: 'conv-1',
+      assistant_message_id: 'msg-amr-balance',
+      run_id: 'run-amr-balance',
+    });
+  });
 });
 
 function renderChatPane(props: {
@@ -134,5 +186,35 @@ function conversation(overrides: Partial<Conversation> & { id: string }): Conver
     createdAt: 1,
     updatedAt: 1,
     ...overrides,
+  };
+}
+
+function failedAssistantMessage({
+  id,
+  runId,
+  code,
+  agentId,
+}: {
+  id: string;
+  runId: string;
+  code: string;
+  agentId: string;
+}): ChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    content: '',
+    createdAt: 1,
+    runId,
+    runStatus: 'failed',
+    agentId,
+    events: [
+      {
+        kind: 'status',
+        label: 'error',
+        detail: 'AMR balance empty',
+        code,
+      },
+    ],
   };
 }

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -267,7 +267,24 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     await act(async () => {});
 
     await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith('/api/integrations/vela/login', { method: 'POST' });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/integrations/vela/login',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: expect.any(String),
+        }),
+      );
+    });
+    const loginInit = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith('/api/integrations/vela/login'),
+    )?.[1] as RequestInit;
+    expect(JSON.parse(String(loginInit.body))).toMatchObject({
+      attribution: {
+        entryId: expect.stringMatching(/^od-amr-/u),
+        sourceProduct: 'open_design',
+        sourceDetail: 'onboarding_amr_sign_in_continue',
+      },
     });
     expect(screen.getByText('Signing in…')).toBeTruthy();
     expect(screen.queryByText('Not signed in')).toBeNull();
@@ -341,7 +358,14 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(fetchMock).toHaveBeenCalledWith('/api/integrations/vela/login', { method: 'POST' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/integrations/vela/login',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: expect.any(String),
+      }),
+    );
     expect(screen.getByText('Signing in…')).toBeTruthy();
 
     await act(async () => {

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -623,10 +623,21 @@ describe('FileWorkspace generation failure recovery', () => {
     fireEvent.click(screen.getByTestId('generation-preview-recharge'));
     fireEvent.click(screen.getByTestId('generation-preview-retry'));
 
-    expect(openSpy).toHaveBeenCalledWith(
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const [walletUrl, target, features] = openSpy.mock.calls[0] ?? [];
+    expect(target).toBe('_blank');
+    expect(features).toBe('noopener,noreferrer');
+    const parsedWalletUrl = new URL(String(walletUrl));
+    expect(`${parsedWalletUrl.origin}${parsedWalletUrl.pathname}`).toBe(
       'https://open-design.ai/amr/wallet',
-      '_blank',
-      'noopener,noreferrer',
+    );
+    expect(parsedWalletUrl.searchParams.get('od_origin')).toBe('open_design');
+    expect(parsedWalletUrl.searchParams.get('od_entry_source')).toBe(
+      'generation_preview_recharge',
+    );
+    expect(parsedWalletUrl.searchParams.get('od_entry_id')).toMatch(/^od-amr-/u);
+    expect(Number.isFinite(Date.parse(parsedWalletUrl.searchParams.get('od_entry_at') ?? ''))).toBe(
+      true,
     );
     expect(onRetry).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'msg-amr_insufficient_balance', agentId: 'amr' }),

--- a/apps/web/tests/components/InlineModelSwitcher.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.test.tsx
@@ -69,6 +69,37 @@ function renderSwitcher(
   return { ...view, onAgentModelChange };
 }
 
+function expectVelaLoginWithAttribution(
+  fetchMock: ReturnType<typeof vi.fn>,
+  sourceDetail: string,
+) {
+  const loginCall = fetchMock.mock.calls.find(([input, init]) => (
+    input.toString() === '/api/integrations/vela/login'
+    && (init as RequestInit | undefined)?.method === 'POST'
+  ));
+  expect(loginCall).toBeDefined();
+  const init = loginCall?.[1] as RequestInit | undefined;
+  expect(init).toEqual(expect.objectContaining({
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: expect.any(String),
+  }));
+  const body = JSON.parse(String(init?.body)) as {
+    attribution?: {
+      entryId?: string;
+      sourceProduct?: string;
+      sourceDetail?: string;
+      occurredAt?: string;
+    };
+  };
+  expect(body.attribution).toEqual(expect.objectContaining({
+    entryId: expect.stringMatching(/^od-amr-/u),
+    sourceProduct: 'open_design',
+    sourceDetail,
+  }));
+  expect(Number.isFinite(Date.parse(body.attribution?.occurredAt ?? ''))).toBe(true);
+}
+
 describe('InlineModelSwitcher AMR row', () => {
   afterEach(() => {
     cleanup();
@@ -447,7 +478,7 @@ describe('InlineModelSwitcher AMR row', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(fetchMock).toHaveBeenCalledWith('/api/integrations/vela/login', { method: 'POST' });
+    expectVelaLoginWithAttribution(fetchMock, 'inline_model_switcher_amr_row');
     expect(
       within(popover).getByRole('radio', { name: /^AMR\s+Signing in/i }),
     ).toBeTruthy();
@@ -502,7 +533,7 @@ describe('InlineModelSwitcher AMR row', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(fetchMock).toHaveBeenCalledWith('/api/integrations/vela/login', { method: 'POST' });
+    expectVelaLoginWithAttribution(fetchMock, 'inline_model_switcher_amr_row');
     expect(
       within(popover).getByRole('radio', { name: /^AMR\s+Signing in/i }),
     ).toBeTruthy();

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -113,6 +113,26 @@ export type TrackingProjectSource =
   | 'chat_composer'
   | 'unknown';
 
+export type TrackingAmrEntrySource =
+  | 'onboarding_amr_card'
+  | 'onboarding_amr_sign_in_continue'
+  | 'inline_model_switcher_amr_row'
+  | 'settings_amr_agent_card'
+  | 'settings_amr_authorize'
+  | 'chat_error_authorize_retry'
+  | 'chat_error_recharge'
+  | 'chat_error_switch_retry_card'
+  | 'generation_preview_authorize_retry'
+  | 'generation_preview_recharge'
+  | 'generation_preview_switch_retry_card';
+
+export interface AmrEntryAttribution {
+  entryId: string;
+  sourceProduct: 'open_design';
+  sourceDetail: TrackingAmrEntrySource;
+  occurredAt: string;
+}
+
 // The six tabs inside the New project modal (CSV row 7 tab_name).
 export type TrackingNewProjectTab =
   | 'prototype'
@@ -1335,6 +1355,17 @@ export interface RunFailedToastClickProps {
   element: 'go_amr';
 }
 
+export interface AmrEntryClickProps {
+  page_name: TrackingPageName;
+  area: 'amr_entry';
+  element: TrackingAmrEntrySource;
+  action: 'click_amr_entry';
+  entry_id: string;
+  source_product: 'open_design';
+  source_detail: TrackingAmrEntrySource;
+  entry_occurred_at: string;
+}
+
 export interface ChatPanelResourcesPopoverClickProps {
   page_name: 'chat_panel';
   area: 'resources_popover';
@@ -1670,6 +1701,7 @@ export type UiClickProps =
   | IntegrationsUseEverywhereTabClickProps
   | ChatPanelClickProps
   | RunFailedToastClickProps
+  | AmrEntryClickProps
   | ChatPanelResourcesPopoverClickProps
   | FileManagerClickProps
   | ArtifactToolbarClickProps


### PR DESCRIPTION
## Why

This PR instruments Open Design AMR entry traffic so AMR can report paid conversion rate by source. The product need is to distinguish which Open Design entry points drive AMR landing, checkout intent, and successful wallet recharge.

Depends on AMR PR: https://github.com/powerformer/vela/pull/217

AMR PR #217 should be merged and deployed first so AMR accepts `open_design_amr_entry` before this PR starts forwarding entry clicks.

## What users will see

No new visible controls. Existing AMR entry points continue to behave the same, but Open Design now attaches attribution when users enter AMR login or wallet flows.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is attribution plumbing for existing AMR entry points with no visual UI changes.

## Bug fix verification

-

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web exec vitest run tests/analytics/amr-attribution.test.ts tests/components/AmrGuidance.test.tsx tests/components/ChatPane.conversation-title.test.tsx tests/components/AmrLoginPill.test.tsx tests/components/EntryShell.onboarding.test.tsx`
- `pnpm --filter @open-design/daemon exec vitest run tests/integrations/vela.routes.test.ts`
- `git diff --check`
- `pnpm guard` fails on an existing repo layout violation: `tools/pr/ -> tools/ top-level entries are allowlisted; expected only AGENTS.md, dev/, pack/, and serve/`