### PR TITLE
ci(release): throttle the per-push nightly build instead of debouncing it (#3682)

### DIFF
--- a/.github/workflows/notify-release-feishu.yml
+++ b/.github/workflows/notify-release-feishu.yml
@@ -4,7 +4,11 @@ name: notify-release-feishu
 # release-stable (channel=nightly), then post a Feishu card with the download
 # links (macOS arm64 + Intel, Windows, and Linux when enabled) and the changelog
 # since the previously published nightly. Consecutive pushes to the same branch
-# are debounced: a newer push cancels the in-flight build.
+# are throttled, not debounced: an in-flight build is allowed to finish (so a
+# busy release branch always produces a nightly), while pushes that arrive
+# during it coalesce into a single trailing build of the latest commit. With
+# cancel-in-progress the previous behavior starved — pushes spaced closer than
+# the build duration kept cancelling each other and no package was ever cut.
 
 on:
   push:
@@ -17,7 +21,12 @@ permissions:
 
 concurrency:
   group: feishu-release-${{ github.ref }}
-  cancel-in-progress: true
+  # Throttle, not debounce: let the running build finish and coalesce the
+  # queued pushes into one trailing build. GitHub keeps the in-progress run and
+  # only the newest pending run in the group (older pending runs are cancelled),
+  # so a busy release branch still cuts a nightly and converges on the latest
+  # commit, at most one build running plus one queued.
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
Cherry-pick of #3682 (squash `668d556`) onto `release/v0.10.0`. Clean cherry-pick, one file.

## Why

Backports the release-nightly throttle fix to v0.10.0. On `main` this shipped as #3682. **This branch is where it matters most**: `notify-release-feishu` is a `push` workflow, so it runs from the *pushed branch's* definition — release/v0.10.0 needs the change for its own pushes to stop starving.

`cancel-in-progress: true` cancelled the in-flight nightly on every push, so a busy release branch (pushes closer together than a cross-platform build takes) never cut a nightly. Observed on release/v0.10.0 today: a run of consecutive pushes all `cancelled`, last successful nightly hours old.

## What users will see

Pushing to `release/v0.10.0` reliably produces a nightly + Feishu card again; bursts of commits coalesce into one trailing build of the latest commit.

## Surface area

- [x] **None** — CI workflow concurrency change only (`.github/workflows/notify-release-feishu.yml`).

## The change

`cancel-in-progress: true` → `false` (throttle): the running build finishes, queued pushes coalesce (GitHub keeps the in-progress run + only the newest pending run), converging on the latest commit with at most one build running + one queued.

## Validation

- Clean cherry-pick of the squashed `main` commit (already passed CI + Looper approval on #3682). `pnpm guard` passed there. CI re-runs here.
