### PR TITLE
[codex] Auto-open produced HTML previews

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -167,7 +167,10 @@ import {
   useCritiqueTheaterEnabled,
 } from './Theater';
 import { useIframeKeepAlivePool } from './IframeKeepAlivePool';
-import { decideAutoOpenAfterWrite } from './auto-open-file';
+import {
+  decideAutoOpenAfterWrite,
+  selectAutoOpenProducedHtml,
+} from './auto-open-file';
 import { buildRepoImportPrompt, designSystemNeedsRepoConnect } from './design-system-github-evidence';
 import { collectReferencedJsxNames } from '../runtime/jsx-module-refs';
 import { FileWorkspace } from './FileWorkspace';
@@ -2469,6 +2472,8 @@ export function ProjectView({
                 }
                 const diff = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
                 const produced = mergeRecoveredArtifact(diff, recoveredExistingArtifact);
+                const producedHtmlToOpen = selectAutoOpenProducedHtml(produced);
+                if (producedHtmlToOpen) requestOpenFile(producedHtmlToOpen);
                 if (produced.length > 0) {
                   updateMessageById(
                     message.id,
@@ -3144,6 +3149,8 @@ export function ProjectView({
               nextFiles = await refreshProjectFiles();
             }
             const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+            const producedHtmlToOpen = selectAutoOpenProducedHtml(produced);
+            if (producedHtmlToOpen) requestOpenFile(producedHtmlToOpen);
             setMessages((curr) => {
               const updated = curr.map((m) =>
                 m.id === assistantId

--- a/apps/web/src/components/auto-open-file.ts
+++ b/apps/web/src/components/auto-open-file.ts
@@ -19,6 +19,8 @@
 interface CandidateFile {
   readonly name: string;
   readonly path?: string;
+  readonly kind?: string;
+  readonly mtime?: number;
 }
 
 interface AutoOpenOptions {
@@ -92,4 +94,27 @@ export function decideAutoOpenAfterWrite(
     return resolve(basenameMatches[0]!.name);
   }
   return { shouldOpen: false, fileName: null };
+}
+
+function isHtmlPreviewFile(file: CandidateFile): boolean {
+  const path = file.path ?? file.name;
+  return file.kind === 'html' || /\.html?$/i.test(path);
+}
+
+export function selectAutoOpenProducedHtml(
+  producedFiles: ReadonlyArray<CandidateFile>,
+): string | null {
+  let selected: CandidateFile | null = null;
+  for (const file of producedFiles) {
+    if (!isHtmlPreviewFile(file)) continue;
+    if (!selected) {
+      selected = file;
+      continue;
+    }
+    const nextMtime = typeof file.mtime === 'number' && Number.isFinite(file.mtime) ? file.mtime : 0;
+    const selectedMtime =
+      typeof selected.mtime === 'number' && Number.isFinite(selected.mtime) ? selected.mtime : 0;
+    if (nextMtime >= selectedMtime) selected = file;
+  }
+  return selected?.name ?? null;
 }

--- a/apps/web/tests/components/auto-open-file.test.ts
+++ b/apps/web/tests/components/auto-open-file.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { decideAutoOpenAfterWrite } from '../../src/components/auto-open-file';
+import {
+  decideAutoOpenAfterWrite,
+  selectAutoOpenProducedHtml,
+} from '../../src/components/auto-open-file';
 
 describe('decideAutoOpenAfterWrite', () => {
   it('returns shouldOpen=false when filePath is empty', () => {
@@ -135,5 +138,33 @@ describe('decideAutoOpenAfterWrite', () => {
       { moduleFileNames: new Set(['icons.jsx']) },
     );
     expect(result).toEqual({ shouldOpen: true, fileName: 'landing.html' });
+  });
+});
+
+describe('selectAutoOpenProducedHtml', () => {
+  it('selects a newly produced html file for the turn-end auto-open fallback', () => {
+    const result = selectAutoOpenProducedHtml([
+      { name: 'notes.txt', path: 'notes.txt', kind: 'text', mtime: 20 },
+      { name: 'mutuals-v2.html', path: 'mutuals-v2.html', kind: 'html', mtime: 30 },
+    ]);
+
+    expect(result).toBe('mutuals-v2.html');
+  });
+
+  it('prefers the newest produced html file when a turn writes multiple html files', () => {
+    const result = selectAutoOpenProducedHtml([
+      { name: 'index.html', path: 'index.html', kind: 'html', mtime: 10 },
+      { name: 'mutuals-v2.html', path: 'mutuals-v2.html', kind: 'html', mtime: 30 },
+    ]);
+
+    expect(result).toBe('mutuals-v2.html');
+  });
+
+  it('returns null when the produced files are not html previews', () => {
+    const result = selectAutoOpenProducedHtml([
+      { name: 'deck.pptx', path: 'deck.pptx', kind: 'presentation', mtime: 30 },
+    ]);
+
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Why

While generating web prototypes, newly written HTML files were listed under "Files from this turn" but the design preview stayed on the previously active file. That forced users to manually click Open even though the expected workflow is that fresh HTML output appears immediately in the Design Files preview.

The root cause was that ProjectView only auto-opened files through the immediate Write tool-result path. Some runs only surface the completed file through the final turn-end produced-file diff, so those HTML files became chips without focusing the preview tab.

## What users will see

When a chat turn produces a new `.html` or `.htm` file, the Design Files workspace automatically opens that file in the preview tab. If a turn produces multiple HTML files, the newest one is opened.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI surface. This changes automatic focus behavior for generated HTML files.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/auto-open-file.test.ts`
- Did the test go red on `main` and green on this branch? Not rerun on `main`; the new helper tests cover the previously missing turn-end produced HTML fallback and pass on this branch.
- Additional focused coverage: `apps/web/tests/components/ProjectView.reattach-restore.test.tsx`

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web test tests/components/auto-open-file.test.ts`
- `pnpm --filter @open-design/web test tests/components/ProjectView.reattach-restore.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
