### PR TITLE
ci(feishu): preserve issue refs in changelog links

### DIFF
--- a/.github/scripts/release/feishu/notify.ts
+++ b/.github/scripts/release/feishu/notify.ts
@@ -86,15 +86,18 @@ function readChangelog() {
   return { lines: truncated ? all.slice(0, MAX_CHANGELOG_LINES) : all, truncated, total: all.length };
 }
 
-// Turn the plain-text `git log` line into clickable Feishu links: every PR
-// reference (`#1234`, typically the `(#1234)` suffix a squash-merge leaves on
-// the subject) jumps to the pull request, and the trailing short hash appended
-// by `git log %s (%h)` jumps to the commit. Lines without a PR ref (direct
-// pushes to the release branch) still get their commit linked.
+// Turn the plain-text `git log` line into clickable Feishu links: the trailing
+// PR suffix a squash-merge leaves on the subject (`(#1234)`) jumps to the pull
+// request, and the trailing short hash appended by `git log %s (%h)` jumps to
+// the commit. Lines without a PR suffix (direct pushes to the release branch)
+// still get their commit linked.
 function linkifyChangelogLine(line) {
   if (repo.length === 0) return line;
   return line
-    .replace(/#(\d+)/g, (_match, num) => `[#${num}](https://github.com/${repo}/pull/${num})`)
+    .replace(
+      /\(#(\d+)\)(?=\s*\([0-9a-f]{7,40}\)\s*$)/i,
+      (_match, num) => `([#${num}](https://github.com/${repo}/pull/${num}))`,
+    )
     .replace(/\(([0-9a-f]{7,40})\)\s*$/i, (_match, hash) => `([\`${hash}\`](https://github.com/${repo}/commit/${hash}))`);
 }
 


### PR DESCRIPTION
## Why

The Feishu daily PR notifier linkified every `#123`-style reference in changelog lines. That made inline issue references in commit subjects look like pull-request links, even though only the squash-merge suffix before the trailing commit hash should become a PR link.

## What users will see

Feishu daily PR messages still link the final squash-merge PR suffix, but inline issue references in commit subjects remain plain text. Direct-push changelog lines still link the trailing commit hash.

## Surface area

- [x] Release notification script
- [x] Feishu changelog rendering
- [ ] Runtime/daemon behavior
- [ ] Web app
- [ ] Desktop app
- [ ] Packaging/install
- [ ] New dependencies
- [ ] None - internal only

## Validation

- `node --check .github/scripts/release/feishu/notify.ts`
- `git diff --check`
- Small Node smoke covering PR suffix, inline issue reference, and direct-push changelog lines