### PR TITLE
[codex] Expose localized Home folder shortcut

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2289,7 +2289,7 @@ function RailGroup({
               className={isTabs ? 'home-hero__type-tab-icon' : 'home-hero__rail-chip-icon'}
             />
             <span className={isTabs ? 'home-hero__type-tab-label' : 'home-hero__rail-chip-label'}>
-              {homeHeroChipLabel(chip.id, t)}
+              {homeHeroChipLabel(chip, t)}
             </span>
           </button>
         );
@@ -2367,13 +2367,13 @@ function ActiveTypeChip({ chip, onClear }: { chip: HomeHeroChip; onClear: () => 
       data-testid="home-hero-active-type-chip"
       data-chip-id={chip.id}
       title={homeHeroChipTitle(chip, t)}
-      aria-label={`${homeHeroChipLabel(chip.id, t)} ${t('common.delete')}`}
+      aria-label={`${homeHeroChipLabel(chip, t)} ${t('common.delete')}`}
       onClick={onClear}
     >
       <span className="home-hero__active-type-chip-icon" aria-hidden>
         <Icon name={chip.icon} size={13} />
       </span>
-      <span>{homeHeroChipLabel(chip.id, t)}</span>
+      <span>{homeHeroChipLabel(chip, t)}</span>
       <Icon name="close" size={12} className="home-hero__active-type-chip-close" />
     </button>
   );
@@ -2457,7 +2457,7 @@ function ShortcutsMenu({
                 onClick={() => onPickChip(chip)}
               >
                 <Icon name={chip.icon} size={14} className="home-hero__shortcut-menu-icon" />
-                <span>{homeHeroChipLabel(chip.id, t)}</span>
+                <span>{homeHeroChipLabel(chip, t)}</span>
               </button>
             );
           })}
@@ -2467,31 +2467,12 @@ function ShortcutsMenu({
   );
 }
 
