### PR TITLE
feat(daemon): pass Open Design trace env to AMR

### DIFF
--- a/apps/daemon/src/agents.ts
+++ b/apps/daemon/src/agents.ts
@@ -12,7 +12,7 @@ export {
 } from './runtimes/executables.js';
 export { applyAgentLaunchEnv, resolveAgentLaunch } from './runtimes/launch.js';
 export { resolveAgentBin } from './runtimes/resolution.js';
-export { spawnEnvForAgent } from './runtimes/env.js';
+export { openDesignAmrTraceEnv, spawnEnvForAgent } from './runtimes/env.js';
 export { buildLiveArtifactsMcpServersForAgent } from './runtimes/mcp.js';
 export {
   checkPromptArgvBudget,

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -97,6 +97,30 @@ export function spawnEnvForAgent(
   return reapplySandboxRuntimeEnv(env, sandboxRuntime);
 }
 
+export function openDesignAmrTraceEnv(input: {
+  agentId: string;
+  runId: string;
+  conversationId?: string | null;
+  runAttempt: number;
+}): NodeJS.ProcessEnv {
+  if (input.agentId !== 'amr') return {};
+
+  const runId = input.runId.trim();
+  if (!runId) {
+    throw new Error('OPEN_DESIGN_RUN_ID requires a non-empty run id for AMR runs');
+  }
+  if (!Number.isFinite(input.runAttempt) || input.runAttempt < 0) {
+    throw new Error('OPEN_DESIGN_RUN_ATTEMPT requires a non-negative finite attempt index');
+  }
+
+  const conversationId = input.conversationId?.trim();
+  return {
+    OPEN_DESIGN_RUN_ID: runId,
+    OPEN_DESIGN_RUN_ATTEMPT: String(Math.floor(input.runAttempt)),
+    ...(conversationId ? { OPEN_DESIGN_SESSION_ID: conversationId } : {}),
+  };
+}
+
 function isOpenClaudeExecutable(resolvedBin: string | null | undefined): boolean {
   if (typeof resolvedBin !== 'string' || !resolvedBin.trim()) return false;
   const base = path

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -40,6 +40,7 @@ import {
   detectAgents,
   getAgentDef,
   isKnownModel,
+  openDesignAmrTraceEnv,
   applyAgentLaunchEnv,
   resolveAgentLaunch,
   sanitizeCustomModel,
@@ -12256,6 +12257,12 @@ export async function startServer({
         ...agentSpawnEnv,
         ...(mmdRouteLaunchEnv || {}),
         ...odMediaEnv,
+        ...openDesignAmrTraceEnv({
+          agentId: def.id,
+          runId: run.id,
+          conversationId: run.conversationId,
+          runAttempt: run.retryAttemptCount ?? 0,
+        }),
         // OpenCode external-MCP injection (issue #2142). Layered AFTER
         // spawnEnvForAgent / odMediaEnv / configuredAgentEnv so the
         // daemon-built MCP config wins over a stale value the user

--- a/apps/daemon/tests/runtimes/open-design-amr-trace-env.test.ts
+++ b/apps/daemon/tests/runtimes/open-design-amr-trace-env.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { openDesignAmrTraceEnv } from '../../src/runtimes/env.js';
+
+test('openDesignAmrTraceEnv builds Open Design trace identity env for AMR only', () => {
+  const amrEnv = openDesignAmrTraceEnv({
+    agentId: 'amr',
+    runId: ' run_trace_123 ',
+    runAttempt: 2,
+    conversationId: ' conversation_trace_456 ',
+  });
+
+  assert.equal(amrEnv.OPEN_DESIGN_RUN_ID, 'run_trace_123');
+  assert.equal(amrEnv.OPEN_DESIGN_RUN_ATTEMPT, '2');
+  assert.equal(amrEnv.OPEN_DESIGN_SESSION_ID, 'conversation_trace_456');
+
+  const claudeEnv = openDesignAmrTraceEnv({
+    agentId: 'claude',
+    runId: 'run_trace_123',
+    runAttempt: 2,
+    conversationId: 'conversation_trace_456',
+  });
+
+  assert.deepEqual(claudeEnv, {});
+});
+
+test('openDesignAmrTraceEnv omits optional AMR session trace env when no conversation exists', () => {
+  const env = openDesignAmrTraceEnv({
+    agentId: 'amr',
+    runId: 'run_trace_no_session',
+    runAttempt: 0,
+  });
+
+  assert.equal(env.OPEN_DESIGN_RUN_ID, 'run_trace_no_session');
+  assert.equal(env.OPEN_DESIGN_RUN_ATTEMPT, '0');
+  assert.equal(env.OPEN_DESIGN_SESSION_ID, undefined);
+});
+
+test('openDesignAmrTraceEnv fails fast on invalid AMR trace inputs', () => {
+  assert.throws(
+    () => openDesignAmrTraceEnv({ agentId: 'amr', runId: ' ', runAttempt: 0 }),
+    /OPEN_DESIGN_RUN_ID/,
+  );
+  assert.throws(
+    () => openDesignAmrTraceEnv({ agentId: 'amr', runId: 'run_trace', runAttempt: -1 }),
+    /OPEN_DESIGN_RUN_ATTEMPT/,
+  );
+});


### PR DESCRIPTION
## Why

AMR debugging and performance analysis need a stable correlation id that starts in Open Design and survives through Vela/OpenCode runtime work. Open Design already has a per-run id that maps to the Langfuse trace id, but AMR launches did not receive it, leaving downstream logs and telemetry unable to join back to the originating OD run.

This unblocks AMR-side propagation by making the OD run identity available at `vela agent run` process start.

## What users will see

No visible UI change. AMR runs now receive Open Design tracing env vars so downstream AMR/Vela/OpenCode telemetry can correlate logs, errors, and timings to the originating OD run.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface.

## Bug fix verification

- N/A — observability feature, not a bug fix.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/open-design-amr-trace-env.test.ts` ✅
- `pnpm --filter @open-design/daemon typecheck` ❌ blocked by local missing `node-pty` module/types in `apps/daemon/src/terminals.ts`.
- `pnpm guard` ❌ blocked by pre-existing tools layout violation: `tools/pr/ -> tools/ top-level entries are allowlisted; expected only AGENTS.md, dev/, pack/, and serve/`.
