### PR TITLE
Fix viewer modal layering over chat composer

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -8801,8 +8801,8 @@ function HtmlViewer({
         </div>,
         document.body,
       ) : null}
-      {imageExportModalOpen ? (
-        <div className="modal-backdrop" role="presentation">
+      {imageExportModalOpen && typeof document !== 'undefined' ? createPortal(
+        <div className="modal-backdrop viewer-modal-backdrop image-export-backdrop" role="presentation">
           <div
             className="modal deploy-modal image-export-modal"
             role="dialog"
@@ -8867,10 +8867,11 @@ function HtmlViewer({
               </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body,
       ) : null}
-      {templateModalOpen ? (
-        <div className="modal-backdrop" role="presentation">
+      {templateModalOpen && typeof document !== 'undefined' ? createPortal(
+        <div className="modal-backdrop viewer-modal-backdrop" role="presentation">
           <div className="modal deploy-modal" role="dialog" aria-modal="true">
             <div className="modal-head">
               <div className="kicker">TEMPLATE</div>
@@ -8925,11 +8926,12 @@ function HtmlViewer({
               </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body,
       ) : null}
-      {deployModalOpen ? (
+      {deployModalOpen && typeof document !== 'undefined' ? createPortal(
         <div
-          className="modal-backdrop deploy-flow-backdrop"
+          className="modal-backdrop viewer-modal-backdrop deploy-flow-backdrop"
           role="presentation"
           onClick={(event) => {
             if (event.target === event.currentTarget) closeDeployModal();
@@ -9252,7 +9254,8 @@ function HtmlViewer({
               </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body,
       ) : null}
       {deploySavedToast ? (
         <Toast

--- a/apps/web/src/styles/viewer/tools.css
+++ b/apps/web/src/styles/viewer/tools.css
@@ -995,6 +995,9 @@
   box-sizing: border-box;
   padding: clamp(48px, 7vh, 88px) 16px;
 }
+.viewer-modal-backdrop.modal-backdrop {
+  z-index: 1700;
+}
 .deploy-flow-modal.modal {
   /* --modal-padding feeds the .deploy-form horizontal padding below. */
   --modal-padding: 22px;

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1455,7 +1455,7 @@ describe('FileViewer SVG artifacts', () => {
       },
     });
 
-    render(
+    const view = render(
       <FileViewer projectId="project-1" projectKind="prototype" file={file}
         liveHtml="<html><body><h1>Hello</h1></body></html>"
       />,
@@ -1467,6 +1467,10 @@ describe('FileViewer SVG artifacts', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: /Deploy to Cloudflare Pages/i }));
 
     expect(await screen.findByRole('dialog')).toBeTruthy();
+    const backdrop = document.body.querySelector('.viewer-modal-backdrop.deploy-flow-backdrop');
+    expect(backdrop).toBeTruthy();
+    expect(backdrop?.parentElement).toBe(document.body);
+    expect(view.container.querySelector('.viewer-modal-backdrop')).toBeNull();
     expect(screen.getByText('Account ID')).toBeTruthy();
     expect(screen.getByText(/Select Pages Edit when creating the API token/i)).toBeTruthy();
     expect(screen.getByText(/Zone Read/i)).toBeTruthy();
@@ -2666,7 +2670,7 @@ describe('FileViewer SVG artifacts', () => {
       },
     });
 
-    render(
+    const view = render(
       <FileViewer projectId="project-1" projectKind="prototype" file={file}
         liveHtml="<html><body><h1>Hello</h1></body></html>"
       />,
@@ -2676,6 +2680,10 @@ describe('FileViewer SVG artifacts', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: /save as template/i }));
 
     expect(screen.getByRole('dialog')).toBeTruthy();
+    const backdrop = document.body.querySelector('.viewer-modal-backdrop');
+    expect(backdrop).toBeTruthy();
+    expect(backdrop?.parentElement).toBe(document.body);
+    expect(view.container.querySelector('.viewer-modal-backdrop')).toBeNull();
     const nameInput = screen.getByLabelText(/template name/i) as HTMLInputElement;
     expect(nameInput.value).toBe('landing-page');
     fireEvent.change(nameInput, { target: { value: 'Landing Page' } });

--- a/apps/web/tests/components/file-viewer-image-export.test.tsx
+++ b/apps/web/tests/components/file-viewer-image-export.test.tsx
@@ -91,6 +91,27 @@ describe('FileViewer image export', () => {
     vi.resetAllMocks();
   });
 
+  it('portals the image export dialog above fixed chat composer layers', async () => {
+    requestPreviewSnapshotMock.mockResolvedValueOnce({
+      dataUrl: 'data:image/png;base64,ok',
+      w: 800,
+      h: 600,
+    });
+    imageDataUrlToBlobMock.mockResolvedValueOnce(new Blob(['png'], { type: 'image/png' }));
+
+    const { container } = renderHtmlPreview();
+    openImageExportDialog();
+
+    const backdrop = document.body.querySelector('.viewer-modal-backdrop');
+    expect(backdrop).toBeTruthy();
+    expect(backdrop?.classList.contains('image-export-backdrop')).toBe(true);
+    expect(backdrop?.parentElement).toBe(document.body);
+    expect(container.querySelector('.viewer-modal-backdrop')).toBeNull();
+    await waitFor(() => {
+      expect(imageDataUrlToBlobMock).toHaveBeenCalledWith('data:image/png;base64,ok', 'png');
+    });
+  });
+
   it('lets users choose an image format before saving URL-loaded HTML previews', async () => {
     const pngBlob = new Blob(['png'], { type: 'image/png' });
     const imageBlob = new Blob(['jpeg'], { type: 'image/jpeg' });


### PR DESCRIPTION
## Why

While validating 0.10.0, the viewer dialogs opened from Download → Export as image and Download → Save as template could leave the fixed chat composer visually floating above the modal backdrop. These dialogs were rendered inside `FileViewer`, while the chat composer uses its own fixed/elevated stacking layers, so the lower-left composer could pierce the mask.

This fixes a user-facing styling regression for artifact preview dialogs and applies the same treatment to the related deploy configuration modal.

## What users will see

Opening Export as image, Save as template, or deploy configuration from the artifact viewer now dims and covers the chat composer consistently. The dialog controls and copy are unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a modal stacking regression, and the regression is covered by component tests that assert viewer modal backdrops portal to `document.body` instead of staying inside the viewer container. An in-app Browser synthetic `data:` page check was blocked by Browser URL policy, so I did not include a visual capture.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/file-viewer-image-export.test.tsx` and `apps/web/tests/components/FileViewer.test.tsx`
- Did the test go red on `main` and green on this branch? Not rerun on `main`; the new assertions encode the old failure by requiring the viewer modal backdrop to mount under `document.body` and not inside the FileViewer render container. The focused tests are green on this branch.

## Validation

- `pnpm install`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/file-viewer-image-export.test.tsx tests/components/FileViewer.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm typecheck`
- `pnpm guard`
