### PR TITLE
[codex] surface ACP waiting progress

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -800,6 +800,11 @@ export function attachAcpSession({
       },
       'session/prompt',
     );
+    send('agent', {
+      type: 'status',
+      label: 'waiting_for_first_output',
+      elapsedMs: Date.now() - runStartedAt,
+    });
     nextId += 1;
   };
 
@@ -869,6 +874,13 @@ export function attachAcpSession({
     }
     const update = asObject(params?.update);
     if (obj.method === 'session/update' && update) {
+      if (update.sessionUpdate !== 'agent_message_chunk' && update.sessionUpdate !== 'agent_thought_chunk') {
+        send('agent', {
+          type: 'status',
+          label: String(update.sessionUpdate || 'session_update'),
+          elapsedMs: Date.now() - runStartedAt,
+        });
+      }
       if (update.sessionUpdate === 'agent_thought_chunk') {
         const text = asObject(update.content)?.text;
         if (typeof text === 'string' && text.length > 0) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12207,6 +12207,10 @@ export async function startServer({
             : '';
         return `${type}:${text.length} chars`;
       }
+      if (type === 'status') {
+        const label = payload?.label ? String(payload.label) : 'unknown';
+        return `status:${label}`;
+      }
       return type;
     };
     const clearInactivityWatchdog = () => {
@@ -13067,6 +13071,9 @@ export async function startServer({
         mcpServers,
         ...(def.id === 'amr' ? { modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE' } : {}),
         send: (event, data) => {
+          if (event === 'agent') {
+            lastAgentEventPhase = summarizeAgentEventForInactivity(data);
+          }
           noteAgentActivity();
           if (event === 'agent') noteFirstTokenFromAgentEvent(data);
           if (def.id === 'amr' && event === 'error') {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -436,6 +436,55 @@ test('attachAcpSession recovers when bracket-prefixed logs precede JSON frames',
   assert.equal(events.some((entry) => entry.event === 'error'), false);
 });
 
+test('attachAcpSession emits a waiting status after submitting the prompt', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  const events: Array<{ event: string; payload: unknown }> = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'make a simple deck',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+
+  const promptRequest = parseRpcWrites(writes).find((entry) => entry.method === 'session/prompt');
+  assert.ok(promptRequest, 'expected session/prompt to be submitted');
+  assert.ok(
+    hasAgentStatus(events, 'waiting_for_first_output'),
+    `expected waiting status after session/prompt, got ${JSON.stringify(events)}`,
+  );
+});
+
+test('attachAcpSession surfaces non-text ACP updates as status progress', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'make a simple deck',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, { sessionUpdate: 'tool_call_update', toolCallId: 'call-1', status: 'in_progress' });
+
+  assert.ok(
+    hasAgentStatus(events, 'tool_call_update'),
+    `expected tool_call_update status progress, got ${JSON.stringify(events)}`,
+  );
+});
+
 function parseRpcWrites(writes: string[]): Array<Record<string, unknown>> {
   return writes
     .join('')
@@ -464,6 +513,13 @@ function agentModelStatuses(events: Array<{ event: string; payload: unknown }>):
       return entry.event === 'agent' && payload.type === 'status' && payload.label === 'model';
     })
     .map((entry) => (entry.payload as { model?: unknown }).model);
+}
+
+function hasAgentStatus(events: Array<{ event: string; payload: unknown }>, label: string): boolean {
+  return events.some((entry) => {
+    const payload = entry.payload as { type?: unknown; label?: unknown };
+    return entry.event === 'agent' && payload.type === 'status' && payload.label === label;
+  });
 }
 
 test('attachAcpSession force-terminates the child after a clean prompt completion if it does not exit on stdin.end()', async () => {

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -1081,6 +1081,17 @@ function normalizeToolInput(input: unknown): unknown {
   return input;
 }
 
+const TRANSIENT_ACP_STATUS_LABELS = new Set([
+  'waiting_for_first_output',
+  'tool_call',
+  'tool_call_update',
+  'session_update',
+]);
+
+function normalizeAgentStatusLabel(label: string): string {
+  return TRANSIENT_ACP_STATUS_LABELS.has(label) ? 'running' : label;
+}
+
 // Translate a raw `agent` SSE payload (what apps/daemon/src/claude-stream.ts emits)
 // into the UI's AgentEvent union. Keep this liberal — unknown types just
 // return null so the UI ignores them instead of rendering garbage.
@@ -1089,7 +1100,7 @@ function translateAgentEvent(data: DaemonAgentPayload): AgentEvent | null {
   if (t === 'status' && typeof data.label === 'string') {
     return {
       kind: 'status',
-      label: data.label,
+      label: normalizeAgentStatusLabel(data.label),
       detail:
         typeof data.detail === 'string'
           ? data.detail

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -1529,6 +1529,38 @@ describe('streamViaDaemon', () => {
       detail: 'tavily · shallow',
     });
   });
+
+  it('maps transient ACP progress labels to hidden running status events', async () => {
+    const handlers = createDaemonHandlers();
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+      .mockResolvedValueOnce(
+        sseResponse(
+          'event: agent\ndata: {"type":"status","label":"waiting_for_first_output","elapsedMs":12}\n\n' +
+            'event: agent\ndata: {"type":"status","label":"tool_call_update","elapsedMs":34}\n\n' +
+            'event: end\ndata: {"code":0,"status":"succeeded"}\n\n',
+        ),
+      ));
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onAgentEvent).toHaveBeenCalledWith({
+      kind: 'status',
+      label: 'running',
+    });
+    const statusLabels = handlers.onAgentEvent.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.kind === 'status')
+      .map((event) => event.label);
+    expect(statusLabels).not.toContain('waiting_for_first_output');
+    expect(statusLabels).not.toContain('tool_call_update');
+  });
 });
 
 describe('streamMessageOpenAI', () => {


### PR DESCRIPTION
## Why

AMR/ACP runs can sit silently between `session/prompt` submission and the first assistant token. When the outer inactivity watchdog eventually fires, Open Design could still report `last agent event: spawn pending` even though the ACP child had started and stdout was flowing. This PR surfaces the waiting phase explicitly and keeps watchdog phase tracking aligned with ACP adapter events.

## What users will see

AMR runs will show progress while waiting for the first model/tool output instead of appearing stuck until the 600s stall banner. If a run still times out, the failure details should name the latest ACP status or text/thinking phase rather than misleadingly staying on `spawn pending`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is daemon-side progress/event behavior with existing status rendering.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/acp.test.ts`
- Did the test go red on `main` and green on this branch? Yes. The added tests fail against the old source because `session/prompt` submission and non-text ACP updates produce no daemon-visible status events, then pass with this branch.

## Validation

- `PATH="/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH" pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/acp.test.ts --maxWorkers=1`
- `PATH="/Users/alche/.nvm/versions/node/v24.0.0/bin:$PATH" pnpm --filter @open-design/daemon typecheck`
- `git diff --check`

Notes: validation was rerun on Node `v24.0.0` with `pnpm@10.33.2`. After rebasing onto latest `origin/main`, `pnpm install --frozen-lockfile` was run to refresh local dependencies for the new base without changing the lockfile.
