### PR TITLE
[codex] Add CI gate workflow placeholders

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,0 +1,15 @@
+name: ci-gate
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    name: CI gate placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "ci-gate placeholder"

--- a/.github/workflows/ci-hosted.yml
+++ b/.github/workflows/ci-hosted.yml
@@ -1,0 +1,15 @@
+name: ci-hosted
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    name: Hosted CI placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "ci-hosted placeholder"

--- a/.github/workflows/ci-runner.yml
+++ b/.github/workflows/ci-runner.yml
@@ -1,0 +1,15 @@
+name: ci-runner
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    name: Runner CI placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "ci-runner placeholder"


### PR DESCRIPTION
## Summary

- add placeholder workflows for `ci-runner`, `ci-hosted`, and `ci-gate`
- keep them manual-only via `workflow_dispatch`
- leave CI routing and gate logic for follow-up changes

## Validation

- `actionlint .github/workflows/ci-runner.yml .github/workflows/ci-hosted.yml .github/workflows/ci-gate.yml`
