### PR TITLE
Fix Windows app font fallback

### DIFF
--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -67,7 +67,7 @@
   --selected-soft: rgba(37, 99, 235, 0.16);
 
   --serif: 'Source Serif Pro', 'Source Serif 4', 'Iowan Old Style', 'Apple Garamond', Georgia, 'Times New Roman', serif;
-  --sans: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Microsoft YaHei UI', 'Noto Sans', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
 
   --prose-font-size: 15px;

--- a/apps/web/tests/styles/default-background.test.ts
+++ b/apps/web/tests/styles/default-background.test.ts
@@ -24,4 +24,14 @@ describe('default app background colors', () => {
     expect(dark).toContain('--bg: #1a1917;');
     expect(dark).toContain('--bg-app: #1a1917;');
   });
+
+  it('prefers platform UI fonts over optional local app fonts', () => {
+    const root = cssBlock(':root');
+    const sans = /--sans:\s*([^;]+);/.exec(root)?.[1];
+
+    expect(sans).toBeDefined();
+    expect(sans).toContain("'Segoe UI'");
+    expect(sans).not.toContain("'Inter'");
+    expect(sans).toMatch(/'Segoe UI', 'Microsoft YaHei UI', 'Noto Sans'/);
+  });
 });


### PR DESCRIPTION
Closes #1701

## Why

The issue screenshot shows the app web content rendering as icon/tofu-like glyphs inside the desktop shell while the native Electron chrome still renders normally. The app chrome was prioritizing an unbundled local `Inter` font before Windows' platform UI font, so a bad or unexpected local `Inter` install could replace readable UI text.

This bug fix makes the app prefer platform UI fonts for chrome text and adds explicit Windows/CJK fallbacks so localized labels stay readable.

## What users will see

Windows desktop users should see normal readable app text instead of icon-like glyph substitution when a problematic local `Inter` font is present.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this is a font fallback fix for a Windows/local-font-dependent rendering failure.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/default-background.test.ts`
- Did the test go red on `main` and green on this branch? no; the regression test locks the corrected font-stack invariant added with this fix.
- The screenshot-only report depends on a problematic local Windows font state that is not cheaply reproducible in this macOS worktree, so validation focuses on the CSS invariant that prevents app chrome from preferring optional local `Inter` over platform UI fonts.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web test -- tests/styles/default-background.test.ts` (ran the web Vitest suite: 298 files passed, 2940 tests passed, 1 skipped)
- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>