### PR TITLE
fix(web): keep live-artifact tab badges and close button from overflowing onto neighbouring tabs

### DIFF
--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -1459,7 +1459,11 @@
   transition: background 120ms ease, color 120ms ease;
 }
 .ws-tab.live-artifact-tab {
-  max-width: 160px;
+  /* Wide enough to hold the icon, a truncated title, the status badges
+     (LIVE + REFRESH FAILED) and the close button without any of them
+     spilling onto the neighbouring tab. The title yields space first
+     (see .ws-tab-text override below), so the badges stay fully legible. */
+  max-width: 260px;
 }
 .ws-tab:hover { background: var(--bg-subtle); color: var(--text); }
 .ws-tab.draggable { cursor: grab; }
@@ -1546,11 +1550,22 @@
 .ws-tab.live-artifact-tab .ws-tab-label {
   max-width: none;
 }
+/* The title is the lowest-priority element in a live-artifact tab: when the
+   tab is squeezed, collapse the title (it stays available via the tab tooltip)
+   before clipping the status badges or pushing the close button out. */
+.ws-tab.live-artifact-tab .ws-tab-text {
+  flex-shrink: 100;
+}
 .ws-live-artifact-badges {
-  flex: 0 0 auto;
+  /* Shrink (and clip) as a last resort instead of overflowing the tab box.
+     Previously flex:0 0 auto + overflow:visible let long badge combinations
+     (e.g. LIVE + REFRESH FAILED, or longer locales) bleed the badges and the
+     close button onto the adjacent tab. */
+  flex: 0 1 auto;
   flex-wrap: nowrap;
+  min-width: 0;
   max-width: none;
-  overflow: visible;
+  overflow: hidden;
 }
 .ws-live-artifact-badges .live-artifact-badge:not(.live):not(.refreshing):not(.refresh-failed):not(.archived) {
   display: none;


### PR DESCRIPTION
## Why

I hit this while reviewing a live artifact whose refresh kept failing: the **`REFRESH FAILED`** status badge and the tab's **close (✕) button** spilled out of the live-artifact tab and landed on top of the neighbouring tab, so the close button effectively sat "on another tab" and the badge was clipped at the tab boundary.

Root cause is purely layout. A live-artifact tab lays out as `icon · title · [LIVE][REFRESH FAILED] · ✕`, but:

- `.ws-tab.live-artifact-tab` was capped at `max-width: 160px`, which is too narrow to hold the icon + a title + both status badges + the close button.
- `.ws-live-artifact-badges` was `flex: 0 0 auto` + `overflow: visible`, so when the content didn't fit it could not shrink — it overflowed the tab box and bled the badges and close button onto the adjacent tab instead of being contained.

With the default English strings, the non-shrinkable content (icon + `LIVE` + `REFRESH FAILED` + close + padding) needs ~190px, so even after the title collapsed to zero the close button overflowed the 160px tab by ~28px. Longer locales (e.g. French `Échec de l'actualisation`) overflowed by 100px+.

## What users will see

A live-artifact tab that is refreshing/failed now keeps everything inside its own tab. The `LIVE` and `REFRESH FAILED` badges render in full and the ✕ close button stays within the tab — it no longer overlaps the next tab. The tab title truncates first (and is still available via the tab's hover tooltip); the status badges are the last thing to give up space, and in extreme/long locales the badge text clips inside the tab rather than spilling out.

## Surface area

- [x] **UI** — live-artifact tab in the design workspace tab strip (`apps/web`)
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change

## Screenshots

This is a containment fix in the tab strip; the relevant before/after evidence is the per-element geometry below (px relative to each live-artifact tab's right edge; **positive = overflowing past the tab onto the neighbour**):

| Scenario | close button — before | close button — after |
| --- | --- | --- |
| `LIVE` + `REFRESH FAILED` (en) | **+28px** (overflows) | −8px (inside) |
| `LIVE` only (en) | −8px (inside) | −8px (inside) |
| `LIVE` + `REFRESH FAILED` (fr, long) | **+117px** (overflows) | −8px (inside) |
| `LIVE` + `REFRESH FAILED` (zh) | −8px (inside) | −8px (inside) |

After the change every scenario is fully contained, and the `LIVE` / `REFRESH FAILED` badges remain legible.

## Bug fix verification

- Reproduced and verified with a Playwright + Chromium harness that renders the exact live-artifact tab DOM against the real shipped `apps/web/src/styles/workspace/drawer.css`, then measures each element's `getBoundingClientRect()` against the tab's right edge across four locales/states (table above). The bug is geometric, so the assertion is "no child extends past the tab's right edge".
- Why no in-repo red spec: the symptom is computed layout (flex overflow), which jsdom/Vitest cannot observe, and a full daemon+web Playwright e2e that creates a live artifact, forces `refreshStatus: 'failed'`, and opens it as a tab is disproportionately heavy and flaky for a three-property CSS containment fix. I verified deterministically with the harness above instead. Happy to add a UI regression test if a reviewer prefers.

## Validation

- `pnpm guard` — pass (40/40)
- `pnpm --filter @open-design/web build` — pass (Turbopack compile + TypeScript OK; CSS bundles cleanly)
- Pixel-accurate before/after geometry across en/fr/zh and LIVE-only vs REFRESH FAILED (table above)
