### PR TITLE
fix(web): keep generation progress card on the design-files tab (#3671)

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -1665,17 +1665,24 @@ export function FileWorkspace({
 
   const isActiveSketch = activeFile?.kind === 'sketch' && isSketchName(activeFile.name);
   const activeSketch = activeFile && isActiveSketch ? sketches[activeFile.name] : null;
-  // The generation progress card takes priority over the design-files tab's
-  // empty "Creations will appear here" list: while a run is in flight and no
-  // previewable artifact exists yet, the design-files tab (the default landing
-  // tab) must still show generation progress rather than an idle empty state.
-  // `buildGenerationPreviewState` already returns null once a preview surface
-  // exists, so this never hides a finished artifact. (Pre-#3516 the preview
-  // branch rendered before the design-files branch with no tab guard; the
-  // composer rewrite added an `activeTab !== DESIGN_FILES_TAB` clause here that
-  // accidentally hid the progress card on the default tab.)
+  // The design-files tab is the default landing tab, so while a run is in
+  // flight and no previewable artifact exists yet the progress card must take
+  // over its empty "Creations will appear here" state rather than leave an idle
+  // empty list. (Pre-#3516 the preview branch rendered before the design-files
+  // branch with no tab guard; the composer rewrite added an `activeTab !==
+  // DESIGN_FILES_TAB` clause here that hid the progress card on the default
+  // tab.) But the override is scoped to the *empty* design-files tab: a
+  // populated project keeps its file browser while generating. The condition
+  // mirrors DesignFilesPanel's own empty-state gate exactly (no files, no live
+  // artifacts, no folders), so the card only wins where the panel would have
+  // shown its empty placeholder.
+  const designFilesTabIsEmpty =
+    visibleFiles.length === 0
+    && liveArtifactEntries.length === 0
+    && projectFolders.length === 0;
   const showGenerationPreview = Boolean(generationPreview)
     && activeTab !== DESIGN_SYSTEM_TAB
+    && (activeTab !== DESIGN_FILES_TAB || designFilesTabIsEmpty)
     && !isBrowserTabId(activeTab)
     && !isSideChatTabId(activeTab)
     && !isTerminalTabId(activeTab)

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -1665,8 +1665,16 @@ export function FileWorkspace({
 
   const isActiveSketch = activeFile?.kind === 'sketch' && isSketchName(activeFile.name);
   const activeSketch = activeFile && isActiveSketch ? sketches[activeFile.name] : null;
+  // The generation progress card takes priority over the design-files tab's
+  // empty "Creations will appear here" list: while a run is in flight and no
+  // previewable artifact exists yet, the design-files tab (the default landing
+  // tab) must still show generation progress rather than an idle empty state.
+  // `buildGenerationPreviewState` already returns null once a preview surface
+  // exists, so this never hides a finished artifact. (Pre-#3516 the preview
+  // branch rendered before the design-files branch with no tab guard; the
+  // composer rewrite added an `activeTab !== DESIGN_FILES_TAB` clause here that
+  // accidentally hid the progress card on the default tab.)
   const showGenerationPreview = Boolean(generationPreview)
-    && activeTab !== DESIGN_FILES_TAB
     && activeTab !== DESIGN_SYSTEM_TAB
     && !isBrowserTabId(activeTab)
     && !isSideChatTabId(activeTab)

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -6,7 +6,11 @@ import { createRoot, type Root } from 'react-dom/client';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { FileWorkspace, scrollWorkspaceTabsWithWheel } from '../../src/components/FileWorkspace';
+import {
+  DESIGN_FILES_TAB,
+  FileWorkspace,
+  scrollWorkspaceTabsWithWheel,
+} from '../../src/components/FileWorkspace';
 import { DesignFilesPanel } from '../../src/components/DesignFilesPanel';
 import { projectSplitClassName, projectSplitStyle } from '../../src/components/ProjectView';
 import {
@@ -186,6 +190,21 @@ function failedAssistantMessage(
     agentId,
     preTurnFileNames: [],
     events: [{ kind: 'status', label: 'error', detail, code }],
+  };
+}
+
+function generatingAssistantMessage(): ChatMessage {
+  return {
+    id: 'msg-generating',
+    role: 'assistant',
+    content: '',
+    createdAt: 1700000000,
+    startedAt: 1700000000,
+    runId: 'run-generating',
+    runStatus: 'running',
+    agentId: 'claude',
+    preTurnFileNames: [],
+    events: [{ kind: 'status', label: 'thinking' }],
   };
 }
 
@@ -1276,6 +1295,31 @@ describe('FileWorkspace generation failure recovery', () => {
     expect(onRetry).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'msg-rate_limited', agentId: 'antigravity' }),
     );
+  });
+
+  // Regression guard for #3516: the giant Lexical-composer merge added an
+  // `activeTab !== DESIGN_FILES_TAB` clause to `showGenerationPreview`, which
+  // suppressed the generation progress card on the design-files tab — the
+  // default landing tab. While a run is in flight and no previewable artifact
+  // exists yet, the progress card must take priority over the empty
+  // "Creations will appear here" file list instead of being hidden behind it.
+  it('keeps the generation preview on the design-files tab while generating with no artifacts yet', () => {
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        streaming
+        tabsState={{ tabs: [], active: DESIGN_FILES_TAB }}
+        onTabsStateChange={vi.fn()}
+        messages={[generatingAssistantMessage()]}
+      />,
+    );
+
+    expect(screen.getByTestId('generation-preview-stage')).toBeTruthy();
   });
 });
 

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -1321,6 +1321,30 @@ describe('FileWorkspace generation failure recovery', () => {
 
     expect(screen.getByTestId('generation-preview-stage')).toBeTruthy();
   });
