### PR TITLE
fix(web): stop early analytics events shipping app_version=0.0.0

### DIFF
--- a/apps/web/src/analytics/provider.tsx
+++ b/apps/web/src/analytics/provider.tsx
@@ -85,29 +85,62 @@ function isSameOriginApiCall(url: unknown): boolean {
   }
 }
 
+const APP_VERSION_PLACEHOLDER = '0.0.0';
+let runtimeAppVersion: string | null = null;
+let runtimeAppVersionPromise: Promise<string | null> | null = null;
+
+// Shared single-flight fetch of the daemon-pinned version. Cached at module
+// scope so the hook, the capture paths, and repeated calls all settle on one
+// /api/version round-trip and the same resolved value.
+async function loadRuntimeAppVersion(): Promise<string | null> {
+  if (runtimeAppVersion) return runtimeAppVersion;
+  if (!runtimeAppVersionPromise) {
+    runtimeAppVersionPromise = (async () => {
+      try {
+        const res = await fetch('/api/version');
+        if (!res.ok) return null;
+        const body = (await res.json()) as { version?: { version?: string } };
+        const next = body?.version?.version;
+        if (!next) return null;
+        runtimeAppVersion = next;
+        return next;
+      } catch {
+        return null;
+      } finally {
+        // Allow a retry on the next call when the fetch yielded nothing.
+        if (!runtimeAppVersion) runtimeAppVersionPromise = null;
+      }
+    })();
+  }
+  return runtimeAppVersionPromise;
+}
+
+// Capture paths call this before emitting so an event never ships with the
+// placeholder once the real version is knowable. When the caller already has
+// a real version (state resolved) it returns immediately; otherwise it awaits
+// the shared fetch. This closes the race where high-frequency early events
+// (page_view in particular) fired before the version-resolving effect re-ran
+// and re-registered the PostHog super-property, permanently stamping them
+// with app_version='0.0.0'.
+export async function resolveAppVersionForCapture(current: string): Promise<string> {
+  if (current && current !== APP_VERSION_PLACEHOLDER) return current;
+  return (await loadRuntimeAppVersion()) ?? current;
+}
+
 // App version is read from a runtime endpoint rather than at build time so
 // the same web bundle reports the daemon-pinned version even when running
