### PR TITLE
fix(web): keep design system picker fullscreen above modal chrome

### DIFF
--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -1911,7 +1911,7 @@
 .project-ds-picker-fullscreen {
   position: fixed;
   inset: 0;
-  z-index: 210;
+  z-index: 1800;
   background: color-mix(in srgb, var(--text) 38%, transparent);
   backdrop-filter: blur(2px);
   display: flex;

--- a/apps/web/tests/styles/project-design-system-picker.test.ts
+++ b/apps/web/tests/styles/project-design-system-picker.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { readExpandedIndexCss } from '../helpers/read-expanded-css';
+
+const indexCss = readExpandedIndexCss();
+
+function cssDeclarations(css: string, selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g'))];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+function zIndex(css: string, selector: string): number {
+  const value = Number.parseInt(ruleValue(cssDeclarations(css, selector), 'z-index'), 10);
+  if (!Number.isFinite(value)) throw new Error(`Expected numeric z-index for ${selector}`);
+  return value;
+}
+
+describe('ProjectDesignSystemPicker fullscreen styles', () => {
+  it('keeps fullscreen design-system previews above app modal chrome', () => {
+    const fullscreenLayer = zIndex(indexCss, '.project-ds-picker-fullscreen');
+
+    expect(fullscreenLayer).toBeGreaterThan(zIndex(indexCss, '.ds-modal-backdrop'));
+    expect(fullscreenLayer).toBeGreaterThan(zIndex(indexCss, '.prompt-template-lightbox-backdrop'));
+  });
+});


### PR DESCRIPTION
Fixes #3696.

## Summary
- raise the project design-system picker fullscreen overlay above existing app modal/lightbox chrome
- add a style regression test that checks the fullscreen layer stays above `ds-modal` and prompt lightbox surfaces

## Surface area
- [x] UI
- [ ] API
- [ ] CLI
- [ ] Daemon/runtime
- [ ] Docs

## Bug fix verification
- Confirmed the fullscreen picker now resolves to a higher z-index than the Settings modal and prompt lightbox chrome that could previously bleed over it, so the header/modal chrome no longer overlaps the fullscreen picker.
- Added `ProjectDesignSystemPicker fullscreen styles` regression coverage against the expanded web stylesheet to keep that layer ordering locked.

## Testing
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/styles/project-design-system-picker.test.ts`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/styles`
- `pnpm --filter @open-design/web typecheck`
