### PR TITLE
fix(landing): pin brand flex-shrink to prevent logo shrinking in long-label locales

### DIFF
--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -427,7 +427,7 @@ body::before {
    * left-aligned in its column and the side actions stay right-aligned in
    * theirs. */
   .nav-inner > .brand {
-    flex: 1 1 0;
+    flex: 1 0 0;
     min-width: 0;
     justify-content: flex-start;
   }


### PR DESCRIPTION
## Summary
When the primary nav labels grow wider than the container (e.g. German, Russian, Portuguese), the browser proportionally shrinks every flex-shrinkable child inside `.nav-inner`, including the brand. That makes the top-left SVG logo smaller or even collapse to zero width.

This PR pins `.nav-inner > .brand` with `flex-shrink: 0` so the logo always keeps its intrinsic size and the nav links absorb the squeeze instead — which they already handle, tightening gaps at ≤1180px and folding into the hamburger at ≤1080px.

Fixes #3738

## Surface area
- [x] **UI** — header nav logo no longer shrinks in long-label locales
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag
- [ ] **API / contract** — new `/api/*` endpoint
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, etc.
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — root `package.json` change