### PR TITLE
[codex] Localize automation review policy labels

### DIFF
--- a/apps/web/src/components/TasksView.tsx
+++ b/apps/web/src/components/TasksView.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   AutomationEvolutionProposal,
   AutomationEvolutionProposalListResponse,
+  AutomationReviewPolicy,
   AutomationTemplate as ContractAutomationTemplate,
   AutomationTemplateListResponse,
   ConnectorDetail,
@@ -16,10 +17,11 @@ import type {
 
 import { Icon, type IconName } from './Icon';
 import { navigate } from '../router';
-import { useT } from '../i18n';
+import { useI18n } from '../i18n';
+import type { Locale } from '../i18n/types';
 import type { SkillSummary } from '../types';
 
-type TranslateFn = ReturnType<typeof useT>;
+type TranslateFn = ReturnType<typeof useI18n>['t'];
 import { useAnalytics } from '../analytics/provider';
 import { trackAutomationsClick, trackPageView } from '../analytics/events';
 import {
@@ -357,8 +359,15 @@ function proposalActionLabel(action: AutomationEvolutionProposal['action'], t: T
   return t('automations.proposalActionPromote');
 }
 
+function proposalReviewPolicyLabel(policy: AutomationReviewPolicy, locale: Locale): string {
+  if (policy === 'always') return locale === 'zh-CN' ? '总是审核' : 'Always review';
+  if (policy === 'trusted-source') return locale === 'zh-CN' ? '可信来源' : 'Trusted source';
+  if (policy === 'auto-apply') return locale === 'zh-CN' ? '自动应用' : 'Auto-apply';
+  return policy;
+}
+
 export function TasksView({ skills = [], designTemplates = [], connectors = [] }: Props) {
-  const t = useT();
+  const { locale, t } = useI18n();
   const analytics = useAnalytics();
   // P2 page_view page_name=automations. Ref-keyed so re-renders don't
   // double-fire while the user is on the page.
@@ -784,7 +793,7 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
                         <span aria-hidden="true">·</span>
                         <span>{proposalActionLabel(proposal.action, t)}</span>
                         <span aria-hidden="true">·</span>
-                        <span>{proposal.reviewPolicy}</span>
+                        <span>{proposalReviewPolicyLabel(proposal.reviewPolicy, locale)}</span>
                       </span>
                       <span className="automation-row__prompt">{proposal.summary}</span>
                       {proposal.patch.diffSummary ? (

--- a/apps/web/tests/components/TasksView.templates.test.tsx
+++ b/apps/web/tests/components/TasksView.templates.test.tsx
@@ -8,6 +8,7 @@ import type {
 } from '@open-design/contracts';
 
 import { TasksView } from '../../src/components/TasksView';
+import { I18nProvider } from '../../src/i18n';
 
 const originalFetch = globalThis.fetch;
 
@@ -160,6 +161,64 @@ describe('TasksView automation templates', () => {
       expect(applyCalls).toEqual(['/api/automation-proposals/proposal-memory-1/apply']);
       expect(screen.queryByText('Project memory from connector digest')).toBeNull();
     });
+  });
+
+  it('localizes zh-CN proposal review policy labels for contract values', async () => {
+    const proposals: AutomationEvolutionProposal[] = [
+      {
+        ...memoryProposal,
+        id: 'proposal-trusted-source-1',
+        title: 'Trusted connector update',
+        reviewPolicy: 'trusted-source',
+      },
+      {
+        ...memoryProposal,
+        id: 'proposal-auto-apply-1',
+        title: 'Auto-apply release note',
+        reviewPolicy: 'auto-apply',
+      },
+    ];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/routines' && (!init || init.method === undefined)) {
+        return new Response(JSON.stringify({ routines: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/projects' && (!init || init.method === undefined)) {
+        return new Response(JSON.stringify({ projects: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/automation-templates' && (!init || init.method === undefined)) {
+        return new Response(JSON.stringify({ templates: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === '/api/automation-proposals?status=pending-review' && (!init || init.method === undefined)) {
+        return new Response(JSON.stringify({ proposals }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as typeof fetch;
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <TasksView />
+      </I18nProvider>,
+    );
+
+    expect(await screen.findByText('Trusted connector update')).toBeTruthy();
+    expect(screen.getByText('Auto-apply release note')).toBeTruthy();
+    expect(screen.getByText('可信来源')).toBeTruthy();
+    expect(screen.getByText('自动应用')).toBeTruthy();
+    expect(screen.queryByText('trusted-source')).toBeNull();
+    expect(screen.queryByText('auto-apply')).toBeNull();
   });
 
   it('crystallizes a successful automation run into reviewable proposals', async () => {


### PR DESCRIPTION
## Summary
- Localize automation proposal review-policy labels in TasksView.
- Keep the stored contract values unchanged while rendering user-facing labels.
- Add zh-CN regression coverage for the review policy values.

## Context
This is a focused split-out from the closed large localization PR (#2205). It only covers TasksView automation review-policy labels.

## Surface area
- [x] **UI** — TasksView automation proposal copy in apps/web.
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — no new translation keys; localizes existing contract values at render time.
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Bug fix verification
- Test path that reproduces the bug: tests/components/TasksView.templates.test.tsx
- Red/green check: the zh-CN review-policy label expectations fail without the source change and pass on this branch.

## Validation
- corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/TasksView.templates.test.tsx
- corepack pnpm --filter @open-design/web typecheck

## Screenshots
![zh-CN TasksView proposal rows showing localized review-policy labels](https://raw.githubusercontent.com/mcncarl/open-design/fe7d764f663c97d89b00ea5627fedef644bc6a0f/pr-screenshots/pr-3823-zh-cn-proposal-review-policy.png)