### PR TITLE
fix(daemon): include user toolchain dirs in agent spawn PATH so shebang interpreters resolve

### DIFF
--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -57,6 +57,16 @@ function userToolchainDirs() {
   return cachedToolchainDirs;
 }
 
+// The user-level toolchain bin directories (Homebrew, ~/.local/bin, ~/.bun/bin,
+// version-manager node dirs, npm prefixes, …) that binary *resolution* searches
+// beyond process.env.PATH. Exposed so the spawn env can append the same dirs:
+// a binary can resolve here yet fail to *execute* if its shebang interpreter
+// (e.g. `#!/usr/bin/env bun`) lives in one of these dirs and the spawn PATH
+// doesn't include it. Keeping resolution and spawn PATH symmetric fixes that.
+export function userToolchainBinDirs(): string[] {
+  return userToolchainDirs();
+}
+
 function resolvePathDirs() {
   const seen = new Set();
   const dirs = [

--- a/apps/daemon/src/runtimes/launch.ts
+++ b/apps/daemon/src/runtimes/launch.ts
@@ -1,6 +1,6 @@
 import { accessSync, constants, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import path, { delimiter } from 'node:path';
-import { inspectAgentExecutableResolution } from './executables.js';
+import { inspectAgentExecutableResolution, userToolchainBinDirs } from './executables.js';
 import type { RuntimeAgentDef } from './types.js';
 
 export type AgentLaunchKind = 'selected' | 'codex-native';
@@ -40,6 +40,7 @@ export function applyAgentLaunchEnv(
   env: NodeJS.ProcessEnv,
   launch: Pick<AgentLaunchResolution, 'childPathPrepend'>,
   nodeBinDir: string = path.dirname(process.execPath),
+  appendPathDirs: string[] = userToolchainBinDirs(),
 ): NodeJS.ProcessEnv {
   // Build the ordered list of directories to guarantee are at the front of
   // PATH: the running Node binary directory first (so npm .cmd shims on
@@ -49,8 +50,17 @@ export function applyAgentLaunchEnv(
   // every call site — detectAgents, connection tests, and chat runs —
   // consistently reaches the correct Node binary without each caller having
   // to duplicate the dirname(process.execPath) prepend independently.
+  //
+  // `appendPathDirs` adds the user toolchain bin dirs (Homebrew, ~/.bun/bin,
+  // version-manager dirs, …) to the END of PATH so a resolved binary's shebang
+  // interpreter is findable at spawn time even when the daemon's own PATH is
+  // minimal (GUI launch). Without this, an agent like Pi — a `#!/usr/bin/env
+  // bun` script — resolves but the version probe / run spawn fails with exit
+  // 127 ("env: bun: No such file or directory"), so detection wrongly marks it
+  // unavailable. Defaults to the real toolchain dirs; tests pass [] for
+  // determinism.
   const toPrepend = [...(nodeBinDir ? [nodeBinDir] : []), ...launch.childPathPrepend];
-  if (toPrepend.length === 0) return env;
+  if (toPrepend.length === 0 && appendPathDirs.length === 0) return env;
   // Case-insensitive key lookup — Windows uses 'Path', not 'PATH'.
   // Using env.PATH directly would be undefined on Windows, yielding a
   // one-entry PATH that contains only toPrepend and discards all system
@@ -65,7 +75,7 @@ export function applyAgentLaunchEnv(
   const existingParts = existing.split(delimiter).filter((e) => e.length > 0);
   const seen = new Set<string>();
   const merged: string[] = [];
-  for (const entry of [...toPrepend, ...existingParts]) {
+  for (const entry of [...toPrepend, ...existingParts, ...appendPathDirs]) {
     const n = normalize(entry);
     if (!seen.has(n)) {
       seen.add(n);

--- a/apps/daemon/tests/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/agent-runtime-env.test.ts
@@ -113,13 +113,13 @@ describe('agent runtime tool environment', () => {
 describe('applyAgentLaunchEnv', () => {
   it('returns env unchanged when childPathPrepend is empty and no node dir is provided', () => {
     const base = { Path: ['/usr/local/bin', '/usr/bin'].join(path.delimiter), OTHER: 'val' };
-    const result = applyAgentLaunchEnv(base, { childPathPrepend: [] }, '');
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: [] }, '', []);
     expect(result).toBe(base);
   });
 
   it('prepends childPathPrepend entries to PATH when key is uppercase', () => {
     const base = { PATH: '/usr/bin' };
-    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['/opt/copilot'] }, '');
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['/opt/copilot'] }, '', []);
     expect(result.PATH).toBe(`/opt/copilot${path.delimiter}/usr/bin`);
     expect(result.Path).toBeUndefined();
   });
@@ -132,7 +132,7 @@ describe('applyAgentLaunchEnv', () => {
     // Pure POSIX paths + path.delimiter keep the assertion correct on all platforms;
     // the real Windows C:\...;... shape is covered by winTest in launch.test.ts.
     const base = { Path: ['/opt/nodejs', '/usr/bin'].join(path.delimiter) };
-    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['/opt/agent/bin'] }, '');
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['/opt/agent/bin'] }, '', []);
 
     // The existing 'Path' key must be updated in place.
     expect(result.Path).toBe(
@@ -145,7 +145,7 @@ describe('applyAgentLaunchEnv', () => {
   it('deduplicates entries already present in Path', () => {
     const existing = ['/opt/bin', '/usr/bin'].join(path.delimiter);
     const base = { Path: existing };
-    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['/opt/bin'] }, '');
+    const result = applyAgentLaunchEnv(base, { childPathPrepend: ['/opt/bin'] }, '', []);
     expect(result.Path).toBe(existing);
   });
 });

--- a/apps/daemon/tests/runtimes/launch.test.ts
+++ b/apps/daemon/tests/runtimes/launch.test.ts
@@ -27,11 +27,39 @@ test('applyAgentLaunchEnv prepends nodeBinDir and wrapper dir, deduping PATH', (
     { PATH: ['/usr/bin', '/opt/tools/bin', '/bin', '/usr/bin'].join(delimiter) },
     launch,
     '/node/bin',
+    [],
   );
 
   assert.equal(
     env.PATH,
     ['/node/bin', '/opt/tools/bin', '/usr/bin', '/bin'].join(delimiter),
+  );
+});
+
+test('applyAgentLaunchEnv appends toolchain dirs so shebang interpreters (e.g. bun) resolve at spawn time', () => {
+  // Regression for: Pi (`#!/usr/bin/env bun`) resolved on PATH but its version
+  // probe / run spawn failed with exit 127 ("env: bun: No such file or
+  // directory") because the spawn PATH didn't include ~/.bun/bin, so detection
+  // wrongly marked it unavailable. The fix appends the user toolchain bin dirs
+  // (where bun lives) to the spawn PATH.
+  const env = applyAgentLaunchEnv(
+    { PATH: ['/usr/bin', '/bin'].join(delimiter) },
+    { childPathPrepend: ['/opt/homebrew/bin'] },
+    '/node/bin',
+    ['/home/me/.bun/bin', '/usr/bin'],
+  );
+
+  const parts = (env.PATH as string).split(delimiter);
+  assert.equal(parts[0], '/node/bin', 'node dir stays first');
+  assert.equal(parts[1], '/opt/homebrew/bin', 'wrapper dir stays second');
+  assert.ok(
+    parts.includes('/home/me/.bun/bin'),
+    'toolchain bin dir (where the bun interpreter lives) must be on the spawn PATH',
+  );
+  assert.equal(
+    parts.filter((p: string) => p === '/usr/bin').length,
+    1,
+    'a toolchain dir already on PATH must not be duplicated',
   );
 });
 
@@ -44,7 +72,7 @@ test('applyAgentLaunchEnv updates the Path key in-place without creating a compe
   };
   const launch = { childPathPrepend: ['/opt/agent/bin'] };
 
-  const env = applyAgentLaunchEnv(base, launch, '/opt/node/bin');
+  const env = applyAgentLaunchEnv(base, launch, '/opt/node/bin', []);
 
   // Original 'Path' key must be updated in-place.
   assert.ok('Path' in env, 'original Path key must be preserved');
@@ -68,7 +96,7 @@ winTest('applyAgentLaunchEnv injects Node binary dir and wrapper dir into a Wind
   };
   const launch = { childPathPrepend: ['C:\\Users\\User\\AppData\\Roaming\\npm'] };
 
-  const env = applyAgentLaunchEnv(windowsBase, launch, 'C:\\Program Files\\nodejs');
+  const env = applyAgentLaunchEnv(windowsBase, launch, 'C:\\Program Files\\nodejs', []);
 
   // Original 'Path' key must be updated in-place — no competing 'PATH' key.
   assert.ok('Path' in env, 'original Path key must be preserved');


### PR DESCRIPTION
## Why

- **Use case:** I was wiring a local tool (an HTML→video orchestrator) to drive the local OD daemon and let users pick the runtime — Claude / Codex / **Pi**. Pi was installed and authenticated, yet OD reported it unavailable while Claude and Codex worked.
- **Pain:** Agent detection resolves a binary's path using `resolvePathDirs()` (process PATH **+** `wellKnownUserToolchainBins`, which includes `~/.bun/bin`, version-manager dirs, npm prefixes, …), but it **spawns** the `--version` probe with a PATH built from only `nodeBinDir` + the agent's own dir. An agent whose shebang interpreter lives in a toolchain dir that isn't on the daemon's own PATH therefore resolves but fails to *execute*. Pi ships as a `#!/usr/bin/env bun` script (`@oh-my-pi/pi-coding-agent`), so its probe exits 127 (`env: bun: No such file or directory`) → `probeVersionAtPath` classifies it `not-invocable` → `unavailableAgent`. Claude/Codex only survived because their interpreter (`node`) happened to be on the spawn PATH. This silently breaks **any** agent installed via bun/deno/a version manager whose interpreter dir is off the GUI-launched daemon's minimal PATH.

The fix makes resolution and spawn PATH **symmetric**: `applyAgentLaunchEnv` now appends the same user toolchain bin dirs (lowest priority, deduped) to the spawn PATH, so a resolved binary's shebang interpreter is findable at spawn time. Because every spawn site (detection, chat runs, connection tests) routes through this one function, detection **and** runs are fixed together.

## What users will see

Agents whose CLI is a `#!/usr/bin/env <interpreter>` script where the interpreter lives in a user toolchain dir (e.g. **Pi** via bun) now detect correctly in Settings → AI providers and become selectable, instead of showing as unavailable. No change for agents that were already detected.

## Surface area

- [x] **None** — internal detection/launch fix + tests. No new UI, CLI, API/contract, dependency, or opt-in default.

(Behavioral effect is a bug fix: agents that were wrongly unavailable now detect; nothing users opted into changes.)

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/launch.test.ts` → "appends toolchain dirs so shebang interpreters (e.g. bun) resolve at spawn time"
- Red on `main`, green on this branch? **yes** — ran the test against `origin/main`'s `launch.ts`/`executables.ts` (main's 3-param `applyAgentLaunchEnv` ignores the toolchain-dirs argument, so the interpreter dir never lands on PATH and the assertion fails → 1 failed); green on this branch.
- Existing exact-PATH tests (`launch.test.ts`, `agent-runtime-env.test.ts`) pass `[]` for `appendPathDirs` to stay deterministic (mirrors how they already pin the machine-dependent `nodeBinDir`).
- Also verified empirically: rebuilt + restarted the daemon; `GET /api/agents` flipped Pi from unavailable (no path) to available (`path=/opt/homebrew/bin/pi`, `version=omp/15.8.0`), alongside Claude and Codex.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/launch.test.ts tests/agent-runtime-env.test.ts tests/runtimes/env-and-detection.test.ts tests/runtimes/probe-ghost-cli.test.ts` — 54 passed, 1 skipped
- `pnpm --filter @open-design/daemon build` (tsc typecheck) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)