### PR TITLE
fix(web): handle draft design systems in New Project

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1185,19 +1185,42 @@ function AppInner() {
       const fidelity = fidelityToTracking(input.metadata?.fidelity ?? null);
       const creationSource: 'blank' | 'template' | 'zip' | 'folder' =
         kind === 'template' ? 'template' : 'blank';
-      const result = await createProject({
-        name: input.name,
-        skillId: input.skillId,
-        designSystemId: input.designSystemId,
-        pendingPrompt: derivedPendingPrompt,
-        metadata: input.metadata,
-        ...(input.conversationMode ? { conversationMode: input.conversationMode } : {}),
-        ...(input.pluginId ? { pluginId: input.pluginId } : {}),
-        ...(input.appliedPluginSnapshotId
-          ? { appliedPluginSnapshotId: input.appliedPluginSnapshotId }
-          : {}),
-        ...(input.pluginInputs ? { pluginInputs: input.pluginInputs } : {}),
-      });
+      let result;
+      try {
+        result = await createProject({
+          name: input.name,
+          skillId: input.skillId,
+          designSystemId: input.designSystemId,
+          pendingPrompt: derivedPendingPrompt,
+          metadata: input.metadata,
+          ...(input.conversationMode ? { conversationMode: input.conversationMode } : {}),
+          ...(input.pluginId ? { pluginId: input.pluginId } : {}),
+          ...(input.appliedPluginSnapshotId
+            ? { appliedPluginSnapshotId: input.appliedPluginSnapshotId }
+            : {}),
+          ...(input.pluginInputs ? { pluginInputs: input.pluginInputs } : {}),
+        });
+      } catch (err) {
+        const errorCode =
+          err instanceof Error && err.message.trim()
+            ? err.message
+            : 'CREATE_REQUEST_FAILED';
+        trackProjectCreateResult(
+          analytics.track,
+          {
+            page_name: 'home',
+            area: 'new_project',
+            project_source: 'create_button',
+            project_id: null,
+            project_kind: projectKindToTracking(kind),
+            fidelity,
+            result: 'failed',
+            error_code: errorCode,
+          },
+          { requestId: input.requestId },
+        );
+        throw err;
+      }
       if (!result) {
         trackProjectCreateResult(
           analytics.track,

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -237,6 +237,13 @@ export function defaultDesignSystemSelection(
     : [];
 }
 
+function isSelectableProjectDesignSystem(system: DesignSystemSummary): boolean {
+  if (system.source === 'user' || system.isEditable === true) {
+    return (system.status ?? 'draft') === 'published';
+  }
+  return true;
+}
+
 export function buildDesignSystemCreateSelection(
   showDesignSystemPicker: boolean,
   selectedIds: string[],
@@ -306,9 +313,13 @@ export function NewProjectPanel({
   // Design-system selection is now an *array* internally so the same
   // component can drive both single-select and multi-select modes without
   // duplicating state. Single-select coerces to length 0/1.
+  const selectableDesignSystems = useMemo(
+    () => designSystems.filter(isSelectableProjectDesignSystem),
+    [designSystems],
+  );
   const initialDefaultDsSelection = useMemo(
-    () => defaultDesignSystemSelection(defaultDesignSystemId, designSystems),
-    [defaultDesignSystemId, designSystems],
+    () => defaultDesignSystemSelection(defaultDesignSystemId, selectableDesignSystems),
+    [defaultDesignSystemId, selectableDesignSystems],
   );
   const [selectedDsIds, setSelectedDsIds] = useState<string[]>(
     () => initialDefaultDsSelection,
@@ -406,7 +417,7 @@ export function NewProjectPanel({
     if (!primary) return;
     if (autoSelectFiredForRef.current === primary) return;
     autoSelectFiredForRef.current = primary;
-    const picked = designSystems.find((d) => d.id === primary);
+    const picked = selectableDesignSystems.find((d) => d.id === primary);
     trackDesignSystemApplyResult(analytics.track, {
       page_name: 'home',
       area: 'design_system_picker',
@@ -425,9 +436,9 @@ export function NewProjectPanel({
     });
   }, [
     analytics.track,
-    designSystems,
     dsSelectionTouched,
     initialDefaultDsSelection,
+    selectableDesignSystems,
     showDesignSystemPicker,
     tab,
   ]);
@@ -873,7 +884,7 @@ export function NewProjectPanel({
 
         {showDesignSystemPicker ? (
           <DesignSystemPicker
-            designSystems={designSystems}
+            designSystems={selectableDesignSystems}
             defaultDesignSystemId={defaultDesignSystemId}
             selectedIds={selectedDsIds}
             multi={dsMulti}

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -238,10 +238,7 @@ export function defaultDesignSystemSelection(
 }
 
 function isSelectableProjectDesignSystem(system: DesignSystemSummary): boolean {
-  if (system.source === 'user' || system.isEditable === true) {
-    return (system.status ?? 'draft') === 'published';
-  }
-  return true;
+  return system.status !== 'draft';
 }
 
 export function buildDesignSystemCreateSelection(

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -69,7 +69,7 @@ export async function createProject(input: {
   pluginId?: string;
   appliedPluginSnapshotId?: string;
   pluginInputs?: Record<string, unknown>;
-}): Promise<{ project: Project; conversationId: string; appliedPluginSnapshotId?: string } | null> {
+}): Promise<{ project: Project; conversationId: string; appliedPluginSnapshotId?: string }> {
   try {
     // `randomUUID` falls back to `crypto.getRandomValues` / `Math.random`
     // when `crypto.randomUUID` is unavailable. Open Design served over
@@ -83,14 +83,31 @@ export async function createProject(input: {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id, ...input }),
     });
-    if (!resp.ok) return null;
+    if (!resp.ok) {
+      let message = 'Could not create project';
+      try {
+        const body = await resp.json() as { error?: unknown };
+        if (
+          body.error &&
+          typeof body.error === 'object' &&
+          'message' in body.error &&
+          typeof body.error.message === 'string' &&
+          body.error.message.trim()
+        ) {
+          message = body.error.message;
+        }
+      } catch {
+        // Keep the generic fallback when the error body is absent or invalid.
+      }
+      throw new Error(message);
+    }
     return (await resp.json()) as {
       project: Project;
       conversationId: string;
       appliedPluginSnapshotId?: string;
     };
-  } catch {
-    return null;
+  } catch (err) {
+    throw err instanceof Error ? err : new Error('Could not create project');
   }
 }
 

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -61,6 +61,8 @@ const designSystems: DesignSystemSummary[] = [
     summary: 'Friendly tactile product UI.',
     category: 'Product',
     swatches: ['#f4efe7', '#25211d'],
+    source: 'built-in',
+    status: 'published',
   },
   {
     id: 'noir',
@@ -68,6 +70,18 @@ const designSystems: DesignSystemSummary[] = [
     summary: 'High-contrast editorial system.',
     category: 'Editorial',
     swatches: ['#111111', '#f7f0e8'],
+    source: 'built-in',
+    status: 'published',
+  },
+  {
+    id: 'user:draft-system',
+    title: 'Draft Personal DS',
+    summary: 'Should not be selectable for project creation.',
+    category: 'Personal',
+    swatches: ['#663399', '#faf7ff'],
+    source: 'user',
+    isEditable: true,
+    status: 'draft',
   },
 ];
 
@@ -128,6 +142,26 @@ describe('NewProjectPanel design system defaults', () => {
     expect(markup).toContain('Clay');
     expect(markup).toContain('Default');
     expect(markup).not.toContain('Freeform');
+  });
+
+  it('filters draft personal design systems out of the new project picker', () => {
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId="clay"
+        templates={[]}
+        onDeleteTemplate={vi.fn()}
+        promptTemplates={[]}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('design-system-trigger'));
+
+    expect(screen.queryByRole('option', { name: /Draft Personal DS/i })).toBeNull();
+    expect(screen.getByRole('option', { name: /Clay/i })).toBeTruthy();
+    expect(screen.getByRole('option', { name: /Editorial Noir/i })).toBeTruthy();
   });
 
   it('keeps media project creation from inheriting a hidden design system pick', () => {

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   applyPlugin,
   contributeGeneratedPluginToOpenDesign,
+  createProject,
   createPluginShareProject,
   importClaudeDesignZip,
   importFolderProject,
@@ -58,6 +59,38 @@ describe('applyPlugin', () => {
       grantCaps: [],
       locale: 'zh-CN',
     });
+  });
+});
+
+describe('createProject', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves daemon validation messages from non-2xx create responses', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({
+        error: {
+          message: 'draft design systems cannot be used by projects',
+        },
+      }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(createProject({
+      name: 'Draft DS project',
+      skillId: null,
+      designSystemId: 'user:draft-system',
+    })).rejects.toThrow('draft design systems cannot be used by projects');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/projects',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
Fixes #3792

## Why

I hit a bug in the New Project flow when testing custom design systems.

The modal allowed selecting a draft / unpublished design system even though the daemon correctly rejects draft design systems for project creation. That created two user-facing problems:
- the UI exposed an invalid selection
- when creation failed, the modal collapsed the daemon response into a generic `Could not create project. Please try again.` message instead of showing the real reason

This PR fixes both sides so the web flow matches the daemon’s validation rules and still surfaces the backend validation if a create request is rejected.

## What users will see

In New Project:
- draft / unpublished personal design systems no longer appear as selectable options in the design system picker
- if project creation is rejected by the daemon, the modal shows the real validation message instead of a generic create failure

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

I’ll attach two screenshots here:
- the New Project picker with draft / unpublished design systems filtered out
<img width="1397" height="316" alt="draft-design-system" src="https://github.com/user-attachments/assets/9191f217-a268-4b82-9893-5bbad1082b69" />
<img width="766" height="868" alt="draft-design-system-filtered-out" src="https://github.com/user-attachments/assets/340fbf2d-3df8-47e1-b22d-5690b5d705b6" />


- the New Project modal surfacing the backend validation message when project creation is rejected
<img width="770" height="788" alt="surface-the-backend-errors" src="https://github.com/user-attachments/assets/78e8f8b9-64b2-4d0b-abe9-c89fe7a9527f" />

## Bug fix verification

- Test path that reproduces the picker-side bug:
  `apps/web/tests/components/NewProjectPanel.test.tsx`
- Test path that reproduces the surfaced-error behavior:
  `apps/web/tests/state/projects.test.ts`
- Did the test go red on `main` and green on this branch?
  Not explicitly re-run against a clean `main` checkout in this workspace. I added focused regression coverage for both behaviors and verified the updated tests pass on this branch.
- Manual verification:
  I reproduced the issue locally against an existing desktop data directory, confirmed the picker could expose a draft design system, then verified the updated flow and error messaging in the local Electron app.

## Validation

- `pnpm --filter @open-design/web test -- --run apps/web/tests/components/NewProjectPanel.test.tsx apps/web/tests/state/projects.test.ts`
- `pnpm --filter @open-design/web typecheck`

- Note:
  I also attempted daemon-side focused verification, but the isolated daemon test run in this shell was blocked by a local `better-sqlite3` Node ABI mismatch outside the code change itself. The existing daemon route guard was already present and this PR does not modify daemon validation logic.
