### PR TITLE
Improve export fidelity contract for editable PPTX and PDF readiness

### DIFF
--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -272,16 +272,58 @@ function injectPrintStylesheet(doc: string, css: string): string {
 
 export async function waitForPrintableContent(window: BrowserWindow): Promise<void> {
   await window.webContents.executeJavaScript(
-    `Promise.all([
-      document.fonts && document.fonts.ready ? document.fonts.ready.catch(function(){}) : Promise.resolve(),
-      Promise.all(Array.from(document.images || []).map(function(img) {
-        if (img.complete) return Promise.resolve();
-        return new Promise(function(resolve) {
-          img.addEventListener('load', resolve, { once: true });
-          img.addEventListener('error', resolve, { once: true });
+    `(function() {
+      function waitForImages() {
+        return Promise.all(Array.from(document.images || []).map(function(img) {
+          if (img.complete) return Promise.resolve();
+          return new Promise(function(resolve) {
+            img.addEventListener('load', resolve, { once: true });
+            img.addEventListener('error', resolve, { once: true });
+          });
+        }));
+      }
+
+      function cssUrlValues(value) {
+        var urls = [];
+        if (!value || value === 'none') return urls;
+        value.replace(/url\\((['"]?)(.*?)\\1\\)/g, function(_, _quote, rawUrl) {
+          if (rawUrl && !/^data:/i.test(rawUrl)) urls.push(rawUrl);
+          return '';
         });
-      }))
-    ]).then(function(){ return true; })`,
+        return urls;
+      }
+
+      function waitForCssBackgroundImages() {
+        var urls = new Set();
+        Array.from(document.querySelectorAll('*')).forEach(function(el) {
+          var style = window.getComputedStyle(el);
+          cssUrlValues(style.backgroundImage).forEach(function(url) { urls.add(url); });
+          cssUrlValues(style.borderImageSource).forEach(function(url) { urls.add(url); });
+          cssUrlValues(style.listStyleImage).forEach(function(url) { urls.add(url); });
+        });
+        return Promise.all(Array.from(urls).map(function(url) {
+          return new Promise(function(resolve) {
+            var img = new Image();
+            img.onload = resolve;
+            img.onerror = resolve;
+            img.src = url;
+          });
+        }));
+      }
+
+      function nextFrame() {
+        return new Promise(function(resolve) { requestAnimationFrame(function() { resolve(true); }); });
+      }
+
+      return Promise.all([
+        document.fonts && document.fonts.ready ? document.fonts.ready.catch(function(){}) : Promise.resolve(),
+        waitForImages(),
+        waitForCssBackgroundImages()
+      ])
+        .then(nextFrame)
+        .then(nextFrame)
+        .then(function(){ return true; });
+    })()`,
     true,
   );
 }

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, test } from 'vitest';
 import {
   pdfFilenameFromDocument,
   savePrintReadyDocumentAsPdf,
+  waitForPrintableContent,
   type PrintReadyPdfTarget,
 } from '../../src/main/pdf-export.js';
 
@@ -211,5 +212,30 @@ describe('pdfFilenameFromDocument', () => {
       'artifact.pdf',
     );
     expect(pdfFilenameFromDocument('<title>   </title>')).toBe('artifact.pdf');
+  });
+});
+
+describe('waitForPrintableContent', () => {
+  test('waits for fonts, document images, CSS image URLs, and stable animation frames', async () => {
+    const scripts: string[] = [];
+    const window = {
+      webContents: {
+        async executeJavaScript(script: string) {
+          scripts.push(script);
+          return true;
+        },
+      },
+    };
+
+    await waitForPrintableContent(window as Parameters<typeof waitForPrintableContent>[0]);
+
+    expect(scripts).toHaveLength(1);
+    expect(scripts[0]).toContain('document.fonts.ready');
+    expect(scripts[0]).toContain('document.images');
+    expect(scripts[0]).toContain('waitForCssBackgroundImages');
+    expect(scripts[0]).toContain('style.backgroundImage');
+    expect(scripts[0]).toContain('style.borderImageSource');
+    expect(scripts[0]).toContain('style.listStyleImage');
+    expect(scripts[0]).toContain('.then(nextFrame)');
   });
 });

