### PR TITLE
ci: add standalone Nix validation lane

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -119,9 +119,8 @@ jobs:
           CI regenerated a patch for `nix/pnpm-deps.nix` and uploaded it as the
           `nix-hash-refresh` artifact for this run.
 
-          - same-repo PRs: the follow-up `nix-hash-autofix` workflow will try to
-            push the hash-only patch back to the PR branch automatically;
-          - fork PRs: a PR comment will include the patch and artifact guidance.
+          Apply the patch from the artifact to refresh the generated Nix pnpm
+          dependency hash, then rerun this workflow.
           EOF
               ;;
             no-change)

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -1,0 +1,148 @@
+name: ci-nix
+
+on:
+  pull_request:
+    paths:
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - flake.nix
+      - flake.lock
+      - nix/**
+      - .github/workflows/ci-nix.yml
+      - .github/workflows/nix-check.yml
+      - .github/workflows/nix-hash-autofix.yml
+      - apps/daemon/**
+      - apps/web/**
+      - packages/components/**
+      - packages/contracts/**
+      - packages/registry-protocol/**
+      - packages/agui-adapter/**
+      - packages/plugin-runtime/**
+      - packages/sidecar-proto/**
+      - packages/sidecar/**
+      - packages/platform/**
+      - packages/diagnostics/**
+      - packages/host/**
+      - assets/**
+      - plugins/**
+      - skills/**
+      - design-systems/**
+      - design-templates/**
+      - craft/**
+      - prompt-templates/**
+      - scripts/update-nix-pnpm-deps-hash.ts
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Nix flake
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Setup Node for Nix hash refresh
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+
+      - name: nix flake check
+        id: flake_check
+        continue-on-error: true
+        run: nix flake check --print-build-logs --keep-going
+
+      - name: Generate Nix hash refresh patch
+        id: hash_refresh
+        if: ${{ github.event_name == 'pull_request' && steps.flake_check.outcome == 'failure' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          out_dir="$RUNNER_TEMP/nix-hash-refresh"
+          mkdir -p "$out_dir"
+
+          status="update-failed"
+          if node --experimental-strip-types ./scripts/update-nix-pnpm-deps-hash.ts >"$out_dir/update.log" 2>&1; then
+            if git diff --quiet --exit-code -- nix/pnpm-deps.nix; then
+              status="no-change"
+            else
+              git diff -- nix/pnpm-deps.nix >"$out_dir/nix-pnpm-deps.patch"
+              cp nix/pnpm-deps.nix "$out_dir/pnpm-deps.nix"
+              status="patch-generated"
+            fi
+          fi
+
+          printf '{"status":"%s","runId":%s,"prNumber":%s,"headSha":"%s"}\n' \
+            "$status" \
+            '${{ github.run_id }}' \
+            '${{ github.event.pull_request.number }}' \
+            '${{ github.event.pull_request.head.sha }}' >"$out_dir/metadata.json"
+
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Nix hash refresh artifact
+        if: ${{ github.event_name == 'pull_request' && steps.flake_check.outcome == 'failure' && steps.hash_refresh.outputs.status != 'no-change' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: nix-hash-refresh
+          path: ${{ runner.temp }}/nix-hash-refresh
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Summarize Nix hash refresh guidance
+        if: ${{ github.event_name == 'pull_request' && steps.flake_check.outcome == 'failure' }}
+        env:
+          HASH_REFRESH_STATUS: ${{ steps.hash_refresh.outputs.status }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${HASH_REFRESH_STATUS:-not-run}" in
+            patch-generated)
+              cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## Generated Nix hash refresh
+
+          CI regenerated a patch for `nix/pnpm-deps.nix` and uploaded it as the
+          `nix-hash-refresh` artifact for this run.
+
+          - same-repo PRs: the follow-up `nix-hash-autofix` workflow will try to
+            push the hash-only patch back to the PR branch automatically;
+          - fork PRs: a PR comment will include the patch and artifact guidance.
+          EOF
+              ;;
+            no-change)
+              cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## Nix hash refresh unavailable
+
+          `nix flake check` failed, but `nix/pnpm-deps.nix` did not change after
+          running the hash refresh helper. Inspect the Nix build logs for a
+          non-hash failure.
+          EOF
+              ;;
+            *)
+              cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## Nix hash refresh failed
+
+          `nix flake check` failed and the helper could not generate a hash-only
+          patch. See the `nix-hash-refresh` artifact for `update.log`.
+          EOF
+              ;;
+          esac
+
+      - name: Fail when Nix validation fails
+        if: ${{ steps.flake_check.outcome == 'failure' }}
+        run: exit 1


### PR DESCRIPTION
## Why

This adds a small standalone Nix validation lane so follow-up CI gate work can treat Nix as an independent evidence source instead of keeping it tied to the legacy `ci` workflow shape.

The pain being addressed is migration risk: the upcoming `ci-gate` experiment needs a clean Nix lane before workspace evidence, self-hosted hot paths, and hosted fallback policy are changed in a larger PR.

## What users will see

No product UI changes. Pull requests that touch Nix inputs or the daemon/web Nix closures will have a separate `ci-nix` workflow available for Nix flake validation.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A.

## Bug fix verification

N/A.

## Validation

- `actionlint -color .github/workflows/ci-nix.yml`

Note: I did not run `pnpm guard`; this workflow-only PR has no workspace package changes, and the temporary worktree did not have `node_modules` installed.