### PR TITLE
fix(web): bottom-anchor the chat transcript so short and forked conversations don't strand at the top

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -728,6 +728,7 @@ export function ChatPane({
   const anchorPendingRef = useRef(false);
   const anchorActiveRef = useRef(false);
   const tailSpacerRef = useRef<HTMLDivElement | null>(null);
+  const prevStreamingRef = useRef(streaming);
   const prevLastUserIdRef = useRef<string | undefined>(undefined);
   // AssistantMessage's interaction callbacks are re-created per render and
   // excluded from its memo comparison (so streaming doesn't re-render every
@@ -926,9 +927,14 @@ export function ChatPane({
   useEffect(() => {
     didInitialScrollRef.current = false;
     // A new conversation should land at the bottom (its own initial
-    // scroll), not inherit the previous conversation's saved position.
+    // scroll), not inherit the previous conversation's saved position —
+    // including any anchor-to-top reserve still held by the tail spacer, which
+    // would otherwise strand the freshly opened conversation below a dead gap.
     savedChatScrollRef.current = null;
     scrolledToFormRef.current = new Set();
+    anchorActiveRef.current = false;
+    anchorPendingRef.current = false;
+    resetTailSpacer();
   }, [activeConversationId]);
 
   // ChatComposer's internal `seededRef` latches after the first
@@ -1010,6 +1016,26 @@ export function ChatPane({
     // then re-runs when the user returns to Chat and the element is
     // available, scrolling the new conversation to its initial bottom.
   }, [activeConversationId, messages.length, tab]);
+
+  // When a turn finishes streaming, release the anchor-to-top reserve. The
+  // tail spacer only exists to give a streaming reply room to grow while the
+  // user message stays pinned at the top; once the reply is final it must not
+  // linger, or a short turn (typical of a fresh fork) is left with a large
+  // dead gap below it. Collapsing the spacer lets the bottom-anchored layout
+  // settle the finished transcript against the composer.
+  useEffect(() => {
+    const was = prevStreamingRef.current;
+    prevStreamingRef.current = streaming;
+    // The tail spacer only ever holds the anchor-to-top reserve for an actively
+    // streaming reply, so once the turn ends it must collapse unconditionally —
+    // even if a mid-turn scroll already cleared `anchorActiveRef` (which leaves
+    // the spacer sized). Collapsing it lets the bottom-anchored layout settle a
+    // finished short turn against the composer instead of below a dead gap.
+    if (was && !streaming) {
+      anchorActiveRef.current = false;
+      resetTailSpacer();
+    }
+  }, [streaming]);
 
   useEffect(() => {
     const el = logRef.current;

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -220,6 +220,17 @@
   scrollbar-width: thin;
   scrollbar-color: color-mix(in srgb, var(--text-muted) 18%, transparent) transparent;
 }
+/* Bottom-anchor the transcript so a short conversation (e.g. a fresh fork)
+   rests against the composer instead of stranding its messages at the top with
+   a large blank area below. The auto top margin absorbs the free space above
+   the first row when the content is shorter than the viewport; once the content
+   outgrows the viewport the auto margin resolves to 0 and the log scrolls
+   normally with the top fully reachable (unlike `justify-content: flex-end`,
+   which clips overflowing content above the scroll range). The empty/loading
+   states own their own vertical layout, so they're excluded. */
+.chat-log > :first-child:not(.chat-empty-wrap):not(.chat-loading-state) {
+  margin-top: auto;
+}
 .chat-log::-webkit-scrollbar {
   width: 8px;
 }


### PR DESCRIPTION
## Why

Reproducing a user report: a fresh **Fork from here** conversation (and any short conversation) renders its messages stuck to the **top** of the chat log with a large empty area below, instead of resting against the composer like a normal chat. After sending, the new turn jumps to the top and a big blank gap sits below it — even after the reply finishes.

Two root causes:
1. `.chat-log` is a flex column with no vertical anchoring, so when content is shorter than the viewport the messages sit at the top (~530px dead space below). This is the baseline behavior; it's just most visible in short/forked conversations (long ones fill the viewport).
2. The anchor-to-top reserve (`.chat-log-tail-spacer`, sized while a reply streams so the user's turn can reach the top) **never collapsed when the turn finished**. A completed short turn was left pinned at the top above ~540px of reserved blank ("Done" + huge gap).

## What users will see

`Fork from here` (and any short conversation) now rests against the composer with no large blank area. Sending still floats your message toward the top while the reply streams; once it finishes, a short exchange settles cleanly next to the composer instead of leaving dead space. Long conversations are unchanged — they scroll normally and the top stays reachable.

## Surface area

- [x] **UI** — chat transcript vertical layout / scroll-anchoring in `apps/web` (no new element; behavior fix on the existing chat log)
- [ ] API / contract · Keyboard · CLI · Extension point · i18n · dependency
- [ ] **None**

## Screenshots

No new UI; this is a layout/anchoring fix. The visual-regression bot comparison covers the rendered change. Measured before/after below.

## Bug fix verification

A layout/scroll-anchoring bug can't be encoded as a jsdom unit test (jsdom doesn't compute layout — `offsetHeight` is 0, so the spacer sizing is a no-op). Verified instead by driving the real app with Playwright against a local daemon+web (the repo's "stage human verification for visible bugs" path), measuring the chat log geometry:

| Scenario | Before | After |
| --- | --- | --- |
| Fresh short conversation — last-message-to-bottom gap | **532px** (stranded at top) | **20px** (rests at composer) |
| Completed short turn — tail spacer height | **549px** (dead gap persists) | **0px** (collapses) |
| Long conversation — scroll + top reachable | scrolls; top reachable | unchanged: `scrollTop 0`, first row `+18px` |
| Active streaming turn — anchor-to-top reserve | message floats to top + reserve below | unchanged (preserved) |

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `apps/web` `ChatPane` + `ProjectView` suites — 113 passed
- Live Playwright geometry checks above (Node 24, isolated `OD_DATA_DIR`)
