### PR TITLE
fix(web): create files in the open Design Files folder, not the root (#3358 regression)

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -41,6 +41,10 @@ interface Props {
   onUploadFiles: (files: File[]) => void;
   onPaste: () => void;
   onNewSketch: () => void;
+  // Reports the folder the panel is currently viewing so the parent can create
+  // new files (upload / paste / new sketch / dropped files) under it instead
+  // of the project root. Fires whenever the user navigates folders.
+  onCurrentDirChange?: (dir: string) => void;
   uploadError?: string | null;
   onClearUploadError?: () => void;
   onPluginFolderAgentAction?: (
@@ -156,6 +160,7 @@ export function DesignFilesPanel({
   onNewSketch,
   uploadError = null,
   onClearUploadError,
+  onCurrentDirChange,
   onPluginFolderAgentAction,
   activePluginActionPaths = new Set(),
   hiddenPluginActionPaths = new Set(),
@@ -178,6 +183,13 @@ export function DesignFilesPanel({
   const [installNotice, setInstallNotice] = useState<ActionNotice | null>(null);
   const [renaming, setRenaming] = useState<{ name: string; draft: string; saving: boolean } | null>(null);
   const [currentDir, setCurrentDir] = useState<string>('');
+
+  // Keep the parent's create-target in sync with the folder being viewed, so
+  // uploads / pastes / new sketches / dropped files land in the open folder
+  // rather than the project root.
+  useEffect(() => {
+    onCurrentDirChange?.(currentDir);
+  }, [currentDir, onCurrentDirChange]);
 
   // Derive immediate subdirectories and files at the current directory level
   // from the flat files list. Files with names like "a/b/c.html" contribute

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -2054,6 +2054,7 @@ export function FileWorkspace({
             files={visibleFiles}
             liveArtifacts={liveArtifactEntries}
             onRefreshFiles={onRefreshFiles}
+            onCurrentDirChange={setUploadDir}
             onOpenFile={openFile}
             onOpenLiveArtifact={(tabId) => openFile(tabId)}
             onRenameFile={handleRename}

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -428,3 +428,24 @@ describe('DesignFilesPanel directory navigation', () => {
     expect(screen.getByTestId('design-file-row-top.html')).toBeTruthy();
   });
 });
+
+describe('DesignFilesPanel current-directory sync', () => {
+  afterEach(() => cleanup());
+
+  it('reports the active folder so new files are created under it, not the root', () => {
+    const onCurrentDirChange = vi.fn();
+    renderPanel(
+      [
+        file({ name: 'top.html', kind: 'html' }),
+        file({ name: 'assets/logo.png', kind: 'image' }),
+      ],
+      { onCurrentDirChange },
+    );
+    // Mounts at the root.
+    expect(onCurrentDirChange).toHaveBeenLastCalledWith('');
+    // Navigate into the folder — the parent must learn the new target dir, or
+    // upload / paste / new-sketch would create at the project root (#3358 regression).
+    fireEvent.click(document.querySelector('.df-dir-row .df-row-name-btn')!);
+    expect(onCurrentDirChange).toHaveBeenLastCalledWith('assets');
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #3358 (merged). Its Design Files panel redesign dropped the `onCurrentDirChange` handoff, so `FileWorkspace.uploadDir` stays at the project root while `DesignFilesPanel` tracks the viewed folder only in local `currentDir` state. After a user navigates into a subfolder (e.g. `assets/`), **Upload / Paste / New sketch / dropped files all create at the project root** instead of the folder they're looking at.

Surfaced by review on the v0.10.0 cherry-pick (#3618). Fixing on `main` first; the cherry-pick will carry this in.

## What users will see

In the Design Files panel, open a subfolder and Upload / Paste / New sketch / drop a file — the new file now lands in that folder, not back at the project root.

## How it works

- `DesignFilesPanel` re-adds an `onCurrentDirChange?(dir)` prop and reports `currentDir` via a `useEffect` (fires on mount and on every folder navigation).
- `FileWorkspace` passes `onCurrentDirChange={setUploadDir}`, restoring the sync the redesign removed; all create paths already key off `uploadDir`.

## Surface area

- [x] **UI** — Design Files panel create-target behavior (`apps/web`)
- [ ] **CLI / env var** — N/A

## Bug fix verification

- `apps/web/tests/components/DesignFilesPanel.test.tsx` — added: navigating into a folder reports the nested dir via `onCurrentDirChange` (mount reports `''`, then `assets`), so the parent creates files there.

## Validation

- `pnpm guard` ✅, `pnpm --filter @open-design/web typecheck` ✅
- `pnpm --filter @open-design/web exec vitest run` for `DesignFilesPanel.test.tsx` (23) and `FileWorkspace.test.tsx` (50) ✅