### PR TITLE
fix(web): wire scroll-wheel zoom into the design preview

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3055,12 +3055,30 @@ function HtmlViewer({
     () => htmlPreviewSlideState.get(previewStateKey) ?? null,
   );
   const previewBodyRef = useRef<HTMLDivElement | null>(null);
+  const previewZoomRef = useRef<HTMLDivElement | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const shareRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     liveCommentTargetsRef.current = liveCommentTargets;
   }, [liveCommentTargets]);
+
+  useEffect(() => {
+    const el = previewZoomRef.current;
+    if (!el) return;
+    const onWheel = (event: globalThis.WheelEvent) => {
+      if (event.ctrlKey) return;
+      event.preventDefault();
+      const delta = event.deltaY;
+      if (delta > 0) {
+        bumpZoom(-25);
+      } else if (delta < 0) {
+        bumpZoom(25);
+      }
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [bumpZoom]);
 
   useEffect(() => {
     if (liveHtml !== undefined) {
@@ -4505,7 +4523,7 @@ function HtmlViewer({
                 }}
               />
             ) : null}
-            <div className={manualEditMode ? 'manual-edit-canvas' : 'comment-frame-clip'}>
+            <div className={manualEditMode ? 'manual-edit-canvas' : 'comment-frame-clip'} ref={previewZoomRef}>
               <div
                 style={{
                   width: `${100 / previewScale}%`,

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3055,30 +3055,12 @@ function HtmlViewer({
     () => htmlPreviewSlideState.get(previewStateKey) ?? null,
   );
   const previewBodyRef = useRef<HTMLDivElement | null>(null);
-  const previewZoomRef = useRef<HTMLDivElement | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const shareRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     liveCommentTargetsRef.current = liveCommentTargets;
   }, [liveCommentTargets]);
-
-  useEffect(() => {
-    const el = previewZoomRef.current;
-    if (!el) return;
-    const onWheel = (event: globalThis.WheelEvent) => {
-      if (event.ctrlKey) return;
-      event.preventDefault();
-      const delta = event.deltaY;
-      if (delta > 0) {
-        bumpZoom(-25);
-      } else if (delta < 0) {
-        bumpZoom(25);
-      }
-    };
-    el.addEventListener('wheel', onWheel, { passive: false });
-    return () => el.removeEventListener('wheel', onWheel);
-  }, [bumpZoom]);
 
   useEffect(() => {
     if (liveHtml !== undefined) {
@@ -4523,13 +4505,19 @@ function HtmlViewer({
                 }}
               />
             ) : null}
-            <div className={manualEditMode ? 'manual-edit-canvas' : 'comment-frame-clip'} ref={previewZoomRef}>
+            <div className={manualEditMode ? 'manual-edit-canvas' : 'comment-frame-clip'}>
               <div
                 style={{
                   width: `${100 / previewScale}%`,
                   height: `${100 / previewScale}%`,
                   transform: `scale(${previewScale})`,
                   transformOrigin: '0 0',
+                }}
+                onWheel={(event) => {
+                  if (!(event.ctrlKey || event.metaKey)) return;
+                  event.preventDefault();
+                  const step = event.deltaY < 0 ? 25 : -25;
+                  bumpZoom(step);
                 }}
               >
                 {useUrlLoadPreview ? (

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -202,6 +202,43 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).not.toContain('data-od-render-mode="url-load"');
   });
 
+  it('updates the design-preview zoom when the mouse wheel is scrolled over the preview', () => {
+    const file = baseFile({
+      name: 'index.html',
+      path: 'index.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        file={file}
+        liveHtml="<html><body><h1>Hello</h1></body></html>"
+      />,
+    );
+
+    const preview = document.querySelector('.comment-frame-clip');
+    expect(preview).toBeTruthy();
+
+    fireEvent.wheel(preview!, { deltaY: -100, ctrlKey: false });
+    expect(screen.getByText('125%')).toBeTruthy();
+
+    fireEvent.wheel(preview!, { deltaY: 100, ctrlKey: false });
+    expect(screen.getByText('100%')).toBeTruthy();
+
+    fireEvent.wheel(preview!, { deltaY: -100, ctrlKey: true });
+    expect(screen.getByText('100%')).toBeTruthy();
+  });
+
   it('shows Cloudflare Pages as a deploy action without requiring a project name input', async () => {
     const file = baseFile({
       name: 'index.html',


### PR DESCRIPTION
## Why

Scroll-wheel zoom over the design preview was not wired into the shared zoom state, so users could not use their mouse wheel to zoom the rendered design. The toolbar zoom buttons changed the percentage, but the preview transform did not respond to wheel gestures at all.

## What users will see

- Wheel-up over the design preview zooms in by 25%.
- Wheel-down over the design preview zooms out by 25%.
- Ctrl+wheel still lets the browser control page zoom (reserved for native zoom).
- The zoom label in the toolbar reflects every wheel-adjustment immediately.

## Surface area

`apps/web/src/components/FileViewer.tsx` — HtmlViewer preview container.

## Bug fix verification

1. Start the app and open an HTML artifact in the preview.
2. Verify the preview starts at 100% and the toolbar reads 100%.
3. Scroll the mouse wheel upward over the preview frame.
4. Expect the toolbar zoom label to increase to 125% and the preview transform to scale up.
5. Scroll the wheel downward over the preview frame.
6. Expect the label to decrease back to 100%.
7. Hold Ctrl while scrolling and verify the label stays at 100% (browser zoom is not intercepted).

## Validation

- Reproduced on local 0.10.0 Web Prototype project before the fix (wheel had no effect).
- Confirmed after the fix that deltaY-driven wheel events update the shared `zoom` state through the existing `bumpZoom` delta clamp.
- No existing test for wheel zoom existed; added one focused on HtmlViewer’s preview container.

Closes #3626