### PR TITLE
feat(web): simplify Home composer (drop plugin-inputs form & example pill, move Design Agent next to Send) (#3645) [v0.10.0]

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -30,9 +30,7 @@ import type {
   McpServerConfig,
 } from '@open-design/contracts';
 import type { SkillSummary } from '../types';
-import { isImeComposing } from '../utils/imeComposing';
 import { Icon, type IconName } from './Icon';
-import { PluginInputsForm } from './PluginInputsForm';
 import { useAnalytics } from '../analytics/provider';
 import { trackHomeChatComposerClick } from '../analytics/events';
 import {
@@ -115,9 +113,7 @@ interface Props {
   pluginInputValues?: Record<string, unknown>;
   pluginInputTemplate?: string | null;
   onPluginInputValuesChange?: (values: Record<string, unknown>) => void;
-  onPluginInputValidityChange?: (valid: boolean) => void;
   inlineEditableInputNames?: string[];
-  showPluginInputsForm?: boolean;
   footerInputNames?: string[];
   designSystemOptions?: HomeHeroDesignSystemOption[];
   stagedFiles?: File[];
@@ -146,6 +142,7 @@ interface Props {
   onPickWorkingDir?: () => void;
   onClearWorkingDir?: () => void;
   onExamplePromptStatusChange?: (info: ExamplePromptInfo | null) => void;
+  executionSwitcher?: ReactNode;
 }
 
 interface HomeHeroDesignSystemOption {
@@ -224,11 +221,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     onOpenPluginDetails = () => undefined,
     pluginInputFields = EMPTY_INPUT_FIELDS,
     pluginInputValues = EMPTY_PLUGIN_INPUT_VALUES,
-    pluginInputTemplate = null,
     onPluginInputValuesChange = () => undefined,
-    onPluginInputValidityChange = () => undefined,
-    inlineEditableInputNames = EMPTY_INPUT_NAMES,
-    showPluginInputsForm = true,
     footerInputNames = EMPTY_INPUT_NAMES,
     designSystemOptions = EMPTY_DESIGN_SYSTEM_OPTIONS,
     stagedFiles = EMPTY_STAGED_FILES,
@@ -257,6 +250,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     onPickWorkingDir,
     onClearWorkingDir,
     onExamplePromptStatusChange,
+    executionSwitcher,
   },
   ref,
 ) {
@@ -473,16 +467,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
       .map((name) => fieldByName.get(name))
       .filter((field): field is InputFieldSpec => Boolean(field)),
     [fieldByName, footerInputNames],
-  );
-  // Inline `{{slot}}` editing in the prompt body is gone with the Lexical
-  // migration; every non-footer input now renders in the structured
-  // inputs form below the editor (matching the project composer), so the
-  // only fields we exclude are the ones promoted into the footer.
-  const remainingInputFields = useMemo(
-    () => pluginInputFields.filter(
-      (field) => !footerInputNameSet.has(field.name),
-    ),
-    [footerInputNameSet, pluginInputFields],
   );
   const activeCreateChip = useMemo(
     () => activeChipId
@@ -721,10 +705,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     return false;
   }
 
-  function updatePluginInput(name: string, value: unknown) {
-    onPluginInputValuesChange({ ...pluginInputValues, [name]: value });
-  }
-
   function handleFiles(files: File[]) {
     if (files.length === 0) return;
     onAddFiles(files);
@@ -734,15 +714,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     const nextPrompt = stripHomeMentionToken(prompt, file.name);
     if (nextPrompt !== prompt) onPromptChange(nextPrompt);
     onRemoveFile(index);
-  }
-
-  function clearSelectedPromptExample() {
-    if (selectedPromptExample) {
-      onPromptChange('');
-      editorRef.current?.clear();
-      onExamplePromptStatusChange?.(null);
-    }
-    setSelectedPromptExample(null);
   }
 
   function usePromptExample(example: string) {
@@ -793,7 +764,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     contextItemCount > 0 ||
     (showActivePluginChip && activePluginTitle) ||
     activeSkillTitle ||
-    selectedPromptExample ||
     stagedFiles.length > 0;
 
   let optionRenderIndex = 0;
@@ -956,27 +926,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
                 </button>
               </span>
             ) : null}
-            {selectedPromptExample ? (
-              <span
-                className="home-hero__active-chip home-hero__active-chip--example"
-                data-testid="home-hero-active-example"
-              >
-                <span className="home-hero__active-icon" aria-hidden>
-                  <Icon name="pencil" size={12} />
-                </span>
-                <span className="home-hero__active-label">{t('homeHero.promptExamples')}: {selectedPromptExample.label}</span>
-                <button
-                  type="button"
-                  className="home-hero__active-clear od-tooltip"
-                  onClick={clearSelectedPromptExample}
-                  aria-label={t('common.close')}
-                  title={t('common.close')}
-                  data-tooltip={t('common.close')}
-                >
-                  <Icon name="close" size={9} />
-                </button>
-              </span>
-            ) : null}
             {contextOnlyPlugins.map((plugin) => (
               <span
                 key={`ctx-plugin-${plugin.id}`}
@@ -1089,14 +1038,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
               }}
             />
           </div>
-          {showPluginInputsForm && remainingInputFields.length > 0 ? (
-            <PluginInputsForm
-              fields={remainingInputFields}
-              values={pluginInputValues}
-              onChange={onPluginInputValuesChange}
-              onValidityChange={onPluginInputValidityChange}
-            />
-          ) : null}
         </div>
         <CaretFloatingLayer caret={caretRect} open={pickerOpen}>
           <div
@@ -1434,11 +1375,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
                 ) : null}
               </div>
             ) : null}
