### PR TITLE
fix(web): let new projects choose target folder

### DIFF
--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { createTabToTracking } from '@open-design/contracts/analytics';
+import { isOpenDesignHostAvailable, pickHostWorkingDir } from '@open-design/host';
 import type { OpenDesignHostProjectImportSuccess } from '@open-design/host';
 import { useAnalytics } from '../analytics/provider';
 import {
@@ -17,7 +18,7 @@ import type {
 
 import { useT } from '../i18n';
 import type { Dict } from '../i18n/types';
-import { fetchPromptTemplate } from '../providers/registry';
+import { fetchPromptTemplate, openFolderDialog } from '../providers/registry';
 import { isStoredMediaProviderEntryPresent } from '../state/config';
 import { isMediaProviderPickerReady } from '../media/provider-readiness';
 import type {
@@ -116,6 +117,7 @@ export interface CreateInput {
   skillId: string | null;
   designSystemId: string | null;
   metadata: ProjectMetadata;
+  userWorkingDirToken?: string;
 }
 
 export type ImportClaudeDesignOutcome =
@@ -270,6 +272,12 @@ export function NewProjectPanel({
   const importInputRef = useRef<HTMLInputElement | null>(null);
   const [importing, setImporting] = useState(false);
   const [importZipError, setImportZipError] = useState<
+    { message: string; details?: string } | null
+  >(null);
+  const [workingDir, setWorkingDir] = useState<string | null>(null);
+  const [workingDirToken, setWorkingDirToken] = useState<string | null>(null);
+  const [workingDirPicking, setWorkingDirPicking] = useState(false);
+  const [workingDirError, setWorkingDirError] = useState<
     { message: string; details?: string } | null
   >(null);
   const [tab, setTab] = useState<CreateTab>(initialTab);
@@ -700,9 +708,39 @@ export function NewProjectPanel({
       metadata: {
         ...metadata,
         nameSource: trimmedName ? 'user' : 'generated',
+        ...(workingDir ? { userWorkingDir: workingDir } : {}),
       },
+      ...(workingDirToken ? { userWorkingDirToken: workingDirToken } : {}),
       requestId,
     });
+  }
+
+  async function handlePickWorkingDir() {
+    if (workingDirPicking) return;
+    setWorkingDirPicking(true);
+    setWorkingDirError(null);
+    try {
+      if (isOpenDesignHostAvailable()) {
+        const result = await pickHostWorkingDir();
+        if (result.ok) {
+          setWorkingDir(result.baseDir);
+          setWorkingDirToken(result.token);
+          return;
+        }
+        if ('canceled' in result && result.canceled) return;
+        setWorkingDirError({
+          message: `Couldn't open the folder picker (${'reason' in result ? result.reason : 'host unavailable'}). Please update Open Design and try again.`,
+        });
+        return;
+      }
+      const picked = await openFolderDialog();
+      if (picked) {
+        setWorkingDir(picked);
+        setWorkingDirToken(null);
+      }
+    } finally {
+      setWorkingDirPicking(false);
+    }
   }
 
   async function handleImportPicked(ev: React.ChangeEvent<HTMLInputElement>) {
@@ -799,6 +837,38 @@ export function NewProjectPanel({
             value={name}
             onChange={(e) => setName(e.target.value)}
           />
+        </div>
+
+        <div className="newproj-working-dir-row">
+          <button
+            type="button"
+            className={`ghost newproj-working-dir${workingDir ? ' picked' : ''}`}
+            onClick={() => void handlePickWorkingDir()}
+            disabled={workingDirPicking}
+            title={workingDir ?? t('workingDirPicker.homeTitle')}
+          >
+            <Icon name="folder" size={13} />
+            <span>
+              {workingDirPicking
+                ? t('workingDirPicker.processing')
+                : workingDir
+                  ? displayFolderName(workingDir)
+                  : t('workingDirPicker.select')}
+            </span>
+          </button>
+          {workingDir ? (
+            <button
+              type="button"
+              className="newproj-working-dir-clear"
+              onClick={() => {
+                setWorkingDir(null);
+                setWorkingDirToken(null);
+              }}
+              aria-label={t('workingDirPicker.clearAria')}
+            >
+              <Icon name="close" size={10} />
+            </button>
+          ) : null}
         </div>
 
         {showDesignSystemPicker ? (
@@ -1027,8 +1097,20 @@ export function NewProjectPanel({
           onDismiss={folderImport.clearError}
         />
       ) : null}
+      {workingDirError ? (
+        <Toast
+          message={workingDirError.message}
+          details={workingDirError.details ?? null}
+          ttlMs={6000}
+          onDismiss={() => setWorkingDirError(null)}
+        />
+      ) : null}
     </div>
   );
+}
+
+function displayFolderName(path: string): string {
+  return path.split(/[/\\]/).filter(Boolean).pop() ?? path;
 }
 
 function PlatformPicker({

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -2287,6 +2287,51 @@
   line-height: 1.4;
 }
 .newproj-name { width: 100%; height: 30px; padding: 0 10px; }
+.newproj-working-dir-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+}
+.newproj-working-dir {
+  min-width: 0;
+  height: 30px;
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 7px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.newproj-working-dir.picked {
+  color: var(--text);
+  border-color: var(--border-strong);
+  background: var(--bg-subtle);
+}
+.newproj-working-dir span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.newproj-working-dir-clear {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  color: var(--text-muted);
+}
+.newproj-working-dir-clear:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+  background: var(--bg-subtle);
+}
 .newproj-section { display: flex; flex-direction: column; gap: 6px; }
 .platform-picker-hint {
   margin: 0;

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -4,12 +4,37 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { isOpenDesignHostAvailable, pickHostWorkingDir } from '@open-design/host';
 import {
   buildDesignSystemCreateSelection,
   defaultDesignSystemSelection,
   NewProjectPanel,
 } from '../../src/components/NewProjectPanel';
+import { openFolderDialog } from '../../src/providers/registry';
 import type { DesignSystemSummary, ProjectTemplate, SkillSummary } from '../../src/types';
+
+vi.mock('@open-design/host', async () => {
+  const actual = await vi.importActual<typeof import('@open-design/host')>('@open-design/host');
+  return {
+    ...actual,
+    isOpenDesignHostAvailable: vi.fn(),
+    pickHostWorkingDir: vi.fn(),
+  };
+});
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    openFolderDialog: vi.fn(),
+  };
+});
+
+const mockedIsHostAvailable = vi.mocked(isOpenDesignHostAvailable);
+const mockedPickHostWorkingDir = vi.mocked(pickHostWorkingDir);
+const mockedOpenFolderDialog = vi.mocked(openFolderDialog);
 
 const skills: SkillSummary[] = [
   {
@@ -75,6 +100,9 @@ class ResizeObserverMock {
 beforeEach(() => {
   globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
   Element.prototype.scrollIntoView = vi.fn();
+  vi.clearAllMocks();
+  mockedIsHostAvailable.mockReturnValue(false);
+  mockedOpenFolderDialog.mockResolvedValue(null);
 });
 
 describe('NewProjectPanel design system defaults', () => {
@@ -632,6 +660,106 @@ describe('NewProjectPanel design system defaults', () => {
         }),
       }),
     );
+  });
+});
+
+describe('NewProjectPanel working directory picker', () => {
+  it('includes a browser-picked working directory in the create payload', async () => {
+    const onCreate = vi.fn();
+    mockedIsHostAvailable.mockReturnValue(false);
+    mockedOpenFolderDialog.mockResolvedValue('/Users/me/product-designs');
+
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId="clay"
+        templates={templates}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={onCreate}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose folder' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /product-designs/i })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          userWorkingDir: '/Users/me/product-designs',
+        }),
+      }),
+    );
+    expect(mockedPickHostWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('threads the desktop host working-dir token into the create payload', async () => {
+    const onCreate = vi.fn();
+    mockedIsHostAvailable.mockReturnValue(true);
+    mockedPickHostWorkingDir.mockResolvedValue({
+      ok: true,
+      baseDir: '/Users/me/host-designs',
+      token: 'host-token',
+    });
+
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId="clay"
+        templates={templates}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={onCreate}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose folder' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /host-designs/i })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('create-project'));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userWorkingDirToken: 'host-token',
+        metadata: expect.objectContaining({
+          userWorkingDir: '/Users/me/host-designs',
+        }),
+      }),
+    );
+    expect(mockedOpenFolderDialog).not.toHaveBeenCalled();
+  });
+
+  it('surfaces host picker failures without falling back to an untokened browser path', async () => {
+    mockedIsHostAvailable.mockReturnValue(true);
+    mockedPickHostWorkingDir.mockResolvedValue({
+      ok: false,
+      reason: 'host build does not support pickWorkingDir',
+    });
+
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId="clay"
+        templates={templates}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose folder' }));
+
+    expect(await screen.findByText(/Couldn't open the folder picker/i)).toBeTruthy();
+    expect(mockedOpenFolderDialog).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #2803

## Why

Issue #2803 reports that the New project flow no longer exposes a direct way to choose where the new design project should live. That leaves users creating projects in the managed default location even when the design is part of an existing folder they need to keep using.

This PR restores that creation-time folder affordance while reusing the existing post-create working-directory handoff that already applies `metadata.userWorkingDir` safely.

## What users will see

The New project modal now shows a compact folder picker under the project name. Users can pick or clear a target folder before pressing Create, and the project is handed off to that folder during creation.

In desktop builds, the picker carries the host-minted working-directory token into the create payload. If the host cannot mint a token, the modal surfaces the picker error instead of falling back to an untokened browser path.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from this run. The local web runtime was available, but the in-app Browser backend was unavailable, so I could not capture the modal screenshot in this environment.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/NewProjectPanel.test.tsx`
- Did the test go red on `main` and green on this branch? no — the issue scope was clarified from the screenshot/comment thread, and I added focused regression coverage for the restored create-time folder picker and token handoff.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web test -- NewProjectPanel.test.tsx` (expanded to full web Vitest suite: 303 files passed, 2972 tests passed, 1 skipped)
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>