### PR TITLE
Allow sandbox imports from explicit roots

### DIFF
--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -7,7 +7,7 @@ import {
   inlineRelativeAssets,
   type InlineAssetReader,
 } from './inline-assets.js';
-import { isSandboxModeEnabled } from './sandbox-mode.js';
+import { sandboxImportedProjectRootUnavailableReason } from './sandbox-mode.js';
 
 export interface RegisterImportRoutesDeps extends RouteDeps<'db' | 'http' | 'uploads' | 'node' | 'ids' | 'paths' | 'imports' | 'auth' | 'projectStore' | 'conversations' | 'projectFiles' | 'validation'> {}
 
@@ -30,11 +30,6 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
   const { insertConversation } = ctx.conversations;
   const { setTabs } = ctx.projectFiles;
   const { validateProjectDesignSystemId } = ctx.validation;
-  const rejectSandboxFolderImport = () =>
-    isSandboxModeEnabled(process.env)
-      ? 'folder imports are disabled when OD_SANDBOX_MODE is enabled'
-      : null;
-
   app.post(
     '/api/import/claude-design',
     importUpload.single('file'),
@@ -114,10 +109,6 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
       if (typeof baseDir !== 'string' || !baseDir.trim()) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'baseDir required');
       }
-      const sandboxReason = rejectSandboxFolderImport();
-      if (sandboxReason) {
-        return sendApiError(res, 400, 'BAD_REQUEST', sandboxReason);
-      }
       let trustedPickerImport = false;
       if (isDesktopAuthGateActive()) {
         const secret = desktopAuthSecret();
@@ -185,6 +176,10 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
       ) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'cannot point at the data directory');
       }
+      const sandboxReason = sandboxImportedProjectRootUnavailableReason(normalizedPath);
+      if (sandboxReason) {
+        return sendApiError(res, 400, 'BAD_REQUEST', sandboxReason);
+      }
 
       const entryFile = await detectEntryFile(normalizedPath);
       const existingMeta = existing.metadata ?? {};
@@ -217,10 +212,6 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
       const { baseDir, name, skillId, designSystemId } = req.body || {};
       if (typeof baseDir !== 'string' || !baseDir.trim()) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'baseDir required');
-      }
-      const sandboxReason = rejectSandboxFolderImport();
-      if (sandboxReason) {
-        return sendApiError(res, 400, 'BAD_REQUEST', sandboxReason);
       }
       let trustedPickerImport = false;
       if (isDesktopAuthGateActive()) {
@@ -300,6 +291,10 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
         normalizedPath.startsWith(RUNTIME_DATA_DIR_CANONICAL + path.sep)
       ) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'cannot import the data directory');
+      }
+      const sandboxReason = sandboxImportedProjectRootUnavailableReason(normalizedPath);
+      if (sandboxReason) {
+        return sendApiError(res, 400, 'BAD_REQUEST', sandboxReason);
       }
 
       const id = randomId();

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -203,7 +203,7 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
       const body = { project: updated, baseDir: normalizedPath, entryFile };
       res.json(body);
     } catch (err: any) {
-      sendApiError(res, 400, 'BAD_REQUEST', String(err));
+      sendApiError(res, 400, 'BAD_REQUEST', String(err?.message || err));
     }
   });
 
@@ -347,7 +347,7 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
       const body = { project, conversationId: cid, entryFile };
       res.json(body);
     } catch (err: any) {
-      sendApiError(res, 400, 'BAD_REQUEST', String(err));
+      sendApiError(res, 400, 'BAD_REQUEST', String(err?.message || err));
     }
   });
 

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -26,7 +26,11 @@ import {
   isPublicationGuardedArtifactKind,
 } from './artifact-publication-guard.js';
 import { isIgnoredProjectDirName } from './project-ignored-dirs.js';
-import { isSandboxModeEnabled } from './sandbox-mode.js';
+import {
+  isSandboxImportedProjectRootAllowed,
+  isSandboxModeEnabled,
+  SANDBOX_IMPORTED_PROJECT_UNAVAILABLE_MESSAGE,
+} from './sandbox-mode.js';
 
 const FORBIDDEN_SEGMENT = /^$|^\.\.?$/;
 const RESERVED_PROJECT_FILE_SEGMENTS = new Set(['.live-artifacts']);
@@ -51,9 +55,7 @@ export class SandboxImportedProjectError extends Error {
   code = 'SANDBOX_IMPORTED_PROJECT_UNAVAILABLE';
 
   constructor() {
-    super(
-      'Imported-folder projects are not available in OD_SANDBOX_MODE until their files are mirrored into the managed project directory.',
-    );
+    super(SANDBOX_IMPORTED_PROJECT_UNAVAILABLE_MESSAGE);
     this.name = 'SandboxImportedProjectError';
   }
 }
