### PR TITLE
[codex] Fix AMR OpenCode error presentation

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -147,6 +147,17 @@ function rpcErrorMessage(raw: unknown): string {
     : message;
 }
 
+function rpcErrorData(raw: unknown): unknown {
+  const obj = asObject(raw);
+  const error = asObject(obj?.error);
+  return error && 'data' in error ? error.data : undefined;
+}
+
+function rpcErrorRetryable(data: unknown): boolean | undefined {
+  const details = asObject(data);
+  return typeof details?.retryable === 'boolean' ? details.retryable : undefined;
+}
+
 interface FormattedUsage {
   input_tokens?: number;
   output_tokens?: number;
@@ -740,7 +751,7 @@ export function attachAcpSession({
 
   const fail = (
     message: string,
-    options: { forceModelUnavailable?: boolean } = {},
+    options: { forceModelUnavailable?: boolean; details?: unknown; retryable?: boolean } = {},
   ) => {
     if (finished) return;
     finished = true;
@@ -751,7 +762,19 @@ export function attachAcpSession({
       (options.forceModelUnavailable || isModelUnavailableError(message));
     send(
       'error',
-      useModelUnavailable ? amrModelUnavailablePayload(message) : { message },
+      useModelUnavailable
+        ? amrModelUnavailablePayload(message)
+        : options.details === undefined && options.retryable === undefined
+          ? { message }
+          : {
+              message,
+              error: {
+                code: 'AGENT_EXECUTION_FAILED',
+                message,
+                retryable: options.retryable ?? false,
+                ...(options.details === undefined ? {} : { details: options.details }),
+              },
+            },
     );
     if (!child.killed) child.kill('SIGTERM');
   };
@@ -832,7 +855,12 @@ export function attachAcpSession({
       if (error?.code === -32603 && obj.id !== expectedId) {
         return;
       }
-      fail(rpcErr);
+      const details = rpcErrorData(obj);
+      const retryable = rpcErrorRetryable(details);
+      fail(rpcErr, {
+        details,
+        ...(retryable === undefined ? {} : { retryable }),
+      });
       return;
     }
     if (obj.method === 'session/request_permission') {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -449,6 +449,10 @@ function writeAcpResult(child: FakeAcpChild, id: number, result: unknown): void 
   child.stdout.write(`${JSON.stringify({ id, result })}\n`);
 }
 
+function writeAcpError(child: FakeAcpChild, id: number, error: unknown): void {
+  child.stdout.write(`${JSON.stringify({ id, error })}\n`);
+}
+
 function writeAcpUpdate(child: FakeAcpChild, update: unknown): void {
   child.stdout.write(`${JSON.stringify({ method: 'session/update', params: { update } })}\n`);
 }
@@ -715,4 +719,48 @@ test('attachAcpSession still fails an AMR turn that produces no text and no tool
     (errorEvents[0]?.payload as { message?: string }).message ?? '',
     /without producing any assistant text/,
   );
+});
+
+test('attachAcpSession preserves structured OpenCode session error details from ACP failures', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  const details = {
+    kind: 'opencode_session_error',
+    source: 'opencode',
+    message: 'Not Found',
+    statusCode: 404,
+    retryable: false,
+    url: 'https://example.invalid/v1/chat/completions',
+    suggestion: 'Check the configured AMR Link URL or model route.',
+  };
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpError(child, 3, {
+    code: -32600,
+    message: 'OpenCode session failed: Not Found',
+    data: details,
+  });
+
+  const errorEvents = events.filter((entry) => entry.event === 'error');
+  assert.equal(errorEvents.length, 1);
+  assert.deepEqual(errorEvents[0]?.payload, {
+    message: 'json-rpc id 3: OpenCode session failed: Not Found',
+    error: {
+      code: 'AGENT_EXECUTION_FAILED',
+      message: 'json-rpc id 3: OpenCode session failed: Not Found',
+      retryable: false,
+      details,
+    },
+  });
 });

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -268,7 +268,13 @@ function notifyRunsChanged() {
 }
 
 function daemonSseErrorMessage(data: SseErrorPayload): string {
+  const formattedOpenCodeError = formatOpenCodeSessionError(data.error?.details);
+  if (formattedOpenCodeError) return formattedOpenCodeError;
+
   const message = String(data.error?.message ?? data.message ?? 'daemon error');
+  const legacyOpenCodeError = formatLegacyOpenCodeSessionError(message);
+  if (legacyOpenCodeError) return legacyOpenCodeError;
+
   const detail =
     data.error?.details &&
     typeof data.error.details === 'object' &&
@@ -303,6 +309,195 @@ function shouldSuppressLifecycleExitFallback(
     normalizedStderr.includes('opencode server listening') ||
     normalizedStderr.includes('opencode_server_password')
   );
+}
+
+const AMR_OPENCODE_INCOMPLETE_MESSAGE =
+  'AMR/OpenCode started, but the run did not complete. Please retry or check the run details for the session stream error.';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readStringField(record: Record<string, unknown> | null, key: string): string | null {
+  const value = record?.[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function readNumberField(record: Record<string, unknown> | null, key: string): number | null {
+  const value = record?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function readBooleanField(record: Record<string, unknown> | null, key: string): boolean | null {
+  const value = record?.[key];
+  return typeof value === 'boolean' ? value : null;
+}
+
+interface OpenCodeSessionErrorDetails {
+  message: string | null;
+  statusCode: number | null;
+  retryable: boolean | null;
+  suggestion: string | null;
+  responseBodyPreview: string | null;
+}
+
+function inferOpenCodeRetryable(statusCode: number | null): boolean | null {
+  if (statusCode === null) return null;
+  return statusCode === 429 || statusCode >= 500;
+}
+
+function normalizeOpenCodeSessionErrorDetails(value: unknown): OpenCodeSessionErrorDetails | null {
+  if (!isRecord(value) || value.kind !== 'opencode_session_error') return null;
+  const statusCode = readNumberField(value, 'statusCode');
+  return {
+    message: readStringField(value, 'message'),
+    statusCode,
+    retryable: readBooleanField(value, 'retryable') ?? inferOpenCodeRetryable(statusCode),
+    suggestion: readStringField(value, 'suggestion'),
+    responseBodyPreview: readStringField(value, 'responseBodyPreview'),
+  };
+}
+
+function linkErrorMessageFromResponseBodyPreview(preview: string | null): string | null {
+  if (!preview) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(preview);
+  } catch {
+    return null;
+  }
+  const error = isRecord(parsed) && isRecord(parsed.error) ? parsed.error : null;
+  return readStringField(error, 'message');
+}
+
+function retryExhaustedMessage(details: OpenCodeSessionErrorDetails): string | null {
+  const linkMessage = linkErrorMessageFromResponseBodyPreview(details.responseBodyPreview);
+  if (!linkMessage) return null;
+  const retryMatch = linkMessage.match(/\bRetried the upstream request\s+(\d+)\s+times\b/i);
+  if (!retryMatch) return null;
+  const retryCount = retryMatch[1];
+  return [
+    'The upstream model service is temporarily unavailable.',
+    '',
+    `We already retried ${retryCount} times, but the request still failed. Please retry later or switch to another model.`,
+  ].join('\n');
+}
+
+function formatOpenCodeSessionError(value: unknown): string | null {
+  const details = normalizeOpenCodeSessionErrorDetails(value);
+  if (!details) return null;
+  const statusCode = details.statusCode;
+  const message = details.message;
+  if (statusCode === 404) {
+    return 'The model service returned 404 Not Found for the configured runtime endpoint. Check the AMR Link URL or model route.';
+  }
+  if (statusCode === 401 || statusCode === 403) {
+    return 'AMR authentication failed. Please sign in again or refresh the runtime key.';
+  }
+  if (statusCode === 429) {
+    return 'The model service rejected the request due to quota or rate limits. Retry later or check quota and rate limits.';
+  }
+  if (typeof statusCode === 'number' && statusCode >= 500) {
+    const exhaustedMessage = retryExhaustedMessage(details);
+    if (exhaustedMessage) return exhaustedMessage;
+    return 'The upstream model provider returned a temporary error. Please retry or switch models.';
+  }
+  const base = message ? `OpenCode session failed: ${message}` : 'OpenCode session failed.';
+  return details.suggestion ? `${base}\n${details.suggestion}` : base;
+}
+
+function extractBalancedJsonObject(text: string, startIndex: number): string | null {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = startIndex; i < text.length; i += 1) {
+    const char = text[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === '{') {
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return text.slice(startIndex, i + 1);
+    }
+  }
+  return null;
+}
+
+function legacyOpenCodeSessionErrorDetails(text: string): OpenCodeSessionErrorDetails | null {
+  const marker = 'opencode session error:';
+  const markerIndex = text.toLowerCase().indexOf(marker);
+  if (markerIndex === -1) return null;
+  const jsonStart = text.indexOf('{', markerIndex + marker.length);
+  if (jsonStart === -1) return null;
+  const jsonText = extractBalancedJsonObject(text, jsonStart);
+  if (!jsonText) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  const error = isRecord(parsed.error) ? parsed.error : null;
+  const data = isRecord(error?.data) ? error.data : null;
+  const statusCode = readNumberField(data, 'statusCode');
+  const retryable = readBooleanField(data, 'isRetryable') ?? inferOpenCodeRetryable(statusCode);
+  return {
+    message: readStringField(data, 'message') ?? readStringField(error, 'message'),
+    statusCode,
+    retryable,
+    suggestion: null,
+    responseBodyPreview: readStringField(data, 'responseBodyPreview') ?? readStringField(data, 'responseBody'),
+  };
+}
+
+function formatLegacyOpenCodeSessionError(text: string): string | null {
+  const details = legacyOpenCodeSessionErrorDetails(text);
+  if (!details) return null;
+  return formatOpenCodeSessionError({
+    kind: 'opencode_session_error',
+    ...details,
+  });
+}
+
+function isAmrOpenCodeExitFallback(agentId: string | undefined, stderr: string): boolean {
+  if (agentId === 'amr' || agentId === 'opencode') return true;
+  const normalized = stderr.toLowerCase();
+  return normalized.includes('opencode server listening') || normalized.includes('opencode session error:');
+}
+
+function isAmrOpenCodeBootstrapLine(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    /^AMR run id:\s*\S+/i.test(trimmed) ||
+    /^Performing one time database migration/i.test(trimmed) ||
+    /^sqlite-migration:done$/i.test(trimmed) ||
+    /^Database migration complete\.?$/i.test(trimmed) ||
+    /^Warning:\s*OPENCODE_SERVER_PASSWORD is not set/i.test(trimmed) ||
+    /^opencode server listening on http:\/\/127\.0\.0\.1:\d+/i.test(trimmed)
+  );
+}
+
+function cleanAmrOpenCodeStderrFallback(agentId: string | undefined, stderr: string): string {
+  if (!isAmrOpenCodeExitFallback(agentId, stderr)) return stderr.trim();
+  return stderr
+    .split(/\r?\n/)
+    .filter((line) => line.trim() && !isAmrOpenCodeBootstrapLine(line))
+    .join('\n')
+    .trim();
 }
 
 export async function streamViaDaemon({
@@ -852,9 +1047,13 @@ async function consumeDaemonRun({
         handlers.onDone(acc);
         return;
       }
-      const tail = stderrBuf.trim().slice(-400);
+      const cleanedStderr = cleanAmrOpenCodeStderrFallback(agentId, stderrBuf);
+      const formattedOpenCodeError = formatLegacyOpenCodeSessionError(cleanedStderr);
+      const tail = (formattedOpenCodeError ?? cleanedStderr).trim().slice(-400);
+      const fallbackTail =
+        tail || (isAmrOpenCodeExitFallback(agentId, stderrBuf) ? AMR_OPENCODE_INCOMPLETE_MESSAGE : '');
       handlers.onError(
-        new Error(`agent exited with ${exitSignal ? `signal ${exitSignal}` : `code ${exitCode}`}${tail ? `\n${tail}` : ''}`),
+        new Error(`agent exited with ${exitSignal ? `signal ${exitSignal}` : `code ${exitCode}`}${fallbackTail ? `\n${fallbackTail}` : ''}`),
       );
       return;
     }

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -589,6 +589,133 @@ describe('streamViaDaemon', () => {
     expect(handlers.onDone).not.toHaveBeenCalled();
   });
 
+  it('renders structured OpenCode session errors without JSON-RPC wrapper text', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: error',
+              `data: ${JSON.stringify({
+                message: 'json-rpc id 4: OpenCode session failed: Not Found',
+                error: {
+                  code: 'AGENT_EXECUTION_FAILED',
+                  message: 'json-rpc id 4: OpenCode session failed: Not Found',
+                  details: {
+                    kind: 'opencode_session_error',
+                    source: 'opencode',
+                    message: 'Not Found',
+                    statusCode: 404,
+                    retryable: false,
+                    url: 'https://example.invalid/v1/chat/completions',
+                    suggestion: 'Check the configured AMR Link URL or model route.',
+                  },
+                },
+              })}`,
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'amr',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('404 Not Found'),
+        code: 'AGENT_EXECUTION_FAILED',
+      }),
+    );
+    const message = (handlers.onError.mock.calls[0]?.[0] as Error).message;
+    expect(message).toContain('AMR Link URL or model route');
+    expect(message).not.toContain('json-rpc id 4');
+    expect(message).not.toContain('https://example.invalid');
+    expect(handlers.onDone).not.toHaveBeenCalled();
+  });
+
+  it('renders structured retry-exhausted provider errors from responseBodyPreview', async () => {
+    const handlers = createDaemonHandlers();
+    const responseBodyPreview = JSON.stringify({
+      error: {
+        message:
+          '[code=upstream_error] Provider returned error Retried the upstream request 5 times for retryable provider/network failures, but it still failed. Please try again later or switch to another model.',
+        type: 'upstream_error',
+        code: 'upstream_error',
+      },
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: error',
+              `data: ${JSON.stringify({
+                message: 'json-rpc id 4: OpenCode session failed: upstream provider error',
+                error: {
+                  code: 'AGENT_EXECUTION_FAILED',
+                  message: 'json-rpc id 4: OpenCode session failed: upstream provider error',
+                  details: {
+                    kind: 'opencode_session_error',
+                    source: 'opencode',
+                    sessionId: 'ses_xxx',
+                    errorName: 'APIError',
+                    message: 'Provider returned error',
+                    statusCode: 503,
+                    retryable: true,
+                    url: 'https://amr-link.open-design.ai/v1/chat/completions',
+                    suggestion: 'Retry later or switch to another model.',
+                    responseBodyPreview,
+                  },
+                },
+              })}`,
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'amr',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'AGENT_EXECUTION_FAILED',
+        details: expect.objectContaining({
+          kind: 'opencode_session_error',
+          statusCode: 503,
+          retryable: true,
+        }),
+      }),
+    );
+    const message = (handlers.onError.mock.calls[0]?.[0] as Error).message;
+    expect(message).toContain('retried 5 times');
+    expect(message).toContain('still failed');
+    expect(message).toContain('retry later or switch to another model');
+    expect(message).not.toContain('opencode event stream');
+    expect(message).not.toContain('opencode session error');
+    expect(message).not.toContain('json-rpc id 4');
+    expect(message).not.toContain('https://amr-link.open-design.ai');
+  });
+
   it('treats an explicit succeeded status with a SIGTERM exit as a successful run', async () => {
     // ACP agents that don't shut down on stdin.end() (e.g. Devin for Terminal)
     // are SIGTERM'd by the daemon after a clean prompt completion. The end
@@ -762,6 +889,175 @@ describe('streamViaDaemon', () => {
     expect(onRunStatus).toHaveBeenCalledWith('failed');
     expect(handlers.onError).not.toHaveBeenCalled();
     expect(handlers.onDone).toHaveBeenCalledWith('');
+  });
+
+  it('cleans AMR/OpenCode bootstrap stderr from fallback errors', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: stderr',
+              'data: {"chunk":"AMR run id: arun_7edd8e97efd5a5ffe5737280224ca8bd\\n"}',
+              '',
+              'event: stderr',
+              'data: {"chunk":"Performing one time database migration, may take a few minutes...\\n"}',
+              '',
+              'event: stderr',
+              'data: {"chunk":"sqlite-migration:done\\nDatabase migration complete.\\n"}',
+              '',
+              'event: stderr',
+              'data: {"chunk":"Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.\\n"}',
+              '',
+              'event: stderr',
+              'data: {"chunk":"opencode server listening on http://127.0.0.1:51954\\n"}',
+              '',
+              'event: end',
+              'data: {"code":1,"status":"failed"}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'amr',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onError).toHaveBeenCalledWith(expect.any(Error));
+    const message = (handlers.onError.mock.calls[0]?.[0] as Error).message;
+    expect(message).toContain('AMR/OpenCode started, but the run did not complete');
+    expect(message).not.toContain('sqlite-migration');
+    expect(message).not.toContain('OPENCODE_SERVER_PASSWORD');
+    expect(message).not.toContain('opencode server listening');
+    expect(handlers.onDone).not.toHaveBeenCalled();
+  });
+
+  it('keeps real AMR/OpenCode stderr errors after removing bootstrap lines', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: stderr',
+              'data: {"chunk":"sqlite-migration:done\\nopencode server listening on http://127.0.0.1:51954\\n"}',
+              '',
+              'event: stderr',
+              'data: {"chunk":"json-rpc id 4: opencode event stream: provider disconnected\\n"}',
+              '',
+              'event: end',
+              'data: {"code":1,"status":"failed"}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'amr',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    const message = (handlers.onError.mock.calls[0]?.[0] as Error).message;
+    expect(message).toContain('provider disconnected');
+    expect(message).not.toContain('sqlite-migration');
+    expect(message).not.toContain('opencode server listening');
+  });
+
+  it('formats legacy raw OpenCode session errors in fallback stderr', async () => {
+    const handlers = createDaemonHandlers();
+    const legacyError = {
+      sessionID: 'ses_1',
+      error: {
+        name: 'APIError',
+        data: {
+          message: 'Provider returned error',
+          statusCode: 503,
+          isRetryable: true,
+          metadata: { url: 'https://example.invalid/v1/chat/completions' },
+        },
+      },
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: stderr',
+              `data: ${JSON.stringify({ chunk: `json-rpc id 4: opencode event stream: opencode session error: ${JSON.stringify(legacyError)}\n` })}`,
+              '',
+              'event: end',
+              'data: {"code":1,"status":"failed"}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'amr',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    const message = (handlers.onError.mock.calls[0]?.[0] as Error).message;
+    expect(message).toContain('upstream model provider returned a temporary error');
+    expect(message).toContain('retry');
+    expect(message).not.toContain('json-rpc id 4');
+  });
+
+  it('falls back gracefully for malformed legacy OpenCode session error JSON', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: stderr',
+              'data: {"chunk":"opencode event stream: opencode session error: {bad json\\n"}',
+              '',
+              'event: end',
+              'data: {"code":1,"status":"failed"}',
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'amr',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    const message = (handlers.onError.mock.calls[0]?.[0] as Error).message;
+    expect(message).toContain('opencode session error');
+    expect(message).toContain('{bad json');
   });
 
   it('still surfaces an error when the end event has a signal but no status field', async () => {


### PR DESCRIPTION
## Why

AMR runs through Vela/OpenCode can fail with transport-wrapped errors or normal bootstrap logs in stderr. Today Open Design can surface those raw wrappers directly, so users see messages like `json-rpc id 4: opencode event stream: opencode session error: ...` or sqlite/OpenCode startup logs instead of the actual model/provider failure.

This PR fixes the Open Design side of that chain: preserve Vela's structured OpenCode session error details, render useful provider guidance, and keep bootstrap output out of the user-facing error body.

## What users will see

AMR/OpenCode failures now show concise model/provider guidance instead of raw transport text. For retry-exhausted 503 provider failures, the error explains that the upstream model service is temporarily unavailable, that the request was already retried 5 times, and that the user should retry later or switch models.

Normal bootstrap lines such as sqlite migration output, `OPENCODE_SERVER_PASSWORD`, and `opencode server listening` are no longer shown as the apparent cause of failure.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No screenshots: this changes error text produced by existing run failure handling, not a new UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/providers/sse.test.ts`
- Did the test go red on `main` and green on this branch? yes — the retry-exhausted provider case failed before `responseBodyPreview` parsing, then passed after the formatter change.
- Additional coverage: `apps/daemon/tests/acp.test.ts` verifies ACP JSON-RPC `error.data` is preserved into the daemon error payload.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web test -- apps/web/tests/providers/sse.test.ts`
- `pnpm --filter @open-design/daemon exec vitest run tests/acp.test.ts --maxWorkers=1`
- `pnpm guard`
- `pnpm typecheck`
