### PR TITLE
ci(e2e): tune main UI regression workflow alerts

### DIFF
--- a/.github/workflows/notify-main-ci-feishu.yml
+++ b/.github/workflows/notify-main-ci-feishu.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - ci
+      - ui-extended-main
     types:
       - completed
 
@@ -20,7 +21,7 @@ jobs:
       ${{
         github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.head_branch == 'main' &&
-        github.event.workflow_run.conclusion == 'failure'
+        contains(fromJSON('["failure","timed_out","cancelled"]'), github.event.workflow_run.conclusion)
       }}
     steps:
       - name: Send main CI failure alert
@@ -46,8 +47,8 @@ jobs:
               per_page: 100,
             });
             const failedJobs = jobsResponse.data.jobs
-              .filter((job) => job.conclusion === 'failure')
-              .map((job) => `- ${job.name}`)
+              .filter((job) => ['failure', 'timed_out', 'cancelled'].includes(job.conclusion))
+              .map((job) => `- ${job.name} (${job.conclusion})`)
               .join('\n') || '- Unknown';
 
             const pullsResponse = await github.rest.repos.listPullRequestsAssociatedWithCommit({
@@ -64,6 +65,9 @@ jobs:
             const author = run.head_commit?.author?.name || run.actor?.login || 'unknown';
             const subject = run.head_commit?.message?.split('\n')[0] || run.display_title || 'unknown';
             const repoName = `${owner}/${repo}`;
+            const title = run.name === 'ui-extended-main'
+              ? 'Open Design Main UI regression failed'
+              : 'Open Design Main CI failed';
 
             const body = {
               msg_type: 'interactive',
@@ -75,7 +79,7 @@ jobs:
                   template: 'red',
                   title: {
                     tag: 'plain_text',
-                    content: 'Open Design Main CI failed',
+                    content: title,
                   },
                 },
                 elements: [
@@ -87,6 +91,7 @@ jobs:
                         `**Repository:** ${repoName}`,
                         `**Branch:** main`,
                         `**Workflow:** ${run.name}`,
+                        `**Conclusion:** ${run.conclusion}`,
                         `**Commit:** ${shortSha}`,
                         `**Author:** ${author}`,
                         `**Subject:** ${subject}`,

--- a/.github/workflows/notify-main-ci-feishu.yml
+++ b/.github/workflows/notify-main-ci-feishu.yml
@@ -39,6 +39,16 @@ jobs:
             const run = context.payload.workflow_run;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const startedAt = new Date(run.run_started_at || run.created_at).getTime();
+            const updatedAt = new Date(run.updated_at).getTime();
+            const durationMinutes = Number.isFinite(startedAt) && Number.isFinite(updatedAt)
+              ? Math.round((updatedAt - startedAt) / 60000)
+              : null;
+
+            if (run.conclusion === 'cancelled' && durationMinutes !== null && durationMinutes < 35) {
+              core.info(`Skipping short cancelled run (${durationMinutes}m), likely superseded by a newer main push.`);
+              return;
+            }
 
             const jobsResponse = await github.rest.actions.listJobsForWorkflowRun({
               owner,
@@ -92,6 +102,7 @@ jobs:
                         `**Branch:** main`,
                         `**Workflow:** ${run.name}`,
                         `**Conclusion:** ${run.conclusion}`,
+                        `**Duration:** ${durationMinutes === null ? 'unknown' : `${durationMinutes}m`}`,
                         `**Commit:** ${shortSha}`,
                         `**Author:** ${author}`,
                         `**Subject:** ${subject}`,

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -12,9 +12,10 @@ on:
       suite:
         description: "UI suite to run"
         required: true
-        default: p0p1
+        default: p0
         type: choice
         options:
+          - p0
           - p0p1
           - full
 
@@ -26,9 +27,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ui_extended:
-    name: Extended UI regression
-    if: ${{ github.repository == 'nexu-io/open-design' }}
+  ui_p0_main:
+    name: UI P0 on main
+    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -54,12 +55,60 @@ jobs:
       - name: Clean Playwright state
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
+      - name: Run UI P0
+        run: pnpm -C e2e test:ui:p0
+
+      - name: Upload Playwright debug artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-p0-main-${{ github.run_id }}
+          path: |
+            e2e/ui/reports/playwright-html-report
+            e2e/ui/reports/test-results
+            e2e/ui/reports/results.json
+            e2e/ui/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+  ui_extended:
+    name: Extended UI regression
+    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name != 'push' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+        with:
+          package-json-path: e2e/package.json
+          install-command: pnpm -C e2e exec playwright install --with-deps chromium
+
+      - name: Prebuild workspace type declarations
+        run: |
+          pnpm --filter @open-design/daemon build
+          pnpm --filter @open-design/desktop build
+          pnpm --filter @open-design/web build:sidecar
+
+      - name: Clean Playwright state
+        run: pnpm -C e2e exec tsx scripts/playwright.ts clean
+
+      - name: Run UI P0
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.suite == 'p0' }}
+        run: pnpm -C e2e test:ui:p0
+
       - name: Run UI P0/P1
-        if: ${{ github.event_name != 'schedule' && inputs.suite != 'full' }}
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.suite == 'p0p1') }}
         run: pnpm -C e2e test:ui:p0p1
 
       - name: Run full UI
