### PR TITLE
fix(daemon+web): rebase mock replay project paths before counting active-project writes

### DIFF
--- a/apps/daemon/src/run-artifacts.ts
+++ b/apps/daemon/src/run-artifacts.ts
@@ -54,6 +54,24 @@ function extractToolFilePath(input: unknown): string | null {
   return null;
 }
 
+// Rebase mock/anonymized project paths (e.g. `.../data/projects/proj-001/...`)
+// onto the currently active project root so they count as active-project writes.
+// This keeps artifact counts, side-effect flags, and web tool cards aligned with
+// the actual project the user is watching rather than a stale anonymized identity.
+// See issue https://github.com/nexu-io/open-design/issues/3604.
+function rebaseMockPath(path: string, projectRoot?: string | null): string {
+  if (!projectRoot || path.startsWith(projectRoot)) return path;
+  const normalizedPath = path.replace(/[\\/]+/g, '/').replace(/\/$/, '');
+  const normalizedRoot =
+    typeof projectRoot === 'string' ? projectRoot.replace(/[\\/]+/g, '/').replace(/\/$/, '') : '';
+  if (!normalizedRoot) return path;
+  const match = normalizedPath.match(/^(.*\/projects\/)([^/]+)(\/.*)$/);
+  if (!match) return path;
+  const projectDir = normalizedRoot.split('/').pop();
+  if (!projectDir || !match[2] || !/^proj-\d+$/i.test(match[2]!)) return path;
+  return `${match[1]}${projectDir}${match[3]}`;
+}
+
 function isHtmlPath(path: string): boolean {
   return path.toLowerCase().endsWith('.html');
 }
