### PR TITLE
fix(landing): harden plugin preview sandbox

### DIFF
--- a/apps/landing-page/app/pages/plugins/[slug]/index.astro
+++ b/apps/landing-page/app/pages/plugins/[slug]/index.astro
@@ -201,7 +201,7 @@ const jsonLd = [
                 src={plugin.previewEntryUrl}
                 title={pcopy.previewIframeTitle(pluginTitle)}
                 loading="lazy"
-                sandbox="allow-scripts allow-same-origin"
+                sandbox="allow-scripts"
                 class="detail-preview-frame"
               />
               <a

--- a/apps/landing-page/tests/plugin-preview-sandbox.test.ts
+++ b/apps/landing-page/tests/plugin-preview-sandbox.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const pluginDetailRoute = join(testDir, "../app/pages/plugins/[slug]/index.astro");
+
+describe("plugin detail live preview sandbox", () => {
+  it("does not grant same-origin access to scripted preview iframes", async () => {
+    const source = await readFile(pluginDetailRoute, "utf8");
+
+    assert.match(source, /sandbox="allow-scripts"/);
+    assert.doesNotMatch(source, /sandbox="allow-scripts allow-same-origin"/);
+  });
+});


### PR DESCRIPTION
## Why

I noticed the landing-page plugin detail live preview iframe grants both `allow-scripts` and `allow-same-origin`. That pairing lets scripted preview content keep same-origin privileges, which weakens the isolation that the sandbox is meant to provide.

This PR tightens the preview iframe to `allow-scripts` only and adds a regression test so the sandbox does not silently drift back.

## What users will see

There is no intentional visual change. Plugin detail pages still show live previews, but the embedded preview iframe runs with stricter origin isolation.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: this is a security hardening change to iframe sandbox attributes with no intended visual difference.

## Bug fix verification

- Test path that reproduces the bug: `apps/landing-page/tests/plugin-preview-sandbox.test.ts`
- Did the test go red on `main` and green on this branch? Not run as a separate red/green loop; the new regression test asserts the intended sandbox invariant on this branch.

## Validation

- `pnpm --filter @open-design/landing-page test`
- `pnpm --filter @open-design/landing-page typecheck`
- `pnpm --filter @open-design/landing-page build` passed unsandboxed after the sandbox blocked `tsx` IPC
- `pnpm guard`
- Root typecheck equivalent via Corepack `pnpm 10.33.2`; the literal root `pnpm typecheck` script hit the known nested global `pnpm 9.0.0` shim, so I ran the recursive workspace typechecks and remaining nested daemon/packaged/script checks explicitly with Corepack.
