### PR TITLE
fix: prevent execution card text clipping

### DIFF
--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1129,6 +1129,7 @@
     );
 }
 .agent-card-installed.active .agent-card-select {
+  align-items: flex-start;
   min-height: 78px;
   padding: 14px 18px 12px 22px;
 }
@@ -1140,9 +1141,30 @@
 }
 .agent-card-installed.active .agent-card-name {
   font-size: 13px;
+  flex-wrap: wrap;
+  row-gap: 2px;
+  overflow: visible;
+  white-space: normal;
+  line-height: 1.35;
+}
+.agent-card-installed.active .agent-card-title,
+.agent-card-installed.active .agent-card-tagline {
+  overflow-wrap: anywhere;
+}
+.agent-card-installed.active .agent-card-name-divider {
+  display: none;
+}
+.agent-card-installed.active .agent-card-tagline {
+  flex-basis: 100%;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
 }
 .agent-card-installed.active .agent-card-meta {
   margin-top: 1px;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
 }
 .agent-card.disabled {
   cursor: not-allowed;

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1163,6 +1163,7 @@
 .agent-card-installed.active .agent-card-meta {
   margin-top: 1px;
   overflow: visible;
+  overflow-wrap: anywhere;
   text-overflow: clip;
   white-space: normal;
 }

--- a/apps/web/tests/styles/settings-agent-card.test.ts
+++ b/apps/web/tests/styles/settings-agent-card.test.ts
@@ -57,5 +57,8 @@ describe('Settings agent card styles', () => {
     expect(ruleValue('.agent-card-installed.active .agent-card-meta', 'overflow')).toBe(
       'visible',
     );
+    expect(ruleValue('.agent-card-installed.active .agent-card-meta', 'overflow-wrap')).toBe(
+      'anywhere',
+    );
   });
 });

--- a/apps/web/tests/styles/settings-agent-card.test.ts
+++ b/apps/web/tests/styles/settings-agent-card.test.ts
@@ -1,0 +1,61 @@
+import postcss, { type Declaration, type Rule } from 'postcss';
+import { describe, expect, it } from 'vitest';
+import { readExpandedIndexCss } from '../helpers/read-expanded-css';
+
+const css = readExpandedIndexCss();
+const root = postcss.parse(css, { from: 'src/index.css' });
+
+function declarationsFor(selector: string): Declaration[] {
+  const declarations: Declaration[] = [];
+  root.walkRules((rule: Rule) => {
+    const selectors = rule.selectors.map((item) => item.trim());
+    if (!selectors.includes(selector)) return;
+    rule.walkDecls((decl) => {
+      declarations.push(decl);
+    });
+  });
+  if (declarations.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return declarations;
+}
+
+function ruleValue(selector: string, property: string): string {
+  const declarations = declarationsFor(selector).filter((decl) => decl.prop === property);
+  const declaration = declarations.at(-1);
+  if (!declaration) throw new Error(`Missing CSS property ${property} for ${selector}`);
+  return declaration.value;
+}
+
+describe('Settings agent card styles', () => {
+  it('lets selected execution cards wrap text instead of clipping it', () => {
+    expect(ruleValue('.agent-card-name', 'white-space')).toBe('nowrap');
+    expect(ruleValue('.agent-card-name', 'overflow')).toBe('hidden');
+
+    expect(ruleValue('.agent-card-installed.active .agent-card-select', 'align-items')).toBe(
+      'flex-start',
+    );
+    expect(ruleValue('.agent-card-installed.active .agent-card-name', 'white-space')).toBe(
+      'normal',
+    );
+    expect(ruleValue('.agent-card-installed.active .agent-card-name', 'overflow')).toBe(
+      'visible',
+    );
+    expect(ruleValue('.agent-card-installed.active .agent-card-name', 'flex-wrap')).toBe(
+      'wrap',
+    );
+    expect(ruleValue('.agent-card-installed.active .agent-card-tagline', 'flex-basis')).toBe(
+      '100%',
+    );
+    expect(ruleValue('.agent-card-installed.active .agent-card-tagline', 'white-space')).toBe(
+      'normal',
+    );
+    expect(ruleValue('.agent-card-installed.active .agent-card-tagline', 'overflow')).toBe(
+      'visible',
+    );
+    expect(ruleValue('.agent-card-installed.active .agent-card-meta', 'white-space')).toBe(
+      'normal',
+    );
+    expect(ruleValue('.agent-card-installed.active .agent-card-meta', 'overflow')).toBe(
+      'visible',
+    );
+  });
+});


### PR DESCRIPTION
Fixes #3554.

## Why
Selected execution cards could clip long titles, taglines, versions, or paths, which made the active installed agent hard to read.

## Surface area
- [x] UI
- [ ] API
- [ ] Data / persistence
- [ ] Build / tooling
- [ ] Tests only

## What changed
- Let the selected execution card header wrap instead of clipping the title/tagline row.
- Allow the selected card metadata line to wrap so long versions or paths stay readable.
- Added a style regression test that keeps the compact inactive-card ellipsis while requiring selected cards to use wrap-safe styles.

## Validation
- pnpm install --frozen-lockfile
- pnpm --filter @open-design/web exec vitest run tests/styles/settings-agent-card.test.ts --reporter=dot --maxWorkers=1 --pool=forks
- pnpm --filter @open-design/web exec vitest run tests/components/SettingsDialog.execution.test.tsx -t "Local CLI interactions" --reporter=dot --maxWorkers=1 --pool=forks
- NODE_OPTIONS="--localstorage-file=/tmp/open-design-3554-vitest-localstorage" pnpm --filter @open-design/web exec vitest run tests/components/SettingsDialog.execution.test.tsx --reporter=dot --maxWorkers=1 --pool=forks
- pnpm --filter @open-design/web typecheck
- git diff --check

Local Node v26 emitted the expected Node ~24 engine warning. The full SettingsDialog test file also needs the localStorage file flag under Node v26; without it, the unrelated language tests cannot read window.localStorage.