### PR TITLE
fix(home,daemon): keep mode card on-screen and let plugin authoring pause on a question-form

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11423,7 +11423,33 @@ export async function startServer({
         ? (def.reasoningOptions.find((r) => r.id === reasoning)?.id ?? null)
         : null;
     const agentOptions = { model: safeModel, reasoning: safeReasoning };
+    // Tracks whether the agent emitted a clarifying `<question-form>` in its
+    // visible text this run. The `od-plugin-authoring` plugin's turn-1 flow
+    // is to emit a `<question-form>` collecting the plugin brief, then STOP
+    // and wait for the user to answer (see the `discovery-question-form` atom
+    // in `plugins/scaffold.ts`). That turn legitimately closes with
+    // `code === 0` and no `generated-plugin/` artifacts yet, so the
+    // missing-artifacts guard must not treat it as a failure. We watch the
+    // streamed text rather than the persisted message because the assistant
+    // message row may not be wired up at close time. A small rolling tail
+    // keeps the `<question-form` marker detectable even when it straddles two
+    // `text_delta` chunks.
+    let agentEmittedClarifyingQuestion = false;
+    let clarifyingQuestionTail = '';
     const send = (event, data) => {
+      if (
+        !agentEmittedClarifyingQuestion &&
+        event === 'agent' &&
+        data &&
+        data.type === 'text_delta' &&
+        typeof data.delta === 'string'
+      ) {
+        const combined = clarifyingQuestionTail + data.delta;
+        if (combined.toLowerCase().includes('<question-form')) {
+          agentEmittedClarifyingQuestion = true;
+        }
+        clarifyingQuestionTail = combined.slice(-64);
+      }
       persistRunEventToAssistantMessage(db, run, event, data);
       design.runs.emit(run, event, data);
     };
@@ -13056,7 +13082,8 @@ export async function startServer({
         code === 0 &&
         !run.cancelRequested &&
         isPluginAuthoringRun(db, run) &&
-        !(await hasGeneratedPluginArtifacts(cwd))
+        !(await hasGeneratedPluginArtifacts(cwd)) &&
+        !agentEmittedClarifyingQuestion
       ) {
         send('error', createSseErrorPayload(
           'AGENT_EXECUTION_FAILED',

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11423,7 +11423,7 @@ export async function startServer({
         ? (def.reasoningOptions.find((r) => r.id === reasoning)?.id ?? null)
         : null;
     const agentOptions = { model: safeModel, reasoning: safeReasoning };
-    // Tracks whether the agent emitted a clarifying `<question-form>` in its
+    // Tracks whether the agent emitted a clarifying question form in its
     // visible text this run. The `od-plugin-authoring` plugin's turn-1 flow
     // is to emit a `<question-form>` collecting the plugin brief, then STOP
     // and wait for the user to answer (see the `discovery-question-form` atom
@@ -11432,8 +11432,17 @@ export async function startServer({
     // missing-artifacts guard must not treat it as a failure. We watch the
     // streamed text rather than the persisted message because the assistant
     // message row may not be wired up at close time. A small rolling tail
-    // keeps the `<question-form` marker detectable even when it straddles two
-    // `text_delta` chunks.
+    // keeps the marker detectable even when it straddles two `text_delta`
+    // chunks.
+    //
+    // `<question-form>` is canonical, but the web form parser also accepts
+    // `<ask-question>` as an alias (models drift to it) — see the open-tag
+    // contract in `apps/web/src/artifacts/question-form.ts`. The app boundary
+    // forbids importing that web module here, so we mirror its accepted tag
+    // set; keep the two in sync. Recognizing only the canonical tag would
+    // recreate this exact missing-artifacts failure for an alias form the UI
+    // still renders as a valid brief.
+    const CLARIFYING_QUESTION_TAGS = ['<question-form', '<ask-question'];
     let agentEmittedClarifyingQuestion = false;
     let clarifyingQuestionTail = '';
     const send = (event, data) => {
@@ -11444,8 +11453,8 @@ export async function startServer({
         data.type === 'text_delta' &&
         typeof data.delta === 'string'
       ) {
-        const combined = clarifyingQuestionTail + data.delta;
-        if (combined.toLowerCase().includes('<question-form')) {
+        const combined = (clarifyingQuestionTail + data.delta).toLowerCase();
+        if (CLARIFYING_QUESTION_TAGS.some((tag) => combined.includes(tag))) {
           agentEmittedClarifyingQuestion = true;
         }
         clarifyingQuestionTail = combined.slice(-64);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2546,6 +2546,62 @@ async function hasGeneratedPluginArtifacts(projectRoot) {
   }
 }
 
+// Canonical open tag is `<question-form>`; `<ask-question>` is an accepted
+// alias models drift to. Mirrors the open-tag set in the web parser.
+const QUESTION_FORM_OPEN_RE = /<(question-form|ask-question)\b[^>]*>/i;
+
+// True when `body` is a renderable question-form body: JSON (optionally
+// fenced) parsing to an object with a non-empty `questions` array. This is
+// the minimal contract `tryParseForm` enforces in
+// `apps/web/src/artifacts/question-form.ts`; a body that fails it is kept as
+// raw prose by the UI (no form card renders).
+function questionFormBodyIsRenderable(body) {
+  const trimmed = typeof body === 'string' ? body.trim() : '';
+  if (!trimmed) return false;
+  const stripped = trimmed
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/```\s*$/i, '')
+    .trim();
+  let data;
+  try {
+    data = JSON.parse(stripped);
+  } catch {
+    return false;
+  }
+  if (!data || typeof data !== 'object') return false;
+  const questions = data.questions;
+  return Array.isArray(questions) && questions.some((q) => q && typeof q === 'object');
+}
+
+// Whether the agent's visible text contains a *renderable* clarifying form —
+// a closed `<question-form>`/`<ask-question>` block whose body satisfies the
+// parser contract above. The plugin-authoring missing-artifacts guard treats
+// this as a legitimate "paused to ask the user" turn rather than a failure.
+//
+// We deliberately mirror (not import) the web parser: the app boundary
+// forbids `apps/daemon` importing `apps/web/src`. Matching only the open tag
+// would let a malformed, non-renderable body suppress the failure — a false
+// success with no usable brief card. Keep this in sync with
+// `apps/web/src/artifacts/question-form.ts`, or promote a shared parser into
+// `packages/contracts` if the two drift.
+function emittedRenderableQuestionForm(text) {
+  if (typeof text !== 'string' || !text) return false;
+  const lower = text.toLowerCase();
+  let cursor = 0;
+  while (cursor < text.length) {
+    const m = QUESTION_FORM_OPEN_RE.exec(text.slice(cursor));
+    if (!m) return false;
+    const tagName = (m[1] ?? 'question-form').toLowerCase();
+    const closeTag = `</${tagName}>`;
+    const openEnd = cursor + m.index + m[0].length;
+    const closeIdx = lower.indexOf(closeTag, openEnd);
+    if (closeIdx === -1) return false;
+    if (questionFormBodyIsRenderable(text.slice(openEnd, closeIdx))) return true;
+    cursor = closeIdx + closeTag.length;
+  }
+  return false;
+}
+
 function detectSkillPluginCandidateOnRunSuccess(db, runs, run, input, projectRoot) {
   if (!run.projectId || !run.conversationId) return;
   void runs
@@ -11423,41 +11479,33 @@ export async function startServer({
         ? (def.reasoningOptions.find((r) => r.id === reasoning)?.id ?? null)
         : null;
     const agentOptions = { model: safeModel, reasoning: safeReasoning };
-    // Tracks whether the agent emitted a clarifying question form in its
-    // visible text this run. The `od-plugin-authoring` plugin's turn-1 flow
-    // is to emit a `<question-form>` collecting the plugin brief, then STOP
-    // and wait for the user to answer (see the `discovery-question-form` atom
-    // in `plugins/scaffold.ts`). That turn legitimately closes with
-    // `code === 0` and no `generated-plugin/` artifacts yet, so the
-    // missing-artifacts guard must not treat it as a failure. We watch the
-    // streamed text rather than the persisted message because the assistant
-    // message row may not be wired up at close time. A small rolling tail
-    // keeps the marker detectable even when it straddles two `text_delta`
-    // chunks.
-    //
-    // `<question-form>` is canonical, but the web form parser also accepts
-    // `<ask-question>` as an alias (models drift to it) — see the open-tag
-    // contract in `apps/web/src/artifacts/question-form.ts`. The app boundary
-    // forbids importing that web module here, so we mirror its accepted tag
-    // set; keep the two in sync. Recognizing only the canonical tag would
-    // recreate this exact missing-artifacts failure for an alias form the UI
-    // still renders as a valid brief.
-    const CLARIFYING_QUESTION_TAGS = ['<question-form', '<ask-question'];
-    let agentEmittedClarifyingQuestion = false;
-    let clarifyingQuestionTail = '';
+    // Accumulates the agent's visible text this run so the close handler can
+    // tell whether the turn ended on a clarifying question form. The
+    // `od-plugin-authoring` plugin's turn-1 flow is to emit a
+    // `<question-form>` collecting the plugin brief, then STOP and wait for
+    // the user to answer (see the `discovery-question-form` atom in
+    // `plugins/scaffold.ts`). That turn legitimately closes with `code === 0`
+    // and no `generated-plugin/` artifacts yet, so the missing-artifacts
+    // guard must not treat it as a failure. We buffer the streamed text
+    // rather than read the persisted message because the assistant message
+    // row may not be wired up at close time. The buffer is capped because a
+    // discovery form streams near the top of the turn; we only need enough to
+    // validate the first complete form block (see
+    // `emittedRenderableQuestionForm`).
+    const CLARIFYING_QUESTION_BUFFER_CAP = 256 * 1024;
+    let clarifyingQuestionText = '';
     const send = (event, data) => {
       if (
-        !agentEmittedClarifyingQuestion &&
         event === 'agent' &&
         data &&
         data.type === 'text_delta' &&
-        typeof data.delta === 'string'
+        typeof data.delta === 'string' &&
+        clarifyingQuestionText.length < CLARIFYING_QUESTION_BUFFER_CAP
       ) {
-        const combined = (clarifyingQuestionTail + data.delta).toLowerCase();
-        if (CLARIFYING_QUESTION_TAGS.some((tag) => combined.includes(tag))) {
-          agentEmittedClarifyingQuestion = true;
-        }
-        clarifyingQuestionTail = combined.slice(-64);
+        clarifyingQuestionText = (clarifyingQuestionText + data.delta).slice(
+          0,
+          CLARIFYING_QUESTION_BUFFER_CAP,
+        );
       }
       persistRunEventToAssistantMessage(db, run, event, data);
       design.runs.emit(run, event, data);
@@ -13092,7 +13140,7 @@ export async function startServer({
         !run.cancelRequested &&
         isPluginAuthoringRun(db, run) &&
         !(await hasGeneratedPluginArtifacts(cwd)) &&
-        !agentEmittedClarifyingQuestion
+        !emittedRenderableQuestionForm(clarifyingQuestionText)
       ) {
         send('error', createSseErrorPayload(
           'AGENT_EXECUTION_FAILED',

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2573,6 +2573,23 @@ function questionFormBodyIsRenderable(body) {
   return Array.isArray(questions) && questions.some((q) => q && typeof q === 'object');
 }
 
+// Locate `closeTag` (case-insensitively) at or after `from`, returning an
+// index in the ORIGINAL `text` coordinate space. Mirrors the web parser's
+// `findCloseTag`: scanning char-by-char and lowercasing each fixed-length
+// candidate slice keeps the result aligned with `openEnd`. Lowercasing the
+// whole string up front instead would desync the index, because some code
+// points expand under `toLowerCase()` (e.g. `"İ" -> "i̇"`) and shift every
+// offset after them — corrupting the body slice and failing a valid form.
+function findQuestionFormCloseTag(text, from, closeTag) {
+  const closeLower = closeTag.toLowerCase();
+  const tagLen = closeTag.length;
+  const maxStart = text.length - tagLen;
+  for (let i = from; i <= maxStart; i++) {
+    if (text.slice(i, i + tagLen).toLowerCase() === closeLower) return i;
+  }
+  return -1;
+}
+
 // Whether the agent's visible text contains a *renderable* clarifying form —
 // a closed `<question-form>`/`<ask-question>` block whose body satisfies the
 // parser contract above. The plugin-authoring missing-artifacts guard treats
@@ -2586,7 +2603,6 @@ function questionFormBodyIsRenderable(body) {
 // `packages/contracts` if the two drift.
 function emittedRenderableQuestionForm(text) {
   if (typeof text !== 'string' || !text) return false;
-  const lower = text.toLowerCase();
   let cursor = 0;
   while (cursor < text.length) {
     const m = QUESTION_FORM_OPEN_RE.exec(text.slice(cursor));
@@ -2594,7 +2610,7 @@ function emittedRenderableQuestionForm(text) {
     const tagName = (m[1] ?? 'question-form').toLowerCase();
     const closeTag = `</${tagName}>`;
     const openEnd = cursor + m.index + m[0].length;
-    const closeIdx = lower.indexOf(closeTag, openEnd);
+    const closeIdx = findQuestionFormCloseTag(text, openEnd, closeTag);
     if (closeIdx === -1) return false;
     if (questionFormBodyIsRenderable(text.slice(openEnd, closeIdx))) return true;
     cursor = closeIdx + closeTag.length;

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -570,7 +570,7 @@ process.stdin.on('end', () => {
 process.stdin.resume();
 process.stdin.on('end', () => {
   console.log(JSON.stringify({ type: 'step_start' }));
-  console.log(JSON.stringify({ type: 'text', part: { text: '先确认几个问题再开始搭建。\\n<question-form id="discovery" title="Plugin brief">\\n<field name="purpose" type="text" label="What should it do?" />\\n</question-form>' } }));
+  console.log(JSON.stringify({ type: 'text', part: { text: '先确认几个问题再开始搭建。\\n<question-form id="discovery" title="Plugin brief">\\n{"questions":[{"id":"purpose","label":"What should it do?","type":"text"}]}\\n</question-form>' } }));
   console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
   process.exit(0);
 });
@@ -634,7 +634,7 @@ process.stdin.on('end', () => {
 process.stdin.resume();
 process.stdin.on('end', () => {
   console.log(JSON.stringify({ type: 'step_start' }));
-  console.log(JSON.stringify({ type: 'text', part: { text: '先确认几个问题再开始搭建。\\n<ask-question id="discovery" title="Plugin brief">\\n<field name="purpose" type="text" label="What should it do?" />\\n</ask-question>' } }));
+  console.log(JSON.stringify({ type: 'text', part: { text: '先确认几个问题再开始搭建。\\n<ask-question id="discovery" title="Plugin brief">\\n{"questions":[{"id":"purpose","label":"What should it do?","type":"text"}]}\\n</ask-question>' } }));
   console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
   process.exit(0);
 });
@@ -661,6 +661,69 @@ process.stdin.on('end', () => {
         expect(eventsBody).toContain('<ask-question');
         expect(eventsBody).not.toContain('ended before generating the required generated-plugin artifacts');
         expect(statusBody.status).toBe('succeeded');
+      },
+    );
+  });
+  it('still fails plugin authoring when a question-form tag wraps a non-renderable (non-JSON) body', async () => {
+    // The clarification carve-out must match the web parser's renderable-form
+    // contract (JSON body with a `questions` array), not just the opening
+    // tag. A `<question-form>` whose body is not valid form JSON renders as
+    // raw prose in the UI — no usable brief card — so suppressing the
+    // missing-artifacts failure for it would turn a hard failure into a false
+    // success. This pins that the guard stays gated on a renderable body.
+    const projectId = `proj-plugin-authoring-badform-${randomUUID()}`;
+
+    const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Plugin authoring malformed-form fixture',
+        skillId: null,
+        designSystemId: null,
+      }),
+    });
+    expect(createProjectResponse.status).toBe(200);
+    const conversationsResponse = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`);
+    expect(conversationsResponse.status).toBe(200);
+    const conversationsBody = await conversationsResponse.json() as {
+      conversations: Array<{ id: string }>;
+    };
+    const conversationId = conversationsBody.conversations[0]?.id;
+    expect(conversationId).toBeTruthy();
+
+    await withFakeAgent(
+      'opencode',
+      `
+process.stdin.resume();
+process.stdin.on('end', () => {
+  console.log(JSON.stringify({ type: 'step_start' }));
+  console.log(JSON.stringify({ type: 'text', part: { text: '先确认几个问题。\\n<question-form id="discovery">\\nWhat should it do? (free text)\\n</question-form>' } }));
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+});
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            projectId,
+            conversationId,
+            pluginId: 'od-plugin-authoring',
+            message: '帮我做个插件。',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`);
+        const eventsBody = await readSseUntil(eventsResponse, 'event: final');
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('ended before generating the required generated-plugin artifacts');
+        expect(statusBody.status).not.toBe('succeeded');
       },
     );
   });

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -536,6 +536,70 @@ process.stdin.on('end', () => {
       },
     );
   });
+  it('does not fail plugin authoring when the turn-1 reply is a clarifying question-form awaiting the brief', async () => {
+    // The `od-plugin-authoring` plugin's turn-1 flow is to emit a
+    // `<question-form>` collecting the plugin brief, then STOP and wait for
+    // the user to answer — artifacts only land on the follow-up turn. The
+    // missing-artifacts guard must not treat that expected pause as a
+    // failure (regression: "Plugin authoring ended before generating the
+    // required generated-plugin artifacts.").
+    const projectId = `proj-plugin-authoring-question-${randomUUID()}`;
+
+    const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Plugin authoring question-form fixture',
+        skillId: null,
+        designSystemId: null,
+      }),
+    });
+    expect(createProjectResponse.status).toBe(200);
+    const conversationsResponse = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`);
+    expect(conversationsResponse.status).toBe(200);
+    const conversationsBody = await conversationsResponse.json() as {
+      conversations: Array<{ id: string }>;
+    };
+    const conversationId = conversationsBody.conversations[0]?.id;
+    expect(conversationId).toBeTruthy();
+
+    await withFakeAgent(
+      'opencode',
+      `
+process.stdin.resume();
+process.stdin.on('end', () => {
+  console.log(JSON.stringify({ type: 'step_start' }));
+  console.log(JSON.stringify({ type: 'text', part: { text: '先确认几个问题再开始搭建。\\n<question-form id="discovery" title="Plugin brief">\\n<field name="purpose" type="text" label="What should it do?" />\\n</question-form>' } }));
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+});
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            projectId,
+            conversationId,
+            pluginId: 'od-plugin-authoring',
+            message: '帮我做个插件。',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`);
+        const eventsBody = await readSseUntil(eventsResponse, 'event: final');
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('<question-form');
+        expect(eventsBody).not.toContain('ended before generating the required generated-plugin artifacts');
+        expect(statusBody.status).toBe('succeeded');
+      },
+    );
+  });
   it('closes the # Instructions block with an explicit "do not echo" guard so models do not parrot the prompt back', async () => {
     // claude-opus-4-7 (and a few other instruction-tuned models) start
     // their reply by echoing the # Instructions block verbatim, which

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -600,6 +600,70 @@ process.stdin.on('end', () => {
       },
     );
   });
+  it('does not fail plugin authoring when the clarifying form uses the <ask-question> alias', async () => {
+    // `<ask-question>` is the alias the web form parser accepts alongside
+    // the canonical `<question-form>` (apps/web/src/artifacts/question-form.ts).
+    // Models sometimes drift to it; the UI still renders a valid brief form,
+    // so the daemon's missing-artifacts guard must recognize the alias too —
+    // otherwise the same "ended before generating…" regression returns for a
+    // supported clarification shape.
+    const projectId = `proj-plugin-authoring-alias-${randomUUID()}`;
+
+    const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Plugin authoring ask-question alias fixture',
+        skillId: null,
+        designSystemId: null,
+      }),
+    });
+    expect(createProjectResponse.status).toBe(200);
+    const conversationsResponse = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`);
+    expect(conversationsResponse.status).toBe(200);
+    const conversationsBody = await conversationsResponse.json() as {
+      conversations: Array<{ id: string }>;
+    };
+    const conversationId = conversationsBody.conversations[0]?.id;
+    expect(conversationId).toBeTruthy();
+
+    await withFakeAgent(
+      'opencode',
+      `
+process.stdin.resume();
+process.stdin.on('end', () => {
+  console.log(JSON.stringify({ type: 'step_start' }));
+  console.log(JSON.stringify({ type: 'text', part: { text: '先确认几个问题再开始搭建。\\n<ask-question id="discovery" title="Plugin brief">\\n<field name="purpose" type="text" label="What should it do?" />\\n</ask-question>' } }));
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+});
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            projectId,
+            conversationId,
+            pluginId: 'od-plugin-authoring',
+            message: '帮我做个插件。',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`);
+        const eventsBody = await readSseUntil(eventsResponse, 'event: final');
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('<ask-question');
+        expect(eventsBody).not.toContain('ended before generating the required generated-plugin artifacts');
+        expect(statusBody.status).toBe('succeeded');
+      },
+    );
+  });
   it('closes the # Instructions block with an explicit "do not echo" guard so models do not parrot the prompt back', async () => {
     // claude-opus-4-7 (and a few other instruction-tuned models) start
     // their reply by echoing the # Instructions block verbatim, which

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -727,6 +727,68 @@ process.stdin.on('end', () => {
       },
     );
   });
