### PR TITLE
design-systems: guard component manifest token references

### DIFF
--- a/design-systems/airtable/components.html
+++ b/design-systems/airtable/components.html
@@ -275,8 +275,12 @@
         width: 10px;
         height: 10px;
         border-radius: 50%;
-        background: var(--chip-color, var(--accent));
+        background: var(--accent);
       }
+      .base-chip-product::before { background: #1b61c9; }
+      .base-chip-marketing::before { background: #f5a623; }
+      .base-chip-design::before { background: #ec4899; }
+      .base-chip-sales::before { background: #16a34a; }
 
       /* ─── Links ─────────────────────────────────────────────── */
       a { color: var(--accent); text-decoration: none; }
@@ -355,10 +359,10 @@
                 Your bases
               </p>
               <div class="base-chips">
-                <span class="base-chip" style="--chip-color: #1b61c9">Product</span>
-                <span class="base-chip" style="--chip-color: #f5a623">Marketing</span>
-                <span class="base-chip" style="--chip-color: #ec4899">Design</span>
-                <span class="base-chip" style="--chip-color: #16a34a">Sales</span>
+                <span class="base-chip base-chip-product">Product</span>
+                <span class="base-chip base-chip-marketing">Marketing</span>
+                <span class="base-chip base-chip-design">Design</span>
+                <span class="base-chip base-chip-sales">Sales</span>
               </div>
             </div>
             <p class="body-sm body-muted">

--- a/design-systems/airtable/components.manifest.json
+++ b/design-systems/airtable/components.manifest.json
@@ -9,8 +9,8 @@
     "title": "Airtable — reference components",
     "description": "Reference fixture for design-systems/airtable. White canvas, Deep Navy text, Airtable Blue accent, Haas typography, blue-tinted multi-layer card shadow.",
     "styleBlockCount": 1,
-    "selectorCount": 58,
-    "classCount": 31,
+    "selectorCount": 62,
+    "classCount": 35,
     "elementCount": 27
   },
   "tokens": {
@@ -80,7 +80,6 @@
       "--bg",
       "--border",
       "--border-soft",
-      "--chip-color",
       "--container-gutter-desktop",
       "--container-gutter-phone",
       "--container-gutter-tablet",
@@ -133,9 +132,7 @@
       "--text-2xl",
       "--warn"
     ],
-    "undeclaredReferenced": [
-      "--chip-color"
-    ]
+    "undeclaredReferenced": []
   },
   "selectors": [
     ".badge",
@@ -143,6 +140,10 @@
     ".badge-muted",
     ".badge-success",
     ".base-chip",
+    ".base-chip-design::before",
+    ".base-chip-marketing::before",
+    ".base-chip-product::before",
+    ".base-chip-sales::before",
     ".base-chip::before",
     ".base-chips",
     ".body-muted",
@@ -202,6 +203,10 @@
     "badge-dot",
     "badge-success",
     "base-chip",
+    "base-chip-design",
+    "base-chip-marketing",
+    "base-chip-product",
+    "base-chip-sales",
     "base-chips",
     "body-muted",
     "body-sm",
@@ -493,7 +498,7 @@
     }
   ],
   "literals": {
-    "colorExpressions": 4,
+    "colorExpressions": 8,
     "pixelValues": 47,
     "hardcodedFontFamilies": 5
   }

--- a/design-systems/lovable/components.html
+++ b/design-systems/lovable/components.html
@@ -268,7 +268,7 @@
         text-underline-offset: 3px;
         text-decoration-thickness: 1px;
       }
-      a:hover { color: var(--accent); }             /* hsl(var(--primary)) per §4 */
+      a:hover { color: var(--accent); }             /* primary accent per §4 */
 
       kbd {
         font-family: var(--font-mono);

--- a/design-systems/lovable/components.manifest.json
+++ b/design-systems/lovable/components.manifest.json
@@ -93,7 +93,6 @@
       "--motion-base",
       "--motion-fast",
       "--muted",
-      "--primary",
       "--radius-md",
       "--radius-pill",
       "--radius-sm",
@@ -133,9 +132,7 @@
       "--text-2xl",
       "--warn"
     ],
-    "undeclaredReferenced": [
-      "--primary"
-    ]
+    "undeclaredReferenced": []
   },
   "selectors": [
     ".body-muted",

--- a/design-systems/together-ai/components.html
+++ b/design-systems/together-ai/components.html
@@ -169,7 +169,7 @@
         color: var(--fg);
         border-color: var(--border);
       }
-      .btn-secondary:hover { background: rgba(189, 187, 255, 0.12); border-color: var(--lavender); }
+      .btn-secondary:hover { background: rgba(189, 187, 255, 0.12); border-color: #bdbbff; }
 
       /* ─── Inputs ────────────────────────────────────────────── */
       .field { display: flex; flex-direction: column; gap: var(--space-2); }
@@ -227,7 +227,7 @@
         border-color: rgba(255, 255, 255, 0.1);
       }
       .section-dark .btn-primary {
-        background: var(--lavender);
+        background: #bdbbff;
         color: var(--accent);            /* Dark on lavender — reverse CTA */
       }
       .section-dark .btn-primary:hover { background: #d4d3ff; }
@@ -373,7 +373,7 @@
             </div>
             <div class="features-grid" style="grid-template-columns: 1fr;">
               <article class="card" style="background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.1);">
-                <span class="badge" style="color: var(--lavender); background: rgba(189,187,255,0.15);">Technical</span>
+                <span class="badge" style="color: #bdbbff; background: rgba(189,187,255,0.15);">Technical</span>
                 <h3 style="color: #ffffff;">PP Neue Montreal Mono</h3>
                 <p style="color: rgba(255,255,255,0.6); font-size: var(--text-sm)">
                   --font-mono: "PP Neue Montreal Mono". Used for uppercase section

--- a/design-systems/together-ai/components.manifest.json
+++ b/design-systems/together-ai/components.manifest.json
@@ -91,7 +91,6 @@
       "--font-body",
       "--font-display",
       "--font-mono",
-      "--lavender",
       "--leading-body",
       "--leading-tight",
       "--motion-fast",
@@ -133,9 +132,7 @@
       "--text-xl",
       "--warn"
     ],
