### PR TITLE
Fix stale chat spacer after resending

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -688,6 +688,10 @@ export function ChatPane({
 
   useEffect(() => {
     didInitialScrollRef.current = false;
+    anchorPendingRef.current = false;
+    anchorActiveRef.current = false;
+    prevLastUserIdRef.current = undefined;
+    resetTailSpacer();
     // A new conversation should land at the bottom (its own initial
     // scroll), not inherit the previous conversation's saved position.
     savedChatScrollRef.current = null;
@@ -796,6 +800,7 @@ export function ChatPane({
     prevLastUserIdRef.current = lastUser?.id;
     if (anchorPendingRef.current && lastUser && lastUser.id !== prevUserId) {
       anchorPendingRef.current = false;
+      resetTailSpacer();
       anchorActiveRef.current = true;
       pinnedToBottomRef.current = false;
       setScrolledFromBottom(true);
@@ -1602,6 +1607,8 @@ export function ChatPane({
               }
               // Arm "anchor to top": the messages effect promotes this once
               // the new user turn renders, pinning it to the top of the view.
+              anchorActiveRef.current = false;
+              resetTailSpacer();
               anchorPendingRef.current = true;
               onSend(prompt, attachments, commentAttachments, meta);
             }}

--- a/apps/web/tests/components/ChatPane.streaming.test.tsx
+++ b/apps/web/tests/components/ChatPane.streaming.test.tsx
@@ -448,6 +448,40 @@ Expected output:
     expect(screen.getByTestId('assistant-streaming-assistant-1').textContent).toBe('streaming');
   });
 
+  it('clears stale anchor spacer before sending another local turn', () => {
+    const onSend = vi.fn();
+    const { container } = render(
+      <ChatPane
+        projectKindForTracking="prototype"
+        messages={[
+          { id: 'user-1', role: 'user', content: 'Make the landing page', createdAt: 1 },
+          { id: 'assistant-1', role: 'assistant', content: 'Done', createdAt: 2 },
+        ]}
+        streaming={false}
+        error={null}
+        projectId="project-1"
+        projectFiles={[]}
+        onEnsureProject={async () => 'project-1'}
+        onSend={onSend}
+        onStop={vi.fn()}
+        conversations={conversations}
+        activeConversationId="conv-1"
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+        projectMetadata={projectMetadata}
+      />,
+    );
+
+    const spacer = container.querySelector<HTMLElement>('.chat-log-tail-spacer');
+    expect(spacer).not.toBeNull();
+    spacer!.style.height = '320px';
+
+    fireEvent.click(screen.getByTestId('composer-submit'));
+
+    expect(onSend).toHaveBeenCalledOnce();
+    expect(spacer!.style.height).toBe('0px');
+  });
+
   it('renders a stopped pinned todo after a terminal run without a final TodoWrite', () => {
     const messages: ChatMessage[] = [
       {


### PR DESCRIPTION
## Why

A Feishu nightly acceptance row reported that after adding many attachments, deleting them, and running again, the chat pane could show a large blank area. I reproduced the underlying stale `.chat-log-tail-spacer` state with a red ChatPane test: a previous anchor spacer survived into the next local send instead of resetting.

This is user-facing because the blank area makes the chat history look missing or broken after a follow-up run.

## What users will see

Follow-up sends start from a clean chat anchor state. Deleting attachments and sending again should no longer inherit old blank space below the previous turn.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Browser validation: opened a local project at `http://127.0.0.1:17621/`, confirmed the chat pane rendered normally, and confirmed `.chat-log-tail-spacer` was `height: 0px`. The meaningful regression is the send-time scroll state transition, covered by the red/green test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ChatPane.streaming.test.tsx`
- Did the test go red on `main` and green on this branch? yes. Before the source change, `clears stale anchor spacer before sending another local turn` failed with expected `0px`, received `320px`; after the fix it passes.

## Validation

- `pnpm --filter @open-design/web test -- ChatPane.streaming.test.tsx -t "clears stale anchor spacer"` (ran the web Vitest suite; 287 files passed)
- `pnpm --filter @open-design/web typecheck`
- Browser validation against `pnpm tools-dev run web --namespace codex-blank-fix --daemon-port 17620 --web-port 17621`
- `pnpm guard`
- `pnpm typecheck`
