### PR TITLE
fix(web): keep empty persisted folders visible in Design Files (#3358 regression)

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -6,7 +6,7 @@ import { useT } from '../i18n';
 import type { Dict } from '../i18n/types';
 import { projectFileUrl, projectRawUrl } from '../providers/registry';
 import { buildSrcdoc } from '../runtime/srcdoc';
-import type { LiveArtifactWorkspaceEntry, ProjectFile, ProjectFileKind } from '../types';
+import type { LiveArtifactWorkspaceEntry, ProjectFile, ProjectFileKind, ProjectFolder } from '../types';
 import {
   createFileSystemReadError,
   FILE_SYSTEM_READ_ERROR_MESSAGE,
@@ -37,6 +37,11 @@ interface Props {
   // a loading overlay so the panel doesn't sit silently on the stale tree.
   reloading?: boolean;
   files: ProjectFile[];
+  // Persisted folders from `/api/projects/:id/folders`, including empty ones
+  // that no file lives under. Without these, a folder only appears once a file
+  // with a matching path prefix exists, so empty (user-created or imported)
+  // folders would vanish from the tree.
+  folders?: ProjectFolder[];
   liveArtifacts: LiveArtifactWorkspaceEntry[];
   onRefreshFiles: () => Promise<void> | void;
   onOpenFile: (name: string) => void;
@@ -157,6 +162,7 @@ export function DesignFilesPanel({
   rootDirName,
   reloading,
   files,
+  folders,
   liveArtifacts,
   onOpenFile,
   onOpenLiveArtifact,
@@ -229,11 +235,20 @@ export function DesignFilesPanel({
         if (currentDir === '') localFiles.push(f);
       }
     }
+    // Also surface persisted folders (including empty ones with no files under
+    // them) as immediate children of the current directory.
+    for (const folder of folders ?? []) {
+      if (!folder.path.startsWith(prefix)) continue;
+      const remainder = folder.path.slice(prefix.length);
+      if (!remainder) continue; // the current directory itself
+      const slashIdx = remainder.indexOf('/');
+      dirs.add(slashIdx === -1 ? remainder : remainder.slice(0, slashIdx));
+    }
     return {
       dirsAtCurrentDir: [...dirs].sort((a, b) => a.localeCompare(b)),
       filesAtCurrentDir: localFiles,
     };
-  }, [files, currentDir]);
+  }, [files, folders, currentDir]);
 
   // Group files at the current level into semantic sections, ordered by
   // SECTION_ORDER. Files within a section sort most-recently-modified first.
@@ -260,22 +275,27 @@ export function DesignFilesPanel({
     setRenaming(null);
   }, [currentDir]);
 
-  // Navigate up to the nearest ancestor that still exists when files under
-  // currentDir disappear (e.g. after deleting the last file in a subfolder).
+  // Navigate up to the nearest ancestor that still exists when the current
+  // directory disappears (e.g. after deleting the last file in a subfolder).
+  // A directory "exists" if it has files under it OR is a persisted folder
+  // (possibly empty) — otherwise navigating into an empty folder would bounce
+  // straight back to the root.
   useEffect(() => {
     if (currentDir === '') return;
-    const prefix = `${currentDir}/`;
-    if (files.some((f) => f.name.startsWith(prefix))) return;
+    const dirExists = (dir: string) =>
+      files.some((f) => f.name.startsWith(`${dir}/`)) ||
+      (folders ?? []).some((fo) => fo.path === dir || fo.path.startsWith(`${dir}/`));
+    if (dirExists(currentDir)) return;
     const parts = currentDir.split('/');
     for (let i = parts.length - 1; i > 0; i--) {
       const ancestor = parts.slice(0, i).join('/');
-      if (files.some((f) => f.name.startsWith(`${ancestor}/`))) {
+      if (dirExists(ancestor)) {
         setCurrentDir(ancestor);
         return;
       }
     }
     setCurrentDir('');
-  }, [files, currentDir]);
+  }, [files, folders, currentDir]);
 
   const pluginFolders = useMemo(() => getPluginFolderCandidates(files), [files]);
 
@@ -781,7 +801,7 @@ export function DesignFilesPanel({
               </div>
             </div>
           ) : null}
