### PR TITLE
fix(web): respond to scroll-wheel on preview frames to update zoom level

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,49 +1,21 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
-import { createPortal } from 'react-dom';
-import { Button, Input, Select } from '@open-design/components';
-import { APP_CHROME_FILE_ACTIONS_ID, APP_CHROME_FILE_ACTIONS_SELECTOR } from './AppChromeHeader';
-import {
-  buildSocialSharePayload,
-  OPEN_DESIGN_GITHUB_REPO_URL,
-  type SocialShareRequest,
-  type SocialShareResponse,
-} from '@open-design/contracts';
-import {
-  anonymizeArtifactId,
-  artifactKindToTracking,
-  type TrackingProjectKind,
-} from '@open-design/contracts/analytics';
-import { useAnalytics } from '../analytics/provider';
-import { trackIframeLoad } from '../observability/iframe-error';
-import {
-  trackArtifactExportResult,
-  trackArtifactHeaderClick,
-  trackArtifactToolbarClick,
-  trackCommentPopoverClick,
-  trackPageView,
-  trackPresentPopoverClick,
-  trackShareOptionPopoverClick,
-} from '../analytics/events';
+import { useEffect, useId, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
 import { MarkdownRenderer, artifactRendererRegistry } from '../artifacts/renderer-registry';
 import { renderMarkdownToSafeHtml } from '../artifacts/markdown';
-import { useT, useI18n } from '../i18n';
-import type { Dict, Locale } from '../i18n/types';
+import { useT } from '../i18n';
+import type { Dict } from '../i18n/types';
 import {
   fetchLiveArtifact,
   fetchLiveArtifactCode,
   fetchLiveArtifactRefreshes,
   checkDeploymentLink,
   CLOUDFLARE_PAGES_PROVIDER_ID,
-  createSocialSharePayload,
   DEFAULT_DEPLOY_PROVIDER_ID,
   deployProjectFile,
   fetchCloudflarePagesZones,
   fetchDeployConfig,
   fetchProjectDeployments,
   fetchProjectFilePreview,
-  fetchProjectFiles,
   fetchProjectFileText,
-  uploadProjectFiles,
   liveArtifactPreviewUrl,
   projectFileUrl,
   projectRawUrl,
@@ -57,39 +29,21 @@ import {
   type WebDeployProviderId,
   type WebUpdateDeployConfigRequest,
   writeProjectTextFile,
-  writeProjectTextFileDetailed,
 } from '../providers/registry';
 import type { ProjectFilePreview } from '../providers/registry';
 import {
-  downloadImageDataUrl,
   exportAsHtml,
   exportAsJsx,
   exportAsMd,
   exportAsPdf,
-  exportProjectAsPdf,
   exportProjectAsZip,
-  copyImageDataUrlToClipboard,
   exportReactComponentAsHtml,
   exportReactComponentAsZip,
-  captureHostIframeSnapshot,
-  imageDataUrlToBlob,
   openSandboxedPreviewInNewTab,
-  prepareImageExportTarget,
-  requestPreviewSnapshot,
-  type ImageExportFormat,
 } from '../runtime/exports';
-import { copyToClipboard } from '../lib/copy-to-clipboard';
 import { buildReactComponentSrcdoc } from '../runtime/react-component';
-import { shouldConsumeSlideNav } from '../runtime/slide-nav';
-import { findHtmlEntriesReferencing } from '../runtime/jsx-module-refs';
-import { buildLazySrcdocTransport, buildSrcdoc, canActivateSrcDocTransport } from '../runtime/srcdoc';
-import {
-  hasUrlModeBridge,
-  htmlNeedsFocusGuard,
-  htmlNeedsSandboxShim,
-  parseForceInline,
-  shouldUrlLoadHtmlPreview,
-} from './file-viewer-render-mode';
+import { buildSrcdoc } from '../runtime/srcdoc';
+import { parseForceInline, shouldUrlLoadHtmlPreview } from './file-viewer-render-mode';
 import { saveTemplate } from '../state/projects';
 import type {
   LiveArtifactEventItem,
@@ -100,91 +54,34 @@ import type {
   ProjectFile,
 } from '../types';
 import { Icon } from './Icon';
-import { RemixIcon } from './RemixIcon';
-import { SocialShareGrid } from './SocialShareGrid';
-import { Toast } from './Toast';
-import { PreviewDrawOverlay } from './PreviewDrawOverlay';
 import {
   buildBoardCommentAttachments,
-  commentSnapshotEqual,
-  commentTargetDisplayName,
-  commentVisibleOnDeckSlide,
-  commentsToAttachments,
-  isValidCommentOverlayPosition,
-  liveCommentTargetMapsEqual,
   liveSnapshotForComment,
   overlayBoundsFromSnapshot,
   selectionKindLabel,
   targetFromSnapshot,
   type PreviewCommentSnapshot,
 } from '../comments';
-import { applyPodMemberRemoval } from '../lib/pod-members';
-import { AnnotationHoverPopover, BoardComposerPopover } from './BoardComposerPopover';
-import {
-  OD_PREVIEW_KEEP_ALIVE,
-  PooledIframe,
-  previewIframeKeepAliveKey,
-} from './IframeKeepAlivePool';
 import type {
   ChatCommentAttachment,
   PreviewComment,
-  PreviewCommentAttachment,
   PreviewCommentMember,
   PreviewCommentTarget,
 } from '../types';
 import { ManualEditPanel, emptyManualEditDraft, type ManualEditDraft } from './ManualEditPanel';
 import {
   applyManualEditPatch,
-  isManualEditFullHtmlDocument,
   readManualEditAttributes,
   readManualEditFields,
   readManualEditOuterHtml,
   readManualEditStyles,
 } from '../edit-mode/source-patches';
-import { MANUAL_EDIT_STYLE_PROPS, type ManualEditBridgeMessage, type ManualEditHistoryEntry, type ManualEditPatch, type ManualEditStyles, type ManualEditTarget } from '../edit-mode/types';
-import { isRenderableSketchJson, SketchPreview } from './SketchPreview';
-
-function resolveChromeActionsHost(): HTMLElement | null {
-  return document.querySelector<HTMLElement>(APP_CHROME_FILE_ACTIONS_SELECTOR)
-    ?? document.getElementById(APP_CHROME_FILE_ACTIONS_ID);
-}
+import type { ManualEditBridgeMessage, ManualEditHistoryEntry, ManualEditPatch, ManualEditTarget } from '../edit-mode/types';
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 type SlideState = { active: number; count: number };
 type BoardTool = 'inspect' | 'pod';
 type StrokePoint = { x: number; y: number };
-export type ManualEditPendingStyleSave = {
-  id: string;
-  styles: Partial<ManualEditStyles>;
-  label: string;
-  version: number;
-};
-type PreviewViewportId = 'desktop' | 'tablet' | 'mobile';
-type PreviewCanvasSize = { width: number; height: number; scrollLeft?: number; scrollTop?: number };
-type CommentPreviewCanvasOptions = {
-  boardMode: boolean;
-  sidePanelCollapsed: boolean;
-  viewport?: PreviewViewportId;
-};
-type PreviewScaleOptions = {
-  canvasPadding?: number;
-};
-type PreviewViewportPreset = {
-  id: PreviewViewportId;
-  width: number | null;
-  height: number | null;
-  labelKey: keyof Dict;
-  titleKey: keyof Dict;
-};
-const IMAGE_EXPORT_FORMAT_OPTIONS: Array<{
-  value: ImageExportFormat;
-  label: string;
-  extension: string;
-}> = [
-  { value: 'png', label: 'PNG', extension: '.png' },
-  { value: 'jpeg', label: 'JPEG', extension: '.jpg' },
-  { value: 'webp', label: 'WebP', extension: '.webp' },
-];
 type DeployProviderOption = {
   id: WebDeployProviderId;
   labelKey: 'fileViewer.vercelProvider' | 'fileViewer.cloudflarePagesProvider';
@@ -195,6 +92,7 @@ type DeployProviderOption = {
     | 'fileViewer.cloudflareApiTokenPlaceholder';
   tokenReuseHintKey: 'fileViewer.vercelTokenReuseHint' | 'fileViewer.cloudflareApiTokenReuseHint';
   tokenRequiredKey: 'fileViewer.vercelTokenRequired' | 'fileViewer.cloudflareApiTokenRequired';
+  previewHintKey: 'fileViewer.vercelPreviewOnly' | 'fileViewer.cloudflarePagesPreviewHint';
   tokenLabelKey:
     | 'fileViewer.vercelToken'
     | 'fileViewer.cloudflareApiToken';
@@ -215,49 +113,6 @@ type DeployResultCard = {
   message?: string;
 };
 const MAX_BRIDGE_COORDINATE = 1_000_000;
-const PREVIEW_VIEWPORT_PRESETS: PreviewViewportPreset[] = [
-  {
-    id: 'desktop',
-    width: null,
-    height: null,
-    labelKey: 'fileViewer.viewportDesktop',
-    titleKey: 'fileViewer.viewportDesktopTitle',
-  },
-  {
-    id: 'tablet',
-    width: 820,
-    height: 1180,
-    labelKey: 'fileViewer.viewportTablet',
-    titleKey: 'fileViewer.viewportTabletTitle',
-  },
-  {
-    id: 'mobile',
-    width: 390,
-    height: 844,
-    labelKey: 'fileViewer.viewportMobile',
-    titleKey: 'fileViewer.viewportMobileTitle',
-  },
-];
-
-function previewViewportIcon(viewport: PreviewViewportId): string {
-  if (viewport === 'tablet') return 'tablet-line';
-  if (viewport === 'mobile') return 'smartphone-line';
-  return 'computer-line';
-}
-
-const EXPORT_READY_NUDGE_STORAGE_PREFIX = 'open-design:export-ready-nudge:';
-const COMMENT_SIDE_DOCK_WIDTH = 320;
-const COMMENT_SIDE_DOCK_RAIL_WIDTH = 42;
-const COMMENT_SIDE_DOCK_GAP = 12;
-const COMMENT_SIDE_DOCK_PADDING = 8;
-const COMMENT_SIDE_DOCK_NON_DESKTOP_PADDING = 24;
-const COMMENT_SIDE_DOCK_MIN_CANVAS_WIDTH = 280;
-const COMMENT_SIDE_DOCK_STACKED_PANEL_HEIGHT = 220;
-const COMMENT_SIDE_DOCK_STACKED_RAIL_HEIGHT = 48;
-const COMMENT_SIDE_DOCK_STACKED_HEIGHT_DEDUCTION =
-  (COMMENT_SIDE_DOCK_PADDING * 2) + COMMENT_SIDE_DOCK_GAP + COMMENT_SIDE_DOCK_STACKED_PANEL_HEIGHT;
-const COMMENT_SIDE_DOCK_STACKED_COLLAPSED_HEIGHT_DEDUCTION =
-  (COMMENT_SIDE_DOCK_PADDING * 2) + COMMENT_SIDE_DOCK_GAP + COMMENT_SIDE_DOCK_STACKED_RAIL_HEIGHT;
 
 // The five basic style facets the inspect panel exposes. Kept narrow on
 // purpose — open-slide's design tokens panel only edits global tokens, so
@@ -278,29 +133,16 @@ type InspectStyleSnapshot = {
   lineHeight?: string;
 };
 
-type InspectClickedDescendant = {
-  label: string;
-  text: string;
-};
-
 type InspectTarget = {
   elementId: string;
   selector: string;
   label: string;
   text: string;
   style: InspectStyleSnapshot;
-  clickedDescendant?: InspectClickedDescendant;
 };
 
 const MAX_CACHED_SLIDE_STATES = 64;
 const htmlPreviewSlideState = new Map<string, SlideState>();
-const MAX_CACHED_PREVIEW_VIEWPORTS = 128;
-// Grace window before the inspect hover card is torn down. Long enough to absorb
-// the async iframe mouseout (od:comment-leave) that fires when the pointer slides
-// onto the card or hops back onto the element under it, short enough to read as
-// an immediate dismiss when the pointer really leaves.
-const HOVER_CARD_DISMISS_DELAY_MS = 80;
-const htmlPreviewViewportState = new Map<string, PreviewViewportId>();
 const MARKDOWN_CODE_BLOCK_ATTR = 'data-markdown-code-block';
 const MARKDOWN_COPY_BLOCK_ATTR = 'data-copy-code-block';
 const MARKDOWN_COPY_BUTTON_CLASS = 'markdown-code-copy';
@@ -315,6 +157,7 @@ const DEPLOY_PROVIDER_OPTIONS: DeployProviderOption[] = [
     tokenPlaceholderKey: 'fileViewer.vercelTokenPlaceholder',
     tokenReuseHintKey: 'fileViewer.vercelTokenReuseHint',
     tokenRequiredKey: 'fileViewer.vercelTokenRequired',
+    previewHintKey: 'fileViewer.vercelPreviewOnly',
     tokenLabelKey: 'fileViewer.vercelToken',
   },
   {
@@ -325,62 +168,12 @@ const DEPLOY_PROVIDER_OPTIONS: DeployProviderOption[] = [
     tokenPlaceholderKey: 'fileViewer.cloudflareApiTokenPlaceholder',
     tokenReuseHintKey: 'fileViewer.cloudflareApiTokenReuseHint',
     tokenRequiredKey: 'fileViewer.cloudflareApiTokenRequired',
+    previewHintKey: 'fileViewer.cloudflarePagesPreviewHint',
     tokenLabelKey: 'fileViewer.cloudflareApiToken',
     accountIdLabelKey: 'fileViewer.cloudflareAccountId',
     accountIdHintKey: 'fileViewer.cloudflareAccountIdHint',
   },
 ];
-
-function mergeManualEditInspectorStyles(
-  sourceStyles: ManualEditStyles,
-  previewStyles: ManualEditStyles,
-): ManualEditStyles {
-  return MANUAL_EDIT_STYLE_PROPS.reduce<ManualEditStyles>((acc, key) => {
-    const sourceValue = sourceStyles[key]?.trim();
-    const previewValue = previewStyles[key]?.trim();
-    const value = sourceValue || previewValue || '';
-    acc[key] = manualEditInspectorStyleValue(key, value);
-    return acc;
-  }, {} as ManualEditStyles);
-}
-
-function manualEditInspectorStyleValue(key: keyof ManualEditStyles, value: string): string {
-  if (!value) return '';
-  if (key === 'color' || key === 'backgroundColor' || key === 'borderColor') {
-    return normalizeManualEditInspectorColor(value);
-  }
-  return value;
-}
-
-function normalizeManualEditInspectorColor(value: string): string {
-  const trimmed = value.trim();
-  if (/^#[0-9a-f]{6}$/i.test(trimmed)) return trimmed.toLowerCase();
-  if (/^#[0-9a-f]{3}$/i.test(trimmed)) {
-    const r = trimmed[1]!, g = trimmed[2]!, b = trimmed[3]!;
-    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
-  }
-  const rgba = trimmed.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i);
-  if (!rgba) return trimmed;
-  if (rgba[4] !== undefined && Number(rgba[4]) === 0) return '';
-  const toHex = (raw: string) => Math.max(0, Math.min(255, Math.round(Number(raw))))
-    .toString(16)
-    .padStart(2, '0');
-  return `#${toHex(rgba[1]!)}${toHex(rgba[2]!)}${toHex(rgba[3]!)}`;
-}
-
-function manualEditPersistedValueMatchesSavedSnapshot(
-  key: keyof ManualEditStyles,
-  persistedValue: string,
-  savedValue: string,
-): boolean {
-  return canonicalManualEditStyleValue(key, persistedValue) === canonicalManualEditStyleValue(key, savedValue);
-}
-
-function canonicalManualEditStyleValue(key: keyof ManualEditStyles, value: string): string {
-  const normalized = manualEditInspectorStyleValue(key, value).trim();
-  if (!normalized) return '';
-  return normalized.toLowerCase();
-}
 
 function getDeployProviderOption(providerId: WebDeployProviderId): DeployProviderOption {
   return DEPLOY_PROVIDER_OPTIONS.find((option) => option.id === providerId) ?? DEPLOY_PROVIDER_OPTIONS[0]!;
@@ -400,22 +193,6 @@ function deployResultState(status?: string): 'ready' | 'delayed' | 'protected' |
   if (status === 'failed' || status === 'conflict') return 'failed';
   if (status === 'link-delayed' || status === 'pending') return 'delayed';
   return 'ready';
-}
-
-function publicShareUrlForDeployment(deployment?: WebDeploymentInfo | null): string {
-  if (!deployment) return '';
-  const cloudflare = deployment.cloudflarePages;
-  const customDomainUrl = cloudflare?.customDomain?.status === 'ready'
-    ? cloudflare.customDomain.url?.trim()
-    : '';
-  if (customDomainUrl) return customDomainUrl;
-  const pagesDevUrl = cloudflare?.pagesDev?.status === 'ready'
-    ? cloudflare.pagesDev.url?.trim()
-    : '';
-  if (pagesDevUrl) return pagesDevUrl;
-  return deployResultState(deployment.status) === 'ready'
-    ? deployment.url?.trim() || ''
-    : '';
 }
 
 async function copyTextToClipboard(text: string): Promise<boolean> {
@@ -481,373 +258,6 @@ function setMarkdownCodeBlockCopiedState(block: HTMLElement, copied: boolean, t:
   existingToast?.remove();
 }
 
-function PreviewViewportControls({
-  viewport,
-  onViewport,
-  t,
-  tabIndex,
-}: {
-  viewport: PreviewViewportId;
-  onViewport: (viewport: PreviewViewportId) => void;
-  t: TranslateFn;
-  tabIndex?: number;
-}) {
-  const [open, setOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const listboxId = useId();
-  const activePreset =
-    PREVIEW_VIEWPORT_PRESETS.find((preset) => preset.id === viewport) ?? PREVIEW_VIEWPORT_PRESETS[0]!;
-
-  useEffect(() => {
-    if (!open) return;
-    const onPointerDown = (event: PointerEvent) => {
-      if (!menuRef.current) return;
-      if (!menuRef.current.contains(event.target as Node)) setOpen(false);
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(false);
-    };
-    document.addEventListener('pointerdown', onPointerDown);
-    document.addEventListener('keydown', onKeyDown);
-    return () => {
-      document.removeEventListener('pointerdown', onPointerDown);
-      document.removeEventListener('keydown', onKeyDown);
-    };
-  }, [open]);
-
-  return (
-    <div className="viewer-viewport-switcher" ref={menuRef}>
-      <button
-        type="button"
-        className={`viewer-action viewer-viewport-trigger${open ? '' : ' od-tooltip'}`}
-        aria-label={t('fileViewer.viewportAria')}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-controls={open ? listboxId : undefined}
-        title={t(activePreset.titleKey)}
-        data-tooltip={open ? undefined : t(activePreset.titleKey)}
-        data-tooltip-placement="bottom"
-        tabIndex={tabIndex}
-        onClick={() => setOpen((value) => !value)}
-      >
-        <RemixIcon
-          name={previewViewportIcon(activePreset.id)}
-          size={14}
-          className="viewer-viewport-icon"
-        />
-        <span>{t(activePreset.labelKey)}</span>
-        <RemixIcon name="arrow-down-s-line" size={14} />
-      </button>
-      {open ? (
-        <div className="viewer-viewport-menu" id={listboxId} role="listbox" aria-label={t('fileViewer.viewportAria')}>
-          {PREVIEW_VIEWPORT_PRESETS.map((preset) => {
-            const selected = viewport === preset.id;
-            return (
-              <button
-                key={preset.id}
-                type="button"
-                className={`viewer-viewport-menu-item${selected ? ' active' : ''}`}
-                role="option"
-                aria-selected={selected}
-                title={t(preset.titleKey)}
-                onClick={() => {
-                  onViewport(preset.id);
-                  setOpen(false);
-                }}
-              >
-                <span className="viewer-viewport-menu-label">
-                  <RemixIcon name={previewViewportIcon(preset.id)} size={14} />
-                  <span>{t(preset.labelKey)}</span>
-                </span>
-                {selected ? <Icon name="check" size={13} /> : null}
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function previewViewportStyle(
-  viewport: PreviewViewportId,
-  previewScale = 1,
-  canvasSize?: PreviewCanvasSize,
-  options?: PreviewScaleOptions,
-): CSSProperties & Record<string, string | number> {
-  const preset = PREVIEW_VIEWPORT_PRESETS.find((item) => item.id === viewport) ?? PREVIEW_VIEWPORT_PRESETS[0]!;
-  if (!preset.width) return {};
-  const effectiveScale = effectivePreviewScale(viewport, previewScale, canvasSize, options);
-  return {
-    '--preview-viewport-width': `${preset.width}px`,
-    '--preview-viewport-height': `${preset.height}px`,
-    '--preview-scale': effectiveScale,
-    '--preview-user-scale': previewScale,
-  };
-}
-
-export function commentPreviewCanvasSize(
-  canvasSize: PreviewCanvasSize | undefined,
-  options: CommentPreviewCanvasOptions,
-): PreviewCanvasSize | undefined {
-  if (!canvasSize || !options.boardMode) return canvasSize;
-  const dockPadding = options.viewport && options.viewport !== 'desktop'
-    ? COMMENT_SIDE_DOCK_NON_DESKTOP_PADDING
-    : COMMENT_SIDE_DOCK_PADDING;
-  const sideDockWidth = options.sidePanelCollapsed ? COMMENT_SIDE_DOCK_RAIL_WIDTH : COMMENT_SIDE_DOCK_WIDTH;
-  const dockedWidth = canvasSize.width - (dockPadding * 2) - COMMENT_SIDE_DOCK_GAP - sideDockWidth;
-  if (usesStackedCommentSideDock(canvasSize, options)) {
-    const stackedHeightDeduction = options.sidePanelCollapsed
-      ? COMMENT_SIDE_DOCK_STACKED_COLLAPSED_HEIGHT_DEDUCTION
-      : COMMENT_SIDE_DOCK_STACKED_HEIGHT_DEDUCTION;
-    return {
-      width: Math.max(1, canvasSize.width - (COMMENT_SIDE_DOCK_PADDING * 2)),
-      height: Math.max(1, canvasSize.height - stackedHeightDeduction),
-    };
-  }
-  return {
-    width: Math.max(1, dockedWidth),
-    height: Math.max(1, canvasSize.height - (dockPadding * 2)),
-  };
-}
-
-function usesStackedCommentSideDock(
-  canvasSize: PreviewCanvasSize | undefined,
-  options: CommentPreviewCanvasOptions,
-) {
-  if (!canvasSize || !options.boardMode) return false;
-  const dockPadding = options.viewport && options.viewport !== 'desktop'
-    ? COMMENT_SIDE_DOCK_NON_DESKTOP_PADDING
-    : COMMENT_SIDE_DOCK_PADDING;
-  const sideDockWidth = options.sidePanelCollapsed ? COMMENT_SIDE_DOCK_RAIL_WIDTH : COMMENT_SIDE_DOCK_WIDTH;
-  const dockedWidth = canvasSize.width - (dockPadding * 2) - COMMENT_SIDE_DOCK_GAP - sideDockWidth;
-  return dockedWidth < COMMENT_SIDE_DOCK_MIN_CANVAS_WIDTH;
-}
-
-export function effectivePreviewScale(
-  viewport: PreviewViewportId,
-  previewScale: number,
-  canvasSize?: PreviewCanvasSize,
-  options?: PreviewScaleOptions,
-) {
-  if (viewport === 'desktop') return previewScale;
-  const preset = PREVIEW_VIEWPORT_PRESETS.find((item) => item.id === viewport);
-  if (!preset?.width || !preset.height || !canvasSize?.width || !canvasSize.height) return previewScale;
-  const canvasPadding = options?.canvasPadding ?? 48;
-  const availableWidth = Math.max(1, canvasSize.width - canvasPadding);
-  const availableHeight = Math.max(1, canvasSize.height - canvasPadding);
-  const fitScale = Math.min(1, availableWidth / preset.width, availableHeight / preset.height);
-  return Math.min(previewScale, fitScale);
-}
-
-type PreviewOverlayTransform = { scale: number; offsetX: number; offsetY: number };
-
-export function previewOverlayTransform(
-  viewport: PreviewViewportId,
-  previewScale: number,
-  canvasSize?: PreviewCanvasSize,
-): PreviewOverlayTransform {
-  const scale = effectivePreviewScale(viewport, previewScale, canvasSize);
-  if (viewport === 'desktop') return { scale, offsetX: 0, offsetY: 0 };
-  const preset = PREVIEW_VIEWPORT_PRESETS.find((item) => item.id === viewport);
-  const pad = 24;
-  if (!preset?.width || !preset.height) return { scale, offsetX: pad, offsetY: pad };
-  const availableWidth = Math.max(1, (canvasSize?.width ?? preset.width * scale + pad * 2) - pad * 2);
-  const scaledWidth = preset.width * scale;
-  return {
-    scale,
-    offsetX: pad + Math.max(0, (availableWidth - scaledWidth) / 2),
-    offsetY: pad,
-  };
-}
-
-function previewScaleShellStyle(
-  viewport: PreviewViewportId,
-  previewScale: number,
-): CSSProperties & Record<string, string | number> {
-  if (viewport === 'desktop') {
-    return {
-      width: `${100 / previewScale}%`,
-      height: `${100 / previewScale}%`,
-      transform: `scale(${previewScale})`,
-      transformOrigin: '0 0',
-    };
-  }
-  return {
-    width: 'var(--preview-viewport-width)',
-    height: 'var(--preview-viewport-height)',
-    transform: 'scale(var(--preview-scale, 1))',
-    transformOrigin: '0 0',
-  };
-}
-
-function manualEditPreviewShellStyle(
-  viewport: PreviewViewportId,
-  previewScale: number,
-  frozenWidth: number | null,
-): CSSProperties & Record<string, string | number> {
-  if (viewport === 'desktop' && frozenWidth) {
-    return {
-      width: `${frozenWidth / previewScale}px`,
-      height: `${100 / previewScale}%`,
-      transform: `scale(${previewScale})`,
-      transformOrigin: '0 0',
-    };
-  }
-  return previewScaleShellStyle(viewport, previewScale);
-}
-
-function deploymentTimestamp(deployment: WebDeploymentInfo): number {
-  const maybeDeployedAt = (deployment as WebDeploymentInfo & { deployedAt?: number | string }).deployedAt;
-  const candidates = [maybeDeployedAt, deployment.updatedAt, deployment.createdAt];
-  for (const candidate of candidates) {
-    if (typeof candidate === 'number' && Number.isFinite(candidate)) return candidate;
-    if (typeof candidate === 'string') {
-      const parsed = Date.parse(candidate);
-      if (Number.isFinite(parsed)) return parsed;
-    }
-  }
-  return 0;
-}
-
-function compareDeploymentsByNewest(a: WebDeploymentInfo, b: WebDeploymentInfo): number {
-  return deploymentTimestamp(b) - deploymentTimestamp(a);
-}
-
-function shareUrlForDeployment(deployment: WebDeploymentInfo): string {
-  const customDomain = deployment.providerId === CLOUDFLARE_PAGES_PROVIDER_ID
-    ? deployment.cloudflarePages?.customDomain
-    : undefined;
-  if (customDomain?.status === 'ready' && customDomain.url?.trim()) {
-    return customDomain.url.trim();
-  }
-  return deployment.url?.trim() || '';
-}
-
-function resolveShareUrl(rawUrl: string): string {
-  const trimmed = rawUrl.trim();
-  if (!trimmed) return '';
-  if (/^https?:\/\//i.test(trimmed)) return trimmed;
-  if (typeof window === 'undefined') return trimmed;
-  return new URL(trimmed, window.location.origin).toString();
-}
-
-function pickLatestShareDeployment(
-  deploymentsByProvider: Partial<Record<WebDeployProviderId, WebDeploymentInfo>>,
-): WebDeploymentInfo | null {
-  return Object.values(deploymentsByProvider)
-    .filter((deployment): deployment is WebDeploymentInfo =>
-      Boolean(deployment && shareUrlForDeployment(deployment) && deployResultState(deployment.status) !== 'failed'))
-    .sort(compareDeploymentsByNewest)[0] ?? null;
-}
-
-function manualEditFloatingPanelStyle(
-  target: ManualEditTarget,
-  previewScale: number,
-  canvasSize: PreviewCanvasSize | undefined,
-): CSSProperties {
-  const scale = Number.isFinite(previewScale) && previewScale > 0 ? previewScale : 1;
-  const panelWidth = 320;
-  const preferredPanelHeight = 380;
-  const pad = 12;
-  const canvasWidth = canvasSize?.width ?? 1200;
-  const canvasHeight = canvasSize?.height ?? 800;
-  const panelHeight = Math.min(preferredPanelHeight, Math.max(260, canvasHeight - pad * 2));
-  const targetLeft = target.rect.x * scale;
-  const targetTop = target.rect.y * scale;
-  const targetRight = (target.rect.x + target.rect.width) * scale;
-  let left = targetRight + pad;
-  if (left + panelWidth > canvasWidth - pad) {
-    left = Math.max(pad, targetLeft - panelWidth - pad);
-  }
-  const top = Math.max(
-    pad,
-    Math.min(targetTop, Math.max(pad, canvasHeight - panelHeight - pad)),
-  );
-  // Height is left to the content (auto): a short inspector (e.g. typography
-  // only) should be a compact card, not a tall half-empty panel. The cap only
-  // engages for long inspectors, at which point the scroll body takes over.
-  return {
-    left,
-    top,
-    width: panelWidth,
-    maxHeight: panelHeight,
-  };
-}
-
-// Anchors the hover "edit params" affordance to the top-right corner of the
-// hovered element, just inside its bounds so moving the cursor from the
-// element onto the icon does not drop the hover. Uses the same iframe→canvas
-// coordinate basis as the floating inspector panel.
-function manualEditHoverIconStyle(
-  target: ManualEditTarget,
-  previewScale: number,
-  canvasSize: PreviewCanvasSize | undefined,
-): CSSProperties {
-  const scale = Number.isFinite(previewScale) && previewScale > 0 ? previewScale : 1;
-  const iconSize = 26;
-  const inset = 4;
-  const canvasWidth = canvasSize?.width ?? 1200;
-  const canvasHeight = canvasSize?.height ?? 800;
-  const targetTop = target.rect.y * scale;
-  const targetRight = (target.rect.x + target.rect.width) * scale;
-  const left = Math.max(
-    inset,
-    Math.min(targetRight - iconSize - inset, canvasWidth - iconSize - inset),
-  );
-  const top = Math.max(
-    inset,
-    Math.min(targetTop + inset, canvasHeight - iconSize - inset),
-  );
-  return { left, top, width: iconSize, height: iconSize };
-}
-
-export function cancelManualEditPendingStyleSnapshot(
-  pending: ManualEditPendingStyleSave | null,
-  id: string,
-  keys: Array<keyof ManualEditStyles>,
-): ManualEditPendingStyleSave | null {
-  if (!pending || pending.id !== id || keys.length === 0) return pending;
-  const nextStyles = { ...pending.styles };
-  for (const key of keys) delete nextStyles[key];
-  if (Object.keys(nextStyles).length === 0) return null;
-  return { ...pending, styles: nextStyles };
-}
-
-function usePreviewCanvasSize<T extends HTMLElement>() {
-  const ref = useRef<T | null>(null);
-  const [size, setSize] = useState<PreviewCanvasSize | undefined>(undefined);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const measure = () => {
-      const rect = el.getBoundingClientRect();
-      setSize({
-        width: rect.width,
-        height: rect.height,
-        scrollLeft: el.scrollLeft,
-        scrollTop: el.scrollTop,
-      });
-    };
-    measure();
-    let observer: ResizeObserver | null = null;
-    if (typeof ResizeObserver !== 'undefined') {
-      observer = new ResizeObserver(measure);
-      observer.observe(el);
-    }
-    el.addEventListener('scroll', measure, { passive: true });
-    window.addEventListener('resize', measure);
-    return () => {
-      observer?.disconnect();
-      el.removeEventListener('scroll', measure);
-      window.removeEventListener('resize', measure);
-    };
-  }, []);
-
-  return [ref, size] as const;
-}
-
 function ensureMarkdownCodeBlockControls(root: HTMLElement, t: TranslateFn) {
   for (const block of root.querySelectorAll<HTMLElement>(`[${MARKDOWN_CODE_BLOCK_ATTR}]`)) {
     let button = block.querySelector<HTMLButtonElement>(`.${MARKDOWN_COPY_BUTTON_CLASS}`);
@@ -871,172 +281,57 @@ function setSlideStateCached(key: string, state: SlideState) {
   }
 }
 
-function waitForIframeLoadOrTimeout(iframe: HTMLIFrameElement, timeout = 750): Promise<void> {
-  return new Promise((resolve) => {
-    let settled = false;
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      iframe.removeEventListener('load', finish);
-      window.clearTimeout(timer);
-      resolve();
-    };
-    const timer = window.setTimeout(finish, timeout);
-    iframe.addEventListener('load', finish, { once: true });
-  });
-}
-
-function waitForAnimationFrame(): Promise<void> {
-  return new Promise((resolve) => {
-    if (typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(() => resolve());
-      return;
-    }
-    window.setTimeout(resolve, 0);
-  });
-}
-
-function temporarilyExposeIframeForSnapshot(iframe: HTMLIFrameElement): () => void {
-  const previousVisibility = iframe.style.visibility;
-  const previousOpacity = iframe.style.opacity;
-  const previousPointerEvents = iframe.style.pointerEvents;
-  iframe.style.visibility = 'visible';
-  iframe.style.opacity = '0.001';
-  iframe.style.pointerEvents = 'none';
-  return () => {
-    iframe.style.visibility = previousVisibility;
-    iframe.style.opacity = previousOpacity;
-    iframe.style.pointerEvents = previousPointerEvents;
-  };
-}
-
-async function requestPreviewSnapshotWithRetry(iframe: HTMLIFrameElement): Promise<Awaited<ReturnType<typeof requestPreviewSnapshot>>> {
-  const timeouts = [1500, 3000, 6000];
-  for (const timeout of timeouts) {
-    const snapshot = await requestPreviewSnapshot(iframe, timeout);
-    if (snapshot) return snapshot;
-    await waitForAnimationFrame();
-  }
-  return null;
-}
-
-function previewViewportStateKey(projectId: string, file: Pick<ProjectFile, 'name' | 'path'>): string {
-  return `${projectId}:${file.path || file.name}`;
-}
-
-function setPreviewViewportCached(key: string, viewport: PreviewViewportId) {
-  htmlPreviewViewportState.set(key, viewport);
-  if (htmlPreviewViewportState.size > MAX_CACHED_PREVIEW_VIEWPORTS) {
-    const oldest = htmlPreviewViewportState.keys().next().value;
-    if (oldest != null) htmlPreviewViewportState.delete(oldest);
-  }
-}
-
 interface Props {
   projectId: string;
-  projectKind: TrackingProjectKind;
   file: ProjectFile;
   liveHtml?: string;
-  filesRefreshKey?: number;
   isDeck?: boolean;
   onExportAsPptx?: ((fileName: string) => void) | undefined;
   streaming?: boolean;
-  commentQueueOnSend?: boolean;
-  commentSendDisabled?: boolean;
   previewComments?: PreviewComment[];
-  onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean, images?: File[]) => Promise<PreviewComment | null>;
+  onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
-  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[], images?: File[]) => Promise<boolean | void> | boolean | void;
+  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
   onFileSaved?: () => Promise<void> | void;
-  // Open `openName` as a tab (focusing it) and close `closeName` in one
-  // atomic tab-state update. The React module pointer uses this to jump to the
-  // HTML entry that renders a module and drop the dead-end module tab.
-  onOpenFileReplacing?: (openName: string, closeName: string) => void;
-  commentPortalId?: string;
-  onCommentModeChange?: (active: boolean) => void;
-  // Bumped nonce asking this viewer to open its Share/Export menu (chat-side
-  // "Share" next-step action). Only HTML artifacts expose a Share menu.
-  shareRequest?: { nonce: number } | null;
-  // Bumped nonce asking a deck preview to flip to `slideIndex` (a queued chat
-  // send for this file just started processing).
-  slideNavRequest?: { slideIndex: number; nonce: number } | null;
 }
 
 export function FileViewer({
   projectId,
-  projectKind,
   file,
   liveHtml,
-  filesRefreshKey = 0,
   isDeck,
   onExportAsPptx,
   streaming,
-  commentQueueOnSend = false,
-  commentSendDisabled = false,
   previewComments = [],
   onSavePreviewComment,
   onRemovePreviewComment,
   onSendBoardCommentAttachments,
   onFileSaved,
-  onOpenFileReplacing,
-  commentPortalId,
-  onCommentModeChange,
-  shareRequest,
-  slideNavRequest,
 }: Props) {
   const rendererMatch = artifactRendererRegistry.resolve({
     file,
     isDeckHint: Boolean(isDeck),
   });
 
-  // studio_view artifact — fire once per (project, file) pair so the
-  // activation funnel can attribute "user opened the produced artifact"
-  // even when the sub-viewer below is HtmlViewer / MarkdownViewer / etc.
-  // artifact_id is anonymized to satisfy the CSV's no-filename rule.
-  const analytics = useAnalytics();
-  const studioViewKeyRef = useRef<string | null>(null);
-  useEffect(() => {
-    const key = `${projectId}::${file.name}`;
-    if (studioViewKeyRef.current === key) return;
-    studioViewKeyRef.current = key;
-    trackPageView(analytics.track, {
-      page_name: 'artifact',
-    });
-  }, [projectId, projectKind, file.name, file.kind, rendererMatch?.renderer.id, analytics.track]);
-
   if (rendererMatch?.renderer.id === 'html' || rendererMatch?.renderer.id === 'deck-html') {
     return (
       <HtmlViewer
         projectId={projectId}
-        projectKind={projectKind}
         file={file}
         liveHtml={liveHtml}
-        filesRefreshKey={filesRefreshKey}
         isDeck={rendererMatch.renderer.id === 'deck-html'}
         onExportAsPptx={onExportAsPptx}
         streaming={Boolean(streaming)}
-        commentQueueOnSend={commentQueueOnSend}
-        commentSendDisabled={commentSendDisabled}
         previewComments={previewComments}
         onSavePreviewComment={onSavePreviewComment}
         onRemovePreviewComment={onRemovePreviewComment}
         onSendBoardCommentAttachments={onSendBoardCommentAttachments}
         onFileSaved={onFileSaved}
-        commentPortalId={commentPortalId}
-        onCommentModeChange={onCommentModeChange}
-        shareRequest={shareRequest}
-        slideNavRequest={slideNavRequest}
       />
     );
   }
   if (rendererMatch?.renderer.id === 'react-component') {
-    return (
-      <ReactComponentViewer
-        projectId={projectId}
-        file={file}
-        onOpenFileReplacing={onOpenFileReplacing}
-      />
-    );
+    return <ReactComponentViewer projectId={projectId} file={file} />;
   }
   if (rendererMatch?.renderer.id === 'markdown') {
     return <MarkdownViewer projectId={projectId} file={file} />;
@@ -1054,9 +349,6 @@ export function FileViewer({
     return <AudioViewer projectId={projectId} file={file} />;
   }
   if (file.kind === 'sketch') {
-    if (isRenderableSketchJson(file)) {
-      return <SketchViewer projectId={projectId} file={file} />;
-    }
     return <ImageViewer projectId={projectId} file={file} />;
   }
   if (file.kind === 'text' || file.kind === 'code') {
@@ -1091,59 +383,17 @@ export function LiveArtifactViewer({
   const [loading, setLoading] = useState(true);
   const [reloadKey, setReloadKey] = useState(0);
   const [zoom, setZoom] = useState(100);
-  const liveArtifactViewportKey = `${projectId}:live-artifact:${liveArtifact.artifactId}`;
-  const [previewViewport, setPreviewViewportState] = useState<PreviewViewportId>(
-    () => htmlPreviewViewportState.get(liveArtifactViewportKey) ?? 'desktop',
-  );
-  const setPreviewViewport = useCallback((viewport: PreviewViewportId) => {
-    setPreviewViewportCached(liveArtifactViewportKey, viewport);
-    setPreviewViewportState(viewport);
-  }, [liveArtifactViewportKey]);
-  const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [refreshError, setRefreshError] = useState<string | null>(null);
   const [refreshSuccess, setRefreshSuccess] = useState<string | null>(null);
   const [refreshEvents, setRefreshEvents] = useState<LiveArtifactRefreshEvent[]>([]);
   const [refreshHistory, setRefreshHistory] = useState<LiveArtifactRefreshLogEntry[]>([]);
-  const [presentMenuOpen, setPresentMenuOpen] = useState(false);
-  const [zoomMenuOpen, setZoomMenuOpen] = useState(false);
-  const zoomMenuRef = useRef<HTMLDivElement | null>(null);
-  const [inTabPresent, setInTabPresent] = useState(false);
-  const presentWrapRef = useRef<HTMLDivElement | null>(null);
-  const [chromeActionsHost, setChromeActionsHost] = useState<HTMLElement | null>(null);
-  useEffect(() => {
-    if (typeof document === 'undefined') return;
-    setChromeActionsHost(resolveChromeActionsHost());
-  }, []);
-  useEffect(() => {
-    if (!presentMenuOpen) return;
-    const onPointer = (e: MouseEvent) => {
-      const target = e.target as HTMLElement | null;
-      if (!target) return;
-      if (target.closest('.present-wrap')) return;
-      setPresentMenuOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setPresentMenuOpen(false);
-    };
-    document.addEventListener('mousedown', onPointer);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [presentMenuOpen]);
 
   useEffect(() => {
     setRefreshError(null);
     setRefreshSuccess(null);
     setRefreshEvents([]);
   }, [projectId, liveArtifact.artifactId]);
-
-  useEffect(() => {
-    setPreviewViewportState(htmlPreviewViewportState.get(liveArtifactViewportKey) ?? 'desktop');
-  }, [liveArtifactViewportKey]);
 
   useEffect(() => {
     if (!refreshSuccess) return;
@@ -1254,21 +504,9 @@ export function LiveArtifactViewer({
   );
   const previewScale = zoom / 100;
 
-  // Instrument the live-artifact iframe so failed loads — usually a
-  // missing artifact file or a stuck `od://` resolver — surface in
-  // PostHog. iframe load errors don't propagate to window.error, so
-  // observability/install.ts cannot catch them globally.
-  useEffect(() => {
-    if (mode !== 'preview') return undefined;
-    const node = iframeRef.current;
-    if (!node) return undefined;
-    return trackIframeLoad({
-      iframe: node,
-      surface: 'live_artifact_preview',
-      artifactId: liveArtifact.artifactId,
-      projectId,
-    });
-  }, [mode, previewUrl, liveArtifact.artifactId, projectId]);
+  function bumpZoom(delta: number) {
+    setZoom((z) => Math.max(25, Math.min(200, z + delta)));
+  }
 
   async function handleRefresh() {
     if (refreshing) return;
@@ -1306,108 +544,17 @@ export function LiveArtifactViewer({
   const currentRefreshStatus = detail?.refreshStatus ?? liveArtifact.refreshStatus;
   const isRunning = refreshing || currentRefreshStatus === 'running';
 
-  const presentInThisTab = () => {
-    setPresentMenuOpen(false);
-    setMode('preview');
-    setInTabPresent(true);
-  };
-  const presentFullscreen = () => {
-    setPresentMenuOpen(false);
-    setMode('preview');
-    const target = previewBodyRef.current ?? iframeRef.current;
-    if (target?.requestFullscreen) {
-      void target.requestFullscreen().catch(() => {});
-    }
-  };
-  const presentNewTab = () => {
-    setPresentMenuOpen(false);
-    if (typeof window === 'undefined') return;
-    window.open(liveArtifactPreviewUrl(projectId, liveArtifact.artifactId), '_blank', 'noopener,noreferrer');
-  };
-  useEffect(() => {
-    if (!inTabPresent) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setInTabPresent(false);
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [inTabPresent]);
-
-  useEffect(() => {
-    if (!zoomMenuOpen) return;
-    const onDocClick = (e: MouseEvent) => {
-      if (!zoomMenuRef.current) return;
-      if (!zoomMenuRef.current.contains(e.target as Node)) setZoomMenuOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setZoomMenuOpen(false);
-    };
-    document.addEventListener('mousedown', onDocClick);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onDocClick);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [zoomMenuOpen]);
-
   return (
-    <div className={`viewer html-viewer live-artifact-viewer${inTabPresent ? ' is-tab-present' : ''}`}>
-      {((node: ReactNode) => (
-        chromeActionsHost ? createPortal(node, chromeActionsHost) : node
-      ))(
-        <div className="present-wrap chrome-present-wrap" ref={presentWrapRef}>
-          <button
-            className="chrome-action chrome-action-secondary chrome-action-icon present-trigger od-tooltip"
-            aria-haspopup="menu"
-            aria-expanded={presentMenuOpen}
-            aria-label={t('fileViewer.present')}
-            data-tooltip={t('fileViewer.present')}
-            data-tooltip-placement="bottom"
-            title={t('fileViewer.present')}
-            onClick={() => setPresentMenuOpen((v) => !v)}
-          >
-            <RemixIcon name="slideshow-3-line" size={15} />
-          </button>
-          {presentMenuOpen ? (
-            <div className="present-menu" role="menu">
-              <button role="menuitem" onClick={presentInThisTab}>
-                <span className="present-icon"><RemixIcon name="eye-line" size={14} /></span>{' '}
-                {t('fileViewer.presentInTab')}
-              </button>
-              <button role="menuitem" onClick={presentFullscreen}>
-                <span className="present-icon"><RemixIcon name="play-line" size={14} /></span>{' '}
-                {t('fileViewer.presentFullscreen')}
-              </button>
-              <button role="menuitem" onClick={presentNewTab}>
-                <span className="present-icon"><RemixIcon name="share-forward-line" size={14} /></span>{' '}
-                {t('fileViewer.presentNewTab')}
-              </button>
-            </div>
-          ) : null}
-        </div>
-      )}
-      {inTabPresent ? (
-        <button
-          type="button"
-          className="present-exit-btn"
-          onClick={() => setInTabPresent(false)}
-          title={t('common.exitFullscreen')}
-          aria-label={t('common.exitFullscreen')}
-        >
-          <Icon name="close" size={14} />
-        </button>
-      ) : null}
+    <div className="viewer html-viewer live-artifact-viewer">
       <div className="viewer-toolbar">
         <div className="viewer-toolbar-left">
-            <button
-              type="button"
-              className="icon-only od-tooltip"
-              onClick={() => setReloadKey((n) => n + 1)}
-              title={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-              data-tooltip={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-              data-tooltip-placement="bottom"
-              aria-label={`${t('fileViewer.reloadAria')} ${t('fileViewer.preview')}`}
-            >
+          <button
+            type="button"
+            className="icon-only"
+            onClick={() => setReloadKey((n) => n + 1)}
+            title={t('fileViewer.reload')}
+            aria-label={t('fileViewer.reloadAria')}
+          >
             <Icon name="reload" size={14} />
           </button>
         </div>
@@ -1430,49 +577,35 @@ export function LiveArtifactViewer({
             aria-hidden={mode === 'preview' ? undefined : true}
           >
             <span className="viewer-divider" aria-hidden />
-            <PreviewViewportControls
-              viewport={previewViewport}
-              onViewport={setPreviewViewport}
-              t={t}
+            <button
+              type="button"
+              className="icon-only"
+              onClick={() => bumpZoom(-25)}
+              title={t('fileViewer.zoomOut')}
+              aria-label={t('fileViewer.zoomOut')}
               tabIndex={mode === 'preview' ? 0 : -1}
-            />
-            <span className="viewer-divider" aria-hidden />
-            <div className="zoom-menu viewer-toolbar-zoom" ref={zoomMenuRef}>
-              <button
-                type="button"
-                className="viewer-action zoom-trigger od-tooltip"
-                aria-haspopup="menu"
-                aria-expanded={zoomMenuOpen}
-                title={t('fileViewer.resetZoom')}
-                data-tooltip={t('fileViewer.resetZoom')}
-                data-tooltip-placement="bottom"
-                tabIndex={mode === 'preview' ? 0 : -1}
-                onClick={() => setZoomMenuOpen((v) => !v)}
-              >
-                <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
-              </button>
-              {zoomMenuOpen && mode === 'preview' ? (
-                <div className="zoom-menu-popover" role="menu">
-                  {[50, 75, 100, 125, 150, 200].map((level) => (
-                    <button
-                      key={level}
-                      type="button"
-                      className={`zoom-menu-item${zoom === level ? ' active' : ''}`}
-                      role="menuitem"
-                      onClick={() => {
-                        setZoom(level);
-                        setZoomMenuOpen(false);
-                      }}
-                    >
-                      <span style={{ fontVariantNumeric: 'tabular-nums' }}>{level}%</span>
-                      {zoom === level ? (
-                        <Icon name="check" size={13} />
-                      ) : null}
-                    </button>
-                  ))}
-                </div>
-              ) : null}
-            </div>
+            >
+              <Icon name="minus" size={14} />
+            </button>
+            <button
+              type="button"
+              className="viewer-action viewer-zoom-level"
+              onClick={() => setZoom(100)}
+              title={t('fileViewer.resetZoom')}
+              tabIndex={mode === 'preview' ? 0 : -1}
+            >
+              <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
+            </button>
+            <button
+              type="button"
+              className="icon-only"
+              onClick={() => bumpZoom(25)}
+              title={t('fileViewer.zoomIn')}
+              aria-label={t('fileViewer.zoomIn')}
+              tabIndex={mode === 'preview' ? 0 : -1}
+            >
+              <Icon name="plus" size={14} />
+            </button>
             <span className="viewer-divider" aria-hidden />
             <a
               className="ghost-link"
@@ -1504,7 +637,7 @@ export function LiveArtifactViewer({
           </button>
         </div>
       </div>
-      <div className="viewer-body" ref={previewBodyRef}>
+      <div className="viewer-body">
         {refreshError ? (
           <LiveArtifactRefreshNotice
             tone="error"
@@ -1532,27 +665,27 @@ export function LiveArtifactViewer({
             action={t('liveArtifact.refresh.failureAction')}
           />
         ) : null}
-        <div
-          className={`live-artifact-preview-layer preview-viewport preview-viewport-${previewViewport}`}
-          data-active={mode === 'preview' ? 'true' : 'false'}
-          aria-hidden={mode === 'preview' ? undefined : true}
-          style={previewViewportStyle(previewViewport, previewScale, previewBodySize)}
-        >
-          <div className="preview-frame-clip">
-            <div style={previewScaleShellStyle(previewViewport, previewScale)}>
-              <PreviewDrawOverlay>
-                <iframe
-                  ref={iframeRef}
-                  data-testid="live-artifact-preview-frame"
-                  title={liveArtifact.title}
-                  sandbox="allow-scripts allow-popups allow-downloads"
-                  src={previewUrl}
-                />
-              </PreviewDrawOverlay>
-            </div>
+        {mode === 'preview' ? (
+          <div
+            onWheel={(event: React.WheelEvent<HTMLDivElement>) => {
+              event.preventDefault();
+              bumpZoom(event.deltaY < 0 ? 10 : -10);
+            }}
+            style={{
+              width: `${100 / previewScale}%`,
+              height: `${100 / previewScale}%`,
+              transform: `scale(${previewScale})`,
+              transformOrigin: '0 0',
+            }}
+          >
+            <iframe
+              data-testid="live-artifact-preview-frame"
+              title={liveArtifact.title}
+              sandbox="allow-scripts allow-popups"
+              src={previewUrl}
+            />
           </div>
-        </div>
-        {mode !== 'preview' && loading ? (
+        ) : loading ? (
           <div className="viewer-empty">{t('fileViewer.loading')}</div>
         ) : mode === 'code' ? (
           <LiveArtifactCodePanel
@@ -1809,44 +942,20 @@ function formatAbsoluteDateTime(iso: string | number | undefined): string | null
   }
 }
 
-function formatRelativeTime(
-  iso: string | number | undefined,
-  now = Date.now(),
-  locale: Locale = 'en',
-  t?: TranslateFn,
-): string | null {
+function formatRelativeTime(iso: string | number | undefined, now = Date.now()): string | null {
   if (iso === undefined || iso === null) return null;
   const ms = typeof iso === 'number' ? iso : new Date(iso).getTime();
   if (Number.isNaN(ms)) return null;
   const deltaSec = Math.round((ms - now) / 1000);
   const abs = Math.abs(deltaSec);
-  if (abs < 5) {
-    // "just now" lives in the i18n dict because Intl.RelativeTimeFormat's
-    // "0 seconds ago" reads awkwardly in narrow style and we want a
-    // single canonical translation per locale. Fall back to the English
-    // literal only when called without t (background utilities, tests).
-    return t ? t('liveArtifact.refresh.justNow') : 'just now';
-  }
-  // Intl.RelativeTimeFormat handles tense (past / future), pluralisation,
-  // and word-order per locale so the panel matches the rest of the
-  // localised UI instead of mixing in English units like `5s ago`.
-  // `style: 'narrow'` keeps the English output close to the historical
-  // `5s ago` shape; `numeric: 'always'` forces numeric output so we
-  // don't get "yesterday" / "now" mixed in unexpectedly with the
-  // bucketing above.
-  let rtf: Intl.RelativeTimeFormat;
-  try {
-    rtf = new Intl.RelativeTimeFormat(locale, { style: 'narrow', numeric: 'always' });
-  } catch {
-    rtf = new Intl.RelativeTimeFormat('en', { style: 'narrow', numeric: 'always' });
-  }
-  const value = deltaSec; // negative = past, positive = future
-  if (abs < 60) return rtf.format(value, 'second');
-  if (abs < 3600) return rtf.format(Math.round(value / 60), 'minute');
-  if (abs < 86400) return rtf.format(Math.round(value / 3600), 'hour');
-  if (abs < 86400 * 30) return rtf.format(Math.round(value / 86400), 'day');
-  if (abs < 86400 * 365) return rtf.format(Math.round(value / (86400 * 30)), 'month');
-  return rtf.format(Math.round(value / (86400 * 365)), 'year');
+  const suffix = deltaSec <= 0 ? ' ago' : ' from now';
+  if (abs < 5) return 'just now';
+  if (abs < 60) return `${abs}s${suffix}`;
+  if (abs < 3600) return `${Math.round(abs / 60)}m${suffix}`;
+  if (abs < 86400) return `${Math.round(abs / 3600)}h${suffix}`;
+  if (abs < 86400 * 30) return `${Math.round(abs / 86400)}d${suffix}`;
+  if (abs < 86400 * 365) return `${Math.round(abs / (86400 * 30))}mo${suffix}`;
+  return `${Math.round(abs / (86400 * 365))}y${suffix}`;
 }
 
 function formatDurationMs(ms: number | undefined): string | null {
@@ -1858,102 +967,54 @@ function formatDurationMs(ms: number | undefined): string | null {
   return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
 }
 
-function exportReadyNudgeKey(projectId: string, fileName: string): string {
-  return `${EXPORT_READY_NUDGE_STORAGE_PREFIX}${projectId}:${fileName}`;
-}
-
-function hasSeenExportReadyNudge(projectId: string, fileName: string): boolean {
-  try {
-    return window.sessionStorage.getItem(exportReadyNudgeKey(projectId, fileName)) === '1';
-  } catch {
-    return false;
-  }
-}
-
-function markExportReadyNudgeSeen(projectId: string, fileName: string) {
-  try {
-    window.sessionStorage.setItem(exportReadyNudgeKey(projectId, fileName), '1');
-  } catch {
-    // Ignore storage-denied contexts; the in-memory state still prevents loops.
-  }
-}
-
 interface RefreshStatusDescriptor {
   label: string;
   tone: 'neutral' | 'running' | 'success' | 'warning' | 'error';
   description: string;
 }
 
-function describeRefreshStatus(
-  status: LiveArtifactRefreshStatus,
-  t: TranslateFn,
-): RefreshStatusDescriptor {
+function describeRefreshStatus(status: LiveArtifactRefreshStatus): RefreshStatusDescriptor {
   switch (status) {
     case 'running':
       return {
-        label: t('liveArtifact.refresh.statusRunning'),
+        label: 'Refreshing',
         tone: 'running',
-        description: t('liveArtifact.refresh.statusRunningDescription'),
+        description: 'A refresh run is currently in progress.',
       };
     case 'succeeded':
       return {
-        label: t('liveArtifact.refresh.statusSucceeded'),
+        label: 'Up to date',
         tone: 'success',
-        description: t('liveArtifact.refresh.statusSucceededDescription'),
+        description: 'The last refresh finished successfully.',
       };
     case 'failed':
       return {
-        label: t('liveArtifact.refresh.statusFailed'),
+        label: 'Refresh failed',
         tone: 'error',
-        description: t('liveArtifact.refresh.statusFailedDescription'),
+        description: 'The last refresh attempt did not complete successfully.',
       };
     case 'idle':
       return {
-        label: t('liveArtifact.refresh.statusReady'),
+        label: 'Ready to refresh',
         tone: 'neutral',
-        description: t('liveArtifact.refresh.statusReadyDescription'),
+        description: 'Refreshable sources are configured but no run is in progress.',
       };
     case 'never':
     default:
       return {
-        label: t('liveArtifact.refresh.statusNever'),
+        label: 'Not refreshable',
         tone: 'warning',
-        description: t('liveArtifact.refresh.statusNeverDescription'),
+        description: 'This live artifact has no refresh source yet.',
       };
   }
 }
 
 function describeEventPhase(
   event: LiveArtifactRefreshEvent,
-  t: TranslateFn,
 ): { label: string; tone: 'running' | 'success' | 'error' } {
-  if (event.phase === 'started')
-    return { label: t('liveArtifact.refresh.eventStarted'), tone: 'running' };
-  if (event.phase === 'succeeded')
-    return { label: t('liveArtifact.refresh.eventSucceeded'), tone: 'success' };
-  return { label: t('liveArtifact.refresh.eventFailed'), tone: 'error' };
-}
-
-function describePersistedStatus(
-  status: LiveArtifactRefreshLogEntry['status'],
-  t: TranslateFn,
-): string {
-  switch (status) {
-    case 'succeeded':
-      return t('liveArtifact.refresh.persistedStatusSucceeded');
-    case 'running':
-      return t('liveArtifact.refresh.persistedStatusRunning');
-    case 'failed':
-      return t('liveArtifact.refresh.persistedStatusFailed');
-    case 'cancelled':
-      return t('liveArtifact.refresh.persistedStatusCancelled');
-    case 'skipped':
-      return t('liveArtifact.refresh.persistedStatusSkipped');
-    default: {
-      const exhaustive: never = status;
-      return exhaustive;
-    }
-  }
+  if (event.phase === 'started') return { label: 'Started', tone: 'running' };
+  if (event.phase === 'succeeded') return { label: 'Succeeded', tone: 'success' };
+  return { label: 'Failed', tone: 'error' };
 }
 
 export function LiveArtifactRefreshHistoryPanel({
@@ -1971,8 +1032,6 @@ export function LiveArtifactRefreshHistoryPanel({
   sessionEvents: LiveArtifactRefreshEvent[];
   persistedEvents?: LiveArtifactRefreshLogEntry[];
 }) {
-  const t = useT();
-  const { locale } = useI18n();
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
@@ -1984,7 +1043,7 @@ export function LiveArtifactRefreshHistoryPanel({
   const status: LiveArtifactRefreshStatus = isRunning
     ? 'running'
     : liveArtifact?.refreshStatus ?? fallbackRefreshStatus;
-  const descriptor = describeRefreshStatus(status, t);
+  const descriptor = describeRefreshStatus(status);
   const lastRefreshedAt = liveArtifact?.lastRefreshedAt ?? fallbackLastRefreshedAt;
   const createdAt = liveArtifact?.createdAt;
   const updatedAt = liveArtifact?.updatedAt;
@@ -2013,13 +1072,11 @@ export function LiveArtifactRefreshHistoryPanel({
         </div>
         <div className="live-artifact-refresh-hero-meta">
           <div className="live-artifact-refresh-hero-metric">
-            <span className="live-artifact-refresh-label">
-              {t('liveArtifact.refresh.heroLastRefreshedLabel')}
-            </span>
+            <span className="live-artifact-refresh-label">Last refreshed</span>
             {lastRefreshedAt ? (
               <>
                 <span className="live-artifact-refresh-value">
-                  {formatRelativeTime(lastRefreshedAt, now, locale, t) ?? '—'}
+                  {formatRelativeTime(lastRefreshedAt, now) ?? '—'}
                 </span>
                 <span
                   className="live-artifact-refresh-sub"
@@ -2029,9 +1086,7 @@ export function LiveArtifactRefreshHistoryPanel({
                 </span>
               </>
             ) : (
-              <span className="live-artifact-refresh-value muted">
-                {t('liveArtifact.refresh.heroLastRefreshedNever')}
-              </span>
+              <span className="live-artifact-refresh-value muted">Never</span>
             )}
           </div>
         </div>
@@ -2039,33 +1094,29 @@ export function LiveArtifactRefreshHistoryPanel({
 
       <section className="live-artifact-refresh-facts">
         <LiveArtifactRefreshFact
-          label={t('liveArtifact.refresh.factCreated')}
+          label="Created"
           iso={createdAt}
-          emptyLabel={t('liveArtifact.refresh.factUnknown')}
+          emptyLabel="Unknown"
           now={now}
-          locale={locale}
-          t={t}
         />
         <LiveArtifactRefreshFact
-          label={t('liveArtifact.refresh.factLastUpdated')}
+          label="Last updated"
           iso={updatedAt}
-          emptyLabel={t('liveArtifact.refresh.factUnknown')}
+          emptyLabel="Unknown"
           now={now}
-          locale={locale}
-          t={t}
         />
       </section>
 
       <section className="live-artifact-refresh-section">
         <header className="live-artifact-refresh-section-header">
-          <h4>{t('liveArtifact.refresh.persistedTitle')}</h4>
+          <h4>Persisted refresh history</h4>
           <span className="live-artifact-refresh-hint">
-            {t('liveArtifact.refresh.persistedHint')}
+            Entries loaded from refreshes.jsonl
           </span>
         </header>
         {reversedPersistedEvents.length === 0 ? (
           <div className="live-artifact-refresh-empty">
-            {t('liveArtifact.refresh.persistedEmpty')}
+            No persisted refresh history yet.
           </div>
         ) : (
           <ol className="live-artifact-refresh-timeline">
@@ -2084,12 +1135,11 @@ export function LiveArtifactRefreshHistoryPanel({
                   <div className="live-artifact-refresh-event-body">
                     <div className="live-artifact-refresh-event-row">
                       <span className={`live-artifact-badge refresh-status tone-${tone}`}>
-                        {describePersistedStatus(event.status, t)}
+                        {event.status}
                       </span>
                       <strong>{event.step}</strong>
                       <span className="live-artifact-refresh-event-time">
-                        {formatRelativeTime(event.startedAt, now, locale, t)
-                          ?? t('liveArtifact.refresh.justNow')}
+                        {formatRelativeTime(event.startedAt, now) ?? 'just now'}
                       </span>
                     </div>
                     <div className="live-artifact-refresh-event-meta">
@@ -2107,21 +1157,21 @@ export function LiveArtifactRefreshHistoryPanel({
 
       <section className="live-artifact-refresh-section">
         <header className="live-artifact-refresh-section-header">
-          <h4>{t('liveArtifact.refresh.sessionTitle')}</h4>
+          <h4>Session activity</h4>
           <span className="live-artifact-refresh-hint">
-            {t('liveArtifact.refresh.sessionHint')}
+            Events observed while this tab is open
           </span>
         </header>
         {reversedEvents.length === 0 ? (
           <div className="live-artifact-refresh-empty">
-            {t('liveArtifact.refresh.timelineEmpty')}
+            No refresh activity yet in this session. Trigger
+            {' '}<em>Refresh</em>{' '}to record a timeline, or wait for automated runs.
           </div>
         ) : (
           <ol className="live-artifact-refresh-timeline">
             {reversedEvents.map((event) => {
-              const phase = describeEventPhase(event, t);
+              const phase = describeEventPhase(event);
               const duration = formatDurationMs(event.durationMs);
-              const refreshedCount = event.refreshedSourceCount ?? 0;
               return (
                 <li key={event.id} className={`live-artifact-refresh-event tone-${phase.tone}`}>
                   <span className="live-artifact-refresh-event-dot" aria-hidden />
@@ -2136,27 +1186,24 @@ export function LiveArtifactRefreshHistoryPanel({
                         className="live-artifact-refresh-event-time"
                         title={formatAbsoluteDateTime(event.at) ?? undefined}
                       >
-                        {formatRelativeTime(event.at, now, locale, t) ?? ''}
+                        {formatRelativeTime(event.at, now) ?? ''}
                       </span>
                     </div>
                     <div className="live-artifact-refresh-event-detail">
                       {event.phase === 'succeeded' ? (
                         <span>
-                          {t(
-                            refreshedCount === 1
-                              ? 'liveArtifact.refresh.sourcesUpdatedOne'
-                              : 'liveArtifact.refresh.sourcesUpdatedMany',
-                            { n: refreshedCount },
-                          )}
+                          {`${event.refreshedSourceCount ?? 0} source${
+                            (event.refreshedSourceCount ?? 0) === 1 ? '' : 's'
+                          } updated`}
                           {duration ? ` · ${duration}` : ''}
                         </span>
                       ) : event.phase === 'failed' ? (
                         <span>
-                          {event.error ?? t('liveArtifact.refresh.genericFailure')}
+                          {event.error ?? 'Refresh failed.'}
                           {duration ? ` · ${duration}` : ''}
                         </span>
                       ) : (
-                        <span>{t('liveArtifact.refresh.eventStartedDetail')}</span>
+                        <span>Refresh started…</span>
                       )}
                     </div>
                   </div>
@@ -2170,19 +1217,19 @@ export function LiveArtifactRefreshHistoryPanel({
       {documentSource ? (
         <section className="live-artifact-refresh-section">
           <header className="live-artifact-refresh-section-header">
-            <h4>{t('liveArtifact.refresh.docSourceTitle')}</h4>
+            <h4>Document source</h4>
             <span className="live-artifact-refresh-hint">
-              {t('liveArtifact.refresh.docSourceHint')}
+              Source configured
             </span>
           </header>
           <dl className="live-artifact-refresh-kv">
             <div>
-              <dt>{t('liveArtifact.refresh.docSourceType')}</dt>
+              <dt>Type</dt>
               <dd>{documentSource.type}</dd>
             </div>
             {documentSource.toolName ? (
               <div>
-                <dt>{t('liveArtifact.refresh.docSourceTool')}</dt>
+                <dt>Tool</dt>
                 <dd>
                   <code>{documentSource.toolName}</code>
                 </dd>
@@ -2190,7 +1237,7 @@ export function LiveArtifactRefreshHistoryPanel({
             ) : null}
             {documentSource.connector ? (
               <div>
-                <dt>{t('liveArtifact.refresh.docSourceConnector')}</dt>
+                <dt>Connector</dt>
                 <dd>
                   {documentSource.connector.accountLabel ??
                     documentSource.connector.connectorId}
@@ -2203,9 +1250,9 @@ export function LiveArtifactRefreshHistoryPanel({
 
       {rawDebugPayload != null ? (
         <details className="live-artifact-refresh-raw">
-          <summary>{t('liveArtifact.refresh.debugSummary')}</summary>
+          <summary>Advanced debug metadata</summary>
           <p className="live-artifact-refresh-raw-note">
-            {t('liveArtifact.refresh.debugNote')}
+            May include connector IDs, file names, source metadata, and internal artifact paths.
           </p>
           <pre className="viewer-source">{JSON.stringify(rawDebugPayload, null, 2)}</pre>
         </details>
@@ -2221,8 +1268,6 @@ function LiveArtifactRefreshFact({
   helper,
   emptyLabel,
   now,
-  locale,
-  t,
 }: {
   label: string;
   iso?: string;
@@ -2230,10 +1275,8 @@ function LiveArtifactRefreshFact({
   helper?: string;
   emptyLabel?: string;
   now?: number;
-  locale?: Locale;
-  t?: TranslateFn;
 }) {
-  const relative = iso !== undefined ? formatRelativeTime(iso, now, locale, t) : null;
+  const relative = iso !== undefined ? formatRelativeTime(iso, now) : null;
   const absolute = iso !== undefined ? formatAbsoluteDateTime(iso) : null;
   const resolved = value ?? relative ?? emptyLabel ?? '—';
   const sub = helper ?? (iso !== undefined ? absolute ?? '' : '');
@@ -2277,540 +1320,126 @@ function FileActions({
   );
 }
 
-function formatCommentTime(ts: number, t: TranslateFn): string {
-  const diff = Date.now() - ts;
-  if (diff < 60_000) return t('common.justNow');
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 60) return t('common.minutesAgo', { n: mins });
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return t('common.hoursAgo', { n: hours });
-  const days = Math.floor(hours / 24);
-  if (days < 7) return t('common.daysAgo', { n: days });
-  const weeks = Math.floor(days / 7);
-  if (weeks < 5) return t('common.weeksAgo', { n: weeks });
-  return new Date(ts).toLocaleDateString();
-}
-
-function commentActivityAt(comment: PreviewComment): number {
-  return Math.max(
-    Number.isFinite(comment.updatedAt) ? comment.updatedAt : 0,
-    Number.isFinite(comment.createdAt) ? comment.createdAt : 0,
-  );
-}
-
-function commentCreatedAt(comment: PreviewComment): number {
-  return Number.isFinite(comment.createdAt) ? comment.createdAt : commentActivityAt(comment);
-}
-
-function commentTargetIntersectsPreview(
-  target: PreviewCommentSnapshot | null,
-  scale: number,
-  offset: { x: number; y: number },
-  bounds?: PreviewCanvasSize,
-): boolean {
-  if (!target || !bounds?.width || !bounds.height) return true;
-  const rect = overlayBoundsFromSnapshot(target, scale, offset);
-  const margin = 8;
-  return (
-    rect.left + rect.width > margin &&
-    rect.top + rect.height > margin &&
-    rect.left < bounds.width - margin &&
-    rect.top < bounds.height - margin
-  );
-}
-
-function commentDisplayLabel(comment: PreviewComment, t: TranslateFn): string {
-  if (comment.elementId.startsWith('pin-')) return t('chat.comments.pin');
-  const label = String(comment.label || '').trim().toLowerCase();
-  const htmlHint = String(comment.htmlHint || '').trim().toLowerCase();
-  const elementId = String(comment.elementId || '').trim().toLowerCase();
-  const source = `${label} ${htmlHint} ${elementId}`;
-  if (/\b(?:img|picture|video|canvas|svg)\b/.test(source)) return t('chat.comments.targetImage');
-  if (/\b(?:button|input|textarea|select|label)\b/.test(source)) return t('chat.comments.targetControl');
-  if (/^<a\b/.test(htmlHint)) return t('chat.comments.targetLink');
-  if (/\b(?:h1|h2|h3|h4|h5|h6|p|span|strong|em|small|li|dt|dd)\b/.test(source)) return t('chat.comments.targetText');
-  if (/\b(?:section|main|header|footer|nav|article|aside)\b/.test(source)) return t('chat.comments.targetSection');
-  if (label.endsWith('.html') || elementId.startsWith('file-comment-')) return t('chat.comments.targetPage');
-  if (comment.text.trim()) return t('chat.comments.targetText');
-  return t('chat.comments.targetArea');
-}
-
-export function CommentSidePanel({
-  comments,
-  projectId,
-  selectedIds,
-  activeCommentId,
-  collapsed,
-  onCollapsedChange,
-  onToggleSelect,
-  onSelectAll,
-  onClearSelection,
-  onReorder,
-  onReply,
-  onSendSelected,
-  onCreateComment,
+function BoardComposerPopover({
+  target,
+  existing,
+  draft,
+  notes,
+  onDraft,
+  onAddDraft,
+  onRemoveQueuedNote,
+  onClose,
+  onSaveComment,
+  onSendBatch,
+  onRemove,
   sending,
-  queueOnSend = false,
-  sendDisabled = false,
-  renderCreateForm = true,
   t,
-  composer,
 }: {
-  comments: PreviewComment[];
-  projectId?: string;
-  selectedIds: Set<string>;
-  activeCommentId: string | null;
-  collapsed: boolean;
-  onCollapsedChange: (collapsed: boolean) => void;
-  onToggleSelect: (commentId: string) => void;
-  onSelectAll: () => void;
-  onClearSelection: () => void;
-  onReorder?: (orderedIds: string[]) => void;
-  onReply: (comment: PreviewComment) => void;
-  onSendSelected: () => void | Promise<void>;
-  onCreateComment?: (note: string) => boolean | Promise<boolean>;
+  target: PreviewCommentSnapshot;
+  existing: PreviewComment | null;
+  draft: string;
+  notes: string[];
+  onDraft: (value: string) => void;
+  onAddDraft: () => void;
+  onRemoveQueuedNote: (index: number) => void;
+  onClose: () => void;
+  onSaveComment: () => void | Promise<void>;
+  onSendBatch: () => void | Promise<void>;
+  onRemove: (commentId: string) => void | Promise<void>;
   sending: boolean;
-  queueOnSend?: boolean;
-  sendDisabled?: boolean;
-  renderCreateForm?: boolean;
   t: TranslateFn;
-  composer?: ReactNode;
 }) {
-  const [newCommentDraft, setNewCommentDraft] = useState('');
-  const [dragState, setDragState] = useState<CommentSideDragState | null>(null);
-  const sorted = comments;
-  const visibleSelectedIds = new Set(comments.filter((comment) => selectedIds.has(comment.id)).map((comment) => comment.id));
-  const selectedCount = visibleSelectedIds.size;
-  const allSelected = comments.length > 0 && selectedCount === comments.length;
-  const commentsLabel = t('chat.tabComments');
-  const canCreateComment = Boolean(onCreateComment) && newCommentDraft.trim().length > 0 && !sending && !sendDisabled;
-  const canReorder = Boolean(onReorder && sorted.length > 1);
-  const collapsedRailRef = useRef<HTMLButtonElement | null>(null);
-  const expandedToggleRef = useRef<HTMLButtonElement | null>(null);
-  const pendingToggleFocusRef = useRef<'collapsed' | 'expanded' | null>(null);
-  const panelId = useId();
-  const handleDragStart = (event: ReactDragEvent<HTMLButtonElement>, comment: PreviewComment) => {
-    if (!canReorder) return;
-    event.dataTransfer.effectAllowed = 'move';
-    event.dataTransfer.setData(COMMENT_SIDE_DRAG_MIME, comment.id);
-    event.dataTransfer.setData('text/plain', comment.id);
-    setDragState({ draggingId: comment.id, overId: comment.id, edge: null });
-  };
-  const handleDragOver = (event: ReactDragEvent<HTMLDivElement>, targetId: string) => {
-    if (!canReorder) return;
-    const draggingId = dragState?.draggingId || event.dataTransfer.getData(COMMENT_SIDE_DRAG_MIME);
-    if (!draggingId) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
-    if (draggingId === targetId) {
-      if (dragState?.overId !== targetId || dragState.edge !== null) {
-        setDragState({ draggingId, overId: targetId, edge: null });
-      }
-      return;
-    }
-    const edge = commentSideDropEdgeForEvent(event);
-    if (
-      dragState?.draggingId !== draggingId ||
-      dragState.overId !== targetId ||
-      dragState.edge !== edge
-    ) {
-      setDragState({ draggingId, overId: targetId, edge });
-    }
-  };
-  const handleDrop = (event: ReactDragEvent<HTMLDivElement>, targetId: string) => {
-    if (!canReorder) return;
-    event.preventDefault();
-    const draggingId =
-      dragState?.draggingId ||
-      event.dataTransfer.getData(COMMENT_SIDE_DRAG_MIME) ||
-      event.dataTransfer.getData('text/plain');
-    if (!draggingId || draggingId === targetId) {
-      setDragState(null);
-      return;
-    }
-    const edge = dragState?.overId === targetId && dragState.edge
-      ? dragState.edge
-      : commentSideDropEdgeForEvent(event);
-    const nextIds = reorderPreviewCommentIds(sorted, draggingId, targetId, edge);
-    if (nextIds.join('\0') !== sorted.map((comment) => comment.id).join('\0')) {
-      onReorder?.(nextIds);
-    }
-    setDragState(null);
-  };
-  const submitNewComment = async () => {
-    if (!onCreateComment || !newCommentDraft.trim()) return;
-    const saved = await onCreateComment(newCommentDraft.trim());
-    if (saved) setNewCommentDraft('');
-  };
-
-  useEffect(() => {
-    const target =
-      pendingToggleFocusRef.current === 'collapsed'
-        ? collapsedRailRef.current
-        : pendingToggleFocusRef.current === 'expanded'
-          ? expandedToggleRef.current
-          : null;
-    if (!target) return;
-    pendingToggleFocusRef.current = null;
-    target.focus();
-  }, [collapsed]);
-
-  const handleCollapsedChange = (
-    nextCollapsed: boolean,
-    nextFocusTarget: 'collapsed' | 'expanded',
-  ) => {
-    pendingToggleFocusRef.current = nextFocusTarget;
-    onCollapsedChange(nextCollapsed);
-  };
-
-  if (collapsed) {
-    return (
-      <button
-        ref={collapsedRailRef}
-        type="button"
-        className="comment-side-rail"
-        data-testid="comment-side-collapsed-rail"
-        aria-label={t('preview.showSidebar', { label: commentsLabel })}
-        aria-expanded={false}
-        title={t('preview.showSidebar', { label: commentsLabel })}
-        onClick={() => handleCollapsedChange(false, 'expanded')}
-      >
-        <RemixIcon name="message-3-line" size={15} />
-        <span>{commentsLabel}</span>
-        {comments.length > 0 ? <strong>{comments.length}</strong> : null}
-      </button>
-    );
-  }
-
-  return (
-    <aside id={panelId} className="comment-side-panel" data-testid="comment-side-panel" aria-label={commentsLabel}>
-      <div className="comment-side-header">
-        <div className="comment-side-title">
-          <RemixIcon name="message-3-line" size={15} />
-          <span>{commentsLabel}</span>
-        </div>
-        <div className="comment-side-header-actions">
-          {comments.length > 0 ? (
-            <button
-              type="button"
-              className="comment-side-select-all"
-              disabled={allSelected}
-              onClick={onSelectAll}
-            >
-              {t('chat.comments.selectAll')}
-            </button>
-          ) : null}
-          <button
-            ref={expandedToggleRef}
-            type="button"
-            className="comment-side-collapse"
-            aria-label={t('preview.hideSidebar', { label: commentsLabel })}
-            aria-controls={panelId}
-            aria-expanded={true}
-            title={t('preview.hideSidebar', { label: commentsLabel })}
-            onClick={() => handleCollapsedChange(true, 'collapsed')}
-          >
-            <Icon name="chevron-right" size={14} />
-          </button>
-        </div>
-      </div>
-      <div
-        className="comment-side-list"
-        onDragLeave={(event) => {
-          const related = event.relatedTarget;
-          if (related instanceof Node && event.currentTarget.contains(related)) return;
-          setDragState(null);
-        }}
-      >
-        {sorted.length === 0 ? (
-          <div className="comment-side-empty">
-            {t('chat.comments.emptySaved')}
-          </div>
-        ) : sorted.map((comment, index) => {
-          const selected = visibleSelectedIds.has(comment.id);
-          const active = comment.id === activeCommentId;
-          const isDragging = dragState?.draggingId === comment.id;
-          const dropClass = dragState?.overId === comment.id &&
-            dragState.draggingId !== comment.id &&
-            dragState.edge
-            ? ` comment-side-item-drop-${dragState.edge}`
-            : '';
-          return (
-            <div
-              key={comment.id}
-              className={`comment-side-item${selected ? ' selected' : ''}${active ? ' active' : ''}${isDragging ? ' dragging' : ''}${dropClass}`}
-              data-testid="comment-side-item"
-              data-comment-id={comment.id}
-              aria-current={active ? 'true' : undefined}
-              role="button"
-              tabIndex={0}
-              onDragOver={(event) => handleDragOver(event, comment.id)}
-              onDrop={(event) => handleDrop(event, comment.id)}
-              onClick={() => onReply(comment)}
-              onKeyDown={(event) => {
-                if (event.key !== 'Enter' && event.key !== ' ') return;
-                event.preventDefault();
-                onReply(comment);
-              }}
-            >
-              <div className="comment-side-item-head">
-                <button
-                  type="button"
-                  className="comment-side-drag-handle"
-                  title={t('chat.queuedReorder')}
-                  aria-label={t('chat.queuedReorder')}
-                  draggable={canReorder}
-                  disabled={!canReorder}
-                  onClick={(event) => event.stopPropagation()}
-                  onDragStart={(event) => handleDragStart(event, comment)}
-                  onDragEnd={() => setDragState(null)}
-                >
-                  <Icon name="grip-vertical" size={13} />
-                </button>
-                <span className="comment-side-author">
-                  <strong>{`${index + 1}. ${commentDisplayLabel(comment, t)}`}</strong>
-                </span>
-                <span className="comment-side-time">{formatCommentTime(commentActivityAt(comment), t)}</span>
-                <button
-                  type="button"
-                  className={`comment-side-check${selected ? ' checked' : ''}`}
-                  aria-label={selected ? t('chat.comments.deselect') : t('chat.comments.select')}
-                  aria-pressed={selected}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onToggleSelect(comment.id);
-                  }}
-                >
-                  {selected ? <Icon name="check" size={11} /> : null}
-                </button>
-              </div>
-              <div className="comment-side-body">{comment.note}</div>
-              {projectId && comment.attachments && comment.attachments.length > 0 ? (
-                <div className="comment-side-attachments">
-                  {comment.attachments.map((attachment) => {
-                    const url = projectRawUrl(projectId, attachment.path);
-                    return (
-                      <a
-                        key={attachment.path}
-                        className="comment-side-attachment"
-                        data-testid="comment-side-attachment"
-                        href={url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={attachment.name}
-                        title={attachment.name}
-                        onClick={(event) => event.stopPropagation()}
-                      >
-                        <img src={url} alt={attachment.name} />
-                      </a>
-                    );
-                  })}
-                </div>
-              ) : null}
-            </div>
-          );
-        })}
-      </div>
-      {selectedCount > 0 ? (
-        <div className="comment-side-selectbar" data-testid="comment-side-selectbar">
-          <span className="comment-side-selectcount">{t('chat.comments.nSelected', { n: selectedCount })}</span>
-          <Button variant="ghost" onClick={onClearSelection}>
-            {t('chat.comments.clear')}
-          </Button>
-          <Button
-            variant="primary"
-            data-testid="comment-side-send-claude"
-            disabled={sending || sendDisabled}
-            onClick={() => void onSendSelected()}
-          >
-            {sending
-              ? t('chat.comments.sending')
-              : queueOnSend
-                ? t('chat.annotationQueue')
-                : t('chat.comments.sendToChat')}
-          </Button>
-        </div>
-      ) : null}
-      {composer ? <div className="comment-side-composer">{composer}</div> : null}
-      {renderCreateForm && onCreateComment ? (
-        <form
-          className="comment-side-new-comment composer"
-          onSubmit={(event) => {
-            event.preventDefault();
-            void submitNewComment();
-          }}
-        >
-          <div className="composer-shell comment-side-new-comment-shell">
-            <div className="composer-input-wrap">
-              <div className="composer-textarea-layer">
-                <textarea
-                  value={newCommentDraft}
-                  placeholder={t('chat.comments.placeholder')}
-                  aria-label={t('chat.comments.placeholder')}
-                  onChange={(event) => setNewCommentDraft(event.target.value)}
-                  onKeyDown={(event) => {
-                    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
-                      event.preventDefault();
-                      void submitNewComment();
-                    }
-                  }}
-                />
-              </div>
-            </div>
-            <div className="composer-row comment-side-new-comment-actions">
-              <button
-                type="button"
-                className="icon-btn"
-                title={t('chat.cliSettingsTitle')}
-                aria-label={t('chat.cliSettingsAria')}
-                disabled
-              >
-                <span className="composer-tools-at" aria-hidden>
-                  @
-                </span>
-              </button>
-              <button
-                type="button"
-                className="icon-btn"
-                title={t('chat.attachTitle')}
-                aria-label={t('chat.attachAria')}
-                disabled
-              >
-                <Icon name="attach" size={15} />
-              </button>
-              <span className="composer-spacer" />
-              <button
-                type="submit"
-                className={`composer-send${sending ? ' is-sending' : ''}`}
-                disabled={!canCreateComment}
-              >
-                <Icon name="send" size={13} />
-                <span>{sending ? t('chat.comments.sending') : t('chat.send')}</span>
-              </button>
-            </div>
-          </div>
-        </form>
-      ) : null}
-    </aside>
-  );
-}
-
-const COMMENT_SIDE_DRAG_MIME = 'application/x-open-design-preview-comment';
-
-type CommentSideDropEdge = 'before' | 'after';
-
-interface CommentSideDragState {
-  draggingId: string;
-  overId: string | null;
-  edge: CommentSideDropEdge | null;
-}
-
-function commentSideDropEdgeForEvent(event: ReactDragEvent<HTMLElement>): CommentSideDropEdge {
-  const rect = event.currentTarget.getBoundingClientRect();
-  return event.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
-}
-
-function reorderPreviewCommentIds(
-  comments: PreviewComment[],
-  draggingId: string,
-  targetId: string,
-  edge: CommentSideDropEdge,
-): string[] {
-  const ids = comments.map((comment) => comment.id);
-  const from = ids.indexOf(draggingId);
-  if (from < 0) return ids;
-  const [draggedId] = ids.splice(from, 1);
-  const targetIndex = ids.indexOf(targetId);
-  if (targetIndex < 0 || !draggedId) return comments.map((comment) => comment.id);
-  ids.splice(edge === 'after' ? targetIndex + 1 : targetIndex, 0, draggedId);
-  return ids;
-}
-
-export function appendSavedPreviewCommentOrder(
-  currentOrderIds: string[],
-  visibleComments: Array<Pick<PreviewComment, 'id'>>,
-  savedId: string,
-): string[] {
-  if (!savedId) return currentOrderIds;
-  const visibleIds = visibleComments.map((comment) => comment.id);
-  if (currentOrderIds.includes(savedId) || visibleIds.includes(savedId)) {
-    return currentOrderIds;
-  }
-  const visibleIdSet = new Set(visibleIds);
-  const kept = currentOrderIds.filter((id) => visibleIdSet.has(id));
-  const missingVisibleIds = visibleIds.filter((id) => !kept.includes(id));
-  const base = currentOrderIds.length > 0 ? [...kept, ...missingVisibleIds] : visibleIds;
-  const next = [...base, savedId];
-  return next.join('\0') === currentOrderIds.join('\0') ? currentOrderIds : next;
-}
-
-function CommentSideDock({
-  comments,
-  projectId,
-  selectedIds,
-  activeCommentId,
-  collapsed,
-  onCollapsedChange,
-  onToggleSelect,
-  onSelectAll,
-  onClearSelection,
-  onReorder,
-  onReply,
-  onSendSelected,
-  onCreateComment,
-  sending,
-  queueOnSend = false,
-  sendDisabled = false,
-  renderCreateForm = true,
-  t,
-  composer,
-}: {
-  comments: PreviewComment[];
-  projectId?: string;
-  selectedIds: Set<string>;
-  activeCommentId: string | null;
-  collapsed: boolean;
-  onCollapsedChange: (collapsed: boolean) => void;
-  onToggleSelect: (commentId: string) => void;
-  onSelectAll: () => void;
-  onClearSelection: () => void;
-  onReorder?: (orderedIds: string[]) => void;
-  onReply: (comment: PreviewComment) => void;
-  onSendSelected: () => void | Promise<void>;
-  onCreateComment?: (note: string) => boolean | Promise<boolean>;
-  sending: boolean;
-  queueOnSend?: boolean;
-  sendDisabled?: boolean;
-  renderCreateForm?: boolean;
-  t: TranslateFn;
-  composer?: ReactNode;
-}) {
+  const pendingCount = notes.length + (draft.trim() ? 1 : 0);
+  const podMembers = target.podMembers ?? [];
+  const titleId = useId();
   return (
     <div
-      className={`comment-side-dock${collapsed ? ' collapsed' : ''}`}
-      data-testid="comment-side-dock"
+      className="comment-popover"
+      data-testid="comment-popover"
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={titleId}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          onClose();
+        }
+      }}
     >
-      <CommentSidePanel
-        comments={comments}
-        projectId={projectId}
-        selectedIds={selectedIds}
-        activeCommentId={activeCommentId}
-        collapsed={collapsed}
-        onCollapsedChange={onCollapsedChange}
-        onToggleSelect={onToggleSelect}
-        onSelectAll={onSelectAll}
-        onClearSelection={onClearSelection}
-        onReorder={onReorder}
-        onReply={onReply}
-        onSendSelected={onSendSelected}
-        onCreateComment={onCreateComment}
-        sending={sending}
-        queueOnSend={queueOnSend}
-        sendDisabled={sendDisabled}
-        renderCreateForm={renderCreateForm}
-        t={t}
-        composer={composer}
+      <div className="comment-popover-head">
+        <div title={target.elementId}>
+          <strong id={titleId}>{target.elementId}</strong>
+          <span>{target.label}</span>
+          <span>{selectionKindLabel(target.selectionKind, target.memberCount)}</span>
+        </div>
+        <button type="button" className="ghost" onClick={onClose} title={t('common.close')}>
+          {t('common.close')}
+        </button>
+      </div>
+      {podMembers.length > 0 ? (
+        <div className="board-pod-summary">
+          <strong>{target.memberCount || podMembers.length} captured items</strong>
+          <div className="board-pod-members">
+            {podMembers.slice(0, 6).map((member) => (
+              <span key={member.elementId} className="board-pod-chip">
+                {summarizeMember(member)}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      {notes.length > 0 ? (
+        <div className="board-note-list">
+          {notes.map((note, index) => (
+            <div key={`${target.elementId}-${index}`} className="board-note-item">
+              <span>{note}</span>
+              <button type="button" className="ghost" onClick={() => onRemoveQueuedNote(index)}>
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+      <textarea
+        data-testid="comment-popover-input"
+        value={draft}
+        autoFocus
+        aria-label={t('chat.comments.placeholder')}
+        placeholder={t('chat.comments.placeholder')}
+        onChange={(event) => onDraft(event.target.value)}
       />
+      <div className="comment-popover-actions">
+        {existing ? (
+          <button type="button" className="comment-popover-remove" onClick={() => onRemove(existing.id)}>
+            {t('chat.comments.remove')}
+          </button>
+        ) : <span />}
+        <button
+          type="button"
+          className="ghost"
+          disabled={!draft.trim()}
+          onClick={onAddDraft}
+        >
+          Add note
+        </button>
+        <button
+          type="button"
+          className="ghost"
+          disabled={target.selectionKind === 'pod' || !draft.trim()}
+          onClick={() => void onSaveComment()}
+        >
+          Save comment
+        </button>
+        <button
+          type="button"
+          className="primary"
+          data-testid="comment-add-send"
+          disabled={pendingCount === 0 || sending}
+          onClick={() => void onSendBatch()}
+        >
+          {sending ? 'Sending...' : 'Send to chat'}
+        </button>
+      </div>
     </div>
   );
 }
@@ -2935,39 +1564,23 @@ function InspectPanel({
           <strong title={target.label || target.elementId}>{target.label || target.elementId}</strong>
           <code title={target.selector}>{target.elementId}</code>
         </div>
-        <Button variant="ghost" onClick={onClose} aria-label="Close inspect">
+        <button type="button" className="ghost" onClick={onClose} aria-label="Close inspect">
           ×
-        </Button>
+        </button>
       </header>
-
-      {target.clickedDescendant ? (
-        <div className="inspect-ancestor-notice" data-testid="inspect-ancestor-notice">
-          <div className="inspect-ancestor-notice-icon" aria-hidden>
-            i
-          </div>
-          <div className="inspect-ancestor-notice-text">
-            You clicked <strong>{target.clickedDescendant.label}</strong>
-            {target.clickedDescendant.text
-              ? ` ("${target.clickedDescendant.text.slice(0, 40)}${target.clickedDescendant.text.length > 40 ? '...' : ''}")`
-              : ''}
-            , but it has no <code>data-od-id</code> annotation. Editing{' '}
-            <strong>{target.label || target.elementId}</strong> instead, the nearest annotated ancestor.
-          </div>
-        </div>
-      ) : null}
 
       <section className="inspect-section">
         <div className="inspect-section-label">Colors</div>
         <div className="inspect-row">
           <label htmlFor="ip-color">Text</label>
-          <Input
+          <input
             id="ip-color"
             data-testid="inspect-color"
             type="color"
             value={colorHex}
             onChange={(e) => setVal('color', e.target.value)}
           />
-          <Input
+          <input
             type="text"
             value={colorHex}
             onChange={(e) => setVal('color', e.target.value)}
@@ -2976,14 +1589,14 @@ function InspectPanel({
         </div>
         <div className="inspect-row">
           <label htmlFor="ip-bg">Background</label>
-          <Input
+          <input
             id="ip-bg"
             data-testid="inspect-bg"
             type="color"
             value={bgHex}
             onChange={(e) => setVal('background-color', e.target.value)}
           />
-          <Input
+          <input
             type="text"
             value={bgHex}
             onChange={(e) => setVal('background-color', e.target.value)}
@@ -3010,7 +1623,7 @@ function InspectPanel({
         </div>
         <div className="inspect-row">
           <label htmlFor="ip-fw">Weight</label>
-          <Select
+          <select
             id="ip-fw"
             value={fontWeight}
             onChange={(e) => setVal('font-weight', e.target.value)}
@@ -3018,11 +1631,11 @@ function InspectPanel({
             {['100', '300', '400', '500', '600', '700', '800', '900'].map((w) => (
               <option key={w} value={w}>{w}</option>
             ))}
-          </Select>
+          </select>
         </div>
         <div className="inspect-row">
           <label htmlFor="ip-ta">Align</label>
-          <Select
+          <select
             id="ip-ta"
             value={textAlign}
             onChange={(e) => setVal('text-align', e.target.value)}
@@ -3030,7 +1643,7 @@ function InspectPanel({
             {['left', 'center', 'right', 'justify'].map((a) => (
               <option key={a} value={a}>{a}</option>
             ))}
-          </Select>
+          </select>
         </div>
       </section>
 
@@ -3067,23 +1680,25 @@ function InspectPanel({
       </section>
 
       <footer className="inspect-panel-footer">
-        <Button
-          variant="ghost"
+        <button
+          type="button"
+          className="ghost"
           onClick={() => {
             setDraft({});
             onResetElement(target.elementId);
           }}
         >
           Reset element
-        </Button>
-        <Button
-          variant="primary"
+        </button>
+        <button
+          type="button"
+          className="primary"
           data-testid="inspect-save"
           disabled={saving}
           onClick={onSaveToSource}
         >
           {saving ? 'Saving…' : justSaved ? 'Saved ✓' : 'Save to source'}
-        </Button>
+        </button>
       </footer>
       {error ? <div className="inspect-panel-error">{error}</div> : null}
     </aside>
@@ -3517,68 +2132,48 @@ export function applyInspectOverridesToSource(source: string, css: string): stri
   return block + out;
 }
 
+function summarizeMember(member: PreviewCommentMember): string {
+  const text = String(member.text || '').trim();
+  if (text) {
+    const trimmed = text.length > 24 ? `${text.slice(0, 21)}...` : text;
+    return `${member.label || member.elementId} · ${trimmed}`;
+  }
+  return member.label || member.elementId;
+}
+
 function CommentPreviewOverlays({
   comments,
   liveTargets,
   hoveredTarget,
-  hoveredPodMemberId,
   activeTarget,
-  activeExistingCommentId = null,
   boardTool,
-  showActivePin = false,
   scale,
-  offsetX,
-  offsetY,
   strokePoints,
-  activeSlideIndex = null,
   onOpenComment,
 }: {
   comments: PreviewComment[];
   liveTargets: Map<string, PreviewCommentSnapshot>;
   hoveredTarget: PreviewCommentSnapshot | null;
-  hoveredPodMemberId: string | null;
   activeTarget: PreviewCommentSnapshot | null;
-  activeExistingCommentId?: string | null;
   boardTool: BoardTool;
-  showActivePin?: boolean;
   scale: number;
-  offsetX: number;
-  offsetY: number;
   strokePoints: StrokePoint[];
-  activeSlideIndex?: number | null;
   onOpenComment: (comment: PreviewComment, snapshot: PreviewCommentSnapshot) => void;
 }) {
-  const overlayOffset = useMemo(() => ({ x: offsetX, y: offsetY }), [offsetX, offsetY]);
-  const visibleComments = useMemo(
-    () =>
-      comments
-        .map((comment, globalIndex) => ({
-          comment,
-          markerNumber: globalIndex + 1,
-          snapshot: liveSnapshotForComment(comment, liveTargets),
-        }))
-        .filter((item): item is { comment: PreviewComment; markerNumber: number; snapshot: PreviewCommentSnapshot } =>
-          Boolean(item.snapshot),
-        )
-        .filter(({ comment }) => commentVisibleOnDeckSlide(comment, activeSlideIndex)),
-    [comments, liveTargets, activeSlideIndex],
-  );
-  // `onOpenComment` is an inline arrow from the parent (new identity every
-  // render), so read it through a ref to keep the saved-marker memo below from
-  // busting. The closure only calls stable state setters, so a current ref read
-  // is always correct.
-  const onOpenCommentRef = useRef(onOpenComment);
-  onOpenCommentRef.current = onOpenComment;
-  // Memoize the saved-marker subtree. While the user draws a pod lasso,
-  // `strokePoints` updates on every pointermove and re-renders this overlay;
-  // without this, every saved marker (bounds + JSX) was rebuilt each frame.
-  // Keyed only on the marker inputs (NOT strokePoints), so a steady set of
-  // comments reuses the whole subtree and React skips reconciling it.
-  const savedMarkers = useMemo(
-    () =>
-      visibleComments.map(({ comment, markerNumber, snapshot }) => {
-        const bounds = overlayBoundsFromSnapshot(snapshot, scale, overlayOffset);
-        const label = commentTargetDisplayName(comment);
+  const visibleComments = comments
+    .map((comment, index) => ({
+      comment,
+      index,
+      snapshot: liveSnapshotForComment(comment, liveTargets),
+    }))
+    .filter((item): item is { comment: PreviewComment; index: number; snapshot: PreviewCommentSnapshot } =>
+      Boolean(item.snapshot),
+    );
+  const targetOverlay = activeTarget ?? hoveredTarget;
+  return (
+    <div className="comment-overlay-layer" aria-hidden={false}>
+      {visibleComments.map(({ comment, index, snapshot }) => {
+        const bounds = overlayBoundsFromSnapshot(snapshot, scale);
         return (
           <div
             key={comment.id}
@@ -3590,59 +2185,31 @@ function CommentPreviewOverlays({
               height: bounds.height,
             }}
             data-testid={`comment-saved-marker-${comment.elementId}`}
-            onClick={() => onOpenCommentRef.current(comment, snapshot)}
           >
             <div className="comment-saved-outline" />
             <button
               type="button"
               className="comment-saved-pin"
-              onClick={(event) => {
-                event.stopPropagation();
-                onOpenCommentRef.current(comment, snapshot);
-              }}
-              title={`${markerNumber}. ${label}: ${comment.note}`}
-              aria-label={`Open comment for ${label}`}
+              onClick={() => onOpenComment(comment, snapshot)}
+              title={`${comment.elementId}: ${comment.note}`}
+              aria-label={`Open comment for ${comment.elementId}`}
             >
-              {markerNumber}
+              {index + 1}
             </button>
           </div>
         );
-      }),
-    [visibleComments, scale, overlayOffset],
-  );
-  const activeSavedIndex = activeExistingCommentId
-    ? comments.findIndex((comment) => comment.id === activeExistingCommentId)
-    : -1;
-  const activePinNumber = activeSavedIndex >= 0
-    ? activeSavedIndex + 1
-    : comments.length + 1;
-  const targetOverlay = activeTarget ?? hoveredTarget;
-  return (
-    <div className="comment-overlay-layer" aria-hidden={false}>
-      {savedMarkers}
+      })}
       {targetOverlay ? (
         <CommentTargetOverlay
           snapshot={targetOverlay}
           scale={scale}
-          offset={overlayOffset}
           selected={Boolean(activeTarget)}
-          hoveredMemberId={hoveredPodMemberId}
         />
-      ) : null}
-      {showActivePin && activeTarget ? (
-        <div
-          className="comment-active-pin"
-          style={activeCommentPinStyle(activeTarget, scale, overlayOffset)}
-          data-testid="comment-active-pin"
-          aria-hidden="true"
-        >
-          {activePinNumber}
-        </div>
       ) : null}
       {boardTool === 'pod' && strokePoints.length > 1 ? (
         <svg className="board-pod-stroke">
           <polyline
-            points={strokePoints.map((point) => `${offsetX + point.x * scale},${offsetY + point.y * scale}`).join(' ')}
+            points={strokePoints.map((point) => `${point.x * scale},${point.y * scale}`).join(' ')}
           />
         </svg>
       ) : null}
@@ -3650,43 +2217,22 @@ function CommentPreviewOverlays({
   );
 }
 
-function activeCommentPinStyle(
-  target: PreviewCommentSnapshot,
-  scale: number,
-  offset: { x: number; y: number } = { x: 0, y: 0 },
-): CSSProperties {
-  const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
-  const anchor = target.hoverPoint ?? {
-    x: target.position.x,
-    y: target.position.y,
-  };
-  return {
-    left: Math.round(offset.x + anchor.x * safeScale),
-    top: Math.round(offset.y + anchor.y * safeScale),
-  };
-}
-
-export function CommentTargetOverlay({
+function CommentTargetOverlay({
   snapshot,
   scale,
-  offset,
   selected,
-  hoveredMemberId,
 }: {
   snapshot: PreviewCommentSnapshot;
   scale: number;
-  offset?: { x: number; y: number };
   selected: boolean;
-  hoveredMemberId?: string | null;
 }) {
-  const overlayOffset = offset ?? { x: 0, y: 0 };
   const displayMembers = podDisplayMembers(snapshot);
   if (displayMembers.length > 0) {
     const overlayWeights = podOverlayWeights(displayMembers);
     return (
       <>
         {displayMembers.map((member, index) => {
-          const bounds = overlayBoundsFromSnapshot(member, scale, overlayOffset);
+          const bounds = overlayBoundsFromSnapshot(member, scale);
           const width = Math.round(member.position.width);
           const height = Math.round(member.position.height);
           const overlayWeight = overlayWeights[index] ?? {
@@ -3703,11 +2249,10 @@ export function CommentTargetOverlay({
             '--comment-overlay-ring': `rgba(22, 119, 255, ${overlayWeight.ringOpacity})`,
             '--comment-overlay-border': `rgba(22, 119, 255, ${overlayWeight.outlineOpacity})`,
           };
-          const isHoverFocused = hoveredMemberId === member.elementId;
           return (
             <div
               key={`${member.elementId}-${index}`}
-              className={`comment-target-overlay comment-target-overlay--member${selected ? ' selected' : ''}${isHoverFocused ? ' is-hover-focused' : ''}`}
+              className={`comment-target-overlay comment-target-overlay--member${selected ? ' selected' : ''}`}
               style={overlayStyle}
               data-testid="comment-target-overlay"
             >
@@ -3718,10 +2263,7 @@ export function CommentTargetOverlay({
       </>
     );
   }
-  // Non-member fallback: single-element snapshots have no per-member chips,
-  // so the hover-focus channel never reaches this branch — no is-hover-focused
-  // class needed here.
-  const bounds = overlayBoundsFromSnapshot(snapshot, scale, overlayOffset);
+  const bounds = overlayBoundsFromSnapshot(snapshot, scale);
   return (
     <div
       className={`comment-target-overlay${selected ? ' selected' : ''}`}
@@ -3819,7 +2361,6 @@ function buildPodSnapshot(input: {
     text: snapshot.text,
     position: snapshot.position,
     htmlHint: snapshot.htmlHint,
-    style: snapshot.style,
   }));
   const summary = selected
     .slice(0, 3)
@@ -4002,85 +2543,18 @@ function finiteBridgeInteger(value: unknown): number | undefined {
   return clampBridgeCoordinate(value);
 }
 
-function normalizeAnnotationStyle(input: unknown): PreviewCommentSnapshot['style'] {
-  if (!input || typeof input !== 'object') return undefined;
-  const raw = input as Record<string, unknown>;
-  const style: NonNullable<PreviewCommentSnapshot['style']> = {};
-  for (const key of ANNOTATION_STYLE_KEYS) {
-    const value = raw[key];
-    if (typeof value !== 'string') continue;
-    const trimmed = value.replace(/\s+/g, ' ').trim();
-    if (trimmed) style[key] = trimmed.slice(0, 120);
-  }
-  return Object.keys(style).length > 0 ? style : undefined;
-}
-
-const ANNOTATION_STYLE_KEYS = [
-  'color',
-  'backgroundColor',
-  'fontSize',
-  'fontWeight',
-  'lineHeight',
-  'textAlign',
-  'fontFamily',
-  'paddingTop',
-  'paddingRight',
-  'paddingBottom',
-  'paddingLeft',
-  'borderRadius',
-] as const;
-
 function clampBridgeCoordinate(value: unknown): number {
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return 0;
   return Math.max(-MAX_BRIDGE_COORDINATE, Math.min(MAX_BRIDGE_COORDINATE, Math.round(numeric)));
 }
 
-// Shown instead of the React runtime when a .jsx/.tsx is a module loaded by a
-// sibling HTML entry (issue #2744): such a file has no standalone component to
-// render, so point the user at the page(s) that do. Clicking an entry opens
-// (or focuses) that page and closes the now-useless module tab.
-function ReactModulePointer({
-  entries,
-  onOpenEntry,
-}: {
-  entries: string[];
-  onOpenEntry?: (name: string) => void;
-}) {
-  const t = useT();
-  return (
-    <div className="viewer-module-pointer" role="note">
-      <Icon name="info" size={20} />
-      <h2 className="viewer-module-pointer__title">{t('fileViewer.jsxModuleTitle')}</h2>
-      <p className="viewer-module-pointer__body">{t('fileViewer.jsxModuleBody')}</p>
-      <p className="viewer-module-pointer__cta">{t('fileViewer.jsxModuleCta')}</p>
-      <ul className="viewer-module-pointer__entries">
-        {entries.map((name) => (
-          <li key={name}>
-            <button
-              type="button"
-              className="viewer-module-pointer__link"
-              onClick={() => onOpenEntry?.(name)}
-              disabled={!onOpenEntry}
-            >
-              <Icon name="external-link" size={14} />
-              <span>{name}</span>
-            </button>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
 function ReactComponentViewer({
   projectId,
   file,
-  onOpenFileReplacing,
 }: {
   projectId: string;
   file: ProjectFile;
-  onOpenFileReplacing?: (openName: string, closeName: string) => void;
 }) {
   const t = useT();
   const [mode, setMode] = useState<'preview' | 'source'>('preview');
@@ -4089,11 +2563,6 @@ function ReactComponentViewer({
   const [reloadKey, setReloadKey] = useState(0);
   const [shareMenuOpen, setShareMenuOpen] = useState(false);
   const shareRef = useRef<HTMLDivElement | null>(null);
-  // HTML entries that load this file as a Babel module. `null` = still
-  // checking; `[]` = standalone artifact; non-empty = a module of a
-  // multi-file React prototype, which has no standalone preview. Issue #2744.
-  const [moduleEntries, setModuleEntries] = useState<string[] | null>(null);
-  const isModule = (moduleEntries?.length ?? 0) > 0;
 
   useEffect(() => {
     setSource(null);
@@ -4101,36 +2570,6 @@ function ReactComponentViewer({
     void fetchProjectFileText(projectId, file.name).then((text) => {
       if (!cancelled) setSource(text ?? '');
     });
-    return () => {
-      cancelled = true;
-    };
-  }, [projectId, file.name, file.mtime, reloadKey]);
-
-  // Detect whether this .jsx/.tsx is a module loaded by a sibling HTML entry.
-  // Runs before any srcdoc is built so a module never flashes the raw
-  // "No React component export found" error from the React runtime.
-  useEffect(() => {
-    setModuleEntries(null);
-    let cancelled = false;
-    void (async () => {
-      try {
-        const files = await fetchProjectFiles(projectId);
-        const htmlNames = files
-          .filter((entry) => /\.html?$/i.test(entry.name))
-          .map((entry) => entry.name);
-        const htmlSources = new Map<string, string>();
-        await Promise.all(
-          htmlNames.map(async (name) => {
-            const text = await fetchProjectFileText(projectId, name).catch(() => null);
-            if (text != null) htmlSources.set(name, text);
-          }),
-        );
-        if (cancelled) return;
-        setModuleEntries(findHtmlEntriesReferencing(file.name, htmlSources));
-      } catch {
-        if (!cancelled) setModuleEntries([]);
-      }
-    })();
     return () => {
       cancelled = true;
     };
@@ -4157,9 +2596,7 @@ function ReactComponentViewer({
   const sourceExtension = file.name.toLowerCase().endsWith('.tsx') ? '.tsx' : '.jsx';
 
   useEffect(() => {
-    if (source === null || moduleEntries === null || isModule) {
-      // No source yet, still checking module status, or this file is a module
-      // with no standalone preview — never build the React runtime srcdoc.
+    if (source === null) {
       setSrcDoc('');
       return;
     }
@@ -4183,7 +2620,7 @@ function ReactComponentViewer({
     return () => {
       cancelled = true;
     };
-  }, [source, exportTitle, moduleEntries, isModule]);
+  }, [source, exportTitle]);
 
   return (
     <div className="viewer react-component-viewer">
@@ -4191,12 +2628,10 @@ function ReactComponentViewer({
         <div className="viewer-toolbar-left">
           <button
             type="button"
-            className="icon-only od-tooltip"
+            className="icon-only"
             onClick={() => setReloadKey((n) => n + 1)}
-            title={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-            data-tooltip={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-            data-tooltip-placement="bottom"
-            aria-label={`${t('fileViewer.reloadAria')} ${t('fileViewer.preview')}`}
+            title={t('fileViewer.reload')}
+            aria-label={t('fileViewer.reloadAria')}
           >
             <Icon name="reload" size={14} />
           </button>
@@ -4227,23 +2662,16 @@ function ReactComponentViewer({
               <div className="share-menu" ref={shareRef}>
                 <button
                   type="button"
-                  className="viewer-action primary viewer-action-export od-tooltip"
+                  className="viewer-action primary"
                   aria-haspopup="menu"
                   aria-expanded={shareMenuOpen}
-                  title={t('fileViewer.shareLabel')}
-                  data-tooltip={t('fileViewer.shareLabel')}
-                  data-tooltip-placement="bottom"
                   onClick={() => setShareMenuOpen((v) => !v)}
                 >
-                  <span className="export-action-spacer" aria-hidden />
                   <span>{t('fileViewer.shareLabel')}</span>
-                  <RemixIcon name="arrow-down-s-line" size={14} />
+                  <Icon name="chevron-down" size={11} />
                 </button>
                 {shareMenuOpen ? (
                   <div className="share-menu-popover" role="menu">
-                    <div className="share-menu-section-label" role="presentation">
-                      {t('common.share')}
-                    </div>
                     <button
                       type="button"
                       className="share-menu-item"
@@ -4253,7 +2681,7 @@ function ReactComponentViewer({
                         exportAsJsx(source, exportTitle, sourceExtension);
                       }}
                     >
-                      <span className="share-menu-icon"><RemixIcon name="file-code-line" size={15} /></span>
+                      <span className="share-menu-icon"><Icon name="file-code" size={14} /></span>
                       <span>{t('fileViewer.exportJsx')}</span>
                     </button>
                     <button
@@ -4265,7 +2693,7 @@ function ReactComponentViewer({
                         exportReactComponentAsHtml(source, exportTitle);
                       }}
                     >
-                      <span className="share-menu-icon"><RemixIcon name="file-line" size={15} /></span>
+                      <span className="share-menu-icon"><Icon name="file" size={14} /></span>
                       <span>{t('fileViewer.exportReactHtml')}</span>
                     </button>
                     <div className="share-menu-divider" />
@@ -4278,7 +2706,7 @@ function ReactComponentViewer({
                         exportReactComponentAsZip(source, exportTitle, sourceExtension);
                       }}
                     >
-                      <span className="share-menu-icon"><RemixIcon name="file-zip-line" size={15} /></span>
+                      <span className="share-menu-icon"><Icon name="download" size={14} /></span>
                       <span>{t('fileViewer.exportZip')}</span>
                     </button>
                   </div>
@@ -4289,26 +2717,15 @@ function ReactComponentViewer({
         </div>
       </div>
       <div className="viewer-body">
-        {isModule && mode === 'preview' ? (
-          // Module of a multi-file prototype: no standalone preview, so the
-          // Preview tab shows a pointer to the HTML entry. The Source tab still
-          // renders the raw code below. Issue #2744.
-          <ReactModulePointer
-            entries={moduleEntries ?? []}
-            onOpenEntry={(htmlName) => onOpenFileReplacing?.(htmlName, file.name)}
-          />
-        ) : source === null || (mode === 'preview' && !srcDoc) ? (
+        {source === null || (mode === 'preview' && !srcDoc) ? (
           <div className="viewer-empty">{t('fileViewer.loading')}</div>
         ) : mode === 'preview' ? (
-          <PreviewDrawOverlay>
-            <iframe
-              data-testid="react-component-preview-frame"
-              title={file.name}
-              sandbox="allow-scripts allow-downloads"
-              srcDoc={srcDoc}
-              style={{ width: '100%', height: '100%', border: 0 }}
-            />
-          </PreviewDrawOverlay>
+          <iframe
+            data-testid="react-component-preview-frame"
+            title={file.name}
+            sandbox="allow-scripts"
+            srcDoc={srcDoc}
+          />
         ) : (
           <CodeWithLines text={source} />
         )}
@@ -4405,216 +2822,47 @@ function DocumentPreviewViewer({
 
 function HtmlViewer({
   projectId,
-  projectKind,
   file,
   liveHtml,
-  filesRefreshKey = 0,
   isDeck,
   onExportAsPptx,
   streaming,
-  commentQueueOnSend = false,
-  commentSendDisabled = false,
   previewComments = [],
   onSavePreviewComment,
   onRemovePreviewComment,
   onSendBoardCommentAttachments,
   onFileSaved,
-  commentPortalId,
-  onCommentModeChange,
-  shareRequest,
-  slideNavRequest,
 }: {
   projectId: string;
-  projectKind: TrackingProjectKind;
   file: ProjectFile;
   liveHtml?: string;
-  filesRefreshKey?: number;
   isDeck: boolean;
   onExportAsPptx?: ((fileName: string) => void) | undefined;
   streaming: boolean;
-  commentQueueOnSend?: boolean;
-  commentSendDisabled?: boolean;
   previewComments?: PreviewComment[];
-  onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean, images?: File[]) => Promise<PreviewComment | null>;
+  onSavePreviewComment?: (target: PreviewCommentTarget, note: string, attachAfterSave: boolean) => Promise<PreviewComment | null>;
   onRemovePreviewComment?: (commentId: string) => Promise<void>;
-  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[], images?: File[]) => Promise<boolean | void> | boolean | void;
+  onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[]) => Promise<void> | void;
   onFileSaved?: () => Promise<void> | void;
-  commentPortalId?: string;
-  onCommentModeChange?: (active: boolean) => void;
-  shareRequest?: { nonce: number } | null;
-  slideNavRequest?: { slideIndex: number; nonce: number } | null;
 }) {
-  const { locale, t } = useI18n();
-  const analytics = useAnalytics();
-  // Shared helper for the share menu: emit studio_click share_option on
-  // entry and artifact_export_result on resolution. Sync exports report
-  // success immediately after the call returns; async exports get .then
-  // / .catch. The same request_id threads both events so PostHog can
-  // stitch click → result via $insert_id correlation.
-  const fireShareExport = (
-    format:
-      | 'pdf'
-      | 'pptx'
-      | 'zip'
-      | 'html'
-      | 'image'
-      | 'markdown'
-      | 'template'
-      | 'share_link'
-      | 'share_page'
-      | 'vercel'
-      | 'cloudflare_pages',
-    fn: () => Promise<unknown> | unknown,
-  ) => {
-    const requestId = analytics.newRequestId();
-    const artifactId = anonymizeArtifactId({ projectId, fileName: file.name });
-    const artifactKind = artifactKindToTracking({ fileKind: file.kind ?? null });
-    const trackingFormat = format as Exclude<typeof format, 'image'>;
-    trackShareOptionPopoverClick(
-      analytics.track,
-      {
-        page_name: 'artifact',
-        area: 'share_option_popover',
-        artifact_id: artifactId,
-        artifact_kind: artifactKind,
-        element: trackingFormat,
-        project_id: projectId,
-        project_kind: projectKind,
-      },
-      { requestId },
-    );
-    const started = performance.now();
-    const finish = (result: 'success' | 'failed' | 'cancelled', errorCode?: string) => {
-      trackArtifactExportResult(
-        analytics.track,
-        {
-          page_name: 'artifact',
-          area: 'share_option_popover',
-          artifact_id: artifactId,
-          artifact_kind: artifactKind,
-          project_id: projectId,
-          project_kind: projectKind,
-          export_format: trackingFormat,
-          result,
-          ...(errorCode ? { error_code: errorCode } : {}),
-          export_duration_ms: Math.round(performance.now() - started),
-        },
-        { requestId },
-      );
-    };
-    const toastFormats = new Set(['pdf', 'pptx', 'zip', 'html', 'image', 'markdown']);
-    try {
-      const out = fn();
-      if (out && typeof (out as Promise<unknown>).then === 'function') {
-        (out as Promise<unknown>).then(
-          () => { finish('success'); if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportStarted'), tone: 'default' }); },
-          (err) => finish('failed', err instanceof Error ? err.name : 'UNKNOWN'),
-        );
-      } else {
-        finish('success');
-        if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportStarted'), tone: 'default' });
-      }
-    } catch (err) {
-      finish('failed', err instanceof Error ? err.name : 'UNKNOWN');
-    }
-  };
-  // P0 helpers — keep the artifact_id + artifact_kind derivation in one place
-  // so each per-button onClick stays a one-liner. We compute lazily inside the
-  // closure because `file.kind` / `file.name` can change as the user navigates
-  // tabs without remounting HtmlViewer.
-  const fireArtifactToolbarClick = (
-    element:
-      | 'reload'
-      | 'preview'
-      | 'source'
-      | 'tweaks'
-      | 'draw'
-      | 'comment'
-      | 'pods'
-      | 'inspect'
-      | 'edit'
-      | 'zoom_out'
-      | 'zoom_level_dropdown'
-      | 'zoom_in',
-  ) => {
-    trackArtifactToolbarClick(analytics.track, {
-      page_name: 'artifact',
-      area: 'artifact_toolbar',
-      element,
-      artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-      artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-    });
-  };
-  const fireArtifactHeaderClick = (
-    element: 'back' | 'edit' | 'present_dropdown' | 'share_dropdown' | 'settings',
-  ) => {
-    trackArtifactHeaderClick(analytics.track, {
-      page_name: 'artifact',
-      area: 'artifact_header',
-      element,
-      artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-      artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-    });
-  };
-  const firePresentPopoverClick = (
-    element: 'in_this_tab' | 'fullscreen' | 'new_tab',
-  ) => {
-    trackPresentPopoverClick(analytics.track, {
-      page_name: 'artifact',
-      area: 'present_popover',
-      element,
-      artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-      artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-    });
-  };
-  const fireCommentPopoverClick = (
-    element: 'save_comment' | 'send_to_chat' | 'add_note',
-  ) => {
-    trackCommentPopoverClick(analytics.track, {
-      page_name: 'artifact',
-      area: 'comment_popover',
-      element,
-      artifact_id: anonymizeArtifactId({ projectId, fileName: file.name }),
-      artifact_kind: artifactKindToTracking({ fileKind: file.kind ?? null }),
-    });
-  };
+  const t = useT();
   const [mode, setMode] = useState<'preview' | 'source'>('preview');
   const [source, setSource] = useState<string | null>(liveHtml ?? null);
   const [inlinedSource, setInlinedSource] = useState<string | null>(null);
   const [zoom, setZoom] = useState(100);
-  const fileViewportKey = previewViewportStateKey(projectId, file);
-  const [previewViewport, setPreviewViewportState] = useState<PreviewViewportId>(
-    () => htmlPreviewViewportState.get(fileViewportKey) ?? 'desktop',
-  );
-  const setPreviewViewport = useCallback((viewport: PreviewViewportId) => {
-    setPreviewViewportCached(fileViewportKey, viewport);
-    setPreviewViewportState(viewport);
-  }, [fileViewportKey]);
-  const [zoomMenuOpen, setZoomMenuOpen] = useState(false);
-  const zoomMenuRef = useRef<HTMLDivElement | null>(null);
   const [presentMenuOpen, setPresentMenuOpen] = useState(false);
-  const [deployMenuOpen, setDeployMenuOpen] = useState(false);
-  const [downloadMenuOpen, setDownloadMenuOpen] = useState(false);
-  const [exportReadyNudge, setExportReadyNudge] = useState(false);
-  const exportReadyNudgeSeenRef = useRef<Set<string>>(new Set());
+  const [shareMenuOpen, setShareMenuOpen] = useState(false);
   // Template save UX. We surface a transient "Saved" pill in the share
   // menu so the user gets feedback without a noisy toast layer.
   const [savingTemplate, setSavingTemplate] = useState(false);
   const [templateNote, setTemplateNote] = useState<string | null>(null);
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [templateName, setTemplateName] = useState('');
-
-  useEffect(() => {
-    setPreviewViewportState(htmlPreviewViewportState.get(fileViewportKey) ?? 'desktop');
-  }, [fileViewportKey]);
   const [templateDescription, setTemplateDescription] = useState('');
   const [templateSaveError, setTemplateSaveError] = useState<string | null>(null);
   const [deployment, setDeployment] = useState<WebDeploymentInfo | null>(null);
   const [deploymentsByProvider, setDeploymentsByProvider] = useState<Partial<Record<WebDeployProviderId, WebDeploymentInfo>>>({});
   const [deployModalOpen, setDeployModalOpen] = useState(false);
-  const closeDeployModal = useCallback(() => {
-    setDeployModalOpen(false);
-  }, []);
   const [deployConfig, setDeployConfig] = useState<WebDeployConfigResponse | null>(null);
   const [deploying, setDeploying] = useState(false);
   const [deployPhase, setDeployPhase] = useState<'idle' | 'deploying' | 'preparing-link'>('idle');
@@ -4623,7 +2871,6 @@ function HtmlViewer({
   const [deployResult, setDeployResult] = useState<WebDeployProjectFileResponse | null>(null);
   const [copiedDeployLink, setCopiedDeployLink] = useState<string | null>(null);
   const [deployProviderId, setDeployProviderId] = useState<WebDeployProviderId>(DEFAULT_DEPLOY_PROVIDER_ID);
-  const [projectSocialShare, setProjectSocialShare] = useState<SocialShareResponse | null>(null);
   const [deployToken, setDeployToken] = useState('');
   const [teamId, setTeamId] = useState('');
   const [teamSlug, setTeamSlug] = useState('');
@@ -4634,204 +2881,22 @@ function HtmlViewer({
   const [cloudflareZoneId, setCloudflareZoneId] = useState('');
   const [cloudflareDomainPrefix, setCloudflareDomainPrefix] = useState('');
   const deployProviderLoadSeqRef = useRef(0);
-  const deployTokenInputRef = useRef<HTMLInputElement | null>(null);
-  useEffect(() => {
-    if (!deployModalOpen) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return;
-      event.preventDefault();
-      closeDeployModal();
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [closeDeployModal, deployModalOpen]);
   const [inTabPresent, setInTabPresent] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
   const [boardMode, setBoardMode] = useState(false);
-  const [commentPanelOpen, setCommentPanelOpen] = useState(false);
-  const [commentCreateMode, setCommentCreateMode] = useState(false);
   const [boardTool, setBoardTool] = useState<BoardTool>('inspect');
   const [inspectMode, setInspectMode] = useState(false);
-  const [agentToolsOpen, setAgentToolsOpen] = useState(false);
-  const [drawOverlayOpen, setDrawOverlayOpen] = useState(false);
-  // for hint managing hint box state
-  const [openHintBox, setOpenHintBox] = useState(true);
-  const [manualEditMode, setManualEditModeRaw] = useState(false);
-  const [manualEditSrcDocActive, setManualEditSrcDocActive] = useState(false);
-  const [manualEditFrozenSource, setManualEditFrozenSource] = useState<string | null>(null);
-  const [manualEditViewportWidth, setManualEditViewportWidth] = useState<number | null>(null);
-  const [commentPortalHost, setCommentPortalHost] = useState<HTMLElement | null>(null);
-  const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
-  const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
-  const activatedSrcDocTransportHtmlRef = useRef<string | null>(null);
-  // Tracks the iframe DOM node whose dedupe ref was last reset by the
-  // srcDoc onLoad handler. We reset the dedupe exactly once per freshly
-  // mounted iframe (the first load is the shell HTML), and skip every
-  // subsequent load on the same node (those are our own
-  // document.open/write/close inside the shell). See onLoad below for
-  // the infinite-loop story (issue #2361).
-  const srcDocFrameDedupeResetForRef = useRef<HTMLIFrameElement | null>(null);
-  const isActivePreviewIframeSource = useCallback((source: MessageEventSource | null) => {
-    return !!source && source === iframeRef.current?.contentWindow;
-  }, []);
-  const isOurPreviewIframeSource = useCallback((source: MessageEventSource | null) => {
-    if (!source) return false;
-    return (
-      source === iframeRef.current?.contentWindow ||
-      source === urlPreviewIframeRef.current?.contentWindow ||
-      source === srcDocPreviewIframeRef.current?.contentWindow
-    );
-  }, []);
-  const previewScrollRestoreRef = useRef<{
-    hostLeft: number;
-    hostTop: number;
-    frameLeft: number;
-    frameTop: number;
-    canvasLeft: number;
-    canvasTop: number;
-    expiresAt: number;
-  } | null>(null);
-  const previewScrollPositionRef = useRef({
-    frameLeft: 0,
-    frameTop: 0,
-    canvasLeft: 0,
-    canvasTop: 0,
-  });
-  const previewScrollRequestAtRef = useRef(0);
-  const dcViewportRef = useRef({
-    x: 0,
-    y: 0,
-    scale: 1,
-  });
-  const dcViewportRestoreAtRef = useRef(0);
-  const setManualEditMode = useCallback((next: boolean | ((prev: boolean) => boolean)) => {
-    setManualEditModeRaw((prev) => {
-      const value = typeof next === 'function' ? (next as (p: boolean) => boolean)(prev) : next;
-      if (value !== prev && !value) {
-        setManualEditViewportWidth(null);
-      }
-      return value;
-    });
-  }, []);
-  useEffect(() => {
-    setManualEditSrcDocActive(false);
-    setManualEditFrozenSource(null);
-  }, [projectId, file.name]);
-  useEffect(() => {
-    onCommentModeChange?.(commentPanelOpen);
-  }, [commentPanelOpen, onCommentModeChange]);
-  useEffect(() => () => {
-    onCommentModeChange?.(false);
-  }, [onCommentModeChange]);
-  useEffect(() => {
-    if (!commentPanelOpen || !commentPortalId) {
-      setCommentPortalHost(null);
-      return;
-    }
-    let cancelled = false;
-    let raf = 0;
-    const findHost = () => {
-      if (cancelled) return;
-      const host = document.getElementById(commentPortalId);
-      setCommentPortalHost(host);
-      if (!host) raf = window.requestAnimationFrame(findHost);
-    };
-    findHost();
-    return () => {
-      cancelled = true;
-      if (raf) window.cancelAnimationFrame(raf);
-      setCommentPortalHost(null);
-    };
-  }, [commentPanelOpen, commentPortalId]);
-  const capturePreviewScrollPosition = useCallback(() => {
-    const host = previewBodyRef.current;
-    let frameLeft = 0;
-    let frameTop = 0;
-    let canvasLeft = 0;
-    let canvasTop = 0;
-    try {
-      const frameDocument = iframeRef.current?.contentWindow?.document;
-      const frameScroll = frameDocument?.scrollingElement;
-      const canvasScroll = frameDocument?.querySelector<HTMLElement>('.design-canvas');
-      frameLeft = frameScroll?.scrollLeft ?? 0;
-      frameTop = frameScroll?.scrollTop ?? 0;
-      canvasLeft = canvasScroll?.scrollLeft ?? 0;
-      canvasTop = canvasScroll?.scrollTop ?? 0;
-    } catch {
-      frameLeft = 0;
-      frameTop = 0;
-      canvasLeft = 0;
-      canvasTop = 0;
-    }
-    previewScrollRestoreRef.current = {
-      hostLeft: host?.scrollLeft ?? 0,
-      hostTop: host?.scrollTop ?? 0,
-      frameLeft: frameLeft || previewScrollPositionRef.current.frameLeft,
-      frameTop: frameTop || previewScrollPositionRef.current.frameTop,
-      canvasLeft: canvasLeft || previewScrollPositionRef.current.canvasLeft,
-      canvasTop: canvasTop || previewScrollPositionRef.current.canvasTop,
-      expiresAt: Date.now() + 5000,
-    };
-  }, []);
-  const restorePreviewScrollPosition = useCallback(() => {
-    const snapshot = previewScrollRestoreRef.current;
-    if (!snapshot) return;
-    if (Date.now() > snapshot.expiresAt) {
-      previewScrollRestoreRef.current = null;
-      return;
-    }
-    const apply = () => {
-      const previewBody = previewBodyRef.current;
-      if (typeof previewBody?.scrollTo === 'function') {
-        previewBody.scrollTo(snapshot.hostLeft, snapshot.hostTop);
-      }
-      try {
-        const frameDocument = iframeRef.current?.contentWindow?.document;
-        frameDocument?.scrollingElement?.scrollTo(snapshot.frameLeft, snapshot.frameTop);
-        frameDocument?.querySelector<HTMLElement>('.design-canvas')?.scrollTo(snapshot.canvasLeft, snapshot.canvasTop);
-        iframeRef.current?.contentWindow?.postMessage({
-          type: 'od:preview-scroll-restore',
-          frameLeft: snapshot.frameLeft,
-          frameTop: snapshot.frameTop,
-          canvasLeft: snapshot.canvasLeft,
-          canvasTop: snapshot.canvasTop,
-        }, '*');
-      } catch {}
-    };
-    window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => {
-        apply();
-        window.setTimeout(apply, 80);
-        window.setTimeout(() => {
-          if (previewScrollRestoreRef.current === snapshot) {
-            apply();
-          }
-        }, 260);
-      });
-    });
-  }, []);
+  const [manualEditMode, setManualEditMode] = useState(false);
   const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([]);
   const [selectedManualEditTarget, setSelectedManualEditTarget] = useState<ManualEditTarget | null>(null);
-  const [manualEditHoverTarget, setManualEditHoverTarget] = useState<ManualEditTarget | null>(null);
-  const [manualEditPageStylesOpen, setManualEditPageStylesOpen] = useState(false);
-  const [manualEditPanelPosition, setManualEditPanelPosition] = useState<{ left: number; top: number } | null>(null);
-  const selectedManualEditTargetIdRef = useRef<string | null>(null);
   const [manualEditDraft, setManualEditDraft] = useState<ManualEditDraft>(() => emptyManualEditDraft());
   const [manualEditHistory, setManualEditHistory] = useState<ManualEditHistoryEntry[]>([]);
   const [manualEditUndone, setManualEditUndone] = useState<ManualEditHistoryEntry[]>([]);
   const [manualEditError, setManualEditError] = useState<string | null>(null);
   const [manualEditSaving, setManualEditSaving] = useState(false);
   const manualEditSavingRef = useRef(false);
-  const manualEditPendingStyleRef = useRef<ManualEditPendingStyleSave | null>(null);
-  const manualEditStyleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const manualEditPreviewVersionRef = useRef(0);
-  const sourceRef = useRef<string | null>(source);
-  const sourceFileKeyRef = useRef<string | null>(null);
   const templateNameId = useId();
   const templateDescriptionId = useId();
-  const imageExportTitleId = useId();
   // Opt back into the legacy inline-asset srcDoc path via `?forceInline=1`
   // on the host page. Lets users escape-hatch around the URL-load default
   // for non-deck HTML that depends on the in-iframe localStorage shim.
@@ -4841,49 +2906,8 @@ function HtmlViewer({
   );
   const [activeCommentTarget, setActiveCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
   const [hoveredCommentTarget, setHoveredCommentTarget] = useState<PreviewCommentSnapshot | null>(null);
-  // True while the pointer is physically over the floating hover card. The card
-  // sits on top of the preview iframe, so reaching it makes the iframe fire a
-  // mouseout -> od:comment-leave. We ignore that leave while pinned so the card
-  // (and its selectable values) stays put instead of unmounting and flickering.
-  // The pointer cannot be over the iframe and the host card at once, so a fresh
-  // od:comment-hover never races this; only the card's own leave clears it.
-  const hoverCardPinnedRef = useRef(false);
-  // Tearing the card down is always deferred by a beat rather than done
-  // synchronously. The iframe's mouseout (od:comment-leave) arrives async via
-  // postMessage; the card's own mouseenter and the next od:comment-hover are the
-  // signals that the pointer actually landed on the card or back on the element
-  // it overlaps. Deferring lets those cancel the dismiss before it lands.
-  // Synchronous teardown raced ahead of them: the card flickered on the way in
-  // and vanished the moment you moved off it back onto the element it described.
-  const hoverCardDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const cancelHoverCardDismiss = useCallback(() => {
-    if (hoverCardDismissTimerRef.current !== null) {
-      clearTimeout(hoverCardDismissTimerRef.current);
-      hoverCardDismissTimerRef.current = null;
-    }
-  }, []);
-  const scheduleHoverCardDismiss = useCallback(() => {
-    if (hoverCardDismissTimerRef.current !== null) clearTimeout(hoverCardDismissTimerRef.current);
-    hoverCardDismissTimerRef.current = setTimeout(() => {
-      hoverCardDismissTimerRef.current = null;
-      // hoverCardPinnedRef tracks "pointer is physically over the card". If it
-      // got (re-)pinned while we waited, this now-stale dismiss must not fire.
-      if (!hoverCardPinnedRef.current) setHoveredCommentTarget(null);
-    }, HOVER_CARD_DISMISS_DELAY_MS);
-  }, []);
-  const [hoveredPodMemberId, setHoveredPodMemberId] = useState<string | null>(null);
-  // If the card unmounts for any other reason while the pointer is still over
-  // it (its onMouseLeave never fires), drop the pin so later leaves dismiss
-  // normally instead of being swallowed forever.
-  useEffect(() => {
-    if (!hoveredCommentTarget) hoverCardPinnedRef.current = false;
-  }, [hoveredCommentTarget]);
-  // Don't let a pending dismiss outlive the component.
-  useEffect(() => cancelHoverCardDismiss, [cancelHoverCardDismiss]);
-  const [activePreviewCommentId, setActivePreviewCommentId] = useState<string | null>(null);
   const [liveCommentTargets, setLiveCommentTargets] = useState<Map<string, PreviewCommentSnapshot>>(() => new Map());
   const liveCommentTargetsRef = useRef(liveCommentTargets);
-  const [commentOrderIds, setCommentOrderIds] = useState<string[]>([]);
   const [commentDraft, setCommentDraft] = useState('');
   // Inspect mode shares the iframe selection bridge with comment mode but
   // routes the picked element to a side panel that mutates per-element CSS
@@ -4907,64 +2931,17 @@ function HtmlViewer({
   const [inspectSavedAt, setInspectSavedAt] = useState<number | null>(null);
   const [inspectError, setInspectError] = useState<string | null>(null);
   const [queuedBoardNotes, setQueuedBoardNotes] = useState<string[]>([]);
-  // Images attached to an element comment ("评论此元素"). Kept as raw Files
-  // (uploaded on send) with object-URL thumbnails for preview/remove, mirroring
-  // the markup overlay's image tray.
-  const [boardImages, setBoardImages] = useState<File[]>([]);
-  const [activeCommentExistingAttachments, setActiveCommentExistingAttachments] =
-    useState<PreviewCommentAttachment[]>([]);
-  const [boardImagePreviews, setBoardImagePreviews] = useState<{ file: File; url: string }[]>([]);
-  const [boardPreviewIndex, setBoardPreviewIndex] = useState<number | null>(null);
   const [sendingBoardBatch, setSendingBoardBatch] = useState(false);
-  useEffect(() => {
-    const next = boardImages.map((file) => ({ file, url: URL.createObjectURL(file) }));
-    setBoardImagePreviews(next);
-    return () => {
-      next.forEach((item) => URL.revokeObjectURL(item.url));
-    };
-  }, [boardImages]);
-  const [commentSavedToast, setCommentSavedToast] = useState<string | null>(null);
-  const [templateSavedToast, setTemplateSavedToast] = useState<string | null>(null);
-  const [deploySavedToast, setDeploySavedToast] = useState<{ message: string; details: string } | null>(null);
-  const [deployActionToast, setDeployActionToast] = useState<string | null>(null);
-  const [imageExportModalOpen, setImageExportModalOpen] = useState(false);
-  const [imageExportFormat, setImageExportFormat] = useState<ImageExportFormat>('png');
-  const [imageExportBusy, setImageExportBusy] = useState(false);
-  const [imageExportPreparing, setImageExportPreparing] = useState(false);
-  const [imageExportError, setImageExportError] = useState<string | null>(null);
-  const [imageExportSavedToast, setImageExportSavedToast] = useState<{ message: string; details: string } | null>(null);
-  const [imageExportPreparedBlob, setImageExportPreparedBlob] = useState<{ format: ImageExportFormat; blob: Blob } | null>(null);
-  const imageExportSnapshotDataUrlRef = useRef<string | null>(null);
-  const imageExportPrepareIdRef = useRef(0);
-  const screenshotInFlightRef = useRef(false);
-  const [exportToast, setExportToast] = useState<
-    { message: string; tone: 'default' | 'success' | 'error' | 'loading' } | null
-  >(null);
-  const [shareLinkFeedback, setShareLinkFeedback] = useState<'copied' | 'failed' | null>(null);
-  const [shareGuideToast, setShareGuideToast] = useState<string | null>(null);
-  const [selectedSideCommentIds, setSelectedSideCommentIds] = useState<Set<string>>(() => new Set());
-  const [commentSidePanelCollapsed, setCommentSidePanelCollapsed] = useState(false);
   const [strokePoints, setStrokePoints] = useState<StrokePoint[]>([]);
   const previewStateKey = `${projectId}:${file.name}`;
   const previewScale = zoom / 100;
-  const localCommentSideDockActive = commentPanelOpen && !commentPortalHost;
-  const boardPreviewCanvasSize = commentPreviewCanvasSize(previewBodySize, {
-    boardMode: localCommentSideDockActive,
-    sidePanelCollapsed: commentSidePanelCollapsed,
-    viewport: previewViewport,
-  });
-  const boardSideDockStacked = usesStackedCommentSideDock(previewBodySize, {
-    boardMode: localCommentSideDockActive,
-    sidePanelCollapsed: commentSidePanelCollapsed,
-    viewport: previewViewport,
-  });
 
   function deploymentMapForCurrentFile(items: WebDeploymentInfo[]) {
     const next: Partial<Record<WebDeployProviderId, WebDeploymentInfo>> = {};
     for (const option of DEPLOY_PROVIDER_OPTIONS) {
-      const deploymentForProvider = items
-        .filter((item) => item.fileName === file.name && item.providerId === option.id && item.url?.trim())
-        .sort(compareDeploymentsByNewest)[0];
+      const deploymentForProvider = items.find(
+        (item) => item.fileName === file.name && item.providerId === option.id && item.url?.trim(),
+      );
       if (deploymentForProvider) next[option.id] = deploymentForProvider;
     }
     return next;
@@ -5081,66 +3058,28 @@ function HtmlViewer({
   const [slideState, setSlideState] = useState<SlideState | null>(
     () => htmlPreviewSlideState.get(previewStateKey) ?? null,
   );
-  const boardPreviewScaleOptions = localCommentSideDockActive ? { canvasPadding: 0 } : undefined;
-  const overlayPreviewScale = effectivePreviewScale(
-    previewViewport,
-    previewScale,
-    boardPreviewCanvasSize,
-    boardPreviewScaleOptions,
-  );
-  const overlayPreviewTransform: PreviewOverlayTransform = {
-    scale: overlayPreviewScale,
-    offsetX: 0,
-    offsetY: 0,
-  };
+  const previewBodyRef = useRef<HTMLDivElement | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const shareRef = useRef<HTMLDivElement | null>(null);
-  const [chromeActionsHost, setChromeActionsHost] = useState<HTMLElement | null>(null);
-  useEffect(() => {
-    if (typeof document === 'undefined') return;
-    setChromeActionsHost(resolveChromeActionsHost());
-  }, []);
 
   useEffect(() => {
     liveCommentTargetsRef.current = liveCommentTargets;
   }, [liveCommentTargets]);
 
   useEffect(() => {
-    const sourceFileKey = `${projectId}\0${file.name}\0${liveHtml === undefined ? 'raw' : 'live'}`;
     if (liveHtml !== undefined) {
-      sourceFileKeyRef.current = sourceFileKey;
       setSource(liveHtml);
-      sourceRef.current = liveHtml;
       return;
     }
-    const fileChanged = sourceFileKeyRef.current !== sourceFileKey;
-    sourceFileKeyRef.current = sourceFileKey;
-    if (fileChanged) {
-      setSource(null);
-      sourceRef.current = null;
-    }
+    setSource(null);
     let cancelled = false;
-    // Cache-bust the fetch on every mtime / reload / files-refresh bump.
-    // Without this, an agent edit during Comment mode (srcDoc path) gets
-    // stale HTML from the browser HTTP cache — the source state ends up
-    // identical to the previous value, srcDoc is byte-equal to the last
-    // activated HTML, canActivateSrcDocTransport bails on the dedupe
-    // check, and the preview only refreshes when Comment closes and the
-    // url-load iframe takes over with its own ?v=mtime cache-bust.
-    void fetchProjectFileText(projectId, file.name, {
-      cacheBustKey: `${file.mtime}-${reloadKey}-${filesRefreshKey}`,
-    }).then((text) => {
-      if (cancelled) return;
-      // Chokidar emits agent rewrites as unlink+add+change bursts; a
-      // transient null mid-burst would blank source → srcDoc empty →
-      // shell stays on prior frame. Keep the last good text instead.
-      if (text == null) return;
-      setSource(text);
-      sourceRef.current = text;
+    void fetchProjectFileText(projectId, file.name).then((text) => {
+      if (!cancelled) setSource(text);
     });
     return () => {
       cancelled = true;
     };
-  }, [projectId, file.name, file.mtime, liveHtml, reloadKey, filesRefreshKey]);
+  }, [projectId, file.name, file.mtime, liveHtml, reloadKey]);
 
   useEffect(() => {
     let cancelled = false;
@@ -5170,84 +3109,21 @@ function HtmlViewer({
     return /class\s*=\s*['"][^'"]*\bslide\b/i.test(source);
   }, [source]);
   const effectiveDeck = isDeck || looksLikeDeck;
-  const livePreviewSource = inlinedSource ?? source;
-  // Freeze the iframe input on the snapshot taken at Edit-mode entry. Any
-  // source rewrite during edit (1.5s debounced set-style patches) stays
-  // invisible to the iframe — live updates flow through od-edit-preview-style
-  // postMessage instead, so the canvas never has to reload.
-  useEffect(() => {
-    if (manualEditMode && manualEditFrozenSource === null && livePreviewSource != null) {
-      setManualEditFrozenSource(livePreviewSource);
-    }
-  }, [manualEditMode, manualEditFrozenSource, livePreviewSource]);
-  const previewSource = (manualEditMode && manualEditFrozenSource !== null)
-    ? manualEditFrozenSource
-    : livePreviewSource;
-  const manualEditPageStylesEnabled = typeof source === 'string' && isManualEditFullHtmlDocument(source);
-  const urlModeBridge = hasUrlModeBridge(source);
-  const manualEditRequiresSrcDoc = manualEditSrcDocActive && !urlModeBridge;
+  const previewSource = inlinedSource ?? source;
   // When we URL-load the iframe directly, skip every in-host inlining /
   // srcDoc-rebuilding step. The browser does the asset resolution itself,
   // which is the whole point of the URL-load path.
-  // Auto-fall back to the srcDoc path when the artifact will crash under
-  // the URL-load iframe's bare `sandbox="allow-scripts"` — Babel-standalone
-  // React prototypes and any HTML that reads Web Storage at mount throw
-  // SecurityError without `allow-same-origin`. The srcDoc path runs
-  // `injectSandboxShim` before any user script, so those artifacts render.
-  // Memoized on `source` so HtmlViewer's frequent re-renders (board/inspect/
-  // edit mode toggles, slide nav) don't re-scan the HTML each time.
-  const needsSandboxShim = useMemo(
-    () => source != null && htmlNeedsSandboxShim(source),
-    [source],
-  );
-  const needsFocusGuard = useMemo(
-    () => source != null && htmlNeedsFocusGuard(source),
-    [source],
-  );
-  const [urlSelectionBridgeReady, setUrlSelectionBridgeReady] = useState(false);
   const useUrlLoadPreview = shouldUrlLoadHtmlPreview({
     mode,
     isDeck: effectiveDeck,
-    commentMode: boardMode,
-    urlCommentBridge: urlSelectionBridgeReady,
-    editMode: manualEditMode,
-    urlModeBridge,
+    commentMode: boardMode || manualEditMode,
     inspectMode,
-    drawMode: drawOverlayOpen,
-    forceInline: forceInline || needsSandboxShim,
-    needsFocusGuard,
-  }) && !manualEditRequiresSrcDoc;
-  const basePreviewSrcUrl = useMemo(
-    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot`,
+    forceInline,
+  });
+  const previewSrcUrl = useMemo(
+    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}`,
     [projectId, file.name, file.mtime, reloadKey],
   );
-  const [previewSrcUrl, setPreviewSrcUrl] = useState(basePreviewSrcUrl);
-  const activePreviewSrcUrl = (
-    previewSrcUrl === basePreviewSrcUrl ||
-    previewSrcUrl.startsWith(`${basePreviewSrcUrl}&`)
-  )
-    ? previewSrcUrl
-    : basePreviewSrcUrl;
-  useEffect(() => {
-    setPreviewSrcUrl(basePreviewSrcUrl);
-    setUrlSelectionBridgeReady(false);
-  }, [basePreviewSrcUrl]);
-  useEffect(() => {
-    iframeRef.current = useUrlLoadPreview ? urlPreviewIframeRef.current : srcDocPreviewIframeRef.current;
-  }, [useUrlLoadPreview]);
-
-  useEffect(() => {
-    if (filesRefreshKey === 0) return;
-    const nextSrc = `${basePreviewSrcUrl}&fr=${filesRefreshKey}`;
-    const timeout = window.setTimeout(() => {
-      if (useUrlLoadPreview && urlPreviewIframeRef.current?.contentWindow) {
-        urlPreviewIframeRef.current.contentWindow.location.replace(nextSrc);
-      } else {
-        setPreviewSrcUrl(nextSrc);
-      }
-    }, 180);
-    return () => window.clearTimeout(timeout);
-  }, [basePreviewSrcUrl, filesRefreshKey, useUrlLoadPreview]);
 
   useEffect(() => {
     setInlinedSource(null);
@@ -5260,230 +3136,19 @@ function HtmlViewer({
     return () => {
       cancelled = true;
     };
-  }, [source, effectiveDeck, projectId, file.name, reloadKey, useUrlLoadPreview]);
+  }, [source, effectiveDeck, projectId, file.name, useUrlLoadPreview]);
 
   const srcDoc = useMemo(
     () => (previewSource ? buildSrcdoc(previewSource, {
       deck: effectiveDeck,
       baseHref: projectRawUrl(projectId, baseDirFor(file.name)),
       initialSlideIndex: htmlPreviewSlideState.get(previewStateKey)?.active ?? 0,
-      selectionBridge: true,
-      editBridge: manualEditRequiresSrcDoc,
-      paletteBridge: false,
-      previewFocusGuard: true,
+      commentBridge: boardMode && !manualEditMode,
+      inspectBridge: inspectMode,
+      editBridge: manualEditMode,
     }) : ''),
-    [previewSource, effectiveDeck, projectId, file.name, previewStateKey, manualEditRequiresSrcDoc],
+    [previewSource, effectiveDeck, projectId, file.name, previewStateKey, boardMode, manualEditMode, inspectMode],
   );
-  const lazySrcDocTransport = useMemo(() => buildLazySrcdocTransport(), []);
-  const [srcDocTransportResetKey, setSrcDocTransportResetKey] = useState(0);
-  const [srcDocShellReady, setSrcDocShellReady] = useState(false);
-  const wasUrlLoadPreviewRef = useRef(useUrlLoadPreview);
-  const urlPreviewKeepAliveKey = previewIframeKeepAliveKey(projectId, file.name);
-  // Reset the shell-ready latch whenever the srcDoc iframe re-mounts. The
-  // next shell will post `od:srcdoc-transport-ready` (or fire onLoad) and
-  // flip this back to true. See #2253.
-  useEffect(() => {
-    setSrcDocShellReady(false);
-  }, [srcDocTransportResetKey]);
-  // Listen for the shell's ready handshake. Gating activation on this is
-  // what fixes the #2253 race: opening Tweaks right after a key-driven
-  // re-mount used to post `activate` before the shell's listener was
-  // installed, dropping the message and stranding the iframe on the empty
-  // 536-byte body.
-  useEffect(() => {
-    function onMessage(ev: MessageEvent) {
-      if (ev.source !== srcDocPreviewIframeRef.current?.contentWindow) return;
-      const data = ev.data as { type?: string } | null;
-      if (data?.type !== 'od:srcdoc-transport-ready') return;
-      setSrcDocShellReady(true);
-    }
-    window.addEventListener('message', onMessage);
-    return () => window.removeEventListener('message', onMessage);
-  }, []);
-  useEffect(() => {
-    function onMessage(ev: MessageEvent) {
-      const frame = urlPreviewIframeRef.current;
-      if (ev.source !== frame?.contentWindow) return;
-      if (frame.getAttribute('src') === 'about:blank') return;
-      const data = ev.data as { type?: string } | null;
-      if (data?.type !== 'od:url-selection-bridge-ready') return;
-      setUrlSelectionBridgeReady(true);
-    }
-    window.addEventListener('message', onMessage);
-    return () => window.removeEventListener('message', onMessage);
-  }, []);
-  // Lazy transport preloads an empty shell only while URL-load is the active
-  // transport. Once srcdoc becomes active (sandbox shim, Draw, Screenshot,
-  // Tweaks, etc.), mount the real artifact HTML directly so we do not depend on
-  // a postMessage activation that can race (#2253) and strand the iframe blank
-  // (#2361, #2791).
-  const captureModeActive = drawOverlayOpen;
-  const useLazySrcDocTransport = !manualEditRequiresSrcDoc && !captureModeActive && useUrlLoadPreview;
-  const srcDocTransportContent = useLazySrcDocTransport ? lazySrcDocTransport : srcDoc;
-  const urlTransportSrc = useUrlLoadPreview ? activePreviewSrcUrl : 'about:blank';
-  const activateSrcDocTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
-    if (!canActivateSrcDocTransport({
-      srcDoc,
-      useUrlLoadPreview,
-      useLazySrcDocTransport,
-      shellReady: srcDocShellReady,
-      activatedHtml: activatedSrcDocTransportHtmlRef.current,
-    })) return false;
-    // A SECOND activation while Comment mode is on would document.open +
-    // write over the iframe's existing document. The window-level message
-    // listener survives, but iframe.onLoad does NOT refire for
-    // document.write, so host-side re-init (slide nav sync, scroll
-    // restore, bridge replay) is silently skipped — the visible page can
-    // drift out of sync with the host's tracked state (e.g. the page
-    // indicator shows 3 while the iframe rendered page 4 of the freshly
-    // edited deck). Force a fresh shell mount under Comment so onLoad
-    // fires and the full re-init pipeline runs against the new HTML.
-    //
-    // Skip the remount path in Manual Edit, where the postMessage
-    // activate carries the patched HTML and host-side scroll/slide
-    // state intentionally stays put across the patch.
-    if (boardMode && activatedSrcDocTransportHtmlRef.current !== null) {
-      activatedSrcDocTransportHtmlRef.current = null;
-      setSrcDocTransportResetKey((key) => key + 1);
-      return true;
-    }
-    const win = target?.contentWindow;
-    if (!win) return false;
-    win.postMessage({ type: 'od:srcdoc-transport-activate', html: srcDoc }, '*');
-    activatedSrcDocTransportHtmlRef.current = srcDoc;
-    return true;
-  }, [srcDoc, useLazySrcDocTransport, useUrlLoadPreview, srcDocShellReady, boardMode]);
-  const activateLoadedSrcDocTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
-    if (!canActivateSrcDocTransport({
-      srcDoc,
-      useUrlLoadPreview,
-      useLazySrcDocTransport,
-      shellReady: true,
-      activatedHtml: activatedSrcDocTransportHtmlRef.current,
-    })) return false;
-    const win = target?.contentWindow;
-    if (!win) return false;
-    win.postMessage({ type: 'od:srcdoc-transport-activate', html: srcDoc }, '*');
-    activatedSrcDocTransportHtmlRef.current = srcDoc;
-    return true;
-  }, [srcDoc, useLazySrcDocTransport, useUrlLoadPreview]);
-  const activateSrcDocSnapshotTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
-    if (!srcDoc) return false;
-    const win = target?.contentWindow;
-    if (!win) return false;
-    win.postMessage({ type: 'od:srcdoc-transport-activate', html: srcDoc }, '*');
-    return true;
-  }, [srcDoc]);
-  useEffect(() => {
-    if (useUrlLoadPreview) {
-      activatedSrcDocTransportHtmlRef.current = null;
-      if (!wasUrlLoadPreviewRef.current) {
-        setSrcDocTransportResetKey((key) => key + 1);
-      }
-      wasUrlLoadPreviewRef.current = true;
-      return;
-    }
-    if (wasUrlLoadPreviewRef.current) {
-      setSrcDocTransportResetKey((key) => key + 1);
-      activatedSrcDocTransportHtmlRef.current = null;
-    }
-    wasUrlLoadPreviewRef.current = false;
-    activateSrcDocTransport();
-  }, [activateSrcDocTransport, useUrlLoadPreview]);
-  
-  useEffect(() => {
-    restorePreviewScrollPosition();
-  }, [boardMode, drawOverlayOpen, manualEditMode, srcDoc, restorePreviewScrollPosition]);
-
-  useEffect(() => {
-    function onMessage(ev: MessageEvent) {
-      if (!isOurPreviewIframeSource(ev.source)) return;
-      if (!isActivePreviewIframeSource(ev.source)) return;
-      const data = ev.data as {
-        type?: string;
-        frameLeft?: number;
-        frameTop?: number;
-        canvasLeft?: number;
-        canvasTop?: number;
-      } | null;
-      if (!data || data.type !== 'od:preview-scroll') return;
-      if (previewScrollRestoreRef.current && Number(data.canvasLeft || 0) === 0 && Number(data.canvasTop || 0) === 0) return;
-      if (
-        previewScrollPositionRef.current.canvasLeft !== 0 ||
-        previewScrollPositionRef.current.canvasTop !== 0
-      ) {
-        const isInitialZeroReport = Number(data.canvasLeft || 0) === 0 && Number(data.canvasTop || 0) === 0;
-        if (isInitialZeroReport && Date.now() - previewScrollRequestAtRef.current < 1200) return;
-      }
-      previewScrollPositionRef.current = {
-        frameLeft: Number(data.frameLeft || 0),
-        frameTop: Number(data.frameTop || 0),
-        canvasLeft: Number(data.canvasLeft || 0),
-        canvasTop: Number(data.canvasTop || 0),
-      };
-    }
-    function onRestoreRequest(ev: MessageEvent) {
-      if (!isOurPreviewIframeSource(ev.source)) return;
-      if (!isActivePreviewIframeSource(ev.source)) return;
-      const data = ev.data as { type?: string } | null;
-      if (!data || data.type !== 'od:preview-scroll-request') return;
-      previewScrollRequestAtRef.current = Date.now();
-      const snapshot = previewScrollRestoreRef.current;
-      const scroll = snapshot ?? {
-        frameLeft: previewScrollPositionRef.current.frameLeft,
-        frameTop: previewScrollPositionRef.current.frameTop,
-        canvasLeft: previewScrollPositionRef.current.canvasLeft,
-        canvasTop: previewScrollPositionRef.current.canvasTop,
-      };
-      iframeRef.current?.contentWindow?.postMessage({
-        type: 'od:preview-scroll-restore',
-        frameLeft: scroll.frameLeft,
-        frameTop: scroll.frameTop,
-        canvasLeft: scroll.canvasLeft,
-        canvasTop: scroll.canvasTop,
-      }, '*');
-    }
-    function onDcViewportMessage(ev: MessageEvent) {
-      if (!isOurPreviewIframeSource(ev.source)) return;
-      if (!isActivePreviewIframeSource(ev.source)) return;
-      const data = ev.data as {
-        type?: string;
-        x?: number;
-        y?: number;
-        scale?: number;
-      } | null;
-      if (!data || !data.type) return;
-      if (data.type === '__dc_viewport') {
-        const x = Number(data.x || 0);
-        const y = Number(data.y || 0);
-        const scale = Number(data.scale || 1);
-        const hasExistingPosition = dcViewportRef.current.x !== 0 || dcViewportRef.current.y !== 0;
-        const isInitialZeroReport = x === 0 && y === 0 && scale === 1;
-        if (hasExistingPosition && isInitialZeroReport && Date.now() - dcViewportRestoreAtRef.current < 1500) return;
-        dcViewportRef.current = {
-          x: Number.isFinite(x) ? x : 0,
-          y: Number.isFinite(y) ? y : 0,
-          scale: Number.isFinite(scale) && scale > 0 ? scale : 1,
-        };
-        return;
-      }
-      if (data.type === '__dc_viewport_request') {
-        dcViewportRestoreAtRef.current = Date.now();
-        iframeRef.current?.contentWindow?.postMessage({
-          type: '__dc_set_viewport',
-          ...dcViewportRef.current,
-        }, '*');
-      }
-    }
-    window.addEventListener('message', onMessage);
-    window.addEventListener('message', onRestoreRequest);
-    window.addEventListener('message', onDcViewportMessage);
-    return () => {
-      window.removeEventListener('message', onMessage);
-      window.removeEventListener('message', onRestoreRequest);
-      window.removeEventListener('message', onDcViewportMessage);
-    };
-  }, [isActivePreviewIframeSource, isOurPreviewIframeSource]);
 
   useEffect(() => {
     if (!effectiveDeck) {
@@ -5492,8 +3157,7 @@ function HtmlViewer({
     }
     setSlideState(htmlPreviewSlideState.get(previewStateKey) ?? null);
     function onMessage(ev: MessageEvent) {
-      if (!isOurPreviewIframeSource(ev.source)) return;
-      if (!isActivePreviewIframeSource(ev.source)) return;
+      if (ev.source !== iframeRef.current?.contentWindow) return;
       const data = ev?.data as
         | { type?: string; active?: number; count?: number }
         | null;
@@ -5505,148 +3169,59 @@ function HtmlViewer({
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [effectiveDeck, isActivePreviewIframeSource, isOurPreviewIframeSource, previewStateKey]);
+  }, [effectiveDeck, previewStateKey]);
 
   useEffect(() => {
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
-    win.postMessage({
-      type: 'od:comment-mode',
-      enabled: boardMode,
-      mode: boardTool,
-    }, '*');
-  }, [boardMode, boardTool, srcDoc, useUrlLoadPreview]);
+    win.postMessage({ type: 'od:comment-mode', enabled: boardMode, mode: boardTool }, '*');
+  }, [boardMode, boardTool, srcDoc]);
 
   useEffect(() => {
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
     win.postMessage({ type: 'od-edit-mode', enabled: manualEditMode }, '*');
-    postSelectedManualEditTargetToIframe(manualEditMode ? selectedManualEditTarget?.id ?? null : null);
-  }, [manualEditMode, selectedManualEditTarget?.id, srcDoc, useUrlLoadPreview]);
+  }, [manualEditMode, srcDoc]);
 
-  const previewStyleToIframe = useCallback((id: string, styles: Partial<ManualEditStyles>, version: number) => {
+  function syncBridgeModes() {
     const win = iframeRef.current?.contentWindow;
-    if (!win) return false;
-    win.postMessage({ type: 'od-edit-preview-style', id, styles, version }, '*');
-    return true;
-  }, []);
-
-  function postSelectedManualEditTargetToIframe(id: string | null, target: HTMLIFrameElement | null = iframeRef.current) {
-    const win = target?.contentWindow;
     if (!win) return;
-    win.postMessage({ type: 'od-edit-selected-target', id }, '*');
-  }
-
-  function syncBridgeModes(target: HTMLIFrameElement | null = iframeRef.current) {
-    const win = target?.contentWindow;
-    if (!win) return;
-    win.postMessage({
-      type: 'od:comment-mode',
-      enabled: boardMode,
-      mode: boardTool,
-    }, '*');
+    win.postMessage({ type: 'od:comment-mode', enabled: boardMode, mode: boardTool }, '*');
     win.postMessage({ type: 'od-edit-mode', enabled: manualEditMode }, '*');
-    postSelectedManualEditTargetToIframe(manualEditMode ? selectedManualEditTarget?.id ?? null : null, target);
-    win.postMessage({ type: 'od:inspect-mode', enabled: inspectMode }, '*');
   }
 
   useEffect(() => {
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
     win.postMessage({ type: 'od:inspect-mode', enabled: inspectMode }, '*');
-  }, [inspectMode, srcDoc, useUrlLoadPreview]);
-
-  // Mirror the bridge's `od:comment-targets` broadcast into
-  // `liveCommentTargets` whenever EITHER Inspect or Comments mode is
-  // active. The boardMode-only useEffect below still handles its
-  // own comment-specific events (hover / click target / pod), but
-  // the targets list itself is mode-agnostic — it's just "which
-  // elements on the page carry data-od-id / data-screen-label".
-  // Without this listener Inspect mode never learns the artifact's
-  // annotation count, and the empty-state hint added for #890 would
-  // misfire (always firing in Inspect mode, even on annotated
-  // artifacts) because the comment-mode listener short-circuits on
-  // `!boardMode`. Issue #890.
-  useEffect(() => {
-    if (!inspectMode && !boardMode) {
-      setLiveCommentTargets((current) => (current.size > 0 ? new Map() : current));
-      return;
-    }
-    function onMessage(ev: MessageEvent) {
-      if (!isOurPreviewIframeSource(ev.source)) return;
-      const data = ev.data as
-        | {
-            type?: string;
-            targets?: Array<Partial<PreviewCommentSnapshot>>;
-          }
-        | null;
-      if (data?.type !== 'od:comment-targets' || !Array.isArray(data.targets)) return;
-      const next = new Map<string, PreviewCommentSnapshot>();
-      data.targets.forEach((item) => {
-        const elementId = String(item?.elementId || '');
-        if (!elementId) return;
-        const position = {
-          x: clampBridgeCoordinate(item?.position?.x),
-          y: clampBridgeCoordinate(item?.position?.y),
-          width: clampBridgeCoordinate(item?.position?.width),
-          height: clampBridgeCoordinate(item?.position?.height),
-        };
-        if (!isValidCommentOverlayPosition(position)) return;
-        next.set(elementId, {
-          filePath: file.name,
-          elementId,
-          selector: String(item?.selector || ''),
-          label: String(item?.label || ''),
-          text: String(item?.text || ''),
-          position,
-          htmlHint: String(item?.htmlHint || ''),
-          style: normalizeAnnotationStyle(item?.style),
-          selectionKind: 'element',
-          memberCount: undefined,
-          ...(typeof item?.slideIndex === 'number' ? { slideIndex: item.slideIndex } : {}),
-        });
-      });
-      setLiveCommentTargets((current) => (
-        liveCommentTargetMapsEqual(current, next) ? current : next
-      ));
-    }
-    window.addEventListener('message', onMessage);
-    return () => window.removeEventListener('message', onMessage);
-  }, [inspectMode, boardMode, file.name, isOurPreviewIframeSource]);
+  }, [inspectMode, srcDoc]);
 
   useEffect(() => {
     setActiveCommentTarget(null);
     setHoveredCommentTarget(null);
     setLiveCommentTargets(new Map());
     setCommentDraft('');
-    setActiveCommentExistingAttachments([]);
     setActiveInspectTarget(null);
     setInspectOverrides({});
     setInspectSavedAt(null);
     setInspectError(null);
     setQueuedBoardNotes([]);
     setStrokePoints([]);
-    setManualEditFrozenSource(null);
-    setManualEditViewportWidth(null);
     setManualEditTargets([]);
     setSelectedManualEditTarget(null);
-    setManualEditPanelPosition(null);
-    selectedManualEditTargetIdRef.current = null;
     setManualEditDraft(emptyManualEditDraft());
     setManualEditHistory([]);
     setManualEditUndone([]);
     setManualEditError(null);
-    manualEditPendingStyleRef.current = null;
-    clearManualEditStyleTimer();
   }, [file.name]);
 
-  // Selecting a new file or turning inspect/comment-inspect off resets the panel target.
+  // Selecting a new file or turning inspect off resets the panel target.
   useEffect(() => {
-    if (!inspectMode && !(boardMode && boardTool === 'inspect')) {
+    if (!inspectMode) {
       setActiveInspectTarget(null);
       setInspectError(null);
     }
-  }, [inspectMode, boardMode, boardTool]);
+  }, [inspectMode]);
 
   // Hydrate the host-authoritative override map from the artifact source
   // synchronously, *before* React commits a render that carries a new
@@ -5671,7 +3246,6 @@ function HtmlViewer({
   }
 
   useEffect(() => {
-    sourceRef.current = source;
     if (source == null) return;
     setManualEditDraft((current) => (
       current.fullSource === source ? current : { ...current, fullSource: source }
@@ -5679,15 +3253,9 @@ function HtmlViewer({
   }, [source]);
 
   useEffect(() => {
-    selectedManualEditTargetIdRef.current = selectedManualEditTarget?.id ?? null;
-  }, [selectedManualEditTarget?.id]);
-
-  useEffect(() => {
     if (!boardMode) {
-      setCommentCreateMode(false);
       setActiveCommentTarget((current) => (current ? null : current));
       setHoveredCommentTarget((current) => (current ? null : current));
-      setActivePreviewCommentId((current) => (current ? null : current));
       setLiveCommentTargets((current) => (current.size > 0 ? new Map() : current));
       setQueuedBoardNotes((current) => (current.length > 0 ? [] : current));
       setStrokePoints((current) => (current.length > 0 ? [] : current));
@@ -5705,21 +3273,13 @@ function HtmlViewer({
         width: clampBridgeCoordinate(data.position?.width),
         height: clampBridgeCoordinate(data.position?.height),
       },
-      hoverPoint: data.hoverPoint
-        ? {
-            x: clampBridgeCoordinate(data.hoverPoint.x),
-            y: clampBridgeCoordinate(data.hoverPoint.y),
-          }
-        : undefined,
       htmlHint: String(data.htmlHint || ''),
-      style: normalizeAnnotationStyle(data.style),
       selectionKind: data.selectionKind === 'pod' ? 'pod' : 'element',
       memberCount: finiteBridgeInteger(data.memberCount),
       podMembers: Array.isArray(data.podMembers) ? data.podMembers : undefined,
-      ...(typeof data.slideIndex === 'number' ? { slideIndex: data.slideIndex } : {}),
     });
     function onMessage(ev: MessageEvent) {
-      if (!isOurPreviewIframeSource(ev.source)) return;
+      if (ev.source !== iframeRef.current?.contentWindow) return;
       const data = ev.data as (Partial<PreviewCommentSnapshot> & {
         type?: string;
         targets?: Array<Partial<PreviewCommentSnapshot>>;
@@ -5730,100 +3290,45 @@ function HtmlViewer({
         const next = new Map<string, PreviewCommentSnapshot>();
         data.targets.forEach((item) => {
           const snapshot = snapshotFromData(item);
-          if (!snapshot.elementId || !isValidCommentOverlayPosition(snapshot.position)) return;
-          next.set(snapshot.elementId, snapshot);
+          if (snapshot.elementId) next.set(snapshot.elementId, snapshot);
         });
-        setLiveCommentTargets((current) => (
-          liveCommentTargetMapsEqual(current, next) ? current : next
+        setLiveCommentTargets(next);
+        setActiveCommentTarget((current) => (
+          current
+            ? current.selectionKind === 'pod'
+              ? current
+              : next.get(current.elementId) ?? null
+            : null
         ));
-        setActiveCommentTarget((current) => {
-          if (!current) return null;
-          if (current.selectionKind === 'pod') return current;
-          const updated = next.get(current.elementId);
-          if (!updated || !isValidCommentOverlayPosition(updated.position)) return null;
-          return commentSnapshotEqual(current, updated) ? current : updated;
-        });
-        setHoveredCommentTarget((current) => {
-          if (!current) return null;
-          if (current.selectionKind === 'pod') return current;
-          const updated = next.get(current.elementId);
-          if (!updated || !isValidCommentOverlayPosition(updated.position)) return null;
-          return commentSnapshotEqual(current, updated) ? current : updated;
-        });
-        return;
-      }
-      if (data.type === 'od:comment-active-target-update') {
-        const snapshot = snapshotFromData(data);
-        if (!snapshot.elementId || !isValidCommentOverlayPosition(snapshot.position)) return;
-        // Fires on every pointermove while a target is active — skip the Map
-        // clone and the active/hovered state writes when nothing changed, so a
-        // steady hover doesn't re-render the whole overlay each frame.
-        setLiveCommentTargets((current) => {
-          const existing = current.get(snapshot.elementId);
-          if (existing && commentSnapshotEqual(existing, snapshot)) return current;
-          return new Map(current).set(snapshot.elementId, snapshot);
-        });
-        setActiveCommentTarget((current) =>
-          current && current.elementId === snapshot.elementId && !commentSnapshotEqual(current, snapshot)
-            ? snapshot
-            : current,
-        );
-        setHoveredCommentTarget((current) =>
-          current && current.elementId === snapshot.elementId && !commentSnapshotEqual(current, snapshot)
-            ? snapshot
-            : current,
-        );
+        setHoveredCommentTarget((current) => (
+          current
+            ? current.selectionKind === 'pod'
+              ? current
+              : next.get(current.elementId) ?? null
+            : null
+        ));
         return;
       }
       if (data.type === 'od:comment-leave') {
-        // Already firmly on the card — nothing to dismiss.
-        if (hoverCardPinnedRef.current) return;
-        // The pointer left the element. It may be sliding onto the floating card
-        // (which overlaps the iframe) or hopping toward an adjacent element —
-        // both should keep the card up. Defer the dismiss so the card's
-        // mouseenter or the next comment-hover can cancel it; only a leave with
-        // nothing following actually tears the card down.
-        scheduleHoverCardDismiss();
+        setHoveredCommentTarget(null);
         return;
       }
       if (data.type === 'od:comment-hover') {
         const snapshot = snapshotFromData(data);
-        if (!snapshot.elementId || !isValidCommentOverlayPosition(snapshot.position)) return;
-        // Pointer landed on an element — cancel any deferred dismiss so moving
-        // from the card back onto the element it describes keeps the card.
-        cancelHoverCardDismiss();
-        // Hover repeats the same snapshot per pointermove frame — keep the
-        // existing state object (and skip the Map clone) when it is unchanged.
-        setHoveredCommentTarget((current) =>
-          current && current.elementId === snapshot.elementId && commentSnapshotEqual(current, snapshot)
-            ? current
-            : snapshot,
-        );
-        setLiveCommentTargets((current) => {
-          const existing = current.get(snapshot.elementId);
-          if (existing && commentSnapshotEqual(existing, snapshot)) return current;
-          return new Map(current).set(snapshot.elementId, snapshot);
-        });
+        if (!snapshot.elementId) return;
+        setHoveredCommentTarget(snapshot);
+        setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
         return;
       }
       if (data.type === 'od:comment-target') {
         const snapshot = snapshotFromData(data);
-        if (!snapshot.elementId || !isValidCommentOverlayPosition(snapshot.position)) return;
-        const shouldOpenComposer = boardMode || commentCreateMode;
-        cancelHoverCardDismiss();
-        setActiveCommentTarget((current) => (shouldOpenComposer ? snapshot : current));
+        if (!snapshot.elementId) return;
+        const existing = previewComments.find((comment) => comment.elementId === snapshot.elementId);
+        setActiveCommentTarget(snapshot);
         setHoveredCommentTarget(snapshot);
-        setLiveCommentTargets((current) => {
-          const existing = current.get(snapshot.elementId);
-          if (existing && commentSnapshotEqual(existing, snapshot)) return current;
-          return new Map(current).set(snapshot.elementId, snapshot);
-        });
-        if (shouldOpenComposer) {
-          setActivePreviewCommentId(null);
-          setCommentDraft('');
-          setQueuedBoardNotes([]);
-          setActiveCommentExistingAttachments([]);
-        }
+        setLiveCommentTargets((current) => new Map(current).set(snapshot.elementId, snapshot));
+        setCommentDraft(existing?.note ?? '');
+        setQueuedBoardNotes([]);
         return;
       }
       if (data.type === 'od:pod-clear') {
@@ -5856,236 +3361,51 @@ function HtmlViewer({
         }
         setActiveCommentTarget(nextTarget);
         setHoveredCommentTarget(nextTarget);
-        setActivePreviewCommentId(null);
         setQueuedBoardNotes([]);
         setCommentDraft('');
-        setActiveCommentExistingAttachments([]);
         setStrokePoints([]);
       }
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [activeCommentTarget, boardMode, boardTool, cancelHoverCardDismiss, commentPortalHost, file.name, isOurPreviewIframeSource, previewComments, scheduleHoverCardDismiss]);
-
-  useEffect(() => {
-    if (!boardMode || !activeCommentTarget || activeCommentTarget.selectionKind === 'pod') return;
-    iframeRef.current?.contentWindow?.postMessage({
-      type: 'od:comment-active-target',
-      elementId: activeCommentTarget.elementId,
-      selector: activeCommentTarget.selector,
-    }, '*');
-  }, [activeCommentTarget?.elementId, activeCommentTarget?.selector, activeCommentTarget?.selectionKind, boardMode]);
+  }, [boardMode, file.name, previewComments]);
 
   useEffect(() => {
     if (!manualEditMode) {
       setManualEditTargets([]);
       setSelectedManualEditTarget(null);
-      setManualEditHoverTarget(null);
-      setManualEditPageStylesOpen(false);
-      setManualEditPanelPosition(null);
-      selectedManualEditTargetIdRef.current = null;
       setManualEditError(null);
-      manualEditPendingStyleRef.current = null;
-      if (manualEditStyleTimerRef.current) {
-        clearTimeout(manualEditStyleTimerRef.current);
-        manualEditStyleTimerRef.current = null;
-      }
       return;
     }
     function onMessage(ev: MessageEvent) {
-      if (!isOurPreviewIframeSource(ev.source)) return;
+      if (ev.source !== iframeRef.current?.contentWindow) return;
       const data = ev.data as ManualEditBridgeMessage | null;
       if (!data?.type) return;
       if (data.type === 'od-edit-targets' && Array.isArray(data.targets)) {
         setManualEditTargets(data.targets);
-        // Target broadcasts can be briefly empty while the iframe/save path is
-        // settling; keep the user's inspector selection unless a fresh copy is
-        // available to update its metadata.
         setSelectedManualEditTarget((current) =>
-          current ? data.targets.find((target) => target.id === current.id) ?? current : current,
+          current ? data.targets.find((target) => target.id === current.id) ?? null : current,
         );
-        const selectedId = selectedManualEditTargetIdRef.current;
-        if (selectedId) setTimeout(() => postSelectedManualEditTargetToIframe(selectedId), 0);
         return;
       }
       if (data.type === 'od-edit-select') {
-        setManualEditHoverTarget(null);
-        void selectManualEditTarget(data.target);
-        return;
-      }
-      if (data.type === 'od-edit-hover') {
-        // Hover only surfaces a lightweight "edit params" affordance; it must
-        // NOT switch the pinned inspector. The panel changes only when the
-        // user clicks that affordance (or a container/image body), so moving
-        // the cursor across the canvas never yanks the panel away mid-edit.
-        setManualEditHoverTarget(
-          data.target.id === selectedManualEditTargetIdRef.current ? null : data.target,
-        );
-        return;
-      }
-      if (data.type === 'od-edit-background') {
-        // Clicking empty canvas deselects and opens the compact page-styles
-        // card — only meaningful for full HTML documents.
-        setManualEditHoverTarget(null);
-        if (typeof source === 'string' && isManualEditFullHtmlDocument(source)) {
-          void clearManualEditTargetSelection();
-          setManualEditPageStylesOpen(true);
-        }
-        return;
-      }
-      if (data.type === 'od-edit-text-commit') {
-        void applyManualEdit({
-          id: String(data.id),
-          kind: 'set-text',
-          value: String(data.value),
-        }, 'Edit text');
-        return;
+        selectManualEditTarget(data.target);
       }
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [isOurPreviewIframeSource, manualEditMode, source]);
+  }, [manualEditMode, source]);
 
-  function nextManualEditPreviewVersion(): number {
-    manualEditPreviewVersionRef.current += 1;
-    return manualEditPreviewVersionRef.current;
-  }
-
-  function inspectorManualEditStyles(target: ManualEditTarget, baseSource: string): ManualEditStyles {
-    const inlineStyles = readManualEditStyles(baseSource, target.id);
-    return mergeManualEditInspectorStyles(inlineStyles, target.styles);
-  }
-
-  function reconcileManualEditStyleSave(
-    id: string,
-    savedStyles: Partial<ManualEditStyles>,
-    savedSource: string,
-  ) {
-    if (id !== '__body__' && !readManualEditOuterHtml(savedSource, id)) {
-      setManualEditError('The selected target no longer exists in the saved source. Refreshing the preview.');
-      setSelectedManualEditTarget(null);
-      setManualEditFrozenSource(null);
-      setReloadKey((key) => key + 1);
-      return;
-    }
-    const sourceStyles = readManualEditStyles(savedSource, id);
-    const supersededStyles = manualEditPendingStyleRef.current?.id === id
-      ? manualEditPendingStyleRef.current.styles
-      : {};
-    const repairStyles: Partial<ManualEditStyles> = {};
-    for (const key of Object.keys(savedStyles) as Array<keyof ManualEditStyles>) {
-      if (Object.prototype.hasOwnProperty.call(supersededStyles, key)) continue;
-      const sourceValue = manualEditInspectorStyleValue(key, sourceStyles[key] ?? '');
-      const savedValue = savedStyles[key] ?? '';
-      if (manualEditPersistedValueMatchesSavedSnapshot(key, sourceValue, savedValue)) continue;
-      repairStyles[key] = sourceValue;
-    }
-    if (Object.keys(repairStyles).length === 0) return;
-    previewStyleToIframe(id, repairStyles, nextManualEditPreviewVersion());
-    setManualEditDraft((current) => ({
-      ...current,
-      styles: { ...current.styles, ...repairStyles },
-    }));
-    setManualEditError('Saved styles differed from the active preview. Reconciled the selected target from source.');
-  }
-
-  function clearManualEditStyleTimer() {
-    if (!manualEditStyleTimerRef.current) return;
-    clearTimeout(manualEditStyleTimerRef.current);
-    manualEditStyleTimerRef.current = null;
-  }
-
-  function cancelManualEditPendingStyles(id: string, keys: Array<keyof ManualEditStyles>) {
-    const nextPending = cancelManualEditPendingStyleSnapshot(manualEditPendingStyleRef.current, id, keys);
-    if (!nextPending) {
-      manualEditPendingStyleRef.current = null;
-      clearManualEditStyleTimer();
-      return;
-    }
-    manualEditPendingStyleRef.current = nextPending;
-  }
-
-  async function handleManualEditStyleChange(id: string, styles: Partial<ManualEditStyles>, label: string) {
-    const version = nextManualEditPreviewVersion();
-    const currentPending = manualEditPendingStyleRef.current;
-    const pendingStyles = currentPending?.id === id
-      ? { ...currentPending.styles, ...styles }
-      : styles;
-    const pending: ManualEditPendingStyleSave = { id, styles: pendingStyles, label, version };
-    manualEditPendingStyleRef.current = pending;
-    setManualEditError(null);
-    previewStyleToIframe(id, styles, version);
-  }
-
-  async function flushManualEditStyleSave(): Promise<boolean> {
-    const pending = manualEditPendingStyleRef.current;
-    if (!pending) return true;
-    if (manualEditSavingRef.current) return false;
-    manualEditPendingStyleRef.current = null;
-    return applyManualEdit({ id: pending.id, kind: 'set-style', styles: pending.styles }, pending.label);
-  }
-
-  function cancelManualEditStyleDraft() {
-    const pending = manualEditPendingStyleRef.current;
-    if (!pending) return;
-    clearManualEditStyleTimer();
-    manualEditPendingStyleRef.current = null;
-    const base = sourceRef.current ?? '';
-    const target = pending.id === '__body__'
-      ? null
-      : selectedManualEditTarget?.id === pending.id
-        ? selectedManualEditTarget
-        : manualEditTargets.find((item) => item.id === pending.id) ?? null;
-    const sourceStyles = target
-      ? inspectorManualEditStyles(target, base)
-      : readManualEditStyles(base, pending.id);
-    const resetStyles = MANUAL_EDIT_STYLE_PROPS.reduce<Partial<ManualEditStyles>>((acc, key) => {
-      acc[key] = sourceStyles[key] ?? '';
-      return acc;
-    }, {});
-    previewStyleToIframe(pending.id, resetStyles, nextManualEditPreviewVersion());
-    if (!target || target.id === selectedManualEditTarget?.id) {
-      setManualEditDraft((current) => ({
-        ...current,
-        styles: target ? sourceStyles : current.styles,
-        fullSource: base,
-      }));
-    }
-    setManualEditError(null);
-  }
-
-  async function exitManualEditModeAfterFlush(): Promise<boolean> {
-    const ok = await flushManualEditStyleSave();
-    if (!ok) return false;
-    setManualEditPanelPosition(null);
-    setManualEditMode(false);
-    return true;
-  }
-
-  // Clears the hover affordance and re-arms the iframe's per-element hover
-  // dedupe so re-entering the same element re-announces it. Called from the
-  // workspace's own mouseleave (host-side), NOT the iframe's mouseleave — the
-  // affordance overlays the iframe, so reacting to the iframe leaving would
-  // yank it out from under the cursor and strobe on/off.
-  function clearManualEditHover() {
-    setManualEditHoverTarget(null);
-    const win = iframeRef.current?.contentWindow;
-    if (win) win.postMessage({ type: 'od-edit-hover-reset' }, '*');
-  }
-
-  async function selectManualEditTarget(target: ManualEditTarget) {
-    setManualEditPageStylesOpen(false);
-    if (manualEditPendingStyleRef.current?.id !== target.id) cancelManualEditStyleDraft();
-    const base = sourceRef.current ?? '';
+  function selectManualEditTarget(target: ManualEditTarget) {
+    const base = source ?? '';
     const fields = readManualEditFields(base, target.id);
-    selectedManualEditTargetIdRef.current = target.id;
     setSelectedManualEditTarget(target);
     setManualEditDraft({
       text: fields.text ?? target.fields.text ?? target.text,
       href: fields.href ?? target.fields.href ?? '',
       src: fields.src ?? target.fields.src ?? '',
       alt: fields.alt ?? target.fields.alt ?? '',
-      styles: inspectorManualEditStyles(target, base),
+      styles: readManualEditStyles(base, target.id),
       attributesText: JSON.stringify(readManualEditAttributes(base, target.id), null, 2),
       outerHtml: readManualEditOuterHtml(base, target.id) || target.outerHtml,
       fullSource: base,
@@ -6093,63 +3413,29 @@ function HtmlViewer({
     setManualEditError(null);
   }
 
-  async function clearManualEditTargetSelection() {
-    cancelManualEditStyleDraft();
-    selectedManualEditTargetIdRef.current = null;
-    setSelectedManualEditTarget(null);
-    setManualEditPanelPosition(null);
-    setManualEditDraft(emptyManualEditDraft(sourceRef.current ?? ''));
-    setManualEditError(null);
-  }
-
-  // The inspector is scoped to one element (or the page). Closing it should
-  // only collapse the panel and keep the user in edit mode — exiting edit is
-  // the toolbar toggle's job. Dismiss flushes any in-flight tweak first so
-  // nothing is lost; cancel reverts the in-flight unsaved tweak instead.
-  async function dismissManualEditPanel() {
-    const ok = await flushManualEditStyleSave();
-    if (!ok) return;
-    if (selectedManualEditTarget) void clearManualEditTargetSelection();
-    else setManualEditPageStylesOpen(false);
-  }
-
-  function cancelManualEditPanel() {
-    if (selectedManualEditTarget) {
-      void clearManualEditTargetSelection();
-    } else {
-      cancelManualEditStyleDraft();
-      setManualEditPageStylesOpen(false);
-    }
-  }
-
-  async function applyManualEdit(patch: ManualEditPatch, label: string): Promise<boolean> {
-    if (manualEditSavingRef.current) return false;
-    if (sourceRef.current == null) return false;
+  async function applyManualEdit(patch: ManualEditPatch, label: string) {
+    if (manualEditSavingRef.current) return;
+    if (source == null) return;
     manualEditSavingRef.current = true;
     setManualEditSaving(true);
     setManualEditError(null);
     try {
-      const baseSource = sourceRef.current;
+      const baseSource = source;
       const result = applyManualEditPatch(baseSource, patch);
       if (!result.ok) {
         setManualEditError(result.error ?? 'Could not apply edit.');
-        return false;
+        return;
       }
       if (!(await confirmManualEditHistorySource(
         baseSource,
         'The file changed outside manual edit mode. Refreshing before applying manual edits.',
-      ))) return false;
-      const saved = await writeProjectTextFileDetailed(projectId, file.name, result.source, {
+      ))) return;
+      const saved = await writeProjectTextFile(projectId, file.name, result.source, {
         artifactManifest: file.artifactManifest,
       });
-      if (!saved.ok) {
-        const status = 'status' in saved ? saved.status : undefined;
-        const code = 'code' in saved ? saved.code : undefined;
-        const message = 'message' in saved ? saved.message : 'Unknown save error';
-        setManualEditError(
-          `Could not save the edited file${status ? ` (${status}${code ? ` ${code}` : ''})` : ''}: ${message}`,
-        );
-        return false;
+      if (!saved) {
+        setManualEditError('Could not save the edited file.');
+        return;
       }
       const entry: ManualEditHistoryEntry = {
         id: `${Date.now()}-${manualEditHistory.length}`,
@@ -6160,37 +3446,11 @@ function HtmlViewer({
         createdAt: Date.now(),
       };
       setSource(result.source);
-      sourceRef.current = result.source;
       setInlinedSource(null);
-      if (patch.kind !== 'set-style') {
-        setManualEditFrozenSource(result.source);
-      }
       setManualEditHistory((current) => [entry, ...current]);
       setManualEditUndone([]);
       setManualEditDraft((current) => ({ ...current, fullSource: result.source }));
-      if (patch.kind === 'set-text') {
-        setSelectedManualEditTarget((current) => current?.id === patch.id
-          ? { ...current, text: patch.value, fields: { ...current.fields, text: patch.value } }
-          : current);
-      } else if (patch.kind === 'remove-element') {
-        if (manualEditPendingStyleRef.current?.id === patch.id) {
-          manualEditPendingStyleRef.current = null;
-          clearManualEditStyleTimer();
-        }
-        selectedManualEditTargetIdRef.current = null;
-        setSelectedManualEditTarget(null);
-        setManualEditTargets((current) => current.filter((target) => target.id !== patch.id));
-        setManualEditDraft(emptyManualEditDraft(result.source));
-        postSelectedManualEditTargetToIframe(null);
-      } else {
-        setManualEditDraft((current) => ({ ...current, fullSource: result.source }));
-      }
-      if (patch.kind === 'set-style') {
-        reconcileManualEditStyleSave(patch.id, patch.styles, result.source);
-      }
-      setManualEditError(null);
       await onFileSaved?.();
-      return true;
     } finally {
       manualEditSavingRef.current = false;
       setManualEditSaving(false);
@@ -6204,11 +3464,9 @@ function HtmlViewer({
     });
     if (persisted == null || persisted === expectedSource) return true;
     setSource(persisted);
-    sourceRef.current = persisted;
     setInlinedSource(null);
     setManualEditHistory([]);
     setManualEditUndone([]);
-    manualEditPendingStyleRef.current = null;
     setManualEditDraft((current) => ({ ...current, fullSource: persisted }));
     setManualEditError(message);
     return false;
@@ -6233,9 +3491,7 @@ function HtmlViewer({
         return;
       }
       setSource(latest.beforeSource);
-      sourceRef.current = latest.beforeSource;
       setInlinedSource(null);
-      setManualEditFrozenSource(latest.beforeSource);
       setManualEditHistory(rest);
       setManualEditUndone((current) => [latest, ...current]);
       setManualEditDraft((current) => ({ ...current, fullSource: latest.beforeSource }));
@@ -6265,9 +3521,7 @@ function HtmlViewer({
         return;
       }
       setSource(latest.afterSource);
-      sourceRef.current = latest.afterSource;
       setInlinedSource(null);
-      setManualEditFrozenSource(latest.afterSource);
       setManualEditUndone(rest);
       setManualEditHistory((current) => [latest, ...current]);
       setManualEditDraft((current) => ({ ...current, fullSource: latest.afterSource }));
@@ -6284,53 +3538,30 @@ function HtmlViewer({
   useEffect(() => {
     if (!inspectMode) return;
     function onMessage(ev: MessageEvent) {
-      if (!isOurPreviewIframeSource(ev.source)) return;
+      if (ev.source !== iframeRef.current?.contentWindow) return;
       const data = ev.data as
-        | {
-            type?: string;
-            elementId?: string;
-            selector?: string;
-            label?: string;
-            text?: string;
-            style?: InspectStyleSnapshot;
-            clickedDescendant?: Partial<InspectClickedDescendant>;
-          }
+        | { type?: string; elementId?: string; selector?: string; label?: string; text?: string; style?: InspectStyleSnapshot }
         | null;
       if (!data || data.type !== 'od:comment-target') return;
       if (!data.elementId || !data.selector) return;
-      const clickedDescendant =
-        data.clickedDescendant && typeof data.clickedDescendant === 'object'
-          ? {
-              label: String(data.clickedDescendant.label || ''),
-              text: String(data.clickedDescendant.text || ''),
-            }
-          : null;
       setActiveInspectTarget({
         elementId: String(data.elementId),
         selector: String(data.selector),
         label: String(data.label || ''),
         text: String(data.text || ''),
         style: data.style && typeof data.style === 'object' ? data.style : {},
-        ...(clickedDescendant ? { clickedDescendant } : {}),
       });
       setInspectError(null);
       setInspectSavedAt(null);
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [inspectMode, isOurPreviewIframeSource]);
+  }, [inspectMode]);
 
   function postSlide(action: 'next' | 'prev' | 'first' | 'last') {
     const win = iframeRef.current?.contentWindow;
     if (!win) return;
     win.postMessage({ type: 'od:slide', action }, '*');
-  }
-
-  function syncCachedSlideStateToIframe(target: HTMLIFrameElement | null = iframeRef.current) {
-    const active = htmlPreviewSlideState.get(previewStateKey)?.active;
-    const win = target?.contentWindow;
-    if (!win || typeof active !== 'number') return;
-    win.postMessage({ type: 'od:slide', action: 'go', index: active }, '*');
   }
 
   function postInspectSet(elementId: string, selector: string, prop: string, value: string) {
@@ -6368,8 +3599,8 @@ function HtmlViewer({
   // the bridge's DOM-hydrated one and silently strip the persisted styles
   // from preview. Re-derive synchronously from `source` whenever the
   // hydration ref disagrees so onLoad never sends a stale snapshot.
-  function replayInspectOverridesToIframe(target: HTMLIFrameElement | null = iframeRef.current) {
-    const win = target?.contentWindow;
+  function replayInspectOverridesToIframe() {
+    const win = iframeRef.current?.contentWindow;
     if (!win) return;
     const overrides = inspectHydratedSourceRef.current === source
       ? inspectOverrides
@@ -6466,52 +3697,13 @@ function HtmlViewer({
   }, [presentMenuOpen]);
 
   useEffect(() => {
-    if (!zoomMenuOpen) return;
-    const onDocClick = (e: MouseEvent) => {
-      if (!zoomMenuRef.current) return;
-      if (!zoomMenuRef.current.contains(e.target as Node)) setZoomMenuOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setZoomMenuOpen(false);
-    };
-    document.addEventListener('mousedown', onDocClick);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onDocClick);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [zoomMenuOpen]);
-
-  useEffect(() => {
-    if (!agentToolsOpen) return;
-    const onDocClick = (e: MouseEvent) => {
-      const target = e.target as HTMLElement | null;
-      if (target?.closest('.artifact-tool-menu-anchor')) return;
-      closeArtifactToolMenus();
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeArtifactToolMenus();
-    };
-    document.addEventListener('mousedown', onDocClick);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onDocClick);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [agentToolsOpen]);
-
-  useEffect(() => {
-    if (!deployMenuOpen && !downloadMenuOpen) return;
+    if (!shareMenuOpen) return;
     const onDocClick = (e: MouseEvent) => {
       if (!shareRef.current) return;
-      if (shareRef.current.contains(e.target as Node)) return;
-      setDeployMenuOpen(false);
-      setDownloadMenuOpen(false);
+      if (!shareRef.current.contains(e.target as Node)) setShareMenuOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape') return;
-      setDeployMenuOpen(false);
-      setDownloadMenuOpen(false);
+      if (e.key === 'Escape') setShareMenuOpen(false);
     };
     document.addEventListener('mousedown', onDocClick);
     document.addEventListener('keydown', onKey);
@@ -6519,40 +3711,15 @@ function HtmlViewer({
       document.removeEventListener('mousedown', onDocClick);
       document.removeEventListener('keydown', onKey);
     };
-  }, [deployMenuOpen, downloadMenuOpen]);
+  }, [shareMenuOpen]);
 
   useEffect(() => {
     if (!inTabPresent) return;
-    const bodyStyle = document.body.style;
-    const previousChromeHeight = bodyStyle.getPropertyValue('--workspace-tabs-chrome-height');
-    const updateChromeHeight = () => {
-      const chrome = document.querySelector<HTMLElement>('.workspace-tabs-chrome.app-chrome-header');
-      const height = chrome?.getBoundingClientRect().height ?? 0;
-      if (height > 0) {
-        bodyStyle.setProperty('--workspace-tabs-chrome-height', `${Math.round(height)}px`);
-      } else {
-        bodyStyle.removeProperty('--workspace-tabs-chrome-height');
-      }
-    };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setInTabPresent(false);
     };
-    updateChromeHeight();
     document.addEventListener('keydown', onKey);
-    window.addEventListener('resize', updateChromeHeight);
-    const chrome = document.querySelector<HTMLElement>('.workspace-tabs-chrome.app-chrome-header');
-    const observer = chrome && typeof ResizeObserver !== 'undefined' ? new ResizeObserver(updateChromeHeight) : null;
-    if (observer && chrome) observer.observe(chrome);
-    return () => {
-      document.removeEventListener('keydown', onKey);
-      window.removeEventListener('resize', updateChromeHeight);
-      observer?.disconnect();
-      if (previousChromeHeight) {
-        bodyStyle.setProperty('--workspace-tabs-chrome-height', previousChromeHeight);
-      } else {
-        bodyStyle.removeProperty('--workspace-tabs-chrome-height');
-      }
-    };
+    return () => document.removeEventListener('keydown', onKey);
   }, [inTabPresent]);
 
   function openInNewTab() {
@@ -6567,10 +3734,10 @@ function HtmlViewer({
   // Snapshot this project as a reusable template. The daemon snapshots
   // EVERY html/text/code file in the project (not just the file open in
   // the viewer), so the template captures the whole design, not a single
-  // page. Surfaced here in the Download menu because templates are saved
-  // from the same artifact output surface as files.
+  // page. Surfaced here in the Share menu because that's where the user's
+  // share / export mental model already lives.
   function openSaveAsTemplateModal() {
-    setDownloadMenuOpen(false);
+    setShareMenuOpen(false);
     const defaultName =
       file.name.replace(/\.html?$/i, '') || t('fileViewer.templateNameDefault');
     setTemplateName(defaultName);
@@ -6601,8 +3768,6 @@ function HtmlViewer({
       setTemplateName('');
       setTemplateDescription('');
       setTemplateNote(t('fileViewer.savedTemplate', { name: tpl.name }));
-      // Show success toast
-      setTemplateSavedToast(t('fileViewer.savedTemplate', { name: tpl.name }));
     } finally {
       setSavingTemplate(false);
       if (savedName) {
@@ -6613,20 +3778,12 @@ function HtmlViewer({
   }
 
   async function openDeployModal(nextProviderId: WebDeployProviderId = deployProviderId) {
-    setDeployMenuOpen(false);
+    setShareMenuOpen(false);
     setDeployModalOpen(true);
     setDeployError(null);
-    setDeployActionToast(null);
     setCopiedDeployLink(null);
     setDeployPhase('idle');
     await loadDeployProvider(nextProviderId, { fallbackToExisting: true });
-  }
-
-  async function openSocialShareFlow() {
-    const providerWithDeployment = DEPLOY_PROVIDER_OPTIONS.find(
-      (option) => deploymentsByProvider[option.id]?.url?.trim(),
-    )?.id;
-    await openDeployModal(providerWithDeployment ?? deployProviderId);
   }
 
   async function changeDeployProvider(nextProviderId: WebDeployProviderId) {
@@ -6639,13 +3796,10 @@ function HtmlViewer({
   async function saveDeployConfig() {
     setSavingDeployConfig(true);
     setDeployError(null);
-    setDeployActionToast(null);
     try {
       if (deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID) {
         if (!deployToken.trim()) {
-          setDeployActionToast(t('fileViewer.cloudflareApiTokenRequired'));
-          deployTokenInputRef.current?.focus();
-          return null;
+          throw new Error(t('fileViewer.cloudflareApiTokenRequired'));
         }
         if (!cloudflareAccountId.trim()) {
           throw new Error(t('fileViewer.cloudflareAccountIdRequired'));
@@ -6690,7 +3844,6 @@ function HtmlViewer({
     setDeploying(true);
     setDeployPhase('deploying');
     setDeployError(null);
-    setDeployActionToast(null);
     setCopiedDeployLink(null);
     try {
       const cloudflarePagesSelection = buildCloudflarePagesDeploySelection();
@@ -6725,26 +3878,11 @@ function HtmlViewer({
       }));
       setDeployment(next);
       setDeployResult(next);
-      if (deployResultState(next.status) !== 'failed') {
-        setDeploySavedToast({
-          message: t('fileViewer.deploySuccessToast'),
-          details: t('fileViewer.deploySuccessToastDetails', {
-            provider: deployProviderLabel,
-            url: next.url,
-          }),
-        });
-      }
     } catch (err) {
       const option = getDeployProviderOption(deployProviderId);
-      const message = err instanceof Error
-        ? err.message
-        : t('fileViewer.deployProviderFailed', { provider: t(option.labelKey) });
-      if (message === t(option.tokenRequiredKey, { provider: t(option.labelKey) })) {
-        setDeployActionToast(message);
-        deployTokenInputRef.current?.focus();
-      } else {
-        setDeployError(message);
-      }
+      setDeployError(
+        err instanceof Error ? err.message : t('fileViewer.deployProviderFailed', { provider: t(option.labelKey) }),
+      );
     } finally {
       setDeploying(false);
       setDeployPhase('idle');
@@ -6793,26 +3931,8 @@ function HtmlViewer({
     }, 1800);
   }
 
-  async function copyShareLink(url: string) {
-    const safeUrl = url.trim();
-    if (!safeUrl) {
-      setShareLinkFeedback('failed');
-      setExportToast({ message: t('useEverywhere.copyFailed'), tone: 'error' });
-      return false;
-    }
-    const ok = await copyToClipboard(safeUrl);
-    const feedback = ok ? 'copied' : 'failed';
-    setShareLinkFeedback(feedback);
-    if (!ok) setExportToast({ message: t('useEverywhere.copyFailed'), tone: 'error' });
-    window.setTimeout(() => {
-      setShareLinkFeedback((current) => (current === feedback ? null : current));
-    }, 1800);
-    return ok;
-  }
-
   function presentInThisTab() {
     setPresentMenuOpen(false);
-    setMode('preview');
     setInTabPresent(true);
   }
 
@@ -6831,173 +3951,24 @@ function HtmlViewer({
     openInNewTab();
   }
 
-  function reloadHtmlPreview() {
-    fireArtifactToolbarClick('reload');
-    capturePreviewScrollPosition();
-    imageExportSnapshotDataUrlRef.current = null;
-    setInlinedSource(null);
-    setReloadKey((key) => key + 1);
-    if (!useUrlLoadPreview) {
-      activatedSrcDocTransportHtmlRef.current = null;
-      setSrcDocShellReady(false);
-      setSrcDocTransportResetKey((key) => key + 1);
-    }
-  }
-
-  function selectMode(nextMode: 'preview' | 'source') {
-    if (nextMode === 'source') setDrawOverlayOpen(false);
-    setMode(nextMode);
-  }
-
-  function activateBoard(nextTool?: BoardTool) {
-    setMode('preview');
-    setBoardMode(true);
-    if (nextTool) setBoardTool(nextTool);
-  }
-
-  function activateBoardPicker(nextTool: BoardTool) {
-    clearBoardComposer();
-    fireArtifactToolbarClick(nextTool === 'pod' ? 'pods' : 'comment');
-    setCommentPanelOpen(false);
-    setCommentCreateMode(false);
-    activateBoard(nextTool);
-    setAgentToolsOpen(false);
+  function bumpZoom(delta: number) {
+    setZoom((z) => Math.max(25, Math.min(200, z + delta)));
   }
 
   function clearBoardComposer() {
     setActiveCommentTarget(null);
     setHoveredCommentTarget(null);
-    setHoveredPodMemberId(null);
-    setActivePreviewCommentId(null);
     setCommentDraft('');
     setQueuedBoardNotes([]);
-    setBoardImages([]);
-    setActiveCommentExistingAttachments([]);
-    setBoardPreviewIndex(null);
     setStrokePoints([]);
   }
 
-  function addBoardImages(files: File[]) {
-    const imgs = files.filter((file) => file.type.startsWith('image/'));
-    if (imgs.length > 0) setBoardImages((current) => [...current, ...imgs]);
-  }
-
-  function removeBoardImage(index: number) {
-    setBoardImages((current) => current.filter((_, i) => i !== index));
-    setBoardPreviewIndex(null);
-  }
-
-  function closeArtifactToolMenus() {
-    setAgentToolsOpen(false);
-  }
-
-  function activateDrawTool() {
-    fireArtifactToolbarClick('draw');
-    const next = !drawOverlayOpen;
-    if (!next) {
-      setDrawOverlayOpen(false);
-      setAgentToolsOpen(false);
-      return;
+  function activateBoard(nextTool?: BoardTool) {
+    setMode('preview');
+    setBoardMode(true);
+    if (nextTool) {
+      setBoardTool(nextTool);
     }
-    capturePreviewScrollPosition();
-    const activateDraw = () => {
-      setCommentPanelOpen(false);
-      setCommentCreateMode(false);
-      setBoardMode(false);
-      clearBoardComposer();
-      setInspectMode(false);
-      setMode('preview');
-      setDrawOverlayOpen(true);
-      closeArtifactToolMenus();
-    };
-    if (manualEditMode) {
-      void exitManualEditModeAfterFlush().then((ok) => {
-        if (ok) activateDraw();
-      });
-      return;
-    }
-    activateDraw();
-  }
-
-  function activateCommentTool() {
-    fireArtifactToolbarClick('comment');
-    capturePreviewScrollPosition();
-    if (boardMode && !commentCreateMode && boardTool === 'inspect') {
-      setBoardMode(false);
-      setCommentCreateMode(false);
-      clearBoardComposer();
-      setAgentToolsOpen(false);
-      return;
-    }
-    const activateComment = () => {
-      setCommentPanelOpen(false);
-      setCommentCreateMode(false);
-      clearBoardComposer();
-      setInspectMode(false);
-      setDrawOverlayOpen(false);
-      setMode('preview');
-      activateBoard('inspect');
-      closeArtifactToolMenus();
-    };
-    if (manualEditMode) {
-      void exitManualEditModeAfterFlush().then((ok) => {
-        if (ok) activateComment();
-      });
-      return;
-    }
-    activateComment();
-  }
-
-  function activateCommentCreateTool() {
-    fireArtifactToolbarClick('comment');
-    capturePreviewScrollPosition();
-    if (boardMode && commentCreateMode) {
-      setBoardMode(false);
-      setCommentCreateMode(false);
-      setCommentPanelOpen(false);
-      clearBoardComposer();
-      closeArtifactToolMenus();
-      return;
-    }
-    const activateCommentCreate = () => {
-      setCommentPanelOpen(true);
-      setCommentSidePanelCollapsed(false);
-      setCommentCreateMode(true);
-      if (!activeCommentTarget) clearBoardComposer();
-      setInspectMode(false);
-      setDrawOverlayOpen(false);
-      setMode('preview');
-      activateBoard('inspect');
-      closeArtifactToolMenus();
-    };
-    if (manualEditMode) {
-      void exitManualEditModeAfterFlush().then((ok) => {
-        if (ok) activateCommentCreate();
-      });
-      return;
-    }
-    activateCommentCreate();
-  }
-
-  function activateManualEditTool() {
-    fireArtifactToolbarClick('edit');
-    capturePreviewScrollPosition();
-    if (!manualEditMode) {
-      setCommentPanelOpen(false);
-      setCommentCreateMode(false);
-      setBoardMode(false);
-      clearBoardComposer();
-      setInspectMode(false);
-      setDrawOverlayOpen(false);
-      setMode('preview');
-      setManualEditViewportWidth(previewBodyRef.current?.clientWidth ?? null);
-      setManualEditSrcDocActive(true);
-      setManualEditMode(true);
-      closeArtifactToolMenus();
-      return;
-    }
-    closeArtifactToolMenus();
-    void exitManualEditModeAfterFlush();
   }
 
   function queueCurrentDraft() {
@@ -7007,60 +3978,19 @@ function HtmlViewer({
     setCommentDraft('');
   }
 
-  function currentActiveComposerComment(): PreviewComment | null {
-    if (!activePreviewCommentId) return null;
-    return previewComments.find((comment) => (
-      comment.id === activePreviewCommentId &&
-      comment.filePath === file.name &&
-      comment.status === 'open'
-    )) ?? null;
-  }
-
-  function currentActiveComposerAttachments(): PreviewCommentAttachment[] {
-    return currentActiveComposerComment()?.attachments ?? activeCommentExistingAttachments;
-  }
-
-  function withDeckSlideIndex(target: PreviewCommentTarget): PreviewCommentTarget {
-    if (!effectiveDeck || typeof slideState?.active !== 'number') return target;
-    if (typeof target.slideIndex === 'number') return target;
-    return { ...target, slideIndex: slideState.active };
-  }
-
   async function sendBoardBatch() {
     if (!activeCommentTarget || !onSendBoardCommentAttachments) return;
     const nextNotes = [...queuedBoardNotes];
     if (commentDraft.trim()) nextNotes.push(commentDraft.trim());
-    if (nextNotes.length === 0 && boardImages.length === 0) {
-      const existingComment = currentActiveComposerComment();
-      if (existingComment) {
-        setSendingBoardBatch(true);
-        try {
-          await onSendBoardCommentAttachments(commentsToAttachments([existingComment]));
-          clearBoardComposer();
-        } finally {
-          setSendingBoardBatch(false);
-        }
-      }
-      return;
-    }
+    if (nextNotes.length === 0) return;
     setSendingBoardBatch(true);
     try {
-      const existingAttachments = currentActiveComposerAttachments();
-      const attachments = buildBoardCommentAttachments({
-        target: withDeckSlideIndex(targetFromSnapshot(activeCommentTarget)),
-        notes: nextNotes,
-        includeImageOnly: boardImages.length > 0,
-        imageAttachmentCount: boardImages.length,
-      }).map((attachment) => (
-        existingAttachments.length > 0
-          ? { ...attachment, imageAttachments: existingAttachments }
-          : attachment
-      ));
-      const accepted = await onSendBoardCommentAttachments(
-        attachments,
-        boardImages,
+      await onSendBoardCommentAttachments(
+        buildBoardCommentAttachments({
+          target: targetFromSnapshot(activeCommentTarget),
+          notes: nextNotes,
+        }),
       );
-      if (accepted === false) return;
       clearBoardComposer();
     } finally {
       setSendingBoardBatch(false);
@@ -7068,369 +3998,22 @@ function HtmlViewer({
   }
 
   async function savePersistentComment() {
-    if (!activeCommentTarget || !onSavePreviewComment) return;
-    // Allow saving when there is text OR an attached image (image-only notes).
-    if (!commentDraft.trim() && boardImages.length === 0 && currentActiveComposerAttachments().length === 0) return;
-    const isFreePin = activeCommentTarget.elementId.startsWith('pin-');
-    setSendingBoardBatch(true);
-    try {
-      const target = withDeckSlideIndex(targetFromSnapshot(activeCommentTarget));
-      const saved = await onSavePreviewComment(
-        target,
-        commentDraft.trim(),
-        false,
-        boardImages,
-      );
-      if (saved) {
-        rememberSavedPreviewCommentOrder(saved.id);
-        clearBoardComposer();
-        setActiveCommentExistingAttachments(saved.attachments ?? []);
-        setBoardMode(true);
-        setCommentCreateMode(true);
-        setCommentPanelOpen(true);
-        setCommentSidePanelCollapsed(false);
-        setActivePreviewCommentId(saved.id);
-        setCommentSavedToast(isFreePin ? t('chat.comments.pinSavedToast') : t('chat.comments.savedToast'));
-      }
-    } finally {
-      setSendingBoardBatch(false);
-    }
-  }
-
-  async function savePanelComment(note: string) {
-    if (!onSavePreviewComment) return false;
-    const cleanNote = note.trim();
-    if (!cleanNote) return false;
-    const idSeed = Date.now().toString(36);
-    const target: PreviewCommentTarget = activeCommentTarget
-      ? targetFromSnapshot(activeCommentTarget)
-      : {
-          filePath: file.name,
-          elementId: `file-comment-${idSeed}-${Math.floor(Math.random() * 1e6).toString(36)}`,
-          selector: 'html',
-          label: file.name,
-          text: '',
-          position: { x: 0, y: 0, width: 0, height: 0 },
-          htmlHint: '',
-          selectionKind: 'element',
-        };
-    setSendingBoardBatch(true);
-    try {
-      const saved = await onSavePreviewComment(target, cleanNote, false);
-      if (saved) {
-        rememberSavedPreviewCommentOrder(saved.id);
-        setCommentSavedToast(t('chat.comments.savedToast'));
-        if (activeCommentTarget) clearBoardComposer();
-      }
-      return Boolean(saved);
-    } finally {
-      setSendingBoardBatch(false);
-    }
-  }
-
-  const showPresent = source !== null;
-  const exportTitle = file.name.replace(/\.html?$/i, '') || file.name;
-  const artifactKind = file.artifactManifest?.kind ?? file.artifactKind ?? null;
-  const rendererId = file.artifactManifest?.renderer ?? null;
-  const isDeckArtifact = isDeck || artifactKind === 'deck' || rendererId === 'deck-html' || file.kind === 'presentation';
-  const isMarkdownArtifact =
-    artifactKind === 'markdown-document' ||
-    rendererId === 'markdown' ||
-    file.kind === 'text' && /\.mdx?$/i.test(file.name);
-  const isShareableArtifact =
-    file.kind === 'html' ||
-    isDeckArtifact ||
-    artifactKind === 'html' ||
-    rendererId === 'html';
-  const canShare = source !== null && isShareableArtifact;
-  const canDownload = source !== null && (isShareableArtifact || isMarkdownArtifact);
-  const canPptx = canShare && isDeckArtifact && Boolean(onExportAsPptx) && !streaming;
-  const showPptxExport = canShare && isDeckArtifact;
-  const showMarkdownExport = source !== null && isMarkdownArtifact;
-  const showImageExport = canShare;
-
-  useEffect(() => {
-    const nudgeKey = `${projectId}\n${file.name}`;
-    if (!canShare || exportReadyNudgeSeenRef.current.has(nudgeKey)) return;
-    exportReadyNudgeSeenRef.current.add(nudgeKey);
-    if (hasSeenExportReadyNudge(projectId, file.name)) return;
-    markExportReadyNudgeSeen(projectId, file.name);
-    setExportReadyNudge(true);
-    const timeout = window.setTimeout(() => setExportReadyNudge(false), 1800);
-    return () => window.clearTimeout(timeout);
-  }, [canShare, file.name, projectId]);
-
-  // Chat-side "Share" next-step action: when a new share request arrives, open
-  // the share menu (the toolbar's "Share" button → deploy menu, which holds the
-  // share-link items AND the "publish online" providers). This is the right
-  // surface for "share" — publishing is the prerequisite for a shareable link,
-  // and that publish step lives here; the download menu is export-to-disk, a
-  // different intent. The artifact source may still be loading when the request
-  // lands (the file was just auto-opened), so we defer until `canShare` flips
-  // true and only consume each nonce once.
-  const consumedShareNonceRef = useRef<number | null>(null);
-  useEffect(() => {
-    const nonce = shareRequest?.nonce;
-    if (nonce == null) return;
-    if (consumedShareNonceRef.current === nonce) return;
-    if (!canShare) return;
-    consumedShareNonceRef.current = nonce;
-    setExportReadyNudge(false);
-    markExportReadyNudgeSeen(projectId, file.name);
-    setDownloadMenuOpen(false);
-    setDeployMenuOpen(true);
-  }, [shareRequest?.nonce, canShare, projectId, file.name]);
-
-  // A queued chat send for this deck just started: flip the preview to the
-  // slide its marked element lives on. We write the cached slide state first so
-  // a freshly-mounted iframe (the tab may have just been activated) restores to
-  // the target on load via syncCachedSlideStateToIframe(), then post directly
-  // to cover the already-loaded iframe. The consume-once guard lives in
-  // `shouldConsumeSlideNav` (keyed by file outside this component) so it holds
-  // across remounts — switching away from and back to the deck must not replay
-  // the stale request and yank the preview off wherever the user navigated.
-  useEffect(() => {
-    const nonce = slideNavRequest?.nonce;
-    if (nonce == null) return;
-    if (!effectiveDeck) return;
-    const requested = slideNavRequest?.slideIndex;
-    if (typeof requested !== 'number' || !Number.isFinite(requested) || requested < 0) return;
-    if (!shouldConsumeSlideNav(previewStateKey, nonce)) return;
-    const target = Math.floor(requested);
-    const cachedCount = htmlPreviewSlideState.get(previewStateKey)?.count;
-    const count = slideState?.count ?? cachedCount ?? target + 1;
-    setSlideStateCached(previewStateKey, { active: target, count });
-    setSlideState({ active: target, count });
-    syncCachedSlideStateToIframe();
-  }, [slideNavRequest?.nonce, slideNavRequest?.slideIndex, effectiveDeck, previewStateKey, slideState?.count]);
-
-  const openDownloadMenu = () => {
-    fireArtifactHeaderClick('share_dropdown');
-    setExportReadyNudge(false);
-    markExportReadyNudgeSeen(projectId, file.name);
-    setDeployMenuOpen(false);
-    setDownloadMenuOpen((v) => !v);
-  };
-  const openDeployMenu = () => {
-    fireArtifactHeaderClick('share_dropdown');
-    setExportReadyNudge(false);
-    markExportReadyNudgeSeen(projectId, file.name);
-    setDownloadMenuOpen(false);
-    setDeployMenuOpen((v) => !v);
-  };
-  const captureExportImageSnapshot = useCallback(async () => {
-    // Prefer the desktop compositor screenshot of the visible preview region:
-    // it returns the real rendered pixels (fonts, external CSS, gradients,
-    // images) and is never tainted, so it cannot produce the black/blank frames
-    // the in-iframe SVG-foreignObject bridge does. Works for both srcDoc and
-    // URL-load previews. Falls through to the bridge on pure web (no host).
-    const visibleIframe = iframeRef.current ?? srcDocPreviewIframeRef.current;
-    const hostSnapshot = await captureHostIframeSnapshot(visibleIframe);
-    if (hostSnapshot) return hostSnapshot;
-
-    if (!useUrlLoadPreview) {
-      const activeIframe = srcDocPreviewIframeRef.current ?? iframeRef.current;
-      if (!activeIframe) return null;
-      await waitForIframeLoadOrTimeout(activeIframe, 250);
-      await waitForAnimationFrame();
-      return requestPreviewSnapshotWithRetry(activeIframe);
-    }
-
-    const urlIframe = iframeRef.current ?? urlPreviewIframeRef.current;
-    if (urlIframe) {
-      await waitForIframeLoadOrTimeout(urlIframe, 250);
-      await waitForAnimationFrame();
-      const urlSnapshot = await requestPreviewSnapshotWithRetry(urlIframe);
-      if (urlSnapshot) return urlSnapshot;
-    }
-
-    const srcDocIframe = srcDocPreviewIframeRef.current;
-    if (!srcDocIframe) {
-      const activeIframe = iframeRef.current;
-      if (!activeIframe) return null;
-      return requestPreviewSnapshotWithRetry(activeIframe);
-    }
-
-    if (useLazySrcDocTransport && !srcDocShellReady) {
-      await waitForIframeLoadOrTimeout(srcDocIframe, 500);
-    }
-    if (useLazySrcDocTransport && activateSrcDocSnapshotTransport(srcDocIframe)) {
-      await waitForIframeLoadOrTimeout(srcDocIframe);
-    }
-    const restoreVisibility = temporarilyExposeIframeForSnapshot(srcDocIframe);
-    try {
-      await waitForAnimationFrame();
-      return requestPreviewSnapshotWithRetry(srcDocIframe);
-    } finally {
-      restoreVisibility();
-    }
-  }, [
-    activateSrcDocSnapshotTransport,
-    srcDocShellReady,
-    useLazySrcDocTransport,
-    useUrlLoadPreview,
-  ]);
-
-  const handleCopyScreenshot = useCallback(async () => {
-    if (screenshotInFlightRef.current) return;
-    screenshotInFlightRef.current = true;
-    setExportToast({ message: t('fileViewer.screenshotCopying'), tone: 'loading' });
-    try {
-      const snap = await captureExportImageSnapshot();
-      if (!snap) {
-        setExportToast({ message: t('fileViewer.screenshotPreviewLoading'), tone: 'error' });
-        return;
-      }
-      const result = await copyImageDataUrlToClipboard(snap.dataUrl);
-      setExportToast(
-        result === 'copied'
-          ? { message: t('fileViewer.screenshotCopied'), tone: 'success' }
-          : {
-              message: t(
-                result === 'denied'
-                  ? 'fileViewer.screenshotClipboardDenied'
-                  : 'fileViewer.screenshotCaptureFailed',
-              ),
-              tone: 'error',
-            },
-      );
-    } catch (err) {
-      console.warn('[handleCopyScreenshot] failed:', err);
-      setExportToast({ message: t('fileViewer.screenshotCaptureFailed'), tone: 'error' });
-    } finally {
-      screenshotInFlightRef.current = false;
-    }
-  }, [captureExportImageSnapshot, t]);
-
-  const prepareImageExportBlob = useCallback(async (format: ImageExportFormat) => {
-    const prepareId = imageExportPrepareIdRef.current + 1;
-    imageExportPrepareIdRef.current = prepareId;
-    setImageExportPreparing(true);
-    setImageExportError(null);
-    setImageExportPreparedBlob(null);
-    try {
-      let dataUrl = imageExportSnapshotDataUrlRef.current;
-      if (!dataUrl) {
-        const snap = await captureExportImageSnapshot();
-        if (!snap) throw new Error('Snapshot capture returned null');
-        dataUrl = snap.dataUrl;
-        imageExportSnapshotDataUrlRef.current = dataUrl;
-      }
-      const blob = await imageDataUrlToBlob(dataUrl, format);
-      if (blob.size <= 0) throw new Error('Snapshot capture produced an empty image');
-      if (imageExportPrepareIdRef.current === prepareId) {
-        setImageExportPreparedBlob({ format, blob });
-      }
-    } catch (err) {
-      console.warn('[exportAsImage] failed to prepare snapshot:', err);
-      if (imageExportPrepareIdRef.current === prepareId) {
-        setImageExportError(t('fileViewer.exportImageFailed'));
-      }
-    } finally {
-      if (imageExportPrepareIdRef.current === prepareId) {
-        setImageExportPreparing(false);
-      }
-    }
-  }, [captureExportImageSnapshot, t]);
-
-  const openImageExportModal = () => {
-    setDownloadMenuOpen(false);
-    setImageExportError(null);
-    setImageExportPreparedBlob(null);
-    imageExportSnapshotDataUrlRef.current = null;
-    setImageExportModalOpen(true);
-    void prepareImageExportBlob(imageExportFormat);
-  };
-
-  const changeImageExportFormat = (format: ImageExportFormat) => {
-    setImageExportFormat(format);
-    void prepareImageExportBlob(format);
-  };
-
-  async function handleImageExportSave() {
-    const prepared = imageExportPreparedBlob;
-    if (!prepared || prepared.format !== imageExportFormat) {
-      setImageExportError(t('fileViewer.exportImageFailed'));
-      return;
-    }
-    setImageExportBusy(true);
-    setImageExportError(null);
-    try {
-      const target = await prepareImageExportTarget(exportTitle, imageExportFormat, { useNativePicker: false });
-      if (!target) return;
-      const preparedDataUrl = imageExportSnapshotDataUrlRef.current;
-      if (target.method === 'download' && imageExportFormat === 'png' && preparedDataUrl) {
-        downloadImageDataUrl(preparedDataUrl, target.filename);
-      } else {
-        await target.save(prepared.blob);
-      }
-      setImageExportModalOpen(false);
-      setImageExportSavedToast({
-        message: target.method === 'picker'
-          ? t('fileViewer.exportImageSaved')
-          : t('fileViewer.exportImageDownloadStarted'),
-        details: target.method === 'picker'
-          ? target.filename
-          : t('fileViewer.exportImageDownloadDetails', { filename: target.filename }),
-      });
-    } catch (err) {
-      console.warn('[exportAsImage] failed to save snapshot:', err);
-      setImageExportError(t('fileViewer.exportImageFailed'));
-    } finally {
-      setImageExportBusy(false);
-    }
-  }
-  const creationSortedSideComments = useMemo(
-    () => previewComments
-      .filter((comment) => comment.filePath === file.name && comment.status === 'open')
-      .sort((a, b) => commentCreatedAt(a) - commentCreatedAt(b)),
-    [file.name, previewComments],
-  );
-  useEffect(() => {
-    const creationIds = creationSortedSideComments.map((comment) => comment.id);
-    setCommentOrderIds((current) => {
-      const visible = new Set(creationIds);
-      const kept = current.filter((id) => visible.has(id));
-      const added = creationIds.filter((id) => !kept.includes(id));
-      const next = [...kept, ...added];
-      return next.join('\0') === current.join('\0') ? current : next;
-    });
-  }, [creationSortedSideComments]);
-  const visibleSideComments = useMemo(() => {
-    if (commentOrderIds.length === 0) return creationSortedSideComments;
-    const byId = new Map(creationSortedSideComments.map((comment) => [comment.id, comment]));
-    const ordered = commentOrderIds
-      .map((id) => byId.get(id))
-      .filter((comment): comment is PreviewComment => Boolean(comment));
-    const orderedIds = new Set(ordered.map((comment) => comment.id));
-    const missing = creationSortedSideComments.filter((comment) => !orderedIds.has(comment.id));
-    return [...ordered, ...missing];
-  }, [creationSortedSideComments, commentOrderIds]);
-  function rememberSavedPreviewCommentOrder(savedId: string) {
-    setCommentOrderIds((current) =>
-      appendSavedPreviewCommentOrder(current, visibleSideComments, savedId),
+    if (!activeCommentTarget || !commentDraft.trim() || !onSavePreviewComment) return;
+    const saved = await onSavePreviewComment(
+      targetFromSnapshot(activeCommentTarget),
+      commentDraft.trim(),
+      false,
     );
-  }
-  const activeSideCommentId = activePreviewCommentId;
-  const activeCommentTargetVisible = commentTargetIntersectsPreview(
-    activeCommentTarget,
-    overlayPreviewScale,
-    { x: overlayPreviewTransform.offsetX, y: overlayPreviewTransform.offsetY },
-    previewBodySize,
-  );
-  useEffect(() => {
-    if (!boardMode || !activePreviewCommentId) return;
-    const stillOpen = visibleSideComments.some((comment) => comment.id === activePreviewCommentId);
-    if (!stillOpen) clearBoardComposer();
-  }, [activePreviewCommentId, boardMode, visibleSideComments]);
-  useEffect(() => {
-    if (!effectiveDeck || slideState == null || !boardMode) return;
-    if (!activePreviewCommentId) return;
-    const activeComment = visibleSideComments.find((comment) => comment.id === activePreviewCommentId);
-    if (activeComment && !commentVisibleOnDeckSlide(activeComment, slideState.active)) {
-      clearBoardComposer();
+    if (saved) {
+      setCommentDraft('');
     }
-  }, [activePreviewCommentId, boardMode, effectiveDeck, slideState?.active, visibleSideComments]);
+  }
+
+  const showPresent = effectiveDeck && source !== null;
+  const canShare = source !== null;
+  const exportTitle = file.name.replace(/\.html?$/i, '') || file.name;
+  const canPptx = canShare && Boolean(onExportAsPptx) && !streaming;
+  const boardAvailable = source !== null;
   const activeDeployment = deployResult || deployment;
   const activeDeployedUrl = activeDeployment?.url?.trim() || '';
   const activeDeploymentDelayed = activeDeployment?.status === 'link-delayed';
@@ -7498,466 +4081,46 @@ function HtmlViewer({
       ? t('fileViewer.redeployToProvider', { provider: label })
       : t('fileViewer.deployToProvider', { provider: label });
   };
-  const deployedEntries = DEPLOY_PROVIDER_OPTIONS
-    .map((option) => deploymentsByProvider[option.id])
-    .filter((item): item is WebDeploymentInfo => Boolean(item?.url?.trim()));
-  const shareableDeploymentUrl =
-    DEPLOY_PROVIDER_OPTIONS.map((option) => deploymentsByProvider[option.id])
-      .map((item) => publicShareUrlForDeployment(item))
-      .find(Boolean) ?? '';
-  const socialShareBlockedDeployment =
-    shareableDeploymentUrl
-      ? null
-      : deployedEntries.find((item) => deployResultState(item.status) === 'protected' && !publicShareUrlForDeployment(item)) ??
-        deployedEntries.find((item) => !publicShareUrlForDeployment(item)) ??
-        null;
-  const socialShareBlockedState = socialShareBlockedDeployment
-    ? deployResultState(socialShareBlockedDeployment.status)
-    : null;
-  const socialShareDisplayUrl =
-    shareableDeploymentUrl || socialShareBlockedDeployment?.url?.trim() || activeDeployedUrl;
-  const socialShareUnavailableMessage =
-    socialShareBlockedState === 'protected'
-      ? t('fileViewer.deployLinkProtected')
-      : socialShareBlockedState === 'delayed'
-        ? t('fileViewer.deployLinkDelayed')
-        : t('socialShare.deployFirst');
-  const projectSocialShareRequest = useMemo<SocialShareRequest | null>(() => {
-    if (!socialShareDisplayUrl) return null;
-    const title = t('socialShare.projectTitle', { title: exportTitle });
-    const text = t('socialShare.projectText', {
-      title: exportTitle,
-      repo: OPEN_DESIGN_GITHUB_REPO_URL,
-    });
-    return {
-      kind: 'project-html',
-      locale,
-      url: socialShareDisplayUrl,
-      title,
-      text,
-      copyText: t('socialShare.projectCopyText', {
-        title: exportTitle,
-        url: socialShareDisplayUrl,
-        repo: OPEN_DESIGN_GITHUB_REPO_URL,
-      }),
-    };
-  }, [exportTitle, locale, socialShareDisplayUrl, t]);
-  const projectSocialShareFallback = useMemo(
-    () => (projectSocialShareRequest ? buildSocialSharePayload(projectSocialShareRequest) : null),
-    [projectSocialShareRequest],
-  );
-  // Gate the async payload load on a stable *content* key, not the memo's
-  // object identity. The request object can take a fresh identity on renders
-  // where its inputs are value-equal (e.g. while deployment polling re-sets
-  // state with a new map reference), and keying the effect on that identity
-  // made `setProjectSocialShare` re-fire every render — an infinite render
-  // loop once a deployment URL is available (#regression: ready-deploy share).
-  const projectSocialShareKey = projectSocialShareRequest
-    ? JSON.stringify(projectSocialShareRequest)
-    : '';
-  useEffect(() => {
-    setProjectSocialShare(null);
-    if (!projectSocialShareRequest) return;
-    let cancelled = false;
-    void createSocialSharePayload(projectSocialShareRequest)
-      .then((payload) => {
-        if (!cancelled) setProjectSocialShare(payload);
-      })
-      .catch(() => {
-        if (!cancelled) setProjectSocialShare(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectSocialShareKey]);
-  const activeProjectSocialShare = projectSocialShare ?? projectSocialShareFallback;
-  const socialShareMenuLabel =
-    activeProjectSocialShare
-      ? t('socialShare.projectSection')
-      : socialShareBlockedState === 'protected'
-        ? t('fileViewer.deployLinkProtectedLabel')
-        : socialShareBlockedState === 'delayed'
-        ? t('fileViewer.deployLinkPreparingLabel')
-          : t('socialShare.deployFirst');
-  const deployActionIconFor = (providerId: WebDeployProviderId) => {
-    if (providerId === 'cloudflare-pages') return 'pages-line';
-    return 'upload-cloud-line';
-  };
-  const latestShareDeployment = useMemo(
-    () => pickLatestShareDeployment(deploymentsByProvider),
-    [deploymentsByProvider],
-  );
-  const latestDeployedShareUrl = latestShareDeployment
-    ? shareUrlForDeployment(latestShareDeployment)
-    : '';
-  const latestShareState = latestShareDeployment
-    ? deployResultState(latestShareDeployment.status)
-    : null;
-  const sharePageUrl = useMemo(
-    () => resolveShareUrl(latestDeployedShareUrl),
-    [latestDeployedShareUrl],
-  );
-  const canCopyShareLink = !streaming && Boolean(sharePageUrl);
-  const canOpenSharePage = !streaming && Boolean(sharePageUrl) && latestShareState !== 'delayed';
-  const shareLinkStatusHint =
-    streaming
-      ? t('fileViewer.shareAfterGenerationComplete')
-      : latestShareState === 'delayed'
-      ? t('fileViewer.deployLinkDelayed')
-      : latestShareState === 'protected'
-        ? t('fileViewer.deployLinkProtected')
-        : '';
-  const shareUnavailableHint = streaming
-    ? t('fileViewer.shareAfterGenerationComplete')
-    : t('fileViewer.shareLinkRequiresDeploy');
-  const copyShareLinkLabel =
-    shareLinkFeedback === 'copied'
-      ? t('fileViewer.copied')
-      : shareLinkFeedback === 'failed'
-        ? t('useEverywhere.copyFailed')
-        : t('fileViewer.copyShareLink');
-  const shareMenuLabel = t('fileViewer.shareLabel');
-  const deployMenuLabel = t('fileViewer.deployModalTitle') || 'Deploy';
+  const deployCopyLinks = DEPLOY_PROVIDER_OPTIONS.map((option) => ({
+    providerId: option.id,
+    providerLabel: t(option.labelKey),
+    url: deploymentsByProvider[option.id]?.url?.trim() || '',
+  })).filter((item) => item.url);
   const deployButtonLabel =
     deployPhase === 'deploying'
       ? t('fileViewer.deployingToProvider', { provider: deployProviderLabel })
       : deployPhase === 'preparing-link'
         ? t('fileViewer.preparingPublicLink')
-        : deployMenuLabel;
+        : t('fileViewer.deployToProvider', { provider: deployProviderLabel });
   const copyDeployLabel = (url: string) =>
     copiedDeployLink === url.trim()
       ? t('fileViewer.copied')
       : t('fileViewer.copyDeployLink');
+  const copyDeployMenuLabel = (providerLabel: string, url: string) =>
+    copiedDeployLink === url.trim()
+      ? t('fileViewer.copied')
+      : `${t('fileViewer.copyDeployLink')} · ${providerLabel}`;
   const statusLabelFor = (state: ReturnType<typeof deployResultState>) => {
     if (state === 'ready') return t('fileViewer.deployLinkReady');
     if (state === 'protected') return t('fileViewer.deployLinkProtectedLabel');
     if (state === 'failed') return t('fileViewer.deployLinkFailed');
     return t('fileViewer.deployLinkPreparingLabel');
   };
-  const boardAvailable = mode === 'preview' && source !== null;
-  const showPreviewToolbarControls = mode === 'preview';
-  const commentPreviewLayoutClass = [
-    'comment-preview-layer',
-    localCommentSideDockActive ? 'comment-preview-layer-with-side-dock' : '',
-    localCommentSideDockActive && commentSidePanelCollapsed ? 'comment-preview-layer-dock-collapsed' : '',
-    boardSideDockStacked ? 'comment-preview-layer-side-dock-stacked' : '',
-  ].filter(Boolean).join(' ');
-  // Edit mode opens clean: the inspector only appears once the user pins an
-  // element (click its hover affordance / a container) or opens page styles by
-  // clicking the empty canvas. No more full-height panel popping on toggle.
-  const manualEditPageCardActive =
-    manualEditMode && !selectedManualEditTarget && manualEditPageStylesOpen;
-  const manualEditPanelActive =
-    manualEditMode && (!!selectedManualEditTarget || manualEditPageCardActive);
-  const manualEditPanel = manualEditPanelActive ? (
-    <ManualEditPanel
-      targets={manualEditTargets}
-      selectedTarget={selectedManualEditTarget}
-      draft={manualEditDraft}
-      history={manualEditHistory}
-      error={manualEditError}
-      canUndo={manualEditHistory.length > 0}
-      canRedo={manualEditUndone.length > 0}
-      busy={manualEditSaving}
-      pageStylesEnabled={manualEditPageStylesEnabled}
-      onSelectTarget={(target) => {
-        void selectManualEditTarget(target);
-      }}
-      onDraftChange={setManualEditDraft}
-      onStyleChange={(id, styles, label) => {
-        void handleManualEditStyleChange(id, styles, label);
-      }}
-      onInvalidStyle={cancelManualEditPendingStyles}
-      onApplyPatch={(patch, label) => {
-        void applyManualEdit(patch, label);
-      }}
-      onError={setManualEditError}
-      onClearSelection={() => {
-        void clearManualEditTargetSelection();
-      }}
-      onExit={() => {
-        void dismissManualEditPanel();
-      }}
-      onCancelDraft={() => {
-        cancelManualEditPanel();
-      }}
-      onSaveDraft={() => {
-        void dismissManualEditPanel();
-      }}
-      onUndo={() => {
-        void undoManualEdit();
-      }}
-      onRedo={() => {
-        void redoManualEdit();
-      }}
-      floatingClassName={manualEditPageCardActive ? 'manual-edit-page-card' : undefined}
-      floatingStyle={selectedManualEditTarget
-        ? {
-            ...manualEditFloatingPanelStyle(
-              selectedManualEditTarget,
-              overlayPreviewScale,
-              previewBodySize,
-            ),
-            ...(manualEditPanelPosition ?? {}),
-          }
-        : { top: 12, right: 12, width: 320 }}
-      onFloatingPositionChange={selectedManualEditTarget ? setManualEditPanelPosition : undefined}
-      onPickImage={async (pickedFile) => {
-        const result = await uploadProjectFiles(projectId, [pickedFile]);
-        const uploaded = result.uploaded[0];
-        if (!uploaded?.path) {
-          setManualEditError(result.error ?? t('manualEdit.uploadImageFailed'));
-          return null;
-        }
-        setManualEditError(null);
-        return toOwnerRelativePath(file.name, uploaded.path);
-      }}
-    />
-  ) : null;
-  const manualEditHoverAffordance =
-    manualEditMode &&
-    manualEditHoverTarget &&
-    manualEditHoverTarget.id !== selectedManualEditTarget?.id ? (
-      <button
-        type="button"
-        className="manual-edit-hover-action"
-        data-testid="manual-edit-hover-open"
-        aria-label={t('manualEdit.editParams')}
-        title={t('manualEdit.editParams')}
-        style={manualEditHoverIconStyle(
-          manualEditHoverTarget,
-          overlayPreviewScale,
-          previewBodySize,
-        )}
-        onClick={() => {
-          const target = manualEditHoverTarget;
-          setManualEditHoverTarget(null);
-          void selectManualEditTarget(target);
-        }}
-      >
-        <Icon name="sliders" size={15} />
-      </button>
-    ) : null;
-  const activeComposerComment = activePreviewCommentId
-    ? visibleSideComments.find((comment) => comment.id === activePreviewCommentId) ?? null
-    : null;
-  const activeComposerAttachments =
-    activeComposerComment?.attachments ?? activeCommentExistingAttachments;
-  const commentComposer = boardMode && activeCommentTarget && activeCommentTargetVisible ? (
-    <BoardComposerPopover
-      target={activeCommentTarget}
-      existing={activeComposerComment}
-      draft={commentDraft}
-      notes={queuedBoardNotes}
-      onDraft={setCommentDraft}
-      onAddDraft={queueCurrentDraft}
-      onRemoveQueuedNote={(index) =>
-        setQueuedBoardNotes((current) => current.filter((_, currentIndex) => currentIndex !== index))
-      }
-      onClose={clearBoardComposer}
-      onSaveComment={() => { fireCommentPopoverClick('save_comment'); return savePersistentComment(); }}
-      onSendBatch={() => { fireCommentPopoverClick('send_to_chat'); return sendBoardBatch(); }}
-      images={boardImagePreviews}
-      existingImages={
-        activeComposerAttachments.map((attachment) => ({
-          url: projectRawUrl(projectId, attachment.path),
-          name: attachment.name,
-        }))
-      }
-      onAttachImages={addBoardImages}
-      onRemoveImage={removeBoardImage}
-      onPreviewImage={setBoardPreviewIndex}
-      onRemoveMember={(elementId) => {
-        setActiveCommentTarget((current) => {
-          const { next, shouldClose } = applyPodMemberRemoval(current, elementId);
-          if (shouldClose) clearBoardComposer();
-          return next;
-        });
-        setHoveredPodMemberId((current) => (current === elementId ? null : current));
-      }}
-      onHoverMember={setHoveredPodMemberId}
-      onDeleteComment={onRemovePreviewComment ? async (commentId) => {
-        await onRemovePreviewComment(commentId);
-        clearBoardComposer();
-        setSelectedSideCommentIds((current) => {
-          if (!current.has(commentId)) return current;
-          const next = new Set(current);
-          next.delete(commentId);
-          return next;
-        });
-        setActivePreviewCommentId((current) => (current === commentId ? null : current));
-      } : undefined}
-      sending={sendingBoardBatch}
-      queueOnSend={commentQueueOnSend}
-      sendDisabled={commentSendDisabled}
-      t={t}
-      scale={overlayPreviewScale}
-      offset={{ x: overlayPreviewTransform.offsetX, y: overlayPreviewTransform.offsetY }}
-      bounds={previewBodySize}
-      docked={false}
-      commenting
-    />
-  ) : null;
-  const boardPreviewImage =
-    boardPreviewIndex !== null ? boardImagePreviews[boardPreviewIndex] ?? null : null;
-  const boardImagePreviewModal = boardPreviewImage
-    ? createPortal(
-        <div
-          className="staged-preview-modal"
-          role="dialog"
-          aria-modal="true"
-          aria-label={boardPreviewImage.file.name}
-          onMouseDown={(e) => {
-            if (e.target === e.currentTarget) setBoardPreviewIndex(null);
-          }}
-        >
-          <div className="staged-preview-card">
-            <div className="staged-preview-head">
-              <span title={boardPreviewImage.file.name}>{boardPreviewImage.file.name}</span>
-              <button
-                type="button"
-                className="icon-only od-tooltip"
-                onClick={() => setBoardPreviewIndex(null)}
-                aria-label={t('common.close')}
-                title={t('common.close')}
-                data-tooltip={t('common.close')}
-              >
-                <Icon name="close" size={14} />
-              </button>
-            </div>
-            <img src={boardPreviewImage.url} alt={boardPreviewImage.file.name} />
-          </div>
-        </div>,
-        document.body,
-      )
-    : null;
-  const commentSidePanel = commentPanelOpen ? (
-    <CommentSideDock
-      comments={visibleSideComments}
-      projectId={projectId}
-      selectedIds={selectedSideCommentIds}
-      activeCommentId={activeSideCommentId}
-      collapsed={commentPortalHost ? false : commentSidePanelCollapsed}
-      onCollapsedChange={setCommentSidePanelCollapsed}
-      onToggleSelect={(commentId) => {
-        setSelectedSideCommentIds((current) => {
-          const next = new Set(current);
-          if (next.has(commentId)) next.delete(commentId);
-          else next.add(commentId);
-          return next;
-        });
-      }}
-      onSelectAll={() => setSelectedSideCommentIds(new Set(visibleSideComments.map((comment) => comment.id)))}
-      onClearSelection={() => setSelectedSideCommentIds(new Set())}
-      onReorder={(orderedIds) => setCommentOrderIds(orderedIds)}
-      onReply={(comment) => {
-        // Reply == edit on a flat-thread model: prefill the
-        // popover with the existing note so the user sees and
-        // mutates the current text. Save runs through the
-        // same upsert path; matching project/conv/file/element
-        // updates note in place rather than creating a new row.
-        const snapshot = liveSnapshotForComment(comment, liveCommentTargets) ?? {
-          filePath: comment.filePath,
-          elementId: comment.elementId,
-          selector: comment.selector,
-          label: comment.label,
-          text: comment.text,
-          position: comment.position,
-          htmlHint: comment.htmlHint,
-          style: comment.style,
-          selectionKind: comment.selectionKind ?? 'element',
-          memberCount: comment.memberCount,
-          podMembers: comment.podMembers,
-          ...(typeof comment.slideIndex === 'number' ? { slideIndex: comment.slideIndex } : {}),
-        };
-        setActiveCommentTarget(snapshot);
-        setHoveredCommentTarget(snapshot);
-        setActivePreviewCommentId(comment.id);
-        setCommentDraft(comment.note);
-        setQueuedBoardNotes([]);
-        setActiveCommentExistingAttachments(comment.attachments ?? []);
-        setBoardMode(true);
-        setCommentCreateMode(true);
-        setCommentPanelOpen(true);
-        setCommentSidePanelCollapsed(false);
-      }}
-      onSendSelected={async () => {
-        if (!onSendBoardCommentAttachments) return;
-        const selected = visibleSideComments.filter(
-          (comment) => selectedSideCommentIds.has(comment.id),
-        );
-        if (selected.length === 0) return;
-        fireCommentPopoverClick('send_to_chat');
-        const sentIds = new Set(selected.map((comment) => comment.id));
-        setSendingBoardBatch(true);
-        try {
-          const accepted = await onSendBoardCommentAttachments(commentsToAttachments(selected));
-          if (accepted !== false) {
-            setSelectedSideCommentIds(new Set());
-            setCommentOrderIds((current) => current.filter((id) => !sentIds.has(id)));
-            setActivePreviewCommentId((current) => current && sentIds.has(current) ? null : current);
-          }
-        } finally {
-          setSendingBoardBatch(false);
-        }
-      }}
-      onCreateComment={savePanelComment}
-      sending={sendingBoardBatch}
-      queueOnSend={commentQueueOnSend}
-      sendDisabled={commentSendDisabled}
-      renderCreateForm={!commentPortalHost}
-      t={t}
-      composer={null}
-    />
-  ) : null;
 
   return (
-    <div className={`viewer html-viewer${inTabPresent ? ' is-tab-present' : ''}`}>
+    <div className="viewer html-viewer">
       <div className="viewer-toolbar">
         <div className="viewer-toolbar-left">
           <button
             type="button"
-            className="icon-only od-tooltip"
-            onClick={reloadHtmlPreview}
-            title={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-            data-tooltip={`${t('fileViewer.reload')} ${t('fileViewer.preview')}`}
-            data-tooltip-placement="bottom"
-            aria-label={`${t('fileViewer.reloadAria')} ${t('fileViewer.preview')}`}
+            className="icon-only"
+            onClick={() => setReloadKey((n) => n + 1)}
+            title={t('fileViewer.reload')}
+            aria-label={t('fileViewer.reloadAria')}
           >
             <Icon name="reload" size={14} />
           </button>
-          <div className="viewer-tabs" role="tablist" aria-label="View mode">
-            {([
-              ['preview', t('fileViewer.preview')],
-              ['source', t('fileViewer.source')],
-            ] as const).map(([id, label]) => (
-              <button
-                key={id}
-                type="button"
-                role="tab"
-                className={`viewer-tab ${mode === id ? 'active' : ''}`}
-                aria-selected={mode === id}
-                onClick={() => {
-                  fireArtifactToolbarClick(id);
-                  selectMode(id);
-                }}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-          {showPreviewToolbarControls ? (
-            <>
-              <span className="viewer-divider" aria-hidden />
-              <PreviewViewportControls
-                viewport={previewViewport}
-                onViewport={setPreviewViewport}
-                t={t}
-              />
-            </>
-          ) : null}
-          {showPreviewToolbarControls && effectiveDeck ? (
+          {effectiveDeck ? (
             <span
               className="deck-nav"
               role="group"
@@ -7965,11 +4128,9 @@ function HtmlViewer({
             >
               <button
                 type="button"
-                className="icon-only od-tooltip"
+                className="icon-only"
                 onClick={() => postSlide('prev')}
                 title={t('fileViewer.previousSlide')}
-                data-tooltip={t('fileViewer.previousSlide')}
-                data-tooltip-placement="bottom"
                 aria-label={t('fileViewer.previousSlide')}
                 disabled={slideState !== null && slideState.active <= 0}
               >
@@ -7982,11 +4143,9 @@ function HtmlViewer({
               </span>
               <button
                 type="button"
-                className="icon-only od-tooltip"
+                className="icon-only"
                 onClick={() => postSlide('next')}
                 title={t('fileViewer.nextSlide')}
-                data-tooltip={t('fileViewer.nextSlide')}
-                data-tooltip-placement="bottom"
                 aria-label={t('fileViewer.nextSlide')}
                 disabled={
                   slideState !== null &&
@@ -7997,386 +4156,237 @@ function HtmlViewer({
               </button>
             </span>
           ) : null}
+          <button
+            type="button"
+            className={`viewer-toggle${boardMode ? ' active' : ''}`}
+            data-testid="board-mode-toggle"
+            title={t('fileViewer.tweaks')}
+            aria-pressed={boardMode}
+            disabled={!boardAvailable}
+            onClick={() => {
+              if (boardMode) {
+                setBoardMode(false);
+                clearBoardComposer();
+                return;
+              }
+              setManualEditMode(false);
+              activateBoard(boardTool);
+            }}
+          >
+            <Icon name="tweaks" size={13} />
+            <span>{t('fileViewer.tweaks')}</span>
+            <span className="switch" aria-hidden />
+          </button>
         </div>
         <div className="viewer-toolbar-actions">
-          {showPreviewToolbarControls ? (
+          <div className="viewer-tabs">
+            <button
+              className={`viewer-tab ${mode === 'preview' ? 'active' : ''}`}
+              onClick={() => setMode('preview')}
+            >
+              {t('fileViewer.preview')}
+            </button>
+            <button
+              className={`viewer-tab ${mode === 'source' ? 'active' : ''}`}
+              onClick={() => setMode('source')}
+            >
+              {t('fileViewer.source')}
+            </button>
+          </div>
+          <span className="viewer-divider" aria-hidden />
+          {boardMode ? (
             <>
-              {mode === 'preview' ? (
-                <button
-                  type="button"
-                  className="viewer-action viewer-action-icon od-tooltip"
-                  data-testid="screenshot-copy-button"
-                  data-tooltip={t('fileViewer.screenshot')}
-                  data-tooltip-placement="bottom"
-                  title={t('fileViewer.screenshot')}
-                  aria-label={t('fileViewer.screenshot')}
-                  onClick={handleCopyScreenshot}
-                >
-                  <RemixIcon name="screenshot-2-line" size={15} />
-                </button>
-              ) : null}
-              <div className="artifact-tool-menu-anchor">
-                <button
-                  type="button"
-                  className={`viewer-action viewer-action-icon viewer-comment-toggle od-tooltip${boardMode && !commentCreateMode && boardTool === 'inspect' ? ' active' : ''}`}
-                  data-testid="board-mode-toggle"
-                  data-tooltip={t('fileViewer.comment')}
-                  data-tooltip-placement="bottom"
-                  title={t('fileViewer.comment')}
-                  aria-label={t('fileViewer.comment')}
-                  aria-pressed={boardMode && !commentCreateMode && boardTool === 'inspect'}
-                  onClick={activateCommentTool}
-                >
-                  <RemixIcon name="chat-new-line" size={15} />
-                </button>
-              </div>
               <button
-                className={`viewer-action viewer-action-icon od-tooltip${drawOverlayOpen ? ' active' : ''}`}
+                className={`viewer-action${boardTool === 'inspect' ? ' active' : ''}`}
                 type="button"
-                data-testid="draw-overlay-toggle"
-                data-tooltip={t('fileViewer.mark')}
-                data-tooltip-placement="bottom"
-                title={t('fileViewer.mark')}
-                aria-label={t('fileViewer.mark')}
-                aria-pressed={drawOverlayOpen}
-                onClick={activateDrawTool}
+                data-testid="comment-mode-toggle"
+                disabled={!boardAvailable}
+                title="Pick one element"
+                aria-label="Picker"
+                aria-pressed={boardTool === 'inspect'}
+                onClick={() => activateBoard('inspect')}
               >
-                <RemixIcon name="mark-pen-line" size={15} />
+                <Icon name="edit" size={13} />
+                <span>Picker</span>
               </button>
-              <span className="viewer-toolbar-tool-divider" aria-hidden />
               <button
-                className={`viewer-action viewer-action-icon od-tooltip${manualEditMode ? ' active' : ''}`}
+                className={`viewer-action${boardTool === 'pod' ? ' active' : ''}`}
                 type="button"
-                data-testid="manual-edit-mode-toggle"
-                data-tooltip={t('fileViewer.edit')}
-                data-tooltip-placement="bottom"
-                title={t('fileViewer.edit')}
-                aria-label={t('fileViewer.edit')}
-                aria-pressed={manualEditMode}
-                onClick={activateManualEditTool}
+                disabled={!boardAvailable}
+                title="Draw a pod selection"
+                aria-label="Pods"
+                aria-pressed={boardTool === 'pod'}
+                onClick={() => activateBoard('pod')}
               >
-                <RemixIcon name="edit-line" size={15} />
+                <Icon name="draw" size={13} />
+                <span>Pods</span>
               </button>
-              <span className="viewer-toolbar-tool-divider" aria-hidden />
-              <button
-                type="button"
-                className={`viewer-action viewer-comment-count-trigger viewer-comment-toggle od-tooltip${boardMode && commentCreateMode ? ' active' : ''}`}
-                data-testid="comment-panel-toggle"
-                data-tooltip={t('chat.tabComments')}
-                data-tooltip-placement="bottom"
-                title={t('chat.tabComments')}
-                aria-label={`${t('chat.tabComments')} (${visibleSideComments.length})`}
-                aria-pressed={boardMode && commentCreateMode}
-                onClick={activateCommentCreateTool}
-              >
-                <RemixIcon name="message-3-line" size={15} />
-                <span className="viewer-comment-count" aria-hidden>{visibleSideComments.length}</span>
-              </button>
-              {source !== null && mode === 'preview' ? (
-                <div className="zoom-menu viewer-toolbar-zoom" ref={zoomMenuRef}>
-                  <button
-                    type="button"
-                    className="viewer-action zoom-trigger od-tooltip"
-                    aria-haspopup="menu"
-                    aria-expanded={zoomMenuOpen}
-                    title={t('fileViewer.resetZoom')}
-                    data-tooltip={t('fileViewer.resetZoom')}
-                    data-tooltip-placement="bottom"
-                    onClick={() => {
-                      fireArtifactToolbarClick('zoom_level_dropdown');
-                      setZoomMenuOpen((v) => !v);
-                    }}
-                  >
-                    <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
-                  </button>
-                  {zoomMenuOpen ? (
-                    <div className="zoom-menu-popover" role="menu">
-                      {[50, 75, 100, 125, 150, 200].map((level) => (
-                        <button
-                          key={level}
-                          type="button"
-                          className={`zoom-menu-item${zoom === level ? ' active' : ''}`}
-                          role="menuitem"
-                          onClick={() => {
-                            setZoom(level);
-                            setZoomMenuOpen(false);
-                          }}
-                        >
-                          <span style={{ fontVariantNumeric: 'tabular-nums' }}>{level}%</span>
-                          {zoom === level ? (
-                            <Icon name="check" size={13} />
-                          ) : null}
-                        </button>
-                      ))}
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
             </>
           ) : null}
-        </div>
-      </div>
-      {((filePrimaryActions: ReactNode) => (
-        chromeActionsHost ? createPortal(filePrimaryActions, chromeActionsHost) : filePrimaryActions
-      ))(<>
+          <button
+            className={`viewer-action${inspectMode ? ' active' : ''}`}
+            type="button"
+            data-testid="inspect-mode-toggle"
+            title="Inspect"
+            aria-pressed={inspectMode}
+            onClick={() => {
+              setInspectMode((v) => {
+                const next = !v;
+                if (next) {
+                  setBoardMode(false);
+                  clearBoardComposer();
+                  setManualEditMode(false);
+                }
+                return next;
+              });
+            }}
+          >
+            <Icon name="tweaks" size={13} />
+            <span>Inspect</span>
+          </button>
+          <button
+            className={`viewer-action${manualEditMode ? ' active' : ''}`}
+            type="button"
+            data-testid="manual-edit-mode-toggle"
+            title={t('fileViewer.edit')}
+            aria-pressed={manualEditMode}
+            onClick={() => {
+              if (!manualEditMode) {
+                setBoardMode(false);
+                clearBoardComposer();
+                setInspectMode(false);
+                setMode('preview');
+              }
+              setManualEditMode((value) => !value);
+            }}
+          >
+            <Icon name="edit" size={13} />
+            <span>{t('fileViewer.edit')}</span>
+          </button>
+          <span className="viewer-divider" aria-hidden />
+          <button
+            type="button"
+            className="icon-only"
+            onClick={() => bumpZoom(-25)}
+            title={t('fileViewer.zoomOut')}
+            aria-label={t('fileViewer.zoomOut')}
+          >
+            <Icon name="minus" size={14} />
+          </button>
+          <button
+            type="button"
+            className="viewer-action"
+            onClick={() => setZoom(100)}
+            title={t('fileViewer.resetZoom')}
+            style={{ minWidth: 60 }}
+          >
+            <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
+          </button>
+          <button
+            type="button"
+            className="icon-only"
+            onClick={() => bumpZoom(25)}
+            title={t('fileViewer.zoomIn')}
+            aria-label={t('fileViewer.zoomIn')}
+          >
+            <Icon name="plus" size={14} />
+          </button>
+          <span className="viewer-divider" aria-hidden />
           {showPresent ? (
-            <div className="present-wrap chrome-present-wrap">
+            <div className="present-wrap">
               <button
-                className="chrome-action chrome-action-secondary chrome-action-icon present-trigger od-tooltip"
+                className="viewer-action present-trigger"
                 aria-haspopup="menu"
                 aria-expanded={presentMenuOpen}
-                aria-label={t('fileViewer.present')}
-                data-tooltip={t('fileViewer.present')}
-                data-tooltip-placement="bottom"
-                title={t('fileViewer.present')}
-                onClick={() => {
-                  fireArtifactHeaderClick('present_dropdown');
-                  setPresentMenuOpen((v) => !v);
-                }}
+                onClick={() => setPresentMenuOpen((v) => !v)}
               >
-                <RemixIcon name="slideshow-3-line" size={15} />
+                <Icon name="present" size={13} />
+                <span>{t('fileViewer.present')}</span>
+                <Icon name="chevron-down" size={11} />
               </button>
               {presentMenuOpen ? (
                 <div className="present-menu" role="menu">
-                  <button role="menuitem" onClick={() => { firePresentPopoverClick('in_this_tab'); presentInThisTab(); }}>
-                    <span className="present-icon"><RemixIcon name="eye-line" size={14} /></span>{' '}
+                  <button role="menuitem" onClick={presentInThisTab}>
+                    <span className="present-icon"><Icon name="eye" size={13} /></span>{' '}
                     {t('fileViewer.presentInTab')}
                   </button>
-                  <button role="menuitem" onClick={() => { firePresentPopoverClick('fullscreen'); presentFullscreen(); }}>
-                    <span className="present-icon"><RemixIcon name="play-line" size={14} /></span>{' '}
+                  <button role="menuitem" onClick={presentFullscreen}>
+                    <span className="present-icon"><Icon name="play" size={13} /></span>{' '}
                     {t('fileViewer.presentFullscreen')}
                   </button>
-                  <button role="menuitem" onClick={() => { firePresentPopoverClick('new_tab'); presentNewTab(); }}>
-                    <span className="present-icon"><RemixIcon name="share-forward-line" size={14} /></span>{' '}
+                  <button role="menuitem" onClick={presentNewTab}>
+                    <span className="present-icon"><Icon name="share" size={13} /></span>{' '}
                     {t('fileViewer.presentNewTab')}
                   </button>
                 </div>
               ) : null}
             </div>
           ) : null}
-          {canShare || canDownload ? (
-            <div className="chrome-file-action-menus" ref={shareRef}>
-              {canShare ? (
-                <div className="share-menu chrome-share-menu">
-                  <button
-                    type="button"
-                    className="chrome-action chrome-action-secondary chrome-action-with-label"
-                    aria-haspopup="menu"
-                    aria-expanded={deployMenuOpen}
-                    aria-label={shareMenuLabel}
-                    onClick={openDeployMenu}
-                  >
-                    <RemixIcon name="share-forward-line" size={15} />
-                    <span>{shareMenuLabel}</span>
-                  </button>
-                  {deployMenuOpen ? (
-                    <div className="share-menu-popover" role="menu">
-                      <div className="share-menu-section-label" role="presentation">
-                        {t('fileViewer.shareMenuShareLink')}
-                      </div>
-                      {sharePageUrl ? (
-                        <>
-                          <button
-                            type="button"
-                            className="share-menu-item"
-                            role="menuitem"
-                            disabled={!canCopyShareLink}
-                            title={!canCopyShareLink ? shareUnavailableHint : shareLinkStatusHint || undefined}
-                            onClick={() => {
-                              if (!canCopyShareLink || !sharePageUrl) return;
-                              fireShareExport('share_link', async () => {
-                                const ok = await copyShareLink(sharePageUrl);
-                                if (!ok) throw new Error('copy_share_link_failed');
-                              });
-                            }}
-                          >
-                            <span className="share-menu-icon"><RemixIcon name="file-copy-line" size={15} /></span>
-                            <span className="share-menu-text">
-                              <span>{copyShareLinkLabel}</span>
-                              {shareLinkStatusHint ? (
-                                <small>{shareLinkStatusHint}</small>
-                              ) : null}
-                            </span>
-                          </button>
-                          <button
-                            type="button"
-                            className="share-menu-item"
-                            role="menuitem"
-                            disabled={!canOpenSharePage}
-                            title={!canOpenSharePage ? shareLinkStatusHint || shareUnavailableHint : shareLinkStatusHint || undefined}
-                            onClick={() => {
-                              if (!canOpenSharePage || !sharePageUrl) return;
-                              setDeployMenuOpen(false);
-                              fireShareExport('share_page', () => {
-                                window.open(sharePageUrl, '_blank', 'noopener');
-                              });
-                            }}
-                          >
-                            <span className="share-menu-icon"><RemixIcon name="external-link-line" size={15} /></span>
-                            <span className="share-menu-text">
-                              <span>{t('fileViewer.openSharePage')}</span>
-                              {shareLinkStatusHint ? (
-                                <small>{shareLinkStatusHint}</small>
-                              ) : null}
-                            </span>
-                          </button>
-                        </>
-                      ) : (
-                        <button
-                          type="button"
-                          className="share-menu-item share-menu-guide"
-                          role="menuitem"
-                          title={shareUnavailableHint}
-                          onClick={() => {
-                            setShareGuideToast(shareUnavailableHint);
-                          }}
-                        >
-                          <span className="share-menu-icon"><RemixIcon name="link" size={15} /></span>
-                          <span className="share-menu-text">
-                            <span>
-                              {streaming
-                                ? t('fileViewer.shareAfterGenerationComplete')
-                                : t('fileViewer.shareLinkPublishGuide')}
-                            </span>
-                          </span>
-                        </button>
-                      )}
-                      <div className="share-menu-divider" />
-                      <div className="share-menu-section-label" role="presentation">
-                        {t('fileViewer.shareMenuPublishOnline')}
-                      </div>
-                      {DEPLOY_PROVIDER_OPTIONS.map((option) => (
-                        <button
-                          key={option.id}
-                          type="button"
-                          className="share-menu-item"
-                          role="menuitem"
-                          onClick={() => {
-                            const format =
-                              option.id === 'cloudflare-pages'
-                                ? 'cloudflare_pages'
-                                : option.id === 'vercel-self'
-                                  ? 'vercel'
-                                  : 'vercel';
-                            fireShareExport(format, () => openDeployModal(option.id));
-                          }}
-                        >
-                          <span className="share-menu-icon">
-                            <RemixIcon name={deployActionIconFor(option.id)} size={15} />
-                          </span>
-                          <span>{deployActionLabelFor(option.id)}</span>
-                        </button>
-                      ))}
-                      <div className="share-menu-divider" />
-                      <div className="share-menu-section-label" role="presentation">
-                        {t('socialShare.projectSection')}
-                      </div>
-                      <button
-                        type="button"
-                        className="share-menu-item"
-                        role="menuitem"
-                        onClick={() => {
-                          setDeployMenuOpen(false);
-                          fireShareExport('vercel', () => openSocialShareFlow());
-                        }}
-                      >
-                        <span className="share-menu-icon">
-                          <RemixIcon
-                            name={activeProjectSocialShare ? 'share-forward-line' : 'upload-cloud-line'}
-                            size={15}
-                          />
-                        </span>
-                        <span>{socialShareMenuLabel}</span>
-                      </button>
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
-              {canDownload ? (
-                <div className="share-menu chrome-share-menu">
-                  <button
-                    type="button"
-                    className={
-                      'chrome-action chrome-action-primary chrome-action-export' +
-                      (exportReadyNudge ? ' export-ready-nudge' : '')
-                    }
-                    aria-haspopup="menu"
-                    aria-expanded={downloadMenuOpen}
-                    onClick={openDownloadMenu}
-                  >
-                    <RemixIcon name="download-line" size={15} />
-                    <span>{t('fileViewer.download')}</span>
-                  </button>
-                  {downloadMenuOpen ? (
-                    <div className="share-menu-popover" role="menu">
+          {canShare ? (
+            <div className="share-menu" ref={shareRef}>
+              <button
+                className="viewer-action primary"
+                aria-haspopup="menu"
+                aria-expanded={shareMenuOpen}
+                onClick={() => setShareMenuOpen((v) => !v)}
+              >
+                <span>{t('fileViewer.shareLabel')}</span>
+                <Icon name="chevron-down" size={11} />
+              </button>
+              {shareMenuOpen ? (
+                <div className="share-menu-popover" role="menu">
                   <button
                     type="button"
                     className="share-menu-item"
                     role="menuitem"
                     onClick={() => {
-                      setDownloadMenuOpen(false);
-                      fireShareExport('pdf', () => exportProjectAsPdf({
-                        deck: effectiveDeck,
-                        fallbackPdf: () => exportAsPdf(source ?? '', exportTitle, { deck: effectiveDeck }),
-                        filePath: file.name,
-                        projectId,
-                        title: exportTitle,
-                      }));
+                      setShareMenuOpen(false);
+                      exportAsPdf(source ?? '', exportTitle, { deck: effectiveDeck });
                     }}
                   >
-                    <span className="share-menu-icon"><RemixIcon name="file-line" size={15} /></span>
-                    <span>{t('fileViewer.exportPdf')}</span>
+                    <span className="share-menu-icon"><Icon name="file" size={14} /></span>
+                    <span>
+                      {effectiveDeck
+                        ? t('fileViewer.exportPdfAllSlides')
+                        : t('fileViewer.exportPdf')}
+                    </span>
                   </button>
-                  {showPptxExport ? (
-                    <button
-                      type="button"
-                      className="share-menu-item"
-                      role="menuitem"
-                      disabled={!canPptx}
-                      title={
-                        onExportAsPptx
-                          ? streaming
-                            ? t('fileViewer.exportPptxBusy')
-                            : t('fileViewer.exportPptxHint')
-                          : t('fileViewer.exportPptxNa')
-                      }
-                      onClick={() => {
-                        setDownloadMenuOpen(false);
-                        fireShareExport('pptx', () => {
-                          if (onExportAsPptx) onExportAsPptx(file.name);
-                        });
-                      }}
-                    >
-                      <span className="share-menu-icon"><RemixIcon name="file-ppt-line" size={15} /></span>
-                      <span>{t('fileViewer.exportPptx')}</span>
-                    </button>
-                  ) : null}
-                  {showImageExport ? (
-                    <button
-                      type="button"
-                      className="share-menu-item"
-                      role="menuitem"
-                      onClick={openImageExportModal}
-                    >
-                      <span className="share-menu-icon"><RemixIcon name="image-line" size={15} /></span>
-                      <span>{t('fileViewer.exportImage')}</span>
-                    </button>
-                  ) : null}
+                  <button
+                    type="button"
+                    className="share-menu-item"
+                    role="menuitem"
+                    disabled={!canPptx}
+                    title={
+                      onExportAsPptx
+                        ? streaming
+                          ? t('fileViewer.exportPptxBusy')
+                          : t('fileViewer.exportPptxHint')
+                        : t('fileViewer.exportPptxNa')
+                    }
+                    onClick={() => {
+                      setShareMenuOpen(false);
+                      if (onExportAsPptx) onExportAsPptx(file.name);
+                    }}
+                  >
+                    <span className="share-menu-icon"><Icon name="present" size={14} /></span>
+                    <span>{t('fileViewer.exportPptx') + '…'}</span>
+                  </button>
+                  <div className="share-menu-divider" />
                   <button
                     type="button"
                     className="share-menu-item"
                     role="menuitem"
                     onClick={() => {
-                      setDownloadMenuOpen(false);
-                      fireShareExport('zip', () => exportProjectAsZip({
+                      setShareMenuOpen(false);
+                      void exportProjectAsZip({
                         projectId,
                         filePath: file.name,
                         fallbackHtml: source ?? '',
                         fallbackTitle: exportTitle,
-                      }));
+                      });
                     }}
                   >
-                    <span className="share-menu-icon"><RemixIcon name="file-zip-line" size={15} /></span>
+                    <span className="share-menu-icon"><Icon name="download" size={14} /></span>
                     <span>{t('fileViewer.exportZip')}</span>
                   </button>
                   <button
@@ -8384,43 +4394,42 @@ function HtmlViewer({
                     className="share-menu-item"
                     role="menuitem"
                     onClick={() => {
-                      setDownloadMenuOpen(false);
-                      fireShareExport('html', () => exportAsHtml(source ?? '', exportTitle));
+                      setShareMenuOpen(false);
+                      exportAsHtml(source ?? '', exportTitle);
                     }}
                   >
-                    <span className="share-menu-icon"><RemixIcon name="file-code-line" size={15} /></span>
+                    <span className="share-menu-icon"><Icon name="file-code" size={14} /></span>
                     <span>{t('fileViewer.exportHtml')}</span>
                   </button>
-                  {showMarkdownExport ? (
-                    <button
-                      type="button"
-                      className="share-menu-item"
-                      role="menuitem"
-                      onClick={() => {
-                        setDownloadMenuOpen(false);
-                        fireShareExport('markdown', () => exportAsMd(source ?? '', exportTitle));
-                      }}
-                    >
-                      <span className="share-menu-icon"><RemixIcon name="file-line" size={15} /></span>
-                      <span>{t('fileViewer.exportMd')}</span>
-                    </button>
-                  ) : null}
+                  {/* Export as Markdown — pass-through download of the
+                      artifact source with a `.md` extension. No conversion
+                      runs; the file body is identical to the Source view.
+                      Useful for piping the artifact into markdown-aware
+                      tooling (LLM context windows, vault apps). See
+                      issue #279. */}
+                  <button
+                    type="button"
+                    className="share-menu-item"
+                    role="menuitem"
+                    onClick={() => {
+                      setShareMenuOpen(false);
+                      exportAsMd(source ?? '', exportTitle);
+                    }}
+                  >
+                    <span className="share-menu-icon"><Icon name="file" size={14} /></span>
+                    <span>{t('fileViewer.exportMd')}</span>
+                  </button>
                   <div className="share-menu-divider" />
-                  <div className="share-menu-section-label" role="presentation">
-                    {t('fileViewer.shareMenuSave')}
-                  </div>
                   <button
                     type="button"
                     className="share-menu-item"
                     role="menuitem"
                     disabled={savingTemplate}
                     onClick={() => {
-                      fireShareExport('template', () => {
-                        openSaveAsTemplateModal();
-                      });
+                      openSaveAsTemplateModal();
                     }}
                   >
-                    <span className="share-menu-icon"><RemixIcon name="file-copy-line" size={15} /></span>
+                    <span className="share-menu-icon"><Icon name="copy" size={14} /></span>
                     <span>
                       {savingTemplate
                         ? t('fileViewer.savingTemplate')
@@ -8429,305 +4438,162 @@ function HtmlViewer({
                           : t('fileViewer.saveAsTemplate')}
                     </span>
                   </button>
+                  <div className="share-menu-divider" />
+                  {DEPLOY_PROVIDER_OPTIONS.map((option) => (
+                    <button
+                      key={option.id}
+                      type="button"
+                      className="share-menu-item"
+                      role="menuitem"
+                      onClick={() => {
+                        void openDeployModal(option.id);
+                      }}
+                    >
+                      <span className="share-menu-icon"><Icon name="upload" size={14} /></span>
+                      <span>{deployActionLabelFor(option.id)}</span>
+                    </button>
+                  ))}
+                  {deployCopyLinks.length > 0 ? (
+                    <div className="share-menu-divider" />
+                  ) : null}
+                  {deployCopyLinks.map((item) => (
+                    <button
+                      key={`copy-${item.providerId}`}
+                      type="button"
+                      className="share-menu-item"
+                      role="menuitem"
+                      onClick={() => {
+                        setShareMenuOpen(false);
+                        void copyDeployLink(item.url);
+                      }}
+                    >
+                      <span className="share-menu-icon"><Icon name="copy" size={14} /></span>
+                      <span>{copyDeployMenuLabel(item.providerLabel, item.url)}</span>
+                    </button>
+                  ))}
                 </div>
-                ) : null}
-              </div>
               ) : null}
             </div>
           ) : null}
-        </>)}
+        </div>
+      </div>
       <div className="viewer-body" ref={previewBodyRef}>
         {source === null ? (
           <div className="viewer-empty">{t('fileViewer.loading')}</div>
         ) : mode === 'preview' ? (
-          <div
-            className={`${manualEditMode ? 'manual-edit-workspace' : commentPreviewLayoutClass} preview-viewport preview-viewport-${previewViewport}${drawOverlayOpen ? ' preview-draw-active' : ''}`}
-            data-testid={manualEditMode ? undefined : 'comment-preview-layout'}
-            style={previewViewportStyle(previewViewport, previewScale, boardPreviewCanvasSize, boardPreviewScaleOptions)}
-            onMouseLeave={manualEditMode ? clearManualEditHover : undefined}
-          >
-            {manualEditPanel}
-            {manualEditHoverAffordance}
-            <div
-              className={manualEditMode ? 'manual-edit-canvas' : 'comment-preview-canvas'}
-              data-testid={manualEditMode ? undefined : 'comment-preview-canvas'}
-            >
-              <div className={manualEditMode ? undefined : 'comment-frame-clip'} style={manualEditMode ? { height: '100%' } : undefined}>
-                <div
-                  style={
-                    manualEditMode
-                      ? manualEditPreviewShellStyle(previewViewport, previewScale, manualEditViewportWidth)
-                      : previewScaleShellStyle(previewViewport, previewScale)
-                  }
-                >
-                  <PreviewDrawOverlay
-                    active={drawOverlayOpen}
-                    onActiveChange={setDrawOverlayOpen}
-                    captureViewport
-                    captureSnapshot={captureExportImageSnapshot}
-                    captureTarget={null}
-                    filePath={file.name}
-                    sendDisabled={streaming}
-                    sendDisabledReason={t('chat.annotationSendDisabledReason')}
-                  >
-                    <div className="artifact-preview-transport-stack">
-                      {OD_PREVIEW_KEEP_ALIVE ? (
-                        <PooledIframe
-                          ref={urlPreviewIframeRef}
-                          cacheKey={urlPreviewKeepAliveKey}
-                          data-testid={useUrlLoadPreview ? 'artifact-preview-frame' : 'artifact-preview-frame-url-load'}
-                          data-od-render-mode="url-load"
-                          data-od-active={useUrlLoadPreview ? 'true' : 'false'}
-                          aria-hidden={useUrlLoadPreview ? undefined : true}
-                          tabIndex={useUrlLoadPreview ? 0 : -1}
-                          title={file.name}
-                          sandbox="allow-scripts allow-downloads"
-                          src={urlTransportSrc}
-                          onLoad={() => {
-                            const frame = urlPreviewIframeRef.current;
-                            if (useUrlLoadPreview) iframeRef.current = frame;
-                            setUrlSelectionBridgeReady(false);
-                            dcViewportRestoreAtRef.current = Date.now();
-                            frame?.contentWindow?.postMessage({
-                              type: '__dc_set_viewport',
-                              ...dcViewportRef.current,
-                            }, '*');
-                            frame?.contentWindow?.postMessage({ type: 'od:url-selection-bridge-probe' }, '*');
-                            syncBridgeModes(frame);
-                            if (useUrlLoadPreview) restorePreviewScrollPosition();
-                          }}
-                        />
-                      ) : (
-                        <iframe
-                          ref={urlPreviewIframeRef}
-                          data-testid={useUrlLoadPreview ? 'artifact-preview-frame' : 'artifact-preview-frame-url-load'}
-                          data-od-render-mode="url-load"
-                          data-od-active={useUrlLoadPreview ? 'true' : 'false'}
-                          aria-hidden={useUrlLoadPreview ? undefined : true}
-                          tabIndex={useUrlLoadPreview ? 0 : -1}
-                          title={file.name}
-                          sandbox="allow-scripts allow-downloads"
-                          src={urlTransportSrc}
-                          onLoad={() => {
-                            const frame = urlPreviewIframeRef.current;
-                            if (useUrlLoadPreview) iframeRef.current = frame;
-                            setUrlSelectionBridgeReady(false);
-                            dcViewportRestoreAtRef.current = Date.now();
-                            frame?.contentWindow?.postMessage({
-                              type: '__dc_set_viewport',
-                              ...dcViewportRef.current,
-                            }, '*');
-                            frame?.contentWindow?.postMessage({ type: 'od:url-selection-bridge-probe' }, '*');
-                            syncBridgeModes(frame);
-                            if (useUrlLoadPreview) restorePreviewScrollPosition();
-                          }}
-                        />
-                      )}
-                      <iframe
-                        key={srcDocTransportResetKey}
-                        ref={srcDocPreviewIframeRef}
-                        data-testid={useUrlLoadPreview ? 'artifact-preview-frame-srcdoc' : 'artifact-preview-frame'}
-                        data-od-render-mode="srcdoc"
-                        data-od-active={useUrlLoadPreview ? 'false' : 'true'}
-                        aria-hidden={useUrlLoadPreview ? true : undefined}
-                        tabIndex={useUrlLoadPreview ? -1 : 0}
-                        title={file.name}
-                        sandbox="allow-scripts allow-downloads"
-                        srcDoc={srcDocTransportContent}
-                        onLoad={() => {
-                          const frame = srcDocPreviewIframeRef.current;
-                          if (!useUrlLoadPreview) iframeRef.current = frame;
-                          // Reset the activation dedupe exactly ONCE per
-                          // freshly mounted iframe DOM node, never on the
-                          // subsequent load events that the same node
-                          // emits during normal srcDoc rendering.
-                          //
-                          // The iframe's load event fires twice for one
-                          // successful activation: once when the lazy
-                          // transport shell HTML loads, and again when
-                          // our own document.open/write/close inside the
-                          // shell finishes. PR #2699 reset the dedupe on
-                          // every load so that switching
-                          // preview -> source -> preview (which remounts
-                          // this iframe as a fresh DOM node) would
-                          // re-activate the new shell. But resetting on
-                          // every load also re-activated on the SECOND
-                          // load of a non-remounted frame, which
-                          // re-triggered document.open/write/close, which
-                          // re-fired the load event, ad infinitum. The
-                          // dedupe ref oscillated between null and the
-                          // current srcDoc thousands of times per render
-                          // and each iteration restarted every CSS
-                          // animation from its `from` keyframe. Designs
-                          // using `animation-fill-mode: both` with
-                          // `from { opacity: 0 }` stayed at opacity 0
-                          // forever and the preview read as blank.
-                          // That is issue #2361.
-                          //
-                          // Tracking the last frame we reset for lets us
-                          // keep PR #2699's "remount after Source toggle"
-                          // fix while breaking the loop on plain renders.
-                          if (frame && srcDocFrameDedupeResetForRef.current !== frame) {
-                            srcDocFrameDedupeResetForRef.current = frame;
-                            activatedSrcDocTransportHtmlRef.current = null;
-                          }
-                          if (useLazySrcDocTransport) setSrcDocShellReady(true);
-                          activateLoadedSrcDocTransport(frame);
-                          dcViewportRestoreAtRef.current = Date.now();
-                          frame?.contentWindow?.postMessage({
-                            type: '__dc_set_viewport',
-                            ...dcViewportRef.current,
-                          }, '*');
-                          replayInspectOverridesToIframe(frame);
-                          syncBridgeModes(frame);
-                          syncCachedSlideStateToIframe(frame);
-                          if (!useUrlLoadPreview) restorePreviewScrollPosition();
-                        }}
-                      />
-                    </div>
-                  </PreviewDrawOverlay>
-                </div>
+          <div className={manualEditMode ? 'manual-edit-workspace' : 'comment-preview-layer'}>
+            {manualEditMode ? (
+              <ManualEditPanel
+                targets={manualEditTargets}
+                selectedTarget={selectedManualEditTarget}
+                draft={manualEditDraft}
+                history={manualEditHistory}
+                error={manualEditError}
+                canUndo={manualEditHistory.length > 0}
+                canRedo={manualEditUndone.length > 0}
+                busy={manualEditSaving}
+                onSelectTarget={selectManualEditTarget}
+                onDraftChange={setManualEditDraft}
+                onApplyPatch={(patch, label) => {
+                  void applyManualEdit(patch, label);
+                }}
+                onError={setManualEditError}
+                onCancelDraft={() => {
+                  if (selectedManualEditTarget) selectManualEditTarget(selectedManualEditTarget);
+                }}
+                onUndo={() => {
+                  void undoManualEdit();
+                }}
+                onRedo={() => {
+                  void redoManualEdit();
+                }}
+              />
+            ) : null}
+            <div className={manualEditMode ? 'manual-edit-canvas' : 'comment-frame-clip'}>
+              <div
+                onWheel={(event: React.WheelEvent<HTMLDivElement>) => {
+                  event.preventDefault();
+                  bumpZoom(event.deltaY < 0 ? 10 : -10);
+                }}
+                style={{
+                  width: `${100 / previewScale}%`,
+                  height: `${100 / previewScale}%`,
+                  transform: `scale(${previewScale})`,
+                  transformOrigin: '0 0',
+                }}
+              >
+                {useUrlLoadPreview ? (
+                  <iframe
+                    ref={iframeRef}
+                    data-testid="artifact-preview-frame"
+                    data-od-render-mode="url-load"
+                    title={file.name}
+                    sandbox="allow-scripts"
+                    src={previewSrcUrl}
+                    onLoad={syncBridgeModes}
+                  />
+                ) : (
+                  <iframe
+                    ref={iframeRef}
+                    data-testid="artifact-preview-frame"
+                    data-od-render-mode="srcdoc"
+                    title={file.name}
+                    sandbox="allow-scripts"
+                    srcDoc={srcDoc}
+                    // Re-seeds the iframe-side bridge with the host's
+                    // authoritative inspect override map after each srcdoc
+                    // rebuild, then syncs comment/edit bridge modes.
+                    // URL-loaded iframes have no inspect bridge, so the
+                    // replay handler is intentionally only on the srcDoc
+                    // branch.
+                    onLoad={() => {
+                      replayInspectOverridesToIframe();
+                      syncBridgeModes();
+                    }}
+                  />
+                )}
               </div>
-              {boardMode ? (
-                <CommentPreviewOverlays
-                  comments={commentCreateMode ? visibleSideComments : []}
-                  liveTargets={liveCommentTargets}
-                  hoveredTarget={hoveredCommentTarget}
-                  hoveredPodMemberId={hoveredPodMemberId}
-                  activeTarget={activeCommentTarget}
-                  activeExistingCommentId={activeComposerComment?.id ?? null}
-                  boardTool={boardTool}
-                  showActivePin={commentCreateMode}
-                  scale={overlayPreviewScale}
-                  offsetX={overlayPreviewTransform.offsetX}
-                  offsetY={overlayPreviewTransform.offsetY}
-                  strokePoints={strokePoints}
-                  activeSlideIndex={effectiveDeck ? slideState?.active ?? null : null}
-                  onOpenComment={(comment, snapshot) => {
-                    setCommentPanelOpen(true);
-                    setCommentSidePanelCollapsed(false);
-                    setCommentCreateMode(true);
-                    setBoardMode(true);
-                    setActiveCommentTarget(snapshot);
-                    setHoveredCommentTarget(snapshot);
-                    setActivePreviewCommentId(comment.id);
-                    setCommentDraft(comment.note);
-                    setQueuedBoardNotes([]);
-                    setActiveCommentExistingAttachments(comment.attachments ?? []);
-                  }}
-                />
-              ) : null}
-              {/* Portaled to <body> so the screenshot/export toast escapes the
-                  preview pane's transform + overflow:hidden. */}
-              {exportToast
-                ? createPortal(
-                    <Toast
-                      message={exportToast.message}
-                      tone={exportToast.tone}
-                      role={exportToast.tone === 'error' ? 'alert' : 'status'}
-                      ttlMs={exportToast.tone === 'loading' ? 8000 : 2200}
-                      placement="top"
-                      onDismiss={() => setExportToast(null)}
-                    />,
-                    document.body,
-                  )
-                : null}
-              {commentSavedToast ? (
-                <div className="comment-toast-anchor">
-                  <Toast
-                    message={commentSavedToast}
-                    ttlMs={2200}
-                    onDismiss={() => setCommentSavedToast(null)}
-                  />
-                </div>
-              ) : null}
-              {templateSavedToast ? (
-                <div className="comment-toast-anchor">
-                  <Toast
-                    message={templateSavedToast}
-                    ttlMs={2200}
-                    onDismiss={() => setTemplateSavedToast(null)}
-                  />
-                </div>
-              ) : null}
-              {commentComposer}
-              {boardMode && !commentCreateMode && hoveredCommentTarget && (!activeCommentTarget || commentPortalHost) ? (
-                <AnnotationHoverPopover
-                  target={hoveredCommentTarget}
-                  scale={overlayPreviewScale}
-                  onMouseEnter={() => {
-                    hoverCardPinnedRef.current = true;
-                    cancelHoverCardDismiss();
-                  }}
-                  onMouseLeave={() => {
-                    hoverCardPinnedRef.current = false;
-                    scheduleHoverCardDismiss();
-                  }}
-                />
-              ) : null}
-              {/*
-                Hint banner for Inspect / Picker modes. The bridge in
-                `apps/web/src/runtime/srcdoc.ts` posts `od:comment-targets`
-                with every element annotated with `data-od-id` /
-                `data-screen-label`, so `liveCommentTargets.size` is the
-                authoritative annotation count for the current artifact.
-
-                Two states:
-                - "has targets": the existing copy ("Click any element with
-                  `data-od-id` to tune its style.") for users who just don't
-                  see the crosshair cursor.
-                - "no targets" (issue #890): a freeform-generated artifact
-                  (e.g. PRD → HTML through a Claude-Code-compatible CLI
-                  without a skill) ships zero `data-od-id` annotations. The
-                  bridge's click handler walks up to <html>, finds nothing,
-                  and bails — clicks no-op silently. The static copy made
-                  this look broken; the empty-state copy explains what's
-                  missing and how to fix it. Mirrored across Inspect and
-                  element-pick annotation mode because the failure surface is identical.
-              */}
-              {inspectMode
-                && openHintBox
-                && !activeInspectTarget
-                && !activeCommentTarget ? (
-                <div
-                  className="inspect-empty-hint-container"
-                  data-testid="inspect-empty-hint-container"
-                >
-                  {liveCommentTargets.size === 0 ? (
-                    <div
-                      className="inspect-empty-hint"
-                      data-testid="inspect-empty-hint-no-targets"
-                    >
-                      {inspectMode
-                        ? t('chat.inspect.noEditableTargets')
-                        : t('chat.inspect.noCommentTargets')}
-                    </div>
-                  ) : (
-                    <div
-                      className="inspect-empty-hint"
-                      data-testid="inspect-empty-hint"
-                    >
-                      {inspectMode ? t('chat.inspect.editHint') : t('chat.inspect.commentHint')}
-                    </div>
-                  )}
-                  <button
-                    type="button"
-                    title="Close Inspect Hint"
-                    aria-label="Close Inspect Hint"
-                    onClick={() => setOpenHintBox(false)}
-                    className="orbit-artifact-ghost"
-                  >
-                    <Icon className="" name="close" size={12} />
-                  </button>
-                </div>
-              ) : null}
             </div>
-            {boardImagePreviewModal}
-            {commentPortalHost && commentSidePanel
-              ? createPortal(commentSidePanel, commentPortalHost)
-              : commentPortalId
-                ? null
-                : commentSidePanel}
+            {boardMode ? (
+              <CommentPreviewOverlays
+                comments={previewComments}
+                liveTargets={liveCommentTargets}
+                hoveredTarget={hoveredCommentTarget}
+                activeTarget={activeCommentTarget}
+                boardTool={boardTool}
+                scale={previewScale}
+                strokePoints={strokePoints}
+                onOpenComment={(comment, snapshot) => {
+                  setActiveCommentTarget(snapshot);
+                  setHoveredCommentTarget(snapshot);
+                  setCommentDraft(comment.note);
+                  setQueuedBoardNotes([]);
+                }}
+              />
+            ) : null}
+            {boardMode && activeCommentTarget ? (
+              <BoardComposerPopover
+                target={activeCommentTarget}
+                existing={previewComments.find((comment) => comment.elementId === activeCommentTarget.elementId) ?? null}
+                draft={commentDraft}
+                notes={queuedBoardNotes}
+                onDraft={setCommentDraft}
+                onAddDraft={queueCurrentDraft}
+                onRemoveQueuedNote={(index) =>
+                  setQueuedBoardNotes((current) => current.filter((_, currentIndex) => currentIndex !== index))
+                }
+                onClose={clearBoardComposer}
+                onSaveComment={savePersistentComment}
+                onSendBatch={sendBoardBatch}
+                onRemove={async (commentId) => {
+                  if (!onRemovePreviewComment) return;
+                  await onRemovePreviewComment(commentId);
+                  clearBoardComposer();
+                }}
+                sending={sendingBoardBatch || streaming}
+                t={t}
+              />
+            ) : null}
             {inspectMode && activeInspectTarget ? (
               <InspectPanel
                 target={activeInspectTarget}
@@ -8753,24 +4619,23 @@ function HtmlViewer({
                 onSaveToSource={() => {
                   void saveInspectToSource();
                 }}
-                onClose={() => {
-                  setActiveInspectTarget(null);
-                  if (boardMode && boardTool === 'inspect') {
-                    setActiveCommentTarget(null);
-                    setHoveredCommentTarget(null);
-                  }
-                }}
+                onClose={() => setActiveInspectTarget(null)}
                 saving={savingInspect}
                 savedAt={inspectSavedAt}
                 error={inspectError}
               />
+            ) : null}
+            {inspectMode && !activeInspectTarget ? (
+              <div className="inspect-empty-hint" data-testid="inspect-empty-hint">
+                Click any element with <code>data-od-id</code> to tune its style.
+              </div>
             ) : null}
           </div>
         ) : (
           <pre className="viewer-source">{source}</pre>
         )}
       </div>
-      {inTabPresent && source && typeof document !== 'undefined' ? createPortal(
+      {inTabPresent && source ? (
         <div
           className="present-overlay"
           role="dialog"
@@ -8786,87 +4651,18 @@ function HtmlViewer({
           {useUrlLoadPreview ? (
             <iframe
               title="present"
-              sandbox="allow-scripts allow-downloads"
+              sandbox="allow-scripts"
               data-od-render-mode="url-load"
-              src={activePreviewSrcUrl}
+              src={previewSrcUrl}
             />
           ) : (
             <iframe
               title="present"
-              sandbox="allow-scripts allow-downloads"
+              sandbox="allow-scripts"
               data-od-render-mode="srcdoc"
               srcDoc={srcDoc}
             />
           )}
-        </div>,
-        document.body,
-      ) : null}
-      {imageExportModalOpen ? (
-        <div className="modal-backdrop" role="presentation">
-          <div
-            className="modal deploy-modal image-export-modal"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby={imageExportTitleId}
-          >
-            <div className="modal-head">
-              <div className="kicker">IMAGE</div>
-              <h2 id={imageExportTitleId}>{t('fileViewer.exportImage')}</h2>
-              <p className="subtitle">{t('fileViewer.exportImageModalSubtitle')}</p>
-            </div>
-            <div className="deploy-form image-export-form">
-              <fieldset className="image-export-format-field" disabled={imageExportBusy}>
-                <legend>{t('fileViewer.exportImageFormatLabel')}</legend>
-                <div className="image-export-format-options">
-                  {IMAGE_EXPORT_FORMAT_OPTIONS.map((option) => (
-                    <label
-                      key={option.value}
-                      className={`image-export-format-option${imageExportFormat === option.value ? ' active' : ''}`}
-                    >
-                      <input
-                        type="radio"
-                        name="image-export-format"
-                        value={option.value}
-                        aria-label={option.label}
-                        checked={imageExportFormat === option.value}
-                        onChange={() => changeImageExportFormat(option.value)}
-                      />
-                      <span className="image-export-format-text">
-                        <strong>{option.label}</strong>
-                        <span aria-hidden="true">{option.extension}</span>
-                      </span>
-                    </label>
-                  ))}
-                </div>
-              </fieldset>
-              {imageExportError ? (
-                <p className="deploy-error" role="alert">{imageExportError}</p>
-              ) : null}
-            </div>
-            <div className="modal-foot">
-              <button
-                type="button"
-                className="ghost-link button-like"
-                disabled={imageExportBusy}
-                onClick={() => {
-                  setImageExportModalOpen(false);
-                  setImageExportError(null);
-                }}
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                type="button"
-                className="viewer-action primary"
-                disabled={imageExportBusy || imageExportPreparing || !imageExportPreparedBlob}
-                onClick={() => {
-                  void handleImageExportSave();
-                }}
-              >
-                {imageExportBusy ? t('fileViewer.exportImageSaving') : t('common.save')}
-              </button>
-            </div>
-          </div>
         </div>
       ) : null}
       {templateModalOpen ? (
@@ -8928,77 +4724,16 @@ function HtmlViewer({
         </div>
       ) : null}
       {deployModalOpen ? (
-        <div
-          className="modal-backdrop deploy-flow-backdrop"
-          role="presentation"
-          onClick={(event) => {
-            if (event.target === event.currentTarget) closeDeployModal();
-          }}
-        >
-          <div className="modal deploy-modal deploy-flow-modal" role="dialog" aria-modal="true">
-            <div className="deploy-flow-modal__scroll">
-              <div className="modal-head">
-                <div className="kicker">{deployProviderLabel}</div>
-                <h2>{t('fileViewer.deployToProvider', { provider: deployProviderLabel })}</h2>
-                <p className="subtitle">{t('fileViewer.deployModalSubtitle')}</p>
-              </div>
-              <div className="deploy-form">
-                <div className={`deploy-social-share${activeProjectSocialShare ? '' : ' is-locked'}${socialShareBlockedState ? ` is-${socialShareBlockedState}` : ''}`}>
-                  <div className="deploy-social-share__head">
-                    <div className="deploy-social-share__label">
-                      {t('socialShare.projectSection')}
-                    </div>
-                    {socialShareDisplayUrl ? (
-                      <a
-                        className="deploy-social-share__url"
-                        href={socialShareDisplayUrl}
-                        target="_blank"
-                        rel="noreferrer noopener"
-                      >
-                        {socialShareDisplayUrl}
-                      </a>
-                    ) : null}
-                  </div>
-                  {!activeProjectSocialShare || socialShareBlockedState ? (
-                    <p className="hint">{socialShareUnavailableMessage}</p>
-                  ) : null}
-                  {activeProjectSocialShare ? (
-                    <SocialShareGrid
-                      share={activeProjectSocialShare}
-                      onAfterShare={closeDeployModal}
-                    />
-                  ) : null}
-                  {socialShareBlockedDeployment?.url ? (
-                    <div className="deploy-social-share__actions">
-                      <button
-                        type="button"
-                        className="viewer-action"
-                        onClick={() => {
-                          void copyDeployLink(socialShareBlockedDeployment.url);
-                        }}
-                      >
-                        <Icon name="copy" size={14} />
-                        <span>{copyDeployLabel(socialShareBlockedDeployment.url)}</span>
-                      </button>
-                      {activeDeployment?.id === socialShareBlockedDeployment.id ? (
-                        <button
-                          type="button"
-                          className="viewer-action"
-                          disabled={deployPhase === 'preparing-link'}
-                          onClick={() => {
-                            void retryDeploymentLink();
-                          }}
-                        >
-                          {deployPhase === 'preparing-link'
-                            ? t('fileViewer.preparingPublicLink')
-                            : t('fileViewer.retryLink')}
-                        </button>
-                      ) : null}
-                    </div>
-                  ) : null}
-                </div>
+        <div className="modal-backdrop" role="presentation">
+          <div className="modal deploy-modal" role="dialog" aria-modal="true">
+            <div className="modal-head">
+              <div className="kicker">{deployProviderLabel}</div>
+              <h2>{t('fileViewer.deployToProvider', { provider: deployProviderLabel })}</h2>
+              <p className="subtitle">{t('fileViewer.deployModalSubtitle')}</p>
+            </div>
+            <div className="deploy-form">
               <label className="deploy-provider-field">
-                <span className="deploy-field-title">{t('fileViewer.deployProviderLabel')}</span>
+                <span>{t('fileViewer.deployProviderLabel')}</span>
                 <select
                   value={deployProviderId}
                   onChange={(e) => {
@@ -9012,25 +4747,32 @@ function HtmlViewer({
                   ))}
                 </select>
               </label>
-              <div className="field-label-row deploy-token-label-row">
-                <label htmlFor="deploy-token" className="deploy-field-title required">{t(deployProvider.tokenLabelKey)}</label>
-                <a
-                  href={deployProvider.tokenLink}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  {t(deployProvider.tokenLinkKey)}
-                </a>
+              <div className="field-label-row">
+                <label htmlFor="deploy-token">{t(deployProvider.tokenLabelKey)}</label>
+                <div className="field-label-note">
+                  {deployConfig?.configured ? (
+                    <p className="hint">{t(deployProvider.tokenReuseHintKey, { provider: deployProviderLabel })}</p>
+                  ) : null}
+                  {deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID ? (
+                    <p className="hint">{t('fileViewer.cloudflareApiTokenScopeHint')}</p>
+                  ) : null}
+                  <a
+                    href={deployProvider.tokenLink}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    {t(deployProvider.tokenLinkKey)}
+                  </a>
+                </div>
               </div>
-              <div className="deploy-token-input-row">
-                <input
-                  ref={deployTokenInputRef}
-                  id="deploy-token"
-                  type="password"
-                  value={deployToken}
-                  placeholder={t(deployProvider.tokenPlaceholderKey, { provider: deployProviderLabel })}
-                  onChange={(e) => setDeployToken(e.target.value)}
-                />
+              <input
+                id="deploy-token"
+                type="password"
+                value={deployToken}
+                placeholder={t(deployProvider.tokenPlaceholderKey, { provider: deployProviderLabel })}
+                onChange={(e) => setDeployToken(e.target.value)}
+              />
+              <div className="deploy-config-actions">
                 <button
                   type="button"
                   className="ghost-link button-like"
@@ -9042,21 +4784,11 @@ function HtmlViewer({
                   {savingDeployConfig ? t('fileViewer.savingConfig') : t('fileViewer.save')}
                 </button>
               </div>
-              {deployConfig?.configured || deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID ? (
-                <div className="deploy-token-hints">
-                  {deployConfig?.configured ? (
-                    <p className="hint">{t(deployProvider.tokenReuseHintKey, { provider: deployProviderLabel })}</p>
-                  ) : null}
-                  {deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID ? (
-                    <p className="hint">{t('fileViewer.cloudflareApiTokenScopeHint')}</p>
-                  ) : null}
-                </div>
-              ) : null}
               {deployProviderId === CLOUDFLARE_PAGES_PROVIDER_ID ? (
                 <>
                   <div className="deploy-field-grid single-field">
                     <label>
-                      <span className="deploy-field-title required">{t('fileViewer.cloudflareAccountId')}</span>
+                      <span>{t('fileViewer.cloudflareAccountId')}</span>
                       <input
                         value={cloudflareAccountId}
                         onChange={(e) => setCloudflareAccountId(e.target.value)}
@@ -9066,32 +4798,16 @@ function HtmlViewer({
                   </div>
                   <div className="deploy-field-grid cloudflare-domain-grid">
                     <label>
-                      <span className="deploy-field-title">{t('fileViewer.cloudflareDomainPrefixLabel')}</span>
+                      <span>{t('fileViewer.cloudflareDomainPrefixLabel')}</span>
                       <input
                         value={cloudflareDomainPrefix}
                         placeholder={t('fileViewer.cloudflareDomainPrefixPlaceholder')}
                         onChange={(e) => setCloudflareDomainPrefix(e.target.value)}
                       />
                     </label>
-                    <div className="deploy-field-control">
-                      <span className="deploy-field-title-row">
-                        <label className="deploy-field-title" htmlFor="cloudflare-zone-select">
-                          {t('fileViewer.cloudflareZoneLabel')}
-                        </label>
-                        <button
-                          type="button"
-                          className="ghost-link deploy-field-inline-action"
-                          disabled={cloudflareZonesLoading || !deployConfig?.configured}
-                          onClick={() => {
-                            void loadCloudflareZones();
-                          }}
-                        >
-                          <RemixIcon name="refresh-line" size={13} />
-                          {cloudflareZonesLoading ? t('fileViewer.cloudflareZonesLoading') : t('fileViewer.cloudflareZonesRefresh')}
-                        </button>
-                      </span>
+                    <label>
+                      <span>{t('fileViewer.cloudflareZoneLabel')}</span>
                       <select
-                        id="cloudflare-zone-select"
                         value={cloudflareZoneId}
                         disabled={cloudflareZonesLoading || (!deployConfig?.configured && !cloudflareZones.length)}
                         onChange={(e) => setCloudflareZoneId(e.target.value)}
@@ -9105,7 +4821,19 @@ function HtmlViewer({
                           </option>
                         ))}
                       </select>
-                    </div>
+                    </label>
+                  </div>
+                  <div className="deploy-config-actions secondary">
+                    <button
+                      type="button"
+                      className="ghost-link button-like"
+                      disabled={cloudflareZonesLoading || !deployConfig?.configured}
+                      onClick={() => {
+                        void loadCloudflareZones();
+                      }}
+                    >
+                      {cloudflareZonesLoading ? t('fileViewer.cloudflareZonesLoading') : t('fileViewer.cloudflareZonesRefresh')}
+                    </button>
                   </div>
                   {cloudflareZonesError ? (
                     <p className="deploy-error">{cloudflareZonesError}</p>
@@ -9113,7 +4841,9 @@ function HtmlViewer({
                     <p className="hint">{t('fileViewer.cloudflareZonesLoading')}</p>
                   ) : deployConfig?.configured && cloudflareZones.length === 0 ? (
                     <p className="hint">{t('fileViewer.cloudflareZonesEmpty')}</p>
-                  ) : null}
+                  ) : (
+                    <p className="hint">{t('fileViewer.cloudflareCustomDomainHint')}</p>
+                  )}
                   {cloudflareDomainPrefix.trim() && !isValidCloudflareDomainPrefixInput(cloudflareDomainPrefix) ? (
                     <p className="deploy-error">{t('fileViewer.cloudflareDomainPrefixInvalid')}</p>
                   ) : cloudflareHostnamePreview ? (
@@ -9125,7 +4855,7 @@ function HtmlViewer({
               ) : (
                 <div className="deploy-field-grid">
                   <label>
-                    <span className="deploy-field-title">{t('fileViewer.vercelTeamId')}</span>
+                    <span>{t('fileViewer.vercelTeamId')}</span>
                     <input
                       value={teamId}
                       placeholder={t('fileViewer.optional')}
@@ -9133,7 +4863,7 @@ function HtmlViewer({
                     />
                   </label>
                   <label>
-                    <span className="deploy-field-title">{t('fileViewer.vercelTeamSlug')}</span>
+                    <span>{t('fileViewer.vercelTeamSlug')}</span>
                     <input
                       value={teamSlug}
                       placeholder={t('fileViewer.optional')}
@@ -9142,15 +4872,8 @@ function HtmlViewer({
                   </label>
                 </div>
               )}
+              <p className="hint">{t(deployProvider.previewHintKey)}</p>
               {deployError ? <p className="deploy-error">{deployError}</p> : null}
-              {!deployError
-                && deployPhase === 'idle'
-                && deployResultCards.length > 0
-                && deployResultState(activeDeployment?.status) === 'ready' ? (
-                <p className="hint" role="status">
-                  {t('fileViewer.deployLinkReady')} · {t('fileViewer.deployResultLabel')}
-                </p>
-              ) : null}
               {deployResultCards.length > 0 ? (
                 <div className={`deploy-result-block ${deployResultState(activeDeployment?.status)}`}>
                   <div className="deploy-result-summary">
@@ -9230,13 +4953,12 @@ function HtmlViewer({
                   </div>
                 </div>
               ) : null}
-              </div>
             </div>
             <div className="modal-foot">
               <button
                 type="button"
                 className="ghost-link button-like"
-                onClick={closeDeployModal}
+                onClick={() => setDeployModalOpen(false)}
               >
                 {t('common.cancel')}
               </button>
@@ -9254,45 +4976,6 @@ function HtmlViewer({
           </div>
         </div>
       ) : null}
-      {deploySavedToast ? (
-        <Toast
-          message={deploySavedToast.message}
-          details={deploySavedToast.details}
-          tone="success"
-          placement="top"
-          ttlMs={3600}
-          onDismiss={() => setDeploySavedToast(null)}
-        />
-      ) : null}
-      {deployActionToast && typeof document !== 'undefined' ? createPortal(
-        <Toast
-          message={deployActionToast}
-          placement="top"
-          ttlMs={2400}
-          role="alert"
-          onDismiss={() => setDeployActionToast(null)}
-        />,
-        document.body,
-      ) : null}
-      {imageExportSavedToast ? (
-        <Toast
-          message={imageExportSavedToast.message}
-          details={imageExportSavedToast.details}
-          tone="success"
-          placement="top"
-          ttlMs={3600}
-          onDismiss={() => setImageExportSavedToast(null)}
-        />
-      ) : null}
-      {shareGuideToast && typeof document !== 'undefined' ? createPortal(
-        <Toast
-          message={shareGuideToast}
-          placement="top"
-          ttlMs={2200}
-          onDismiss={() => setShareGuideToast(null)}
-        />,
-        document.body,
-      ) : null}
     </div>
   );
 }
@@ -9300,40 +4983,6 @@ function HtmlViewer({
 function baseDirFor(fileName: string): string {
   const idx = fileName.lastIndexOf('/');
   return idx >= 0 ? fileName.slice(0, idx + 1) : '';
-}
-
-function toOwnerRelativePath(ownerFileName: string, targetPath: string): string {
-  const normalize = (value: string) => decodeURIComponent(value).replace(/^\/+/, '');
-  const squash = (parts: string[]) => {
-    const out: string[] = [];
-    for (const part of parts) {
-      if (!part || part === '.') continue;
-      if (part === '..') {
-        if (out.length > 0) out.pop();
-        continue;
-      }
-      out.push(part);
-    }
-    return out;
-  };
-  const ownerDirPath = normalize(baseDirFor(ownerFileName));
-  const targetFilePath = normalize(targetPath);
-  const ownerParts = squash(ownerDirPath.split('/'));
-  const targetParts = squash(targetFilePath.split('/'));
-
-  let common = 0;
-  while (
-    common < ownerParts.length &&
-    common < targetParts.length &&
-    ownerParts[common] === targetParts[common]
-  ) {
-    common += 1;
-  }
-
-  const up = new Array(ownerParts.length - common).fill('..');
-  const down = targetParts.slice(common);
-  const rel = [...up, ...down].join('/');
-  return rel || '.';
 }
 
 function hasRelativeAssetRefs(html: string): boolean {
@@ -9478,31 +5127,6 @@ function ImageViewer({
       </div>
       <div className="viewer-body image-body">
         <img alt={file.name} src={url} />
-      </div>
-    </div>
-  );
-}
-
-function SketchViewer({
-  projectId,
-  file,
-}: {
-  projectId: string;
-  file: ProjectFile;
-}) {
-  const t = useT();
-  return (
-    <div className="viewer image-viewer sketch-viewer">
-      <div className="viewer-toolbar">
-        <div className="viewer-toolbar-left">
-          <span className="viewer-meta">
-            {t('fileViewer.sketchMeta', { size: humanSize(file.size) })}
-          </span>
-        </div>
-        <FileActions projectId={projectId} file={file} />
-      </div>
-      <div className="viewer-body image-body">
-        <SketchPreview projectId={projectId} file={file} className="viewer-sketch-preview" />
       </div>
     </div>
   );
@@ -9726,11 +5350,7 @@ function TextViewer({
     }
   }
 
-  const displayText = useMemo(
-    () => (text == null ? null : formatJsonFileTextForDisplay(file, text)),
-    [file.name, file.mime, text],
-  );
-  const lineCount = displayText ? displayText.split('\n').length : 0;
+  const lineCount = text ? text.split('\n').length : 0;
 
   return (
     <div className="viewer text-viewer">
@@ -9769,117 +5389,14 @@ function TextViewer({
       <div className="viewer-body">
         {text === null ? (
           <div className="viewer-empty">{t('fileViewer.loading')}</div>
-        ) : displayText !== null && lineCount > 0 ? (
-          <CodeWithLines text={displayText} />
+        ) : lineCount > 0 ? (
+          <CodeWithLines text={text} />
         ) : (
-          <pre className="viewer-source">{displayText}</pre>
+          <pre className="viewer-source">{text}</pre>
         )}
       </div>
     </div>
   );
-}
-
-function formatJsonFileTextForDisplay(file: ProjectFile, text: string): string {
-  if (!isJsonFile(file)) return text;
-  try {
-    if (hasPrecisionSensitiveJsonNumberText(text)) return text;
-    const parsed = JSON.parse(text) as unknown;
-    if (hasUnsafeJsonNumber(parsed)) return text;
-    return JSON.stringify(parsed, null, 2);
-  } catch {
-    return text;
-  }
-}
-
-function hasPrecisionSensitiveJsonNumberText(text: string): boolean {
-  let inString = false;
-  let escaped = false;
-  const numberTokenPattern = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
-  for (let i = 0; i < text.length;) {
-    const char = text[i];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === '\\') {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      i += 1;
-      continue;
-    }
-
-    if (char === '"') {
-      inString = true;
-      i += 1;
-      continue;
-    }
-
-    numberTokenPattern.lastIndex = i;
-    const match = numberTokenPattern.exec(text);
-    if (!match) {
-      i += 1;
-      continue;
-    }
-
-    const token = match[0];
-    if (isSignedNegativeZeroJsonNumberToken(token)) return true;
-    if (/[.eE]/.test(token) && isPrecisionSensitiveJsonNumberToken(token)) return true;
-    i = numberTokenPattern.lastIndex;
-  }
-  return false;
-}
-
-function isSignedNegativeZeroJsonNumberToken(token: string): boolean {
-  return /^-0(?:\.0+)?(?:[eE][+-]?\d+)?$/.test(token);
-}
-
-function isPrecisionSensitiveJsonNumberToken(token: string): boolean {
-  const parsed = Number(token);
-  if (!Number.isFinite(parsed)) return true;
-  const rendered = JSON.stringify(parsed);
-  if (!rendered) return true;
-  const originalValue = parseJsonNumberTokenAsDecimal(token);
-  const renderedValue = parseJsonNumberTokenAsDecimal(rendered);
-  return (
-    !originalValue ||
-    !renderedValue ||
-    originalValue.coefficient !== renderedValue.coefficient ||
-    originalValue.exponent !== renderedValue.exponent
-  );
-}
-
-function parseJsonNumberTokenAsDecimal(token: string): { coefficient: bigint; exponent: number } | null {
-  const match = /^(-)?(\d+)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/.exec(token);
-  if (!match) return null;
-  const [, sign, integerPart, fractionPart = '', exponentPart = '0'] = match;
-  const coefficient = BigInt(`${sign ?? ''}${integerPart}${fractionPart}`);
-  const exponent = Number(exponentPart) - fractionPart.length;
-  return normalizeDecimalParts(coefficient, exponent);
-}
-
-function normalizeDecimalParts(coefficient: bigint, exponent: number): { coefficient: bigint; exponent: number } {
-  if (coefficient === 0n) return { coefficient: 0n, exponent: 0 };
-  let normalizedCoefficient = coefficient;
-  let normalizedExponent = exponent;
-  while (normalizedCoefficient % 10n === 0n) {
-    normalizedCoefficient /= 10n;
-    normalizedExponent += 1;
-  }
-  return { coefficient: normalizedCoefficient, exponent: normalizedExponent };
-}
-
-function hasUnsafeJsonNumber(value: unknown): boolean {
-  if (typeof value === 'number') {
-    return !Number.isFinite(value) || (Number.isInteger(value) && !Number.isSafeInteger(value));
-  }
-  if (Array.isArray(value)) return value.some(hasUnsafeJsonNumber);
-  if (value && typeof value === 'object') return Object.values(value).some(hasUnsafeJsonNumber);
-  return false;
-}
-
-function isJsonFile(file: ProjectFile): boolean {
-  return file.name.toLowerCase().endsWith('.json') || file.mime.toLowerCase().startsWith('application/json');
 }
 
 function MarkdownViewer({
@@ -9893,14 +5410,12 @@ function MarkdownViewer({
   const [text, setText] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
   const [copied, setCopied] = useState(false);
-  const [downloadMenuOpen, setDownloadMenuOpen] = useState(false);
   const markdownArticleRef = useRef<HTMLElement | null>(null);
   const copyBlockTimerRef = useRef<number | null>(null);
   const copiedMarkdownBlockRef = useRef<HTMLElement | null>(null);
   const status = file.artifactManifest?.status ?? 'complete';
   const isStreaming = status === 'streaming';
   const isError = status === 'error';
-  const exportTitle = file.name.replace(/\.mdx?$/i, '') || file.name;
 
   useEffect(() => {
     setText(null);
@@ -10005,36 +5520,6 @@ function MarkdownViewer({
             <Icon name={copied ? 'check' : 'copy'} size={13} />
             <span>{copied ? t('fileViewer.copied') : t('fileViewer.copy')}</span>
           </button>
-          {text !== null ? (
-            <div className="share-menu chrome-share-menu">
-              <button
-                type="button"
-                className="viewer-action"
-                aria-haspopup="menu"
-                aria-expanded={downloadMenuOpen}
-                onClick={() => setDownloadMenuOpen((v) => !v)}
-              >
-                <Icon name="download" size={13} />
-                <span>{t('fileViewer.download')}</span>
-              </button>
-              {downloadMenuOpen ? (
-                <div className="share-menu-popover" role="menu">
-                  <button
-                    type="button"
-                    className="share-menu-item"
-                    role="menuitem"
-                    onClick={() => {
-                      setDownloadMenuOpen(false);
-                      exportAsMd(text, exportTitle);
-                    }}
-                  >
-                    <span className="share-menu-icon"><RemixIcon name="file-line" size={15} /></span>
-                    <span>{t('fileViewer.exportMd')}</span>
-                  </button>
-                </div>
-              ) : null}
-            </div>
-          ) : null}
         </div>
       </div>
       <div className="viewer-body">


### PR DESCRIPTION
## Summary

Scroll-wheel gestures over the design preview did nothing because  had no  handler on the preview frame containers. Users saw the preview stay locked at 100% regardless of wheel input.

## Changes

- Add  to both live artifact preview containers in .
- Wheel-up bumps zoom by +10%, wheel-down by -10%, clamped to the existing 25%-200% range.

Closes #3626