### PR TITLE
feat(plugins): support bundle plugin layout

### DIFF
--- a/apps/daemon/src/plugins/apply.ts
+++ b/apps/daemon/src/plugins/apply.ts
@@ -51,6 +51,13 @@ export class MissingInputError extends Error {
   }
 }
 
+export class NonApplyablePluginError extends Error {
+  constructor(pluginId: string) {
+    super(`Plugin ${pluginId} is not applyable`);
+    this.name = 'NonApplyablePluginError';
+  }
+}
+
 // Apply result narrows the trust tier to 'trusted' | 'restricted'. The
 // installed-plugin record can carry 'bundled' (per §5.3); we coerce to
 // 'trusted' at apply time so the snapshot's permission contract is binary.
@@ -88,6 +95,9 @@ export interface ApplyComputed {
 
 export function applyPlugin(input: ApplyInput): ApplyComputed {
   const manifest = input.plugin.manifest;
+  if (isBundleResourceOnlyPlugin(input.plugin)) {
+    throw new NonApplyablePluginError(input.plugin.id);
+  }
   const rawTrust: TrustTier = input.trust ?? input.plugin.trust;
   const trust: ApplyTrust = rawTrust === 'restricted' ? 'restricted' : 'trusted';
 
@@ -213,6 +223,11 @@ export function applyPlugin(input: ApplyInput): ApplyComputed {
   };
 
   return { result, manifestSourceDigest: digest, warnings: resolved.warnings };
+}
+
+export function isBundleResourceOnlyPlugin(plugin: InstalledPluginRecord): boolean {
+  const od = (plugin.manifest.od ?? {}) as Record<string, unknown>;
+  return od.hidden === true && (od.bundleResourceKind === 'design-system' || od.bundleResourceKind === 'craft');
 }
 
 interface ValidationResult {

--- a/apps/daemon/src/plugins/bundle.ts
+++ b/apps/daemon/src/plugins/bundle.ts
@@ -304,10 +304,11 @@ function readSkillMetadata(folder: string, fallbackId: string): { title?: string
   try {
     const raw = fs.readFileSync(path.join(folder, 'SKILL.md'), 'utf8');
     const adapted = adaptAgentSkill(raw, { folderId: fallbackId });
-    return {
+    const metadata: { title?: string; description?: string } = {
       title: adapted.manifest.title ?? adapted.manifest.name ?? fallbackId,
-      description: adapted.manifest.description,
     };
+    if (adapted.manifest.description) metadata.description = adapted.manifest.description;
+    return metadata;
   } catch {
     return { title: fallbackId };
   }

--- a/apps/daemon/src/plugins/bundle.ts
+++ b/apps/daemon/src/plugins/bundle.ts
@@ -273,7 +273,10 @@ async function synthesizeResourceChild(
     name: child.id,
     version: options.bundleRecord.version,
     title,
-    od: {},
+    od: {
+      hidden: true,
+      bundleResourceKind: kind,
+    },
   };
   const record: InstalledPluginRecord = {
     id: fullId,

--- a/apps/daemon/src/plugins/bundle.ts
+++ b/apps/daemon/src/plugins/bundle.ts
@@ -1,0 +1,338 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import { promises as fsp } from 'node:fs';
+import {
+  adaptAgentSkill,
+  parseManifest,
+  type RegistryView,
+} from '@open-design/plugin-runtime';
+import type {
+  BundleChild,
+  InstalledPluginRecord,
+  PluginBundle,
+  PluginManifest,
+  PluginSourceKind,
+} from '@open-design/contracts';
+import type { ResolveOptions } from './registry.js';
+import { resolvePluginFolder } from './registry.js';
+
+export type BundleChildKind = 'skill' | 'design-system' | 'craft';
+
+export interface BundleChildRecord {
+  kind: BundleChildKind;
+  declaration: BundleChild;
+  id: string;
+  fsPath: string;
+  record: InstalledPluginRecord;
+}
+
+export interface BundleResolveOptions {
+  bundleRoot: string;
+  bundleRecord: InstalledPluginRecord;
+  namespace: string;
+  sourceKind: PluginSourceKind;
+  source: string;
+  resolveOptions: Omit<ResolveOptions, 'folder' | 'folderId' | 'sourceKind' | 'source'>;
+}
+
+export function bundleDeclarationFromManifest(manifest: PluginManifest): PluginBundle | null {
+  return manifest.od?.kind === 'bundle' ? manifest.od.bundle ?? {} : null;
+}
+
+export function isBundleManifest(manifest: PluginManifest): boolean {
+  return bundleDeclarationFromManifest(manifest) !== null;
+}
+
+export async function resolveBundleChildRecords(
+  options: BundleResolveOptions,
+): Promise<{ ok: true; records: BundleChildRecord[]; warnings: string[] } | { ok: false; errors: string[]; warnings: string[] }> {
+  const declaration = bundleDeclarationFromManifest(options.bundleRecord.manifest);
+  if (!declaration) return { ok: true, records: [], warnings: [] };
+
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const records: BundleChildRecord[] = [];
+  const seenIds = new Set<string>();
+
+  const groups: Array<{ kind: BundleChildKind; children: readonly BundleChild[] }> = [
+    { kind: 'skill', children: declaration.skills ?? [] },
+    { kind: 'design-system', children: declaration.designSystems ?? [] },
+    { kind: 'craft', children: declaration.craft ?? [] },
+  ];
+
+  for (const group of groups) {
+    for (const child of group.children) {
+      const fullId = namespacedBundleChildId(options.namespace, child.id);
+      if (seenIds.has(fullId)) {
+        errors.push(`Bundle child id '${fullId}' is declared more than once`);
+        continue;
+      }
+      seenIds.add(fullId);
+
+      const resolvedPath = resolveBundleChildPath(options.bundleRoot, child.path);
+      if (!resolvedPath.ok) {
+        errors.push(`Bundle child '${child.id}' has unsafe path '${child.path}': ${resolvedPath.error}`);
+        continue;
+      }
+
+      const built = group.kind === 'skill'
+        ? await resolveSkillChild(options, child, fullId, resolvedPath.path)
+        : await synthesizeResourceChild(options, group.kind, child, fullId, resolvedPath.path);
+      if (!built.ok) {
+        errors.push(...built.errors);
+        warnings.push(...built.warnings);
+        continue;
+      }
+      warnings.push(...built.warnings);
+      records.push({
+        kind: group.kind,
+        declaration: child,
+        id: fullId,
+        fsPath: resolvedPath.path,
+        record: built.record,
+      });
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors, warnings };
+  return { ok: true, records, warnings };
+}
+
+export function buildBundleRegistryOverlay(
+  manifest: PluginManifest,
+  fallback: RegistryView,
+  bundleRoot?: string,
+  namespace = manifest.name,
+): RegistryView {
+  const declaration = bundleDeclarationFromManifest(manifest);
+  if (!declaration || !bundleRoot) return fallback;
+
+  const skills: Array<{ id: string; title?: string; description?: string }> = [];
+  const designSystems: Array<{ id: string; title?: string }> = [];
+  const craft: Array<{ id: string; title?: string }> = [];
+
+  for (const child of declaration.skills ?? []) {
+    const resolved = resolveBundleChildPath(bundleRoot, child.path);
+    if (!resolved.ok) continue;
+    const metadata = readSkillMetadata(resolved.path, child.id);
+    const entry: { title?: string; description?: string } = {};
+    if (metadata.title) entry.title = metadata.title;
+    if (metadata.description) entry.description = metadata.description;
+    addRegistryAliases(skills, child.id, namespacedBundleChildId(namespace, child.id), entry);
+  }
+
+  for (const child of declaration.designSystems ?? []) {
+    const resolved = resolveBundleChildPath(bundleRoot, child.path);
+    if (!resolved.ok) continue;
+    const title = readDesignSystemTitle(resolved.path, child.id);
+    addRegistryAliases(designSystems, child.id, namespacedBundleChildId(namespace, child.id), { title });
+  }
+
+  for (const child of declaration.craft ?? []) {
+    const resolved = resolveBundleChildPath(bundleRoot, child.path);
+    if (!resolved.ok) continue;
+    const title = readMarkdownTitle(resolved.path, child.id);
+    addRegistryAliases(craft, child.id, namespacedBundleChildId(namespace, child.id), { title });
+  }
+
+  return {
+    ...fallback,
+    skills: [...skills, ...fallback.skills],
+    designSystems: [...designSystems, ...fallback.designSystems],
+    craft: [...craft, ...fallback.craft],
+  };
+}
+
+export function buildBundleRegistryOverlayForPlugin(
+  plugin: InstalledPluginRecord,
+  fallback: RegistryView,
+): RegistryView {
+  const namespace = bundleNamespaceForRecord(plugin);
+  const direct = buildBundleRegistryOverlay(plugin.manifest, fallback, plugin.fsPath, namespace);
+  if (direct !== fallback || isBundleManifest(plugin.manifest)) return direct;
+
+  const ancestor = findAncestorBundleManifest(plugin.fsPath);
+  if (!ancestor) return fallback;
+  return buildBundleRegistryOverlay(ancestor.manifest, fallback, ancestor.root, namespace);
+}
+
+export function namespacedBundleChildId(namespace: string, childId: string): string {
+  return `${namespace}/${childId}`;
+}
+
+export function bundleNamespaceForRecord(record: InstalledPluginRecord): string {
+  if (record.sourceMarketplaceEntryName) return record.sourceMarketplaceEntryName;
+  const slash = record.id.lastIndexOf('/');
+  return slash > 0 ? record.id.slice(0, slash) : record.id;
+}
+
+function findAncestorBundleManifest(startPath: string): { root: string; manifest: PluginManifest } | null {
+  let current = fs.existsSync(startPath) && fs.statSync(startPath).isDirectory()
+    ? startPath
+    : path.dirname(startPath);
+  for (let i = 0; i < 8; i += 1) {
+    const manifestPath = path.join(current, 'open-design.json');
+    if (fs.existsSync(manifestPath)) {
+      try {
+        const parsed = parseManifest(fs.readFileSync(manifestPath, 'utf8'));
+        if (parsed.ok && isBundleManifest(parsed.manifest)) {
+          return { root: current, manifest: parsed.manifest };
+        }
+      } catch {
+        return null;
+      }
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}
+
+function resolveBundleChildPath(root: string, declaredPath: string): { ok: true; path: string } | { ok: false; error: string } {
+  if (declaredPath.includes('\0')) return { ok: false, error: 'path contains NUL' };
+  if (path.isAbsolute(declaredPath)) return { ok: false, error: 'absolute paths are not allowed' };
+  const rootAbs = path.resolve(root);
+  const childAbs = path.resolve(rootAbs, declaredPath);
+  const rel = path.relative(rootAbs, childAbs);
+  if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+    return { ok: false, error: 'path escapes the bundle root' };
+  }
+  return { ok: true, path: childAbs };
+}
+
+async function resolveSkillChild(
+  options: BundleResolveOptions,
+  child: BundleChild,
+  fullId: string,
+  fsPath: string,
+): Promise<{ ok: true; record: InstalledPluginRecord; warnings: string[] } | { ok: false; errors: string[]; warnings: string[] }> {
+  const resolved = await resolvePluginFolder({
+    ...options.resolveOptions,
+    folder: fsPath,
+    folderId: child.id,
+    sourceKind: options.sourceKind,
+    source: options.source,
+  });
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      errors: resolved.errors.map((error) => `Bundle skill '${child.id}': ${error}`),
+      warnings: resolved.warnings,
+    };
+  }
+  if (resolved.record.id !== child.id) {
+    return {
+      ok: false,
+      errors: [`Bundle skill '${child.id}' resolved manifest id '${resolved.record.id}', expected '${child.id}'`],
+      warnings: resolved.warnings,
+    };
+  }
+  return {
+    ok: true,
+    warnings: resolved.warnings,
+    record: {
+      ...resolved.record,
+      id: fullId,
+      source: options.source,
+      fsPath,
+    },
+  };
+}
+
+async function synthesizeResourceChild(
+  options: BundleResolveOptions,
+  kind: Exclude<BundleChildKind, 'skill'>,
+  child: BundleChild,
+  fullId: string,
+  fsPath: string,
+): Promise<{ ok: true; record: InstalledPluginRecord; warnings: string[] } | { ok: false; errors: string[]; warnings: string[] }> {
+  const requiredFile = kind === 'design-system' ? path.join(fsPath, 'DESIGN.md') : fsPath;
+  let stat: fs.Stats;
+  try {
+    stat = await fsp.stat(requiredFile);
+  } catch (err) {
+    return {
+      ok: false,
+      errors: [`Bundle ${kind} '${child.id}' not found at ${child.path}: ${(err as Error).message}`],
+      warnings: [],
+    };
+  }
+  if (kind === 'design-system' && !stat.isFile()) {
+    return { ok: false, errors: [`Bundle design-system '${child.id}' must contain DESIGN.md`], warnings: [] };
+  }
+  if (kind === 'craft' && !stat.isFile()) {
+    return { ok: false, errors: [`Bundle craft '${child.id}' path must point to a markdown file`], warnings: [] };
+  }
+
+  const now = Date.now();
+  const title = kind === 'design-system'
+    ? readDesignSystemTitle(fsPath, child.id)
+    : readMarkdownTitle(fsPath, child.id);
+  const manifest: PluginManifest = {
+    name: child.id,
+    version: options.bundleRecord.version,
+    title,
+    od: {},
+  };
+  const record: InstalledPluginRecord = {
+    id: fullId,
+    title,
+    version: options.bundleRecord.version,
+    sourceKind: options.sourceKind,
+    source: options.source,
+    pinnedRef: options.resolveOptions.pinnedRef,
+    sourceMarketplaceId: options.resolveOptions.sourceMarketplaceId,
+    sourceMarketplaceEntryName: options.resolveOptions.sourceMarketplaceEntryName,
+    sourceMarketplaceEntryVersion: options.resolveOptions.sourceMarketplaceEntryVersion,
+    marketplaceTrust: options.resolveOptions.marketplaceTrust,
+    resolvedSource: options.resolveOptions.resolvedSource,
+    resolvedRef: options.resolveOptions.resolvedRef,
+    manifestDigest: options.resolveOptions.manifestDigest,
+    archiveIntegrity: options.resolveOptions.archiveIntegrity,
+    trust: options.resolveOptions.trust ?? 'restricted',
+    capabilitiesGranted: options.bundleRecord.capabilitiesGranted,
+    manifest,
+    fsPath,
+    installedAt: now,
+    updatedAt: now,
+  };
+  return { ok: true, record, warnings: [] };
+}
+
+function readSkillMetadata(folder: string, fallbackId: string): { title?: string; description?: string } {
+  try {
+    const raw = fs.readFileSync(path.join(folder, 'SKILL.md'), 'utf8');
+    const adapted = adaptAgentSkill(raw, { folderId: fallbackId });
+    return {
+      title: adapted.manifest.title ?? adapted.manifest.name ?? fallbackId,
+      description: adapted.manifest.description,
+    };
+  } catch {
+    return { title: fallbackId };
+  }
+}
+
+function readDesignSystemTitle(folder: string, fallbackId: string): string {
+  return readMarkdownTitle(path.join(folder, 'DESIGN.md'), fallbackId);
+}
+
+function readMarkdownTitle(filePath: string, fallbackId: string): string {
+  try {
+    const body = fs.readFileSync(filePath, 'utf8');
+    const heading = /^#\s+(.+)$/m.exec(body);
+    return heading?.[1]?.trim() || fallbackId;
+  } catch {
+    return fallbackId;
+  }
+}
+
+function addRegistryAliases<T extends { id: string }>(
+  entries: T[],
+  shortId: string,
+  fullId: string,
+  rest: Omit<T, 'id'>,
+): void {
+  entries.push({ id: shortId, ...rest } as T);
+  entries.push({ id: fullId, ...rest } as T);
+}

--- a/apps/daemon/src/plugins/doctor.ts
+++ b/apps/daemon/src/plugins/doctor.ts
@@ -21,6 +21,7 @@ import { findAtom, isImplementedAtom, isKnownAtom } from './atoms.js';
 import { validateConnectorRefs, type ConnectorProbe } from './connector-gate.js';
 import { isParseableUntil } from './until.js';
 import { listSnapshotsForProject, markSnapshotStale } from './snapshots.js';
+import { buildBundleRegistryOverlay, buildBundleRegistryOverlayForPlugin } from './bundle.js';
 
 type SqliteDb = Database.Database;
 
@@ -50,6 +51,7 @@ export function doctorPlugin(
 ): DoctorReport {
   const issues: Diagnostic[] = [];
   const manifest = plugin.manifest;
+  const expandedRegistry = buildBundleRegistryOverlayForPlugin(plugin, registry);
 
   const validation = validateSafe(manifest);
   for (const err of validation.errors) {
@@ -144,7 +146,7 @@ export function doctorPlugin(
   }
 
   const resolved = resolveContext(manifest, {
-    registry,
+    registry: expandedRegistry,
     warnOnMissing: options?.warnOnMissingRefs ?? true,
   });
   for (const warn of resolved.warnings) {
@@ -204,9 +206,11 @@ export function summarizeDoctor(report: DoctorReport): string {
   return parts.join('\n');
 }
 
-export function buildRegistryViewFromManifest(_manifest: PluginManifest, fallback: RegistryView): RegistryView {
-  // Phase 1 stub — returns the fallback unchanged. Phase 2A will overlay
-  // bundled-plugin-specific catalogs when the plugin ships its own skills /
-  // design systems within `<plugin>/skills/` etc.
-  return fallback;
+export function buildRegistryViewFromManifest(
+  manifest: PluginManifest,
+  fallback: RegistryView,
+  bundleRoot?: string,
+  namespace = manifest.name,
+): RegistryView {
+  return buildBundleRegistryOverlay(manifest, fallback, bundleRoot, namespace);
 }

--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -59,6 +59,7 @@ export interface InstallProgressEvent {
 export interface InstallSuccessEvent {
   kind: 'success';
   plugin: InstalledPluginRecord;
+  plugins: InstalledPluginRecord[];
   warnings: string[];
 }
 
@@ -779,10 +780,15 @@ export async function* installFromLocalFolder(
         await upsertPluginLockfileEntry(opts.lockfilePath, child.record);
       }
     }
-    for (const child of bundleChildren.records) {
-      recordInstallEvent(opts, child.record, warnings);
+    for (const record of [bundleRecord, ...bundleChildren.records.map((child) => child.record)]) {
+      recordInstallEvent(opts, record, warnings);
     }
-    yield { kind: 'success', plugin: bundleRecord, warnings };
+    yield {
+      kind: 'success',
+      plugin: bundleRecord,
+      plugins: [bundleRecord, ...bundleChildren.records.map((child) => child.record)],
+      warnings,
+    };
     return;
   }
 
@@ -794,7 +800,7 @@ export async function* installFromLocalFolder(
 
   recordInstallEvent(opts, parsed.record, warnings);
 
-  yield { kind: 'success', plugin: parsed.record, warnings };
+  yield { kind: 'success', plugin: parsed.record, plugins: [parsed.record], warnings };
 }
 
 export interface UninstallResult {

--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -711,38 +711,45 @@ export async function* installFromLocalFolder(
     yield { kind: 'error', message: `Plugin id '${pluginId}' is not a safe folder name`, warnings };
     return;
   }
-  const destFolder = path.join(roots.userPluginsRoot, pluginId);
-
-  // Block overwriting a foreign plugin id. The destination folder may
-  // contain a previous version of the same id, in which case we replace it.
-  if (fs.existsSync(destFolder) && (opts.overwriteExisting ?? true) === false) {
-    yield { kind: 'error', message: `Destination folder already exists: ${destFolder}. Pass overwriteExisting=true to replace.`, warnings };
+  const installId = isBundleManifest(probe.record.manifest)
+    ? bundleNamespaceForRecord(probe.record)
+    : pluginId;
+  const destFolder = resolveInstallFolder(roots.userPluginsRoot, installId);
+  if (!destFolder.ok) {
+    yield { kind: 'error', message: `Plugin id '${installId}' is not a safe install path`, warnings };
     return;
   }
 
-  yield { kind: 'progress', phase: 'copying', message: `Copying to ${destFolder}` };
+  // Block overwriting a foreign plugin id. The destination folder may
+  // contain a previous version of the same id, in which case we replace it.
+  if (fs.existsSync(destFolder.path) && (opts.overwriteExisting ?? true) === false) {
+    yield { kind: 'error', message: `Destination folder already exists: ${destFolder.path}. Pass overwriteExisting=true to replace.`, warnings };
+    return;
+  }
+
+  yield { kind: 'progress', phase: 'copying', message: `Copying to ${destFolder.path}` };
   await fsp.mkdir(roots.userPluginsRoot, { recursive: true });
-  if (fs.existsSync(destFolder)) {
-    await fsp.rm(destFolder, { recursive: true, force: true });
+  if (fs.existsSync(destFolder.path)) {
+    await fsp.rm(destFolder.path, { recursive: true, force: true });
   }
   try {
-    await safeCopyTree(sourceFolder, destFolder, maxBytes);
+    await safeCopyTree(sourceFolder, destFolder.path, maxBytes);
   } catch (err) {
     yield { kind: 'error', message: `Copy failed: ${(err as Error).message}`, warnings };
-    await fsp.rm(destFolder, { recursive: true, force: true }).catch(() => undefined);
+    await fsp.rm(destFolder.path, { recursive: true, force: true }).catch(() => undefined);
     return;
   }
 
   yield { kind: 'progress', phase: 'parsing', message: 'Re-parsing destination' };
   const parsedOptions = buildResolveOptions({
-    folder: destFolder,
+    folder: destFolder.path,
     folderId: pluginId,
     sourceKind: recordedSourceKind,
     source: recordedSource,
   }, opts);
   const parsed = await resolvePluginFolder(parsedOptions);
   if (!parsed.ok) {
-    await fsp.rm(destFolder, { recursive: true, force: true }).catch(() => undefined);
+    await fsp.rm(destFolder.path, { recursive: true, force: true }).catch(() => undefined);
     yield { kind: 'error', message: parsed.errors.join('; '), warnings: [...warnings, ...parsed.warnings] };
     return;
   }
@@ -754,7 +761,7 @@ export async function* installFromLocalFolder(
       ? parsed.record
       : { ...parsed.record, id: namespace };
     const bundleChildren = await resolveBundleChildRecords({
-      bundleRoot: destFolder,
+      bundleRoot: destFolder.path,
       bundleRecord,
       namespace,
       sourceKind: recordedSourceKind,
@@ -762,7 +769,7 @@ export async function* installFromLocalFolder(
       resolveOptions: buildResolveOptions({}, opts),
     });
     if (!bundleChildren.ok) {
-      await fsp.rm(destFolder, { recursive: true, force: true }).catch(() => undefined);
+      await fsp.rm(destFolder.path, { recursive: true, force: true }).catch(() => undefined);
       yield {
         kind: 'error',
         message: bundleChildren.errors.join('; '),
@@ -917,6 +924,14 @@ function isSafeBasename(name: string): boolean {
   if (name === '.' || name === '..') return false;
   if (name.includes('/') || name.includes('\\') || name.includes('\0')) return false;
   return true;
+}
+
+function resolveInstallFolder(root: string, id: string): { ok: true; path: string } | { ok: false } {
+  const segments = id.split('/');
+  if (segments.length === 0 || segments.some((segment) => !SAFE_BASENAME.test(segment))) {
+    return { ok: false };
+  }
+  return { ok: true, path: path.join(root, ...segments) };
 }
 
 function buildResolveOptions(

--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -25,6 +25,7 @@ import { x as tarExtract } from 'tar';
 import {
   defaultRegistryRoots,
   deleteInstalledPlugin,
+  getInstalledPlugin,
   listInstalledPlugins,
   resolvePluginFolder,
   upsertInstalledPlugin,
@@ -748,9 +749,12 @@ export async function* installFromLocalFolder(
 
   if (isBundleManifest(parsed.record.manifest)) {
     const namespace = bundleNamespaceForRecord(parsed.record);
+    const bundleRecord: InstalledPluginRecord = namespace === parsed.record.id
+      ? parsed.record
+      : { ...parsed.record, id: namespace };
     const bundleChildren = await resolveBundleChildRecords({
       bundleRoot: destFolder,
-      bundleRecord: parsed.record,
+      bundleRecord,
       namespace,
       sourceKind: recordedSourceKind,
       source: recordedSource,
@@ -768,8 +772,9 @@ export async function* installFromLocalFolder(
     warnings.push(...bundleChildren.warnings);
 
     yield { kind: 'progress', phase: 'persisting', message: 'Writing installed_plugins rows' };
-    persistBundleChildren(db, namespace, bundleChildren.records);
+    persistBundleRecords(db, bundleRecord, namespace, bundleChildren.records);
     if (opts.lockfilePath) {
+      await upsertPluginLockfileEntry(opts.lockfilePath, bundleRecord);
       for (const child of bundleChildren.records) {
         await upsertPluginLockfileEntry(opts.lockfilePath, child.record);
       }
@@ -777,9 +782,7 @@ export async function* installFromLocalFolder(
     for (const child of bundleChildren.records) {
       recordInstallEvent(opts, child.record, warnings);
     }
-    for (const child of bundleChildren.records) {
-      yield { kind: 'success', plugin: child.record, warnings };
-    }
+    yield { kind: 'success', plugin: bundleRecord, warnings };
     return;
   }
 
@@ -805,8 +808,12 @@ export async function uninstallPlugin(
   id: string,
   roots: RegistryRoots = defaultRegistryRoots(),
 ): Promise<UninstallResult> {
-  const removed = deleteInstalledPlugin(db, id);
-  const folder = path.join(roots.userPluginsRoot, id);
+  const target = getInstalledPlugin(db, id);
+  const bundleTarget = resolveBundleUninstallTarget(db, id, target);
+  const folder = bundleTarget?.folder ?? path.join(roots.userPluginsRoot, id);
+  const removed = bundleTarget
+    ? deleteInstalledPluginIds(db, bundleTarget.ids)
+    : deleteInstalledPlugin(db, id);
   let removedFolder: string | undefined;
   try {
     await fsp.rm(folder, { recursive: true, force: true });
@@ -830,6 +837,39 @@ export async function uninstallPlugin(
     });
   }
   return { ok: removed || removedFolder !== undefined, removedFolder };
+}
+
+function resolveBundleUninstallTarget(
+  db: SqliteDb,
+  id: string,
+  target: InstalledPluginRecord | null,
+): { ids: string[]; folder: string } | null {
+  const namespace = target && isBundleManifest(target.manifest)
+    ? id
+    : id.includes('/')
+      ? id.slice(0, id.lastIndexOf('/'))
+      : null;
+  if (!namespace) return null;
+
+  const rows = listInstalledPlugins(db).filter((row) => row.id === namespace || row.id.startsWith(`${namespace}/`));
+  if (rows.length === 0) return null;
+  const root = rows.find((row) => row.id === namespace);
+  if (!root) return null;
+  return {
+    ids: rows.map((row) => row.id),
+    folder: root.fsPath,
+  };
+}
+
+function deleteInstalledPluginIds(db: SqliteDb, ids: string[]): boolean {
+  const remove = db.transaction(() => {
+    let removed = false;
+    for (const id of ids) {
+      removed = deleteInstalledPlugin(db, id) || removed;
+    }
+    return removed;
+  });
+  return remove();
 }
 
 // Recursive copy with budget tracking. Symlinks anywhere in the tree fail
@@ -896,13 +936,19 @@ function installedTrustFromMarketplace(trust: MarketplaceTrust): TrustTier {
   return trust === 'restricted' ? 'restricted' : 'trusted';
 }
 
-function persistBundleChildren(db: SqliteDb, namespace: string, children: BundleChildRecord[]): void {
+function persistBundleRecords(
+  db: SqliteDb,
+  bundle: InstalledPluginRecord,
+  namespace: string,
+  children: BundleChildRecord[],
+): void {
   const replaceNamespace = db.transaction(() => {
     for (const existing of listInstalledPlugins(db)) {
-      if (existing.id.startsWith(`${namespace}/`)) {
+      if (existing.id === namespace || existing.id.startsWith(`${namespace}/`)) {
         deleteInstalledPlugin(db, existing.id);
       }
     }
+    upsertInstalledPlugin(db, bundle);
     for (const child of children) {
       upsertInstalledPlugin(db, child.record);
     }

--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -25,6 +25,7 @@ import { x as tarExtract } from 'tar';
 import {
   defaultRegistryRoots,
   deleteInstalledPlugin,
+  listInstalledPlugins,
   resolvePluginFolder,
   upsertInstalledPlugin,
   type ResolveOptions,
@@ -39,6 +40,12 @@ import type {
 import type Database from 'better-sqlite3';
 import { recordPluginEvent } from './events.js';
 import { upsertPluginLockfileEntry } from './lockfile.js';
+import {
+  bundleNamespaceForRecord,
+  isBundleManifest,
+  resolveBundleChildRecords,
+  type BundleChildRecord,
+} from './bundle.js';
 
 type SqliteDb = Database.Database;
 
@@ -739,32 +746,50 @@ export async function* installFromLocalFolder(
   }
   warnings.push(...parsed.warnings);
 
+  if (isBundleManifest(parsed.record.manifest)) {
+    const namespace = bundleNamespaceForRecord(parsed.record);
+    const bundleChildren = await resolveBundleChildRecords({
+      bundleRoot: destFolder,
+      bundleRecord: parsed.record,
+      namespace,
+      sourceKind: recordedSourceKind,
+      source: recordedSource,
+      resolveOptions: buildResolveOptions({}, opts),
+    });
+    if (!bundleChildren.ok) {
+      await fsp.rm(destFolder, { recursive: true, force: true }).catch(() => undefined);
+      yield {
+        kind: 'error',
+        message: bundleChildren.errors.join('; '),
+        warnings: [...warnings, ...bundleChildren.warnings],
+      };
+      return;
+    }
+    warnings.push(...bundleChildren.warnings);
+
+    yield { kind: 'progress', phase: 'persisting', message: 'Writing installed_plugins rows' };
+    persistBundleChildren(db, namespace, bundleChildren.records);
+    if (opts.lockfilePath) {
+      for (const child of bundleChildren.records) {
+        await upsertPluginLockfileEntry(opts.lockfilePath, child.record);
+      }
+    }
+    for (const child of bundleChildren.records) {
+      recordInstallEvent(opts, child.record, warnings);
+    }
+    for (const child of bundleChildren.records) {
+      yield { kind: 'success', plugin: child.record, warnings };
+    }
+    return;
+  }
+
   yield { kind: 'progress', phase: 'persisting', message: 'Writing installed_plugins row' };
   upsertInstalledPlugin(db, parsed.record);
   if (opts.lockfilePath) {
     await upsertPluginLockfileEntry(opts.lockfilePath, parsed.record);
   }
 
-  // Plan §3.II1 / §3.JJ1 — emit 'plugin.installed' OR
-  // 'plugin.upgraded' (per opts.eventKind) so ops dashboards +
-  // `od plugin events tail` see the operation land in the in-
-  // memory ring buffer. Best-effort; recordPluginEvent never
-  // throws.
-  recordPluginEvent({
-    kind:     opts.eventKind === 'upgraded' ? 'plugin.upgraded' : 'plugin.installed',
-    pluginId: parsed.record.id,
-    details:  {
-      version:    parsed.record.version,
-      sourceKind: parsed.record.sourceKind,
-      source:     parsed.record.source,
-      sourceMarketplaceId: parsed.record.sourceMarketplaceId,
-      sourceMarketplaceEntryName: parsed.record.sourceMarketplaceEntryName,
-      sourceMarketplaceEntryVersion: parsed.record.sourceMarketplaceEntryVersion,
-      marketplaceTrust: parsed.record.marketplaceTrust,
-      trust:      parsed.record.trust,
-      warnings:   warnings.length,
-    },
-  });
+  recordInstallEvent(opts, parsed.record, warnings);
 
   yield { kind: 'success', plugin: parsed.record, warnings };
 }
@@ -849,10 +874,10 @@ function isSafeBasename(name: string): boolean {
 }
 
 function buildResolveOptions(
-  base: Pick<ResolveOptions, 'folder' | 'folderId' | 'sourceKind' | 'source'>,
+  base: Partial<Pick<ResolveOptions, 'folder' | 'folderId' | 'sourceKind' | 'source'>>,
   opts: InstallOptions,
 ): ResolveOptions {
-  const resolveOptions: ResolveOptions = { ...base };
+  const resolveOptions: ResolveOptions = { ...base } as ResolveOptions;
   if (opts.sourceMarketplaceId) resolveOptions.sourceMarketplaceId = opts.sourceMarketplaceId;
   if (opts.sourceMarketplaceEntryName) resolveOptions.sourceMarketplaceEntryName = opts.sourceMarketplaceEntryName;
   if (opts.sourceMarketplaceEntryVersion) resolveOptions.sourceMarketplaceEntryVersion = opts.sourceMarketplaceEntryVersion;
@@ -869,6 +894,43 @@ function buildResolveOptions(
 
 function installedTrustFromMarketplace(trust: MarketplaceTrust): TrustTier {
   return trust === 'restricted' ? 'restricted' : 'trusted';
+}
+
+function persistBundleChildren(db: SqliteDb, namespace: string, children: BundleChildRecord[]): void {
+  const replaceNamespace = db.transaction(() => {
+    for (const existing of listInstalledPlugins(db)) {
+      if (existing.id.startsWith(`${namespace}/`)) {
+        deleteInstalledPlugin(db, existing.id);
+      }
+    }
+    for (const child of children) {
+      upsertInstalledPlugin(db, child.record);
+    }
+  });
+  replaceNamespace();
+}
+
+function recordInstallEvent(opts: InstallOptions, record: InstalledPluginRecord, warnings: string[]): void {
+  // Plan §3.II1 / §3.JJ1 — emit 'plugin.installed' OR
+  // 'plugin.upgraded' (per opts.eventKind) so ops dashboards +
+  // `od plugin events tail` see the operation land in the in-
+  // memory ring buffer. Best-effort; recordPluginEvent never
+  // throws.
+  recordPluginEvent({
+    kind:     opts.eventKind === 'upgraded' ? 'plugin.upgraded' : 'plugin.installed',
+    pluginId: record.id,
+    details:  {
+      version:    record.version,
+      sourceKind: record.sourceKind,
+      source:     record.source,
+      sourceMarketplaceId: record.sourceMarketplaceId,
+      sourceMarketplaceEntryName: record.sourceMarketplaceEntryName,
+      sourceMarketplaceEntryVersion: record.sourceMarketplaceEntryVersion,
+      marketplaceTrust: record.marketplaceTrust,
+      trust:      record.trust,
+      warnings:   warnings.length,
+    },
+  });
 }
 
 export type { PluginSourceKind };

--- a/apps/daemon/src/plugins/registry.ts
+++ b/apps/daemon/src/plugins/registry.ts
@@ -230,6 +230,16 @@ export function listInstalledPlugins(db: SqliteDb): InstalledPluginRecord[] {
   return rows.map(rowToInstalledPlugin);
 }
 
+export function listVisibleInstalledPlugins(db: SqliteDb): InstalledPluginRecord[] {
+  return filterVisibleInstalledPlugins(listInstalledPlugins(db));
+}
+
+export function filterVisibleInstalledPlugins(
+  plugins: ReadonlyArray<InstalledPluginRecord>,
+): InstalledPluginRecord[] {
+  return plugins.filter((plugin) => plugin.manifest.od?.hidden !== true);
+}
+
 export function getInstalledPlugin(db: SqliteDb, id: string): InstalledPluginRecord | null {
   const row = db.prepare(`SELECT * FROM installed_plugins WHERE id = ?`).get(id) as DbRow | undefined;
   return row ? rowToInstalledPlugin(row) : null;

--- a/apps/daemon/src/plugins/resolve-snapshot.ts
+++ b/apps/daemon/src/plugins/resolve-snapshot.ts
@@ -46,6 +46,7 @@ import {
   type ConnectorProbe,
 } from './connector-gate.js';
 import type { RegistryView } from '@open-design/plugin-runtime';
+import { buildBundleRegistryOverlayForPlugin } from './bundle.js';
 
 type SqliteDb = Database.Database;
 
@@ -211,10 +212,11 @@ export function resolvePluginSnapshot(input: ResolveSnapshotInput): ResolveSnaps
 
   let applyComputed;
   try {
+    const registry = buildBundleRegistryOverlayForPlugin(plugin, input.registry);
     applyComputed = applyPlugin({
       plugin,
       inputs: fields.pluginInputs ?? {},
-      registry: input.registry,
+      registry,
       activeProjectDesignSystem: input.activeProjectDesignSystem,
       connectorProbe: input.connectorProbe,
       locale: fields.locale,

--- a/apps/daemon/src/plugins/search.ts
+++ b/apps/daemon/src/plugins/search.ts
@@ -59,6 +59,7 @@ export function searchInstalledPlugins(input: SearchInstalledPluginsInput): Sear
 
   const out: SearchInstalledPluginsResultEntry[] = [];
   for (const plugin of input.plugins) {
+    if (plugin.manifest.od?.hidden === true) continue;
     const manifest = plugin.manifest;
     const matched: SearchInstalledPluginsResultEntry['matched'] = [];
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -144,6 +144,7 @@ import {
   isDiffReviewSurfaceId,
   listSkillPluginCandidates,
   listInstalledPlugins,
+  listVisibleInstalledPlugins,
   listIterationsForRun,
   MissingInputError,
   NonApplyablePluginError,
@@ -6834,7 +6835,7 @@ export async function startServer({
   // and snapshot fetch by id (used by run replay tooling).
   app.get('/api/plugins', async (_req, res) => {
     try {
-      const plugins = listInstalledPlugins(db);
+      const plugins = listVisibleInstalledPlugins(db);
       res.json({ plugins });
     } catch (err) {
       res.status(500).json({ error: String(err) });

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -146,6 +146,7 @@ import {
   listInstalledPlugins,
   listIterationsForRun,
   MissingInputError,
+  NonApplyablePluginError,
   pluginPromptBlock,
   pruneExpiredSnapshots,
   readPluginLockfile,
@@ -7290,6 +7291,9 @@ export async function startServer({
     } catch (err) {
       if (err instanceof MissingInputError) {
         return res.status(422).json({ error: 'missing_inputs', fields: err.fields });
+      }
+      if (err instanceof NonApplyablePluginError) {
+        return res.status(409).json({ error: 'plugin_not_applyable', message: err.message });
       }
       res.status(500).json({ error: String(err) });
     }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9466,12 +9466,14 @@ export async function startServer({
       const warnings = [];
       const log = [];
       let plugin = null;
+      let plugins = [];
       let message = 'Install finished.';
       for await (const ev of installPlugin(db, { source: folder, roots: PLUGIN_REGISTRY_ROOTS })) {
         if (ev.message) log.push(ev.message);
         if (Array.isArray(ev.warnings)) warnings.splice(0, warnings.length, ...ev.warnings);
         if (ev.kind === 'success') {
           plugin = ev.plugin;
+          plugins = ev.plugins ?? [ev.plugin];
           message = `Installed ${ev.plugin.title}.`;
           break;
         }
@@ -9480,7 +9482,7 @@ export async function startServer({
           break;
         }
       }
-      res.status(plugin ? 200 : 400).json({ ok: Boolean(plugin), plugin, warnings, message, log });
+      res.status(plugin ? 200 : 400).json({ ok: Boolean(plugin), plugin, plugins, warnings, message, log });
     } catch (err) {
       const code = err && err.code;
       const status = code === 'ENOENT' || code === 'ENOTDIR' ? 404 : 400;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6833,9 +6833,10 @@ export async function startServer({
   // needed for the §12.5 walkthrough: list/get installed plugins, install
   // (SSE), uninstall, apply (returns ApplyResult + snapshotId), atom catalog,
   // and snapshot fetch by id (used by run replay tooling).
-  app.get('/api/plugins', async (_req, res) => {
+  app.get('/api/plugins', async (req, res) => {
     try {
-      const plugins = listVisibleInstalledPlugins(db);
+      const includeHidden = req.query.includeHidden === 'true' || req.query.includeHidden === '1';
+      const plugins = includeHidden ? listInstalledPlugins(db) : listVisibleInstalledPlugins(db);
       res.json({ plugins });
     } catch (err) {
       res.status(500).json({ error: String(err) });

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -165,6 +165,7 @@ import {
   marketplaceManifestUrlForRegistry,
   marketplaceRegistryIdFromUrl,
 } from './plugins/marketplaces.js';
+import { buildBundleRegistryOverlayForPlugin } from './plugins/bundle.js';
 import {
   getSurface,
   listSurfacesForProject,
@@ -7279,7 +7280,8 @@ export async function startServer({
 
       const registry = await loadPluginRegistryView();
       const connectorProbe = buildConnectorProbe(connectorService);
-      const computed = applyPlugin({ plugin, inputs, registry, locale, connectorProbe });
+      const expandedRegistry = buildBundleRegistryOverlayForPlugin(plugin, registry);
+      const computed = applyPlugin({ plugin, inputs, registry: expandedRegistry, locale, connectorProbe });
       // Plan §3.B2 — apply-time grants are merged into the snapshot's
       // capabilitiesGranted so the §9 capability gate sees them, but
       // they are NOT written back to installed_plugins.capabilities_granted.

--- a/apps/daemon/tests/plugins-apply.test.ts
+++ b/apps/daemon/tests/plugins-apply.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it } from 'vitest';
 import path from 'node:path';
-import { applyPlugin, MissingInputError } from '../src/plugins/apply.js';
+import { applyPlugin, MissingInputError, NonApplyablePluginError } from '../src/plugins/apply.js';
 import { defaultRegistryRoots } from '../src/plugins/registry.js';
 import { TRUSTED_DEFAULT_CAPABILITIES } from '../src/plugins/trust.js';
 import type { ContextItem, InstalledPluginRecord } from '@open-design/contracts';
@@ -69,6 +69,23 @@ describe('applyPlugin', () => {
 
   it('throws MissingInputError when a required input is missing', () => {
     expect(() => applyPlugin({ plugin: pluginFixture(), inputs: {}, registry: REGISTRY })).toThrow(MissingInputError);
+  });
+
+  it('rejects hidden bundle resource children as non-applyable', () => {
+    const resource = pluginFixture({
+      id: 'my-bundle/linear-clone',
+      manifest: {
+        name: 'linear-clone',
+        title: 'Linear Clone',
+        version: '1.0.0',
+        od: {
+          hidden: true,
+          bundleResourceKind: 'design-system',
+        },
+      },
+    });
+
+    expect(() => applyPlugin({ plugin: resource, inputs: {}, registry: REGISTRY })).toThrow(NonApplyablePluginError);
   });
 
   it('coerces optional inputs by defaulting when blank', () => {

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -14,6 +14,9 @@ import { listInstalledPlugins } from '../src/plugins/registry.js';
 import { addMarketplace, resolvePluginInMarketplaces } from '../src/plugins/marketplaces.js';
 import type { InstalledPluginRecord } from '@open-design/contracts';
 import { doctorPlugin } from '../src/plugins/doctor.js';
+import { applyPlugin } from '../src/plugins/apply.js';
+import { buildBundleRegistryOverlayForPlugin } from '../src/plugins/bundle.js';
+import { resolvePluginSnapshot } from '../src/plugins/resolve-snapshot.js';
 
 let tmpRoot: string;
 let pluginsRoot: string;
@@ -437,6 +440,57 @@ describe('installFromLocalFolder', () => {
       atoms: [],
     });
     expect(report.issues.filter((issue) => issue.code === 'context.unresolved')).toEqual([]);
+  });
+
+  it('apply and snapshot resolution preserve bundle-local short references', async () => {
+    const bundleRoot = await writeBundleFixture('runtime-bundle', {
+      skillContext: true,
+    });
+
+    for await (const ev of installFromLocalFolder(db, {
+      source: bundleRoot,
+      roots: { userPluginsRoot: pluginsRoot },
+    })) {
+      if (ev.kind === 'error') throw new Error(ev.message);
+    }
+
+    db.prepare(`INSERT INTO projects (id, name) VALUES (?, ?)`).run('project-1', 'Project 1');
+    const skill = listInstalledPlugins(db).find((row) => row.id === 'runtime-bundle/deck-skeleton');
+    expect(skill).toBeTruthy();
+
+    const emptyRegistry = {
+      skills: [],
+      designSystems: [],
+      craft: [],
+      atoms: [],
+    };
+    const applied = applyPlugin({
+      plugin: skill!,
+      inputs: {},
+      registry: buildBundleRegistryOverlayForPlugin(skill!, emptyRegistry),
+    });
+    expect(applied.warnings).toEqual([]);
+    expect(applied.result.projectMetadata.designSystemId).toBe('linear-clone');
+    expect(applied.result.projectMetadata.craftRequires).toEqual(['deck-pacing']);
+
+    const resolved = resolvePluginSnapshot({
+      db,
+      body: { pluginId: 'runtime-bundle/deck-skeleton' },
+      projectId: 'project-1',
+      registry: emptyRegistry,
+    });
+    expect(resolved?.ok).toBe(true);
+    if (resolved?.ok) {
+      const contextIds = resolved.snapshot.resolvedContext.items
+        .filter((item) => item.kind === 'skill' || item.kind === 'design-system' || item.kind === 'craft')
+        .map((item) => item.id)
+        .sort();
+      expect(contextIds).toEqual([
+        'deck-pacing',
+        'deck-skeleton',
+        'linear-clone',
+      ]);
+    }
   });
 });
 

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -268,6 +268,18 @@ describe('installFromLocalFolder', () => {
     expect(rows.every((row) => row.sourceKind === 'local')).toBe(true);
     expect(rows.find((row) => row.id === 'my-bundle/deck-skeleton')?.fsPath)
       .toBe(path.join(pluginsRoot, 'my-bundle', 'skills', 'deck-skeleton'));
+    expect(rows.find((row) => row.id === 'my-bundle/deck-pacing')?.manifest.od).toMatchObject({
+      hidden: true,
+      bundleResourceKind: 'craft',
+    });
+    expect(rows.find((row) => row.id === 'my-bundle/linear-clone')?.manifest.od).toMatchObject({
+      hidden: true,
+      bundleResourceKind: 'design-system',
+    });
+    expect(rows.filter((row) => row.manifest.od?.hidden !== true).map((row) => row.id).sort()).toEqual([
+      'my-bundle',
+      'my-bundle/deck-skeleton',
+    ]);
   });
 
   it('keeps bundle marketplace aliases and local reinstalls in separate namespace folders', async () => {

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -239,15 +239,25 @@ describe('installFromLocalFolder', () => {
     const bundleRoot = await writeBundleFixture('my-bundle');
 
     const successIds: string[] = [];
+    const successPluginIds: string[][] = [];
     for await (const ev of installFromLocalFolder(db, {
       source: bundleRoot,
       roots: { userPluginsRoot: pluginsRoot },
     })) {
-      if (ev.kind === 'success') successIds.push(ev.plugin.id);
+      if (ev.kind === 'success') {
+        successIds.push(ev.plugin.id);
+        successPluginIds.push(ev.plugins.map((plugin) => plugin.id).sort());
+      }
       if (ev.kind === 'error') throw new Error(ev.message);
     }
 
     expect(successIds).toEqual(['my-bundle']);
+    expect(successPluginIds).toEqual([[
+      'my-bundle',
+      'my-bundle/deck-pacing',
+      'my-bundle/deck-skeleton',
+      'my-bundle/linear-clone',
+    ]]);
     const rows = listInstalledPlugins(db);
     expect(rows.map((row) => row.id).sort()).toEqual([
       'my-bundle',
@@ -278,6 +288,56 @@ describe('installFromLocalFolder', () => {
     expect(result.ok).toBe(true);
     expect(listInstalledPlugins(db)).toHaveLength(0);
     await expect(stat(installedFolder)).rejects.toThrow();
+  });
+
+  it('upgrading a bundle child emits one success event with the full installed set', async () => {
+    const bundleRoot = await writeBundleFixture('upgrade-bundle', {
+      version: '1.0.0',
+    });
+
+    for await (const ev of installFromLocalFolder(db, {
+      source: bundleRoot,
+      roots: { userPluginsRoot: pluginsRoot },
+    })) {
+      if (ev.kind === 'error') throw new Error(ev.message);
+    }
+
+    await writeBundleFixture('upgrade-bundle', {
+      version: '2.0.0',
+    });
+
+    const successEvents: Array<{ root: string; plugins: string[]; version: string }> = [];
+    for await (const ev of installPlugin(db, {
+      source: bundleRoot,
+      roots: { userPluginsRoot: pluginsRoot },
+      eventKind: 'upgraded',
+    })) {
+      if (ev.kind === 'success') {
+        successEvents.push({
+          root: ev.plugin.id,
+          plugins: ev.plugins.map((plugin) => plugin.id).sort(),
+          version: ev.plugin.version,
+        });
+      }
+      if (ev.kind === 'error') throw new Error(ev.message);
+    }
+
+    expect(successEvents).toEqual([{
+      root: 'upgrade-bundle',
+      plugins: [
+        'upgrade-bundle',
+        'upgrade-bundle/deck-pacing',
+        'upgrade-bundle/deck-skeleton',
+        'upgrade-bundle/linear-clone',
+      ],
+      version: '2.0.0',
+    }]);
+    expect(listInstalledPlugins(db).map((row) => `${row.id}@${row.version}`).sort()).toEqual([
+      'upgrade-bundle/deck-pacing@2.0.0',
+      'upgrade-bundle/deck-skeleton@2.0.0',
+      'upgrade-bundle/linear-clone@2.0.0',
+      'upgrade-bundle@2.0.0',
+    ]);
   });
 
   it('rejects unsafe bundle child paths without leaving registry rows', async () => {
@@ -327,6 +387,7 @@ async function writeBundleFixture(
   overrides: {
     skills?: Array<{ id: string; path: string }>;
     skillContext?: boolean;
+    version?: string;
   } = {},
 ): Promise<string> {
   const bundleRoot = path.join(tmpRoot, id);
@@ -336,7 +397,7 @@ async function writeBundleFixture(
   await writeFile(path.join(bundleRoot, 'SKILL.md'), `# ${id}\n`);
   await writeFile(path.join(bundleRoot, 'open-design.json'), JSON.stringify({
     name: id,
-    version: '1.0.0',
+    version: overrides.version ?? '1.0.0',
     title: 'Deck Bundle',
     od: {
       kind: 'bundle',
@@ -356,7 +417,7 @@ async function writeBundleFixture(
   ].join('\n'));
   await writeFile(path.join(bundleRoot, 'skills', 'deck-skeleton', 'open-design.json'), JSON.stringify({
     name: 'deck-skeleton',
-    version: '1.0.0',
+    version: overrides.version ?? '1.0.0',
     title: 'Deck Skeleton',
     ...(overrides.skillContext ? {
       od: {

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -13,6 +13,7 @@ import { installFromLocalFolder, installPlugin, uninstallPlugin } from '../src/p
 import { listInstalledPlugins } from '../src/plugins/registry.js';
 import { addMarketplace, resolvePluginInMarketplaces } from '../src/plugins/marketplaces.js';
 import type { InstalledPluginRecord } from '@open-design/contracts';
+import { doctorPlugin } from '../src/plugins/doctor.js';
 
 let tmpRoot: string;
 let pluginsRoot: string;
@@ -233,4 +234,125 @@ describe('installFromLocalFolder', () => {
     expect(row?.marketplaceTrust).toBe('restricted');
     expect(row?.trust).toBe('restricted');
   });
+
+  it('registers every declared local bundle child under the bundle namespace', async () => {
+    const bundleRoot = await writeBundleFixture('my-bundle');
+
+    const successIds: string[] = [];
+    for await (const ev of installFromLocalFolder(db, {
+      source: bundleRoot,
+      roots: { userPluginsRoot: pluginsRoot },
+    })) {
+      if (ev.kind === 'success') successIds.push(ev.plugin.id);
+      if (ev.kind === 'error') throw new Error(ev.message);
+    }
+
+    expect(successIds).toEqual([
+      'my-bundle/deck-skeleton',
+      'my-bundle/linear-clone',
+      'my-bundle/deck-pacing',
+    ]);
+    const rows = listInstalledPlugins(db);
+    expect(rows.map((row) => row.id).sort()).toEqual([
+      'my-bundle/deck-pacing',
+      'my-bundle/deck-skeleton',
+      'my-bundle/linear-clone',
+    ]);
+    expect(rows.every((row) => row.sourceKind === 'local')).toBe(true);
+    expect(rows.find((row) => row.id === 'my-bundle/deck-skeleton')?.fsPath)
+      .toBe(path.join(pluginsRoot, 'my-bundle', 'skills', 'deck-skeleton'));
+  });
+
+  it('rejects unsafe bundle child paths without leaving registry rows', async () => {
+    const bundleRoot = await writeBundleFixture('unsafe-bundle', {
+      skills: [{ id: 'deck-skeleton', path: '../deck-skeleton' }],
+    });
+
+    let errorMessage = '';
+    for await (const ev of installFromLocalFolder(db, {
+      source: bundleRoot,
+      roots: { userPluginsRoot: pluginsRoot },
+    })) {
+      if (ev.kind === 'error') errorMessage = ev.message;
+    }
+
+    expect(errorMessage).toContain('unsafe path');
+    expect(listInstalledPlugins(db)).toHaveLength(0);
+  });
+
+  it('doctor resolves bundle-local skill, design-system, and craft references', async () => {
+    const bundleRoot = await writeBundleFixture('doctor-bundle', {
+      skillContext: true,
+    });
+
+    for await (const ev of installFromLocalFolder(db, {
+      source: bundleRoot,
+      roots: { userPluginsRoot: pluginsRoot },
+    })) {
+      if (ev.kind === 'error') throw new Error(ev.message);
+    }
+
+    const skill = listInstalledPlugins(db).find((row) => row.id === 'doctor-bundle/deck-skeleton');
+    expect(skill).toBeTruthy();
+
+    const report = doctorPlugin(skill!, {
+      skills: [],
+      designSystems: [],
+      craft: [],
+      atoms: [],
+    });
+    expect(report.issues.filter((issue) => issue.code === 'context.unresolved')).toEqual([]);
+  });
 });
+
+async function writeBundleFixture(
+  id: string,
+  overrides: {
+    skills?: Array<{ id: string; path: string }>;
+    skillContext?: boolean;
+  } = {},
+): Promise<string> {
+  const bundleRoot = path.join(tmpRoot, id);
+  await mkdir(path.join(bundleRoot, 'skills', 'deck-skeleton'), { recursive: true });
+  await mkdir(path.join(bundleRoot, 'design-systems', 'linear-clone'), { recursive: true });
+  await mkdir(path.join(bundleRoot, 'craft'), { recursive: true });
+  await writeFile(path.join(bundleRoot, 'SKILL.md'), `# ${id}\n`);
+  await writeFile(path.join(bundleRoot, 'open-design.json'), JSON.stringify({
+    name: id,
+    version: '1.0.0',
+    title: 'Deck Bundle',
+    od: {
+      kind: 'bundle',
+      bundle: {
+        skills: overrides.skills ?? [{ id: 'deck-skeleton', path: 'skills/deck-skeleton' }],
+        designSystems: [{ id: 'linear-clone', path: 'design-systems/linear-clone' }],
+        craft: [{ id: 'deck-pacing', path: 'craft/deck-pacing.md' }],
+      },
+    },
+  }, null, 2));
+  await writeFile(path.join(bundleRoot, 'skills', 'deck-skeleton', 'SKILL.md'), [
+    '---',
+    'name: deck-skeleton',
+    'description: Deck skeleton skill',
+    '---',
+    '# Deck Skeleton',
+  ].join('\n'));
+  await writeFile(path.join(bundleRoot, 'skills', 'deck-skeleton', 'open-design.json'), JSON.stringify({
+    name: 'deck-skeleton',
+    version: '1.0.0',
+    title: 'Deck Skeleton',
+    ...(overrides.skillContext ? {
+      od: {
+        kind: 'skill',
+        context: {
+          skills: [{ ref: 'deck-skeleton' }],
+          designSystem: { ref: 'linear-clone' },
+          craft: ['deck-pacing'],
+        },
+      },
+    } : { od: { kind: 'skill' } }),
+  }, null, 2));
+  await writeFile(path.join(bundleRoot, 'design-systems', 'linear-clone', 'DESIGN.md'), '# Linear Clone\n');
+  await writeFile(path.join(bundleRoot, 'craft', 'deck-pacing.md'), '# Deck Pacing\n');
+  return bundleRoot;
+}

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -4,7 +4,7 @@
 // arrival lands in Phase 2A.
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
@@ -235,7 +235,7 @@ describe('installFromLocalFolder', () => {
     expect(row?.trust).toBe('restricted');
   });
 
-  it('registers every declared local bundle child under the bundle namespace', async () => {
+  it('registers every declared local bundle child under the bundle namespace with one success event', async () => {
     const bundleRoot = await writeBundleFixture('my-bundle');
 
     const successIds: string[] = [];
@@ -247,13 +247,10 @@ describe('installFromLocalFolder', () => {
       if (ev.kind === 'error') throw new Error(ev.message);
     }
 
-    expect(successIds).toEqual([
-      'my-bundle/deck-skeleton',
-      'my-bundle/linear-clone',
-      'my-bundle/deck-pacing',
-    ]);
+    expect(successIds).toEqual(['my-bundle']);
     const rows = listInstalledPlugins(db);
     expect(rows.map((row) => row.id).sort()).toEqual([
+      'my-bundle',
       'my-bundle/deck-pacing',
       'my-bundle/deck-skeleton',
       'my-bundle/linear-clone',
@@ -261,6 +258,26 @@ describe('installFromLocalFolder', () => {
     expect(rows.every((row) => row.sourceKind === 'local')).toBe(true);
     expect(rows.find((row) => row.id === 'my-bundle/deck-skeleton')?.fsPath)
       .toBe(path.join(pluginsRoot, 'my-bundle', 'skills', 'deck-skeleton'));
+  });
+
+  it('uninstalling a bundle child removes the bundle root and sibling rows', async () => {
+    const bundleRoot = await writeBundleFixture('remove-bundle');
+
+    for await (const ev of installFromLocalFolder(db, {
+      source: bundleRoot,
+      roots: { userPluginsRoot: pluginsRoot },
+    })) {
+      if (ev.kind === 'error') throw new Error(ev.message);
+    }
+
+    const installedFolder = path.join(pluginsRoot, 'remove-bundle');
+    await expect(stat(installedFolder)).resolves.toBeTruthy();
+
+    const result = await uninstallPlugin(db, 'remove-bundle/deck-skeleton', { userPluginsRoot: pluginsRoot });
+
+    expect(result.ok).toBe(true);
+    expect(listInstalledPlugins(db)).toHaveLength(0);
+    await expect(stat(installedFolder)).rejects.toThrow();
   });
 
   it('rejects unsafe bundle child paths without leaving registry rows', async () => {

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -270,6 +270,38 @@ describe('installFromLocalFolder', () => {
       .toBe(path.join(pluginsRoot, 'my-bundle', 'skills', 'deck-skeleton'));
   });
 
+  it('keeps bundle marketplace aliases in separate namespace folders', async () => {
+    const bundleRoot = await writeBundleFixture('shared-bundle');
+
+    for (const entryName of ['market-a/shared-bundle', 'market-b/shared-bundle']) {
+      for await (const ev of installFromLocalFolder(db, {
+        source: bundleRoot,
+        roots: { userPluginsRoot: pluginsRoot },
+        sourceMarketplaceEntryName: entryName,
+      })) {
+        if (ev.kind === 'error') throw new Error(ev.message);
+      }
+    }
+
+    const rows = listInstalledPlugins(db);
+    expect(rows.map((row) => row.id).sort()).toEqual([
+      'market-a/shared-bundle',
+      'market-a/shared-bundle/deck-pacing',
+      'market-a/shared-bundle/deck-skeleton',
+      'market-a/shared-bundle/linear-clone',
+      'market-b/shared-bundle',
+      'market-b/shared-bundle/deck-pacing',
+      'market-b/shared-bundle/deck-skeleton',
+      'market-b/shared-bundle/linear-clone',
+    ]);
+    expect(rows.find((row) => row.id === 'market-a/shared-bundle')?.fsPath)
+      .toBe(path.join(pluginsRoot, 'market-a', 'shared-bundle'));
+    expect(rows.find((row) => row.id === 'market-b/shared-bundle')?.fsPath)
+      .toBe(path.join(pluginsRoot, 'market-b', 'shared-bundle'));
+    await expect(stat(path.join(pluginsRoot, 'market-a', 'shared-bundle'))).resolves.toBeTruthy();
+    await expect(stat(path.join(pluginsRoot, 'market-b', 'shared-bundle'))).resolves.toBeTruthy();
+  });
+
   it('uninstalling a bundle child removes the bundle root and sibling rows', async () => {
     const bundleRoot = await writeBundleFixture('remove-bundle');
 

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -270,7 +270,7 @@ describe('installFromLocalFolder', () => {
       .toBe(path.join(pluginsRoot, 'my-bundle', 'skills', 'deck-skeleton'));
   });
 
-  it('keeps bundle marketplace aliases in separate namespace folders', async () => {
+  it('keeps bundle marketplace aliases and local reinstalls in separate namespace folders', async () => {
     const bundleRoot = await writeBundleFixture('shared-bundle');
 
     for (const entryName of ['market-a/shared-bundle', 'market-b/shared-bundle']) {
@@ -283,6 +283,13 @@ describe('installFromLocalFolder', () => {
       }
     }
 
+    for await (const ev of installFromLocalFolder(db, {
+      source: bundleRoot,
+      roots: { userPluginsRoot: pluginsRoot },
+    })) {
+      if (ev.kind === 'error') throw new Error(ev.message);
+    }
+
     const rows = listInstalledPlugins(db);
     expect(rows.map((row) => row.id).sort()).toEqual([
       'market-a/shared-bundle',
@@ -293,13 +300,20 @@ describe('installFromLocalFolder', () => {
       'market-b/shared-bundle/deck-pacing',
       'market-b/shared-bundle/deck-skeleton',
       'market-b/shared-bundle/linear-clone',
+      'shared-bundle',
+      'shared-bundle/deck-pacing',
+      'shared-bundle/deck-skeleton',
+      'shared-bundle/linear-clone',
     ]);
     expect(rows.find((row) => row.id === 'market-a/shared-bundle')?.fsPath)
       .toBe(path.join(pluginsRoot, 'market-a', 'shared-bundle'));
     expect(rows.find((row) => row.id === 'market-b/shared-bundle')?.fsPath)
       .toBe(path.join(pluginsRoot, 'market-b', 'shared-bundle'));
+    expect(rows.find((row) => row.id === 'shared-bundle')?.fsPath)
+      .toBe(path.join(pluginsRoot, 'shared-bundle'));
     await expect(stat(path.join(pluginsRoot, 'market-a', 'shared-bundle'))).resolves.toBeTruthy();
     await expect(stat(path.join(pluginsRoot, 'market-b', 'shared-bundle'))).resolves.toBeTruthy();
+    await expect(stat(path.join(pluginsRoot, 'shared-bundle'))).resolves.toBeTruthy();
   });
 
   it('uninstalling a bundle child removes the bundle root and sibling rows', async () => {

--- a/apps/daemon/tests/plugins-list-route.test.ts
+++ b/apps/daemon/tests/plugins-list-route.test.ts
@@ -1,0 +1,115 @@
+import type http from 'node:http';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { InstalledPluginRecord } from '@open-design/contracts';
+
+import { startServer } from '../src/server.js';
+import { searchInstalledPlugins } from '../src/plugins/search.js';
+
+type StartedServer = { server: http.Server; url: string; shutdown?: () => Promise<void> | void };
+
+let server: http.Server | undefined;
+let shutdown: (() => Promise<void> | void) | undefined;
+let baseUrl = '';
+let tmpRoot = '';
+
+beforeEach(async () => {
+  tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'od-plugin-list-route-'));
+  const started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+  server = started.server;
+  shutdown = started.shutdown;
+  baseUrl = started.url;
+});
+
+afterEach(async () => {
+  await Promise.resolve(shutdown?.());
+  if (server) {
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+  }
+  server = undefined;
+  shutdown = undefined;
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe('GET /api/plugins', () => {
+  it('hides synthesized bundle resource children from public list and search surfaces', async () => {
+    const bundleRoot = await writeBundleFixture('public-bundle');
+    await installPlugin(bundleRoot);
+
+    const resp = await fetch(`${baseUrl}/api/plugins`);
+    expect(resp.status).toBe(200);
+    const data = await resp.json() as { plugins: InstalledPluginRecord[] };
+    const bundlePlugins = data.plugins.filter((plugin) => plugin.id.startsWith('public-bundle'));
+    const ids = bundlePlugins.map((plugin) => plugin.id).sort();
+    expect(ids).toEqual(['public-bundle', 'public-bundle/deck-skeleton']);
+
+    const search = searchInstalledPlugins({ plugins: bundlePlugins, query: 'public-bundle' });
+    expect(search.entries.map((entry) => entry.plugin.id).sort()).toEqual([
+      'public-bundle',
+      'public-bundle/deck-skeleton',
+    ]);
+    expect(bundlePlugins.some((plugin) => plugin.manifest.od?.hidden === true)).toBe(false);
+  });
+});
+
+async function installPlugin(source: string): Promise<void> {
+  const resp = await fetch(`${baseUrl}/api/plugins/install`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'text/event-stream' },
+    body: JSON.stringify({ source }),
+  });
+  expect(resp.status).toBe(200);
+  if (!resp.body) throw new Error('install stream missing body');
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let raw = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    raw += decoder.decode(value, { stream: true });
+  }
+  if (!raw.includes('event: success')) {
+    throw new Error(`installer did not finalize:\n${raw}`);
+  }
+}
+
+async function writeBundleFixture(id: string): Promise<string> {
+  const bundleRoot = path.join(tmpRoot, id);
+  await mkdir(path.join(bundleRoot, 'skills', 'deck-skeleton'), { recursive: true });
+  await mkdir(path.join(bundleRoot, 'design-systems', 'linear-clone'), { recursive: true });
+  await mkdir(path.join(bundleRoot, 'craft'), { recursive: true });
+  await writeFile(path.join(bundleRoot, 'SKILL.md'), `# ${id}\n`);
+  await writeFile(path.join(bundleRoot, 'open-design.json'), JSON.stringify({
+    name: id,
+    version: '1.0.0',
+    title: 'Public Bundle',
+    od: {
+      kind: 'bundle',
+      bundle: {
+        skills: [{ id: 'deck-skeleton', path: 'skills/deck-skeleton' }],
+        designSystems: [{ id: 'linear-clone', path: 'design-systems/linear-clone' }],
+        craft: [{ id: 'deck-pacing', path: 'craft/deck-pacing.md' }],
+      },
+    },
+  }, null, 2));
+  await writeFile(path.join(bundleRoot, 'skills', 'deck-skeleton', 'SKILL.md'), [
+    '---',
+    'name: deck-skeleton',
+    'description: Deck skeleton skill',
+    '---',
+    '# Deck Skeleton',
+  ].join('\n'));
+  await writeFile(path.join(bundleRoot, 'skills', 'deck-skeleton', 'open-design.json'), JSON.stringify({
+    name: 'deck-skeleton',
+    version: '1.0.0',
+    title: 'Deck Skeleton',
+    od: { kind: 'skill' },
+  }, null, 2));
+  await writeFile(path.join(bundleRoot, 'design-systems', 'linear-clone', 'DESIGN.md'), '# Linear Clone\n');
+  await writeFile(path.join(bundleRoot, 'craft', 'deck-pacing.md'), '# Deck Pacing\n');
+  return bundleRoot;
+}

--- a/apps/daemon/tests/plugins-list-route.test.ts
+++ b/apps/daemon/tests/plugins-list-route.test.ts
@@ -52,6 +52,25 @@ describe('GET /api/plugins', () => {
       'public-bundle/deck-skeleton',
     ]);
     expect(bundlePlugins.some((plugin) => plugin.manifest.od?.hidden === true)).toBe(false);
+
+    const internalResp = await fetch(`${baseUrl}/api/plugins?includeHidden=true`);
+    expect(internalResp.status).toBe(200);
+    const internalData = await internalResp.json() as { plugins: InstalledPluginRecord[] };
+    const internalIds = internalData.plugins
+      .filter((plugin) => plugin.id.startsWith('public-bundle'))
+      .map((plugin) => plugin.id)
+      .sort();
+    expect(internalIds).toEqual([
+      'public-bundle',
+      'public-bundle/deck-pacing',
+      'public-bundle/deck-skeleton',
+      'public-bundle/linear-clone',
+    ]);
+    expect(
+      internalData.plugins
+        .filter((plugin) => plugin.id === 'public-bundle/deck-pacing' || plugin.id === 'public-bundle/linear-clone')
+        .every((plugin) => plugin.manifest.od?.hidden === true),
+    ).toBe(true);
   });
 });
 

--- a/apps/daemon/tests/plugins-search.test.ts
+++ b/apps/daemon/tests/plugins-search.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import type { InstalledPluginRecord, PluginManifest } from '@open-design/contracts';
 import { searchInstalledPlugins } from '../src/plugins/search.js';
 
-const make = (id: string, over: Partial<{ title: string; description: string; tags: string[]; taskKind: string; mode: string; trust: 'trusted' | 'restricted' | 'bundled'; sourceKind: 'bundled' | 'local' | 'github' | 'url'; }>): InstalledPluginRecord => ({
+const make = (id: string, over: Partial<{ title: string; description: string; tags: string[]; taskKind: string; mode: string; trust: 'trusted' | 'restricted' | 'bundled'; sourceKind: 'bundled' | 'local' | 'github' | 'url'; hidden: boolean; }>): InstalledPluginRecord => ({
   id,
   title: over.title ?? `Title for ${id}`,
   version: '0.1.0',
@@ -26,7 +26,9 @@ const make = (id: string, over: Partial<{ title: string; description: string; ta
       ? { od: {
           ...(over.taskKind ? { taskKind: over.taskKind } : {}),
           ...(over.mode     ? { mode: over.mode } : {}),
+          ...(over.hidden   ? { hidden: true } : {}),
         } }
+      : over.hidden ? { od: { hidden: true } }
       : {}),
   } as PluginManifest,
 });
@@ -68,6 +70,21 @@ describe('searchInstalledPlugins — free-text query', () => {
   it('returns empty entries when query matches nothing', () => {
     const r = searchInstalledPlugins({ plugins, query: 'no-such-thing' });
     expect(r.entries).toEqual([]);
+  });
+
+  it('hides od.hidden records from installed search results', () => {
+    const r = searchInstalledPlugins({
+      plugins: [
+        make('visible-bundle', { title: 'Visible Bundle' }),
+        make('visible-bundle/deck-skeleton', { title: 'Deck Skeleton' }),
+        make('visible-bundle/deck-pacing', { title: 'Deck Pacing', hidden: true }),
+      ],
+      query: 'visible-bundle',
+    });
+    expect(r.entries.map((entry) => entry.plugin.id).sort()).toEqual([
+      'visible-bundle',
+      'visible-bundle/deck-skeleton',
+    ]);
   });
 });
 

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -681,6 +681,7 @@ interface PluginInstallEvent {
   phase?: string;
   message?: string;
   plugin?: InstalledPluginRecord;
+  plugins?: InstalledPluginRecord[];
   warnings?: string[];
 }
 
@@ -706,17 +707,22 @@ export async function installPluginSource(source: string): Promise<PluginInstall
     }
 
     let success: InstalledPluginRecord | undefined;
+    let installedPlugins: InstalledPluginRecord[] | undefined;
     let warnings: string[] = [];
     let errorMessage: string | undefined;
     for await (const ev of readServerSentEvents(resp.body)) {
       if (ev.message) log.push(ev.message);
       if (ev.warnings) warnings = ev.warnings;
-      if (ev.kind === 'success') success = ev.plugin;
+      if (ev.kind === 'success') {
+        success = ev.plugin;
+        installedPlugins = ev.plugins;
+      }
       if (ev.kind === 'error') errorMessage = ev.message ?? 'Install failed.';
     }
     return {
       ok: Boolean(success) && !errorMessage,
       plugin: success,
+      ...(installedPlugins ? { plugins: installedPlugins } : {}),
       warnings,
       message: errorMessage ?? (success ? `Installed ${success.title}.` : 'Install finished.'),
       log,
@@ -991,17 +997,22 @@ export async function upgradePlugin(id: string): Promise<PluginInstallOutcome> {
       };
     }
     let success: InstalledPluginRecord | undefined;
+    let installedPlugins: InstalledPluginRecord[] | undefined;
     let warnings: string[] = [];
     let errorMessage: string | undefined;
     for await (const ev of readServerSentEvents(resp.body)) {
       if (ev.message) log.push(ev.message);
       if (ev.warnings) warnings = ev.warnings;
-      if (ev.kind === 'success') success = ev.plugin;
+      if (ev.kind === 'success') {
+        success = ev.plugin;
+        installedPlugins = ev.plugins;
+      }
       if (ev.kind === 'error') errorMessage = ev.message ?? 'Upgrade failed.';
     }
     return {
       ok: Boolean(success) && !errorMessage,
       plugin: success,
+      ...(installedPlugins ? { plugins: installedPlugins } : {}),
       warnings,
       message: errorMessage ?? (success ? `Upgraded ${success.title}.` : 'Upgrade finished.'),
       log,
@@ -1029,6 +1040,7 @@ async function postPluginUpload(url: string, form: FormData): Promise<PluginInst
       return {
         ok: true,
         plugin: json.plugin,
+        ...(json.plugins ? { plugins: json.plugins } : {}),
         warnings: json.warnings ?? [],
         message: json.message ?? 'Plugin installed.',
         log: json.log ?? [],
@@ -1062,6 +1074,7 @@ async function readPluginInstallOutcome(resp: Response): Promise<PluginInstallOu
     return {
       ok: true,
       ...(json.plugin ? { plugin: json.plugin } : {}),
+      ...(json.plugins ? { plugins: json.plugins } : {}),
       warnings: json.warnings ?? [],
       message: json.message ?? 'Plugin installed.',
       log: json.log ?? [],

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -661,7 +661,7 @@ export async function listPlugins(
   options: ListPluginsOptions = {},
 ): Promise<InstalledPluginRecord[]> {
   try {
-    const resp = await fetch('/api/plugins');
+    const resp = await fetch(options.includeHidden ? '/api/plugins?includeHidden=true' : '/api/plugins');
     if (!resp.ok) return [];
     const json = (await resp.json()) as { plugins?: InstalledPluginRecord[] };
     const plugins = json.plugins ?? [];

--- a/packages/contracts/src/plugins/installed.ts
+++ b/packages/contracts/src/plugins/installed.ts
@@ -61,15 +61,23 @@ export const PluginInstallSourceSchema = z.object({
 
 export type PluginInstallSource = z.infer<typeof PluginInstallSourceSchema>;
 
-export const PluginInstallOutcomeSchema = z.object({
+export interface PluginInstallOutcome {
+  ok: boolean;
+  plugin?: InstalledPluginRecord | null | undefined;
+  plugins?: InstalledPluginRecord[] | undefined;
+  warnings: string[];
+  message?: string | undefined;
+  log: string[];
+}
+
+export const PluginInstallOutcomeSchema: z.ZodType<PluginInstallOutcome, z.ZodTypeDef, unknown> = z.object({
   ok:       z.boolean(),
   plugin:   InstalledPluginRecordSchema.nullable().optional(),
+  plugins:  z.array(InstalledPluginRecordSchema).optional(),
   warnings: z.array(z.string()),
   message:  z.string().optional(),
   log:      z.array(z.string()),
 });
-
-export type PluginInstallOutcome = z.infer<typeof PluginInstallOutcomeSchema>;
 
 export const ProjectPluginFolderInstallRequestSchema = z.object({
   path: z.string().min(1),

--- a/packages/contracts/src/plugins/manifest.ts
+++ b/packages/contracts/src/plugins/manifest.ts
@@ -136,6 +136,21 @@ export const PluginConnectorRefSchema = z.object({
 
 export type PluginConnectorRef = z.infer<typeof PluginConnectorRefSchema>;
 
+export const BundleChildSchema = z.object({
+  id:   z.string().min(1).regex(/^[a-z0-9][a-z0-9._-]*$/),
+  path: z.string().min(1),
+}).passthrough();
+
+export type BundleChild = z.infer<typeof BundleChildSchema>;
+
+export const PluginBundleSchema = z.object({
+  skills:        z.array(BundleChildSchema).optional(),
+  designSystems: z.array(BundleChildSchema).optional(),
+  craft:         z.array(BundleChildSchema).optional(),
+}).passthrough();
+
+export type PluginBundle = z.infer<typeof PluginBundleSchema>;
+
 export const PluginManifestSchema = z.object({
   $schema:     z.string().optional(),
   specVersion: OpenDesignSpecVersionSchema.optional(),
@@ -200,6 +215,7 @@ export const PluginManifestSchema = z.object({
       required: z.array(PluginConnectorRefSchema).optional(),
       optional: z.array(PluginConnectorRefSchema).optional(),
     }).passthrough().optional(),
+    bundle: PluginBundleSchema.optional(),
     inputs: z.array(InputFieldSchema).optional(),
     capabilities: z.array(z.string()).optional(),
   }).passthrough().optional(),

--- a/packages/contracts/tests/plugins-manifest.test.ts
+++ b/packages/contracts/tests/plugins-manifest.test.ts
@@ -85,6 +85,25 @@ describe('plugin manifest localized text', () => {
     expect(resolveLocalizedText(entry.description_i18n, 'zh-CN')).toBe('中文描述。');
   });
 
+  it('accepts declared bundle children', () => {
+    const manifest = PluginManifestSchema.parse({
+      name: 'deck-bundle',
+      version: '1.0.0',
+      od: {
+        kind: 'bundle',
+        bundle: {
+          skills: [{ id: 'deck-skeleton', path: 'skills/deck-skeleton' }],
+          designSystems: [{ id: 'linear-clone', path: 'design-systems/linear-clone' }],
+          craft: [{ id: 'deck-pacing', path: 'craft/deck-pacing.md' }],
+        },
+      },
+    });
+
+    expect(manifest.od?.bundle?.skills?.[0]?.id).toBe('deck-skeleton');
+    expect(manifest.od?.bundle?.designSystems?.[0]?.path).toBe('design-systems/linear-clone');
+    expect(manifest.od?.bundle?.craft?.[0]?.id).toBe('deck-pacing');
+  });
+
   it('falls back from exact locale to base language, English, then first value', () => {
     expect(resolveLocalizedText({ en: 'English', zh: '中文' }, 'zh-CN')).toBe('中文');
     expect(resolveLocalizedText({ 'zh-CN': '中文' }, 'fr')).toBe('中文');


### PR DESCRIPTION
Closes #2146

## Why

Phase 3 plugin work needs one install source to declare multiple skills, design systems, and craft files without silently publishing arbitrary folders. This PR implements the bundle layout contract from the issue so installer fan-out and doctor validation have a concrete, tested path.

## What users will see

Installing a local, GitHub, or tarball source whose root `open-design.json` has `od.kind: "bundle"` now registers each declared child under the bundle namespace, for example `my-bundle/deck-skeleton`. `od plugin doctor <child-id>` can resolve bundle-local short references declared by those children. Single-plugin installs keep the existing behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. No UI surface changed.

## Bug fix verification

Not a bug fix.

## Validation

- `git diff --check`
- Attempted `pnpm --filter @open-design/contracts test -- plugins-manifest.test.ts` and `pnpm --filter @open-design/daemon test -- plugins-installer.test.ts`, but this runner has no `pnpm` or `node` on PATH (`command not found`).

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>