### PR TITLE
fix(github): tighten bug report preflight

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,6 @@
 name: 🐛 Bug report
 description: Something isn't working as expected in Open Design.
+title: "[Bug]: "
 labels: ["bug"]
 body:
   - type: markdown
@@ -9,12 +10,23 @@ body:
 
         Before you submit:
         - Check whether the issue is already reported in [open issues](https://github.com/nexu-io/open-design/issues?q=is%3Aissue).
+        - Replace example text with your actual bug details. Placeholder reports like `testing` or `0.0.0` are not actionable.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you submit
+      options:
+        - label: I searched existing issues and confirmed this is not a duplicate.
+          required: true
+        - label: I replaced the example text with the real behavior, reproduction steps, expected result, and version from the app's About menu or `od --version`.
+          required: true
 
   - type: textarea
     id: description
     attributes:
       label: What happened?
-      description: A clear and concise description of the bug.
+      description: Describe the real bug you hit, not example or placeholder text.
       placeholder: When I do X, I expected Y but I see Z.
     validations:
       required: true
@@ -44,7 +56,7 @@ body:
     attributes:
       label: Open Design version
       description: Find this in the app's About menu, or run `od --version`.
-      placeholder: e.g. 0.7.0
+      placeholder: e.g. 0.8.0 or 0.8.0-preview.2
     validations:
       required: true
 


### PR DESCRIPTION
Closes #3007

## Why

Issue #3007 was effectively a placeholder bug report: the title and required fields were filled with example text like `testing` and `0.0.0`, which still produced a triageable bug issue. Tightening the bug-report form reduces this low-signal intake and makes future reports more actionable for maintainers.

## What users will see

When someone opens the bug-report form, they now see a `[Bug]: ` title prefix, an explicit warning not to submit placeholder content, and required preflight checkboxes confirming they searched for duplicates and replaced the example text with real reproduction details and a real version.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots


## Bug fix verification

- Test path that reproduces the bug: not applicable; this change is a GitHub issue form update rather than runtime product code.
- Did the test go red on `main` and green on this branch? no
- A red spec was not cheap to write because GitHub validates issue forms outside the app/runtime test harness. Verification was done by parsing `.github/ISSUE_TEMPLATE/bug-report.yml` with Ruby YAML and confirming the new title metadata and required preflight checkboxes.

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm typecheck`
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/ISSUE_TEMPLATE/bug-report.yml"); raise "missing title" unless data["title"] == "[Bug]: "; raise "missing preflight" unless data.fetch("body")[1].fetch("type") == "checkboxes"; puts "YAML OK"'`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>