### PR TITLE
fix(web): copy run error diagnostics

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -384,6 +384,17 @@ const CONVERSATION_ROW_HEIGHT_PX = 34;
 const CONVERSATION_VIRTUALIZE_THRESHOLD = 36;
 const CONVERSATION_OVERSCAN_ROWS = 8;
 
+interface RunErrorDiagnosticInput {
+  message: string;
+  rawMessage?: string | null;
+  errorCode?: string;
+  traceId?: string;
+  projectId?: string | null;
+  conversationId?: string | null;
+  assistantMessageId?: string;
+  agentId?: string;
+}
+
 interface QueuedSendItem {
   id: string;
   prompt: string;
@@ -601,6 +612,39 @@ export function ChatPane({
   // / audio errors) then the persisted run error so a reload still shows it.
   const rawError = error ?? failedRunErrorEvent?.detail ?? null;
   const displayError = runFailureUi?.messageKey ? t(runFailureUi.messageKey) : rawError;
+  const errorDiagnosticText = displayError
+    ? buildRunErrorDiagnosticText({
+        message: displayError,
+        rawMessage: rawError,
+        errorCode: failedRunErrorEvent?.code,
+        traceId: retryAssistant?.runId,
+        projectId,
+        conversationId: activeConversationId,
+        assistantMessageId: retryAssistant?.id,
+        agentId: retryAssistant?.agentId,
+      })
+    : null;
+  const [copiedErrorDiagnostic, setCopiedErrorDiagnostic] = useState(false);
+  const errorDiagnosticCopyTimerRef = useRef<number | null>(null);
+  const copyErrorDiagnostic = useCallback(async () => {
+    if (!errorDiagnosticText) return;
+    const ok = await copyToClipboard(errorDiagnosticText);
+    if (!ok) return;
+    if (errorDiagnosticCopyTimerRef.current != null) {
+      window.clearTimeout(errorDiagnosticCopyTimerRef.current);
+    }
+    setCopiedErrorDiagnostic(true);
+    errorDiagnosticCopyTimerRef.current = window.setTimeout(() => {
+      errorDiagnosticCopyTimerRef.current = null;
+      setCopiedErrorDiagnostic(false);
+    }, 1600);
+  }, [errorDiagnosticText]);
+  useEffect(() => () => {
+    if (errorDiagnosticCopyTimerRef.current != null) {
+      window.clearTimeout(errorDiagnosticCopyTimerRef.current);
+      errorDiagnosticCopyTimerRef.current = null;
+    }
+  }, []);
   // The failed run whose error this top-level card represents. AssistantMessage
   // suppresses only THIS message's per-message error pill (to avoid the
   // duplicate); other failed turns — older history, or once a follow-up makes
@@ -1439,70 +1483,85 @@ export function ChatPane({
               {displayError ? (
                 <div className="msg error">
                   <span className="chat-error-text">{displayError}</span>
-                  {retryAssistant && onRetry && runFailureUi ? (
+                  {errorDiagnosticText || (retryAssistant && onRetry && runFailureUi) ? (
                     <div className="chat-error-actions">
-                      {runFailureUi.primaryAction === 'authorize' ? (
+                      {errorDiagnosticText ? (
                         <button
                           type="button"
-                          className="chat-error-action"
-                          onClick={() => {
-                            recordAmrEntry(analytics.track, 'chat_error_authorize_retry');
-                            if (onSwitchToAmrAndRetry) {
-                              onSwitchToAmrAndRetry(retryAssistant);
-                            } else {
-                              onOpenAmrSettings?.();
-                            }
-                          }}
+                          className="ghost chat-error-copy"
+                          onClick={() => void copyErrorDiagnostic()}
+                          aria-label={copiedErrorDiagnostic ? t('chat.copyDone') : t('chat.copyErrorDiagnostic')}
+                          title={copiedErrorDiagnostic ? t('chat.copyDone') : t('chat.copyErrorDiagnostic')}
                         >
-                          {t('chat.amrError.authorizeCta')}
-                        </button>
-                      ) : runFailureUi.primaryAction === 'launch-terminal-auth' ? (
-                        <button
-                          type="button"
-                          className="chat-error-action"
-                          onClick={() => {
-                            onLaunchAntigravityOauth?.();
-                          }}
-                        >
-                          {t('chat.antigravityError.launchTerminalCta')}
-                        </button>
-                      ) : runFailureUi.primaryAction === 'launch-terminal-switch-model' ? (
-                        <button
-                          type="button"
-                          className="chat-error-action"
-                          onClick={() => {
-                            onLaunchAntigravityOauth?.();
-                          }}
-                        >
-                          {t('chat.antigravityError.launchSwitchModelCta')}
-                        </button>
-                      ) : runFailureUi.primaryAction === 'recharge' ? (
-                        <button
-                          type="button"
-                          className="chat-error-action"
-                          onClick={() => {
-                            const attribution = recordAmrEntry(
-                              analytics.track,
-                              'chat_error_recharge',
-                            );
-                            window.open(
-                              attributedAmrUrl(AMR_RECHARGE_URL, attribution),
-                              '_blank',
-                              'noopener,noreferrer',
-                            );
-                          }}
-                        >
-                          {t('chat.amrError.rechargeCta')}
+                          <Icon name={copiedErrorDiagnostic ? 'check' : 'copy'} size={13} />
                         </button>
                       ) : null}
-                      {runFailureUi.primaryAction === 'retry' || runFailureUi.secondaryRetry ? (
-                        <button
-                          type="button"
-                          className="ghost chat-error-retry"
-                          onClick={() => onRetry(retryAssistant)}
-                        >
-                          {t('promptTemplates.retry')}
-                        </button>
+                      {retryAssistant && onRetry && runFailureUi ? (
+                        <>
+                          {runFailureUi.primaryAction === 'authorize' ? (
+                            <button
+                              type="button"
+                              className="chat-error-action"
+                              onClick={() => {
+                                recordAmrEntry(analytics.track, 'chat_error_authorize_retry');
+                                if (onSwitchToAmrAndRetry) {
+                                  onSwitchToAmrAndRetry(retryAssistant);
+                                } else {
+                                  onOpenAmrSettings?.();
+                                }
+                              }}
+                            >
+                              {t('chat.amrError.authorizeCta')}
+                            </button>
+                          ) : runFailureUi.primaryAction === 'launch-terminal-auth' ? (
+                            <button
+                              type="button"
+                              className="chat-error-action"
+                              onClick={() => {
+                                onLaunchAntigravityOauth?.();
+                              }}
+                            >
+                              {t('chat.antigravityError.launchTerminalCta')}
+                            </button>
+                          ) : runFailureUi.primaryAction === 'launch-terminal-switch-model' ? (
+                            <button
+                              type="button"
+                              className="chat-error-action"
+                              onClick={() => {
+                                onLaunchAntigravityOauth?.();
+                              }}
+                            >
+                              {t('chat.antigravityError.launchSwitchModelCta')}
+                            </button>
+                          ) : runFailureUi.primaryAction === 'recharge' ? (
+                            <button
+                              type="button"
+                              className="chat-error-action"
+                              onClick={() => {
+                                const attribution = recordAmrEntry(
+                                  analytics.track,
+                                  'chat_error_recharge',
+                                );
+                                window.open(
+                                  attributedAmrUrl(AMR_RECHARGE_URL, attribution),
+                                  '_blank',
+                                  'noopener,noreferrer',
+                                );
+                              }}
+                            >
+                              {t('chat.amrError.rechargeCta')}
+                            </button>
+                          ) : null}
+                          {runFailureUi.primaryAction === 'retry' || runFailureUi.secondaryRetry ? (
+                            <button
+                              type="button"
+                              className="ghost chat-error-retry"
+                              onClick={() => onRetry(retryAssistant)}
+                            >
+                              {t('promptTemplates.retry')}
+                            </button>
+                          ) : null}
+                        </>
                       ) : null}
                     </div>
                   ) : null}
@@ -2537,6 +2596,29 @@ export function isAssistantMessageStreaming(
   if (message.endedAt !== undefined) return false;
   if (isTerminalRunStatus(message.runStatus)) return false;
   return true;
+}
+
+export function buildRunErrorDiagnosticText(input: RunErrorDiagnosticInput): string {
+  const lines = [
+    'Open Design run error diagnostics',
+    `trace_id: ${input.traceId ?? 'n/a'}`,
+    `run_id: ${input.traceId ?? 'n/a'}`,
+    `error_code: ${input.errorCode ?? 'n/a'}`,
+    `project_id: ${input.projectId ?? 'n/a'}`,
+    `conversation_id: ${input.conversationId ?? 'n/a'}`,
+    `assistant_message_id: ${input.assistantMessageId ?? 'n/a'}`,
+    `agent_id: ${input.agentId ?? 'n/a'}`,
+    '',
+    'error:',
+    input.message.trim(),
+  ];
+
+  const raw = input.rawMessage?.trim();
+  if (raw && raw !== input.message.trim()) {
+    lines.push('', 'raw_error:', raw);
+  }
+
+  return lines.join('\n');
 }
 
 function filterConversations(

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -879,6 +879,7 @@ export const ar: Dict = {
   'chat.you': 'أنت',
   'chat.openFile': 'فتح {name}',
   'chat.copyPrompt': 'نسخ الأمر',
+  'chat.copyErrorDiagnostic': 'نسخ تشخيصات الخطأ',
   'chat.copyDone': 'تم النسخ!',
   'chat.composerPlaceholder': "صِف ما تريد إنشاءه…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -767,6 +767,7 @@ export const de: Dict = {
   'chat.you': 'Sie',
   'chat.openFile': '{name} öffnen',
   'chat.copyPrompt': 'Prompt kopieren',
+  'chat.copyErrorDiagnostic': 'Fehlerdiagnose kopieren',
   'chat.copyDone': 'Kopiert!',
   'chat.composerPlaceholder': "Beschreiben Sie, was Sie generieren möchten…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1543,6 +1543,7 @@ export const en: Dict = {
   'chat.you': 'You',
   'chat.openFile': 'Open {name}',
   'chat.copyPrompt': 'Copy prompt',
+  'chat.copyErrorDiagnostic': 'Copy error diagnostics',
   'chat.copyDone': 'Copied!',
   'chat.inspect.noEditableTargets': 'No editable text or style targets found.',
   'chat.inspect.noCommentTargets': 'No commentable text or visual targets found.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -768,6 +768,7 @@ export const esES: Dict = {
   'chat.you': 'Tú',
   'chat.openFile': 'Abrir {name}',
   'chat.copyPrompt': 'Copiar prompt',
+  'chat.copyErrorDiagnostic': 'Copiar diagnóstico del error',
   'chat.copyDone': '¡Copiado!',
   'chat.composerPlaceholder': "Describe lo que quieres generar…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -901,6 +901,7 @@ export const fa: Dict = {
   'chat.you': 'شما',
   'chat.openFile': 'باز کردن {name}',
   'chat.copyPrompt': 'کپی پرامپت',
+  'chat.copyErrorDiagnostic': 'کپی اطلاعات عیب‌یابی خطا',
   'chat.copyDone': 'کپی شد!',
   'chat.composerPlaceholder': "آنچه می‌خواهید بسازید را توصیف کنید…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1414,6 +1414,7 @@ export const fr: Dict = {
   'chat.you': 'Vous',
   'chat.openFile': 'Ouvrir {name}',
   'chat.copyPrompt': 'Copier le prompt',
+  'chat.copyErrorDiagnostic': 'Copier le diagnostic d’erreur',
   'chat.copyDone': 'Copié !',
   'chat.composerPlaceholder': 'Décrivez ce que vous voulez générer…',
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -879,6 +879,7 @@ export const hu: Dict = {
   'chat.you': 'Te',
   'chat.openFile': '{name} megnyitása',
   'chat.copyPrompt': 'Prompt másolása',
+  'chat.copyErrorDiagnostic': 'Hibadiagnosztika másolása',
   'chat.copyDone': 'Másolva!',
   'chat.composerPlaceholder': "Írd le, mit szeretnél létrehozni…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -991,6 +991,7 @@ export const id: Dict = {
   'chat.you': 'Kamu',
   'chat.openFile': 'Buka {name}',
   'chat.copyPrompt': 'Salin prompt',
+  'chat.copyErrorDiagnostic': 'Salin diagnostik error',
   'chat.copyDone': 'Disalin!',
   'chat.composerPlaceholder': "Jelaskan apa yang ingin kamu hasilkan…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -766,6 +766,7 @@ export const ja: Dict = {
   'chat.you': 'あなた',
   'chat.openFile': '{name} を開く',
   'chat.copyPrompt': 'プロンプトをコピー',
+  'chat.copyErrorDiagnostic': 'エラー診断をコピー',
   'chat.copyDone': 'コピーしました！',
   'chat.composerPlaceholder': "生成したい内容を説明してください…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -879,6 +879,7 @@ export const ko: Dict = {
   'chat.you': '나',
   'chat.openFile': '{name} 열기',
   'chat.copyPrompt': '프롬프트 복사',
+  'chat.copyErrorDiagnostic': '오류 진단 복사',
   'chat.copyDone': '복사됨!',
   'chat.composerPlaceholder': "생성하고 싶은 내용을 설명하세요…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -879,6 +879,7 @@ export const pl: Dict = {
   'chat.you': 'Ty',
   'chat.openFile': 'Otwórz {name}',
   'chat.copyPrompt': 'Kopiuj prompt',
+  'chat.copyErrorDiagnostic': 'Kopiuj diagnostykę błędu',
   'chat.copyDone': 'Skopiowano!',
   'chat.composerPlaceholder': "Opisz, co chcesz wygenerować…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -900,6 +900,7 @@ export const ptBR: Dict = {
   'chat.you': 'Você',
   'chat.openFile': 'Abrir {name}',
   'chat.copyPrompt': 'Copiar prompt',
+  'chat.copyErrorDiagnostic': 'Copiar diagnóstico do erro',
   'chat.copyDone': 'Copiado!',
   'chat.composerPlaceholder': "Descreva o que você quer gerar…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -900,6 +900,7 @@ export const ru: Dict = {
   'chat.you': 'Вы',
   'chat.openFile': 'Открыть {name}',
   'chat.copyPrompt': 'Скопировать запрос',
+  'chat.copyErrorDiagnostic': 'Скопировать диагностику ошибки',
   'chat.copyDone': 'Скопировано!',
   'chat.composerPlaceholder': "Опишите, что хотите сгенерировать…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -834,6 +834,7 @@ export const th: Dict = {
   'chat.you': 'คุณ',
   'chat.openFile': 'เปิด {name}',
   'chat.copyPrompt': 'คัดลอกพรอมต์',
+  'chat.copyErrorDiagnostic': 'คัดลอกข้อมูลวิเคราะห์ข้อผิดพลาด',
   'chat.copyDone': 'คัดลอกแล้ว!',
   'chat.composerPlaceholder': "อธิบายสิ่งที่ต้องการสร้าง…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -868,6 +868,7 @@ export const tr: Dict = {
   'chat.you': 'Sen',
   'chat.openFile': '{name}’ı aç',
   'chat.copyPrompt': 'Promptu kopyala',
+  'chat.copyErrorDiagnostic': 'Hata tanısını kopyala',
   'chat.copyDone': 'Kopyalandı!',
   'chat.composerPlaceholder': "Oluşturmak istediğiniz şeyi açıklayın…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -901,6 +901,7 @@ export const uk: Dict = {
   'chat.you': 'Ви',
   'chat.openFile': 'Відкрити {name}',
   'chat.copyPrompt': 'Копіювати запит',
+  'chat.copyErrorDiagnostic': 'Скопіювати діагностику помилки',
   'chat.copyDone': 'Скопійовано!',
   'chat.composerPlaceholder': "Опишіть, що хочете згенерувати…",
   'chat.mode.chat.label': 'Chat',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1533,6 +1533,7 @@ export const zhCN: Dict = {
   'chat.you': '你',
   'chat.openFile': '打开 {name}',
   'chat.copyPrompt': '复制提示词',
+  'chat.copyErrorDiagnostic': '复制错误诊断信息',
   'chat.copyDone': '已复制！',
   'chat.inspect.noEditableTargets': '未找到可编辑的文本或样式目标。',
   'chat.inspect.noCommentTargets': '未找到可评论的文本或视觉目标。',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1130,6 +1130,7 @@ export const zhTW: Dict = {
   'chat.you': '你',
   'chat.openFile': '開啟 {name}',
   'chat.copyPrompt': '複製提示詞',
+  'chat.copyErrorDiagnostic': '複製錯誤診斷資訊',
   'chat.copyDone': '已複製！',
   'chat.inspect.noEditableTargets': '未找到可編輯的文字或樣式目標。',
   'chat.inspect.noCommentTargets': '未找到可評論的文字或視覺目標。',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1870,6 +1870,7 @@ export interface Dict {
   'chat.you': string;
   'chat.openFile': string;
   'chat.copyPrompt': string;
+  'chat.copyErrorDiagnostic': string;
   'chat.copyDone': string;
   'chat.composerPlaceholder': string;
   'chat.mode.chat.label': string;

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -748,6 +748,14 @@
   align-items: center;
   gap: 8px;
 }
+.chat-error-copy {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
 .chat-error-retry {
   flex: 0 0 auto;
   padding: 4px 10px;

--- a/apps/web/tests/components/ChatPane.streaming.test.tsx
+++ b/apps/web/tests/components/ChatPane.streaming.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { forwardRef, useImperativeHandle } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ChatPane, retryableAssistantMessage } from '../../src/components/ChatPane';
+import { ChatPane, buildRunErrorDiagnosticText, retryableAssistantMessage } from '../../src/components/ChatPane';
 import { DESIGN_SYSTEM_WORKSPACE_PROMPT_PREFIX } from '../../src/design-system-auto-prompt';
 import { readExpandedIndexCss } from '../helpers/read-expanded-css';
 import type { ChatMessage, Conversation, ProjectMetadata } from '../../src/types';
@@ -13,6 +13,10 @@ const composerMocks = vi.hoisted(() => ({
   focus: vi.fn(),
   restoreDraft: vi.fn(),
   setDraft: vi.fn(),
+}));
+
+const clipboardMocks = vi.hoisted(() => ({
+  copyToClipboard: vi.fn(async (_text: string) => true),
 }));
 
 const translations: Record<string, string> = {
@@ -27,6 +31,8 @@ const translations: Record<string, string> = {
   'chat.queuedEdit': 'Edit',
   'chat.queuedMore': 'more queued',
   'chat.queuedFollowUpFallback': 'Queued follow-up',
+  'chat.copyErrorDiagnostic': 'Copy error diagnostics',
+  'chat.copyDone': 'Copied!',
 };
 
 vi.mock('../../src/i18n', () => ({
@@ -42,6 +48,10 @@ vi.mock('../../src/components/AssistantMessage', () => ({
   AssistantMessage: ({ streaming, message }: { streaming: boolean; message: ChatMessage }) => (
     <output data-testid={`assistant-streaming-${message.id}`}>{streaming ? 'streaming' : 'idle'}</output>
   ),
+}));
+
+vi.mock('../../src/lib/copy-to-clipboard', () => ({
+  copyToClipboard: clipboardMocks.copyToClipboard,
 }));
 
 vi.mock('../../src/components/ChatComposer', () => ({
@@ -193,6 +203,72 @@ describe('ChatPane streaming state', () => {
     expect(retryableAssistantMessage(messages, failed.id, true)).toBeNull();
     expect(retryableAssistantMessage([...messages, { ...messages[0]!, id: 'user-2' }], failed.id, false))
       .toBeNull();
+  });
+
+  it('copies failed-run diagnostics with the trace id from the error card', async () => {
+    const messages: ChatMessage[] = [
+      { id: 'user-1', role: 'user', content: 'Create a login page', createdAt: 0 },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Generation failed',
+        agentId: 'amr',
+        createdAt: 1,
+        runId: 'run-trace-123',
+        runStatus: 'failed',
+        events: [
+          {
+            kind: 'status',
+            label: 'error',
+            detail: 'json-rpc id 4: Connection reset by server',
+            code: 'AGENT_EXECUTION_FAILED',
+          },
+        ],
+      },
+    ];
+
+    render(
+      <ChatPane
+        projectKindForTracking="prototype"
+        messages={messages}
+        streaming={false}
+        error={null}
+        projectId="project-1"
+        projectFiles={[]}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        conversations={conversations}
+        activeConversationId="conv-1"
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+        projectMetadata={projectMetadata}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy error diagnostics' }));
+
+    await waitFor(() => expect(clipboardMocks.copyToClipboard).toHaveBeenCalledTimes(1));
+    const copied = clipboardMocks.copyToClipboard.mock.calls[0]?.[0] ?? '';
+    expect(copied).toContain('trace_id: run-trace-123');
+    expect(copied).toContain('run_id: run-trace-123');
+    expect(copied).toContain('error_code: AGENT_EXECUTION_FAILED');
+    expect(copied).toContain('project_id: project-1');
+    expect(copied).toContain('conversation_id: conv-1');
+    expect(copied).toContain('json-rpc id 4: Connection reset by server');
+  });
+
+  it('formats run error diagnostics with a raw error when guidance copy differs', () => {
+    expect(buildRunErrorDiagnosticText({
+      message: 'Service unavailable. Try again.',
+      rawMessage: 'json-rpc id 4: Connection reset by server',
+      errorCode: 'UPSTREAM_UNAVAILABLE',
+      traceId: 'run-abc',
+      projectId: 'project-1',
+      conversationId: 'conv-1',
+      assistantMessageId: 'assistant-1',
+      agentId: 'amr',
+    })).toContain('raw_error:\njson-rpc id 4: Connection reset by server');
   });
 
   it('renders user turns with the chat bubble styling hook', () => {


### PR DESCRIPTION
## Why

0.10.0 release validation is still surfacing transient agent failures such as `json-rpc id 4: Connection reset by server`. The current chat error card only shows the short message, so users have to manually gather run IDs and trace context before reporting an issue.

This PR adds a low-risk diagnostics copy affordance directly on the failed-run error card so release feedback includes the trace identifier and surrounding run metadata by default.

## What users will see

When a chat run fails, the gray error card now includes a copy icon next to the existing recovery actions. Clicking it copies a diagnostic block containing the visible error, raw error when different, `trace_id` / `run_id`, error code, project ID, conversation ID, assistant message ID, and agent ID.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Manual verification comment: https://github.com/nexu-io/open-design/pull/3630#issuecomment-4620343357

The local repro shows the failed-run error card with the new copy icon next to `Retry`; after clicking, the icon switches to the copied/check state. The copied payload includes `trace_id`, `run_id`, error code, project ID, conversation ID, assistant message ID, agent ID, and the visible error text.

Note: the Codex GitHub browser session is not signed in, and the GitHub CLI/comment API does not expose PR image attachment upload, so the PNG screenshot could not be attached from this environment.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ChatPane.streaming.test.tsx`
- Did the test go red on `main` and green on this branch? No. This is a release supportability improvement rather than a deterministic UI regression; the new test locks the failed-card copy behavior and trace payload.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/ChatPane.streaming.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`