### PR TITLE
fix(web): flip deck preview to a queued send's marked slide

### DIFF
--- a/apps/web/src/comments.ts
+++ b/apps/web/src/comments.ts
@@ -125,6 +125,31 @@ export function commentVisibleOnDeckSlide(
   return comment.slideIndex === activeSlideIndex;
 }
 
+// When a queued chat send starts processing, the deck preview should flip to
+// the slide its marked element lives on so the user watches the edit land in
+// context instead of staring at slide 1. The mark's `slideIndex` is captured
+// at queue time and carried on each comment attachment. Return the first
+// attachment that names a deck file and a concrete slide; null means there is
+// nothing slide-scoped to navigate to (plain prompt, free pin, missing index).
+export function queuedSlideNavTarget(
+  commentAttachments: readonly ChatCommentAttachment[] | null | undefined,
+): { filePath: string; slideIndex: number } | null {
+  if (!commentAttachments) return null;
+  for (const attachment of commentAttachments) {
+    const filePath = attachment.filePath?.trim();
+    const slideIndex = attachment.slideIndex;
+    if (
+      filePath &&
+      typeof slideIndex === 'number' &&
+      Number.isFinite(slideIndex) &&
+      slideIndex >= 0
+    ) {
+      return { filePath, slideIndex: Math.floor(slideIndex) };
+    }
+  }
+  return null;
+}
+
 export function commentSnapshotOverlayEqual(
   a: PreviewCommentSnapshot,
   b: PreviewCommentSnapshot,
@@ -242,6 +267,7 @@ export function commentToAttachment(
               : 0)
         : undefined,
     podMembers: podMembers.length > 0 ? podMembers : undefined,
+    ...(typeof comment.slideIndex === 'number' ? { slideIndex: comment.slideIndex } : {}),
     imageAttachments: imageAttachments.length > 0 ? imageAttachments : undefined,
     source: 'saved-comment',
   };
@@ -292,6 +318,7 @@ export function buildBoardCommentAttachments(input: {
       selectionKind,
       memberCount,
       podMembers: podMembers.length > 0 ? podMembers : undefined,
+      ...(typeof input.target.slideIndex === 'number' ? { slideIndex: input.target.slideIndex } : {}),
       source: 'board-batch',
     }));
 }

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -80,6 +80,7 @@ import {
 } from '../runtime/exports';
 import { copyToClipboard } from '../lib/copy-to-clipboard';
 import { buildReactComponentSrcdoc } from '../runtime/react-component';
