### PR TITLE
Add Expo gym app design audit plugin

### DIFF
--- a/plugins/community/bfitlog-expo-design-audit/SKILL.md
+++ b/plugins/community/bfitlog-expo-design-audit/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: bfitlog-expo-design-audit
+description: Audit a mobile-first Expo gym tracking app for design quality, responsive Expo Web behavior, workout-flow usability, accessibility, and reusable UI-system opportunities.
+od:
+  scenario: design-audit
+  mode: critique
+---
+
+# BFitLog Expo Design Audit
+
+Use this skill when the user wants a design analysis of a personal gym tracking app built with Expo, Expo Router, React Native, and Expo Web. The intended app shape is mobile-layout-first, with responsive web support for wider browser screens.
+
+## Outcome
+
+Produce a concise, actionable design audit grounded in the project files. Prioritize findings that affect the product experience:
+
+- Mobile workout logging speed and cognitive load.
+- Responsive Expo Web layout behavior.
+- Navigation and information architecture across Home, Plan, Workout, History, Stats, Settings, Login, Setup, and Exercise detail.
+- Visual-system consistency, including theme tokens, repeated style blocks, typography, spacing, cards, buttons, inputs, status states, and charts.
+- Accessibility and touch ergonomics.
+- Gym-domain specificity: workout progression, set entry, rest timer, substitutions, skip states, body-weight logging, partner visibility, and training media.
+
+## Workflow
+
+1. Inspect the project shape before making claims.
+   - Read `package.json` and `apps/mobile/package.json` to confirm Expo, React Native, Expo Router, and Expo Web dependencies.
+   - Read `apps/mobile/src/theme.ts` or equivalent theme files.
+   - List `apps/mobile/app/**/*.{tsx,ts}` and `apps/mobile/src/**/*.{tsx,ts}` to identify screens and reusable modules.
+
+2. Read the highest-impact screens first.
+   - `apps/mobile/app/(tabs)/index.tsx`
+   - `apps/mobile/app/workout.tsx`
+   - `apps/mobile/app/(tabs)/plan.tsx`
+   - `apps/mobile/app/(tabs)/history.tsx`
+   - `apps/mobile/app/(tabs)/stats.tsx`
+   - `apps/mobile/app/(tabs)/settings.tsx`
+   - `apps/mobile/app/exercise.tsx`
+   - Authentication and setup screens when the audit covers onboarding.
+
+3. Search for design-system and responsive signals.
+   - Theme tokens: colors, spacing, radii, max widths, typography, minimum hit targets.
+   - Repeated `StyleSheet.create` definitions for cards, buttons, fields, empty states, rows, and section headers.
+   - Web/responsive APIs such as `useWindowDimensions`, `Platform.select`, `maxWidth`, CSS-like layout branches, and fixed SVG/chart dimensions.
+   - Accessibility props including `accessibilityRole`, `accessibilityLabel`, `accessibilityState`, live regions, and focus helpers.
+
+4. Analyze the design in this order.
+   - First, summarize what is already working.
+   - Then list the main design risks ordered by user impact.
+   - Anchor each concrete issue to files and line references where possible.
+   - Separate source-backed findings from product-design recommendations.
+
+5. Check for these common issues.
+   - Web layout is only a centered mobile column instead of a true wider-screen adaptation.
+   - Workout cards expose too many secondary controls at once.
+   - Implementation details leak into UI, especially IDs, sync state, raw status labels, or admin-only concepts.
+   - Shared UI primitives are missing, causing repeated local styles.
+   - Charts and metrics work but lack hover/touch readouts, clear deltas, or responsive density.
+   - Accessibility exists in isolated controls but not consistently across custom tab lists, segmented controls, destructive actions, or live status.
+
+6. Recommend the next design pass.
+   - Prefer one high-leverage screen first, usually Workout.
+   - Specify mobile-first changes and web-specific layout adaptations separately.
+   - Propose a small component system only when repeated patterns in the code justify it.
+   - Avoid generic redesign advice; tie every recommendation to the gym-tracking domain.
+
+## Output Format
+
+Use this structure unless the user asks for something else:
+
+```markdown
+**Current Design Audit**
+
+One short paragraph summarizing the current design maturity.
+
+**What Works**
+- ...
+
+**Main Design Risks**
+1. ...
+
+**Recommended Next Design Pass**
+- ...
+```
+
+Keep the tone direct and pragmatic. Do not rewrite code unless the user asks for implementation.

