### PR TITLE
[codex] Localize plugin apply notices

### DIFF
--- a/apps/web/src/components/InlinePluginsRail.tsx
+++ b/apps/web/src/components/InlinePluginsRail.tsx
@@ -76,7 +76,9 @@ export function InlinePluginsRail(props: Props) {
     setPendingId(null);
     if (!result) {
       setError(
-        `Failed to apply ${record.title}. Make sure the daemon is reachable.`,
+        locale === 'zh-CN'
+          ? `应用 ${record.title} 失败。请确认守护进程可访问。`
+          : `Failed to apply ${record.title}. Make sure the daemon is reachable.`,
       );
       return;
     }

--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -205,7 +205,11 @@ export function PluginsView({
     if (!result) {
       setNotice({
         ok: false,
-        message: `Failed to apply ${record.title}. Make sure the daemon is reachable.`,
+        message: localizedPluginMessage(
+          locale,
+          `Failed to apply ${record.title}. Make sure the daemon is reachable.`,
+          `应用 ${record.title} 失败。请确认守护进程可访问。`,
+        ),
       });
       return;
     }
@@ -213,7 +217,11 @@ export function PluginsView({
     setDetailsRecord(null);
     setNotice({
       ok: true,
-      message: `${record.title} is ready. Use it from Home with @ search or pick it from the gallery.`,
+      message: localizedPluginMessage(
+        locale,
+        `${record.title} is ready. Use it from Home with @ search or pick it from the gallery.`,
+        `${record.title} 已准备好。你可以在主页用 @ 搜索使用，也可以从插件库中选择。`,
+      ),
     });
   }
 
@@ -224,7 +232,11 @@ export function PluginsView({
     if (!onCreatePluginShareProject) {
       setNotice({
         ok: false,
-        message: 'Plugin sharing is not available in this shell.',
+        message: localizedPluginMessage(
+          locale,
+          'Plugin sharing is not available in this shell.',
+          '当前外壳不支持插件分享。',
+        ),
       });
       setShareConfirm(null);
       return;
@@ -589,6 +601,10 @@ export function PluginsView({
       ) : null}
     </section>
   );
+}
+
+function localizedPluginMessage(locale: string, english: string, simplifiedChinese: string): string {
+  return locale === 'zh-CN' ? simplifiedChinese : english;
 }
 
 function PluginShareConfirmModal({

--- a/apps/web/tests/components/InlinePluginsRail.test.tsx
+++ b/apps/web/tests/components/InlinePluginsRail.test.tsx
@@ -11,6 +11,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { InlinePluginsRail } from '../../src/components/InlinePluginsRail';
+import { I18nProvider } from '../../src/i18n';
 
 const PLUGIN_ROW = {
   id: 'sample-plugin',
@@ -95,6 +96,37 @@ describe('InlinePluginsRail', () => {
     const [record, result] = onApplied.mock.calls[0]!;
     expect(record.id).toBe('sample-plugin');
     expect(result.appliedPlugin.snapshotId).toBe('snap-1');
+  });
+
+  it('localizes apply failures in Simplified Chinese', async () => {
+    fetchMock.mockImplementation(async (url) => {
+      if (typeof url === 'string' && url === '/api/plugins') {
+        return new Response(JSON.stringify({ plugins: [PLUGIN_ROW] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (typeof url === 'string' && url.includes('/apply')) {
+        return new Response(JSON.stringify({ ok: false }), {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <InlinePluginsRail onApplied={() => undefined} />
+      </I18nProvider>,
+    );
+    fireEvent.click(await waitFor(() => screen.getByTitle('A fixture')));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain(
+        '应用 Sample Plugin 失败。请确认守护进程可访问。',
+      );
+    });
   });
 
   it('filters by taskKind when supplied', async () => {


### PR DESCRIPTION
## Summary
- Localize plugin apply success and failure notices for zh-CN.
- Localize share-unavailable plugin notice copy for zh-CN.
- Cover InlinePluginsRail and PluginsView notice rendering with focused tests.

## Surface area
- [x] **UI** — plugin application notices and unavailable-share copy in apps/web.
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — no new translation keys; localized fallback copy only.
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Bug fix verification
- Test path that reproduces the bug: tests/components/InlinePluginsRail.test.tsx and tests/components/PluginsView.test.tsx
- Red/green check: zh-CN plugin-notice expectations fail without the source change and pass on this branch.

## Validation
- corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/InlinePluginsRail.test.tsx tests/components/PluginsView.test.tsx
- corepack pnpm --filter @open-design/web typecheck