@@ -64,14 +66,19 @@ function hasExternalProjectRoot(metadata?) {
 }
 
 export function assertSandboxProjectRootAvailable(metadata?) {
-  if (isSandboxModeEnabled(process.env) && hasExternalProjectRoot(metadata)) {
+  if (
+    isSandboxModeEnabled(process.env) &&
+    hasExternalProjectRoot(metadata) &&
+    !isSandboxImportedProjectRootAllowed(metadata.baseDir)
+  ) {
     throw new SandboxImportedProjectError();
   }
 }
 
 function usesExternalProjectRoot(metadata?) {
-  if (isSandboxModeEnabled(process.env)) return false;
-  return hasExternalProjectRoot(metadata);
+  if (!hasExternalProjectRoot(metadata)) return false;
+  if (!isSandboxModeEnabled(process.env)) return true;
+  return isSandboxImportedProjectRootAllowed(metadata.baseDir);
 }
 
 // Returns the folder a project's files live in. For git-linked projects

--- a/apps/daemon/src/sandbox-mode.ts
+++ b/apps/daemon/src/sandbox-mode.ts
@@ -4,6 +4,10 @@ import path from 'node:path';
 import { resolveProjectRelativePath } from './home-expansion.js';
 
 export const SANDBOX_MODE_ENV = 'OD_SANDBOX_MODE';
+export const SANDBOX_IMPORT_ALLOWED_ROOTS_ENV = 'OD_SANDBOX_IMPORT_ALLOWED_ROOTS';
+export const SANDBOX_IMPORTED_PROJECT_UNAVAILABLE_MESSAGE =
+  `Imported-folder projects are not available in ${SANDBOX_MODE_ENV} unless ` +
+  `their root is under ${SANDBOX_IMPORT_ALLOWED_ROOTS_ENV}.`;
 
 export interface SandboxRuntimeRoots {
   agentHomeDir: string;
@@ -40,6 +44,56 @@ export function isSandboxModeEnabled(
     `${SANDBOX_MODE_ENV} must be one of ${Array.from(TRUTHY_VALUES).join(', ')} ` +
       `or ${Array.from(FALSY_VALUES).join(', ')}`,
   );
+}
+
+function configuredSandboxImportRoots(
+  env: Record<string, string | undefined>,
+): string[] {
+  const raw = env[SANDBOX_IMPORT_ALLOWED_ROOTS_ENV];
+  if (typeof raw !== 'string' || !raw.trim()) return [];
+  return raw
+    .split(path.delimiter)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function canonicalizePathForContainment(value: string): string {
+  const resolved = path.resolve(value);
+  try {
+    return fs.realpathSync.native(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function isPathInsideDir(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+export function sandboxImportAllowedRoots(
+  env: Record<string, string | undefined> = process.env,
+): string[] {
+  return configuredSandboxImportRoots(env).map(canonicalizePathForContainment);
+}
+
+export function isSandboxImportedProjectRootAllowed(
+  projectRoot: string,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  if (!isSandboxModeEnabled(env)) return true;
+  const candidate = canonicalizePathForContainment(projectRoot);
+  return sandboxImportAllowedRoots(env).some((root) => isPathInsideDir(root, candidate));
+}
+
+export function sandboxImportedProjectRootUnavailableReason(
+  projectRoot: string,
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  if (!isSandboxModeEnabled(env)) return null;
+  return isSandboxImportedProjectRootAllowed(projectRoot, env)
+    ? null
+    : SANDBOX_IMPORTED_PROJECT_UNAVAILABLE_MESSAGE;
 }
 
 export function resolveSandboxRuntimeConfig(

--- a/apps/daemon/src/sandbox-mode.ts
+++ b/apps/daemon/src/sandbox-mode.ts
@@ -8,6 +8,8 @@ export const SANDBOX_IMPORT_ALLOWED_ROOTS_ENV = 'OD_SANDBOX_IMPORT_ALLOWED_ROOTS
 export const SANDBOX_IMPORTED_PROJECT_UNAVAILABLE_MESSAGE =
   `Imported-folder projects are not available in ${SANDBOX_MODE_ENV} unless ` +
   `their root is under ${SANDBOX_IMPORT_ALLOWED_ROOTS_ENV}.`;
+export const SANDBOX_IMPORT_ALLOWED_ROOTS_INVALID_MESSAGE =
+  `${SANDBOX_IMPORT_ALLOWED_ROOTS_ENV} entries must be absolute paths.`;
 
 export interface SandboxRuntimeRoots {
   agentHomeDir: string;
@@ -51,14 +53,19 @@ function configuredSandboxImportRoots(
 ): string[] {
   const raw = env[SANDBOX_IMPORT_ALLOWED_ROOTS_ENV];
   if (typeof raw !== 'string' || !raw.trim()) return [];
-  return raw
+  const roots = raw
     .split(path.delimiter)
     .map((part) => part.trim())
     .filter(Boolean);
+  const relativeRoot = roots.find((root) => !path.isAbsolute(path.normalize(root)));
+  if (relativeRoot) {
+    throw new Error(`${SANDBOX_IMPORT_ALLOWED_ROOTS_INVALID_MESSAGE} Got: ${relativeRoot}`);
+  }
+  return roots;
 }
 
 function canonicalizePathForContainment(value: string): string {
-  const resolved = path.resolve(value);
+  const resolved = path.normalize(value);
   try {
     return fs.realpathSync.native(resolved);
   } catch {

--- a/apps/daemon/tests/folder-import-projects.test.ts
+++ b/apps/daemon/tests/folder-import-projects.test.ts
@@ -23,6 +23,17 @@ function withSandboxMode<T>(run: () => T): T {
   }
 }
 
+function withSandboxImportAllowedRoots<T>(roots: string[], run: () => T): T {
+  const previous = process.env.OD_SANDBOX_IMPORT_ALLOWED_ROOTS;
+  process.env.OD_SANDBOX_IMPORT_ALLOWED_ROOTS = roots.join(path.delimiter);
+  try {
+    return run();
+  } finally {
+    if (previous == null) delete process.env.OD_SANDBOX_IMPORT_ALLOWED_ROOTS;
+    else process.env.OD_SANDBOX_IMPORT_ALLOWED_ROOTS = previous;
+  }
+}
+
 describe('resolveProjectDir', () => {
   const projectsRoot = '/var/od/projects';
   const projectId = 'proj-abc';
@@ -81,6 +92,20 @@ describe('resolveProjectDir', () => {
         kind: 'prototype',
         baseDir,
       })).toThrowError();
+    });
+  });
+
+  it('uses metadata.baseDir in sandbox mode when it is under an allowed import root', () => {
+    withSandboxMode(() => {
+      const baseDir = '/Users/me/scratch/od-clone/job-1';
+      withSandboxImportAllowedRoots(['/Users/me/scratch/od-clone'], () => {
+        expect(
+          resolveProjectDir(projectsRoot, projectId, { kind: 'prototype', baseDir }),
+        ).toBe(path.normalize(baseDir));
+        expect(() =>
+          assertSandboxProjectRootAvailable({ kind: 'prototype', baseDir }),
+        ).not.toThrow();
+      });
     });
   });
 });

--- a/apps/daemon/tests/folder-import-projects.test.ts
+++ b/apps/daemon/tests/folder-import-projects.test.ts
@@ -108,6 +108,17 @@ describe('resolveProjectDir', () => {
       });
     });
   });
