### PR TITLE
fix(landing): drop unused agent nav placeholders

### DIFF
--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -72,33 +72,6 @@ const SOLUTION_USE_CASES: ReadonlyArray<{
 //   { name: 'Marketing', href: '/for/marketing/' },
 // ];
 
-/*
- * Agent dropdown — AMR (the design Agent) plus the 17 first-party coding-agent
- * adapters. Display names are verbatim from the Header spec; `slug` maps to the
- * agent's anchor on the /agents/ hub (apps/landing-page/app/pages/agents/
- * index.astro). Per-agent detail pages are a later milestone — until then the
- * anchor is the destination. Agent product names are not localized.
- */
-const AGENT_LINKS: ReadonlyArray<{ name: string; slug: string }> = [
-  { name: 'Codex CLI', slug: 'codex' },
-  { name: 'Devin for Terminal', slug: 'devin' },
-  { name: 'OpenCode', slug: 'opencode' },
-  { name: 'Kimi CLI', slug: 'kimi' },
-  { name: 'Qwen Code', slug: 'qwen' },
-  { name: 'Qoder CLI', slug: 'qoder' },
-  { name: 'GitHub Copilot CLI', slug: 'copilot' },
-  { name: 'Pi', slug: 'pi' },
-  { name: 'Kiro CLI', slug: 'kiro' },
-  { name: 'Kilo', slug: 'kilo' },
-  { name: 'Mistral Vibe CLI', slug: 'vibe' },
-  { name: 'DeepSeek TUI', slug: 'deepseek' },
-  { name: 'Claude Code', slug: 'claude-code' },
-  { name: 'Gemini CLI', slug: 'gemini' },
-  { name: 'Hermes', slug: 'hermes' },
-  { name: 'Grok Build', slug: 'grok' },
-  { name: 'Cursor Agent', slug: 'cursor' },
-];
-
 export interface HeaderProps {
   /** Nav highlight target. `'home'` is the default for `/`. */
   active?:
@@ -306,9 +279,9 @@ export function Header({
             </li>
             {/*
               Agent — for now this dropdown lists only AMR (the design Agent).
-              The 17 first-party coding-agent adapters (see AGENT_LINKS) and the
-              per-agent /agents/ hub anchors are intentionally held back for a
-              later pass; re-add the AGENT_LINKS map below when that ships.
+              The first-party coding-agent adapters and per-agent /agents/ hub
+              anchors are intentionally held back for a later pass; add that
+              adapter map next to this dropdown when that ships.
             */}
             <li className='has-dropdown'>
               <a

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -582,26 +582,6 @@ body::before {
   text-transform: uppercase;
   color: var(--ink-faint);
 }
-/* Disabled placeholder item (e.g. Weekly Newsletter before it ships). */
-.nav-dropdown .dropdown-disabled {
-  display: block;
-  padding: 10px 12px;
-  font-family: var(--sans);
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--ink-faint);
-  opacity: 0.55;
-  cursor: default;
-}
-/* Agent dropdown carries AMR + 17 adapters — too tall for one column.
- * Lay the items out in two columns; the menu widens to fit. */
-.nav-dropdown-agents {
-  min-width: 460px;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0 4px;
-  align-content: start;
-}
 /* Solution dropdown is tall (two groups, 11 items). Cap height and let it
  * scroll rather than run off the bottom of short viewports. */
 .nav-dropdown-solution {

--- a/apps/landing-page/app/pages/solutions/dashboard/index.astro
+++ b/apps/landing-page/app/pages/solutions/dashboard/index.astro
@@ -1,6 +1,6 @@
 ---
 /*
- * /solutions/dashboard/ — Solution use-case page: prototyping with Open Design.
+ * /solutions/dashboard/ — Solution use-case page: dashboards with Open Design.
  *
  * Solution use-case page; structure mirrors /solutions/prototype/ (the
  * template). Copy lives in solution-pages-i18n.ts under the 'dashboard' key.


### PR DESCRIPTION
Follow-up for #3598 review comments.

This removes the live-but-unused Agent dropdown placeholder list and its unused CSS, and fixes the dashboard solution page docblock copy.

Checks run:
- rg AGENT_LINKS/nav-dropdown-agents/dropdown-disabled apps/landing-page/app/_components/header.tsx apps/landing-page/app/globals.css apps/landing-page/app/pages/solutions/dashboard/index.astro
- git diff --check

Note: pnpm --filter @open-design/landing-page typecheck could not start in this worktree because node_modules is missing and astro is not installed locally.