### PR TITLE
chore(release): bump main to 0.10.0 + clear plugin context after send (#3708 residual)

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -1432,6 +1432,9 @@ export function HomeView({
         return { examplePromptContext: examplePromptInfoRef.current };
       })(),
     });
+    setSelectedPluginContexts([]);
+    setSelectedMcpContexts([]);
+    setSelectedConnectorContexts([]);
   }
 
   return (

--- a/apps/web/tests/components/HomeView.context-picker.test.tsx
+++ b/apps/web/tests/components/HomeView.context-picker.test.tsx
@@ -244,7 +244,7 @@ describe('HomeView context picker', () => {
     }));
   });
 
-  it('keeps a context-only `Use` selection in the submit payload without an @mention', async () => {
+  it('keeps a context-only `Use` selection in the submit payload without an @mention, then clears the composer chip', async () => {
     // Regression: the submit-time reconciliation dropped every context that
     // lacked an inline `@mention` token, which silently discarded contexts
     // staged through the plain `Use` action (which never writes a token). The
@@ -307,6 +307,9 @@ describe('HomeView context picker', () => {
         expect.objectContaining({ id: 'chart-plugin', title: 'Chart Plugin' }),
       ],
     }));
+    await waitFor(() => {
+      expect(screen.queryByTestId('home-hero-context-plugin-chart-plugin')).toBeNull();
+    });
   });
 
   it('drops a context-only `Use` selection from the submit payload once its chip is cleared', async () => {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/download",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/host",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "Open Design renderer host bridge protocol.",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why
Prep `main` to cut a 0.10.0 beta directly from `main`:

1. **Version bump 0.9.1 → 0.10.0** across the 15 workspace package.json files (same set as the prior `fd3f0a16f` 0.9.0→0.10.0 bump). `main` sat at 0.9.1, below the published beta base `0.10.0`, so `release-beta` refused to build a regressed beta from main. This clears the anti-regression gate.
2. **#3708 residual** — `clear plugin context after send` in the Home composer (clear selected plugin/MCP/connector contexts after `submit()`'s `onSubmit(...)`). This was the **only** part of the release QA backlog genuinely missing from main. Extends the existing context-only `Use` test to assert the chip clears after send.

## Back-merge backlog audit (content-verified, not by PR#)
The #3715 back-merge already carried essentially all the release-only QA fixes into `main` under different SHAs. Verified by content:
- **#3653** (stale chat spacer), **#3706** (deck pagination) — present.
- **#3638** (route project file links to workspace tabs) — present, in fact the **enhanced** projectId-scoped version (incl. #3637/d1142db02).
- **#3707** (official plugin/skill catalog search + provenance gate) — present (`availablePluginTitle`/`availablePluginDescription`/`localizedValues`/`bundledPluginMatchesMarketplaceEntry` all in main).
- **#3708** — present except the after-send context clear in this PR.
- **#3638**'s separate open main PR #3678 is a different/narrower fix; #3638 itself is already in via #3715.

Net: nothing dropped; this PR adds the one genuine residual + the version bump.

## What users will see
No behavior change from the version bump. The #3708 fix clears Home composer context chips after sending, so the next prompt starts clean.