### PR TITLE
[codex] send newsletter welcome emails

### DIFF
--- a/apps/landing-page/functions/subscribe.ts
+++ b/apps/landing-page/functions/subscribe.ts
@@ -16,6 +16,9 @@ interface Env {
   NEWSLETTER_SALT?: string;
   RESEND_API_KEY?: string;
   RESEND_NEWSLETTER_SEGMENT_ID?: string;
+  RESEND_WELCOME_EMAIL_ENABLED?: string;
+  RESEND_WELCOME_EMAIL_FROM?: string;
+  RESEND_WELCOME_EMAIL_REPLY_TO?: string;
 }
 
 type SubscribeRecord = {
@@ -26,6 +29,9 @@ type SubscribeRecord = {
   userAgentHash: string;
   country?: string;
   region?: string;
+  welcomeEmailAttemptedAt?: string;
+  welcomeEmailSentAt?: string;
+  welcomeEmailId?: string;
 };
 
 // Origins allowed to POST here: the marketing site and the desktop client.
@@ -43,6 +49,51 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_EMAIL_LENGTH = 254;
 const ALLOWED_SOURCES = new Set(["landing", "client"]);
 const RESEND_CONTACTS_URL = "https://api.resend.com/contacts";
+const RESEND_EMAILS_URL = "https://api.resend.com/emails";
+const DEFAULT_WELCOME_EMAIL_FROM = "Open Design <updates@open-design.ai>";
+const DEFAULT_WELCOME_EMAIL_REPLY_TO = "updates@open-design.ai";
+const WELCOME_EMAIL_SUBJECT = "Welcome to OpenDesign — you're in 🎉";
+const WELCOME_EMAIL_TEXT = `Hi there,
+
+Thanks for subscribing to the OpenDesign newsletter — you're officially on the list.
+
+Here's what to expect from us:
+
+- Product updates — new features, releases, and what we're building next
+- Design system insights — practical lessons on building design systems that scale
+- Behind the scenes — how we think about turning design into living, self-evolving systems.
+
+We send thoughtfully, not often. No spam, no filler — just things we think are genuinely worth your time.
+
+If you ever have feedback, ideas, or just want to say hi, simply reply to this email. We read every one.
+
+Talk soon,
+The OpenDesign Team
+
+---
+You're receiving this because you subscribed at open-design.ai.`;
+const WELCOME_EMAIL_HTML = `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#f7f2e7;color:#171511;font-family:Inter,Arial,sans-serif;">
+    <div style="max-width:640px;margin:0 auto;padding:40px 24px;">
+      <h1 style="margin:0 0 20px;font-family:Georgia,'Times New Roman',serif;font-size:32px;line-height:1.15;color:#171511;">Welcome to OpenDesign</h1>
+      <p style="margin:0 0 18px;font-size:16px;line-height:1.6;">Hi there,</p>
+      <p style="margin:0 0 18px;font-size:16px;line-height:1.6;">Thanks for subscribing to the OpenDesign newsletter — you're officially on the list.</p>
+      <p style="margin:0 0 12px;font-size:16px;line-height:1.6;">Here's what to expect from us:</p>
+      <ul style="margin:0 0 20px;padding-left:22px;font-size:16px;line-height:1.6;">
+        <li><strong>Product updates</strong> — new features, releases, and what we're building next</li>
+        <li><strong>Design system insights</strong> — practical lessons on building design systems that scale</li>
+        <li><strong>Behind the scenes</strong> — how we think about turning design into living, self-evolving systems.</li>
+      </ul>
+      <p style="margin:0 0 18px;font-size:16px;line-height:1.6;">We send thoughtfully, not often. No spam, no filler — just things we think are genuinely worth your time.</p>
+      <p style="margin:0 0 24px;font-size:16px;line-height:1.6;">If you ever have feedback, ideas, or just want to say hi, simply reply to this email. We read every one.</p>
+      <p style="margin:0 0 28px;font-size:16px;line-height:1.6;">Talk soon,<br>The OpenDesign Team</p>
+      <p style="margin:0;padding-top:20px;border-top:1px solid #d8cfbd;color:#6b6559;font-size:13px;line-height:1.5;">You're receiving this because you subscribed at open-design.ai.</p>
+    </div>
+  </body>
+</html>`;
+
+type Fetcher = typeof fetch;
 
 function corsHeaders(origin: string | null): Record<string, string> {
   const allowed =
@@ -99,6 +150,25 @@ async function writeNewsletterKv(
   );
 }
 
+async function readNewsletterKv(
+  namespace: KVNamespace | undefined,
+  key: string,
+): Promise<SubscribeRecord | null> {
+  if (!namespace) return null;
+
+  const value = await namespace.get(key);
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(value) as Partial<SubscribeRecord>;
+    if (typeof parsed.email !== "string" || typeof parsed.subscribedAt !== "string") return null;
+    return parsed as SubscribeRecord;
+  } catch {
+    console.warn("newsletter_subscribe_kv_invalid_record", JSON.stringify({ key }));
+    return null;
+  }
+}
+
 function isExistingContactStatus(status: number): boolean {
   // Resend may return a validation/client error for an existing global contact
   // depending on API version. Treat those as a signal to ensure segment
@@ -110,6 +180,7 @@ async function createResendContact(
   apiKey: string,
   email: string,
   segmentId: string | null,
+  fetcher: Fetcher = fetch,
 ): Promise<Response> {
   const body: {
     email: string;
@@ -123,7 +194,7 @@ async function createResendContact(
     body.segments = [{ id: segmentId }];
   }
 
-  return fetch(RESEND_CONTACTS_URL, {
+  return fetcher(RESEND_CONTACTS_URL, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${apiKey}`,
@@ -137,8 +208,9 @@ async function addResendContactToSegment(
   apiKey: string,
   email: string,
   segmentId: string,
+  fetcher: Fetcher = fetch,
 ): Promise<Response> {
-  return fetch(`${RESEND_CONTACTS_URL}/${encodeURIComponent(email)}/segments/${
+  return fetcher(`${RESEND_CONTACTS_URL}/${encodeURIComponent(email)}/segments/${
     encodeURIComponent(segmentId)
   }`, {
     method: "POST",
@@ -153,6 +225,7 @@ async function syncResendNewsletterContact(
   apiKey: string | undefined,
   segmentId: string | undefined,
   email: string,
+  fetcher: Fetcher = fetch,
 ): Promise<void> {
   if (!apiKey) {
     console.warn("newsletter_resend_unset: RESEND_API_KEY missing; skipped Resend, KV only");
@@ -167,13 +240,13 @@ async function syncResendNewsletterContact(
   }
 
   try {
-    const createRes = await createResendContact(apiKey, email, normalizedSegmentId);
+    const createRes = await createResendContact(apiKey, email, normalizedSegmentId, fetcher);
     if (createRes.ok) return;
 
     if (isExistingContactStatus(createRes.status)) {
       if (!normalizedSegmentId) return;
 
-      const segmentRes = await addResendContactToSegment(apiKey, email, normalizedSegmentId);
+      const segmentRes = await addResendContactToSegment(apiKey, email, normalizedSegmentId, fetcher);
       if (segmentRes.ok || isExistingContactStatus(segmentRes.status)) return;
       console.warn("newsletter_resend_segment_failed", JSON.stringify({ status: segmentRes.status }));
       return;
@@ -183,6 +256,111 @@ async function syncResendNewsletterContact(
   } catch {
     console.warn("newsletter_resend_request_failed");
   }
+}
+
+function isWelcomeEmailEnabled(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized !== "0" && normalized !== "false" && normalized !== "off" && normalized !== "no";
+}
+
+function shouldAttemptWelcomeEmail(existingRecord: SubscribeRecord | null): boolean {
+  if (existingRecord?.welcomeEmailSentAt) return false;
+  if (!existingRecord) return true;
+  return Boolean(existingRecord.welcomeEmailAttemptedAt);
+}
+
+async function sendResendWelcomeEmail(
+  env: Env,
+  email: string,
+  idempotencyKey: string,
+  fetcher: Fetcher = fetch,
+): Promise<{ id?: string; sentAt: string } | null> {
+  if (!isWelcomeEmailEnabled(env.RESEND_WELCOME_EMAIL_ENABLED)) return null;
+
+  const apiKey = env.RESEND_API_KEY?.trim();
+  if (!apiKey) {
+    console.warn("newsletter_welcome_resend_unset: RESEND_API_KEY missing; skipped welcome email");
+    return null;
+  }
+
+  const from = env.RESEND_WELCOME_EMAIL_FROM?.trim() || DEFAULT_WELCOME_EMAIL_FROM;
+  const replyTo = env.RESEND_WELCOME_EMAIL_REPLY_TO?.trim() || DEFAULT_WELCOME_EMAIL_REPLY_TO;
+
+  try {
+    const response = await fetcher(RESEND_EMAILS_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": idempotencyKey,
+      },
+      body: JSON.stringify({
+        from,
+        to: email,
+        reply_to: replyTo,
+        subject: WELCOME_EMAIL_SUBJECT,
+        html: WELCOME_EMAIL_HTML,
+        text: WELCOME_EMAIL_TEXT,
+        tags: [
+          { name: "type", value: "newsletter_welcome" },
+          { name: "surface", value: "landing_subscribe" },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      console.warn("newsletter_welcome_send_failed", JSON.stringify({ status: response.status }));
+      return null;
+    }
+
+    const data = (await response.json().catch(() => ({}))) as { id?: unknown };
+    return {
+      id: typeof data.id === "string" ? data.id : undefined,
+      sentAt: new Date().toISOString(),
+    };
+  } catch {
+    console.warn("newsletter_welcome_request_failed");
+    return null;
+  }
+}
+
+async function persistNewsletterSubscription(
+  env: Env,
+  key: string,
+  record: SubscribeRecord,
+  fetcher: Fetcher = fetch,
+): Promise<void> {
+  const existingRecord = await readNewsletterKv(env.NEWSLETTER_SUBSCRIBERS, key);
+  const canDeduplicateWelcome = Boolean(env.NEWSLETTER_SUBSCRIBERS);
+  const attemptWelcome = canDeduplicateWelcome && shouldAttemptWelcomeEmail(existingRecord);
+  const welcomeAttemptedAt = attemptWelcome ? new Date().toISOString() : undefined;
+  const nextRecord: SubscribeRecord = {
+    ...existingRecord,
+    ...record,
+    welcomeEmailAttemptedAt: welcomeAttemptedAt ?? existingRecord?.welcomeEmailAttemptedAt,
+    welcomeEmailSentAt: existingRecord?.welcomeEmailSentAt,
+    welcomeEmailId: existingRecord?.welcomeEmailId,
+  };
+
+  await writeNewsletterKv(env.NEWSLETTER_SUBSCRIBERS, key, nextRecord);
+
+  await syncResendNewsletterContact(
+    env.RESEND_API_KEY,
+    env.RESEND_NEWSLETTER_SEGMENT_ID,
+    record.email,
+    fetcher,
+  );
+
+  if (!attemptWelcome) return;
+
+  const welcomeResult = await sendResendWelcomeEmail(env, record.email, `newsletter-welcome-${key}`, fetcher);
+  if (!welcomeResult) return;
+
+  await writeNewsletterKv(env.NEWSLETTER_SUBSCRIBERS, key, {
+    ...nextRecord,
+    welcomeEmailSentAt: welcomeResult.sentAt,
+    welcomeEmailId: welcomeResult.id,
+  });
 }
 
 export const onRequest: PagesFunction<Env> = async (context) => {
@@ -231,14 +409,12 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   // overwrites the same record instead of growing the namespace unbounded.
   const key = `sub:${await sha256Hex(email)}`;
 
-  context.waitUntil(Promise.allSettled([
-    writeNewsletterKv(context.env.NEWSLETTER_SUBSCRIBERS, key, record),
-    syncResendNewsletterContact(
-      context.env.RESEND_API_KEY,
-      context.env.RESEND_NEWSLETTER_SEGMENT_ID,
-      email,
-    ),
-  ]));
+  context.waitUntil(persistNewsletterSubscription(context.env, key, record));
 
   return json({ ok: true }, 200, origin);
+};
+
+export const __newsletterSubscribeTest = {
+  persistNewsletterSubscription,
+  shouldAttemptWelcomeEmail,
 };

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -9,6 +9,7 @@
     "build:static": "astro build && tsx scripts/copy-example-html.ts",
     "preview": "astro preview --host 127.0.0.1 --port 17574",
     "previews": "tsx scripts/generate-previews.ts",
+    "test": "node --import tsx --test tests/*.test.ts",
     "typecheck": "astro check"
   },
   "dependencies": {

--- a/apps/landing-page/tests/subscribe.test.ts
+++ b/apps/landing-page/tests/subscribe.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { __newsletterSubscribeTest } from "../functions/subscribe.ts";
+
+type TestKv = {
+  put(key: string, value: string): Promise<void>;
+  get(key: string): Promise<string | null>;
+};
+
+type FetchCall = {
+  url: string;
+  init: RequestInit;
+};
+
+const BASE_RECORD = {
+  email: "user@example.com",
+  subscribedAt: "2026-06-05T00:00:00.000Z",
+  source: "landing",
+  referer: "https://open-design.ai/",
+  userAgentHash: "agent-hash",
+};
+
+class MemoryKv implements TestKv {
+  readonly values = new Map<string, string>();
+
+  async put(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.values.get(key) ?? null;
+  }
+}
+
+function createFetchRecorder(emailResponseStatus = 200): {
+  calls: FetchCall[];
+  fetcher: typeof fetch;
+} {
+  const calls: FetchCall[] = [];
+  const fetcher: typeof fetch = async (input, init = {}) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    calls.push({ url, init });
+
+    if (url === "https://api.resend.com/emails") {
+      return new Response(JSON.stringify({ id: "welcome-email-id" }), {
+        status: emailResponseStatus,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ id: "contact-id" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  return { calls, fetcher };
+}
+
+function createEnv(kv: TestKv) {
+  return {
+    NEWSLETTER_SUBSCRIBERS: kv,
+    RESEND_API_KEY: "re_test",
+    RESEND_NEWSLETTER_SEGMENT_ID: "segment-id",
+  };
+}
+
+describe("newsletter subscribe welcome email", () => {
+  it("sends and records a welcome email for a new subscriber", async () => {
+    const kv = new MemoryKv();
+    const { calls, fetcher } = createFetchRecorder();
+
+    await __newsletterSubscribeTest.persistNewsletterSubscription(
+      createEnv(kv),
+      "sub:abc",
+      BASE_RECORD,
+      fetcher,
+    );
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0]?.url, "https://api.resend.com/contacts");
+    assert.equal(calls[1]?.url, "https://api.resend.com/emails");
+    assert.equal(calls[1]?.init.headers?.["Idempotency-Key" as keyof HeadersInit], "newsletter-welcome-sub:abc");
+
+    const emailBody = JSON.parse(String(calls[1]?.init.body));
+    assert.equal(emailBody.from, "Open Design <updates@open-design.ai>");
+    assert.equal(emailBody.reply_to, "updates@open-design.ai");
+    assert.equal(emailBody.to, "user@example.com");
+    assert.equal(emailBody.subject, "Welcome to OpenDesign — you're in 🎉");
+    assert.match(emailBody.text, /Thanks for subscribing to the OpenDesign newsletter/);
+    assert.match(emailBody.html, /Welcome to OpenDesign/);
+
+    const stored = JSON.parse(kv.values.get("sub:abc") ?? "{}");
+    assert.equal(stored.welcomeEmailId, "welcome-email-id");
+    assert.equal(typeof stored.welcomeEmailAttemptedAt, "string");
+    assert.equal(typeof stored.welcomeEmailSentAt, "string");
+  });
+
+  it("does not backfill welcome email for legacy subscribers without a welcome attempt", async () => {
+    const kv = new MemoryKv();
+    await kv.put("sub:abc", JSON.stringify(BASE_RECORD));
+    const { calls, fetcher } = createFetchRecorder();
+
+    await __newsletterSubscribeTest.persistNewsletterSubscription(
+      createEnv(kv),
+      "sub:abc",
+      { ...BASE_RECORD, subscribedAt: "2026-06-05T01:00:00.000Z" },
+      fetcher,
+    );
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.url, "https://api.resend.com/contacts");
+
+    const stored = JSON.parse(kv.values.get("sub:abc") ?? "{}");
+    assert.equal(stored.welcomeEmailAttemptedAt, undefined);
+    assert.equal(stored.welcomeEmailSentAt, undefined);
+    assert.equal(stored.subscribedAt, "2026-06-05T01:00:00.000Z");
+  });
+
+  it("retries welcome email when a previous first-subscribe attempt did not send", async () => {
+    const kv = new MemoryKv();
+    await kv.put(
+      "sub:abc",
+      JSON.stringify({
+        ...BASE_RECORD,
+        welcomeEmailAttemptedAt: "2026-06-05T00:01:00.000Z",
+      }),
+    );
+    const { calls, fetcher } = createFetchRecorder();
+
+    await __newsletterSubscribeTest.persistNewsletterSubscription(
+      createEnv(kv),
+      "sub:abc",
+      { ...BASE_RECORD, subscribedAt: "2026-06-05T02:00:00.000Z" },
+      fetcher,
+    );
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1]?.url, "https://api.resend.com/emails");
+
+    const stored = JSON.parse(kv.values.get("sub:abc") ?? "{}");
+    assert.equal(stored.welcomeEmailId, "welcome-email-id");
+    assert.equal(typeof stored.welcomeEmailSentAt, "string");
+  });
+});


### PR DESCRIPTION
## Why

Newsletter signups are now stored in KV and grouped in Resend contacts, but new subscribers do not receive an immediate confirmation. That leaves the user with no email-side acknowledgement that the subscription worked.

This adds a backend-only welcome email in the existing Cloudflare Pages `/subscribe` Function, keeping the landing-page request fast by doing the work in `waitUntil`.

## What users will see

After a new email subscribes through the landing page or client onboarding flow, Open Design sends a one-time welcome email from `Open Design <updates@open-design.ai>`.

Existing KV subscribers are not backfilled. If a first-subscribe welcome send fails, the KV record keeps the attempted state and the next same-email subscribe attempt can retry. Subscription success still does not depend on Resend email delivery.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

New optional env vars:

- `RESEND_WELCOME_EMAIL_ENABLED` — defaults on; set `0`, `false`, `off`, or `no` to disable welcome email sends.
- `RESEND_WELCOME_EMAIL_FROM` — defaults to `Open Design <updates@open-design.ai>`.
- `RESEND_WELCOME_EMAIL_REPLY_TO` — defaults to `updates@open-design.ai`.

Existing required setup remains `RESEND_API_KEY` for any Resend write. `RESEND_NEWSLETTER_SEGMENT_ID` is still only needed for contact grouping.

## Screenshots

Not applicable; this is a backend Pages Function behavior change.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/landing-page test`
- `pnpm --filter @open-design/landing-page typecheck`
- `pnpm --filter @open-design/landing-page build`
- `pnpm guard`
- `git diff --check`
