### PR TITLE
fix(web): relax standalone readiness probe

### DIFF
--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -10,7 +10,7 @@ import { request as createHttpsRequest } from "node:https";
 import { existsSync, readFileSync } from "node:fs";
 import { readFile, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { createServer as createTcpServer, type AddressInfo, type Server as TcpServer } from "node:net";
+import { createConnection, createServer as createTcpServer, type AddressInfo, type Server as TcpServer } from "node:net";
 import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -510,6 +510,8 @@ async function stopStandaloneChild(child: ChildProcess): Promise<void> {
 }
 
 async function probeStandaloneBackend(origin: string): Promise<boolean> {
+  if (await probeStandaloneBackendPort(origin)) return true;
+
   return await new Promise<boolean>((resolveProbe) => {
     const request = createHttpRequest(new URL("/", origin), { method: "HEAD", timeout: 800 }, (response) => {
       response.resume();
@@ -521,6 +523,32 @@ async function probeStandaloneBackend(origin: string): Promise<boolean> {
     });
     request.on("error", () => resolveProbe(false));
     request.end();
+  });
+}
+
+async function probeStandaloneBackendPort(origin: string): Promise<boolean> {
+  let parsed: URL;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    return false;
+  }
+  const port = Number(parsed.port || defaultPortForProtocol(parsed.protocol));
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return false;
+  const host = parsed.hostname.replace(/^\[(.*)\]$/, "$1");
+
+  return await new Promise<boolean>((resolveProbe) => {
+    const socket = createConnection({ host, port });
+    let settled = false;
+    const settle = (ready: boolean) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolveProbe(ready);
+    };
+    socket.setTimeout(800, () => settle(false));
+    socket.once("connect", () => settle(true));
+    socket.once("error", () => settle(false));
   });
 }
 

--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -42,6 +42,8 @@ const WEB_STANDALONE_ROOT_ENV = "OD_WEB_STANDALONE_ROOT";
 const STANDALONE_PARENT_PID_ENV = "OD_STANDALONE_PARENT_PID";
 const STANDALONE_STARTUP_TIMEOUT_ENV = "OD_STANDALONE_STARTUP_TIMEOUT_MS";
 const SHUTDOWN_TIMEOUT_MS = 3000;
+const STANDALONE_READINESS_POLL_MS = 150;
+const STANDALONE_TCP_READINESS_GRACE_MS = STANDALONE_READINESS_POLL_MS;
 const require = createRequire(import.meta.url);
 
 type NextApp = {
@@ -509,9 +511,15 @@ async function stopStandaloneChild(child: ChildProcess): Promise<void> {
   }
 }
 
