### PR TITLE
[codex] Fix question form panel flow

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -33,8 +33,8 @@ import {
   stripTrailingOpenQuestionForm,
   type QuestionForm,
 } from "../artifacts/question-form";
+import { parseSubmittedAnswers } from "./QuestionForm";
 import { splitStreamingArtifact, stripArtifact } from "../artifacts/strip";
-import { QuestionFormView, parseSubmittedAnswers } from "./QuestionForm";
 import {
   getPluginFolderCandidates,
   type PluginFolderCandidate,
@@ -72,6 +72,12 @@ type TranslateFn = (
   key: keyof Dict,
   vars?: Record<string, string | number>
 ) => string;
+
+export type QuestionFormOpenRequest = {
+  form: QuestionForm;
+  messageId: string;
+  submittedAnswers?: Record<string, string | string[]>;
+};
 
 const DISCORD_INVITE_URL = "https://discord.gg/mHAjSMV6gz";
 
@@ -306,17 +312,15 @@ interface Props {
   ) => Promise<{ message?: string; url?: string } | void> | { message?: string; url?: string } | void;
   activePluginActionPaths?: Set<string>;
   hiddenPluginActionPaths?: Set<string>;
-  // True only for the most recent assistant message — gate question-form
-  // interactivity on this so older forms render as a locked "answered"
-  // capsule instead of being re-submittable.
+  // True only for the most recent assistant message.
   isLast?: boolean;
   // Assistant message id whose run-failure error is rendered as ChatPane's
   // top-level error card; that message's per-message error pill is suppressed
   // to avoid duplication. Other messages keep their error pill.
   errorCardOwnerId?: string | null;
-  // The user message that immediately follows this assistant turn (if
-  // any). Used to detect that a form was already answered so we can
-  // render its locked state with the user's picks visible.
+  // The user message that immediately follows this assistant turn, if any.
+  // Kept for ChatPane compatibility; chat-side question forms now always
+  // render as a compact Questions banner.
   nextUserContent?: string;
   // Submit handler the form fires when the user picks answers — opaque
   // to AssistantMessage; ProjectView wires it into onSend.
@@ -324,7 +328,7 @@ interface Props {
   // Open the right-hand Questions tab. The active discovery form renders
   // there (Claude-Design style) instead of inline; this assistant message
   // shows a banner that focuses the tab on click.
-  onOpenQuestions?: () => void;
+  onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
   onContinueRemainingTasks?: (todos: TodoItem[]) => void;
   onForkFromMessage?: () => void;
   forking?: boolean;
@@ -622,11 +626,6 @@ function AssistantMessageImpl({
       setOutputStartedAt(undefined);
     }
   }, [streaming, hasContent]);
-  // Track which forms the user submitted in this session so we lock them
-  // immediately on click (without waiting for the parent to re-render).
-  const [locallySubmitted, setLocallySubmitted] = useState<Set<string>>(
-    () => new Set()
-  );
   const [dismissedCandidateIds, setDismissedCandidateIds] = useState<Set<string>>(
     () => new Set()
   );
@@ -678,20 +677,12 @@ function AssistantMessageImpl({
               <ProseBlock
                 key={i}
                 text={b.text}
+                assistantMessageId={message.id}
                 isLastAssistant={!!isLast}
                 streaming={streaming}
                 showStreamCursor={streaming && i === lastTextBlockIndex}
                 nextUserContent={nextUserContent}
-                locallySubmitted={locallySubmitted}
                 suppressDirectionForms={suppressDirectionForms}
-                onSubmitForm={(formId, text) => {
-                  setLocallySubmitted((prev) => {
-                    const next = new Set(prev);
-                    next.add(formId);
-                    return next;
-                  });
-                  onSubmitForm?.(text);
-                }}
                 onOpenQuestions={onOpenQuestions}
                 projectId={projectId}
                 projectFileNames={projectFileNames}
@@ -1952,29 +1943,27 @@ function hasPluginFinalActionHint(content: string): boolean {
 
 function ProseBlock({
   text,
+  assistantMessageId,
   isLastAssistant,
   streaming,
   showStreamCursor,
   nextUserContent,
-  locallySubmitted,
   suppressDirectionForms,
-  onSubmitForm,
   onOpenQuestions,
   projectId,
   projectFileNames,
   onRequestOpenFile,
 }: {
   text: string;
+  assistantMessageId: string;
   isLastAssistant: boolean;
   streaming: boolean;
   showStreamCursor?: boolean;
   nextUserContent?: string;
-  locallySubmitted: Set<string>;
   suppressDirectionForms: boolean;
-  onSubmitForm: (formId: string, text: string) => void;
-  onOpenQuestions?: () => void;
   projectId?: string | null;
   projectFileNames?: Set<string>;
+  onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
   onRequestOpenFile?: (name: string) => void;
 }) {
   const t = useT();
@@ -2067,10 +2056,8 @@ function ProseBlock({
           <FormBlock
             key={seg.key}
             form={seg.form}
-            isLastAssistant={isLastAssistant}
+            assistantMessageId={assistantMessageId}
             nextUserContent={nextUserContent}
-            locallySubmitted={locallySubmitted}
-            onSubmitForm={onSubmitForm}
             onOpenQuestions={onOpenQuestions}
           />
         );
@@ -2087,8 +2074,9 @@ function ProseBlock({
   );
 }
 
-// Chat-side banner that points to the right-hand Questions tab where the
-// active discovery form lives. Clicking it focuses that tab.
+// Chat-side banner that points to the right-hand Questions tab where discovery
+// forms live. The chat column always stays compact: no inline form preview,
+// answered or not.
 function QuestionsBanner({ onOpen }: { onOpen?: () => void }) {
   const t = useT();
   return (
@@ -2117,40 +2105,27 @@ function isDirectionForm(form: QuestionForm): boolean {
 
 function FormBlock({
   form,
-  isLastAssistant,
+  assistantMessageId,
   nextUserContent,
-  locallySubmitted,
-  onSubmitForm,
   onOpenQuestions,
 }: {
   form: QuestionForm;
-  isLastAssistant: boolean;
+  assistantMessageId: string;
   nextUserContent?: string;
-  locallySubmitted: Set<string>;
-  onSubmitForm: (formId: string, text: string) => void;
-  onOpenQuestions?: () => void;
+  onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
 }) {
-  // Reconstruct prior answers from a follow-up user message so older
-  // forms in the scrollback render in their answered state.
-  const submittedFromHistory = useMemo(() => {
-    if (!nextUserContent) return null;
-    return parseSubmittedAnswers(form, nextUserContent);
-  }, [form, nextUserContent]);
-  const wasSubmittedLocally = locallySubmitted.has(form.id);
-  // The live, still-unanswered form lives in the right-hand Questions tab —
-  // even mid-stream. In chat we only show a banner that focuses it, so the
-  // left side never renders the form itself. Answered / historical forms stay
-  // inline so the scrollback reads naturally.
-  const showBanner = isLastAssistant && !submittedFromHistory && !wasSubmittedLocally;
-  if (showBanner) {
-    return <QuestionsBanner onOpen={onOpenQuestions} />;
-  }
   return (
-    <QuestionFormView
-      form={form}
-      interactive={false}
-      submittedAnswers={submittedFromHistory ?? undefined}
-      onSubmit={(text) => onSubmitForm(form.id, text)}
+    <QuestionsBanner
+      onOpen={() => {
+        const submittedFromHistory = nextUserContent
+          ? parseSubmittedAnswers(form, nextUserContent)
+          : null;
+        onOpenQuestions?.({
+          form,
+          messageId: assistantMessageId,
+          submittedAnswers: submittedFromHistory ?? undefined,
+        });
+      }}
     />
   );
 }

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -31,7 +31,7 @@ import { TodoCard } from './ToolCard';
 import type { AppConfig, ChatAttachment, ChatCommentAttachment, ChatMessage, ChatMessageFeedbackChange, Conversation, DesignSystemSummary, PreviewComment, Project, ProjectFile, ProjectMetadata, SkillSummary } from '../types';
 import { dayKey, dayLabel, exactDateTime, messageTime, relativeTimeLong, shortTime } from '../utils/chatTime';
 import { commentTargetDisplayName, commentsToAttachments, simplePositionLabel } from '../comments';
-import { AssistantMessage } from './AssistantMessage';
+import { AssistantMessage, type QuestionFormOpenRequest } from './AssistantMessage';
 import { AmrGuidance } from './AmrGuidance';
 import { AMR_RECHARGE_URL, resolveRunFailureUi } from '../runtime/amr-guidance';
 import {
@@ -287,7 +287,7 @@ interface Props {
   // routes that text through onSend (no attachments).
   onSubmitForm?: (text: string) => void;
   // Focus the right-hand Questions tab from the chat banner.
-  onOpenQuestions?: () => void;
+  onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
   onContinueRemainingTasks?: (assistantMessage: ChatMessage, todos: TodoItem[]) => void;
   onAssistantFeedback?: (assistantMessage: ChatMessage, change: ChatMessageFeedbackChange) => void;
   // "Next step" affordance handlers forwarded to the last assistant message.
@@ -724,9 +724,9 @@ export function ChatPane({
     () => messages.find((m) => m.role === 'user')?.id,
     [messages],
   );
-  // Map each assistant message id to the user message that follows it
-  // (if any) so QuestionFormView can render its locked "answered" state
-  // with the user's picks.
+  // Map each assistant message id to the user message that follows it (if any)
+  // so the chat-side Questions banner can reopen that exact answered form in
+  // the right-hand panel later.
   const nextUserContentByAssistantId = useMemo(() => {
     const map = new Map<string, string>();
     for (let i = 0; i < messages.length - 1; i++) {
@@ -1822,7 +1822,7 @@ function ChatRows({
   forkingMessageId?: string | null;
   t: TranslateFn;
   onAssistantFormSubmitStart: () => void;
-  onOpenQuestions?: () => void;
+  onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
   scrollContainerRef: MutableRefObject<HTMLDivElement | null>;
 }) {
   const items = useMemo(() => buildChatRenderItems(messages), [messages]);

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -409,12 +409,10 @@ export function FileWorkspace({
   focusQuestionsRequest = null,
 }: Props) {
   const t = useT();
-  // The Questions tab only exists while there's an unanswered form. Once the
-  // user replies, the answered copy moves back into chat and the tab must close
-  // — so gate on `questionFormSubmittedAnswers === undefined` rather than the
-  // mere presence of a form, otherwise a locked duplicate lingers in the panel.
-  const showQuestionsTab =
-    Boolean(questionForm || questionsGenerating) && questionFormSubmittedAnswers === undefined;
+  // The chat column only shows a compact Questions banner; the form itself
+  // lives here, including after submission when a banner click can reopen the
+  // answered preview.
+  const showQuestionsTab = Boolean(questionForm || questionFormPreview || questionsGenerating);
   const analytics = useAnalytics();
   // P1 page_view page_name=file_manager — once per project the user lands
   // inside the workspace. Re-fire when the projectId changes so a
@@ -749,8 +747,21 @@ export function FileWorkspace({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusQuestionsRequest?.nonce]);
 
-  // If the Questions tab is active but the form is gone (answered, or a new
-  // assistant turn without a form), fall back to the default root tab.
+  // Submitting from the right-hand panel should close the preview once. The
+  // answered form remains available, so a later chat-banner click can reopen
+  // the same Questions tab without this effect immediately closing it again.
+  const previousQuestionFormSubmittedAnswersRef = useRef(questionFormSubmittedAnswers);
+  useEffect(() => {
+    const wasAnswered = previousQuestionFormSubmittedAnswersRef.current !== undefined;
+    const isAnswered = questionFormSubmittedAnswers !== undefined;
+    previousQuestionFormSubmittedAnswersRef.current = questionFormSubmittedAnswers;
+    if (activeTab === QUESTIONS_TAB && !wasAnswered && isAnswered) {
+      setActiveTab(defaultRootTab);
+    }
+  }, [activeTab, defaultRootTab, questionFormSubmittedAnswers]);
+
+  // If the Questions tab is active but the form is gone because a new assistant
+  // turn has no form, fall back to the default root tab.
   useEffect(() => {
     if (activeTab === QUESTIONS_TAB && !showQuestionsTab) {
       setActiveTab(defaultRootTab);

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -161,6 +161,7 @@ import { ProjectDesignSystemPicker } from './ProjectDesignSystemPicker';
 import { PluginDetailsModal } from './PluginDetailsModal';
 import { DesignSystemPreviewModal } from './DesignSystemPreviewModal';
 import { ChatPane } from './ChatPane';
+import type { QuestionFormOpenRequest } from './AssistantMessage';
 import { WorkingDirPill } from './WorkingDirPill';
 import type { ChatSendMeta } from './ChatComposer';
 import {
@@ -1030,6 +1031,23 @@ export function ProjectView({
       ? `${activeConversationId}:${lastAssistantMessageId}:${f.id}`
       : null;
   }, [activeConversationId, lastAssistantMessageId, questionForm, questionFormPreview]);
+  const [manualQuestionFormRequest, setManualQuestionFormRequest] =
+    useState<QuestionFormOpenRequest | null>(null);
+  useEffect(() => {
+    setManualQuestionFormRequest(null);
+  }, [project.id, activeConversationId]);
+  useEffect(() => {
+    if (hasQuestions && questionFormKey) setManualQuestionFormRequest(null);
+  }, [hasQuestions, questionFormKey]);
+  const displayedQuestionForm = manualQuestionFormRequest?.form ?? questionForm;
+  const displayedQuestionFormPreview = manualQuestionFormRequest ? null : questionFormPreview;
+  const displayedQuestionFormSubmittedAnswers =
+    manualQuestionFormRequest?.submittedAnswers ?? questionFormSubmittedAnswers;
+  const displayedQuestionFormActive = manualQuestionFormRequest ? false : questionFormActive;
+  const displayedQuestionsGenerating = manualQuestionFormRequest ? false : questionsGenerating;
+  const displayedQuestionFormKey = manualQuestionFormRequest
+    ? `${activeConversationId ?? 'conversation'}:${manualQuestionFormRequest.messageId}:${manualQuestionFormRequest.form.id}:manual`
+    : questionFormKey;
 
   // Auto-switch the workspace to the Questions tab when a new discovery form
   // first appears, and let the chat banner re-focus it on click. The nonce
@@ -1046,9 +1064,29 @@ export function ProjectView({
     () => (questionsFocusNonce > 0 ? { nonce: questionsFocusNonce } : null),
     [questionsFocusNonce],
   );
-  const openQuestionsTab = useCallback(() => {
+  const submittedAnswersForQuestionFormRequest = useCallback((request: QuestionFormOpenRequest) => {
+    const assistantIndex = messages.findIndex((m) => m.id === request.messageId);
+    if (assistantIndex < 0) return null;
+    for (let i = assistantIndex + 1; i < messages.length; i++) {
+      const m = messages[i];
+      if (!m) continue;
+      if (m.role === 'assistant') break;
+      if (m.role !== 'user') continue;
+      const parsed = parseSubmittedAnswers(request.form, m.content ?? '');
+      if (parsed) return parsed;
+    }
+    return null;
+  }, [messages]);
+  const openQuestionsTab = useCallback((request?: QuestionFormOpenRequest) => {
+    if (request) {
+      setManualQuestionFormRequest({
+        ...request,
+        submittedAnswers:
+          request.submittedAnswers ?? submittedAnswersForQuestionFormRequest(request) ?? undefined,
+      });
+    }
     setQuestionsFocusNonce((n) => n + 1);
-  }, []);
+  }, [submittedAnswersForQuestionFormRequest]);
 
   const currentConversationQueuedItems = activeConversationId
     ? queuedChatSends
@@ -5324,13 +5362,13 @@ export function ProjectView({
               />
             </>
           )}
-          questionForm={questionForm}
-          questionFormPreview={questionFormPreview}
-          questionFormKey={questionFormKey}
-          questionFormInteractive={questionFormActive}
+          questionForm={displayedQuestionForm}
+          questionFormPreview={displayedQuestionFormPreview}
+          questionFormKey={displayedQuestionFormKey}
+          questionFormInteractive={displayedQuestionFormActive}
           questionFormSubmitDisabled={currentConversationActionDisabled}
-          questionFormSubmittedAnswers={questionFormSubmittedAnswers}
-          questionsGenerating={questionsGenerating}
+          questionFormSubmittedAnswers={displayedQuestionFormSubmittedAnswers}
+          questionsGenerating={displayedQuestionsGenerating}
           focusQuestionsRequest={focusQuestionsRequest}
           onSubmitQuestionForm={(text) => {
             if (currentConversationActionDisabled) return;

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -361,7 +361,7 @@ describe('AssistantMessage thinking blocks', () => {
 });
 
 describe('AssistantMessage question forms', () => {
-  it('renders only the first question form for a repeated form id in one assistant turn', () => {
+  it('renders repeated question forms as one compact Questions banner in chat', () => {
     const firstForm = [
       '<question-form id="discovery" title="Quick brief — tailored">',
       JSON.stringify({
@@ -390,12 +390,8 @@ describe('AssistantMessage question forms', () => {
       }),
       '</question-form>',
     ].join('\n');
+    const onOpenQuestions = vi.fn();
 
-    // A historical (non-last) assistant turn renders its question forms
-    // inline in the scrollback. The live, still-unanswered form on the most
-    // recent turn lives in the right-hand Questions tab (chat shows only a
-    // focus banner), so the dedup behavior is asserted on a historical turn
-    // where the form markup is rendered in place.
     render(
       <AssistantMessage
         message={baseMessage({
@@ -408,13 +404,62 @@ describe('AssistantMessage question forms', () => {
         })}
         streaming={false}
         projectId="proj-1"
+        onOpenQuestions={onOpenQuestions}
       />,
     );
 
-    expect(screen.getByText('Quick brief — tailored')).toBeTruthy();
-    expect(screen.getByText('Who is this for?')).toBeTruthy();
+    const banners = screen.getAllByTestId('questions-banner');
+    expect(banners).toHaveLength(1);
+    fireEvent.click(banners[0]!);
+    expect(onOpenQuestions).toHaveBeenCalledWith(expect.objectContaining({
+      form: expect.objectContaining({ id: 'discovery', title: 'Quick brief — tailored' }),
+    }));
+    expect(screen.queryByText('Quick brief — tailored')).toBeNull();
+    expect(screen.queryByText('Who is this for?')).toBeNull();
     expect(screen.queryByText('Quick brief — 30 seconds')).toBeNull();
     expect(screen.queryByText('What are we making?')).toBeNull();
+  });
+
+  it('keeps answered question forms collapsed in chat', () => {
+    const form = [
+      '<question-form id="discovery" title="Quick brief — tailored">',
+      JSON.stringify({
+        questions: [
+          {
+            id: 'audience',
+            label: 'Who is this for?',
+            type: 'text',
+          },
+        ],
+      }),
+      '</question-form>',
+    ].join('\n');
+
+    const onOpenQuestions = vi.fn();
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          events: [
+            {
+              kind: 'text',
+              text: form,
+            } as ChatMessage['events'][number],
+          ],
+        })}
+        streaming={false}
+        projectId="proj-1"
+        nextUserContent="[form answers for discovery]\n- Who is this for?: Product evaluators"
+        onOpenQuestions={onOpenQuestions}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('questions-banner'));
+    expect(onOpenQuestions).toHaveBeenCalledWith(expect.objectContaining({
+      form: expect.objectContaining({ id: 'discovery', title: 'Quick brief — tailored' }),
+    }));
+    expect(screen.queryByText('Quick brief — tailored')).toBeNull();
+    expect(screen.queryByText('Who is this for?')).toBeNull();
+    expect(screen.queryByText('Product evaluators')).toBeNull();
   });
 });
 

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -1522,25 +1522,40 @@ describe('FileWorkspace Questions tab', () => {
     expect(screen.getByTestId('questions-tab')).toBeTruthy();
   });
 
-  it('removes the Questions tab once the form has been answered', () => {
-    // Regression for #3355: answering a question moved the answered copy back
-    // into chat but left a locked duplicate mounted in the Questions tab.
-    render(
+  it('closes the Questions preview after submit, then lets the answered form reopen', async () => {
+    const baseProps: React.ComponentProps<typeof FileWorkspace> = {
+      projectId: 'project-1',
+      projectKind: 'prototype',
+      files: [],
+      liveArtifacts: [],
+      onRefreshFiles: vi.fn(),
+      isDeck: false,
+      tabsState: { tabs: [], active: null },
+      onTabsStateChange: vi.fn(),
+      questionForm: discoveryForm,
+      focusQuestionsRequest: { nonce: 1 },
+    };
+    const { rerender } = render(<FileWorkspace {...baseProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Quick brief')).toBeTruthy();
+    });
+
+    rerender(
       <FileWorkspace
-        projectId="project-1"
-        projectKind="prototype"
-        files={[]}
-        liveArtifacts={[]}
-        onRefreshFiles={vi.fn()}
-        isDeck={false}
-        tabsState={{ tabs: [], active: null }}
-        onTabsStateChange={vi.fn()}
-        questionForm={discoveryForm}
+        {...baseProps}
         questionFormSubmittedAnswers={{ platform: 'Mobile' }}
       />,
     );
 
-    expect(screen.queryByTestId('questions-tab')).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByText('Quick brief')).toBeNull();
+    });
+    expect(screen.getByTestId('questions-tab')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('questions-tab'));
+    expect(screen.getByText('Quick brief')).toBeTruthy();
+    expect(screen.getByText('Mobile')).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Why

This release fix addresses the question-form regression found while validating generated design flows: forms could expand back into the left chat column after selection or answering, which made the chat scrollback jump and duplicated the right-side form surface.

The fix keeps discovery forms in one consistent place and preserves the compact chat flow.

## What users will see

- Question forms in the left chat column always appear as a compact Questions banner/button.
- Clicking that banner opens the corresponding form in the right-side Questions panel.
- Submitting the right-side form closes the preview and returns to the default workspace surface.
- Clicking the left banner later reopens the same form on the right, including answered historical forms.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Actual local page screenshots were captured in the Codex thread:

- `/tmp/open-design-actual-form-right-panel.png` — left chat shows compact Questions banner, right side shows form preview.
- `/tmp/open-design-actual-form-closed-after-answer.png` — answered form is closed by default after submission.
- `/tmp/open-design-actual-form-reopened-after-answer.png` — clicking the left banner reopens the answered form on the right.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/web/tests/components/AssistantMessage.test.tsx`
  - `apps/web/tests/components/FileWorkspace.test.tsx`
- Did the test go red on `main` and green on this branch? no, scoped regression tests were added and verified green on the release branch base after the fix.
- Additional verification: real `tools-dev` web/daemon page was seeded and visually checked through the browser.

## Validation

- `pnpm tools-dev` started daemon, web, and desktop successfully.
- `pnpm tools-dev status --json`
- `pnpm --filter @open-design/web test tests/components/AssistantMessage.test.tsx tests/components/FileWorkspace.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
