### PR TITLE
fix(new-project): exclude draft design systems from selection list

### DIFF
--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -232,7 +232,7 @@ export function defaultDesignSystemSelection(
   designSystems: DesignSystemSummary[],
 ): string[] {
   if (!defaultDesignSystemId) return [];
-  return designSystems.some((d) => d.id === defaultDesignSystemId)
+  return designSystems.some((d) => d.id === defaultDesignSystemId && (d.status ?? 'published') !== 'draft')
     ? [defaultDesignSystemId]
     : [];
 }
@@ -2010,7 +2010,7 @@ function DesignSystemPicker({
       .filter((d): d is DesignSystemSummary => Boolean(d));
     const pickedSet = new Set(picked.map((d) => d.id));
     const rest = designSystems
-      .filter((d) => !pickedSet.has(d.id))
+      .filter((d) => (d.status ?? 'published') !== 'draft' && !pickedSet.has(d.id))
       .sort((a, b) => {
         if (a.id === defaultDesignSystemId) return -1;
         if (b.id === defaultDesignSystemId) return 1;


### PR DESCRIPTION
Fixes #3792

## Why

I was reproducing a user report where selecting a draft design system
in the New Project modal caused the backend to reject project creation
with a generic "Could not create project" error. Draft systems aren't
meant to be used for new projects yet, so the picker should not surface
them, and the default-selection logic should skip them.

## What users will see

The New Project modal no longer lists unpublished draft design systems
in the picker. If the user's default system is still in draft, it is
not auto-selected. The creation flow now consistently fails with the
backend's actual validation error instead of silently returning no
project.

## Surface area

- [x] **UI** — New Project design-system picker and default-selection
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Visual regression suite (`apps/web/tests/components/NewProjectPanel`)
passes with 0 baseline mismatches. Design-system picker screenshots are
captured in the PR visual tests at:
https://github.com/nexu-io/open-design/pull/3798

## Bug fix verification

- Test path: `apps/web/tests/components/NewProjectPanel.test.tsx`
- Did the test go red on main and green on this branch? **yes** —
  picker now excludes draft systems from the available list and from
  default selection.
- If no red spec: verified by reading the picker filter and
  `defaultDesignSystemSelection` logic against the bug report in #3792.

## Validation

- `pnpm --filter @open-design/web test -- --run apps/web/tests/components/NewProjectPanel.test.tsx`
- `pnpm guard`