+import { shouldConsumeSlideNav } from '../runtime/slide-nav';
 import { findHtmlEntriesReferencing } from '../runtime/jsx-module-refs';
 import { buildLazySrcdocTransport, buildSrcdoc, canActivateSrcDocTransport } from '../runtime/srcdoc';
 import {
@@ -7156,17 +7157,17 @@ function HtmlViewer({
   // slide its marked element lives on. We write the cached slide state first so
   // a freshly-mounted iframe (the tab may have just been activated) restores to
   // the target on load via syncCachedSlideStateToIframe(), then post directly
-  // to cover the already-loaded iframe. Each nonce is consumed once so manual
-  // navigation afterwards is never clobbered.
-  const consumedSlideNavNonceRef = useRef<number | null>(null);
+  // to cover the already-loaded iframe. The consume-once guard lives in
+  // `shouldConsumeSlideNav` (keyed by file outside this component) so it holds
+  // across remounts — switching away from and back to the deck must not replay
+  // the stale request and yank the preview off wherever the user navigated.
   useEffect(() => {
     const nonce = slideNavRequest?.nonce;
     if (nonce == null) return;
-    if (consumedSlideNavNonceRef.current === nonce) return;
     if (!effectiveDeck) return;
     const requested = slideNavRequest?.slideIndex;
     if (typeof requested !== 'number' || !Number.isFinite(requested) || requested < 0) return;
-    consumedSlideNavNonceRef.current = nonce;
+    if (!shouldConsumeSlideNav(previewStateKey, nonce)) return;
     const target = Math.floor(requested);
     const cachedCount = htmlPreviewSlideState.get(previewStateKey)?.count;
     const count = slideState?.count ?? cachedCount ?? target + 1;

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -956,6 +956,9 @@ interface Props {
   // Bumped nonce asking this viewer to open its Share/Export menu (chat-side
   // "Share" next-step action). Only HTML artifacts expose a Share menu.
   shareRequest?: { nonce: number } | null;
+  // Bumped nonce asking a deck preview to flip to `slideIndex` (a queued chat
+  // send for this file just started processing).
+  slideNavRequest?: { slideIndex: number; nonce: number } | null;
 }
 
 export function FileViewer({
@@ -978,6 +981,7 @@ export function FileViewer({
   commentPortalId,
   onCommentModeChange,
   shareRequest,
+  slideNavRequest,
 }: Props) {
   const rendererMatch = artifactRendererRegistry.resolve({
     file,
@@ -1020,6 +1024,7 @@ export function FileViewer({
         commentPortalId={commentPortalId}
         onCommentModeChange={onCommentModeChange}
         shareRequest={shareRequest}
+        slideNavRequest={slideNavRequest}
       />
     );
   }
@@ -4414,6 +4419,7 @@ function HtmlViewer({
   commentPortalId,
   onCommentModeChange,
   shareRequest,
+  slideNavRequest,
 }: {
   projectId: string;
   projectKind: TrackingProjectKind;
@@ -4433,6 +4439,7 @@ function HtmlViewer({
   commentPortalId?: string;
   onCommentModeChange?: (active: boolean) => void;
   shareRequest?: { nonce: number } | null;
+  slideNavRequest?: { slideIndex: number; nonce: number } | null;
 }) {
   const { locale, t } = useI18n();
   const analytics = useAnalytics();
@@ -7144,6 +7151,29 @@ function HtmlViewer({
     setDownloadMenuOpen(false);
     setDeployMenuOpen(true);
   }, [shareRequest?.nonce, canShare, projectId, file.name]);
+
+  // A queued chat send for this deck just started: flip the preview to the
+  // slide its marked element lives on. We write the cached slide state first so
+  // a freshly-mounted iframe (the tab may have just been activated) restores to
+  // the target on load via syncCachedSlideStateToIframe(), then post directly
+  // to cover the already-loaded iframe. Each nonce is consumed once so manual
+  // navigation afterwards is never clobbered.
+  const consumedSlideNavNonceRef = useRef<number | null>(null);
+  useEffect(() => {
+    const nonce = slideNavRequest?.nonce;
+    if (nonce == null) return;
+    if (consumedSlideNavNonceRef.current === nonce) return;
+    if (!effectiveDeck) return;
+    const requested = slideNavRequest?.slideIndex;
+    if (typeof requested !== 'number' || !Number.isFinite(requested) || requested < 0) return;
+    consumedSlideNavNonceRef.current = nonce;
+    const target = Math.floor(requested);
+    const cachedCount = htmlPreviewSlideState.get(previewStateKey)?.count;
+    const count = slideState?.count ?? cachedCount ?? target + 1;
+    setSlideStateCached(previewStateKey, { active: target, count });
+    setSlideState({ active: target, count });
+    syncCachedSlideStateToIframe();
+  }, [slideNavRequest?.nonce, slideNavRequest?.slideIndex, effectiveDeck, previewStateKey, slideState?.count]);
 
   const openDownloadMenu = () => {
     fireArtifactHeaderClick('share_dropdown');

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -115,6 +115,10 @@ interface Props {
   // Open the named file AND surface its Share/Export menu. Drives the chat-side
   // "Share" next-step action without a dedicated share backend.
   shareRequest?: { name: string; nonce: number } | null;
+  // Flip a deck preview to a given slide when a queued chat send starts. Mirrors
+  // `shareRequest`: the named file is activated (if open) and the matching
+  // FileViewer consumes the nonce to navigate.
+  slideNavRequest?: { name: string; slideIndex: number; nonce: number } | null;
   liveArtifactEvents?: LiveArtifactEventItem[];
   designSystemActivityEvents?: AgentEvent[];
   // Persisted set of open tabs + active tab. Owned by ProjectView so the
@@ -361,6 +365,7 @@ export function FileWorkspace({
   commentSendDisabled = false,
   openRequest,
   shareRequest,
+  slideNavRequest,
   liveArtifactEvents = [],
   designSystemActivityEvents = [],
   tabsState,
@@ -771,6 +776,18 @@ export function FileWorkspace({
     setActiveTab(name);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shareRequest]);
+
+  // Slide-nav request: if the named deck is an open tab, bring it forward so the
+  // matching FileViewer below is mounted and can consume the nonce. We do not
+  // open a closed file — auto-flipping a slide is a follow-along, not a reason
+  // to yank the user into a tab they never opened.
+  useEffect(() => {
+    if (!slideNavRequest) return;
+    const name = slideNavRequest.name;
+    if (!name || !persistedTabs.includes(name)) return;
+    setActiveTab(name);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slideNavRequest]);
 
   // Focus the Questions tab when the parent bumps the nonce (banner click in
   // chat, or a freshly generated form). The tab is transient — not added to
@@ -2237,6 +2254,11 @@ export function FileWorkspace({
             shareRequest={
               shareRequest && shareRequest.name === activeFile.name
                 ? { nonce: shareRequest.nonce }
+                : null
+            }
+            slideNavRequest={
+              slideNavRequest && slideNavRequest.name === activeFile.name
+                ? { slideIndex: slideNavRequest.slideIndex, nonce: slideNavRequest.nonce }
                 : null
             }
           />

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -33,6 +33,7 @@ import {
 } from '../providers/registry';
 import { deriveFileOps, type FileOpEntry } from '../runtime/file-ops';
 import { latestTodosFromEvents, type TodoItem } from '../runtime/todos';
+import { deliverableSlideNavForActiveFile, isSlideNavDeliverableNow } from '../runtime/slide-nav';
 import {
   type AgentEvent,
   type AgentInfo,
@@ -777,15 +778,19 @@ export function FileWorkspace({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shareRequest]);
 
-  // Slide-nav request: if the named deck is an open tab, bring it forward so the
-  // matching FileViewer below is mounted and can consume the nonce. We do not
-  // open a closed file — auto-flipping a slide is a follow-along, not a reason
-  // to yank the user into a tab they never opened.
+  // Slide-nav request: decide deliverability once, at fire time. Only if the
+  // named deck is already an open tab do we mark this nonce deliverable and
+  // bring it forward so the matching FileViewer is mounted and flips. We never
+  // open a closed file — auto-flipping is a follow-along, not a reason to yank
+  // the user into a tab they never opened. Recording the deliverable nonce in
+  // state (not a ref) also means a request for a closed deck stays undeliverable
+  // forever: opening that file later matches the name but not the nonce, so the
+  // stale request can't resurface and jump the preview.
+  const [slideNavDeliverableNonce, setSlideNavDeliverableNonce] = useState<number | null>(null);
   useEffect(() => {
-    if (!slideNavRequest) return;
-    const name = slideNavRequest.name;
-    if (!name || !persistedTabs.includes(name)) return;
-    setActiveTab(name);
+    if (!isSlideNavDeliverableNow(slideNavRequest, persistedTabs)) return;
+    setSlideNavDeliverableNonce(slideNavRequest!.nonce);
+    setActiveTab(slideNavRequest!.name);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [slideNavRequest]);
 
@@ -2256,11 +2261,11 @@ export function FileWorkspace({
                 ? { nonce: shareRequest.nonce }
                 : null
             }
-            slideNavRequest={
-              slideNavRequest && slideNavRequest.name === activeFile.name
-                ? { slideIndex: slideNavRequest.slideIndex, nonce: slideNavRequest.nonce }
-                : null
-            }
+            slideNavRequest={deliverableSlideNavForActiveFile(
+              slideNavRequest,
+              activeFile.name,
+              slideNavDeliverableNonce,
+            )}
           />
         ) : (
           <div className="viewer-empty">

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -149,6 +149,7 @@ import {
   historyWithCommentAttachmentContext,
   mergeAttachedComments,
   mergePreviewCommentAttachments,
+  queuedSlideNavTarget,
   removeAttachedComment,
 } from '../comments';
 import { filterImplicitProducedFiles } from '../produced-files';
@@ -983,6 +984,14 @@ export function ProjectView({
   // file's Share/Export menu. Drives the "Share" next-step action: it reuses the
   // existing export/deploy surface rather than introducing a new share backend.
   const [shareRequest, setShareRequest] = useState<{ name: string; nonce: number } | null>(null);
+  // When a queued chat send starts processing, ask the workspace to flip the
+  // deck preview to the slide its marked element lives on, so the user watches
+  // the edit land in context instead of staying parked on slide 1. Mirrors the
+  // `shareRequest` nonce signal: FileWorkspace matches `name` against the open
+  // file and FileViewer consumes each nonce once.
+  const [slideNavRequest, setSlideNavRequest] = useState<
+    { name: string; slideIndex: number; nonce: number } | null
+  >(null);
   const abortRef = useRef<AbortController | null>(null);
   const cancelRef = useRef<AbortController | null>(null);
   const streamingConversationIdRef = useRef<string | null>(null);
@@ -3558,6 +3567,16 @@ export function ProjectView({
     ],
   );
 
+  // Flip the deck preview to the slide a queued send's marked element lives on
+  // the moment that send starts processing. No-op for plain prompts or marks
+  // without a slide index; FileWorkspace/FileViewer ignore it unless the named
+  // file is the open deck.
+  const armSlideNavForQueuedSend = useCallback((item: QueuedChatSend) => {
+    const target = queuedSlideNavTarget(item.commentAttachments);
+    if (!target) return;
+    setSlideNavRequest({ name: target.filePath, slideIndex: target.slideIndex, nonce: Date.now() });
+  }, []);
+
   const sendQueuedChatSendNow = useCallback((id: string) => {
     const item = queuedChatSendsRef.current.find((candidate) => candidate.id === id);
     if (!item) return;
@@ -3566,6 +3585,7 @@ export function ProjectView({
       return;
     }
     void (async () => {
+      armSlideNavForQueuedSend(item);
       const started = await handleSend(
         item.prompt,
         item.attachments,
@@ -3574,7 +3594,7 @@ export function ProjectView({
       );
       if (started) removeQueuedChatSend(id);
     })();
-  }, [currentConversationBusy, handleSend, prioritizeQueuedChatSend, removeQueuedChatSend]);
+  }, [armSlideNavForQueuedSend, currentConversationBusy, handleSend, prioritizeQueuedChatSend, removeQueuedChatSend]);
 
   useEffect(() => {
     if (currentConversationBusy) {
@@ -3589,6 +3609,7 @@ export function ProjectView({
     );
     if (!next) return;
     startingQueuedChatSendIdRef.current = next.id;
+    armSlideNavForQueuedSend(next);
     void (async () => {
       const started = await handleSend(
         next.prompt,
@@ -3611,6 +3632,7 @@ export function ProjectView({
     })();
   }, [
     activeConversationId,
+    armSlideNavForQueuedSend,
     currentConversationBusy,
     queuedAutoStartTick,
     queuedChatSends,
@@ -5372,6 +5394,7 @@ export function ProjectView({
           commentSendDisabled={currentConversationQueueDisabled}
           openRequest={openRequest}
           shareRequest={shareRequest}
+          slideNavRequest={slideNavRequest}
           liveArtifactEvents={liveArtifactEvents}
           designSystemActivityEvents={designSystemActivityEvents}
           tabsState={openTabsState}

--- a/apps/web/src/runtime/slide-nav.ts
+++ b/apps/web/src/runtime/slide-nav.ts
@@ -1,0 +1,30 @@
+// Dedupe deck slide-navigation requests across HtmlViewer remounts.
+//
+// A queued chat send arms a `slideNavRequest` that lives in parent (ProjectView)
+// state and stays set after the viewer handles it. A per-mount ref would only
+// suppress replays for the current mount: leaving the deck tab and coming back
+// remounts HtmlViewer, the ref resets, and the stale nonce reads as fresh — so
+// the preview yanks back to the queued slide and clobbers wherever the user had
+// navigated manually. Keying consumed nonces by preview-state key *outside* the
+// component makes "consume once" survive remounts.
+//
+// The map is keyed by `${projectId}:${fileName}`, so a fresh queued send (new
+// nonce, via Date.now()) for the same deck still navigates, and each file is
+// tracked independently. One entry per opened deck — bounded and tiny.
+const consumedSlideNavNonces = new Map<string, number>();
+
+/**
+ * Returns true exactly once per (key, nonce) pair, recording it as consumed.
+ * Returns false for a nonce already consumed under that key — including after a
+ * remount — so the navigation fires only on the first handling of each request.
+ */
+export function shouldConsumeSlideNav(key: string, nonce: number): boolean {
+  if (consumedSlideNavNonces.get(key) === nonce) return false;
+  consumedSlideNavNonces.set(key, nonce);
+  return true;
+}
+
+/** Test seam: drop all recorded consumptions. */
+export function resetConsumedSlideNavForTests(): void {
+  consumedSlideNavNonces.clear();
+}

--- a/apps/web/src/runtime/slide-nav.ts
+++ b/apps/web/src/runtime/slide-nav.ts
@@ -28,3 +28,38 @@ export function shouldConsumeSlideNav(key: string, nonce: number): boolean {
 export function resetConsumedSlideNavForTests(): void {
   consumedSlideNavNonces.clear();
 }
+
+export interface SlideNavRequest {
+  name: string;
+  slideIndex: number;
+  nonce: number;
+}
+
+// A slide-nav request is "follow-along only": it must flip the preview only if
+// the target deck was already open when the queued send started. If the deck
+// was closed at that moment, there is nothing to follow along, and the request
+// must NOT resurface later when the user opens that file by hand. Deliverability
+// is therefore decided once, at fire time, against the open-tab set — not
+// re-evaluated on a later tab open.
+export function isSlideNavDeliverableNow(
+  request: Pick<SlideNavRequest, 'name'> | null | undefined,
+  openTabs: readonly string[],
+): boolean {
+  return !!request && !!request.name && openTabs.includes(request.name);
+}
+
+// Gate what reaches the viewer: forward the request to the active file only
+// when it both names that file AND was marked deliverable at fire time
+// (`deliverableNonce` === the request's nonce). A request for a deck that was
+// closed at fire time never became deliverable, so opening that deck afterwards
+// matches the name but not the nonce → no jump.
+export function deliverableSlideNavForActiveFile(
+  request: SlideNavRequest | null | undefined,
+  activeFileName: string | null | undefined,
+  deliverableNonce: number | null,
+): { slideIndex: number; nonce: number } | null {
+  if (!request) return null;
+  if (!activeFileName || request.name !== activeFileName) return null;
+  if (request.nonce !== deliverableNonce) return null;
+  return { slideIndex: request.slideIndex, nonce: request.nonce };
+}

--- a/apps/web/tests/comments.test.ts
+++ b/apps/web/tests/comments.test.ts
@@ -12,11 +12,30 @@ import {
   mergePreviewCommentAttachments,
   messageContentWithCommentAttachments,
   overlayBoundsFromSnapshot,
+  queuedSlideNavTarget,
   removeAttachedComment,
   targetFromSnapshot,
 } from '../src/comments';
 import type { PreviewCommentSnapshot } from '../src/comments';
-import type { ChatMessage, PreviewComment } from '../src/types';
+import type { ChatCommentAttachment, ChatMessage, PreviewComment } from '../src/types';
+
+function commentAttachment(
+  overrides: Partial<ChatCommentAttachment> = {},
+): ChatCommentAttachment {
+  return {
+    id: 'att-1',
+    order: 1,
+    filePath: 'deck.html',
+    elementId: 'el-1',
+    selector: '[data-od-id="el-1"]',
+    label: 'span.capsule.accent',
+    comment: 'make it white',
+    currentText: 'DTC launches',
+    pagePosition: { x: 0, y: 0, width: 10, height: 10 },
+    htmlHint: '<span></span>',
+    ...overrides,
+  };
+}
 
 describe('preview comment attachment helpers', () => {
   it('builds compact target context from an iframe snapshot', () => {
@@ -453,3 +472,45 @@ function comment(patch: Partial<PreviewComment>): PreviewComment {
     ...patch,
   };
 }
+
+describe('queuedSlideNavTarget', () => {
+  it('returns the slide a queued send should flip the deck to', () => {
+    const target = queuedSlideNavTarget([
+      commentAttachment({ filePath: 'deck.html', slideIndex: 1 }),
+    ]);
+    expect(target).toEqual({ filePath: 'deck.html', slideIndex: 1 });
+  });
+
+  it('uses the first attachment that names a deck file and a slide', () => {
+    const target = queuedSlideNavTarget([
+      commentAttachment({ id: 'a', filePath: 'deck.html', slideIndex: undefined }),
+      commentAttachment({ id: 'b', filePath: 'deck.html', slideIndex: 3 }),
+      commentAttachment({ id: 'c', filePath: 'deck.html', slideIndex: 5 }),
+    ]);
+    expect(target).toEqual({ filePath: 'deck.html', slideIndex: 3 });
+  });
+
+  it('floors fractional slide indices and accepts slide zero', () => {
+    expect(
+      queuedSlideNavTarget([commentAttachment({ slideIndex: 0 })]),
+    ).toEqual({ filePath: 'deck.html', slideIndex: 0 });
+    expect(
+      queuedSlideNavTarget([commentAttachment({ slideIndex: 2.9 })]),
+    ).toEqual({ filePath: 'deck.html', slideIndex: 2 });
+  });
+
+  it('returns null when nothing is slide-scoped', () => {
+    expect(queuedSlideNavTarget(undefined)).toBeNull();
+    expect(queuedSlideNavTarget(null)).toBeNull();
+    expect(queuedSlideNavTarget([])).toBeNull();
+    expect(
+      queuedSlideNavTarget([commentAttachment({ slideIndex: undefined })]),
+    ).toBeNull();
+    expect(
+      queuedSlideNavTarget([commentAttachment({ filePath: '', slideIndex: 2 })]),
+    ).toBeNull();
+    expect(
+      queuedSlideNavTarget([commentAttachment({ slideIndex: -1 })]),
+    ).toBeNull();
+  });
+});

--- a/apps/web/tests/runtime/slide-nav.test.ts
+++ b/apps/web/tests/runtime/slide-nav.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  resetConsumedSlideNavForTests,
+  shouldConsumeSlideNav,
+} from '../../src/runtime/slide-nav';
+
+describe('shouldConsumeSlideNav', () => {
+  beforeEach(() => resetConsumedSlideNavForTests());
+
+  it('navigates only on the first handling of a request, even across remounts', () => {
+    const key = 'proj:deck.html';
+    // First mount handles the queued send's request → flip the preview.
+    expect(shouldConsumeSlideNav(key, 5)).toBe(true);
+    // The request stays live in parent state; leaving the deck tab and coming
+    // back remounts the viewer with the same nonce. It must NOT flip again —
+    // otherwise manual navigation after the queued send gets yanked back.
+    expect(shouldConsumeSlideNav(key, 5)).toBe(false);
+    expect(shouldConsumeSlideNav(key, 5)).toBe(false);
+  });
+
+  it('navigates again when a new queued send arms a fresh nonce', () => {
+    const key = 'proj:deck.html';
+    expect(shouldConsumeSlideNav(key, 5)).toBe(true);
+    expect(shouldConsumeSlideNav(key, 9)).toBe(true);
+    expect(shouldConsumeSlideNav(key, 9)).toBe(false);
+  });
+
+  it('tracks consumed nonces per file independently', () => {
+    expect(shouldConsumeSlideNav('proj:a.html', 5)).toBe(true);
+    expect(shouldConsumeSlideNav('proj:b.html', 5)).toBe(true);
+    expect(shouldConsumeSlideNav('proj:a.html', 5)).toBe(false);
+    expect(shouldConsumeSlideNav('proj:b.html', 5)).toBe(false);
+  });
+});

--- a/apps/web/tests/runtime/slide-nav.test.ts
+++ b/apps/web/tests/runtime/slide-nav.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  deliverableSlideNavForActiveFile,
+  isSlideNavDeliverableNow,
   resetConsumedSlideNavForTests,
   shouldConsumeSlideNav,
 } from '../../src/runtime/slide-nav';
@@ -31,5 +33,30 @@ describe('shouldConsumeSlideNav', () => {
     expect(shouldConsumeSlideNav('proj:b.html', 5)).toBe(true);
     expect(shouldConsumeSlideNav('proj:a.html', 5)).toBe(false);
     expect(shouldConsumeSlideNav('proj:b.html', 5)).toBe(false);
+  });
+});
+
+describe('slide-nav deliverability (follow-along only)', () => {
+  it('is deliverable only when the target deck is already an open tab', () => {
+    expect(isSlideNavDeliverableNow({ name: 'deck.html' }, ['deck.html', 'index.html'])).toBe(true);
+    expect(isSlideNavDeliverableNow({ name: 'deck.html' }, ['index.html'])).toBe(false);
+    expect(isSlideNavDeliverableNow({ name: '' }, ['index.html'])).toBe(false);
+    expect(isSlideNavDeliverableNow(null, ['deck.html'])).toBe(false);
+  });
+
+  it('forwards a request to the active file once it is marked deliverable', () => {
+    const req = { name: 'deck.html', slideIndex: 3, nonce: 7 };
+    // Target was open at fire time → its nonce became deliverable.
+    expect(deliverableSlideNavForActiveFile(req, 'deck.html', 7)).toEqual({ slideIndex: 3, nonce: 7 });
+  });
+
+  it('does NOT jump a deck the user opens after a queued send started while it was closed', () => {
+    const req = { name: 'deck.html', slideIndex: 3, nonce: 7 };
+    // Deck was closed when the send started → nonce never became deliverable
+    // (deliverableNonce stays null). Later opening the deck makes it the active
+    // file, but the stale request must not resurface and flip the preview.
+    expect(deliverableSlideNavForActiveFile(req, 'deck.html', null)).toBeNull();
+    // A different deck being active never matches either.
+    expect(deliverableSlideNavForActiveFile(req, 'other.html', 7)).toBeNull();
   });
 });

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -297,6 +297,9 @@ export interface ChatCommentAttachment {
   selectionKind?: ChatCommentSelectionKind;
   memberCount?: number;
   podMembers?: PreviewCommentMember[];
+  // Zero-based slide the marked element lives on, for deck artifacts. Carried
+  // so the host can flip the preview to that slide when the send starts.
+  slideIndex?: number;
   screenshotPath?: string;
   markKind?: PreviewVisualMarkKind;
   intent?: string;


### PR DESCRIPTION
## Why

While iterating on a deck I queued several edits, each tied to a marked element on a different slide (the "N Queued to Send" strip). As the agent drained the queue, the preview stayed parked on slide 1 — so I watched a counter tick down with no idea whether each edit was landing where I meant it to. The fix follows the preview along: when a queued send starts processing, the deck flips to the slide its marked element lives on.

The plumbing for this was *almost* there — the mark's slide index is already captured into the comment snapshot/target — but it got dropped the moment the snapshot became a `ChatCommentAttachment`, so nothing downstream knew which slide a queued send touched.

## What users will see

When a queued chat send that targets a marked element on a deck starts processing, the preview automatically flips to that element's slide (activating the deck's tab first if it's open but not in front). Plain prompts, free pins, and marks without a slide index behave exactly as before — nothing flips. Manual slide navigation afterward is never yanked back.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — changes what existing users experience without opting in

Contract change is additive only: an optional `slideIndex?: number` on `ChatCommentAttachment` (persisted in the existing comment-attachments JSON blob; no migration). This is not a new user capability but a preview-runtime behavior, so the UI/CLI dual-track rule does not apply — the `od` CLI has no deck preview to navigate.

## Screenshots

Behavior change with no new chrome, so there's nothing new to point at in a still. Best verified live (see below). Happy to stand up a buggy-vs-fix comparison (two namespaced runtimes, one on `main`, one on this branch) if a reviewer wants to drive it.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/comments.test.ts` → `describe('queuedSlideNavTarget')`
- Did the test go red on `main` and green on this branch? **yes** — `queuedSlideNavTarget` does not exist on `main`, so the spec fails to import (red); it passes on this branch (green).
- The pure helper encodes the decision a queued send must make (which slide, if any, to flip to). The remaining wiring is a `shareRequest`-style nonce signal threaded ProjectView → FileWorkspace → FileViewer that reuses the existing `od:slide` `go` bridge; an end-to-end test of that path would need a rendered ProjectView plus a live iframe, which isn't cheap, so it's covered by `typecheck` + mirroring the proven `shareRequest` pattern.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` (web, daemon, contracts) — pass
- `pnpm --filter @open-design/web test` — 2958 passed, 1 skipped (3 unrelated component suites flaked under full-suite load; all green re-run in isolation)
- `pnpm --filter @open-design/contracts build` after the contract change

🤖 Generated with [Claude Code](https://claude.com/claude-code)