### PR TITLE
fix(web): backport release-only fixes to main ahead of v0.10.0 re-cut (batch 1)

### DIFF
--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -533,6 +533,184 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
 })();
 </script>`;
 
+const URL_PREVIEW_SNAPSHOT_BRIDGE = `<script data-od-url-snapshot-bridge>
+(function(){
+  if (window.__odUrlSnapshotBridge) return;
+  window.__odUrlSnapshotBridge = true;
+  var SNAPSHOT_STYLE_PROPS = [
+    'display','position','box-sizing','width','height','min-width','max-width','min-height','max-height',
+    'margin','margin-top','margin-right','margin-bottom','margin-left',
+    'padding','padding-top','padding-right','padding-bottom','padding-left',
+    'border','border-top','border-right','border-bottom','border-left','border-radius',
+    'font','font-family','font-size','font-weight','font-style','line-height','letter-spacing',
+    'color','background-color','opacity','transform','transform-origin','overflow','overflow-x','overflow-y',
+    'white-space','text-align','vertical-align','object-fit','object-position',
+    'flex','flex-direction','flex-wrap','flex-grow','flex-shrink','flex-basis',
+    'grid','grid-template-columns','grid-template-rows','grid-column','grid-row',
+    'gap','row-gap','column-gap','align-items','align-content','align-self',
+    'justify-items','justify-content','justify-self','inset','top','right','bottom','left',
+    'z-index','box-shadow','text-shadow'
+  ];
+  function copyComputedStyle(source, target){
+    if (!source || !target || source.nodeType !== 1 || target.nodeType !== 1) return;
+    var computed = window.getComputedStyle(source);
+    var style = target.getAttribute('style') || '';
+    for (var i = 0; i < SNAPSHOT_STYLE_PROPS.length; i++){
+      var prop = SNAPSHOT_STYLE_PROPS[i];
+      var value = computed.getPropertyValue(prop);
+      if (value) style += prop + ':' + value + ';';
+    }
+    target.setAttribute('style', style);
+  }
+  function syncElementState(source, target){
+    var tag = source.tagName ? source.tagName.toLowerCase() : '';
+    if (tag === 'img' && source.currentSrc) target.setAttribute('src', source.currentSrc);
+    if (tag === 'input' || tag === 'textarea') target.setAttribute('value', source.value || '');
+    if (tag === 'canvas') {
+      try {
+        var img = document.createElement('img');
+        img.setAttribute('src', source.toDataURL('image/png'));
+        img.setAttribute('style', target.getAttribute('style') || '');
+        target.parentNode && target.parentNode.replaceChild(img, target);
+      } catch (_) {}
+    }
+  }
+  function inlineSnapshotStyles(originalRoot, cloneRoot){
+    copyComputedStyle(originalRoot, cloneRoot);
+    syncElementState(originalRoot, cloneRoot);
+    var originals = originalRoot.querySelectorAll('*');
+    var clones = cloneRoot.querySelectorAll('*');
+    var count = Math.min(originals.length, clones.length, 3500);
+    for (var i = 0; i < count; i++){
+      copyComputedStyle(originals[i], clones[i]);
+      syncElementState(originals[i], clones[i]);
+    }
+    var scripts = cloneRoot.querySelectorAll('script');
+    for (var s = scripts.length - 1; s >= 0; s--) scripts[s].remove();
+    var links = cloneRoot.querySelectorAll('link[rel~="stylesheet"], link[rel~="preload"], link[rel~="preconnect"]');
+    for (var l = links.length - 1; l >= 0; l--) links[l].remove();
+    var styles = cloneRoot.querySelectorAll('style');
+    for (var st = 0; st < styles.length; st++) {
+      styles[st].textContent = (styles[st].textContent || '')
+        .replace(/@import[^;]+;/gi, '')
+        .replace(/@font-face\\s*\\{[^}]*\\}/gi, '');
+    }
+  }
+  function pruneHiddenSnapshotNodes(originalRoot, cloneRoot){
+    var originals = originalRoot.querySelectorAll('*');
+    var clones = cloneRoot.querySelectorAll('*');
+    var count = Math.min(originals.length, clones.length);
+    var removals = [];
+    for (var i = 0; i < count; i++){
+      var original = originals[i];
+      var clone = clones[i];
+      if (!original || !clone || !clone.parentNode) continue;
+      var computed = window.getComputedStyle(original);
+      if (computed && (computed.display === 'none' || computed.visibility === 'hidden')) removals.push(clone);
+    }
+    for (var r = removals.length - 1; r >= 0; r--) {
+      if (removals[r].parentNode) removals[r].parentNode.removeChild(removals[r]);
+    }
+  }
+  function waitForImages(){
+    var imgs = Array.prototype.slice.call(document.images || []);
+    return Promise.all(imgs.map(function(img){
+      if (img.complete) return Promise.resolve();
+      return new Promise(function(resolve){
+        img.addEventListener('load', resolve, { once: true });
+        img.addEventListener('error', resolve, { once: true });
+      });
+    }));
+  }
+  function scrollOffset(){
+    var doc = document.documentElement;
+    var body = document.body;
+    return {
+      x: Math.max(window.scrollX || 0, doc ? doc.scrollLeft || 0 : 0, body ? body.scrollLeft || 0 : 0),
+      y: Math.max(window.scrollY || 0, doc ? doc.scrollTop || 0 : 0, body ? body.scrollTop || 0 : 0)
+    };
+  }
+  function escapeAttribute(value){
+    return String(value || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+  }
+  function snapshotBackgroundColor(){
+    try {
+      var probe = window.getComputedStyle(document.body || document.documentElement);
+      var bg = probe && probe.backgroundColor || '';
+      if (!bg || bg === 'transparent' || bg === 'rgba(0, 0, 0, 0)') return '#ffffff';
+      return bg;
+    } catch (_) { return '#ffffff'; }
+  }
+  function canvasLooksBlank(ctx, cw, ch){
+    try {
+      var data = ctx.getImageData(0, 0, cw, ch).data;
+      var step = Math.max(4, Math.floor((cw * ch) / 4096)) * 4;
+      var first = null, samples = 0;
+      for (var i = 0; i + 3 < data.length; i += step){
+        samples++;
+        if (!first){ first = [data[i], data[i+1], data[i+2], data[i+3]]; continue; }
+        if (Math.abs(data[i]-first[0]) > 6 || Math.abs(data[i+1]-first[1]) > 6 ||
+            Math.abs(data[i+2]-first[2]) > 6 || Math.abs(data[i+3]-first[3]) > 6) return false;
+      }
+      return samples > 8;
+    } catch (_) { return false; }
+  }
+  function renderSnapshot(id){
+    var w = Math.max(1, window.innerWidth || document.documentElement.clientWidth || 1);
+    var h = Math.max(1, window.innerHeight || document.documentElement.clientHeight || 1);
+    var dpr = window.devicePixelRatio || 1;
+    var bgColor = snapshotBackgroundColor();
+    var docW = Math.max(w, document.documentElement.scrollWidth || 0, document.body ? document.body.scrollWidth : 0);
+    var docH = Math.max(h, document.documentElement.scrollHeight || 0, document.body ? document.body.scrollHeight : 0);
+    var clone = document.documentElement.cloneNode(true);
+    clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+    inlineSnapshotStyles(document.documentElement, clone);
+    pruneHiddenSnapshotNodes(document.documentElement, clone);
+    var scroll = scrollOffset();
+    var cloneBody = clone.querySelector('body');
+    var rootStyle = clone.getAttribute('style') || '';
+    var bodyStyle = cloneBody ? cloneBody.getAttribute('style') || '' : '';
+    var bodyContent = cloneBody ? cloneBody.innerHTML : clone.innerHTML;
+    var wrapperStyle = rootStyle + bodyStyle +
+      'margin:0;position:relative;left:' + (-scroll.x) + 'px;top:' + (-scroll.y) + 'px;' +
+      'width:' + docW + 'px;height:' + docH + 'px;overflow:visible;';
+    var html = '<div xmlns="http://www.w3.org/1999/xhtml" style="' + escapeAttribute(wrapperStyle) + '">' + bodyContent + '</div>';
+    var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' + w + '" height="' + h + '" viewBox="0 0 ' + w + ' ' + h + '">' +
+      '<foreignObject x="0" y="0" width="' + docW + '" height="' + docH + '">' + html + '</foreignObject></svg>';
+    var img = new Image();
+    img.onload = function(){
+      try {
+        var canvas = document.createElement('canvas');
+        canvas.width = Math.max(1, Math.floor(w * dpr));
+        canvas.height = Math.max(1, Math.floor(h * dpr));
+        var ctx = canvas.getContext('2d');
+        if (!ctx) throw new Error('no 2d context');
+        ctx.scale(dpr, dpr);
+        ctx.fillStyle = bgColor;
+        ctx.fillRect(0, 0, w, h);
+        ctx.drawImage(img, 0, 0, w, h);
+        if (canvasLooksBlank(ctx, canvas.width, canvas.height)) {
+          window.parent.postMessage({ type: 'od:snapshot:result', id: id, error: 'empty-render' }, '*');
+          return;
+        }
+        window.parent.postMessage({ type: 'od:snapshot:result', id: id, dataUrl: canvas.toDataURL('image/png'), w: canvas.width, h: canvas.height }, '*');
+      } catch (err) {
+        window.parent.postMessage({ type: 'od:snapshot:result', id: id, error: String(err && err.message || err) }, '*');
+      }
+    };
+    img.onerror = function(){
+      window.parent.postMessage({ type: 'od:snapshot:result', id: id, error: 'snapshot image failed' }, '*');
+    };
+    img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+  }
+  window.addEventListener('message', function(ev){
+    var data = ev && ev.data;
+    if (!data || data.type !== 'od:snapshot' || !data.id) return;
+    waitForImages().then(function(){ renderSnapshot(String(data.id)); });
+  });
+})();
+</script>`;
+
 function previewBridgeTokens(value: unknown): string[] {
   if (Array.isArray(value)) return value.flatMap(previewBridgeTokens);
   if (typeof value !== 'string') return [];
@@ -547,6 +725,10 @@ function wantsUrlPreviewSelectionBridge(value: unknown): boolean {
   return previewBridgeTokens(value).some((token) => token === 'selection' || token === 'comment' || token === 'comments' || token === 'annotation');
 }
 
+function wantsUrlPreviewSnapshotBridge(value: unknown): boolean {
+  return previewBridgeTokens(value).some((token) => token === 'snapshot' || token === 'image' || token === 'capture');
+}
+
 function injectBeforeBodyClose(html: string, marker: string, injection: string): string {
   if (html.includes(marker)) return html;
   const bodyCloseIndex = html.search(/<\/body\s*>/i);
@@ -556,10 +738,14 @@ function injectBeforeBodyClose(html: string, marker: string, injection: string):
   return `${html}${injection}`;
 }
 
-function injectUrlPreviewBridge(html: string, bridge: 'scroll' | 'selection'): string {
-  return bridge === 'scroll'
-    ? injectBeforeBodyClose(html, 'data-od-url-scroll-bridge', URL_PREVIEW_SCROLL_BRIDGE)
-    : injectBeforeBodyClose(html, 'data-od-url-selection-bridge', URL_PREVIEW_SELECTION_BRIDGE);
+function injectUrlPreviewBridge(html: string, bridge: 'scroll' | 'selection' | 'snapshot'): string {
+  if (bridge === 'scroll') {
+    return injectBeforeBodyClose(html, 'data-od-url-scroll-bridge', URL_PREVIEW_SCROLL_BRIDGE);
+  }
+  if (bridge === 'selection') {
+    return injectBeforeBodyClose(html, 'data-od-url-selection-bridge', URL_PREVIEW_SELECTION_BRIDGE);
+  }
+  return injectBeforeBodyClose(html, 'data-od-url-snapshot-bridge', URL_PREVIEW_SNAPSHOT_BRIDGE);
 }
 
 function normalizeChatSessionMode(value: unknown): ChatSessionMode {
@@ -2040,7 +2226,8 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
         (file) => {
           if (
             (wantsUrlPreviewScrollBridge(req.query.odPreviewBridge) ||
-              wantsUrlPreviewSelectionBridge(req.query.odPreviewBridge)) &&
+              wantsUrlPreviewSelectionBridge(req.query.odPreviewBridge) ||
+              wantsUrlPreviewSnapshotBridge(req.query.odPreviewBridge)) &&
             /^text\/html(?:;|$)/i.test(file.mime)
           ) {
             let html = file.buffer.toString('utf8');
@@ -2049,6 +2236,9 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
             }
             if (wantsUrlPreviewSelectionBridge(req.query.odPreviewBridge)) {
               html = injectUrlPreviewBridge(html, 'selection');
+            }
+            if (wantsUrlPreviewSnapshotBridge(req.query.odPreviewBridge)) {
+              html = injectUrlPreviewBridge(html, 'snapshot');
             }
             return html;
           }

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -174,6 +174,10 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
       path.join(dir, 'selection-bridged.html'),
       Buffer.from('<html><body><script data-od-url-selection-bridge></script><main>Preview</main></body></html>'),
     );
+    await writeFile(
+      path.join(dir, 'snapshot-bridged.html'),
+      Buffer.from('<html><body><script data-od-url-snapshot-bridge></script><main>Preview</main></body></html>'),
+    );
   });
 
   afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
@@ -266,14 +270,29 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(html).not.toContain('data-od-url-scroll-bridge');
   });
 
+  it('injects the URL preview snapshot bridge only when requested', async () => {
+    const plain = await fetch(rawUrl('page.html'));
+    expect(await plain.text()).toBe('<html/>');
+
+    const bridged = await fetch(`${rawUrl('page.html')}?odPreviewBridge=snapshot`);
+    expect(bridged.status).toBe(200);
+    const html = await bridged.text();
+    expect(html).toContain('data-od-url-snapshot-bridge');
+    expect(html).toContain("type: 'od:snapshot:result'");
+    expect(html).not.toContain('data-od-url-scroll-bridge');
+    expect(html).not.toContain('data-od-url-selection-bridge');
+  });
+
   it('injects scroll and selection URL preview bridges together', async () => {
-    const bridged = await fetch(`${rawUrl('body.html')}?odPreviewBridge=scroll&odPreviewBridge=selection`);
+    const bridged = await fetch(`${rawUrl('body.html')}?odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot`);
     expect(bridged.status).toBe(200);
     const html = await bridged.text();
     expect(html).toContain('data-od-url-scroll-bridge');
     expect(html).toContain('data-od-url-selection-bridge');
+    expect(html).toContain('data-od-url-snapshot-bridge');
     expect(html.indexOf('data-od-url-scroll-bridge')).toBeLessThan(html.indexOf('</body>'));
     expect(html.indexOf('data-od-url-selection-bridge')).toBeLessThan(html.indexOf('</body>'));
+    expect(html.indexOf('data-od-url-snapshot-bridge')).toBeLessThan(html.indexOf('</body>'));
   });
 
   it('does not inject the URL preview scroll bridge twice', async () => {
@@ -288,6 +307,13 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(bridged.status).toBe(200);
     const html = await bridged.text();
     expect(html.match(/data-od-url-selection-bridge/g)?.length).toBe(1);
+  });
+
+  it('does not inject the URL preview snapshot bridge twice', async () => {
+    const bridged = await fetch(`${rawUrl('snapshot-bridged.html')}?odPreviewBridge=snapshot`);
+    expect(bridged.status).toBe(200);
+    const html = await bridged.text();
+    expect(html.match(/data-od-url-snapshot-bridge/g)?.length).toBe(1);
   });
 
   it('returns 404 for a missing file', async () => {

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -349,16 +349,12 @@ function navElementForView(
 }
 
 // Tab views stay mounted (so previews/thumbnails survive a tab switch) but the
-// inactive ones must leave the accessibility tree and tab order — otherwise
-// keyboard users tab into off-screen controls and screen readers announce
-// several pages at once. `content-visibility: hidden` only skips paint, so the
-// inactive wrapper also gets `inert` (drops it from focus + a11y) and
-// `aria-hidden`. React renders `inert={false}` as no attribute and
-// `inert={true}` as the real boolean attribute, so toggling on `!active` is
-// enough — the active view stays fully interactive.
+// inactive ones must leave layout, the accessibility tree, and tab order.
+// `content-visibility: hidden` still reserves the hidden pane's block size,
+// which pushes later sidebar destinations far below the sticky topbar.
 function inactiveViewProps(active: boolean) {
   return {
-    style: active ? undefined : ({ contentVisibility: 'hidden' } as const),
+    style: active ? undefined : ({ display: 'none' } as const),
     inert: !active,
     'aria-hidden': !active,
   };

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5218,7 +5218,7 @@ function HtmlViewer({
     needsFocusGuard,
   }) && !manualEditRequiresSrcDoc;
   const basePreviewSrcUrl = useMemo(
-    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}&odPreviewBridge=scroll&odPreviewBridge=selection`,
+    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot`,
     [projectId, file.name, file.mtime, reloadKey],
   );
   const [previewSrcUrl, setPreviewSrcUrl] = useState(basePreviewSrcUrl);
@@ -7208,6 +7208,14 @@ function HtmlViewer({
       await waitForIframeLoadOrTimeout(activeIframe, 250);
       await waitForAnimationFrame();
       return requestPreviewSnapshotWithRetry(activeIframe);
+    }
+
+    const urlIframe = iframeRef.current ?? urlPreviewIframeRef.current;
+    if (urlIframe) {
+      await waitForIframeLoadOrTimeout(urlIframe, 250);
+      await waitForAnimationFrame();
+      const urlSnapshot = await requestPreviewSnapshotWithRetry(urlIframe);
+      if (urlSnapshot) return urlSnapshot;
     }
 
     const srcDocIframe = srcDocPreviewIframeRef.current;

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1814,8 +1814,11 @@ function FooterSelectOption({
           {groupedOptions.length === 0 ? (
             <div className="home-hero__footer-select-empty">{t('homeHero.footer.noMatches')}</div>
           ) : (
-            groupedOptions.map((group) => (
-              <div className="home-hero__footer-select-group" key={group.label ?? 'ungrouped'}>
+            groupedOptions.map((group, index) => (
+              <div
+                className="home-hero__footer-select-group"
+                key={`${group.label ?? 'ungrouped'}:${group.options[0]?.value ?? index}`}
+              >
                 {group.label ? (
                   <div className="home-hero__footer-select-group-label">{group.label}</div>
                 ) : null}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -169,7 +169,10 @@ import {
   useCritiqueTheaterEnabled,
 } from './Theater';
 import { useIframeKeepAlivePool } from './IframeKeepAlivePool';
-import { decideAutoOpenAfterWrite } from './auto-open-file';
+import {
+  decideAutoOpenAfterWrite,
+  selectAutoOpenProducedHtml,
+} from './auto-open-file';
 import { buildRepoImportPrompt, designSystemNeedsRepoConnect } from './design-system-github-evidence';
 import { collectReferencedJsxNames } from '../runtime/jsx-module-refs';
 import { FileWorkspace } from './FileWorkspace';
@@ -2596,6 +2599,8 @@ export function ProjectView({
                 }
                 const diff = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
                 const produced = mergeRecoveredArtifact(diff, recoveredExistingArtifact);
+                const producedHtmlToOpen = selectAutoOpenProducedHtml(produced);
+                if (producedHtmlToOpen) requestOpenFile(producedHtmlToOpen);
                 if (produced.length > 0) {
                   updateMessageById(
                     message.id,
@@ -3286,6 +3291,8 @@ export function ProjectView({
               nextFiles = await refreshProjectFiles();
             }
             const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+            const producedHtmlToOpen = selectAutoOpenProducedHtml(produced);
+            if (producedHtmlToOpen) requestOpenFile(producedHtmlToOpen);
             setMessages((curr) => {
               const updated = curr.map((m) =>
                 m.id === assistantId

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2914,7 +2914,7 @@ export function ProjectView({
             )
           : apiProtocolModelLabel(config.apiProtocol, config.model);
       const preTurnFileNames = projectFiles.map((f) => f.name);
-      const assistantId = retryTarget?.failedAssistant.id ?? randomUUID();
+      const assistantId = randomUUID();
       const assistantMsg: ChatMessage = {
         id: assistantId,
         role: 'assistant',
@@ -2922,7 +2922,7 @@ export function ProjectView({
         agentId: assistantAgentId,
         agentName: assistantAgentName,
         events: [],
-        createdAt: retryTarget?.failedAssistant.createdAt ?? startedAt,
+        createdAt: startedAt,
         runStatus: config.mode === 'daemon' ? 'running' : undefined,
         startedAt,
         preTurnFileNames,
@@ -2957,7 +2957,10 @@ export function ProjectView({
       const nextHistory = retryTarget
         ? [...retryTarget.priorMessages, userMsg]
         : [...historyBase, userMsg];
-      setMessages([...nextHistory, assistantMsg]);
+      const nextVisibleMessages = retryTarget
+        ? [...nextHistory, ...retryTarget.preservedAttempts, assistantMsg]
+        : [...nextHistory, assistantMsg];
+      setMessages(nextVisibleMessages);
       markStreamingConversation(runConversationId);
       updateConversationLatestRun(config.mode === 'daemon' ? 'running' : 'queued');
       setArtifact(null);
@@ -5718,6 +5721,7 @@ export interface RetryTarget {
   failedAssistant: ChatMessage;
   userMsg: ChatMessage;
   priorMessages: ChatMessage[];
+  preservedAttempts: ChatMessage[];
 }
 
 export function resolveRetryTarget(
@@ -5732,14 +5736,24 @@ export function resolveRetryTarget(
   );
   if (failedIndex <= 0 || failedIndex !== messages.length - 1) return null;
 
-  const userMsg = messages[failedIndex - 1];
+  let userIndex = failedIndex - 1;
+  while (
+    userIndex >= 0 &&
+    messages[userIndex]?.role === 'assistant' &&
+    messages[userIndex]?.runStatus === 'failed'
+  ) {
+    userIndex -= 1;
+  }
+
+  const userMsg = messages[userIndex];
   const failedAssistant = messages[failedIndex];
   if (!userMsg || userMsg.role !== 'user' || !failedAssistant) return null;
 
   return {
     failedAssistant,
     userMsg,
-    priorMessages: messages.slice(0, failedIndex - 1),
+    priorMessages: messages.slice(0, userIndex),
+    preservedAttempts: messages.slice(userIndex + 1, failedIndex + 1),
   };
 }
 

--- a/apps/web/src/components/auto-open-file.ts
+++ b/apps/web/src/components/auto-open-file.ts
@@ -19,6 +19,8 @@
 interface CandidateFile {
   readonly name: string;
   readonly path?: string;
+  readonly kind?: string;
+  readonly mtime?: number;
 }
 
 interface AutoOpenOptions {
@@ -92,4 +94,27 @@ export function decideAutoOpenAfterWrite(
     return resolve(basenameMatches[0]!.name);
   }
   return { shouldOpen: false, fileName: null };
+}
+
+function isHtmlPreviewFile(file: CandidateFile): boolean {
+  const path = file.path ?? file.name;
+  return file.kind === 'html' || /\.html?$/i.test(path);
+}
+
+export function selectAutoOpenProducedHtml(
+  producedFiles: ReadonlyArray<CandidateFile>,
+): string | null {
+  let selected: CandidateFile | null = null;
+  for (const file of producedFiles) {
+    if (!isHtmlPreviewFile(file)) continue;
+    if (!selected) {
+      selected = file;
+      continue;
+    }
+    const nextMtime = typeof file.mtime === 'number' && Number.isFinite(file.mtime) ? file.mtime : 0;
+    const selectedMtime =
+      typeof selected.mtime === 'number' && Number.isFinite(selected.mtime) ? selected.mtime : 0;
+    if (nextMtime >= selectedMtime) selected = file;
+  }
+  return selected?.name ?? null;
 }

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -627,7 +627,7 @@ describe('FileViewer SVG artifacts', () => {
     const { container } = render(<Shell />);
 
     const firstFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-    expect(firstFrame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection');
+    expect(firstFrame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot');
 
     fireEvent.click(screen.getByRole('button', { name: 'Leave project' }));
 
@@ -635,7 +635,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.getByTestId('home-view')).toBeTruthy();
     const parkedFrame = container.querySelector<HTMLIFrameElement>('.iframe-keep-alive-pool iframe');
     expect(parkedFrame).toBe(firstFrame);
-    expect(parkedFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection');
+    expect(parkedFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot');
 
     fireEvent.click(screen.getByRole('button', { name: 'Return project' }));
 
@@ -782,7 +782,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).toContain('data-od-render-mode="url-load"');
     expect(markup).toContain('data-od-render-mode="url-load" data-od-active="true"');
     expect(markup).toContain('data-od-render-mode="srcdoc" data-od-active="false"');
-    expect(markup).toContain('src="/api/projects/project-1/raw/page.html?v=1710000000&amp;r=0&amp;odPreviewBridge=scroll&amp;odPreviewBridge=selection"');
+    expect(markup).toContain('src="/api/projects/project-1/raw/page.html?v=1710000000&amp;r=0&amp;odPreviewBridge=scroll&amp;odPreviewBridge=selection&amp;odPreviewBridge=snapshot"');
     expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
   });
 
@@ -812,13 +812,13 @@ describe('FileViewer SVG artifacts', () => {
     );
 
     const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-    expect(frame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection');
+    expect(frame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot');
 
     fireEvent.click(screen.getByRole('button', { name: /reload preview/i }));
 
     const reloadedFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     expect(reloadedFrame).toBe(frame);
-    expect(reloadedFrame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=1&odPreviewBridge=scroll&odPreviewBridge=selection');
+    expect(reloadedFrame.getAttribute('src')).toBe('/api/projects/project-1/raw/page.html?v=1710000000&r=1&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot');
   });
 
   it('remounts the srcDoc HTML preview when reload is requested', () => {
@@ -1168,7 +1168,7 @@ describe('FileViewer SVG artifacts', () => {
     const { container } = render(<Switcher />);
     const getFrame = () => container.querySelector<HTMLIFrameElement>('[data-testid="artifact-preview-frame"]');
     const initialFrame = getFrame();
-    expect(initialFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/first.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection');
+    expect(initialFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/first.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot');
 
     const observationsBeforeSwitch = observedCommittedSrcs.length;
     fireEvent.click(screen.getByRole('button', { name: 'Switch file' }));
@@ -1176,9 +1176,9 @@ describe('FileViewer SVG artifacts', () => {
     const nextFrame = getFrame();
     expect(nextFrame).toBeTruthy();
     expect(observedCommittedSrcs[observationsBeforeSwitch]).toBe(
-      '/api/projects/project-1/raw/second.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection',
+      '/api/projects/project-1/raw/second.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot',
     );
-    expect(nextFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/second.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection');
+    expect(nextFrame?.getAttribute('src')).toBe('/api/projects/project-1/raw/second.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot');
   });
 
   it('allows downloads in the in-tab HTML presentation iframe', async () => {

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -127,6 +127,28 @@ describe('HomeView media composer options', () => {
     expect(within(menu).getByText('Official preset')).toBeTruthy();
   });
 
+  it('opens the Home style picker without duplicate group key warnings', async () => {
+    stubFetch();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      renderHome({
+        defaultDesignSystemId: 'official-default',
+        designSystems: [
+          designSystem('official-default', 'Official Default', 'built-in', 'published'),
+          designSystem('official-alt', 'Official Alt', 'built-in', 'published'),
+        ],
+      });
+
+      await clickHomeRailChip('image');
+      await openOption('designSystem');
+
+      const messages = consoleError.mock.calls.map((call) => call.map(String).join(' '));
+      expect(messages.some((message) => message.includes('Encountered two children with the same key'))).toBe(false);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('switches media chips without opening the replacement dialog', async () => {
     stubFetch();
     renderHome();

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -243,6 +243,37 @@ describe('retry target resolution', () => {
       failedAssistant,
       userMsg: userMessage,
       priorMessages: [systemContext],
+      preservedAttempts: [failedAssistant],
+    });
+  });
+
+  it('keeps earlier failed retry attempts visible while reusing the original user turn', () => {
+    const firstFailure: ChatMessage = {
+      ...failedAssistant,
+      id: 'assistant-1',
+      content: 'First attempt produced partial output',
+      events: [{ kind: 'text', text: 'thinking before failure' }],
+      producedFiles: [
+        {
+          name: 'partial.html',
+          kind: 'html',
+          mime: 'text/html',
+          mtime: 1,
+          size: 100,
+        },
+      ],
+    };
+    const secondFailure: ChatMessage = {
+      ...failedAssistant,
+      id: 'assistant-2',
+      content: 'Retry failed too',
+    };
+
+    expect(resolveRetryTarget([userMessage, firstFailure, secondFailure], secondFailure.id)).toEqual({
+      failedAssistant: secondFailure,
+      userMsg: userMessage,
+      priorMessages: [],
+      preservedAttempts: [firstFailure, secondFailure],
     });
   });
 

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -291,6 +291,19 @@ vi.mock('../../src/components/ChatPane', () => ({
             .filter(Boolean)
             .join('\n')}
         </output>
+        <output data-testid="assistant-summary">
+          {(messages ?? [])
+            .filter((message) => message.role === 'assistant')
+            .map((message) =>
+              [
+                message.id,
+                message.runStatus ?? '',
+                message.content,
+                ...(message.producedFiles ?? []).map((file) => file.name),
+              ].join('|'),
+            )
+            .join('\n')}
+        </output>
         <output data-testid="attached-comment-count">{attached.length}</output>
         {queuedItems?.map((item, index) => (
           <button
@@ -1127,6 +1140,57 @@ describe('ProjectView conversation run isolation', () => {
     fireEvent.click(screen.getByTestId('workspace-retry'));
 
     await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
+  });
+
+  it('preserves the failed attempt transcript when retry starts a replacement run', async () => {
+    const userMessage: ChatMessage = {
+      id: 'user-retry',
+      role: 'user',
+      content: 'make an editorial landing page',
+      createdAt: 1,
+    };
+    const failedAssistant: ChatMessage = {
+      id: 'assistant-failed',
+      role: 'assistant',
+      content: 'Partial plan before the crash',
+      createdAt: 2,
+      runStatus: 'failed',
+      events: [{ kind: 'text', text: 'I will build the page' }],
+      producedFiles: [
+        {
+          name: 'partial.html',
+          kind: 'html',
+          mime: 'text/html',
+          mtime: 2,
+          size: 100,
+        },
+      ],
+    };
+    conversationAMessages = [userMessage, failedAssistant];
+    fetchChatRunStatus.mockResolvedValue(null);
+    streamViaDaemon.mockImplementation(async () => {});
+
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('workspace-retry')).toBeTruthy());
+
+    fireEvent.click(screen.getByTestId('workspace-retry'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    const retryCall = streamViaDaemon.mock.calls[0]?.[0] as {
+      assistantMessageId?: string;
+      history?: ChatMessage[];
+    };
+    expect(retryCall.assistantMessageId).toBeTruthy();
+    expect(retryCall.assistantMessageId).not.toBe('assistant-failed');
+    expect(retryCall.history).toEqual([userMessage]);
+
+    await waitFor(() => {
+      const summary = screen.getByTestId('assistant-summary').textContent ?? '';
+      expect(summary).toContain('assistant-failed|failed|Partial plan before the crash|partial.html');
+      expect(summary).toContain(`${retryCall.assistantMessageId}|running|`);
+    });
   });
 
   it('routes workspace authorize recovery through AMR mode switching for structured auth failures', async () => {

--- a/apps/web/tests/components/auto-open-file.test.ts
+++ b/apps/web/tests/components/auto-open-file.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { decideAutoOpenAfterWrite } from '../../src/components/auto-open-file';
+import {
+  decideAutoOpenAfterWrite,
+  selectAutoOpenProducedHtml,
+} from '../../src/components/auto-open-file';
 
 describe('decideAutoOpenAfterWrite', () => {
   it('returns shouldOpen=false when filePath is empty', () => {
@@ -135,5 +138,33 @@ describe('decideAutoOpenAfterWrite', () => {
       { moduleFileNames: new Set(['icons.jsx']) },
     );
     expect(result).toEqual({ shouldOpen: true, fileName: 'landing.html' });
+  });
+});
+
+describe('selectAutoOpenProducedHtml', () => {
+  it('selects a newly produced html file for the turn-end auto-open fallback', () => {
+    const result = selectAutoOpenProducedHtml([
+      { name: 'notes.txt', path: 'notes.txt', kind: 'text', mtime: 20 },
+      { name: 'mutuals-v2.html', path: 'mutuals-v2.html', kind: 'html', mtime: 30 },
+    ]);
+
+    expect(result).toBe('mutuals-v2.html');
+  });
+
+  it('prefers the newest produced html file when a turn writes multiple html files', () => {
+    const result = selectAutoOpenProducedHtml([
+      { name: 'index.html', path: 'index.html', kind: 'html', mtime: 10 },
+      { name: 'mutuals-v2.html', path: 'mutuals-v2.html', kind: 'html', mtime: 30 },
+    ]);
+
+    expect(result).toBe('mutuals-v2.html');
+  });
+
+  it('returns null when the produced files are not html previews', () => {
+    const result = selectAutoOpenProducedHtml([
+      { name: 'deck.pptx', path: 'deck.pptx', kind: 'presentation', mtime: 30 },
+    ]);
+
+    expect(result).toBeNull();
   });
 });

--- a/apps/web/tests/components/file-viewer-image-export.test.tsx
+++ b/apps/web/tests/components/file-viewer-image-export.test.tsx
@@ -68,7 +68,7 @@ function renderHtmlPreview() {
   const srcDocFrame = container.querySelector<HTMLIFrameElement>('iframe[data-od-render-mode="srcdoc"]');
   expect(srcDocFrame).toBeTruthy();
   fireEvent.load(srcDocFrame as HTMLIFrameElement);
-  return { ...view, srcDocFrame: srcDocFrame as HTMLIFrameElement };
+  return { ...view, activeFrame, srcDocFrame: srcDocFrame as HTMLIFrameElement };
 }
 
 function openImageExportDialog() {
@@ -86,7 +86,7 @@ async function waitForSaveButton() {
 describe('FileViewer image export', () => {
   afterEach(() => {
     cleanup();
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   it('lets users choose an image format before saving URL-loaded HTML previews', async () => {
@@ -107,12 +107,12 @@ describe('FileViewer image export', () => {
       save: saveImageBlobMock,
     });
 
-    const { srcDocFrame } = renderHtmlPreview();
+    const { activeFrame } = renderHtmlPreview();
     openImageExportDialog();
     expect(screen.getByRole('radio', { name: 'PNG' })).toBeTruthy();
 
     await waitFor(() => {
-      expect(requestPreviewSnapshotMock).toHaveBeenCalledWith(srcDocFrame, 1500);
+      expect(requestPreviewSnapshotMock).toHaveBeenCalledWith(activeFrame, 1500);
       expect(imageDataUrlToBlobMock).toHaveBeenCalledWith('data:image/png;base64,ok', 'png');
     });
     await waitForSaveButton();
@@ -123,7 +123,7 @@ describe('FileViewer image export', () => {
     });
 
     fireEvent.click(await waitForSaveButton());
-    fireEvent.load(srcDocFrame as HTMLIFrameElement);
+    fireEvent.load(activeFrame as HTMLIFrameElement);
 
     await waitFor(() => {
       expect(prepareImageExportTargetMock).toHaveBeenCalledWith('workspace', 'jpeg', { useNativePicker: false });
@@ -135,24 +135,52 @@ describe('FileViewer image export', () => {
 
   it('retries the srcDoc snapshot bridge before giving up on URL-loaded previews', async () => {
     const pngBlob = new Blob(['png'], { type: 'image/png' });
-    requestPreviewSnapshotMock
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({
+    let srcDocAttempts = 0;
+    requestPreviewSnapshotMock.mockImplementation(async (iframe: HTMLIFrameElement) => {
+      if (iframe.getAttribute('data-od-render-mode') === 'url-load') return null;
+      srcDocAttempts += 1;
+      if (srcDocAttempts === 1) return null;
+      return {
         dataUrl: 'data:image/png;base64,recovered',
         w: 800,
         h: 600,
-      });
+      };
+    });
     imageDataUrlToBlobMock.mockResolvedValueOnce(pngBlob);
 
     const { srcDocFrame } = renderHtmlPreview();
     openImageExportDialog();
 
     await waitFor(() => {
-      expect(requestPreviewSnapshotMock).toHaveBeenCalledTimes(2);
-      expect(requestPreviewSnapshotMock).toHaveBeenNthCalledWith(1, srcDocFrame, 1500);
-      expect(requestPreviewSnapshotMock).toHaveBeenNthCalledWith(2, srcDocFrame, 3000);
+      expect(requestPreviewSnapshotMock).toHaveBeenCalledWith(srcDocFrame, 1500);
+      expect(requestPreviewSnapshotMock).toHaveBeenCalledWith(srcDocFrame, 3000);
       expect(imageDataUrlToBlobMock).toHaveBeenCalledWith('data:image/png;base64,recovered', 'png');
+    }, { timeout: 4000 });
+  });
+
+  it('captures the visible URL-loaded preview before falling back to the hidden srcDoc transport', async () => {
+    const pngBlob = new Blob(['png'], { type: 'image/png' });
+    requestPreviewSnapshotMock.mockImplementation(async (iframe: HTMLIFrameElement) => {
+      if (iframe.getAttribute('data-od-render-mode') === 'url-load') {
+        return {
+          dataUrl: 'data:image/png;base64,visible',
+          w: 800,
+          h: 600,
+        };
+      }
+      return null;
     });
+    imageDataUrlToBlobMock.mockResolvedValueOnce(pngBlob);
+
+    const { activeFrame, srcDocFrame } = renderHtmlPreview();
+    openImageExportDialog();
+
+    await waitFor(() => {
+      expect(requestPreviewSnapshotMock).toHaveBeenCalledWith(activeFrame, 1500);
+      expect(imageDataUrlToBlobMock).toHaveBeenCalledWith('data:image/png;base64,visible', 'png');
+    });
+    expect(requestPreviewSnapshotMock).not.toHaveBeenCalledWith(srcDocFrame, 1500);
+    expect(screen.queryByRole('alert')).toBeNull();
   });
 
   it('uses the prepared PNG data URL for fallback downloads', async () => {
@@ -196,7 +224,7 @@ describe('FileViewer image export', () => {
       expect(screen.getByRole('alert').textContent).toBe(
         "Image capture failed. Please try again or use your browser's screenshot tool.",
       );
-    });
+    }, { timeout: 4000 });
     expect((screen.getByRole('button', { name: /^save$/i }) as HTMLButtonElement).disabled).toBe(true);
     expect(prepareImageExportTargetMock).not.toHaveBeenCalled();
     expect(imageDataUrlToBlobMock).not.toHaveBeenCalled();
@@ -223,7 +251,7 @@ describe('FileViewer image export', () => {
       expect(screen.getByRole('alert').textContent).toBe(
         "Image capture failed. Please try again or use your browser's screenshot tool.",
       );
-    });
+    }, { timeout: 4000 });
     expect((screen.getByRole('button', { name: /^save$/i }) as HTMLButtonElement).disabled).toBe(true);
     expect(imageDataUrlToBlobMock).toHaveBeenCalledWith('data:image/png;base64,ok', 'png');
     expect(prepareImageExportTargetMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## What users will see

Small fixes already shipped on the v0.10.0 line, now also on main: the Home style picker no longer warns on duplicate group keys; a failed-then-retried turn keeps its earlier messages instead of blanking; produced HTML files auto-open their preview; image/URL preview export captures correctly; and on the Design Files view, hidden panes no longer reserve space that pushed sidebar items below the topbar.


## Why

Reconciliation ahead of re-cutting `release/v0.10.0` from `main`. A batch of fixes were merged **directly** into `release/v0.10.0` (base=release) and never landed on `main`. Re-cutting the release branch from `main` would silently drop them, so they need to be on `main` first.

This PR ports the **cleanly-applicable** subset (verified by content-level audit, not SHA — cherry-picks/patch-ids are unreliable across squash/rebase). Each fix applied cleanly to current `main` except #3629, resolved as noted below.

## What's included

| Origin (release PR) | Fix |
| --- | --- |
| #3620 | avoid duplicate style picker group keys |
| #3629 | Design Files / sidebar layout regression — hidden panes used `content-visibility: hidden` (still reserves block size, pushing sidebar items below the sticky topbar); switch to `display: none` |
| #3639 | preserve failed retry attempts |
| #3636 | auto-open produced HTML previews |
| #3685 | URL preview image export capture |

**#3629 conflict resolution:** the release commit also reverted main's `#3260` table-cell ellipsis fix (`max-width:0; min-width:0`) in `design-files.css` in favor of `overflow: hidden`. Main's `#3260` approach is newer and more precise, so I kept main's CSS and took only #3629's `EntryShell` `content-visibility → display:none` change (the actual sidebar-layout fix). Porting the CSS blindly would have regressed #3260.

## Not in this PR (deliberately)

Verified already-present or partially-superseded on `main`; being handled surgically in follow-ups so we don't regress newer main work:
- **#3653** (stale chat anchor spacer on resend) — already covered on `main` by #3669 (same `resetTailSpacer` / anchor-reset). Not porting.
- **#3638** (route project file links to tabs) — `main` already routes in-project links to the workspace tab; only the *project-id scoping* sliver is missing. Surgical port.
- **#3630** (copy run error diagnostics) — genuinely missing, but conflicts in the heavily-evolved `ChatPane.tsx`. Own PR.
- **#3661** (question forms in questions panel) — overlaps `main`'s Questions tab (#3355); needs careful resolution. Own PR.

## Surface area

- [x] **UI** — small web fixes (style picker, retry preservation, produced-file auto-open, image export, Design Files layout) in `apps/web`.
- [x] **i18n keys** — none added here.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `apps/web` ProjectView / FileViewer / EntryShell + related suites — 271 passed