### PR TITLE
fix: back off offline star fetch logging

### DIFF
--- a/apps/packaged/src/logging.ts
+++ b/apps/packaged/src/logging.ts
@@ -174,11 +174,29 @@ function serializeMessage(level: LogLevel, message: string, meta?: Record<string
   }
 }
 
+type DesktopLogAppend = (path: string, data: string, encoding: BufferEncoding) => void;
+
+export function appendDesktopLogLine(
+  desktopLogPath: string,
+  line: string,
+  append: DesktopLogAppend = appendFileSync,
+): boolean {
+  try {
+    append(desktopLogPath, line, "utf8");
+    return true;
+  } catch {
+    // Logging must never be the thing that crashes the packaged app.
+    // Under offline retry storms the log file itself can hit EMFILE;
+    // swallowing the write breaks the fatal log -> append failure loop.
+    return false;
+  }
+}
+
 export function createPackagedDesktopLogger(paths: PackagedNamespacePaths): PackagedDesktopLogger {
   const echo = process.env[DESKTOP_LOG_ECHO_ENV] !== "0";
 
   const write = (level: LogLevel, message: string, meta?: Record<string, unknown>) => {
-    appendFileSync(paths.desktopLogPath, serializeMessage(level, message, meta), "utf8");
+    appendDesktopLogLine(paths.desktopLogPath, serializeMessage(level, message, meta));
   };
 
   const logger: PackagedDesktopLogger = {

--- a/apps/packaged/tests/logging.test.ts
+++ b/apps/packaged/tests/logging.test.ts
@@ -14,14 +14,28 @@
  * @see https://github.com/nexu-io/open-design/issues/895
  */
 
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  appendDesktopLogLine,
+  createPackagedDesktopLogger,
   createFatalUncaughtExceptionHandler,
   createFatalUnhandledRejectionHandler,
   isHarmlessSocketOptionError,
   type PackagedDesktopLogger,
 } from '../src/logging.js';
+import type { PackagedNamespacePaths } from '../src/paths.js';
+
+const ORIGINAL_CONSOLE = {
+  error: console.error,
+  info: console.info,
+  log: console.log,
+  warn: console.warn,
+};
 
 function stubLogger(): PackagedDesktopLogger {
   return {
@@ -32,8 +46,33 @@ function stubLogger(): PackagedDesktopLogger {
 }
 
 afterEach(() => {
+  console.error = ORIGINAL_CONSOLE.error;
+  console.info = ORIGINAL_CONSOLE.info;
+  console.log = ORIGINAL_CONSOLE.log;
+  console.warn = ORIGINAL_CONSOLE.warn;
   vi.restoreAllMocks();
 });
+
+function makePaths(root: string, desktopLogPath = join(root, 'logs', 'desktop', 'latest.log')): PackagedNamespacePaths {
+  return {
+    cacheRoot: join(root, 'cache'),
+    desktopIdentityPath: join(root, 'runtime', 'desktop-root.json'),
+    desktopLogPath,
+    dataRoot: join(root, 'data'),
+    desktopLogsRoot: join(root, 'logs', 'desktop'),
+    electronSessionDataRoot: join(root, 'user-data', 'session'),
+    electronUserDataRoot: join(root, 'user-data'),
+    headlessIdentityPath: join(root, 'runtime', 'headless-root.json'),
+    installationRoot: root,
+    installerObservationRoot: join(root, 'data', 'observations', 'installer'),
+    logsRoot: join(root, 'logs'),
+    namespaceRoot: root,
+    resourceRoot: join(root, 'resources'),
+    runtimeRoot: join(root, 'runtime'),
+    updateRoot: join(root, 'updates'),
+    webIdentityPath: join(root, 'runtime', 'web-root.json'),
+  };
+}
 
 describe('isHarmlessSocketOptionError (issue #895)', () => {
   it('matches the canonical undici setTypeOfService EINVAL shape', () => {
@@ -104,6 +143,38 @@ describe('isHarmlessSocketOptionError (issue #895)', () => {
     const error = new Error('') as NodeJS.ErrnoException;
     error.code = 'EINVAL';
     expect(isHarmlessSocketOptionError(error)).toBe(false);
+  });
+});
+
+describe('createPackagedDesktopLogger log-write failures', () => {
+  it('drops descriptor-pressure append failures instead of throwing', () => {
+    const emfile = new Error('too many files') as NodeJS.ErrnoException;
+    emfile.code = 'EMFILE';
+    const append = vi.fn(() => {
+      throw emfile;
+    });
+
+    expect(appendDesktopLogLine('/tmp/latest.log', '{"level":"error"}\n', append)).toBe(false);
+    expect(append).toHaveBeenCalledWith('/tmp/latest.log', '{"level":"error"}\n', 'utf8');
+  });
+
+  it('does not let desktop log append failures escape through the logger', () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-log-'));
+    const previousEcho = process.env.OD_DESKTOP_LOG_ECHO;
+    process.env.OD_DESKTOP_LOG_ECHO = '0';
+    try {
+      const logger = createPackagedDesktopLogger(makePaths(root, root));
+
+      expect(() => logger.error('packaged desktop fatal uncaught exception')).not.toThrow();
+      expect(() => console.error('renderer fetch failed')).not.toThrow();
+    } finally {
+      if (previousEcho == null) {
+        delete process.env.OD_DESKTOP_LOG_ECHO;
+      } else {
+        process.env.OD_DESKTOP_LOG_ECHO = previousEcho;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/web/src/components/useGithubStars.ts
+++ b/apps/web/src/components/useGithubStars.ts
@@ -11,6 +11,7 @@ import type { OpenDesignGithubRepoResponse } from '@open-design/contracts';
 const API = '/api/github/open-design';
 const REPO = 'https://github.com/nexu-io/open-design';
 const LS_KEY = 'open-design:gh-stars';
+const FAILURE_LS_KEY = 'open-design:gh-stars:last-failure';
 export const GITHUB_STARS_FALLBACK_LABEL = '40K+';
 
 // One-hour soft cache — long enough to dodge GitHub's 60/hr
@@ -18,10 +19,12 @@ export const GITHUB_STARS_FALLBACK_LABEL = '40K+';
 // times in a session, short enough that growing star counts still
 // surface within a single working day.
 const CACHE_TTL_MS = 60 * 60 * 1000;
+const FAILURE_COOLDOWN_MS = 5 * 60 * 1000;
 
 type CachedStars = { count: number; ts: number };
 
 let memoryCache: CachedStars | null = null;
+let memoryFailureAt: number | null = null;
 
 function readPersistedCache(): CachedStars | null {
   if (typeof window === 'undefined') return null;
@@ -48,6 +51,44 @@ function writePersistedCache(value: CachedStars): void {
   }
 }
 
+function readPersistedFailureAt(): number | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(FAILURE_LS_KEY);
+    if (!raw) return null;
+    const ts = Number(raw);
+    return Number.isFinite(ts) && ts > 0 ? ts : null;
+  } catch {
+    return null;
+  }
+}
+
+function writePersistedFailureAt(ts: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(FAILURE_LS_KEY, String(ts));
+  } catch {
+    // Same as the star cache: storage failures should not turn a
+    // quiet offline badge into a renderer error source.
+  }
+}
+
+function clearPersistedFailureAt(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(FAILURE_LS_KEY);
+  } catch {
+    // Ignore storage failures; the in-memory cooldown still covers
+    // this renderer session.
+  }
+}
+
+function rememberFetchFailure(): void {
+  const failedAt = Date.now();
+  memoryFailureAt = failedAt;
+  writePersistedFailureAt(failedAt);
+}
+
 export function formatStars(count: number): string {
   if (!Number.isFinite(count) || count <= 0) return '0';
   if (count < 1000) return String(count);
@@ -72,25 +113,39 @@ export function useGithubStars(): number | null {
       setCount(cached.count);
       return;
     }
+    const failedAt = memoryFailureAt ?? readPersistedFailureAt();
+    if (failedAt && now - failedAt < FAILURE_COOLDOWN_MS) {
+      memoryFailureAt = failedAt;
+      return;
+    }
     const ctrl = new AbortController();
     (async () => {
       try {
         const res = await fetch(API, {
           signal: ctrl.signal,
         });
-        if (!res.ok) return;
+        if (!res.ok) {
+          rememberFetchFailure();
+          return;
+        }
         const data = (await res.json()) as Partial<OpenDesignGithubRepoResponse>;
-        if (typeof data.stargazers_count !== 'number') return;
+        if (typeof data.stargazers_count !== 'number') {
+          rememberFetchFailure();
+          return;
+        }
         const next: CachedStars = {
           count: data.stargazers_count,
           ts: Date.now(),
         };
         memoryCache = next;
+        memoryFailureAt = null;
         writePersistedCache(next);
+        clearPersistedFailureAt();
         setCount(next.count);
       } catch {
         // Network failures and rate-limit 403s both land here. The
         // caller keeps rendering its previous (or fallback) count.
+        rememberFetchFailure();
       }
     })();
     return () => ctrl.abort();

--- a/apps/web/src/components/useGithubStars.ts
+++ b/apps/web/src/components/useGithubStars.ts
@@ -142,7 +142,10 @@ export function useGithubStars(): number | null {
         writePersistedCache(next);
         clearPersistedFailureAt();
         setCount(next.count);
-      } catch {
+      } catch (error) {
+        if (ctrl.signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
+          return;
+        }
         // Network failures and rate-limit 403s both land here. The
         // caller keeps rendering its previous (or fallback) count.
         rememberFetchFailure();

--- a/apps/web/tests/components/GithubStarBadge.test.tsx
+++ b/apps/web/tests/components/GithubStarBadge.test.tsx
@@ -63,6 +63,39 @@ describe('GithubStarBadge', () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
+  it('does not back off after effect cleanup aborts an in-flight request', async () => {
+    const fetchCalls: AbortSignal[] = [];
+    globalThis.fetch = vi.fn((_url, init) => {
+      const signal = (init as RequestInit | undefined)?.signal;
+      if (!(signal instanceof AbortSignal)) {
+        throw new Error('expected fetch to receive an AbortSignal');
+      }
+      fetchCalls.push(signal);
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => {
+            const error = new Error('aborted');
+            error.name = 'AbortError';
+            reject(error);
+          },
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+    const { GithubStarBadge } = await import('../../src/components/GithubStarBadge');
+
+    render(<GithubStarBadge />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+
+    cleanup();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    render(<GithubStarBadge />);
+
+    expect(fetchCalls[0]?.aborted).toBe(true);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2));
+  });
+
   it('renders the live star count returned by the daemon endpoint', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/apps/web/tests/components/GithubStarBadge.test.tsx
+++ b/apps/web/tests/components/GithubStarBadge.test.tsx
@@ -10,7 +10,7 @@ describe('GithubStarBadge', () => {
   afterEach(() => {
     cleanup();
     globalThis.fetch = originalFetch;
-    window.localStorage.clear();
+    window.localStorage?.clear();
     vi.restoreAllMocks();
     vi.resetModules();
   });
@@ -29,6 +29,38 @@ describe('GithubStarBadge', () => {
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       ),
     );
+  });
+
+  it('backs off after an offline failure instead of retrying on every remount', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('offline')) as typeof fetch;
+    const { GithubStarBadge } = await import('../../src/components/GithubStarBadge');
+
+    render(<GithubStarBadge />);
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+    cleanup();
+
+    render(<GithubStarBadge />);
+
+    expect(screen.getByText('40K+')).toBeTruthy();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('backs off when the daemon returns an offline 502 response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false } satisfies Partial<Response>) as typeof fetch;
+    const { GithubStarBadge } = await import('../../src/components/GithubStarBadge');
+
+    render(<GithubStarBadge />);
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+    cleanup();
+
+    render(<GithubStarBadge />);
+
+    expect(screen.getByText('40K+')).toBeTruthy();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
   it('renders the live star count returned by the daemon endpoint', async () => {


### PR DESCRIPTION
## Why
Offline packaged launches can repeatedly hit the GitHub metadata badge path and then log every failed renderer error. If the desktop log append path itself starts failing under file-descriptor pressure, logging should not turn into the fatal crash trigger.

## Surface area
- [x] UI
- [ ] API
- [ ] Database
- [ ] Docs
- [x] Desktop/package runtime

## Summary
- Add a short failure cooldown for the GitHub star badge so rejected requests and daemon 502/offline responses do not refetch on every remount.
- Keep successful star-count fetches clearing the cooldown and preserving the existing cache behavior.
- Route packaged desktop log writes through a guard that drops failed appends instead of letting logger failures escape.
- Add regressions for rejected/502 star fetch backoff and desktop log append failures.

Fixes #3586

## Testing
- pnpm install --frozen-lockfile (Node v26 reports the existing repo engine warning for ~24; install also reports the existing node-pty approve-builds warning)
- pnpm --filter @open-design/web exec vitest run tests/components/GithubStarBadge.test.tsx --reporter=dot --maxWorkers=1 --pool=forks
- pnpm --filter @open-design/web typecheck
- pnpm --filter @open-design/packaged exec vitest run tests/logging.test.ts --reporter=dot --maxWorkers=1 --pool=forks
- pnpm --filter @open-design/packaged typecheck
- git diff --check
