### PR TITLE
Fix image export format switch save label

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -8735,7 +8735,7 @@ function HtmlViewer({
                   void handleImageExportSave();
                 }}
               >
-                {imageExportBusy || imageExportPreparing ? t('fileViewer.exportImageSaving') : t('common.save')}
+                {imageExportBusy ? t('fileViewer.exportImageSaving') : t('common.save')}
               </button>
             </div>
           </div>

--- a/apps/web/tests/components/file-viewer-image-export.test.tsx
+++ b/apps/web/tests/components/file-viewer-image-export.test.tsx
@@ -79,7 +79,9 @@ function openImageExportDialog() {
 
 async function waitForSaveButton() {
   const button = await screen.findByRole('button', { name: /^save$/i });
-  expect((button as HTMLButtonElement).disabled).toBe(false);
+  await waitFor(() => {
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+  });
   return button;
 }
 
@@ -131,6 +133,38 @@ describe('FileViewer image export', () => {
     expect(requestPreviewSnapshotMock).toHaveBeenCalledTimes(1);
     expect(saveImageBlobMock).toHaveBeenCalledWith(imageBlob);
     expect(screen.getByText('workspace.jpg')).toBeTruthy();
+  });
+
+  it('keeps the Save label stable while a format change prepares the next image', async () => {
+    const pngBlob = new Blob(['png'], { type: 'image/png' });
+    let resolveJpegBlob: ((blob: Blob) => void) | undefined;
+    requestPreviewSnapshotMock.mockResolvedValueOnce({
+      dataUrl: 'data:image/png;base64,ok',
+      w: 800,
+      h: 600,
+    });
+    imageDataUrlToBlobMock
+      .mockResolvedValueOnce(pngBlob)
+      .mockImplementationOnce(async () => new Promise<Blob>((resolve) => {
+        resolveJpegBlob = resolve;
+      }));
+
+    renderHtmlPreview();
+    openImageExportDialog();
+
+    await waitForSaveButton();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'JPEG' }));
+    await waitFor(() => {
+      expect(imageDataUrlToBlobMock).toHaveBeenCalledWith('data:image/png;base64,ok', 'jpeg');
+    });
+
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /saving image/i })).toBeNull();
+    expect((screen.getByRole('button', { name: /^save$/i }) as HTMLButtonElement).disabled).toBe(true);
+
+    resolveJpegBlob?.(new Blob(['jpeg'], { type: 'image/jpeg' }));
+    await waitForSaveButton();
   });
 
   it('retries the srcDoc snapshot bridge before giving up on URL-loaded previews', async () => {


### PR DESCRIPTION
## Why

I picked up the 0.10.0 nightly acceptance item "切换tab 保存按钮闪烁". In the image export dialog, switching PNG / JPEG / WebP prepares the next image blob, but the Save button reused the real-save loading label during that prepare step. That made the footer flash as if a save had started even though the user only changed formats.

## What users will see

In Export as image, switching between PNG, JPEG, and WebP keeps the footer action labeled Save / 保存 while the next image is prepared. The button can still be temporarily disabled until the prepared image is ready, but it no longer flashes to Saving image... unless the user actually clicks Save.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Validation video is attached in a PR comment.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/file-viewer-image-export.test.tsx`
- Did the test go red on `main` and green on this branch? yes. The new spec failed before the source change because the Save button accessible name became `Saving image...` during format preparation, then passed after the fix.

## Validation

- `pnpm --filter @open-design/web test -- file-viewer-image-export.test.tsx -t "keeps the Save label stable"`
- `pnpm --filter @open-design/web typecheck`
- `pnpm typecheck`
- `pnpm guard`
- Browser validation video: switch image export formats and confirm Save label stays stable
