### PR TITLE
[codex] Fix duplicate Home style picker group keys

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1810,8 +1810,11 @@ function FooterSelectOption({
           {groupedOptions.length === 0 ? (
             <div className="home-hero__footer-select-empty">{t('homeHero.footer.noMatches')}</div>
           ) : (
-            groupedOptions.map((group) => (
-              <div className="home-hero__footer-select-group" key={group.label ?? 'ungrouped'}>
+            groupedOptions.map((group, index) => (
+              <div
+                className="home-hero__footer-select-group"
+                key={`${group.label ?? 'ungrouped'}:${group.options[0]?.value ?? index}`}
+              >
                 {group.label ? (
                   <div className="home-hero__footer-select-group-label">{group.label}</div>
                 ) : null}

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -127,6 +127,28 @@ describe('HomeView media composer options', () => {
     expect(within(menu).getByText('Official preset')).toBeTruthy();
   });
 
+  it('opens the Home style picker without duplicate group key warnings', async () => {
+    stubFetch();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      renderHome({
+        defaultDesignSystemId: 'official-default',
+        designSystems: [
+          designSystem('official-default', 'Official Default', 'built-in', 'published'),
+          designSystem('official-alt', 'Official Alt', 'built-in', 'published'),
+        ],
+      });
+
+      await clickHomeRailChip('image');
+      await openOption('designSystem');
+
+      const messages = consoleError.mock.calls.map((call) => call.map(String).join(' '));
+      expect(messages.some((message) => message.includes('Encountered two children with the same key'))).toBe(false);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('switches media chips without opening the replacement dialog', async () => {
     stubFetch();
     renderHome();


### PR DESCRIPTION
Fixes #3619

## Why

While checking the local 0.10.0 web app, opening the Home style/design-system picker surfaced a React console warning: `Encountered two children with the same key, Official preset`.

The pain is a noisy runtime warning in the main Home workflow. The picker can render the default official design system first, then the automatic option, then the remaining official presets, which creates two visible groups with the same label. The UI layout is fine, but using only the group label as the React key makes those sibling groups collide.

## What users will see

No visual layout change. Opening the Home style picker no longer raises the React duplicate-key warning or shows a Next.js issue badge for this warning.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visible UI change. Local browser verification captured the same Home style picker before/after; the only visible difference was the Next.js issue badge disappearing after the fix.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/HomeView.media-options.test.tsx`
- Did the test go red on `main` and green on this branch? no — I reproduced the warning locally in the running app and added a focused regression for the duplicate-key warning shape; the focused test is green on this branch.
- Additional manual verification: reloaded the in-app browser on `http://127.0.0.1:49549/`, opened the Image workflow style picker, and confirmed duplicate-key warnings were 0 after the fix.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/HomeView.media-options.test.tsx`
