### PR TITLE
fix(conversation-forking): fork from the in-memory snapshot so an unpersisted turn no longer silently fails

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -1315,8 +1315,29 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       typeof seedFromConversationId === 'string' && seedFromConversationId
         ? getConversation(db, seedFromConversationId)
         : null;
+    // Client-supplied fork snapshot. The chat "Fork" action sends the exact
+    // messages the user is looking at (up to the fork point). We prefer it over
+    // reading the source conversation from the DB so a fork point that was
+    // never persisted — e.g. an assistant turn whose run errored / had its
+    // connection reset before reaching the database — still forks instead of
+    // 404ing on `forkAfterMessageId`.
+    const clientSeedMessages = Array.isArray(req.body?.seedMessages)
+      ? (req.body.seedMessages as any[]).filter(
+          (message) => message && typeof message.role === 'string',
+        )
+      : null;
     let seedMessages: any[] = [];
-    if (sourceConversation && sourceConversation.projectId === req.params.id) {
+    if (clientSeedMessages && clientSeedMessages.length > 0) {
+      seedMessages = clientSeedMessages;
+      if (requestedForkMessageId) {
+        const forkIndex = seedMessages.findIndex(
+          (message) => message.id === requestedForkMessageId,
+        );
+        if (forkIndex >= 0) {
+          seedMessages = seedMessages.slice(0, forkIndex + 1);
+        }
+      }
+    } else if (sourceConversation && sourceConversation.projectId === req.params.id) {
       seedMessages = listMessages(db, seedFromConversationId);
       if (requestedForkMessageId) {
         const forkIndex = seedMessages.findIndex((message) => message.id === requestedForkMessageId);

--- a/apps/daemon/tests/projects-routes.test.ts
+++ b/apps/daemon/tests/projects-routes.test.ts
@@ -250,6 +250,107 @@ describe('GET /api/projects/:id resolvedDir', () => {
     expect(forkMessagesBody.messages[1]?.lastRunEventId).toBeUndefined();
   });
 
+  it('forks from a client-supplied snapshot when the fork point was never persisted', async () => {
+    // Regression: forking an assistant turn whose run errored / had its
+    // connection reset before the message reached the database used to 404 on
+    // `forkAfterMessageId` (the message is only in the browser), so the fork
+    // silently failed and the user never switched into the new conversation.
+    // The "Fork" action now sends the in-memory snapshot, which the daemon
+    // copies even though the fork point is absent from the source DB.
+    const projectId = `proj-conv-fork-snapshot-${Date.now()}`;
+    const createProjectResp = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Fork snapshot fixture',
+        skillId: null,
+        designSystemId: null,
+      }),
+    });
+    expect(createProjectResp.status).toBe(200);
+
+    const sourceResp = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Source', sessionMode: 'chat' }),
+    });
+    expect(sourceResp.status).toBe(200);
+    const sourceId = (
+      (await sourceResp.json()) as { conversation: { id: string } }
+    ).conversation.id;
+
+    // Persist only the user turn. The assistant turn errored before it was
+    // ever written, so it exists solely in the client's snapshot below.
+    const saveUserResp = await fetch(
+      `${baseUrl}/api/projects/${projectId}/conversations/${sourceId}/messages/ghost-user-1`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: 'ghost-user-1', role: 'user', content: 'enrich it' }),
+      },
+    );
+    expect(saveUserResp.status).toBe(200);
+
+    const forkResp = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Fork',
+        sessionMode: 'chat',
+        seedFromConversationId: sourceId,
+        forkAfterMessageId: 'ghost-assistant-1',
+        seedMessages: [
+          { id: 'ghost-user-1', role: 'user', content: 'enrich it' },
+          {
+            id: 'ghost-assistant-1',
+            role: 'assistant',
+            content: 'partial answer before reset',
+            runId: 'dead-run-1',
+            runStatus: 'failed',
+            lastRunEventId: 'evt-dead',
+            events: [{ kind: 'status', label: 'error', detail: 'Connection reset by server' }],
+          },
+          // Anything after the fork point must be dropped.
+          { id: 'ghost-user-2', role: 'user', content: 'should not be copied' },
+        ],
+      }),
+    });
+    expect(forkResp.status).toBe(200);
+    const forkId = (
+      (await forkResp.json()) as { conversation: { id: string } }
+    ).conversation.id;
+
+    const forkMessagesResp = await fetch(
+      `${baseUrl}/api/projects/${projectId}/conversations/${forkId}/messages`,
+    );
+    expect(forkMessagesResp.status).toBe(200);
+    const forkMessages = (
+      (await forkMessagesResp.json()) as {
+        messages: Array<{
+          id: string;
+          role: string;
+          content: string;
+          runId?: string;
+          runStatus?: string;
+          lastRunEventId?: string;
+        }>;
+      }
+    ).messages;
+
+    // Cut at the (unpersisted) fork point — the trailing user turn is dropped.
+    expect(forkMessages.map((m) => m.content)).toEqual([
+      'enrich it',
+      'partial answer before reset',
+    ]);
+    // Fresh ids, and the dead run pointers are not inherited.
+    expect(forkMessages.map((m) => m.id)).not.toContain('ghost-assistant-1');
+    expect(forkMessages[1]).toMatchObject({ role: 'assistant', content: 'partial answer before reset' });
+    expect(forkMessages[1]?.runId).toBeUndefined();
+    expect(forkMessages[1]?.runStatus).toBeUndefined();
+    expect(forkMessages[1]?.lastRunEventId).toBeUndefined();
+  });
+
   it('serves project files through raw and files path routes', async () => {
     const projectId = `proj-raw-route-${Date.now()}`;
     const createResp = await fetch(`${baseUrl}/api/projects`, {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4342,10 +4342,20 @@ export function ProjectView({
         const forkTitle = sourceTitle
           ? t('chat.forkedConversationTitle', { title: sourceTitle })
           : undefined;
+        // Seed the fork from the messages the user is actually looking at,
+        // up to and including the fork point. A run that errored or had its
+        // connection reset before its assistant message was persisted leaves
+        // that message in memory only; copying from the database by id would
+        // 404 and silently drop the fork. Sending the in-memory snapshot makes
+        // the fork resilient to that gap.
+        const forkIndex = messages.findIndex((m) => m.id === assistantMessage.id);
+        const seedMessages =
+          forkIndex >= 0 ? messages.slice(0, forkIndex + 1) : [...messages, assistantMessage];
         const fresh = await createConversation(project.id, forkTitle, {
           seedFromConversationId: activeConversationId,
           forkAfterMessageId: assistantMessage.id,
           sessionMode: activeSessionMode,
+          seedMessages,
         });
         if (!fresh) throw new Error(t('chat.forkConversationFailed'));
         setMessages([]);
@@ -4384,6 +4394,7 @@ export function ProjectView({
       activeConversation?.title,
       activeSessionMode,
       forkingMessageId,
+      messages,
       navigate,
       onProjectsRefresh,
       openTabsState.active,

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -254,6 +254,11 @@ export async function createConversation(
     seedFromConversationId?: string | null;
     forkAfterMessageId?: string | null;
     sessionMode?: ChatSessionMode;
+    // Fork snapshot: the exact in-memory messages to copy (up to the fork
+    // point). Lets the daemon fork from what the user sees even when the fork
+    // point was never persisted (e.g. a run that errored before its assistant
+    // message reached the database).
+    seedMessages?: ChatMessage[];
   },
 ): Promise<Conversation | null> {
   try {
@@ -266,6 +271,9 @@ export async function createConversation(
     }
     if (opts?.forkAfterMessageId) {
       body.forkAfterMessageId = opts.forkAfterMessageId;
+    }
+    if (opts?.seedMessages && opts.seedMessages.length > 0) {
+      body.seedMessages = opts.seedMessages;
     }
     const resp = await fetch(
       `/api/projects/${encodeURIComponent(projectId)}/conversations`,

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -371,6 +371,17 @@ export interface CreateConversationRequest {
    * future follow-ups from the source conversation.
    */
   forkAfterMessageId?: string | null;
+  /**
+   * Client-supplied snapshot of the messages to seed the fork with, in order,
+   * up to and including the fork point. When present, the daemon copies these
+   * instead of reading the source conversation from the database by id. This
+   * makes "Fork" resilient to a fork point that was never persisted — e.g. an
+   * assistant turn whose run errored or had its connection reset before the
+   * message reached the database. Without it, such a fork would 404 on
+   * `forkAfterMessageId` and silently fail. When absent, the daemon falls back
+   * to copying from `seedFromConversationId` (the original Side Chat path).
+   */
+  seedMessages?: ChatMessage[];
 }
 
 export interface UpdateConversationRequest {


### PR DESCRIPTION
## Why

I was reproducing a user report: clicking **Fork from here** on an assistant turn did nothing — the page flashed once and stayed on the same conversation, even though "a new chat got created." The forked-from turn was an AMR reply that had ended in `json-rpc id 4: Connection reset by server`.

Root cause: fork asks the daemon to copy the source conversation's messages up to the fork point, looked up in SQLite by `forkAfterMessageId`. When that turn's run errors / has its connection reset before the assistant message reaches the database, the id only exists in the browser. The daemon returns `404 "fork message not found"`, the web `createConversation` turns the non-OK response into `null`, and `handleForkFromMessage` throws into a quiet error state — so no conversation opens and the user never switches into the fork. Errored/interrupted runs are exactly the turns people most want to fork off of, so this hit a real workflow.

## What users will see

**Fork from here** now always works from what's on screen. Forking an assistant turn whose run errored or was interrupted opens the new conversation and switches into it, instead of flashing and doing nothing. No visible UI change — the existing fork button just stops silently failing on errored turns.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

`CreateConversationRequest` gains an optional `seedMessages?: ChatMessage[]`. The chat Fork action sends the in-memory message slice (up to and including the fork point); the daemon prefers that snapshot over reading the source conversation from the DB by id. The Side Chat path (no `seedMessages`) is unchanged and still seeds from `seedFromConversationId`.

Dual-track note: "Fork from here" is a UI affordance that operates on a rendered message the user points at; there is no `od` equivalent (the CLI doesn't render a transcript to pick a fork point), so this is an internal enhancement to the existing conversation-create endpoint rather than a new capability needing a CLI surface.

## Screenshots

No new UI. Behavior-only fix on the existing fork button.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/projects-routes.test.ts` → `forks from a client-supplied snapshot when the fork point was never persisted`
- Did the test go red on `main` and green on this branch? **yes** — on `main` the daemon ignores `seedMessages` and 404s on the missing `forkAfterMessageId` (`expected 404 to be 200`); on this branch it returns 200 and copies the snapshot.
- Also verified live with Playwright against a local daemon+web: forcing the fork POST to 404 reproduces the no-switch symptom; with the fix the client sends `seedMessages` (user+assistant, fork point last) and the URL switches into the new conversation.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `apps/daemon` `tests/projects-routes.test.ts` — 33 passed (incl. the new red spec)
- `apps/web` `ProjectView` + `AssistantMessage` suites — 124 passed
- Live Playwright fork flow against local daemon+web (Node 24, isolated `OD_DATA_DIR`): clean turn and errored turn both fork + switch; fork POST body now carries `seedMessages`.
