### PR TITLE
fix(web): preserve failed retry attempts

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2787,7 +2787,7 @@ export function ProjectView({
             )
           : apiProtocolModelLabel(config.apiProtocol, config.model);
       const preTurnFileNames = projectFiles.map((f) => f.name);
-      const assistantId = retryTarget?.failedAssistant.id ?? randomUUID();
+      const assistantId = randomUUID();
       const assistantMsg: ChatMessage = {
         id: assistantId,
         role: 'assistant',
@@ -2795,7 +2795,7 @@ export function ProjectView({
         agentId: assistantAgentId,
         agentName: assistantAgentName,
         events: [],
-        createdAt: retryTarget?.failedAssistant.createdAt ?? startedAt,
+        createdAt: startedAt,
         runStatus: config.mode === 'daemon' ? 'running' : undefined,
         startedAt,
         preTurnFileNames,
@@ -2830,7 +2830,10 @@ export function ProjectView({
       const nextHistory = retryTarget
         ? [...retryTarget.priorMessages, userMsg]
         : [...historyBase, userMsg];
-      setMessages([...nextHistory, assistantMsg]);
+      const nextVisibleMessages = retryTarget
+        ? [...nextHistory, ...retryTarget.preservedAttempts, assistantMsg]
+        : [...nextHistory, assistantMsg];
+      setMessages(nextVisibleMessages);
       markStreamingConversation(runConversationId);
       updateConversationLatestRun(config.mode === 'daemon' ? 'running' : 'queued');
       setArtifact(null);
@@ -5460,6 +5463,7 @@ export interface RetryTarget {
   failedAssistant: ChatMessage;
   userMsg: ChatMessage;
   priorMessages: ChatMessage[];
+  preservedAttempts: ChatMessage[];
 }
 
 export function resolveRetryTarget(
@@ -5474,14 +5478,24 @@ export function resolveRetryTarget(
   );
   if (failedIndex <= 0 || failedIndex !== messages.length - 1) return null;
 
-  const userMsg = messages[failedIndex - 1];
+  let userIndex = failedIndex - 1;
+  while (
+    userIndex >= 0 &&
+    messages[userIndex]?.role === 'assistant' &&
+    messages[userIndex]?.runStatus === 'failed'
+  ) {
+    userIndex -= 1;
+  }
+
+  const userMsg = messages[userIndex];
   const failedAssistant = messages[failedIndex];
   if (!userMsg || userMsg.role !== 'user' || !failedAssistant) return null;
 
   return {
     failedAssistant,
     userMsg,
-    priorMessages: messages.slice(0, failedIndex - 1),
+    priorMessages: messages.slice(0, userIndex),
+    preservedAttempts: messages.slice(userIndex + 1, failedIndex + 1),
   };
 }
 

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -243,6 +243,37 @@ describe('retry target resolution', () => {
       failedAssistant,
       userMsg: userMessage,
       priorMessages: [systemContext],
+      preservedAttempts: [failedAssistant],
+    });
+  });
+
+  it('keeps earlier failed retry attempts visible while reusing the original user turn', () => {
+    const firstFailure: ChatMessage = {
+      ...failedAssistant,
+      id: 'assistant-1',
+      content: 'First attempt produced partial output',
+      events: [{ kind: 'text', text: 'thinking before failure' }],
+      producedFiles: [
+        {
+          name: 'partial.html',
+          kind: 'html',
+          mime: 'text/html',
+          mtime: 1,
+          size: 100,
+        },
+      ],
+    };
+    const secondFailure: ChatMessage = {
+      ...failedAssistant,
+      id: 'assistant-2',
+      content: 'Retry failed too',
+    };
+
+    expect(resolveRetryTarget([userMessage, firstFailure, secondFailure], secondFailure.id)).toEqual({
+      failedAssistant: secondFailure,
+      userMsg: userMessage,
+      priorMessages: [],
+      preservedAttempts: [firstFailure, secondFailure],
     });
   });
 

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -291,6 +291,19 @@ vi.mock('../../src/components/ChatPane', () => ({
             .filter(Boolean)
             .join('\n')}
         </output>
+        <output data-testid="assistant-summary">
+          {(messages ?? [])
+            .filter((message) => message.role === 'assistant')
+            .map((message) =>
+              [
+                message.id,
+                message.runStatus ?? '',
+                message.content,
+                ...(message.producedFiles ?? []).map((file) => file.name),
+              ].join('|'),
+            )
+            .join('\n')}
+        </output>
         <output data-testid="attached-comment-count">{attached.length}</output>
         {queuedItems?.map((item, index) => (
           <button
@@ -1127,6 +1140,57 @@ describe('ProjectView conversation run isolation', () => {
     fireEvent.click(screen.getByTestId('workspace-retry'));
 
     await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
+  });
+
+  it('preserves the failed attempt transcript when retry starts a replacement run', async () => {
+    const userMessage: ChatMessage = {
+      id: 'user-retry',
+      role: 'user',
+      content: 'make an editorial landing page',
+      createdAt: 1,
+    };
+    const failedAssistant: ChatMessage = {
+      id: 'assistant-failed',
+      role: 'assistant',
+      content: 'Partial plan before the crash',
+      createdAt: 2,
+      runStatus: 'failed',
+      events: [{ kind: 'text', text: 'I will build the page' }],
+      producedFiles: [
+        {
+          name: 'partial.html',
+          kind: 'html',
+          mime: 'text/html',
+          mtime: 2,
+          size: 100,
+        },
+      ],
+    };
+    conversationAMessages = [userMessage, failedAssistant];
+    fetchChatRunStatus.mockResolvedValue(null);
+    streamViaDaemon.mockImplementation(async () => {});
+
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('workspace-retry')).toBeTruthy());
+
+    fireEvent.click(screen.getByTestId('workspace-retry'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    const retryCall = streamViaDaemon.mock.calls[0]?.[0] as {
+      assistantMessageId?: string;
+      history?: ChatMessage[];
+    };
+    expect(retryCall.assistantMessageId).toBeTruthy();
+    expect(retryCall.assistantMessageId).not.toBe('assistant-failed');
+    expect(retryCall.history).toEqual([userMessage]);
+
+    await waitFor(() => {
+      const summary = screen.getByTestId('assistant-summary').textContent ?? '';
+      expect(summary).toContain('assistant-failed|failed|Partial plan before the crash|partial.html');
+      expect(summary).toContain(`${retryCall.assistantMessageId}|running|`);
+    });
   });
 
   it('routes workspace authorize recovery through AMR mode switching for structured auth failures', async () => {


### PR DESCRIPTION
## Why

Retrying a failed chat run replaced the failed assistant message in the visible transcript. When an agent failed after producing partial reasoning/output, clicking Retry made that prior output and any produced-file metadata disappear, which matched the release validation report for v0.10.0.

## What users will see

When a failed assistant run is retried, the previous failed attempt remains visible in the conversation. The retry starts as a new assistant attempt below it, using the original user message as daemon history so the model does not receive failed assistant output as prior context.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

E2E recording captured locally at:

`/private/tmp/open-design-retry-recording/retry-e2e-validation.mp4`

The recording shows: blank project -> fake OpenCode selected -> partial output before failure -> Retry -> original failed attempt still visible while the retry creates a second attempt.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ProjectView.run-isolation.test.tsx` (preserves failed attempt transcript on retry) and `apps/web/tests/components/ProjectView.run-cleanup.test.tsx` (retry target resolution across repeated failures).
- Did the test go red on main and green on this branch? Red behavior is encoded in the new focused tests; verified green on this branch.
- Manual E2E: used an isolated `tools-dev` runtime with a temporary fake OpenCode binary that emits partial text and then an OpenCode error frame. Browser validation confirmed the partial text remains visible after clicking Retry.

## Validation

- `pnpm --filter @open-design/web test -- ProjectView.run-isolation.test.tsx`
- `pnpm --filter @open-design/web test -- ProjectView.run-cleanup.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- Browser E2E validation with simulated partial-output failure and retry preservation.
