### PR TITLE
fix(web): restore manual edit content editor

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5475,9 +5475,6 @@ const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([
         return;
       }
       if (data.type === 'od-edit-hover') {
-        if (data.target.id !== selectedManualEditTargetIdRef.current) {
-          void selectManualEditTarget(data.target);
-        }
         return;
       }
       if (data.type === 'od-edit-text-commit') {

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -92,6 +92,25 @@ export function ManualEditPanel({
     onError('');
     onStyleChange?.(targetForInspector.id, normalized.styles, `Style: ${targetForInspector.label}`);
   };
+  const applyContent = () => {
+    if (!targetForInspector) return;
+    onError('');
+    if (targetForInspector.kind === 'link') {
+      onApplyPatch(
+        { id: targetForInspector.id, kind: 'set-link', text: draft.text, href: draft.href },
+        `Content: ${targetForInspector.label}`,
+      );
+      return;
+    }
+    if (targetForInspector.kind === 'image') {
+      onApplyPatch(
+        { id: targetForInspector.id, kind: 'set-image', src: draft.src, alt: draft.alt },
+        `Content: ${targetForInspector.label}`,
+      );
+      return;
+    }
+    onApplyPatch({ id: targetForInspector.id, kind: 'set-text', value: draft.text }, `Content: ${targetForInspector.label}`);
+  };
 
   const startPanelDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
     if (!onFloatingPositionChange) return;
@@ -159,12 +178,21 @@ export function ManualEditPanel({
         </div>
         <div className="manual-edit-scroll">
           {targetForInspector ? (
-            <StyleInspector
-              targetKind={targetForInspector.kind}
-              styles={draft.styles}
-              layoutEnabled={targetForInspector.isLayoutContainer}
-              onChange={changeTargetStyle}
-            />
+            <>
+              <ContentEditor
+                target={targetForInspector}
+                draft={draft}
+                busy={Boolean(busy)}
+                onDraftChange={onDraftChange}
+                onApply={applyContent}
+              />
+              <StyleInspector
+                targetKind={targetForInspector.kind}
+                styles={draft.styles}
+                layoutEnabled={targetForInspector.isLayoutContainer}
+                onChange={changeTargetStyle}
+              />
+            </>
           ) : !targetForInspector ? (
             <PageInspector
               enabled={pageStylesEnabled}
@@ -292,6 +320,74 @@ export function ManualEditPanel({
         </div>
       </section>
     </aside>
+  );
+}
+
+function ContentEditor({
+  target,
+  draft,
+  busy,
+  onDraftChange,
+  onApply,
+}: {
+  target: ManualEditTarget;
+  draft: ManualEditDraft;
+  busy: boolean;
+  onDraftChange: (draft: ManualEditDraft) => void;
+  onApply: () => void;
+}) {
+  const t = useT();
+  return (
+    <div className="manual-edit-tab-body manual-edit-content-editor">
+      <div className="cc-section">
+        <header className="cc-section-head">{t('manualEdit.tabContent')}</header>
+        <div className="cc-section-body">
+          {target.kind === 'image' ? (
+            <>
+              <label className="manual-edit-field">
+                <span>{t('manualEdit.imageUrl')}</span>
+                <input
+                  value={draft.src}
+                  onChange={(event) => onDraftChange({ ...draft, src: event.currentTarget.value })}
+                />
+              </label>
+              <label className="manual-edit-field">
+                <span>{t('manualEdit.altText')}</span>
+                <input
+                  value={draft.alt}
+                  onChange={(event) => onDraftChange({ ...draft, alt: event.currentTarget.value })}
+                />
+              </label>
+            </>
+          ) : (
+            <label className="manual-edit-field">
+              <span>{t('manualEdit.text')}</span>
+              <textarea
+                value={draft.text}
+                onChange={(event) => onDraftChange({ ...draft, text: event.currentTarget.value })}
+              />
+            </label>
+          )}
+          {target.kind === 'link' ? (
+            <label className="manual-edit-field">
+              <span>{t('manualEdit.href')}</span>
+              <input
+                value={draft.href}
+                onChange={(event) => onDraftChange({ ...draft, href: event.currentTarget.value })}
+              />
+            </label>
+          ) : null}
+          <button
+            type="button"
+            className="manual-edit-footer-btn primary manual-edit-apply-content"
+            disabled={busy}
+            onClick={onApply}
+          >
+            {t('manualEdit.applyContent')}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -94,6 +94,7 @@ export function ManualEditPanel({
   };
   const applyContent = () => {
     if (!targetForInspector) return;
+    if (!isContentEditableTarget(targetForInspector)) return;
     onError('');
     if (targetForInspector.kind === 'link') {
       onApplyPatch(
@@ -179,13 +180,15 @@ export function ManualEditPanel({
         <div className="manual-edit-scroll">
           {targetForInspector ? (
             <>
-              <ContentEditor
-                target={targetForInspector}
-                draft={draft}
-                busy={Boolean(busy)}
-                onDraftChange={onDraftChange}
-                onApply={applyContent}
-              />
+              {isContentEditableTarget(targetForInspector) ? (
+                <ContentEditor
+                  target={targetForInspector}
+                  draft={draft}
+                  busy={Boolean(busy)}
+                  onDraftChange={onDraftChange}
+                  onApply={applyContent}
+                />
+              ) : null}
               <StyleInspector
                 targetKind={targetForInspector.kind}
                 styles={draft.styles}
@@ -321,6 +324,10 @@ export function ManualEditPanel({
       </section>
     </aside>
   );
+}
+
+function isContentEditableTarget(target: ManualEditTarget): boolean {
+  return target.kind === 'text' || target.kind === 'link' || target.kind === 'image';
 }
 
 function ContentEditor({

--- a/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
@@ -36,7 +36,7 @@ function clickAgentTool(testId: string) {
   fireEvent.click(screen.getByTestId(testId));
 }
 
-async function hoverManualEditTarget(target = heroTarget()) {
+async function selectManualEditTarget(target = heroTarget()) {
   const frame = await waitFor(() => {
     const node = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     if (!node.contentWindow) throw new Error('Preview frame not ready');
@@ -44,7 +44,7 @@ async function hoverManualEditTarget(target = heroTarget()) {
   });
   act(() => {
     window.dispatchEvent(new MessageEvent('message', {
-      data: { type: 'od-edit-hover', target },
+      data: { type: 'od-edit-select', target },
       source: frame.contentWindow,
     }));
   });
@@ -93,7 +93,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
 
     act(() => {
       panelState.props?.onStyleChange?.('hero', { color: '#ef4444' }, 'Style: Hero');
@@ -131,7 +131,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
 
     const editFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     expect(editFrame.getAttribute('data-od-render-mode')).toBe('srcdoc');
@@ -185,7 +185,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
 
     act(() => {
       panelState.props?.onApplyPatch(
@@ -247,7 +247,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const getActivePreviewFrame = () => screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
 
     await waitFor(() => {
@@ -305,7 +305,7 @@ describe('FileViewer manual edit history regressions', () => {
     );
 
     fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     const postMessageSpy = vi.spyOn(frame.contentWindow!, 'postMessage');
 

--- a/apps/web/tests/components/FileViewer.manual-edit.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit.test.tsx
@@ -32,8 +32,22 @@ describe('FileViewer manual edit regressions', () => {
         source: frame.contentWindow,
       }));
     });
+  }
+
+  async function selectManualEditTarget(target = heroTarget()) {
+    const frame = await waitFor(() => {
+      const node = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      if (!node.contentWindow) throw new Error('Preview frame not ready');
+      return node;
+    });
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'od-edit-select', target },
+        source: frame.contentWindow,
+      }));
+    });
     await waitFor(() => {
-      expect(document.querySelector('.manual-edit-right')).not.toBeNull();
+      expect(document.querySelector('.manual-edit-content-editor')).not.toBeNull();
     });
   }
 
@@ -94,6 +108,29 @@ describe('FileViewer manual edit regressions', () => {
 
     await hoverManualEditTarget();
     expect(document.querySelector('.manual-edit-right')).not.toBeNull();
+    expect(screen.getByText('PAGE')).toBeTruthy();
+    expect(document.querySelector('.manual-edit-content-editor')).toBeNull();
+  });
+
+  it('switches from the page inspector to content editing only after explicit target selection', async () => {
+    const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>';
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(source, { status: 200, headers: { 'Content-Type': 'text/html' } }),
+    ));
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={source}
+      />,
+    );
+
+    clickManualTool('manual-edit-mode-toggle');
+    await hoverManualEditTarget();
+    expect(screen.getByText('PAGE')).toBeTruthy();
+
+    await selectManualEditTarget();
+    expect(screen.getByText('Content')).toBeTruthy();
+    expect(screen.getByText('Apply Content')).toBeTruthy();
   });
 
   it('does not let a pending manual edit style save survive a file switch', async () => {
@@ -117,7 +154,7 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const baseSizeInput = await findStyleInput('Size');
     fireEvent.change(baseSizeInput, { target: { value: '18' } });
 
@@ -162,7 +199,7 @@ describe('FileViewer manual edit regressions', () => {
         {},
       ));
       fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
-      await hoverManualEditTarget();
+      await selectManualEditTarget();
       const baseSizeInput = await findStyleInput('Size');
       fireEvent.change(baseSizeInput, { target: { value: '18' } });
 
@@ -213,7 +250,7 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const baseSizeInput = await findStyleInput('Size');
 
     fireEvent.change(baseSizeInput, { target: { value: '18' } });
@@ -243,7 +280,7 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const baseSizeInput = await findStyleInput('Size');
 
     fireEvent.change(baseSizeInput, { target: { value: '18' } });
@@ -279,7 +316,7 @@ describe('FileViewer manual edit regressions', () => {
     );
 
     clickManualTool('manual-edit-mode-toggle');
-    await hoverManualEditTarget();
+    await selectManualEditTarget();
     const baseSizeInput = await findStyleInput('Size');
 
     fireEvent.change(baseSizeInput, { target: { value: '18' } });

--- a/apps/web/tests/components/ManualEditPanel.test.tsx
+++ b/apps/web/tests/components/ManualEditPanel.test.tsx
@@ -55,11 +55,35 @@ describe('ManualEditPanel', () => {
     Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT');
   });
 
-  it('renders the style inspector without the advanced editor entry', () => {
+  it('renders the content editor with the style inspector', () => {
     renderPanel();
 
+    expect(host.textContent).toContain('Content');
+    expect(host.textContent).toContain('Apply Content');
     expect(host.textContent).toContain('TYPOGRAPHY');
     expect(host.textContent).not.toContain('Advanced');
+  });
+
+  it('applies selected text edits from the content editor', () => {
+    const onDraftChange = vi.fn();
+    const onApplyPatch = vi.fn();
+    renderPanel({ onDraftChange, onApplyPatch, draftText: 'Updated headline' });
+
+    const textArea = host.querySelector('.manual-edit-content-editor textarea') as HTMLTextAreaElement | null;
+    const apply = host.querySelector('.manual-edit-apply-content') as HTMLButtonElement | null;
+    if (!textArea || !apply) throw new Error('Content editor controls not found');
+
+    act(() => {
+      textArea.value = 'Edited again';
+      Simulate.change(textArea);
+      apply.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onDraftChange).toHaveBeenCalledWith(expect.objectContaining({ text: 'Edited again' }));
+    expect(onApplyPatch).toHaveBeenCalledWith(
+      { id: 'hero-title', kind: 'set-text', value: 'Updated headline' },
+      'Content: Hero Title',
+    );
   });
 
   it('shows a readable selected element name in the titlebar', () => {
@@ -498,6 +522,7 @@ describe('ManualEditPanel', () => {
     attributesText = '{}',
     selectedTarget = target,
     styles = emptyManualEditStyles(),
+    draftText = 'Updated copy',
     pageStylesEnabled = true,
     floatingStyle,
     onFloatingPositionChange,
@@ -513,13 +538,14 @@ describe('ManualEditPanel', () => {
     attributesText?: string;
     selectedTarget?: ManualEditTarget | null;
     styles?: ReturnType<typeof emptyManualEditStyles>;
+    draftText?: string;
     pageStylesEnabled?: boolean;
     floatingStyle?: CSSProperties;
     onFloatingPositionChange?: (position: { left: number; top: number }) => void;
   } = {}) {
     const draft = {
       ...emptyManualEditDraft('<html></html>'),
-      text: 'Updated copy',
+      text: draftText,
       attributesText,
       styles,
       outerHtml: target.outerHtml,

--- a/apps/web/tests/components/ManualEditPanel.test.tsx
+++ b/apps/web/tests/components/ManualEditPanel.test.tsx
@@ -103,6 +103,31 @@ describe('ManualEditPanel', () => {
     expect(host.querySelector('.manual-edit-titlebar')?.textContent).not.toContain('div.container');
   });
 
+  it('does not show content editing controls for non-content targets', () => {
+    for (const selectedTarget of [
+      {
+        ...target,
+        id: 'layout-wrap',
+        kind: 'container' as const,
+        label: 'div.hero-wrap',
+        className: 'hero-wrap',
+        isLayoutContainer: true,
+      },
+      {
+        ...target,
+        id: 'color-token',
+        kind: 'token' as const,
+        label: 'Color token',
+      },
+    ]) {
+      renderPanel({ selectedTarget });
+
+      expect(host.querySelector('.manual-edit-content-editor')).toBeNull();
+      expect(host.textContent).not.toContain('Apply Content');
+      expect(host.querySelector('.cc-inspector')).not.toBeNull();
+    }
+  });
+
   it('shows a drag handle for floating edit panels', () => {
     renderPanel({ floatingStyle: { left: 20, top: 24, width: 320, height: 380 } });
 


### PR DESCRIPTION
Closes #2884

## Why

Issue #2884 reports that selecting text in Edit mode no longer shows the manual editor module that tutorial videos demonstrate. The current compact manual edit panel still exposed style controls, but the selected-element content editor path had disappeared, leaving users without an obvious way to manually edit text/link/image content from the panel.

## What users will see

In Edit mode, selecting an editable element now shows a Content section at the top of the manual edit panel. Text targets get a text editor and Apply Content action; links also expose href editing; images expose source and alt text editing. Existing style controls remain below the content editor.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not captured in this runner because Node/pnpm are unavailable, so the local web app could not be started.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ManualEditPanel.test.tsx`
- Did the test go red on `main` and green on this branch? no; package-script validation could not run in this environment because `node`, `corepack`, and `pnpm` are unavailable on PATH.

## Validation

- `git diff --check`
- Not run: `pnpm --filter @open-design/web test -- ManualEditPanel.test.tsx` (`pnpm`: command not found)
- Not run: `pnpm guard` / `pnpm typecheck` (`node`, `corepack`, and `pnpm` unavailable on PATH)

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>