### PR TITLE
fix(pi): raise detection timeouts and harden Windows npm prefix resolution

### DIFF
--- a/apps/daemon/src/runtimes/defs/pi.ts
+++ b/apps/daemon/src/runtimes/defs/pi.ts
@@ -7,13 +7,18 @@ export const piAgentDef = {
     name: 'Pi',
     bin: 'pi',
     versionArgs: ['--version'],
+    // On Windows, pi cold-starts in ~5s solo and 11–15s+ under parallel agent
+    // detection load (Windows Defender scans its 593-file node_modules tree on
+    // every spawn). The default 3s version-probe timeout is too tight; raise it
+    // so detection doesn't silently abort before reaching fetchModels.
+    versionProbeTimeoutMs: 15_000,
     // `pi --list-models` prints a TSV table to stderr (not stdout),
     // so we use a custom fetchModels that reads stderr.
     fetchModels: async (resolvedBin, env) => {
       try {
         const { stderr } = await execAgentFile(resolvedBin, ['--list-models'], {
           env,
-          timeout: 20_000,
+          timeout: 60_000, // Windows: 20s exceeded under parallel detection load
           maxBuffer: 8 * 1024 * 1024,
         });
         const parsed = parsePiModels(stderr);

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -920,8 +920,22 @@ export function wellKnownUserToolchainBins(
   if (typeof npmPrefixRaw === "string") {
     const npmPrefix = npmPrefixRaw.trim();
     if (npmPrefix.length > 0) {
-      dirs.push(join(npmPrefix, "bin"));
+      // On Unix, npm global binaries land in <prefix>/bin.
+      // On Windows, npm installs them directly into the prefix root — there is
+      // no /bin subdirectory. Check which layout is present so both platforms
+      // resolve correctly.
+      const npmBinDir = join(npmPrefix, "bin");
+      dirs.push(existsSync(npmBinDir) ? npmBinDir : npmPrefix);
     }
+  }
+  // Always probe npm's default Windows install location (%APPDATA%\npm) as a
+  // fallback. NPM_CONFIG_PREFIX / npm_config_prefix are npm-internal env vars
+  // that are often absent in Electron child-process environments, so the block
+  // above silently no-ops for most Windows users. The default prefix is
+  // deterministic and safe to add unconditionally.
+  if (process.platform === "win32") {
+    const appDataNpm = join(home, "AppData", "Roaming", "npm");
+    if (existsSync(appDataNpm)) dirs.push(appDataNpm);
   }
   dirs.push(
     join(home, ".local", "bin"),

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -920,22 +920,26 @@ export function wellKnownUserToolchainBins(
   if (typeof npmPrefixRaw === "string") {
     const npmPrefix = npmPrefixRaw.trim();
     if (npmPrefix.length > 0) {
-      // On Unix, npm global binaries land in <prefix>/bin.
-      // On Windows, npm installs them directly into the prefix root — there is
-      // no /bin subdirectory. Check which layout is present so both platforms
-      // resolve correctly.
-      const npmBinDir = join(npmPrefix, "bin");
-      dirs.push(existsSync(npmBinDir) ? npmBinDir : npmPrefix);
+      // Unix: npm global binaries live in <prefix>/bin. Always add it as a
+      // search-path candidate — existence is irrelevant for a PATH directory,
+      // and this preserves the long-standing helper contract.
+      dirs.push(join(npmPrefix, "bin"));
+      // Windows: npm installs global binaries directly into the prefix root
+      // (there is no /bin subdirectory), so add the root as well. Additive —
+      // the <prefix>/bin entry above is left untouched for cross-platform
+      // parity.
+      if (process.platform === "win32") {
+        dirs.push(npmPrefix);
+      }
     }
   }
-  // Always probe npm's default Windows install location (%APPDATA%\npm) as a
-  // fallback. NPM_CONFIG_PREFIX / npm_config_prefix are npm-internal env vars
-  // that are often absent in Electron child-process environments, so the block
-  // above silently no-ops for most Windows users. The default prefix is
-  // deterministic and safe to add unconditionally.
+  // Windows: %APPDATA%\npm is npm's default global prefix. NPM_CONFIG_PREFIX /
+  // npm_config_prefix are npm-internal vars that are usually absent in Electron
+  // child-process environments, so the block above no-ops for most Windows
+  // users. Add the default location unconditionally — consistent with the
+  // conventional dirs below, which are also added without an existence check.
   if (process.platform === "win32") {
-    const appDataNpm = join(home, "AppData", "Roaming", "npm");
-    if (existsSync(appDataNpm)) dirs.push(appDataNpm);
+    dirs.push(join(home, "AppData", "Roaming", "npm"));
   }
   dirs.push(
     join(home, ".local", "bin"),

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -791,6 +791,93 @@ describe("wellKnownUserToolchainBins", () => {
     }
   });
 
+  // Windows: npm installs global binaries directly into the prefix root, not
+  // a <prefix>/bin subdirectory. The helper must surface BOTH the canonical
+  // Unix <prefix>/bin (cross-platform parity, no regression) AND the Windows
+  // prefix root so `npm i -g`'d CLIs like `pi` resolve under GUI launchers.
+  it("adds the npm prefix root alongside <prefix>/bin on Windows", () => {
+    const originalPlatform = process.platform;
+    const home = mkdtempSync(join(tmpdir(), "wkutb-win-prefix-"));
+    const customPrefix = mkdtempSync(join(tmpdir(), "wkutb-win-custom-"));
+    try {
+      Object.defineProperty(process, "platform", {
+        configurable: true,
+        value: "win32",
+      });
+      const dirs = wellKnownUserToolchainBins({
+        home,
+        env: { NPM_CONFIG_PREFIX: customPrefix },
+        includeSystemBins: false,
+      });
+      // <prefix>/bin is preserved (contract unchanged) AND the root is added.
+      expect(dirs).toContain(join(customPrefix, "bin"));
+      expect(dirs).toContain(customPrefix);
+    } finally {
+      Object.defineProperty(process, "platform", {
+        configurable: true,
+        value: originalPlatform,
+      });
+      rmSync(home, { recursive: true, force: true });
+      rmSync(customPrefix, { recursive: true, force: true });
+    }
+  });
+
+  // Regression for #3691. NPM_CONFIG_PREFIX / npm_config_prefix are npm-internal
+  // env vars usually absent in Electron child processes, so the env-driven block
+  // no-ops for most Windows users. %APPDATA%\npm (npm's default global prefix)
+  // must still be surfaced so globally-installed agent CLIs are detected.
+  it("always adds %APPDATA%\\npm as a fallback on Windows even without a prefix env var", () => {
+    const originalPlatform = process.platform;
+    const home = mkdtempSync(join(tmpdir(), "wkutb-win-appdata-"));
+    try {
+      Object.defineProperty(process, "platform", {
+        configurable: true,
+        value: "win32",
+      });
+      const dirs = wellKnownUserToolchainBins({
+        home,
+        env: {},
+        includeSystemBins: false,
+      });
+      expect(dirs).toContain(join(home, "AppData", "Roaming", "npm"));
+    } finally {
+      Object.defineProperty(process, "platform", {
+        configurable: true,
+        value: originalPlatform,
+      });
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  // Guards the no-regression promise: the Windows-only additions must never
+  // leak onto POSIX hosts, where <prefix>/bin is the only correct entry.
+  it("does not add the npm prefix root or %APPDATA%\\npm on POSIX", () => {
+    const originalPlatform = process.platform;
+    const home = mkdtempSync(join(tmpdir(), "wkutb-posix-prefix-"));
+    const customPrefix = mkdtempSync(join(tmpdir(), "wkutb-posix-custom-"));
+    try {
+      Object.defineProperty(process, "platform", {
+        configurable: true,
+        value: "linux",
+      });
+      const dirs = wellKnownUserToolchainBins({
+        home,
+        env: { NPM_CONFIG_PREFIX: customPrefix },
+        includeSystemBins: false,
+      });
+      expect(dirs).toContain(join(customPrefix, "bin"));
+      expect(dirs).not.toContain(customPrefix);
+      expect(dirs).not.toContain(join(home, "AppData", "Roaming", "npm"));
+    } finally {
+      Object.defineProperty(process, "platform", {
+        configurable: true,
+        value: originalPlatform,
+      });
+      rmSync(home, { recursive: true, force: true });
+      rmSync(customPrefix, { recursive: true, force: true });
+    }
+  });
+
   it("prepends $VP_HOME/bin and expands ~/ so custom Vite+ homes outrank the default", () => {
     const home = mkdtempSync(join(tmpdir(), "wkutb-vp-home-"));
     try {


### PR DESCRIPTION
Fixes #3691

## Why

On Windows, the Pi agent populates with the **generic hardcoded fallback model list** (Claude Sonnet, GPT-5, Gemini) instead of the user's real provider models (e.g. `prometheus-anemoi`, `prometheus-llama-swap`). Pi works perfectly from a terminal, so the CLI itself is fine.

**Root cause — detection timeouts, not PATH resolution.** Pi cold-starts in ~5s solo and 11–15s+ under parallel agent detection because Windows Defender scans its 593-file `node_modules` tree on every spawn. The daemon runs all agent probes concurrently (`Promise.all` in `detectAgents()`), so Pi's `--list-models` exceeds its 20s budget, `fetchModels` silently catches the timeout, returns `null`, and the agent falls back to the generic list.

`%APPDATA%\Roaming\npm` is already on PATH for a standard npm install, and `buildCmdShimInvocation` already quotes shim paths with spaces correctly — so the detection infrastructure is sound. Only the timeouts (and, defensively, the npm-prefix search path) needed adjusting.

| Spawn context | `pi --version` | `pi --list-models` |
|---|---|---|
| Shell (Git Bash) | ~1s | ~1.2s |
| Cold via `execFile` + cmd.exe shim | ~4.7s | ~5.3s |
| 8× parallel (simulating `Promise.all` detection) | — | **11–15s each** |

## What users will see

Windows users with `pi` installed globally via npm will now see their **real, live model list** in the Pi agent picker (Settings → Execution mode), with the **Live from CLI** badge — instead of a generic fallback list of models they may not even have access to. No more silent `[test:agent] Pi → timeout` during startup detection. macOS/Linux behavior is unchanged.

## Surface area

- [ ] **UI** — small assistant-message card in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-*` flag, or new `OD_*` env var
- [ ] **API / contract** — new SSE event or run status field in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — on Windows, the Pi agent now surfaces live CLI models where it previously fell back to the static list under detection-timeout conditions. The platform PATH helper additionally surfaces the Windows npm prefix root and `%APPDATA%\npm`. POSIX behavior is unchanged.
- [ ] **None**

## Changes

### `apps/daemon/src/runtimes/defs/pi.ts`
- Add `versionProbeTimeoutMs: 15_000` — the 3s default is too tight for Windows cold-start (~5s solo). Same pattern already used by `trae-cli.ts` (`10_000`).
- Raise `fetchModels` timeout `20_000` → `60_000` to absorb 11–15s spawn times under parallel detection load.

### `packages/platform/src/index.ts` — `wellKnownUserToolchainBins()`
- **Additive, non-regressing.** The env-driven `<prefix>/bin` entry is always pushed unchanged on every platform (preserves the existing contract).
- On Windows only, also push the prefix **root** (Windows npm installs binaries into `<prefix>` directly, with no `bin` subdirectory) and `%APPDATA%\Roaming\npm` (npm's default global prefix — `NPM_CONFIG_PREFIX`/`npm_config_prefix` are npm-internal vars usually absent in Electron child processes, so the env-driven block no-ops for most Windows users).

## Bug fix verification

- The bug is environment-dependent (Windows Defender + parallel-spawn timing), so it does not reproduce deterministically in CI on Linux. Verified manually on Windows 11 (pi 0.78.0): simulating the daemon's exact spawn path (`execFile("cmd.exe", ["/d","/s","/c", '"\"…\\pi.cmd\" --list-models"'], { windowsVerbatimArguments: true })`) returns all 16 live models, and `parsePiModels` parses them correctly. The 8× parallel benchmark above demonstrates the timeout pressure the new budgets absorb.
- New unit tests cover the platform-helper contract change (see Validation).

## Validation

- `pnpm --filter @open-design/platform test` — **57 passed** (includes 3 new Windows/POSIX npm-prefix tests)
- `pnpm --filter @open-design/platform typecheck` — clean
- `pnpm --filter @open-design/daemon typecheck` — clean

Local note: run under Node `v26.1.0`, so pnpm printed the repo's expected `node: ~24` engine warning.
