### PR TITLE
feat: stream agent questions token-by-token (#3582) [v0.10.0]

### DIFF
--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -309,9 +309,15 @@ export function parsePartialQuestionForm(input: string): QuestionForm | null {
     parsed && typeof parsed === 'object' && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : {};
-  const topId = typeof top.id === 'string' && top.id.trim().length > 0 ? top.id.trim() : undefined;
+  // `id` keys the live (still-editable) Questions panel, so it must be stable
+  // for the whole stream. Do NOT derive it from the streaming body `id`: that
+  // token arrives char-by-char and `parsePartialJson` repairs the open string,
+  // so `top.id` would churn (`"d"` → `"di"` → …) and remount the panel,
+  // discarding in-progress answers. Use the open-tag attr (complete the instant
+  // the tag streams) or a stable default; the final parse (`tryParseForm`,
+  // after the close tag) adopts the real body id.
   const topTitle = typeof top.title === 'string' && top.title.trim().length > 0 ? top.title : undefined;
-  const id = attrs.id ?? topId ?? 'discovery';
+  const id = attrs.id ?? 'discovery';
   const title = attrs.title ?? topTitle ?? 'A few quick questions';
   const description = typeof top.description === 'string' ? top.description : undefined;
   // Carry submitLabel through the preview too — `tryParseForm` reads it for the

--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -310,14 +310,15 @@ export function parsePartialQuestionForm(input: string): QuestionForm | null {
       ? (parsed as Record<string, unknown>)
       : {};
   // `id` keys the live (still-editable) Questions panel, so it must be stable
-  // for the whole stream. Do NOT derive it from the streaming body `id`: that
-  // token arrives char-by-char and `parsePartialJson` repairs the open string,
-  // so `top.id` would churn (`"d"` → `"di"` → …) and remount the panel,
-  // discarding in-progress answers. Use the open-tag attr (complete the instant
-  // the tag streams) or a stable default; the final parse (`tryParseForm`,
-  // after the close tag) adopts the real body id.
+  // for the whole stream. Don't adopt the *streaming* body `id`: it arrives
+  // char-by-char and `parsePartialJson` repairs the open string, so it would
+  // churn (`"d"` → `"di"` → …) and remount the panel. Adopt the body id only
+  // once its string literal is fully terminated — then it equals the id the
+  // final parse (`tryParseForm`) assigns, so there's also no preview→final
+  // remount. The open-tag attr (complete the instant the tag streams) wins,
+  // and a stable default covers the gap before any id is known.
   const topTitle = typeof top.title === 'string' && top.title.trim().length > 0 ? top.title : undefined;
-  const id = attrs.id ?? 'discovery';
+  const id = attrs.id ?? completeTopLevelString(body, 'id') ?? 'discovery';
   const title = attrs.title ?? topTitle ?? 'A few quick questions';
   const description = typeof top.description === 'string' ? top.description : undefined;
   // Carry submitLabel through the preview too — `tryParseForm` reads it for the
@@ -372,6 +373,72 @@ function endsInsideJsonString(s: string): boolean {
 // streaming, matching the AskUserQuestion card. The trailing in-flight object
 // with no label yet is held back (no "q1" placeholder flicker); it appears
 // once its label lands.
+// Return a top-level (depth-1) string field's value ONLY if its string literal
+// is fully terminated in the (possibly partial) body. Used to adopt the form
+// `id` from a streaming body without churn: while the value is still arriving
+// it returns undefined (caller keeps the stable default); once the closing
+// quote lands it returns the final value. Depth-aware so a nested question
+// `id` can't be mistaken for the form's own.
+function completeTopLevelString(body: string, field: string): string | undefined {
+  const marker = `"${field}"`;
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '{' || c === '[') {
+      depth++;
+      continue;
+    }
+    if (c === '}' || c === ']') {
+      depth--;
+      continue;
+    }
+    if (c === '"') {
+      if (depth === 1 && body.startsWith(marker, i)) {
+        let j = i + marker.length;
+        while (j < body.length && /\s/.test(body[j] as string)) j++;
+        if (body[j] !== ':') {
+          inStr = true; // it's a value string, not our key — skip it
+          continue;
+        }
+        j++;
+        while (j < body.length && /\s/.test(body[j] as string)) j++;
+        if (body[j] !== '"') return undefined; // value not a (started) string
+        let value = '';
+        let vesc = false;
+        for (let k = j + 1; k < body.length; k++) {
+          const vc = body[k] as string;
+          if (vesc) {
+            value += vc;
+            vesc = false;
+          } else if (vc === '\\') {
+            value += vc;
+            vesc = true;
+          } else if (vc === '"') {
+            try {
+              return JSON.parse(`"${value}"`) as string;
+            } catch {
+              return value;
+            }
+          } else {
+            value += vc;
+          }
+        }
+        return undefined; // closing quote hasn't streamed yet
+      }
+      inStr = true;
+    }
+  }
+  return undefined;
+}
+
 function shapeStreamingQuestions(rawQuestions: unknown, closedCount: number): FormQuestion[] {
   if (!Array.isArray(rawQuestions)) return [];
   const out: FormQuestion[] = [];

--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -25,6 +25,8 @@
  * Splits a final assistant text payload into ordered segments — prose +
  * forms — so AssistantMessage can render the form inline.
  */
+import { parsePartialJson } from '../runtime/partial-json';
+
 export type QuestionType =
   | 'radio'
   | 'checkbox'
@@ -292,50 +294,128 @@ export function parsePartialQuestionForm(input: string): QuestionForm | null {
   const attrs = parseAttrs(m[2] ?? '');
   const closeIdx = findCloseTag(input, openEnd, closeTag);
   const rawBody = closeIdx === -1 ? input.slice(openEnd) : input.slice(openEnd, closeIdx);
-  // Strip a leading fenced ```json wrapper; the closing fence may not have
-  // streamed in yet, so only the opening fence is removed.
-  const body = rawBody.replace(/^\s*```(?:json)?\s*/i, '');
-  const id = attrs.id ?? extractJsonStringField(body, 'id') ?? 'discovery';
-  const title =
-    attrs.title ?? extractJsonStringField(body, 'title') ?? 'A few quick questions';
-  const description = extractJsonStringField(body, 'description');
-  const questions = extractCompleteQuestions(body);
+  // Strip the fenced ```json wrapper some models emit. The opening fence is
+  // removed always; the trailing fence is removed too once it streams in
+  // (possibly only a partial ``` so far) — otherwise the leftover backticks
+  // make the JSON unparseable in the gap between "fence closed" and
+  // "</question-form> arrived", dropping the live preview back to empty.
+  const body = stripTrailingFence(rawBody.replace(/^\s*```(?:json)?\s*/i, ''));
+  // Derive form-level metadata from the *parsed top-level object*, not a
+  // whole-body regex scan: a nested question/option `id`/`title`/`description`
+  // must not masquerade as the form's own. `id` keys the live Questions panel
+  // (see ProjectView), so a mid-stream identity change would remount it.
+  const parsed = parsePartialJson(body);
+  const top =
+    parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  const topId = typeof top.id === 'string' && top.id.trim().length > 0 ? top.id.trim() : undefined;
+  const topTitle = typeof top.title === 'string' && top.title.trim().length > 0 ? top.title : undefined;
+  const id = attrs.id ?? topId ?? 'discovery';
+  const title = attrs.title ?? topTitle ?? 'A few quick questions';
+  const description = typeof top.description === 'string' ? top.description : undefined;
+  // Carry submitLabel through the preview too — `tryParseForm` reads it for the
+  // final form and `QuestionForm` renders `form.submitLabel ?? default`, so
+  // omitting it here makes a custom CTA flicker in only once the close tag
+  // arrives.
+  const submitLabel = typeof top.submitLabel === 'string' ? top.submitLabel : undefined;
+  const questions = shapeStreamingQuestions(top.questions, countClosedQuestionObjects(body));
   return {
     id,
     title,
     questions,
     ...(description ? { description } : {}),
+    ...(submitLabel ? { submitLabel } : {}),
   };
 }
 
-// Pull complete `{...}` question objects out of a partial `"questions": [ … ]`
-// array, stopping at the first object whose closing brace hasn't streamed in.
-function extractCompleteQuestions(body: string): FormQuestion[] {
-  const keyMatch = /"questions"\s*:\s*\[/.exec(body);
-  if (!keyMatch) return [];
+// Strip a trailing ```` ``` ```` fence (possibly only partially streamed) from
+// a form body — but only when those backticks are the closing wrapper, not
+// content of a JSON string value still being typed. Stripping unconditionally
+// would eat real backticks from a label like `"Use ``` ..."` mid-stream.
+function stripTrailingFence(body: string): string {
+  const m = /\s*`{1,3}\s*$/.exec(body);
+  if (!m) return body;
+  const before = body.slice(0, m.index);
+  // If the text before the trailing backticks ends inside an open JSON string,
+  // the backticks belong to that value — leave them for the repair pass.
+  if (endsInsideJsonString(before)) return body;
+  return before;
+}
+
+function endsInsideJsonString(s: string): boolean {
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+    } else if (c === '"') {
+      inStr = true;
+    }
+  }
+  return inStr;
+}
+
+// Shape questions from a still-streaming, already-parsed `questions` array.
+// Unlike a complete-objects-only pass, the repaired prefix (see
+// `parsePartialJson`) means a question shows the moment its `label` (prompt)
+// text exists and its options grow in one at a time — true token-by-token
+// streaming, matching the AskUserQuestion card. The trailing in-flight object
+// with no label yet is held back (no "q1" placeholder flicker); it appears
+// once its label lands.
+function shapeStreamingQuestions(rawQuestions: unknown, closedCount: number): FormQuestion[] {
+  if (!Array.isArray(rawQuestions)) return [];
   const out: FormQuestion[] = [];
+  rawQuestions.forEach((raw, index) => {
+    if (!raw || typeof raw !== 'object') return;
+    const q = raw as Record<string, unknown>;
+    const label = q.label;
+    if (typeof label !== 'string' || label.trim().length === 0) return;
+    // Surface a question only once its canonical id is determinable, so the
+    // preview id is identical to the id the final parse assigns — `id` keys
+    // both the rendered field and the user's answer in the still-editable
+    // panel, so a mismatch would orphan an in-progress answer (mid-stream when
+    // a late id replaces the fallback, and again at the preview→final swap).
+    //   - object's braces have streamed (closed) → its id is final, whether a
+    //     real `id` or `mapRawQuestion`'s `q${index+1}` fallback → show it.
+    //   - in-flight (last, not yet closed) object WITH an `id` → id is stable
+    //     even as more fields stream → show it (options keep growing).
+    //   - in-flight object with no id yet → it may still gain one; hold back.
+    const isClosed = index < closedCount;
+    const hasId = typeof q.id === 'string' && q.id.trim().length > 0;
+    if (!isClosed && !hasId) return;
+    const mapped = mapRawQuestion(raw, index);
+    if (mapped) out.push(mapped);
+  });
+  return out;
+}
+
+// Count how many question objects in a partial `"questions": [ … ]` body have
+// their closing brace already streamed (string-aware). A closed object's id is
+// final (real `id` or the `q${index+1}` fallback), so it's safe to surface;
+// only the trailing still-open object might still gain an `id`.
+function countClosedQuestionObjects(body: string): number {
+  const keyMatch = /"questions"\s*:\s*\[/.exec(body);
+  if (!keyMatch) return 0;
   let i = keyMatch.index + keyMatch[0].length;
-  let index = 0;
+  let count = 0;
   while (i < body.length) {
     while (i < body.length && /[\s,]/.test(body[i] as string)) i++;
     if (i >= body.length || body[i] === ']') break;
     if (body[i] !== '{') break;
-    const objStr = extractBalancedObject(body, i);
-    if (!objStr) break;
-    try {
-      const mapped = mapRawQuestion(JSON.parse(objStr), index);
-      if (mapped) out.push(mapped);
-    } catch {
-      break;
-    }
-    i += objStr.length;
-    index++;
+    const obj = extractBalancedObject(body, i);
+    if (!obj) break; // trailing object hasn't closed yet
+    count++;
+    i += obj.length;
   }
-  return out;
+  return count;
 }
 
-// Return the substring for the balanced `{...}` object starting at `start`,
-// or null if it never closes (string-aware so braces inside strings don't count).
+// Return the substring for the balanced `{...}` object starting at `start`, or
+// null if it never closes (string-aware so braces inside strings don't count).
 function extractBalancedObject(s: string, start: number): string | null {
   let depth = 0;
   let inStr = false;
@@ -356,19 +436,6 @@ function extractBalancedObject(s: string, start: number): string | null {
     }
   }
   return null;
-}
-
-// Best-effort extraction of a top-level "field": "value" string from a partial
-// JSON body — used for title/id/description before the full body parses.
-function extractJsonStringField(body: string, field: string): string | undefined {
-  const re = new RegExp(`"${field}"\\s*:\\s*"((?:[^"\\\\]|\\\\.)*)"`);
-  const m = re.exec(body);
-  if (!m) return undefined;
-  try {
-    return JSON.parse(`"${m[1]}"`) as string;
-  } catch {
-    return m[1];
-  }
 }
 
 function normalizeType(raw: unknown): QuestionType {

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -1,5 +1,5 @@
 import { Fragment, memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ToolCard } from "./ToolCard";
+import { ToolCard, StreamingAskUserQuestionCard, isAskUserQuestionName } from "./ToolCard";
 import { FileOpsSummary } from "./FileOpsSummary";
 import {
   renderMarkdown,
@@ -289,7 +289,7 @@ interface Props {
   // mid-token JSON accumulated from `input_json_delta`). Used to render an
   // in-flight Write/Edit's code in real time before the full `tool_use`
   // arrives. Never persisted.
-  liveToolInput?: Record<string, { name: string; text: string }>;
+  liveToolInput?: Record<string, { name: string; text: string; seq?: number }>;
   projectId: string | null;
   // Analytics context for the assistant_feedback_* events. Defaults
   // applied at the call site keep AssistantMessage usable in tests
@@ -360,6 +360,11 @@ const ASSISTANT_MESSAGE_COMPARED_PROPS: Array<keyof Props> = [
   'forking',
   'suppressDirectionForms',
   'hasDesignSystemContext',
+  // Live streaming tool input changes identity on every `tool_input_delta`.
+  // ChatPane passes it only to the streaming row (undefined elsewhere), so
+  // comparing it re-renders just that row as the card grows — without it the
+  // memo swallows the deltas and the card only updates on the final tool_use.
+  'liveToolInput',
 ];
 
 function areAssistantMessagePropsEqual(prev: Props, next: Props): boolean {
@@ -420,24 +425,25 @@ function AssistantMessageImpl({
   // The chat-pane-level PinnedTodoBar renders the canonical TodoWrite card
   // above the composer, so we strip any TodoWrite tool-groups out of the
   // per-message flow to avoid the same task list rendering twice.
-  const persistedBlocks = stripTodoToolGroups(
-    stripEmptyThinkingBlocks(
-      suppressDuplicateQuestionForms(
-        suppressAskUserQuestionFallbackText(buildBlocks(events)),
-      ),
-    ),
+  const settledUseIds = useMemo(
+    () => new Set(events.filter((e) => e.kind === "tool_use").map((e) => e.id)),
+    [events],
   );
-  // Synthesize live code boxes for tool calls whose JSON input is still
-  // streaming (no full `tool_use` event yet). Gated to code-writing tools so
-  // a Bash/Grep/TodoWrite input stream doesn't spawn a code panel. These
-  // append after the persisted blocks since the in-flight tool is the latest
-  // activity. Disappear automatically once the full `tool_use` lands (the id
-  // leaves `liveToolInput`) or the run ends (the map is wiped upstream).
-  const liveBlocks = useMemo<Block[]>(() => {
+  // The earliest still-streaming AskUserQuestion (no full `tool_use` yet),
+  // tagged with the event position the tool call started at so we can place
+  // its live card there — text before it is preamble, text after is hedging.
+  const liveAuq = useMemo(() => {
+    if (!streaming || !liveToolInput) return null;
+    const entries = Object.entries(liveToolInput)
+      .filter(([id, e]) => !settledUseIds.has(id) && isAskUserQuestionName(e.name))
+      .map(([id, e]) => ({ id, raw: e.text, seq: e.seq ?? events.length }))
+      .sort((a, b) => a.seq - b.seq);
+    return entries[0] ?? null;
+  }, [streaming, liveToolInput, settledUseIds, events.length]);
+  // Live code boxes (Write/Edit streaming) append after everything else; they
+  // aren't part of the fallback-suppression ordering.
+  const liveCodeBlocks = useMemo<Block[]>(() => {
     if (!streaming || !liveToolInput) return [];
-    const settledUseIds = new Set(
-      events.filter((e) => e.kind === "tool_use").map((e) => e.id),
-    );
     const out: Block[] = [];
     for (const [id, entry] of Object.entries(liveToolInput)) {
       if (settledUseIds.has(id)) continue;
@@ -445,8 +451,30 @@ function AssistantMessageImpl({
       out.push({ kind: "live-tool", id, name: entry.name, raw: entry.text });
     }
     return out;
-  }, [streaming, liveToolInput, events]);
-  const blocks = liveBlocks.length ? [...persistedBlocks, ...liveBlocks] : persistedBlocks;
+  }, [streaming, liveToolInput, settledUseIds]);
+  // Compose the block list with the live AskUserQuestion at its real stream
+  // position (split the events around `seq`), then run the strip/suppress
+  // pipeline once. Because the live AUQ sits between preamble and any hedging,
+  // `suppressAskUserQuestionFallbackText` keeps the preamble and drops the
+  // hedging — matching the settled-case semantics.
+  const blocks = useMemo(() => {
+    const rawBlocks = liveAuq
+      ? (() => {
+          const n = Math.min(Math.max(liveAuq.seq, 0), events.length);
+          return [
+            ...buildBlocks(events.slice(0, n)),
+            { kind: "live-tool", id: liveAuq.id, name: "AskUserQuestion", raw: liveAuq.raw } as Block,
+            ...buildBlocks(events.slice(n)),
+            ...liveCodeBlocks,
+          ];
+        })()
+      : [...buildBlocks(events), ...liveCodeBlocks];
+    return stripTodoToolGroups(
+      stripEmptyThinkingBlocks(
+        suppressDuplicateQuestionForms(suppressAskUserQuestionFallbackText(rawBlocks)),
+      ),
+    );
+  }, [events, liveAuq, liveCodeBlocks]);
   const fileOps = useMemo(() => deriveFileOps(events), [events]);
   const produced = message.producedFiles ?? [];
   const displayedProduced = useMemo(
@@ -679,6 +707,9 @@ function AssistantMessageImpl({
             );
           }
           if (b.kind === "live-tool") {
+            if (isAskUserQuestionName(b.name)) {
+              return <StreamingAskUserQuestionCard key={b.id} raw={b.raw} />;
+            }
             return <LiveCodeBox key={b.id} name={b.name} raw={b.raw} />;
           }
           if (b.kind === "plugin-candidate") {
@@ -2677,6 +2708,14 @@ function suppressAskUserQuestionFallbackText(blocks: Block[]): Block[] {
           it.use.name === "ask_user_question",
       );
       if (hasAuq) seenAskUserQuestion = true;
+      filtered.push(block);
+      continue;
+    }
+    // A still-streaming AskUserQuestion (live block, no persisted tool_use yet)
+    // counts the same as a settled one: hedging text after it is suppressed,
+    // preamble before it is kept.
+    if (block.kind === "live-tool" && isAskUserQuestionName(block.name)) {
+      seenAskUserQuestion = true;
       filtered.push(block);
       continue;
     }

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -281,7 +281,7 @@ interface Props {
   // Live-only streaming tool-input partials keyed by tool-use id. Threaded to
   // AssistantMessage so an in-flight Write/Edit can render its code in real
   // time before the full `tool_use` arrives. Never persisted.
-  liveToolInput?: Record<string, { name: string; text: string }>;
+  liveToolInput?: Record<string, { name: string; text: string; seq?: number }>;
   initialDraft?: string;
   // Question-form submissions become a normal user message; the parent
   // routes that text through onSend (no attachments).
@@ -1770,7 +1770,7 @@ function ChatRows({
 }: {
   messages: ChatMessage[];
   streaming: boolean;
-  liveToolInput?: Record<string, { name: string; text: string }>;
+  liveToolInput?: Record<string, { name: string; text: string; seq?: number }>;
   projectId: string | null;
   projectKindForTracking: TrackingProjectKind | null;
   activeConversationId: string | null;
@@ -1850,7 +1850,10 @@ function ChatRows({
       <AssistantMessage
         message={m}
         streaming={messageStreaming}
-        liveToolInput={liveToolInput}
+        // Only the streaming row consumes live tool input. Non-streaming rows
+        // get a stable `undefined`, so adding `liveToolInput` to the memo
+        // comparator re-renders just this row per `tool_input_delta`, not all N.
+        liveToolInput={messageStreaming ? liveToolInput : undefined}
         projectId={projectId}
         projectKind={projectKindForTracking}
         conversationId={activeConversationId}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -746,7 +746,10 @@ export function ProjectView({
   // while the model is still emitting `input_json_delta`; dropped per-id once
   // the full `tool_use` lands and wiped when the run ends. Never persisted —
   // see daemon `daemonAgentPayloadToPersistedAgentEvent` (returns null).
-  const [liveToolInput, setLiveToolInput] = useState<Record<string, { name: string; text: string }>>({});
+  // `seq` records how many persisted events existed when the tool started
+  // streaming, so the renderer can place the live card at the tool call's
+  // position in the message (text before it = preamble, after it = hedging).
+  const [liveToolInput, setLiveToolInput] = useState<Record<string, { name: string; text: string; seq: number }>>({});
   // True once the initial DB read for the active conversation has settled.
   // Auto-send gates on this so it can't fire before listMessages resolves and
   // race-clobber the freshly-pushed user + assistant placeholder. Without
@@ -3065,7 +3068,19 @@ export function ProjectView({
         onToolInputDelta: (id: string, name: string, delta: string) => {
           setLiveToolInput((prev) => ({
             ...prev,
-            [id]: { name, text: (prev[id]?.text ?? '') + delta },
+            [id]: {
+              name,
+              text: (prev[id]?.text ?? '') + delta,
+              // Pin the tool's stream position the first time we see it: the
+              // count of events already on the message is everything the model
+              // emitted before the tool call (its preamble). Buffered text
+              // (appendTextEvent) isn't flushed into `events` until the next
+              // frame, so add 1 for any still-pending preamble chunk — it will
+              // commit as one text event just before this tool's position.
+              seq:
+                prev[id]?.seq ??
+                ((latestAssistantMsg.events?.length ?? 0) + (textBuffer.hasPendingText() ? 1 : 0)),
+            },
           }));
         },
         onDone: (fullText = '') => {
@@ -5836,5 +5851,10 @@ export function createBufferedTextUpdates({
     window.addEventListener('pagehide', onPageHide);
   }
 
-  return { appendContent, appendTextEvent, appendEvent, flush, cancel };
+  // True when text has been appended but not yet flushed into a `text` event.
+  // Callers that need the soon-to-be-committed event count (e.g. pinning a live
+  // tool's stream position) add 1 for this still-buffered preamble.
+  const hasPendingText = () => pendingTextEventDelta.length > 0;
+
+  return { appendContent, appendTextEvent, appendEvent, flush, cancel, hasPendingText };
 }

--- a/apps/web/src/components/ToolCard.tsx
+++ b/apps/web/src/components/ToolCard.tsx
@@ -12,8 +12,16 @@ import { useState } from 'react';
 import { useT } from '../i18n';
 import { isTodoWriteToolName, parseTodoWriteInput } from '../runtime/todos';
 import { getToolRenderer, toRenderProps } from '../runtime/tool-renderers';
+import {
+  parseAskUserQuestionInput,
+  parsePartialAskUserQuestion,
+} from '../runtime/ask-user-question';
 import type { AgentEvent } from '../types';
 import { Icon } from './Icon';
+
+export function isAskUserQuestionName(name: string): boolean {
+  return name === 'AskUserQuestion' || name === 'ask_user_question';
+}
 
 interface Props {
   use: Extract<AgentEvent, { kind: 'tool_use' }>;
@@ -77,7 +85,7 @@ export function ToolCard({
     }
   }
   const ctx: FileToolCtx = { projectFileNames, onRequestOpenFile };
-  if (name === 'AskUserQuestion' || name === 'ask_user_question')
+  if (isAskUserQuestionName(name))
     return (
       <AskUserQuestionCard
         toolUseId={use.id}
@@ -100,8 +108,8 @@ export function ToolCard({
   if (name === 'Bash') return <BashCard input={use.input} result={result} runStreaming={isStreaming} runSucceeded={isSucceeded} />;
   if (name === 'Glob' || name === 'list_files') return <GlobCard input={use.input} result={result} runStreaming={isStreaming} runSucceeded={isSucceeded} />;
   if (name === 'Grep') return <GrepCard input={use.input} result={result} runStreaming={isStreaming} runSucceeded={isSucceeded} />;
-  if (name === 'WebFetch' || name === 'web_fetch') return <WebFetchCard input={use.input} />;
-  if (name === 'WebSearch' || name === 'web_search') return <WebSearchCard input={use.input} />;
+  if (name === 'WebFetch' || name === 'web_fetch') return <WebFetchCard input={use.input} result={result} runStreaming={isStreaming} runSucceeded={isSucceeded} />;
+  if (name === 'WebSearch' || name === 'web_search') return <WebSearchCard input={use.input} result={result} runStreaming={isStreaming} runSucceeded={isSucceeded} />;
   return <GenericCard name={name} input={use.input} result={result} runStreaming={isStreaming} runSucceeded={isSucceeded} />;
 }
 
@@ -142,42 +150,73 @@ function OpenInTabButton({ filePath, ctx }: { filePath: string; ctx: FileToolCtx
 //   { questions: [{ question, header, options: [{ label, description }],
 //     multiSelect }, ...] }
 // We accept either array of objects or array of plain strings for `options`
-// to stay tolerant of small protocol drift.
-type AuqOption = { label: string; description?: string };
-type AuqQuestion = {
-  question: string;
-  header?: string;
-  options: AuqOption[];
-  multiSelect: boolean;
-};
+// to stay tolerant of small protocol drift. Parsing lives in
+// `../runtime/ask-user-question` (strict for finished input, lenient +
+// truncation-tolerant for the streaming pass).
 
-function parseAskUserQuestionInput(input: unknown): AuqQuestion[] {
-  const obj = (input ?? {}) as { questions?: unknown };
-  if (!Array.isArray(obj.questions)) return [];
-  const result: AuqQuestion[] = [];
-  for (const raw of obj.questions) {
-    if (!raw || typeof raw !== 'object') continue;
-    const q = raw as Record<string, unknown>;
-    const question = typeof q.question === 'string' ? q.question : '';
-    if (!question) continue;
-    const header = typeof q.header === 'string' ? q.header : undefined;
-    const multiSelect = q.multiSelect === true;
-    const rawOptions = Array.isArray(q.options) ? q.options : [];
-    const options: AuqOption[] = [];
-    for (const opt of rawOptions) {
-      if (typeof opt === 'string') options.push({ label: opt });
-      else if (opt && typeof opt === 'object') {
-        const o = opt as Record<string, unknown>;
-        const label = typeof o.label === 'string' ? o.label : '';
-        if (!label) continue;
-        const description = typeof o.description === 'string' ? o.description : undefined;
-        options.push(description ? { label, description } : { label });
-      }
-    }
-    if (options.length === 0) continue;
-    result.push({ question, header, options, multiSelect });
+/**
+ * Read-only AskUserQuestion card rendered from the still-streaming raw JSON
+ * input (the daemon's accumulated `tool_input_delta` for this tool id). It
+ * grows token-by-token via the tolerant parser and plays the reveal; once the
+ * full `tool_use` lands, the id leaves `liveToolInput` and the interactive
+ * card (the persisted block) takes over.
+ */
+export function StreamingAskUserQuestionCard({ raw }: { raw: string }) {
+  const t = useT();
+  const questions = parsePartialAskUserQuestion(raw);
+  if (questions.length === 0) {
+    // Frame-only: the questions array hasn't produced a prompt yet.
+    return (
+      <div className="op-card op-ask-question op-ask-question-locked op-ask-question-streaming" data-testid="ask-user-question" aria-busy>
+        <div className="op-card-head">
+          <span className="op-icon" aria-hidden>?</span>
+          <span className="op-title">{t('tool.askQuestion')}</span>
+          <span className="op-ask-question-typing" aria-hidden><i /><i /><i /></span>
+        </div>
+      </div>
+    );
   }
-  return result;
+  return (
+    <div
+      className="op-card op-ask-question op-ask-question-locked op-ask-question-streaming"
+      data-testid="ask-user-question"
+      aria-busy
+    >
+      <div className="op-card-head">
+        <span className="op-icon" aria-hidden>?</span>
+        <span className="op-title">{t('tool.askQuestion')}</span>
+        <span className="op-ask-question-typing" aria-hidden><i /><i /><i /></span>
+      </div>
+      <div className="op-ask-question-body">
+        {/* Positional keys: the prompt/label strings are themselves growing
+            token-by-token, so keying on them would remount each field/option
+            every delta and replay the reveal. Questions and options only
+            append during streaming, so the index is stable and each node
+            mounts once and updates its text in place. */}
+        {questions.map((q, qi) => (
+          <div key={qi} className="op-ask-question-field">
+            {q.header ? <div className="op-ask-question-header">{q.header}</div> : null}
+            <div className="op-ask-question-prompt">{q.question}</div>
+            <div className="op-ask-question-options">
+              {q.options.map((opt, oi) => (
+                <button
+                  key={`${qi}:${oi}`}
+                  type="button"
+                  className="op-ask-question-option"
+                  disabled
+                >
+                  <span className="op-ask-question-option-label">{opt.label}</span>
+                  {opt.description ? (
+                    <span className="op-ask-question-option-desc">{opt.description}</span>
+                  ) : null}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 function AskUserQuestionCard({
@@ -664,13 +703,13 @@ function GrepCard({ input, result, runStreaming, runSucceeded }: { input: unknow
   );
 }
 
-function WebFetchCard({ input }: { input: unknown }) {
+function WebFetchCard({ input, result, runStreaming, runSucceeded }: { input: unknown; result?: Props['result']; runStreaming: boolean; runSucceeded: boolean }) {
   const t = useT();
   const obj = (input ?? {}) as { url?: string };
   return (
     <div className="op-card op-web">
       <div className="op-card-head">
-        <span className="op-status op-status-ok"><Icon name="check" size={14} /></span>
+        <ResultBadge result={result} runStreaming={runStreaming} runSucceeded={runSucceeded} />
         <span className="op-title">{t('tool.fetch')}</span>
         <span className="op-meta">{obj.url ?? ''}</span>
       </div>
@@ -678,13 +717,13 @@ function WebFetchCard({ input }: { input: unknown }) {
   );
 }
 
-function WebSearchCard({ input }: { input: unknown }) {
+function WebSearchCard({ input, result, runStreaming, runSucceeded }: { input: unknown; result?: Props['result']; runStreaming: boolean; runSucceeded: boolean }) {
   const t = useT();
   const obj = (input ?? {}) as { query?: string };
   return (
     <div className="op-card op-web">
       <div className="op-card-head">
-        <span className="op-status op-status-ok"><Icon name="check" size={14} /></span>
+        <ResultBadge result={result} runStreaming={runStreaming} runSucceeded={runSucceeded} />
         <span className="op-title">{t('tool.search')}</span>
         <span className="op-meta">{obj.query ?? ''}</span>
       </div>

--- a/apps/web/src/runtime/ask-user-question.ts
+++ b/apps/web/src/runtime/ask-user-question.ts
@@ -1,0 +1,104 @@
+/**
+ * Parsing for Claude's `AskUserQuestion` tool input, in two modes:
+ *
+ *   - parseAskUserQuestionInput — strict. For a *finished* tool_use whose
+ *     input is already a complete object. Drops anything malformed so the
+ *     locked, interactive card never shows half-built options.
+ *
+ *   - parsePartialAskUserQuestion — lenient + truncation-tolerant. For the
+ *     live streaming pass, where the input is the raw JSON *prefix* that grows
+ *     one token at a time (fed from the daemon's `tool_input_delta`). It
+ *     repairs the truncated prefix, then keeps every question that already has
+ *     its prompt text (even with zero options yet) so a question doesn't
+ *     flicker in → out → back in as its options arrive.
+ *
+ * Input shape (per the SDK):
+ *   { questions: [{ question, header, options: [{ label, description }],
+ *     multiSelect }, ...] }
+ * Both parsers accept `options` as an array of objects or of plain strings
+ * to stay tolerant of small protocol drift.
+ */
+import { parsePartialJson } from './partial-json';
+
+// Re-exported so importers/tests of these generic helpers can reach them
+// through this module too.
+export { repairJsonPrefix, parsePartialJson } from './partial-json';
+
+export type AuqOption = { label: string; description?: string };
+export type AuqQuestion = {
+  question: string;
+  header?: string;
+  options: AuqOption[];
+  multiSelect: boolean;
+};
+
+function coerceOptions(raw: unknown): AuqOption[] {
+  if (!Array.isArray(raw)) return [];
+  const options: AuqOption[] = [];
+  for (const opt of raw) {
+    if (typeof opt === 'string') {
+      if (opt) options.push({ label: opt });
+      continue;
+    }
+    if (!opt || typeof opt !== 'object') continue;
+    const o = opt as Record<string, unknown>;
+    const label = typeof o.label === 'string' ? o.label : '';
+    // While streaming, an option object can exist before its label has
+    // finished typing; skip it for now (it reappears once a char lands).
+    if (!label) continue;
+    const description = typeof o.description === 'string' ? o.description : undefined;
+    options.push(description ? { label, description } : { label });
+  }
+  return options;
+}
+
+/**
+ * Strict parser for a finished AskUserQuestion input. Drops questions with no
+ * prompt or no options so the interactive card is always well-formed.
+ */
+export function parseAskUserQuestionInput(input: unknown): AuqQuestion[] {
+  const obj = (input ?? {}) as { questions?: unknown };
+  if (!Array.isArray(obj.questions)) return [];
+  const result: AuqQuestion[] = [];
+  for (const raw of obj.questions) {
+    if (!raw || typeof raw !== 'object') continue;
+    const q = raw as Record<string, unknown>;
+    const question = typeof q.question === 'string' ? q.question : '';
+    if (!question) continue;
+    const header = typeof q.header === 'string' ? q.header : undefined;
+    const multiSelect = q.multiSelect === true;
+    const options = coerceOptions(q.options);
+    if (options.length === 0) continue;
+    result.push({ question, header, options, multiSelect });
+  }
+  return result;
+}
+
+/**
+ * Lenient parser for the streaming pass. Takes the *accumulated raw JSON
+ * buffer* (concatenated `tool_input_delta` fragments), repairs the truncation,
+ * and shapes it — keeping any question that already has prompt text even if
+ * its options have not arrived. The card renders these read-only until the
+ * final tool_use supersedes them.
+ */
+export function parsePartialAskUserQuestion(buf: string): AuqQuestion[] {
+  return shapePartialQuestions(parsePartialJson(buf));
+}
+
+/** Shape an already-parsed (lenient) object into questions. */
+export function shapePartialQuestions(input: unknown): AuqQuestion[] {
+  const obj = (input ?? {}) as { questions?: unknown };
+  if (!Array.isArray(obj.questions)) return [];
+  const result: AuqQuestion[] = [];
+  for (const raw of obj.questions) {
+    if (!raw || typeof raw !== 'object') continue;
+    const q = raw as Record<string, unknown>;
+    const question = typeof q.question === 'string' ? q.question : '';
+    if (!question) continue; // need at least the prompt to show anything
+    const header = typeof q.header === 'string' ? q.header : undefined;
+    const multiSelect = q.multiSelect === true;
+    const options = coerceOptions(q.options);
+    result.push({ question, header, options, multiSelect });
+  }
+  return result;
+}

--- a/apps/web/src/runtime/partial-json.ts
+++ b/apps/web/src/runtime/partial-json.ts
@@ -1,0 +1,94 @@
+/**
+ * Truncation-tolerant JSON parsing for streamed LLM output. Both question
+ * surfaces (the `AskUserQuestion` tool card and the `<question-form>`
+ * discovery form) need to render a JSON *prefix* that grows one token at a
+ * time, so they share this repair pass.
+ *
+ * It deliberately handles only the shapes a streaming model emits — balanced
+ * structure that simply hasn't finished — not arbitrary corruption. Callers
+ * still wrap the `JSON.parse` in try/catch and keep their last good result.
+ */
+
+/**
+ * Repair a truncated JSON prefix into the largest valid JSON text we can
+ * parse, by walking the buffer once to track string/escape state and the
+ * open-container stack, then closing whatever is still open.
+ */
+export function repairJsonPrefix(buf: string): string {
+  const stack: string[] = []; // closers owed, e.g. ['}', ']']
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < buf.length; i++) {
+    const c = buf[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') inStr = true;
+    else if (c === '{') stack.push('}');
+    else if (c === '[') stack.push(']');
+    else if (c === '}' || c === ']') stack.pop();
+  }
+
+  let out = buf;
+  // 1. Close a string cut off mid-value (or mid-key). First neutralize a
+  //    dangling escape at the cut point, otherwise the closing quote would be
+  //    swallowed (`...x\` + `"` → escaped quote) or a partial `\uXXXX` would
+  //    be an invalid escape — either makes JSON.parse fail and collapses the
+  //    live preview. Common in prompts that mention Windows paths, regexes,
+  //    or escaped quotes.
+  if (inStr) {
+    out = out.replace(/\\u[0-9a-fA-F]{0,3}$/, ''); // incomplete \uXXXX
+    if (/(?:^|[^\\])(?:\\\\)*\\$/.test(out)) out = out.slice(0, -1); // lone trailing backslash
+    out += '"';
+  }
+  // 2. Trim trailing structural noise that can't be completed into a value:
+  //    a dangling comma, a `"key":` with no value yet, and an unfinished
+  //    *scalar* value cut mid-token (a partial `true`/`false`/`null`, or a
+  //    number ending on `.`/`e`/sign). Leaving those makes `{… :f}` etc.
+  //    unparseable, collapsing the live preview whenever a literal splits
+  //    across deltas. Each trim leaves a `"key":` / `,` / `[` boundary that
+  //    the next loop iteration cleans up. Complete literals (`true`, `12`,
+  //    `1.5`, `1e3`) are not prefixes of these patterns, so they survive.
+  const valueStart = '([:[,]\\s*)';
+  let prev: string;
+  do {
+    prev = out;
+    out = out.replace(/[,\s]+$/, '');
+    out = out.replace(/"(?:[^"\\]|\\.)*"\s*:\s*$/, ''); // key + colon, no value
+    out = out.replace(new RegExp(`${valueStart}(?:tru|tr|t|fals|fal|fa|f|nul|nu|n)$`), '$1'); // partial bool/null
+    out = out.replace(new RegExp(`${valueStart}-?(?:\\d+\\.?\\d*|\\d*\\.\\d+)?[eE][+-]?$`), '$1'); // dangling exponent
+    out = out.replace(new RegExp(`${valueStart}-?\\d*\\.$`), '$1'); // number ending in '.'
+    out = out.replace(new RegExp(`${valueStart}-$`), '$1'); // lone minus
+    out = out.replace(/"(?:[^"\\]|\\.)*"\s*:\s*$/, ''); // key + colon exposed by the trims above
+    out = out.replace(/[,\s]+$/, '');
+  } while (out !== prev);
+  // A bare trailing key (string with no following colon) only happens when
+  // the *innermost* open container is an object. Drop it so we don't emit
+  // `{"hea"}` which is invalid (key without value).
+  if (stack[stack.length - 1] === '}' && /"(?:[^"\\]|\\.)*"\s*$/.test(out)) {
+    const trimmed = out.replace(/"(?:[^"\\]|\\.)*"\s*$/, '');
+    // Only drop it if what precedes is a container/comma boundary (i.e. the
+    // string really is a pending key, not a completed value like `:"x"`).
+    if (/[{,]\s*$/.test(trimmed)) {
+      out = trimmed.replace(/[,\s]+$/, '');
+    }
+  }
+  // 3. Close every still-open container, innermost first.
+  for (let i = stack.length - 1; i >= 0; i--) out += stack[i];
+  return out;
+}
+
+/** Best-effort parse of a (possibly truncated) JSON prefix. Returns null on
+ *  failure so callers fall back to their last good value. */
+export function parsePartialJson(buf: string): unknown {
+  const trimmed = buf.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(repairJsonPrefix(trimmed));
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/styles/viewer/tools.css
+++ b/apps/web/src/styles/viewer/tools.css
@@ -114,6 +114,50 @@
 .op-ask-question-locked .op-ask-question-option.on .op-ask-question-option-desc {
   color: var(--text-muted);
 }
+
+/*
+ * Streaming state: the tool's input JSON is still arriving token-by-token
+ * (rendered from the live `tool_input_delta` accumulation, before the full
+ * tool_use lands). The card frame paints immediately; each question field and
+ * option mounts the moment its text settles in the partial parse and animates
+ * in once. The live card is replaced by the interactive (persisted) card when
+ * the tool_use completes, so the reveal never replays.
+ */
+@keyframes op-auq-reveal {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: none; }
+}
+.op-ask-question-streaming .op-ask-question-field,
+.op-ask-question-streaming .op-ask-question-option {
+  animation: op-auq-reveal 200ms cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+/* Three pulsing dots standing in for the "still writing" status pill — no
+ * text, so it needs no translation. */
+.op-ask-question-typing {
+  display: inline-flex;
+  gap: 3px;
+  margin-left: auto;
+  align-items: center;
+}
+.op-ask-question-typing i {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  animation: op-auq-typing 1s ease-in-out infinite;
+}
+.op-ask-question-typing i:nth-child(2) { animation-delay: 0.15s; }
+.op-ask-question-typing i:nth-child(3) { animation-delay: 0.3s; }
+@keyframes op-auq-typing {
+  0%, 100% { opacity: 0.25; transform: translateY(0); }
+  50% { opacity: 0.9; transform: translateY(-2px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .op-ask-question-streaming .op-ask-question-field,
+  .op-ask-question-streaming .op-ask-question-option { animation: none; }
+  .op-ask-question-typing i { animation: none; opacity: 0.6; }
+}
+
 .op-meta { color: var(--text-muted); font-size: 11.5px; }
 .op-desc { font-style: italic; }
 .op-path {

--- a/apps/web/tests/artifacts/question-form.test.ts
+++ b/apps/web/tests/artifacts/question-form.test.ts
@@ -160,17 +160,27 @@ describe('parsePartialQuestionForm (true token-by-token streaming)', () => {
     expect(f?.questions).toEqual([]);
   });
 
-  it('keeps the preview form id stable while the body id token streams (no churn)', () => {
-    // No tag attr; the body `id` arrives char-by-char. The preview id must NOT
-    // follow the partial token (which would remount the editable panel and drop
-    // answers) — it stays the stable default until the final parse.
-    for (const buf of [
-      '<question-form>{"id":"d',
-      '<question-form>{"id":"disc',
-      '<question-form>{"id":"discovery-form","questions":[{"id":"a","label":"Q"}]}',
-    ]) {
-      expect(parsePartialQuestionForm(buf)?.id).toBe('discovery');
-    }
+  it('does not adopt a partial body id (no char-by-char churn)', () => {
+    // No tag attr; the body `id` is still arriving — the preview id must NOT
+    // follow the partial token (which would remount the editable panel).
+    expect(parsePartialQuestionForm('<question-form>{"id":"d')?.id).toBe('discovery');
+    expect(parsePartialQuestionForm('<question-form>{"id":"disc')?.id).toBe('discovery');
+  });
+
+  it('adopts the body id once complete so it matches the final parse (no swap remount)', () => {
+    // Once the id string literal is terminated, the preview adopts it — which
+    // is exactly what tryParseForm assigns after the close tag, so there's no
+    // preview→final identity change to remount the panel.
+    const buf = '<question-form>{"id":"discovery-form","questions":[{"id":"a","label":"Q"}]}';
+    expect(parsePartialQuestionForm(buf)?.id).toBe('discovery-form');
+    const seg = splitOnQuestionForms(`${buf}</question-form>`).find((s) => s.kind === 'form');
+    expect(seg && seg.kind === 'form' ? seg.form.id : null).toBe('discovery-form');
+  });
+
+  it('ignores a nested question id when deriving the form id', () => {
+    expect(
+      parsePartialQuestionForm('<question-form>{"questions":[{"id":"platform","label":"P"}')?.id,
+    ).toBe('discovery');
   });
 
   it('does not let a nested question id/description masquerade as form metadata', () => {

--- a/apps/web/tests/artifacts/question-form.test.ts
+++ b/apps/web/tests/artifacts/question-form.test.ts
@@ -160,6 +160,19 @@ describe('parsePartialQuestionForm (true token-by-token streaming)', () => {
     expect(f?.questions).toEqual([]);
   });
 
+  it('keeps the preview form id stable while the body id token streams (no churn)', () => {
+    // No tag attr; the body `id` arrives char-by-char. The preview id must NOT
+    // follow the partial token (which would remount the editable panel and drop
+    // answers) — it stays the stable default until the final parse.
+    for (const buf of [
+      '<question-form>{"id":"d',
+      '<question-form>{"id":"disc',
+      '<question-form>{"id":"discovery-form","questions":[{"id":"a","label":"Q"}]}',
+    ]) {
+      expect(parsePartialQuestionForm(buf)?.id).toBe('discovery');
+    }
+  });
+
   it('does not let a nested question id/description masquerade as form metadata', () => {
     // No form-level id on the tag or top-level body — only a question-level
     // id. The form id must stay the stable fallback, not adopt "platform"

--- a/apps/web/tests/artifacts/question-form.test.ts
+++ b/apps/web/tests/artifacts/question-form.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatFormAnswers, splitOnQuestionForms } from '../../src/artifacts/question-form';
+import {
+  formatFormAnswers,
+  splitOnQuestionForms,
+  parsePartialQuestionForm,
+} from '../../src/artifacts/question-form';
 
 const VALID_BODY = `{
   "questions": [
@@ -121,5 +125,131 @@ describe('splitOnQuestionForms', () => {
     if (out[1]?.kind === 'form') {
       expect(out[1].form.id).toBe('x');
     }
+  });
+});
+
+describe('parsePartialQuestionForm (true token-by-token streaming)', () => {
+  it('surfaces a question before its object closes, then grows its options', () => {
+    const midLabel = '<question-form id="discovery">{"questions":[{"id":"platform","label":"Platform"';
+    expect(parsePartialQuestionForm(midLabel)?.questions.map((q) => q.label)).toEqual(['Platform']);
+
+    const oneOption =
+      '<question-form id="discovery">{"questions":[{"id":"platform","label":"Platform","type":"radio","options":["Mobile"';
+    expect(parsePartialQuestionForm(oneOption)?.questions[0]?.options?.map((o) => o.label)).toEqual([
+      'Mobile',
+    ]);
+
+    const twoOptions =
+      '<question-form id="discovery">{"questions":[{"id":"platform","label":"Platform","type":"radio","options":["Mobile","Desktop"';
+    expect(parsePartialQuestionForm(twoOptions)?.questions[0]?.options?.map((o) => o.label)).toEqual([
+      'Mobile',
+      'Desktop',
+    ]);
+  });
+
+  it('holds back a trailing question until its label exists (no id placeholder flicker)', () => {
+    const buf =
+      '<question-form id="discovery">{"questions":[{"id":"a","label":"First","type":"text"},{"id":"b"';
+    expect(parsePartialQuestionForm(buf)?.questions.map((q) => q.label)).toEqual(['First']);
+  });
+
+  it('reads title/id from the open tag before any question arrives', () => {
+    const f = parsePartialQuestionForm('<question-form id="discovery" title="Quick brief">{"questions":[');
+    expect(f?.id).toBe('discovery');
+    expect(f?.title).toBe('Quick brief');
+    expect(f?.questions).toEqual([]);
+  });
+
+  it('does not let a nested question id/description masquerade as form metadata', () => {
+    // No form-level id on the tag or top-level body — only a question-level
+    // id. The form id must stay the stable fallback, not adopt "platform"
+    // (which would change the live panel's identity mid-stream).
+    const f = parsePartialQuestionForm(
+      '<question-form>{"questions":[{"id":"platform","label":"Platform","description":"nested"',
+    );
+    expect(f?.id).toBe('discovery');
+    expect(f?.description).toBeUndefined();
+    expect(f?.questions.map((q) => q.label)).toEqual(['Platform']);
+  });
+
+  it('keeps streaming through a closed ```json fence before the close tag arrives', () => {
+    // Fenced body fully written, trailing ``` present, but </question-form>
+    // not yet — the preview must stay populated, not drop to empty.
+    const buf =
+      '<question-form id="discovery">```json\n{"questions":[{"id":"a","label":"First","type":"text"}]}\n```';
+    expect(parsePartialQuestionForm(buf)?.questions.map((q) => q.label)).toEqual(['First']);
+  });
+
+  it('keeps streaming while only a partial trailing fence has arrived', () => {
+    const buf =
+      '<question-form id="discovery">```json\n{"questions":[{"id":"a","label":"First","type":"text"}]}\n``';
+    expect(parsePartialQuestionForm(buf)?.questions.map((q) => q.label)).toEqual(['First']);
+  });
+
+  it('does not strip backticks that are content of a label still being typed', () => {
+    // The trailing ``` here is inside an open string value, not a closing
+    // fence — it must survive into the preview, not be trimmed to "Use ".
+    const buf = '<question-form id="discovery">{"questions":[{"id":"a","label":"Use ```';
+    expect(parsePartialQuestionForm(buf)?.questions[0]?.label).toContain('```');
+  });
+
+  it('carries a custom submitLabel through the streaming preview', () => {
+    const buf =
+      '<question-form id="discovery">{"submitLabel":"Generate brief","questions":[{"id":"a","label":"First","type":"text"}';
+    expect(parsePartialQuestionForm(buf)?.submitLabel).toBe('Generate brief');
+  });
+
+  it('keeps already-visible questions when a boolean value is split across deltas', () => {
+    // `required` cut mid-`true` must not drop the question already shown.
+    const buf = '<question-form id="discovery">{"questions":[{"id":"a","label":"Q","required":t';
+    expect(parsePartialQuestionForm(buf)?.questions.map((q) => q.label)).toEqual(['Q']);
+  });
+
+  it('streams a single closed no-id question before the close tag arrives', () => {
+    // The object is complete (its `}` streamed) but has no explicit id and no
+    // `]`/close tag yet. Its fallback id (q1) is already final, so it should
+    // show now rather than waiting for the close tag.
+    const buf = '<question-form id="discovery">{"questions":[{"label":"First","type":"text"}';
+    expect(parsePartialQuestionForm(buf)?.questions.map((q) => q.label)).toEqual(['First']);
+    expect(parsePartialQuestionForm(buf)?.questions.map((q) => q.id)).toEqual(['q1']);
+  });
+
+  it('still holds a no-id question whose object is not yet closed', () => {
+    // Same content but the object is still open (no `}`): it might still gain
+    // an id, so surfacing it now risks an id swap that orphans an answer.
+    const buf = '<question-form id="discovery">{"questions":[{"label":"First","type":"text"';
+    expect(parsePartialQuestionForm(buf)?.questions).toEqual([]);
+  });
+
+  it('holds a label-first question until its canonical id is determinable', () => {
+    // label streamed, the in-flight object has no id yet — surfacing it now
+    // would force a later id swap that orphans an in-progress answer, so it
+    // waits. Once the id streams it appears with the canonical id.
+    const labelFirst = parsePartialQuestionForm(
+      '<question-form id="discovery">{"questions":[{"label":"Platform"',
+    );
+    expect(labelFirst?.questions).toEqual([]);
+    const idLater = parsePartialQuestionForm(
+      '<question-form id="discovery">{"questions":[{"label":"Platform","id":"platform"',
+    );
+    expect(idLater?.questions[0]?.id).toBe('platform');
+  });
+
+  it('gives preview question ids identical to the final parse (no orphaned answers on swap)', () => {
+    const finalIds = (input: string) => {
+      const seg = splitOnQuestionForms(input).find((s) => s.kind === 'form');
+      return seg && seg.kind === 'form' ? seg.form.questions.map((q) => q.id) : [];
+    };
+    // id-bearing question: preview id == final canonical id.
+    const withId =
+      '<question-form id="discovery">{"questions":[{"id":"platform","label":"Platform","type":"radio","options":["A"]}';
+    expect(parsePartialQuestionForm(withId)?.questions.map((q) => q.id)).toEqual(['platform']);
+    expect(finalIds(`${withId}]}</question-form>`)).toEqual(['platform']);
+    // no-id question that has closed (not in-flight): preview falls back to the
+    // same index id the final parse will assign.
+    const noId =
+      '<question-form id="discovery">{"questions":[{"label":"First","type":"text"},{"id":"b"';
+    expect(parsePartialQuestionForm(noId)?.questions.map((q) => q.id)).toEqual(['q1']);
+    expect(finalIds('<question-form id="discovery">{"questions":[{"label":"First","type":"text"}]}</question-form>')).toEqual(['q1']);
   });
 });

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -209,6 +209,35 @@ describe('AssistantMessage feedback gate', () => {
   });
 });
 
+describe('AssistantMessage re-renders on live tool input changes', () => {
+  it('updates the streaming card when only liveToolInput changes (memo includes it)', () => {
+    // Same message object across renders — only liveToolInput differs, the way
+    // a burst of tool_input_delta arrives. The memo comparator must compare
+    // liveToolInput or the card freezes at its first frame.
+    const message = baseMessage({ content: '', runStatus: 'running', endedAt: undefined, events: [] });
+    const { container, rerender } = render(
+      <AssistantMessage
+        message={message}
+        streaming
+        projectId="proj-1"
+        liveToolInput={{ t1: { name: 'AskUserQuestion', text: '{"questions":[{"question":"Which databa","options":[]}]}', seq: 0 } }}
+      />,
+    );
+    expect(container.querySelector('.op-ask-question-prompt')?.textContent).toBe('Which databa');
+
+    rerender(
+      <AssistantMessage
+        message={message}
+        streaming
+        projectId="proj-1"
+        liveToolInput={{ t1: { name: 'AskUserQuestion', text: '{"questions":[{"question":"Which database?","options":[]}]}', seq: 0 } }}
+      />,
+    );
+    // Re-rendered to the grown prompt rather than frozen at "Which databa".
+    expect(container.querySelector('.op-ask-question-prompt')?.textContent).toBe('Which database?');
+  });
+});
+
 describe('AssistantMessage status badge updates (Bug A)', () => {
   // Regression coverage for the model-badge stale-detail bug. ACP agents
   // emit two `status: 'model'` events per turn:
@@ -507,5 +536,55 @@ describe('AssistantMessage recovered produced files', () => {
     );
 
     expect(screen.getByText('agent-sketch.sketch.json')).toBeTruthy();
+  });
+});
+
+describe('AssistantMessage live AskUserQuestion fallback suppression', () => {
+  it('keeps preamble before a live AskUserQuestion but drops hedging after it', () => {
+    const message = baseMessage({
+      content: '',
+      runStatus: 'running',
+      endedAt: undefined,
+      // event[0] = preamble (before the tool call), event[1] = duplicate
+      // hedging the model emitted after starting the tool call.
+      events: [
+        { kind: 'text', text: 'INTROPREAMBLEXYZ' } as ChatMessage['events'][number],
+        { kind: 'text', text: 'HEDGINGDUPEXYZ' } as ChatMessage['events'][number],
+      ],
+    });
+    const { container } = render(
+      <AssistantMessage
+        message={message}
+        streaming
+        projectId="proj-1"
+        // seq=1 → the tool call started after event[0], so it sits between the
+        // preamble and the hedging.
+        liveToolInput={{
+          t1: {
+            name: 'AskUserQuestion',
+            text: '{"questions":[{"question":"Which database?","options":[{"label":"Postgres"}]}]}',
+            seq: 1,
+          },
+        }}
+      />,
+    );
+    expect(container.querySelector('[data-testid="ask-user-question"]')).not.toBeNull();
+    // Preamble before the card is preserved…
+    expect(container.textContent).toContain('INTROPREAMBLEXYZ');
+    // …hedging after the card is suppressed.
+    expect(container.textContent).not.toContain('HEDGINGDUPEXYZ');
+  });
+
+  it('keeps assistant prose when no live AskUserQuestion is present', () => {
+    const message = baseMessage({
+      content: '',
+      runStatus: 'running',
+      endedAt: undefined,
+      events: [{ kind: 'text', text: 'UNIQUENORMALPROSEXYZ' } as ChatMessage['events'][number]],
+    });
+    const { container } = render(
+      <AssistantMessage message={message} streaming projectId="proj-1" />,
+    );
+    expect(container.textContent).toContain('UNIQUENORMALPROSEXYZ');
   });
 });

--- a/apps/web/tests/components/StreamingAskUserQuestionCard.test.tsx
+++ b/apps/web/tests/components/StreamingAskUserQuestionCard.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { StreamingAskUserQuestionCard } from '../../src/components/ToolCard';
+
+afterEach(() => cleanup());
+
+describe('StreamingAskUserQuestionCard key stability', () => {
+  it('keeps the same field/option DOM nodes as the prompt grows token-by-token', () => {
+    // Successive streamed prefixes of the same tool input.
+    const p1 = '{"questions":[{"question":"Which databa","options":[{"label":"Postgr"}]}]}';
+    const p2 = '{"questions":[{"question":"Which database?","options":[{"label":"Postgres"}]}]}';
+
+    const { container, rerender } = render(<StreamingAskUserQuestionCard raw={p1} />);
+    const field1 = container.querySelector('.op-ask-question-field');
+    const option1 = container.querySelector('.op-ask-question-option');
+    expect(field1).not.toBeNull();
+    expect(option1).not.toBeNull();
+    // text reflects the early prefix
+    expect(container.querySelector('.op-ask-question-prompt')?.textContent).toBe('Which databa');
+
+    rerender(<StreamingAskUserQuestionCard raw={p2} />);
+    const field2 = container.querySelector('.op-ask-question-field');
+    const option2 = container.querySelector('.op-ask-question-option');
+
+    // Positional keys mean React updates these nodes in place rather than
+    // remounting them (which would replay the reveal every token).
+    expect(field2).toBe(field1);
+    expect(option2).toBe(option1);
+    // …and the text updated in place to the longer prefix.
+    expect(container.querySelector('.op-ask-question-prompt')?.textContent).toBe('Which database?');
+    expect(container.querySelector('.op-ask-question-option-label')?.textContent).toBe('Postgres');
+  });
+});

--- a/apps/web/tests/components/buffered-text-pending.test.tsx
+++ b/apps/web/tests/components/buffered-text-pending.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createBufferedTextUpdates } from '../../src/components/ProjectView';
+import type { ChatMessage } from '../../src/types';
+
+// Covers the mechanism the live-tool `seq` fix relies on: text appended via
+// `appendTextEvent` is buffered and not committed to `message.events` until a
+// flush. If a tool's first `input_json_delta` arrives in the same burst as the
+// preamble (before the rAF/250ms flush), `events.length` undercounts the
+// preamble by one — so the seq computation adds `hasPendingText() ? 1 : 0`.
+describe('createBufferedTextUpdates pending text accounting', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('reports buffered text until it is flushed into a single event', () => {
+    // No-op the scheduled flush so only the explicit flush() commits.
+    vi.stubGlobal('requestAnimationFrame', () => 0);
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+
+    let msg = { events: [] } as unknown as ChatMessage;
+    const buf = createBufferedTextUpdates({
+      updateMessage: (u) => {
+        msg = u(msg);
+      },
+      persistSoon: () => {},
+    });
+
+    expect(buf.hasPendingText()).toBe(false);
+
+    buf.appendTextEvent('intro preamble');
+    // Buffered — not yet a committed event, so events.length still 0.
+    expect(buf.hasPendingText()).toBe(true);
+    expect(msg.events?.length ?? 0).toBe(0);
+
+    buf.flush();
+    // Committed as exactly one text event; nothing pending now.
+    expect(buf.hasPendingText()).toBe(false);
+    expect(msg.events?.length).toBe(1);
+    expect(msg.events?.[0]).toMatchObject({ kind: 'text', text: 'intro preamble' });
+
+    buf.cancel();
+  });
+});

--- a/apps/web/tests/runtime/ask-user-question.test.ts
+++ b/apps/web/tests/runtime/ask-user-question.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  repairJsonPrefix,
+  parsePartialJson,
+  parsePartialAskUserQuestion,
+  parseAskUserQuestionInput,
+} from '../../src/runtime/ask-user-question';
+
+const FULL =
+  '{"questions":[{"header":"DB","question":"Which database?","multiSelect":false,"options":[{"label":"Postgres","description":"Relational"},{"label":"SQLite"}]}]}';
+
+describe('repairJsonPrefix', () => {
+  it('closes open containers in a truncated object', () => {
+    expect(JSON.parse(repairJsonPrefix('{"a":1'))).toEqual({ a: 1 });
+    expect(JSON.parse(repairJsonPrefix('{"a":[1,2'))).toEqual({ a: [1, 2] });
+  });
+
+  it('closes a string cut off mid-value', () => {
+    expect(JSON.parse(repairJsonPrefix('{"a":"hel'))).toEqual({ a: 'hel' });
+  });
+
+  it('drops a dangling key with a colon and no value', () => {
+    expect(JSON.parse(repairJsonPrefix('{"a":1,"b":'))).toEqual({ a: 1 });
+  });
+
+  it('drops a bare pending key with no colon', () => {
+    expect(JSON.parse(repairJsonPrefix('{"a":1,"b'))).toEqual({ a: 1 });
+  });
+
+  it('drops a trailing comma', () => {
+    expect(JSON.parse(repairJsonPrefix('[1,2,'))).toEqual([1, 2]);
+  });
+
+  it('does not mistake an escaped quote for the string end', () => {
+    expect(JSON.parse(repairJsonPrefix('{"a":"x\\"y'))).toEqual({ a: 'x"y' });
+  });
+
+  it('leaves complete JSON untouched', () => {
+    expect(JSON.parse(repairJsonPrefix(FULL))).toEqual(JSON.parse(FULL));
+  });
+
+  it('neutralizes a dangling escape inside an open string', () => {
+    expect(JSON.parse(repairJsonPrefix('{"a":"x\\'))).toEqual({ a: 'x' });
+    expect(JSON.parse(repairJsonPrefix('{"a":"x\\u'))).toEqual({ a: 'x' });
+    expect(JSON.parse(repairJsonPrefix('{"a":"x\\u12'))).toEqual({ a: 'x' });
+  });
+
+  it('keeps a completed escape and even backslash runs', () => {
+    expect(JSON.parse(repairJsonPrefix('{"a":"x\\u0041'))).toEqual({ a: 'xA' });
+    // Windows path mid-stream: escaped backslashes are complete pairs.
+    expect(JSON.parse(repairJsonPrefix('{"a":"C:\\\\Users\\\\foo'))).toEqual({ a: 'C:\\Users\\foo' });
+    // A lone trailing backslash (odd run) is the incomplete one — drop it.
+    expect(JSON.parse(repairJsonPrefix('{"a":"C:\\\\Users\\'))).toEqual({ a: 'C:\\Users' });
+  });
+
+  it('drops an unfinished scalar value cut mid-token', () => {
+    expect(JSON.parse(repairJsonPrefix('{"a":f'))).toEqual({});
+    expect(JSON.parse(repairJsonPrefix('{"a":tru'))).toEqual({});
+    expect(JSON.parse(repairJsonPrefix('{"a":nul'))).toEqual({});
+    expect(JSON.parse(repairJsonPrefix('{"a":true,"b":f'))).toEqual({ a: true });
+    expect(JSON.parse(repairJsonPrefix('{"a":1.'))).toEqual({});
+    expect(JSON.parse(repairJsonPrefix('{"a":1e'))).toEqual({});
+    expect(JSON.parse(repairJsonPrefix('{"a":-'))).toEqual({});
+    expect(JSON.parse(repairJsonPrefix('{"a":[1,2,f'))).toEqual({ a: [1, 2] });
+  });
+
+  it('keeps complete scalar literals (not prefixes of the partial patterns)', () => {
+    expect(JSON.parse(repairJsonPrefix('{"a":true'))).toEqual({ a: true });
+    expect(JSON.parse(repairJsonPrefix('{"a":false'))).toEqual({ a: false });
+    expect(JSON.parse(repairJsonPrefix('{"a":null'))).toEqual({ a: null });
+    expect(JSON.parse(repairJsonPrefix('{"a":12'))).toEqual({ a: 12 });
+    expect(JSON.parse(repairJsonPrefix('{"a":1.5'))).toEqual({ a: 1.5 });
+    expect(JSON.parse(repairJsonPrefix('{"a":1e3'))).toEqual({ a: 1000 });
+    // a string value that merely starts like a literal must not be touched
+    expect(JSON.parse(repairJsonPrefix('{"a":"f'))).toEqual({ a: 'f' });
+  });
+});
+
+describe('parsePartialJson', () => {
+  it('returns null for empty / unparseable input', () => {
+    expect(parsePartialJson('')).toBeNull();
+    expect(parsePartialJson('   ')).toBeNull();
+  });
+});
+
+describe('parsePartialAskUserQuestion (token-by-token stability)', () => {
+  it('keeps a question as soon as its prompt text exists, before options arrive', () => {
+    const buf = '{"questions":[{"header":"DB","question":"Which database?"';
+    const qs = parsePartialAskUserQuestion(buf);
+    expect(qs).toHaveLength(1);
+    expect(qs[0]).toMatchObject({ question: 'Which database?', header: 'DB', options: [] });
+  });
+
+  it('does not surface a question before its prompt has any text', () => {
+    expect(parsePartialAskUserQuestion('{"questions":[{"header":"DB"')).toHaveLength(0);
+    expect(parsePartialAskUserQuestion('{"questions":[{"header":"DB","question":""')).toHaveLength(0);
+  });
+
+  it('grows options as they stream in, skipping a half-typed label', () => {
+    const afterFirst = parsePartialAskUserQuestion(
+      '{"questions":[{"question":"Q","options":[{"label":"Postgres"},{"label":"SQ',
+    );
+    expect(afterFirst[0]?.options.map((o) => o.label)).toEqual(['Postgres', 'SQ']);
+
+    const labelNotYetStarted = parsePartialAskUserQuestion(
+      '{"questions":[{"question":"Q","options":[{"label":"Postgres"},{"lab',
+    );
+    expect(labelNotYetStarted[0]?.options.map((o) => o.label)).toEqual(['Postgres']);
+  });
+
+  it('does not collapse when a boolean value is split across deltas', () => {
+    // `multiSelect` cut mid-`false` used to make the whole prefix unparseable.
+    const qs = parsePartialAskUserQuestion('{"questions":[{"question":"Q","multiSelect":f');
+    expect(qs.map((q) => q.question)).toEqual(['Q']);
+  });
+
+  it('does not collapse mid-stream on a prompt ending in a dangling escape', () => {
+    // A question mentioning a Windows path, cut right after a backslash, used
+    // to make the repaired JSON invalid and drop the whole preview to [].
+    const qs = parsePartialAskUserQuestion('{"questions":[{"question":"Edit C:\\');
+    expect(qs).toHaveLength(1);
+    expect(qs[0]?.question).toBe('Edit C:');
+  });
+
+  it('monotonically converges to the strict parse at completion', () => {
+    let sawPrompt = false;
+    for (let i = 1; i <= FULL.length; i++) {
+      const qs = parsePartialAskUserQuestion(FULL.slice(0, i));
+      if (qs.length > 0 && qs[0]!.question === 'Which database?') sawPrompt = true;
+      if (sawPrompt && qs.length > 0) {
+        expect('Which database?'.startsWith(qs[0]!.question) || qs[0]!.question === 'Which database?').toBe(true);
+      }
+    }
+    expect(parsePartialAskUserQuestion(FULL)).toEqual(parseAskUserQuestionInput(JSON.parse(FULL)));
+  });
+});

--- a/apps/web/tests/runtime/tool-renderers.test.tsx
+++ b/apps/web/tests/runtime/tool-renderers.test.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { ToolCard } from '../../src/components/ToolCard';
+import { ToolCard, StreamingAskUserQuestionCard } from '../../src/components/ToolCard';
 import {
   clearToolRenderers,
   deriveToolStatus,
@@ -223,5 +223,27 @@ describe('ToolCard dispatch', () => {
 
     expect(markup).toContain('C:\\repo\\canvas2-nodes.jsx');
     expect(markup).toContain('String to replace was not found');
+  });
+});
+
+describe('StreamingAskUserQuestionCard', () => {
+  it('renders partial questions read-only from a truncated raw JSON prefix', () => {
+    // Mid-stream: prompt + one option arrived, object not yet closed.
+    const raw = '{"questions":[{"header":"DB","question":"Which database?","options":[{"label":"Postgres"}';
+    const markup = renderToStaticMarkup(<StreamingAskUserQuestionCard raw={raw} />);
+    expect(markup).toContain('op-ask-question-streaming');
+    expect(markup).toContain('Which database?');
+    expect(markup).toContain('Postgres');
+    // Read-only: options are disabled and there is no submit affordance.
+    expect(markup).toContain('disabled=""');
+    expect(markup).not.toContain('op-ask-question-submit');
+    expect(markup).toContain('op-ask-question-typing');
+  });
+
+  it('shows a frame-only card before any question prompt has arrived', () => {
+    const markup = renderToStaticMarkup(<StreamingAskUserQuestionCard raw={'{"questions":[{'} />);
+    expect(markup).toContain('op-ask-question-streaming');
+    expect(markup).toContain('op-ask-question-typing');
+    expect(markup).not.toContain('op-ask-question-field');
   });
 });


### PR DESCRIPTION
Cherry-pick of #3582 (merged to `main` as `6e10fa485`) into `release/v0.10.0`, so token-by-token question streaming ships in v0.10.0 as well as main.

- Original PR: #3582 (approved + merged to main after a full review pass).
- `git cherry-pick -x` applied cleanly onto `release/v0.10.0` (no conflicts); records `(cherry picked from commit 6e10fa485…)`.
- Same diff as the merged main commit (14 files); all the review follow-ups (#3582's 16 rounds) are included.

What it does: both agent question surfaces render as they generate — the Claude `AskUserQuestion` card grows from the live `tool_input_delta` stream, and `<question-form>` discovery questions appear as their fields settle — instead of popping in only once the whole payload finishes.

CI validates against the release base here.