### PR TITLE
chore(web): re-home in-flight release/v0.10.0 fixes to main (#3716, #3710, #3662)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -8836,7 +8836,7 @@ function HtmlViewer({
                   void handleImageExportSave();
                 }}
               >
-                {imageExportBusy || imageExportPreparing ? t('fileViewer.exportImageSaving') : t('common.save')}
+                {imageExportBusy ? t('fileViewer.exportImageSaving') : t('common.save')}
               </button>
             </div>
           </div>

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -657,6 +657,13 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     }
   }
 
+  function dismissMentionPicker() {
+    setMentionTrigger(null);
+    setMentionTab('all');
+    setHoveredPlugin(null);
+    setSelectedIndex(0);
+  }
+
   // Routes popover navigation keys from the Lexical editor over the visible
   // picker option union. Returns true when consumed so the editor can
   // preventDefault.
@@ -1122,7 +1129,10 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
                 <button
                   type="button"
                   onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => onOpenPluginDetails(hoveredPlugin)}
+                  onClick={() => {
+                    dismissMentionPicker();
+                    onOpenPluginDetails(hoveredPlugin);
+                  }}
                 >
                   {t('homeHero.details')}
                 </button>

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -118,8 +118,9 @@
   pointer-events: auto;
 }
 .od-toast.placement-top {
-  top: 24px;
+  top: 64px;
   bottom: auto;
+  z-index: 1200;
 }
 .od-toast.tone-success {
   border: 1px solid color-mix(in srgb, var(--success, #2da44e) 42%, var(--border));

--- a/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
+++ b/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
@@ -451,6 +451,41 @@ describe('HomeHero plugin picker', () => {
     expect(screen.queryByTestId('home-hero-plugin-picker')).toBeNull();
   });
 
+  it('closes the @ picker when opening plugin details from the hover card', async () => {
+    const onOpenPluginDetails = vi.fn();
+    const plugin = makePlugin('sample-plugin', 'Sample Plugin');
+    render(
+      <HomeHero
+        prompt=""
+        onPromptChange={() => undefined}
+        onSubmit={() => undefined}
+        activePluginTitle={null}
+        activeChipId={null}
+        onClearActivePlugin={() => undefined}
+        onOpenPluginDetails={onOpenPluginDetails}
+        pluginOptions={[plugin]}
+        pluginsLoading={false}
+        pendingPluginId={null}
+        pendingChipId={null}
+        onPickPlugin={() => undefined}
+        onPickChip={() => undefined}
+        contextItemCount={0}
+        error={null}
+      />,
+    );
+
+    setHomeHeroPrompt('@sam');
+    await settle();
+    fireEvent.mouseEnter(screen.getByRole('option', { name: /sample plugin/i }));
+    await settle();
+
+    expect(screen.getByTestId('home-hero-plugin-picker')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }));
+
+    expect(onOpenPluginDetails).toHaveBeenCalledWith(plugin);
+    expect(screen.queryByTestId('home-hero-plugin-picker')).toBeNull();
+  });
+
   it('opens active plugin details from the active plugin chip', () => {
     const onOpenPluginDetails = vi.fn();
     const active = makePlugin('prototype-plugin', 'Prototype Plugin');

--- a/apps/web/tests/components/file-viewer-image-export.test.tsx
+++ b/apps/web/tests/components/file-viewer-image-export.test.tsx
@@ -79,7 +79,9 @@ function openImageExportDialog() {
 
 async function waitForSaveButton() {
   const button = await screen.findByRole('button', { name: /^save$/i });
-  expect((button as HTMLButtonElement).disabled).toBe(false);
+  await waitFor(() => {
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+  });
   return button;
 }
 
@@ -131,6 +133,38 @@ describe('FileViewer image export', () => {
     expect(requestPreviewSnapshotMock).toHaveBeenCalledTimes(1);
     expect(saveImageBlobMock).toHaveBeenCalledWith(imageBlob);
     expect(screen.getByText('workspace.jpg')).toBeTruthy();
+  });
+
+  it('keeps the Save label stable while a format change prepares the next image', async () => {
+    const pngBlob = new Blob(['png'], { type: 'image/png' });
+    let resolveJpegBlob: ((blob: Blob) => void) | undefined;
+    requestPreviewSnapshotMock.mockResolvedValueOnce({
+      dataUrl: 'data:image/png;base64,ok',
+      w: 800,
+      h: 600,
+    });
+    imageDataUrlToBlobMock
+      .mockResolvedValueOnce(pngBlob)
+      .mockImplementationOnce(async () => new Promise<Blob>((resolve) => {
+        resolveJpegBlob = resolve;
+      }));
+
+    renderHtmlPreview();
+    openImageExportDialog();
+
+    await waitForSaveButton();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'JPEG' }));
+    await waitFor(() => {
+      expect(imageDataUrlToBlobMock).toHaveBeenCalledWith('data:image/png;base64,ok', 'jpeg');
+    });
+
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /saving image/i })).toBeNull();
+    expect((screen.getByRole('button', { name: /^save$/i }) as HTMLButtonElement).disabled).toBe(true);
+
+    resolveJpegBlob?.(new Blob(['jpeg'], { type: 'image/jpeg' }));
+    await waitForSaveButton();
   });
 
   it('retries the srcDoc snapshot bridge before giving up on URL-loaded previews', async () => {


### PR DESCRIPTION
## Why

Re-homes the **3 still-open PRs that targeted `release/v0.10.0`** onto `main`, so the release branch can be retired/deleted without losing their fixes. These were opened against the release branch (base=release); their fix commits cherry-pick cleanly onto `main` now that #3715 reconciled the branches.

| Re-homed from | Fix |
| --- | --- |
| #3716 | Close the Home mention/plugin picker before opening details |
| #3710 | Fix image-export download toast offset |
| #3662 | Fix the image-export format-switch save label |

Once this lands, #3716 / #3710 / #3662 are superseded and can be closed; `release/v0.10.0` then has nothing main lacks.

## Surface area

- [x] **UI** — Home picker dismissal (`HomeHero`), image-export toast offset (`routines.css`), image-export save label (`FileViewer`) in `apps/web`.

## Validation

- `pnpm guard` — pass · `pnpm --filter @open-design/web typecheck` — pass
- `apps/web` HomeHero + FileViewer suites — **199 passed**
- Clean cherry-picks of the three release-branch fix commits (no conflicts).
