### PR TITLE
fix(settings): style builtin skill edit confirmation warning

### DIFF
--- a/apps/web/src/styles/viewer/templates-plugins.css
+++ b/apps/web/src/styles/viewer/templates-plugins.css
@@ -2267,6 +2267,26 @@
   font-size: 12.5px;
 }
 
+.settings-skills .skills-edit-builtin-warning {
+  padding: 10px 14px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin: 0;
+}
+.settings-skills .skills-edit-builtin-warning p {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+.settings-skills .skills-edit-builtin-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
 @media (max-width: 640px) {
   .plugin-details-modal-backdrop {
     padding: 0;


### PR DESCRIPTION
Closes #3558

Add consistent spacing and readable background to the built-in skill edit confirmation prompt so the text is no longer visually cramped against the card borders. The warning now uses the same padding / border / radius treatment as the row detail chrome, and the action buttons sit on their own row with a comfortable gap and top margin.