### PR TITLE
fix(daemon): reject live-artifact read_json refresh sources with no file to read

### DIFF
--- a/apps/daemon/src/live-artifacts/schema.ts
+++ b/apps/daemon/src/live-artifacts/schema.ts
@@ -349,7 +349,9 @@ function validateReadJsonSelector(value: string, path: string, issues: LiveArtif
   if (segments.some((part) => RESERVED_READ_JSON_SEGMENTS.has(part))) {
     issues.push({ path, message: `${path} cannot reference a reserved project path` });
   }
-  if (!value.toLowerCase().endsWith('.json')) {
+  // Case-sensitive to match executeProjectFilesReadJson's `endsWith('.json')` exactly;
+  // lowercasing here would accept `DATA.JSON` that the runtime then rejects.
+  if (!value.endsWith('.json')) {
     issues.push({ path, message: `${path} must point to a .json file for project_files.read_json sources` });
   }
 }

--- a/apps/daemon/src/live-artifacts/schema.ts
+++ b/apps/daemon/src/live-artifacts/schema.ts
@@ -470,14 +470,26 @@ function validateDaemonRefreshRequiredInput(
   issues: LiveArtifactValidationIssue[],
 ): void {
   if (effectiveTool !== 'project_files.read_json') return;
-  // Mirror selectJsonPath (refresh.ts): the first of path/file/name names the file.
-  const selectorKey = (['path', 'file', 'name'] as const).find(
-    (key) => typeof input[key] === 'string' && (input[key] as string).trim().length > 0,
-  );
+  // Mirror selectJsonPath (refresh.ts) precedence AND type rules. It reads
+  // path → file → name through optionalString() + `??`, so the first alias that
+  // is *present* (not undefined) is the selector — even a non-string or empty
+  // value, which makes optionalString()/validateProjectPath() throw at refresh
+  // rather than falling through to a later alias. Resolving by "first non-empty
+  // string" instead would accept e.g. { path: 123, file: 'ok.json' } here while
+  // refresh fails forever, recreating the persisted-but-unrefreshable class.
+  const selectorKey = (['path', 'file', 'name'] as const).find((key) => input[key] !== undefined);
   if (selectorKey === undefined) {
     issues.push({
       path: `${path}.path`,
       message: `${path}.path is required for project_files.read_json sources (or provide ${path}.file / ${path}.name)`,
+    });
+    return;
+  }
+  const selector = input[selectorKey];
+  if (typeof selector !== 'string' || selector.trim().length === 0) {
+    issues.push({
+      path: `${path}.${selectorKey}`,
+      message: `${path}.${selectorKey} must be a non-empty string for project_files.read_json sources`,
     });
     return;
   }
@@ -486,7 +498,7 @@ function validateDaemonRefreshRequiredInput(
   // same. Validate the resolved name selector here so a traversal/absolute target
   // is rejected at creation instead of persisting a source that only fails on refresh.
   if (selectorKey === 'name') {
-    validateRelativePath(input[selectorKey] as string, `${path}.${selectorKey}`, issues);
+    validateRelativePath(selector, `${path}.${selectorKey}`, issues);
   }
 }
 

--- a/apps/daemon/src/live-artifacts/schema.ts
+++ b/apps/daemon/src/live-artifacts/schema.ts
@@ -329,6 +329,31 @@ function validateRelativePath(value: string, path: string, issues: LiveArtifactV
   }
 }
 
+// Reserved project path segments rejected by validateProjectPath() in projects.ts.
+// Mirrored here (kept in sync with RESERVED_PROJECT_FILE_SEGMENTS) so schema-side
+// acceptance stays a subset of what a refresh can actually read.
+const RESERVED_READ_JSON_SEGMENTS = new Set(['.live-artifacts']);
+
+// project_files.read_json resolves a selector, feeds it to validateProjectPath()
+// (refresh.ts → projects.ts), and then requires a .json extension. validateRelativePath
+// alone misses single-dot segments, reserved segments, and the extension, so mirror the
+// remaining static rules here — otherwise sources like { path: './report.json' } or
+// { file: '.live-artifacts/cache.json' } pass creation yet fail every refresh, recreating
+// the persisted-but-unrefreshable artifact class this validation exists to prevent.
+function validateReadJsonSelector(value: string, path: string, issues: LiveArtifactValidationIssue[]): void {
+  validateRelativePath(value, path, issues); // absolute / .. / null-byte / length
+  const segments = value.replace(/\\/g, '/').split('/').filter((part) => part.length > 0);
+  if (segments.some((part) => part === '.')) {
+    issues.push({ path, message: `${path} cannot contain '.' path segments` });
+  }
+  if (segments.some((part) => RESERVED_READ_JSON_SEGMENTS.has(part))) {
+    issues.push({ path, message: `${path} cannot reference a reserved project path` });
+  }
+  if (!value.toLowerCase().endsWith('.json')) {
+    issues.push({ path, message: `${path} must point to a .json file for project_files.read_json sources` });
+  }
+}
+
 function validateNoDaemonOwnedFields(raw: Record<string, unknown>, issues: LiveArtifactValidationIssue[]): void {
   for (const key of Object.keys(raw)) {
     if (DAEMON_OWNED_INPUT_FIELDS.has(key)) {
@@ -493,13 +518,12 @@ function validateDaemonRefreshRequiredInput(
     });
     return;
   }
-  // path and file already pass through validateSourceInputPaths' key filter, but
-  // name does not — yet selectJsonPath feeds it to validateProjectPath all the
-  // same. Validate the resolved name selector here so a traversal/absolute target
-  // is rejected at creation instead of persisting a source that only fails on refresh.
-  if (selectorKey === 'name') {
-    validateRelativePath(selector, `${path}.${selectorKey}`, issues);
-  }
+  // Validate the resolved selector with the same static rules the runtime applies
+  // (validateProjectPath + .json extension). path/file also pass through
+  // validateSourceInputPaths' key filter; name does not — and none of the three are
+  // checked for single-dot/reserved segments or the extension there — so do it here
+  // on whichever alias selectJsonPath would actually read.
+  validateReadJsonSelector(selector, `${path}.${selectorKey}`, issues);
 }
 
 function validatePreview(value: unknown, path: string, issues: LiveArtifactValidationIssue[]): LiveArtifactPreview | undefined {

--- a/apps/daemon/src/live-artifacts/schema.ts
+++ b/apps/daemon/src/live-artifacts/schema.ts
@@ -470,14 +470,23 @@ function validateDaemonRefreshRequiredInput(
   issues: LiveArtifactValidationIssue[],
 ): void {
   if (effectiveTool !== 'project_files.read_json') return;
-  const hasTarget = ['path', 'file', 'name'].some(
+  // Mirror selectJsonPath (refresh.ts): the first of path/file/name names the file.
+  const selectorKey = (['path', 'file', 'name'] as const).find(
     (key) => typeof input[key] === 'string' && (input[key] as string).trim().length > 0,
   );
-  if (!hasTarget) {
+  if (selectorKey === undefined) {
     issues.push({
       path: `${path}.path`,
       message: `${path}.path is required for project_files.read_json sources (or provide ${path}.file / ${path}.name)`,
     });
+    return;
+  }
+  // path and file already pass through validateSourceInputPaths' key filter, but
+  // name does not — yet selectJsonPath feeds it to validateProjectPath all the
+  // same. Validate the resolved name selector here so a traversal/absolute target
+  // is rejected at creation instead of persisting a source that only fails on refresh.
+  if (selectorKey === 'name') {
+    validateRelativePath(input[selectorKey] as string, `${path}.${selectorKey}`, issues);
   }
 }
 

--- a/apps/daemon/src/live-artifacts/schema.ts
+++ b/apps/daemon/src/live-artifacts/schema.ts
@@ -448,6 +448,39 @@ function validateSourceInputPaths(value: BoundedJsonValue, path: string, issues:
   }
 }
 
+// Mirrors executeLocalDaemonRefreshSource: a local_file source reads JSON via
+// project_files.read_json unless it carries another explicit daemon toolName.
+function resolveDaemonRefreshToolName(
+  type: LiveArtifactSource['type'] | undefined,
+  toolName: string | undefined,
+): string | undefined {
+  if (type === 'local_file') return toolName ?? 'project_files.read_json';
+  if (type === 'daemon_tool') return toolName;
+  return undefined;
+}
+
+// project_files.read_json fails every refresh unless input names a file to read
+// (selectJsonPath in refresh.ts requires path/file/name). Reject such sources at
+// registration so the agent's fallback runs instead of persisting a source that
+// can only ever fail.
+function validateDaemonRefreshRequiredInput(
+  effectiveTool: string | undefined,
+  input: BoundedJsonObject,
+  path: string,
+  issues: LiveArtifactValidationIssue[],
+): void {
+  if (effectiveTool !== 'project_files.read_json') return;
+  const hasTarget = ['path', 'file', 'name'].some(
+    (key) => typeof input[key] === 'string' && (input[key] as string).trim().length > 0,
+  );
+  if (!hasTarget) {
+    issues.push({
+      path: `${path}.path`,
+      message: `${path}.path is required for project_files.read_json sources (or provide ${path}.file / ${path}.name)`,
+    });
+  }
+}
+
 function validatePreview(value: unknown, path: string, issues: LiveArtifactValidationIssue[]): LiveArtifactPreview | undefined {
   if (!isPlainObject(value)) {
     issues.push({ path, message: `${path} must be an object` });
@@ -487,7 +520,10 @@ function validateSource(value: unknown, path: string, issues: LiveArtifactValida
   const toolName = asOptionalString(value.toolName, `${path}.toolName`, issues, MAX_ID_LENGTH);
   const inputResult = validateBoundedJsonObject(value.input, `${path}.input`);
   if (!inputResult.ok) issues.push(...inputResult.issues);
-  else validateSourceInputPaths(inputResult.value, `${path}.input`, issues);
+  else {
+    validateSourceInputPaths(inputResult.value, `${path}.input`, issues);
+    validateDaemonRefreshRequiredInput(resolveDaemonRefreshToolName(type, toolName), inputResult.value, `${path}.input`, issues);
+  }
 
   let connector: LiveArtifactSource['connector'];
   if (value.connector !== undefined) {

--- a/apps/daemon/tests/live-artifacts-schema.test.ts
+++ b/apps/daemon/tests/live-artifacts-schema.test.ts
@@ -350,6 +350,39 @@ describe('live artifact schema validation', () => {
     }
   });
 
+  it('rejects an invalid earlier read_json alias even when a later alias is valid', () => {
+    // selectJsonPath resolves path → file → name through `??`; a present-but-invalid
+    // path/file is a hard error there and never falls through, so it must be rejected
+    // at creation rather than persisting an artifact that only fails on refresh.
+    const cases = [
+      { input: { path: 123, file: 'reports/data.json' }, expectedPath: 'input.document.sourceJson.input.path' },
+      { input: { path: '', file: 'reports/data.json' }, expectedPath: 'input.document.sourceJson.input.path' },
+      { input: { path: '   ', name: 'data.json' }, expectedPath: 'input.document.sourceJson.input.path' },
+      { input: { file: 42, name: 'data.json' }, expectedPath: 'input.document.sourceJson.input.file' },
+    ];
+    for (const { input, expectedPath } of cases) {
+      const result = validateLiveArtifactCreateInput({
+        ...validCreateInput(),
+        document: {
+          ...validCreateInput().document,
+          sourceJson: {
+            type: 'local_file',
+            toolName: 'project_files.read_json',
+            input,
+            refreshPermission: 'manual_refresh_granted_for_read_only',
+          },
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toEqual(expect.arrayContaining([
+          expect.objectContaining({ path: expectedPath }),
+        ]));
+      }
+    }
+  });
+
   it('rejects oversized bounded JSON payloads', () => {
     const oversized = Object.fromEntries(Array.from({ length: 100 }, (_, index) => [`field${index}`, 'x'.repeat(3_000)]));
     const result = validateBoundedJsonObject(oversized, 'data');

--- a/apps/daemon/tests/live-artifacts-schema.test.ts
+++ b/apps/daemon/tests/live-artifacts-schema.test.ts
@@ -414,6 +414,34 @@ describe('live artifact schema validation', () => {
     }
   });
 
+  it('rejects uppercase or mixed-case .JSON read_json selectors across every alias', () => {
+    // executeProjectFilesReadJson does a case-sensitive endsWith('.json'); schema
+    // must match or a `DATA.JSON` source persists yet fails every refresh.
+    for (const alias of ['path', 'file', 'name'] as const) {
+      for (const value of ['reports/DATA.JSON', 'reports/data.Json']) {
+        const result = validateLiveArtifactCreateInput({
+          ...validCreateInput(),
+          document: {
+            ...validCreateInput().document,
+            sourceJson: {
+              type: 'local_file',
+              toolName: 'project_files.read_json',
+              input: { [alias]: value },
+              refreshPermission: 'manual_refresh_granted_for_read_only',
+            },
+          },
+        });
+
+        expect(result.ok, `${alias}=${value} should be rejected`).toBe(false);
+        if (!result.ok) {
+          expect(result.issues).toEqual(expect.arrayContaining([
+            expect.objectContaining({ path: `input.document.sourceJson.input.${alias}` }),
+          ]));
+        }
+      }
+    }
+  });
+
   it('rejects oversized bounded JSON payloads', () => {
     const oversized = Object.fromEntries(Array.from({ length: 100 }, (_, index) => [`field${index}`, 'x'.repeat(3_000)]));
     const result = validateBoundedJsonObject(oversized, 'data');

--- a/apps/daemon/tests/live-artifacts-schema.test.ts
+++ b/apps/daemon/tests/live-artifacts-schema.test.ts
@@ -383,6 +383,37 @@ describe('live artifact schema validation', () => {
     }
   });
 
+  it('rejects single-dot and reserved-path read_json selectors across every alias', () => {
+    // validateProjectPath (refresh.ts → projects.ts) rejects '.' segments and the
+    // reserved '.live-artifacts' segment; the executor also requires a .json file.
+    // Schema acceptance must stay a subset of that, or the source persists yet
+    // fails every refresh with "invalid file name" / "reserved project path".
+    const badValues = ['./report.json', '.live-artifacts/cache.json', 'nested/./report.json', 'reports/notes.txt'];
+    for (const alias of ['path', 'file', 'name'] as const) {
+      for (const value of badValues) {
+        const result = validateLiveArtifactCreateInput({
+          ...validCreateInput(),
+          document: {
+            ...validCreateInput().document,
+            sourceJson: {
+              type: 'local_file',
+              toolName: 'project_files.read_json',
+              input: { [alias]: value },
+              refreshPermission: 'manual_refresh_granted_for_read_only',
+            },
+          },
+        });
+
+        expect(result.ok, `${alias}=${value} should be rejected`).toBe(false);
+        if (!result.ok) {
+          expect(result.issues).toEqual(expect.arrayContaining([
+            expect.objectContaining({ path: `input.document.sourceJson.input.${alias}` }),
+          ]));
+        }
+      }
+    }
+  });
+
   it('rejects oversized bounded JSON payloads', () => {
     const oversized = Object.fromEntries(Array.from({ length: 100 }, (_, index) => [`field${index}`, 'x'.repeat(3_000)]));
     const result = validateBoundedJsonObject(oversized, 'data');

--- a/apps/daemon/tests/live-artifacts-schema.test.ts
+++ b/apps/daemon/tests/live-artifacts-schema.test.ts
@@ -326,6 +326,30 @@ describe('live artifact schema validation', () => {
     }
   });
 
+  it('rejects traversal and absolute project_files.read_json name selectors', () => {
+    for (const name of ['../secrets.json', '/etc/passwd', 'C:\\secrets.json', '\\etc\\passwd']) {
+      const result = validateLiveArtifactCreateInput({
+        ...validCreateInput(),
+        document: {
+          ...validCreateInput().document,
+          sourceJson: {
+            type: 'local_file',
+            toolName: 'project_files.read_json',
+            input: { name },
+            refreshPermission: 'manual_refresh_granted_for_read_only',
+          },
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.issues).toEqual(expect.arrayContaining([
+          expect.objectContaining({ path: 'input.document.sourceJson.input.name' }),
+        ]));
+      }
+    }
+  });
+
   it('rejects oversized bounded JSON payloads', () => {
     const oversized = Object.fromEntries(Array.from({ length: 100 }, (_, index) => [`field${index}`, 'x'.repeat(3_000)]));
     const result = validateBoundedJsonObject(oversized, 'data');

--- a/apps/daemon/tests/live-artifacts-schema.test.ts
+++ b/apps/daemon/tests/live-artifacts-schema.test.ts
@@ -268,6 +268,64 @@ describe('live artifact schema validation', () => {
     }
   });
 
+  it('rejects project_files.read_json sources whose input names no file to read', () => {
+    const daemonTool = validateLiveArtifactCreateInput({
+      ...validCreateInput(),
+      document: {
+        ...validCreateInput().document,
+        sourceJson: {
+          type: 'daemon_tool',
+          toolName: 'project_files.read_json',
+          input: { query: 'launch' },
+          refreshPermission: 'manual_refresh_granted_for_read_only',
+        },
+      },
+    });
+    const localFile = validateLiveArtifactCreateInput({
+      ...validCreateInput(),
+      document: {
+        ...validCreateInput().document,
+        sourceJson: {
+          type: 'local_file',
+          input: {},
+          refreshPermission: 'manual_refresh_granted_for_read_only',
+        },
+      },
+    });
+
+    expect(daemonTool.ok).toBe(false);
+    if (!daemonTool.ok) {
+      expect(daemonTool.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({ path: 'input.document.sourceJson.input.path' }),
+      ]));
+    }
+    expect(localFile.ok).toBe(false);
+    if (!localFile.ok) {
+      expect(localFile.issues).toEqual(expect.arrayContaining([
+        expect.objectContaining({ path: 'input.document.sourceJson.input.path' }),
+      ]));
+    }
+  });
+
+  it('accepts project_files.read_json sources that name a file via path, file, or name', () => {
+    for (const input of [{ path: 'reports/data.json' }, { file: 'reports/data.json' }, { name: 'data.json' }]) {
+      const result = validateLiveArtifactCreateInput({
+        ...validCreateInput(),
+        document: {
+          ...validCreateInput().document,
+          sourceJson: {
+            type: 'local_file',
+            toolName: 'project_files.read_json',
+            input,
+            refreshPermission: 'manual_refresh_granted_for_read_only',
+          },
+        },
+      });
+
+      expect(result.ok).toBe(true);
+    }
+  });
+
   it('rejects oversized bounded JSON payloads', () => {
     const oversized = Object.fromEntries(Array.from({ length: 100 }, (_, index) => [`field${index}`, 'x'.repeat(3_000)]));
     const result = validateBoundedJsonObject(oversized, 'data');


### PR DESCRIPTION
## Why

A user hit a live artifact stuck on **REFRESH FAILED** — every manual Refresh returned `Error: project_files.read_json requires input.path` and `LAST REFRESHED` stayed `Never`, with the persisted refresh history showing the same failure on every attempt (`refresh-0000002`, `…0016`, `…0026`).

Root cause: the artifact's `document.sourceJson` registered a `project_files.read_json` refresh source whose `input` named no file to read (no `path`/`file`/`name`). `selectJsonPath` in `apps/daemon/src/live-artifacts/refresh.ts` throws on that — deterministically, on every refresh. But `validateSource` in `schema.ts` accepted the source at creation time: it only required a `toolName` for `daemon_tool` sources and never checked tool-specific required input. So the broken source was persisted and the Refresh button was bricked forever.

`apps/daemon/src/orbit.ts` already documents an agent fallback ("if refresh registration fails, retry with a smaller input; if it still fails, create a static artifact without `document.sourceJson`"). Because validation let the bad source through, registration never "failed" and that fallback never ran.

## What users will see

When the agent generates a live artifact, a refresh source that says "read a JSON file" without naming which file is now rejected at creation instead of silently persisted. The agent's existing fallback takes over (smaller retry, or a static artifact), so users stop ending up with a digest whose Refresh button can only ever fail. No change to valid live artifacts.

## Surface area

- [x] **None** — daemon-internal validation + tests only. No UI/CLI/contract/i18n surface; the live-artifact schema is internal to `apps/daemon`.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/live-artifacts-schema.test.ts` → `rejects project_files.read_json sources whose input names no file to read` (covers both the `daemon_tool` and `local_file` spellings), plus a guard test `accepts project_files.read_json sources that name a file via path, file, or name` to prevent over-rejection.
- Did the test go red on `main` and green on this branch? **yes** — red with `expected true to be false` before the `schema.ts` change, green after.

## Validation

- `pnpm --filter @open-design/daemon test` — all green except a pre-existing baseline failure in `tests/diagnostics-export.test.ts` (red on `main` before this change, unrelated).
- `pnpm --filter @open-design/daemon typecheck` — clean.
- `pnpm guard` — clean.

## Notes / follow-up

- This prevents *future* artifacts from registering an unrefreshable source. It does not retroactively repair an artifact whose broken `sourceJson` is already on disk — that one still needs regenerating (or its `sourceJson` cleared). A read-time downgrade for already-persisted bad sources could be a separate follow-up if we want self-healing.
- The `unknown certificate verification error` seen from AMR/opencode in the same session is an independent agent-runtime failure, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)