### PR TITLE
ci: classify main CI Feishu alerts

### DIFF
--- a/.github/workflows/notify-main-ci-feishu.yml
+++ b/.github/workflows/notify-main-ci-feishu.yml
@@ -107,6 +107,211 @@ jobs:
               .map((job) => `- ${job.name} (${job.conclusion})`)
               .join('\n') || '- Unknown';
 
+            function textFromLogData(data) {
+              if (typeof data === 'string') {
+                return data;
+              }
+              if (data instanceof ArrayBuffer) {
+                return Buffer.from(data).toString('utf8');
+              }
+              if (ArrayBuffer.isView(data)) {
+                return Buffer.from(data.buffer).toString('utf8');
+              }
+              return String(data || '');
+            }
+
+            function countMatches(text, patterns) {
+              return patterns.reduce((count, pattern) => count + (pattern.test(text) ? 1 : 0), 0);
+            }
+
+            function sampleMatches(text, patterns, labels) {
+              const matches = [];
+              patterns.forEach((pattern, index) => {
+                if (pattern.test(text)) {
+                  matches.push(labels[index]);
+                }
+              });
+              return matches;
+            }
+
+            function extractTopFailures(text) {
+              const failures = [];
+              for (const line of text.split('\n')) {
+                const clean = line.replace(/\x1b\[[0-9;]*m/g, '').trim();
+                const match = clean.match(/(?:\d+\)\s+|\[[^\]]+\]\s+)?(?:\[chromium\]\s+)?[›>]\s+(ui\/[^›]+)\s+›\s+(.+)/);
+                if (match) {
+                  failures.push(`${match[1]} › ${match[2].replace(/\s+/g, ' ')}`);
+                }
+                if (failures.length >= 4) {
+                  break;
+                }
+              }
+              return [...new Set(failures)];
+            }
+
+            function classifyFailure({ runName, conclusion, problemJobs, logs }) {
+              const combined = logs.join('\n').slice(0, 250_000);
+              const jobText = problemJobs.map((job) => `${job.name} ${job.conclusion}`).join('\n');
+              const text = `${jobText}\n${combined}`;
+              const stalePatterns = [
+                /strict mode violation/i,
+                /element\(s\) not found/i,
+                /waiting for getBy(TestId|Role|Text|Label|Placeholder)/i,
+                /not an input element/i,
+                /locator\.(click|fill|selectOption|check|hover): Test timeout/i,
+                /getByTestId\('new-conversation'\)/i,
+                /Open settings\|.*Account & settings/i,
+                /AMR v\|AMR CLI|onboarding-view__setup-panel/i,
+              ];
+              const staleLabels = [
+                '选择器 strict mode 命中多个元素',
+                '页面元素/文案未按旧选择器出现',
+                '失败卡在 getBy* 定位等待',
+                '控件类型已从原生 input/select 变更',
+                'locator 交互阶段超时',
+                '仍在依赖旧 new-conversation testid',
+                '设置入口选择器命中过宽',
+                '仍在依赖旧 AMR/onboarding UI',
+              ];
+              const productPatterns = [
+                /expect\(received\)\.(toEqual|toBe|toContain|toMatch)/i,
+                /Received:\s+\[\]/i,
+                /Generation failed|No output|provider ended the request/i,
+                /\b(500|502|503|504)\b|Internal Server Error|Bad Gateway/i,
+                /artifact.*not found|file.*not found|conversation.*not found/i,
+                /toHaveCount\(expected\).*Received:\s+0/i,
+              ];
+              const productLabels = [
+                '业务结果断言不符合预期',
+                '预期产物/文件列表为空',
+                '生成链路返回失败或空输出',
+                '服务端/API 返回 5xx',
+                '核心业务对象缺失',
+                '预期实体数量为 0',
+              ];
+              const infraPatterns = [
+                /Process from config\.webServer was not able to start/i,
+                /command failed:.*pnpm.*build|ELIFECYCLE|ERR_PNPM/i,
+                /browserType\.launch|Executable doesn't exist|playwright install/i,
+                /No space left on device|ENOSPC/i,
+                /Cannot find module|MODULE_NOT_FOUND|node_modules/i,
+              ];
+              const infraLabels = [
+                'Playwright webServer 启动失败',
+                '构建/包管理命令失败',
+                '浏览器安装或启动失败',
+                'Runner 磁盘空间不足',
+                '依赖或模块缺失',
+              ];
+              const flakyPatterns = [
+                /Test timeout of \d+ms exceeded/i,
+                /Timeout \d+ms exceeded while waiting/i,
+                /page\.waitFor(Response|Request|URL).*Timeout|Test ended/i,
+                /ECONNRESET|ETIMEDOUT|socket hang up/i,
+              ];
+              const flakyLabels = [
+                '测试整体超时',
+                '等待条件超时',
+                '请求/响应等待超时',
+                '网络连接短暂异常',
+              ];
+
+              const infraReasons = sampleMatches(text, infraPatterns, infraLabels);
+              const staleReasons = sampleMatches(text, stalePatterns, staleLabels);
+              const productReasons = sampleMatches(text, productPatterns, productLabels);
+              const flakyReasons = sampleMatches(text, flakyPatterns, flakyLabels);
+              const infraScore = countMatches(text, infraPatterns);
+              const staleScore = countMatches(text, stalePatterns);
+              const productScore = countMatches(text, productPatterns);
+              const flakyScore = countMatches(text, flakyPatterns);
+              const failedTests = extractTopFailures(text);
+              const failedJobNames = problemJobs.map((job) => job.name);
+
+              let category = '需要人工判断';
+              let confidence = '低';
+              let suggestedAction = '先打开失败 job 的 Playwright report 和日志确认首个真实失败。';
+              let reasons = [];
+
+              if (conclusion === 'timed_out' || problemJobs.some((job) => job.conclusion === 'timed_out')) {
+                category = '可能是超时/资源问题';
+                confidence = flakyScore >= 2 ? '中' : '低';
+                reasons = flakyReasons;
+                suggestedAction = '先看是否集中在长耗时 shard；必要时继续拆分或提高单 job 超时。';
+              }
+
+              if (infraScore > 0) {
+                category = '环境/CI 启动问题';
+                confidence = infraScore >= 2 ? '高' : '中';
+                reasons = infraReasons;
+                suggestedAction = '优先修复 build、依赖、Playwright browser 或 webServer 启动。';
+              } else if (staleScore >= Math.max(2, productScore + 1)) {
+                category = '疑似用例过时/选择器漂移';
+                confidence = staleScore >= 3 || failedJobNames.length >= 2 ? '高' : '中';
+                reasons = staleReasons;
+                suggestedAction = '优先对齐测试选择器、文案或等待条件，再判断是否有产品回归。';
+              } else if (productScore > staleScore) {
+                category = '疑似产品回归';
+                confidence = productScore >= 2 ? '中' : '低';
+                reasons = productReasons;
+                suggestedAction = '优先复现对应 P0 流程，检查最近合入的业务代码和接口响应。';
+              } else if (flakyScore > 0) {
+                category = '可能 flaky/等待不足';
+                confidence = problemJobs.length === 1 ? '中' : '低';
+                reasons = flakyReasons;
+                suggestedAction = '先 rerun failed jobs；若重现，再补稳定等待或拆分耗时 case。';
+              }
+
+              if (runName !== 'ui-extended-main' && infraScore === 0 && staleScore === 0 && productScore === 0) {
+                category = '非 UI CI 失败';
+                confidence = '低';
+                suggestedAction = '查看失败 job 日志定位 build/test/lint 具体阶段。';
+              }
+
+              if (!reasons.length) {
+                reasons = ['未命中明确规则'];
+              }
+
+              return {
+                category,
+                confidence,
+                reasons: reasons.slice(0, 4),
+                failedTests,
+                suggestedAction,
+              };
+            }
+
+            const logTexts = [];
+            if (isTest) {
+              logTexts.push([
+                "1) [chromium] › ui/example-stale.test.ts:1:1 › [P0] sample stale selector",
+                "Error: locator.click: Test timeout of 30000ms exceeded.",
+                "Call log:",
+                "  - waiting for getByRole('dialog').getByRole('tab', { name: /Old Settings/i })",
+              ].join('\n'));
+            } else {
+              for (const job of problemJobs.slice(0, 6)) {
+                try {
+                  const logResponse = await github.rest.actions.downloadJobLogsForWorkflowRun({
+                    owner,
+                    repo,
+                    job_id: job.id,
+                  });
+                  logTexts.push(textFromLogData(logResponse.data).slice(-80_000));
+                } catch (error) {
+                  core.warning(`Failed to download logs for ${job.name}: ${error.message}`);
+                }
+              }
+            }
+            const triage = classifyFailure({
+              runName: run.name,
+              conclusion: run.conclusion,
+              problemJobs,
+              logs: logTexts,
+            });
+            const topFailuresText = triage.failedTests.length
+              ? triage.failedTests.map((failure) => `- ${failure}`).join('\n')
+              : '- 未从日志解析到具体失败用例';
+
             const pull = isTest
               ? null
               : (await github.rest.repos.listPullRequestsAssociatedWithCommit({
@@ -158,6 +363,19 @@ jobs:
                         `**Author:** ${author}`,
                         `**Subject:** ${subject}`,
                         `**Related PR:** ${prText}`,
+                      ].join('\n'),
+                    },
+                  },
+                  {
+                    tag: 'div',
+                    text: {
+                      tag: 'lark_md',
+                      content: [
+                        `**Triage:** ${triage.category}`,
+                        `**Confidence:** ${triage.confidence}`,
+                        `**Why:** ${triage.reasons.join('；')}`,
+                        `**Suggested action:** ${triage.suggestedAction}`,
+                        `**Top failures:**\n${topFailuresText}`,
                       ].join('\n'),
                     },
                   },


### PR DESCRIPTION
## Summary
- add rule-based triage to main CI Feishu alerts
- include category, confidence, reasons, suggested action, and top failed tests
- keep alert logic scoped to failed/timed-out/cancelled main workflow runs

## Verification
- git diff --check -- .github/workflows/notify-main-ci-feishu.yml
- github-script syntax check with Node