### PR TITLE
[codex] Close home mention picker before details

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -657,6 +657,13 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     }
   }
 
+  function dismissMentionPicker() {
+    setMentionTrigger(null);
+    setMentionTab('all');
+    setHoveredPlugin(null);
+    setSelectedIndex(0);
+  }
+
   // Routes popover navigation keys from the Lexical editor over the visible
   // picker option union. Returns true when consumed so the editor can
   // preventDefault.
@@ -1122,7 +1129,10 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
                 <button
                   type="button"
                   onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => onOpenPluginDetails(hoveredPlugin)}
+                  onClick={() => {
+                    dismissMentionPicker();
+                    onOpenPluginDetails(hoveredPlugin);
+                  }}
                 >
                   {t('homeHero.details')}
                 </button>

--- a/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
+++ b/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
@@ -451,6 +451,41 @@ describe('HomeHero plugin picker', () => {
     expect(screen.queryByTestId('home-hero-plugin-picker')).toBeNull();
   });
 
+  it('closes the @ picker when opening plugin details from the hover card', async () => {
+    const onOpenPluginDetails = vi.fn();
+    const plugin = makePlugin('sample-plugin', 'Sample Plugin');
+    render(
+      <HomeHero
+        prompt=""
+        onPromptChange={() => undefined}
+        onSubmit={() => undefined}
+        activePluginTitle={null}
+        activeChipId={null}
+        onClearActivePlugin={() => undefined}
+        onOpenPluginDetails={onOpenPluginDetails}
+        pluginOptions={[plugin]}
+        pluginsLoading={false}
+        pendingPluginId={null}
+        pendingChipId={null}
+        onPickPlugin={() => undefined}
+        onPickChip={() => undefined}
+        contextItemCount={0}
+        error={null}
+      />,
+    );
+
+    setHomeHeroPrompt('@sam');
+    await settle();
+    fireEvent.mouseEnter(screen.getByRole('option', { name: /sample plugin/i }));
+    await settle();
+
+    expect(screen.getByTestId('home-hero-plugin-picker')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
+
+    expect(onOpenPluginDetails).toHaveBeenCalledWith(plugin);
+    expect(screen.queryByTestId('home-hero-plugin-picker')).toBeNull();
+  });
+
   it('opens active plugin details from the active plugin chip', () => {
     const onOpenPluginDetails = vi.fn();
     const active = makePlugin('prototype-plugin', 'Prototype Plugin');


### PR DESCRIPTION
## Why

Opening this PR to fix a Home page layering/focus bug in the @ mention picker. When a user opens the @ picker, hovers a plugin, and clicks Details, the picker currently remains mounted over the plugin details modal because the active @ trigger is still valid at the editor caret.

The pain is user-facing: the lightweight picker competes with the heavier details view and partially covers the content the user explicitly asked to inspect.

## What users will see

On Home, clicking Details from a plugin hover card in the @ picker closes the @ picker before opening the plugin details modal. The typed @ text stays in the composer.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. Behavior is covered by a focused component regression test: the @ picker closes when Details opens.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/HomeHero.plugin-picker.test.tsx`
- Did the test go red on `main` and green on this branch? no, this was added directly as a regression test for the main-targeted fix
- If a red spec wasn't cheap to write, explain why and what verification you did instead: This is a small interaction-state fix in an existing jsdom component harness; the new test asserts the previous bad state by checking the picker is open before Details and gone after Details while the details callback still fires.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web test -- HomeHero.plugin-picker.test.tsx` (current config ran the web Vitest suite on the main base: 305 files passed)
- `pnpm --filter @open-design/web typecheck`