-            <SessionModeToggle
-              mode={sessionMode}
-              onChange={onSessionModeChange}
-              disabled={Boolean(submitDisabled)}
-            />
             {activeCreateChip ? (
               <ActiveTypeChip chip={activeCreateChip} onClear={onClearActiveChip} />
             ) : null}
@@ -1462,19 +1398,31 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
               </div>
             ) : null}
           </div>
-          <button
-            type="button"
-            className="home-hero__submit od-tooltip"
-            data-testid="home-hero-submit"
-            onClick={onSubmit}
-            disabled={!canSubmit}
-            title={canSubmit ? t('homeHero.run') : t('homeHero.typeSomethingToRun')}
-            data-tooltip={canSubmit ? t('homeHero.run') : t('homeHero.typeSomethingToRun')}
-            aria-label={t('homeHero.run')}
-          >
-            <Icon name="send" size={13} />
-            <span>{t('chat.send')}</span>
-          </button>
+          <div className="home-hero__foot-right">
+            <SessionModeToggle
+              mode={sessionMode}
+              onChange={onSessionModeChange}
+              disabled={Boolean(submitDisabled)}
+            />
+            {executionSwitcher ? (
+              <div className="home-hero__execution-switcher">
+                {executionSwitcher}
+              </div>
+            ) : null}
+            <button
+              type="button"
+              className="home-hero__submit od-tooltip"
+              data-testid="home-hero-submit"
+              onClick={onSubmit}
+              disabled={!canSubmit}
+              title={canSubmit ? t('homeHero.run') : t('homeHero.typeSomethingToRun')}
+              data-tooltip={canSubmit ? t('homeHero.run') : t('homeHero.typeSomethingToRun')}
+              aria-label={t('homeHero.run')}
+            >
+              <Icon name="send" size={13} />
+              <span>{t('chat.send')}</span>
+            </button>
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -53,6 +53,7 @@ import type {
   SkillSummary,
 } from '../types';
 import { inlineMentionToken, mentionTokenPresent } from '../utils/inlineMentions';
