### PR TITLE
fix(EntryShell): forward Home slideCount into Simple Deck plugin defaults

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -190,7 +190,7 @@ function defaultPluginInputsForCreate(
       deckType: 'pitch deck',
       topic: projectName || 'the user brief',
       audience: 'decision makers',
-      slideCount: '10-15 pages',
+      slideCount: input.metadata.slideCount ?? '10-15 pages',
       speakerNotes: input.metadata.speakerNotes
         ? 'include speaker notes'
         : 'no speaker notes',


### PR DESCRIPTION
## Summary
On Home, a deck flow selects a `slideCount` (for example `25-30 pages`) and the value is persisted into project metadata and plugin snapshots. But `EntryShell.defaultPluginInputsForCreate()` was returning the hardcoded fallback `"10-15 pages"` for the `example-simple-deck` plugin instead of honoring the stored metadata value.

So a user-selected page-count was saved but never reached the generation plugin inputs, which is why the final deck could ignore a `25-30 pages` selection.

Fixes #3565

## Surface area
- [ ] **UI** — new screens, visible changes
- [x] **Bug** logic fix, behavior change only
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag
- [ ] **API / contract** — new `/api/*` endpoint
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, etc.
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — root `package.json` change
- [ ] **Tests failed** — regression included