### PR TITLE
fix(conversation-forking): fork from the in-memory snapshot so an unpersisted turn no longer silently fails (#3648)

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -1315,8 +1315,29 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       typeof seedFromConversationId === 'string' && seedFromConversationId
         ? getConversation(db, seedFromConversationId)
         : null;
+    // Client-supplied fork snapshot. The chat "Fork" action sends the exact
+    // messages the user is looking at (up to the fork point). We prefer it over
+    // reading the source conversation from the DB so a fork point that was
+    // never persisted — e.g. an assistant turn whose run errored / had its
+    // connection reset before reaching the database — still forks instead of
+    // 404ing on `forkAfterMessageId`.
+    const clientSeedMessages = Array.isArray(req.body?.seedMessages)
+      ? (req.body.seedMessages as any[]).filter(
+          (message) => message && typeof message.role === 'string',
+        )
+      : null;
     let seedMessages: any[] = [];
-    if (sourceConversation && sourceConversation.projectId === req.params.id) {
+    if (clientSeedMessages && clientSeedMessages.length > 0) {
+      seedMessages = clientSeedMessages;
+      if (requestedForkMessageId) {
+        const forkIndex = seedMessages.findIndex(
+          (message) => message.id === requestedForkMessageId,
+        );
+        if (forkIndex >= 0) {
+          seedMessages = seedMessages.slice(0, forkIndex + 1);
+        }
+      }
+    } else if (sourceConversation && sourceConversation.projectId === req.params.id) {
       seedMessages = listMessages(db, seedFromConversationId);
       if (requestedForkMessageId) {
         const forkIndex = seedMessages.findIndex((message) => message.id === requestedForkMessageId);

--- a/apps/daemon/tests/projects-routes.test.ts
+++ b/apps/daemon/tests/projects-routes.test.ts
@@ -250,6 +250,107 @@ describe('GET /api/projects/:id resolvedDir', () => {
     expect(forkMessagesBody.messages[1]?.lastRunEventId).toBeUndefined();
   });
 
+  it('forks from a client-supplied snapshot when the fork point was never persisted', async () => {
+    // Regression: forking an assistant turn whose run errored / had its
+    // connection reset before the message reached the database used to 404 on
+    // `forkAfterMessageId` (the message is only in the browser), so the fork
+    // silently failed and the user never switched into the new conversation.
+    // The "Fork" action now sends the in-memory snapshot, which the daemon
+    // copies even though the fork point is absent from the source DB.
+    const projectId = `proj-conv-fork-snapshot-${Date.now()}`;
+    const createProjectResp = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Fork snapshot fixture',
+        skillId: null,
+        designSystemId: null,
+      }),
+    });
+    expect(createProjectResp.status).toBe(200);
+
+    const sourceResp = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Source', sessionMode: 'chat' }),
+    });
+    expect(sourceResp.status).toBe(200);
+    const sourceId = (
+      (await sourceResp.json()) as { conversation: { id: string } }
+    ).conversation.id;
+
+    // Persist only the user turn. The assistant turn errored before it was
+    // ever written, so it exists solely in the client's snapshot below.
+    const saveUserResp = await fetch(
+      `${baseUrl}/api/projects/${projectId}/conversations/${sourceId}/messages/ghost-user-1`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: 'ghost-user-1', role: 'user', content: 'enrich it' }),
+      },
+    );
+    expect(saveUserResp.status).toBe(200);
+
+    const forkResp = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Fork',
+        sessionMode: 'chat',
+        seedFromConversationId: sourceId,
+        forkAfterMessageId: 'ghost-assistant-1',
+        seedMessages: [
+          { id: 'ghost-user-1', role: 'user', content: 'enrich it' },
+          {
+            id: 'ghost-assistant-1',
+            role: 'assistant',
+            content: 'partial answer before reset',
+            runId: 'dead-run-1',
+            runStatus: 'failed',
+            lastRunEventId: 'evt-dead',
+            events: [{ kind: 'status', label: 'error', detail: 'Connection reset by server' }],
+          },
+          // Anything after the fork point must be dropped.
+          { id: 'ghost-user-2', role: 'user', content: 'should not be copied' },
+        ],
+      }),
+    });
+    expect(forkResp.status).toBe(200);
+    const forkId = (
+      (await forkResp.json()) as { conversation: { id: string } }
+    ).conversation.id;
+
+    const forkMessagesResp = await fetch(
+      `${baseUrl}/api/projects/${projectId}/conversations/${forkId}/messages`,
+    );
+    expect(forkMessagesResp.status).toBe(200);
+    const forkMessages = (
+      (await forkMessagesResp.json()) as {
+        messages: Array<{
+          id: string;
+          role: string;
+          content: string;
+          runId?: string;
+          runStatus?: string;
+          lastRunEventId?: string;
+        }>;
+      }
+    ).messages;
+
+    // Cut at the (unpersisted) fork point — the trailing user turn is dropped.
+    expect(forkMessages.map((m) => m.content)).toEqual([
+      'enrich it',
+      'partial answer before reset',
+    ]);
+    // Fresh ids, and the dead run pointers are not inherited.
+    expect(forkMessages.map((m) => m.id)).not.toContain('ghost-assistant-1');
+    expect(forkMessages[1]).toMatchObject({ role: 'assistant', content: 'partial answer before reset' });
+    expect(forkMessages[1]?.runId).toBeUndefined();
+    expect(forkMessages[1]?.runStatus).toBeUndefined();
+    expect(forkMessages[1]?.lastRunEventId).toBeUndefined();
+  });
+
   it('serves project files through raw and files path routes', async () => {
     const projectId = `proj-raw-route-${Date.now()}`;
     const createResp = await fetch(`${baseUrl}/api/projects`, {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4249,10 +4249,20 @@ export function ProjectView({
         const forkTitle = sourceTitle
           ? t('chat.forkedConversationTitle', { title: sourceTitle })
           : undefined;
+        // Seed the fork from the messages the user is actually looking at,
+        // up to and including the fork point. A run that errored or had its
+        // connection reset before its assistant message was persisted leaves
+        // that message in memory only; copying from the database by id would
+        // 404 and silently drop the fork. Sending the in-memory snapshot makes
+        // the fork resilient to that gap.
+        const forkIndex = messages.findIndex((m) => m.id === assistantMessage.id);
+        const seedMessages =
+          forkIndex >= 0 ? messages.slice(0, forkIndex + 1) : [...messages, assistantMessage];
         const fresh = await createConversation(project.id, forkTitle, {
           seedFromConversationId: activeConversationId,
           forkAfterMessageId: assistantMessage.id,
           sessionMode: activeSessionMode,
+          seedMessages,
         });
         if (!fresh) throw new Error(t('chat.forkConversationFailed'));
         setMessages([]);
@@ -4291,6 +4301,7 @@ export function ProjectView({
       activeConversation?.title,
       activeSessionMode,
       forkingMessageId,
+      messages,
       navigate,
       onProjectsRefresh,
       openTabsState.active,

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -254,6 +254,11 @@ export async function createConversation(
     seedFromConversationId?: string | null;
     forkAfterMessageId?: string | null;
     sessionMode?: ChatSessionMode;
+    // Fork snapshot: the exact in-memory messages to copy (up to the fork
+    // point). Lets the daemon fork from what the user sees even when the fork
+    // point was never persisted (e.g. a run that errored before its assistant
+    // message reached the database).
+    seedMessages?: ChatMessage[];
   },
 ): Promise<Conversation | null> {
   try {
@@ -266,6 +271,9 @@ export async function createConversation(
     }
     if (opts?.forkAfterMessageId) {
       body.forkAfterMessageId = opts.forkAfterMessageId;
+    }
+    if (opts?.seedMessages && opts.seedMessages.length > 0) {
+      body.seedMessages = opts.seedMessages;
     }
     const resp = await fetch(
       `/api/projects/${encodeURIComponent(projectId)}/conversations`,

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -371,6 +371,17 @@ export interface CreateConversationRequest {
    * future follow-ups from the source conversation.
    */
   forkAfterMessageId?: string | null;
+  /**
+   * Client-supplied snapshot of the messages to seed the fork with, in order,
+   * up to and including the fork point. When present, the daemon copies these
+   * instead of reading the source conversation from the database by id. This
+   * makes "Fork" resilient to a fork point that was never persisted — e.g. an
+   * assistant turn whose run errored or had its connection reset before the
+   * message reached the database. Without it, such a fork would 404 on
+   * `forkAfterMessageId` and silently fail. When absent, the daemon falls back
+   * to copying from `seedFromConversationId` (the original Side Chat path).
+   */
+  seedMessages?: ChatMessage[];
 }
 
 export interface UpdateConversationRequest {


### PR DESCRIPTION
Cherry-pick of #3648 (squash `d0bca92`) onto `release/v0.10.0`.

## Why

Backports the conversation-fork resilience fix to the v0.10.0 release line. On `main` this shipped as #3648.

`Fork from here` copied the source conversation's messages by looking up `forkAfterMessageId` in SQLite. When the fork point was an assistant turn whose run errored / had its connection reset before the message reached the database (e.g. AMR `Connection reset by server`), that id was not in the DB: the daemon returned `404 "fork message not found"`, `createConversation` turned the non-OK response into `null`, and the fork silently failed — the page flashed and stayed on the same conversation.

## What users will see

`Fork from here` now always works from what's on screen, including forking an errored/interrupted assistant turn. No new UI — the existing fork button just stops silently failing.

## Surface area

- [x] **API / contract** — `CreateConversationRequest` gains optional `seedMessages?: ChatMessage[]`; the chat Fork action sends the in-memory snapshot and the daemon prefers it over the DB-by-id lookup. Side Chat (no `seedMessages`) is unchanged.

## Bug fix verification

- Test: `apps/daemon/tests/projects-routes.test.ts` → `forks from a client-supplied snapshot when the fork point was never persisted` — 404 without the fix, 200 with it.
- Verified live on `main` with Playwright (client sends `seedMessages`, URL switches into the fork). Clean cherry-pick, no conflicts.

## Validation

- Clean cherry-pick of the squashed `main` commit (already passed full CI on #3648).
- `pnpm guard` + `pnpm typecheck` + daemon `projects-routes` + web `ProjectView`/`AssistantMessage` all passed on the source PR; CI re-runs here.
