### PR TITLE
fix(web): persist BYOK deck artifacts as decks

### DIFF
--- a/apps/web/src/artifacts/manifest.ts
+++ b/apps/web/src/artifacts/manifest.ts
@@ -72,19 +72,21 @@ export function artifactManifestNameFor(entry: string): string {
 export function createHtmlArtifactManifest(input: {
   entry: string;
   title: string;
+  kind?: Extract<ArtifactKind, 'html' | 'deck'>;
   metadata?: Record<string, unknown>;
   sourceSkillId?: string;
   designSystemId?: string | null;
 }): ArtifactManifest {
   const now = new Date().toISOString();
+  const kind = input.kind === 'deck' ? 'deck' : 'html';
   return {
     version: MANIFEST_VERSION,
-    kind: 'html',
+    kind,
     title: input.title,
     entry: input.entry,
-    renderer: 'html',
+    renderer: kind === 'deck' ? 'deck-html' : 'html',
     status: 'complete',
-    exports: ['html', 'pdf', 'zip'],
+    exports: exportsForKind(kind),
     primary: true,
     createdAt: now,
     updatedAt: now,

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1525,6 +1525,7 @@ export function ProjectView({
           ? createHtmlArtifactManifest({
               entry: fileName,
               title,
+              kind: project.metadata?.kind === 'deck' ? 'deck' : 'html',
               sourceSkillId: project.skillId ?? undefined,
               designSystemId: project.designSystemId,
               metadata,

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -545,6 +545,47 @@ describe('ProjectView API empty response handling', () => {
     expect(screen.queryByText('empty_response:deepseek-chat')).toBeNull();
   });
 
+  it('persists API deck artifacts with deck renderer metadata', async () => {
+    const artifact =
+      '<artifact identifier="slide-deck" type="text/html" title="Quarterly Deck">' +
+      '<!doctype html><html><head><title>Quarterly Deck</title></head><body><main><section class="slide is-active"><h1>Quarterly Deck</h1><p>Generated slide deck artifact with enough structure to persist.</p></section><section class="slide"><h2>Roadmap</h2></section></main></body></html>' +
+      '</artifact>';
+    mockedStreamMessage.mockImplementation(async (
+      _cfg: AppConfig,
+      _system: string,
+      _history: ChatMessage[],
+      _signal: AbortSignal,
+      handlers: StreamHandlers,
+    ) => {
+      handlers.onDelta(artifact);
+      handlers.onDone('');
+    });
+    renderProjectView({
+      ...project,
+      skillId: 'html-ppt',
+      metadata: {
+        kind: 'deck',
+      },
+    });
+
+    await sendTestPrompt();
+
+    await waitFor(() => expect(mockedWriteProjectTextFile).toHaveBeenCalled());
+    const [, fileName, , options] = mockedWriteProjectTextFile.mock.calls[0]!;
+    expect(fileName).toBe('slide-deck.html');
+    expect(options?.artifactManifest).toMatchObject({
+      kind: 'deck',
+      renderer: 'deck-html',
+      exports: expect.arrayContaining(['html', 'pdf', 'pptx', 'zip']),
+      primary: true,
+      sourceSkillId: 'html-ppt',
+      metadata: expect.objectContaining({
+        identifier: 'slide-deck',
+        artifactType: 'text/html',
+      }),
+    });
+  });
+
   it('opens the real HTML page instead of saving a pointer artifact as the preview entry', async () => {
     const realPage = {
       name: 'worker-edition-v2.html',


### PR DESCRIPTION
Fixes #1698

## Why

I picked this up from the P0 BYOK/API-key-mode PPT preview bug. In API mode the model emits a plain `<artifact type="text/html">...</artifact>` payload, and the web persistence path was always stamping that HTML artifact as a generic `html` manifest.

That loses the deck renderer metadata and `pptx` export affordance for PPT projects, which can leave the right preview/export path behaving differently from the CLI/tool-emitted deck path.

## What users will see

PPT/deck projects generated through API key mode keep their generated HTML artifact as a deck artifact. The preview path receives `deck-html` renderer metadata, and the artifact manifest includes the `pptx` export option.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no new UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ProjectView.api-empty-response.test.tsx`
- Did the test go red on `main` and green on this branch? The new regression spec failed before the source change on this branch's main-based worktree, then passed after the fix.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/ProjectView.api-empty-response.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
