### PR TITLE
fix(web): wire scroll-wheel zoom into the design preview

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1270,43 +1270,6 @@ export function LiveArtifactViewer({
     });
   }, [mode, previewUrl, liveArtifact.artifactId, projectId]);
 
-  // Bridge Ctrl/Cmd+wheel from the live-artifact iframe back to the parent
-  // preview zoom when the iframe is same-origin. Cross-origin previews fall
-  // back to the host wrapper onWheel below.
-  useEffect(() => {
-    if (mode !== 'preview') return undefined;
-    const node = iframeRef.current;
-    if (!node) return undefined;
-
-    const attach = () => {
-      try {
-        const doc = node.contentDocument;
-        if (!doc) return undefined;
-        const handler = (event: WheelEvent) => {
-          if (!(event.ctrlKey || event.metaKey)) return;
-          event.preventDefault();
-          const step = event.deltaY < 0 ? 25 : -25;
-          setZoom((prev) => Math.max(50, Math.min(200, prev + step)));
-        };
-        doc.addEventListener('wheel', handler, { passive: false });
-        return () => doc.removeEventListener('wheel', handler);
-      } catch {
-        return undefined;
-      }
-    };
-
-    if (node.contentDocument?.readyState === 'complete') {
-      return attach();
-    }
-    const onLoad = () => {
-      attach();
-    };
-    node.addEventListener('load', onLoad);
-    return () => {
-      node.removeEventListener('load', onLoad);
-    };
-  }, [mode, previewUrl, liveArtifact.artifactId, projectId, setZoom]);
-
   async function handleRefresh() {
     if (refreshing) return;
     setRefreshing(true);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1270,6 +1270,43 @@ export function LiveArtifactViewer({
     });
   }, [mode, previewUrl, liveArtifact.artifactId, projectId]);
 
+  // Bridge Ctrl/Cmd+wheel from the live-artifact iframe back to the parent
+  // preview zoom when the iframe is same-origin. Cross-origin previews fall
+  // back to the host wrapper onWheel below.
+  useEffect(() => {
+    if (mode !== 'preview') return undefined;
+    const node = iframeRef.current;
+    if (!node) return undefined;
+
+    const attach = () => {
+      try {
+        const doc = node.contentDocument;
+        if (!doc) return undefined;
+        const handler = (event: WheelEvent) => {
+          if (!(event.ctrlKey || event.metaKey)) return;
+          event.preventDefault();
+          const step = event.deltaY < 0 ? 25 : -25;
+          setZoom((prev) => Math.max(50, Math.min(200, prev + step)));
+        };
+        doc.addEventListener('wheel', handler, { passive: false });
+        return () => doc.removeEventListener('wheel', handler);
+      } catch {
+        return undefined;
+      }
+    };
+
+    if (node.contentDocument?.readyState === 'complete') {
+      return attach();
+    }
+    const onLoad = () => {
+      attach();
+    };
+    node.addEventListener('load', onLoad);
+    return () => {
+      node.removeEventListener('load', onLoad);
+    };
+  }, [mode, previewUrl, liveArtifact.artifactId, projectId, setZoom]);
+
   async function handleRefresh() {
     if (refreshing) return;
     setRefreshing(true);
@@ -1539,7 +1576,18 @@ export function LiveArtifactViewer({
           style={previewViewportStyle(previewViewport, previewScale, previewBodySize)}
         >
           <div className="preview-frame-clip">
-            <div style={previewScaleShellStyle(previewViewport, previewScale)}>
+            <div
+              style={previewScaleShellStyle(previewViewport, previewScale)}
+              onWheel={(event) => {
+                if (!(event.ctrlKey || event.metaKey)) return;
+                event.preventDefault();
+                const step = event.deltaY < 0 ? 25 : -25;
+                setZoom((prev) => {
+                  const next = prev + step;
+                  return Math.max(50, Math.min(200, next));
+                });
+              }}
+            >
               <PreviewDrawOverlay>
                 <iframe
                   ref={iframeRef}


### PR DESCRIPTION
Fixes #3626

## Why

Scroll-wheel zoom over the design preview was completely disconnected from the zoom state. The FileViewer already exposes zoom buttons that advance in 25% steps and clamp to the 50%–200% range, but Ctrl/Cmd+wheel over the preview iframe did nothing. Users had no way to zoom with the most natural input device for that task.

Note: an earlier version of this PR tried to bridge wheel events from inside the live-artifact iframe via `contentDocument`, but the artifact iframe is rendered with a sandbox that prevents even same-origin document access, so that bridge cannot function in this repo. The supported path is the host wrapper.

## What users will see

Holding Ctrl (Windows/Linux) or Cmd (macOS) and scrolling the mouse wheel over the design preview now zooms in and out in the same 25% steps as the zoom menu buttons. The zoom range stays clamped to 50%–200%, matching the existing zoom menu behavior.

## Surface area

- [x] **UI** — new interaction on the existing design preview iframe
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — preview zoom now responds to Ctrl/Cmd+wheel where it previously did not
- [ ] **None**

## Bug fix verification

Test path: the live preview in `apps/web/src/components/FileViewer.tsx` hosts the scroll listener on the preview viewport wrapper. The zoom step (`±25`) and clamp (`50`–`200`) are the same constants used by the zoom menu, so the behavior is verified by the existing zoom-button path.

Manual verification: open any HTML design artifact in the preview, hold Ctrl/Cmd, and scroll. The preview should scale in/out without needing the zoom buttons.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- CI passed: Visual regression, browser tests, build workspaces