+
+  it('rejects relative sandbox import allowed roots', () => {
+    withSandboxMode(() => {
+      const baseDir = path.join(path.parse(process.cwd()).root, 'tmp', 'od-clone', 'job-1');
+      withSandboxImportAllowedRoots(['tmp'], () => {
+        expect(() =>
+          assertSandboxProjectRootAvailable({ kind: 'prototype', baseDir }),
+        ).toThrowError(/OD_SANDBOX_IMPORT_ALLOWED_ROOTS.*absolute/i);
+      });
+    });
+  });
 });
 
 describe('detectEntryFile', () => {

--- a/apps/daemon/tests/folder-import-route.test.ts
+++ b/apps/daemon/tests/folder-import-route.test.ts
@@ -151,6 +151,20 @@ describe('POST /api/import/folder', () => {
     });
   });
 
+  it('rejects relative sandbox import allowed roots', async () => {
+    await withSandboxMode(async () => {
+      const folder = makeFolder();
+      await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+
+      await withSandboxImportAllowedRoots(['tmp'], async () => {
+        const resp = await importFolder({ baseDir: folder });
+        expect(resp.status).toBe(400);
+        const body = (await resp.json()) as { error?: { message?: string } };
+        expect(body.error?.message).toMatch(/OD_SANDBOX_IMPORT_ALLOWED_ROOTS.*absolute/i);
+      });
+    });
+  });
+
   it('rejects sandbox runs for imported folders before creating a run', async () => {
     const folder = makeFolder();
     await writeFile(path.join(folder, 'index.html'), '<!doctype html>');

--- a/apps/daemon/tests/folder-import-route.test.ts
+++ b/apps/daemon/tests/folder-import-route.test.ts
@@ -56,6 +56,20 @@ describe('POST /api/import/folder', () => {
     }
   }
 
+  async function withSandboxImportAllowedRoots<T>(
+    roots: string[],
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const previous = process.env.OD_SANDBOX_IMPORT_ALLOWED_ROOTS;
+    process.env.OD_SANDBOX_IMPORT_ALLOWED_ROOTS = roots.join(path.delimiter);
+    try {
+      return await run();
+    } finally {
+      if (previous == null) delete process.env.OD_SANDBOX_IMPORT_ALLOWED_ROOTS;
+      else process.env.OD_SANDBOX_IMPORT_ALLOWED_ROOTS = previous;
+    }
+  }
+
   it('creates a project rooted at the submitted folder', async () => {
     const folder = makeFolder();
     await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
@@ -93,6 +107,47 @@ describe('POST /api/import/folder', () => {
       expect(resp.status).toBe(400);
       const body = (await resp.json()) as { error?: { message?: string } };
       expect(body.error?.message).toMatch(/OD_SANDBOX_MODE/i);
+    });
+  });
+
+  it('allows sandbox folder imports under an explicit import root', async () => {
+    await withSandboxMode(async () => {
+      const root = makeFolder();
+      const folder = path.join(root, 'job-clone');
+      await mkdir(folder, { recursive: true });
+      await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+
+      await withSandboxImportAllowedRoots([root], async () => {
+        const resp = await importFolder({ baseDir: folder });
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as {
+          project: { id: string; metadata?: { baseDir?: string; importedFrom?: string } };
+          entryFile: string | null;
+        };
+        expect(body.project.metadata?.baseDir).toBe(await realpath(folder));
+        expect(body.project.metadata?.importedFrom).toBe('folder');
+        expect(body.entryFile).toBe('index.html');
+
+        const filesResp = await fetch(`${baseUrl}/api/projects/${body.project.id}/files`);
+        expect(filesResp.status).toBe(200);
+        const filesBody = (await filesResp.json()) as { files: Array<{ name: string }> };
+        expect(filesBody.files.map((file) => file.name)).toContain('index.html');
+      });
+    });
+  });
+
+  it('rejects sandbox folder imports outside the explicit import roots', async () => {
+    await withSandboxMode(async () => {
+      const allowedRoot = makeFolder();
+      const folder = makeFolder();
+      await writeFile(path.join(folder, 'index.html'), '<!doctype html>');
+
+      await withSandboxImportAllowedRoots([allowedRoot], async () => {
+        const resp = await importFolder({ baseDir: folder });
+        expect(resp.status).toBe(400);
+        const body = (await resp.json()) as { error?: { message?: string } };
+        expect(body.error?.message).toMatch(/OD_SANDBOX_IMPORT_ALLOWED_ROOTS/i);
+      });
     });
   });
 


### PR DESCRIPTION
## Why

Sandboxed daemon deployments currently reject every `POST /api/import/folder` request while `OD_SANDBOX_MODE=1` is enabled. That is a useful default for arbitrary local folders, but it blocks external orchestrators that prepare a disposable workspace clone and then need the daemon to run a code harness inside that clone.

This PR keeps the default rejection, then adds an explicit realpath allowlist so sandboxed deployments can opt in to imports only from known mounted scratch roots. The pain addressed is operational: without a scoped import root, callers must choose between disabling sandbox mode or giving the harness direct access to a live workspace.

## What users will see

No UI change. Operators of sandboxed daemon deployments can set `OD_SANDBOX_IMPORT_ALLOWED_ROOTS` to a path-delimited list of directories. Folder imports under those roots work in sandbox mode; imports outside those roots keep returning an error.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/folder-import-route.test.ts` covers sandbox import rejection, allowed-root import, and outside-root rejection. `apps/daemon/tests/folder-import-projects.test.ts` covers later project-root resolution under the same allowlist.
- Did the test go red on `main` and green on this branch? The new allowed-root cases encode behavior that `main` does not support; I did not keep a separate red-run transcript, but the branch is validated below.

## Validation

- `env PATH=/Users/dr/.nvm/versions/node/v24.16.0/bin:$PATH /Users/dr/.nvm/versions/node/v24.16.0/bin/node /Users/dr/.nvm/versions/node/v24.16.0/bin/pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/folder-import-route.test.ts tests/folder-import-projects.test.ts`
- `env PATH=/Users/dr/.nvm/versions/node/v24.16.0/bin:$PATH /Users/dr/.nvm/versions/node/v24.16.0/bin/node /Users/dr/.nvm/versions/node/v24.16.0/bin/pnpm --filter @open-design/daemon typecheck`
- `env PATH=/Users/dr/.nvm/versions/node/v24.16.0/bin:$PATH /Users/dr/.nvm/versions/node/v24.16.0/bin/node /Users/dr/.nvm/versions/node/v24.16.0/bin/pnpm guard`