-        if: ${{ github.event_name == 'schedule' || inputs.suite == 'full' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.suite == 'full' }}
         run: pnpm -C e2e test:ui
 
       - name: Upload Playwright debug artifact

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -72,10 +72,23 @@ jobs:
           retention-days: 7
 
   ui_extended:
-    name: Extended UI regression
-    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name != 'push' }}
+    name: Extended UI regression (${{ matrix.name }})
+    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name != 'push' && (github.event_name == 'schedule' || inputs.suite != 'full') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: P0
+            part: p0
+            command: pnpm -C e2e test:ui:p0
+          - name: P1 shard 1
+            part: p1
+            command: pnpm -C e2e exec playwright test -c playwright.config.ts ui --grep '\[P1\]' --shard=1/2
+          - name: P1 shard 2
+            part: p1
+            command: pnpm -C e2e exec playwright test -c playwright.config.ts ui --grep '\[P1\]' --shard=2/2
 
     steps:
       - name: Checkout
@@ -99,23 +112,59 @@ jobs:
       - name: Clean Playwright state
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
-      - name: Run UI P0
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.suite == 'p0' }}
-        run: pnpm -C e2e test:ui:p0
+      - name: Run UI suite part
+        if: ${{ matrix.part == 'p0' || github.event_name == 'schedule' || inputs.suite == 'p0p1' }}
+        run: ${{ matrix.command }}
 
-      - name: Run UI P0/P1
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.suite == 'p0p1') }}
-        run: pnpm -C e2e test:ui:p0p1
+      - name: Upload Playwright debug artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-extended-main-${{ github.run_id }}-${{ matrix.part }}-${{ matrix.name }}
+          path: |
+            e2e/ui/reports/playwright-html-report
+            e2e/ui/reports/test-results
+            e2e/ui/reports/results.json
+            e2e/ui/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+  ui_full_manual:
+    name: Full UI regression
+    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite == 'full' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+        with:
+          package-json-path: e2e/package.json
+          install-command: pnpm -C e2e exec playwright install --with-deps chromium
+
+      - name: Prebuild workspace type declarations
+        run: |
+          pnpm --filter @open-design/daemon build
+          pnpm --filter @open-design/desktop build
+          pnpm --filter @open-design/web build:sidecar
+
+      - name: Clean Playwright state
+        run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
       - name: Run full UI
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.suite == 'full' }}
         run: pnpm -C e2e test:ui
 
       - name: Upload Playwright debug artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-extended-main-${{ github.run_id }}
