### PR TITLE
[codex] Fix deck keyboard pagination double step

### DIFF
--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -1821,10 +1821,17 @@ function injectDeckBridge(doc: string, initialSlideIndex = 0): string {
     return 0;
   }
   function dispatchKey(key){
-    // Bubbles so any listener on window picks it up too. We dispatch on
-    // document only — dispatching on window/body in addition would cause
-    // bubbling to fire the same document-level listener twice.
+    // Try window first: many deck frameworks listen on both window and
+    // document in capture phase for iframe focus resilience. Dispatching a
+    // bubbling event at document hits the document listener and then the
+    // window listener, turning one host "next" request into two slide moves.
     var init = { key: key, code: key, bubbles: true, cancelable: true, composed: true };
+    var before = activeIndex(slides());
+    try {
+      window.dispatchEvent(new KeyboardEvent('keydown', init));
+      window.dispatchEvent(new KeyboardEvent('keyup', init));
+    } catch (_) {}
+    if (activeIndex(slides()) !== before) return;
     try {
       document.dispatchEvent(new KeyboardEvent('keydown', init));
       document.dispatchEvent(new KeyboardEvent('keyup', init));

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
@@ -129,6 +129,41 @@ describe('deck bridge — nested slide markup (#1530)', () => {
     expect(state).toMatchObject({ active: 1, count: 3 });
   });
 
+  it('does not double-advance decks that listen for keyboard navigation on both window and document', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(`
+      <section class="slide active">One</section>
+      <section class="slide">Two</section>
+      <section class="slide">Three</section>
+      <section class="slide">Four</section>
+    `);
+    const slides = Array.from(win.document.querySelectorAll('.slide'));
+    let active = 0;
+    function paint() {
+      slides.forEach((slide, index) => {
+        slide.classList.toggle('active', index === active);
+      });
+    }
+    function go(index: number) {
+      active = Math.max(0, Math.min(slides.length - 1, index));
+      paint();
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === 'ArrowRight') go(active + 1);
+      else if (event.key === 'ArrowLeft') go(active - 1);
+    }
+    win.addEventListener('keydown', onKey, true);
+    win.document.addEventListener('keydown', onKey, true);
+    paint();
+
+    postSlide(win, 'next');
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 350));
+
+    const activeSlide = Array.from(win.document.querySelectorAll('.slide'))
+      .findIndex((slide) => slide.classList.contains('active'));
+    expect(activeSlide).toBe(1);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 4 });
+  });
+
   it('scrolls documentElement when body looks horizontally scrollable in a sandboxed Simple Deck', async () => {
     const { win, parentPostMessage } = setupDeckBridge(`
       <style>


### PR DESCRIPTION
## Why

This fixes the Feishu sheet row 19 P1 report: `ppt左右键翻页2页翻一次`.

The issue showed up in deck previews whose own runtime listens for keyboard navigation on both `window` and `document` in capture phase. Open Design's srcDoc deck bridge sometimes falls back to synthetic keyboard events when a deck cannot be driven by scroll, transform, or direct active-class mutation. Dispatching that synthetic key at `document` let the event hit the document listener and then bubble to the window listener, so one host "next slide" request could move two pages.

## What users will see

When previewing an HTML/PPT-style deck, pressing the right or left arrow advances exactly one slide at a time, including generated decks that install both `window` and `document` key listeners for iframe focus resilience.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [x] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI surface. Browser verification screenshot is hosted on GitHub release assets and shows the existing deck preview after one right-arrow keypress: the preview remains on slide 2 with toolbar counter `2 / 4`.

![Browser verification: deck advances from 1 / 4 to 2 / 4](https://github.com/nexu-io/open-design/releases/download/pr-3706-verification-assets/open-design-ppt-keyboard-fixed.jpg)

Asset: https://github.com/nexu-io/open-design/releases/download/pr-3706-verification-assets/open-design-ppt-keyboard-fixed.jpg
Release asset host: https://github.com/nexu-io/open-design/releases/tag/pr-3706-verification-assets

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts`
- Did the test go red on `main` and green on this branch? Yes. The new regression failed before the fix with active slide index `2` instead of expected `1`, then passed after the bridge change.
- Manual browser verification: seeded a 4-slide deck whose runtime listens on both `window` and `document`, opened it in `pnpm tools-dev run web --namespace codex-ppt-p1 --daemon-port 17456 --web-port 17573`, and used the in-app Browser to press `ArrowRight`. The toolbar changed from `1 / 4` to `2 / 4`, confirming one-page navigation.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts tests/runtime/srcdoc-deck-bridge-transform-driven.test.ts tests/runtime/srcdoc-deck-bridge-framework-deck.test.ts tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

