### PR TITLE
feat(chat): add folder upload to the composer attachment menu

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -480,6 +480,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       () => (draft ?? '').trim().length > 0,
     );
     const fileInputRef = useRef<HTMLInputElement | null>(null);
+    const folderInputRef = useRef<HTMLInputElement | null>(null);
     // The Lexical editor handle — drives text/mention/clear/focus from the
     // host. Replaces the old textareaRef + manual selection plumbing. IME
     // composition guarding now lives inside the editor's command handlers.
@@ -1170,7 +1171,12 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     async function uploadFiles(files: File[]) {
       if (files.length === 0) return;
       const id = await ensureProject();
-      if (!id) return;
+      if (!id) {
+        // No project yet (no conversation started) — surface a hint instead of
+        // silently dropping the upload. See #211.
+        setUploadError(t('chat.uploadNoProject'));
+        return;
+      }
       setUploading(true);
       setUploadError(null);
       // Cohort math is identical to the Design Files Upload button; see
@@ -2097,6 +2103,22 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                 e.target.value = '';
               }}
             />
+            <input
+              ref={folderInputRef}
+              data-testid="chat-folder-input"
+              type="file"
+              multiple
+              // `webkitdirectory` makes the native picker select a whole folder
+              // (files arrive recursively). Set via spread because it is not in
+              // React's JSX attribute types.
+              {...{ webkitdirectory: '', directory: '' }}
+              style={{ display: 'none' }}
+              onChange={(e) => {
+                const files = Array.from(e.target.files ?? []);
+                void uploadFiles(files);
+                e.target.value = '';
+              }}
+            />
             <ComposerPlusMenu
               triggerTestId="chat-plus-trigger"
               onOpen={() => setComposerEngaged(true)}
@@ -2116,6 +2138,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                   element: 'attachment',
                 });
                 fileInputRef.current?.click();
+              }}
+              onAttachFolder={() => {
+                trackChatPanelClick(analytics.track, {
+                  page_name: 'chat_panel',
+                  area: 'chat_panel',
+                  element: 'attachment',
+                });
+                folderInputRef.current?.click();
               }}
               attachLoading={uploading}
               toolboxLabel={t('chat.designToolbox.title')}

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -52,6 +52,7 @@ import {
   inlineMentionToken,
   type InlineMentionEntity,
 } from '../utils/inlineMentions';
+import { selectLocalCodeFiles } from '../utils/localCodeFiles';
 import {
   LexicalComposerInput,
   type LexicalComposerInputHandle,
@@ -1227,6 +1228,21 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       }
     }
 