-// against a newer/older daemon during dev. Falls back to '0.0.0' until the
-// fetch resolves, then the resolved value flows through state so every
-// downstream effect that depends on `appVersion` re-runs and re-registers
-// the PostHog super-property with the real version. Earlier `useRef` shape
-// silently broke this: ref writes don't trigger re-renders, so every event
-// shipped with `app_version='0.0.0'`.
+// against a newer/older daemon during dev. The hook exposes the placeholder
+// for first paint, but capture() paths call resolveAppVersionForCapture() so
+// early events wait for the real value instead of permanently shipping with
+// app_version='0.0.0'. Earlier `useRef` shape silently broke even the hook:
+// ref writes don't trigger re-renders, so every event shipped with '0.0.0'.
 export function useAppVersion(): string {
-  const [version, setVersion] = useState('0.0.0');
+  const [version, setVersion] = useState(APP_VERSION_PLACEHOLDER);
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      try {
-        const res = await fetch('/api/version');
-        if (!res.ok) return;
-        const body = (await res.json()) as { version?: { version?: string } };
-        if (cancelled) return;
-        const next = body?.version?.version;
-        if (next) setVersion(next);
-      } catch {
-        // Best-effort.
-      }
+      const next = await loadRuntimeAppVersion();
+      if (!cancelled && next) setVersion(next);
     })();
     return () => {
       cancelled = true;
@@ -138,28 +171,30 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
   const [resolvedAnonId, setResolvedAnonId] = useState<string | null>(null);
   useEffect(() => {
     let cancelled = false;
-    // Bridge the always-on error tracker to /api/analytics/config so any
-    // exceptions buffered since module load (see client-app.tsx) can flush
-    // to PostHog. This runs regardless of the user's analytics consent
-    // toggle — error reports are intentionally not gated by it.
-    void bootstrapExceptionTracking({
-      anonymousId: identity.anonymousId,
-      sessionId: identity.sessionId,
-      clientType: identity.clientType,
-      locale,
-      appVersion,
-    });
-    void getAnalyticsClient({
-      anonymousId: identity.anonymousId,
-      sessionId: identity.sessionId,
-      clientType: identity.clientType,
-      locale,
-      appVersion,
-    }).then(() => {
+    void (async () => {
+      const resolvedAppVersion = await resolveAppVersionForCapture(appVersion);
+      // Bridge the always-on error tracker to /api/analytics/config so any
+      // exceptions buffered since module load (see client-app.tsx) can flush
+      // to PostHog. This runs regardless of the user's analytics consent
+      // toggle — error reports are intentionally not gated by it.
+      void bootstrapExceptionTracking({
+        anonymousId: identity.anonymousId,
+        sessionId: identity.sessionId,
+        clientType: identity.clientType,
+        locale,
+        appVersion: resolvedAppVersion,
+      });
+      await getAnalyticsClient({
+        anonymousId: identity.anonymousId,
+        sessionId: identity.sessionId,
+        clientType: identity.clientType,
+        locale,
+        appVersion: resolvedAppVersion,
+      });
       if (cancelled) return;
       const resolved = getResolvedAnonymousId();
       if (resolved) setResolvedAnonId(resolved);
-    });
+    })();
     return () => {
       cancelled = true;
     };
@@ -205,16 +240,21 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
+      const resolvedAppVersion = await resolveAppVersionForCapture(appVersion);
       const client = await getAnalyticsClient({
         anonymousId: identity.anonymousId,
         sessionId: identity.sessionId,
         clientType: identity.clientType,
         locale: locale,
-        appVersion,
+        appVersion: resolvedAppVersion,
       });
       if (cancelled || !client) return;
       try {
-        client.register({ locale: locale, app_version: appVersion, ui_version: appVersion });
+        client.register({
+          locale: locale,
+          app_version: resolvedAppVersion,
+          ui_version: resolvedAppVersion,
+        });
       } catch {
         // Best-effort.
       }
@@ -258,14 +298,24 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
         }
       }
       void (async () => {
+        const resolvedAppVersion = await resolveAppVersionForCapture(appVersion);
         const client = await getAnalyticsClient({
           anonymousId: identity.anonymousId,
           sessionId: identity.sessionId,
           clientType: identity.clientType,
           locale: locale,
-          appVersion,
+          appVersion: resolvedAppVersion,
         });
-        capture(client, { event, properties, insertId, requestId });
+        capture(client, {
+          event,
+          properties: {
+            ...properties,
+            app_version: resolvedAppVersion,
+            ui_version: resolvedAppVersion,
+          },
+          insertId,
+          requestId,
+        });
       })();
     },
     [identity, locale, appVersion],
