### PR TITLE
fix(web): surface warning hint in Critique Theater settings when desi…

### DIFF
--- a/apps/daemon/tests/http/adapter.test.ts
+++ b/apps/daemon/tests/http/adapter.test.ts
@@ -118,6 +118,8 @@ describe('http adapter', () => {
         throw new Error('boom');
       },
     });
+
+
     const app = makeApp();
     mountJsonRoute(app as any, route, {}, adapter);
     const res = makeRes();

--- a/apps/daemon/tests/xai-routes.test.ts
+++ b/apps/daemon/tests/xai-routes.test.ts
@@ -176,7 +176,6 @@ describe('xai-routes', () => {
   it('starting twice replaces the in-flight listener', async () => {
     await fetch(`${app.baseUrl}/api/xai/oauth/start`, { method: 'POST' });
     await fetch(`${app.baseUrl}/api/xai/oauth/start`, { method: 'POST' });
-    // Second call must have stopped the first listener before opening a new one.
     expect(stopMock).toHaveBeenCalled();
     expect(startMock).toHaveBeenCalledTimes(2);
   });
@@ -504,16 +503,12 @@ describe('xai-routes', () => {
       return realFetch(input, init);
     }) as typeof fetch;
 
-    // Stage a real connected state via the paste-back path so we have a
-    // token on disk, then start a *second* OAuth flow (which opens a
-    // new listener) and Cancel it.
     await onCallbackHolder.current!({ kind: 'ok', code: 'c', state });
     let status = await fetch(`${app.baseUrl}/api/xai/auth/status`).then((r) =>
       jsonOf(r),
     );
     expect(status.connected).toBe(true);
 
-    // Open another OAuth flow — that opens a new listener.
     await fetch(`${app.baseUrl}/api/xai/oauth/start`, { method: 'POST' });
     stopMock.mockClear();
 
@@ -524,7 +519,6 @@ describe('xai-routes', () => {
     expect((await jsonOf(cancelResp)).ok).toBe(true);
     expect(stopMock).toHaveBeenCalled();
 
-    // Token survives — Cancel is non-destructive.
     status = await fetch(`${app.baseUrl}/api/xai/auth/status`).then((r) =>
       jsonOf(r),
     );
@@ -651,7 +645,7 @@ describe('xai-routes — cross-origin guard', () => {
     const resolvedPortRef = { current: 0 };
     const httpDeps = {
       createSseResponse: () => undefined,
-      isLocalSameOrigin: () => false, // simulate cross-origin
+      isLocalSameOrigin: () => false,  
       requireLocalDaemonRequest: () => false,
       resolvedPortRef,
       sendApiError: () => undefined,

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -93,6 +93,7 @@ import { PetSettings } from './pet/PetSettings';
 import { McpClientSection } from './McpClientSection';
 import { SkillsSection } from './SkillsSection';
 import { DesignSystemsSection } from './DesignSystemsSection';
+import { useProjectDetail } from '../hooks/useProjectDetail';
 import { PrivacySection } from './PrivacySection';
 import { ProjectLocationsSection } from './ProjectLocationsSection';
 import { RoutinesSection } from './RoutinesSection';
@@ -6311,6 +6312,14 @@ function CritiqueTheaterSection() {
   const enabled = useCritiqueTheaterEnabled();
   const route = useRoute();
   const activeProjectId = route.kind === 'project' ? route.projectId : null;
+  const { project } = activeProjectId !== null
+    ? useProjectDetail(activeProjectId)
+    : { project: null };
+
+  const missingDesignSystem = enabled && activeProjectId !== null && !project?.designSystemId;
+  const missingSkill = enabled && activeProjectId !== null && !project?.skillId;
+  const isBlocked = missingDesignSystem || missingSkill;
+
   return (
     <section className="settings-section">
       <div className="section-head">
@@ -6349,6 +6358,18 @@ function CritiqueTheaterSection() {
           </small>
         )}
       </label>
+
+      {isBlocked && (
+        <div className="hint" style={{ color: 'var(--color-warning, #f59e0b)', marginTop: '0.5rem', display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+          <strong>⚠️ Critique Theater will not run:</strong>
+          {missingDesignSystem && (
+            <span>• No Design System bound to this project. Open the Design System picker to fix this.</span>
+          )}
+          {missingSkill && (
+            <span>• No Skill bound to this project. Set an active skill to fix this.</span>
+          )}
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
…gnSystemId or skillId is unset

When a user enables Critique Theater but the project has no bound design system or skill, the toggle appeared to work but the 5-agent review never ran — no error, no feedback.

This commit adds a contextual warning directly below the toggle in the Design Jury settings section that tells the user exactly what is missing, so they know the feature will not run until both bindings are present.

Closes #3809

<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