+          name: ui-full-manual-${{ github.run_id }}
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -27,11 +27,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ui_p0_main:
-    name: UI P0 on main
-    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'push' }}
+  ui_p0:
+    name: UI P0 (${{ matrix.name }})
+    if: ${{ github.repository == 'nexu-io/open-design' && (github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.suite != 'full')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: entry-onboarding
+            command: >-
+              pnpm -C e2e exec playwright test -c playwright.config.ts
+              ui/critical-smoke.test.ts
+              ui/entry-chrome-flows.test.ts
+              ui/amr-onboarding.test.ts
+              ui/api-empty-response.test.ts
+              --grep '\[P0\]'
+          - name: project-workspace
+            command: >-
+              pnpm -C e2e exec playwright test -c playwright.config.ts
+              ui/app.test.ts
+              ui/app-restoration.test.ts
+              ui/app-design-files.test.ts
+              ui/app-manual-edit.test.ts
+              ui/project-management-flows.test.ts
+              ui/workspace-keyboard-flows.test.ts
+              --grep '\[P0\]'
+          - name: runtime-recovery
+            command: >-
+              pnpm -C e2e exec playwright test -c playwright.config.ts
+              ui/real-daemon-run.test.ts
+              ui/amr-run-failure-recovery.test.ts
+              ui/amr-logout-requires-relogin.test.ts
+              ui/settings-local-cli-codex-fallback.test.ts
+              --grep '\[P0\]'
+          - name: settings-connectors
+            command: >-
+              pnpm -C e2e exec playwright test -c playwright.config.ts
+              ui/settings-api-protocol.test.ts
+              ui/settings-connectors-auth-happy-path.test.ts
+              ui/settings-connectors-auth-recovery.test.ts
+              --grep '\[P0\]'
 
     steps:
       - name: Checkout
@@ -55,14 +92,14 @@ jobs:
       - name: Clean Playwright state
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
-      - name: Run UI P0
-        run: pnpm -C e2e test:ui:p0
+      - name: Run UI P0 domain
+        run: ${{ matrix.command }}
 
       - name: Upload Playwright debug artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-p0-main-${{ github.run_id }}
+          name: ui-p0-${{ github.run_id }}-${{ matrix.name }}
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results
@@ -72,17 +109,14 @@ jobs:
           retention-days: 7
 
   ui_extended:
-    name: Extended UI regression (${{ matrix.name }})
-    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name != 'push' && (github.event_name == 'schedule' || inputs.suite != 'full') }}
+    name: UI P1 (${{ matrix.name }})
+    if: ${{ github.repository == 'nexu-io/open-design' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.suite == 'p0p1')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: P0
-            part: p0
-            command: pnpm -C e2e test:ui:p0
           - name: P1 shard 1
             part: p1
             command: pnpm -C e2e exec playwright test -c playwright.config.ts ui --grep '\[P1\]' --shard=1/2
@@ -112,8 +146,7 @@ jobs:
       - name: Clean Playwright state
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
-      - name: Run UI suite part
-        if: ${{ matrix.part == 'p0' || github.event_name == 'schedule' || inputs.suite == 'p0p1' }}
+      - name: Run UI P1 shard
         run: ${{ matrix.command }}
 
       - name: Upload Playwright debug artifact

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -41,6 +41,7 @@ jobs:
               pnpm -C e2e exec playwright test -c playwright.config.ts
               ui/critical-smoke.test.ts
               ui/entry-chrome-flows.test.ts
+              ui/entry-configuration-flows.test.ts
               ui/amr-onboarding.test.ts
               ui/api-empty-response.test.ts
               --grep '\[P0\]'


### PR DESCRIPTION
## Summary

- run only UI P0 after pushes to main
- run UI P0/P1 on the nightly schedule
- keep manual dispatch options for P0, P0/P1, and full UI
- extend Feishu alerts to cover both CI and ui-extended-main failures/cancellations/timeouts

## Surface area

- [x] GitHub Actions workflow config only
- [x] Main post-merge UI regression scheduling
- [x] Feishu failure notification routing
- [ ] Product/runtime code
- [ ] E2E test case implementation

## Validation

- GitHub Actions workflow lint/checks are green on this PR
- Did not run the Playwright suites locally; this change only adjusts workflow scheduling and notification conditions

## Notes

- main push signal should finish faster than the previous P0/P1 post-merge run
- nightly extended coverage keeps P1 in the automated loop
- alerting now catches ui-extended-main cancellation/timeout instead of only CI failures
