### PR TITLE
fix(web): route project file links to workspace tabs

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -649,6 +649,7 @@ function AssistantMessageImpl({
                   onSubmitForm?.(text);
                 }}
                 onOpenQuestions={onOpenQuestions}
+                projectId={projectId}
                 projectFileNames={projectFileNames}
                 onRequestOpenFile={onRequestOpenFile}
               />
@@ -1889,6 +1890,7 @@ function ProseBlock({
   suppressDirectionForms,
   onSubmitForm,
   onOpenQuestions,
+  projectId,
   projectFileNames,
   onRequestOpenFile,
 }: {
@@ -1901,6 +1903,7 @@ function ProseBlock({
   suppressDirectionForms: boolean;
   onSubmitForm: (formId: string, text: string) => void;
   onOpenQuestions?: () => void;
+  projectId?: string | null;
   projectFileNames?: Set<string>;
   onRequestOpenFile?: (name: string) => void;
 }) {
@@ -1934,12 +1937,12 @@ function ProseBlock({
   const onLinkClick = useMemo<MarkdownLinkClickHandler | undefined>(() => {
     if (!onRequestOpenFile) return undefined;
     return (href, event) => {
-      const path = asInProjectFilePath(href, projectFileNames);
+      const path = asInProjectFilePath(href, projectFileNames, projectId);
       if (!path) return;
       event.preventDefault();
       onRequestOpenFile(path);
     };
-  }, [onRequestOpenFile, projectFileNames]);
+  }, [onRequestOpenFile, projectFileNames, projectId]);
   // Each text segment is further split on `<system-reminder>` blocks so
   // those render as their own collapsible chip instead of raw markup.
   const renderable = segments.flatMap(

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -649,6 +649,7 @@ function AssistantMessageImpl({
                   onSubmitForm?.(text);
                 }}
                 onOpenQuestions={onOpenQuestions}
+                projectFileNames={projectFileNames}
                 onRequestOpenFile={onRequestOpenFile}
               />
             );
@@ -1888,6 +1889,7 @@ function ProseBlock({
   suppressDirectionForms,
   onSubmitForm,
   onOpenQuestions,
+  projectFileNames,
   onRequestOpenFile,
 }: {
   text: string;
@@ -1899,6 +1901,7 @@ function ProseBlock({
   suppressDirectionForms: boolean;
   onSubmitForm: (formId: string, text: string) => void;
   onOpenQuestions?: () => void;
+  projectFileNames?: Set<string>;
   onRequestOpenFile?: (name: string) => void;
 }) {
   const t = useT();
@@ -1931,12 +1934,12 @@ function ProseBlock({
   const onLinkClick = useMemo<MarkdownLinkClickHandler | undefined>(() => {
     if (!onRequestOpenFile) return undefined;
     return (href, event) => {
-      const path = asInProjectFilePath(href);
+      const path = asInProjectFilePath(href, projectFileNames);
       if (!path) return;
       event.preventDefault();
       onRequestOpenFile(path);
     };
-  }, [onRequestOpenFile]);
+  }, [onRequestOpenFile, projectFileNames]);
   // Each text segment is further split on `<system-reminder>` blocks so
   // those render as their own collapsible chip instead of raw markup.
   const renderable = segments.flatMap(

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -691,11 +691,7 @@ export function FileWorkspace({
       setActiveTab(name);
       return;
     }
-    onTabsStateChange(workspaceTabsState(
-      persistedTabs.includes(name) ? persistedTabs : [...persistedTabs, name],
-      name,
-    ));
-    setActiveTab(name);
+    openFile(name);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openRequest]);
 
@@ -724,7 +720,8 @@ export function FileWorkspace({
     // resolves a new terminal/side-chat id), so the closure could be stale and
     // clobber tabs added in the meantime.
     const currentTabs = tabsStateRef.current.tabs;
-    const nextTabs = currentTabs.includes(name) ? currentTabs : [...currentTabs, name];
+    const alreadyOpen = currentTabs.includes(name);
+    const nextTabs = alreadyOpen ? currentTabs : [...currentTabs, name];
     commitTabsState(workspaceTabsState(nextTabs, name));
     setActiveTab(name);
   }

--- a/apps/web/src/runtime/in-project-link.ts
+++ b/apps/web/src/runtime/in-project-link.ts
@@ -18,14 +18,18 @@
 export function asInProjectFilePath(
   href: string | null | undefined,
   projectFileNames?: ReadonlySet<string>,
+  projectId?: string | null,
 ): string | null {
   if (typeof href !== 'string') return null;
   const trimmed = href.trim();
   if (!trimmed) return null;
   if (trimmed.startsWith('#')) return null;
   const normalizedHref = normalizeSameOriginHref(trimmed);
-  const appRoutePath = extractAppProjectFilePath(normalizedHref);
-  if (appRoutePath) return normalizeProjectFilePath(appRoutePath);
+  const appRoute = extractAppProjectFileRoute(normalizedHref);
+  if (appRoute) {
+    if (projectId && appRoute.projectId !== projectId) return null;
+    return normalizeProjectFilePath(appRoute.filePath);
+  }
   const knownProjectFilePath = matchKnownProjectFilePath(normalizedHref, projectFileNames);
   if (knownProjectFilePath) return knownProjectFilePath;
   // RFC 3986 scheme: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) followed by `:`.
@@ -52,20 +56,37 @@ function normalizeSameOriginHref(href: string): string {
   }
 }
 
-function extractAppProjectFilePath(href: string): string | null {
+interface AppProjectFileRoute {
+  projectId: string;
+  filePath: string;
+}
+
+function extractAppProjectFileRoute(href: string): AppProjectFileRoute | null {
   const withoutHash = href.split('#')[0] ?? href;
   const withoutQuery = withoutHash.split('?')[0] ?? withoutHash;
   const patterns = [
-    /^\/api\/projects\/[^/]+\/raw\/(.+)$/i,
-    /^\/api\/projects\/[^/]+\/files\/(.+)$/i,
-    /^\/projects\/[^/]+\/files\/(.+)$/i,
-    /^\/projects\/[^/]+\/conversations\/[^/]+\/files\/(.+)$/i,
+    /^\/api\/projects\/([^/]+)\/raw\/(.+)$/i,
+    /^\/api\/projects\/([^/]+)\/files\/(.+)$/i,
+    /^\/projects\/([^/]+)\/files\/(.+)$/i,
+    /^\/projects\/([^/]+)\/conversations\/[^/]+\/files\/(.+)$/i,
   ];
   for (const pattern of patterns) {
     const match = pattern.exec(withoutQuery);
-    if (match?.[1]) return match[1];
+    if (!match?.[1] || !match[2]) continue;
+    return {
+      projectId: decodeRouteSegment(match[1]),
+      filePath: match[2],
+    };
   }
   return null;
+}
+
+function decodeRouteSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
 }
 
 function matchKnownProjectFilePath(

--- a/apps/web/src/runtime/in-project-link.ts
+++ b/apps/web/src/runtime/in-project-link.ts
@@ -15,11 +15,19 @@
  * Returns the normalized file path when the href looks like an
  * in-project link, or `null` to let the default link behavior win.
  */
-export function asInProjectFilePath(href: string | null | undefined): string | null {
+export function asInProjectFilePath(
+  href: string | null | undefined,
+  projectFileNames?: ReadonlySet<string>,
+): string | null {
   if (typeof href !== 'string') return null;
   const trimmed = href.trim();
   if (!trimmed) return null;
   if (trimmed.startsWith('#')) return null;
+  const normalizedHref = normalizeSameOriginHref(trimmed);
+  const appRoutePath = extractAppProjectFilePath(normalizedHref);
+  if (appRoutePath) return normalizeProjectFilePath(appRoutePath);
+  const knownProjectFilePath = matchKnownProjectFilePath(normalizedHref, projectFileNames);
+  if (knownProjectFilePath) return knownProjectFilePath;
   // RFC 3986 scheme: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) followed by `:`.
   // Catches http:, https:, mailto:, file:, od:, blob:, javascript:, etc.
   if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null;
@@ -29,9 +37,56 @@ export function asInProjectFilePath(href: string | null | undefined): string | n
   // project root. Cheaper and safer than full path normalization, and
   // assistant chat output never emits `..` for legitimate file refs.
   if (stripped.split('/').some((segment) => segment === '..')) return null;
+  return normalizeProjectFilePath(stripped);
+}
+
+function normalizeSameOriginHref(href: string): string {
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(href)) return href;
+  if (typeof window === 'undefined' || !window.location?.origin) return href;
+  try {
+    const url = new URL(href);
+    if (url.origin !== window.location.origin) return href;
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return href;
+  }
+}
+
+function extractAppProjectFilePath(href: string): string | null {
+  const withoutHash = href.split('#')[0] ?? href;
+  const withoutQuery = withoutHash.split('?')[0] ?? withoutHash;
+  const patterns = [
+    /^\/api\/projects\/[^/]+\/raw\/(.+)$/i,
+    /^\/api\/projects\/[^/]+\/files\/(.+)$/i,
+    /^\/projects\/[^/]+\/files\/(.+)$/i,
+    /^\/projects\/[^/]+\/conversations\/[^/]+\/files\/(.+)$/i,
+  ];
+  for (const pattern of patterns) {
+    const match = pattern.exec(withoutQuery);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
+
+function matchKnownProjectFilePath(
+  href: string,
+  projectFileNames: ReadonlySet<string> | undefined,
+): string | null {
+  if (!projectFileNames || projectFileNames.size === 0) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return null;
+  const normalized = normalizeProjectFilePath(href);
+  if (!normalized) return null;
+  if (projectFileNames.has(normalized)) return normalized;
+  const matches = Array.from(projectFileNames)
+    .filter((name) => normalized === name || normalized.endsWith(`/${name}`))
+    .sort((a, b) => b.length - a.length);
+  return matches[0] ?? null;
+}
+
+function normalizeProjectFilePath(path: string): string | null {
   // Strip query and fragment — the workspace tab opener takes a file
   // path, not a URL.
-  const withoutHash = stripped.split('#')[0] ?? stripped;
+  const withoutHash = path.split('#')[0] ?? path;
   const withoutQuery = withoutHash.split('?')[0] ?? withoutHash;
   if (!withoutQuery) return null;
   // Chat markdown emits links as URL-encoded text (`Mock%20Page.html`

--- a/apps/web/tests/components/AssistantMessage.linkClick.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.linkClick.test.tsx
@@ -98,6 +98,28 @@ describe('AssistantMessage — chat file-link routing (#1239)', () => {
     expect(clickEvent.defaultPrevented).toBe(true);
   });
 
+  it('does not route app file URLs for a different project through the current workspace opener', () => {
+    const onRequestOpenFile = vi.fn();
+    const { container } = render(
+      <AssistantMessage
+        message={messageWithText('Open [index.html](/projects/other-project/files/index.html).')}
+        streaming={false}
+        projectId="project-1"
+        projectFileNames={new Set(['index.html'])}
+        onRequestOpenFile={onRequestOpenFile}
+      />,
+    );
+
+    const anchor = container.querySelector('a.md-link');
+    expect(anchor).not.toBeNull();
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor!.dispatchEvent(clickEvent);
+
+    expect(onRequestOpenFile).not.toHaveBeenCalled();
+    expect(clickEvent.defaultPrevented).toBe(false);
+  });
+
   it('routes same-origin absolute project raw URLs through onRequestOpenFile', () => {
     const onRequestOpenFile = vi.fn();
     const href = `${window.location.origin}/api/projects/project-1/raw/Web%20Prototype%20mutuals-v2.html`;

--- a/apps/web/tests/components/AssistantMessage.linkClick.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.linkClick.test.tsx
@@ -75,6 +75,77 @@ describe('AssistantMessage — chat file-link routing (#1239)', () => {
     expect(onRequestOpenFile).toHaveBeenCalledWith('subdir/hero.html');
   });
 
+  it('routes project raw file URLs through onRequestOpenFile instead of opening a new window', () => {
+    const onRequestOpenFile = vi.fn();
+    const { container } = render(
+      <AssistantMessage
+        message={messageWithText('Open [mutuals-v2.html](/api/projects/project-1/raw/mutuals-v2.html).')}
+        streaming={false}
+        projectId="project-1"
+        onRequestOpenFile={onRequestOpenFile}
+      />,
+    );
+
+    const anchor = container.querySelector('a.md-link');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toBe('/api/projects/project-1/raw/mutuals-v2.html');
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor!.dispatchEvent(clickEvent);
+
+    expect(onRequestOpenFile).toHaveBeenCalledTimes(1);
+    expect(onRequestOpenFile).toHaveBeenCalledWith('mutuals-v2.html');
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+
+  it('routes same-origin absolute project raw URLs through onRequestOpenFile', () => {
+    const onRequestOpenFile = vi.fn();
+    const href = `${window.location.origin}/api/projects/project-1/raw/Web%20Prototype%20mutuals-v2.html`;
+    const { container } = render(
+      <AssistantMessage
+        message={messageWithText(`Open [Web Prototype mutuals-v2.html](${href}).`)}
+        streaming={false}
+        projectId="project-1"
+        onRequestOpenFile={onRequestOpenFile}
+      />,
+    );
+
+    const anchor = container.querySelector('a.md-link');
+    expect(anchor).not.toBeNull();
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor!.dispatchEvent(clickEvent);
+
+    expect(onRequestOpenFile).toHaveBeenCalledTimes(1);
+    expect(onRequestOpenFile).toHaveBeenCalledWith('Web Prototype mutuals-v2.html');
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+
+  it('routes local absolute paths that match project files through onRequestOpenFile', () => {
+    const onRequestOpenFile = vi.fn();
+    const { container } = render(
+      <AssistantMessage
+        message={messageWithText(
+          '已完成单文件原型：[index.html](/Users/mac/open-design/open-design-preview-0.10.0/projects/Web%20Prototype/index.html)。',
+        )}
+        streaming={false}
+        projectId="project-1"
+        projectFileNames={new Set(['index.html'])}
+        onRequestOpenFile={onRequestOpenFile}
+      />,
+    );
+
+    const anchor = container.querySelector('a.md-link');
+    expect(anchor).not.toBeNull();
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor!.dispatchEvent(clickEvent);
+
+    expect(onRequestOpenFile).toHaveBeenCalledTimes(1);
+    expect(onRequestOpenFile).toHaveBeenCalledWith('index.html');
+    expect(clickEvent.defaultPrevented).toBe(true);
+  });
+
   it('does not intercept external https:// URLs — preserves default target="_blank" behavior', () => {
     const onRequestOpenFile = vi.fn();
     const { container } = render(

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -880,6 +880,34 @@ describe('FileWorkspace launcher tab creation', () => {
       });
     });
   });
+
+  it('focuses an already-open file tab without adding a duplicate tab', async () => {
+    const onTabsStateChange = vi.fn();
+
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[workspaceFile('Web Prototype mutuals-v2.html')]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{
+          tabs: ['Web Prototype mutuals-v2.html'],
+          active: 'notes.html',
+        }}
+        openRequest={{ name: 'Web Prototype mutuals-v2.html', nonce: 1 }}
+        onTabsStateChange={onTabsStateChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onTabsStateChange).toHaveBeenCalledWith({
+        tabs: ['Web Prototype mutuals-v2.html'],
+        active: 'Web Prototype mutuals-v2.html',
+      });
+    });
+  });
 });
 
 describe('FileWorkspace generation failure recovery', () => {

--- a/apps/web/tests/runtime/in-project-link.test.ts
+++ b/apps/web/tests/runtime/in-project-link.test.ts
@@ -72,6 +72,14 @@ describe('asInProjectFilePath', () => {
       expect(asInProjectFilePath('/api/projects/project-1/raw/mutuals-v2.html')).toBe('mutuals-v2.html');
     });
 
+    it('extracts project raw file URLs only when the route project matches the current project', () => {
+      expect(asInProjectFilePath('/api/projects/project-1/raw/mutuals-v2.html', undefined, 'project-1')).toBe(
+        'mutuals-v2.html',
+      );
+      expect(asInProjectFilePath('/api/projects/other-project/raw/index.html', new Set(['index.html']), 'project-1'))
+        .toBeNull();
+    });
+
     it('extracts same-origin absolute project raw file URLs', () => {
       expect(asInProjectFilePath(`${window.location.origin}/api/projects/project-1/raw/mutuals-v2.html`)).toBe(
         'mutuals-v2.html',
@@ -107,6 +115,14 @@ describe('asInProjectFilePath', () => {
       expect(asInProjectFilePath('/projects/project-1/conversations/conv-1/files/mutuals-v2.html')).toBe(
         'mutuals-v2.html',
       );
+    });
+
+    it('extracts workspace file routes only when the route project matches the current project', () => {
+      expect(asInProjectFilePath('/projects/project-1/files/mutuals-v2.html', undefined, 'project-1')).toBe(
+        'mutuals-v2.html',
+      );
+      expect(asInProjectFilePath('/projects/other-project/files/index.html', new Set(['index.html']), 'project-1'))
+        .toBeNull();
     });
 
     it('returns null for malformed percent-encoding rather than throwing', () => {

--- a/apps/web/tests/runtime/in-project-link.test.ts
+++ b/apps/web/tests/runtime/in-project-link.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { describe, expect, it } from 'vitest';
 import { asInProjectFilePath } from '../../src/runtime/in-project-link';
 
@@ -64,6 +66,47 @@ describe('asInProjectFilePath', () => {
       // correctly; the catch arm below keeps malformed encodings
       // from throwing.
       expect(asInProjectFilePath('%E9%A6%96%E9%A1%B5.html')).toBe('首页.html');
+    });
+
+    it('extracts project raw file URLs produced by assistant file links', () => {
+      expect(asInProjectFilePath('/api/projects/project-1/raw/mutuals-v2.html')).toBe('mutuals-v2.html');
+    });
+
+    it('extracts same-origin absolute project raw file URLs', () => {
+      expect(asInProjectFilePath(`${window.location.origin}/api/projects/project-1/raw/mutuals-v2.html`)).toBe(
+        'mutuals-v2.html',
+      );
+    });
+
+    it('matches local absolute paths against known project files', () => {
+      expect(
+        asInProjectFilePath(
+          '/Users/mac/open-design/open-design-preview-0.10.0/projects/Web%20Prototype/index.html',
+          new Set(['index.html']),
+        ),
+      ).toBe('index.html');
+    });
+
+    it('keeps unknown local absolute paths as normal links', () => {
+      expect(
+        asInProjectFilePath(
+          '/Users/mac/open-design/open-design-preview-0.10.0/projects/Web%20Prototype/index.html',
+          new Set(['summary.html']),
+        ),
+      ).toBeNull();
+    });
+
+    it('extracts encoded project raw file paths with nested folders', () => {
+      expect(asInProjectFilePath('/api/projects/project-1/raw/Web%20Prototype/mutuals-v2.html?v=2')).toBe(
+        'Web Prototype/mutuals-v2.html',
+      );
+    });
+
+    it('extracts project file routes from workspace links', () => {
+      expect(asInProjectFilePath('/projects/project-1/files/mutuals-v2.html')).toBe('mutuals-v2.html');
+      expect(asInProjectFilePath('/projects/project-1/conversations/conv-1/files/mutuals-v2.html')).toBe(
+        'mutuals-v2.html',
+      );
     });
 
     it('returns null for malformed percent-encoding rather than throwing', () => {

--- a/e2e/ui/project-file-link-routing.test.ts
+++ b/e2e/ui/project-file-link-routing.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { applyStandardMocks } from '@/playwright/mock-factory';
+import { T } from '@/timeouts';
+
+const ACTIVE_ARTIFACT_PREVIEW_SELECTOR = '[data-testid="artifact-preview-frame"]:visible, [data-testid="artifact-preview-frame-url-load"]:visible, [data-testid="artifact-preview-frame-srcdoc"]:visible, [data-testid="live-artifact-preview-frame"]:visible';
+
+test.describe.configure({ timeout: 30_000 });
+
+test.beforeEach(async ({ page }) => {
+  await applyStandardMocks(page);
+});
+
+test('[P1] assistant project file links open workspace tabs instead of new browser windows', async ({ page }) => {
+  const { projectId, conversationId } = await seedProjectWithAssistantFileLink(page);
+
+  await page.goto(`/projects/${projectId}/conversations/${conversationId}`, { waitUntil: 'domcontentloaded' });
+  await waitForWorkspaceReady(page);
+  await expect(page.getByText('已完成单文件原型：')).toBeVisible();
+
+  const fileTab = page.getByRole('tab', { name: /index\.html/i });
+  await expect(fileTab).toBeVisible();
+  await page.getByTestId('design-files-tab').click();
+  await expect(page.getByTestId('design-files-tab')).toHaveAttribute('aria-selected', 'true');
+
+  const pageCountBefore = page.context().pages().length;
+  const popupPromise = page.waitForEvent('popup', { timeout: 1_000 }).catch(() => null);
+  await page.locator('.msg.assistant a.md-link', { hasText: 'index.html' }).click();
+  const popup = await popupPromise;
+
+  expect(popup).toBeNull();
+  expect(page.context().pages()).toHaveLength(pageCountBefore);
+  await expect(fileTab).toHaveAttribute('aria-selected', 'true');
+  await expect(page.frameLocator(ACTIVE_ARTIFACT_PREVIEW_SELECTOR).getByRole('heading', {
+    name: 'Project file link target',
+  })).toBeVisible();
+});
+
+async function seedProjectWithAssistantFileLink(
+  page: Page,
+): Promise<{ projectId: string; conversationId: string }> {
+  const projectId = `file-link-routing-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const projectResponse = await page.request.post('/api/projects', {
+    data: {
+      id: projectId,
+      name: 'File Link Routing',
+      skillId: null,
+      designSystemId: null,
+      metadata: { kind: 'prototype' },
+    },
+  });
+  expect(projectResponse.ok(), `create project: ${await projectResponse.text()}`).toBeTruthy();
+  const { conversationId } = (await projectResponse.json()) as { conversationId: string };
+
+  const fileResponse = await page.request.post(`/api/projects/${projectId}/files`, {
+    data: {
+      name: 'index.html',
+      content: '<!doctype html><html><body><main><h1>Project file link target</h1></main></body></html>',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'index.html',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    },
+  });
+  expect(fileResponse.ok(), `seed index.html: ${await fileResponse.text()}`).toBeTruthy();
+
+  const localAbsoluteHref = `/Users/mac/open-design/open-design-preview-0.10.0/projects/File%20Link%20Routing/index.html`;
+  const assistantText = `已完成单文件原型：[index.html](${localAbsoluteHref})。`;
+  const assistantResponse = await page.request.put(
+    `/api/projects/${projectId}/conversations/${conversationId}/messages/a-${projectId}`,
+    {
+      data: {
+        role: 'assistant',
+        content: assistantText,
+        runStatus: 'succeeded',
+        events: [{ kind: 'text', text: assistantText }],
+        createdAt: Date.now() - 1_000,
+      },
+    },
+  );
+  expect(assistantResponse.ok(), `seed assistant message: ${await assistantResponse.text()}`).toBeTruthy();
+
+  return { projectId, conversationId };
+}
+
+async function waitForWorkspaceReady(page: Page) {
+  await page.getByText('Loading Open Design…').waitFor({ state: 'hidden', timeout: T.medium }).catch(() => {});
+  await expect(page.getByTestId('chat-composer')).toBeVisible({ timeout: T.medium });
+  await expect(page.getByTestId('file-workspace')).toBeVisible({ timeout: T.medium });
+}


### PR DESCRIPTION
## Summary
- Route assistant project file links through the workspace tab opener instead of browser navigation
- Handle project raw/file routes, same-origin raw URLs, and local absolute paths that match project files
- Reuse existing workspace tabs without opening duplicate browser windows

## Tests
- pnpm test -- tests/runtime/in-project-link.test.ts tests/components/AssistantMessage.linkClick.test.tsx tests/components/FileWorkspace.test.tsx