### PR TITLE
fix(web): stop conversation list flashing "0 msg" while switching chats (#3663) [v0.10.0]

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -303,6 +303,14 @@ interface Props {
   // leaving the pane.
   conversations: Conversation[];
   activeConversationId: string | null;
+  // The conversation whose history the live `messages` array currently
+  // reflects. Null while a switch is mid-flight (or after a load failure),
+  // which is exactly when `messages.length` must NOT be trusted as the active
+  // conversation's count — see `conversationMessageCount`. Callers that do not
+  // track this (mounts whose loader resets/retags `messages` asynchronously)
+  // leave it undefined and fall back to the persisted `conversation.messageCount`
+  // for a stable list count.
+  messagesConversationId?: string | null;
   onSelectConversation: (id: string) => void;
   onDeleteConversation: (id: string) => void;
   // Composer settings/CLI button forwards to here. The dialog lives in App
@@ -465,6 +473,7 @@ export function ChatPane({
   newConversationDisabled = false,
   conversations,
   activeConversationId,
+  messagesConversationId = null,
   onSelectConversation,
   onDeleteConversation,
   onOpenSettings,
@@ -1346,7 +1355,7 @@ export function ChatPane({
                       key={c.id}
                       conversation={c}
                       active={c.id === activeConversationId}
-                      messageCount={conversationMessageCount(c, activeConversationId, messages.length)}
+                      messageCount={conversationMessageCount(c, activeConversationId, messagesConversationId, messages.length)}
                       onSelect={() => {
                         onSelectConversation(c.id);
                         setShowConvList(false);
@@ -2675,9 +2684,22 @@ function filterConversations(
 function conversationMessageCount(
   conversation: Conversation,
   activeConversationId: string | null,
+  messagesConversationId: string | null,
   activeMessageCount: number,
 ): number | null {
-  if (conversation.id === activeConversationId) return activeMessageCount;
+  // The live `messages` array is authoritative for the active conversation —
+  // it stays fresh as a run streams new turns in — but ONLY once it has
+  // actually loaded for that conversation. While a switch is mid-flight (or a
+  // load failed) `messages` is reset to [] and `messagesConversationId` no
+  // longer matches the active id; trusting `messages.length` there renders a
+  // phantom "0 msg". Fall back to the persisted server count until the live
+  // array catches up.
+  if (
+    conversation.id === activeConversationId &&
+    messagesConversationId === activeConversationId
+  ) {
+    return activeMessageCount;
+  }
   return typeof conversation.messageCount === 'number' ? conversation.messageCount : null;
 }
 

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -1775,6 +1775,11 @@ export function DesignSystemDetailView({
             initialDraft={chatSeed?.text}
             conversations={conversations}
             activeConversationId={activeConversationId}
+            // Intentionally omit `messagesConversationId`: the loader above does
+            // not retag `projectChatMessages` during a conversation switch, so
+            // trusting the live length would show the previous conversation's
+            // count for the newly active row. Fall back to the persisted
+            // `conversation.messageCount` for a stable list count instead.
             onSelectConversation={setActiveConversationId}
             onDeleteConversation={() => {}}
             onNewConversation={createProjectChatConversation}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5158,6 +5158,7 @@ export function ProjectView({
               newConversationDisabled={newConversationDisabled}
               conversations={conversations}
               activeConversationId={activeConversationId}
+              messagesConversationId={messagesConversationId}
               onSelectConversation={handleSelectConversation}
               onDeleteConversation={handleDeleteConversation}
               onOpenSettings={onOpenSettings}

--- a/apps/web/src/components/workspace/SideChatTab.tsx
+++ b/apps/web/src/components/workspace/SideChatTab.tsx
@@ -159,6 +159,10 @@ export function SideChatTab({
           onRequestOpenFile={onRequestOpenFile}
           conversations={conversations}
           activeConversationId={conversationId}
+          // Intentionally omit `messagesConversationId`: `useConversationChat`
+          // resets `messages` to [] while a conversation loads, so trusting the
+          // live length here would flash a phantom "0 msg". Falling back to the
+          // persisted `conversation.messageCount` keeps the list count stable.
           onSelectConversation={onSelectConversation}
           onDeleteConversation={onDeleteConversation}
           onNewConversation={onNewConversation}

--- a/apps/web/tests/components/ChatPane.conversation-msg-count.test.tsx
+++ b/apps/web/tests/components/ChatPane.conversation-msg-count.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { forwardRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatPane } from '../../src/components/ChatPane';
+import type { ChatMessage, Conversation } from '../../src/types';
+
+vi.mock('../../src/i18n', () => ({
+  useT: () => (key: string, vars?: Record<string, string | number>) => {
+    if (vars && Object.keys(vars).length > 0) {
+      return `${key} ${Object.values(vars).join(' ')}`;
+    }
+    return key;
+  },
+}));
+
+vi.mock('../../src/components/AssistantMessage', () => ({
+  AssistantMessage: ({ message }: { message: ChatMessage }) => (
+    <div data-testid={`assistant-${message.id}`}>{message.content}</div>
+  ),
+}));
+
+vi.mock('../../src/components/ChatComposer', () => ({
+  ChatComposer: forwardRef((_props, _ref) => <div data-testid="composer" />),
+}));
+
+vi.mock('../../src/analytics/events', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/events')>();
+  return {
+    ...actual,
+    trackChatPanelClick: vi.fn(),
+    trackRunFailedToastSurfaceView: vi.fn(),
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// Regression: switching conversations resets `messages` to [] while the new
+// conversation's history is fetched. During that window the active
+// conversation must NOT render a phantom "0 msg" — it should fall back to the
+// persisted `messageCount` until the live messages array reflects it.
+describe('ChatPane conversation message count', () => {
+  it('shows the persisted count for the active conversation while its messages are still loading', () => {
+    render(
+      chatPaneElement({
+        // Switch just happened: activeConversationId is conv-2 but the loaded
+        // messages still belong to nothing yet (messagesConversationId !== active).
+        messages: [],
+        conversations: [
+          conversation({ id: 'conv-1', title: 'Older chat', messageCount: 4 }),
+          conversation({ id: 'conv-2', title: 'Just switched', messageCount: 18 }),
+        ],
+        activeConversationId: 'conv-2',
+        messagesConversationId: null,
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId('conversation-history-trigger'));
+
+    const activeRow = screen.getByTestId('conversation-item-conv-2');
+    // Must reflect the real persisted count, not a phantom 0 from the empty array.
+    expect(within(activeRow).getByText(/18 msg/)).toBeTruthy();
+    expect(within(activeRow).queryByText(/0 msg/)).toBeNull();
+  });
+
+  it('uses the live messages length for the active conversation once it has loaded', () => {
+    render(
+      chatPaneElement({
+        messages: [
+          userMessage('m1'),
+          userMessage('m2'),
+          userMessage('m3'),
+        ],
+        conversations: [
+          conversation({ id: 'conv-2', title: 'Loaded chat', messageCount: 1 }),
+        ],
+        activeConversationId: 'conv-2',
+        // Messages array now reflects the active conversation's loaded history.
+        messagesConversationId: 'conv-2',
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId('conversation-history-trigger'));
+
+    const activeRow = screen.getByTestId('conversation-item-conv-2');
+    // Live count (3) wins over the stale persisted count (1) so streaming stays fresh.
+    expect(within(activeRow).getByText(/3 msg/)).toBeTruthy();
+  });
+
+  it('falls back to the persisted count when the caller does not track messagesConversationId', () => {
+    // Secondary mounts (SideChatTab, DesignSystemFlow) whose loaders reset/retag
+    // `messages` asynchronously omit the prop on purpose; the active row must use
+    // the stable persisted count rather than a phantom live length.
+    render(
+      <ChatPane
+        messages={[]}
+        streaming={false}
+        error={null}
+        projectId="project-1"
+        projectFiles={[]}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        conversations={[conversation({ id: 'conv-1', title: 'Active', messageCount: 12 })]}
+        activeConversationId="conv-1"
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('conversation-history-trigger'));
+
+    const activeRow = screen.getByTestId('conversation-item-conv-1');
+    expect(within(activeRow).getByText(/12 msg/)).toBeTruthy();
+    expect(within(activeRow).queryByText(/0 msg/)).toBeNull();
+  });
+
+  it('shows the persisted count for non-active conversations', () => {
+    render(
+      chatPaneElement({
+        messages: [userMessage('m1')],
+        conversations: [
+          conversation({ id: 'conv-1', title: 'Active', messageCount: 99 }),
+          conversation({ id: 'conv-2', title: 'Background', messageCount: 7 }),
+        ],
+        activeConversationId: 'conv-1',
+        messagesConversationId: 'conv-1',
+      }),
+    );
+
+    fireEvent.click(screen.getByTestId('conversation-history-trigger'));
+
+    const bgRow = screen.getByTestId('conversation-item-conv-2');
+    expect(within(bgRow).getByText(/7 msg/)).toBeTruthy();
+  });
+});
+
+function chatPaneElement({
+  messages,
+  conversations,
+  activeConversationId,
+  messagesConversationId,
+}: {
+  messages: ChatMessage[];
+  conversations: Conversation[];
+  activeConversationId: string | null;
+  messagesConversationId: string | null;
+}) {
+  return (
+    <ChatPane
+      messages={messages}
+      streaming={false}
+      error={null}
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      conversations={conversations}
+      activeConversationId={activeConversationId}
+      messagesConversationId={messagesConversationId}
+      onSelectConversation={vi.fn()}
+      onDeleteConversation={vi.fn()}
+    />
+  );
+}
+
+function conversation(
+  overrides: Partial<Conversation> & { id: string },
+): Conversation {
+  return {
+    projectId: 'project-1',
+    title: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function userMessage(id: string): ChatMessage {
+  return { id, role: 'user', content: 'hello', createdAt: 1 };
+}


### PR DESCRIPTION
Cherry-pick of #3663 (merged to `main` as b33ea26de) onto `release/v0.10.0`.

## Why

After switching between conversations, the CONVERSATIONS panel rendered **"0 msg"** for a chat that actually has history. The active conversation's count is derived from the live `messages` array, which `ProjectView` resets to `[]` while the newly selected conversation's history loads (and leaves empty if the load fails) — so the active row showed a phantom 0 for the whole load window.

## What users will see

The conversation you just switched to keeps showing its correct message count (e.g. "18 msg · 4m") instead of briefly flashing "0 msg" while its history loads. Counts for other conversations are unchanged.

## Surface area

- [x] **UI** — conversation list message-count label in `apps/web` chat tab
- [ ] **None**

## Bug fix verification

- Test path: `apps/web/tests/components/ChatPane.conversation-msg-count.test.tsx`
- Red on the pre-fix code (active row shows "0 msg" during load), green after. `conversationMessageCount` now trusts the live count for the active conversation only once the live array reflects it (`messagesConversationId === activeConversationId`), else falls back to the persisted server `messageCount`. The two secondary `ChatPane` mounts (`SideChatTab`, `DesignSystemFlow`) intentionally omit the marker — their loaders reset/retag `messages` asynchronously — so their list uses the stable persisted count.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test` (ChatPane msg-count + conversation-title suites green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)