### PR TITLE
[codex] Implement Langfuse phase 2 telemetry

### DIFF
--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -428,6 +428,7 @@ export async function reportRunCompletedFromDaemon(
         ...(errorCode ? { errorCode } : {}),
         ...(failure ? { failure } : {}),
         timings,
+        ...(run.analyticsTelemetry ? { timingMarks: run.analyticsTelemetry } : {}),
         ...(stderr ? { stderr } : {}),
       },
       message: {

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -22,9 +22,13 @@ import type { TelemetryPrefs } from './app-config.js';
 import {
   buildPromptStackFlatMetadata,
   promptStackWithoutContent,
+  structuredPromptStackInput,
   type PromptStackTelemetry,
 } from './prompt-telemetry.js';
-import type { RunTimingAnalytics } from './run-analytics-observability.js';
+import type {
+  RunTelemetryTimestamps,
+  RunTimingAnalytics,
+} from './run-analytics-observability.js';
 import type { RunFailureClassification } from './run-failure-classification.js';
 
 // Langfuse US region: confirmed by an end-to-end smoke on 2026-05-07 — the
@@ -95,6 +99,7 @@ export interface RunSummary {
   errorCode?: string;
   failure?: RunFailureClassification;
   timings?: RunTimingAnalytics;
+  timingMarks?: RunTelemetryTimestamps;
   stderr?: {
     tail: string;
     lineCount: number;
@@ -349,6 +354,99 @@ function buildTagList(ctx: ReportContext): string[] {
   return tags;
 }
 
+function validTimestamp(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function timingSpanBody(input: {
+  traceId: string;
+  parentObservationId: string;
+  runId: string;
+  name: string;
+  start: number | undefined;
+  end: number | undefined;
+  metadata?: Record<string, unknown>;
+}): Record<string, unknown> | null {
+  const start = validTimestamp(input.start);
+  const end = validTimestamp(input.end);
+  if (start === undefined || end === undefined || end < start) return null;
+  return {
+    id: `${input.runId}-phase-${input.name}`,
+    traceId: input.traceId,
+    parentObservationId: input.parentObservationId,
+    name: input.name,
+    startTime: new Date(start).toISOString(),
+    endTime: new Date(end).toISOString(),
+    metadata: {
+      durationMs: Math.round(end - start),
+      ...(input.metadata ?? {}),
+    },
+  };
+}
+
+function buildTimingSpanBodies(ctx: ReportContext, generationId: string): Record<string, unknown>[] {
+  const marks = ctx.run.timingMarks ?? {};
+  const runStart = ctx.run.startedAt;
+  const runEnd = ctx.run.endedAt;
+  const queueEnd = marks.promptBuildStartAt ?? marks.startChatRunStartedAt;
+  const definitions = [
+    {
+      name: 'queue',
+      start: runStart,
+      end: queueEnd,
+      metadata: { boundary: 'run.startedAt -> promptBuildStartAt' },
+    },
+    {
+      name: 'prompt-build',
+      start: marks.promptBuildStartAt,
+      end: marks.promptBuildEndAt,
+      metadata: { boundary: 'promptBuildStartAt -> promptBuildEndAt' },
+    },
+    {
+      name: 'spawn',
+      start: marks.processSpawnStartedAt,
+      end: marks.processSpawnedAt,
+      metadata: {
+        boundary: 'processSpawnStartedAt -> processSpawnedAt',
+      },
+    },
+    {
+      name: 'model-call',
+      start: marks.modelCallStartAt,
+      end: runEnd,
+      metadata: {
+        boundary: 'modelCallStartAt -> run.endedAt',
+        toolCallCount: ctx.eventsSummary.toolCalls,
+      },
+    },
+    {
+      name: 'stream-output',
+      start: marks.firstTokenAt,
+      end: marks.finalizeStartAt ?? runEnd,
+      metadata: { boundary: 'firstTokenAt -> finalizeStartAt' },
+    },
+    {
+      name: 'finalize',
+      start: marks.finalizeStartAt,
+      end: runEnd,
+      metadata: { boundary: 'finalizeStartAt -> run.endedAt' },
+    },
+  ];
+
+  return definitions
+    .map((definition) =>
+      timingSpanBody({
+        traceId: ctx.run.runId,
+        parentObservationId: generationId,
+        runId: ctx.run.runId,
+        ...definition,
+      }),
+    )
+    .filter((body): body is Record<string, unknown> => body !== null);
+}
+
 export function buildTracePayload(ctx: ReportContext): unknown[] {
   const wantsContent = ctx.prefs.metrics === true && ctx.prefs.content === true;
   const wantsArtifacts = ctx.prefs.artifactManifest === true;
@@ -414,6 +512,9 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   const promptStackFlatMetadata = promptStack
     ? buildPromptStackFlatMetadata(promptStack)
     : {};
+  const generationInput = promptStack
+    ? structuredPromptStackInput(promptStack)
+    : inputText;
 
   // Trace metadata is the queryable + exportable fact-sheet for each turn.
   // Anything we want to slice on for evals or dataset construction lives
@@ -455,6 +556,12 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   // shows them in the dedicated Model Parameters card and filters work.
   const modelParameters: Record<string, unknown> | undefined =
     ctx.turn?.reasoning ? { reasoning: ctx.turn.reasoning } : undefined;
+  const timingSpanBodies = buildTimingSpanBodies(ctx, generationId);
+  const toolParentObservationId = timingSpanBodies.some(
+    (span) => span.name === 'model-call',
+  )
+    ? `${ctx.run.runId}-phase-model-call`
+    : agentSpanId;
 
   const batch: unknown[] = [
     {
@@ -512,7 +619,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
         modelParameters,
         startTime: startTimeIso,
         endTime: endTimeIso,
-        input: inputText,
+        input: generationInput,
         output: outputText,
         level: success ? 'DEFAULT' : 'ERROR',
         statusMessage: ctx.run.error ?? undefined,
@@ -525,6 +632,15 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
       },
     },
   ];
+
+  for (const span of timingSpanBodies) {
+    batch.push({
+      id: randomUUID(),
+      type: 'span-create',
+      timestamp: nowIso,
+      body: span,
+    });
+  }
 
   if (ctx.tools?.length) {
     for (const tool of ctx.tools) {
@@ -544,7 +660,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
         body: {
           id: toolSpanId,
           traceId,
-          parentObservationId: agentSpanId,
+          parentObservationId: toolParentObservationId,
           name: `tool:${tool.name}`,
           startTime: toolStartedAt,
           endTime: toolEndedAt,

--- a/apps/daemon/src/prompt-telemetry.ts
+++ b/apps/daemon/src/prompt-telemetry.ts
@@ -62,6 +62,28 @@ export interface PromptStackTelemetry {
   sections: PromptTelemetrySection[];
 }
 
+export interface StructuredPromptStackInput {
+  type: 'open-design.prompt-stack';
+  redactionVersion: typeof PROMPT_STACK_REDACTION_VERSION;
+  promptFingerprint: string;
+  stackFingerprint: string;
+  sectionCount: number;
+  redactedContentBytes: number;
+  redactedContentBudgetBytes: number;
+  sections: Array<{
+    kind: PromptTelemetrySectionKind;
+    ordinal: number;
+    contentMode: PromptTelemetrySection['contentMode'];
+    rawBytes: number;
+    redactedBytes: number;
+    fingerprint: string;
+    truncated: boolean;
+    truncationReason?: PromptTelemetrySection['truncationReason'];
+    redactedContent?: string;
+    metadata?: Record<string, unknown>;
+  }>;
+}
+
 interface MutablePromptTelemetrySection extends PromptTelemetrySection {
   redactedSource: string;
 }
@@ -343,10 +365,40 @@ export function promptStackWithoutContent(
   };
 }
 
+export function structuredPromptStackInput(
+  telemetry: PromptStackTelemetry,
+): StructuredPromptStackInput {
+  return {
+    type: 'open-design.prompt-stack',
+    redactionVersion: telemetry.redactionVersion,
+    promptFingerprint: telemetry.promptFingerprint,
+    stackFingerprint: telemetry.stackFingerprint,
+    sectionCount: telemetry.sectionCount,
+    redactedContentBytes: telemetry.redactedContentBytes,
+    redactedContentBudgetBytes: telemetry.redactedContentBudgetBytes,
+    sections: telemetry.sections.map((section) => ({
+      kind: section.kind,
+      ordinal: section.ordinal,
+      contentMode: section.contentMode,
+      rawBytes: section.rawBytes,
+      redactedBytes: section.redactedBytes,
+      fingerprint: section.fingerprint,
+      truncated: section.truncated,
+      ...(section.truncationReason
+        ? { truncationReason: section.truncationReason }
+        : {}),
+      ...(section.redactedContent !== undefined
+        ? { redactedContent: section.redactedContent }
+        : {}),
+      ...(section.metadata ? { metadata: section.metadata } : {}),
+    })),
+  };
+}
+
 export function buildPromptStackFlatMetadata(
   telemetry: PromptStackTelemetry,
 ): Record<string, unknown> {
-  const out: Record<string, unknown> = {
+  return {
     promptStack_redactionVersion: telemetry.redactionVersion,
     promptStack_promptFingerprint: telemetry.promptFingerprint,
     promptStack_stackFingerprint: telemetry.stackFingerprint,
@@ -354,26 +406,4 @@ export function buildPromptStackFlatMetadata(
     promptStack_redactedContentBytes: telemetry.redactedContentBytes,
     promptStack_redactedContentBudgetBytes: telemetry.redactedContentBudgetBytes,
   };
-
-  const daemonSystemPrompt = telemetry.sections.find(
-    (section) => section.kind === 'daemonSystemPrompt',
-  );
-  const runtimeToolPrompt = telemetry.sections.find(
-    (section) => section.kind === 'runtimeToolPrompt',
-  );
-  const pluginStagePrompt = telemetry.sections.find(
-    (section) => section.kind === 'pluginStagePrompt',
-  );
-
-  out.promptStack_section_daemonSystemPrompt_present = Boolean(daemonSystemPrompt);
-  out.promptStack_section_daemonSystemPrompt_truncated =
-    daemonSystemPrompt?.truncated ?? false;
-  out.promptStack_section_runtimeToolPrompt_present = Boolean(runtimeToolPrompt);
-  out.promptStack_section_pluginStagePrompt_present = Boolean(pluginStagePrompt);
-
-  if (daemonSystemPrompt?.truncationReason) {
-    out.promptStack_section_daemonSystemPrompt_truncationReason =
-      daemonSystemPrompt.truncationReason;
-  }
-  return out;
 }

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -8,9 +8,13 @@ export interface RunEventForAnalyticsObservability {
 export interface RunTelemetryTimestamps {
   startRequestedAt?: number;
   startChatRunStartedAt?: number;
+  promptBuildStartAt?: number;
+  promptBuildEndAt?: number;
   processSpawnStartedAt?: number;
   processSpawnedAt?: number;
+  modelCallStartAt?: number;
   firstTokenAt?: number;
+  finalizeStartAt?: number;
 }
 
 export interface RunUsageAnalytics {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11267,6 +11267,10 @@ export async function startServer({
       research,
       context,
     } = chatBody;
+    run.analyticsTelemetry = {
+      ...(run.analyticsTelemetry ?? {}),
+      promptBuildStartAt: Date.now(),
+    };
     if (typeof projectId === 'string' && projectId) run.projectId = projectId;
     if (typeof conversationId === 'string' && conversationId)
       run.conversationId = conversationId;
@@ -11740,6 +11744,10 @@ export async function startServer({
         },
       ],
     });
+    run.analyticsTelemetry = {
+      ...(run.analyticsTelemetry ?? {}),
+      promptBuildEndAt: Date.now(),
+    };
     // Per-agent model + reasoning the user picked in the model menu.
     // Trust the value when it matches the most recent /api/agents listing
     // (live or fallback). Otherwise allow it through if it passes a
@@ -11857,6 +11865,10 @@ export async function startServer({
       });
     };
     const finishWithRetryDecision = (status, code = null, signal = null) => {
+      run.analyticsTelemetry = {
+        ...(run.analyticsTelemetry ?? {}),
+        finalizeStartAt: run.analyticsTelemetry?.finalizeStartAt ?? Date.now(),
+      };
       const result = runResultFromStatus(status);
       const errorCode = deriveRunErrorCode({
         status,
@@ -13626,6 +13638,10 @@ export async function startServer({
     });
     if (writePromptToChildStdin && child.stdin) {
       const promptInputFormat = def.promptInputFormat ?? 'text';
+      run.analyticsTelemetry = {
+        ...(run.analyticsTelemetry ?? {}),
+        modelCallStartAt: Date.now(),
+      };
       if (promptInputFormat === 'stream-json') {
         // Wrap the prompt as an Anthropic user message and write it as one
         // JSONL line. Do NOT close stdin: claude-code keeps reading further

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -309,7 +309,19 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     const trace = batch[0].body;
     const generation = bodyOf(batch, 'generation-create', 'llm');
     expect(trace.input).toBe('design a coffee landing page');
-    expect(generation.input).toBe('design a coffee landing page');
+    expect(generation.input).toMatchObject({
+      type: 'open-design.prompt-stack',
+      sections: [
+        expect.objectContaining({
+          kind: 'daemonSystemPrompt',
+          redactedContent: expect.stringContaining('[REDACTED:path]'),
+        }),
+        expect.objectContaining({
+          kind: 'userRequest',
+          redactedContent: 'design a coffee landing page',
+        }),
+      ],
+    });
     expect(trace.metadata.promptStack.sections[0].redactedContent).toContain(
       '[REDACTED:path]',
     );

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -327,7 +327,25 @@ describe('buildTracePayload', () => {
     const trace = bodyOf(batch, 'trace-create');
     const generation = bodyOf(batch, 'generation-create', 'llm');
     expect(trace.input).toBe('Make a landing page for a coffee shop.');
-    expect(generation.input).toBe('Make a landing page for a coffee shop.');
+    expect(generation.input).toMatchObject({
+      type: 'open-design.prompt-stack',
+      redactionVersion: 'prompt-stack-redaction-v1',
+      sectionCount: 3,
+      sections: [
+        expect.objectContaining({
+          kind: 'daemonSystemPrompt',
+          redactedContent: expect.stringContaining('[REDACTED:path]'),
+        }),
+        expect.objectContaining({
+          kind: 'userRequest',
+          redactedContent: 'Build a card',
+        }),
+        expect.objectContaining({
+          kind: 'attachments',
+          contentMode: 'metadata-only',
+        }),
+      ],
+    });
     expect(trace.metadata.promptStack).toMatchObject({
       redactionVersion: 'prompt-stack-redaction-v1',
       sectionCount: 3,
@@ -337,7 +355,7 @@ describe('buildTracePayload', () => {
       '[REDACTED:path]',
     );
     expect(trace.metadata.promptStack.sections[2].redactedContent).toBeUndefined();
-    expect(trace.metadata.promptStack_section_daemonSystemPrompt_present).toBe(true);
+    expect(trace.metadata.promptStack_section_daemonSystemPrompt_present).toBeUndefined();
     expect(trace.metadata.promptStack_section_attachments_present).toBeUndefined();
     expect(trace.metadata.promptStack_section_daemonSystemPrompt_rawBytes).toBeUndefined();
     expect(trace.metadata.promptStack_promptFingerprint).toMatch(/^sha256:/);
@@ -355,9 +373,15 @@ describe('buildTracePayload', () => {
     ]) {
       const batch = buildTracePayload(makeCtx({ prefs, promptTelemetry }));
       const trace = bodyOf(batch, 'trace-create');
+      const generation = bodyOf(batch, 'generation-create', 'llm');
       expect(trace.input).toBeUndefined();
       expect(trace.metadata.promptStack.sections[0].redactedContent).toBeUndefined();
       expect(trace.metadata.promptStack.redactedContentBytes).toBe(0);
+      expect(generation.input).toMatchObject({
+        type: 'open-design.prompt-stack',
+        redactedContentBytes: 0,
+        sections: [expect.not.objectContaining({ redactedContent: expect.any(String) })],
+      });
     }
   });
 
@@ -659,6 +683,54 @@ describe('buildTracePayload', () => {
     expect(metadata.time_to_first_token_ms).toBe(40);
     expect(metadata.tool_call_count).toBe(2);
     expect(metadata.total_duration_ms).toBe(100);
+  });
+
+  it('adds duration spans for run timing marks', () => {
+    const batch = buildTracePayload(
+      makeCtx({
+        run: {
+          runId: 'run-spans',
+          status: 'succeeded',
+          startedAt: 1_700_000_000_000,
+          endedAt: 1_700_000_004_500,
+          timingMarks: {
+            startChatRunStartedAt: 1_700_000_000_100,
+            promptBuildStartAt: 1_700_000_000_200,
+            promptBuildEndAt: 1_700_000_000_260,
+            processSpawnStartedAt: 1_700_000_000_300,
+            processSpawnedAt: 1_700_000_000_380,
+            modelCallStartAt: 1_700_000_000_420,
+            firstTokenAt: 1_700_000_001_000,
+            finalizeStartAt: 1_700_000_004_200,
+          },
+        },
+      }),
+    );
+
+    const spans = (batch as any[])
+      .filter((item) => item.type === 'span-create')
+      .map((item) => item.body);
+    expect(spans.map((span) => span.name)).toEqual(
+      expect.arrayContaining([
+        'queue',
+        'prompt-build',
+        'spawn',
+        'model-call',
+        'stream-output',
+        'finalize',
+      ]),
+    );
+    expect(bodyOf(batch, 'span-create', 'spawn')).toMatchObject({
+      id: 'run-spans-phase-spawn',
+      parentObservationId: 'run-spans-gen',
+      metadata: {
+        durationMs: 80,
+        boundary: 'processSpawnStartedAt -> processSpawnedAt',
+      },
+    });
+    expect(bodyOf(batch, 'span-create', 'tool:Bash').parentObservationId).toBe(
+      'run-spans-phase-model-call',
+    );
   });
 
   it('passes through anonymous installationId as userId', () => {

--- a/apps/daemon/tests/prompt-telemetry.test.ts
+++ b/apps/daemon/tests/prompt-telemetry.test.ts
@@ -323,11 +323,15 @@ describe('prompt telemetry builder', () => {
     });
 
     const flat = buildPromptStackFlatMetadata(telemetry);
+    expect(Object.keys(flat).sort()).toEqual([
+      'promptStack_promptFingerprint',
+      'promptStack_redactedContentBudgetBytes',
+      'promptStack_redactedContentBytes',
+      'promptStack_redactionVersion',
+      'promptStack_sectionCount',
+      'promptStack_stackFingerprint',
+    ]);
     expect(flat.promptStack_promptFingerprint).toMatch(/^sha256:/);
-    expect(flat.promptStack_section_daemonSystemPrompt_present).toBe(true);
-    expect(flat.promptStack_section_runtimeToolPrompt_present).toBe(true);
-    expect(flat.promptStack_section_pluginStagePrompt_present).toBe(true);
-    expect(flat.promptStack_section_userRequest_present).toBeUndefined();
     expect(flat.promptStack_section_daemonSystemPrompt_rawBytes).toBeUndefined();
     expect(flat.promptStack_rawBytes).toBeUndefined();
   });


### PR DESCRIPTION
Fixes #3578

## Why

This implements the Phase 2 Langfuse telemetry slice requested in #3578. Phase 1 made prompt-stack diagnostics available in metadata, but the Langfuse generation still showed the user prompt as its input and lacked a duration timeline for the run phases around prompt build, spawn, model call, streaming, and finalization.

## What users will see

No app UI changes. For opted-in Langfuse telemetry, the trace remains readable with the user prompt at `trace.input`, while the generation now carries a structured, redacted prompt-stack input and phase spans for debugging one model call.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm install`
- `pnpm exec vitest run -c vitest.config.ts tests/langfuse-trace.test.ts tests/langfuse-bridge.test.ts tests/prompt-telemetry.test.ts tests/run-analytics-observability.test.ts` from `apps/daemon`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
