### PR TITLE
fix(daemon): skip Cursor model_call_id replay to prevent duplicate output

### DIFF
--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -223,6 +223,31 @@ function emitCursorTextDelta(text: string, onEvent: StreamEventHandler, state: P
   onEvent({ type: 'text_delta', delta: text });
 }
 
+/**
+ * Reconcile a Cursor terminal replay against the text already emitted for the
+ * CURRENT turn. A terminal replay (either a `model_call_id` message or a
+ * non-timestamped final assistant message) carries the full text for the
+ * current turn only, so it must be compared against
+ * `cursorTextSoFar.slice(cursorTurnStart)` — NOT the whole cross-turn buffer,
+ * which would miss the current-turn prefix on later turns and re-append the
+ * whole replay (duplicate output like "secondsecond turn").
+ *
+ * Only a verified prefix permits suffix recovery: if the emitted turn text is
+ * a prefix of the replay (including the empty case where no chunk arrived),
+ * emit the missing suffix. On divergence (a non-final chunk was dropped, so
+ * the emitted text is not a prefix) leave the append-only stream untouched
+ * rather than duplicate already-shown text. Always advances the turn boundary.
+ */
+function reconcileCursorTurnReplay(text: string, onEvent: StreamEventHandler, state: ParserState): void {
+  const emittedTurn = state.cursorTextSoFar.slice(state.cursorTurnStart);
+  if (text && text !== emittedTurn && text.startsWith(emittedTurn)) {
+    const suffix = text.slice(emittedTurn.length);
+    if (suffix) onEvent({ type: 'text_delta', delta: suffix });
+    state.cursorTextSoFar += suffix;
+  }
+  state.cursorTurnStart = state.cursorTextSoFar.length;
+}
+
 function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: ParserState): boolean {
   if (!isRecord(obj)) return false;
 
@@ -236,45 +261,27 @@ function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
   }
 
   if (obj.type === 'assistant' && obj.message) {
-    // Cursor sends a final assistant message with `model_call_id` that
-    // replays the full accumulated text for the current turn. Reconcile
-    // it against the text we have actually emitted for this turn
-    // (`cursorTextSoFar` from `cursorTurnStart` onward) — NOT against the
-    // emitted length. Length-only slicing wrongly assumes the emitted
-    // text is always a complete prefix of the replay; that breaks when a
-    // middle chunk was dropped (e.g. emitted "hello world" but the replay
-    // is "hello brave world"), re-emitting an already-shown suffix while
-    // still losing the gap. Only a verified prefix permits suffix
-    // recovery.
+    // Cursor sends a final assistant message that replays the full text for
+    // the current turn — either tagged with `model_call_id`, or (fallback)
+    // as a non-timestamped terminal assistant message. Both are reconciled
+    // against the current turn's emitted text via reconcileCursorTurnReplay.
     if (typeof obj.model_call_id === 'string') {
       const text = extractCursorText(obj.message);
-      const emittedTurn = state.cursorTextSoFar.slice(state.cursorTurnStart);
-      if (text && text !== emittedTurn && text.startsWith(emittedTurn)) {
-        // Verified prefix: a trailing chunk was dropped. Emit only the
-        // missing suffix so the turn ends with the full replay text.
-        const suffix = text.slice(emittedTurn.length);
-        if (suffix) onEvent({ type: 'text_delta', delta: suffix });
-        state.cursorTextSoFar += suffix;
-      }
-      // When the emitted text is NOT a prefix of the replay the live
-      // stream already diverged from the authoritative text (a non-final
-      // chunk was dropped). Re-emitting any part of the replay here would
-      // duplicate already-shown text in an append-only delta stream, so we
-      // leave the stream as-is rather than corrupt it with length slicing.
-      // Mark the next turn's start after processing the replay.
-      state.cursorTurnStart = state.cursorTextSoFar.length;
+      reconcileCursorTurnReplay(text, onEvent, state);
       return true;
     }
     const text = extractCursorText(obj.message);
     if (!text) return false;
-    emitCursorTextDelta(text, onEvent, state);
-    // Non-timestamped assistant events are final replays that mark a turn
-    // boundary. Advance cursorTurnStart so the next model_call_id replay
-    // measures turnLength from the right offset. Timestamped events are
-    // incremental streaming chunks within a turn and must not advance it.
-    if (typeof obj.timestamp_ms !== 'number') {
-      state.cursorTurnStart = state.cursorTextSoFar.length;
+    if (typeof obj.timestamp_ms === 'number') {
+      // Incremental streaming chunk within a turn — accumulate as usual.
+      emitCursorTextDelta(text, onEvent, state);
+      return true;
     }
+    // Non-timestamped final assistant message: a terminal replay that marks a
+    // turn boundary. Reconcile against the current turn (not the whole
+    // cross-turn buffer) so later fallback-terminated turns do not duplicate
+    // output, then advance the turn boundary.
+    reconcileCursorTurnReplay(text, onEvent, state);
     return true;
   }
 

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -205,27 +205,16 @@ function extractCursorText(message: unknown): string {
 }
 
 function emitCursorTextDelta(text: string, onEvent: StreamEventHandler, state: ParserState): void {
-  // Dedupe a streamed chunk against the CURRENT turn's emitted text
-  // (`cursorTextSoFar` from `cursorTurnStart` onward), NOT the whole
-  // cross-turn buffer. Cursor sends cumulative snapshots within a turn
-  // (`"second"` then `"second turn"`); comparing against the full buffer
-  // would, after an earlier turn, miss the current-turn prefix and append
-  // the whole snapshot again, duplicating output (`"secondsecond turn"`).
-  const emittedTurn = state.cursorTextSoFar.slice(state.cursorTurnStart);
-  if (!emittedTurn) {
-    state.cursorTextSoFar += text;
-    onEvent({ type: 'text_delta', delta: text });
-    return;
-  }
-  if (text === emittedTurn) {
-    return;
-  }
-  if (text.startsWith(emittedTurn)) {
-    const delta = text.slice(emittedTurn.length);
-    if (delta) onEvent({ type: 'text_delta', delta });
-    state.cursorTextSoFar += delta;
-    return;
-  }
+  // Timestamped assistant events WITHOUT `model_call_id` are cursor-agent's
+  // real-time incremental deltas (`--stream-partial-output`): the final turn
+  // text is the in-order concatenation of every such delta. Emit each one
+  // verbatim — do NOT dedupe by content. Legitimately repeated deltas
+  // (`"ha"`, `"ha"` -> `"haha"`) or a delta that happens to be a prefix of
+  // earlier text are real content, not duplicates; content-based prefix or
+  // equality checks would silently drop them. Duplicate suppression and
+  // dropped-chunk recovery belong to the buffered terminal replay paths
+  // (`model_call_id` and no-timestamp events) via reconcileCursorTurnReplay.
+  if (!text) return;
   state.cursorTextSoFar += text;
   onEvent({ type: 'text_delta', delta: text });
 }

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -237,19 +237,30 @@ function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
 
   if (obj.type === 'assistant' && obj.message) {
     // Cursor sends a final assistant message with `model_call_id` that
-    // replays the full accumulated text for the current turn. Compare
-    // the replay against only the current turn's portion of
-    // `cursorTextSoFar` (starting from `cursorTurnStart`). If a
-    // streamed chunk was dropped, the replay may be longer than what
-    // we emitted for this turn — emit the missing suffix.
+    // replays the full accumulated text for the current turn. Reconcile
+    // it against the text we have actually emitted for this turn
+    // (`cursorTextSoFar` from `cursorTurnStart` onward) — NOT against the
+    // emitted length. Length-only slicing wrongly assumes the emitted
+    // text is always a complete prefix of the replay; that breaks when a
+    // middle chunk was dropped (e.g. emitted "hello world" but the replay
+    // is "hello brave world"), re-emitting an already-shown suffix while
+    // still losing the gap. Only a verified prefix permits suffix
+    // recovery.
     if (typeof obj.model_call_id === 'string') {
       const text = extractCursorText(obj.message);
-      const turnLength = state.cursorTextSoFar.length - state.cursorTurnStart;
-      if (text && text.length > turnLength) {
-        const suffix = text.slice(turnLength);
+      const emittedTurn = state.cursorTextSoFar.slice(state.cursorTurnStart);
+      if (text && text !== emittedTurn && text.startsWith(emittedTurn)) {
+        // Verified prefix: a trailing chunk was dropped. Emit only the
+        // missing suffix so the turn ends with the full replay text.
+        const suffix = text.slice(emittedTurn.length);
         if (suffix) onEvent({ type: 'text_delta', delta: suffix });
         state.cursorTextSoFar += suffix;
       }
+      // When the emitted text is NOT a prefix of the replay the live
+      // stream already diverged from the authoritative text (a non-final
+      // chunk was dropped). Re-emitting any part of the replay here would
+      // duplicate already-shown text in an append-only delta stream, so we
+      // leave the stream as-is rather than corrupt it with length slicing.
       // Mark the next turn's start after processing the replay.
       state.cursorTurnStart = state.cursorTextSoFar.length;
       return true;

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -205,18 +205,25 @@ function extractCursorText(message: unknown): string {
 }
 
 function emitCursorTextDelta(text: string, onEvent: StreamEventHandler, state: ParserState): void {
-  if (!state.cursorTextSoFar) {
-    state.cursorTextSoFar = text;
+  // Dedupe a streamed chunk against the CURRENT turn's emitted text
+  // (`cursorTextSoFar` from `cursorTurnStart` onward), NOT the whole
+  // cross-turn buffer. Cursor sends cumulative snapshots within a turn
+  // (`"second"` then `"second turn"`); comparing against the full buffer
+  // would, after an earlier turn, miss the current-turn prefix and append
+  // the whole snapshot again, duplicating output (`"secondsecond turn"`).
+  const emittedTurn = state.cursorTextSoFar.slice(state.cursorTurnStart);
+  if (!emittedTurn) {
+    state.cursorTextSoFar += text;
     onEvent({ type: 'text_delta', delta: text });
     return;
   }
-  if (text === state.cursorTextSoFar) {
+  if (text === emittedTurn) {
     return;
   }
-  if (text.startsWith(state.cursorTextSoFar)) {
-    const delta = text.slice(state.cursorTextSoFar.length);
+  if (text.startsWith(emittedTurn)) {
+    const delta = text.slice(emittedTurn.length);
     if (delta) onEvent({ type: 'text_delta', delta });
-    state.cursorTextSoFar = text;
+    state.cursorTextSoFar += delta;
     return;
   }
   state.cursorTextSoFar += text;

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -236,10 +236,21 @@ function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
 
   if (obj.type === 'assistant' && obj.message) {
     // Cursor sends a final assistant message with `model_call_id` that
-    // replays the full accumulated text for the turn. Since the
-    // incremental deltas have already been emitted, skip this replay
-    // to avoid duplicating content in the persisted message.
-    if (typeof obj.model_call_id === 'string') return true;
+    // replays the full accumulated text for the turn. If all incremental
+    // deltas arrived, the replay content equals `cursorTextSoFar` and
+    // emitCursorTextDelta will deduplicate it. If a streamed chunk was
+    // dropped, the replay may contain a suffix that was never emitted —
+    // emit only that missing suffix to keep the persisted message complete
+    // without duplicating the content that was already sent.
+    if (typeof obj.model_call_id === 'string') {
+      const text = extractCursorText(obj.message);
+      if (text && text.length > state.cursorTextSoFar.length && state.cursorTextSoFar.length > 0) {
+        const suffix = text.slice(state.cursorTextSoFar.length);
+        if (suffix) onEvent({ type: 'text_delta', delta: suffix });
+        state.cursorTextSoFar = text;
+      }
+      return true;
+    }
     const text = extractCursorText(obj.message);
     if (!text) return false;
     emitCursorTextDelta(text, onEvent, state);

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -5,6 +5,7 @@ type ParserKind = string;
 
 type ParserState = {
   cursorTextSoFar: string;
+  cursorTurnStart: number;
   openCodeToolUses: Set<string>;
   codexToolUses: Set<string>;
   codexErrorEmitted: boolean;
@@ -236,24 +237,33 @@ function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
 
   if (obj.type === 'assistant' && obj.message) {
     // Cursor sends a final assistant message with `model_call_id` that
-    // replays the full accumulated text for the turn. If all incremental
-    // deltas arrived, the replay content equals `cursorTextSoFar` and
-    // emitCursorTextDelta will deduplicate it. If a streamed chunk was
-    // dropped, the replay may contain a suffix that was never emitted —
-    // emit only that missing suffix to keep the persisted message complete
-    // without duplicating the content that was already sent.
+    // replays the full accumulated text for the current turn. Compare
+    // the replay against only the current turn's portion of
+    // `cursorTextSoFar` (starting from `cursorTurnStart`). If a
+    // streamed chunk was dropped, the replay may be longer than what
+    // we emitted for this turn — emit the missing suffix.
     if (typeof obj.model_call_id === 'string') {
       const text = extractCursorText(obj.message);
-      if (text && text.length > state.cursorTextSoFar.length && state.cursorTextSoFar.length > 0) {
-        const suffix = text.slice(state.cursorTextSoFar.length);
+      const turnLength = state.cursorTextSoFar.length - state.cursorTurnStart;
+      if (text && text.length > turnLength) {
+        const suffix = text.slice(turnLength);
         if (suffix) onEvent({ type: 'text_delta', delta: suffix });
-        state.cursorTextSoFar = text;
+        state.cursorTextSoFar += suffix;
       }
+      // Mark the next turn's start after processing the replay.
+      state.cursorTurnStart = state.cursorTextSoFar.length;
       return true;
     }
     const text = extractCursorText(obj.message);
     if (!text) return false;
     emitCursorTextDelta(text, onEvent, state);
+    // Non-timestamped assistant events are final replays that mark a turn
+    // boundary. Advance cursorTurnStart so the next model_call_id replay
+    // measures turnLength from the right offset. Timestamped events are
+    // incremental streaming chunks within a turn and must not advance it.
+    if (typeof obj.timestamp_ms !== 'number') {
+      state.cursorTurnStart = state.cursorTextSoFar.length;
+    }
     return true;
   }
 
@@ -405,6 +415,7 @@ export function createJsonEventStreamHandler(kind: ParserKind, onEvent: StreamEv
   let buffer = '';
   const state: ParserState = {
     cursorTextSoFar: '',
+    cursorTurnStart: 0,
     openCodeToolUses: new Set<string>(),
     codexToolUses: new Set<string>(),
     codexErrorEmitted: false,

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -235,12 +235,13 @@ function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
   }
 
   if (obj.type === 'assistant' && obj.message) {
+    // Cursor sends a final assistant message with `model_call_id` that
+    // replays the full accumulated text for the turn. Since the
+    // incremental deltas have already been emitted, skip this replay
+    // to avoid duplicating content in the persisted message.
+    if (typeof obj.model_call_id === 'string') return true;
     const text = extractCursorText(obj.message);
     if (!text) return false;
-    if (typeof obj.timestamp_ms === 'number') {
-      emitCursorTextDelta(text, onEvent, state);
-      return true;
-    }
     emitCursorTextDelta(text, onEvent, state);
     return true;
   }

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -515,6 +515,58 @@ test('cursor stream does not duplicate output across two fallback-terminated tur
   ]);
 });
 
+test('cursor stream dedupes cumulative timestamped chunks on a later turn', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Turn 1 completes. Turn 2 streams cumulative snapshots ("second" then
+  // "second turn") via the timestamped path. That path must dedupe against
+  // the CURRENT turn slice, not the whole cross-turn buffer — otherwise
+  // "second turn" fails the startsWith("hellosecond") check and is appended
+  // whole, duplicating output as "secondsecond turn".
+  handler.feed(
+    // Turn 1: streamed "hello", terminal replay "hello"
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      model_call_id: 'call-1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    // Turn 2: cumulative timestamped snapshots before the terminal replay
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 3,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 4,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second turn' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 5,
+      model_call_id: 'call-2',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second turn' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: 'second' },
+    { type: 'text_delta', delta: ' turn' },
+  ]);
+});
+
 test('cursor stream recovers a dropped middle chunk from a later cumulative snapshot', () => {
   const { events, handler } = collectEvents('cursor-agent');
 

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -471,6 +471,83 @@ test('cursor stream recovers dropped chunk via model_call_id after fallback-term
   ]);
 });
 
+test('cursor stream recovers a dropped middle chunk from a later cumulative snapshot', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Cursor's timestamped chunks are cumulative snapshots of the turn. When
+  // a middle snapshot is dropped, the next snapshot still carries the full
+  // text, so prefix reconciliation recovers the gap with no loss and no
+  // duplication. (Regression for the reviewer's "drop a middle fragment
+  // before a later fragment is delivered" scenario.)
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    // "hello brave" snapshot is dropped / never received
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello brave world' }] },
+    }) +
+    '\n' +
+    // Replay confirms the full turn text — nothing more to emit
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 3,
+      model_call_id: 'call-1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello brave world' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: ' brave world' },
+  ]);
+});
+
+test('cursor stream does not duplicate output when emitted text is not a replay prefix', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Pathological non-cumulative case: a middle fragment (" brave") is
+  // dropped while a later fragment (" world") still arrives, so the emitted
+  // turn text "hello world" is NOT a prefix of the replay "hello brave
+  // world". Length-only slicing would emit " world" a second time (yielding
+  // "hello world world"). The replay must instead be reconciled against the
+  // emitted text: since it is not a verified prefix, the append-only stream
+  // is left untouched rather than corrupted with a duplicate suffix.
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    // " brave" fragment dropped; " world" still arrives
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { role: 'assistant', content: [{ type: 'text', text: ' world' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 3,
+      model_call_id: 'call-1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello brave world' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: ' world' },
+  ]);
+});
+
 test('codex json stream emits status text and usage events', () => {
   const { events, handler } = collectEvents('codex');
 

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -471,6 +471,50 @@ test('cursor stream recovers dropped chunk via model_call_id after fallback-term
   ]);
 });
 
