### PR TITLE
docs: clarify 0.8.0 stable release in preview announcement

### DIFF
--- a/docs/v0.8.0-announcement.md
+++ b/docs/v0.8.0-announcement.md
@@ -1,8 +1,10 @@
 # 🔥 Open Design 0.8.0-preview — Design's old world ends here. Help us build the new one.
 
-> **Status:** Now landed on `main` · 0.8.0 release tag coming up · feedback still wanted
+> **Status:** Historical preview thread · **0.8.0 stable shipped on 2026-05-22** · feedback still welcome
 > **Branch:** [`main`](https://github.com/nexu-io/open-design/tree/main) — everything below tracks `main`
 > **Runs alongside 0.7:** installs side-by-side — try it without giving anything up.
+
+> **Looking for the stable release?** Use [`open-design-v0.8.0`](https://github.com/nexu-io/open-design/releases/tag/open-design-v0.8.0). This document stays up as the original preview announcement so the rollout context is still preserved.
 
 ---
 

--- a/docs/v0.8.0-announcement.zh-CN.md
+++ b/docs/v0.8.0-announcement.zh-CN.md
@@ -1,8 +1,10 @@
 # 🔥 Open Design 0.8.0-preview —— 设计的旧世界，到此为止。新世界，和我们一起造。
 
-> **状态：** 已合并进 `main` · 0.8.0 正式版 tag 即将到来 · 反馈仍然欢迎
+> **状态：** 历史预览帖 · **0.8.0 正式版已于 2026-05-22 发布** · 反馈仍然欢迎
 > **分支：** [`main`](https://github.com/nexu-io/open-design/tree/main)——下文所有内容都跟随 `main`
 > **与 0.7 并存：** 预览版可与你现有的 0.7 并行安装——零成本试用，不必割舍任何东西。
+
+> **想找正式版？** 请直接使用 [`open-design-v0.8.0`](https://github.com/nexu-io/open-design/releases/tag/open-design-v0.8.0)。这份文档保留为最初的预览发布帖，方便追踪当时的 rollout 背景。
 
 ---
 


### PR DESCRIPTION
Closes #2621

## Why

Issue #2621 asked when 0.8.0 stable would be released. The lingering 0.8.0 preview announcement still said the release tag was coming soon, which left stale guidance in a user-facing doc even though 0.8.0 had already shipped.

## What users will see

Anyone opening the 0.8.0 preview announcement now sees that 0.8.0 stable shipped on 2026-05-22 and gets a direct link to the stable GitHub release from both the English and Chinese announcement docs.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- No red spec: this is a docs-only stale-copy fix. Verified the announcement docs now point readers to the shipped stable tag in both English and Chinese.

## Validation

- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=opencode · An autonomous AI dev team for your GitHub repos.</sub>