### PR TITLE
fix(web): space built-in skill edit warning

### DIFF
--- a/apps/web/src/styles/viewer/plugin-inputs.css
+++ b/apps/web/src/styles/viewer/plugin-inputs.css
@@ -51,6 +51,35 @@
   border-radius: 6px;
 }
 
+.settings-skills .skills-edit-builtin-warning {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 2px 14px 14px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--warning, #d97706) 30%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--warning, #d97706) 8%, var(--bg-panel));
+  color: var(--text);
+}
+.settings-skills .skills-edit-builtin-warning p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.settings-skills .skills-edit-builtin-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.settings-skills .skills-edit-builtin-actions .btn {
+  min-height: 30px;
+  padding: 6px 12px;
+  border-radius: 7px;
+}
+
 .settings-skills .skills-row-detail {
   display: flex;
   flex-direction: column;
@@ -331,4 +360,3 @@
 
 	text-align: left;
 }
-


### PR DESCRIPTION
Fixes #3558

## Why

The built-in skill edit confirmation in Settings -> Skills is a visible rough edge: the warning text sits too close to the row border and the Cancel/Edit actions feel cramped against the surrounding content. This is a small CSS-only polish pass for that pre-save confirmation state.

## What users will see

When a user clicks Edit on a built-in skill, the confirmation now appears as an inset warning panel with clearer padding, better line height, and a wrapped action row with more space between the buttons.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The issue includes the before screenshot for this confirmation state. I did not attach a fresh local screenshot; this PR only changes the existing CSS spacing for the warning block.

## Bug fix verification

- Test path that covers the affected flow: `apps/web/tests/components/SkillsSection.test.tsx`
- Did the test go red on `main` and green on this branch? no — this is a CSS spacing bug, so the existing interaction test confirms the warning flow remains intact while the fix is style-only.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/web exec vitest run tests/components/SkillsSection.test.tsx`
- `pnpm --filter @open-design/web run typecheck`
- `git diff --check`