### PR TITLE
Show AMR startup errors in client UI

### DIFF
--- a/apps/web/src/components/AmrLoginPill.tsx
+++ b/apps/web/src/components/AmrLoginPill.tsx
@@ -99,6 +99,7 @@ export function AmrAccountControl({
   className,
   compact = false,
   email = '',
+  errorMessage,
   profile,
   showProfileBadge = false,
   showSignInAction = true,
@@ -121,6 +122,7 @@ export function AmrAccountControl({
   const isSigningIn = status === 'signing-in';
   const isCanceled = status === 'canceled';
   const hasError = status === 'error';
+  const loginErrorText = errorMessage || t('settings.amrLoginErrorCompact');
   const statusText = isSignedIn
     ? hideSignedInStatus
       ? ''
@@ -197,7 +199,7 @@ export function AmrAccountControl({
       ) : null}
       {hasError ? (
         <span className="amr-account-control__error" role="alert">
-          {t('settings.amrLoginErrorCompact')}
+          {loginErrorText}
         </span>
       ) : null}
     </div>
@@ -481,6 +483,7 @@ export function AmrLoginPill({
         status={accountStatus}
         compact
         email={userEmail}
+        errorMessage={errorMessage}
         profile={status?.profile}
         showProfileBadge
         hideSignedOutStatus={hideSignedOutStatus}

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -863,7 +863,7 @@ function OnboardingView({
   const [cliScanStatus, setCliScanStatus] = useState<'idle' | 'scanning' | 'done'>('idle');
   const [amrStatus, setAmrStatus] = useState<VelaLoginStatus | null>(null);
   const [amrLoginPending, setAmrLoginPending] = useState(false);
-  const [amrLoginError, setAmrLoginError] = useState(false);
+  const [amrLoginError, setAmrLoginError] = useState<string | null>(null);
   const [visibleAgentIds, setVisibleAgentIds] = useState<string[]>([]);
   const [providerTestState, setProviderTestState] = useState<
     | { status: 'idle' }
@@ -1426,7 +1426,7 @@ function OnboardingView({
   ) {
     if (amrLoginPending) return;
     amrLoginPollCancelledRef.current = false;
-    setAmrLoginError(false);
+    setAmrLoginError(null);
     setAmrLoginPending(true);
     try {
       const currentStatus = await fetchVelaLoginStatus();
@@ -1437,7 +1437,7 @@ function OnboardingView({
       }
       const loginResult = await startVelaLogin(attribution);
       if (!loginResult.ok && !loginResult.alreadyRunning) {
-        setAmrLoginError(true);
+        setAmrLoginError(loginResult.error || t('settings.amrLoginErrorCompact'));
         return;
       }
       if (await pollAmrLoginCompletion()) {
@@ -1461,7 +1461,7 @@ function OnboardingView({
       if (outcome === 'signed-in') return true;
       if (outcome === 'stopped' || outcome === 'timed-out') {
         if (outcome === 'timed-out') void cancelVelaLogin();
-        setAmrLoginError(true);
+        setAmrLoginError(t('settings.amrLoginErrorCompact'));
         return false;
       }
     }
@@ -1994,7 +1994,7 @@ function OnboardingView({
             <div className="onboarding-view__actions">
               {step === 0 && amrLoginError ? (
                 <span className="onboarding-view__action-status is-error" role="alert">
-                  {t('settings.amrLoginErrorCompact')}
+                  {amrLoginError}
                 </span>
               ) : null}
               <button

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -126,7 +126,7 @@ export function InlineModelSwitcher({
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const [amrStatus, setAmrStatus] = useState<VelaLoginStatus | null>(null);
   const [amrLoginPending, setAmrLoginPending] = useState(false);
-  const [amrLoginError, setAmrLoginError] = useState(false);
+  const [amrLoginError, setAmrLoginError] = useState<string | null>(null);
   const [amrReminderSeen, setAmrReminderSeen] = useState(readAmrReminderSeen);
   const [showAmrReminderInPopover, setShowAmrReminderInPopover] =
     useState(false);
@@ -181,36 +181,36 @@ export function InlineModelSwitcher({
         }
         amrLoginStartedAtRef.current = null;
         setAmrLoginPending(false);
-        setAmrLoginError(true);
+        setAmrLoginError(t('settings.amrLoginErrorCompact'));
       }
     };
     amrPollRef.current = window.setInterval(() => {
       void tick();
     }, AMR_LOGIN_POLL_INTERVAL_MS);
-  }, [refreshAmrStatus, stopAmrPolling]);
+  }, [refreshAmrStatus, stopAmrPolling, t]);
 
   const handleAmrSignIn = useCallback(async (
     attribution?: AmrEntryAttribution | null,
   ) => {
     const startedAt = Date.now();
     amrLoginStartedAtRef.current = startedAt;
-    setAmrLoginError(false);
+    setAmrLoginError(null);
     setAmrLoginPending(true);
     const result = await startVelaLogin(attribution);
     if (!result.ok && !result.alreadyRunning) {
       amrLoginStartedAtRef.current = null;
       setAmrLoginPending(false);
-      setAmrLoginError(true);
+      setAmrLoginError(result.error || t('settings.amrLoginErrorCompact'));
       return;
     }
     notifyAmrLoginStatusChanged('login-started');
     startAmrPolling(startedAt);
-  }, [startAmrPolling]);
+  }, [startAmrPolling, t]);
 
   const handleAmrCancelLogin = useCallback(async () => {
     stopAmrPolling();
     amrLoginStartedAtRef.current = null;
-    setAmrLoginError(false);
+    setAmrLoginError(null);
     setAmrLoginPending(false);
     await cancelVelaLogin();
     notifyAmrLoginStatusChanged('login-canceled');
@@ -273,7 +273,7 @@ export function InlineModelSwitcher({
       if (reason === 'login-started') {
         const startedAt = Date.now();
         amrLoginStartedAtRef.current = startedAt;
-        setAmrLoginError(false);
+        setAmrLoginError(null);
         setAmrLoginPending(true);
         startAmrPolling(startedAt);
       } else if (reason === 'login-canceled') {
@@ -353,7 +353,7 @@ export function InlineModelSwitcher({
       : t('settings.amrSignIn');
   const amrPendingHoverLabel = t('settings.amrCancelSignIn');
   const amrInlineStatus = amrLoginError
-    ? t('settings.amrLoginErrorCompact')
+    ? amrLoginError
     : amrLoggedIn
       ? t('settings.amrSignedIn')
       : amrLoginPending

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1425,7 +1425,23 @@
   cursor: default;
   opacity: 0.62;
 }
-.agent-card-amr-auth .amr-account-control__error,
+.agent-card-amr-auth .amr-account-control--error {
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  row-gap: 6px;
+  padding: 6px 12px;
+}
+.agent-card-amr-auth .amr-account-control__error {
+  flex: 1 1 100%;
+  max-width: 100%;
+  color: var(--danger-text, #991b1b);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
 .agent-card-amr-auth .amr-login-pill-badge {
   display: none;
 }

--- a/apps/web/tests/components/AmrLoginPill.test.tsx
+++ b/apps/web/tests/components/AmrLoginPill.test.tsx
@@ -109,7 +109,7 @@ describe('AmrAccountControl', () => {
     expect(screen.queryByText('local')).toBeNull();
   });
 
-  it('renders compact login errors with AMR-labeled text', () => {
+  it('renders compact login errors with daemon-provided text', () => {
     renderAccountControl({
       status: 'error',
       compact: true,
@@ -117,8 +117,8 @@ describe('AmrAccountControl', () => {
       onSignIn: vi.fn(),
     });
 
-    expect(screen.getByText('AMR sign-in failed.')).toBeTruthy();
-    expect(screen.queryByText('command failed')).toBeNull();
+    expect(screen.getByRole('alert').textContent).toBe('command failed');
+    expect(screen.queryByText('AMR sign-in failed.')).toBeNull();
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeTruthy();
   });
 });
@@ -281,7 +281,10 @@ describe('AmrLoginPill', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert')).toBeTruthy();
     });
-    expect(screen.getByText('AMR sign-in failed.')).toBeTruthy();
+    expect(screen.getByRole('alert').textContent).toBe(
+      'profile "prod" api URL: is not configured',
+    );
+    expect(screen.queryByText('AMR sign-in failed.')).toBeNull();
     expect(screen.queryByText('Signing in…')).toBeNull();
   });
 

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -393,6 +393,30 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     expect(screen.getByText('Connect')).toBeTruthy();
   });
 
+  it('shows daemon startup errors when AMR sign-in fails immediately', async () => {
+    const startupError = 'profile "prod" api URL: is not configured';
+    const fetchMock = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' });
+      }
+      if (url.endsWith('/api/integrations/vela/login') && init?.method === 'POST') {
+        return jsonResponse({ error: startupError }, 500);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    renderOnboarding();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Sign in to continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toBe(startupError);
+    });
+    expect(screen.queryByText('AMR sign-in failed.')).toBeNull();
+    expect(screen.queryByText('Signing in…')).toBeNull();
+  });
+
   it('clears AMR login pending when the user switches to another runtime', async () => {
     const fetchMock = vi.fn(async (input, init) => {
       const url = String(input);

--- a/apps/web/tests/components/InlineModelSwitcher.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.test.tsx
@@ -484,6 +484,56 @@ describe('InlineModelSwitcher AMR row', () => {
     ).toBeTruthy();
   });
 
+  it('shows daemon startup errors when AMR sign-in fails immediately', async () => {
+    const startupError = 'profile "prod" api URL: is not configured';
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn: false,
+            loginInFlight: false,
+            profile: 'prod',
+            user: null,
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/login' && init?.method === 'POST') {
+        return new Response(JSON.stringify({ error: startupError }), {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSwitcher();
+    fireEvent.click(screen.getByTestId('inline-model-switcher-chip'));
+
+    const popover = screen.getByTestId('inline-model-switcher-popover');
+    const amrButton = await within(popover).findByRole('radio', {
+      name: /^AMR\s+Sign in$/i,
+    });
+    fireEvent.click(amrButton);
+
+    await waitFor(() => {
+      expect(
+        within(popover).getByRole('radio', {
+          name: /^AMR\s+profile "prod" api URL: is not configured/i,
+        }),
+      ).toBeTruthy();
+    });
+    expect(
+      within(popover).queryByRole('radio', {
+        name: /^AMR\s+AMR sign-in failed\./i,
+      }),
+    ).toBeNull();
+    expect(within(popover).getByText('Sign in')).toBeTruthy();
+  });
+
   it('cancels a timed-out AMR sign-in from the inline switcher', async () => {
     let loginStarted = false;
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/apps/web/tests/styles/amr-account-control.test.ts
+++ b/apps/web/tests/styles/amr-account-control.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const artifactsCss = readFileSync(
+  new URL('../../src/styles/workspace/artifacts.css', import.meta.url),
+  'utf8',
+);
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(artifactsCss)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+describe('AMR account control workspace styles', () => {
+  it('keeps settings startup errors visible while hiding profile badges', () => {
+    const errorBlock = cssDeclarations('.agent-card-amr-auth .amr-account-control__error');
+    const badgeBlock = cssDeclarations('.agent-card-amr-auth .amr-login-pill-badge');
+
+    expect(errorBlock).not.toMatch(/(?:^|[;\n])\s*display:\s*none\s*;/);
+    expect(badgeBlock).toMatch(/(?:^|[;\n])\s*display:\s*none\s*;/);
+  });
+});


### PR DESCRIPTION
Fixes #3602

## Why
AMR authorize startup failures already carried a daemon error like `profile "prod" api URL: is not configured`, but the client dropped or hid that detail before users could see it. The Settings AMR card also hid the compact error span entirely.

## What users will see
- The Settings AMR card now shows the daemon-provided startup error in the card UI instead of silently returning to Authorize.
- The shared AMR pill renders its `errorMessage` prop, with the existing generic fallback for timeout/cancel paths.
- The inline model switcher and onboarding sign-in flow keep the daemon error string instead of collapsing it to a boolean.

## Surface area
- Web AMR login pill and Settings execution card styling
- Inline model switcher AMR sign-in state
- Onboarding AMR sign-in alert
- Focused regression tests for the startup 500 path and the Settings-card CSS visibility rule

## Screenshots
Not included. The failing path requires an AMR daemon startup error; it is covered by component tests and a CSS regression test.

## Bug fix verification
Red check before the fix failed on the intended assertions: the shared pill showed `AMR sign-in failed.`, the inline/onboarding surfaces lost the daemon message, and the Settings card CSS hid the alert.

Validated after the fix with:
- `corepack pnpm exec vitest run -c vitest.config.ts tests/components/AmrLoginPill.test.tsx tests/components/InlineModelSwitcher.test.tsx tests/components/EntryShell.onboarding.test.tsx tests/styles/amr-account-control.test.ts`
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `git diff --check`
