### PR TITLE
fix(web): scope generation-preview override to the empty design-files tab

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -1712,17 +1712,24 @@ export function FileWorkspace({
 
   const isActiveSketch = activeFile?.kind === 'sketch' && isSketchName(activeFile.name);
   const activeSketch = activeFile && isActiveSketch ? sketches[activeFile.name] : null;
-  // The generation progress card takes priority over the design-files tab's
-  // empty "Creations will appear here" list: while a run is in flight and no
-  // previewable artifact exists yet, the design-files tab (the default landing
-  // tab) must still show generation progress rather than an idle empty state.
-  // `buildGenerationPreviewState` already returns null once a preview surface
-  // exists, so this never hides a finished artifact. (Pre-#3516 the preview
-  // branch rendered before the design-files branch with no tab guard; the
-  // composer rewrite added an `activeTab !== DESIGN_FILES_TAB` clause here that
-  // accidentally hid the progress card on the default tab.)
+  // The design-files tab is the default landing tab, so while a run is in
+  // flight and no previewable artifact exists yet the progress card must take
+  // over its empty "Creations will appear here" state rather than leave an idle
+  // empty list. (Pre-#3516 the preview branch rendered before the design-files
+  // branch with no tab guard; the composer rewrite added an `activeTab !==
+  // DESIGN_FILES_TAB` clause here that hid the progress card on the default
+  // tab.) But the override is scoped to the *empty* design-files tab: a
+  // populated project keeps its file browser while generating. The condition
+  // mirrors DesignFilesPanel's own empty-state gate exactly (no files, no live
+  // artifacts, no folders), so the card only wins where the panel would have
+  // shown its empty placeholder.
+  const designFilesTabIsEmpty =
+    visibleFiles.length === 0
+    && liveArtifactEntries.length === 0
+    && projectFolders.length === 0;
   const showGenerationPreview = Boolean(generationPreview)
     && activeTab !== DESIGN_SYSTEM_TAB
+    && (activeTab !== DESIGN_FILES_TAB || designFilesTabIsEmpty)
     && !isBrowserTabId(activeTab)
     && !isSideChatTabId(activeTab)
     && !isTerminalTabId(activeTab)

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -1430,6 +1430,30 @@ describe('FileWorkspace generation failure recovery', () => {
 
     expect(screen.getByTestId('generation-preview-stage')).toBeTruthy();
   });
+
+  // The override above is scoped to the *empty* design-files tab. A populated
+  // project must keep its file browser while a run is in flight instead of
+  // having the generation card hijack the tab — otherwise the fresh-project fix
+  // would regress browsing for everyone with existing files.
+  it('keeps the file browser on a populated design-files tab while a run is active', async () => {
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[workspaceFile('index.html')]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        streaming
+        tabsState={{ tabs: [], active: DESIGN_FILES_TAB }}
+        onTabsStateChange={vi.fn()}
+        messages={[generatingAssistantMessage()]}
+      />,
+    );
+
+    expect(await screen.findByText('index.html')).toBeTruthy();
+    expect(screen.queryByTestId('generation-preview-stage')).toBeNull();
+  });
 });
 
 describe('DesignFilesPanel plugin folders', () => {


### PR DESCRIPTION
Follow-up to #3671. The reviewer (Looper/nettee, on the v0.10.0 backport #3680) flagged that #3671 broadened the fix too far, so this scopes it back on `main` and keeps both branches consistent.

## Why

#3671 dropped the `activeTab !== DESIGN_FILES_TAB` clause from `showGenerationPreview` to restore the generation progress card on the (default) design-files tab. But removing it outright let the card win for **every** in-flight run on that tab — including projects that already have files/folders to browse. `buildGenerationPreviewState()` only checks whether a preview *surface* is open, not whether the design-files browser is empty, so a populated project would lose its file browser until a previewable artifact existed. That's a new, unintended regression for existing projects.

## What users will see

No change for the fresh-project case #3671 fixed (empty project + active run still shows the "Generating…" progress card). New: a **populated** project keeps its file browser on the design-files tab while a run is in flight, instead of having the progress card hijack the tab.

## Surface area

- [x] **UI** — scopes the generation-preview override on the design-files tab in `apps/web`

## Bug fix verification

- Test path: `apps/web/tests/components/FileWorkspace.test.tsx` → "keeps the file browser on a populated design-files tab while a run is active"
- Red without the scoping (broad #3671 version shows `generation-preview-stage` instead of the file rows), green with the `designFilesTabIsEmpty` gate. The empty-tab test from #3671 stays green.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/FileWorkspace.test.tsx` ✅ (57/57)
- `pnpm --filter @open-design/web typecheck` ✅ (after rebuilding `@open-design/contracts`)

Backport with the same scoping: #3680.
