### PR TITLE
fix: override yauzl to 3.3.1 to fix Electron postinstall hang on Node 24.16.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       "protobufjs": "8.4.0",
       "qs": "6.15.2",
       "tmp": "0.2.7",
-      "yaml": "2.9.0"
+      "yaml": "2.9.0",
+      "yauzl": "3.3.1"
     },
     "onlyBuiltDependencies": [
       "better-sqlite3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   qs: 6.15.2
   tmp: 0.2.7
   yaml: 2.9.0
+  yauzl: 3.3.1
 
 importers:
 
@@ -3096,9 +3097,6 @@ packages:
     resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
     hasBin: true
 
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -5216,8 +5214,9 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+  yauzl@3.3.1:
+    resolution: {integrity: sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==}
+    engines: {node: '>=12'}
 
   yjs@13.6.31:
     resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
@@ -7954,7 +7953,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       get-stream: 5.2.0
-      yauzl: 2.10.0
+      yauzl: 3.3.1
     optionalDependencies:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
@@ -7998,10 +7997,6 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
       xml-naming: 0.1.0
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -10393,10 +10388,10 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yauzl@2.10.0:
+  yauzl@3.3.1:
     dependencies:
       buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
+      pend: 1.2.0
 
   yjs@13.6.31:
     dependencies:


### PR DESCRIPTION
Discovered while testing linux appimage build as part of this [closed issue](https://github.com/nexu-io/open-design/issues/728)
Reported in [this comment](https://github.com/nexu-io/open-design/issues/728#issuecomment-4608366916)

## Why

Running `pnpm tools-pack linux build --to appimage` on Node ≥ 24.16.0 fails
with:

```
⨯ ENOENT: no such file or directory, rename '.../builder/linux-unpacked/electron'
  -> '.../builder/linux-unpacked/Open Design'
```

`electron-builder` tries to rename the extracted Electron binary, but it
doesn't exist because Electron's postinstall silently produced a broken
runtime: `electron/dist/` contains only `v8_context_snapshot.bin` — no binary,
no `locales/`, no `resources/`. The postinstall script exits 0 with no error or
warning.

### Root cause

Electron's `install.js` uses `extract-zip` → `yauzl` → `fd-slicer` to extract
the downloaded binary zip. `fd-slicer@1.1.0` implements its own `destroy()` on
`ReadStream`, dating back to before Node 8 added a native `Readable.destroy()`.
These two implementations collide with a stream-lifecycle change introduced in
Node 24.16.0 ([nodejs/node#63487]).

When `zlib.createInflateRaw()` applies backpressure during decompression, Node
24's stream internals interact with `fd-slicer`'s broken `destroy` in a way that
prevents the Readable from ever resuming. The raw stream stops after exactly 3
read operations (196,608 / 204,997 bytes), and inflation stalls at 97% (694,688
/ 715,208 bytes). No error event, no close event, no rejection — a silent hang.

This was confirmed by testing each layer in isolation: `fs.createReadStream` →
`InflateRaw` works fine; `fd-slicer` ReadStream → `PassThrough` works fine;
`fd-slicer` ReadStream → `InflateRaw` hangs. The issue is specific to custom
JavaScript Readables with async `_read` piped into zlib on Node ≥ 24.16.0.

### Why a pnpm override

`yauzl@3.3.1` ([thejoshwolfe/yauzl#170]) fixes this by dropping `fd-slicer`
entirely — it only depends on `pend`. However, `extract-zip@2.0.1` (used by
Electron's installer) pins `yauzl@^2.10.0` and has been unmaintained for 6 years
([max-mapper/extract-zip#154]), so the fix cannot flow through normal dependency
resolution. A pnpm override is the same approach used by VS Code
([microsoft/vscode#318682]) and other projects hitting the same issue.

[nodejs/node#63487]: https://github.com/nodejs/node/issues/63487
[thejoshwolme/yauzl#170]: https://github.com/thejoshwolfe/yauzl/pull/170
[max-mapper/extract-zip#154]: https://github.com/max-mapper/extract-zip/issues/154
[microsoft/vscode#318682]: https://github.com/microsoft/vscode/pull/318682

## What users will see

No visible UI change. Users building the packaged app on Node ≥ 24.16.0 will
find that `pnpm tools-pack linux build` (and the equivalent macOS/Windows
paths) now complete successfully instead of silently producing a broken Electron
runtime.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [x] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

**New top-level dependency note:** This is not a new dependency — it is a pnpm
override that forces all transitive `yauzl` resolution to the fixed `3.3.1`.
No new package enters the dependency tree; existing `yauzl@2.10.0` instances
(from `extract-zip` → `yauzl`) are replaced in-place.

## Screenshots

Not applicable — no UI change.

## Bug fix verification

The bug is a silent hang in a transitive dependency during postinstall, which
is not easily reproducible in a unit test. Verification was done by:

1. Confirming `electron/dist/` is empty (only `v8_context_snapshot.bin`) on
   Node 24.16.0 without the override.
2. Applying the override, running `pnpm install`, and confirming `electron/dist/`
   now contains the full runtime (binary, `locales/`, `resources/`,
   `libffmpeg.so`, etc.).
3. Running `pnpm tools-pack linux build --to appimage` end-to-end successfully.

## Validation

```bash
pnpm install                        # apply override, verify Electron installs correctly
pnpm guard                          # no new .js/.mjs/.cjs outside allowlist
pnpm typecheck                      # no type errors
```
