### PR TITLE
[codex] Fix image export toast offset

### DIFF
--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -118,8 +118,9 @@
   pointer-events: auto;
 }
 .od-toast.placement-top {
-  top: 24px;
+  top: 64px;
   bottom: auto;
+  z-index: 1200;
 }
 .od-toast.tone-success {
   border: 1px solid color-mix(in srgb, var(--success, #2da44e) 42%, var(--border));


### PR DESCRIPTION
## Why

The image export success toast in the desktop/web file viewer could render too close to the top of the app window. In practice the app toolbar clipped the top of the green download confirmation, making the feedback look broken right after users clicked Download -> Export as image.

This release fix keeps that confirmation visible and layered above the viewer chrome.

## What users will see

After exporting an HTML preview as an image, the green "download started" toast appears fully below the top app toolbar instead of being partially hidden.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Verified locally in the desktop app: the image-export success toast is fully visible below the top toolbar.

## Bug fix verification

- Test path that reproduces the bug: no focused automated visual regression exists for this transient desktop toast.
- Did the test go red on `main` and green on this branch? no; this was verified manually in the desktop app because the issue is a short-lived visual layering/positioning bug.
- Manual verification: launched `tools-dev` desktop for this worktree, exported the current HTML preview as an image, and confirmed the green toast is no longer clipped.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test -- Toast.test.tsx`
- `pnpm guard`