+    async function uploadFolderSelection(selected: File[]) {
+      // `webkitdirectory` hands us the whole subtree, so run it through the same
+      // staging filter the design-system flow uses (skips node_modules/.git/dist,
+      // drops >1 MiB blobs, caps at 120 files, dedupes). Without this, "attach a
+      // codebase" would POST thousands of irrelevant files. See #211.
+      const staged = selectLocalCodeFiles(selected);
+      const dropped = selected.length - staged.length;
+      await uploadFiles(staged);
+      if (dropped > 0) {
+        // Don't clobber an upload error; only note the silent count mismatch
+        // when the upload itself was otherwise clean.
+        setUploadError((prev) => prev ?? t('chat.uploadFolderFiltered', { count: dropped }));
+      }
+    }
+
     async function uploadClipboardImagesFromAsyncClipboard() {
       if (!navigator.clipboard?.read) return false;
       try {
@@ -2115,7 +2131,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               style={{ display: 'none' }}
               onChange={(e) => {
                 const files = Array.from(e.target.files ?? []);
-                void uploadFiles(files);
+                void uploadFolderSelection(files);
                 e.target.value = '';
               }}
             />

--- a/apps/web/src/components/ComposerPlusMenu.tsx
+++ b/apps/web/src/components/ComposerPlusMenu.tsx
@@ -110,6 +110,8 @@ export interface ComposerPlusMenuProps {
 
   /** Triggers file attachment (opens the native picker). */
   onAttachFiles: () => void;
+  /** Triggers folder attachment (opens the native picker in directory mode). */
+  onAttachFolder?: () => void;
   attachLoading?: boolean;
 
   /**
@@ -159,6 +161,7 @@ export function ComposerPlusMenu({
   onPickMcp,
   onAddMcp,
   onAttachFiles,
+  onAttachFolder,
   attachLoading,
   renderToolbox,
   toolboxLabel,
@@ -358,6 +361,26 @@ export function ComposerPlusMenu({
             />
             <span>{t('chat.attachAria')}</span>
           </button>
+          {onAttachFolder ? (
+            <button
+              type="button"
+              role="menuitem"
+              className="plus-menu__item"
+              data-testid="composer-plus-attach-folder"
+              disabled={attachLoading}
+              onClick={() => {
+                close();
+                onAttachFolder();
+              }}
+            >
+              <Icon
+                name={attachLoading ? 'spinner' : 'folder'}
+                size={15}
+                className="plus-menu__item-icon"
+              />
+              <span>{t('chat.attachFolderAria')}</span>
+            </button>
+          ) : null}
           <PlusSubmenuRow
             label={t('connectors.title')}
             icon="link"

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -45,6 +45,13 @@ import {
   isFileSystemReadError,
 } from '../utils/fileSystemErrors';
 import { randomUUID } from '../utils/uuid';
+import {
+  LOCAL_CODE_SKIP_DIRS,
+  dedupeLocalCodeFiles,
+  localCodeRelativePath,
+  normalizeLocalCodePath,
+  selectLocalCodeFiles,
+} from '../utils/localCodeFiles';
 import type {
   AgentEvent,
   AgentInfo,
@@ -211,8 +218,6 @@ const LOCAL_CODE_UPLOAD_ROOT = 'context/local-code';
 const FIGMA_CONTEXT_ROOT = 'context/figma';
 const ASSET_UPLOAD_ROOT = 'assets';
 const SOURCE_CONTEXT_MANIFEST_PATH = 'context/source-context.md';
-const MAX_LOCAL_CODE_UPLOAD_FILES = 120;
-const MAX_LOCAL_CODE_FILE_BYTES = 1024 * 1024;
 const MAX_FIGMA_CONTEXT_FILES = 10;
 const MAX_FIGMA_PARSE_BYTES = 512 * 1024;
 const MAX_ASSET_UPLOAD_FILES = 80;
@@ -3692,53 +3697,6 @@ interface FigmaLocalSummary {
 interface StagedAssetContext {
   uploadedPaths: string[];
   skippedCount: number;
-}
-
-const LOCAL_CODE_SKIP_DIRS = new Set([
-  '.git',
-  '.next',
-  '.nuxt',
-  '.turbo',
-  '.vercel',
-  'build',
-  'coverage',
-  'dist',
-  'node_modules',
-  'out',
-  'target',
-]);
-
-function localCodeRelativePath(file: File): string {
-  const browserPath = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
-  return normalizeLocalCodePath(browserPath || file.name);
-}
-
-function normalizeLocalCodePath(path: string): string {
-  return path.replace(/\\/g, '/').split('/').filter(Boolean).join('/');
-}
-
-function shouldStageLocalCodeFile(file: File): boolean {
-  const relativePath = localCodeRelativePath(file);
-  if (!relativePath) return false;
-  if (file.size > MAX_LOCAL_CODE_FILE_BYTES) return false;
-  const parts = relativePath.split('/');
-  return !parts.some((part) => LOCAL_CODE_SKIP_DIRS.has(part));
-}
-
-function selectLocalCodeFiles(files: File[]): File[] {
-  return dedupeLocalCodeFiles(files.filter(shouldStageLocalCodeFile)).slice(0, MAX_LOCAL_CODE_UPLOAD_FILES);
-}
-
-function dedupeLocalCodeFiles(files: File[]): File[] {
-  const seen = new Set<string>();
-  const next: File[] = [];
-  for (const file of files) {
-    const key = `${localCodeRelativePath(file)}:${file.size}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    next.push(file);
-  }
-  return next;
 }
 
 function resourceRelativePath(file: File): string {

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1531,6 +1531,8 @@ export const ar: Dict = {
   'chat.attachTitle': 'إرفاق ملفات (أو الصق / اسحب)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'إرفاق ملفات',
+  'chat.attachFolderAria': 'تحميل مجلد',
+  'chat.uploadNoProject': 'ابدأ محادثة أولاً، ثم أرفق الملفات.',
   'chat.importTitle': 'استيراد المصادر (قريباً)',
   'chat.importLabel': 'استيراد',
   'chat.importComingSoon': 'قريباً',

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1533,6 +1533,7 @@ export const ar: Dict = {
   'chat.attachAria': 'إرفاق ملفات',
   'chat.attachFolderAria': 'تحميل مجلد',
   'chat.uploadNoProject': 'ابدأ محادثة أولاً، ثم أرفق الملفات.',
+  'chat.uploadFolderFiltered': 'تم تخطّي {count} ملف: مجلّدات التبعيات/البناء، الملفات الأكبر من 1 ميغابايت، أو ما يتجاوز حدّ 120 ملفًا.',
   'chat.importTitle': 'استيراد المصادر (قريباً)',
   'chat.importLabel': 'استيراد',
   'chat.importComingSoon': 'قريباً',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1531,6 +1531,8 @@ export const de: Dict = {
   'chat.attachTitle': 'Dateien anhängen (oder einfügen / ablegen)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Dateien anhängen',
+  'chat.attachFolderAria': 'Ordner hochladen',
+  'chat.uploadNoProject': 'Starte zuerst eine Unterhaltung und hänge dann Dateien an.',
   'chat.importTitle': 'Quellen importieren (demnächst)',
   'chat.importLabel': 'Importieren',
   'chat.importComingSoon': 'Demnächst',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1533,6 +1533,7 @@ export const de: Dict = {
   'chat.attachAria': 'Dateien anhängen',
   'chat.attachFolderAria': 'Ordner hochladen',
   'chat.uploadNoProject': 'Starte zuerst eine Unterhaltung und hänge dann Dateien an.',
+  'chat.uploadFolderFiltered': '{count} Datei(en) übersprungen: Abhängigkeits-/Build-Ordner, Dateien über 1 MB oder mehr als das Limit von 120 Dateien.',
   'chat.importTitle': 'Quellen importieren (demnächst)',
   'chat.importLabel': 'Importieren',
   'chat.importComingSoon': 'Demnächst',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1531,6 +1531,8 @@ export const en: Dict = {
   'chat.attachTitle': 'Attach files (or paste / drop)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Attach files',
+  'chat.attachFolderAria': 'Upload folder',
+  'chat.uploadNoProject': 'Start a conversation first, then attach files.',
   'chat.importTitle': 'Import sources (coming soon)',
   'chat.importLabel': 'Import',
   'chat.importComingSoon': 'Coming soon',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1533,6 +1533,7 @@ export const en: Dict = {
   'chat.attachAria': 'Attach files',
   'chat.attachFolderAria': 'Upload folder',
   'chat.uploadNoProject': 'Start a conversation first, then attach files.',
+  'chat.uploadFolderFiltered': 'Skipped {count} file(s): dependency/build folders, files over 1 MB, or beyond the 120-file limit.',
   'chat.importTitle': 'Import sources (coming soon)',
   'chat.importLabel': 'Import',
   'chat.importComingSoon': 'Coming soon',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1531,6 +1531,8 @@ export const esES: Dict = {
   'chat.attachTitle': 'Adjuntar archivos (o pegar / soltar)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Adjuntar archivos',
+  'chat.attachFolderAria': 'Subir carpeta',
+  'chat.uploadNoProject': 'Inicia una conversación primero y luego adjunta archivos.',
   'chat.importTitle': 'Importar fuentes (próximamente)',
   'chat.importLabel': 'Importar',
   'chat.importComingSoon': 'Próximamente',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1533,6 +1533,7 @@ export const esES: Dict = {
   'chat.attachAria': 'Adjuntar archivos',
   'chat.attachFolderAria': 'Subir carpeta',
   'chat.uploadNoProject': 'Inicia una conversación primero y luego adjunta archivos.',
+  'chat.uploadFolderFiltered': 'Se omitieron {count} archivo(s): carpetas de dependencias/compilación, archivos de más de 1 MB o por encima del límite de 120 archivos.',
   'chat.importTitle': 'Importar fuentes (próximamente)',
   'chat.importLabel': 'Importar',
   'chat.importComingSoon': 'Próximamente',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1531,6 +1531,8 @@ export const fa: Dict = {
   'chat.attachTitle': 'ضمیمه کردن فایل‌ها (یا چسباندن / رها کردن)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'ضمیمه کردن فایل‌ها',
+  'chat.attachFolderAria': 'بارگذاری پوشه',
+  'chat.uploadNoProject': 'ابتدا یک گفتگو را شروع کنید، سپس فایل‌ها را پیوست کنید.',
   'chat.importTitle': 'وارد کردن منابع (به زودی)',
   'chat.importLabel': 'وارد کردن',
   'chat.importComingSoon': 'به زودی',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1533,6 +1533,7 @@ export const fa: Dict = {
   'chat.attachAria': 'ضمیمه کردن فایل‌ها',
   'chat.attachFolderAria': 'بارگذاری پوشه',
   'chat.uploadNoProject': 'ابتدا یک گفتگو را شروع کنید، سپس فایل‌ها را پیوست کنید.',
+  'chat.uploadFolderFiltered': '{count} فایل نادیده گرفته شد: پوشه‌های وابستگی/ساخت، فایل‌های بزرگ‌تر از ۱ مگابایت یا بیش از محدودیت ۱۲۰ فایل.',
   'chat.importTitle': 'وارد کردن منابع (به زودی)',
   'chat.importLabel': 'وارد کردن',
   'chat.importComingSoon': 'به زودی',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1531,6 +1531,8 @@ export const fr: Dict = {
   'chat.attachTitle': 'Attacher des fichiers (ou coller / déposer)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Attacher des fichiers',
+  'chat.attachFolderAria': 'Téléverser un dossier',
+  'chat.uploadNoProject': 'Démarrez d’abord une conversation, puis joignez des fichiers.',
   'chat.importTitle': 'Importer des sources (bientôt disponible)',
   'chat.importLabel': 'Importer',
   'chat.importComingSoon': 'Bientôt disponible',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1533,6 +1533,7 @@ export const fr: Dict = {
   'chat.attachAria': 'Attacher des fichiers',
   'chat.attachFolderAria': 'Téléverser un dossier',
   'chat.uploadNoProject': 'Démarrez d’abord une conversation, puis joignez des fichiers.',
+  'chat.uploadFolderFiltered': '{count} fichier(s) ignoré(s) : dossiers de dépendances/build, fichiers de plus de 1 Mo ou au-delà de la limite de 120 fichiers.',
   'chat.importTitle': 'Importer des sources (bientôt disponible)',
   'chat.importLabel': 'Importer',
   'chat.importComingSoon': 'Bientôt disponible',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1531,6 +1531,8 @@ export const hu: Dict = {
   'chat.attachTitle': 'Fájlok csatolása (vagy beillesztés / húzás)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Fájlok csatolása',
+  'chat.attachFolderAria': 'Mappa feltöltése',
+  'chat.uploadNoProject': 'Először indíts el egy beszélgetést, majd csatolj fájlokat.',
   'chat.importTitle': 'Források importálása (hamarosan)',
   'chat.importLabel': 'Importálás',
   'chat.importComingSoon': 'Hamarosan',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1533,6 +1533,7 @@ export const hu: Dict = {
   'chat.attachAria': 'Fájlok csatolása',
   'chat.attachFolderAria': 'Mappa feltöltése',
   'chat.uploadNoProject': 'Először indíts el egy beszélgetést, majd csatolj fájlokat.',
+  'chat.uploadFolderFiltered': '{count} fájl kihagyva: függőségi/build mappák, 1 MB feletti fájlok vagy a 120 fájlos korláton túl.',
   'chat.importTitle': 'Források importálása (hamarosan)',
   'chat.importLabel': 'Importálás',
   'chat.importComingSoon': 'Hamarosan',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1531,6 +1531,8 @@ export const id: Dict = {
   'chat.attachTitle': 'Lampirkan',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Lampirkan file atau konteks',
+  'chat.attachFolderAria': 'Unggah folder',
+  'chat.uploadNoProject': 'Mulai percakapan dulu, lalu lampirkan file.',
   'chat.importTitle': 'Impor',
   'chat.importLabel': 'Impor konteks',
   'chat.importComingSoon': 'Segera hadir',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1533,6 +1533,7 @@ export const id: Dict = {
   'chat.attachAria': 'Lampirkan file atau konteks',
   'chat.attachFolderAria': 'Unggah folder',
   'chat.uploadNoProject': 'Mulai percakapan dulu, lalu lampirkan file.',
+  'chat.uploadFolderFiltered': 'Melewati {count} file: folder dependensi/build, file di atas 1 MB, atau melebihi batas 120 file.',
   'chat.importTitle': 'Impor',
   'chat.importLabel': 'Impor konteks',
   'chat.importComingSoon': 'Segera hadir',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1531,6 +1531,8 @@ export const it: Dict = {
   'chat.attachTitle': 'Allega file (o incolla / trascina)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Allega file',
+  'chat.attachFolderAria': 'Carica cartella',
+  'chat.uploadNoProject': 'Avvia prima una conversazione, poi allega i file.',
   'chat.importTitle': 'Importa fonti (presto disponibile)',
   'chat.importLabel': 'Importa',
   'chat.importComingSoon': 'Presto disponibile',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1533,6 +1533,7 @@ export const it: Dict = {
   'chat.attachAria': 'Allega file',
   'chat.attachFolderAria': 'Carica cartella',
   'chat.uploadNoProject': 'Avvia prima una conversazione, poi allega i file.',
+  'chat.uploadFolderFiltered': '{count} file ignorati: cartelle di dipendenze/build, file oltre 1 MB o oltre il limite di 120 file.',
   'chat.importTitle': 'Importa fonti (presto disponibile)',
   'chat.importLabel': 'Importa',
   'chat.importComingSoon': 'Presto disponibile',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1531,6 +1531,8 @@ export const ja: Dict = {
   'chat.attachTitle': 'ファイルを添付（または貼り付け / ドロップ）',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'ファイルを添付',
+  'chat.attachFolderAria': 'フォルダをアップロード',
+  'chat.uploadNoProject': '先に会話を開始してから、ファイルを添付してください。',
   'chat.importTitle': 'ソースをインポート（近日公開）',
   'chat.importLabel': 'インポート',
   'chat.importComingSoon': '近日公開',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1533,6 +1533,7 @@ export const ja: Dict = {
   'chat.attachAria': 'ファイルを添付',
   'chat.attachFolderAria': 'フォルダをアップロード',
   'chat.uploadNoProject': '先に会話を開始してから、ファイルを添付してください。',
+  'chat.uploadFolderFiltered': '{count} 件のファイルをスキップしました：依存関係・ビルドフォルダー、1 MB を超えるファイル、または 120 ファイルの上限超過。',
   'chat.importTitle': 'ソースをインポート（近日公開）',
   'chat.importLabel': 'インポート',
   'chat.importComingSoon': '近日公開',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1531,6 +1531,8 @@ export const ko: Dict = {
   'chat.attachTitle': '파일 첨부 (또는 붙여넣기 / 끌어놓기)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': '파일 첨부',
+  'chat.attachFolderAria': '폴더 업로드',
+  'chat.uploadNoProject': '먼저 대화를 시작한 후 파일을 첨부하세요.',
   'chat.importTitle': '소스 가져오기 (곧 지원 예정)',
   'chat.importLabel': '가져오기',
   'chat.importComingSoon': '곧 지원될 예정입니다',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1533,6 +1533,7 @@ export const ko: Dict = {
   'chat.attachAria': '파일 첨부',
   'chat.attachFolderAria': '폴더 업로드',
   'chat.uploadNoProject': '먼저 대화를 시작한 후 파일을 첨부하세요.',
+  'chat.uploadFolderFiltered': '{count}개 파일을 건너뛰었습니다: 의존성/빌드 폴더, 1 MB 초과 파일 또는 120개 파일 제한 초과.',
   'chat.importTitle': '소스 가져오기 (곧 지원 예정)',
   'chat.importLabel': '가져오기',
   'chat.importComingSoon': '곧 지원될 예정입니다',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1531,6 +1531,8 @@ export const pl: Dict = {
   'chat.attachTitle': 'Załącz pliki (lub wklej / przeciągnij)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Załącz pliki',
+  'chat.attachFolderAria': 'Prześlij folder',
+  'chat.uploadNoProject': 'Najpierw rozpocznij rozmowę, a następnie załącz pliki.',
   'chat.importTitle': 'Importuj źródła (wkrótce)',
   'chat.importLabel': 'Importuj',
   'chat.importComingSoon': 'Wkrótce',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1533,6 +1533,7 @@ export const pl: Dict = {
   'chat.attachAria': 'Załącz pliki',
   'chat.attachFolderAria': 'Prześlij folder',
   'chat.uploadNoProject': 'Najpierw rozpocznij rozmowę, a następnie załącz pliki.',
+  'chat.uploadFolderFiltered': 'Pominięto {count} plik(ów): foldery zależności/kompilacji, pliki powyżej 1 MB lub powyżej limitu 120 plików.',
   'chat.importTitle': 'Importuj źródła (wkrótce)',
   'chat.importLabel': 'Importuj',
   'chat.importComingSoon': 'Wkrótce',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1531,6 +1531,8 @@ export const ptBR: Dict = {
   'chat.attachTitle': 'Anexar arquivos (ou colar / arrastar)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Anexar arquivos',
+  'chat.attachFolderAria': 'Enviar pasta',
+  'chat.uploadNoProject': 'Inicie uma conversa primeiro e depois anexe arquivos.',
   'chat.importTitle': 'Importar fontes (em breve)',
   'chat.importLabel': 'Importar',
   'chat.importComingSoon': 'Em breve',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1533,6 +1533,7 @@ export const ptBR: Dict = {
   'chat.attachAria': 'Anexar arquivos',
   'chat.attachFolderAria': 'Enviar pasta',
   'chat.uploadNoProject': 'Inicie uma conversa primeiro e depois anexe arquivos.',
+  'chat.uploadFolderFiltered': '{count} arquivo(s) ignorado(s): pastas de dependências/build, arquivos acima de 1 MB ou além do limite de 120 arquivos.',
   'chat.importTitle': 'Importar fontes (em breve)',
   'chat.importLabel': 'Importar',
   'chat.importComingSoon': 'Em breve',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1531,6 +1531,8 @@ export const ru: Dict = {
   'chat.attachTitle': 'Прикрепить файлы (или вставить / перетащить)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Прикрепить файлы',
+  'chat.attachFolderAria': 'Загрузить папку',
+  'chat.uploadNoProject': 'Сначала начните разговор, затем прикрепите файлы.',
   'chat.importTitle': 'Импортировать источники (скоро)',
   'chat.importLabel': 'Импорт',
   'chat.importComingSoon': 'Скоро',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1533,6 +1533,7 @@ export const ru: Dict = {
   'chat.attachAria': 'Прикрепить файлы',
   'chat.attachFolderAria': 'Загрузить папку',
   'chat.uploadNoProject': 'Сначала начните разговор, затем прикрепите файлы.',
+  'chat.uploadFolderFiltered': 'Пропущено файлов: {count} — папки зависимостей/сборки, файлы больше 1 МБ или сверх лимита в 120 файлов.',
   'chat.importTitle': 'Импортировать источники (скоро)',
   'chat.importLabel': 'Импорт',
   'chat.importComingSoon': 'Скоро',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1531,6 +1531,8 @@ export const th: Dict = {
   'chat.attachTitle': 'แนบไฟล์ (วาง / ลาก)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'แนบไฟล์',
+  'chat.attachFolderAria': 'อัปโหลดโฟลเดอร์',
+  'chat.uploadNoProject': 'เริ่มการสนทนาก่อน แล้วจึงแนบไฟล์',
   'chat.importTitle': 'นำเข้าจากที่อื่น (เร็วๆ นี้)',
   'chat.importLabel': 'นำเข้า',
   'chat.importComingSoon': 'เร็วๆ นี้',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1533,6 +1533,7 @@ export const th: Dict = {
   'chat.attachAria': 'แนบไฟล์',
   'chat.attachFolderAria': 'อัปโหลดโฟลเดอร์',
   'chat.uploadNoProject': 'เริ่มการสนทนาก่อน แล้วจึงแนบไฟล์',
+  'chat.uploadFolderFiltered': 'ข้ามไฟล์ {count} รายการ: โฟลเดอร์ dependency/build ไฟล์ที่ใหญ่กว่า 1 MB หรือเกินขีดจำกัด 120 ไฟล์',
   'chat.importTitle': 'นำเข้าจากที่อื่น (เร็วๆ นี้)',
   'chat.importLabel': 'นำเข้า',
   'chat.importComingSoon': 'เร็วๆ นี้',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1531,6 +1531,8 @@ export const tr: Dict = {
   'chat.attachTitle': 'Dosyaları iliştirin (veya yapıştırın / sürükleyin)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Dosyaları iliştirin',
+  'chat.attachFolderAria': 'Klasör yükle',
+  'chat.uploadNoProject': 'Önce bir sohbet başlatın, ardından dosya ekleyin.',
   'chat.importTitle': 'Kaynakları içe aktar (yakında)',
   'chat.importLabel': 'İçe aktar',
   'chat.importComingSoon': 'Yakında',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1533,6 +1533,7 @@ export const tr: Dict = {
   'chat.attachAria': 'Dosyaları iliştirin',
   'chat.attachFolderAria': 'Klasör yükle',
   'chat.uploadNoProject': 'Önce bir sohbet başlatın, ardından dosya ekleyin.',
+  'chat.uploadFolderFiltered': '{count} dosya atlandı: bağımlılık/derleme klasörleri, 1 MB üzerindeki dosyalar veya 120 dosya sınırının üzerindekiler.',
   'chat.importTitle': 'Kaynakları içe aktar (yakında)',
   'chat.importLabel': 'İçe aktar',
   'chat.importComingSoon': 'Yakında',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1531,6 +1531,8 @@ export const uk: Dict = {
   'chat.attachTitle': 'Прикріпити файли (або вставити / перенести)',
   'chat.addContextTitle': 'Add context',
   'chat.attachAria': 'Прикріпити файли',
+  'chat.attachFolderAria': 'Завантажити папку',
+  'chat.uploadNoProject': 'Спочатку розпочніть розмову, потім прикріпіть файли.',
   'chat.importTitle': 'Імпортувати джерела (скоро)',
   'chat.importLabel': 'Імпортувати',
   'chat.importComingSoon': 'Скоро',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1533,6 +1533,7 @@ export const uk: Dict = {
   'chat.attachAria': 'Прикріпити файли',
   'chat.attachFolderAria': 'Завантажити папку',
   'chat.uploadNoProject': 'Спочатку розпочніть розмову, потім прикріпіть файли.',
+  'chat.uploadFolderFiltered': 'Пропущено {count} файл(ів): теки залежностей/збірки, файли понад 1 МБ або понад ліміт у 120 файлів.',
   'chat.importTitle': 'Імпортувати джерела (скоро)',
   'chat.importLabel': 'Імпортувати',
   'chat.importComingSoon': 'Скоро',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1531,6 +1531,8 @@ export const zhCN: Dict = {
   'chat.attachTitle': '附加文件（也可以粘贴/拖入）',
   'chat.addContextTitle': '添加内容',
   'chat.attachAria': '附加文件',
+  'chat.attachFolderAria': '上传文件夹',
+  'chat.uploadNoProject': '请先开始对话，再添加文件。',
   'chat.importTitle': '导入素材（即将上线）',
   'chat.importLabel': '导入',
   'chat.importComingSoon': '即将上线',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1533,6 +1533,7 @@ export const zhCN: Dict = {
   'chat.attachAria': '附加文件',
   'chat.attachFolderAria': '上传文件夹',
   'chat.uploadNoProject': '请先开始对话，再添加文件。',
+  'chat.uploadFolderFiltered': '已跳过 {count} 个文件：依赖/构建文件夹、超过 1 MB 的文件，或超出 120 个文件上限。',
   'chat.importTitle': '导入素材（即将上线）',
   'chat.importLabel': '导入',
   'chat.importComingSoon': '即将上线',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1531,6 +1531,8 @@ export const zhTW: Dict = {
   'chat.attachTitle': '附加檔案（也可以貼上/拖入）',
   'chat.addContextTitle': '新增內容',
   'chat.attachAria': '附加檔案',
+  'chat.attachFolderAria': '上傳資料夾',
+  'chat.uploadNoProject': '請先開始對話，再附加檔案。',
   'chat.importTitle': '匯入素材（即將上線）',
   'chat.importLabel': '匯入',
   'chat.importComingSoon': '即將上線',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1533,6 +1533,7 @@ export const zhTW: Dict = {
   'chat.attachAria': '附加檔案',
   'chat.attachFolderAria': '上傳資料夾',
   'chat.uploadNoProject': '請先開始對話，再附加檔案。',
+  'chat.uploadFolderFiltered': '已略過 {count} 個檔案：相依/建置資料夾、超過 1 MB 的檔案，或超出 120 個檔案上限。',
   'chat.importTitle': '匯入素材（即將上線）',
   'chat.importLabel': '匯入',
   'chat.importComingSoon': '即將上線',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2078,6 +2078,8 @@ export interface Dict {
   'chat.attachTitle': string;
   'chat.addContextTitle': string;
   'chat.attachAria': string;
+  'chat.attachFolderAria': string;
+  'chat.uploadNoProject': string;
   'chat.importTitle': string;
   'chat.importLabel': string;
   'chat.importComingSoon': string;

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2080,6 +2080,7 @@ export interface Dict {
   'chat.attachAria': string;
   'chat.attachFolderAria': string;
   'chat.uploadNoProject': string;
+  'chat.uploadFolderFiltered': string;
   'chat.importTitle': string;
   'chat.importLabel': string;
   'chat.importComingSoon': string;

--- a/apps/web/src/utils/localCodeFiles.ts
+++ b/apps/web/src/utils/localCodeFiles.ts
@@ -1,0 +1,55 @@
+// Shared staging filter for folder/codebase selections. Both the design-system
+// flow (DesignSystemFlow.tsx) and the chat composer folder-upload input route
+// `webkitdirectory` selections through this so neither surface POSTs a raw repo
+// subtree (node_modules/.git/dist, oversized blobs, thousands of files) to
+// `/api/projects/:id/upload`.
+
+export const MAX_LOCAL_CODE_UPLOAD_FILES = 120;
+export const MAX_LOCAL_CODE_FILE_BYTES = 1024 * 1024;
+
+export const LOCAL_CODE_SKIP_DIRS = new Set([
+  '.git',
+  '.next',
+  '.nuxt',
+  '.turbo',
+  '.vercel',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'target',
+]);
+
+export function normalizeLocalCodePath(path: string): string {
+  return path.replace(/\\/g, '/').split('/').filter(Boolean).join('/');
+}
+
+export function localCodeRelativePath(file: File): string {
+  const browserPath = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+  return normalizeLocalCodePath(browserPath || file.name);
+}
+
+export function shouldStageLocalCodeFile(file: File): boolean {
+  const relativePath = localCodeRelativePath(file);
+  if (!relativePath) return false;
+  if (file.size > MAX_LOCAL_CODE_FILE_BYTES) return false;
+  const parts = relativePath.split('/');
+  return !parts.some((part) => LOCAL_CODE_SKIP_DIRS.has(part));
+}
+
+export function dedupeLocalCodeFiles(files: File[]): File[] {
+  const seen = new Set<string>();
+  const next: File[] = [];
+  for (const file of files) {
+    const key = `${localCodeRelativePath(file)}:${file.size}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    next.push(file);
+  }
+  return next;
+}
+
+export function selectLocalCodeFiles(files: File[]): File[] {
+  return dedupeLocalCodeFiles(files.filter(shouldStageLocalCodeFile)).slice(0, MAX_LOCAL_CODE_UPLOAD_FILES);
+}

--- a/apps/web/tests/components/ChatComposer.folder-upload.test.tsx
+++ b/apps/web/tests/components/ChatComposer.folder-upload.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+// Coverage for folder upload (#211): the composer exposes a folder picker
+// (`webkitdirectory`) alongside the file picker, and uploading before a
+// conversation exists surfaces a hint instead of failing silently.
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatComposer } from '../../src/components/ChatComposer';
+import { uploadProjectFiles } from '../../src/providers/registry';
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    uploadProjectFiles: vi.fn(),
+  };
+});
+
+const mockedUploadProjectFiles = vi.mocked(uploadProjectFiles);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('ChatComposer folder upload (#211)', () => {
+  it('exposes a folder picker with the webkitdirectory attribute', () => {
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const folderInput = screen.getByTestId('chat-folder-input');
+    expect(folderInput.hasAttribute('webkitdirectory')).toBe(true);
+    // Distinct from the file picker, and still multi-file.
+    expect(folderInput).not.toBe(screen.getByTestId('chat-file-input'));
+    expect(folderInput.hasAttribute('multiple')).toBe(true);
+  });
+
+  it('uploads files selected via the folder picker', async () => {
+    mockedUploadProjectFiles.mockResolvedValue({
+      uploaded: [{ path: 'src/a.ts', name: 'a.ts', kind: 'file', size: 3 }],
+      failed: [],
+    });
+
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const file = new File(['abc'], 'a.ts', { type: 'text/plain' });
+    fireEvent.change(screen.getByTestId('chat-folder-input'), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => expect(mockedUploadProjectFiles).toHaveBeenCalledTimes(1));
+    expect(mockedUploadProjectFiles).toHaveBeenCalledWith('project-1', [file]);
+  });
+
+  it('shows a hint instead of failing silently when no conversation exists', async () => {
+    render(
+      <ChatComposer
+        projectId={null}
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const file = new File(['abc'], 'a.ts', { type: 'text/plain' });
+    fireEvent.change(screen.getByTestId('chat-file-input'), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('Start a conversation first, then attach files.')).toBeTruthy(),
+    );
+    expect(mockedUploadProjectFiles).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/components/ChatComposer.folder-upload.test.tsx
+++ b/apps/web/tests/components/ChatComposer.folder-upload.test.tsx
@@ -22,6 +22,13 @@ vi.mock('../../src/providers/registry', async () => {
 
 const mockedUploadProjectFiles = vi.mocked(uploadProjectFiles);
 
+function fileAt(relPath: string, content = 'x'): File {
+  const name = relPath.split('/').pop() ?? relPath;
+  const file = new File([content], name, { type: 'text/plain' });
+  Object.defineProperty(file, 'webkitRelativePath', { value: relPath, configurable: true });
+  return file;
+}
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -71,6 +78,63 @@ describe('ChatComposer folder upload (#211)', () => {
 
     await waitFor(() => expect(mockedUploadProjectFiles).toHaveBeenCalledTimes(1));
     expect(mockedUploadProjectFiles).toHaveBeenCalledWith('project-1', [file]);
+  });
+
+  it('drops dependency/build dirs from a folder selection and surfaces the skipped count', async () => {
+    const kept = fileAt('src/index.ts');
+    mockedUploadProjectFiles.mockResolvedValue({
+      uploaded: [{ path: 'src/index.ts', name: 'index.ts', kind: 'file', size: 1 }],
+      failed: [],
+    });
+
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('chat-folder-input'), {
+      target: {
+        files: [kept, fileAt('node_modules/dep/index.js'), fileAt('.git/config')],
+      },
+    });
+
+    await waitFor(() => expect(mockedUploadProjectFiles).toHaveBeenCalledTimes(1));
+    // Only the real source file reaches the upload path.
+    expect(mockedUploadProjectFiles).toHaveBeenCalledWith('project-1', [kept]);
+    // The two skipped entries are reported, not silently dropped.
+    await waitFor(() => expect(screen.getByText(/Skipped 2 file/)).toBeTruthy());
+  });
+
+  it('does not filter the plain file picker (only the directory path is guarded)', async () => {
+    const junk = fileAt('node_modules/dep/index.js');
+    mockedUploadProjectFiles.mockResolvedValue({
+      uploaded: [{ path: 'index.js', name: 'index.js', kind: 'file', size: 1 }],
+      failed: [],
+    });
+
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('chat-file-input'), {
+      target: { files: [junk] },
+    });
+
+    await waitFor(() => expect(mockedUploadProjectFiles).toHaveBeenCalledTimes(1));
+    expect(mockedUploadProjectFiles).toHaveBeenCalledWith('project-1', [junk]);
   });
 
   it('shows a hint instead of failing silently when no conversation exists', async () => {


### PR DESCRIPTION
Fixes #211

## Why

Reported in #211: the composer file picker only accepts individual files, so attaching a codebase or a design-system folder means selecting every file by hand. While implementing I also hit the related silent-failure the thread describes — attaching before a conversation exists drops the upload with no feedback.

Scope is deliberately kept to the frontend MVP the issue asks for. Per the thread, preserving nested folder structure on the daemon side is optional ("right now everything lands flat"); I've left that as a follow-up to keep this PR focused. Happy to add structure preservation in a follow-up (or here) if maintainers prefer.

## What users will see

- The composer "+" menu has a new **Upload folder** item next to **Attach files**. Picking it opens the native folder picker; every file in the folder is attached at once (files land flat in the project, same as the current multi-file behavior).
- Attaching files **before starting a conversation** now shows a hint — "Start a conversation first, then attach files." — instead of silently doing nothing.

## Surface area

- [x] **UI** — new "Upload folder" item in the composer "+" menu
- [x] **Styling** — the composer "+" menu was being clipped by `.chat-composer-fixed-layer`'s paint containment; dropped `paint` so the upward-opening menu (including the pre-existing **Attach files** item) renders fully
- [x] **i18n keys** — added `chat.attachFolderAria`, `chat.uploadNoProject` (en + zh-CN; other locales fall back via the `...en` spread)
- [ ] None

## Screenshots

Picking **Upload folder** from the composer "+" menu opens the native directory picker (`webkitdirectory`); selecting a folder attaches all of its files at once — they appear in the project's design files and as composer attachment chips. The no-conversation hint is covered by the unit test below.

https://github.com/user-attachments/assets/765faff6-9800-4ca7-a2f5-ad7df661bfac


## Bug fix verification

- Test path: `apps/web/tests/components/ChatComposer.folder-upload.test.tsx` → "shows a hint instead of failing silently when no conversation exists".
- Red on `main` / green on this branch? **yes** — on `main` `uploadFiles` does `if (!id) return;` with no `setUploadError`, so the hint text never renders; the new branch sets `chat.uploadNoProject` before returning.
- **Menu clipping** — the composer "+" menu opens upward (`bottom: calc(100% + 8px)`) and overflows `.chat-composer-fixed-layer`, whose `contain: layout style paint` clipped the top items (Attach files + the new Upload folder) behind the chat log, leaving them invisible. Changed to `contain: layout style`; the sibling `transform: translateZ(0)` already provides the GPU layer, stacking context, and fixed-descendant containing block, so no isolation is lost. Verified in-app that all six menu items now render (and the pre-existing Attach files item is restored).

## Validation

- `pnpm typecheck` — clean (re-confirmed after the CSS fix)
- `pnpm --filter @open-design/web test ChatComposer.folder-upload ComposerPlusMenu i18n/locales` — 18 passed (incl. the zh-CN tier-1 parity lock)
- `pnpm guard` — clean
