### PR TITLE
fix: scroll nested deck containers

### DIFF
--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1759,10 +1759,31 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
       for (var i=0; i<targets.length; i++) if (targets[i] === node) return;
       targets.push(node);
     }
+    var list = slides();
+    if (list && list.length) {
+      var node = list[0] && list[0].parentElement;
+      while (node && node !== document.body && node !== document.documentElement) {
+        var mode = overflowMode(node);
+        if (scrollOverflow(node) > 1 && isScrollableOverflowMode(mode)) add(node);
+        node = node.parentElement;
+      }
+    }
     add(document.scrollingElement);
     add(document.documentElement);
     add(document.body);
     return targets;
+  }
+  function scrollWidthOf(el){
+    if (!el) return Math.max(1, window.innerWidth);
+    var width = Number(el.clientWidth || 0);
+    return width > 0 ? width : Math.max(1, window.innerWidth);
+  }
+  function activeScrollTarget(){
+    var targets = scrollTargets();
+    for (var i=0; i<targets.length; i++) {
+      if (scrollOverflow(targets[i]) > 1) return targets[i];
+    }
+    return targets[0] || null;
   }
   function maxScrollLeft(){
     var targets = scrollTargets();
@@ -1809,8 +1830,9 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   function activeIndex(list){
     if (!list || !list.length) return 0;
     if (isScrollDeck()) {
-      var w = Math.max(1, window.innerWidth);
-      return Math.max(0, Math.min(list.length - 1, Math.round(maxScrollLeft() / w)));
+      var target = activeScrollTarget();
+      var w = scrollWidthOf(target);
+      return Math.max(0, Math.min(list.length - 1, Math.round(scrollLeftOf(target) / w)));
     }
     var byTransform = activeIndexFromTransform(list);
     if (byTransform >= 0) return byTransform;
@@ -1879,6 +1901,10 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
           if (node.children[i].classList && node.children[i].classList.contains('slide')) directSlides += 1;
         }
         var style = window.getComputedStyle(node);
+        if (isScrollableOverflowMode(String(style.overflowX || '').toLowerCase())) {
+          node = node.parentElement;
+          continue;
+        }
         if (
           directSlides >= list.length &&
           (
@@ -1924,6 +1950,10 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     if (total) total.textContent = pad2(count);
     if (prev) prev.toggleAttribute('disabled', i <= 0);
     if (next) next.toggleAttribute('disabled', i >= count - 1);
+    document.querySelectorAll('#deck-counter,.deck-counter').forEach(function(el){
+      var text = String(el.textContent || '');
+      if (/^\\s*\\d+\\s*\\/\\s*\\d+\\s*$/.test(text)) el.textContent = (i + 1) + ' / ' + count;
+    });
   }
   function setActive(i){
     var list = slides();
@@ -1961,15 +1991,16 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   function scrollGo(i){
     var list = slides();
     var next = Math.max(0, Math.min(list.length - 1, i));
-    var left = next * window.innerWidth;
     var targets = scrollTargets();
     for (var t=0; t<targets.length; t++) {
+      var left = next * scrollWidthOf(targets[t]);
       try {
         targets[t].scrollTo({ left: left, behavior: 'smooth' });
       } catch (_) {
         try { targets[t].scrollLeft = left; } catch (__) {}
       }
     }
+    updateDeckChrome(next, list.length);
     setTimeout(report, 380);
   }
   function targetFor(action, list){

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1768,6 +1768,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
         if (scrollOverflow(node) > 1 && isScrollableOverflowMode(mode)) {
           foundNested = true;
           add(node);
+          break;
         }
         node = node.parentElement;
       }
@@ -1798,6 +1799,12 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     }
     return active || targets[0] || null;
   }
+  function hasNestedScrollTarget(targets){
+    for (var i=0; i<targets.length; i++) {
+      if (!isRootScrollContainer(targets[i])) return true;
+    }
+    return false;
+  }
   function maxScrollLeft(){
     var targets = scrollTargets();
     var value = 0;
@@ -1805,6 +1812,30 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
       value = Math.max(value, Number(targets[i].scrollLeft || 0));
     }
     return value;
+  }
+  function slideScrollLeftFor(target, list, index){
+    if (target && !isRootScrollContainer(target) && list && list[index]) {
+      var slideLeft = Number(list[index].offsetLeft || 0);
+      var targetLeft = Number(target.offsetLeft || 0);
+      var relative = Math.max(0, slideLeft - targetLeft);
+      if (relative > 0 || index === 0) return relative;
+    }
+    return index * scrollWidthOf(target);
+  }
+  function activeIndexFromOffsets(target, list){
+    if (!target || !list || !list.length || isRootScrollContainer(target)) return -1;
+    var left = scrollLeftOf(target);
+    var best = 0;
+    var bestDistance = Infinity;
+    for (var i=0; i<list.length; i++) {
+      var candidate = slideScrollLeftFor(target, list, i);
+      var distance = Math.abs(candidate - left);
+      if (distance < bestDistance) {
+        best = i;
+        bestDistance = distance;
+      }
+    }
+    return best;
   }
   function hasHorizontalScroll(){
     var targets = scrollTargets();
@@ -1843,9 +1874,15 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   function activeIndex(list){
     if (!list || !list.length) return 0;
     if (isScrollDeck()) {
+      var targets = scrollTargets();
       var target = activeScrollTarget();
+      if (hasNestedScrollTarget(targets)) {
+        var offsetIndex = activeIndexFromOffsets(target, list);
+        if (offsetIndex >= 0) return Math.max(0, Math.min(list.length - 1, offsetIndex));
+      }
       var w = scrollWidthOf(target);
-      return Math.max(0, Math.min(list.length - 1, Math.round(scrollLeftOf(target) / w)));
+      var left = isRootScrollContainer(target) ? maxScrollLeft() : scrollLeftOf(target);
+      return Math.max(0, Math.min(list.length - 1, Math.round(left / w)));
     }
     var byTransform = activeIndexFromTransform(list);
     if (byTransform >= 0) return byTransform;
@@ -2009,7 +2046,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     var next = Math.max(0, Math.min(list.length - 1, i));
     var targets = scrollTargets();
     for (var t=0; t<targets.length; t++) {
-      var left = next * scrollWidthOf(targets[t]);
+      var left = slideScrollLeftFor(targets[t], list, next);
       try {
         targets[t].scrollTo({ left: left, behavior: 'smooth' });
       } catch (_) {

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1754,6 +1754,7 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   }
   function scrollTargets(){
     var targets = [];
+    var foundNested = false;
     function add(node){
       if (!node) return;
       for (var i=0; i<targets.length; i++) if (targets[i] === node) return;
@@ -1764,13 +1765,18 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
       var node = list[0] && list[0].parentElement;
       while (node && node !== document.body && node !== document.documentElement) {
         var mode = overflowMode(node);
-        if (scrollOverflow(node) > 1 && isScrollableOverflowMode(mode)) add(node);
+        if (scrollOverflow(node) > 1 && isScrollableOverflowMode(mode)) {
+          foundNested = true;
+          add(node);
+        }
         node = node.parentElement;
       }
     }
-    add(document.scrollingElement);
-    add(document.documentElement);
-    add(document.body);
+    if (!foundNested) {
+      add(document.scrollingElement);
+      add(document.documentElement);
+      add(document.body);
+    }
     return targets;
   }
   function scrollWidthOf(el){
@@ -1780,10 +1786,17 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   }
   function activeScrollTarget(){
     var targets = scrollTargets();
+    var active = null;
+    var activeLeft = -1;
     for (var i=0; i<targets.length; i++) {
-      if (scrollOverflow(targets[i]) > 1) return targets[i];
+      if (scrollOverflow(targets[i]) <= 1) continue;
+      var left = scrollLeftOf(targets[i]);
+      if (!active || left > activeLeft) {
+        active = targets[i];
+        activeLeft = left;
+      }
     }
-    return targets[0] || null;
+    return active || targets[0] || null;
   }
   function maxScrollLeft(){
     var targets = scrollTargets();
@@ -1901,7 +1914,10 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
           if (node.children[i].classList && node.children[i].classList.contains('slide')) directSlides += 1;
         }
         var style = window.getComputedStyle(node);
-        if (isScrollableOverflowMode(String(style.overflowX || '').toLowerCase())) {
+        if (
+          scrollOverflow(node) > 1 &&
+          isScrollableOverflowMode(String(style.overflowX || '').toLowerCase())
+        ) {
           node = node.parentElement;
           continue;
         }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1815,12 +1815,28 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
   }
   function slideScrollLeftFor(target, list, index){
     if (target && !isRootScrollContainer(target) && list && list[index]) {
-      var slideLeft = Number(list[index].offsetLeft || 0);
-      var targetLeft = Number(target.offsetLeft || 0);
-      var relative = Math.max(0, slideLeft - targetLeft);
+      var relative = offsetLeftWithin(list[index], target);
       if (relative > 0 || index === 0) return relative;
     }
     return index * scrollWidthOf(target);
+  }
+  function offsetLeftWithin(node, ancestor){
+    var left = 0;
+    var cur = node;
+    var guard = 0;
+    while (cur && cur !== ancestor && cur !== document.body && cur !== document.documentElement && guard < 50) {
+      left += Number(cur.offsetLeft || 0);
+      cur = cur.offsetParent || cur.parentElement;
+      guard += 1;
+    }
+    if (cur === ancestor) return Math.max(0, left);
+    try {
+      var nodeRect = node.getBoundingClientRect();
+      var ancestorRect = ancestor.getBoundingClientRect();
+      return Math.max(0, scrollLeftOf(ancestor) + nodeRect.left - ancestorRect.left);
+    } catch (_) {
+      return 0;
+    }
   }
   function activeIndexFromOffsets(target, list){
     if (!target || !list || !list.length || isRootScrollContainer(target)) return -1;

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
@@ -165,6 +165,111 @@ describe('deck bridge — nested slide markup (#1530)', () => {
     expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
   });
 
+  it('scrolls a nested horizontal flex deck instead of translating the scroll container', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(`
+      <style>
+        html, body { margin: 0; height: 100%; overflow: hidden; }
+        .slide { flex: 0 0 100vw; width: 100vw; height: 100vh; scroll-snap-align: start; }
+      </style>
+      <div
+        id="deck-container"
+        class="deck-container"
+        style="display: flex; overflow-x: auto; overflow-y: hidden; scroll-snap-type: x mandatory;"
+      >
+        <section class="slide">One</section>
+        <section class="slide">Two</section>
+        <section class="slide">Three</section>
+      </div>
+    `);
+    Object.defineProperty(win, 'innerWidth', { configurable: true, value: 1000 });
+    const container = win.document.getElementById('deck-container') as HTMLElement;
+    Object.defineProperties(container, {
+      scrollWidth: { configurable: true, value: 3000 },
+      clientWidth: { configurable: true, value: 1000 },
+    });
+    const containerScrollTo = vi.fn((options?: ScrollToOptions | number) => {
+      const left = typeof options === 'number' ? options : Number(options?.left || 0);
+      container.scrollLeft = left;
+    });
+    container.scrollTo = containerScrollTo;
+
+    postSlide(win, 'next');
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 450));
+
+    expect(containerScrollTo).toHaveBeenCalledWith({ left: 1000, behavior: 'smooth' });
+    expect(container.style.transform).toBe('');
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
+
+  it('scrolls a nested horizontal grid deck before transform fallback', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(`
+      <style>
+        html, body { margin: 0; height: 100%; overflow: hidden; }
+        .slide { width: 100vw; height: 100vh; scroll-snap-align: start; }
+      </style>
+      <div
+        id="deck-container"
+        class="deck-container"
+        style="display: grid; grid-auto-flow: column; grid-auto-columns: 100vw; overflow-x: auto; overflow-y: hidden; scroll-snap-type: x mandatory;"
+      >
+        <section class="slide">One</section>
+        <section class="slide">Two</section>
+        <section class="slide">Three</section>
+      </div>
+    `);
+    Object.defineProperty(win, 'innerWidth', { configurable: true, value: 1000 });
+    const container = win.document.getElementById('deck-container') as HTMLElement;
+    Object.defineProperties(container, {
+      scrollWidth: { configurable: true, value: 3000 },
+      clientWidth: { configurable: true, value: 1000 },
+    });
+    container.scrollTo = vi.fn((options?: ScrollToOptions | number) => {
+      const left = typeof options === 'number' ? options : Number(options?.left || 0);
+      container.scrollLeft = left;
+    });
+
+    postSlide(win, 'next');
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 450));
+
+    expect(container.scrollTo).toHaveBeenCalledWith({ left: 1000, behavior: 'smooth' });
+    expect(container.style.transform).toBe('');
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
+
+  it('updates a plain in-artifact deck counter when host navigation drives the slide', async () => {
+    const { win } = setupDeckBridge(`
+      <style>
+        html, body { margin: 0; height: 100%; overflow: hidden; }
+        .slide { flex: 0 0 100vw; width: 100vw; height: 100vh; scroll-snap-align: start; }
+      </style>
+      <div
+        id="deck-container"
+        class="deck-container"
+        style="display: flex; overflow-x: auto; overflow-y: hidden; scroll-snap-type: x mandatory;"
+      >
+        <section class="slide">One</section>
+        <section class="slide">Two</section>
+        <section class="slide">Three</section>
+      </div>
+      <div class="deck-counter" id="deck-counter">1 / 3</div>
+    `);
+    Object.defineProperty(win, 'innerWidth', { configurable: true, value: 1000 });
+    const container = win.document.getElementById('deck-container') as HTMLElement;
+    Object.defineProperties(container, {
+      scrollWidth: { configurable: true, value: 3000 },
+      clientWidth: { configurable: true, value: 1000 },
+    });
+    container.scrollTo = vi.fn((options?: ScrollToOptions | number) => {
+      const left = typeof options === 'number' ? options : Number(options?.left || 0);
+      container.scrollLeft = left;
+    });
+
+    postSlide(win, 'next');
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 450));
+
+    expect(win.document.getElementById('deck-counter')?.textContent).toBe('2 / 3');
+  });
+
   it('updates Simple Deck direct progress fill when host navigation drives the slide', async () => {
     const { win } = setupDeckBridge(`
       <style>

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
@@ -591,4 +591,98 @@ describe('deck bridge - scroll container fallback', () => {
     expect(deckScroller.scrollLeft).toBe(920);
     expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
   });
+
+  it('computes nested slide offsets through positioned track coordinate space', async () => {
+    const bodyHtml = `
+      <style>
+        .deck-scroller { width: 800px; overflow-x: auto; }
+        .track { display: flex; gap: 120px; position: relative; left: 120px; }
+        .slide { flex: 0 0 800px; }
+      </style>
+      <div class="deck-scroller" id="deck-scroller">
+        <div class="track" id="track">
+          <section class="slide" id="slide-1">One</section>
+          <section class="slide" id="slide-2">Two</section>
+          <section class="slide" id="slide-3">Three</section>
+        </div>
+      </div>
+    `;
+    const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      deck: true,
+    });
+    const script = extractDeckBridgeScript(srcdoc);
+    const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      runScripts: 'outside-only',
+      pretendToBeVisual: true,
+    });
+    const win = dom.window;
+    const parentPostMessage = vi.fn();
+    Object.defineProperty(win, 'parent', {
+      configurable: true,
+      value: { postMessage: parentPostMessage },
+    });
+    Object.defineProperty(win, 'innerWidth', {
+      configurable: true,
+      value: 800,
+    });
+    const deckScroller = win.document.getElementById('deck-scroller') as HTMLElement;
+    const track = win.document.getElementById('track') as HTMLElement;
+    const slides = [
+      win.document.getElementById('slide-1') as HTMLElement,
+      win.document.getElementById('slide-2') as HTMLElement,
+      win.document.getElementById('slide-3') as HTMLElement,
+    ];
+    Object.defineProperty(deckScroller, 'scrollWidth', {
+      configurable: true,
+      value: 2760,
+    });
+    Object.defineProperty(deckScroller, 'clientWidth', {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(track, 'offsetLeft', {
+      configurable: true,
+      value: 120,
+    });
+    Object.defineProperty(track, 'offsetParent', {
+      configurable: true,
+      value: deckScroller,
+    });
+    slides.forEach((slide, index) => {
+      Object.defineProperty(slide, 'offsetLeft', {
+        configurable: true,
+        value: index * 920,
+      });
+      Object.defineProperty(slide, 'offsetParent', {
+        configurable: true,
+        value: track,
+      });
+    });
+    let deckScrollLeft = 0;
+    Object.defineProperty(deckScroller, 'scrollLeft', {
+      configurable: true,
+      get: () => deckScrollLeft,
+      set: (value: number) => {
+        deckScrollLeft = value;
+      },
+    });
+    Object.defineProperty(deckScroller, 'scrollTo', {
+      configurable: true,
+      value: ({ left }: { left?: number }) => {
+        if (typeof left === 'number') deckScroller.scrollLeft = left;
+      },
+    });
+
+    const evaluate = new win.Function(script);
+    evaluate.call(win);
+    win.dispatchEvent(new win.Event('load'));
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'next' },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 420));
+
+    expect(deckScroller.scrollLeft).toBe(1040);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
 });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
@@ -204,4 +204,219 @@ describe('deck bridge - scroll container fallback', () => {
     expect(win.document.documentElement.scrollLeft).toBe(2000);
     expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 2, count: 3 });
   });
+
+  it('tracks slide state from body when documentElement scrollLeft stays at zero', async () => {
+    const bodyHtml = `
+      <style>
+        body { overflow-x: auto; }
+      </style>
+      <section class="slide">One</section>
+      <section class="slide">Two</section>
+      <section class="slide">Three</section>
+    `;
+    const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      deck: true,
+    });
+    const script = extractDeckBridgeScript(srcdoc);
+    const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      runScripts: 'outside-only',
+      pretendToBeVisual: true,
+    });
+    const win = dom.window;
+    const parentPostMessage = vi.fn();
+    Object.defineProperty(win, 'parent', {
+      configurable: true,
+      value: { postMessage: parentPostMessage },
+    });
+    Object.defineProperty(win, 'innerWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(win.document.body, 'scrollWidth', {
+      configurable: true,
+      value: 3000,
+    });
+    Object.defineProperty(win.document.body, 'clientWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(win.document.documentElement, 'scrollWidth', {
+      configurable: true,
+      value: 3000,
+    });
+    Object.defineProperty(win.document.documentElement, 'clientWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(win.document, 'scrollingElement', {
+      configurable: true,
+      value: win.document.documentElement,
+    });
+    let bodyScrollLeft = 0;
+    let documentScrollLeft = 0;
+    Object.defineProperty(win.document.body, 'scrollLeft', {
+      configurable: true,
+      get: () => bodyScrollLeft,
+      set: (value: number) => {
+        bodyScrollLeft = value;
+      },
+    });
+    Object.defineProperty(win.document.documentElement, 'scrollLeft', {
+      configurable: true,
+      get: () => documentScrollLeft,
+      set: (_value: number) => {
+        documentScrollLeft = 0;
+      },
+    });
+    Object.defineProperty(win.document.body, 'scrollTo', {
+      configurable: true,
+      value: ({ left }: { left?: number }) => {
+        if (typeof left === 'number') {
+          win.document.body.scrollLeft = left;
+        }
+      },
+    });
+    Object.defineProperty(win.document.documentElement, 'scrollTo', {
+      configurable: true,
+      value: () => {},
+    });
+
+    const evaluate = new win.Function(script);
+    evaluate.call(win);
+    win.dispatchEvent(new win.Event('load'));
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'next' },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 420));
+
+    expect(win.document.documentElement.scrollLeft).toBe(0);
+    expect(win.document.body.scrollLeft).toBe(1000);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'next' },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 420));
+
+    expect(win.document.body.scrollLeft).toBe(2000);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 2, count: 3 });
+  });
+
+  it('scrolls only the nested deck container when the root also overflows', async () => {
+    const bodyHtml = `
+      <style>
+        body { overflow-x: auto; }
+        .outer { width: 1000px; overflow-x: auto; }
+        .track { display: flex; width: 3000px; }
+        .slide { flex: 0 0 1000px; }
+      </style>
+      <div class="outer" id="outer">
+        <div class="track">
+          <section class="slide">One</section>
+          <section class="slide">Two</section>
+          <section class="slide">Three</section>
+        </div>
+      </div>
+    `;
+    const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      deck: true,
+    });
+    const script = extractDeckBridgeScript(srcdoc);
+    const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      runScripts: 'outside-only',
+      pretendToBeVisual: true,
+    });
+    const win = dom.window;
+    const parentPostMessage = vi.fn();
+    Object.defineProperty(win, 'parent', {
+      configurable: true,
+      value: { postMessage: parentPostMessage },
+    });
+    Object.defineProperty(win, 'innerWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    const outer = win.document.getElementById('outer') as HTMLElement;
+    Object.defineProperty(outer, 'scrollWidth', {
+      configurable: true,
+      value: 3000,
+    });
+    Object.defineProperty(outer, 'clientWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(win.document.body, 'scrollWidth', {
+      configurable: true,
+      value: 3000,
+    });
+    Object.defineProperty(win.document.body, 'clientWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(win.document.documentElement, 'scrollWidth', {
+      configurable: true,
+      value: 3000,
+    });
+    Object.defineProperty(win.document.documentElement, 'clientWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    let outerScrollLeft = 0;
+    let bodyScrollLeft = 0;
+    let documentScrollLeft = 0;
+    Object.defineProperty(outer, 'scrollLeft', {
+      configurable: true,
+      get: () => outerScrollLeft,
+      set: (value: number) => {
+        outerScrollLeft = value;
+      },
+    });
+    Object.defineProperty(win.document.body, 'scrollLeft', {
+      configurable: true,
+      get: () => bodyScrollLeft,
+      set: (value: number) => {
+        bodyScrollLeft = value;
+      },
+    });
+    Object.defineProperty(win.document.documentElement, 'scrollLeft', {
+      configurable: true,
+      get: () => documentScrollLeft,
+      set: (value: number) => {
+        documentScrollLeft = value;
+      },
+    });
+    Object.defineProperty(outer, 'scrollTo', {
+      configurable: true,
+      value: ({ left }: { left?: number }) => {
+        if (typeof left === 'number') outer.scrollLeft = left;
+      },
+    });
+    Object.defineProperty(win.document.body, 'scrollTo', {
+      configurable: true,
+      value: ({ left }: { left?: number }) => {
+        if (typeof left === 'number') win.document.body.scrollLeft = left;
+      },
+    });
+    Object.defineProperty(win.document.documentElement, 'scrollTo', {
+      configurable: true,
+      value: ({ left }: { left?: number }) => {
+        if (typeof left === 'number') win.document.documentElement.scrollLeft = left;
+      },
+    });
+
+    const evaluate = new win.Function(script);
+    evaluate.call(win);
+    win.dispatchEvent(new win.Event('load'));
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'next' },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 420));
+
+    expect(outer.scrollLeft).toBe(1000);
+    expect(win.document.body.scrollLeft).toBe(0);
+    expect(win.document.documentElement.scrollLeft).toBe(0);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
 });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
@@ -419,4 +419,176 @@ describe('deck bridge - scroll container fallback', () => {
     expect(win.document.documentElement.scrollLeft).toBe(0);
     expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
   });
+
+  it('stops nested navigation at the nearest deck scroller', async () => {
+    const bodyHtml = `
+      <style>
+        .outer { width: 1000px; overflow-x: auto; }
+        .deck-scroller { width: 1000px; overflow-x: auto; }
+        .track { display: flex; width: 3000px; }
+        .slide { flex: 0 0 1000px; }
+      </style>
+      <div class="outer" id="outer">
+        <div class="deck-scroller" id="deck-scroller">
+          <div class="track">
+            <section class="slide">One</section>
+            <section class="slide">Two</section>
+            <section class="slide">Three</section>
+          </div>
+        </div>
+      </div>
+    `;
+    const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      deck: true,
+    });
+    const script = extractDeckBridgeScript(srcdoc);
+    const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      runScripts: 'outside-only',
+      pretendToBeVisual: true,
+    });
+    const win = dom.window;
+    const parentPostMessage = vi.fn();
+    Object.defineProperty(win, 'parent', {
+      configurable: true,
+      value: { postMessage: parentPostMessage },
+    });
+    Object.defineProperty(win, 'innerWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    const outer = win.document.getElementById('outer') as HTMLElement;
+    const deckScroller = win.document.getElementById('deck-scroller') as HTMLElement;
+    for (const el of [outer, deckScroller]) {
+      Object.defineProperty(el, 'scrollWidth', {
+        configurable: true,
+        value: 3000,
+      });
+      Object.defineProperty(el, 'clientWidth', {
+        configurable: true,
+        value: 1000,
+      });
+    }
+    let outerScrollLeft = 0;
+    let deckScrollLeft = 0;
+    Object.defineProperty(outer, 'scrollLeft', {
+      configurable: true,
+      get: () => outerScrollLeft,
+      set: (value: number) => {
+        outerScrollLeft = value;
+      },
+    });
+    Object.defineProperty(deckScroller, 'scrollLeft', {
+      configurable: true,
+      get: () => deckScrollLeft,
+      set: (value: number) => {
+        deckScrollLeft = value;
+      },
+    });
+    Object.defineProperty(outer, 'scrollTo', {
+      configurable: true,
+      value: ({ left }: { left?: number }) => {
+        if (typeof left === 'number') outer.scrollLeft = left;
+      },
+    });
+    Object.defineProperty(deckScroller, 'scrollTo', {
+      configurable: true,
+      value: ({ left }: { left?: number }) => {
+        if (typeof left === 'number') deckScroller.scrollLeft = left;
+      },
+    });
+
+    const evaluate = new win.Function(script);
+    evaluate.call(win);
+    win.dispatchEvent(new win.Event('load'));
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'next' },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 420));
+
+    expect(deckScroller.scrollLeft).toBe(1000);
+    expect(outer.scrollLeft).toBe(0);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
+
+  it('uses slide offsets for nested deck scroll targets when stride differs from the scroller width', async () => {
+    const bodyHtml = `
+      <style>
+        .deck-scroller { width: 800px; overflow-x: auto; }
+        .track { display: flex; gap: 120px; }
+        .slide { flex: 0 0 800px; }
+      </style>
+      <div class="deck-scroller" id="deck-scroller">
+        <div class="track">
+          <section class="slide" id="slide-1">One</section>
+          <section class="slide" id="slide-2">Two</section>
+          <section class="slide" id="slide-3">Three</section>
+        </div>
+      </div>
+    `;
+    const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      deck: true,
+    });
+    const script = extractDeckBridgeScript(srcdoc);
+    const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      runScripts: 'outside-only',
+      pretendToBeVisual: true,
+    });
+    const win = dom.window;
+    const parentPostMessage = vi.fn();
+    Object.defineProperty(win, 'parent', {
+      configurable: true,
+      value: { postMessage: parentPostMessage },
+    });
+    Object.defineProperty(win, 'innerWidth', {
+      configurable: true,
+      value: 800,
+    });
+    const deckScroller = win.document.getElementById('deck-scroller') as HTMLElement;
+    const slides = [
+      win.document.getElementById('slide-1') as HTMLElement,
+      win.document.getElementById('slide-2') as HTMLElement,
+      win.document.getElementById('slide-3') as HTMLElement,
+    ];
+    Object.defineProperty(deckScroller, 'scrollWidth', {
+      configurable: true,
+      value: 2640,
+    });
+    Object.defineProperty(deckScroller, 'clientWidth', {
+      configurable: true,
+      value: 800,
+    });
+    slides.forEach((slide, index) => {
+      Object.defineProperty(slide, 'offsetLeft', {
+        configurable: true,
+        value: index * 920,
+      });
+    });
+    let deckScrollLeft = 0;
+    Object.defineProperty(deckScroller, 'scrollLeft', {
+      configurable: true,
+      get: () => deckScrollLeft,
+      set: (value: number) => {
+        deckScrollLeft = value;
+      },
+    });
+    Object.defineProperty(deckScroller, 'scrollTo', {
+      configurable: true,
+      value: ({ left }: { left?: number }) => {
+        if (typeof left === 'number') deckScroller.scrollLeft = left;
+      },
+    });
+
+    const evaluate = new win.Function(script);
+    evaluate.call(win);
+    win.dispatchEvent(new win.Event('load'));
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'next' },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 420));
+
+    expect(deckScroller.scrollLeft).toBe(920);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
 });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-transform-driven.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-transform-driven.test.ts
@@ -140,4 +140,80 @@ describe('deck bridge - transform-driven decks', () => {
       .filter((message) => message?.type === 'od:slide-state');
     expect(slideStates.at(-1)).toMatchObject({ active: 1, count: 3 });
   });
+
+  it('keeps transform fallback for auto-overflow tracks that are not scrollable', async () => {
+    const bodyHtml = `
+      <style>
+        html, body { margin: 0; overflow-x: hidden; }
+        .deck-shell { width: 100vw; overflow: hidden; }
+        .deck-track { display: flex; overflow-x: auto; transform: translateX(0vw); }
+        .slide { flex: 0 0 100vw; }
+      </style>
+      <div class="deck-shell">
+        <div class="deck-track" id="deck-track">
+          <section class="slide">One</section>
+          <section class="slide">Two</section>
+          <section class="slide">Three</section>
+        </div>
+      </div>
+    `;
+    const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      deck: true,
+    });
+    const script = extractDeckBridgeScript(srcdoc);
+    const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      runScripts: 'outside-only',
+      pretendToBeVisual: true,
+    });
+    const win = dom.window;
+    const parentPostMessage = vi.fn();
+    Object.defineProperty(win, 'parent', {
+      configurable: true,
+      value: { postMessage: parentPostMessage },
+    });
+    Object.defineProperty(win, 'innerWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(win.document.body, 'scrollWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(win.document.body, 'clientWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(win.document.documentElement, 'scrollWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(win.document.documentElement, 'clientWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    const track = win.document.getElementById('deck-track') as HTMLElement;
+    Object.defineProperty(track, 'scrollWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(track, 'clientWidth', {
+      configurable: true,
+      value: 1000,
+    });
+
+    const evaluate = new win.Function(script);
+    evaluate.call(win);
+    win.dispatchEvent(new win.Event('load'));
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'next' },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 360));
+
+    expect(track.style.transform).toBe('translateX(-100vw)');
+    const slideStates = parentPostMessage.mock.calls
+      .map((call) => call[0])
+      .filter((message) => message?.type === 'od:slide-state');
+    expect(slideStates.at(-1)).toMatchObject({ active: 1, count: 3 });
+  });
 });


### PR DESCRIPTION
Fixes #3562
Fixes #3563

## Why

I picked this up from the Simple Deck reports where host-driven deck navigation could blank nested scroll decks and leave an in-artifact page counter stale. Both failures point at the same bridge path in `srcdoc.ts`: the host navigation fallback could treat a scrollable flex/grid deck container like a transform track, and the chrome sync only knew the split `#deck-cur` / `#deck-total` counter shape.

The pain is user-visible: keyboard or host controls can move away from the actual scroll surface, and the visible deck counter can disagree with the slide the user is seeing.

## What users will see

Decks whose slides live inside a nested horizontal scroll container now keep using that scroll container when the host controls, arrow keys, or scrubber drive navigation. The bridge no longer writes `translateX(...)` onto scrollable flex/grid containers.

Plain in-artifact counters such as `1 / 15` in `#deck-counter` / `.deck-counter` also update when host navigation changes the slide, as long as the element only contains that narrow page-count text shape.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — host deck navigation now prefers nested scroll containers and syncs simple in-artifact counters
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No screenshot. This is bridge behavior inside the rendered deck iframe; the regression is covered by the focused runtime fixture.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts` now covers nested flex and grid horizontal scroll decks, asserts the bridge scrolls the nested container instead of translating it, and checks a plain `#deck-counter` updates on host navigation.
- Did the test go red on `main` and green on this branch? Not run separately on `main`; the new assertions target the old transform fallback / missing counter-sync behavior and pass on this branch.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/web exec vitest run tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts --reporter=dot --maxWorkers=1 --pool=forks`
- `pnpm --filter @open-design/web typecheck`
- `git diff --check`

Note: local Node is `v26.0.0`, so pnpm emitted the repo's expected Node `~24` engine warning during validation.