### PR TITLE
fix(landing): keep nav logo from shrinking in long-label locales

### DIFF
--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -410,6 +410,16 @@ body::before {
   color: var(--ink);
   text-decoration: none;
   font-size: 18px;
+  /*
+   * Pin the brand so it never participates in flex-shrink. `.nav-inner` is a
+   * `justify-content: space-between` flex row; in locales whose nav labels are
+   * longer (de/ru/pt-BR…) the link list widens the row past the container and
+   * the browser shrinks every shrinkable child proportionally — including the
+   * logo, which is why the wordmark looked smaller in some languages. The nav
+   * links absorb the squeeze instead (they already tighten/collapse to the
+   * hamburger at the 1180/1080 breakpoints below).
+   */
+  flex-shrink: 0;
 }
 .brand-mark {
   /*

--- a/design-templates/open-design-landing/example.html
+++ b/design-templates/open-design-landing/example.html
@@ -218,6 +218,16 @@ body::before {
   color: var(--ink);
   text-decoration: none;
   font-size: 18px;
+  /*
+   * Pin the brand so it never participates in flex-shrink. `.nav-inner` is a
+   * `justify-content: space-between` flex row; in locales whose nav labels are
+   * longer (de/ru/pt-BR…) the link list widens the row past the container and
+   * the browser shrinks every shrinkable child proportionally — including the
+   * logo, which is why the wordmark looked smaller in some languages. The nav
+   * links absorb the squeeze instead (they already tighten/collapse to the
+   * hamburger at the 1180/1080 breakpoints below).
+   */
+  flex-shrink: 0;
 }
 .brand-mark {
   width: 36px; height: 36px;

--- a/design-templates/open-design-landing/styles.css
+++ b/design-templates/open-design-landing/styles.css
@@ -208,6 +208,16 @@ body::before {
   color: var(--ink);
   text-decoration: none;
   font-size: 18px;
+  /*
+   * Pin the brand so it never participates in flex-shrink. `.nav-inner` is a
+   * `justify-content: space-between` flex row; in locales whose nav labels are
+   * longer (de/ru/pt-BR…) the link list widens the row past the container and
+   * the browser shrinks every shrinkable child proportionally — including the
+   * logo, which is why the wordmark looked smaller in some languages. The nav
+   * links absorb the squeeze instead (they already tighten/collapse to the
+   * hamburger at the 1180/1080 breakpoints below).
+   */
+  flex-shrink: 0;
 }
 .brand-mark {
   width: 36px; height: 36px;


### PR DESCRIPTION
## Why

I noticed on the live site (open-design.ai) that the top-left header logo renders **different sizes depending on the UI language** — fine in English, visibly smaller (and at some widths gone entirely) in German / Russian / Portuguese. Scratching that itch.

Root cause: the header brand is a direct flex child of `.nav-inner`, which is a `justify-content: space-between` row, and `.brand` had no `flex-shrink` override (so the default `flex-shrink: 1` applies). Locales whose nav labels are longer than English (`Produkt · Lösungen · Agent · Plugins · Ressourcen · Community` + AMR + Stern + Download) widen the link list past the container, so the browser shrinks **every** shrinkable child proportionally — including the brand. The single SVG wordmark (`/open-design-logo-new.svg`, `.nav .brand-logo { width: auto; height: 42px }`) then renders smaller, or collapses to zero width when the row is tight.

The fix pins `.brand` with `flex-shrink: 0` so the logo always keeps its intrinsic 103×42; the nav links absorb the squeeze instead — which they already handle, tightening their gap at ≤1180px and folding into the hamburger at ≤1080px.

## What users will see

The top-left "Open Design" logo now renders at a consistent size on the marketing site **regardless of UI language**. Previously, switching to German/Russian/etc. (or just a mid-width desktop window) shrank the logo or made it disappear; now it stays put and the nav links flex instead.

## Surface area

- [x] **UI** — landing-page header logo sizing
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — header logo no longer shrinks/collapses in long-label locales (no opt-in)

## Screenshots

Before / after at viewport width 1140px, German locale (`/de/`):

- **Before:** logo squeezed to 0 width — the nav starts straight at "Produkt", no logo visible.
- **After:** "Open Design" wordmark renders full-size on the left.

_(Screenshots captured locally via Playwright against the live site; attaching here.)_

## Bug fix verification

This is a CSS layout bug; I encoded the falsifiable check as a Playwright measurement of `.brand-logo`'s rendered width against the **live `main` site** vs. the same page with `.brand { flex-shrink: 0 }` injected. `full = 103.2px` (intrinsic 42 × 150/61).

Measured against live `main` (logo width in px):

| viewport | en | de | ru |
|---|---|---|---|
| 1200px | 0 | 0 | 0 |
| 1280px | 11.5 | 0 | 0 |
| 1366px | 11.5 | 0 | 0 |
| 1440px | 11.5 | 0 | 0 |
| 1140px (+fix) | **103.2** | **103.2** | **103.2** |

So on `main` the logo collapses across the common desktop band and the residual size differs per locale (en 11.5 vs de/ru 0 — the "different size per language" symptom); with the fix every locale holds 103.2. A committed red spec wasn't added because the marketing `apps/landing-page` site isn't part of the `e2e/` product-app harness; the Playwright measurement above is the equivalent before/after check.

## Validation

- Playwright before/after measurement + screenshots against the live site (above).
- CSS-only change to `apps/landing-page/app/globals.css` (`astro check` validates `.astro`/`.ts`, not CSS, so it's not a meaningful gate here); no logic, build, or contract surface touched.
