### PR TITLE
Add derived design-system token outputs

### DIFF
--- a/apps/daemon/src/design-system-import.ts
+++ b/apps/daemon/src/design-system-import.ts
@@ -9,6 +9,7 @@ import {
   type DesignTokenBinding,
   type DesignTokenContractReport,
 } from './design-token-contract.js';
+import { renderDesignTokensJson, renderTailwindV4Css } from './design-token-derived-outputs.js';
 import { extractCssCustomProperties } from './design-token-evidence.js';
 
 export type LocalDesignSystemImportResult = {
@@ -135,7 +136,16 @@ export async function importLocalDesignSystemProject(
   const craftApplies = normalizeCraftList(options.craftApplies);
   const now = options.now ?? new Date();
 
-  const files = ['USAGE.md', 'DESIGN.md', 'tokens.css', 'components.html', 'components.manifest.json', 'manifest.json'];
+  const files = [
+    'USAGE.md',
+    'DESIGN.md',
+    'tokens.css',
+    'design-tokens.json',
+    'tailwind-v4.css',
+    'components.html',
+    'components.manifest.json',
+    'manifest.json',
+  ];
   const designMd = renderDesignMd(id, displayName, scan);
   const tokenContract = buildDesignTokenContract({ sourceTokens: scan.cssVariables, generatedAt: now });
   const tokensCss = tokenContract.tokensCss;
@@ -153,6 +163,11 @@ export async function importLocalDesignSystemProject(
   await writeFile(path.join(outDir, 'USAGE.md'), renderUsageMd(displayName, scan), 'utf8');
   await writeFile(path.join(outDir, 'DESIGN.md'), designMd, 'utf8');
   await writeFile(path.join(outDir, 'tokens.css'), tokensCss, 'utf8');
+  await writeFile(path.join(outDir, 'design-tokens.json'), renderDesignTokensJson({
+    bindings: tokenContract.bindings,
+    report: tokenContractReport,
+  }), 'utf8');
+  await writeFile(path.join(outDir, 'tailwind-v4.css'), renderTailwindV4Css(tokenContract.bindings), 'utf8');
   await writeFile(path.join(outDir, 'components.html'), componentsHtml, 'utf8');
   await writeFile(
     path.join(outDir, 'components.manifest.json'),
@@ -432,6 +447,8 @@ function renderManifest(
     files: {
       design: 'DESIGN.md',
       tokens: 'tokens.css',
+      designTokens: 'design-tokens.json',
+      tailwind: 'tailwind-v4.css',
       components: 'components.html',
     },
     usage: 'USAGE.md',

--- a/apps/daemon/src/design-system-import.ts
+++ b/apps/daemon/src/design-system-import.ts
@@ -2,6 +2,7 @@ import { copyFile, mkdir, readFile, readdir, realpath, stat, writeFile } from 'n
 import path from 'node:path';
 
 import { extractComponentsManifest } from '@open-design/contracts/design-systems/components-manifest';
+import { renderDesignTokensJson, renderTailwindV4Css } from '@open-design/contracts/design-systems/derived-token-outputs';
 import {
   buildDesignTokenContract,
   buildReportWithSelfCheck,
@@ -9,7 +10,6 @@ import {
   type DesignTokenBinding,
   type DesignTokenContractReport,
 } from './design-token-contract.js';
-import { renderDesignTokensJson, renderTailwindV4Css } from './design-token-derived-outputs.js';
 import { extractCssCustomProperties } from './design-token-evidence.js';
 
 export type LocalDesignSystemImportResult = {

--- a/apps/daemon/src/design-systems.ts
+++ b/apps/daemon/src/design-systems.ts
@@ -129,6 +129,8 @@ type DesignSystemProjectManifest = {
   files: {
     design: 'DESIGN.md';
     tokens: 'tokens.css';
+    designTokens?: 'design-tokens.json';
+    tailwind?: 'tailwind-v4.css';
     components?: 'components.html';
   };
   assetsDir?: 'assets';
@@ -628,6 +630,8 @@ function buildDesignSystemPullIndex(
   add(manifest.sourceFiles?.tokens, 'source-token evidence');
   add(manifest.sourceFiles?.report, 'token contract quality report');
   add(manifest.sourceFiles?.snippets, 'source snippet index');
+  add(manifest.files.designTokens, 'derived Design Tokens JSON');
+  add(manifest.files.tailwind, 'derived Tailwind v4 theme CSS');
 
   if (entries.length === 0) return undefined;
   return ['Additional design-system files declared by manifest.json:', ...entries].join('\n');
@@ -649,6 +653,8 @@ async function buildDesignSystemPullFileAllowlist(
   add(manifest.sourceFiles?.tokens);
   add(manifest.sourceFiles?.report);
   add(manifest.sourceFiles?.snippets);
+  add(manifest.files.designTokens);
+  add(manifest.files.tailwind);
 
   if (manifest.assetsDir === 'assets') {
     await addFilesUnderDeclaredDir(brandRoot, 'assets', allowed);
@@ -2961,6 +2967,8 @@ function isProjectManifest(value: unknown, expectedId: string): value is DesignS
   return (
     fileRecord.design === 'DESIGN.md' &&
     fileRecord.tokens === 'tokens.css' &&
+    (fileRecord.designTokens === undefined || fileRecord.designTokens === 'design-tokens.json') &&
+    (fileRecord.tailwind === undefined || fileRecord.tailwind === 'tailwind-v4.css') &&
     (fileRecord.components === undefined || fileRecord.components === 'components.html')
   );
 }

--- a/apps/daemon/src/design-token-derived-outputs.ts
+++ b/apps/daemon/src/design-token-derived-outputs.ts
@@ -1,0 +1,145 @@
+import type { DesignTokenBinding, DesignTokenContractReport } from './design-token-contract.js';
+
+export function renderDesignTokensJson(input: {
+  bindings: readonly DesignTokenBinding[];
+  report: DesignTokenContractReport;
+}): string {
+  return `${JSON.stringify({
+    schemaVersion: 1,
+    format: 'od-design-tokens/v1',
+    contract: 'TOKEN_SCHEMA',
+    generatedAt: input.report.generatedAt,
+    source: {
+      tokensCss: 'tokens.css',
+      tokenContractReport: 'source/token-contract.report.json',
+    },
+    summary: input.report.summary,
+    tokens: input.bindings.map((binding) => ({
+      name: binding.name,
+      value: binding.value,
+      type: inferDesignTokenType(binding.name),
+      layer: binding.layer,
+      confidence: binding.confidence,
+      reason: binding.reason,
+      sources: binding.sources,
+      ...(binding.sourceName === undefined ? {} : { sourceName: binding.sourceName }),
+    })),
+  }, null, 2)}\n`;
+}
+
+export function renderTailwindV4Css(bindings: readonly DesignTokenBinding[]): string {
+  const declared = new Set(bindings.map((binding) => binding.name));
+  const lines = [
+    '/* Derived from tokens.css. Keep tokens.css as the source of truth. */',
+    '@import "tailwindcss";',
+    '@import "./tokens.css";',
+    '',
+    '@theme {',
+  ];
+  for (const [tailwindName, odToken] of tailwindThemeBindings) {
+    if (declared.has(odToken)) lines.push(`  ${tailwindName}: var(${odToken});`);
+  }
+  lines.push('}', '');
+  return lines.join('\n');
+}
+
+function inferDesignTokenType(name: string): string {
+  if (
+    [
+      '--bg',
+      '--surface',
+      '--surface-warm',
+      '--fg',
+      '--fg-2',
+      '--muted',
+      '--meta',
+      '--border',
+      '--border-soft',
+      '--accent',
+      '--accent-on',
+      '--accent-hover',
+      '--accent-active',
+      '--success',
+      '--warn',
+      '--danger',
+    ].includes(name)
+  ) {
+    return 'color';
+  }
+  if (name.startsWith('--font-')) return 'fontFamily';
+  if (name.startsWith('--leading-')) return 'number';
+  if (name === '--ease-standard') return 'cubicBezier';
+  if (name.startsWith('--motion-')) return 'duration';
+  if (name.startsWith('--elev-') || name === '--focus-ring') return 'shadow';
+  if (
+    name.startsWith('--text-')
+    || name.startsWith('--space-')
+    || name.startsWith('--section-y-')
+    || name.startsWith('--radius-')
+    || name.startsWith('--container-')
+    || name.startsWith('--tracking-')
+  ) {
+    return 'dimension';
+  }
+  return 'other';
+}
+
+const tailwindThemeBindings: ReadonlyArray<readonly [string, string]> = [
+  ['--color-bg', '--bg'],
+  ['--color-surface', '--surface'],
+  ['--color-surface-warm', '--surface-warm'],
+  ['--color-fg', '--fg'],
+  ['--color-fg-2', '--fg-2'],
+  ['--color-muted', '--muted'],
+  ['--color-meta', '--meta'],
+  ['--color-border', '--border'],
+  ['--color-border-soft', '--border-soft'],
+  ['--color-accent', '--accent'],
+  ['--color-accent-on', '--accent-on'],
+  ['--color-accent-hover', '--accent-hover'],
+  ['--color-accent-active', '--accent-active'],
+  ['--color-success', '--success'],
+  ['--color-warn', '--warn'],
+  ['--color-danger', '--danger'],
+  ['--font-display', '--font-display'],
+  ['--font-body', '--font-body'],
+  ['--font-sans', '--font-body'],
+  ['--font-mono', '--font-mono'],
+  ['--text-xs', '--text-xs'],
+  ['--text-sm', '--text-sm'],
+  ['--text-base', '--text-base'],
+  ['--text-lg', '--text-lg'],
+  ['--text-xl', '--text-xl'],
+  ['--text-2xl', '--text-2xl'],
+  ['--text-3xl', '--text-3xl'],
+  ['--text-4xl', '--text-4xl'],
+  ['--leading-body', '--leading-body'],
+  ['--leading-tight', '--leading-tight'],
+  ['--tracking-display', '--tracking-display'],
+  ['--spacing-1', '--space-1'],
+  ['--spacing-2', '--space-2'],
+  ['--spacing-3', '--space-3'],
+  ['--spacing-4', '--space-4'],
+  ['--spacing-5', '--space-5'],
+  ['--spacing-6', '--space-6'],
+  ['--spacing-8', '--space-8'],
+  ['--spacing-12', '--space-12'],
+  ['--spacing-section-desktop', '--section-y-desktop'],
+  ['--spacing-section-tablet', '--section-y-tablet'],
+  ['--spacing-section-phone', '--section-y-phone'],
+  ['--radius-sm', '--radius-sm'],
+  ['--radius-md', '--radius-md'],
+  ['--radius-lg', '--radius-lg'],
+  ['--radius-pill', '--radius-pill'],
+  ['--shadow-flat', '--elev-flat'],
+  ['--shadow-ring', '--elev-ring'],
+  ['--shadow-raised', '--elev-raised'],
+  ['--shadow-focus-ring', '--focus-ring'],
+  ['--duration-fast', '--motion-fast'],
+  ['--duration-base', '--motion-base'],
+  ['--ease-standard', '--ease-standard'],
+  ['--container-max', '--container-max'],
+  ['--spacing-container-desktop', '--container-gutter-desktop'],
+  ['--spacing-container-tablet', '--container-gutter-tablet'],
+  ['--spacing-container-phone', '--container-gutter-phone'],
+];

--- a/apps/daemon/tests/design-system-assets.test.ts
+++ b/apps/daemon/tests/design-system-assets.test.ts
@@ -250,6 +250,8 @@ describe('Design System Project manifest runtime consumption', () => {
         files: {
           design: 'DESIGN.md',
           tokens: 'tokens.css',
+          designTokens: 'design-tokens.json',
+          tailwind: 'tailwind-v4.css',
           components: 'components.html',
         },
         usage: 'USAGE.md',
@@ -280,6 +282,8 @@ describe('Design System Project manifest runtime consumption', () => {
       components: '<button class="btn">Derived should lose to cache</button>',
     });
     writeFileSync(path.join(dir, 'USAGE.md'), '## Read Order\n\nUse cache first.');
+    writeFileSync(path.join(dir, 'design-tokens.json'), '{"format":"od-design-tokens/v1","tokens":[]}\n');
+    writeFileSync(path.join(dir, 'tailwind-v4.css'), '@import "tailwindcss";\n');
     writeFileSync(
       path.join(dir, 'components.manifest.json'),
       `${JSON.stringify({
@@ -328,6 +332,8 @@ describe('Design System Project manifest runtime consumption', () => {
     expect(assets.componentsManifest).toContain('components.manifest schema v1 for cache-brand');
     expect(assets.componentsManifest).toContain('Cached buttons');
     expect(assets.pullIndex).toContain('preview/colors.html: Colors; colors');
+    expect(assets.pullIndex).toContain('design-tokens.json: derived Design Tokens JSON');
+    expect(assets.pullIndex).toContain('tailwind-v4.css: derived Tailwind v4 theme CSS');
     expect(assets.pullIndex).toContain('fonts/Inter-Medium.woff2: font: Inter 500');
     expect(assets.pullIndex).toContain('source/snippets/INDEX.json: source snippet index');
   });
@@ -344,6 +350,8 @@ describe('Design System Project manifest runtime consumption', () => {
         files: {
           design: 'DESIGN.md',
           tokens: 'tokens.css',
+          designTokens: 'design-tokens.json',
+          tailwind: 'tailwind-v4.css',
           components: 'components.html',
         },
         assetsDir: 'assets',
@@ -365,6 +373,8 @@ describe('Design System Project manifest runtime consumption', () => {
       schemaVersion: 1,
       snippets: [{ path: 'source/snippets/Button.tsx', role: 'button' }],
     })}\n`);
+    writeFileSync(path.join(dir, 'design-tokens.json'), '{"format":"od-design-tokens/v1","tokens":[]}\n');
+    writeFileSync(path.join(dir, 'tailwind-v4.css'), '@import "tailwindcss";\n');
     writeFileSync(path.join(dir, 'source', 'snippets', 'Button.tsx'), 'export function Button() {}');
     writeFileSync(path.join(dir, 'assets', 'icons', 'mark.svg'), '<svg />');
 
@@ -380,6 +390,14 @@ describe('Design System Project manifest runtime consumption', () => {
     await expect(readDesignSystemPullFile(root, 'pull-project', 'assets/icons/mark.svg')).resolves.toMatchObject({
       path: 'assets/icons/mark.svg',
       content: '<svg />',
+    });
+    await expect(readDesignSystemPullFile(root, 'pull-project', 'design-tokens.json')).resolves.toMatchObject({
+      path: 'design-tokens.json',
+      content: expect.stringContaining('od-design-tokens/v1'),
+    });
+    await expect(readDesignSystemPullFile(root, 'pull-project', 'tailwind-v4.css')).resolves.toMatchObject({
+      path: 'tailwind-v4.css',
+      content: expect.stringContaining('@import "tailwindcss"'),
     });
     await expect(readDesignSystemPullFile(root, 'pull-project', 'preview/spacing.html')).resolves.toBeNull();
     await expect(readDesignSystemPullFile(root, 'pull-project', '../pull-project/preview/colors.html')).resolves.toBeNull();

--- a/apps/daemon/tests/design-system-import.test.ts
+++ b/apps/daemon/tests/design-system-import.test.ts
@@ -59,6 +59,8 @@ describe('importLocalDesignSystemProject', () => {
         'USAGE.md',
         'DESIGN.md',
         'tokens.css',
+        'design-tokens.json',
+        'tailwind-v4.css',
         'components.html',
         'components.manifest.json',
         'manifest.json',
@@ -93,6 +95,8 @@ describe('importLocalDesignSystemProject', () => {
       files: {
         design: 'DESIGN.md',
         tokens: 'tokens.css',
+        designTokens: 'design-tokens.json',
+        tailwind: 'tailwind-v4.css',
         components: 'components.html',
       },
       usage: 'USAGE.md',
@@ -128,6 +132,30 @@ describe('importLocalDesignSystemProject', () => {
     expect(usage).toContain('## Read Order');
     expect(usage).toContain('source/tokens.source.json');
     expect(usage).toContain('source/token-contract.report.json');
+
+    const designTokens = JSON.parse(
+      fs.readFileSync(path.join(result.dir, 'design-tokens.json'), 'utf8'),
+    ) as {
+      format: string;
+      contract: string;
+      tokens: Array<{ name: string; value: string; type: string; confidence: string; sourceName?: string }>;
+    };
+    expect(designTokens).toMatchObject({
+      format: 'od-design-tokens/v1',
+      contract: 'TOKEN_SCHEMA',
+    });
+    expect(designTokens.tokens).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: '--accent', value: '#ff3366', type: 'color', sourceName: '--color-primary' }),
+        expect.objectContaining({ name: '--bg', value: '#101014', type: 'color', sourceName: '--color-background' }),
+      ]),
+    );
+
+    const tailwindV4 = fs.readFileSync(path.join(result.dir, 'tailwind-v4.css'), 'utf8');
+    expect(tailwindV4).toContain('@import "tailwindcss";');
+    expect(tailwindV4).toContain('@import "./tokens.css";');
+    expect(tailwindV4).toContain('--color-accent: var(--accent);');
+    expect(tailwindV4).toContain('--radius-md: var(--radius-md);');
 
     const componentsManifest = JSON.parse(
       fs.readFileSync(path.join(result.dir, 'components.manifest.json'), 'utf8'),

--- a/apps/daemon/tests/design-system-tool-routes.test.ts
+++ b/apps/daemon/tests/design-system-tool-routes.test.ts
@@ -29,6 +29,8 @@ function writeHybridDesignSystem(root: string, id: string): string {
   mkdirSync(path.join(dir, 'preview'), { recursive: true });
   writeFileSync(path.join(dir, 'DESIGN.md'), '# Test\n');
   writeFileSync(path.join(dir, 'tokens.css'), ':root { --bg: #fff; }');
+  writeFileSync(path.join(dir, 'design-tokens.json'), '{"format":"od-design-tokens/v1","tokens":[]}\n');
+  writeFileSync(path.join(dir, 'tailwind-v4.css'), '@import "tailwindcss";\n');
   writeFileSync(path.join(dir, 'components.html'), '<button>ok</button>');
   writeFileSync(path.join(dir, 'preview', 'colors.html'), '<h1>Colors</h1>');
   writeFileSync(path.join(dir, 'preview', 'spacing.html'), '<h1>Spacing</h1>');
@@ -41,6 +43,8 @@ function writeHybridDesignSystem(root: string, id: string): string {
     files: {
       design: 'DESIGN.md',
       tokens: 'tokens.css',
+      designTokens: 'design-tokens.json',
+      tailwind: 'tailwind-v4.css',
       components: 'components.html',
     },
     preview: {
@@ -129,6 +133,17 @@ describe('design-system pull tool route', () => {
       path: 'preview/colors.html',
       encoding: 'utf8',
       content: '<h1>Colors</h1>',
+    });
+
+    const derived = await jsonFetch(`${baseUrl}/api/tools/design-systems/read`, {
+      path: 'design-tokens.json',
+    });
+
+    expect(derived.status).toBe(200);
+    expect(derived.body.file).toMatchObject({
+      path: 'design-tokens.json',
+      encoding: 'utf8',
+      content: expect.stringContaining('od-design-tokens/v1'),
     });
   });
 

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -2188,6 +2188,8 @@ function DesignSystemPackageCard({
     manifest?.usage ? manifest.usage : null,
     manifest?.files?.design ?? 'DESIGN.md',
     manifest?.files?.tokens ?? 'tokens.css',
+    manifest?.files?.designTokens,
+    manifest?.files?.tailwind,
     manifest?.files?.components,
     manifest?.componentsManifest,
   ].filter((item): item is string => typeof item === 'string' && item.length > 0);

--- a/design-systems/_schema/AGENTS.md
+++ b/design-systems/_schema/AGENTS.md
@@ -32,6 +32,10 @@ Design System Project folders use fixed v1 file names:
 - `manifest.json` — machine-readable project entry.
 - `DESIGN.md` — canonical design prose.
 - `tokens.css` — canonical compiled tokens.
+- `design-tokens.json` — optional Design Tokens JSON derived from
+  `tokens.css` + `source/token-contract.report.json`.
+- `tailwind-v4.css` — optional Tailwind v4 `@theme` CSS derived from
+  `tokens.css`; it must not redefine source values independently.
 - `components.html` — optional standalone component fixture.
 - `assets/` — optional brand assets.
 - `preview/` — optional static preview pages.

--- a/design-systems/_schema/manifest.schema.ts
+++ b/design-systems/_schema/manifest.schema.ts
@@ -65,6 +65,10 @@ export type DesignSystemProjectFiles = {
    * it; legacy folders without a manifest may still be DESIGN.md-only.
    */
   readonly tokens: "tokens.css";
+  /** Optional Design Tokens JSON derived from the final TOKEN_SCHEMA contract. */
+  readonly designTokens?: "design-tokens.json";
+  /** Optional Tailwind v4 @theme CSS derived from the final TOKEN_SCHEMA contract. */
+  readonly tailwind?: "tailwind-v4.css";
   /**
    * Optional standalone component fixture. First-class in the contract,
    * but optional for MVP imports and prose-only brands.
@@ -165,7 +169,7 @@ const ALLOWED_SOURCE_KEYS: Record<DesignSystemProjectSource["type"], ReadonlySet
   shadcn: new Set(["type", "reference", "registryUrl", "item", "homepage", "importedAt"]),
 };
 
-const ALLOWED_FILES_KEYS = new Set(["design", "tokens", "components"]);
+const ALLOWED_FILES_KEYS = new Set(["design", "tokens", "designTokens", "tailwind", "components"]);
 const ALLOWED_CRAFT_KEYS = new Set(["applies", "suggested", "exemptions"]);
 const ALLOWED_FONT_KEYS = new Set(["family", "file", "weight", "style"]);
 const ALLOWED_PREVIEW_KEYS = new Set(["dir", "pages"]);
@@ -274,6 +278,12 @@ function validateFiles(errors: string[], value: unknown): void {
   rejectUnknownKeys(errors, "$.files", value, ALLOWED_FILES_KEYS);
   expectLiteral(errors, "$.files.design", value.design, "DESIGN.md");
   expectLiteral(errors, "$.files.tokens", value.tokens, "tokens.css");
+  if (value.designTokens !== undefined) {
+    expectLiteral(errors, "$.files.designTokens", value.designTokens, "design-tokens.json");
+  }
+  if (value.tailwind !== undefined) {
+    expectLiteral(errors, "$.files.tailwind", value.tailwind, "tailwind-v4.css");
+  }
   if (value.components !== undefined) {
     expectLiteral(errors, "$.files.components", value.components, "components.html");
   }

--- a/packages/contracts/esbuild.config.mjs
+++ b/packages/contracts/esbuild.config.mjs
@@ -13,6 +13,7 @@ await build({
     "./src/api/providerModels.ts",
     "./src/api/research.ts",
     "./src/design-systems/components-manifest.ts",
+    "./src/design-systems/derived-token-outputs.ts",
     "./src/design-systems/token-schema.ts",
     "./src/analytics/index.ts",
   ],

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -42,6 +42,10 @@
       "types": "./dist/design-systems/components-manifest.d.ts",
       "default": "./dist/design-systems/components-manifest.mjs"
     },
+    "./design-systems/derived-token-outputs": {
+      "types": "./dist/design-systems/derived-token-outputs.d.ts",
+      "default": "./dist/design-systems/derived-token-outputs.mjs"
+    },
     "./design-systems/token-schema": {
       "types": "./dist/design-systems/token-schema.d.ts",
       "default": "./dist/design-systems/token-schema.mjs"

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -298,6 +298,8 @@ export interface DesignSystemPackageInfo {
     files?: {
       design?: string;
       tokens?: string;
+      designTokens?: string;
+      tailwind?: string;
       components?: string;
     };
     usage?: string;

--- a/packages/contracts/src/design-systems/derived-token-outputs.ts
+++ b/packages/contracts/src/design-systems/derived-token-outputs.ts
@@ -1,8 +1,21 @@
-import type { DesignTokenBinding, DesignTokenContractReport } from './design-token-contract.js';
+export type DerivedDesignTokenBinding = {
+  name: string;
+  layer: string;
+  value: string;
+  confidence: string;
+  reason: string;
+  sources: readonly string[];
+  sourceName?: string;
+};
+
+export type DerivedDesignTokenReport = {
+  generatedAt: string;
+  summary: unknown;
+};
 
 export function renderDesignTokensJson(input: {
-  bindings: readonly DesignTokenBinding[];
-  report: DesignTokenContractReport;
+  bindings: readonly DerivedDesignTokenBinding[];
+  report: DerivedDesignTokenReport;
 }): string {
   return `${JSON.stringify({
     schemaVersion: 1,
@@ -27,7 +40,7 @@ export function renderDesignTokensJson(input: {
   }, null, 2)}\n`;
 }
 
-export function renderTailwindV4Css(bindings: readonly DesignTokenBinding[]): string {
+export function renderTailwindV4Css(bindings: readonly Pick<DerivedDesignTokenBinding, 'name'>[]): string {
   const declared = new Set(bindings.map((binding) => binding.name));
   const lines = [
     '/* Derived from tokens.css. Keep tokens.css as the source of truth. */',
@@ -36,7 +49,7 @@ export function renderTailwindV4Css(bindings: readonly DesignTokenBinding[]): st
     '',
     '@theme {',
   ];
-  for (const [tailwindName, odToken] of tailwindThemeBindings) {
+  for (const [tailwindName, odToken] of TAILWIND_V4_THEME_BINDINGS) {
     if (declared.has(odToken)) lines.push(`  ${tailwindName}: var(${odToken});`);
   }
   lines.push('}', '');
@@ -84,7 +97,7 @@ function inferDesignTokenType(name: string): string {
   return 'other';
 }
 
-const tailwindThemeBindings: ReadonlyArray<readonly [string, string]> = [
+export const TAILWIND_V4_THEME_BINDINGS: ReadonlyArray<readonly [string, string]> = [
   ['--color-bg', '--bg'],
   ['--color-surface', '--surface'],
   ['--color-surface-warm', '--surface-warm'],

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -32,6 +32,7 @@ export * from './api/terminals.js';
 export * from './api/version.js';
 export * from './examples.js';
 export * from './design-systems/components-manifest.js';
+export * from './design-systems/derived-token-outputs.js';
 export * from './design-systems/token-schema.js';
 export * from './sse/common.js';
 export * from './sse/chat.js';

--- a/scripts/check-design-system-manifests.test.ts
+++ b/scripts/check-design-system-manifests.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -9,7 +9,71 @@ import {
   type DesignSystemProjectManifest,
   validateDesignSystemProjectManifest,
 } from "../design-systems/_schema/manifest.schema.ts";
-import { validateManifestSemantics, validateTailwindV4Css } from "./check-design-system-manifests.ts";
+import { TOKEN_SCHEMA } from "../design-systems/_schema/tokens.schema.ts";
+import {
+  renderDesignTokensJson,
+  renderTailwindV4Css,
+  type DerivedDesignTokenBinding,
+} from "../packages/contracts/src/design-systems/derived-token-outputs.ts";
+import { validateDesignTokensJson, validateManifestSemantics, validateTailwindV4Css } from "./check-design-system-manifests.ts";
+
+const REPORT_PATH = "source/token-contract.report.json";
+
+function writeDerivedTokenFixture(root: string): void {
+  const bindings = TOKEN_SCHEMA.map((spec, index): DerivedDesignTokenBinding => ({
+    name: spec.name,
+    layer: spec.layer,
+    value: tokenValueForIndex(index),
+    confidence: "high",
+    reason: `Fixture source matched ${spec.name}.`,
+    sources: [`tokens.css:${index + 2}`],
+    sourceName: spec.name,
+  }));
+  const report = {
+    schemaVersion: 1,
+    contract: "TOKEN_SCHEMA",
+    generatedAt: "2026-05-19T00:00:00.000Z",
+    summary: {
+      totalTokens: bindings.length,
+      declaredTokens: bindings.length,
+      sourceBackedTokens: bindings.length,
+      sourceBackedA1: bindings.length,
+      requiredA1: bindings.length,
+      fallbackTokens: 0,
+      aliasTokens: 0,
+      score: 100,
+      grade: "excellent",
+      recommendRebuild: false,
+    },
+    tokens: bindings,
+  };
+  mkdirSync(path.join(root, "source"), { recursive: true });
+  writeFileSync(path.join(root, "tokens.css"), `:root {\n${bindings.map((binding) => `  ${binding.name}: ${binding.value};`).join("\n")}\n}\n`);
+  writeFileSync(path.join(root, REPORT_PATH), `${JSON.stringify(report, null, 2)}\n`);
+  writeFileSync(path.join(root, "design-tokens.json"), renderDesignTokensJson({ bindings, report }));
+  writeFileSync(path.join(root, "tailwind-v4.css"), renderTailwindV4Css(bindings));
+}
+
+function tokenValueForIndex(index: number): string {
+  const token = TOKEN_SCHEMA[index]!;
+  if (token.name.startsWith("--font-")) return '"Inter", sans-serif';
+  if (token.name.startsWith("--leading-")) return "1.4";
+  if (token.name.startsWith("--tracking-")) return "0";
+  if (token.name.startsWith("--motion-")) return "150ms";
+  if (token.name === "--ease-standard") return "cubic-bezier(0.2, 0, 0, 1)";
+  if (token.name.startsWith("--elev-")) return "none";
+  if (token.name === "--focus-ring") return "0 0 0 2px #111111";
+  if (
+    token.name.startsWith("--text-")
+    || token.name.startsWith("--space-")
+    || token.name.startsWith("--section-y-")
+    || token.name.startsWith("--radius-")
+    || token.name.startsWith("--container-")
+  ) {
+    return `${index + 1}px`;
+  }
+  return `#${(index + 1).toString(16).padStart(6, "0").slice(0, 6)}`;
+}
 
 test("design-system project manifest schema accepts the v1 minimum shape", () => {
   const result = validateDesignSystemProjectManifest({
@@ -167,22 +231,46 @@ test("design-system project manifest schema accepts import-project optional inde
   }
 });
 
-test("design-system tailwind v4 guard only allows aliases to schema tokens", async () => {
-  const root = mkdtempSync(path.join(os.tmpdir(), "od-tailwind-guard-"));
+test("design-system design tokens guard rejects stale derived JSON", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "od-design-tokens-guard-"));
   try {
-    const filePath = path.join(root, "tailwind-v4.css");
-    writeFileSync(filePath, '@import "tailwindcss";\n@import "./tokens.css";\n\n@theme {\n  --color-accent: var(--accent);\n}\n');
+    writeDerivedTokenFixture(root);
     const okViolations: string[] = [];
-    await validateTailwindV4Css(okViolations, "design-systems/test/manifest.json", root, "tailwind-v4.css");
+    await validateDesignTokensJson(okViolations, "design-systems/test/manifest.json", root, "tokens.css", "design-tokens.json", REPORT_PATH);
     assert.deepEqual(okViolations, []);
 
-    writeFileSync(filePath, '@import "tailwindcss";\n@theme {\n  --color-accent: #fff;\n  --color-custom: var(--custom);\n}\n');
+    const stale = JSON.parse(readFileSync(path.join(root, "design-tokens.json"), "utf8")) as {
+      tokens: Array<{ value: string }>;
+    };
+    stale.tokens[0]!.value = "#abcdef";
+    writeFileSync(path.join(root, "design-tokens.json"), `${JSON.stringify(stale, null, 2)}\n`);
     const violations: string[] = [];
-    await validateTailwindV4Css(violations, "design-systems/test/manifest.json", root, "tailwind-v4.css");
+    await validateDesignTokensJson(violations, "design-systems/test/manifest.json", root, "tokens.css", "design-tokens.json", REPORT_PATH);
     assert.deepEqual(violations, [
-      "design-systems/test/manifest.json: tailwind-v4.css must import ./tokens.css",
-      "design-systems/test/manifest.json: tailwind-v4.css @theme declarations must be var(--token) aliases",
-      "design-systems/test/manifest.json: tailwind-v4.css maps --color-custom to non-schema token --custom",
+      "design-systems/test/manifest.json: design-tokens.json is stale; regenerate it from source/token-contract.report.json",
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("design-system tailwind v4 guard rejects swapped canonical mappings", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "od-tailwind-guard-"));
+  try {
+    writeDerivedTokenFixture(root);
+    const okViolations: string[] = [];
+    await validateTailwindV4Css(okViolations, "design-systems/test/manifest.json", root, "tokens.css", "tailwind-v4.css");
+    assert.deepEqual(okViolations, []);
+
+    const filePath = path.join(root, "tailwind-v4.css");
+    writeFileSync(
+      filePath,
+      readFileSync(filePath, "utf8").replace("  --color-accent: var(--accent);", "  --color-accent: var(--bg);"),
+    );
+    const violations: string[] = [];
+    await validateTailwindV4Css(violations, "design-systems/test/manifest.json", root, "tokens.css", "tailwind-v4.css");
+    assert.deepEqual(violations, [
+      "design-systems/test/manifest.json: tailwind-v4.css is stale; regenerate it from tokens.css",
     ]);
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/scripts/check-design-system-manifests.test.ts
+++ b/scripts/check-design-system-manifests.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -6,7 +9,7 @@ import {
   type DesignSystemProjectManifest,
   validateDesignSystemProjectManifest,
 } from "../design-systems/_schema/manifest.schema.ts";
-import { validateManifestSemantics } from "./check-design-system-manifests.ts";
+import { validateManifestSemantics, validateTailwindV4Css } from "./check-design-system-manifests.ts";
 
 test("design-system project manifest schema accepts the v1 minimum shape", () => {
   const result = validateDesignSystemProjectManifest({
@@ -83,6 +86,8 @@ test("design-system project manifest schema rejects path drift and unknown keys"
     files: {
       design: "design.md",
       tokens: "colors.css",
+      designTokens: "tokens.json",
+      tailwind: "tailwind.css",
     },
     extra: "field",
   });
@@ -94,6 +99,8 @@ test("design-system project manifest schema rejects path drift and unknown keys"
     assert.match(errors, /\$\.source\.unexpected/);
     assert.match(errors, /\$\.files\.design/);
     assert.match(errors, /\$\.files\.tokens/);
+    assert.match(errors, /\$\.files\.designTokens/);
+    assert.match(errors, /\$\.files\.tailwind/);
     assert.match(errors, /\$\.extra/);
   }
 });
@@ -114,6 +121,8 @@ test("design-system project manifest schema accepts import-project optional inde
     files: {
       design: "DESIGN.md",
       tokens: "tokens.css",
+      designTokens: "design-tokens.json",
+      tailwind: "tailwind-v4.css",
       components: "components.html",
     },
     assetsDir: "assets",
@@ -149,10 +158,34 @@ test("design-system project manifest schema accepts import-project optional inde
   assert.equal(result.ok, true);
   if (result.ok) {
     assert.equal(result.manifest.usage, "USAGE.md");
+    assert.equal(result.manifest.files.designTokens, "design-tokens.json");
+    assert.equal(result.manifest.files.tailwind, "tailwind-v4.css");
     assert.equal(result.manifest.componentsManifest, "components.manifest.json");
     assert.equal(result.manifest.importMode, "hybrid");
     assert.equal(result.manifest.preview?.pages.length, 2);
     assert.equal(result.manifest.sourceFiles?.report, "source/token-contract.report.json");
+  }
+});
+
+test("design-system tailwind v4 guard only allows aliases to schema tokens", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "od-tailwind-guard-"));
+  try {
+    const filePath = path.join(root, "tailwind-v4.css");
+    writeFileSync(filePath, '@import "tailwindcss";\n@import "./tokens.css";\n\n@theme {\n  --color-accent: var(--accent);\n}\n');
+    const okViolations: string[] = [];
+    await validateTailwindV4Css(okViolations, "design-systems/test/manifest.json", root, "tailwind-v4.css");
+    assert.deepEqual(okViolations, []);
+
+    writeFileSync(filePath, '@import "tailwindcss";\n@theme {\n  --color-accent: #fff;\n  --color-custom: var(--custom);\n}\n');
+    const violations: string[] = [];
+    await validateTailwindV4Css(violations, "design-systems/test/manifest.json", root, "tailwind-v4.css");
+    assert.deepEqual(violations, [
+      "design-systems/test/manifest.json: tailwind-v4.css must import ./tokens.css",
+      "design-systems/test/manifest.json: tailwind-v4.css @theme declarations must be var(--token) aliases",
+      "design-systems/test/manifest.json: tailwind-v4.css maps --color-custom to non-schema token --custom",
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/scripts/check-design-system-manifests.ts
+++ b/scripts/check-design-system-manifests.ts
@@ -18,12 +18,17 @@ import { parseDesignSystemProjectManifest } from "../design-systems/_schema/mani
 import type { DesignSystemProjectManifest } from "../design-systems/_schema/manifest.schema.ts";
 import { TOKEN_SCHEMA } from "../design-systems/_schema/tokens.schema.ts";
 import { extractComponentsManifest } from "../packages/contracts/src/design-systems/components-manifest.ts";
+import {
+  renderDesignTokensJson,
+  renderTailwindV4Css,
+  type DerivedDesignTokenBinding,
+  type DerivedDesignTokenReport,
+} from "../packages/contracts/src/design-systems/derived-token-outputs.ts";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const designSystemsRoot = path.join(repoRoot, "design-systems");
 const craftRoot = path.join(repoRoot, "craft");
 const SKIPPED_DIRECTORIES = new Set(["_schema"]);
-const TOKEN_SCHEMA_NAMES = new Set(TOKEN_SCHEMA.map((spec) => spec.name));
 
 function toRepositoryPath(filePath: string): string {
   return path.relative(repoRoot, filePath).split(path.sep).join("/");
@@ -113,8 +118,21 @@ export async function checkDesignSystemManifests(): Promise<boolean> {
     }
 
     await validateDeclaredJsonFiles(violations, repositoryManifestPath, brandRoot, manifest);
-    await validateDesignTokensJson(violations, repositoryManifestPath, brandRoot, manifest.files.designTokens);
-    await validateTailwindV4Css(violations, repositoryManifestPath, brandRoot, manifest.files.tailwind);
+    await validateDesignTokensJson(
+      violations,
+      repositoryManifestPath,
+      brandRoot,
+      manifest.files.tokens,
+      manifest.files.designTokens,
+      manifest.sourceFiles?.report,
+    );
+    await validateTailwindV4Css(
+      violations,
+      repositoryManifestPath,
+      brandRoot,
+      manifest.files.tokens,
+      manifest.files.tailwind,
+    );
     await validateComponentsManifestCache(violations, repositoryManifestPath, brandRoot, folderSlug, manifest.componentsManifest);
   }
 
@@ -130,17 +148,21 @@ export async function checkDesignSystemManifests(): Promise<boolean> {
   return true;
 }
 
-async function validateDesignTokensJson(
+export async function validateDesignTokensJson(
   violations: string[],
   repositoryManifestPath: string,
   brandRoot: string,
+  tokensPath: string,
   designTokensPath: string | undefined,
+  reportPath: string | undefined,
 ): Promise<void> {
   if (designTokensPath === undefined) return;
   const filePath = path.join(brandRoot, designTokensPath);
+  let actualText: string;
   let parsed: unknown;
   try {
-    parsed = await readJson(filePath);
+    actualText = await readFile(filePath, "utf8");
+    parsed = JSON.parse(actualText) as unknown;
   } catch (error) {
     violations.push(
       `${repositoryManifestPath}: ${designTokensPath} could not be parsed: ${
@@ -163,17 +185,60 @@ async function validateDesignTokensJson(
     violations.push(`${repositoryManifestPath}: ${designTokensPath} tokens must be an array`);
     return;
   }
-  const declared = new Set<string>();
-  for (const [index, token] of parsed.tokens.entries()) {
-    if (!isRecord(token) || typeof token.name !== "string" || typeof token.value !== "string") {
-      violations.push(`${repositoryManifestPath}: ${designTokensPath} tokens[${index}] must include string name and value`);
-      continue;
-    }
-    declared.add(token.name);
+  if (reportPath === undefined) {
+    violations.push(`${repositoryManifestPath}: ${designTokensPath} requires sourceFiles.report`);
+    return;
   }
+  const reportFilePath = path.join(brandRoot, reportPath);
+  let reportJson: unknown;
+  try {
+    reportJson = await readJson(reportFilePath);
+  } catch (error) {
+    violations.push(
+      `${repositoryManifestPath}: ${reportPath} could not be parsed while validating ${designTokensPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return;
+  }
+  const report = toDerivedDesignTokenReport(reportJson);
+  if (report === undefined) {
+    violations.push(`${repositoryManifestPath}: ${reportPath} must contain generatedAt, summary, and token contract bindings`);
+    return;
+  }
+  const expected = renderDesignTokensJson({
+    bindings: report.tokens,
+    report,
+  });
+  if (actualText !== expected) {
+    violations.push(`${repositoryManifestPath}: ${designTokensPath} is stale; regenerate it from ${reportPath}`);
+  }
+
+  const reportNames = new Set(report.tokens.map((token) => token.name));
   for (const spec of TOKEN_SCHEMA) {
-    if (!declared.has(spec.name)) {
-      violations.push(`${repositoryManifestPath}: ${designTokensPath} is missing ${spec.name}`);
+    if (!reportNames.has(spec.name)) {
+      violations.push(`${repositoryManifestPath}: ${reportPath} is missing ${spec.name}`);
+    }
+  }
+
+  let tokensCss: string;
+  try {
+    tokensCss = await readFile(path.join(brandRoot, tokensPath), "utf8");
+  } catch (error) {
+    violations.push(
+      `${repositoryManifestPath}: ${tokensPath} could not be read while validating ${designTokensPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return;
+  }
+  const tokenDeclarations = parseRootTokenDeclarations(tokensCss);
+  for (const binding of report.tokens) {
+    const declaredValue = tokenDeclarations.get(binding.name);
+    if (declaredValue === undefined) {
+      violations.push(`${repositoryManifestPath}: ${reportPath} token ${binding.name} is missing from ${tokensPath}`);
+    } else if (declaredValue !== normalizeTokenValue(binding.value)) {
+      violations.push(`${repositoryManifestPath}: ${reportPath} token ${binding.name} value does not match ${tokensPath}`);
     }
   }
 }
@@ -182,12 +247,13 @@ export async function validateTailwindV4Css(
   violations: string[],
   repositoryManifestPath: string,
   brandRoot: string,
+  tokensPath: string,
   tailwindPath: string | undefined,
 ): Promise<void> {
   if (tailwindPath === undefined) return;
-  let css: string;
+  let actualCss: string;
   try {
-    css = await readFile(path.join(brandRoot, tailwindPath), "utf8");
+    actualCss = await readFile(path.join(brandRoot, tailwindPath), "utf8");
   } catch (error) {
     violations.push(
       `${repositoryManifestPath}: ${tailwindPath} could not be read: ${
@@ -196,28 +262,88 @@ export async function validateTailwindV4Css(
     );
     return;
   }
-  if (!css.includes('@import "./tokens.css";')) {
-    violations.push(`${repositoryManifestPath}: ${tailwindPath} must import ./tokens.css`);
-  }
-  const themeBody = css.match(/@theme\s*\{([\s\S]*?)\}/)?.[1];
-  if (themeBody === undefined) {
-    violations.push(`${repositoryManifestPath}: ${tailwindPath} must declare an @theme block`);
+  let tokensCss: string;
+  try {
+    tokensCss = await readFile(path.join(brandRoot, tokensPath), "utf8");
+  } catch (error) {
+    violations.push(
+      `${repositoryManifestPath}: ${tokensPath} could not be read while validating ${tailwindPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
     return;
   }
-  for (const rawDeclaration of themeBody.split(";")) {
-    const declaration = rawDeclaration.trim();
-    if (declaration.length === 0) continue;
-    const match = declaration.match(/^(--[A-Za-z0-9_-]+)\s*:\s*var\(\s*(--[A-Za-z0-9_-]+)\s*\)$/);
-    if (match === null) {
-      violations.push(`${repositoryManifestPath}: ${tailwindPath} @theme declarations must be var(--token) aliases`);
-      continue;
-    }
-    const tailwindName = match[1]!;
-    const sourceName = match[2]!;
-    if (!TOKEN_SCHEMA_NAMES.has(sourceName)) {
-      violations.push(`${repositoryManifestPath}: ${tailwindPath} maps ${tailwindName} to non-schema token ${sourceName}`);
-    }
+  const expectedCss = renderTailwindV4Css(
+    Array.from(parseRootTokenDeclarations(tokensCss).keys(), (name) => ({ name })),
+  );
+  if (actualCss !== expectedCss) {
+    violations.push(`${repositoryManifestPath}: ${tailwindPath} is stale; regenerate it from ${tokensPath}`);
   }
+}
+
+function toDerivedDesignTokenReport(value: unknown): (DerivedDesignTokenReport & {
+  tokens: DerivedDesignTokenBinding[];
+}) | undefined {
+  if (!isRecord(value) || typeof value.generatedAt !== "string" || !isRecord(value.summary) || !Array.isArray(value.tokens)) {
+    return undefined;
+  }
+  const tokens: DerivedDesignTokenBinding[] = [];
+  for (const token of value.tokens) {
+    const binding = toDerivedDesignTokenBinding(token);
+    if (binding === undefined) return undefined;
+    tokens.push(binding);
+  }
+  return {
+    generatedAt: value.generatedAt,
+    summary: value.summary,
+    tokens,
+  };
+}
+
+function toDerivedDesignTokenBinding(value: unknown): DerivedDesignTokenBinding | undefined {
+  if (
+    !isRecord(value)
+    || typeof value.name !== "string"
+    || typeof value.layer !== "string"
+    || typeof value.value !== "string"
+    || typeof value.confidence !== "string"
+    || typeof value.reason !== "string"
+    || !Array.isArray(value.sources)
+    || !value.sources.every((source): source is string => typeof source === "string")
+    || (value.sourceName !== undefined && typeof value.sourceName !== "string")
+  ) {
+    return undefined;
+  }
+  return {
+    name: value.name,
+    layer: value.layer,
+    value: value.value,
+    confidence: value.confidence,
+    reason: value.reason,
+    sources: value.sources,
+    ...(value.sourceName === undefined ? {} : { sourceName: value.sourceName }),
+  };
+}
+
+function parseRootTokenDeclarations(css: string): Map<string, string> {
+  const rootBody = css.replace(/\/\*[\s\S]*?\*\//g, "").match(/:root(?!\[)\s*\{([\s\S]*?)\}/)?.[1];
+  const declarations = new Map<string, string>();
+  if (rootBody === undefined) return declarations;
+  for (const rawDeclaration of rootBody.split(";")) {
+    const declaration = rawDeclaration.trim();
+    if (!declaration.startsWith("--")) continue;
+    const colonIndex = declaration.indexOf(":");
+    if (colonIndex === -1) continue;
+    declarations.set(
+      declaration.slice(0, colonIndex).trim(),
+      normalizeTokenValue(declaration.slice(colonIndex + 1)),
+    );
+  }
+  return declarations;
+}
+
+function normalizeTokenValue(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
 }
 
 async function discoverCraftSlugs(): Promise<Set<string>> {

--- a/scripts/check-design-system-manifests.ts
+++ b/scripts/check-design-system-manifests.ts
@@ -16,12 +16,14 @@ import { fileURLToPath } from "node:url";
 
 import { parseDesignSystemProjectManifest } from "../design-systems/_schema/manifest.schema.ts";
 import type { DesignSystemProjectManifest } from "../design-systems/_schema/manifest.schema.ts";
+import { TOKEN_SCHEMA } from "../design-systems/_schema/tokens.schema.ts";
 import { extractComponentsManifest } from "../packages/contracts/src/design-systems/components-manifest.ts";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const designSystemsRoot = path.join(repoRoot, "design-systems");
 const craftRoot = path.join(repoRoot, "craft");
 const SKIPPED_DIRECTORIES = new Set(["_schema"]);
+const TOKEN_SCHEMA_NAMES = new Set(TOKEN_SCHEMA.map((spec) => spec.name));
 
 function toRepositoryPath(filePath: string): string {
   return path.relative(repoRoot, filePath).split(path.sep).join("/");
@@ -38,6 +40,10 @@ async function exists(filePath: string): Promise<boolean> {
 
 async function readJson(filePath: string): Promise<unknown> {
   return JSON.parse(await readFile(filePath, "utf8")) as unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 async function discoverManifestPaths(): Promise<string[]> {
@@ -83,6 +89,8 @@ export async function checkDesignSystemManifests(): Promise<boolean> {
     const requiredFiles = [
       manifest.files.design,
       manifest.files.tokens,
+      ...(manifest.files.designTokens === undefined ? [] : [manifest.files.designTokens]),
+      ...(manifest.files.tailwind === undefined ? [] : [manifest.files.tailwind]),
       ...(manifest.files.components === undefined ? [] : [manifest.files.components]),
       ...(manifest.usage === undefined ? [] : [manifest.usage]),
       ...(manifest.componentsManifest === undefined ? [] : [manifest.componentsManifest]),
@@ -104,7 +112,9 @@ export async function checkDesignSystemManifests(): Promise<boolean> {
       violations.push(`${repositoryManifestPath}: preview.dir is declared but ${manifest.preview.dir}/ does not exist`);
     }
 
-    await validateDeclaredJsonFiles(violations, repositoryManifestPath, brandRoot, manifest.sourceFiles);
+    await validateDeclaredJsonFiles(violations, repositoryManifestPath, brandRoot, manifest);
+    await validateDesignTokensJson(violations, repositoryManifestPath, brandRoot, manifest.files.designTokens);
+    await validateTailwindV4Css(violations, repositoryManifestPath, brandRoot, manifest.files.tailwind);
     await validateComponentsManifestCache(violations, repositoryManifestPath, brandRoot, folderSlug, manifest.componentsManifest);
   }
 
@@ -118,6 +128,96 @@ export async function checkDesignSystemManifests(): Promise<boolean> {
     `Design system manifest check passed: ${manifestPaths.length} project manifest${manifestPaths.length === 1 ? "" : "s"} valid; DESIGN.md-only systems skipped.`,
   );
   return true;
+}
+
+async function validateDesignTokensJson(
+  violations: string[],
+  repositoryManifestPath: string,
+  brandRoot: string,
+  designTokensPath: string | undefined,
+): Promise<void> {
+  if (designTokensPath === undefined) return;
+  const filePath = path.join(brandRoot, designTokensPath);
+  let parsed: unknown;
+  try {
+    parsed = await readJson(filePath);
+  } catch (error) {
+    violations.push(
+      `${repositoryManifestPath}: ${designTokensPath} could not be parsed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return;
+  }
+  if (!isRecord(parsed)) {
+    violations.push(`${repositoryManifestPath}: ${designTokensPath} must be a JSON object`);
+    return;
+  }
+  if (parsed.format !== "od-design-tokens/v1") {
+    violations.push(`${repositoryManifestPath}: ${designTokensPath} format must be od-design-tokens/v1`);
+  }
+  if (parsed.contract !== "TOKEN_SCHEMA") {
+    violations.push(`${repositoryManifestPath}: ${designTokensPath} contract must be TOKEN_SCHEMA`);
+  }
+  if (!Array.isArray(parsed.tokens)) {
+    violations.push(`${repositoryManifestPath}: ${designTokensPath} tokens must be an array`);
+    return;
+  }
+  const declared = new Set<string>();
+  for (const [index, token] of parsed.tokens.entries()) {
+    if (!isRecord(token) || typeof token.name !== "string" || typeof token.value !== "string") {
+      violations.push(`${repositoryManifestPath}: ${designTokensPath} tokens[${index}] must include string name and value`);
+      continue;
+    }
+    declared.add(token.name);
+  }
+  for (const spec of TOKEN_SCHEMA) {
+    if (!declared.has(spec.name)) {
+      violations.push(`${repositoryManifestPath}: ${designTokensPath} is missing ${spec.name}`);
+    }
+  }
+}
+
+export async function validateTailwindV4Css(
+  violations: string[],
+  repositoryManifestPath: string,
+  brandRoot: string,
+  tailwindPath: string | undefined,
+): Promise<void> {
+  if (tailwindPath === undefined) return;
+  let css: string;
+  try {
+    css = await readFile(path.join(brandRoot, tailwindPath), "utf8");
+  } catch (error) {
+    violations.push(
+      `${repositoryManifestPath}: ${tailwindPath} could not be read: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return;
+  }
+  if (!css.includes('@import "./tokens.css";')) {
+    violations.push(`${repositoryManifestPath}: ${tailwindPath} must import ./tokens.css`);
+  }
+  const themeBody = css.match(/@theme\s*\{([\s\S]*?)\}/)?.[1];
+  if (themeBody === undefined) {
+    violations.push(`${repositoryManifestPath}: ${tailwindPath} must declare an @theme block`);
+    return;
+  }
+  for (const rawDeclaration of themeBody.split(";")) {
+    const declaration = rawDeclaration.trim();
+    if (declaration.length === 0) continue;
+    const match = declaration.match(/^(--[A-Za-z0-9_-]+)\s*:\s*var\(\s*(--[A-Za-z0-9_-]+)\s*\)$/);
+    if (match === null) {
+      violations.push(`${repositoryManifestPath}: ${tailwindPath} @theme declarations must be var(--token) aliases`);
+      continue;
+    }
+    const tailwindName = match[1]!;
+    const sourceName = match[2]!;
+    if (!TOKEN_SCHEMA_NAMES.has(sourceName)) {
+      violations.push(`${repositoryManifestPath}: ${tailwindPath} maps ${tailwindName} to non-schema token ${sourceName}`);
+    }
+  }
 }
 
 async function discoverCraftSlugs(): Promise<Set<string>> {
@@ -189,13 +289,13 @@ async function validateDeclaredJsonFiles(
   violations: string[],
   repositoryManifestPath: string,
   brandRoot: string,
-  sourceFiles: Record<string, string | undefined> | undefined,
+  manifest: DesignSystemProjectManifest,
 ): Promise<void> {
   const jsonPaths = [
-    sourceFiles?.scanned,
-    sourceFiles?.tokens,
-    sourceFiles?.report,
-    sourceFiles?.snippets,
+    manifest.sourceFiles?.scanned,
+    manifest.sourceFiles?.tokens,
+    manifest.sourceFiles?.report,
+    manifest.sourceFiles?.snippets,
   ].filter((fileName): fileName is string => fileName !== undefined);
 
   for (const fileName of jsonPaths) {


### PR DESCRIPTION
## Why

This is PR3 in the design-system extraction stack. PR2 makes imported design systems produce a TOKEN_SCHEMA contract and quality report; this PR adds the two common derived formats that agents and MCP/skill consumers expect, without creating a second token source of truth.

The pain being addressed: imported design-system packages currently expose DESIGN.md, tokens.css, and components.html, so consumers that want Design Tokens JSON or Tailwind v4 theme variables have to infer or convert them ad hoc.

Stacking note: this is intentionally a draft PR stacked on `codex/ds-token-contract-rebuild-pr2` until PR2 lands.

## What users will see

Imported design-system packages now include `design-tokens.json` and `tailwind-v4.css` next to `tokens.css`. The design-system detail package/push list shows those files, and skill/MCP pull reads can fetch them when the manifest declares them.

Existing import surfaces, including the `od design-systems import-*` commands added in PR2, produce these derived files through the same import path. There is no new CLI command or flag.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Draft PR: not captured yet. The UI change is the existing design-system package file list showing two additional manifest-declared file chips.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/design-system-import.test.ts tests/design-system-assets.test.ts tests/design-system-tool-routes.test.ts --pool=threads --no-file-parallelism`
- `node --import tsx --test scripts/check-design-system-manifests.test.ts`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`

Note: local validation prints the existing Node engine warning because this machine is on Node v26.0.0 while the repo asks for `~24`. The commands completed successfully.
