### PR TITLE
[codex] Localize design system manager dates

### DIFF
--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -89,11 +89,15 @@ function mapStatusToTracking(
   }
 }
 
-function formatShortDate(value: number | string | undefined): string {
-  if (!value) return 'just now';
+function formatShortDate(
+  value: number | string | undefined,
+  locale?: string,
+  emptyLabel = 'just now',
+): string {
+  if (!value) return emptyLabel;
   const time = typeof value === 'number' ? value : Date.parse(value);
   if (!Number.isFinite(time)) return String(value);
-  return new Intl.DateTimeFormat(undefined, {
+  return new Intl.DateTimeFormat(locale, {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',
@@ -162,6 +166,10 @@ export function DesignSystemsTab({
     if (userFilter === 'all') return editable;
     return editable.filter((system) => (system.status ?? 'draft') === userFilter);
   }, [systems, userFilter]);
+  const showOfficialLibrary =
+    primaryCollection === 'design-system' &&
+    (designSystemCollection === 'official' ||
+      (designSystemCollection === 'mine' && userSystems.length === 0 && librarySystems.length > 0));
 
   // Total systems per surface, ignoring every active filter. Drives the
   // "this surface is now empty" fallback below — that guard must react to
@@ -299,7 +307,11 @@ export function DesignSystemsTab({
   }
 
   async function deleteSystem(system: DesignSystemSummary) {
-    const ok = window.confirm(`Delete "${system.title}"? This removes the draft design system from this device.`);
+    const ok = window.confirm(
+      locale === 'zh-CN'
+        ? `删除“${system.title}”？这会从此设备移除该设计体系草稿。`
+        : `Delete "${system.title}"? This removes the draft design system from this device.`,
+    );
     if (!ok) {
       trackDesignSystemStatusResult(analytics.track, {
         page_name: 'design_systems',
@@ -509,7 +521,13 @@ export function DesignSystemsTab({
                       {selected ? <span className="ds-card-badge">{t('dsManager.badgeDefault')}</span> : null}
                     </span>
                     <span className="ds-user-row__meta">
-                      {t('dsManager.rowMetaUpdated', { date: formatShortDate(system.updatedAt) })}
+                      {t('dsManager.rowMetaUpdated', {
+                        date: formatShortDate(
+                          system.updatedAt,
+                          locale,
+                          locale === 'zh-CN' ? '刚刚' : 'just now',
+                        ),
+                      })}
                     </span>
                   </button>
                   <div className="ds-user-row__actions">
@@ -570,7 +588,7 @@ export function DesignSystemsTab({
         </section>
       ) : null}
 
-      {primaryCollection === 'design-system' && designSystemCollection === 'official' ? (
+      {showOfficialLibrary ? (
         <section className="ds-settings-card" aria-label={t('dsManager.presetsAria')}>
         <div className="ds-settings-card__head">
           <div>

--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -161,15 +161,16 @@ export function DesignSystemsTab({
     [librarySystems, surfaceFilter],
   );
 
+  const allUserSystems = useMemo(() => systems.filter(isUserSystem), [systems]);
+
   const userSystems = useMemo(() => {
-    const editable = systems.filter(isUserSystem);
-    if (userFilter === 'all') return editable;
-    return editable.filter((system) => (system.status ?? 'draft') === userFilter);
-  }, [systems, userFilter]);
+    if (userFilter === 'all') return allUserSystems;
+    return allUserSystems.filter((system) => (system.status ?? 'draft') === userFilter);
+  }, [allUserSystems, userFilter]);
   const showOfficialLibrary =
     primaryCollection === 'design-system' &&
     (designSystemCollection === 'official' ||
-      (designSystemCollection === 'mine' && userSystems.length === 0 && librarySystems.length > 0));
+      (designSystemCollection === 'mine' && allUserSystems.length === 0 && librarySystems.length > 0));
 
   // Total systems per surface, ignoring every active filter. Drives the
   // "this surface is now empty" fallback below — that guard must react to

--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -526,7 +526,7 @@ export function DesignSystemsTab({
                         date: formatShortDate(
                           system.updatedAt,
                           locale,
-                          locale === 'zh-CN' ? '刚刚' : 'just now',
+                          t('common.justNow'),
                         ),
                       })}
                     </span>

--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -736,7 +736,7 @@ export function DesignSystemsTab({
                     <strong>{template.name}</strong>
                     <span>{template.description?.trim() || t('dsManager.templateDescFallback')}</span>
                   </div>
-                  <small>{formatShortDate(template.createdAt)}</small>
+                  <small>{formatShortDate(template.createdAt, locale)}</small>
                 </div>
               ))}
             </div>

--- a/apps/web/tests/components/DesignSystemsTab.test.tsx
+++ b/apps/web/tests/components/DesignSystemsTab.test.tsx
@@ -176,7 +176,7 @@ describe('DesignSystemsTab', () => {
     const expectedTemplateDate = new Intl.DateTimeFormat('es-ES', {
       month: 'short',
       day: 'numeric',
-      hour: 'numeric',
+      hour: '2-digit',
       minute: '2-digit',
     }).format(new Date(templateCreatedAt));
 

--- a/apps/web/tests/components/DesignSystemsTab.test.tsx
+++ b/apps/web/tests/components/DesignSystemsTab.test.tsx
@@ -171,6 +171,36 @@ describe('DesignSystemsTab', () => {
     expect(screen.queryByText(/just now/)).toBeNull();
   });
 
+  it('formats user template dates with the active app locale', () => {
+    render(
+      <I18nProvider initial="es-ES">
+        <DesignSystemsTab
+          systems={[]}
+          templates={[
+            {
+              id: 'tpl-1',
+              name: 'Launch Template',
+              description: 'Reusable launch plan.',
+              files: [],
+              createdAt: Date.parse('2026-05-13T03:19:00.000Z'),
+            },
+          ]}
+          selectedId={null}
+          onSelect={() => {}}
+          onPreview={() => {}}
+          onCreate={() => {}}
+          onOpenSystem={() => {}}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Plantilla' }));
+
+    expect(screen.getByText('Launch Template')).toBeTruthy();
+    expect(screen.getByText('13 may, 11:19')).toBeTruthy();
+    expect(screen.queryByText(/May 13/)).toBeNull();
+  });
+
   it('shows the official library when there are no user-created design systems', () => {
     render(
         <DesignSystemsTab

--- a/apps/web/tests/components/DesignSystemsTab.test.tsx
+++ b/apps/web/tests/components/DesignSystemsTab.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DesignSystemSummary } from '@open-design/contracts';
 
 import { DesignSystemsTab } from '../../src/components/DesignSystemsTab';
+import { I18nProvider } from '../../src/i18n';
 
 vi.mock('../../src/providers/registry', async () => {
   const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
@@ -127,6 +128,45 @@ describe('DesignSystemsTab', () => {
 
     expect(onPreview).toHaveBeenCalledWith('linear');
     expect(onOpenSystem).not.toHaveBeenCalledWith('linear');
+  });
+
+  it('localizes user-system dates and delete confirmation in Simplified Chinese', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(
+      <I18nProvider initial="zh-CN">
+        <DesignSystemsTab
+          systems={[{ ...systems[0]!, updatedAt: undefined }]}
+          selectedId={null}
+          onSelect={() => {}}
+          onPreview={() => {}}
+          onCreate={() => {}}
+          onOpenSystem={() => {}}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('你 · 更新于 刚刚')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: '删除 Acme Design System' }));
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      '删除“Acme Design System”？这会从此设备移除该设计体系草稿。',
+    );
+  });
+
+  it('shows the official library when there are no user-created design systems', () => {
+    render(
+        <DesignSystemsTab
+        systems={[systems[1]!]}
+        selectedId={null}
+        onSelect={() => {}}
+        onPreview={() => {}}
+        onCreate={() => {}}
+        onOpenSystem={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Linear')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Official presets' })).toBeTruthy();
   });
 });
 

--- a/apps/web/tests/components/DesignSystemsTab.test.tsx
+++ b/apps/web/tests/components/DesignSystemsTab.test.tsx
@@ -153,6 +153,24 @@ describe('DesignSystemsTab', () => {
     );
   });
 
+  it('uses the shared just-now label for missing user-system dates in other locales', () => {
+    render(
+      <I18nProvider initial="es-ES">
+        <DesignSystemsTab
+          systems={[{ ...systems[0]!, updatedAt: undefined }]}
+          selectedId={null}
+          onSelect={() => {}}
+          onPreview={() => {}}
+          onCreate={() => {}}
+          onOpenSystem={() => {}}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText('Tú · actualizado justo ahora')).toBeTruthy();
+    expect(screen.queryByText(/just now/)).toBeNull();
+  });
+
   it('shows the official library when there are no user-created design systems', () => {
     render(
         <DesignSystemsTab

--- a/apps/web/tests/components/DesignSystemsTab.test.tsx
+++ b/apps/web/tests/components/DesignSystemsTab.test.tsx
@@ -172,6 +172,14 @@ describe('DesignSystemsTab', () => {
   });
 
   it('formats user template dates with the active app locale', () => {
+    const templateCreatedAt = Date.parse('2026-05-13T03:19:00.000Z');
+    const expectedTemplateDate = new Intl.DateTimeFormat('es-ES', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(templateCreatedAt));
+
     render(
       <I18nProvider initial="es-ES">
         <DesignSystemsTab
@@ -182,7 +190,7 @@ describe('DesignSystemsTab', () => {
               name: 'Launch Template',
               description: 'Reusable launch plan.',
               files: [],
-              createdAt: Date.parse('2026-05-13T03:19:00.000Z'),
+              createdAt: templateCreatedAt,
             },
           ]}
           selectedId={null}
@@ -197,7 +205,7 @@ describe('DesignSystemsTab', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Plantilla' }));
 
     expect(screen.getByText('Launch Template')).toBeTruthy();
-    expect(screen.getByText('13 may, 11:19')).toBeTruthy();
+    expect(screen.getByText(expectedTemplateDate)).toBeTruthy();
     expect(screen.queryByText(/May 13/)).toBeNull();
   });
 

--- a/apps/web/tests/components/DesignSystemsTab.test.tsx
+++ b/apps/web/tests/components/DesignSystemsTab.test.tsx
@@ -168,6 +168,29 @@ describe('DesignSystemsTab', () => {
     expect(screen.getByText('Linear')).toBeTruthy();
     expect(screen.getByRole('heading', { name: 'Official presets' })).toBeTruthy();
   });
+
+  it('does not show the official library when a status filter hides personal systems', () => {
+    render(
+      <DesignSystemsTab
+        systems={systems}
+        selectedId={null}
+        onSelect={() => {}}
+        onPreview={() => {}}
+        onCreate={() => {}}
+        onOpenSystem={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Filter design systems' }), {
+      target: { value: 'published' },
+    });
+
+    expect(screen.getByText(
+      'No design systems yet. Create one from real product context, review the draft, then publish it for future projects.',
+    )).toBeTruthy();
+    expect(screen.queryByText('Linear')).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Official presets' })).toBeNull();
+  });
 });
 
 // --- #2062: built-in library surface-chip filtering -----------------------


### PR DESCRIPTION
## Summary
- format design-system manager dates with the active locale
- localize the draft delete confirmation for zh-CN
- show the official design-system library when the user has no personal systems yet

## Surface area
- [x] **UI** — DesignSystemsTab dates, empty fallback, and delete confirmation copy in apps/web.
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — no new translation keys; localized fallback copy only.
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the official library appears only when the user has no personal design systems.
- [ ] **None**

## Screenshots
- Visual screenshot artifact: [visual-pr-verify-3827-27092194963](https://github.com/nexu-io/open-design/actions/runs/27092194963/artifacts/7464004131)
- Covers the Design Systems manager surface touched by the date/empty-state fallback changes.

## Bug fix verification
- Test path that reproduces the bug: tests/components/DesignSystemsTab.test.tsx
- Red/green check: date/delete/fallback behavior expectations fail without the source change and pass on this branch.

## Validation
- corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/DesignSystemsTab.test.tsx
- corepack pnpm --filter @open-design/web typecheck