+test('cursor stream does not duplicate output across two fallback-terminated turns', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Both turns end via the non-model_call_id fallback replay path. The
+  // terminal replay must reconcile against the CURRENT turn's emitted text
+  // (cursorTextSoFar.slice(cursorTurnStart)), not the whole cross-turn
+  // buffer. Otherwise turn 2's replay "second turn" is compared against
+  // "hello worldsecond", misses the current-turn prefix, and re-appends the
+  // whole replay — yielding duplicated output "secondsecond turn".
+  handler.feed(
+    // Turn 1: streamed "hello", fallback replay "hello world"
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n' +
+    // Turn 2: streamed "second", fallback replay "second turn"
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second turn' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: ' world' },
+    { type: 'text_delta', delta: 'second' },
+    { type: 'text_delta', delta: ' turn' },
+  ]);
+});
+
 test('cursor stream recovers a dropped middle chunk from a later cumulative snapshot', () => {
   const { events, handler } = collectEvents('cursor-agent');
 

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -262,9 +262,15 @@ test('cursor stream emits suffix when final assistant extends partial text', () 
   ]);
 });
 
-test('cursor stream de-duplicates cumulative timestamped assistant chunks', () => {
+test('cursor stream concatenates independent timestamped fragments verbatim', () => {
   const { events, handler } = collectEvents('cursor-agent');
 
+  // cursor-agent --stream-partial-output sends timestamped assistant events
+  // (without model_call_id) as INDEPENDENT incremental fragments — each
+  // carries only the new text and the turn text is their in-order
+  // concatenation. They must be emitted verbatim, including a fragment that
+  // repeats earlier text; content-based equality/prefix dedup would silently
+  // drop real output.
   handler.feed(
     JSON.stringify({
       type: 'assistant',
@@ -275,19 +281,21 @@ test('cursor stream de-duplicates cumulative timestamped assistant chunks', () =
     JSON.stringify({
       type: 'assistant',
       timestamp_ms: 2,
-      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+      message: { role: 'assistant', content: [{ type: 'text', text: ' world' }] },
     }) +
     '\n' +
+    // A legitimately repeated fragment — must NOT be deduped away.
     JSON.stringify({
       type: 'assistant',
       timestamp_ms: 3,
-      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+      message: { role: 'assistant', content: [{ type: 'text', text: ' world' }] },
     }) +
     '\n',
   );
 
   assert.deepEqual(events, [
     { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: ' world' },
     { type: 'text_delta', delta: ' world' },
   ]);
 });
@@ -515,106 +523,68 @@ test('cursor stream does not duplicate output across two fallback-terminated tur
   ]);
 });
 
-test('cursor stream dedupes cumulative timestamped chunks on a later turn', () => {
+test('cursor stream preserves repeated real deltas on a later turn', () => {
   const { events, handler } = collectEvents('cursor-agent');
 
-  // Turn 1 completes. Turn 2 streams cumulative snapshots ("second" then
-  // "second turn") via the timestamped path. That path must dedupe against
-  // the CURRENT turn slice, not the whole cross-turn buffer — otherwise
-  // "second turn" fails the startsWith("hellosecond") check and is appended
-  // whole, duplicating output as "secondsecond turn".
+  // Turn 1 completes (delta "hi" + its model_call_id replay). Turn 2 streams
+  // two legitimately identical real deltas "ha" + "ha" (turn text "haha"),
+  // then the buffered model_call_id replay "haha". Both timestamped deltas
+  // must be emitted (they are real content, not duplicates), and only the
+  // replay is suppressed. A content equality/prefix check on the timestamped
+  // path would wrongly drop the second "ha" and lose output.
   handler.feed(
-    // Turn 1: streamed "hello", terminal replay "hello"
+    // Turn 1
     JSON.stringify({
       type: 'assistant',
       timestamp_ms: 1,
-      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
     }) +
     '\n' +
     JSON.stringify({
       type: 'assistant',
       timestamp_ms: 2,
       model_call_id: 'call-1',
-      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
     }) +
     '\n' +
-    // Turn 2: cumulative timestamped snapshots before the terminal replay
+    // Turn 2: two identical real deltas, then the buffered replay
     JSON.stringify({
       type: 'assistant',
       timestamp_ms: 3,
-      message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+      message: { role: 'assistant', content: [{ type: 'text', text: 'ha' }] },
     }) +
     '\n' +
     JSON.stringify({
       type: 'assistant',
       timestamp_ms: 4,
-      message: { role: 'assistant', content: [{ type: 'text', text: 'second turn' }] },
+      message: { role: 'assistant', content: [{ type: 'text', text: 'ha' }] },
     }) +
     '\n' +
     JSON.stringify({
       type: 'assistant',
       timestamp_ms: 5,
       model_call_id: 'call-2',
-      message: { role: 'assistant', content: [{ type: 'text', text: 'second turn' }] },
+      message: { role: 'assistant', content: [{ type: 'text', text: 'haha' }] },
     }) +
     '\n',
   );
 
   assert.deepEqual(events, [
-    { type: 'text_delta', delta: 'hello' },
-    { type: 'text_delta', delta: 'second' },
-    { type: 'text_delta', delta: ' turn' },
-  ]);
-});
-
-test('cursor stream recovers a dropped middle chunk from a later cumulative snapshot', () => {
-  const { events, handler } = collectEvents('cursor-agent');
-
-  // Cursor's timestamped chunks are cumulative snapshots of the turn. When
-  // a middle snapshot is dropped, the next snapshot still carries the full
-  // text, so prefix reconciliation recovers the gap with no loss and no
-  // duplication. (Regression for the reviewer's "drop a middle fragment
-  // before a later fragment is delivered" scenario.)
-  handler.feed(
-    JSON.stringify({
-      type: 'assistant',
-      timestamp_ms: 1,
-      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
-    }) +
-    '\n' +
-    // "hello brave" snapshot is dropped / never received
-    JSON.stringify({
-      type: 'assistant',
-      timestamp_ms: 2,
-      message: { role: 'assistant', content: [{ type: 'text', text: 'hello brave world' }] },
-    }) +
-    '\n' +
-    // Replay confirms the full turn text — nothing more to emit
-    JSON.stringify({
-      type: 'assistant',
-      timestamp_ms: 3,
-      model_call_id: 'call-1',
-      message: { role: 'assistant', content: [{ type: 'text', text: 'hello brave world' }] },
-    }) +
-    '\n',
-  );
-
-  assert.deepEqual(events, [
-    { type: 'text_delta', delta: 'hello' },
-    { type: 'text_delta', delta: ' brave world' },
+    { type: 'text_delta', delta: 'hi' },
+    { type: 'text_delta', delta: 'ha' },
+    { type: 'text_delta', delta: 'ha' },
   ]);
 });
 
 test('cursor stream does not duplicate output when emitted text is not a replay prefix', () => {
   const { events, handler } = collectEvents('cursor-agent');
 
-  // Pathological non-cumulative case: a middle fragment (" brave") is
-  // dropped while a later fragment (" world") still arrives, so the emitted
-  // turn text "hello world" is NOT a prefix of the replay "hello brave
-  // world". Length-only slicing would emit " world" a second time (yielding
-  // "hello world world"). The replay must instead be reconciled against the
-  // emitted text: since it is not a verified prefix, the append-only stream
-  // is left untouched rather than corrupted with a duplicate suffix.
+  // A middle fragment (" brave") is dropped while a later fragment (" world")
+  // still arrives, so the emitted turn text "hello world" is NOT a prefix of
+  // the buffered replay "hello brave world". The replay is reconciled against
+  // the emitted turn text: since it is not a verified prefix, the append-only
+  // stream is left untouched rather than re-emitting an already-shown suffix
+  // (which would yield "hello world world").
   handler.feed(
     JSON.stringify({
       type: 'assistant',

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -350,6 +350,34 @@ test('cursor stream skips model_call_id replay to avoid duplicate content', () =
   ]);
 });
 
+test('cursor stream emits missing suffix from model_call_id replay when chunks are dropped', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Only partial fragments arrive — the last chunk is dropped
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    // " world" chunk was dropped / never received
+    // Full replay arrives with model_call_id — should emit the missing suffix
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      model_call_id: 'call-1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: ' world' },
+  ]);
+});
+
 test('codex json stream emits status text and usage events', () => {
   const { events, handler } = collectEvents('codex');
 

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -378,6 +378,99 @@ test('cursor stream emits missing suffix from model_call_id replay when chunks a
   ]);
 });
 
+test('cursor stream emits missing suffix from model_call_id replay in second turn', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Turn 1: all chunks arrive, replay matches
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      model_call_id: 'call-1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n',
+  );
+
+  // Turn 2: "second" arrives but " turn" is dropped
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 3,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+    }) +
+    '\n' +
+    // Replay contains "second turn" — should emit missing " turn"
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 4,
+      model_call_id: 'call-2',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second turn' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello world' },
+    { type: 'text_delta', delta: 'second' },
+    { type: 'text_delta', delta: ' turn' },
+  ]);
+});
+
+test('cursor stream recovers dropped chunk via model_call_id after fallback-terminated turn', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Turn 1 ends via the non-model_call_id fallback path (no timestamp)
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    // Final replay without model_call_id — fallback path
+    JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n',
+  );
+
+  // Turn 2: "second" arrives but " turn" is dropped, then model_call_id
+  // replay recovers the missing suffix. Without the cursorTurnStart
+  // advancement in the fallback path, turnLength would be computed from
+  // position 0 (including turn 1's text), making the replay length
+  // appear shorter than what was already emitted — losing " turn".
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 3,
+      model_call_id: 'call-2',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second turn' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: ' world' },
+    { type: 'text_delta', delta: 'second' },
+    { type: 'text_delta', delta: ' turn' },
+  ]);
+});
+
 test('codex json stream emits status text and usage events', () => {
   const { events, handler } = collectEvents('codex');
 

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -292,6 +292,64 @@ test('cursor stream de-duplicates cumulative timestamped assistant chunks', () =
   ]);
 });
 