@@ -107,6 +125,7 @@ function readToolResultIsError(data: unknown): boolean {
 function collectWrittenPathsMatching(
   events: readonly RunEventLike[],
   predicate: (path: string) => boolean,
+  opts?: { projectRoot?: string | null },
 ): Set<string> {
   if (!events || events.length === 0) return new Set();
   const resultByToolUseId = new Map<string, { isError: boolean }>();
@@ -128,7 +147,9 @@ function collectWrittenPathsMatching(
     if (data?.type !== 'tool_use') continue;
     if (typeof data.name !== 'string') continue;
     if (!WRITE_OR_EDIT_TOOL_NAMES.has(data.name)) continue;
-    const path = extractToolFilePath(data.input);
+    const rawPath = extractToolFilePath(data.input);
+    if (!rawPath) continue;
+    const path = rebaseMockPath(rawPath, opts?.projectRoot);
     if (!path) continue;
     if (!predicate(path)) continue;
     const toolUseId = readToolUseId(rec.data);
@@ -145,8 +166,9 @@ function collectWrittenPathsMatching(
 // Fed into `run_finished.design_system_created` for the DS variant.
 export function didRunCreateDesignSystemFile(
   events: readonly RunEventLike[],
+  opts?: { projectRoot?: string | null },
 ): boolean {
-  return collectWrittenPathsMatching(events, isDesignSystemFile).size > 0;
+  return collectWrittenPathsMatching(events, isDesignSystemFile, opts).size > 0;
 }
 
 // Count of distinct preview modules the run wrote under `preview/`.
@@ -155,11 +177,15 @@ export function didRunCreateDesignSystemFile(
 // path-distinct semantics match countNewHtmlArtifacts).
 export function countDesignSystemPreviewModules(
   events: readonly RunEventLike[],
+  opts?: { projectRoot?: string | null },
 ): number {
-  return collectWrittenPathsMatching(events, isPreviewModulePath).size;
+  return collectWrittenPathsMatching(events, isPreviewModulePath, opts).size;
 }
 
-export function countNewHtmlArtifacts(events: readonly RunEventLike[]): number {
+export function countNewHtmlArtifacts(
+  events: readonly RunEventLike[],
+  opts?: { projectRoot?: string | null },
+): number {
   if (!events || events.length === 0) return 0;
 
   // First pass: collect tool_result records keyed by toolUseId so the
@@ -190,8 +216,9 @@ export function countNewHtmlArtifacts(events: readonly RunEventLike[]): number {
     if (data?.type !== 'tool_use') continue;
     if (typeof data.name !== 'string') continue;
     if (!WRITE_OR_EDIT_TOOL_NAMES.has(data.name)) continue;
-    const path = extractToolFilePath(data.input);
-    if (!path) continue;
+    const rawPath = extractToolFilePath(data.input);
+    if (!rawPath) continue;
+    const path = rebaseMockPath(rawPath, opts?.projectRoot);
     if (!isHtmlPath(path)) continue;
     const toolUseId = readToolUseId(rec.data);
     // No id: legacy / synthetic stream shapes that don't pair. Be

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2284,7 +2284,10 @@ export function __forTestScanRunEventsForFinishedProps(events, reqBodyModel) {
   return scanRunEventsForFinishedProps(events, reqBodyModel);
 }
 
-function scanRunEventsForRetrySideEffects(events) {
+function scanRunEventsForRetrySideEffects(
+  events,
+  projectRoot?,
+) {
   const sideEffects = {
     userVisibleOutputSeen: false,
     toolCallSeen: false,
@@ -2311,17 +2314,17 @@ function scanRunEventsForRetrySideEffects(events) {
     }
   }
   if (
-    countNewHtmlArtifacts(events) > 0 ||
-    didRunCreateDesignSystemFile(events) ||
-    countDesignSystemPreviewModules(events) > 0
+    countNewHtmlArtifacts(events, { projectRoot }) > 0 ||
+    didRunCreateDesignSystemFile(events, { projectRoot }) ||
+    countDesignSystemPreviewModules(events, { projectRoot }) > 0
   ) {
     sideEffects.artifactWriteSeen = true;
   }
   return sideEffects;
 }
 
-export function __forTestScanRunEventsForRetrySideEffects(events) {
-  return scanRunEventsForRetrySideEffects(events);
+export function __forTestScanRunEventsForRetrySideEffects(events, projectRoot) {
+  return scanRunEventsForRetrySideEffects(events, projectRoot);
 }
 
 function retryFinalResultForRunStatus(status, retryAttemptCount) {
@@ -11700,7 +11703,9 @@ export async function startServer({
         failure,
         attemptCount: run.retryAttemptCount ?? 0,
         sideEffects: {
-          ...scanRunEventsForRetrySideEffects(run.events),
+          ...scanRunEventsForRetrySideEffects(run.events, run.projectId
+            ? resolveProjectDir(PROJECTS_DIR, run.projectId, run.project)
+            : undefined),
           cancelRequested: !!run.cancelRequested,
         },
       });
@@ -14248,7 +14253,11 @@ export async function startServer({
             // artifact?" funnel on PostHog. See `run-artifacts.ts`
             // for the dedup semantics; tested in
             // `tests/run-artifacts.test.ts`.
-            artifact_count: countNewHtmlArtifacts(run.events),
+            artifact_count: countNewHtmlArtifacts(run.events, {
+              projectRoot: run.projectId
+                ? resolveProjectDir(PROJECTS_DIR, run.projectId, run.project)
+                : undefined,
+            }),
             // True when the run raised an AskUserQuestion clarification
             // card. Clarification turns inherently produce no artifact, so
             // the dashboard excludes them from the "run finished -> has
@@ -14265,8 +14274,16 @@ export async function startServer({
               // succeeded; the run-artifacts inspector reuses the
               // same Write/Edit pairing it already does for HTML
               // artifact counts, just keyed on `DESIGN.md`.
-              design_system_created: didRunCreateDesignSystemFile(run.events),
-              preview_module_count: countDesignSystemPreviewModules(run.events),
+              design_system_created: didRunCreateDesignSystemFile(run.events, {
+                projectRoot: run.projectId
+                  ? resolveProjectDir(PROJECTS_DIR, run.projectId, run.project)
+                  : undefined,
+              }),
+              preview_module_count: countDesignSystemPreviewModules(run.events, {
+                projectRoot: run.projectId
+                  ? resolveProjectDir(PROJECTS_DIR, run.projectId, run.project)
+                  : undefined,
+              }),
               // `missing_font_count` defaults to 0 — the agent flow
               // doesn't emit a structured "missing fonts" signal yet.
               // Kept on the wire so the dashboard has the column from

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -435,7 +435,8 @@ function AssistantMessageImpl({
   hasDesignSystemContext = false,
   onArtifactShare,
   onArtifactChip,
-}: Props) {
+  currentProjectRoot,
+}: Props & { currentProjectRoot?: string | null }) {
   const t = useT();
   const events = message.events ?? [];
   // Claude sometimes hedges by emitting a markdown duplicate of the same
@@ -496,7 +497,7 @@ function AssistantMessageImpl({
       ),
     );
   }, [events, liveAuq, liveCodeBlocks]);
-  const fileOps = useMemo(() => deriveFileOps(events), [events]);
+  const fileOps = useMemo(() => deriveFileOps(events, { currentProjectRoot }), [events, currentProjectRoot]);
   const produced = message.producedFiles ?? [];
   const displayedProduced = useMemo(
     () =>

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -728,6 +728,7 @@ export function ChatPane({
   backLabel,
   projectHeader,
   designSystemPicker,
+  resolvedDir,
 }: Props) {
   const t = useT();
   const analytics = useAnalytics();
@@ -2319,6 +2320,7 @@ function ChatRows({
         projectId={projectId}
         projectKind={projectKindForTracking}
         conversationId={activeConversationId}
+        currentProjectRoot={resolvedDir}
         projectFiles={projectFiles}
         projectFileNames={projectFileNames}
         onRequestOpenFile={onRequestOpenFile}

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -2423,7 +2423,7 @@ function DesignSystemProjectPanel({
   // "Review <name> design system" does not read redundantly when a system is
   // already named e.g. "Acme Design System".
   const systemDisplayName = system.title.replace(/\s*design system$/i, '').trim() || system.title;
-  const activityFileOps = useMemo(() => deriveFileOps(activityEvents), [activityEvents]);
+  const activityFileOps = useMemo(() => deriveFileOps(activityEvents, { currentProjectRoot: resolvedDir }), [activityEvents, resolvedDir]);
   const activityTodos = useMemo(() => latestTodosFromEvents(activityEvents), [activityEvents]);
   const sectionReviews: DesignSystemProjectSectionReview[] = sections.map((section) => {
     const previewFile = designSystemSectionPreviewFile(section.files, fileByName);

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5391,6 +5391,7 @@ export function ProjectView({
               queuedItems={currentConversationQueuedItems}
               error={conversationLoadError ?? error ?? audioVoiceOptionsError}
               projectId={project.id}
+              resolvedDir={projectDetail.resolvedDir}
               sessionMode={activeSessionMode}
               onSessionModeChange={handleActiveConversationSessionModeChange}
               projectKindForTracking={projectKindToTracking(project.metadata?.kind)}

--- a/apps/web/src/runtime/file-ops.ts
+++ b/apps/web/src/runtime/file-ops.ts
@@ -60,7 +60,27 @@ function mergeStatus(a: FileOpStatus, b: FileOpStatus): FileOpStatus {
   return 'done';
 }
 
-export function deriveFileOps(events: AgentEvent[] | undefined): FileOpEntry[] {
+// Rebase mock/anonymized project paths (e.g. `.../data/projects/proj-001/...`)
+// onto the currently active project root so mock replay tool cards and the
+// daemon artifact counters stay aligned with the real project the user is
+// inspecting. Mirrors `rebaseMockPath` in `apps/daemon/src/run-artifacts.ts`.
+function rebaseMockPath(path: string, currentProjectRoot?: string | null): string {
+  if (!currentProjectRoot || path.startsWith(currentProjectRoot)) return path;
+  const normalizedPath = path.replace(/[\\/]+/g, '/').replace(/\/$/, '');
+  const normalizedRoot =
+    typeof currentProjectRoot === 'string' ? currentProjectRoot.replace(/[\\/]+/g, '/').replace(/\/$/, '') : '';
+  if (!normalizedRoot) return path;
+  const match = normalizedPath.match(/^(.*\/projects\/)([^/]+)(\/.*)$/);
+  if (!match) return path;
+  const projectDir = normalizedRoot.split('/').pop();
+  if (!projectDir || !/^proj-\d+$/i.test(match[2])) return path;
+  return `${match[1]}${projectDir}${match[3]}`;
+}
+
+export function deriveFileOps(
+  events: AgentEvent[] | undefined,
+  opts?: { currentProjectRoot?: string | null },
+): FileOpEntry[] {
   if (!events || events.length === 0) return [];
   const resultByToolId = new Map<
     string,
@@ -75,8 +95,9 @@ export function deriveFileOps(events: AgentEvent[] | undefined): FileOpEntry[] {
     if (ev.kind !== 'tool_use') continue;
     const kind = classify(ev.name);
     if (!kind) continue;
-    const fullPath = extractPath(ev.input);
-    if (!fullPath || fullPath === '(unnamed)') continue;
+    const rawPath = extractPath(ev.input);
+    if (!rawPath || rawPath === '(unnamed)') continue;
+    const fullPath = rebaseMockPath(rawPath, opts?.currentProjectRoot);
     const result = resultByToolId.get(ev.id);
     const status: FileOpStatus =
       result == null ? 'running' : result.isError ? 'error' : 'done';


### PR DESCRIPTION
Resolves #3604

Root cause:
Mock replay tool traces use anonymized project directory names such as `proj-001`, `proj-002`, etc. (see `mocks/README.md`). Both the daemon-side artifact inspector (`apps/daemon/src/run-artifacts.ts`) and the web-side tool-card aggregator (`apps/web/src/runtime/file-ops.ts`) previously treated these recorded paths as literal writes, which let mock runs score `artifact_write_seen`/artifact counts against a stale project identity and left the active project file panels empty.

Fix:
- Added a small path rebase pass that detects `proj-<digits>` project directories inside tool paths and swaps them for the currently active project directory name before the path is used for counting or rendering.
- Wired the active project root through the daemon run artifact counters via `resolveProjectDir` in `apps/daemon/src/server.ts`.
- Wired the active project root through the web tool-card pipeline via existing `resolvedDir`/props from `ProjectView` -> `ChatPane` -> `AssistantMessage` and `FileWorkspace`.

Scope / regression guard:
- Pure path normalisation; no tool-name, event-shape, or UI layout changes.
- The rebase only fires when the extracted path contains a recognizable anonymous project ID and is not already inside the current project root, so real project flows are unaffected.
- Existing call sites (`countNewHtmlArtifacts`, `didRunCreateDesignSystemFile`, `countDesignSystemPreviewModules`, `deriveFileOps`) keep their previous signatures for backward compatibility via optional `projectRoot`/ `currentProjectRoot` options.