### PR TITLE
ci(feishu): unify daily + release build notifications onto one Feishu bot

### DIFF
--- a/.github/workflows/notify-daily-feishu.yml
+++ b/.github/workflows/notify-daily-feishu.yml
@@ -3,8 +3,9 @@ name: notify-daily-feishu
 # Every morning (09:00 Asia/Shanghai) build a beta package off the currently
 # active release branch (highest-semver release/vX.Y.Z) by reusing release-beta,
 # then post a Feishu card with download links and the changelog since the
-# previously published beta — to a separate Feishu group from the per-push
-# release stream (which builds the heavier nightly channel).
+# previously published beta — to the SAME Feishu bot as the per-push release
+# stream (FEISHU_RELEASE_WEBHOOK). The two streams share one group; their cards
+# stay distinguishable via CHANNEL_LABEL (Beta vs Nightly) and STREAM_LABEL.
 #
 # NOTE: schedule triggers only fire from the default branch (main), so this file
 # must live on main to run on its cron.
@@ -108,8 +109,11 @@ jobs:
 
       - name: Post Feishu card
         env:
-          FEISHU_WEBHOOK: ${{ secrets.FEISHU_DAILY_WEBHOOK }}
-          FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_DAILY_SIGN_SECRET }}
+          # Daily and release-push streams share one Feishu bot; both post to
+          # FEISHU_RELEASE_WEBHOOK. CHANNEL_LABEL/STREAM_LABEL still distinguish
+          # the two card types within that single group.
+          FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+          FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}
           CHANNEL_LABEL: "Beta"
           VERSION: ${{ needs.build.outputs.beta_version }}
           BRANCH: ${{ needs.build.outputs.branch }}


### PR DESCRIPTION
## Why

We currently maintain two Feishu bots/groups for build notifications: the morning daily-beta stream posts to `FEISHU_DAILY_WEBHOOK`, and the per-push release-nightly stream posts to `FEISHU_RELEASE_WEBHOOK`. Splitting the same "is there a fresh build?" signal across two groups means people have to watch two places. We want both build notifications in one group, behind one bot.

## What users will see

Nothing in the product. For the team: the 09:00 Asia/Shanghai daily-beta card now lands in the **same Feishu group** as the release-push nightly card. The two are still easy to tell apart — the daily card is labelled **Beta / 每日定时**, the release card **Nightly / release 分支推送** — they just no longer live in separate groups.

## Surface area

- [x] **None** — CI notification routing only: `notify-daily-feishu.yml` now reads `FEISHU_RELEASE_WEBHOOK` / `FEISHU_RELEASE_SIGN_SECRET` instead of the `FEISHU_DAILY_*` pair. No code or product behavior change. `FEISHU_DAILY_WEBHOOK` becomes unused and can be removed from repo secrets once this merges.

## Bug fix verification

Not a bug fix. Verified by inspection: the daily notify step's `FEISHU_WEBHOOK`/`FEISHU_SIGN_SECRET` now point at the release secrets, `CHANNEL_LABEL`/`STREAM_LABEL` are unchanged so the cards remain distinguishable, and no `FEISHU_DAILY_*` reference remains in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
