### PR TITLE
[codex] Raise viewer share menu layer

### DIFF
--- a/apps/web/src/styles/viewer/core.css
+++ b/apps/web/src/styles/viewer/core.css
@@ -8,6 +8,12 @@
   background: var(--bg);
   overflow: hidden;
 }
+.workspace:has(.share-menu-popover, .present-menu),
+.viewer:has(.share-menu-popover, .present-menu) {
+  position: relative;
+  z-index: 220;
+  overflow: visible;
+}
 .viewer-toolbar {
   display: flex;
   justify-content: space-between;

--- a/apps/web/src/styles/viewer/tools.css
+++ b/apps/web/src/styles/viewer/tools.css
@@ -669,6 +669,10 @@
 }
 
 /* Present / Share menus */
+.present-wrap,
+.share-menu {
+  --viewer-action-menu-z: 220;
+}
 .present-wrap { position: relative; display: inline-block; }
 .present-trigger .caret {
   margin-left: 4px;
@@ -679,7 +683,7 @@
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
-  z-index: 60;
+  z-index: var(--viewer-action-menu-z);
   min-width: 168px;
   padding: 4px;
   background: var(--bg-panel);
@@ -776,7 +780,7 @@
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
-  z-index: 50;
+  z-index: var(--viewer-action-menu-z);
   min-width: 300px;
   padding: 4px;
   background: var(--bg-panel);


### PR DESCRIPTION
## Why

The desktop preview can be narrowed enough that the file viewer Share menu extends toward the chat pane. In that constrained layout, the menu layer was lower than nearby shell/pane chrome, so it could be partially obscured instead of remaining usable.

This is a narrow hotfix for the observed layering problem. It avoids changing the menu positioning model, portal behavior, or responsive sheet behavior until product feedback says the overlap itself is unacceptable.

## What users will see

When opening the file viewer Share, Download, or Present menus in a constrained desktop layout, those menus render above the surrounding panes instead of being hidden behind the chat/sidebar layer.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a CSS layer-order hotfix for a constrained desktop layout; no layout, content, or visible styling is intentionally changed outside the menu stacking order.

## Bug fix verification

- Test path that reproduces the bug: not added; this is a CSS stacking-order issue in a constrained desktop pane layout, and a stable automated visual regression was not cheap for this hotfix.
- Did the test go red on `main` and green on this branch? no automated red spec.
- Manual/implementation verification: confirmed the affected file viewer menus now share a higher local action-menu layer (`--viewer-action-menu-z: 220`) instead of the prior lower `50`/`60` values.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
