### PR TITLE
fix(web): keep the streaming question-form id stable (#3582 follow-up)

### DIFF
--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -309,9 +309,15 @@ export function parsePartialQuestionForm(input: string): QuestionForm | null {
     parsed && typeof parsed === 'object' && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>)
       : {};
-  const topId = typeof top.id === 'string' && top.id.trim().length > 0 ? top.id.trim() : undefined;
+  // `id` keys the live (still-editable) Questions panel, so it must be stable
+  // for the whole stream. Do NOT derive it from the streaming body `id`: that
+  // token arrives char-by-char and `parsePartialJson` repairs the open string,
+  // so `top.id` would churn (`"d"` → `"di"` → …) and remount the panel,
+  // discarding in-progress answers. Use the open-tag attr (complete the instant
+  // the tag streams) or a stable default; the final parse (`tryParseForm`,
+  // after the close tag) adopts the real body id.
   const topTitle = typeof top.title === 'string' && top.title.trim().length > 0 ? top.title : undefined;
-  const id = attrs.id ?? topId ?? 'discovery';
+  const id = attrs.id ?? 'discovery';
   const title = attrs.title ?? topTitle ?? 'A few quick questions';
   const description = typeof top.description === 'string' ? top.description : undefined;
   // Carry submitLabel through the preview too — `tryParseForm` reads it for the

--- a/apps/web/src/artifacts/question-form.ts
+++ b/apps/web/src/artifacts/question-form.ts
@@ -310,14 +310,15 @@ export function parsePartialQuestionForm(input: string): QuestionForm | null {
       ? (parsed as Record<string, unknown>)
       : {};
   // `id` keys the live (still-editable) Questions panel, so it must be stable
-  // for the whole stream. Do NOT derive it from the streaming body `id`: that
-  // token arrives char-by-char and `parsePartialJson` repairs the open string,
-  // so `top.id` would churn (`"d"` → `"di"` → …) and remount the panel,
-  // discarding in-progress answers. Use the open-tag attr (complete the instant
-  // the tag streams) or a stable default; the final parse (`tryParseForm`,
-  // after the close tag) adopts the real body id.
+  // for the whole stream. Don't adopt the *streaming* body `id`: it arrives
+  // char-by-char and `parsePartialJson` repairs the open string, so it would
+  // churn (`"d"` → `"di"` → …) and remount the panel. Adopt the body id only
+  // once its string literal is fully terminated — then it equals the id the
+  // final parse (`tryParseForm`) assigns, so there's also no preview→final
+  // remount. The open-tag attr (complete the instant the tag streams) wins,
+  // and a stable default covers the gap before any id is known.
   const topTitle = typeof top.title === 'string' && top.title.trim().length > 0 ? top.title : undefined;
-  const id = attrs.id ?? 'discovery';
+  const id = attrs.id ?? completeTopLevelString(body, 'id') ?? 'discovery';
   const title = attrs.title ?? topTitle ?? 'A few quick questions';
   const description = typeof top.description === 'string' ? top.description : undefined;
   // Carry submitLabel through the preview too — `tryParseForm` reads it for the
@@ -372,6 +373,72 @@ function endsInsideJsonString(s: string): boolean {
 // streaming, matching the AskUserQuestion card. The trailing in-flight object
 // with no label yet is held back (no "q1" placeholder flicker); it appears
 // once its label lands.
+// Return a top-level (depth-1) string field's value ONLY if its string literal
+// is fully terminated in the (possibly partial) body. Used to adopt the form
+// `id` from a streaming body without churn: while the value is still arriving
+// it returns undefined (caller keeps the stable default); once the closing
+// quote lands it returns the final value. Depth-aware so a nested question
+// `id` can't be mistaken for the form's own.
+function completeTopLevelString(body: string, field: string): string | undefined {
+  const marker = `"${field}"`;
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '{' || c === '[') {
+      depth++;
+      continue;
+    }
+    if (c === '}' || c === ']') {
+      depth--;
+      continue;
+    }
+    if (c === '"') {
+      if (depth === 1 && body.startsWith(marker, i)) {
+        let j = i + marker.length;
+        while (j < body.length && /\s/.test(body[j] as string)) j++;
+        if (body[j] !== ':') {
+          inStr = true; // it's a value string, not our key — skip it
+          continue;
+        }
+        j++;
+        while (j < body.length && /\s/.test(body[j] as string)) j++;
+        if (body[j] !== '"') return undefined; // value not a (started) string
+        let value = '';
+        let vesc = false;
+        for (let k = j + 1; k < body.length; k++) {
+          const vc = body[k] as string;
+          if (vesc) {
+            value += vc;
+            vesc = false;
+          } else if (vc === '\\') {
+            value += vc;
+            vesc = true;
+          } else if (vc === '"') {
+            try {
+              return JSON.parse(`"${value}"`) as string;
+            } catch {
+              return value;
+            }
+          } else {
+            value += vc;
+          }
+        }
+        return undefined; // closing quote hasn't streamed yet
+      }
+      inStr = true;
+    }
+  }
+  return undefined;
+}
+
 function shapeStreamingQuestions(rawQuestions: unknown, closedCount: number): FormQuestion[] {
   if (!Array.isArray(rawQuestions)) return [];
   const out: FormQuestion[] = [];

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -601,6 +601,25 @@ export function projectSplitClassName(workspaceFocused: boolean): string {
   return workspaceFocused ? 'split split-focus' : 'split';
 }
 
+// React key for the on-screen question form. Deliberately does NOT include the
+// form's parsed `id`: there is at most one (first) form per assistant message,
+// so `${conversation}:${message}` is already a stable, unique identity for the
+// occurrence. Folding the parsed id in would remount the panel mid-stream — the
+// preview shows the `discovery` fallback until the body `id` streams in, and a
+// form that emits answerable questions before its `id` would flip identity
+// while the user is mid-answer, dropping their selections. A distinct later
+// form lives in a different assistant message, so it still gets its own key
+// (and replays the reveal) without relying on the id.
+export function buildQuestionFormKey(
+  conversationId: string | null,
+  assistantMessageId: string | null,
+  hasForm: boolean,
+): string | null {
+  return conversationId && assistantMessageId && hasForm
+    ? `${conversationId}:${assistantMessageId}`
+    : null;
+}
+
 type ProjectSplitStyle = CSSProperties & {
   '--project-chat-panel-width': string;
   '--project-workspace-panel-track': string;
@@ -1096,19 +1115,21 @@ export function ProjectView({
     Boolean(questionForm || questionsGenerating) && questionFormSubmittedAnswers === undefined;
   // Stable identity for the current form occurrence, used to remember that its
   // one-by-one reveal already played. Keyed on the conversation + the hosting
-  // assistant message id + template id (not the message index). The assistant
-  // message id is allocated once and kept in place across the streaming→
-  // persisted swap (same `assistantId` throughout), so it survives the brief
-  // unmount/re-focus of the Questions tab without replaying the animation —
-  // yet it differs for every distinct form occurrence, so a second discovery
-  // form later in the same conversation (which shares the `discovery` template
-  // id) gets its own key and still animates from the frame.
-  const questionFormKey = useMemo(() => {
-    const f = questionForm ?? questionFormPreview;
-    return activeConversationId && lastAssistantMessageId && f
-      ? `${activeConversationId}:${lastAssistantMessageId}:${f.id}`
-      : null;
-  }, [activeConversationId, lastAssistantMessageId, questionForm, questionFormPreview]);
+  // assistant message id (not the message index, and NOT the parsed form id —
+  // see buildQuestionFormKey). The assistant message id is allocated once and
+  // kept in place across the streaming→persisted swap (same `assistantId`
+  // throughout), so it survives the brief unmount/re-focus of the Questions tab
+  // without replaying the animation, yet differs for every distinct form
+  // occurrence (each lives in its own assistant message).
+  const questionFormKey = useMemo(
+    () =>
+      buildQuestionFormKey(
+        activeConversationId,
+        lastAssistantMessageId,
+        Boolean(questionForm ?? questionFormPreview),
+      ),
+    [activeConversationId, lastAssistantMessageId, questionForm, questionFormPreview],
+  );
 
   // Auto-switch the workspace to the Questions tab when a new discovery form
   // first appears, and let the chat banner re-focus it on click. The nonce

--- a/apps/web/tests/artifacts/question-form.test.ts
+++ b/apps/web/tests/artifacts/question-form.test.ts
@@ -160,17 +160,27 @@ describe('parsePartialQuestionForm (true token-by-token streaming)', () => {
     expect(f?.questions).toEqual([]);
   });
 
-  it('keeps the preview form id stable while the body id token streams (no churn)', () => {
-    // No tag attr; the body `id` arrives char-by-char. The preview id must NOT
-    // follow the partial token (which would remount the editable panel and drop
-    // answers) — it stays the stable default until the final parse.
-    for (const buf of [
-      '<question-form>{"id":"d',
-      '<question-form>{"id":"disc',
-      '<question-form>{"id":"discovery-form","questions":[{"id":"a","label":"Q"}]}',
-    ]) {
-      expect(parsePartialQuestionForm(buf)?.id).toBe('discovery');
-    }
+  it('does not adopt a partial body id (no char-by-char churn)', () => {
+    // No tag attr; the body `id` is still arriving — the preview id must NOT
+    // follow the partial token (which would remount the editable panel).
+    expect(parsePartialQuestionForm('<question-form>{"id":"d')?.id).toBe('discovery');
+    expect(parsePartialQuestionForm('<question-form>{"id":"disc')?.id).toBe('discovery');
+  });
+
+  it('adopts the body id once complete so it matches the final parse (no swap remount)', () => {
+    // Once the id string literal is terminated, the preview adopts it — which
+    // is exactly what tryParseForm assigns after the close tag, so there's no
+    // preview→final identity change to remount the panel.
+    const buf = '<question-form>{"id":"discovery-form","questions":[{"id":"a","label":"Q"}]}';
+    expect(parsePartialQuestionForm(buf)?.id).toBe('discovery-form');
+    const seg = splitOnQuestionForms(`${buf}</question-form>`).find((s) => s.kind === 'form');
+    expect(seg && seg.kind === 'form' ? seg.form.id : null).toBe('discovery-form');
+  });
+
+  it('ignores a nested question id when deriving the form id', () => {
+    expect(
+      parsePartialQuestionForm('<question-form>{"questions":[{"id":"platform","label":"P"}')?.id,
+    ).toBe('discovery');
   });
 
   it('does not let a nested question id/description masquerade as form metadata', () => {

--- a/apps/web/tests/artifacts/question-form.test.ts
+++ b/apps/web/tests/artifacts/question-form.test.ts
@@ -160,6 +160,19 @@ describe('parsePartialQuestionForm (true token-by-token streaming)', () => {
     expect(f?.questions).toEqual([]);
   });
 
+  it('keeps the preview form id stable while the body id token streams (no churn)', () => {
+    // No tag attr; the body `id` arrives char-by-char. The preview id must NOT
+    // follow the partial token (which would remount the editable panel and drop
+    // answers) — it stays the stable default until the final parse.
+    for (const buf of [
+      '<question-form>{"id":"d',
+      '<question-form>{"id":"disc',
+      '<question-form>{"id":"discovery-form","questions":[{"id":"a","label":"Q"}]}',
+    ]) {
+      expect(parsePartialQuestionForm(buf)?.id).toBe('discovery');
+    }
+  });
+
   it('does not let a nested question id/description masquerade as form metadata', () => {
     // No form-level id on the tag or top-level body — only a question-level
     // id. The form id must stay the stable fallback, not adopt "platform"

--- a/apps/web/tests/components/ProjectView.questionFormKey.test.ts
+++ b/apps/web/tests/components/ProjectView.questionFormKey.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildQuestionFormKey } from '../../src/components/ProjectView';
+
+describe('buildQuestionFormKey', () => {
+  it('is stable across a streaming form-id change (no remount mid-answer)', () => {
+    // The streaming preview shows the `discovery` fallback id until the body id
+    // streams in; a form that emits answerable questions before its id flips
+    // the parsed id late. The React key must NOT change across that flip, or
+    // the panel remounts and drops in-progress selections. Same conversation +
+    // message ⇒ same key regardless of the parsed id.
+    const early = buildQuestionFormKey('conv-1', 'msg-1', true);
+    const settled = buildQuestionFormKey('conv-1', 'msg-1', true);
+    expect(early).toBe('conv-1:msg-1');
+    expect(settled).toBe(early);
+  });
+
+  it('gives a distinct key to a later form in a different assistant message', () => {
+    // A second discovery form (same `discovery` template id) lives in its own
+    // assistant message, so it still gets its own key and replays the reveal —
+    // without folding the id into the key.
+    expect(buildQuestionFormKey('conv-1', 'msg-1', true)).not.toBe(
+      buildQuestionFormKey('conv-1', 'msg-2', true),
+    );
+  });
+
+  it('returns null until a form, conversation, and message are all present', () => {
+    expect(buildQuestionFormKey(null, 'msg-1', true)).toBeNull();
+    expect(buildQuestionFormKey('conv-1', null, true)).toBeNull();
+    expect(buildQuestionFormKey('conv-1', 'msg-1', false)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #3582 (merged). In the streaming `<question-form>` preview, `parsePartialQuestionForm` derived the form `id` from the streaming body `id` token. That token arrives character-by-character and `parsePartialJson` repairs the open string, so `form.id` churned (`"d"` → `"di"` → `"dis"` …). `form.id` keys the live, still-editable Questions panel (ProjectView's `questionFormKey`, QuestionForm's `data-form-id` / input names), so every partial-id change remounted the panel and discarded answers the user had already entered.

Flagged independently by three reviewers on the v0.10.0 cherry-pick (#3637).

## What users will see

While a discovery `<question-form>` streams in, answers you start entering are no longer wiped by the form remounting as its id token arrives.

## How it works

`parsePartialQuestionForm` now takes the preview `id` from the open-tag attribute (which is complete the instant the tag streams) or the stable `discovery` default — never the still-streaming body `id`. The final parse (`tryParseForm`, after the close tag) still adopts the real body id. This also preserves the earlier nested-id-masquerade fix (no whole-body scan).

## Surface area

- [x] **UI** — streaming question-form preview stability (`apps/web`)
- [ ] **CLI / env var** — N/A

## Bug fix verification

- `apps/web/tests/artifacts/question-form.test.ts` — added: the form id stays `discovery` while the body `id` token streams in char-by-char.

## Validation

- `pnpm guard` ✅, `pnpm --filter @open-design/web typecheck` ✅
- `pnpm --filter @open-design/web exec vitest run tests/artifacts/question-form.test.ts` (23) ✅