### PR TITLE
feat(workspace): remove the New Side Chat launcher entry

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -162,14 +162,16 @@ interface Props {
   commentPortalId?: string;
   onCommentModeChange?: (active: boolean) => void;
   // Side Chat (`chat:<conversationId>` tab) wiring. Threaded from ProjectView
-  // so a secondary ChatPane can run against a seeded conversation without
+  // so a secondary ChatPane can render an already-open conversation tab without
   // FileWorkspace owning any chat state. All optional: a workspace mounted
-  // without these simply offers no "New Side Chat" launcher entry.
+  // without these simply does not render restored side-chat tabs. There is no
+  // launcher affordance to create new side chats — only persisted `chat:` tabs
+  // are restored.
   chatConfig?: AppConfig;
   chatAgentsById?: Map<string, AgentInfo>;
   chatLocale?: string;
   conversations?: Conversation[];
-  /** The primary chat's active conversation — the seed source for new side chats. */
+  /** The primary chat's active conversation. */
   activeConversationId?: string | null;
   onSelectConversation?: (id: string) => void;
   onDeleteConversation?: (id: string) => void;
@@ -177,8 +179,6 @@ interface Props {
   onConversationSessionModeChange?: (id: string, mode: ChatSessionMode) => void;
   onNewConversation?: () => void;
   activeConversationChat?: ActiveConversationChatState;
-  /** Create a context-seeded conversation and resolve its id (backs the launcher). */
-  onCreateSideChat?: (seedFromConversationId: string | null) => Promise<string | null>;
   onActiveContextChange?: (context: WorkspaceContextItem | null) => void;
   onWorkspaceContextsChange?: (contexts: WorkspaceContextItem[]) => void;
   messages?: ChatMessage[];
@@ -406,7 +406,6 @@ export function FileWorkspace({
   onConversationSessionModeChange,
   onNewConversation,
   activeConversationChat,
-  onCreateSideChat,
   onActiveContextChange,
   onWorkspaceContextsChange,
   messages = [],
@@ -1748,14 +1747,12 @@ export function FileWorkspace({
     && !activeFile;
 
   // The "+" launcher's create-new actions come from the registry. `openTab`
-  // reuses the same tab-state path as opening a file so a new chat:<id> /
-  // terminal:<id> tab is focused; `createBrowser` opens an embedded browser tab.
-  // `createSideChat` is only wired when the parent threaded the chat callbacks,
-  // so a chat-less workspace hides that action entirely.
+  // reuses the same tab-state path as opening a file so a new terminal:<id>
+  // tab is focused; `createBrowser` opens an embedded browser tab.
   // Built fresh each render (not memoized): `createBrowser` closes over
   // `openBrowserTab`, which reads the live `browserTabs` state — memoizing it
   // would capture a stale closure and make every "New Browser" click overwrite
-  // the same single tab. The terminal/side-chat actions route through `openFile`
+  // the same single tab. The terminal action routes through `openFile`
   // (ref-based), so freshness here is cheap and only matters while the launcher
   // is open.
   const launcherContext: LauncherContext = {
@@ -1764,9 +1761,6 @@ export function FileWorkspace({
     // Browser is owned by this branch's DesignBrowserPanel: spin up a browser
     // tab synchronously (no daemon round-trip) and let the launcher close.
     createBrowser: () => openBrowserTab(),
-    ...(onCreateSideChat
-      ? { createSideChat: () => onCreateSideChat(activeConversationId) }
-      : {}),
     // Terminal needs only the project id — spawn the PTY here and hand the
     // resulting session id back so the launcher opens a terminal:<id> tab.
     // Surface a toast when the daemon can't start one (e.g. node-pty not

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4446,26 +4446,6 @@ export function ProjectView({
     [activeConversationId, handleConversationSessionModeChange],
   );
 
-  // Side Chat launcher: create a NEW conversation seeded with the current
-  // chat's context (the daemon copies the source conversation's messages) and
-  // resolve its id. The new conversation is a normal conversation, so it shows
-  // up in the header ConversationsMenu the moment we prepend it here. The
-  // FileWorkspace launcher action then opens it as a `chat:<id>` tab.
-  const handleCreateSideChat = useCallback(
-    async (seedFromConversationId: string | null): Promise<string | null> => {
-      const fresh = await createConversation(
-        project.id,
-        t('workspace.sideChatDefaultTitle'),
-        { seedFromConversationId },
-      );
-      if (!fresh) return null;
-      setConversations((curr) => [fresh, ...curr]);
-      onProjectsRefresh();
-      return fresh.id;
-    },
-    [project.id, t, onProjectsRefresh],
-  );
-
   const handleForkFromMessage = useCallback(
     async (assistantMessage: ChatMessage) => {
       if (!activeConversationId || forkingMessageId) return;
@@ -5672,7 +5652,6 @@ export function ProjectView({
           onConversationSessionModeChange={handleConversationSessionModeChange}
           onNewConversation={handleNewConversation}
           activeConversationChat={activeConversationChatState}
-          onCreateSideChat={handleCreateSideChat}
           onActiveContextChange={handleActiveWorkspaceContextChange}
           onWorkspaceContextsChange={handleWorkspaceContextsChange}
           messages={messages}

--- a/apps/web/src/components/workspace/tab-launcher.ts
+++ b/apps/web/src/components/workspace/tab-launcher.ts
@@ -8,10 +8,10 @@ import type { Dict } from '../../i18n/types';
 // place where new *kinds* of working surfaces are created. Opening an existing
 // file is built into the menu directly (it is the common case and needs the
 // project file list), but every other "create a new tab" affordance —
-// Side Chat (Stage 2), Terminal (Stage 3), and the external Browser worktree —
-// registers exactly ONE LauncherAction here. Adding a tab kind is therefore a
-// two-line change: register an action below, and add a render branch in the
-// `.ws-body` switch of `FileWorkspace.tsx`.
+// Terminal (Stage 3) and the external Browser worktree — registers exactly ONE
+// LauncherAction here. Adding a tab kind is therefore a two-line change:
+// register an action below, and add a render branch in the `.ws-body` switch
+// of `FileWorkspace.tsx`.
 //
 // Keep this module tiny and dependency-light. It owns *what can be created*,
 // not *how it is rendered* — the dropdown (`TabLauncherMenu.tsx`) renders the
@@ -29,12 +29,6 @@ export interface LauncherContext {
    * `terminal:<id>` tab id.
    */
   openTab: (tabId: string) => void;
-  /**
-   * Create a new conversation seeded with the current chat's context and
-   * resolve its id. Backs the "New Side Chat" action. Returns null when the
-   * daemon could not create the conversation (the action then no-ops).
-   */
-  createSideChat?: () => Promise<string | null>;
   /**
    * Spawn a new PTY session for the project and resolve its terminal id. Backs
    * the "New Terminal" action. Returns null when the daemon could not start the
@@ -65,27 +59,13 @@ export interface LauncherAction {
 /**
  * Build the list of "create new" actions for the current context.
  *
- * Each tab kind contributes exactly one action. Stage 2 adds "New Side Chat":
- * it spins up a context-seeded conversation and opens it as a `chat:<id>` tab.
- * Stage 3 adds "New Terminal": it spawns a PTY session and opens it as a
- * `terminal:<id>` tab. The Browser action mounts this branch's
- * DesignBrowserPanel as a `__browser__:<n>` tab the same way, gated on context.
+ * Each tab kind contributes exactly one action. Stage 3 adds "New Terminal":
+ * it spawns a PTY session and opens it as a `terminal:<id>` tab. The Browser
+ * action mounts this branch's DesignBrowserPanel as a `__browser__:<n>` tab the
+ * same way, gated on context.
  */
 export function buildLauncherActions(ctx: LauncherContext): LauncherAction[] {
   const actions: LauncherAction[] = [];
-  if (ctx.createSideChat) {
-    actions.push({
-      id: 'new-side-chat',
-      iconName: 'comment',
-      labelKey: 'workspace.newSideChat',
-      descriptionKey: 'workspace.newSideChatDescription',
-      run: (runCtx) => {
-        void runCtx.createSideChat?.().then((conversationId) => {
-          if (conversationId) runCtx.openTab(`chat:${conversationId}`);
-        });
-      },
-    });
-  }
   if (ctx.createTerminal) {
     actions.push({
       id: 'new-terminal',

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1032,8 +1032,6 @@ export const ar: Dict = {
   'workspace.allFiles': 'All',
   'workspace.createNew': 'Create new',
   'workspace.tabOpen': 'Open',
-  'workspace.newSideChat': 'New Side Chat',
-  'workspace.newSideChatDescription': 'Open a context-aware chat in a new tab',
   'workspace.sideChatContextBanner': 'Integrated context from the current conversation',
   'workspace.sideChatDefaultTitle': 'Side chat',
   'workspace.newTerminal': 'New Terminal',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -920,8 +920,6 @@ export const de: Dict = {
   'workspace.allFiles': 'Alle',
   'workspace.createNew': 'Neu erstellen',
   'workspace.tabOpen': 'Geöffnet',
-  'workspace.newSideChat': 'Neuer Seiten-Chat',
-  'workspace.newSideChatDescription': 'Einen kontextbezogenen Chat in einem neuen Tab öffnen',
   'workspace.sideChatContextBanner': 'Kontext der aktuellen Unterhaltung übernommen',
   'workspace.sideChatDefaultTitle': 'Seiten-Chat',
   'workspace.newTerminal': 'Neues Terminal',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1884,8 +1884,6 @@ export const en: Dict = {
   'workspace.allFiles': 'All',
   'workspace.createNew': 'Create new',
   'workspace.tabOpen': 'Open',
-  'workspace.newSideChat': 'New Side Chat',
-  'workspace.newSideChatDescription': 'Open a context-aware chat in a new tab',
   'workspace.sideChatContextBanner': 'Integrated context from the current conversation',
   'workspace.sideChatDefaultTitle': 'Side chat',
   'workspace.newTerminal': 'New Terminal',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -921,8 +921,6 @@ export const esES: Dict = {
   'workspace.allFiles': 'Todos',
   'workspace.createNew': 'Crear nuevo',
   'workspace.tabOpen': 'Abierto',
-  'workspace.newSideChat': 'Nuevo chat lateral',
-  'workspace.newSideChatDescription': 'Abrir un chat con contexto en una pestaña nueva',
   'workspace.sideChatContextBanner': 'Contexto de la conversación actual integrado',
   'workspace.sideChatDefaultTitle': 'Chat lateral',
   'workspace.newTerminal': 'Nueva terminal',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1054,8 +1054,6 @@ export const fa: Dict = {
   'workspace.allFiles': 'All',
   'workspace.createNew': 'Create new',
   'workspace.tabOpen': 'Open',
-  'workspace.newSideChat': 'New Side Chat',
-  'workspace.newSideChatDescription': 'Open a context-aware chat in a new tab',
   'workspace.sideChatContextBanner': 'Integrated context from the current conversation',
   'workspace.sideChatDefaultTitle': 'Side chat',
   'workspace.newTerminal': 'New Terminal',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1564,8 +1564,6 @@ export const fr: Dict = {
   'workspace.allFiles': 'Tous',
   'workspace.createNew': 'Créer',
   'workspace.tabOpen': 'Ouvert',
-  'workspace.newSideChat': 'Nouveau chat latéral',
-  'workspace.newSideChatDescription': 'Ouvrir un chat contextuel dans un nouvel onglet',
   'workspace.sideChatContextBanner': 'Contexte de la conversation actuelle intégré',
   'workspace.sideChatDefaultTitle': 'Chat latéral',
   'workspace.newTerminal': 'Nouveau terminal',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1032,8 +1032,6 @@ export const hu: Dict = {
   'workspace.allFiles': 'All',
   'workspace.createNew': 'Create new',
   'workspace.tabOpen': 'Open',
-  'workspace.newSideChat': 'New Side Chat',
-  'workspace.newSideChatDescription': 'Open a context-aware chat in a new tab',
   'workspace.sideChatContextBanner': 'Integrated context from the current conversation',
   'workspace.sideChatDefaultTitle': 'Side chat',
   'workspace.newTerminal': 'New Terminal',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1142,8 +1142,6 @@ export const id: Dict = {
   'workspace.allFiles': 'All',
   'workspace.createNew': 'Create new',
   'workspace.tabOpen': 'Open',
-  'workspace.newSideChat': 'New Side Chat',
-  'workspace.newSideChatDescription': 'Open a context-aware chat in a new tab',
   'workspace.sideChatContextBanner': 'Integrated context from the current conversation',
   'workspace.sideChatDefaultTitle': 'Side chat',
   'workspace.newTerminal': 'New Terminal',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -927,8 +927,6 @@ export const it: Dict = {
   'workspace.allFiles': 'Tutti',
   'workspace.createNew': 'Crea nuovo',
   'workspace.tabOpen': 'Aperto',
-  'workspace.newSideChat': 'Nuova chat laterale',
-  'workspace.newSideChatDescription': 'Apri una chat con contesto in una nuova scheda',
   'workspace.sideChatContextBanner': 'Contesto integrato dalla conversazione corrente',
   'workspace.sideChatDefaultTitle': 'Chat laterale',
   'workspace.newTerminal': 'Nuovo terminale',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -919,8 +919,6 @@ export const ja: Dict = {
   'workspace.allFiles': 'すべて',
   'workspace.createNew': '新規作成',
   'workspace.tabOpen': '開いています',
-  'workspace.newSideChat': '新しいサイドチャット',
-  'workspace.newSideChatDescription': 'コンテキストを引き継いだチャットを新しいタブで開く',
   'workspace.sideChatContextBanner': '現在の会話のコンテキストを引き継ぎました',
   'workspace.sideChatDefaultTitle': 'サイドチャット',
   'workspace.newTerminal': '新しいターミナル',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1032,8 +1032,6 @@ export const ko: Dict = {
   'workspace.allFiles': '전체',
   'workspace.createNew': '새로 만들기',
   'workspace.tabOpen': '열림',
-  'workspace.newSideChat': '새 사이드 채팅',
-  'workspace.newSideChatDescription': '컨텍스트를 이어받은 채팅을 새 탭에서 열기',
   'workspace.sideChatContextBanner': '현재 대화의 컨텍스트를 통합했습니다',
   'workspace.sideChatDefaultTitle': '사이드 채팅',
   'workspace.newTerminal': '새 터미널',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1032,8 +1032,6 @@ export const pl: Dict = {
   'workspace.allFiles': 'All',
   'workspace.createNew': 'Create new',
   'workspace.tabOpen': 'Open',
-  'workspace.newSideChat': 'New Side Chat',
-  'workspace.newSideChatDescription': 'Open a context-aware chat in a new tab',
   'workspace.sideChatContextBanner': 'Integrated context from the current conversation',
   'workspace.sideChatDefaultTitle': 'Side chat',
   'workspace.newTerminal': 'New Terminal',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1053,8 +1053,6 @@ export const ptBR: Dict = {
   'workspace.allFiles': 'Todos',
   'workspace.createNew': 'Criar novo',
   'workspace.tabOpen': 'Aberto',
-  'workspace.newSideChat': 'Novo chat lateral',
-  'workspace.newSideChatDescription': 'Abrir um chat com contexto em uma nova aba',
   'workspace.sideChatContextBanner': 'Contexto da conversa atual integrado',
   'workspace.sideChatDefaultTitle': 'Chat lateral',
   'workspace.newTerminal': 'Novo terminal',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1053,8 +1053,6 @@ export const ru: Dict = {
   'workspace.allFiles': 'Все',
   'workspace.createNew': 'Создать',
   'workspace.tabOpen': 'Открыт',
-  'workspace.newSideChat': 'Новый боковой чат',
-  'workspace.newSideChatDescription': 'Открыть чат с контекстом в новой вкладке',
   'workspace.sideChatContextBanner': 'Контекст текущего разговора интегрирован',
   'workspace.sideChatDefaultTitle': 'Боковой чат',
   'workspace.newTerminal': 'Новый терминал',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -977,8 +977,6 @@ export const th: Dict = {
   'workspace.allFiles': 'All',
   'workspace.createNew': 'Create new',
   'workspace.tabOpen': 'Open',
-  'workspace.newSideChat': 'New Side Chat',
-  'workspace.newSideChatDescription': 'Open a context-aware chat in a new tab',
   'workspace.sideChatContextBanner': 'Integrated context from the current conversation',
   'workspace.sideChatDefaultTitle': 'Side chat',
   'workspace.newTerminal': 'New Terminal',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1019,8 +1019,6 @@ export const tr: Dict = {
   'workspace.allFiles': 'All',
   'workspace.createNew': 'Create new',
   'workspace.tabOpen': 'Open',
-  'workspace.newSideChat': 'New Side Chat',
-  'workspace.newSideChatDescription': 'Open a context-aware chat in a new tab',
   'workspace.sideChatContextBanner': 'Integrated context from the current conversation',
   'workspace.sideChatDefaultTitle': 'Side chat',
   'workspace.newTerminal': 'New Terminal',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1054,8 +1054,6 @@ export const uk: Dict = {
   'workspace.allFiles': 'All',
   'workspace.createNew': 'Create new',
   'workspace.tabOpen': 'Open',
-  'workspace.newSideChat': 'New Side Chat',
-  'workspace.newSideChatDescription': 'Open a context-aware chat in a new tab',
   'workspace.sideChatContextBanner': 'Integrated context from the current conversation',
   'workspace.sideChatDefaultTitle': 'Side chat',
   'workspace.newTerminal': 'New Terminal',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1874,8 +1874,6 @@ export const zhCN: Dict = {
   'workspace.allFiles': '全部',
   'workspace.createNew': '新建',
   'workspace.tabOpen': '已打开',
-  'workspace.newSideChat': '新建侧边对话',
-  'workspace.newSideChatDescription': '在新标签页中打开继承上下文的对话',
   'workspace.sideChatContextBanner': '已集成当前会话上下文',
   'workspace.sideChatDefaultTitle': '侧边对话',
   'workspace.newTerminal': '新建终端',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1467,8 +1467,6 @@ export const zhTW: Dict = {
   'workspace.allFiles': '全部',
   'workspace.createNew': '新增',
   'workspace.tabOpen': '已開啟',
-  'workspace.newSideChat': '新增側邊對話',
-  'workspace.newSideChatDescription': '在新分頁中開啟繼承上下文的對話',
   'workspace.sideChatContextBanner': '已整合目前對話的上下文',
   'workspace.sideChatDefaultTitle': '側邊對話',
   'workspace.newTerminal': '新增終端機',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2225,8 +2225,6 @@ export interface Dict {
   'workspace.allFiles': string;
   'workspace.createNew': string;
   'workspace.tabOpen': string;
-  'workspace.newSideChat': string;
-  'workspace.newSideChatDescription': string;
   'workspace.sideChatContextBanner': string;
   'workspace.sideChatDefaultTitle': string;
   'workspace.newTerminal': string;

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -728,41 +728,6 @@ describe('FileWorkspace launcher tab creation', () => {
     });
   });
 
-  it('appends a new side chat to the latest tab list after parent tabs change', async () => {
-    mockedFetchProjectFileText.mockResolvedValue('');
-    const onTabsStateChange = vi.fn();
-    const onCreateSideChat = vi.fn(async () => 'conversation-2');
-    const baseProps: React.ComponentProps<typeof FileWorkspace> = {
-      projectId: 'project-1',
-      projectKind: 'prototype',
-      files: [],
-      liveArtifacts: [],
-      onRefreshFiles: vi.fn(),
-      isDeck: false,
-      tabsState: { tabs: [], active: null },
-      onTabsStateChange,
-      onCreateSideChat,
-    };
-
-    const { rerender } = render(<FileWorkspace {...baseProps} />);
-    rerender(
-      <FileWorkspace
-        {...baseProps}
-        tabsState={{ tabs: ['terminal:existing'], active: null }}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId('workspace-add-tab'));
-    fireEvent.click(await screen.findByRole('button', { name: /New Side Chat/i }));
-
-    await waitFor(() => {
-      expect(onTabsStateChange).toHaveBeenCalledWith({
-        tabs: ['terminal:existing', 'chat:conversation-2'],
-        active: 'chat:conversation-2',
-      });
-    });
-  });
-
   it('renders terminal and side chat tabs after a Design Files-anchored browser tab', () => {
     render(
       <FileWorkspace


### PR DESCRIPTION
## Why

While using the file workspace I hit the **New Side Chat** action in the `+` tab launcher. Picking it creates a conversation and opens it as a `chat:<id>` tab *inside the file area*. That places a full conversation surface in the file workspace, which is inconsistent with how conversations live in the sidebar chrome — it reads as a half-finished surface rather than a coherent place to chat. Rather than reconcile two competing conversation homes, this removes the entry so conversations stay in the sidebar where they belong.

## What users will see

The `+` (new tab) menu in the right-hand file workspace no longer lists **New Side Chat** — only New Terminal and New Browser remain. Users can no longer spawn a conversation as a tab in the file area; conversations continue to live in the sidebar / ConversationsMenu as before. Anyone who already had a side-chat tab open keeps it (persisted `chat:` tabs still restore) — there is just no way to create new ones.

## Surface area

- [x] **UI** — removes the "New Side Chat" item from the file workspace `+` tab launcher menu
- [x] **i18n keys** — removes the now-unused `workspace.newSideChat` / `workspace.newSideChatDescription` keys across all locales
- [ ] **Default behavior change** — n/a (removes an opt-in affordance; no existing data/setting changes)

## Screenshots

Before: the `+` launcher listed **New Side Chat**, and choosing it opened a `侧边对话` conversation tab in the file area (the inconsistent surface this PR removes). After: the launcher offers only New Terminal / New Browser. (Screenshot of the launcher menu to follow.)

## Bug fix verification

Not a bug fix — this is a deliberate removal of an entry point. The existing `FileWorkspace.test.tsx` suite still covers that persisted side-chat tabs render (the kept restore path); the test exercising the removed *creation* action was deleted with it.

## Validation

- `pnpm guard` — green (40/0)
- `pnpm --filter @open-design/web typecheck` — green
- `pnpm --filter @open-design/web exec vitest run tests/components/FileWorkspace.test.tsx` — 57 passed
- `pnpm --filter @open-design/web exec vitest run tests/i18n/locales.test.ts tests/i18n/design-files-agent-copy.test.ts` — green (i18n key removal consistent across all locales + types)
