### PR TITLE
feat(amr): forward installationId to the vela CLI for analytics correlation (cherry-pick #3634)

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -12,6 +12,7 @@
 // for Codex). Those values are local-only and should not be logged or
 // returned outside this machine.
 
+import { readFileSync } from 'node:fs';
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { createHash, randomBytes } from 'node:crypto';
 import path from 'node:path';
@@ -19,6 +20,7 @@ import { expandHomePrefix } from './home-expansion.js';
 
 import {
   readInstallationFile,
+  readInstallationFileSync,
   resolveInstallationDir,
   writeInstallationFile,
   type InstallationFilePatch,
@@ -461,6 +463,46 @@ export async function readAppConfig(dataDir: string): Promise<AppConfigPrefs> {
     }
   }
   return applyTelemetryDefaults(base);
+}
+
+// Synchronous mirror of readAppConfig for callers that cannot await — e.g.
+// building the spawn env for the vela CLI inside the synchronous
+// spawnEnvForAgent. It reuses the exact same parsing, validation and telemetry
+// defaulting as the async path, so the consent decision and installationId can
+// never drift from what the rest of the daemon (and the web analytics config)
+// sees. The only intentional difference is that it skips the best-effort
+// legacy→channel-root migration *write*, which is a side effect rather than
+// part of the read result.
+export function readAppConfigSync(dataDir: string): AppConfigPrefs {
+  const base = readAppConfigFileOnlySync(dataDir);
+  const installation = readInstallationFileSync(resolveInstallationDir(dataDir));
+  if (
+    typeof installation.installationId === 'string' &&
+    installation.installationId.length > 0
+  ) {
+    return applyTelemetryDefaults({
+      ...base,
+      installationId: installation.installationId,
+    });
+  }
+  return applyTelemetryDefaults(base);
+}
+
+function readAppConfigFileOnlySync(dataDir: string): AppConfigPrefs {
+  try {
+    const parsed: unknown = JSON.parse(
+      readFileSync(configFile(dataDir), 'utf8'),
+    );
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return filterAllowedKeys(parsed as Record<string, unknown>);
+    }
+    return {};
+  } catch (err: unknown) {
+    const e = err as { code?: string; name?: string };
+    if (e.code === 'ENOENT') return {};
+    if (e.name === 'SyntaxError') return {};
+    throw err;
+  }
 }
 
 async function readAppConfigFileOnly(dataDir: string): Promise<AppConfigPrefs> {

--- a/apps/daemon/src/installation.ts
+++ b/apps/daemon/src/installation.ts
@@ -33,6 +33,7 @@
 // (where it sits next to app-config.json and behaves like the legacy
 // path — fine for dev because dev doesn't have namespace churn).
 
+import { readFileSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
@@ -58,27 +59,43 @@ function installationFilePath(installationDir: string): string {
   return join(installationDir, 'installation.json');
 }
 
+function parseInstallationFile(raw: string): InstallationFile {
+  const parsed: unknown = JSON.parse(raw);
+  if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {};
+  }
+  const obj = parsed as Record<string, unknown>;
+  const out: InstallationFile = {};
+  if (typeof obj.installationId === 'string' && obj.installationId.length > 0) {
+    out.installationId = obj.installationId;
+  }
+  return out;
+}
+
 export async function readInstallationFile(
   installationDir: string,
 ): Promise<InstallationFile> {
   try {
-    const raw = await readFile(installationFilePath(installationDir), 'utf8');
-    const parsed: unknown = JSON.parse(raw);
-    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return {};
-    }
-    const obj = parsed as Record<string, unknown>;
-    const out: InstallationFile = {};
-    if (typeof obj.installationId === 'string' && obj.installationId.length > 0) {
-      out.installationId = obj.installationId;
-    }
-    return out;
-  } catch (err) {
-    const e = err as { code?: string; name?: string };
-    if (e.code === 'ENOENT') return {};
-    if (e.name === 'SyntaxError') return {};
-    // Anything else (permission denied, EIO) — treat as empty so the
+    return parseInstallationFile(
+      await readFile(installationFilePath(installationDir), 'utf8'),
+    );
+  } catch {
+    // ENOENT, malformed JSON, permission denied, EIO — treat as empty so the
     // fallback path through app-config.json keeps the daemon alive.
+    return {};
+  }
+}
+
+// Synchronous mirror of readInstallationFile for callers on a sync path (e.g.
+// building the spawn env for the vela CLI). Same parse + same fail-soft.
+export function readInstallationFileSync(
+  installationDir: string,
+): InstallationFile {
+  try {
+    return parseInstallationFile(
+      readFileSync(installationFilePath(installationDir), 'utf8'),
+    );
+  } catch {
     return {};
   }
 }

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { mergeProxyAwareEnv, resolveSystemProxyEnv } from '@open-design/platform';
+import { readAppConfigSync } from '../app-config.js';
 import { resolveProjectRelativePath } from '../home-expansion.js';
 import { expandConfiguredEnv } from './paths.js';
 import { resolveAmrOpenCodeExecutable } from './executables.js';
