### PR TITLE
Stabilize manual text editing sessions

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4802,7 +4802,11 @@ function HtmlViewer({
   const [manualEditHoverTarget, setManualEditHoverTarget] = useState<ManualEditTarget | null>(null);
   const [manualEditPageStylesOpen, setManualEditPageStylesOpen] = useState(false);
   const [manualEditPanelPosition, setManualEditPanelPosition] = useState<{ left: number; top: number } | null>(null);
+  const [manualEditTextSessionId, setManualEditTextSessionId] = useState<string | null>(null);
   const selectedManualEditTargetIdRef = useRef<string | null>(null);
+  const manualEditTextSessionIdRef = useRef<string | null>(null);
+  const manualEditCloseAfterTextCommitRef = useRef(false);
+  const manualEditCloseAfterTextCancelRef = useRef(false);
   const [manualEditDraft, setManualEditDraft] = useState<ManualEditDraft>(() => emptyManualEditDraft());
   const [manualEditHistory, setManualEditHistory] = useState<ManualEditHistoryEntry[]>([]);
   const [manualEditUndone, setManualEditUndone] = useState<ManualEditHistoryEntry[]>([]);
@@ -5522,6 +5526,13 @@ function HtmlViewer({
     win.postMessage({ type: 'od-edit-selected-target', id }, '*');
   }
 
+  function postManualEditTextFinishToIframe(commit: boolean): boolean {
+    const win = iframeRef.current?.contentWindow;
+    if (!win || !manualEditTextSessionIdRef.current) return false;
+    win.postMessage({ type: 'od-edit-text-finish', commit }, '*');
+    return true;
+  }
+
   function syncBridgeModes(target: HTMLIFrameElement | null = iframeRef.current) {
     const win = target?.contentWindow;
     if (!win) return;
@@ -5616,7 +5627,11 @@ function HtmlViewer({
     setManualEditTargets([]);
     setSelectedManualEditTarget(null);
     setManualEditPanelPosition(null);
+    setManualEditTextSessionId(null);
     selectedManualEditTargetIdRef.current = null;
+    manualEditTextSessionIdRef.current = null;
+    manualEditCloseAfterTextCommitRef.current = false;
+    manualEditCloseAfterTextCancelRef.current = false;
     setManualEditDraft(emptyManualEditDraft());
     setManualEditHistory([]);
     setManualEditUndone([]);
@@ -5666,6 +5681,10 @@ function HtmlViewer({
   useEffect(() => {
     selectedManualEditTargetIdRef.current = selectedManualEditTarget?.id ?? null;
   }, [selectedManualEditTarget?.id]);
+
+  useEffect(() => {
+    manualEditTextSessionIdRef.current = manualEditTextSessionId;
+  }, [manualEditTextSessionId]);
 
   useEffect(() => {
     if (!boardMode) {
@@ -5869,6 +5888,10 @@ function HtmlViewer({
       setManualEditPageStylesOpen(false);
       setManualEditPanelPosition(null);
       selectedManualEditTargetIdRef.current = null;
+      manualEditTextSessionIdRef.current = null;
+      manualEditCloseAfterTextCommitRef.current = false;
+      manualEditCloseAfterTextCancelRef.current = false;
+      setManualEditTextSessionId(null);
       setManualEditError(null);
       manualEditPendingStyleRef.current = null;
       if (manualEditStyleTimerRef.current) {
@@ -5899,6 +5922,7 @@ function HtmlViewer({
         return;
       }
       if (data.type === 'od-edit-hover') {
+        if (manualEditTextSessionIdRef.current) return;
         // Hover only surfaces a lightweight "edit params" affordance; it must
         // NOT switch the pinned inspector. The panel changes only when the
         // user clicks that affordance (or a container/image body), so moving
@@ -5919,11 +5943,40 @@ function HtmlViewer({
         return;
       }
       if (data.type === 'od-edit-text-commit') {
-        void applyManualEdit({
-          id: String(data.id),
-          kind: 'set-text',
-          value: String(data.value),
-        }, 'Edit text');
+        void (async () => {
+          const ok = await applyManualEdit({
+            id: String(data.id),
+            kind: 'set-text',
+            value: String(data.value),
+          }, 'Edit text');
+          if (ok && manualEditCloseAfterTextCommitRef.current) {
+            manualEditCloseAfterTextCommitRef.current = false;
+            await clearManualEditTargetSelection();
+          }
+        })();
+        return;
+      }
+      if (data.type === 'od-edit-text-session') {
+        const id = String(data.id || '');
+        if (data.active) {
+          manualEditTextSessionIdRef.current = id;
+          setManualEditTextSessionId(id);
+          return;
+        }
+        if (manualEditTextSessionIdRef.current === id) {
+          manualEditTextSessionIdRef.current = null;
+          setManualEditTextSessionId(null);
+        }
+        if (manualEditCloseAfterTextCancelRef.current) {
+          manualEditCloseAfterTextCancelRef.current = false;
+          manualEditCloseAfterTextCommitRef.current = false;
+          void clearManualEditTargetSelection();
+          return;
+        }
+        if (manualEditCloseAfterTextCommitRef.current && (!data.changed || !data.committed)) {
+          manualEditCloseAfterTextCommitRef.current = false;
+          void clearManualEditTargetSelection();
+        }
         return;
       }
     }
@@ -6040,6 +6093,13 @@ function HtmlViewer({
   }
 
   async function exitManualEditModeAfterFlush(): Promise<boolean> {
+    if (manualEditTextSessionIdRef.current) {
+      manualEditCloseAfterTextCommitRef.current = false;
+      manualEditCloseAfterTextCancelRef.current = false;
+      postManualEditTextFinishToIframe(true);
+      manualEditTextSessionIdRef.current = null;
+      setManualEditTextSessionId(null);
+    }
     const ok = await flushManualEditStyleSave();
     if (!ok) return false;
     setManualEditPanelPosition(null);
@@ -6081,6 +6141,8 @@ function HtmlViewer({
   async function clearManualEditTargetSelection() {
     cancelManualEditStyleDraft();
     selectedManualEditTargetIdRef.current = null;
+    manualEditTextSessionIdRef.current = null;
+    setManualEditTextSessionId(null);
     setSelectedManualEditTarget(null);
     setManualEditPanelPosition(null);
     setManualEditDraft(emptyManualEditDraft(sourceRef.current ?? ''));
@@ -6092,6 +6154,12 @@ function HtmlViewer({
   // the toolbar toggle's job. Dismiss flushes any in-flight tweak first so
   // nothing is lost; cancel reverts the in-flight unsaved tweak instead.
   async function dismissManualEditPanel() {
+    if (manualEditTextSessionIdRef.current) {
+      manualEditCloseAfterTextCommitRef.current = true;
+      manualEditCloseAfterTextCancelRef.current = false;
+      if (postManualEditTextFinishToIframe(true)) return;
+      manualEditCloseAfterTextCommitRef.current = false;
+    }
     const ok = await flushManualEditStyleSave();
     if (!ok) return;
     if (selectedManualEditTarget) void clearManualEditTargetSelection();
@@ -6099,6 +6167,12 @@ function HtmlViewer({
   }
 
   function cancelManualEditPanel() {
+    if (manualEditTextSessionIdRef.current) {
+      manualEditCloseAfterTextCancelRef.current = true;
+      manualEditCloseAfterTextCommitRef.current = false;
+      if (postManualEditTextFinishToIframe(false)) return;
+      manualEditCloseAfterTextCancelRef.current = false;
+    }
     if (selectedManualEditTarget) {
       void clearManualEditTargetSelection();
     } else {

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -84,8 +84,16 @@ export function buildManualEditBridge(enabled: boolean): string {
     var tag = el.tagName ? el.tagName.toLowerCase() : '';
     if (tag === 'a') return 'link';
     if (tag === 'img') return 'image';
+    if (['h1','h2','h3','h4','h5','h6','p','button','strong','span'].indexOf(tag) >= 0) return 'text';
+    if (isPlainTextContainer(el)) return 'text';
     if (['section','main','nav','div','article','header','footer'].indexOf(tag) >= 0) return 'container';
     return 'text';
+  }
+  function isPlainTextContainer(el){
+    var tag = el && el.tagName ? el.tagName.toLowerCase() : '';
+    if (['section','main','nav','div','article','header','footer'].indexOf(tag) < 0) return false;
+    if (el.children && el.children.length > 0) return false;
+    return !!((el.textContent || '').replace(/\\s+/g, ' ').trim());
   }
   function labelFor(el, id, kind){
     var explicit = el.getAttribute('data-od-label');
@@ -197,8 +205,8 @@ export function buildManualEditBridge(enabled: boolean): string {
     var el = findById(id);
     if (el) el.setAttribute('data-od-edit-selected', 'true');
   }
-  function closestTarget(event){
-    var el = event.target;
+  function closestEditableTargetFromNode(node){
+    var el = node && node.nodeType === 1 ? node : node && node.parentElement;
     while (el && el !== document.documentElement) {
       if (el !== document.body && el !== document.documentElement && isSourceMappable(el) && isDiscoveryTarget(el)) {
         return el;
@@ -206,6 +214,28 @@ export function buildManualEditBridge(enabled: boolean): string {
       el = el.parentElement;
     }
     return null;
+  }
+  function closestTextTargetFromNode(node){
+    var el = node && node.nodeType === 1 ? node : node && node.parentElement;
+    while (el && el !== document.documentElement) {
+      if (el !== document.body && el !== document.documentElement && isSourceMappable(el) && isDiscoveryTarget(el)) {
+        var kind = inferKind(el);
+        if (kind === 'text' || kind === 'link') return el;
+      }
+      el = el.parentElement;
+    }
+    return null;
+  }
+  function targetFromPoint(event){
+    var range = caretRangeFromClick(event);
+    var textTarget = range ? closestTextTargetFromNode(range.startContainer) : null;
+    if (textTarget) return textTarget;
+    var directTextTarget = closestTextTargetFromNode(event.target);
+    if (directTextTarget) return directTextTarget;
+    return closestEditableTargetFromNode(event.target);
+  }
+  function closestTarget(event){
+    return targetFromPoint(event);
   }
   function caretRangeFromClick(clickEvent){
     try {
@@ -237,45 +267,63 @@ export function buildManualEditBridge(enabled: boolean): string {
       sel.addRange(range);
     } catch (e) {}
   }
+  var activeTextEdit = null;
+  function postTextSession(el, active, extra){
+    if (!el) return;
+    window.parent.postMessage(Object.assign({
+      type: 'od-edit-text-session',
+      id: stableId(el),
+      active: !!active
+    }, extra || {}), '*');
+  }
+  function finishActiveTextEdit(commit){
+    if (!activeTextEdit) return false;
+    var session = activeTextEdit;
+    activeTextEdit = null;
+    var el = session.el;
+    el.removeAttribute('contenteditable');
+    el.removeAttribute('data-od-editing');
+    el.removeEventListener('keydown', session.onKey);
+    var value = (el.textContent || '').trim();
+    var changed = value !== session.originalText.trim();
+    if (commit && changed) {
+      window.parent.postMessage({
+        type: 'od-edit-text-commit',
+        id: stableId(el),
+        value: value
+      }, '*');
+    } else if (!commit) {
+      el.textContent = session.originalText;
+    }
+    postTextSession(el, false, { committed: !!commit, changed: changed });
+    return true;
+  }
   function makeEditable(el, clickEvent){
-    if (!el || el.getAttribute('contenteditable') === 'true') return;
+    if (!el) return;
+    if (activeTextEdit && activeTextEdit.el === el) {
+      placeCaretFromClick(clickEvent, el);
+      return;
+    }
+    if (activeTextEdit) finishActiveTextEdit(true);
+    if (el.getAttribute('contenteditable') === 'true') return;
     var originalText = el.textContent || '';
-    clearSelectedTarget();
     el.setAttribute('contenteditable', 'plaintext-only');
     el.setAttribute('data-od-editing', 'true');
     try { el.focus(); } catch (e) {}
     placeCaretFromClick(clickEvent, el);
-    function finish(commit){
-      el.removeAttribute('contenteditable');
-      el.removeAttribute('data-od-editing');
-      el.removeEventListener('blur', onBlur);
-      el.removeEventListener('keydown', onKey);
-      var value = (el.textContent || '').trim();
-      if (commit && value !== originalText.trim()) {
-        window.parent.postMessage({
-          type: 'od-edit-text-commit',
-          id: stableId(el),
-          value: value
-        }, '*');
-      } else if (!commit) {
-        el.textContent = originalText;
-      }
-    }
-    function onBlur(){ finish(true); }
     function onKey(ev){
       if (ev.key === 'Enter' && !ev.shiftKey) {
         ev.preventDefault();
-        finish(true);
-        try { el.blur(); } catch (e) {}
+        finishActiveTextEdit(true);
       }
       if (ev.key === 'Escape') {
         ev.preventDefault();
-        finish(false);
-        try { el.blur(); } catch (e) {}
+        finishActiveTextEdit(false);
       }
     }
-    el.addEventListener('blur', onBlur);
+    activeTextEdit = { el: el, originalText: originalText, onKey: onKey };
     el.addEventListener('keydown', onKey);
+    postTextSession(el, true);
   }
   function camelToKebab(name){ return String(name).replace(/[A-Z]/g, function(m){ return '-' + m.toLowerCase(); }); }
   function cssEscapeId(value){ if (typeof CSS !== 'undefined' && CSS.escape) return CSS.escape(value); return String(value).replace(/"/g, '\\\\"'); }
@@ -325,7 +373,10 @@ export function buildManualEditBridge(enabled: boolean): string {
     if (ev.data.type === 'od-edit-mode') {
       enabled = !!ev.data.enabled;
       document.documentElement.toggleAttribute('data-od-edit-mode', enabled);
-      if (!enabled) clearSelectedTarget();
+      if (!enabled) {
+        finishActiveTextEdit(true);
+        clearSelectedTarget();
+      }
       if (enabled) setTimeout(postTargets, 0);
       return;
     }
@@ -343,6 +394,10 @@ export function buildManualEditBridge(enabled: boolean): string {
       applyPreviewStyles(ev.data.id, ev.data.styles || {}, ev.data.version);
       return;
     }
+    if (ev.data.type === 'od-edit-text-finish') {
+      finishActiveTextEdit(ev.data.commit !== false);
+      return;
+    }
   });
   document.addEventListener('click', function(ev){
     if (!enabled) return;
@@ -356,6 +411,7 @@ export function buildManualEditBridge(enabled: boolean): string {
       window.parent.postMessage({ type: 'od-edit-background' }, '*');
       return;
     }
+    if (activeTextEdit && activeTextEdit.el !== el) finishActiveTextEdit(true);
     var kind = inferKind(el);
     window.parent.postMessage({ type: 'od-edit-select', target: targetFrom(el, true) }, '*');
     if (kind === 'text' || kind === 'link') {
@@ -365,6 +421,7 @@ export function buildManualEditBridge(enabled: boolean): string {
   }, true);
   document.addEventListener('pointerover', function(ev){
     if (!enabled) return;
+    if (activeTextEdit) return;
     if (ev.target && ev.target.closest && ev.target.closest('[data-od-editing="true"]')) return;
     var el = closestTarget(ev);
     if (!el) return;

--- a/apps/web/src/edit-mode/types.ts
+++ b/apps/web/src/edit-mode/types.ts
@@ -120,13 +120,22 @@ export interface ManualEditTextCommitMessage {
   value: string;
 }
 
+export interface ManualEditTextSessionMessage {
+  type: 'od-edit-text-session';
+  id: string;
+  active: boolean;
+  changed?: boolean;
+  committed?: boolean;
+}
+
 export type ManualEditBridgeMessage =
   | ManualEditTargetMessage
   | ManualEditSelectMessage
   | ManualEditHoverMessage
   | ManualEditBackgroundMessage
   | ManualEditPreviewAppliedMessage
-  | ManualEditTextCommitMessage;
+  | ManualEditTextCommitMessage
+  | ManualEditTextSessionMessage;
 
 export const MANUAL_EDIT_STYLE_PROPS: readonly (keyof ManualEditStyles)[] = [
   'fontFamily', 'fontSize', 'fontWeight', 'color', 'textAlign', 'lineHeight', 'letterSpacing',

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1041,6 +1041,126 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.queryByText('Trend card')).toBeNull();
   });
 
+  it('keeps the manual edit text inspector stable while an inline text session is active', async () => {
+    const textTarget = {
+      ...manualEditTarget('copy', 'Editable copy', 20),
+      kind: 'text' as const,
+      tagName: 'p',
+      text: 'Editable copy',
+      fields: { text: 'Editable copy' },
+      isLayoutContainer: false,
+      outerHtml: '<p data-od-id="copy">Editable copy</p>',
+    };
+    const trendTarget = manualEditTarget('trend-card', 'Trend card', 320);
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={baseFile({
+          name: 'page.html',
+          path: 'page.html',
+          mime: 'text/html',
+          kind: 'html',
+          artifactManifest: {
+            version: 1,
+            kind: 'html',
+            title: 'Page',
+            entry: 'page.html',
+            renderer: 'html',
+            exports: ['html'],
+          },
+        })}
+        liveHtml='<html><body><p data-od-id="copy">Editable copy</p><aside data-od-id="trend-card">Trend</aside></body></html>'
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+    await waitFor(() => {
+      expect(screen.getByTestId('artifact-preview-frame').getAttribute('data-od-render-mode')).toBe('srcdoc');
+    });
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-select', target: textTarget },
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-text-session', id: 'copy', active: true },
+    }));
+    expect(await screen.findByText('Editable copy')).toBeTruthy();
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-hover', target: trendTarget },
+    }));
+
+    expect(screen.getByText('Editable copy')).toBeTruthy();
+    expect(screen.queryByTestId('manual-edit-hover-open')).toBeNull();
+    expect(screen.queryByText('Trend card')).toBeNull();
+  });
+
+  it('asks the iframe to commit or cancel the active manual text session from the panel footer', async () => {
+    const textTarget = {
+      ...manualEditTarget('copy', 'Editable copy', 20),
+      kind: 'text' as const,
+      tagName: 'p',
+      text: 'Editable copy',
+      fields: { text: 'Editable copy' },
+      isLayoutContainer: false,
+      outerHtml: '<p data-od-id="copy">Editable copy</p>',
+    };
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={baseFile({
+          name: 'page.html',
+          path: 'page.html',
+          mime: 'text/html',
+          kind: 'html',
+          artifactManifest: {
+            version: 1,
+            kind: 'html',
+            title: 'Page',
+            entry: 'page.html',
+            renderer: 'html',
+            exports: ['html'],
+          },
+        })}
+        liveHtml='<html><body><p data-od-id="copy">Editable copy</p></body></html>'
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+    await waitFor(() => {
+      expect(screen.getByTestId('artifact-preview-frame').getAttribute('data-od-render-mode')).toBe('srcdoc');
+    });
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-select', target: textTarget },
+    }));
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-text-session', id: 'copy', active: true },
+    }));
+    expect(await screen.findByText('Editable copy')).toBeTruthy();
+
+    fireEvent.click(document.querySelector('.manual-edit-footer-btn.primary') as HTMLButtonElement);
+    expect(postMessage).toHaveBeenCalledWith({ type: 'od-edit-text-finish', commit: true }, '*');
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od-edit-text-session', id: 'copy', active: true },
+    }));
+
+    fireEvent.click(document.querySelector('.manual-edit-footer-btn.subtle') as HTMLButtonElement);
+    expect(postMessage).toHaveBeenCalledWith({ type: 'od-edit-text-finish', commit: false }, '*');
+  });
+
   it('renders sandbox-shim artifacts on the srcdoc transport without entering edit mode (#2791)', () => {
     const file = baseFile({
       name: 'search.html',

--- a/apps/web/tests/edit-mode/bridge.test.ts
+++ b/apps/web/tests/edit-mode/bridge.test.ts
@@ -364,7 +364,69 @@ describe('manual edit bridge target normalization', () => {
     expect(bridge).toContain("display.indexOf('flex') >= 0 || display.indexOf('grid') >= 0");
   });
 
-  it('turns text targets into inline editors and commits changed text', () => {
+  it('prefers nested text targets over their container on click', () => {
+    const dom = new JSDOM(
+      `<main>
+        <section data-od-id="card">
+          <p data-od-id="copy">Card copy</p>
+        </section>
+      </main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const copy = dom.window.document.querySelector('[data-od-id="copy"]') as HTMLElement;
+    const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
+
+    copy.dispatchEvent(new dom.window.MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 8,
+      clientY: 8,
+    }));
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'od-edit-select',
+      target: expect.objectContaining({
+        id: 'copy',
+        kind: 'text',
+      }),
+    }, '*');
+    expect(copy.getAttribute('contenteditable')).toBe('plaintext-only');
+
+    dom.window.close();
+  });
+
+  it('keeps container targets selectable from empty card space', () => {
+    const dom = new JSDOM(
+      `<main>
+        <section data-od-id="card" style="padding: 40px">
+          <p data-od-id="copy">Card copy</p>
+        </section>
+      </main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const card = dom.window.document.querySelector('[data-od-id="card"]') as HTMLElement;
+    const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
+
+    card.dispatchEvent(new dom.window.MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 4,
+      clientY: 4,
+    }));
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'od-edit-select',
+      target: expect.objectContaining({
+        id: 'card',
+        kind: 'container',
+      }),
+    }, '*');
+    expect(card.hasAttribute('contenteditable')).toBe(false);
+
+    dom.window.close();
+  });
+
+  it('turns text targets into inline editors and commits changed text on explicit finish', () => {
     const dom = new JSDOM(
       `<main><h1 data-od-id="title">Original title</h1></main>${buildManualEditBridge(true)}`,
       { runScripts: 'dangerously', url: 'http://localhost' },
@@ -391,12 +453,31 @@ describe('manual edit bridge target normalization', () => {
     title.textContent = 'Edited title';
     title.dispatchEvent(new dom.window.FocusEvent('blur', { bubbles: false }));
 
+    expect(title.getAttribute('contenteditable')).toBe('plaintext-only');
+    expect(title.getAttribute('data-od-editing')).toBe('true');
+    expect(postMessage).not.toHaveBeenCalledWith({
+      type: 'od-edit-text-commit',
+      id: 'title',
+      value: 'Edited title',
+    }, '*');
+
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od-edit-text-finish', commit: true },
+    }));
+
     expect(title.hasAttribute('contenteditable')).toBe(false);
     expect(title.hasAttribute('data-od-editing')).toBe(false);
     expect(postMessage).toHaveBeenCalledWith({
       type: 'od-edit-text-commit',
       id: 'title',
       value: 'Edited title',
+    }, '*');
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'od-edit-text-session',
+      id: 'title',
+      active: false,
+      committed: true,
+      changed: true,
     }, '*');
 
     dom.window.close();
@@ -421,6 +502,25 @@ describe('manual edit bridge target normalization', () => {
     expect(body.textContent).toBe('Original body');
     expect(postMessage).not.toHaveBeenCalledWith(expect.objectContaining({
       type: 'od-edit-text-commit',
+    }), '*');
+
+    dom.window.close();
+  });
+
+  it('suppresses hover retargeting while inline text edit is active', () => {
+    const dom = new JSDOM(
+      `<main><h1 data-od-id="title">Title</h1><p data-od-id="body">Body</p></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
+    const body = dom.window.document.querySelector('[data-od-id="body"]') as HTMLElement;
+    const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
+
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
+    body.dispatchEvent(new dom.window.MouseEvent('pointerover', { bubbles: true, cancelable: true }));
+
+    expect(postMessage).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: 'od-edit-hover',
     }), '*');
 
     dom.window.close();


### PR DESCRIPTION
## Summary

Fixes #3646.

This makes manual edit mode less fragile for text-heavy HTML artifacts and slide-like decks:

- prefer source-mappable text/link targets before container targets when clicking visible copy
- keep container selection available when clicking empty card/background space
- replace blur-driven inline text commits with an explicit text edit session contract
- keep hover retargeting from surfacing/switching affordances while inline text editing is active
- route the floating inspector Save/Cancel buttons through iframe commit/cancel before clearing selection

## Tests

- `pnpm --filter @open-design/host build`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/components build`
- `pnpm --filter @open-design/platform build`
- `pnpm --filter @open-design/sidecar-proto build`
- `pnpm --filter @open-design/sidecar build`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/edit-mode/bridge.test.ts tests/components/FileViewer.test.tsx`
- `pnpm --filter @open-design/web run typecheck`

## Surface area

- [x] Default behavior change
- [x] Web app / artifact preview
- [x] Tests
- [ ] Desktop bridge
- [ ] Export output
