### PR TITLE
fix(web): use persisted slideCount from metadata for simple deck defaults

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -190,7 +190,7 @@ function defaultPluginInputsForCreate(
       deckType: 'pitch deck',
       topic: projectName || 'the user brief',
       audience: 'decision makers',
-      slideCount: '10-15 pages',
+      slideCount: input.metadata.slideCount ?? '10-15 pages',
       speakerNotes: input.metadata.speakerNotes
         ? 'include speaker notes'
         : 'no speaker notes',


### PR DESCRIPTION
## Summary

Home Simple Deck projects persisted the user’s page-count selection in project metadata and plugin snapshot inputs, but `defaultPluginInputsForCreate()` always returned a hard-coded `'10-15 pages'` value. That meant the create-modal/default-project path ignored the user’s actual selection.

## Changes

- `apps/web/src/components/EntryShell.tsx`: read `input.metadata.slideCount` when present; keep `'10-15 pages'` as a fallback only when metadata has no value.

## Notes

This fixes #3565 for the default/create path. The generation-prompt constraint injection path for existing projects (where the user submits from the Home picker) is a separate follow-up.

Closes #3565