-    "undeclaredReferenced": [
-      "--lavender"
-    ]
+    "undeclaredReferenced": []
   },
   "selectors": [
     ".badge",
@@ -273,7 +270,6 @@
         "--ease-standard",
         "--focus-ring",
         "--font-body",
-        "--lavender",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
@@ -458,13 +454,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--lavender",
         "--space-4"
       ]
     }
   ],
   "literals": {
-    "colorExpressions": 13,
+    "colorExpressions": 15,
     "pixelValues": 25,
     "hardcodedFontFamilies": 9
   }

--- a/scripts/check-design-system-manifests.test.ts
+++ b/scripts/check-design-system-manifests.test.ts
@@ -15,7 +15,13 @@ import {
   renderTailwindV4Css,
   type DerivedDesignTokenBinding,
 } from "../packages/contracts/src/design-systems/derived-token-outputs.ts";
-import { validateDesignTokensJson, validateManifestSemantics, validateTailwindV4Css } from "./check-design-system-manifests.ts";
+import { extractComponentsManifest } from "../packages/contracts/src/design-systems/components-manifest.ts";
+import {
+  validateComponentsManifestCache,
+  validateDesignTokensJson,
+  validateManifestSemantics,
+  validateTailwindV4Css,
+} from "./check-design-system-manifests.ts";
 
 const REPORT_PATH = "source/token-contract.report.json";
 
@@ -329,6 +335,40 @@ test("design-system tailwind v4 guard rejects swapped canonical mappings", async
     assert.deepEqual(violations, [
       "design-systems/test/manifest.json: tailwind-v4.css is stale; regenerate it from tokens.css",
     ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("design-system components manifest guard rejects undeclared token references", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "od-components-manifest-guard-"));
+  try {
+    const fixtureHtml = [
+      "<!doctype html>",
+      "<style>",
+      ".btn { color: var(--accent); border-color: var(--missing-token); }",
+      "</style>",
+      '<button class="btn">Continue</button>',
+    ].join("\n");
+    const tokensCss = ":root {\n  --accent: #111111;\n}\n";
+    writeFileSync(path.join(root, "components.html"), fixtureHtml);
+    writeFileSync(path.join(root, "tokens.css"), tokensCss);
+    writeFileSync(
+      path.join(root, "components.manifest.json"),
+      `${JSON.stringify(extractComponentsManifest({ brandId: "test", fixtureHtml, tokensCss }), null, 2)}\n`,
+    );
+
+    const violations: string[] = [];
+    await validateComponentsManifestCache(
+      violations,
+      "design-systems/test/manifest.json",
+      root,
+      "test",
+      "components.manifest.json",
+    );
+
+    assert.equal(violations.length, 1);
+    assert.match(violations[0]!, /references undeclared component token\(s\): --missing-token$/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/check-design-system-manifests.ts
+++ b/scripts/check-design-system-manifests.ts
@@ -503,7 +503,7 @@ async function validateDeclaredJsonFiles(
   }
 }
 
-async function validateComponentsManifestCache(
+export async function validateComponentsManifestCache(
   violations: string[],
   repositoryManifestPath: string,
   brandRoot: string,
@@ -527,6 +527,11 @@ async function validateComponentsManifestCache(
     if (!isDeepStrictEqual(cachedManifest, derivedManifest)) {
       violations.push(
         `${repositoryManifestPath}: ${toRepositoryPath(cachePath)} is stale; regenerate it from components.html + tokens.css`,
+      );
+    }
+    if (derivedManifest.tokens.undeclaredReferenced.length > 0) {
+      violations.push(
+        `${repositoryManifestPath}: ${toRepositoryPath(cachePath)} references undeclared component token(s): ${derivedManifest.tokens.undeclaredReferenced.join(", ")}`,
       );
     }
   } catch (error) {


### PR DESCRIPTION
## Why

This follows the Design System 2.0 bundled-system backfill by tightening the generated component manifest contract now that all bundled systems have 2.0 packages. The backfill made component inventories auditable, but three generated manifests still carried undeclared component token references that were either comment-only, local-only, or non-schema variables.

The pain being addressed is that `tokens.undeclaredReferenced` should be trustworthy for downstream extraction. Leaving non-empty values in committed manifests makes the 2.0 package data look internally inconsistent even when the UI fixture renders correctly.

## What users will see

Users should not see visual behavior changes. Airtable base chips keep their colored dots, Lovable link hover still uses the accent token, and Together AI still uses lavender accents in the dark-section examples.

The generated component manifest data is cleaner: all 150 bundled systems now have empty `tokens.undeclaredReferenced`, and the manifest guard rejects future undeclared component token references.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface changed.

## Bug fix verification

N/A — not a bug fix.

## Validation

- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec tsx scripts/check-design-system-manifests.ts`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec tsx scripts/check-design-system-package-quality.ts`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm exec tsx scripts/check-tokens-fixture-sync.ts`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH node --import tsx --test scripts/check-design-system-manifests.test.ts`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm guard`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm typecheck`