--- a/apps/web/src/lib/build-pptx-export-prompt.ts
+++ b/apps/web/src/lib/build-pptx-export-prompt.ts
@@ -12,6 +12,25 @@ export function buildPptxExportPrompt(fileName: string): string {
     `\`italic=True\` on Latin runs only, set the \`<a:latin>\` and \`<a:ea>\` typeface ` +
     `slots explicitly, and gate the result with \`python ` +
     `skills/pptx-html-fidelity-audit/scripts/verify_layout.py "${baseTitle}.pptx"\`.\n\n` +
+    `Editable fidelity requirements: reproduce the browser deck as editable PowerPoint ` +
+    `objects, not as full-slide screenshots. Create text as editable text boxes with stable ` +
+    `font slots, line heights, weights, colors, alignment, and rich text emphasis; create ` +
+    `cards, bullets, progress rails, chart bars, borders, rounded rectangles, and simple ` +
+    `background layers as native PPTX shapes. Resolve CSS \`color-mix()\`, gradients, ` +
+    `rgba/opacity, shadows, and borders into explicit Office-compatible fills/effects where ` +
+    `possible. Use localized raster images only for isolated effects that PowerPoint cannot ` +
+    `represent natively; do not rasterize an entire slide unless you explicitly report that ` +
+    `the slide could not be made materially editable.\n\n` +
+    `Font and layout discipline: map CSS font stacks to Office-safe fonts with Chinese text ` +
+    `using \`PingFang SC\`, \`Microsoft YaHei\`, or \`Noto Sans CJK SC\` in the \`<a:ea>\` ` +
+    `slot and Latin text using the requested Latin face in \`<a:latin>\`. If a requested font ` +
+    `is unavailable, choose a stable fallback before sizing text. Measure text boxes from the ` +
+    `browser-rendered layout when possible, size boxes to avoid reflow, and disable any PPTX ` +
+    `autofit behavior that enlarges text or changes the layout.\n\n` +
+    `Asset discipline: resolve every local and relative artifact image before export, embed ` +
+    `each referenced image once, and verify all PPTX relationship targets exist. Do not ignore ` +
+    `missing images or path-resolution errors; report them as export failures because they ` +
+    `cause visually incorrect and hard-to-edit slides.\n\n` +
     `If that audited repo flow is genuinely unavailable, use any other PPTX-capable toolchain ` +
     `that is actually available in this environment. Do not refuse solely because a specific ` +
     `library, skill, or verifier is unavailable. If \`python-pptx\`, PptxGenJS, or a PPTX ` +

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -995,14 +995,16 @@ function injectPrintScript(doc: string, title: string): string {
 function injectPrintReadyHandshake(doc: string, nonce: string): string {
   // Wait for fonts, the window load event (which covers initial images), and
   // any images that are still loading after load fires (dynamically added or
-  // slow images that weren't complete by the time this script ran). This
-  // mirrors the safety of the legacy waitForPrintableContent() helper and
+  // slow images that weren't complete by the time this script ran). Also wait
+  // for CSS image URLs and two animation frames so background/list/border
+  // images and final layout are settled before the desktop bridge prints.
+  // This mirrors the safety of the legacy waitForPrintableContent() helper and
   // prevents image-heavy exports from printing with blank images.
   //
   // The nonce is a per-export random UUID that verifies the readiness signal
   // came from our injected handshake, not a spoofed message from untrusted
   // artifact code.
-  const script = `<script data-od-print-ready>(function(){Promise.all([document.fonts&&document.fonts.ready?document.fonts.ready.catch(function(){}):Promise.resolve(),new Promise(function(r){if(document.readyState==='complete')r();else window.addEventListener('load',r,{once:true})})]).then(function(){var imgs=Array.from(document.images).filter(function(img){return !img.complete});return Promise.all(imgs.map(function(img){return new Promise(function(r){img.addEventListener('load',r,{once:true});img.addEventListener('error',r,{once:true});if(img.complete)r()})}))}).then(function(){window.parent.postMessage({type:'OD_PRINT_READY',nonce:'${nonce}'},'*')})})();<\/script>`;
+  const script = `<script data-od-print-ready>(function(){function waitForImages(){var imgs=Array.from(document.images).filter(function(img){return !img.complete});return Promise.all(imgs.map(function(img){return new Promise(function(r){img.addEventListener('load',r,{once:true});img.addEventListener('error',r,{once:true});if(img.complete)r()})}))}function cssUrlValues(value){var urls=[];if(!value||value==='none')return urls;value.replace(/url\\((['"]?)(.*?)\\1\\)/g,function(_,q,rawUrl){if(rawUrl&&!/^data:/i.test(rawUrl))urls.push(rawUrl);return''});return urls}function waitForCssBackgroundImages(){var urls=new Set();Array.from(document.querySelectorAll('*')).forEach(function(el){var style=window.getComputedStyle(el);cssUrlValues(style.backgroundImage).forEach(function(url){urls.add(url)});cssUrlValues(style.borderImageSource).forEach(function(url){urls.add(url)});cssUrlValues(style.listStyleImage).forEach(function(url){urls.add(url)})});return Promise.all(Array.from(urls).map(function(url){return new Promise(function(r){var img=new Image();img.onload=r;img.onerror=r;img.src=url})}))}function nextFrame(){return new Promise(function(r){requestAnimationFrame(function(){r(true)})})}Promise.all([document.fonts&&document.fonts.ready?document.fonts.ready.catch(function(){}):Promise.resolve(),new Promise(function(r){if(document.readyState==='complete')r();else window.addEventListener('load',r,{once:true})})]).then(function(){return Promise.all([waitForImages(),waitForCssBackgroundImages()])}).then(nextFrame).then(nextFrame).then(function(){window.parent.postMessage({type:'OD_PRINT_READY',nonce:'${nonce}'},'*')})})();<\/script>`;
   if (/<\/head>/i.test(doc)) return doc.replace(/<\/head>/i, `${script}</head>`);
   if (/<\/body>/i.test(doc)) return doc.replace(/<\/body>/i, `${script}</body>`);
   return doc + script;

--- a/apps/web/tests/lib/build-pptx-export-prompt.test.ts
+++ b/apps/web/tests/lib/build-pptx-export-prompt.test.ts
@@ -10,9 +10,31 @@ describe('buildPptxExportPrompt', () => {
     expect(prompt).toContain('`Quarterly Plan.pptx`');
     expect(prompt).toContain('Prefer the checked-in `skills/pptx-html-fidelity-audit` flow when that repo path is accessible here and the environment can run it.');
     expect(prompt).toContain('python skills/pptx-html-fidelity-audit/scripts/verify_layout.py "Quarterly Plan.pptx"');
+    expect(prompt).toContain('Editable fidelity requirements: reproduce the browser deck as editable PowerPoint objects');
     expect(prompt).toContain('Do not refuse solely because a specific library, skill, or verifier is unavailable.');
     expect(prompt).toContain('Only report that editable export is impossible if no available toolchain here can produce materially editable slides.');
     expect(prompt).toContain('Do not claim the fidelity is verified if you could not run a real validation step.');
+  });
+
+  it('requires native editable shapes and only localized raster fallbacks', () => {
+    const prompt = buildPptxExportPrompt('deck.html');
+
+    expect(prompt).toContain('not as full-slide screenshots');
+    expect(prompt).toContain('Create text as editable text boxes');
+    expect(prompt).toContain('cards, bullets, progress rails, chart bars, borders, rounded rectangles, and simple background layers as native PPTX shapes');
+    expect(prompt).toContain('Resolve CSS `color-mix()`, gradients, rgba/opacity, shadows, and borders into explicit Office-compatible fills/effects');
+    expect(prompt).toContain('Use localized raster images only for isolated effects that PowerPoint cannot represent natively');
+  });
+
+  it('requires stable font slots, browser-measured layout, and asset validation', () => {
+    const prompt = buildPptxExportPrompt('deck.html');
+
+    expect(prompt).toContain('Chinese text using `PingFang SC`, `Microsoft YaHei`, or `Noto Sans CJK SC` in the `<a:ea>` slot');
+    expect(prompt).toContain('Latin text using the requested Latin face in `<a:latin>`');
+    expect(prompt).toContain('Measure text boxes from the browser-rendered layout when possible');
+    expect(prompt).toContain('disable any PPTX autofit behavior that enlarges text or changes the layout');
+    expect(prompt).toContain('resolve every local and relative artifact image before export');
+    expect(prompt).toContain('verify all PPTX relationship targets exist');
   });
 
   it('falls back only when the audited repo flow is genuinely unavailable', () => {

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -504,6 +504,13 @@ describe('sandboxed preview Blob exports', () => {
     expect(htmlArg).toContain("img.addEventListener('load'");
     expect(htmlArg).toContain("img.addEventListener('error'");
     expect(htmlArg).toContain('img.complete');
+    expect(htmlArg).toContain('waitForCssBackgroundImages');
+    expect(htmlArg).toContain('window.getComputedStyle');
+    expect(htmlArg).toContain('style.backgroundImage');
+    expect(htmlArg).toContain('style.borderImageSource');
+    expect(htmlArg).toContain('style.listStyleImage');
+    expect(htmlArg).toContain('new Image()');
+    expect(htmlArg).toContain('requestAnimationFrame');
     // The original font- and load-waiting logic must still be present.
     expect(htmlArg).toContain('document.fonts');
     expect(htmlArg).toContain('OD_PRINT_READY');


### PR DESCRIPTION
Fixes #3627

## Why

HTML artifact deck export fidelity is user-facing: CSS-heavy decks can lose PDF readiness for CSS images, and editable PPTX exports need a stronger contract so they do not become unusable due to rasterization, missing assets, or font/layout drift.

## What users will see

PDF export readiness now accounts for CSS image URLs in both the desktop bridge and legacy helper paths before printing. PPTX export instructions now explicitly require editable native PPTX objects first, stable Office font slots, browser-measured text boxes, disabled layout-changing autofit, and strict image relationship validation.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not UI-facing; no new UI entry point. The user-visible surface is exported PDF/PPTX output fidelity.

## Bug fix verification

- Test path that covers the desktop bridge readiness path: `apps/web/tests/runtime/exports.test.ts`
- Test path that covers the PPTX export contract: `apps/web/tests/lib/build-pptx-export-prompt.test.ts`
- Legacy desktop PDF helper coverage added in `apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts`; local execution is blocked by an incomplete Electron binary install in this environment.

## Validation

- `pnpm --filter @open-design/host run build`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/lib/build-pptx-export-prompt.test.ts`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/runtime/exports.test.ts`
- Attempted `pnpm --filter @open-design/desktop exec vitest run -c vitest.config.ts tests/main/save-print-ready-document-as-pdf.test.ts`, but local Electron install is incomplete here (`Electron failed to install correctly`).
