### PR TITLE
fix(web): remove stale queuedChatSends dependency from auto-send effect

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3710,7 +3710,6 @@ export function ProjectView({
     armSlideNavForQueuedSend,
     currentConversationBusy,
     queuedAutoStartTick,
-    queuedChatSends,
     handleSend,
     removeQueuedChatSend,
   ]);


### PR DESCRIPTION
Closes #3497.\n\n### Problem\nQueued task cards displayed the wrong description, and the edit input opened empty because the auto-send  was re-triggering on every  change. That stale dependency overwrote the queued card's current value during queue transitions.\n\n### Fix\nRemove  from the effect's dependency array in . The effect already derives its behavior from stable event handlers and the active conversation ID; the queue list itself is not needed as a trigger.\n\n### Scope\n- Single file: \n- Single-line dependency removal, no UI behavior change beyond keeping the queued description intact