+  it('does not fail plugin authoring when a valid form follows a Unicode preamble that expands under toLowerCase', async () => {
+    // The mirrored close-tag scan must stay in the original-string coordinate
+    // space. Some code points expand under toLowerCase ("İ" -> "i̇"), so
+    // lowercasing the whole buffer before indexing would desync the close-tag
+    // offset and corrupt the JSON body slice, failing a valid form. The
+    // preamble here contains "İ" before a well-formed form block.
+    const projectId = `proj-plugin-authoring-unicode-${randomUUID()}`;
+
+    const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Plugin authoring unicode-preamble fixture',
+        skillId: null,
+        designSystemId: null,
+      }),
+    });
+    expect(createProjectResponse.status).toBe(200);
+    const conversationsResponse = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`);
+    expect(conversationsResponse.status).toBe(200);
+    const conversationsBody = await conversationsResponse.json() as {
+      conversations: Array<{ id: string }>;
+    };
+    const conversationId = conversationsBody.conversations[0]?.id;
+    expect(conversationId).toBeTruthy();
+
+    await withFakeAgent(
+      'opencode',
+      `
+process.stdin.resume();
+process.stdin.on('end', () => {
+  console.log(JSON.stringify({ type: 'step_start' }));
+  console.log(JSON.stringify({ type: 'text', part: { text: 'İstanbul brief — 先确认几个问题。\\n<ask-question id="discovery" title="Plugin brief">\\n{"questions":[{"id":"purpose","label":"What should it do?","type":"text"}]}\\n</ask-question>' } }));
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+});
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            projectId,
+            conversationId,
+            pluginId: 'od-plugin-authoring',
+            message: '帮我做个插件。',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`);
+        const eventsBody = await readSseUntil(eventsResponse, 'event: final');
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).not.toContain('ended before generating the required generated-plugin artifacts');
+        expect(statusBody.status).toBe('succeeded');
+      },
+    );
+  });
   it('closes the # Instructions block with an explicit "do not echo" guard so models do not parrot the prompt back', async () => {
     // claude-opus-4-7 (and a few other instruction-tuned models) start
     // their reply by echoing the # Instructions block verbatim, which

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -276,6 +276,15 @@
   z-index: 1700;
   overflow: visible;
 }
+/* The mode toggle's description card (chat.css) anchors upward and is only
+   shown on the home hero — it is `display:none` inside the chat composer.
+   The home-hero toggle sits well down the composer, so the card grows up
+   toward the page header; at its default 360px it crowds (and on smaller
+   windows clips) the top chrome. Cap it shorter here so it always clears the
+   header, and keep the inner scroll for the overflow. */
+.home-hero__input-card .session-mode-toggle__popover-card {
+  max-height: min(300px, calc(100vh - 120px));
+}
 .home-hero__input-card--compact-authoring {
   max-width: 640px;
   padding-block: 12px 10px;


### PR DESCRIPTION
## Why

Two issues surfaced while validating the `release/v0.10.0` build, both reproducible on `main`:

1. On the Home view, opening the **Design Agent** mode picker showed its description card jammed against the top of the window — the card heading and icon were partly hidden under the page header, so the "what this mode does" copy read as cut off.
2. Authoring a plugin (`od-plugin-authoring`) failed with **"Plugin authoring ended before generating the required generated-plugin artifacts."** as soon as the agent did the *expected* thing on turn 1: ask a `<question-form>` brief and wait for the user. The run was killed before the user could even answer, so plugin authoring was unusable with any agent that opens with the discovery form (AMR/Codex/opencode).

## What users will see

- **Home -> Design Agent picker**: the description card ("For creating or changing concrete outputs...", "Best for", "Try asking") now sits fully below the header and scrolls internally instead of being clipped at the top.
- **Plugin authoring**: when the assistant opens with a clarifying brief form, the run stays alive and waits for the answers (as intended) instead of erroring out. The missing-artifacts failure still fires for the real regression — a run that ends with neither artifacts nor a question.

## Surface area

- [x] **UI** — Home hero mode-picker description card sizing (`apps/web/src/styles/home/home-hero.css`)
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change

The daemon change is an internal run-lifecycle guard fix; its behavior is surfaced identically through the web UI and the `od` CLI (both drive the same `/api/runs` run lifecycle), so no new surface is added on either side.

## Screenshots

Verified locally with Playwright by opening the picker on the Home view at both a tall (1600x1000) and short (1280x620) viewport. In both, the card top lands at y~77 (clear of the ~48px header) and the full card stays on screen, scrolling internally for overflow. Before the fix the card top sat at y~17, crowding/overlapping the header.

## Bug fix verification

- Test path: `apps/daemon/tests/chat-route.test.ts` -> `does not fail plugin authoring when the turn-1 reply is a clarifying question-form awaiting the brief`
- Red on `main`, green on this branch? **yes** (confirmed by reverting only the guard clause: run came back `failed` with the artifacts error; restored: `succeeded`).
- The Home card fix is CSS-only and not cheaply unit-testable; verified visually via the Playwright reproduction above on two viewport sizes.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` (daemon + web) — pass
- `pnpm --filter @open-design/daemon test -- chat-route.test.ts` — 46 passed (incl. the new red spec and the existing plugin-authoring success/failure specs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
