### PR TITLE
[codex] fix web preview image export

### DIFF
--- a/apps/web/src/components/PreviewModal.tsx
+++ b/apps/web/src/components/PreviewModal.tsx
@@ -6,6 +6,7 @@ import {
   exportAsImage,
   exportAsPdf,
   exportAsZip,
+  captureHostIframeSnapshot,
   openSandboxedPreviewInNewTab,
   requestPreviewSnapshot,
 } from '../runtime/exports';
@@ -760,7 +761,9 @@ export function PreviewModal({
                               setTemplateShareOpen(false);
                               const iframe = previewIframeRef.current;
                               if (!iframe) return;
-                              const snap = await requestPreviewSnapshot(iframe);
+                              const snap =
+                                (await captureHostIframeSnapshot(iframe)) ??
+                                (await requestPreviewSnapshot(iframe));
                               try {
                                 if (snap) {
                                   exportAsImage(snap.dataUrl, exportTitle);

--- a/apps/web/tests/components/preview-modal-image-export.test.tsx
+++ b/apps/web/tests/components/preview-modal-image-export.test.tsx
@@ -11,12 +11,14 @@ import { PreviewModal } from '../../src/components/PreviewModal';
 // mock them so the test can exercise the full button flow without a real
 // iframe or DOM snapshot.
 
-const { exportAsImageMock, requestPreviewSnapshotMock } = vi.hoisted(() => ({
+const { captureHostIframeSnapshotMock, exportAsImageMock, requestPreviewSnapshotMock } = vi.hoisted(() => ({
+  captureHostIframeSnapshotMock: vi.fn(),
   exportAsImageMock: vi.fn(),
   requestPreviewSnapshotMock: vi.fn(),
 }));
 
 vi.mock('../../src/runtime/exports', () => ({
+  captureHostIframeSnapshot: captureHostIframeSnapshotMock,
   exportAsHtml: vi.fn(),
   exportAsImage: exportAsImageMock,
   exportAsPdf: vi.fn(),
@@ -69,6 +71,7 @@ describe('PreviewModal image export', () => {
 
   it('calls requestPreviewSnapshot and exportAsImage on success', async () => {
     const fakeDataUrl = 'data:image/png;base64,iVBORw0KGgo=';
+    captureHostIframeSnapshotMock.mockResolvedValueOnce(null);
     requestPreviewSnapshotMock.mockResolvedValueOnce({
       dataUrl: fakeDataUrl,
       w: 800,
@@ -91,8 +94,32 @@ describe('PreviewModal image export', () => {
     });
   });
 
+  it('prefers the desktop host iframe snapshot when available', async () => {
+    const fakeDataUrl = 'data:image/png;base64,host';
+    captureHostIframeSnapshotMock.mockResolvedValueOnce({
+      dataUrl: fakeDataUrl,
+      w: 1024,
+      h: 768,
+    });
+
+    render(
+      <PreviewModal {...baseProps} onClose={() => {}} />,
+    );
+
+    openShareMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: /export as image/i }));
+
+    await waitFor(() => {
+      expect(captureHostIframeSnapshotMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(requestPreviewSnapshotMock).not.toHaveBeenCalled();
+    expect(exportAsImageMock).toHaveBeenCalledWith(fakeDataUrl, 'main');
+  });
+
   it('alerts when snapshot capture returns null', async () => {
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    captureHostIframeSnapshotMock.mockResolvedValueOnce(null);
     requestPreviewSnapshotMock.mockResolvedValueOnce(null);
 
     render(
@@ -114,6 +141,7 @@ describe('PreviewModal image export', () => {
 
   it('alerts when exportAsImage throws', async () => {
     const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    captureHostIframeSnapshotMock.mockResolvedValueOnce(null);
     requestPreviewSnapshotMock.mockResolvedValueOnce({
       dataUrl: 'data:image/png;base64,ok',
       w: 800,
@@ -139,6 +167,7 @@ describe('PreviewModal image export', () => {
 
   it('fires onSharePopoverItemClick with "image"', () => {
     const onItemClick = vi.fn();
+    captureHostIframeSnapshotMock.mockResolvedValueOnce(null);
     requestPreviewSnapshotMock.mockResolvedValueOnce({
       dataUrl: 'data:image/png;base64,ok',
       w: 800,


### PR DESCRIPTION
## Why

The design-system preview modal could fail when users picked Share -> Export as image. The modal reused the generic PreviewModal export path, which went straight to the srcdoc snapshot bridge. In Electron/Chromium that bridge can produce an empty render or timeout because it rasterizes iframe DOM through SVG foreignObject.

This PR fixes the user-facing screenshot failure by using the existing desktop host iframe capture path first, matching the more reliable FileViewer screenshot behavior.

## What users will see

Design system preview modals still expose the same Share menu. Export as image should now succeed in the desktop app by capturing the visible preview iframe pixels before falling back to the browser snapshot bridge.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The UI entry point is unchanged; this changes the capture strategy behind the existing Share -> Export as image action.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/preview-modal-image-export.test.tsx` now covers the desktop host snapshot preference and fallback behavior.
- Did the test go red on `main` and green on this branch? No. The new regression assertion covers the missing host-first behavior introduced in this branch.

## Validation

- `pnpm install`
- `pnpm exec vitest run -c vitest.config.ts tests/components/preview-modal-image-export.test.tsx` from `apps/web`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm tools-dev`
- `pnpm tools-dev status --json` confirmed daemon, web, and desktop running in the default namespace
- `pnpm tools-dev inspect desktop status --json` confirmed the desktop process is running
