### PR TITLE
fix(web): prevent execution mode card title overflow clipping

### DIFF
--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1275,6 +1275,9 @@
 }
 .agent-card-title {
   min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .agent-card-name--amr {
   align-items: center;


### PR DESCRIPTION
Closes #3554

Give the agent card title an explicit ellipsis treatment so long provider names no longer clip abruptly inside the execution mode card. The parent .agent-card-name already constrains overflow; this change lets the title degrade gracefully instead of disappearing mid-word.