@@ -287,16 +337,18 @@ export function AnalyticsProvider({ children }: { children: ReactNode }) {
           // (client.ts) allows a fresh /api/analytics/config fetch when
           // the previous response was enabled=false. Resolved id propagates
           // into the wrapper via setResolvedAnonId below.
-          void getAnalyticsClient({
-            anonymousId: identity.anonymousId,
-            sessionId: identity.sessionId,
-            clientType: identity.clientType,
-            locale,
-            appVersion,
-          }).then(() => {
+          void (async () => {
+            const resolvedAppVersion = await resolveAppVersionForCapture(appVersion);
+            await getAnalyticsClient({
+              anonymousId: identity.anonymousId,
+              sessionId: identity.sessionId,
+              clientType: identity.clientType,
+              locale,
+              appVersion: resolvedAppVersion,
+            });
             const resolved = getResolvedAnonymousId();
             if (resolved) setResolvedAnonId(resolved);
-          });
+          })();
         }
       },
       setIdentity: (installationId: string | null) => {

--- a/apps/web/tests/analytics-app-version.test.tsx
+++ b/apps/web/tests/analytics-app-version.test.tsx
@@ -15,16 +15,22 @@
 // This test goes red on the `useRef` version and green on the `useState`
 // version: after the mocked /api/version resolves, the hook must return
 // the fetched value, not the boot placeholder.
+//
+// The `useState` fix alone still left a race: high-frequency early events
+// (page_view) fired before the version-resolving effect re-ran and
+// re-registered the PostHog super-property, so they shipped with '0.0.0'.
+// resolveAppVersionForCapture() closes that race by awaiting the shared
+// /api/version fetch before any capture. The module-scoped cache it uses is
+// why each test re-imports the module after vi.resetModules().
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-import { useAppVersion } from '../src/analytics/provider';
 
 describe('useAppVersion', () => {
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
+    vi.resetModules();
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
       if (url.endsWith('/api/version')) {
@@ -50,12 +56,18 @@ describe('useAppVersion', () => {
     vi.restoreAllMocks();
   });
 
-  it('boots to the 0.0.0 placeholder before the fetch resolves', () => {
+  async function loadProvider() {
+    return import('../src/analytics/provider');
+  }
+
+  it('boots to the 0.0.0 placeholder before the fetch resolves', async () => {
+    const { useAppVersion } = await loadProvider();
     const { result } = renderHook(() => useAppVersion());
     expect(result.current).toBe('0.0.0');
   });
 
   it('updates to the fetched version once /api/version resolves', async () => {
+    const { useAppVersion } = await loadProvider();
     const { result } = renderHook(() => useAppVersion());
     await waitFor(() => {
       expect(result.current).toBe('1.2.3');
@@ -64,6 +76,7 @@ describe('useAppVersion', () => {
 
   it('keeps the 0.0.0 placeholder when the fetch fails', async () => {
     globalThis.fetch = vi.fn(async () => new Response('boom', { status: 500 })) as unknown as typeof fetch;
+    const { useAppVersion } = await loadProvider();
     const { result } = renderHook(() => useAppVersion());
     // Let any pending microtasks settle so a buggy implementation has the
     // same opportunity to "succeed" with stale data as the happy path.
@@ -71,5 +84,16 @@ describe('useAppVersion', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
     expect(result.current).toBe('0.0.0');
+  });
+
+  it('resolves the real version before early capture events use the placeholder', async () => {
+    const { resolveAppVersionForCapture } = await loadProvider();
+    await expect(resolveAppVersionForCapture('0.0.0')).resolves.toBe('1.2.3');
+  });
+
+  it('does not refetch when capture already has a real version', async () => {
+    const { resolveAppVersionForCapture } = await loadProvider();
+    await expect(resolveAppVersionForCapture('9.9.9')).resolves.toBe('9.9.9');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Why

While reviewing the PostHog埋点 against release/v0.10.0, we found `app_version` reporting `0.0.0` on a large share of events for every build after the runtime-fetch approach landed — so the analytics team can't slice usage by app version.

Root cause: `useAppVersion()` reads the daemon-pinned version from `/api/version` at runtime, but PostHog's `app_version` rode **solely** on the `register()` super-property, which races that fetch. High-frequency early events (`page_view` above all) are captured before the version resolves, so they ship with the `0.0.0` placeholder and never get corrected. `useState` (the prior fix for the older `useRef` bug) made the super-property *eventually* correct, but did nothing for events that already fired during the race window.

## What users will see

No user-visible change. PostHog events now carry the real `app_version` (e.g. `0.10.0`) instead of `0.0.0`, including the earliest events of a session.

## Surface area

- [x] **None** — internal analytics plumbing + tests only

## Bug fix verification

- Test path: `apps/web/tests/analytics-app-version.test.tsx`
- New cases assert `resolveAppVersionForCapture('0.0.0')` resolves to the real version before any capture, and that it does not refetch when the caller already has a real version. The existing hook cases (placeholder on first paint, updates after fetch, stays on fetch failure) still pass.

## Validation

- `pnpm guard` ✅
- `pnpm --filter @open-design/web typecheck` ✅
- `pnpm --filter @open-design/web exec vitest run tests/analytics-app-version.test.tsx tests/analytics-configure-globals.test.ts tests/analytics-identity.test.ts tests/analytics-scrub.test.ts tests/components/UpdaterPopup.test.tsx` → 38 passed ✅