### PR TITLE
fix(web): bottom-anchor the chat transcript so short and forked conversations don't strand at the top (#3669)

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -531,6 +531,7 @@ export function ChatPane({
   const anchorPendingRef = useRef(false);
   const anchorActiveRef = useRef(false);
   const tailSpacerRef = useRef<HTMLDivElement | null>(null);
+  const prevStreamingRef = useRef(streaming);
   const prevLastUserIdRef = useRef<string | undefined>(undefined);
   // AssistantMessage's interaction callbacks are re-created per render and
   // excluded from its memo comparison (so streaming doesn't re-render every
@@ -746,9 +747,14 @@ export function ChatPane({
     prevLastUserIdRef.current = undefined;
     resetTailSpacer();
     // A new conversation should land at the bottom (its own initial
-    // scroll), not inherit the previous conversation's saved position.
+    // scroll), not inherit the previous conversation's saved position —
+    // including any anchor-to-top reserve still held by the tail spacer, which
+    // would otherwise strand the freshly opened conversation below a dead gap.
     savedChatScrollRef.current = null;
     scrolledToFormRef.current = new Set();
+    anchorActiveRef.current = false;
+    anchorPendingRef.current = false;
+    resetTailSpacer();
   }, [activeConversationId]);
 
   // ChatComposer's internal `seededRef` latches after the first
@@ -830,6 +836,26 @@ export function ChatPane({
     // then re-runs when the user returns to Chat and the element is
     // available, scrolling the new conversation to its initial bottom.
   }, [activeConversationId, messages.length, tab]);
+
+  // When a turn finishes streaming, release the anchor-to-top reserve. The
+  // tail spacer only exists to give a streaming reply room to grow while the
+  // user message stays pinned at the top; once the reply is final it must not
+  // linger, or a short turn (typical of a fresh fork) is left with a large
+  // dead gap below it. Collapsing the spacer lets the bottom-anchored layout
+  // settle the finished transcript against the composer.
+  useEffect(() => {
+    const was = prevStreamingRef.current;
+    prevStreamingRef.current = streaming;
+    // The tail spacer only ever holds the anchor-to-top reserve for an actively
+    // streaming reply, so once the turn ends it must collapse unconditionally —
+    // even if a mid-turn scroll already cleared `anchorActiveRef` (which leaves
+    // the spacer sized). Collapsing it lets the bottom-anchored layout settle a
+    // finished short turn against the composer instead of below a dead gap.
+    if (was && !streaming) {
+      anchorActiveRef.current = false;
+      resetTailSpacer();
+    }
+  }, [streaming]);
 
   useEffect(() => {
     const el = logRef.current;

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -221,6 +221,17 @@
   scrollbar-width: thin;
   scrollbar-color: color-mix(in srgb, var(--text-muted) 18%, transparent) transparent;
 }
+/* Bottom-anchor the transcript so a short conversation (e.g. a fresh fork)
+   rests against the composer instead of stranding its messages at the top with
+   a large blank area below. The auto top margin absorbs the free space above
+   the first row when the content is shorter than the viewport; once the content
+   outgrows the viewport the auto margin resolves to 0 and the log scrolls
+   normally with the top fully reachable (unlike `justify-content: flex-end`,
+   which clips overflowing content above the scroll range). The empty/loading
+   states own their own vertical layout, so they're excluded. */
+.chat-log > :first-child:not(.chat-empty-wrap):not(.chat-loading-state) {
+  margin-top: auto;
+}
 .chat-log::-webkit-scrollbar {
   width: 8px;
 }


### PR DESCRIPTION
Cherry-pick of #3669 (squash `e260b56`) onto `release/v0.10.0`. Clean auto-merge, no conflicts.

## Why

Backports the chat transcript bottom-anchoring fix to the v0.10.0 release line. On `main` this shipped as #3669.

A short conversation — most visibly a fresh **Fork from here** branch — rendered its messages stuck to the top of the chat log with a large empty area below, instead of resting against the composer. Two causes: `.chat-log` had no vertical anchoring (short content sat at the top), and the anchor-to-top reserve (`.chat-log-tail-spacer`) never collapsed once the turn finished (a completed short turn was left above ~540px of dead space).

## What users will see

`Fork from here` and other short conversations now rest against the composer with no large blank area. Sending still floats the new turn toward the top while the reply streams; once it finishes, a short exchange settles next to the composer. Long conversations scroll normally and the top stays reachable.

## Surface area

- [x] **UI** — chat transcript vertical layout / scroll-anchoring in `apps/web` (behavior fix on the existing chat log; no new element)

## Screenshots

Layout-only fix — no new UI element, so there's nothing new to point a screenshot at; the change is the resting vertical position of the existing chat log. The visual-regression run covers the rendered change, and the before/after geometry is quantified in "Bug fix verification" below (same approach as #3669).

## Bug fix verification

Layout/scroll-anchoring can't be a jsdom unit test (no layout). Verified on `main` (#3669) with Playwright against a local daemon+web: fresh short conversation last-message-to-bottom gap 532px → 20px; completed short turn tail spacer 549px → 0; long conversation still scrolls with the top reachable (`scrollTop 0`, first row +18px). Clean cherry-pick of that commit.

## Validation

- Clean cherry-pick of the squashed `main` commit (already passed full CI + Looper approval on #3669).
- Local `pnpm install` + `pnpm --filter @open-design/web typecheck` on this backport branch — pass. CI re-runs here.