-function homeHeroChipLabel(chipId: string, t: ReturnType<typeof useT>): string {
-  switch (chipId) {
-    case 'prototype': return t('homeHero.chip.prototype');
-    case 'live-artifact': return t('homeHero.chip.liveArtifact');
-    case 'deck': return t('homeHero.chip.deck');
-    case 'image': return t('homeHero.chip.image');
-    case 'video': return t('homeHero.chip.video');
-    case 'hyperframes': return t('homeHero.chip.hyperframes');
-    case 'audio': return t('homeHero.chip.audio');
-    case 'create-plugin': return t('homeHero.chip.createPlugin');
-    case 'figma': return t('homeHero.chip.figma');
-    case 'template': return t('homeHero.chip.template');
-    default: return chipId;
-  }
+function homeHeroChipLabel(chip: HomeHeroChip, t: ReturnType<typeof useT>): string {
+  return t(chip.labelKey);
 }
 
 function homeHeroChipTitle(chip: HomeHeroChip, t: ReturnType<typeof useT>): string {
-  switch (chip.id) {
-    case 'live-artifact': return t('homeHero.chip.liveArtifactHint');
-    case 'hyperframes': return t('homeHero.chip.hyperframesHint');
-    case 'create-plugin': return t('homeHero.chip.createPluginHint');
-    case 'figma': return t('homeHero.chip.figmaHint');
-    case 'template': return t('homeHero.chip.templateHint');
-    default: return homeHeroChipLabel(chip.id, t);
-  }
+  return chip.hintKey ? t(chip.hintKey) : homeHeroChipLabel(chip, t);
 }
 
 function homeHeroExamplePluginsForChip(

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -204,7 +204,7 @@ interface Props {
   // Stage B: optional callbacks the rail's migration chips need.
   // HomeView itself never imports them; EntryShell threads them
   // through so the dispatcher can stay declarative.
-  onOpenNewProject?: (tab: 'template') => void;
+  onOpenNewProject?: (tab: 'prototype' | 'template') => void;
   promptHandoff?: HomePromptHandoff | null;
   skills?: SkillSummary[];
   skillsLoading?: boolean;
@@ -1324,6 +1324,14 @@ export function HomeView({
       }
       case 'create-plugin': {
         queuePluginAuthoring(chip.id);
+        return;
+      }
+      case 'import-folder': {
+        if (!onOpenNewProject) {
+          setError('Folder import is not available in this shell.');
+          return;
+        }
+        onOpenNewProject('prototype');
         return;
       }
       case 'open-template-picker': {

--- a/apps/web/src/components/home-hero/chips.ts
+++ b/apps/web/src/components/home-hero/chips.ts
@@ -11,16 +11,15 @@
 //
 // The catalog stays a pure data table:
 //   - `id` — stable React key + test selector.
-//   - `label` — English copy. Localisation can layer on later by
-//     swapping this for a Dict lookup; keeping it inline lets the
-//     rail ship without burning through 17 locale files for two
-//     new strings (see plan §B / open questions).
+//   - `label` — English fallback for tests and non-UI consumers.
+//   - `labelKey` — localized UI label used by the Home rail.
 //   - `icon` — name from the shared Icon registry.
 //   - `action` — discriminated union the HomeView dispatcher matches
 //     on. The rail component itself stays presentational.
 
 import type { ProjectKind, ProjectMetadata } from '@open-design/contracts';
 import type { DefaultScenarioPluginId } from '@open-design/contracts';
+import type { Dict } from '../../i18n/types';
 import type { IconName } from '../Icon';
 
 // Plugin ids the chip rail can dispatch to. Most chips route to a
@@ -51,6 +50,7 @@ export type ChipAction =
       projectMetadata?: ProjectMetadata;
     }
   | { kind: 'create-plugin' }
+  | { kind: 'import-folder' }
   | { kind: 'open-template-picker' };
 
 // Two intent groups: "create" = produce a design artifact, "migrate" =
@@ -63,9 +63,11 @@ export type ChipGroup = 'create' | 'migrate';
 export interface HomeHeroChip {
   id: string;
   label: string;
+  labelKey: keyof Dict;
   icon: IconName;
   group: ChipGroup;
   hint?: string;
+  hintKey?: keyof Dict;
   action: ChipAction;
 }
 
@@ -73,6 +75,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   {
     id: 'prototype',
     label: 'Prototype',
+    labelKey: 'homeHero.chip.prototype',
     icon: 'palette',
     group: 'create',
     // Prototype now binds to the bundled `example-web-prototype` plugin,
@@ -93,6 +96,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   {
     id: 'deck',
     label: 'Slide deck',
+    labelKey: 'homeHero.chip.deck',
     icon: 'present',
     group: 'create',
     // Slide deck binds to `example-simple-deck`, which ships a 353-line
@@ -114,9 +118,11 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   {
     id: 'hyperframes',
     label: 'HyperFrames',
+    labelKey: 'homeHero.chip.hyperframes',
     icon: 'orbit',
     group: 'create',
     hint: 'Author HTML-based motion: captions, audio-reactive visuals, scene transitions.',
+    hintKey: 'homeHero.chip.hyperframesHint',
     // HyperFrames is its own bundled scenario (motion-graphics
     // specialisation of Video). It surfaces in PluginsHomeSection's
     // primary category list, so the rail picks it up too rather than
@@ -126,9 +132,11 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   {
     id: 'live-artifact',
     label: 'Live artifact',
+    labelKey: 'homeHero.chip.liveArtifact',
     icon: 'refresh',
     group: 'create',
     hint: 'Build a refreshable artifact backed by connector or local data.',
+    hintKey: 'homeHero.chip.liveArtifactHint',
     action: {
       kind: 'apply-scenario',
       pluginId: 'example-live-artifact',
@@ -143,6 +151,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   {
     id: 'image',
     label: 'Image',
+    labelKey: 'homeHero.chip.image',
     icon: 'image',
     group: 'create',
     action: {
@@ -160,6 +169,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   {
     id: 'video',
     label: 'Video',
+    labelKey: 'homeHero.chip.video',
     icon: 'play',
     group: 'create',
     action: {
@@ -177,6 +187,7 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   {
     id: 'audio',
     label: 'Audio',
+    labelKey: 'homeHero.chip.audio',
     icon: 'mic',
     group: 'create',
     action: {
@@ -194,17 +205,21 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
   {
     id: 'create-plugin',
     label: 'Create plugin',
+    labelKey: 'homeHero.chip.createPlugin',
     icon: 'edit',
     group: 'migrate',
     hint: 'Author a reusable Open Design plugin and add it to My plugins.',
+    hintKey: 'homeHero.chip.createPluginHint',
     action: { kind: 'create-plugin' },
   },
   {
     id: 'figma',
     label: 'From Figma',
+    labelKey: 'homeHero.chip.figma',
     icon: 'import',
     group: 'migrate',
     hint: 'Migrate a Figma frame into the active design system.',
+    hintKey: 'homeHero.chip.figmaHint',
     action: {
       kind: 'apply-figma-migration',
       pluginId: 'od-figma-migration',
@@ -216,11 +231,23 @@ export const HOME_HERO_CHIPS: ReadonlyArray<HomeHeroChip> = [
     },
   },
   {
+    id: 'folder',
+    label: 'From folder',
+    labelKey: 'homeHero.chip.folder',
+    icon: 'folder',
+    group: 'migrate',
+    hint: 'Import an existing local folder and continue editing.',
+    hintKey: 'homeHero.chip.folderHint',
+    action: { kind: 'import-folder' },
+  },
+  {
     id: 'template',
     label: 'From template',
+    labelKey: 'homeHero.chip.template',
     icon: 'file-code',
     group: 'migrate',
     hint: 'Start from a bundled template.',
+    hintKey: 'homeHero.chip.templateHint',
     action: { kind: 'open-template-picker' },
   },
 ];

--- a/apps/web/tests/components/HomeHero.rail.test.tsx
+++ b/apps/web/tests/components/HomeHero.rail.test.tsx
@@ -17,6 +17,7 @@ import {
   HOME_HERO_CHIPS,
   findChip,
 } from '../../src/components/home-hero/chips';
+import { I18nProvider, type Locale } from '../../src/i18n';
 
 afterEach(() => {
   cleanup();
@@ -67,31 +68,36 @@ function makePlugin(
   };
 }
 
-function renderHero(overrides: Partial<React.ComponentProps<typeof HomeHero>> = {}) {
+function renderHero(
+  overrides: Partial<React.ComponentProps<typeof HomeHero>> = {},
+  locale: Locale = 'en',
+) {
   const onPickChip = vi.fn();
   const onPickPlugin = vi.fn();
   const onPickExamplePlugin = vi.fn();
   const onClearActiveChip = vi.fn();
   render(
-    <HomeHero
-      prompt=""
-      onPromptChange={() => undefined}
-      onSubmit={() => undefined}
-      activePluginTitle={null}
-      activeChipId={null}
-      onClearActivePlugin={() => undefined}
-      pluginOptions={[]}
-      pluginsLoading={false}
-      pendingPluginId={null}
-      pendingChipId={null}
-      onPickPlugin={onPickPlugin}
-      onPickExamplePlugin={onPickExamplePlugin}
-      onPickChip={onPickChip}
-      onClearActiveChip={onClearActiveChip}
-      contextItemCount={0}
-      error={null}
-      {...overrides}
-    />,
+    <I18nProvider initial={locale}>
+      <HomeHero
+        prompt=""
+        onPromptChange={() => undefined}
+        onSubmit={() => undefined}
+        activePluginTitle={null}
+        activeChipId={null}
+        onClearActivePlugin={() => undefined}
+        pluginOptions={[]}
+        pluginsLoading={false}
+        pendingPluginId={null}
+        pendingChipId={null}
+        onPickPlugin={onPickPlugin}
+        onPickExamplePlugin={onPickExamplePlugin}
+        onPickChip={onPickChip}
+        onClearActiveChip={onClearActiveChip}
+        contextItemCount={0}
+        error={null}
+        {...overrides}
+      />
+    </I18nProvider>,
   );
   return { onPickChip, onPickPlugin, onPickExamplePlugin, onClearActiveChip };
 }
@@ -374,11 +380,20 @@ describe('HomeHero intent rail', () => {
       .closest('[data-rail-group]');
 
     expect(createPluginGroup?.getAttribute('data-rail-group')).toBe('migrate');
-    for (const id of ['figma', 'template']) {
+    for (const id of ['figma', 'folder', 'template']) {
       expect(screen.getByTestId(`home-hero-rail-${id}`).closest('[data-rail-group]'))
         .toBe(createPluginGroup);
     }
-    expect(screen.queryByTestId('home-hero-rail-folder')).toBeNull();
+  });
+
+  it('localizes the folder shortcut label and hint in Simplified Chinese', () => {
+    renderHero({ activeChipId: 'folder' }, 'zh-CN');
+    fireEvent.click(screen.getByTestId('home-hero-shortcuts-trigger'));
+
+    const folder = screen.getByTestId('home-hero-rail-folder');
+    expect(folder.textContent).toContain('来自文件夹');
+    expect(folder.getAttribute('title')).toBe('导入本地文件夹并继续编辑。');
+    expect(folder.className).toContain('is-active');
   });
 
   it('keeps the generic fallback in the free-form prompt instead of an Other chip', () => {
@@ -391,7 +406,7 @@ describe('HomeHero intent rail', () => {
   it('migration chips carry the right action discriminator', () => {
     expect(findChip('create-plugin')?.action).toMatchObject({ kind: 'create-plugin' });
     expect(findChip('figma')?.action).toMatchObject({ kind: 'apply-figma-migration' });
-    expect(findChip('folder')).toBeUndefined();
+    expect(findChip('folder')?.action).toMatchObject({ kind: 'import-folder' });
     expect(findChip('template')?.action).toMatchObject({ kind: 'open-template-picker' });
   });
 

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -53,6 +53,17 @@ afterEach(() => {
 });
 
 describe('HomeView media composer options', () => {
+  it('opens the New Project panel from the folder shortcut', async () => {
+    stubFetch();
+    const onOpenNewProject = vi.fn();
+    renderHome({ onOpenNewProject });
+
+    fireEvent.click(await screen.findByTestId('home-hero-shortcuts-trigger'));
+    fireEvent.click(screen.getByTestId('home-hero-rail-folder'));
+
+    expect(onOpenNewProject).toHaveBeenCalledWith('prototype');
+  });
+
   it('renders the design-system popover outside the prompt editor (not clipped by it)', async () => {
     stubFetch();
     renderHome();


### PR DESCRIPTION
## Summary
- Move Home rail chip labels and hints to existing i18n keys.
- Restore the Home "From folder" shortcut in the More menu.
- Route the folder shortcut through the existing New Project import surface.

## Context
This is a small split-out follow-up from the previously closed large localization PR (#2205). It intentionally keeps the scope to the Home rail folder shortcut instead of carrying the broader zh-CN localization changes.

## Surface area
- [x] **UI** — Home rail shortcut/menu copy and action surface in apps/web.
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — reuses existing Home label/hint keys; no new locale workflow entries.
- [ ] **New top-level dependency**
- [x] **Default behavior change** — restores the existing folder import shortcut in the Home rail More menu.
- [ ] **None**

## Bug fix verification
- Test path that reproduces the bug: tests/components/HomeHero.rail.test.tsx and tests/components/HomeView.media-options.test.tsx
- Red/green check: the Home rail folder shortcut assertions fail without the source change and pass on this branch.

## Validation
- corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/HomeHero.rail.test.tsx tests/components/HomeView.media-options.test.tsx
- corepack pnpm --filter @open-design/web typecheck

## Screenshots
![Home More menu showing the restored From folder shortcut](https://raw.githubusercontent.com/mcncarl/open-design/fe7d764f663c97d89b00ea5627fedef644bc6a0f/pr-screenshots/pr-3822-home-more-folder.png)