### PR TITLE
fix: update od-contribute installation instructions

### DIFF
--- a/apps/landing-page/public/community/contributors/index.html
+++ b/apps/landing-page/public/community/contributors/index.html
@@ -98,8 +98,8 @@
           <h3>Let the <em>agent</em> ship for you.</h3>
           <p class="pane-lede">For makers who'd rather not touch the code. The whole contribution lives in a single skill, spoken in plain language. The brushwork falls to the agent.</p>
         </div>
-        <div class="contrib-install" data-install="curl -sSL https://raw.githubusercontent.com/nexu-io/open-design/main/.claude/skills/od-contribute/install.sh | bash">
-          <span class="cmd">curl -sSL https://raw.githubusercontent.com/nexu-io/open-design/main/.claude/skills/od-contribute/install.sh | bash</span>
+        <div class="contrib-install" data-install="git clone https://github.com/nexu-io/open-design.git && bash open-design/.claude/skills/od-contribute/install.sh">
+          <span class="cmd">git clone https://github.com/nexu-io/open-design.git && bash open-design/.claude/skills/od-contribute/install.sh</span>
           <button type="button" data-copy>Copy</button>
         </div>
         <div class="contrib-steps">


### PR DESCRIPTION
Hi everyone! 

As discussed, I am updating the public install instructions on the Community page (apps/landing-page/public/community/index.html) so they no longer point to an /install.sh URL over HTTP.

Instead of the curl | bash method, I've replaced the instructions with a safer standard git clone approach:

bash
git clone https://github.com/nexu-io/open-design.git && bash open-design/.claude/skills/od-contribute/install.sh
This completely removes the reliance on fetching the script directly from a URL and aligns with the safer installation practices.