### PR TITLE
fix: enforce deck slide count metadata

### DIFF
--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -1074,9 +1074,17 @@ function renderMetadataBlock(
     );
   }
   if (metadata.kind === 'deck') {
+    const slideCount = typeof metadata.slideCount === 'string' && metadata.slideCount.trim().length > 0
+      ? metadata.slideCount.trim()
+      : null;
     lines.push(
-      `- **slideCount**: ${metadata.slideCount ?? '(unknown — ask only if the Active plugin / Plugin inputs block does not already include slideCount)'}`,
+      `- **slideCount**: ${slideCount ?? '(unknown — ask only if the Active plugin / Plugin inputs block does not already include slideCount)'}`,
     );
+    if (slideCount) {
+      lines.push(
+        `- **required slide count**: ${slideCount}. This overrides any conflicting slide-count or page-count text in the user's prompt.`,
+      );
+    }
     lines.push(
       `- **speakerNotes**: ${typeof metadata.speakerNotes === 'boolean' ? metadata.speakerNotes : '(unknown — ask: include speaker notes?)'}`,
     );

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -248,6 +248,21 @@ describe('composeSystemPrompt', () => {
     expect(prompt).not.toContain('**platformTargets**');
   });
 
+  it('makes deck slide count authoritative over conflicting prompt text', () => {
+    const prompt = composeSystemPrompt({
+      metadata: {
+        kind: 'deck',
+        speakerNotes: true,
+        slideCount: '25-30 pages',
+      } as any,
+    });
+
+    expect(prompt).toContain('- **slideCount**: 25-30 pages');
+    expect(prompt).toContain(
+      "- **required slide count**: 25-30 pages. This overrides any conflicting slide-count or page-count text in the user's prompt.",
+    );
+  });
+
   it('tells artifact generation to summarize instead of dumping raw HTML source into chat', () => {
     const prompt = composeSystemPrompt({
       metadata: { kind: 'prototype', fidelity: 'production' } as any,

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -158,7 +158,7 @@ function defaultPluginIdForMetadata(metadata: ProjectMetadata): string | null {
   return defaultScenarioPluginIdForProjectMetadata(metadata);
 }
 
-function defaultPluginInputsForCreate(
+export function defaultPluginInputsForCreate(
   input: CreateInput,
   pluginId: string | null,
 ): Record<string, unknown> | null {
@@ -178,11 +178,14 @@ function defaultPluginInputsForCreate(
   }
 
   if (pluginId === 'example-simple-deck') {
+    const slideCount = typeof input.metadata.slideCount === 'string' && input.metadata.slideCount.trim().length > 0
+      ? input.metadata.slideCount.trim()
+      : '10-15 pages';
     return {
       deckType: 'pitch deck',
       topic: projectName || 'the user brief',
       audience: 'decision makers',
-      slideCount: '10-15 pages',
+      slideCount,
       speakerNotes: input.metadata.speakerNotes
         ? 'include speaker notes'
         : 'no speaker notes',

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { EntryShell } from '../../src/components/EntryShell';
+import { EntryShell, defaultPluginInputsForCreate } from '../../src/components/EntryShell';
 import { AMR_LOGIN_TIMEOUT_MS } from '../../src/components/amrLoginPolling';
 import { I18nProvider } from '../../src/i18n';
 import type { AgentInfo, AppConfig } from '../../src/types';
@@ -283,6 +283,27 @@ describe('EntryShell settings menu', () => {
     fireEvent.click(screen.getByTestId('entry-settings-open-details'));
 
     expect(props.onOpenSettings).toHaveBeenCalledWith();
+  });
+});
+
+describe('EntryShell project defaults', () => {
+  it('uses deck metadata slide count when preparing default plugin inputs', () => {
+    const inputs = defaultPluginInputsForCreate({
+      name: 'Architecture blueprint',
+      skillId: null,
+      designSystemId: null,
+      metadata: {
+        kind: 'deck',
+        slideCount: '25-30 pages',
+        speakerNotes: true,
+      },
+    } as any, 'example-simple-deck');
+
+    expect(inputs).toMatchObject({
+      topic: 'Architecture blueprint',
+      slideCount: '25-30 pages',
+      speakerNotes: 'include speaker notes',
+    });
   });
 });
 

--- a/packages/contracts/src/prompts/system.ts
+++ b/packages/contracts/src/prompts/system.ts
@@ -526,9 +526,17 @@ function renderMetadataBlock(
     );
   }
   if (metadata.kind === 'deck') {
+    const slideCount = typeof metadata.slideCount === 'string' && metadata.slideCount.trim().length > 0
+      ? metadata.slideCount.trim()
+      : null;
     lines.push(
-      `- **slideCount**: ${metadata.slideCount ?? '(unknown — ask only if the Active plugin / Plugin inputs block does not already include slideCount)'}`,
+      `- **slideCount**: ${slideCount ?? '(unknown — ask only if the Active plugin / Plugin inputs block does not already include slideCount)'}`,
     );
+    if (slideCount) {
+      lines.push(
+        `- **required slide count**: ${slideCount}. This overrides any conflicting slide-count or page-count text in the user's prompt.`,
+      );
+    }
     lines.push(
       `- **speakerNotes**: ${typeof metadata.speakerNotes === 'boolean' ? metadata.speakerNotes : '(unknown — ask: include speaker notes?)'}`,
     );

--- a/packages/contracts/tests/system-prompt.test.ts
+++ b/packages/contracts/tests/system-prompt.test.ts
@@ -139,6 +139,21 @@ describe('composeSystemPrompt', () => {
     expect(prompt).not.toContain('`实时作品`');
   });
 
+  it('makes deck slide count authoritative over conflicting prompt text', () => {
+    const prompt = composeSystemPrompt({
+      metadata: {
+        kind: 'deck',
+        speakerNotes: true,
+        slideCount: '25-30 pages',
+      } as any,
+    });
+
+    expect(prompt).toContain('- **slideCount**: 25-30 pages');
+    expect(prompt).toContain(
+      "- **required slide count**: 25-30 pages. This overrides any conflicting slide-count or page-count text in the user's prompt.",
+    );
+  });
+
   it('treats an active design system as the visual direction', () => {
     const prompt = composeSystemPrompt({
       designSystemTitle: 'ComfyUI',


### PR DESCRIPTION
Fixes #3565

## Why

I picked this up from the Home Simple Deck bug report: the user-selected page range was being stored, but a conflicting phrase in the free-form prompt could still win during generation. That makes the page-count selector feel unreliable, especially when the user explicitly chose a longer deck before submitting.

This also fixes the create-path default plugin inputs so deck metadata does not get shadowed by the old `10-15 pages` literal.

## What users will see

When a deck project carries a selected page range such as `25-30 pages`, Open Design now passes that value through the default deck plugin inputs and makes it an explicit required slide-count constraint in the generation prompt. Conflicting text in the user prompt, such as `8-10 slides`, should no longer silently override the selector.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — selected deck page-count metadata is now authoritative during prompt handoff
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No screenshot. This changes the create/handoff data and prompt constraint path, not a visible control.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/EntryShell.onboarding.test.tsx` covers the default deck plugin input handoff, and `apps/daemon/tests/prompts/system.test.ts` / `packages/contracts/tests/system-prompt.test.ts` cover the required slide-count constraint in the composed prompt.
- Did the test go red on `main` and green on this branch? Not run separately on `main`; the new assertions target the old hardcoded `10-15 pages` handoff and the missing required slide-count line, and they pass on this branch.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/web exec vitest run tests/components/EntryShell.onboarding.test.tsx --reporter=dot --maxWorkers=1 --pool=forks`
- `pnpm --filter @open-design/daemon exec vitest run tests/prompts/system.test.ts --reporter=dot --maxWorkers=1 --pool=forks`
- `pnpm --filter @open-design/contracts exec vitest run tests/system-prompt.test.ts --reporter=dot --maxWorkers=1 --pool=forks`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/contracts typecheck`
- `git diff --check`

Note: local Node is `v26.0.0`, so pnpm emitted the repo's expected Node `~24` engine warning during validation.