### PR TITLE
fix(daemon): surface Antigravity no_text handoff failures as AGENT_EXECUTION_FAILED

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13239,6 +13239,26 @@ export async function startServer({
         ));
         return finishWithRetryDecision('failed', code, signal);
       }
+      // Antigravity 1.0.4 "no_text" guard: the CLI can exit cleanly
+      // with a `no_text` signal that means the upstream handoff
+      // dropped the result. Surface a retryable failure instead of
+      // letting it pass through as success.
+      if (
+        code === 0 &&
+        !run.cancelRequested &&
+        def.id === 'antigravity' &&
+        /\bno_text\b/i.test(`${agentStderrTail}\n${agentStdoutTail}`)
+      ) {
+        send(
+          'error',
+          createSseErrorPayload(
+            'AGENT_EXECUTION_FAILED',
+            'Antigravity returned an empty response (no_text) — this usually means the 1.0.4 handoff dropped the upstream result. Try updating agy, switching models, or re-running.',
+            { retryable: true },
+          ),
+        );
+        return finishWithRetryDecision('failed', 0, signal);
+      }
       if (
         code === 0 &&
         !run.cancelRequested &&

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -1757,6 +1757,46 @@ process.exit(0);
     );
   });
 
+  it('surfaces Antigravity no_text handoff failures as AGENT_EXECUTION_FAILED', async () => {
+    await withFakeAgent(
+      'agy',
+      `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+process.stdout.write('no_text\\n');
+process.exit(0);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'antigravity',
+            message: 'hello',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'AGENT_EXECUTION_FAILED');
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('event: error');
+        expect(eventsBody).toContain('AGENT_EXECUTION_FAILED');
+        expect(eventsBody).toContain('no_text');
+        expect(statusBody.status).toBe('failed');
+      },
+    );
+  });
+
   it('surfaces Qoder assistant error records through the SSE error channel', async () => {
     const qoderErrorLine = JSON.stringify({
       type: 'assistant',


### PR DESCRIPTION
Fixes #3536

## Why

Antigravity 1.0.4 can exit cleanly with a `no_text` signal when the
upstream handoff drops the result. Without a guard, the daemon treats
this as a successful run and shows an empty reply to the user — they
have no indication that anything went wrong and no actionable
retry path.

## What users will see

Instead of a silent empty response, the chat now surfaces a clear
`AGENT_EXECUTION_FAILED` error with a retryable flag. The message
explains that the no_text handoff dropped the result and suggests
updating agy, switching models, or re-running.

## Surface area
- [x] **Default behavior change** — the daemon now classifies
  antigravity `no_text` stdout/stderr as a retryable execution failure.
- [ ] **UI** — changes stay in the daemon / chat route layer.

## Bug fix verification

Added a regression test in `apps/daemon/tests/chat-route.test.ts` that
feeds a fake antigravity binary printing `no_text` and exiting 0. The
test asserts the SSE stream emits `AGENT_EXECUTION_FAILED` and the run
status is `failed`.

## Validation

- Unit test added and verified via the existing daemon chat-route test
  harness (`withFakeAgent`).
- No change to the public API or wire format beyond surfacing the
  existing `AGENT_EXECUTION_FAILED` error channel.