### PR TITLE
feat(web): move working-dir pill to composer and label default storage

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -278,6 +278,10 @@ interface Props {
   // ChatPane). Pass `null` (or omit) to render the full rail.
   pinnedPluginId?: string | null;
   footerAccessory?: ReactNode;
+  // Slot rendered in the composer's bottom toolbar, immediately right of the
+  // "+" menu. Hosts the working-directory pill so the folder selector sits by
+  // the composer (mirroring the home input) instead of the file-panel header.
+  leadingAccessory?: ReactNode;
   // Design-system picker slot rendered at the top of the composer (above
   // the textarea). The former standalone chrome header row was removed;
   // ProjectView owns the project record so it renders the picker as a slot.
@@ -382,6 +386,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       onProjectSkillChange,
       pinnedPluginId = null,
       footerAccessory,
+      leadingAccessory,
       designSystemPicker,
       currentDesignSystemId = null,
       onActiveDesignSystemChange,
@@ -2133,6 +2138,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                 />
               )}
             />
+            {leadingAccessory}
             <span className="composer-spacer" />
             {footerAccessory}
             <SessionModeToggle

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -573,6 +573,8 @@ interface Props {
   byokSpeechVoice?: string;
   onChangeByokSpeechVoice?: (voice: string) => void;
   composerFooterAccessory?: ReactNode;
+  // Slot rendered next to the composer's "+" menu (e.g. the working-dir pill).
+  composerLeadingAccessory?: ReactNode;
   // Forwarded straight to the chat composer's mid-chat design-system
   // switcher. ProjectView owns the project record so the parent is the
   // natural place to mirror the patched project after a PATCH lands.
@@ -720,6 +722,7 @@ export function ChatPane({
   onChangeByokSpeechModel,
   byokSpeechVoice,
   onChangeByokSpeechVoice,
+  composerLeadingAccessory,
   composerFooterAccessory,
   currentDesignSystemId,
   onActiveDesignSystemChange,
@@ -1663,6 +1666,7 @@ export function ChatPane({
       onProjectSkillChange={onProjectSkillChange}
       pinnedPluginId={activePluginSnapshot?.pluginId ?? null}
       footerAccessory={composerFooterAccessory}
+      leadingAccessory={composerLeadingAccessory}
       currentDesignSystemId={currentDesignSystemId}
       onActiveDesignSystemChange={onActiveDesignSystemChange}
       onShowToast={onShowToast}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5500,6 +5500,28 @@ export function ProjectView({
               onBack={onBack}
               backLabel={t('project.backToProjects')}
               composerFooterAccessory={executionControls}
+              composerLeadingAccessory={(
+                <WorkingDirPill
+                  projectId={project.id}
+                  resolvedDir={projectDetail.resolvedDir}
+                  onReplaced={({ project: updated }) => {
+                    if (updated) onProjectChange(updated);
+                    // The new working dir has a different file tree, so the
+                    // current listing, breadcrumb nav, and open tabs are all
+                    // stale. Refetch files; DesignFilesPanel's self-heal then
+                    // drops the now-unmatched currentDir back to root.
+                    // projectDetail.refresh() repulls resolvedDir so the
+                    // breadcrumb root + pill show the new folder name even on
+                    // the Electron path, which reports no updated project.
+                    setWorkingDirReplacing(true);
+                    refreshFilesAndDesignMd();
+                    void Promise.all([
+                      refreshWorkspaceItems(),
+                      projectDetail.refresh(),
+                    ]).finally(() => setWorkingDirReplacing(false));
+                  }}
+                />
+              )}
               projectHeader={(
                 <span className="chat-project-title-line">
                   <span
@@ -5663,26 +5685,6 @@ export function ProjectView({
           conversationId={activeConversationId}
           headerActions={(
             <>
-              <WorkingDirPill
-                projectId={project.id}
-                resolvedDir={projectDetail.resolvedDir}
-                onReplaced={({ project: updated }) => {
-                  if (updated) onProjectChange(updated);
-                  // The new working dir has a different file tree, so the
-                  // current listing, breadcrumb nav, and open tabs are all
-                  // stale. Refetch files; DesignFilesPanel's self-heal then
-                  // drops the now-unmatched currentDir back to root.
-                  // projectDetail.refresh() repulls resolvedDir so the
-                  // breadcrumb root + pill show the new folder name even on
-                  // the Electron path, which reports no updated project.
-                  setWorkingDirReplacing(true);
-                  refreshFilesAndDesignMd();
-                  void Promise.all([
-                    refreshWorkspaceItems(),
-                    projectDetail.refresh(),
-                  ]).finally(() => setWorkingDirReplacing(false));
-                }}
-              />
               <EntrySettingsMenu
                 config={config}
                 onThemeChange={handleThemeChange}

--- a/apps/web/src/components/WorkingDirPill.tsx
+++ b/apps/web/src/components/WorkingDirPill.tsx
@@ -56,6 +56,11 @@ export function WorkingDirPill({ projectId, resolvedDir: propResolvedDir, onRepl
   }, [projectId, propResolvedDir]);
 
   const resolvedDir = fetchedDir ?? propResolvedDir ?? null;
+  // Default-storage projects live at `.od/projects/<projectId>`, so the
+  // working dir's basename is the raw project UUID. Surfacing that to users
+  // is meaningless noise; show a friendly label instead. A user-picked /
+  // imported folder has a real basename and falls through to `shortPath`.
+  const isDefaultStorage = resolvedDir != null && shortPath(resolvedDir) === projectId;
 
   useEffect(() => {
     if (!open) return;
@@ -171,11 +176,17 @@ export function WorkingDirPill({ projectId, resolvedDir: propResolvedDir, onRepl
         data-testid="working-dir-pill-trigger"
         onClick={() => setOpen((value) => !value)}
         disabled={busy}
-        title={resolvedDir ?? t('workingDirPicker.title')}
+        title={isDefaultStorage ? t('workingDirPicker.defaultLabel') : (resolvedDir ?? t('workingDirPicker.title'))}
       >
         <Icon name="folder" size={12} />
         <span className="working-dir-pill-label">
-          {busy ? t('workingDirPicker.processing') : resolvedDir ? shortPath(resolvedDir) : t('workingDirPicker.select')}
+          {busy
+            ? t('workingDirPicker.processing')
+            : isDefaultStorage
+              ? t('workingDirPicker.defaultLabel')
+              : resolvedDir
+                ? shortPath(resolvedDir)
+                : t('workingDirPicker.select')}
         </span>
         <Icon name="chevron-down" size={10} />
       </button>

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -542,6 +542,7 @@ export const ar: Dict = {
   'workingDirPicker.showInFileManager': 'إظهار في مدير الملفات',
   'workingDirPicker.replace': 'استبدال الدليل…',
   'workingDirPicker.recent': 'الأدلّة الأخيرة',
+  'workingDirPicker.defaultLabel': 'التخزين المحلي',
   'handoff.toTarget': 'التسليم إلى {target}',
   'handoff.openInTarget': 'فتح في {target}',
   'handoff.openAction': 'فتح',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -542,6 +542,7 @@ export const de: Dict = {
   'workingDirPicker.showInFileManager': 'Im Dateimanager anzeigen',
   'workingDirPicker.replace': 'Verzeichnis ersetzen…',
   'workingDirPicker.recent': 'Zuletzt verwendete Verzeichnisse',
+  'workingDirPicker.defaultLabel': 'Lokaler Speicher',
   'handoff.toTarget': 'An {target} übergeben',
   'handoff.openInTarget': 'In {target} öffnen',
   'handoff.openAction': 'Öffnen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -542,6 +542,7 @@ export const en: Dict = {
   'workingDirPicker.showInFileManager': 'Show in file manager',
   'workingDirPicker.replace': 'Replace directory…',
   'workingDirPicker.recent': 'Recent directories',
+  'workingDirPicker.defaultLabel': 'Local storage',
   'handoff.toTarget': 'Hand off to {target}',
   'handoff.openInTarget': 'Open in {target}',
   'handoff.openAction': 'Open',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -542,6 +542,7 @@ export const esES: Dict = {
   'workingDirPicker.showInFileManager': 'Mostrar en el explorador de archivos',
   'workingDirPicker.replace': 'Reemplazar directorio…',
   'workingDirPicker.recent': 'Directorios recientes',
+  'workingDirPicker.defaultLabel': 'Almacenamiento local',
   'handoff.toTarget': 'Transferir a {target}',
   'handoff.openInTarget': 'Abrir en {target}',
   'handoff.openAction': 'Abrir',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -542,6 +542,7 @@ export const fa: Dict = {
   'workingDirPicker.showInFileManager': 'نمایش در مدیر فایل',
   'workingDirPicker.replace': 'جایگزینی دایرکتوری…',
   'workingDirPicker.recent': 'دایرکتوری‌های اخیر',
+  'workingDirPicker.defaultLabel': 'حافظهٔ محلی',
   'handoff.toTarget': 'واگذاری به {target}',
   'handoff.openInTarget': 'باز کردن در {target}',
   'handoff.openAction': 'باز کردن',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -542,6 +542,7 @@ export const fr: Dict = {
   'workingDirPicker.showInFileManager': 'Afficher dans le gestionnaire de fichiers',
   'workingDirPicker.replace': 'Remplacer le dossier…',
   'workingDirPicker.recent': 'Dossiers récents',
+  'workingDirPicker.defaultLabel': 'Stockage local',
   'handoff.toTarget': 'Transférer vers {target}',
   'handoff.openInTarget': 'Ouvrir dans {target}',
   'handoff.openAction': 'Ouvrir',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -542,6 +542,7 @@ export const hu: Dict = {
   'workingDirPicker.showInFileManager': 'Megjelenítés a fájlkezelőben',
   'workingDirPicker.replace': 'Könyvtár cseréje…',
   'workingDirPicker.recent': 'Legutóbbi könyvtárak',
+  'workingDirPicker.defaultLabel': 'Helyi tárhely',
   'handoff.toTarget': 'Átadás ide: {target}',
   'handoff.openInTarget': 'Megnyitás itt: {target}',
   'handoff.openAction': 'Megnyitás',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -542,6 +542,7 @@ export const id: Dict = {
   'workingDirPicker.showInFileManager': 'Tampilkan di pengelola berkas',
   'workingDirPicker.replace': 'Ganti direktori…',
   'workingDirPicker.recent': 'Direktori terbaru',
+  'workingDirPicker.defaultLabel': 'Penyimpanan lokal',
   'handoff.toTarget': 'Serahkan ke {target}',
   'handoff.openInTarget': 'Buka di {target}',
   'handoff.openAction': 'Buka',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -542,6 +542,7 @@ export const it: Dict = {
   'workingDirPicker.showInFileManager': 'Mostra nel file manager',
   'workingDirPicker.replace': 'Sostituisci directory…',
   'workingDirPicker.recent': 'Directory recenti',
+  'workingDirPicker.defaultLabel': 'Archiviazione locale',
   'handoff.toTarget': 'Passa a {target}',
   'handoff.openInTarget': 'Apri in {target}',
   'handoff.openAction': 'Apri',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -542,6 +542,7 @@ export const ja: Dict = {
   'workingDirPicker.showInFileManager': 'ファイルマネージャーで表示',
   'workingDirPicker.replace': 'ディレクトリを置き換え…',
   'workingDirPicker.recent': '最近使用したディレクトリ',
+  'workingDirPicker.defaultLabel': 'ローカルストレージ',
   'handoff.toTarget': '{target}に引き継ぐ',
   'handoff.openInTarget': '{target}で開く',
   'handoff.openAction': '開く',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -542,6 +542,7 @@ export const ko: Dict = {
   'workingDirPicker.showInFileManager': '파일 관리자에서 표시',
   'workingDirPicker.replace': '디렉터리 교체…',
   'workingDirPicker.recent': '최근 디렉터리',
+  'workingDirPicker.defaultLabel': '로컬 저장소',
   'handoff.toTarget': '{target}(으)로 넘기기',
   'handoff.openInTarget': '{target}에서 열기',
   'handoff.openAction': '열기',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -542,6 +542,7 @@ export const pl: Dict = {
   'workingDirPicker.showInFileManager': 'Pokaż w menedżerze plików',
   'workingDirPicker.replace': 'Zamień katalog…',
   'workingDirPicker.recent': 'Ostatnie katalogi',
+  'workingDirPicker.defaultLabel': 'Pamięć lokalna',
   'handoff.toTarget': 'Przekaż do {target}',
   'handoff.openInTarget': 'Otwórz w {target}',
   'handoff.openAction': 'Otwórz',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -542,6 +542,7 @@ export const ptBR: Dict = {
   'workingDirPicker.showInFileManager': 'Mostrar no gerenciador de arquivos',
   'workingDirPicker.replace': 'Substituir diretório…',
   'workingDirPicker.recent': 'Diretórios recentes',
+  'workingDirPicker.defaultLabel': 'Armazenamento local',
   'handoff.toTarget': 'Transferir para {target}',
   'handoff.openInTarget': 'Abrir em {target}',
   'handoff.openAction': 'Abrir',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -542,6 +542,7 @@ export const ru: Dict = {
   'workingDirPicker.showInFileManager': 'Показать в файловом менеджере',
   'workingDirPicker.replace': 'Заменить каталог…',
   'workingDirPicker.recent': 'Недавние каталоги',
+  'workingDirPicker.defaultLabel': 'Локальное хранилище',
   'handoff.toTarget': 'Передать в {target}',
   'handoff.openInTarget': 'Открыть в {target}',
   'handoff.openAction': 'Открыть',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -542,6 +542,7 @@ export const th: Dict = {
   'workingDirPicker.showInFileManager': 'แสดงในตัวจัดการไฟล์',
   'workingDirPicker.replace': 'แทนที่ไดเรกทอรี…',
   'workingDirPicker.recent': 'ไดเรกทอรีล่าสุด',
+  'workingDirPicker.defaultLabel': 'พื้นที่จัดเก็บในเครื่อง',
   'handoff.toTarget': 'ส่งต่อไปยัง {target}',
   'handoff.openInTarget': 'เปิดใน {target}',
   'handoff.openAction': 'เปิด',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -542,6 +542,7 @@ export const tr: Dict = {
   'workingDirPicker.showInFileManager': 'Dosya yöneticisinde göster',
   'workingDirPicker.replace': 'Dizini değiştir…',
   'workingDirPicker.recent': 'Son dizinler',
+  'workingDirPicker.defaultLabel': 'Yerel depolama',
   'handoff.toTarget': '{target} öğesine devret',
   'handoff.openInTarget': '{target} içinde aç',
   'handoff.openAction': 'Aç',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -542,6 +542,7 @@ export const uk: Dict = {
   'workingDirPicker.showInFileManager': 'Показати у файловому менеджері',
   'workingDirPicker.replace': 'Замінити каталог…',
   'workingDirPicker.recent': 'Нещодавні каталоги',
+  'workingDirPicker.defaultLabel': 'Локальне сховище',
   'handoff.toTarget': 'Передати в {target}',
   'handoff.openInTarget': 'Відкрити в {target}',
   'handoff.openAction': 'Відкрити',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -542,6 +542,7 @@ export const zhCN: Dict = {
   'workingDirPicker.showInFileManager': '在文件管理器中显示',
   'workingDirPicker.replace': '替换目录…',
   'workingDirPicker.recent': '最近使用的目录',
+  'workingDirPicker.defaultLabel': '本地存储',
   'handoff.toTarget': '交付给 {target}',
   'handoff.openInTarget': '在 {target} 中打开',
   'handoff.openAction': '打开',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -542,6 +542,7 @@ export const zhTW: Dict = {
   'workingDirPicker.showInFileManager': '在檔案管理器中顯示',
   'workingDirPicker.replace': '替換目錄…',
   'workingDirPicker.recent': '最近使用的目錄',
+  'workingDirPicker.defaultLabel': '本機儲存',
   'handoff.toTarget': '交付給 {target}',
   'handoff.openInTarget': '在 {target} 中開啟',
   'handoff.openAction': '開啟',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -900,6 +900,7 @@ export interface Dict {
   'workingDirPicker.showInFileManager': string;
   'workingDirPicker.replace': string;
   'workingDirPicker.recent': string;
+  'workingDirPicker.defaultLabel': string;
   'handoff.toTarget': string;
   'handoff.openInTarget': string;
   'handoff.openAction': string;

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -1588,13 +1588,20 @@
   color: var(--text-faint);
   cursor: default;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill {
+/* The pill renders under `.app` (legacy header host) and under
+   `.chat-composer-fixed-layer` (its current home in the composer toolbar).
+   Paired selectors cover both contexts — matching the `.icon-btn` convention
+   above — instead of `:is(.app, .chat-composer-fixed-layer)`, whose inner
+   comma would also break selector-literal style tests. */
+.app .working-dir-pill,
+.chat-composer-fixed-layer .working-dir-pill {
   position: relative;
   display: inline-flex;
   margin-top: 0;
   font-size: 11.5px;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-trigger {
+.app .working-dir-pill-trigger,
+.chat-composer-fixed-layer .working-dir-pill-trigger {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -1607,20 +1614,24 @@
   color: var(--text-muted);
   cursor: pointer;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-trigger:hover {
+.app .working-dir-pill-trigger:hover,
+.chat-composer-fixed-layer .working-dir-pill-trigger:hover {
   background: color-mix(in srgb, var(--text-muted) 6%, var(--bg-panel));
   border-color: var(--border-strong, var(--border));
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-trigger:disabled {
+.app .working-dir-pill-trigger:disabled,
+.chat-composer-fixed-layer .working-dir-pill-trigger:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-label {
+.app .working-dir-pill-label,
+.chat-composer-fixed-layer .working-dir-pill-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu {
+.app .working-dir-pill-menu,
+.chat-composer-fixed-layer .working-dir-pill-menu {
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
@@ -1633,13 +1644,15 @@
   background: var(--bg-panel);
   box-shadow: var(--shadow-md, 0 12px 32px rgba(0, 0, 0, 0.12));
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-path {
+.app .working-dir-pill-menu-path,
+.chat-composer-fixed-layer .working-dir-pill-menu-path {
   padding: 4px 10px;
   color: var(--text-muted);
   font-size: 10.5px;
   word-break: break-all;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-item {
+.app .working-dir-pill-menu-item,
+.chat-composer-fixed-layer .working-dir-pill-menu-item {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -1654,25 +1667,31 @@
   font-size: 12px;
   text-align: left;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-item.small {
+.app .working-dir-pill-menu-item.small,
+.chat-composer-fixed-layer .working-dir-pill-menu-item.small {
   font-size: 11.5px;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-item:hover {
+.app .working-dir-pill-menu-item:hover,
+.chat-composer-fixed-layer .working-dir-pill-menu-item:hover {
   background: color-mix(in srgb, var(--text-muted) 8%, transparent);
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-item:disabled {
+.app .working-dir-pill-menu-item:disabled,
+.chat-composer-fixed-layer .working-dir-pill-menu-item:disabled {
   color: var(--text-faint);
   cursor: not-allowed;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-item:disabled:hover {
+.app .working-dir-pill-menu-item:disabled:hover,
+.chat-composer-fixed-layer .working-dir-pill-menu-item:disabled:hover {
   background: transparent;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-divider {
+.app .working-dir-pill-menu-divider,
+.chat-composer-fixed-layer .working-dir-pill-menu-divider {
   height: 1px;
   margin: 4px 0;
   background: var(--border);
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-section {
+.app .working-dir-pill-menu-section,
+.chat-composer-fixed-layer .working-dir-pill-menu-section {
   padding: 4px 10px;
   color: var(--text-muted);
   font-size: 10.5px;
@@ -1680,13 +1699,15 @@
   letter-spacing: 0;
   text-transform: uppercase;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-recent {
+.app .working-dir-pill-menu-recent,
+.chat-composer-fixed-layer .working-dir-pill-menu-recent {
   max-width: 240px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-error {
+.app .working-dir-pill-menu-error,
+.chat-composer-fixed-layer .working-dir-pill-menu-error {
   padding: 4px 10px 6px;
   color: var(--red, #c0392b);
   font-size: 11.5px;
@@ -1694,7 +1715,8 @@
 /* Hosted in the composer's bottom toolbar (left of the spacer): flip the menu
    to open upward and anchor it left so it neither drops below the viewport nor
    overflows the composer's left edge. */
-:is(.app, .chat-composer-fixed-layer) .composer-row .working-dir-pill-menu {
+.app .composer-row .working-dir-pill-menu,
+.chat-composer-fixed-layer .composer-row .working-dir-pill-menu {
   top: auto;
   right: auto;
   bottom: calc(100% + 6px);
@@ -1702,10 +1724,12 @@
 }
 /* The toolbar is a flex row; without this the pill gets squeezed below its
    content width and the trailing chevron wraps to a second line. */
-:is(.app, .chat-composer-fixed-layer) .composer-row .working-dir-pill {
+.app .composer-row .working-dir-pill,
+.chat-composer-fixed-layer .composer-row .working-dir-pill {
   flex: 0 0 auto;
 }
-:is(.app, .chat-composer-fixed-layer) .composer-row .working-dir-pill-trigger {
+.app .composer-row .working-dir-pill-trigger,
+.chat-composer-fixed-layer .composer-row .working-dir-pill-trigger {
   flex-wrap: nowrap;
 }
 .app .composer-hint {

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -1588,13 +1588,13 @@
   color: var(--text-faint);
   cursor: default;
 }
-.app .working-dir-pill {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill {
   position: relative;
   display: inline-flex;
   margin-top: 0;
   font-size: 11.5px;
 }
-.app .working-dir-pill-trigger {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-trigger {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -1607,20 +1607,20 @@
   color: var(--text-muted);
   cursor: pointer;
 }
-.app .working-dir-pill-trigger:hover {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-trigger:hover {
   background: color-mix(in srgb, var(--text-muted) 6%, var(--bg-panel));
   border-color: var(--border-strong, var(--border));
 }
-.app .working-dir-pill-trigger:disabled {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-trigger:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
-.app .working-dir-pill-label {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.app .working-dir-pill-menu {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu {
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
@@ -1633,13 +1633,13 @@
   background: var(--bg-panel);
   box-shadow: var(--shadow-md, 0 12px 32px rgba(0, 0, 0, 0.12));
 }
-.app .working-dir-pill-menu-path {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-path {
   padding: 4px 10px;
   color: var(--text-muted);
   font-size: 10.5px;
   word-break: break-all;
 }
-.app .working-dir-pill-menu-item {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-item {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -1654,25 +1654,25 @@
   font-size: 12px;
   text-align: left;
 }
-.app .working-dir-pill-menu-item.small {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-item.small {
   font-size: 11.5px;
 }
-.app .working-dir-pill-menu-item:hover {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-item:hover {
   background: color-mix(in srgb, var(--text-muted) 8%, transparent);
 }
-.app .working-dir-pill-menu-item:disabled {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-item:disabled {
   color: var(--text-faint);
   cursor: not-allowed;
 }
-.app .working-dir-pill-menu-item:disabled:hover {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-item:disabled:hover {
   background: transparent;
 }
-.app .working-dir-pill-menu-divider {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-divider {
   height: 1px;
   margin: 4px 0;
   background: var(--border);
 }
-.app .working-dir-pill-menu-section {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-section {
   padding: 4px 10px;
   color: var(--text-muted);
   font-size: 10.5px;
@@ -1680,16 +1680,33 @@
   letter-spacing: 0;
   text-transform: uppercase;
 }
-.app .working-dir-pill-menu-recent {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-recent {
   max-width: 240px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.app .working-dir-pill-menu-error {
+:is(.app, .chat-composer-fixed-layer) .working-dir-pill-menu-error {
   padding: 4px 10px 6px;
   color: var(--red, #c0392b);
   font-size: 11.5px;
+}
+/* Hosted in the composer's bottom toolbar (left of the spacer): flip the menu
+   to open upward and anchor it left so it neither drops below the viewport nor
+   overflows the composer's left edge. */
+:is(.app, .chat-composer-fixed-layer) .composer-row .working-dir-pill-menu {
+  top: auto;
+  right: auto;
+  bottom: calc(100% + 6px);
+  left: 0;
+}
+/* The toolbar is a flex row; without this the pill gets squeezed below its
+   content width and the trailing chevron wraps to a second line. */
+:is(.app, .chat-composer-fixed-layer) .composer-row .working-dir-pill {
+  flex: 0 0 auto;
+}
+:is(.app, .chat-composer-fixed-layer) .composer-row .working-dir-pill-trigger {
+  flex-wrap: nowrap;
 }
 .app .composer-hint {
   margin: 4px 8px 0;

--- a/apps/web/tests/styles/design-files-preview-list.test.ts
+++ b/apps/web/tests/styles/design-files-preview-list.test.ts
@@ -88,4 +88,16 @@ describe('Design Files preview list styles', () => {
     expect(ruleValue(menu, 'right')).toBe('0');
     expect(ruleValue(menu, 'z-index')).toBe('220');
   });
+
+  it('flips the working directory menu upward when hosted in the composer toolbar', () => {
+    // The pill now lives in the composer's bottom toolbar, so the base
+    // "open downward" rule would drop the menu off the bottom of the viewport.
+    // The composer-row override anchors it above the trigger and left-aligned.
+    const override = cssDeclarations(routinesCss, '.app .composer-row .working-dir-pill-menu');
+
+    expect(ruleValue(override, 'bottom')).toBe('calc(100% + 6px)');
+    expect(ruleValue(override, 'top')).toBe('auto');
+    expect(ruleValue(override, 'left')).toBe('0');
+    expect(ruleValue(override, 'right')).toBe('auto');
+  });
 });


### PR DESCRIPTION
## Why

- **Use case** — While dogfooding the design flow I kept landing on a project whose folder selector (top-right of the design-files panel) read as a raw UUID like `10837f5e-3044-4c4a-9a0c-…`. It's noise, and its placement is disconnected from where you actually type.
- **Pain** — Two small UX papercuts: (1) the working-directory pill sits in the file-panel header, away from the composer where the home input trained users to look; (2) for default-storage projects (no folder imported) the pill shows the project UUID because the working dir is `.od/projects/<id>` and we fall back to its basename. Neither is meaningful to a user.

## What users will see

- The folder selector now lives in the **chat composer's bottom toolbar, right next to the `+`** (mirroring the home input), instead of the top-right of the design-files panel. Its dropdown opens **upward**.
- For a project where you haven't picked/imported a real folder, the pill now reads **"Local storage" (本地存储)** instead of a UUID. If you import or replace the working directory, it still shows that folder's real name.
- The former top-right UUID pill is gone; the header keeps only the settings gear and handoff control.

## Surface area

- [x] **UI** — relocates the working-dir selector into the composer toolbar; updates the default-storage label
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [x] **i18n keys** — adds `workingDirPicker.defaultLabel` to all 19 locales
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

## Screenshots

> Verified locally (namespace `wt0607`) against a fresh default-storage project.

**Before** — top-right pill showed the project UUID (`10837f5e-3044-4c4a-9a0c-…`); selector lived in the design-files header.

**After** — composer bottom toolbar reads `+ │ 📁 Local storage ⌄ │ 🐛 │ Design… │ Send`; opening the pill flips the menu upward (Show in file manager / Replace directory…). Top-right no longer carries the UUID.

<!-- Reviewer: local PNGs available on request; I can drag them into this PR. -->

## Bug fix verification

Not a bug fix — UI relocation + display-layer label. No behavior/data change.

## Validation

- `pnpm guard` — 40/40 pass
- `pnpm --filter @open-design/web typecheck` — clean
- Manual: ran `pnpm tools-dev run web` in an isolated namespace, created a default-storage project via `POST /api/projects`, drove the UI with Playwright to confirm pill placement, single-line rendering, the upward-opening menu, and the `Local storage` label (computed `display:flex; height:28px; flex-wrap:nowrap`).