@@ -49,6 +50,35 @@ const RUNTIME_MODULE_PROJECT_ROOT = resolveProjectRootFromNestedModule(
 // object loses Node's case-insensitive accessor — `Anthropic_Api_Key`
 // would survive a literal `delete env.ANTHROPIC_API_KEY` and still reach
 // the child. Iterate keys and compare case-insensitively to close that.
+// When the daemon launches the vela (amr) CLI, forward this installation's id
+// so vela's analytics can be correlated back to it. spawnEnvForAgent is
+// synchronous, so this uses readAppConfigSync — the synchronous mirror of
+// readAppConfig — to resolve consent and the installationId through the exact
+// same parsing/validation/defaulting the daemon and web analytics config use.
+// That keeps vela's correlation in lockstep with what the web side already
+// emits: telemetry defaults to on (opt-out), the id is withheld only when the
+// user has explicitly opted out (metrics !== true) or no id exists, and an
+// unreadable config simply omits the env (vela reports without it).
+function amrAnalyticsIdentityEnv(
+  env: NodeJS.ProcessEnv,
+): Record<string, string> {
+  const dataDir = env.OD_DATA_DIR?.trim();
+  if (!dataDir) return {};
+  let cfg: { telemetry?: { metrics?: boolean }; installationId?: string | null };
+  try {
+    cfg = readAppConfigSync(dataDir);
+  } catch {
+    return {};
+  }
+  // Matches the analytics gate in analytics.ts (`telemetry?.metrics !== true`).
+  if (cfg.telemetry?.metrics !== true) return {};
+  const installationId = cfg.installationId;
+  if (typeof installationId !== 'string' || installationId.length === 0) {
+    return {};
+  }
+  return { OD_INSTALLATION_ID: installationId };
+}
+
 export function spawnEnvForAgent(
   agentId: string,
   baseEnv: RuntimeEnvMap,
@@ -65,6 +95,7 @@ export function spawnEnvForAgent(
   );
   if (agentId === 'amr') {
     Object.assign(env, amrVelaProfileEnv(env));
+    Object.assign(env, amrAnalyticsIdentityEnv(env));
     if (!env.OPENCODE_TEST_HOME?.trim() && env.OD_DATA_DIR?.trim()) {
       env.OPENCODE_TEST_HOME = path.join(
         env.OD_DATA_DIR.trim(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,8 +654,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.10
-        version: 0.0.10
+        specifier: 0.0.11
+        version: 0.0.11
 
   tools/serve:
     dependencies:
@@ -1793,33 +1793,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.10':
-    resolution: {integrity: sha512-/lRuSEJT9mXNIcfhr7qizMUWgAkALT0HEIznsAm6YSkZN2Cd1XjHt9uR/yajfJatSrvyzR2fI6lisDhdi0AxIQ==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.11':
+    resolution: {integrity: sha512-F4QinKhfQZi6hcsXfJz3tq6X5VzKIrDnStOCCWl6h8VLO5AUXN7GIPbIPC337MoJ0rOiaHU9awGk5yI9ivx5oA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.10':
-    resolution: {integrity: sha512-XCertlBb5aAt8CXsdLu0Y1HlA7EUvQOKV/2gKSzEUdtviLs9P/If2162gklD8FEc+YCD9nBZCM277UjKakgZkw==}
+  '@powerformer/vela-cli-darwin-x64@0.0.11':
+    resolution: {integrity: sha512-Wkpv9MroS/PIhLfgtk4cIJv4jRULx+q7encGm2kG09d9Y6mfNmeYUIKbt7lf58ArlGbq9Ue9N2WnXICwv16dlg==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.10':
-    resolution: {integrity: sha512-uHiKCLeOWPu76OjOu919fj2QNTqyNeVWb6y8aeRLcrGLm6sFw4kZYXysdZMahhondUtl49YoH3VhS6EIhpdEUQ==}
+  '@powerformer/vela-cli-linux-arm64@0.0.11':
+    resolution: {integrity: sha512-Cl/YcFObTOfKw8EViEHQYzpIGq7WO3zpxeHJA493AwDXSsj40rjRMB7mNCofsvslXxD0NVhTSFqE7IFzvpuAzg==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.10':
-    resolution: {integrity: sha512-OWD33zlKW6RiOFwCC9oLtAVFgK/6b+YLSQm8bWLByRMC9k2Yfe2cQnH7KqaQl1LKyjhLC3+AnXwYvtW/f4edSA==}
+  '@powerformer/vela-cli-linux-x64@0.0.11':
+    resolution: {integrity: sha512-xanh1LmPpscCdfiV95XQNUJx2/nZWcn+bzrXBJgi1hfPhN6vSClP5J4YrNCLTKrpBH3J6TdIfWNe5Zqa8V0XeQ==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.10':
-    resolution: {integrity: sha512-x5RCaMjrPcKHRiu+0jB7Zlm5IFqZawoSkVQ2tX8zBYuELkaKe4xCjo2oSikGP+kEKbArxAeM1TXKbv366SWygw==}
+  '@powerformer/vela-cli-win32-x64@0.0.11':
+    resolution: {integrity: sha512-Zp4Swj9t1N5RnoLxl/NVULa2vz8jFJSEZxrXUtC4jGlG6ArqobNPeVOZvIKgDOzbfvH4zvWUc22cAfiZ5zbEjw==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.10':
-    resolution: {integrity: sha512-nK5lgFHSYyJTsiQ1A/qdmRvwLJrVFG/RkVxhGk7AZ88986XCZIytJ0km59PvkS2E9Lz57hqOIuhzbNu559xxvg==}
+  '@powerformer/vela-cli@0.0.11':
+    resolution: {integrity: sha512-yS+eC/pMZNjg2/2t4Uh6JefhP+KTU+pvQRJm8wtqUOENlumV3wuaRO87UmGBcPM/T/wyepc1c4Mr3miWDnL+sg==}
     hasBin: true
 
   '@preact/signals-core@1.14.2':
@@ -6508,28 +6508,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.10':
+  '@powerformer/vela-cli-darwin-arm64@0.0.11':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.10':
+  '@powerformer/vela-cli-darwin-x64@0.0.11':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.10':
+  '@powerformer/vela-cli-linux-arm64@0.0.11':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.10':
+  '@powerformer/vela-cli-linux-x64@0.0.11':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.10':
+  '@powerformer/vela-cli-win32-x64@0.0.11':
     optional: true
 
-  '@powerformer/vela-cli@0.0.10':
+  '@powerformer/vela-cli@0.0.11':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.10
-      '@powerformer/vela-cli-darwin-x64': 0.0.10
-      '@powerformer/vela-cli-linux-arm64': 0.0.10
-      '@powerformer/vela-cli-linux-x64': 0.0.10
-      '@powerformer/vela-cli-win32-x64': 0.0.10
+      '@powerformer/vela-cli-darwin-arm64': 0.0.11
+      '@powerformer/vela-cli-darwin-x64': 0.0.11
+      '@powerformer/vela-cli-linux-arm64': 0.0.11
+      '@powerformer/vela-cli-linux-x64': 0.0.11
+      '@powerformer/vela-cli-win32-x64': 0.0.11
     optional: true
 
   '@preact/signals-core@1.14.2': {}

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -22,7 +22,7 @@
     "electron-builder": "26.8.1"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.10"
+    "@powerformer/vela-cli": "0.0.11"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
Cherry-pick of #3634 (squash `817885bc3`) onto `release/v0.10.0`.

daemon forwards this installation's `OD_INSTALLATION_ID` to the vela (amr) CLI when telemetry is consented (resolved via the new sync `readAppConfigSync`), and bundles `@powerformer/vela-cli@0.0.11` (first CLI release that consumes it) so installationId analytics correlation ships end-to-end on the v0.10.0 release line.

原始 PR:nexu-io/open-design#3634(已合并到 main)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)