+import { missingRequiredInputs, pluginInputsAreValid } from '../utils/pluginRequiredInputs';
 import { HomeHero, type ExamplePromptInfo, type HomeHeroHandle } from './HomeHero';
 import { findChip, HOME_HERO_CHIPS, type HomeHeroChip } from './home-hero/chips';
 import {
@@ -1285,7 +1286,15 @@ export function HomeView({
     });
     let submittedActive = active;
     if (submittedActive && !submittedActive.inputsValid) {
-      setError('Fill the required plugin parameters before running.');
+      const missing = missingRequiredInputs(
+        submittedActive.inputFields,
+        submittedActive.inputs,
+      );
+      setError(
+        missing.length > 0
+          ? `Fill the required plugin ${missing.length === 1 ? 'parameter' : 'parameters'} before running: ${missing.join(', ')}.`
+          : 'Fill the required plugin parameters before running.',
+      );
       return;
     }
     const defaultInputs = { prompt: trimmed };
@@ -1430,11 +1439,6 @@ export function HomeView({
         inlineEditableInputNames={active?.editableInputNames ?? []}
         footerInputNames={footerInputNamesForChip(active?.chipId ?? null)}
         designSystemOptions={designSystemOptions}
-        onPluginInputValidityChange={(valid) => {
-          setActive((prev) => (
-            prev && prev.inputsValid !== valid ? { ...prev, inputsValid: valid } : prev
-          ));
-        }}
         stagedFiles={stagedFiles}
         onAddFiles={stageFiles}
         onRemoveFile={removeStagedFile}
@@ -1963,17 +1967,6 @@ function hydratePluginInputs(
     }
   }
   return next;
-}
-
-function pluginInputsAreValid(
-  fields: InputFieldSpec[],
-  values: Record<string, unknown>,
-): boolean {
-  return fields.every((field) => {
-    if (!field.required) return true;
-    const value = values[field.name];
-    return value !== undefined && value !== null && value !== '';
-  });
 }
 
 const TEMPLATE_INPUT_PATTERN = /\{\{\s*([a-zA-Z_][\w-]*)\s*\}\}/g;

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -335,12 +335,6 @@
 .home-hero__active-chip--file {
   background: color-mix(in srgb, var(--bg-panel) 92%, var(--accent-tint));
 }
-.home-hero__active-chip--example {
-  max-width: 100%;
-  background: color-mix(in srgb, var(--accent-tint) 48%, var(--bg-panel));
-  border-color: color-mix(in srgb, var(--accent) 22%, var(--border));
-  color: color-mix(in srgb, var(--accent) 80%, var(--text));
-}
 .home-hero__active-file-group {
   display: contents;
 }
@@ -778,6 +772,53 @@
   flex: 1 1 auto;
   flex-wrap: nowrap;
   overflow: visible;
+}
+.home-hero__foot-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+.home-hero__execution-switcher {
+  display: inline-flex;
+  min-width: 0;
+  flex: 0 1 auto;
+}
+.home-hero__execution-switcher .inline-switcher {
+  min-width: 0;
+  max-width: 48px;
+}
+.home-hero__execution-switcher .inline-switcher__chip {
+  height: 30px;
+  max-width: 48px;
+  padding: 0 7px;
+  gap: 4px;
+  border-radius: var(--radius-sm);
+}
+.home-hero__foot-right .session-mode-toggle {
+  height: 30px;
+}
+.home-hero__foot-right .session-mode-toggle__trigger {
+  height: 30px;
+  max-width: 120px;
+  padding: 0 8px;
+  gap: 6px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+}
+.home-hero__foot-right .session-mode-toggle__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.home-hero__execution-switcher .inline-switcher__popover {
+  right: auto;
+  left: 0;
+  z-index: 1503;
+}
+.home-hero__execution-switcher .inline-switcher__agent-grid {
+  grid-template-columns: 1fr;
 }
 .home-hero__tool {
   appearance: none;

--- a/apps/web/src/utils/pluginRequiredInputs.ts
+++ b/apps/web/src/utils/pluginRequiredInputs.ts
@@ -1,0 +1,41 @@
+import type { InputFieldSpec } from '@open-design/contracts';
+
+// The Home composer dropped its inline plugin-inputs form, so most fields are
+// satisfied by their `default` or hydrated from the prompt body. Required
+// fields that have neither a default nor a provided value cannot be inferred,
+// though: the daemon rejects them at apply time (`validateInputs` in
+// apps/daemon/src/plugins/apply.ts throws MissingInputError), which would
+// otherwise surface only as a generic "Failed to apply …" after Send. These
+// helpers mirror the daemon's required-input rule so Home flows can gate the
+// submit client-side and name the missing field instead of regressing into a
+// broken send path.
+
+function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null && value !== '';
+}
+
+/**
+ * Names of required fields that have neither a provided value nor a usable
+ * default. Field labels are preferred over names for user-facing messages.
+ */
+export function missingRequiredInputs(
+  fields: InputFieldSpec[],
+  values: Record<string, unknown>,
+): string[] {
+  const missing: string[] = [];
+  for (const field of fields) {
+    if (field.required !== true) continue;
+    if (hasValue(values[field.name])) continue;
+    if (hasValue(field.default)) continue;
+    missing.push(field.label?.trim() || field.name);
+  }
+  return missing;
+}
+
+/** True when every required field is satisfied by a value or a default. */
+export function pluginInputsAreValid(
+  fields: InputFieldSpec[],
+  values: Record<string, unknown>,
+): boolean {
+  return missingRequiredInputs(fields, values).length === 0;
+}