-async function probeStandaloneBackend(origin: string): Promise<boolean> {
-  if (await probeStandaloneBackendPort(origin)) return true;
+type StandaloneBackendProbeResult = "http" | "tcp" | null;
 
+async function probeStandaloneBackend(origin: string): Promise<StandaloneBackendProbeResult> {
+  if (await probeStandaloneBackendPort(origin)) return "tcp";
+  if (await probeStandaloneBackendHttp(origin)) return "http";
+  return null;
+}
+
+async function probeStandaloneBackendHttp(origin: string): Promise<boolean> {
   return await new Promise<boolean>((resolveProbe) => {
     const request = createHttpRequest(new URL("/", origin), { method: "HEAD", timeout: 800 }, (response) => {
       response.resume();
@@ -552,6 +560,38 @@ async function probeStandaloneBackendPort(origin: string): Promise<boolean> {
   });
 }
 
+function createStandaloneChildExitError(child: ChildProcess, startedAt: number): Error {
+  const elapsedMs = Date.now() - startedAt;
+  const likelyPortRace = elapsedMs <= 200;
+  return new Error(
+    `standalone Next.js server exited before readiness after ${elapsedMs}ms: code=${child.exitCode} signal=${child.signalCode}`
+    + (likelyPortRace
+      ? "; the reserved startup port may have been claimed before the child process bound it, retry the launch"
+      : ""),
+  );
+}
+
+function throwIfStandaloneChildExited(child: ChildProcess, startedAt: number): void {
+  if (child.exitCode == null && child.signalCode == null) return;
+  throw createStandaloneChildExitError(child, startedAt);
+}
+
+async function waitForStandaloneTcpReadinessGrace(child: ChildProcess): Promise<void> {
+  if (child.exitCode != null || child.signalCode != null) return;
+
+  await new Promise<void>((resolveWait) => {
+    let timeout: NodeJS.Timeout | undefined;
+    const finish = () => {
+      if (timeout != null) clearTimeout(timeout);
+      child.off("exit", finish);
+      resolveWait();
+    };
+    timeout = setTimeout(finish, STANDALONE_TCP_READINESS_GRACE_MS);
+    timeout.unref();
+    child.once("exit", finish);
+  });
+}
+
 async function waitForStandaloneBackendReady(
   child: ChildProcess,
   origin: string,
@@ -560,18 +600,16 @@ async function waitForStandaloneBackendReady(
   const startedAt = Date.now();
 
   while (Date.now() - startedAt < timeoutMs) {
-    if (child.exitCode != null || child.signalCode != null) {
-      const elapsedMs = Date.now() - startedAt;
-      const likelyPortRace = elapsedMs <= 200;
-      throw new Error(
-        `standalone Next.js server exited before readiness after ${elapsedMs}ms: code=${child.exitCode} signal=${child.signalCode}`
-        + (likelyPortRace
-          ? "; the reserved startup port may have been claimed before the child process bound it, retry the launch"
-          : ""),
-      );
+    throwIfStandaloneChildExited(child, startedAt);
+    const readiness = await probeStandaloneBackend(origin);
+    if (readiness != null) {
+      if (readiness === "tcp") {
+        await waitForStandaloneTcpReadinessGrace(child);
+      }
+      throwIfStandaloneChildExited(child, startedAt);
+      return;
     }
-    if (await probeStandaloneBackend(origin)) return;
-    await new Promise((resolveWait) => setTimeout(resolveWait, 150));
+    await new Promise((resolveWait) => setTimeout(resolveWait, STANDALONE_READINESS_POLL_MS));
   }
 
   throw new Error(`timed out after ${timeoutMs}ms waiting for standalone Next.js server at ${origin}; override with ${STANDALONE_STARTUP_TIMEOUT_ENV}`);

--- a/apps/web/tests/sidecar-proxy.test.ts
+++ b/apps/web/tests/sidecar-proxy.test.ts
@@ -12,6 +12,7 @@ import {
   resolveDaemonProxyTarget,
   resolveStandaloneBackendOrigin,
   resolveStandaloneServerEntry,
+  startWebSidecar,
 } from '../sidecar/server';
 
 describe('resolveDaemonProxyTarget', () => {
@@ -136,6 +137,62 @@ describe('standalone backend binding', () => {
     expect(env.PORT).toBe('5876');
     expect(env.NODE_ENV).toBe('production');
     expect(env.OD_STANDALONE_PARENT_PID).toBe('1234');
+  });
+
+  it('accepts a listening standalone backend before the app root responds to HTTP', async () => {
+    const previousOutputMode = process.env.OD_WEB_OUTPUT_MODE;
+    const previousStandaloneRoot = process.env.OD_WEB_STANDALONE_ROOT;
+    const previousStartupTimeout = process.env.OD_STANDALONE_STARTUP_TIMEOUT_MS;
+    const standaloneRoot = await mkdtemp(join(tmpdir(), 'open-design-web-slow-http-'));
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'open-design-web-runtime-'));
+    const fakeWebRoot = join(standaloneRoot, 'apps', 'web');
+
+    try {
+      await mkdir(fakeWebRoot, { recursive: true });
+      await writeFile(
+        join(fakeWebRoot, 'server.js'),
+        `
+import { createServer } from 'node:net';
+
+const server = createServer(() => {
+  // Keep accepted sockets open. A TCP readiness probe should pass, but an
+  // HTTP HEAD/GET probe against "/" will hang until its client timeout.
+});
+
+server.listen(Number(process.env.PORT), process.env.HOSTNAME || '127.0.0.1');
+process.on('SIGTERM', () => server.close(() => process.exit(0)));
+`,
+        'utf8',
+      );
+
+      process.env.OD_WEB_OUTPUT_MODE = 'standalone';
+      process.env.OD_WEB_STANDALONE_ROOT = standaloneRoot;
+      process.env.OD_STANDALONE_STARTUP_TIMEOUT_MS = '500';
+
+      const handle = await startWebSidecar({
+        app: 'web',
+        base: runtimeRoot,
+        ipc: join(runtimeRoot, 'web.sock'),
+        mode: 'runtime',
+        namespace: 'slow-http',
+        source: 'tools-pack',
+      });
+
+      try {
+        await expect(handle.status()).resolves.toMatchObject({ state: 'running' });
+      } finally {
+        await handle.stop();
+      }
+    } finally {
+      if (previousOutputMode == null) delete process.env.OD_WEB_OUTPUT_MODE;
+      else process.env.OD_WEB_OUTPUT_MODE = previousOutputMode;
+      if (previousStandaloneRoot == null) delete process.env.OD_WEB_STANDALONE_ROOT;
+      else process.env.OD_WEB_STANDALONE_ROOT = previousStandaloneRoot;
+      if (previousStartupTimeout == null) delete process.env.OD_STANDALONE_STARTUP_TIMEOUT_MS;
+      else process.env.OD_STANDALONE_STARTUP_TIMEOUT_MS = previousStartupTimeout;
+      await rm(standaloneRoot, { force: true, recursive: true });
+      await rm(runtimeRoot, { force: true, recursive: true });
+    }
   });
 });
 

--- a/apps/web/tests/sidecar-proxy.test.ts
+++ b/apps/web/tests/sidecar-proxy.test.ts
@@ -194,6 +194,74 @@ process.on('SIGTERM', () => server.close(() => process.exit(0)));
       await rm(runtimeRoot, { force: true, recursive: true });
     }
   });
+
+  it('does not treat a hijacked backend port as standalone readiness', async () => {
+    const previousOutputMode = process.env.OD_WEB_OUTPUT_MODE;
+    const previousStandaloneRoot = process.env.OD_WEB_STANDALONE_ROOT;
+    const previousStartupTimeout = process.env.OD_STANDALONE_STARTUP_TIMEOUT_MS;
+    const standaloneRoot = await mkdtemp(join(tmpdir(), 'open-design-web-hijacked-port-'));
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'open-design-web-hijacked-runtime-'));
+    const fakeWebRoot = join(standaloneRoot, 'apps', 'web');
+    let handle: Awaited<ReturnType<typeof startWebSidecar>> | undefined;
+
+    try {
+      await mkdir(fakeWebRoot, { recursive: true });
+      await writeFile(
+        join(fakeWebRoot, 'server.js'),
+        `
+import { createServer } from 'node:net';
+
+const host = process.env.HOSTNAME || '127.0.0.1';
+const port = Number(process.env.PORT);
+let sawProbe = false;
+const dummyServer = createServer((socket) => {
+  socket.end();
+  if (!sawProbe) {
+    sawProbe = true;
+    setTimeout(() => process.exit(70), 100);
+  }
+});
+
+dummyServer.listen(port, host, () => {
+  const intendedServer = createServer();
+  intendedServer.once('error', () => {
+    // Keep the dummy listener alive until the readiness probe connects, then
+    // surface the failed intended bind like a port-race crash.
+  });
+  intendedServer.listen(port, host);
+});
+
+process.on('SIGTERM', () => dummyServer.close(() => process.exit(0)));
+`,
+        'utf8',
+      );
+
+      process.env.OD_WEB_OUTPUT_MODE = 'standalone';
+      process.env.OD_WEB_STANDALONE_ROOT = standaloneRoot;
+      process.env.OD_STANDALONE_STARTUP_TIMEOUT_MS = '1000';
+
+      await expect((async () => {
+        handle = await startWebSidecar({
+          app: 'web',
+          base: runtimeRoot,
+          ipc: join(runtimeRoot, 'web.sock'),
+          mode: 'runtime',
+          namespace: 'hijacked-port',
+          source: 'tools-pack',
+        });
+      })()).rejects.toThrow(/standalone Next\.js server exited before readiness/);
+    } finally {
+      await handle?.stop();
+      if (previousOutputMode == null) delete process.env.OD_WEB_OUTPUT_MODE;
+      else process.env.OD_WEB_OUTPUT_MODE = previousOutputMode;
+      if (previousStandaloneRoot == null) delete process.env.OD_WEB_STANDALONE_ROOT;
+      else process.env.OD_WEB_STANDALONE_ROOT = previousStandaloneRoot;
+      if (previousStartupTimeout == null) delete process.env.OD_STANDALONE_STARTUP_TIMEOUT_MS;
+      else process.env.OD_STANDALONE_STARTUP_TIMEOUT_MS = previousStartupTimeout;
+      await rm(standaloneRoot, { force: true, recursive: true });
+      await rm(runtimeRoot, { force: true, recursive: true });
+    }
+  });
 });
 
 describe('normalizeDaemonProxyOriginHeader', () => {


### PR DESCRIPTION
## Why

While validating a Windows Portable package, the packaged desktop could show the splash screen and then exit because the web sidecar timed out waiting for the standalone Next.js backend readiness check. The backend process had already started, but the sidecar only treated `HEAD /` as readiness, so startup could fail when the loopback port was listening but the root route did not respond to the probe quickly enough.

This fixes the packaged startup path without increasing the timeout as the primary workaround.

## What users will see

Windows packaged/Portable users should be less likely to see the app close during startup when the standalone web backend is already accepting loopback connections. There is no new UI or setting.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/sidecar-proxy.test.ts`
- Did the test go red on `main` and green on this branch? yes — the new test times out on the old `HEAD /`-only readiness check and passes after accepting a listening standalone backend port as ready.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/sidecar-proxy.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `git diff --check upstream/main...HEAD`
- `pnpm guard`
- `pnpm typecheck`
- Pre-PR subagent review requested at `gpt-5.3-codex-spark` / `xhigh`; reviewer found no issues.
