### PR TITLE
ci(release): throttle the per-push nightly build instead of debouncing it

### DIFF
--- a/.github/workflows/notify-release-feishu.yml
+++ b/.github/workflows/notify-release-feishu.yml
@@ -4,7 +4,11 @@ name: notify-release-feishu
 # release-stable (channel=nightly), then post a Feishu card with the download
 # links (macOS arm64 + Intel, Windows, and Linux when enabled) and the changelog
 # since the previously published nightly. Consecutive pushes to the same branch
-# are debounced: a newer push cancels the in-flight build.
+# are throttled, not debounced: an in-flight build is allowed to finish (so a
+# busy release branch always produces a nightly), while pushes that arrive
+# during it coalesce into a single trailing build of the latest commit. With
+# cancel-in-progress the previous behavior starved — pushes spaced closer than
+# the build duration kept cancelling each other and no package was ever cut.
 
 on:
   push:
@@ -17,7 +21,12 @@ permissions:
 
 concurrency:
   group: feishu-release-${{ github.ref }}
-  cancel-in-progress: true
+  # Throttle, not debounce: let the running build finish and coalesce the
+  # queued pushes into one trailing build. GitHub keeps the in-progress run and
+  # only the newest pending run in the group (older pending runs are cancelled),
+  # so a busy release branch still cuts a nightly and converges on the latest
+  # commit, at most one build running plus one queued.
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
## Why

`notify-release-feishu` cuts a full nightly package (via `release-stable`, channel=nightly) and posts a Feishu card on **every push to `release/**`**. Its concurrency used `cancel-in-progress: true`, so a newer push cancelled the in-flight build.

On a busy release branch — pushes spaced closer than a full cross-platform build takes — this **starves**: each build is cancelled by the next push before it finishes, so no nightly is ever cut. Observed on `release/v0.10.0` today: a run of consecutive pushes (back-merges + merged PRs ~15–25 min apart) all show `cancelled`, and the last *successful* nightly was hours old. The mechanism is effectively "always restart", which never converges under sustained pushes.

## What users will see

Pushing to a release branch reliably produces a nightly + Feishu card again. A short burst of release commits coalesces into one trailing build of the latest commit instead of cancelling everything.

## Surface area

- [x] **None** — CI workflow concurrency change (`.github/workflows/notify-release-feishu.yml`); no app code, contract, or user-facing surface.

## The change

`cancel-in-progress: true` → `false` (throttle instead of debounce):

- The in-progress build is **allowed to finish** (a busy branch always cuts a nightly).
- Pushes during a build go **pending and coalesce** — GitHub keeps the in-progress run plus only the *newest* pending run in the group and cancels older pending ones, so it converges on the latest commit with at most one build running + one queued (no unbounded backlog).

Trade-off: a newer push no longer interrupts a running build of an older commit — it waits one build cycle. For nightly (frequent commits; "always cut a package and end on latest") that's the right trade; `cancel-in-progress: true` only wins for sparse pushes where "instantly latest, nothing older" matters.

This lands on `main`; it will be cherry-picked to `release/v0.10.0` (push workflows run from the pushed branch's definition, so the active release branch needs the fix to take effect there).

## Validation

- Behavioral change in GitHub Actions concurrency semantics (no unit-testable surface). Reasoning per GitHub's documented concurrency model: with `cancel-in-progress: false`, a queued run waits for the in-progress one and any previously *pending* run in the same group is cancelled.
- `pnpm guard` — pass.
