### PR TITLE
fix(landing): highlight Resources on download page

### DIFF
--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -95,6 +95,7 @@ export interface HeaderProps {
     | 'resources'
     | 'blog'
     | 'tutorials'
+    | 'download'
     | 'community';
   /**
    * Live counts from the Markdown catalogs. Required so we can never
@@ -340,7 +341,10 @@ export function Header({
               <a
                 href={href('/blog/')}
                 className={
-                  active === 'resources' || active === 'tutorials' || active === 'blog'
+                  active === 'resources' ||
+                  active === 'blog' ||
+                  active === 'tutorials' ||
+                  active === 'download'
                     ? 'is-active'
                     : undefined
                 }
@@ -374,7 +378,10 @@ export function Header({
                     main dropped it from Resources until the subscribe page
                     ships. */}
                 <li>
-                  <a href={href('/download/')}>
+                  <a
+                    href={href('/download/')}
+                    className={active === 'download' ? 'is-active' : undefined}
+                  >
                     <span className='dropdown-name'>
                       {productMenuCopy.resourceItems.download}
                     </span>

--- a/apps/landing-page/app/pages/download/index.astro
+++ b/apps/landing-page/app/pages/download/index.astro
@@ -140,7 +140,7 @@ const jsonLd = [
 ];
 ---
 
-<Layout title={title} description={description} active="resources" jsonLd={jsonLd}>
+<Layout title={title} description={description} active="download" jsonLd={jsonLd}>
   <nav class="breadcrumb" aria-label={common.breadcrumbAria}>
     <a href={href('/')}>Open Design</a>
     <span>/</span>


### PR DESCRIPTION
## Why

The landing header moved Blog, Tutorials, and Download under Resources, but the download page still rendered `active="home"`. That left the Resources trigger and Download submenu item unhighlighted while users were on `/download/`.

## What users will see

On the Download page, the Resources top-level nav item now highlights, and the Download row inside the Resources dropdown uses the same active state as Blog and Tutorials. Other landing pages keep their existing active nav behavior.

## Screenshots

Before state: the Download page did not show an active Resources trigger or active Download row.

![Before: Download page dropdown without active Resources or Download styling](https://raw.githubusercontent.com/mturac/open-design/evidence/pr-3611-screenshots/pr-evidence/3611/before-download-header.png)

After: `/download/` highlights the Resources trigger in the header.

![After: Download page header with Resources active](https://raw.githubusercontent.com/mturac/open-design/evidence/pr-3611-screenshots/pr-evidence/3611/after-download-header.png)

After: the Resources dropdown keeps the Download row active as well.

![After: Resources dropdown with Download row active](https://raw.githubusercontent.com/mturac/open-design/evidence/pr-3611-screenshots/pr-evidence/3611/after-resources-dropdown.png)

## Surface area

- [x] UI
- [ ] Keyboard shortcut
- [ ] CLI
- [ ] env var
- [ ] API
- [ ] contract
- [ ] Extension point
- [ ] i18n keys
- [x] Default behavior change
- [ ] None

## Bug fix verification

Verified the Download page passes `active="download"`, `HeaderProps` accepts that active key, the Resources trigger treats it as active, and the Download submenu item now receives the same active class used by the other dropdown rows.

## Validation

- `pnpm --filter @open-design/landing-page typecheck`
- `git diff --check origin/main...HEAD`
- `git diff --check`