-          {files.length === 0 && liveArtifacts.length === 0 ? (
+          {files.length === 0 && liveArtifacts.length === 0 && (folders?.length ?? 0) === 0 ? (
             <div className="df-empty" data-testid="design-files-empty">
               <div className="df-empty-pill">
                 <span className="df-empty-title">

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -2070,6 +2070,7 @@ export function FileWorkspace({
             rootDirName={rootDirName}
             reloading={reloading}
             files={visibleFiles}
+            folders={projectFolders}
             liveArtifacts={liveArtifactEntries}
             onRefreshFiles={onRefreshFiles}
             onCurrentDirChange={setUploadDir}

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -232,6 +232,10 @@ const BROWSER_TAB_PREFIX = '__browser__:';
 // We keep an LRU of the most-recently-activated browser tabs live and unmount
 // the rest; switching back to an evicted tab remounts (reloads) it.
 const BROWSER_KEEPALIVE_CAP = 3;
+
+// Stable empty folder list so the render-phase project-switch reset is
+// idempotent (passing a fresh `[]` each render would re-trigger the reset).
+const EMPTY_PROJECT_FOLDERS: ProjectFolder[] = [];
 type TabDropEdge = 'before' | 'after';
 type BrowserWorkspaceTab = ProjectBrowserWorkspaceTab;
 type WorkspaceOrderedTab =
@@ -457,7 +461,20 @@ export function FileWorkspace({
   const [uploadDir, setUploadDir] = useState<string>('');
   const [sketches, setSketches] = useState<Record<string, SketchState>>({});
   const [quickSwitcherOpen, setQuickSwitcherOpen] = useState(false);
-  const [projectFolders, setProjectFolders] = useState<ProjectFolder[]>([]);
+  const [projectFolders, setProjectFolders] = useState<ProjectFolder[]>(EMPTY_PROJECT_FOLDERS);
+  // Reset the folder list during render — NOT in an effect — when the project
+  // changes. DesignFilesPanel is keyed by `projectId`, so an effect-based reset
+  // would let the new panel mount once with the previous project's folders and
+  // briefly suppress the new project's empty state (the exact regression this
+  // fix removes). Adjusting state during render discards this render before the
+  // child commits, so the new panel never sees stale folders. Mirrors the
+  // designFilesNav ref reset above. The stable empty constant keeps this
+  // idempotent (no re-entrant render loop).
+  const projectFoldersProjectIdRef = useRef(projectId);
+  if (projectFoldersProjectIdRef.current !== projectId) {
+    projectFoldersProjectIdRef.current = projectId;
+    setProjectFolders(EMPTY_PROJECT_FOLDERS);
+  }
   const [browserTabs, setBrowserTabs] = useState<BrowserWorkspaceTab[]>(
     () => browserTabsFromState(tabsState.browserTabs),
   );
@@ -525,11 +542,8 @@ export function FileWorkspace({
 
   useEffect(() => {
     let cancelled = false;
-    // Clear the previous project's folders synchronously before the async
-    // fetch resolves — otherwise switching projects briefly renders the old
-    // project's folders (and suppresses the new project's empty state, now
-    // that DesignFilesPanel treats a non-empty `folders` prop as content).
-    setProjectFolders([]);
+    // The synchronous clear happens during render (see projectFoldersProjectIdRef
+    // above); here we only fetch the new project's folders.
     void fetchProjectFolders(projectId).then((next) => {
       if (!cancelled) setProjectFolders(next);
     });

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -525,6 +525,11 @@ export function FileWorkspace({
 
   useEffect(() => {
     let cancelled = false;
+    // Clear the previous project's folders synchronously before the async
+    // fetch resolves — otherwise switching projects briefly renders the old
+    // project's folders (and suppresses the new project's empty state, now
+    // that DesignFilesPanel treats a non-empty `folders` prop as content).
+    setProjectFolders([]);
     void fetchProjectFolders(projectId).then((next) => {
       if (!cancelled) setProjectFolders(next);
     });

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -5,7 +5,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ComponentProps } from 'react';
 
 import { DesignFilesPanel, type DesignFilesNavState } from '../../src/components/DesignFilesPanel';
-import type { ProjectFile, ProjectFileKind } from '../../src/types';
+import type { ProjectFile, ProjectFileKind, ProjectFolder } from '../../src/types';
+
+function folder(path: string): ProjectFolder {
+  return { name: path.split('/').pop() ?? path, path, type: 'dir', size: 0, mtime: 1700000000 };
+}
 
 // Stub localStorage so the component's view-state persistence writes to an
 // in-memory store. Cleared in beforeEach so no test bleeds state into the next.
@@ -498,5 +502,28 @@ describe('DesignFilesPanel current-directory sync', () => {
     // upload / paste / new-sketch would create at the project root (#3358 regression).
     fireEvent.click(document.querySelector('.df-dir-row .df-row-name-btn')!);
     expect(onCurrentDirChange).toHaveBeenLastCalledWith('assets');
+  });
+});
+
+describe('DesignFilesPanel persisted (empty) folders', () => {
+  afterEach(() => cleanup());
+
+  it('shows an empty persisted folder that has no files under it', () => {
+    // Only a root file + an empty persisted folder; the folder must still
+    // appear (it would vanish if we derived dirs from file paths alone).
+    renderPanel([file({ name: 'top.html', kind: 'html' })], { folders: [folder('assets')] });
+    const dirRows = [...document.querySelectorAll('.df-dir-row')];
+    expect(dirRows.some((r) => r.textContent?.includes('assets'))).toBe(true);
+  });
+
+  it('surfaces a nested empty persisted folder after navigating into its parent', () => {
+    renderPanel([], { folders: [folder('assets'), folder('assets/icons')] });
+    // Zero files, but the persisted folder still renders the tree (not the
+    // empty state), so 'assets' is navigable at the root.
+    const rootDirs = [...document.querySelectorAll('.df-dir-row .df-row-name')].map((e) => e.textContent);
+    expect(rootDirs).toContain('assets');
+    fireEvent.click(document.querySelector('.df-dir-row .df-row-name-btn')!);
+    const nestedDirs = [...document.querySelectorAll('.df-dir-row .df-row-name')].map((e) => e.textContent);
+    expect(nestedDirs).toContain('icons');
   });
 });

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -89,6 +89,30 @@ vi.mock('../../src/components/workspace/TerminalViewer', () => ({
   ),
 }));
 
+// Records the `folders` prop DesignFilesPanel receives on EVERY render (still
+// renders the real component). Lets a test observe the first render after a
+// project switch — the pre-paint frame RTL's post-rerender DOM assertion can't
+// see — to prove no stale folders ever reach the new panel.
+const { designFilesPanelRenders } = vi.hoisted(() => ({
+  designFilesPanelRenders: [] as { projectId: string; folderCount: number }[],
+}));
+vi.mock('../../src/components/DesignFilesPanel', async () => {
+  const actual = await vi.importActual<typeof import('../../src/components/DesignFilesPanel')>(
+    '../../src/components/DesignFilesPanel',
+  );
+  const Real = actual.DesignFilesPanel;
+  return {
+    ...actual,
+    DesignFilesPanel: (props: Parameters<typeof Real>[0]) => {
+      designFilesPanelRenders.push({
+        projectId: props.projectId,
+        folderCount: props.folders?.length ?? 0,
+      });
+      return <Real {...props} />;
+    },
+  };
+});
+
 const mockedFetchProjectFileText = vi.mocked(fetchProjectFileText);
 const mockedUploadProjectFiles = vi.mocked(uploadProjectFiles);
 const mockedWriteProjectTextFile = vi.mocked(writeProjectTextFile);
@@ -455,12 +479,22 @@ describe('FileWorkspace upload input', () => {
     // Switch to project-b; its folder fetch is still pending. The previous
     // project's 'assets' folder must be gone immediately (reset synchronously),
     // not linger and suppress the new project's empty state.
+    designFilesPanelRenders.length = 0;
     rerender(<FileWorkspace {...baseProps} projectId="project-b" files={[]} />);
     expect(
       [...container.querySelectorAll('.df-dir-row .df-row-name')].some(
         (e) => e.textContent === 'assets',
       ),
     ).toBe(false);
+
+    // The reset happens during render, not in an effect — so the new panel's
+    // FIRST render (and every render thereafter) already sees zero folders.
+    // An effect-based reset would let project-b's first render observe the
+    // stale 'assets' folder before the effect cleared it; RTL's post-rerender
+    // DOM check above can't catch that frame, this can.
+    const projectBRenders = designFilesPanelRenders.filter((r) => r.projectId === 'project-b');
+    expect(projectBRenders.length).toBeGreaterThan(0);
+    expect(projectBRenders.every((r) => r.folderCount === 0)).toBe(true);
   });
 
   it('clears a prior upload failure after a later successful upload', async () => {

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -13,8 +13,9 @@ import {
   fetchProjectFileText,
   uploadProjectFiles,
   writeProjectTextFile,
+  fetchProjectFolders,
 } from '../../src/providers/registry';
-import type { ChatMessage, ProjectFile } from '../../src/types';
+import type { ChatMessage, ProjectFile, ProjectFolder } from '../../src/types';
 
 vi.mock('../../src/components/AmrGuidance', () => ({
   AmrGuidance: ({
@@ -59,6 +60,7 @@ vi.mock('../../src/providers/registry', async () => {
     fetchProjectFileText: vi.fn(),
     uploadProjectFiles: vi.fn(),
     writeProjectTextFile: vi.fn(),
+    fetchProjectFolders: vi.fn().mockResolvedValue([]),
   };
 });
 
@@ -413,6 +415,52 @@ describe('FileWorkspace upload input', () => {
 
     expect(container.querySelector('.df-breadcrumb-current')?.textContent).toBe('project');
     expect(screen.getByTestId('design-file-row-home.html')).toBeTruthy();
+  });
+
+  it('drops the previous project folders when switching, before the new fetch resolves', async () => {
+    const folder = (path: string): ProjectFolder => ({
+      name: path.split('/').pop() ?? path,
+      path,
+      type: 'dir',
+      size: 0,
+      mtime: 1700000000,
+    });
+    const mockedFolders = vi.mocked(fetchProjectFolders);
+    // project-a has an empty persisted folder; project-b's fetch stays pending.
+    // (One-time values take precedence over the factory default `[]`; no reset,
+    // so later tests keep that default.)
+    mockedFolders.mockResolvedValueOnce([folder('assets')]);
+    mockedFolders.mockReturnValueOnce(new Promise<ProjectFolder[]>(() => {}));
+
+    const baseProps: React.ComponentProps<typeof FileWorkspace> = {
+      projectId: 'project-a',
+      projectKind: 'prototype',
+      files: [],
+      liveArtifacts: [],
+      onRefreshFiles: vi.fn(),
+      isDeck: false,
+      tabsState: { tabs: [], active: null },
+      onTabsStateChange: vi.fn(),
+    };
+    const { container, rerender } = render(<FileWorkspace {...baseProps} />);
+    // project-a's empty folder shows once its fetch resolves.
+    await waitFor(() => {
+      expect(
+        [...container.querySelectorAll('.df-dir-row .df-row-name')].some(
+          (e) => e.textContent === 'assets',
+        ),
+      ).toBe(true);
+    });
+
+    // Switch to project-b; its folder fetch is still pending. The previous
+    // project's 'assets' folder must be gone immediately (reset synchronously),
+    // not linger and suppress the new project's empty state.
+    rerender(<FileWorkspace {...baseProps} projectId="project-b" files={[]} />);
+    expect(
+      [...container.querySelectorAll('.df-dir-row .df-row-name')].some(
+        (e) => e.textContent === 'assets',
+      ),
+    ).toBe(false);
   });
 
   it('clears a prior upload failure after a later successful upload', async () => {


### PR DESCRIPTION
## Why

Second follow-up to #3358 (after #3623). The redesign derives the folder list from file paths alone and dropped the `folders` prop, so an **empty persisted folder** — one a user created via the Design Files folder flow, or any empty directory in an imported working directory — disappears from the panel and can't be opened or deleted until a file exists inside it.

Surfaced by review on the v0.10.0 cherry-pick (#3618). Same fix already landed there (`8f45bb14c`); this carries it to `main`.

## What users will see

Empty folders show up in the Design Files panel again — you can open them, navigate into nested empty folders, and create files inside them.

## How it works

- `DesignFilesPanel` re-adds a `folders` prop and merges persisted folder paths into `dirsAtCurrentDir` alongside file-derived directories.
- `FileWorkspace` passes `folders={projectFolders}` (already fetched via `fetchProjectFolders`).
- The project-empty state no longer hides the tree when only folders exist.
- The "prune currentDir when it has no files" effect now treats a persisted folder as a valid directory, so navigating into an empty folder doesn't bounce back to the root.

## Surface area

- [x] **UI** — Design Files panel folder visibility (`apps/web`)
- [ ] **CLI / env var** — N/A

## Bug fix verification

- `apps/web/tests/components/DesignFilesPanel.test.tsx` — added: an empty persisted folder shows at the root, and a nested empty persisted folder is navigable.

## Validation

- `pnpm guard` ✅, `pnpm --filter @open-design/web typecheck` ✅
- `pnpm --filter @open-design/web exec vitest run` for `DesignFilesPanel.test.tsx` (25) and `FileWorkspace.test.tsx` (49) ✅