--- a/plugins/community/bfitlog-expo-design-audit/examples/bfitlog-design-audit.md
+++ b/plugins/community/bfitlog-expo-design-audit/examples/bfitlog-design-audit.md
@@ -1,0 +1,29 @@
+# BFitLog Design Audit Example
+
+BFitLog is a personal gym tracking app built as an Expo app with mobile-first layouts and Expo Web support. The current product surface is functionally strong: Home, Plan, Workout, History, Stats, Settings, setup, login, body-weight logging, partner visibility, training media, substitutions, and rest timer concepts are all represented in the codebase.
+
+## What Works
+
+- The app has a real gym-tracking product model rather than generic fitness placeholders.
+- Expo Router gives the information architecture a clear tab structure: Home, Plan, History, Stats, and Settings.
+- `apps/mobile/src/theme.ts` centralizes the base dark palette, spacing scale, max content width, and Android minimum touch target.
+- The Home and Stats screens expose practical domain modules: next workout, day override, latest body weight, range tabs, body-weight chart, exercise progress, and consistency summaries.
+- Many controls include accessibility roles, labels, and touch-target intent.
+
+## Main Design Risks
+
+1. Responsive web currently reads as a centered mobile or tablet column. The `layout.maxContentWidth` value keeps content controlled, but desktop web needs deliberate two-pane and dashboard-style adaptations for Workout, Plan, and Stats.
+
+2. The Workout screen carries the highest cognitive load. Set inputs, status, notes, substitutions, skip controls, save actions, rest timer, and completion actions compete inside one vertical flow. The workout moment should prioritize the active set, previous set context, primary save action, and rest state.
+
+3. Some implementation details leak into the user experience. Substitute exercise IDs should become a searchable exercise picker or a suggested substitution list.
+
+4. The visual system is coherent but thin. Cards, buttons, fields, status labels, empty states, segmented controls, and metric rows are mostly screen-local styles. Extracting primitives would make consistency and responsive tuning easier.
+
+5. Charts and metrics are useful but basic. Body-weight and exercise progress views would benefit from clearer deltas, touch or hover readouts, and denser desktop layouts.
+
+## Recommended Next Design Pass
+
+Start with the Workout screen. Redesign it around a sticky workout header, one active exercise editor, a compact queued/completed exercise list, and a persistent rest timer panel. On desktop web, split the layout into an exercise list pane and an active set editor pane instead of only widening the mobile column.
+
+Then extract a small UI kit: `Screen`, `Card`, `Button`, `TextField`, `SegmentedControl`, `StatusBadge`, `MetricCard`, and `EmptyState`. Use those primitives to tune Home, Plan, History, Stats, and Settings without repeating local styles.

--- a/plugins/community/bfitlog-expo-design-audit/open-design.json
+++ b/plugins/community/bfitlog-expo-design-audit/open-design.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "bfitlog-expo-design-audit",
+  "title": "Expo gym app design audit",
+  "version": "0.1.0",
+  "description": "Audit a mobile-first Expo gym tracking app for product design quality, responsive Expo Web behavior, workout-flow usability, accessibility, and reusable UI-system opportunities.",
+  "license": "MIT",
+  "author": {
+    "name": "theHimanshuShekhar",
+    "url": "https://github.com/theHimanshuShekhar"
+  },
+  "plugin": {
+    "repo": "https://github.com/theHimanshuShekhar/bfitlog-expo-design-audit"
+  },
+  "tags": [
+    "expo",
+    "react-native",
+    "expo-web",
+    "mobile",
+    "fitness",
+    "design-audit",
+    "responsive",
+    "accessibility"
+  ],
+  "compat": {
+    "agentSkills": [
+      {
+        "path": "./SKILL.md"
+      }
+    ]
+  },
+  "od": {
+    "kind": "scenario",
+    "taskKind": "tune-collab",
+    "mode": "critique",
+    "platform": "responsive",
+    "scenario": "design-audit",
+    "preview": {
+      "type": "markdown",
+      "entry": "./examples/bfitlog-design-audit.md"
+    },
+    "useCase": {
+      "query": {
+        "en": "Analyze the current design of this personal gym tracking app. It is an Expo app, mobile layout first, with Expo Web used to make it responsive for web. Inspect the current screens and styling, then summarize what works, the main design risks, and the next design pass."
+      },
+      "exampleOutputs": [
+        {
+          "path": "./examples/bfitlog-design-audit.md",
+          "title": "BFitLog design audit"
+        }
+      ]
+    },
+    "inputs": [
+      {
+        "name": "projectPath",
+        "label": "Project path",
+        "type": "string",
+        "required": false,
+        "placeholder": "Path to the Expo app repository",
+        "default": "."
+      },
+      {
+        "name": "focus",
+        "label": "Audit focus",
+        "type": "select",
+        "required": false,
+        "options": [
+          "overall design",
+          "workout flow",
+          "responsive web",
+          "component system",
+          "accessibility"
+        ],
+        "default": "overall design"
+      },
+      {
+        "name": "depth",
+        "label": "Audit depth",
+        "type": "select",
+        "required": false,
+        "options": [
+          "summary",
+          "detailed"
+        ],
+        "default": "detailed"
+      }
+    ],
+    "context": {
+      "assets": [
+        "./examples/bfitlog-design-audit.md"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "inspect-project",
+          "atoms": [
+            "file-read"
+          ]
+        },
+        {
+          "id": "analyze-design",
+          "atoms": [
+            "critique-theater"
+          ]
+        },
+        {
+          "id": "report",
+          "atoms": [
+            "file-write"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:read"
+    ]
+  }
+}


### PR DESCRIPTION
Add Expo gym app design audit (bfitlog-expo-design-audit) plugin.
Version: 0.1.0
Description: Audit a mobile-first Expo gym tracking app for product design quality, responsive Expo Web behavior, workout-flow usability, accessibility, and reusable UI-system opportunities.