### PR TITLE
[codex] Fix chat run timer and question drafts

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -623,17 +623,10 @@ function AssistantMessageImpl({
     canFork;
   // Pre-output vs working: before any real content (text / thinking / tools /
   // files) the footer shimmers "Preparing…"; the moment content lands it
-  // flips to "Working" and the elapsed clock restarts from that instant.
+  // flips to "Working". The elapsed clock stays anchored to the persisted run
+  // start so switching project tabs or remounting the message cannot restart it.
   const hasContent = blocks.some((b) => b.kind !== "status") || fileOps.length > 0;
   const preparing = streaming && !hasContent;
-  const [outputStartedAt, setOutputStartedAt] = useState<number | undefined>(undefined);
-  useEffect(() => {
-    if (streaming && hasContent) {
-      setOutputStartedAt((prev) => prev ?? Date.now());
-    } else if (!streaming) {
-      setOutputStartedAt(undefined);
-    }
-  }, [streaming, hasContent]);
   const [dismissedCandidateIds, setDismissedCandidateIds] = useState<Set<string>>(
     () => new Set()
   );
@@ -843,7 +836,6 @@ function AssistantMessageImpl({
                   hasUnfinishedTodos: unfinishedTodos.length > 0,
                   hasEmptyResponse,
                   preparing,
-                  outputStartedAt,
                   copyMarkdown,
                   onFork: canFork ? onForkFromMessage : undefined,
                   forking,
@@ -861,7 +853,6 @@ function AssistantMessageImpl({
                 hasUnfinishedTodos={unfinishedTodos.length > 0}
                 hasEmptyResponse={hasEmptyResponse}
                 preparing={preparing}
-                outputStartedAt={outputStartedAt}
                 copyMarkdown={copyMarkdown}
                 onFork={canFork ? onForkFromMessage : undefined}
                 forking={forking}
@@ -1045,10 +1036,8 @@ interface AssistantFooterProps {
   hasUnfinishedTodos: boolean;
   hasEmptyResponse: boolean;
   // Pre-output phase: streaming but nothing rendered yet. The label shimmers
-  // "Preparing…"; once content lands it flips to "Working" and the elapsed
-  // counter restarts from `outputStartedAt` (the moment content appeared).
+  // "Preparing…"; once content lands it flips to "Working".
   preparing?: boolean;
-  outputStartedAt?: number | undefined;
   copyMarkdown?: string;
   onFork?: () => void;
   forking?: boolean;
@@ -1068,7 +1057,6 @@ function AssistantFooter({
   hasUnfinishedTodos,
   hasEmptyResponse,
   preparing = false,
-  outputStartedAt,
   copyMarkdown,
   onFork,
   forking = false,
@@ -1078,12 +1066,7 @@ function AssistantFooter({
   isLast = false,
 }: AssistantFooterProps) {
   const t = useT();
-  // While "working" (streaming with content) the timer counts from when
-  // content first appeared, not from the run start, so it reads as a fresh
-  // generation clock. Preparing and the final done state both use startedAt.
-  const elapsedStart =
-    streaming && !preparing ? outputStartedAt ?? startedAt : startedAt;
-  const elapsed = useLiveElapsed(streaming, elapsedStart, endedAt, usage?.durationMs);
+  const elapsed = useLiveElapsed(streaming, startedAt, endedAt, usage?.durationMs);
   const formattedCost =
     typeof usage?.costUsd === "number" &&
     Number.isFinite(usage.costUsd) &&

--- a/apps/web/src/components/QuestionForm.tsx
+++ b/apps/web/src/components/QuestionForm.tsx
@@ -16,7 +16,9 @@ interface Props {
   // When the form lives in the Questions tab the Continue button owns the
   // submit, so hide the form's own footer button and report ready-state out.
   hideInternalSubmit?: boolean;
+  draftAnswers?: Record<string, string | string[]>;
   onReadyChange?: (ready: boolean) => void;
+  onDraftChange?: (answers: Record<string, string | string[]>) => void;
   onSubmit?: (text: string, answers: Record<string, string | string[]>) => void;
 }
 
@@ -29,11 +31,23 @@ export interface QuestionFormHandle {
 }
 
 export const QuestionFormView = forwardRef<QuestionFormHandle, Props>(function QuestionFormView(
-  { form, interactive, submittedAnswers, hideInternalSubmit = false, onReadyChange, onSubmit },
+  {
+    form,
+    interactive,
+    submittedAnswers,
+    hideInternalSubmit = false,
+    draftAnswers,
+    onReadyChange,
+    onDraftChange,
+    onSubmit,
+  },
   ref,
 ) {
   const t = useT();
-  const initial = useMemo(() => buildInitialState(form, submittedAnswers), [form, submittedAnswers]);
+  const initial = useMemo(
+    () => buildInitialState(form, submittedAnswers ?? draftAnswers),
+    [form, submittedAnswers, draftAnswers],
+  );
   const [answers, setAnswers] = useState<Record<string, string | string[]>>(initial);
   const locked = !interactive || !onSubmit || submittedAnswers !== undefined;
   const currentAnswers = submittedAnswers ?? answers;
@@ -61,20 +75,20 @@ export const QuestionFormView = forwardRef<QuestionFormHandle, Props>(function Q
 
   function update(id: string, value: string | string[]) {
     if (locked) return;
-    setAnswers((prev) => ({ ...prev, [id]: value }));
+    const next = { ...answers, [id]: value };
+    setAnswers(next);
+    onDraftChange?.(next);
   }
 
   function toggleCheckbox(id: string, option: string, maxSelections?: number) {
     if (locked) return;
-    setAnswers((prev) => {
-      const current = Array.isArray(prev[id]) ? (prev[id] as string[]) : [];
-      const has = current.includes(option);
-      if (!has && maxSelections !== undefined && current.length >= maxSelections) {
-        return prev;
-      }
-      const next = has ? current.filter((v) => v !== option) : [...current, option];
-      return { ...prev, [id]: next };
-    });
+    const current = Array.isArray(answers[id]) ? (answers[id] as string[]) : [];
+    const has = current.includes(option);
+    if (!has && maxSelections !== undefined && current.length >= maxSelections) return;
+    const next = has ? current.filter((v) => v !== option) : [...current, option];
+    const nextAnswers = { ...answers, [id]: next };
+    setAnswers(nextAnswers);
+    onDraftChange?.(nextAnswers);
   }
 
   function handleSubmit() {

--- a/apps/web/src/components/QuestionsPanel.tsx
+++ b/apps/web/src/components/QuestionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useT } from '../i18n';
 import type { QuestionForm } from '../artifacts/question-form';
 import { QuestionFormView, type QuestionFormHandle } from './QuestionForm';
@@ -22,6 +22,9 @@ const revealedOccurrences = new Set<string>();
 // for them — submitting whatever they picked (unanswered questions count as
 // skipped) so generation never stalls waiting on a reply.
 const SKIP_COUNTDOWN_SECONDS = 120;
+const QUESTION_FORM_DRAFT_STORAGE_PREFIX = 'open-design:question-form-draft:';
+
+type QuestionFormAnswers = Record<string, string | string[]>;
 
 interface Props {
   form: QuestionForm | null;
@@ -53,9 +56,37 @@ export function QuestionsPanel({
   const t = useT();
   const formRef = useRef<QuestionFormHandle>(null);
   const [ready, setReady] = useState(false);
+  const [draftAnswers, setDraftAnswers] = useState<QuestionFormAnswers | undefined>(() =>
+    readQuestionFormDraft(formKey),
+  );
 
   const total = form?.questions.length ?? 0;
   const answered = submittedAnswers !== undefined;
+
+  useEffect(() => {
+    setDraftAnswers(readQuestionFormDraft(formKey));
+  }, [formKey]);
+
+  useEffect(() => {
+    if (answered) clearQuestionFormDraft(formKey);
+  }, [answered, formKey]);
+
+  const updateDraftAnswers = useCallback(
+    (answers: QuestionFormAnswers) => {
+      setDraftAnswers(answers);
+      writeQuestionFormDraft(formKey, answers);
+    },
+    [formKey],
+  );
+
+  const submitAndClearDraft = useCallback(
+    (text: string) => {
+      clearQuestionFormDraft(formKey);
+      setDraftAnswers(undefined);
+      onSubmit(text);
+    },
+    [formKey, onSubmit],
+  );
   // If this occurrence already finished its reveal in a prior mount, show it in
   // full immediately rather than replaying the animation on remount.
   const [revealed, setRevealed] = useState(() =>
@@ -140,9 +171,11 @@ export function QuestionsPanel({
               form={visibleForm}
               interactive={interactive}
               submittedAnswers={submittedAnswers}
+              draftAnswers={draftAnswers}
               hideInternalSubmit
               onReadyChange={setReady}
-              onSubmit={(text) => onSubmit(text)}
+              onDraftChange={updateDraftAnswers}
+              onSubmit={(text) => submitAndClearDraft(text)}
             />
             {building ? (
               <div className="questions-panel-typing" aria-hidden>
@@ -184,4 +217,54 @@ export function QuestionsPanel({
       </div>
     </div>
   );
+}
+
+function questionFormDraftStorageKey(formKey: string | null | undefined): string | null {
+  return formKey ? `${QUESTION_FORM_DRAFT_STORAGE_PREFIX}${formKey}` : null;
+}
+
+function readQuestionFormDraft(formKey: string | null | undefined): QuestionFormAnswers | undefined {
+  const key = questionFormDraftStorageKey(formKey);
+  if (!key || typeof window === 'undefined') return undefined;
+  try {
+    const raw = window.sessionStorage.getItem(key);
+    if (!raw) return undefined;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+    const out: QuestionFormAnswers = {};
+    for (const [id, value] of Object.entries(parsed)) {
+      if (typeof value === 'string') {
+        out[id] = value;
+      } else if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+        out[id] = value;
+      }
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeQuestionFormDraft(
+  formKey: string | null | undefined,
+  answers: QuestionFormAnswers,
+): void {
+  const key = questionFormDraftStorageKey(formKey);
+  if (!key || typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(answers));
+  } catch {
+    // Losing an in-progress draft is preferable to blocking form input when
+    // browser storage is unavailable.
+  }
+}
+
+function clearQuestionFormDraft(formKey: string | null | undefined): void {
+  const key = questionFormDraftStorageKey(formKey);
+  if (!key || typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // Ignore storage failures; the submitted answer message is authoritative.
+  }
 }

--- a/apps/web/tests/components/QuestionsPanel.reveal.test.tsx
+++ b/apps/web/tests/components/QuestionsPanel.reveal.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { QuestionsPanel } from '../../src/components/QuestionsPanel';
 import type { QuestionForm } from '../../src/artifacts/question-form';
@@ -20,6 +20,12 @@ function fieldCount() {
   return document.querySelectorAll('.qf-field').length;
 }
 
+function textInputAt(index: number): HTMLInputElement {
+  const input = document.querySelectorAll<HTMLInputElement>('.qf-input')[index];
+  if (!input) throw new Error(`expected text input at index ${index}`);
+  return input;
+}
+
 // Each reveal schedules the next only after its effect re-runs, so the clock
 // must be stepped one interval per question rather than all at once.
 function revealAll() {
@@ -32,6 +38,7 @@ function revealAll() {
 
 afterEach(() => {
   cleanup();
+  window.sessionStorage.clear();
   vi.useRealTimers();
 });
 
@@ -178,5 +185,52 @@ describe('QuestionsPanel staggered reveal', () => {
       );
     });
     expect(fieldCount()).toBe(4);
+  });
+
+  it('restores in-progress answers when the same form occurrence remounts', () => {
+    vi.useFakeTimers();
+    const props = {
+      form,
+      formKey: 'conv-1:assistant-1',
+      interactive: true,
+      generating: false,
+      onSubmit: vi.fn(),
+    } as const;
+
+    const first = render(<QuestionsPanel {...props} />);
+    revealAll();
+    fireEvent.change(textInputAt(0), {
+      target: { value: 'open design' },
+    });
+    first.unmount();
+
+    render(<QuestionsPanel {...props} />);
+
+    expect(textInputAt(0).value).toBe('open design');
+  });
+
+  it('clears restored draft answers after submitting the form', () => {
+    vi.useFakeTimers();
+    const onSubmit = vi.fn();
+    const props = {
+      form,
+      formKey: 'conv-1:assistant-2',
+      interactive: true,
+      generating: false,
+      onSubmit,
+    } as const;
+
+    const first = render(<QuestionsPanel {...props} />);
+    revealAll();
+    fireEvent.change(textInputAt(0), {
+      target: { value: 'open design' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    first.unmount();
+
+    render(<QuestionsPanel {...props} />);
+
+    expect(textInputAt(0).value).toBe('');
   });
 });


### PR DESCRIPTION

## Why

Switching between project tabs remounts parts of the chat and workspace UI. The running assistant footer used a component-local output-start timestamp, so the elapsed timer restarted after remount. The Questions panel also kept in-progress answers only in component state, so partially completed briefs were lost before submit.

This PR keeps those two live UI states recoverable without adding them to the transcript.

## What users will see

- Running assistant messages keep counting from the run start after switching project tabs.
- Partially filled Questions forms restore their draft answers when the same form remounts in the current browser session.
- Submitted or skipped forms clear their draft so old answers do not leak into later forms.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The changed behavior is timer/draft persistence across remounts and is covered by focused component tests.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/QuestionsPanel.reveal.test.tsx`
- Did the test go red on `main` and green on this branch? No. The draft persistence regression was added as focused coverage during the fix; the timer fix was verified by removing the remount-local timestamp and keeping elapsed anchored to `message.startedAt`.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/QuestionsPanel.reveal.test.tsx tests/components/QuestionForm.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
