### PR TITLE
fix(web): clear plugin context after send

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -905,6 +905,8 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       setStagedMcpServers([]);
       setStagedConnectors([]);
       setStagedWorkspaceContexts([]);
+      pluginsSectionRef.current?.clear();
+      setActiveAppliedPlugin(null);
       setUploadError(null);
       setMention(null);
       setMentionTab('all');

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -1399,6 +1399,9 @@ export function HomeView({
         return { examplePromptContext: examplePromptInfoRef.current };
       })(),
     });
+    setSelectedPluginContexts([]);
+    setSelectedMcpContexts([]);
+    setSelectedConnectorContexts([]);
   }
 
   return (

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -517,6 +517,9 @@ describe('ChatComposer context pickers', () => {
       }),
       context: { pluginIds: [USER_PLUGIN.id] },
     });
+    await waitFor(() => {
+      expect(screen.queryByTestId('context-chip-strip')).toBeNull();
+    });
   });
 
   it('removes the inline design file token when its staged chip is removed', async () => {

--- a/apps/web/tests/components/HomeView.context-picker.test.tsx
+++ b/apps/web/tests/components/HomeView.context-picker.test.tsx
@@ -244,7 +244,7 @@ describe('HomeView context picker', () => {
     }));
   });
 
-  it('keeps a context-only `Use` selection in the submit payload without an @mention', async () => {
+  it('keeps a context-only `Use` selection in the submit payload without an @mention, then clears the composer chip', async () => {
     // Regression: the submit-time reconciliation dropped every context that
     // lacked an inline `@mention` token, which silently discarded contexts
     // staged through the plain `Use` action (which never writes a token). The
@@ -307,6 +307,9 @@ describe('HomeView context picker', () => {
         expect.objectContaining({ id: 'chart-plugin', title: 'Chart Plugin' }),
       ],
     }));
+    await waitFor(() => {
+      expect(screen.queryByTestId('home-hero-context-plugin-chart-plugin')).toBeNull();
+    });
   });
 
   it('drops a context-only `Use` selection from the submit payload once its chip is cleared', async () => {


### PR DESCRIPTION
## Why

Feishu row 20 / P1 reported that after typing an example prompt, selecting a plugin, and sending, the plugin reference shown above the chat composer stayed fixed in the dialog and could not be cleared.

This PR fixes that user-facing residue so plugin context is treated as per-turn context after send, matching how users expect composer chips to behave.

## What users will see

After a user applies a plugin and sends a prompt, the sent message still includes the plugin context, but the composer resets cleanly. The plugin chip and plugin input panel no longer remain above the composer for the next turn.

The same cleanup also applies to Home's context-only plugin/MCP/connector chips after submit.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

End-to-end browser verification screenshot: https://raw.githubusercontent.com/nexu-io/open-design/03aa92af96e230a836af48c17fc6af840a779cfd/pr-assets/plugin-context-clear-e2e/after-send-plugin-cleared.png

![Plugin context cleared after send](https://raw.githubusercontent.com/nexu-io/open-design/03aa92af96e230a836af48c17fc6af840a779cfd/pr-assets/plugin-context-clear-e2e/after-send-plugin-cleared.png)

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/web/tests/components/ChatComposer.context-pickers.test.tsx`
  - `apps/web/tests/components/HomeView.context-picker.test.tsx`
- Did the test go red on `main` and green on this branch? Yes. The new ChatComposer assertion failed before `PluginsSection.clear()` was called from composer reset, then passed after the fix. The Home assertion similarly failed before clearing submit-time context chips and passed after the fix.
- Browser verification: in-app Browser on `http://127.0.0.1:17682`, project `plugin-clear-e2e`, conversation `5a715fe4-fb62-4f6f-8373-f66b19cb79b7`. Applied the Airbnb plugin from the composer Plugins menu, sent the generated prompt, verified `context-chip-strip` was absent, active plugin was `null`, and the composer input was empty after send. Screenshot linked above.

## Validation

- `pnpm --filter @open-design/web test -- ChatComposer.context-pickers.test.tsx -t 'sends the applied plugin snapshot'`
- `pnpm --filter @open-design/web test -- HomeView.context-picker.test.tsx -t 'then clears the composer chip'`
- `pnpm --filter @open-design/web typecheck`
- `pnpm typecheck`
- `pnpm guard`
- In-app Browser end-to-end verification with screenshot hosted on GitHub raw link above.
