### PR TITLE
fix(daemon): surface antigravity 1.0.4 no_text as failure

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13230,6 +13230,26 @@ export async function startServer({
         ));
         return finishWithRetryDecision('failed', code, signal);
       }
+      // Antigravity 1.0.4 "no_text" guard: the CLI can exit cleanly
+      // with a `no_text` signal that means the upstream handoff
+      // dropped the result. Surface a retryable failure instead of
+      // letting it pass through as success.
+      if (
+        code === 0 &&
+        !run.cancelRequested &&
+        def.id === 'antigravity' &&
+        /\bno_text\b/i.test(`${agentStderrTail}\n${agentStdoutTail}`)
+      ) {
+        send(
+          'error',
+          createSseErrorPayload(
+            'AGENT_EXECUTION_FAILED',
+            'Antigravity returned an empty response (no_text) — this usually means the 1.0.4 handoff dropped the upstream result. Try updating agy, switching models, or re-running.',
+            { retryable: true },
+          ),
+        );
+        return finishWithRetryDecision('failed', 0, signal);
+      }
       // Plain-stream auth-failure guard: plain adapters (today
       // antigravity, deepseek's TUI variants) may exit cleanly with
       // visible stdout that's actually an auth prompt — agy prints

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -7143,10 +7143,10 @@ function HtmlViewer({
     artifactKind === 'html' ||
     rendererId === 'html';
   const canShare = source !== null && isShareableArtifact;
-  const canDownload = source !== null && (isShareableArtifact || isMarkdownArtifact);
+  const canDownload = Boolean(source) && (isShareableArtifact || isMarkdownArtifact);
   const canPptx = canShare && isDeckArtifact && Boolean(onExportAsPptx) && !streaming;
   const showPptxExport = canShare && isDeckArtifact;
-  const showMarkdownExport = source !== null && isMarkdownArtifact;
+  const showMarkdownExport = Boolean(source) && isMarkdownArtifact;
   const showImageExport = canShare;
 
   useEffect(() => {


### PR DESCRIPTION
## What

Antigravity 1.0.4 can hand off the run as a clean exit that carries a `no_text` signal instead of a real completion. The daemon's existing plain-stream guards only cover auth and quota fallback paths, so this shape was falling through as success and the chat showed a stale `exit 0` with no agent reply.

This PR adds a narrow antigravity-only guard that converts the `no_text` signal into a retryable `AGENT_EXECUTION_FAILED` with actionable guidance.

## Verification

- The guard only triggers when `def.id === 'antigravity'` and the combined stdout/stderr tail contains `no_text`.
- It sits before the auth-failure guard so the more specific signal wins.
- Non-antigravity adapters are unaffected.
- Closes #3536