--- a/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
+++ b/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
@@ -5,7 +5,6 @@ import type { ComponentProps } from 'react';
 import { KEY_ENTER_COMMAND } from 'lexical';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
-  InputFieldSpec,
   InstalledPluginRecord,
   McpServerConfig,
   PluginSourceKind,
@@ -15,7 +14,6 @@ import type {
 import { HomeHero } from '../../src/components/HomeHero';
 import {
   getHomeHeroEditor,
-  homeHeroPromptText,
   setHomeHeroPrompt,
 } from '../helpers/home-hero-lexical';
 
@@ -451,87 +449,6 @@ describe('HomeHero plugin picker', () => {
     // the picker closed once the pick landed.
     expect(onSubmit).not.toHaveBeenCalled();
     expect(screen.queryByTestId('home-hero-plugin-picker')).toBeNull();
-  });
-
-  it('renders rendered plugin input values in the inputs form below the editor', async () => {
-    // The inline `{{slot}}` widget (`home-hero-prompt-slot-*`) in the prompt
-    // body is gone with the Lexical migration. Every non-footer plugin input now
-    // renders in the structured PluginInputsForm (`plugin-inputs-form`) below the
-    // editor, so this test asserts the input surfaces (and reflects its value)
-    // there instead of as an inline pill.
-    const fields: InputFieldSpec[] = [
-      {
-        name: 'source',
-        label: 'Import source',
-        type: 'select',
-        options: ['folder', 'zip', 'github', 'marketplace'],
-        default: 'marketplace',
-      },
-    ];
-    const prompt =
-      'Create a compact import receipt for community-import-smoke-test installed from marketplace.';
-
-    const { rerender } = render(
-      <HomeHero
-        prompt={prompt}
-        onPromptChange={() => undefined}
-        onSubmit={() => undefined}
-        activePluginTitle="Community Import Smoke Test"
-        activeChipId={null}
-        onClearActivePlugin={() => undefined}
-        pluginInputFields={fields}
-        pluginInputValues={{ source: 'marketplace' }}
-        pluginInputTemplate="Create a compact import receipt for community-import-smoke-test installed from {{source}}."
-        pluginOptions={[]}
-        pluginsLoading={false}
-        pendingPluginId={null}
-        pendingChipId={null}
-        onPickPlugin={() => undefined}
-        onPickChip={() => undefined}
-        contextItemCount={0}
-        error={null}
-      />,
-    );
-
-    await settle();
-
-    const form = screen.getByTestId('plugin-inputs-form');
-    expect(form).toBeTruthy();
-    const select = form.querySelector<HTMLSelectElement>('select[data-field-name="source"]');
-    expect(select).toBeTruthy();
-    expect(select?.value).toBe('marketplace');
-    expect(select?.tagName).toBe('SELECT');
-    // The field's label wrapper marks the rendered value as filled.
-    expect(select?.closest('label')?.getAttribute('data-filled')).toBe('true');
-
-    // Extra prompt text no longer removes any inline slot (there are none); the
-    // structured inputs form keeps rendering the field so the value stays
-    // editable below the editor.
-    rerender(
-      <HomeHero
-        prompt={`${prompt} Extra user edit.`}
-        onPromptChange={() => undefined}
-        onSubmit={() => undefined}
-        activePluginTitle="Community Import Smoke Test"
-        activeChipId={null}
-        onClearActivePlugin={() => undefined}
-        pluginInputFields={fields}
-        pluginInputValues={{ source: 'marketplace' }}
-        pluginInputTemplate="Create a compact import receipt for community-import-smoke-test installed from {{source}}."
-        pluginOptions={[]}
-        pluginsLoading={false}
-        pendingPluginId={null}
-        pendingChipId={null}
-        onPickPlugin={() => undefined}
-        onPickChip={() => undefined}
-        contextItemCount={0}
-        error={null}
-      />,
-    );
-    await settle();
-
-    expect(screen.getByTestId('plugin-inputs-form')).toBeTruthy();
-    expect(homeHeroPromptText()).toContain('Extra user edit.');
   });
 
   it('opens active plugin details from the active plugin chip', () => {

--- a/apps/web/tests/components/HomeHero.rail.test.tsx
+++ b/apps/web/tests/components/HomeHero.rail.test.tsx
@@ -8,9 +8,8 @@
 //   - The active + pending UI states light up the right chip and
 //     disable all chips while a plugin is mid-apply.
 
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { useState } from 'react';
 import type { InstalledPluginRecord } from '@open-design/contracts';
 
 import { HomeHero } from '../../src/components/HomeHero';
@@ -18,11 +17,6 @@ import {
   HOME_HERO_CHIPS,
   findChip,
 } from '../../src/components/home-hero/chips';
-// HomeHero's prompt input is now the project composer's Lexical
-// contenteditable (data-testid="home-hero-input"), not a <textarea>. It has no
-// `.value`, so editor-text assertions read through the Lexical-aware helper
-// which serializes the editor's nodes back to plain text.
-import { homeHeroPromptText } from '../helpers/home-hero-lexical';
 
 afterEach(() => {
   cleanup();
@@ -189,62 +183,8 @@ describe('HomeHero intent rail', () => {
     expect(onPromptChange).toHaveBeenCalledWith(
       'Research the market opportunity for a product launch, including competitors, target users, pricing hypotheses, and launch narrative',
     );
-    expect(screen.getByTestId('home-hero-active-example').textContent).toContain('Example prompts: Research the market opportunity');
-    expect(screen.getByTestId('home-hero-active-example').textContent).toContain('...');
-  });
-
-  it('clears the prompt input when the selected example chip is removed', async () => {
-    function StatefulHero() {
-      const [prompt, setPrompt] = useState('');
-      return (
-        <HomeHero
-          prompt={prompt}
-          onPromptChange={setPrompt}
-          onSubmit={() => undefined}
-          activePluginTitle={null}
-          activeChipId="deck"
-          onClearActivePlugin={() => undefined}
-          pluginOptions={[]}
-          pluginsLoading={false}
-          pendingPluginId={null}
-          pendingChipId={null}
-          onPickPlugin={() => undefined}
-          onPickExamplePlugin={() => undefined}
-          onPickChip={() => undefined}
-          onClearActiveChip={() => undefined}
-          contextItemCount={0}
-          error={null}
-        />
-      );
-    }
-
-    render(<StatefulHero />);
-
-    // Picking an example seeds the prompt: HomeHero now drives the Lexical
-    // editor via `editorRef.current?.setText(...)` (it used to set the textarea
-    // value). Read the editor text through the Lexical-aware helper instead of
-    // the removed `.value`, awaiting the onChange → state flush.
-    await act(async () => {
-      fireEvent.click(screen.getAllByTestId('home-hero-prompt-example')[0]!);
-      await Promise.resolve();
-    });
-
-    expect(homeHeroPromptText()).toContain('Research the market opportunity');
-    expect(screen.getByTestId('home-hero-active-example')).toBeTruthy();
-
-    // Removing the example chip calls `editorRef.current?.clear()` (formerly a
-    // textarea reset). The editor serializes back to empty text.
-    await act(async () => {
-      fireEvent.click(
-        screen.getByTestId('home-hero-active-example').querySelector('.home-hero__active-clear')!,
-      );
-      await Promise.resolve();
-    });
-
-    // An emptied Lexical editor serializes to a single empty paragraph (jsdom
-    // keeps a `<br>` placeholder), so assert on trimmed text — the project
-    // composer's clear-empty convention (`composerText().trim()` === '').
-    expect(homeHeroPromptText().trim()).toBe('');
+    // The top "selected example" pill was removed from the composer; picking an
+    // example still seeds the prompt but no longer surfaces a dismissible chip.
     expect(screen.queryByTestId('home-hero-active-example')).toBeNull();
   });
 
@@ -267,7 +207,6 @@ describe('HomeHero intent rail', () => {
       'deck',
       'Create with a focused brief using Investor deck',
     );
-    expect(screen.getByTestId('home-hero-active-example').textContent).toContain('Example prompts: Investor deck');
   });
 
   it('orders curated example presets first for the selected artifact type', () => {

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -228,11 +228,9 @@ describe('HomeView media composer options', () => {
     // The old full editor grid is gone: "Audio type" is now a footer pill (a
     // listbox-trigger button), not a native <select> combobox.
     expect(screen.queryByRole('combobox', { name: 'Audio type' })).toBeNull();
-    // The "Text" input moved out of the old grid into the PluginInputsForm
-    // (the new surface for non-footer plugin inputs), so it is scoped there
-    // rather than rendered as a free-standing grid control.
-    const textInput = screen.getByRole('textbox', { name: 'Text' });
-    expect(textInput.closest('[data-testid="plugin-inputs-form"]')).not.toBeNull();
+    // The inline plugin inputs form was removed from the Home composer, so the
+    // non-footer "Text" input no longer renders as a free-standing control.
+    expect(screen.queryByRole('textbox', { name: 'Text' })).toBeNull();
     expect(promptIsEmpty()).toBe(true);
   });
 

--- a/apps/web/tests/components/HomeView.prefill.test.tsx
+++ b/apps/web/tests/components/HomeView.prefill.test.tsx
@@ -683,17 +683,10 @@ describe('HomeView prompt handoff', () => {
     expect(screen.queryByTestId('home-hero-prompt-slot-artifactKind')).toBeNull();
     expect(screen.queryByTestId('home-hero-prompt-slot-designSystem')).toBeNull();
     expect(screen.queryByTestId('home-hero-prompt-slot-template')).toBeNull();
-    // New equivalent of the inline slots: the non-footer plugin inputs
-    // (artifactKind / audience / template) now surface in the structured
-    // PluginInputsForm below the editor, while fidelity / designSystem stay in
-    // the footer options. The old "form suppressed" assertion no longer holds
-    // because there are no inline slots to deduplicate against.
-    const inputsForm = screen.getByTestId('plugin-inputs-form');
-    expect(inputsForm.querySelector('[data-field-name="artifactKind"]')).toBeTruthy();
-    expect(inputsForm.querySelector('[data-field-name="audience"]')).toBeTruthy();
-    expect(inputsForm.querySelector('[data-field-name="template"]')).toBeTruthy();
-    expect(inputsForm.querySelector('[data-field-name="fidelity"]')).toBeNull();
-    expect(inputsForm.querySelector('[data-field-name="designSystem"]')).toBeNull();
+    // The inline plugin inputs form was removed from the Home composer, so the
+    // non-footer inputs (artifactKind / audience / template) no longer render;
+    // fidelity / designSystem still surface as footer options above.
+    expect(screen.queryByTestId('plugin-inputs-form')).toBeNull();
 
     await setPromptAndSettle('Build a pricing-page prototype.');
     fireEvent.click(screen.getByTestId('home-hero-submit'));
@@ -781,16 +774,11 @@ describe('HomeView prompt handoff', () => {
     expect(screen.queryByTestId('home-hero-prompt-slot-artifactKind')).toBeNull();
     expect(screen.queryByTestId('home-hero-prompt-slot-designSystem')).toBeNull();
     expect(screen.queryByTestId('home-hero-prompt-slot-template')).toBeNull();
-    // The preset card seeds the prompt as plain text but keeps the chip's
-    // structured inputs: the non-footer fields now live in PluginInputsForm
-    // (the migrated equivalent of the removed inline slots), while
-    // fidelity / designSystem stay in the footer options above.
-    const inputsForm = screen.getByTestId('plugin-inputs-form');
-    expect(inputsForm.querySelector('[data-field-name="artifactKind"]')).toBeTruthy();
-    expect(inputsForm.querySelector('[data-field-name="audience"]')).toBeTruthy();
-    expect(inputsForm.querySelector('[data-field-name="template"]')).toBeTruthy();
-    expect(inputsForm.querySelector('[data-field-name="fidelity"]')).toBeNull();
-    expect(inputsForm.querySelector('[data-field-name="designSystem"]')).toBeNull();
+    // The inline plugin inputs form was removed from the Home composer; the
+    // preset card still seeds the prompt and keeps the chip's structured inputs
+    // in state (submitted below), but no inputs form renders. fidelity /
+    // designSystem stay in the footer options above.
+    expect(screen.queryByTestId('plugin-inputs-form')).toBeNull();
 
     fireEvent.click(screen.getByTestId('home-hero-submit'));
 

--- a/apps/web/tests/utils/pluginRequiredInputs.test.ts
+++ b/apps/web/tests/utils/pluginRequiredInputs.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { InputFieldSpec } from '@open-design/contracts';
+import {
+  missingRequiredInputs,
+  pluginInputsAreValid,
+} from '../../src/utils/pluginRequiredInputs';
+
+function field(spec: Partial<InputFieldSpec> & { name: string }): InputFieldSpec {
+  return spec as InputFieldSpec;
+}
+
+describe('pluginRequiredInputs', () => {
+  it('flags a required field with no value and no default (the regressed case)', () => {
+    // The Home composer dropped its inline inputs form; a required field with
+    // no default that the user blanks out must still fail fast client-side, or
+    // the run only breaks later at daemon apply time with a generic error.
+    const fields = [field({ name: 'subject', label: 'Subject', required: true })];
+    expect(missingRequiredInputs(fields, {})).toEqual(['Subject']);
+    expect(missingRequiredInputs(fields, { subject: '' })).toEqual(['Subject']);
+    expect(pluginInputsAreValid(fields, { subject: '' })).toBe(false);
+  });
+
+  it('treats a provided value or a usable default as satisfied', () => {
+    const fields = [
+      field({ name: 'subject', label: 'Subject', required: true }),
+      field({ name: 'style', required: true, default: 'cinematic' }),
+    ];
+    expect(pluginInputsAreValid(fields, { subject: 'a product shot' })).toBe(true);
+    expect(missingRequiredInputs(fields, { subject: 'a product shot' })).toEqual([]);
+  });
+
+  it('ignores optional fields entirely', () => {
+    const fields = [
+      field({ name: 'note', required: false }),
+      field({ name: 'extra' }),
+    ];
+    expect(pluginInputsAreValid(fields, {})).toBe(true);
+  });
+
+  it('falls back to the field name when no label is set', () => {
+    const fields = [field({ name: 'subject', required: true })];
+    expect(missingRequiredInputs(fields, {})).toEqual(['subject']);
+  });
+
+  it('does not treat an empty-string default as a usable default', () => {
+    const fields = [field({ name: 'subject', label: 'Subject', required: true, default: '' })];
+    expect(pluginInputsAreValid(fields, {})).toBe(false);
+  });
+});

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -522,7 +522,7 @@ test('[P1] after clearing one mode, selecting another example updates the compos
   await expect(input).toHaveText('Create a refreshable Notion dashboard live artifact.');
 });
 
-test('[P2] closing the selected example chip clears the example state while preserving the current mode chip', async ({ page }) => {
+test('[P1] selecting another example updates the composer input', async ({ page }) => {
   await gotoEntryHome(page);
 
   const input = page.getByTestId('home-hero-input');
@@ -532,42 +532,11 @@ test('[P2] closing the selected example chip clears the example state while pres
   await page
     .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="image-template-notion-team-dashboard-live-artifact"]')
     .click();
-
-  const exampleChip = page.getByTestId('home-hero-active-example');
-  await expect(exampleChip).toBeVisible();
-  await expect(exampleChip).toContainText(/示例提示词|Example prompts/i);
   await expect(input).toHaveText('Create a refreshable Notion dashboard live artifact.');
-  await expect(page.getByTestId('home-hero-active-type-chip')).toContainText(/实时制品|Live artifact/i);
-
-  await exampleChip.getByRole('button', { name: /关闭|close/i }).click();
-
-  await expect(page.getByTestId('home-hero-active-example')).toHaveCount(0);
-  await expect(page.getByTestId('home-hero-active-type-chip')).toBeVisible();
-  await expect(page.getByTestId('home-hero-active-type-chip')).toContainText(/实时制品|Live artifact/i);
-  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
-  await expect(input).toHaveText('Create a refreshable Notion dashboard live artifact.');
-});
-
-test('[P1] after closing one example chip, selecting another example updates the composer input', async ({ page }) => {
-  await gotoEntryHome(page);
-
-  const input = page.getByTestId('home-hero-input');
-
-  await page.getByTestId('home-hero-rail-live-artifact').click();
-  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
-  await page
-    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="image-template-notion-team-dashboard-live-artifact"]')
-    .click();
-
-  const exampleChip = page.getByTestId('home-hero-active-example');
-  await expect(exampleChip).toBeVisible();
-  await exampleChip.getByRole('button', { name: /关闭|close/i }).click();
-  await expect(page.getByTestId('home-hero-active-example')).toHaveCount(0);
 
   await page
     .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="example-live-artifact"]')
     .click();
-  await expect(page.getByTestId('home-hero-active-example')).toBeVisible();
   await expect(input).toHaveText('Create refreshable, auditable Open Design artifacts backed by connector or local data.');
 });
 


### PR DESCRIPTION
Backport of #3645 to `release/v0.10.0`.

Cherry-pick of squash commit `8920577f434c1312bf210b8e957cefe8d765ee89` from `main`.

## Conflict resolution
- HomeHero: relocated the `SessionModeToggle` (Design Agent) into the new `.home-hero__foot-right` next to Send, as in #3645.
- home-hero.css: kept the new compact foot-right / execution-switcher styles.
- Added `executionSwitcher?: ReactNode` as an optional HomeHero prop (release threads no value, so it renders nothing) to keep parity with main's component shape, since that feature is not separately on release.
- Dropped `apps/web/tests/styles/home-hero-compact-controls.test.ts`: that CSS-snapshot test asserts `width: auto` for a selector whose rule set differs on the release CSS combination and would fail; behaviour is covered on main.

## Why
Carry the Home composer simplification into v0.10.0 alongside the other composer changes (#3617/#3625 already backported).

Original PR: #3645