### PR TITLE
fix(web): reset project folders during render, not in an effect [v0.10.0]

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -229,6 +229,10 @@ const BROWSER_TAB_PREFIX = '__browser__:';
 // We keep an LRU of the most-recently-activated browser tabs live and unmount
 // the rest; switching back to an evicted tab remounts (reloads) it.
 const BROWSER_KEEPALIVE_CAP = 3;
+
+// Stable empty folder list so the render-phase project-switch reset is
+// idempotent (passing a fresh `[]` each render would re-trigger the reset).
+const EMPTY_PROJECT_FOLDERS: ProjectFolder[] = [];
 type TabDropEdge = 'before' | 'after';
 type BrowserWorkspaceTab = ProjectBrowserWorkspaceTab;
 type WorkspaceOrderedTab =
@@ -444,7 +448,20 @@ export function FileWorkspace({
   const [uploadDir, setUploadDir] = useState<string>('');
   const [sketches, setSketches] = useState<Record<string, SketchState>>({});
   const [quickSwitcherOpen, setQuickSwitcherOpen] = useState(false);
-  const [projectFolders, setProjectFolders] = useState<ProjectFolder[]>([]);
+  const [projectFolders, setProjectFolders] = useState<ProjectFolder[]>(EMPTY_PROJECT_FOLDERS);
+  // Reset the folder list during render — NOT in an effect — when the project
+  // changes. DesignFilesPanel is keyed by `projectId`, so an effect-based reset
+  // would let the new panel mount once with the previous project's folders and
+  // briefly suppress the new project's empty state (the exact regression this
+  // fix removes). Adjusting state during render discards this render before the
+  // child commits, so the new panel never sees stale folders. Mirrors the
+  // designFilesNav ref reset above. The stable empty constant keeps this
+  // idempotent (no re-entrant render loop).
+  const projectFoldersProjectIdRef = useRef(projectId);
+  if (projectFoldersProjectIdRef.current !== projectId) {
+    projectFoldersProjectIdRef.current = projectId;
+    setProjectFolders(EMPTY_PROJECT_FOLDERS);
+  }
   const [browserTabs, setBrowserTabs] = useState<BrowserWorkspaceTab[]>(
     () => browserTabsFromState(tabsState.browserTabs),
   );
@@ -503,11 +520,8 @@ export function FileWorkspace({
 
   useEffect(() => {
     let cancelled = false;
-    // Clear the previous project's folders synchronously before the async
-    // fetch resolves — otherwise switching projects briefly renders the old
-    // project's folders (and suppresses the new project's empty state, now
-    // that DesignFilesPanel treats a non-empty `folders` prop as content).
-    setProjectFolders([]);
+    // The synchronous clear happens during render (see projectFoldersProjectIdRef
+    // above); here we only fetch the new project's folders.
     void fetchProjectFolders(projectId).then((next) => {
       if (!cancelled) setProjectFolders(next);
     });

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -89,6 +89,30 @@ vi.mock('../../src/components/workspace/TerminalViewer', () => ({
   ),
 }));
 
+// Records the `folders` prop DesignFilesPanel receives on EVERY render (still
+// renders the real component). Lets a test observe the first render after a
+// project switch — the pre-paint frame RTL's post-rerender DOM assertion can't
+// see — to prove no stale folders ever reach the new panel.
+const { designFilesPanelRenders } = vi.hoisted(() => ({
+  designFilesPanelRenders: [] as { projectId: string; folderCount: number }[],
+}));
+vi.mock('../../src/components/DesignFilesPanel', async () => {
+  const actual = await vi.importActual<typeof import('../../src/components/DesignFilesPanel')>(
+    '../../src/components/DesignFilesPanel',
+  );
+  const Real = actual.DesignFilesPanel;
+  return {
+    ...actual,
+    DesignFilesPanel: (props: Parameters<typeof Real>[0]) => {
+      designFilesPanelRenders.push({
+        projectId: props.projectId,
+        folderCount: props.folders?.length ?? 0,
+      });
+      return <Real {...props} />;
+    },
+  };
+});
+
 const mockedFetchProjectFileText = vi.mocked(fetchProjectFileText);
 const mockedUploadProjectFiles = vi.mocked(uploadProjectFiles);
 const mockedWriteProjectTextFile = vi.mocked(writeProjectTextFile);
@@ -455,12 +479,22 @@ describe('FileWorkspace upload input', () => {
     // Switch to project-b; its folder fetch is still pending. The previous
     // project's 'assets' folder must be gone immediately (reset synchronously),
     // not linger and suppress the new project's empty state.
+    designFilesPanelRenders.length = 0;
     rerender(<FileWorkspace {...baseProps} projectId="project-b" files={[]} />);
     expect(
       [...container.querySelectorAll('.df-dir-row .df-row-name')].some(
         (e) => e.textContent === 'assets',
       ),
     ).toBe(false);
+
+    // The reset happens during render, not in an effect — so the new panel's
+    // FIRST render (and every render thereafter) already sees zero folders.
+    // An effect-based reset would let project-b's first render observe the
+    // stale 'assets' folder before the effect cleared it; RTL's post-rerender
+    // DOM check above can't catch that frame, this can.
+    const projectBRenders = designFilesPanelRenders.filter((r) => r.projectId === 'project-b');
+    expect(projectBRenders.length).toBeGreaterThan(0);
+    expect(projectBRenders.every((r) => r.folderCount === 0)).toBe(true);
   });
 
   it('clears a prior upload failure after a later successful upload', async () => {


### PR DESCRIPTION
## Why

`release/v0.10.0` carries the effect-based folder reset from #3618. On `main`, reviewer feedback (#3631) found that resetting the folder list in a passive `useEffect` is too late: `DesignFilesPanel` is keyed by `projectId`, so when the project changes the new panel mounts **once** with the previous project's folders before the effect clears them — briefly suppressing the new project's empty state, the exact regression #3358's follow-up set out to remove. This back-ports the `main` fix (#3631) so the release branch behaves identically.

## What users will see

No visible change in the happy path. When switching between projects in Design Files, the new project's panel no longer flashes the previous project's folders for a frame; an empty project correctly shows its empty state immediately on switch.

## What changed

- Move the folder reset into the render phase (adjust state during render via a `projectId` ref, mirroring the existing `designFilesNav` ref reset) so the newly-keyed panel never observes stale folders. A stable `EMPTY_PROJECT_FOLDERS` constant keeps the render-phase `setState` idempotent.
- Tighten the regression: a wrapper records the `folders` prop on every `DesignFilesPanel` render, and the test asserts no render for the new project ever sees a non-empty folder list — the pre-paint frame RTL's post-`rerender` DOM check can't observe. Red on the effect-based reset, green here.

Cherry-pick of `main` commit (#3631) via `git cherry-pick -x`.

## Surface area

- [x] Web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)