### PR TITLE
[codex] Localize MCP OAuth status copy

### DIFF
--- a/apps/web/src/components/McpClientSection.tsx
+++ b/apps/web/src/components/McpClientSection.tsx
@@ -32,7 +32,7 @@ import type {
 import { fetchAgents } from '../providers/registry';
 import type { AgentInfo } from '../types';
 import { Icon } from './Icon';
-import { useT } from '../i18n';
+import { useI18n, useT } from '../i18n';
 
 interface Props {
   // Receive a notification when servers list changes so the parent can
@@ -209,6 +209,10 @@ function rowFromBlank(taken: ReadonlySet<string>): DraftRow {
 }
 
 const ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
+
+function zhCN(locale: string, english: string, simplifiedChinese: string): string {
+  return locale === 'zh-CN' ? simplifiedChinese : english;
+}
 
 // Picker grouping. Mirrors `McpTemplateCategory` in `packages/contracts`.
 // The order here is the *display* order in the picker — keep it intentional
@@ -1092,6 +1096,7 @@ function McpRow({ row, idx, total, template, onChange, onRemove, onMoveUp, onMov
  * reach back via postMessage (cross-origin tab opener edge cases).
  */
 function McpOAuthControl({ serverId }: { serverId: string }) {
+  const { locale } = useI18n();
   const [status, setStatus] = useState<McpOAuthStatusResponse | null>(null);
   const [busy, setBusy] = useState<'idle' | 'starting' | 'awaiting' | 'disconnecting' | 'refreshing'>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -1239,7 +1244,7 @@ function McpOAuthControl({ serverId }: { serverId: string }) {
       setPendingAuthUrl(null);
       setStatus({ connected: false });
     } else {
-      setError('Disconnect failed. Check daemon logs.');
+      setError(zhCN(locale, 'Disconnect failed. Check daemon logs.', '断开连接失败。请检查守护进程日志。'));
     }
   };
 
@@ -1257,11 +1262,13 @@ function McpOAuthControl({ serverId }: { serverId: string }) {
           <>
             <span className="mcp-oauth-dot mcp-oauth-dot-ok" aria-hidden />
             <span>
-              <strong>Connected.</strong>{' '}
+              <strong>{zhCN(locale, 'Connected.', '已连接。')}</strong>{' '}
               {expiresLabel ? (
-                <span className="hint">Token expires {expiresLabel}.</span>
+                <span className="hint">
+                  {zhCN(locale, `Token expires ${expiresLabel}.`, `令牌将于 ${expiresLabel} 过期。`)}
+                </span>
               ) : (
-                <span className="hint">Non-expiring token.</span>
+                <span className="hint">{zhCN(locale, 'Non-expiring token.', '令牌不会过期。')}</span>
               )}
             </span>
           </>
@@ -1269,11 +1276,13 @@ function McpOAuthControl({ serverId }: { serverId: string }) {
           <>
             <span className="mcp-oauth-dot mcp-oauth-dot-pending" aria-hidden />
             <span>
-              <strong>Waiting for authorization…</strong>{' '}
+              <strong>{zhCN(locale, 'Waiting for authorization…', '等待授权中…')}</strong>{' '}
               <span className="hint">
-                Approve in the browser tab that opened. We'll catch the callback
-                automatically — or click Refresh below if you completed it
-                already.
+                {zhCN(
+                  locale,
+                  "Approve in the browser tab that opened. We'll catch the callback automatically — or click Refresh below if you completed it already.",
+                  '请在已打开的浏览器标签页中批准授权。我们会自动捕获回调；如果你已经完成，也可以点击下方刷新。',
+                )}
               </span>
             </span>
           </>
@@ -1281,9 +1290,13 @@ function McpOAuthControl({ serverId }: { serverId: string }) {
           <>
             <span className="mcp-oauth-dot" aria-hidden />
             <span>
-              <strong>Not connected.</strong>{' '}
+              <strong>{zhCN(locale, 'Not connected.', '未连接。')}</strong>{' '}
               <span className="hint">
-                Click Connect to grant Open Design access via the provider's OAuth flow.
+                {zhCN(
+                  locale,
+                  "Click Connect to grant Open Design access via the provider's OAuth flow.",
+                  '点击连接，通过提供商的 OAuth 流程授予 Open Design 访问权限。',
+                )}
               </span>
             </span>
           </>
@@ -1298,24 +1311,28 @@ function McpOAuthControl({ serverId }: { serverId: string }) {
               className="primary"
               onClick={onConnect}
               disabled={busy !== 'idle' && busy !== 'refreshing'}
-              title="Reauthenticate (replaces the existing token)"
+              title={zhCN(locale, 'Reauthenticate (replaces the existing token)', '重新认证（替换现有令牌）')}
             >
-              {busy === 'starting' || busy === 'awaiting' ? 'Connecting…' : 'Reconnect'}
+              {busy === 'starting' || busy === 'awaiting'
+                ? zhCN(locale, 'Connecting…', '连接中…')
+                : zhCN(locale, 'Reconnect', '重新连接')}
             </button>
             <button
               type="button"
               onClick={onRefreshStatus}
               disabled={busy !== 'idle' && busy !== 'refreshing'}
-              title="Re-check token status against the daemon"
+              title={zhCN(locale, 'Re-check token status against the daemon', '向守护进程重新检查令牌状态')}
             >
-              {busy === 'refreshing' ? 'Checking…' : 'Refresh'}
+              {busy === 'refreshing' ? zhCN(locale, 'Checking…', '检查中…') : zhCN(locale, 'Refresh', '刷新')}
             </button>
             <button
               type="button"
               onClick={onDisconnect}
               disabled={busy !== 'idle' && busy !== 'refreshing'}
             >
-              {busy === 'disconnecting' ? 'Disconnecting…' : 'Disconnect'}
+              {busy === 'disconnecting'
+                ? zhCN(locale, 'Disconnecting…', '断开中…')
+                : zhCN(locale, 'Disconnect', '断开连接')}
             </button>
           </>
         ) : isAwaiting ? (
@@ -1325,12 +1342,14 @@ function McpOAuthControl({ serverId }: { serverId: string }) {
               className="primary"
               onClick={onRefreshStatus}
               disabled={busy === 'refreshing'}
-              title="I've completed authorization — check connection status now"
+              title={zhCN(locale, "I've completed authorization — check connection status now", '我已完成授权，现在检查连接状态')}
             >
-              {busy === 'refreshing' ? 'Checking…' : 'I\u2019ve approved — Refresh'}
+              {busy === 'refreshing'
+                ? zhCN(locale, 'Checking…', '检查中…')
+                : zhCN(locale, 'I\u2019ve approved — Refresh', '我已批准，刷新')}
             </button>
             <button type="button" onClick={onCancelPending}>
-              Cancel
+              {zhCN(locale, 'Cancel', '取消')}
             </button>
           </>
         ) : (
@@ -1340,7 +1359,7 @@ function McpOAuthControl({ serverId }: { serverId: string }) {
             onClick={onConnect}
             disabled={busy !== 'idle'}
           >
-            {busy === 'starting' ? 'Starting…' : 'Connect'}
+            {busy === 'starting' ? zhCN(locale, 'Starting…', '启动中…') : zhCN(locale, 'Connect', '连接')}
           </button>
         )}
       </div>
@@ -1348,14 +1367,14 @@ function McpOAuthControl({ serverId }: { serverId: string }) {
       {pendingAuthUrl && !connected ? (
         <div className="mcp-oauth-fallback">
           <span className="hint">
-            Browser didn't open?{' '}
+            {zhCN(locale, "Browser didn't open?", '浏览器没有打开？')}{' '}
             <a
               href={pendingAuthUrl}
               target="_blank"
               rel="noreferrer noopener"
               className="md-link"
             >
-              Open authorization page
+              {zhCN(locale, 'Open authorization page', '打开授权页面')}
             </a>
             .
           </span>

--- a/apps/web/src/components/McpClientSection.tsx
+++ b/apps/web/src/components/McpClientSection.tsx
@@ -1251,7 +1251,7 @@ function McpOAuthControl({ serverId }: { serverId: string }) {
   const connected = Boolean(status?.connected);
   const expiresLabel =
     status?.expiresAt && status.expiresAt > 0
-      ? new Date(status.expiresAt).toLocaleString()
+      ? new Date(status.expiresAt).toLocaleString(locale)
       : null;
   const isAwaiting = busy === 'awaiting' || (Boolean(pendingAuthUrl) && !connected);
 

--- a/apps/web/tests/components/McpJsonHelper.test.tsx
+++ b/apps/web/tests/components/McpJsonHelper.test.tsx
@@ -1,25 +1,44 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { McpClientSection } from '../../src/components/McpClientSection';
+import { I18nProvider } from '../../src/i18n';
 
-beforeAll(() => {
-  (global as any).fetch = (input: RequestInfo) => {
+const oauthExpiresAt = Date.UTC(2026, 5, 7, 11, 0, 0);
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : String(input);
     if (url.endsWith('/api/mcp/servers')) {
       return Promise.resolve(new Response(
         JSON.stringify({
           servers: [
             { id: 'srv-1', transport: 'stdio', enabled: true },
-            { id: 'srv-2', transport: 'http', enabled: true },
+            {
+              id: 'srv-2',
+              transport: 'http',
+              enabled: true,
+              url: 'https://example.com/mcp',
+              authMode: 'oauth',
+            },
           ],
           templates: [],
         }),
       )) as any;
     }
+    if (url.includes('/api/mcp/oauth/status')) {
+      return Promise.resolve(new Response(
+        JSON.stringify({ connected: true, expiresAt: oauthExpiresAt }),
+      )) as any;
+    }
     return Promise.resolve(new Response('{}')) as any;
-  };
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
 });
 
 describe('McpJsonHelper (production)', () => {
@@ -54,5 +73,26 @@ describe('McpJsonHelper (production)', () => {
     const panel = document.getElementById(ariaControls!);
     expect(panel).toBeTruthy();
     expect(panel?.textContent).toContain('Example MCP JSON');
+  });
+
+  it('formats managed OAuth expiry timestamps with the selected app locale', async () => {
+    const toLocaleStringSpy = vi.spyOn(Date.prototype, 'toLocaleString');
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <McpClientSection />
+      </I18nProvider>,
+    );
+
+    const expandButtons = await screen.findAllByRole('button', {
+      name: /Expand this MCP server/i,
+    });
+    fireEvent.click(expandButtons[1]!);
+
+    const expectedExpiry = new Date(oauthExpiresAt).toLocaleString('zh-CN');
+    expect(await screen.findByText(`令牌将于 ${expectedExpiry} 过期。`)).toBeTruthy();
+    expect(
+      toLocaleStringSpy.mock.calls.some(([locale]) => locale === 'zh-CN'),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- localize MCP managed OAuth status copy and actions for zh-CN
- localize disconnect failure and browser authorization fallback copy

## Surface area
- [x] **UI** — MCP managed OAuth status/action/fallback copy in apps/web.
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — no new translation keys; localized fallback copy only.
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots
- Visual regression screenshot: [Integrations PR capture](https://releases.open-design.ai/visual-regression/pr-3831/27090583337/pr/visual-integrations.png)
- Latest visual screenshot artifact: [visual-pr-verify-3831-27092013247](https://github.com/nexu-io/open-design/actions/runs/27092013247/artifacts/7463947657)
- Covers the Integrations/MCP surface; the connected OAuth expiry state is covered by the focused zh-CN DOM regression test because CI does not hold a live daemon OAuth token.

## Validation
- corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/McpJsonHelper.test.tsx
- corepack pnpm --filter @open-design/web typecheck