### PR TITLE
fix(web): keep generation progress card on the design-files tab

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -1690,8 +1690,16 @@ export function FileWorkspace({
 
   const isActiveSketch = activeFile?.kind === 'sketch' && isSketchName(activeFile.name);
   const activeSketch = activeFile && isActiveSketch ? sketches[activeFile.name] : null;
+  // The generation progress card takes priority over the design-files tab's
+  // empty "Creations will appear here" list: while a run is in flight and no
+  // previewable artifact exists yet, the design-files tab (the default landing
+  // tab) must still show generation progress rather than an idle empty state.
+  // `buildGenerationPreviewState` already returns null once a preview surface
+  // exists, so this never hides a finished artifact. (Pre-#3516 the preview
+  // branch rendered before the design-files branch with no tab guard; the
+  // composer rewrite added an `activeTab !== DESIGN_FILES_TAB` clause here that
+  // accidentally hid the progress card on the default tab.)
   const showGenerationPreview = Boolean(generationPreview)
-    && activeTab !== DESIGN_FILES_TAB
     && activeTab !== DESIGN_SYSTEM_TAB
     && !isBrowserTabId(activeTab)
     && !isSideChatTabId(activeTab)

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -6,7 +6,11 @@ import { createRoot, type Root } from 'react-dom/client';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { FileWorkspace, scrollWorkspaceTabsWithWheel } from '../../src/components/FileWorkspace';
+import {
+  DESIGN_FILES_TAB,
+  FileWorkspace,
+  scrollWorkspaceTabsWithWheel,
+} from '../../src/components/FileWorkspace';
 import { DesignFilesPanel } from '../../src/components/DesignFilesPanel';
 import { projectSplitClassName, projectSplitStyle } from '../../src/components/ProjectView';
 import {
@@ -186,6 +190,21 @@ function failedAssistantMessage(
     agentId,
     preTurnFileNames: [],
     events: [{ kind: 'status', label: 'error', detail, code }],
+  };
+}
+
+function generatingAssistantMessage(): ChatMessage {
+  return {
+    id: 'msg-generating',
+    role: 'assistant',
+    content: '',
+    createdAt: 1700000000,
+    startedAt: 1700000000,
+    runId: 'run-generating',
+    runStatus: 'running',
+    agentId: 'claude',
+    preTurnFileNames: [],
+    events: [{ kind: 'status', label: 'thinking' }],
   };
 }
 
@@ -1385,6 +1404,31 @@ describe('FileWorkspace generation failure recovery', () => {
     expect(onRetry).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'msg-rate_limited', agentId: 'antigravity' }),
     );
+  });
+
+  // Regression guard for #3516: the giant Lexical-composer merge added an
+  // `activeTab !== DESIGN_FILES_TAB` clause to `showGenerationPreview`, which
+  // suppressed the generation progress card on the design-files tab — the
+  // default landing tab. While a run is in flight and no previewable artifact
+  // exists yet, the progress card must take priority over the empty
+  // "Creations will appear here" file list instead of being hidden behind it.
+  it('keeps the generation preview on the design-files tab while generating with no artifacts yet', () => {
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        streaming
+        tabsState={{ tabs: [], active: DESIGN_FILES_TAB }}
+        onTabsStateChange={vi.fn()}
+        messages={[generatingAssistantMessage()]}
+      />,
+    );
+
+    expect(screen.getByTestId('generation-preview-stage')).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Why

I was driving a fresh Web Prototype project and hit this myself: I sent a prompt, the agent started running, but the right-side preview pane just sat on the empty **"Creations will appear here"** file list with a "New sketch" button — no sign that anything was happening. The generation progress card (the sparkle + **understand → generate → prepare** steps) only reappeared if I happened to be on some other tab.

The pain: on a brand-new project the design-files tab is the default landing tab, so the first generation a user ever runs shows an idle empty state instead of progress. It reads as "nothing is happening / it's broken" exactly when reassurance matters most.

Root cause is a regression from #3516 (the Lexical-composer rewrite): it added an `activeTab !== DESIGN_FILES_TAB` clause to `showGenerationPreview`. Before #3516 the generation-preview branch rendered *ahead* of the design-files branch with no tab guard, so the progress card took priority over the empty list. The rewrite flipped that on the default tab.

## What users will see

On a fresh project, sending the first prompt now keeps the right pane on the **"Generating…"** progress card (with the understand/generate/prepare steps) while the agent works, instead of dropping back to the empty "Creations will appear here" file list. Once a previewable artifact exists, the card yields to the live preview exactly as before — nothing about finished generations changes.

## Surface area

- [x] **UI** — restores the generation progress card / empty-state gating on the design-files tab in `apps/web`

## Screenshots

Bug (this branch fixes it) vs. expected:

| Before (empty state during generation) | After / expected (progress card) |
| --- | --- |
| Right pane shows "Creations will appear here" while the run is in flight | Right pane shows "正在生成… / Generating…" with the step chips |

(Reproduced from the reporter's screenshots; the fix restores the right-hand card.)

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileWorkspace.test.tsx` → *"keeps the generation preview on the design-files tab while generating with no artifacts yet"*
- Did the test go red on `main` and green on this branch? **yes** — red on `origin/main` (got the empty `DesignFilesPanel`, no `generation-preview-stage`), green after dropping the `activeTab !== DESIGN_FILES_TAB` clause.

## Validation

- `pnpm guard` ✅
- `pnpm typecheck` ✅
- `pnpm --filter @open-design/web exec vitest run tests/components/FileWorkspace.test.tsx` ✅ (56/56, incl. the new red-spec)
- `pnpm --filter @open-design/web test` ✅ (full web suite green; `generation-preview` runtime suite included)