+
+  // The override above is scoped to the *empty* design-files tab. A populated
+  // project must keep its file browser while a run is in flight instead of
+  // having the generation card hijack the tab — otherwise the fresh-project fix
+  // would regress browsing for everyone with existing files.
+  it('keeps the file browser on a populated design-files tab while a run is active', async () => {
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[workspaceFile('index.html')]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        streaming
+        tabsState={{ tabs: [], active: DESIGN_FILES_TAB }}
+        onTabsStateChange={vi.fn()}
+        messages={[generatingAssistantMessage()]}
+      />,
+    );
+
+    expect(await screen.findByText('index.html')).toBeTruthy();
+    expect(screen.queryByTestId('generation-preview-stage')).toBeNull();
+  });
 });
 
 describe('DesignFilesPanel plugin folders', () => {


### PR DESCRIPTION
Cherry-pick of #3671 onto `release/v0.10.0`.

## Why

On a fresh project the design-files tab is the default landing tab. While an agent is generating its first artifact (and nothing previewable exists yet), the right-side pane dropped back to the empty "Creations will appear here" file list instead of showing the generation progress card. Root cause: PR #3516 (Lexical composer rewrite) added an `activeTab !== DESIGN_FILES_TAB` clause to `showGenerationPreview`, which suppressed the card on the default tab. This back-ports the fix to the v0.10.0 release line.

## What users will see

Sending the first prompt on a fresh project keeps the right pane on the "Generating…" progress card (understand → generate → prepare) while the agent works, instead of an idle empty state. Once a previewable artifact exists, the card yields to the live preview exactly as before.

## Surface area

- [x] **UI** — restores generation progress card / empty-state gating on the design-files tab in `apps/web`

## Bug fix verification

- Test path: `apps/web/tests/components/FileWorkspace.test.tsx` → "keeps the generation preview on the design-files tab while generating with no artifacts yet"
- Red on `main`/release before the fix (empty `DesignFilesPanel`, no `generation-preview-stage`), green after dropping the clause.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/FileWorkspace.test.tsx` ✅ (54/54, incl. the new red-spec)
- `pnpm --filter @open-design/web typecheck` ✅

Original: #3671 (merged to `main` as 9a18397).
