### PR TITLE
fix(release-beta): pass a valid mac sign mode (on → sign-only)

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -210,7 +210,13 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           MAC_BUILD_TARGET: dmg
           MAC_COMPRESSION: normal
-          MAC_SIGN_MODE: "on"
+          # build-mac.sh accepts no | sign-only | notarize; the legacy "on" is
+          # rejected ("unsupported MAC_SIGN_MODE"). sign-only signs the beta with
+          # the Apple Developer ID cert without notarization (notarize needs the
+          # APPLE_NOTARY_KEYCHAIN_PROFILE plumbing that only lands with the
+          # release-beta-isomorphism mac-lane rework). Unblocks signed mac betas
+          # built directly from main.
+          MAC_SIGN_MODE: "sign-only"
           RELEASE_VERSION: ${{ needs.metadata.outputs.beta_version }}
           TOOLS_PACK_NAMESPACE: release-beta
         run: |


### PR DESCRIPTION
## Why
Building a beta directly from `main` fails in **Build beta mac arm64** with:
```
unsupported MAC_SIGN_MODE: on
```
`release-beta.yml` passes `MAC_SIGN_MODE: "on"` to `.github/scripts/release/build-mac.sh`, but that script only accepts `no | sign-only | notarize` (default `sign-only`) and hard-exits on anything else. The green betas were built from the `release-beta-isomorphism` self-hosted lane, so nobody hit this on main.

## What
One-line: `MAC_SIGN_MODE: "on"` → `"sign-only"`.
- `sign-only` signs the beta with the Apple Developer ID cert (already wired via `APPLE_SIGNING_CERTIFICATE_*`) — the mac build now succeeds from main.
- `notarize` is intentionally **not** used here because it requires `APPLE_NOTARY_KEYCHAIN_PROFILE` (not present on this step). Notarized mac betas come with the `release-beta-isomorphism` mac-lane rework (build-platform.sh + direct-credential notarization); this is the interim unblock.

## What users will see
mac beta builds from main produce a **signed (not notarized)** dmg — first launch needs right-click → Open / allow in System Settings. No change to win or to the notarized betas built from the isomorphism lane.