+test('cursor stream skips model_call_id replay to avoid duplicate content', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  // Cursor sends incremental deltas as independent fragments, then a
+  // final assistant message with model_call_id that replays the full
+  // accumulated text. The replay must be skipped to avoid duplication.
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 2,
+      message: { role: 'assistant', content: [{ type: 'text', text: ' world' }] },
+    }) +
+    '\n' +
+    // Full replay with model_call_id — should be skipped
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 3,
+      model_call_id: 'call-1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello world' }] },
+    }) +
+    '\n' +
+    // New turn starts with fresh incremental deltas
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 4,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 5,
+      message: { role: 'assistant', content: [{ type: 'text', text: ' turn' }] },
+    }) +
+    '\n' +
+    // Full replay of second turn — should also be skipped
+    JSON.stringify({
+      type: 'assistant',
+      timestamp_ms: 6,
+      model_call_id: 'call-2',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'second turn' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: ' world' },
+    { type: 'text_delta', delta: 'second' },
+    { type: 'text_delta', delta: ' turn' },
+  ]);
+});
+
 test('codex json stream emits status text and usage events', () => {
   const { events, handler } = collectEvents('codex');
 


### PR DESCRIPTION
Re-submission of #1954 (auto-closed by queue bot while waiting on reviewer re-confirmation).

Fixes #1840

## Why

- **Use case:** I hit this while using the Cursor agent runtime in Open Design — assistant replies showed the same paragraphs twice during streaming, which made long responses unreadable and polluted persisted conversation history.
- **Pain:** Reporter @Derrick-xn filed #1840 with the same symptom on `main` + `pnpm tools-dev run web`. Root cause is in the daemon Cursor JSONL parser: incremental `text_delta` events are emitted, then a later `model_call_id` assistant replay re-emits the same turn text. Users see duplicate output; the bug is not “prompt sent twice.”

## What users will see

- When chatting with a **Cursor**-backed agent, assistant replies should stream **once** — no repeated paragraphs or duplicated persisted text for the same turn.
- No new UI, settings, or CLI surfaces; behavior change is limited to the existing Cursor runtime chat path.

## Summary

Cursor (`--stream-partial-output`) sends timestamped assistant events **without** `model_call_id` as independent incremental deltas (the turn text is their in-order concatenation), and `model_call_id` / no-timestamp events as buffered duplicate flushes (confirmed by captured daemon logs in #1954 and Cursor's output-format docs).

- Emit timestamped deltas **verbatim** — never dedupe them by content (a later turn streaming `"ha"`, `"ha"` must keep both)
- Suppress duplicates and recover dropped **trailing** chunks only in the buffered terminal replay paths (`model_call_id` and no-timestamp), reconciled against the **current turn's emitted text** (`cursorTextSoFar.slice(cursorTurnStart)`), not the emitted length and not the whole cross-turn buffer
- On divergence (a non-final chunk dropped, so emitted text is not a prefix of the replay) leave the append-only stream untouched instead of re-emitting an already-shown suffix
- Advance `cursorTurnStart` on fallback-terminated turns (addresses @PerishCode review in #1954, commit `37d1908a`)

## Addressed review feedback (blocking)

@nettee / Codex flagged that length-only slicing (`text.slice(turnLength)`) assumed the emitted text was always a complete prefix of the replay, which breaks when a middle chunk is dropped (emitted `"hello world"`, replay `"hello brave world"` → re-emitted `" world"` while losing `" brave"`). Commit `327e4bad` replaces length slicing with text reconciliation:

- emitted turn text **is** a prefix of the replay → emit only the missing suffix (trailing-drop recovery)
- emitted turn text **is not** a prefix → do not slice; leave the stream as-is so no already-shown text is duplicated

New regression tests cover both a recovered middle-snapshot drop and the non-prefix divergence (no duplication).

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — daemon stream parser fix + daemon tests only (`apps/daemon/src/json-event-stream.ts`, `apps/daemon/tests/json-event-stream.test.ts`). No web/desktop/CLI/contract/i18n changes.

## Screenshots

N/A — no UI change. Reporter screenshot for the duplicate-output symptom: https://github.com/nexu-io/open-design/issues/1840#issue-2923846276

## Bug fix verification

- **Test path:** `apps/daemon/tests/json-event-stream.test.ts` — Cursor replay / dedupe / dropped-chunk cases:
  - `cursor stream concatenates independent timestamped fragments verbatim` — repeated fragment preserved, not deduped
  - `cursor stream preserves repeated real deltas on a later turn` — turn 2 streams `"ha"`,`"ha"` then replay `"haha"`; both deltas kept, replay skipped *(PerishCode blocking-review regression)*
  - `cursor stream skips model_call_id replay to avoid duplicate content`
  - `cursor stream emits missing suffix from model_call_id replay when chunks are dropped`
  - `cursor stream emits missing suffix from model_call_id replay in second turn`
  - `cursor stream recovers dropped chunk via model_call_id after fallback-terminated turn`
  - `cursor stream does not duplicate output across two fallback-terminated turns`
  - `cursor stream does not duplicate output when emitted text is not a replay prefix`
- **Red on `main` / green on branch:** The duplicate-output symptom was reproduced manually (issue #1840 + local Cursor runs). The two new regression tests fail against the prior length-slicing implementation (they reproduce the duplicate/lost-text behavior @nettee described) and pass after commit `327e4bad`.
- **Manual check:** Cursor agent run in `pnpm tools-dev run web` — ask a question and confirm the assistant body does not repeat during streaming.

## Validation

```bash
pnpm --filter @open-design/daemon test json-event-stream   # 28 passed
pnpm --filter @open-design/daemon typecheck                # clean
```

Focused file: `apps/daemon/tests/json-event-stream.test.ts` (all Cursor stream cases above pass; 28/28 in the suite).

cc @PerishCode @lefarcen @nettee



