### PR TITLE
fix(daemon): strip inherited opencode session env and grant project dir permissions

### DIFF
--- a/apps/daemon/src/mcp-config.ts
+++ b/apps/daemon/src/mcp-config.ts
@@ -411,7 +411,9 @@ export function buildAcpMcpServers(servers: McpServerConfig[]): AcpMcpServer[] {
  * inline JSON string). The env-var path is what lets a launcher like the
  * Open Design daemon hand servers to a single `opencode run` invocation
  * without writing into the user's global config or leaving a temp file
- * around on crash.
+ * around on crash. We also use the same payload to grant `external_directory`
+ * access to daemon-selected absolute paths (project cwd, staged skill dirs,
+ * etc.) so headless OpenCode runs do not auto-reject them.
  *
  * Schema (verified against the dev branch of `sst/opencode`'s
  * `packages/opencode/src/config/config.ts` and the public docs at
@@ -445,12 +447,16 @@ export function buildAcpMcpServers(servers: McpServerConfig[]): AcpMcpServer[] {
  * works the same way for OpenCode users without forcing them to
  * re-authenticate inside OpenCode.
  */
+export interface OpenCodeConfigBuildOptions {
+  allowedDirectories?: string[];
+}
+
 export function buildOpenCodeMcpConfigContent(
   servers: McpServerConfig[],
   tokens: Record<string, string> = {},
+  options: OpenCodeConfigBuildOptions = {},
 ): string | null {
   const enabled = servers.filter((s) => s.enabled);
-  if (enabled.length === 0) return null;
   const mcp: Record<string, Record<string, unknown>> = {};
   for (const s of enabled) {
     if (s.transport === 'stdio') {
@@ -481,8 +487,52 @@ export function buildOpenCodeMcpConfigContent(
       mcp[s.id] = entry;
     }
   }
-  if (Object.keys(mcp).length === 0) return null;
-  return JSON.stringify({ mcp });
+  const externalDirectory = buildOpenCodeExternalDirectoryAllowlist(
+    options.allowedDirectories,
+  );
+  if (Object.keys(mcp).length === 0 && !externalDirectory) return null;
+
+  const config: Record<string, unknown> = {};
+  if (Object.keys(mcp).length > 0) config.mcp = mcp;
+  if (externalDirectory) {
+    config.permission = {
+      external_directory: externalDirectory,
+    };
+  }
+  return JSON.stringify(config);
+}
+
+function buildOpenCodeExternalDirectoryAllowlist(
+  directories: string[] | undefined,
+): Record<string, 'allow'> | null {
+  const normalized = Array.from(
+    new Set(
+      (directories ?? [])
+        .filter((dir) => typeof dir === 'string' && dir.trim().length > 0)
+        .filter((dir) => path.isAbsolute(dir))
+        .map((dir) => normalizeAllowedDirectory(dir)),
+    ),
+  );
+  if (normalized.length === 0) return null;
+
+  const allowlist: Record<string, 'allow'> = {};
+  for (const dir of normalized) {
+    allowlist[dir] = 'allow';
+    allowlist[joinPermissionGlob(dir, '*')] = 'allow';
+    allowlist[joinPermissionGlob(dir, '**')] = 'allow';
+  }
+  return allowlist;
+}
+
+function normalizeAllowedDirectory(dir: string): string {
+  const resolved = path.resolve(dir);
+  const root = path.parse(resolved).root;
+  if (resolved === root) return root;
+  return resolved.replace(/[\\/]+$/, '');
+}
+
+function joinPermissionGlob(dir: string, suffix: '*' | '**'): string {
+  return dir.endsWith(path.sep) ? `${dir}${suffix}` : `${dir}${path.sep}${suffix}`;
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -133,6 +133,12 @@ export function spawnEnvForAgent(
     return reapplySandboxRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'opencode') {
+    stripKeysCaseInsensitive(env, [
+      'OPENCODE',
+      'OPENCODE_PID',
+      'OPENCODE_RUN_ID',
+      'OPENCODE_SERVER_PASSWORD',
+    ]);
     // OpenCode is bun-based and, left to its defaults, walks up from its cwd to
     // the nearest project root and runs `bun install` there at startup to set up
     // local plugins. When that root is a pnpm workspace (the daemon's own repo,
@@ -224,5 +230,15 @@ function stripUnlessCustomBaseUrl(
   const secretKeysUpper = new Set(secretKeys.map((k) => k.toUpperCase()));
   for (const key of Object.keys(env)) {
     if (secretKeysUpper.has(key.toUpperCase())) delete env[key];
+  }
+}
+
+function stripKeysCaseInsensitive(
+  env: NodeJS.ProcessEnv,
+  keysToStrip: readonly string[],
+): void {
+  const keysUpper = new Set(keysToStrip.map((key) => key.toUpperCase()));
+  for (const key of Object.keys(env)) {
+    if (keysUpper.has(key.toUpperCase())) delete env[key];
   }
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12162,14 +12162,14 @@ export async function startServer({
     // mcp section for this single invocation, which is exactly the kind
     // of surprise the previous silent-failure UX taught us to avoid.
     let opencodeConfigContent: string | null = null;
-    if (
-      def.externalMcpInjection === 'opencode-env-content' &&
-      enabledExternalMcp.length > 0
-    ) {
+    if (def.externalMcpInjection === 'opencode-env-content') {
       try {
         opencodeConfigContent = buildOpenCodeMcpConfigContent(
           enabledExternalMcp,
           oauthTokensForSpawn,
+          {
+            allowedDirectories: [effectiveCwd, ...extraAllowedDirs],
+          },
         );
       } catch (err) {
         console.warn(

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -218,6 +218,117 @@ process.exit(0);
     );
   });
 
+  it('passes OPENCODE_CONFIG_CONTENT external_directory rules for the managed project cwd', async () => {
+    if (!process.env.OD_DATA_DIR) {
+      throw new Error('OD_DATA_DIR is required for OpenCode cwd permission tests');
+    }
+
+    const projectId = `proj-${randomUUID()}`;
+    const markerDir = await fsp.mkdtemp(join(tmpdir(), 'od-opencode-config-'));
+    tempDirs.push(markerDir);
+    const envFile = join(markerDir, 'opencode-config-content.json');
+    const cwdFile = join(markerDir, 'cwd.txt');
+
+    const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: projectId, name: 'OpenCode cwd permission fixture' }),
+    });
+    expect(createProjectResponse.ok).toBe(true);
+
+    await withFakeAgent(
+      'opencode',
+      `
+const fs = require('node:fs');
+process.stdin.resume();
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(envFile)}, process.env.OPENCODE_CONFIG_CONTENT || '');
+  fs.writeFileSync(${JSON.stringify(cwdFile)}, process.cwd());
+  console.log(JSON.stringify({ type: 'step_start' }));
+  console.log(JSON.stringify({ type: 'text', part: { text: 'cwd-permission-ok' } }));
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+});
+`,
+      async () => {
+        const response = await fetch(`${baseUrl}/api/chat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            projectId,
+            message: 'hello',
+          }),
+        });
+        const body = await response.text();
+
+        expect(response.ok).toBe(true);
+        expect(body).toContain('cwd-permission-ok');
+
+        const effectiveCwd = (await fsp.readFile(cwdFile, 'utf8')).trim();
+        const raw = await fsp.readFile(envFile, 'utf8');
+        const parsed = JSON.parse(raw) as {
+          permission?: {
+            external_directory?: Record<string, string>;
+          };
+        };
+
+        expect(parsed.permission?.external_directory).toMatchObject({
+          [effectiveCwd]: 'allow',
+          [`${effectiveCwd}/*`]: 'allow',
+          [`${effectiveCwd}/**`]: 'allow',
+        });
+      },
+    );
+  });
+
+  it('strips inherited OpenCode server auth env before spawning the opencode CLI', async () => {
+    const inheritedPassword = process.env.OPENCODE_SERVER_PASSWORD;
+    process.env.OPENCODE_SERVER_PASSWORD = 'test-parent-server-password';
+
+    const markerDir = await fsp.mkdtemp(join(tmpdir(), 'od-opencode-env-'));
+    tempDirs.push(markerDir);
+    const envFile = join(markerDir, 'opencode-server-password.txt');
+
+    try {
+      await withFakeAgent(
+        'opencode',
+        `
+const fs = require('node:fs');
+process.stdin.resume();
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(envFile)}, process.env.OPENCODE_SERVER_PASSWORD || '');
+  console.log(JSON.stringify({ type: 'step_start' }));
+  console.log(JSON.stringify({ type: 'text', part: { text: 'opencode-env-ok' } }));
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+});
+`,
+        async () => {
+          const response = await fetch(`${baseUrl}/api/chat`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              agentId: 'opencode',
+              message: 'hello',
+            }),
+          });
+          const body = await response.text();
+
+          expect(response.ok).toBe(true);
+          expect(body).toContain('opencode-env-ok');
+          expect(await fsp.readFile(envFile, 'utf8')).toBe('');
+        },
+      );
+    } finally {
+      if (inheritedPassword == null) {
+        delete process.env.OPENCODE_SERVER_PASSWORD;
+      } else {
+        process.env.OPENCODE_SERVER_PASSWORD = inheritedPassword;
+      }
+    }
+  });
+
 
   it('reuses an existing assistant message row instead of creating a duplicate when assistantMessageId is supplied', async () => {
     if (!process.env.OD_DATA_DIR) {

--- a/apps/daemon/tests/mcp-config.test.ts
+++ b/apps/daemon/tests/mcp-config.test.ts
@@ -406,6 +406,75 @@ describe('buildOpenCodeMcpConfigContent', () => {
     ).toBeNull();
   });
 
+  it('emits an external_directory allowlist when the daemon grants OpenCode absolute project dirs', () => {
+    const raw = buildOpenCodeMcpConfigContent(
+      [],
+      {},
+      {
+        allowedDirectories: [
+          '/tmp/od-project',
+          '',
+          'relative/path',
+          '/tmp/od-skills',
+          '/tmp/od-project',
+        ],
+      },
+    );
+
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw as string) as {
+      permission?: {
+        external_directory?: Record<string, string>;
+      };
+      mcp?: Record<string, unknown>;
+    };
+
+    expect(parsed.mcp).toBeUndefined();
+    expect(parsed.permission?.external_directory).toEqual({
+      '/tmp/od-project': 'allow',
+      '/tmp/od-project/*': 'allow',
+      '/tmp/od-project/**': 'allow',
+      '/tmp/od-skills': 'allow',
+      '/tmp/od-skills/*': 'allow',
+      '/tmp/od-skills/**': 'allow',
+    });
+  });
+
+  it('merges MCP servers and granted external_directory rules into one payload', () => {
+    const raw = buildOpenCodeMcpConfigContent(
+      [
+        {
+          id: 'basic-memory',
+          transport: 'stdio',
+          enabled: true,
+          command: '/opt/homebrew/bin/uvx',
+          args: ['basic-memory', 'mcp'],
+        },
+      ],
+      {},
+      { allowedDirectories: ['/tmp/od-project'] },
+    );
+
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw as string) as {
+      permission?: {
+        external_directory?: Record<string, string>;
+      };
+      mcp: Record<string, Record<string, unknown>>;
+    };
+
+    expect(parsed.mcp['basic-memory']).toEqual({
+      type: 'local',
+      command: ['/opt/homebrew/bin/uvx', 'basic-memory', 'mcp'],
+      enabled: true,
+    });
+    expect(parsed.permission?.external_directory).toMatchObject({
+      '/tmp/od-project': 'allow',
+      '/tmp/od-project/*': 'allow',
+      '/tmp/od-project/**': 'allow',
+    });
+  });
+
   it('serialises a stdio server to OpenCode local schema (type=local, command=[cmd,...args])', () => {
     const raw = buildOpenCodeMcpConfigContent([
       {


### PR DESCRIPTION
Fixes #3807

## Why

Building on top of Open Design with OpenCode as the agent runner, I hit two
bugs that made the runner unusable in headless mode: immediate `Session not
found` on every spawn, and `external_directory` auto-rejection when opencode
tried to read/write project files. Both break the local agent workflow entirely.

## What users will see

OpenCode agent runs inside Open Design now start and complete successfully
instead of failing immediately. No UI or setting changes; the fix is transparent.

Previously:
- OpenCode run -> instant `Error: Session not found` (especially when launched
  from within an OpenCode session)
- OpenCode run -> auto-rejects project directory access

Now:
- OpenCode run proceeds normally, producing output and file changes
- Project cwd and staged directories are granted automatically

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal daemon fix (env stripping + config payload), tests only

## Bug fix verification

- Test path: `apps/daemon/tests/chat-route.test.ts` ->
  `strips inherited OpenCode server auth env before spawning the opencode CLI`
- Test path: `apps/daemon/tests/chat-route.test.ts` ->
  `passes OPENCODE_CONFIG_CONTENT external_directory rules for the managed project cwd`
- Test path: `apps/daemon/tests/mcp-config.test.ts` ->
  `emits an external_directory allowlist when the daemon grants OpenCode absolute project dirs`
- Test path: `apps/daemon/tests/mcp-config.test.ts` ->
  `merges MCP servers and granted external_directory rules into one payload`
- All four tests went red on `main` and green on this branch

## Validation

```bash
pnpm guard
pnpm typecheck
pnpm --filter @open-design/daemon build
pnpm exec vitest run tests/mcp-config.test.ts --reporter=dot    # 84/84 pass
pnpm exec vitest run tests/chat-route.test.ts --reporter=dot    # 51/51 pass
```
