### PR TITLE
[codex] Fix official plugin and skill catalog search

### DIFF
--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   PLUGIN_SHARE_ACTION_PLUGIN_IDS,
+  resolveLocalizedText,
   type ApplyResult,
   type InstalledPluginRecord,
   type PluginSourceKind,
@@ -445,6 +446,16 @@ export function PluginsView({
               });
               setAvailableDetails(plugin);
             }}
+            onUseInstalled={(record) => {
+              trackPluginsAvailableTabClick(analytics.track, {
+                page_name: 'plugins',
+                area: 'available_tab',
+                element: 'install',
+                plugin_id: record.sourceMarketplaceEntryName ?? record.id,
+                plugin_type: record.marketplaceTrust ?? 'official',
+              });
+              void handleUsePlugin(record, 'use');
+            }}
             onInstall={(plugin) => {
               trackPluginsAvailableTabClick(analytics.track, {
                 page_name: 'plugins',
@@ -542,6 +553,7 @@ export function PluginsView({
             onClose={() => {
               if (pendingInstallEntry !== availableDetails.key) setAvailableDetails(null);
             }}
+            onUseInstalled={(record) => void handleUsePlugin(record, 'use')}
             onInstall={(plugin) => void handleInstallAvailable(plugin)}
           />
         ) : null}
@@ -800,6 +812,7 @@ interface AvailableMarketplacePlugin {
   key: string;
   marketplace: PluginMarketplace;
   entry: PluginMarketplaceEntry;
+  installedRecord?: InstalledPluginRecord;
   installSource?: string;
 }
 
@@ -825,6 +838,7 @@ function AvailablePluginsPanel({
   plugins,
   pendingKey,
   onOpenDetails,
+  onUseInstalled,
   onInstall,
   onSearchInput,
   onSourceDropdown,
@@ -833,11 +847,13 @@ function AvailablePluginsPanel({
   plugins: AvailableMarketplacePlugin[];
   pendingKey: string | null;
   onOpenDetails: (plugin: AvailableMarketplacePlugin) => void;
+  onUseInstalled: (record: InstalledPluginRecord) => void;
   onInstall: (plugin: AvailableMarketplacePlugin) => void;
   onSearchInput?: () => void;
   onSourceDropdown?: () => void;
   t: ReturnType<typeof useI18n>['t'];
 }) {
+  const { locale } = useI18n();
   const [query, setQuery] = useState('');
   const [sourceFilter, setSourceFilter] = useState('all');
   const searchTrackedRef = useRef(false);
@@ -926,7 +942,9 @@ function AvailablePluginsPanel({
       ) : (
         <div className="plugins-view__available-list">
           {filteredPlugins.map((plugin) => {
-            const title = plugin.entry.title ?? plugin.entry.name;
+            const title = availablePluginTitle(plugin.entry, locale);
+            const installedRecord = plugin.installedRecord ?? null;
+            const description = availablePluginDescription(plugin.entry, locale);
             return (
               <article key={plugin.key} className="plugins-view__available-card">
                 <div className="plugins-view__available-main">
@@ -934,7 +952,7 @@ function AvailablePluginsPanel({
                     <span>{title}</span>
                     <TrustBadge trust={plugin.marketplace.trust} />
                   </div>
-                  {plugin.entry.description ? <p>{plugin.entry.description}</p> : null}
+                  {description ? <p>{description}</p> : null}
                   <div className="plugins-view__meta">
                     <span>{plugin.entry.name}</span>
                     {plugin.entry.version ? <span>v{plugin.entry.version}</span> : null}
@@ -956,11 +974,19 @@ function AvailablePluginsPanel({
                   <button
                     type="button"
                     className="plugins-view__primary"
-                    onClick={() => onInstall(plugin)}
-                    disabled={pendingKey === plugin.key}
+                    onClick={() =>
+                      installedRecord
+                        ? onUseInstalled(installedRecord)
+                        : onInstall(plugin)
+                    }
+                    disabled={!installedRecord && pendingKey === plugin.key}
                     data-testid={`plugins-available-install-${plugin.entry.name}`}
                   >
-                    {pendingKey === plugin.key ? t('pluginsView.installing') : t('pluginsView.install')}
+                    {installedRecord
+                      ? t('pluginCard.use')
+                      : pendingKey === plugin.key
+                        ? t('pluginsView.installing')
+                        : t('pluginsView.install')}
                   </button>
                 </div>
               </article>
@@ -976,14 +1002,16 @@ function AvailablePluginDetailsModal({
   plugin,
   pending,
   onClose,
+  onUseInstalled,
   onInstall,
 }: {
   plugin: AvailableMarketplacePlugin;
   pending: boolean;
   onClose: () => void;
+  onUseInstalled: (record: InstalledPluginRecord) => void;
   onInstall: (plugin: AvailableMarketplacePlugin) => void;
 }) {
-  const { t } = useI18n();
+  const { locale, t } = useI18n();
   const versions = useMemo(() => availablePluginVersions(plugin.entry), [plugin.entry]);
   const [selectedVersion, setSelectedVersion] = useState(
     () => versions[0]?.version ?? plugin.entry.version ?? 'latest',
@@ -991,7 +1019,7 @@ function AvailablePluginDetailsModal({
   const [copiedInstall, setCopiedInstall] = useState(false);
   const selectedVersionInfo =
     versions.find((version) => version.version === selectedVersion) ?? versions[0] ?? null;
-  const title = plugin.entry.title ?? plugin.entry.name;
+  const title = availablePluginTitle(plugin.entry, locale);
   const sourceName = plugin.marketplace.manifest.name ?? plugin.marketplace.url;
   const publisher = plugin.entry.publisher;
   const publisherLabel =
@@ -1009,6 +1037,7 @@ function AvailablePluginDetailsModal({
     version: selectedVersionInfo,
     t,
   });
+  const installedRecord = plugin.installedRecord ?? null;
 
   async function copyInstallCommand() {
     const ok = await copyToClipboard(installCommand);
@@ -1018,6 +1047,10 @@ function AvailablePluginDetailsModal({
   }
 
   function installSelectedVersion() {
+    if (installedRecord) {
+      onUseInstalled(installedRecord);
+      return;
+    }
     onInstall({
       ...plugin,
       key: `${plugin.key}:${selectedVersion}`,
@@ -1089,79 +1122,92 @@ function AvailablePluginDetailsModal({
               <h3 className="plugin-details-modal__section-title">About</h3>
             </div>
             <p className="plugin-details-modal__description">
-              {plugin.entry.description ?? 'No description provided.'}
+              {availablePluginDescription(plugin.entry, locale) ?? 'No description provided.'}
             </p>
           </section>
 
-          <section className="plugin-details-modal__section">
-            <div className="plugin-details-modal__section-head">
-              <h3 className="plugin-details-modal__section-title">
-                {t('plugins.availableDetails.install')}
-              </h3>
-            </div>
-            <div className="plugins-view__version-install">
-              <label className="plugins-view__version-select">
-                <span>{t('plugins.availableDetails.version')}</span>
-                <select
-                  aria-label={t('plugins.availableDetails.pluginVersion')}
-                  value={selectedVersion}
-                  onChange={(event) => {
-                    setSelectedVersion(event.target.value);
-                    setCopiedInstall(false);
-                  }}
-                >
-                  {versions.map((version) => (
-                    <option
-                      key={version.version}
-                      value={version.version}
-                      disabled={version.yanked}
-                    >
-                      {version.version}
-                      {version.deprecated
-                        ? t('plugins.availableDetails.versionDeprecatedSuffix')
-                        : ''}
-                      {version.yanked
-                        ? t('plugins.availableDetails.versionYankedSuffix')
-                        : ''}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <div className="plugins-view__install-command">
-                <code data-testid="plugins-available-install-command">
-                  {installCommand}
-                </code>
-                <button
-                  type="button"
-                  className="plugin-details-modal__chip-btn"
-                  onClick={() => void copyInstallCommand()}
-                >
-                  <Icon name="copy" size={12} />
-                  {copiedInstall
-                    ? t('plugins.availableDetails.copied')
-                    : t('plugins.availableDetails.copyInstallCommand')}
-                </button>
+          {installedRecord ? (
+            <section className="plugin-details-modal__section">
+              <div className="plugin-details-modal__section-head">
+                <h3 className="plugin-details-modal__section-title">
+                  Installed
+                </h3>
               </div>
-            </div>
-            {selectedVersionInfo?.deprecated ? (
               <p className="plugin-details-modal__section-hint">
-                {t('plugins.availableDetails.deprecatedPrefix', {
-                  message: selectedVersionInfo.deprecated === true
-                    ? t('plugins.availableDetails.deprecatedFallback')
-                    : selectedVersionInfo.deprecated,
-                })}
+                This official catalog entry is bundled with Open Design and is ready to use.
               </p>
-            ) : null}
-            {selectedVersionInfo?.yanked ? (
-              <p className="plugin-details-modal__section-hint">
-                {selectedVersionInfo.yankReason
-                  ? t('plugins.availableDetails.yankedWithReason', {
-                    reason: selectedVersionInfo.yankReason,
-                  })
-                  : t('plugins.availableDetails.yanked')}
-              </p>
-            ) : null}
-          </section>
+            </section>
+          ) : (
+            <section className="plugin-details-modal__section">
+              <div className="plugin-details-modal__section-head">
+                <h3 className="plugin-details-modal__section-title">
+                  {t('plugins.availableDetails.install')}
+                </h3>
+              </div>
+              <div className="plugins-view__version-install">
+                <label className="plugins-view__version-select">
+                  <span>{t('plugins.availableDetails.version')}</span>
+                  <select
+                    aria-label={t('plugins.availableDetails.pluginVersion')}
+                    value={selectedVersion}
+                    onChange={(event) => {
+                      setSelectedVersion(event.target.value);
+                      setCopiedInstall(false);
+                    }}
+                  >
+                    {versions.map((version) => (
+                      <option
+                        key={version.version}
+                        value={version.version}
+                        disabled={version.yanked}
+                      >
+                        {version.version}
+                        {version.deprecated
+                          ? t('plugins.availableDetails.versionDeprecatedSuffix')
+                          : ''}
+                        {version.yanked
+                          ? t('plugins.availableDetails.versionYankedSuffix')
+                          : ''}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <div className="plugins-view__install-command">
+                  <code data-testid="plugins-available-install-command">
+                    {installCommand}
+                  </code>
+                  <button
+                    type="button"
+                    className="plugin-details-modal__chip-btn"
+                    onClick={() => void copyInstallCommand()}
+                  >
+                    <Icon name="copy" size={12} />
+                    {copiedInstall
+                      ? t('plugins.availableDetails.copied')
+                      : t('plugins.availableDetails.copyInstallCommand')}
+                  </button>
+                </div>
+              </div>
+              {selectedVersionInfo?.deprecated ? (
+                <p className="plugin-details-modal__section-hint">
+                  {t('plugins.availableDetails.deprecatedPrefix', {
+                    message: selectedVersionInfo.deprecated === true
+                      ? t('plugins.availableDetails.deprecatedFallback')
+                      : selectedVersionInfo.deprecated,
+                  })}
+                </p>
+              ) : null}
+              {selectedVersionInfo?.yanked ? (
+                <p className="plugin-details-modal__section-hint">
+                  {selectedVersionInfo.yankReason
+                    ? t('plugins.availableDetails.yankedWithReason', {
+                      reason: selectedVersionInfo.yankReason,
+                    })
+                    : t('plugins.availableDetails.yanked')}
+                </p>
+              ) : null}
+            </section>
+          )}
 
           <section className="plugin-details-modal__section">
             <div className="plugin-details-modal__section-head">
@@ -1309,7 +1355,11 @@ function AvailablePluginDetailsModal({
             aria-busy={pending ? 'true' : undefined}
             data-testid={`plugins-available-details-install-${plugin.entry.name}`}
           >
-            {pending ? 'Installing...' : 'Install'}
+            {installedRecord
+              ? t('pluginCard.use')
+              : pending
+                ? t('pluginsView.installing')
+                : t('pluginsView.install')}
           </button>
         </footer>
       </div>
@@ -1711,14 +1761,31 @@ function buildAvailablePlugins(
     const entries = marketplace.manifest.plugins ?? [];
     return entries.flatMap((entry) => {
       const installedPlugin = installedByName.get(normalizePluginName(entry.name)) ?? null;
-      if (installedPlugin) return [];
+      if (installedPlugin && installedPlugin.sourceKind !== 'bundled') return [];
       return [{
         key: `${marketplace.id}:${entry.name}:${entry.version ?? ''}`,
         marketplace,
         entry,
+        ...(installedPlugin ? { installedRecord: installedPlugin } : {}),
       }];
     });
   });
+}
+
+function availablePluginTitle(entry: PluginMarketplaceEntry, locale?: string): string {
+  return (
+    resolveLocalizedText(entry.title_i18n, locale) ||
+    entry.title ||
+    entry.name
+  );
+}
+
+function availablePluginDescription(entry: PluginMarketplaceEntry, locale?: string): string | null {
+  return (
+    resolveLocalizedText(entry.description_i18n, locale) ||
+    entry.description ||
+    null
+  );
 }
 
 function availablePluginVersions(entry: PluginMarketplaceEntry): AvailablePluginVersion[] {
@@ -1883,7 +1950,9 @@ function availablePluginSearchText(plugin: AvailableMarketplacePlugin): string {
   const parts = [
     entry.name,
     entry.title,
+    ...localizedValues(entry.title_i18n),
     entry.description,
+    ...localizedValues(entry.description_i18n),
     entry.source,
     entry.version,
     entry.homepage,
@@ -1899,6 +1968,11 @@ function availablePluginSearchText(plugin: AvailableMarketplacePlugin): string {
     ...(entry.capabilitiesSummary ?? []),
   ];
   return parts.filter((part): part is string => typeof part === 'string').join(' ').toLowerCase();
+}
+
+function localizedValues(value: unknown): string[] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return [];
+  return Object.values(value).filter((part): part is string => typeof part === 'string');
 }
 
 function pluginLookupKeys(plugin: InstalledPluginRecord): string[] {

--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -1762,14 +1762,31 @@ function buildAvailablePlugins(
     return entries.flatMap((entry) => {
       const installedPlugin = installedByName.get(normalizePluginName(entry.name)) ?? null;
       if (installedPlugin && installedPlugin.sourceKind !== 'bundled') return [];
+      const installedRecord = installedPlugin && bundledPluginMatchesMarketplaceEntry(
+        installedPlugin,
+        marketplace,
+        entry,
+      )
+        ? installedPlugin
+        : null;
       return [{
         key: `${marketplace.id}:${entry.name}:${entry.version ?? ''}`,
         marketplace,
         entry,
-        ...(installedPlugin ? { installedRecord: installedPlugin } : {}),
+        ...(installedRecord ? { installedRecord } : {}),
       }];
     });
   });
+}
+
+function bundledPluginMatchesMarketplaceEntry(
+  plugin: InstalledPluginRecord,
+  marketplace: PluginMarketplace,
+  entry: PluginMarketplaceEntry,
+): boolean {
+  return plugin.sourceKind === 'bundled'
+    && plugin.sourceMarketplaceId === marketplace.id
+    && normalizePluginName(plugin.sourceMarketplaceEntryName ?? '') === normalizePluginName(entry.name);
 }
 
 function availablePluginTitle(entry: PluginMarketplaceEntry, locale?: string): string {

--- a/apps/web/src/components/SkillsSection.tsx
+++ b/apps/web/src/components/SkillsSection.tsx
@@ -79,7 +79,7 @@ function parseTriggers(raw: string): string[] {
 }
 
 export function SkillsSection({ cfg, setCfg, onSkillsRefresh, onSkillsChanged }: Props) {
-  const t = useT();
+  const { locale, t } = useI18n();
 
   const [skills, setSkills] = useState<SkillSummary[]>([]);
   const [search, setSearch] = useState('');
@@ -170,12 +170,12 @@ export function SkillsSection({ cfg, setCfg, onSkillsRefresh, onSkillsChanged }:
       if (categoryFilter !== 'all' && s.category !== categoryFilter)
         return false;
       if (!q) return true;
-      const hay = `${s.name}\n${s.description}\n${(s.triggers ?? []).join(
+      const hay = `${s.name}\n${localizeSkillName(locale, s)}\n${s.description}\n${localizeSkillDescription(locale, s)}\n${(s.triggers ?? []).join(
         ' ',
       )}\n${s.category ?? ''}`;
       return hay.toLowerCase().includes(q);
     });
-  }, [skills, modeFilter, sourceFilter, categoryFilter, search]);
+  }, [skills, modeFilter, sourceFilter, categoryFilter, search, locale]);
 
   const ensureBody = useCallback(
     async (id: string) => {

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -1128,7 +1128,9 @@ export interface PluginMarketplaceEntry {
   yankReason?: string;
   tags?: string[];
   title?: string;
+  title_i18n?: Record<string, string>;
   description?: string;
+  description_i18n?: Record<string, string>;
   icon?: string;
 }
 

--- a/apps/web/tests/components/PluginsView.test.tsx
+++ b/apps/web/tests/components/PluginsView.test.tsx
@@ -44,7 +44,7 @@ function makePlugin(
   title = id === 'official-plugin' ? 'Official Plugin' : 'User Plugin',
   description = `${id} description`,
 ): InstalledPluginRecord {
-  return {
+  const record: InstalledPluginRecord = {
     id,
     title,
     version: '1.0.0',
@@ -66,6 +66,13 @@ function makePlugin(
     installedAt: 0,
     updatedAt: 0,
   };
+  if (sourceKind === 'bundled') {
+    record.sourceMarketplaceId = 'official';
+    record.sourceMarketplaceEntryName = `open-design/${id}`;
+    record.sourceMarketplaceEntryVersion = record.version;
+    record.marketplaceTrust = 'official';
+  }
+  return record;
 }
 
 const mockedListPlugins = vi.mocked(listPlugins);
@@ -92,14 +99,26 @@ beforeEach(() => {
       manifest: {
         name: 'Example Catalog',
         version: '1.0.0',
-        plugins: [{
-          name: 'remote-plugin',
-          title: 'Remote Plugin',
-          source: 'github:owner/repo',
-          version: '1.2.0',
-          description: 'Remote catalog plugin.',
-          tags: ['deck'],
-        }],
+        plugins: [
+          {
+            name: 'remote-plugin',
+            title: 'Remote Plugin',
+            source: 'github:owner/repo',
+            version: '1.2.0',
+            description: 'Remote catalog plugin.',
+            tags: ['deck'],
+          },
+          {
+            name: 'open-design/official-plugin',
+            title: 'Official Plugin',
+            title_i18n: { 'zh-CN': '官方看板' },
+            source: 'github:nexu-io/open-design@main/plugins/_official/examples/official-plugin',
+            version: '1.0.0',
+            description: 'Bundled official plugin.',
+            description_i18n: { 'zh-CN': '内置官方插件。' },
+            tags: ['prototype', 'kanban'],
+          },
+        ],
       },
     },
   ]);
@@ -201,6 +220,29 @@ describe('PluginsView', () => {
     fireEvent.click(availableTab);
     expect(await screen.findByText('Remote Plugin')).toBeTruthy();
     expect(screen.getAllByText('Example Catalog').length).toBeGreaterThan(0);
+  });
+
+  it('keeps bundled official catalog entries available and uses the installed record', async () => {
+    const onUsePlugin = vi.fn();
+    render(<PluginsView onUsePlugin={onUsePlugin} />);
+
+    fireEvent.click(await screen.findByTestId('plugins-tab-available'));
+    expect(await screen.findByText('官方看板')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Search available plugins'), {
+      target: { value: '官方看板' },
+    });
+
+    expect(await screen.findByText('官方看板')).toBeTruthy();
+    expect(screen.queryByText('Remote Plugin')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('plugins-available-install-open-design/official-plugin'));
+
+    expect(onUsePlugin).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'official-plugin',
+      sourceKind: 'bundled',
+    }), 'use');
+    expect(mockedInstallPluginSource).not.toHaveBeenCalled();
   });
 
   it('shows all installed plugins by default on the Plugins page', async () => {
@@ -507,15 +549,20 @@ describe('PluginsView', () => {
     expect(screen.queryByText('Figma Importer')).toBeNull();
   });
 
-  it('keeps installed registry entries out of Available', async () => {
-    const official = makePlugin('official-plugin', 'bundled', 'bundled', 'Official Plugin');
-    official.sourceMarketplaceId = 'official';
-    official.sourceMarketplaceEntryName = 'open-design/official-plugin';
-    official.sourceMarketplaceEntryVersion = '1.0.0';
-    official.marketplaceTrust = 'official';
-    official.manifest.od = { ...official.manifest.od, hidden: true };
+  it('keeps non-bundled installed registry entries out of Available', async () => {
+    const marketplacePlugin = makePlugin(
+      'marketplace-plugin',
+      'marketplace',
+      'restricted',
+      'Marketplace Plugin',
+    );
+    marketplacePlugin.sourceMarketplaceId = 'official';
+    marketplacePlugin.sourceMarketplaceEntryName = 'open-design/official-plugin';
+    marketplacePlugin.sourceMarketplaceEntryVersion = '1.0.0';
+    marketplacePlugin.marketplaceTrust = 'official';
+    marketplacePlugin.manifest.od = { ...marketplacePlugin.manifest.od, hidden: true };
     mockedListPlugins.mockImplementation(async (options?: { includeHidden?: boolean }) =>
-      options?.includeHidden ? [official] : [],
+      options?.includeHidden ? [marketplacePlugin] : [],
     );
     mockedListMarketplaces.mockResolvedValue([
       {

--- a/apps/web/tests/components/PluginsView.test.tsx
+++ b/apps/web/tests/components/PluginsView.test.tsx
@@ -224,6 +224,29 @@ describe('PluginsView', () => {
 
   it('keeps bundled official catalog entries available and uses the installed record', async () => {
     const onUsePlugin = vi.fn();
+    mockedListMarketplaces.mockResolvedValue([
+      {
+        id: 'official',
+        url: 'https://open-design.ai/marketplace/open-design-marketplace.json',
+        trust: 'official',
+        manifest: {
+          name: 'Open Design Official',
+          version: '1.0.0',
+          plugins: [
+            {
+              name: 'open-design/official-plugin',
+              title: 'Official Plugin',
+              title_i18n: { 'zh-CN': '官方看板' },
+              source: 'github:nexu-io/open-design@main/plugins/_official/examples/official-plugin',
+              version: '1.0.0',
+              description: 'Bundled official plugin.',
+              description_i18n: { 'zh-CN': '内置官方插件。' },
+              tags: ['prototype', 'kanban'],
+            },
+          ],
+        },
+      },
+    ]);
     render(<PluginsView onUsePlugin={onUsePlugin} />);
 
     fireEvent.click(await screen.findByTestId('plugins-tab-available'));
@@ -243,6 +266,45 @@ describe('PluginsView', () => {
       sourceKind: 'bundled',
     }), 'use');
     expect(mockedInstallPluginSource).not.toHaveBeenCalled();
+  });
+
+  it('installs restricted catalog entries that collide with bundled official plugin names', async () => {
+    const onUsePlugin = vi.fn();
+    mockedListMarketplaces.mockResolvedValue([
+      {
+        id: 'team-catalog',
+        url: 'https://team.example.com/open-design-marketplace.json',
+        trust: 'restricted',
+        manifest: {
+          name: 'Team Catalog',
+          version: '1.0.0',
+          plugins: [
+            {
+              name: 'open-design/official-plugin',
+              title: 'Team Official Plugin',
+              source: 'github:team/official-plugin',
+              version: '2.0.0',
+              description: 'Team-scoped plugin that intentionally shares the official entry name.',
+              tags: ['team'],
+            },
+          ],
+        },
+      },
+    ]);
+
+    render(<PluginsView onUsePlugin={onUsePlugin} />);
+
+    fireEvent.click(await screen.findByTestId('plugins-tab-available'));
+    expect(await screen.findByText('Team Official Plugin')).toBeTruthy();
+
+    const install = screen.getByTestId('plugins-available-install-open-design/official-plugin');
+    expect(install.textContent).toBe('Install');
+    fireEvent.click(install);
+
+    await waitFor(() =>
+      expect(mockedInstallPluginSource).toHaveBeenCalledWith('open-design/official-plugin'),
+    );
+    expect(onUsePlugin).not.toHaveBeenCalled();
   });
 
   it('shows all installed plugins by default on the Plugins page', async () => {

--- a/apps/web/tests/components/SkillsSection.test.tsx
+++ b/apps/web/tests/components/SkillsSection.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SkillsSection } from '../../src/components/SkillsSection';
+import { I18nProvider } from '../../src/i18n';
 import type { AppConfig } from '../../src/types';
 import type { SkillSummary } from '@open-design/contracts';
 
@@ -42,6 +43,7 @@ function makeSkill(overrides: Partial<SkillSummary>): SkillSummary {
 function renderSkillsSection(
   skills: SkillSummary[],
   options?: {
+    locale?: 'en' | 'zh-CN';
     onSkillsRefresh?: () => void | Promise<void>;
     onSkillsChanged?: (id?: string) => void;
   },
@@ -112,13 +114,18 @@ function renderSkillsSection(
     return new Response(JSON.stringify({}), { status: 404 });
   }) as typeof fetch;
 
-  render(
+  const section = (
     <SkillsSection
       cfg={TEST_CONFIG}
       setCfg={setCfg}
       onSkillsRefresh={onSkillsRefresh}
       onSkillsChanged={onSkillsChanged}
-    />,
+    />
+  );
+  render(
+    options?.locale ? (
+      <I18nProvider initial={options.locale}>{section}</I18nProvider>
+    ) : section,
   );
   return {
     fetchMock: globalThis.fetch as ReturnType<typeof vi.fn>,
@@ -215,6 +222,46 @@ describe('SkillsSection', () => {
 
     expect(within(row).queryByTestId('skills-edit-builtin-warning')).toBeNull();
     expect(await within(row).findByTestId('skills-edit-form')).toBeTruthy();
+  });
+
+  it('matches localized built-in skill names and descriptions in search', async () => {
+    renderSkillsSection(
+      [
+        makeSkill({
+          id: 'localized-skill',
+          name: 'localized-skill',
+          displayName: {
+            en: 'Localized Skill',
+            'zh-CN': '本地化技能',
+          },
+          description: 'English description',
+          descriptionI18n: {
+            en: 'English description',
+            'zh-CN': '中文能力描述',
+          },
+          source: 'built-in',
+        }),
+        makeSkill({
+          id: 'other-skill',
+          name: 'other-skill',
+          displayName: {
+            en: 'Other Skill',
+            'zh-CN': '其他技能',
+          },
+          description: 'Other description',
+          source: 'built-in',
+        }),
+      ],
+      { locale: 'zh-CN' },
+    );
+
+    expect(await screen.findByText('本地化技能')).toBeTruthy();
+    fireEvent.change(screen.getByPlaceholderText('搜索...'), {
+      target: { value: '中文能力' },
+    });
+
+    expect(screen.getByTestId('skill-row-localized-skill')).toBeTruthy();
+    expect(screen.queryByTestId('skill-row-other-skill')).toBeNull();
   });
 
   it('refreshes app-level skills after creating a skill', async () => {


### PR DESCRIPTION
## Why

Feishu row 22 reported that official plugins and skills had far more available entries than the UI exposed, and that search was not matching those official/localized entries. I reproduced the plugin side on `release/v0.10.0`: `/plugins` showed only the community catalog entries in Available, while `/api/marketplaces` returned hundreds of official entries.

Root cause: official bundled plugins were registered as installed `sourceKind: bundled`, and `buildAvailablePlugins()` removed every marketplace entry that matched an installed plugin. The Installed tab intentionally hides bundled records, so official entries disappeared from both Installed and Available. Skill search had a parallel search-index gap: the visible localized skill name/description were rendered, but not included in the filter haystack.

## What users will see

The Plugins → Available tab now keeps official bundled catalog entries visible and shows them as ready to **Use** instead of **Install**. Available search also matches localized marketplace title/description fields. Settings → Skills search now matches localized built-in skill names and descriptions, so Chinese visible copy is searchable.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Browser validation screenshot: Plugins → Available shows 404 entries, search `看板` matches the official bundled Kanban Board entry, and the action is `使用` / Use.

![Plugins Available validation](https://raw.githubusercontent.com/nexu-io/open-design/5667dbbb8308375104897b3cd1cd97ccfb79ca08/plugins-available-after-search.png)

Browser validation screenshot: Settings → Skills shows 154 built-in skills, and search `杂志文章` matches the localized built-in skill.

![Skills localized search validation](https://raw.githubusercontent.com/nexu-io/open-design/5667dbbb8308375104897b3cd1cd97ccfb79ca08/skills-settings-after-localized-search.png)

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/PluginsView.test.tsx` (`keeps bundled official catalog entries available and uses the installed record`) and `apps/web/tests/components/SkillsSection.test.tsx` (`matches localized built-in skill names and descriptions in search`).
- Red/green: browser reproduction was confirmed on `release/v0.10.0` before the fix; the new component specs are green on this branch. I did not rerun those new specs against a separate base checkout after writing them.
- End-to-end Browser validation: `pnpm tools-dev run web --namespace p1-catalog-fix --daemon-port 20456 --web-port 20573`, then in-app Browser verified `/plugins` and Settings → Skills using the screenshots above.

## Validation

- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/PluginsView.test.tsx tests/components/SkillsSection.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- Browser/in-app Browser E2E verification with GitHub-hosted screenshots linked above.
