### PR TITLE
fix(web): keep in-tab presentation below workspace tabs

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4661,6 +4661,7 @@ function HtmlViewer({
   const [manualEditFrozenSource, setManualEditFrozenSource] = useState<string | null>(null);
   const [manualEditViewportWidth, setManualEditViewportWidth] = useState<number | null>(null);
   const [commentPortalHost, setCommentPortalHost] = useState<HTMLElement | null>(null);
+  const [tabPresentChromeHeight, setTabPresentChromeHeight] = useState<number | null>(null);
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -6523,11 +6524,25 @@ function HtmlViewer({
 
   useEffect(() => {
     if (!inTabPresent) return;
+    const updateChromeHeight = () => {
+      const chrome = document.querySelector<HTMLElement>('.workspace-tabs-chrome.app-chrome-header');
+      const height = chrome?.getBoundingClientRect().height ?? 0;
+      setTabPresentChromeHeight(height > 0 ? Math.round(height) : null);
+    };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setInTabPresent(false);
     };
+    updateChromeHeight();
     document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
+    window.addEventListener('resize', updateChromeHeight);
+    const chrome = document.querySelector<HTMLElement>('.workspace-tabs-chrome.app-chrome-header');
+    const observer = chrome && typeof ResizeObserver !== 'undefined' ? new ResizeObserver(updateChromeHeight) : null;
+    if (observer && chrome) observer.observe(chrome);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      window.removeEventListener('resize', updateChromeHeight);
+      observer?.disconnect();
+    };
   }, [inTabPresent]);
 
   function openInNewTab() {
@@ -6787,6 +6802,7 @@ function HtmlViewer({
 
   function presentInThisTab() {
     setPresentMenuOpen(false);
+    setMode('preview');
     setInTabPresent(true);
   }
 
@@ -7887,7 +7903,7 @@ function HtmlViewer({
   ) : null;
 
   return (
-    <div className="viewer html-viewer">
+    <div className={`viewer html-viewer${inTabPresent ? ' is-tab-present' : ''}`}>
       <div className="viewer-toolbar">
         <div className="viewer-toolbar-left">
           <button
@@ -8744,11 +8760,14 @@ function HtmlViewer({
           <pre className="viewer-source">{source}</pre>
         )}
       </div>
-      {inTabPresent && source ? (
+      {inTabPresent && source && typeof document !== 'undefined' ? createPortal(
         <div
           className="present-overlay"
           role="dialog"
           aria-label={t('fileViewer.exitPresentation')}
+          style={tabPresentChromeHeight ? ({
+            '--workspace-tabs-chrome-height': `${tabPresentChromeHeight}px`,
+          } as CSSProperties) : undefined}
         >
           <button
             className="present-exit"
@@ -8772,7 +8791,8 @@ function HtmlViewer({
               srcDoc={srcDoc}
             />
           )}
-        </div>
+        </div>,
+        document.body,
       ) : null}
       {imageExportModalOpen ? (
         <div className="modal-backdrop" role="presentation">

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4661,7 +4661,6 @@ function HtmlViewer({
   const [manualEditFrozenSource, setManualEditFrozenSource] = useState<string | null>(null);
   const [manualEditViewportWidth, setManualEditViewportWidth] = useState<number | null>(null);
   const [commentPortalHost, setCommentPortalHost] = useState<HTMLElement | null>(null);
-  const [tabPresentChromeHeight, setTabPresentChromeHeight] = useState<number | null>(null);
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -6524,10 +6523,16 @@ function HtmlViewer({
 
   useEffect(() => {
     if (!inTabPresent) return;
+    const bodyStyle = document.body.style;
+    const previousChromeHeight = bodyStyle.getPropertyValue('--workspace-tabs-chrome-height');
     const updateChromeHeight = () => {
       const chrome = document.querySelector<HTMLElement>('.workspace-tabs-chrome.app-chrome-header');
       const height = chrome?.getBoundingClientRect().height ?? 0;
-      setTabPresentChromeHeight(height > 0 ? Math.round(height) : null);
+      if (height > 0) {
+        bodyStyle.setProperty('--workspace-tabs-chrome-height', `${Math.round(height)}px`);
+      } else {
+        bodyStyle.removeProperty('--workspace-tabs-chrome-height');
+      }
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setInTabPresent(false);
@@ -6542,6 +6547,11 @@ function HtmlViewer({
       document.removeEventListener('keydown', onKey);
       window.removeEventListener('resize', updateChromeHeight);
       observer?.disconnect();
+      if (previousChromeHeight) {
+        bodyStyle.setProperty('--workspace-tabs-chrome-height', previousChromeHeight);
+      } else {
+        bodyStyle.removeProperty('--workspace-tabs-chrome-height');
+      }
     };
   }, [inTabPresent]);
 
@@ -8765,9 +8775,6 @@ function HtmlViewer({
           className="present-overlay"
           role="dialog"
           aria-label={t('fileViewer.exitPresentation')}
-          style={tabPresentChromeHeight ? ({
-            '--workspace-tabs-chrome-height': `${tabPresentChromeHeight}px`,
-          } as CSSProperties) : undefined}
         >
           <button
             className="present-exit"

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -19,6 +19,7 @@
 }
 
 .workspace-shell {
+  --workspace-tabs-chrome-height: 38px;
   width: 100vw;
   max-width: 100vw;
   height: 100vh;

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -307,7 +307,10 @@
 
 .present-overlay {
   position: fixed;
-  inset: 0;
+  top: var(--workspace-tabs-chrome-height, 38px);
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: 1000;
   background: black;
   display: flex;

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1196,6 +1196,10 @@ describe('FileViewer SVG artifacts', () => {
         exports: ['html'],
       },
     });
+    const chrome = document.createElement('div');
+    chrome.className = 'workspace-tabs-chrome app-chrome-header';
+    vi.spyOn(chrome, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 100, 34));
+    document.body.appendChild(chrome);
 
     const { container } = render(
       <FileViewer projectId="project-1" projectKind="prototype" file={file} liveHtml="<html><body>hi</body></html>" />,
@@ -1205,10 +1209,15 @@ describe('FileViewer SVG artifacts', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: /in this tab/i }));
 
     await waitFor(() => {
-      const frame = container.querySelector('.present-overlay iframe');
+      const frame = document.body.querySelector('.present-overlay iframe');
       expect(frame?.getAttribute('sandbox')).toBe('allow-scripts allow-downloads');
       expect(frame?.getAttribute('data-od-render-mode')).toBe('url-load');
     });
+    expect(container.querySelector('.html-viewer.is-tab-present')).toBeTruthy();
+    const overlay = document.body.querySelector<HTMLElement>('.present-overlay');
+    expect(overlay?.parentElement).toBe(document.body);
+    expect(overlay?.style.getPropertyValue('--workspace-tabs-chrome-height')).toBe('34px');
+    chrome.remove();
   });
 
   it('allows downloads in React component preview iframes', async () => {
@@ -5104,6 +5113,17 @@ describe('LiveArtifactViewer', () => {
     expect(rule).toContain('right: calc(env(safe-area-inset-right, 0px) + 20px);');
     expect(rule).toContain('display: inline-flex;');
     expect(rule).toContain('align-items: center;');
+  });
+
+  it('keeps in-tab presentation overlays below the workspace tab chrome', () => {
+    const css = readExpandedIndexCss();
+    const overlayRule = css.match(/\.present-overlay\s*\{[^}]+\}/)?.[0] ?? '';
+
+    expect(overlayRule).toContain('position: fixed;');
+    expect(overlayRule).toContain('top: var(--workspace-tabs-chrome-height, 38px);');
+    expect(overlayRule).toContain('right: 0;');
+    expect(overlayRule).toContain('bottom: 0;');
+    expect(overlayRule).toContain('left: 0;');
   });
 
   it('uses the shared zoom dropdown for live artifact previews', async () => {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1196,13 +1196,23 @@ describe('FileViewer SVG artifacts', () => {
         exports: ['html'],
       },
     });
+    const css = readExpandedIndexCss();
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.appendChild(style);
+    const workspaceShell = document.createElement('div');
+    workspaceShell.className = 'workspace-shell';
     const chrome = document.createElement('div');
     chrome.className = 'workspace-tabs-chrome app-chrome-header';
     vi.spyOn(chrome, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 100, 34));
-    document.body.appendChild(chrome);
+    const workspaceBody = document.createElement('div');
+    workspaceBody.className = 'workspace-shell__body';
+    workspaceShell.append(chrome, workspaceBody);
+    document.body.appendChild(workspaceShell);
 
     const { container } = render(
       <FileViewer projectId="project-1" projectKind="prototype" file={file} liveHtml="<html><body>hi</body></html>" />,
+      { container: workspaceBody },
     );
 
     fireEvent.click(screen.getByRole('button', { name: /present/i }));
@@ -1216,8 +1226,18 @@ describe('FileViewer SVG artifacts', () => {
     expect(container.querySelector('.html-viewer.is-tab-present')).toBeTruthy();
     const overlay = document.body.querySelector<HTMLElement>('.present-overlay');
     expect(overlay?.parentElement).toBe(document.body);
-    expect(overlay?.style.getPropertyValue('--workspace-tabs-chrome-height')).toBe('34px');
-    chrome.remove();
+    expect(document.body.style.getPropertyValue('--workspace-tabs-chrome-height')).toBe('34px');
+    expect(overlay?.style.getPropertyValue('--workspace-tabs-chrome-height')).toBe('');
+    const bodyChromeHeight = window
+      .getComputedStyle(document.body)
+      .getPropertyValue('--workspace-tabs-chrome-height')
+      .trim();
+    const resolvedTop = window
+      .getComputedStyle(overlay!)
+      .top.replace(/var\(--workspace-tabs-chrome-height,\s*38px\)/, bodyChromeHeight || '38px');
+    expect(resolvedTop).toBe('34px');
+    style.remove();
+    workspaceShell.remove();
   });
 
   it('allows downloads in React component preview iframes', async () => {
@@ -5115,7 +5135,7 @@ describe('LiveArtifactViewer', () => {
     expect(rule).toContain('align-items: center;');
   });
 
-  it('keeps in-tab presentation overlays below the workspace tab chrome', () => {
+  it('keeps in-tab presentation overlays anchored to the inherited workspace tab height', () => {
     const css = readExpandedIndexCss();
     const overlayRule = css.match(/\.present-overlay\s*\{[^}]+\}/)?.[0] ?? '';
 


### PR DESCRIPTION
## Why

The in-tab presentation view should fill the current application tab content area while leaving only the workspace tab bar visible at the top. The previous fixed overlay could either cover the tab chrome or rely on a CSS variable that was no longer inherited after the overlay was portaled to `document.body`.

This PR keeps the presentation overlay scoped to the usable tab content area by measuring the active workspace tab chrome height and applying it directly to the body-level overlay.

## What users will see

When users choose Present -> In this tab for an HTML artifact, the presentation fills the current app tab content area. The workspace tab bar stays visible at the top, and the presentation is no longer hidden under it.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this is a narrow overlay boundary fix covered by DOM and CSS regression assertions.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.test.tsx`
- Did the test go red on `main` and green on this branch? no — I added focused regression coverage for the corrected in-tab presentation boundary and verified it passes on this branch.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web exec vitest run tests/components/FileViewer.test.tsx -t "in-tab presentation|presentation overlays"`
