### PR TITLE
docs(validation): main-chain validation suite (YAML, 43 cases)

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -1,0 +1,43 @@
+# validation — 主链路验证用例库
+
+`main-chain-suite.yaml` 是 open-design 的**「每次 release 必须工作」回归契约 / 验收标准**。
+它和产品代码住在一起,由产品/QA 团队拥有,改功能时在同一个 PR 里顺手更新对应用例。
+
+## 谁用它
+
+- **nexu-xray agent 自主验证**:验证 open-design 时从本仓读取这份契约,逐条(`per_model` 的 × AMR 全模型)自主跑,产出结果。
+- **自主验证偏差率**:agent 自主验证结果 ↔ 测试同学人工验收结论,按 case `id` 对齐,算偏差(目标逐版→0)。看板:研发页 `/daily/?view=yang` 的「Agent 自主验证 vs 人工验收」卡片。
+
+> 设计理念:**每个产品自带自己的验证契约,工具(nexu-xray)是通用 runner**。所以契约住在产品仓,不在工具仓。
+
+## 怎么长大(沉淀)
+
+- 每份**人工验收文档**的 P0/P1(/P2)→ 找到匹配 case 补 `sources`,或新增 case。
+- 改功能 → 同 PR 更新受影响的 case。
+- 只增不忘:历史人工找到的问题都变成可回归的用例。
+
+## case 结构
+
+```yaml
+- id: mc-exec-completes-no-error   # 稳定 kebab id(两边对齐的主键)
+  chain: generate                  # generate|preview|comment|edit|chat|mark|session|home|ui|export|settings|amr|...
+  scope: per_model                 # per_model = AMR 全模型各跑一遍;once = 跑一次
+  severity: P0                     # P0 主链路阻断 / P1 高 / P2 中 / P3 低
+  exec_dependent: true             # (可选) 依赖真实模型执行 → 应在真后端跑
+  error_path: true                 # (可选) 测错误/边界路径(瞬时报错恢复、超时…)
+  title: 每个 AMR 模型执行生成都不报错
+  steps: [新建项目并输入 prompt, 选定该 AMR 模型, 运行生成]
+  expected: 执行完成、无 connection reset / socket / opencode event stream 等后端报错
+  sources: [0.10.0-nightly P0-2, P0-5/6 gpt-5.5 socket]   # 沉淀来源:验收条目 或 测试文件
+```
+
+## AMR 全模型策略
+
+`amr_regression`:AMR(云端模型 runtime)**全模型是核心,每次 release 必须回归一遍**。
+0.10.0 验收证明多数 P0 是模型后端特定的执行错误,**单后端跑结构性漏掉**。
+模型清单**运行时从 `apps/daemon/src/runtimes/registry.ts` 的 BASE_AGENT_DEFS 枚举 + 每 agent `listModels` 动态发现**,不硬编码。
+
+---
+
+格式选 YAML(人读 + agent 读 + git diff + 可注释,比 JSON 省 token)。从 nexu-xray 工具仓的
+`corpus/main-chain-suite.json` 迁移而来(2026-06-08),后续此处为单一真相。

--- a/validation/README.md
+++ b/validation/README.md
@@ -1,43 +1,56 @@
-# validation — 主链路验证用例库
+# validation — main-chain validation suite
 
-`main-chain-suite.yaml` 是 open-design 的**「每次 release 必须工作」回归契约 / 验收标准**。
-它和产品代码住在一起,由产品/QA 团队拥有,改功能时在同一个 PR 里顺手更新对应用例。
+`main-chain-suite.yaml` is open-design's **"must work every release" regression contract /
+acceptance criteria**. It lives alongside the product code, is owned by the product/QA team,
+and is updated in the same PR whenever a feature changes.
 
-## 谁用它
+## Who uses it
 
-- **nexu-xray agent 自主验证**:验证 open-design 时从本仓读取这份契约,逐条(`per_model` 的 × AMR 全模型)自主跑,产出结果。
-- **自主验证偏差率**:agent 自主验证结果 ↔ 测试同学人工验收结论,按 case `id` 对齐,算偏差(目标逐版→0)。看板:研发页 `/daily/?view=yang` 的「Agent 自主验证 vs 人工验收」卡片。
+- **nexu-xray autonomous validation**: when validating open-design, the agent reads this
+  contract from the repo and runs each case autonomously (`per_model` cases run once per AMR model).
+- **Autonomous-validation deviation**: the agent's results are aligned with the test team's
+  human acceptance by case `id` to compute a deviation rate (target → 0 over releases).
+  Dashboard: the "Agent autonomous validation vs human acceptance" card on the R&D page
+  (`/daily/?view=yang`).
 
-> 设计理念:**每个产品自带自己的验证契约,工具(nexu-xray)是通用 runner**。所以契约住在产品仓,不在工具仓。
+> Design principle: **each product ships its own validation contract; the tool (nexu-xray) is a
+> generic runner.** So the contract lives in the product repo, not the tool repo.
 
-## 怎么长大(沉淀)
+## How it grows (sedimentation)
 
-- 每份**人工验收文档**的 P0/P1(/P2)→ 找到匹配 case 补 `sources`,或新增 case。
-- 改功能 → 同 PR 更新受影响的 case。
-- 只增不忘:历史人工找到的问题都变成可回归的用例。
+- Every **human acceptance doc**: its P0/P1(/P2) issues → match an existing case (append to
+  `sources`) or add a new case.
+- A feature change → update the affected cases in the same PR.
+- Append-only: every issue humans ever found becomes a reproducible case.
 
-## case 结构
+## Case shape
 
 ```yaml
-- id: mc-exec-completes-no-error   # 稳定 kebab id(两边对齐的主键)
+- id: mc-exec-completes-no-error   # stable kebab id (the join key across both sides)
   chain: generate                  # generate|preview|comment|edit|chat|mark|session|home|ui|export|settings|amr|...
-  scope: per_model                 # per_model = AMR 全模型各跑一遍;once = 跑一次
-  severity: P0                     # P0 主链路阻断 / P1 高 / P2 中 / P3 低
-  exec_dependent: true             # (可选) 依赖真实模型执行 → 应在真后端跑
-  error_path: true                 # (可选) 测错误/边界路径(瞬时报错恢复、超时…)
-  title: 每个 AMR 模型执行生成都不报错
+  scope: per_model                 # per_model = run once per AMR model; once = run once
+  severity: P0                     # P0 main-chain blocker / P1 high / P2 medium / P3 low
+  exec_dependent: true             # (optional) needs a real model run → exercise on a real backend
+  error_path: true                 # (optional) tests an error/edge path (transient-error recovery, timeout, ...)
+  title: 每个 AMR 模型执行生成都不报错        # case content is in Chinese (matches the Chinese UI + acceptance docs)
   steps: [新建项目并输入 prompt, 选定该 AMR 模型, 运行生成]
   expected: 执行完成、无 connection reset / socket / opencode event stream 等后端报错
-  sources: [0.10.0-nightly P0-2, P0-5/6 gpt-5.5 socket]   # 沉淀来源:验收条目 或 测试文件
+  sources: [0.10.0-nightly P0-2, P0-5/6 gpt-5.5 socket]   # provenance: acceptance item or test file
 ```
 
-## AMR 全模型策略
+> Note: docs/structure are in English; **case content (`title`/`steps`/`expected`) stays in
+> Chinese** — it mirrors the Chinese UI and is transcribed from the team's Chinese acceptance docs.
 
-`amr_regression`:AMR(云端模型 runtime)**全模型是核心,每次 release 必须回归一遍**。
-0.10.0 验收证明多数 P0 是模型后端特定的执行错误,**单后端跑结构性漏掉**。
-模型清单**运行时从 `apps/daemon/src/runtimes/registry.ts` 的 BASE_AGENT_DEFS 枚举 + 每 agent `listModels` 动态发现**,不硬编码。
+## AMR all-models policy
+
+`amr_regression`: AMR (the cloud model runtime) — **all models are CORE; every release must
+regress the main chain under every model in the live AMR catalog**. The 0.10.0 acceptance proved
+most P0s are model-backend-specific execution errors, which a single-backend run structurally
+misses. The model list is **enumerated at run time** from `apps/daemon/src/runtimes/registry.ts`
+`BASE_AGENT_DEFS` plus each agent's `listModels` discovery — never hardcoded.
 
 ---
 
-格式选 YAML(人读 + agent 读 + git diff + 可注释,比 JSON 省 token)。从 nexu-xray 工具仓的
-`corpus/main-chain-suite.json` 迁移而来(2026-06-08),后续此处为单一真相。
+Format is YAML (readable by humans and agents, diff-friendly, comment-capable, lighter than JSON).
+Migrated from the nexu-xray tool repo's `corpus/main-chain-suite.json` (2026-06-08); this is now
+the single source of truth.

--- a/validation/main-chain-suite.yaml
+++ b/validation/main-chain-suite.yaml
@@ -1,0 +1,540 @@
+# 主链路验证用例库 (main-chain validation suite)
+#
+# open-design 的「每次 release 必须工作」回归契约 / 验收标准。
+# - 由 nexu-xray agent 自主验证读取(每个产品自带自己的验证契约,工具是通用 runner)。
+# - GROWS:每份人工验收 PDF 的 P0/P1 沉淀进来;改功能时同 PR 顺手更新对应 case。
+# - scope: per_model = 该 case 在 AMR 全模型下各跑一遍(见 amr_regression)。
+# - severity: P0 主链路阻断 / P1 高优 / P2 中 / P3 低。
+# - 两边(agent 结果 ↔ 人工验收)按 case `id` 对齐,算自主验证偏差率。
+#
+version: 2
+product: nexu-io/open-design
+amr_regression:
+  principle: AMR (cloud model runtime) all models are CORE — every release MUST regress the main chain
+    under EVERY model in the live AMR catalog. The 0.10.0 acceptance proved most P0s are model-backend-specific
+    execution errors (gpt-5.5 / claude-sonnet-4.6 / opencode connection-reset, no-output, retry-loses-output);
+    a single-backend run structurally misses them.
+  enumerate: AMR agents are defined in apps/daemon/src/runtimes/registry.ts BASE_AGENT_DEFS (+ local profile
+    defs). Each agent's models are discovered LIVE via its `listModels` (subprocess, e.g. `codex debug
+    models`, `opencode models`), cached in liveModelCache. There is NO single HTTP catalog endpoint —
+    enumerate agents from the registry, then each agent's live models. `isKnownModel` trusts live OR static
+    fallback.
+  seed_models_seen_in_acceptance:
+  - gpt-5.5
+  - claude-sonnet-4.6
+  - opencode
+  - deepseek
+  - gemini
+  - qwen
+  - kimi
+  per_model_focus: 'For each model: does execution complete WITHOUT error (no ''Connection reset by server'',
+    no ''socket connection'', no ''opencode event stream'' error), does it PRODUCE an output artifact,
+    and does retry-after-mid-run-error preserve prior thinking/output.'
+  amr_agents_registry:
+  - claude
+  - codex
+  - devin
+  - gemini
+  - opencode
+  - hermes
+  - grok-build
+  - kimi
+  - cursor-agent
+  - qwen
+  - qoder
+  - copilot
+  - pi
+  - kiro
+  - kilo
+  - vibe
+  - deepseek
+severity_legend:
+  P0: 主链路 Bug — 阻断核心功能,上线前必修
+  P1: 高优先级 — 明显影响体验/数据,下次上线前修
+  P2: 中优先级 — 有替代方案,后续迭代
+  P3: 低优先级 — 纯视觉/小概率
+chains:
+- home
+- onboarding
+- generate
+- preview
+- comment
+- edit
+- chat
+- mark
+- session
+- ui
+- export
+- settings
+- amr
+- provider
+- design_files
+- keyboard
+cases:
+- id: mc-exec-completes-no-error
+  chain: generate
+  scope: per_model
+  severity: P0
+  title: 每个 AMR 模型执行生成都不报错
+  steps:
+  - 新建项目并输入 prompt
+  - 选定该 AMR 模型
+  - 运行生成
+  - 观察执行全过程
+  expected: 执行完成、无 connection reset / socket / opencode event stream 等后端报错
+  sources:
+  - 0.10.0-nightly P0-2 执行报错
+  - P0-5/6 gpt-5.5 connection reset/socket
+  - P0-9/10 claude-sonnet-4.6 opencode event stream/connection reset
+- id: mc-exec-produces-output
+  chain: generate
+  scope: per_model
+  severity: P0
+  title: 每个 AMR 模型执行后都产出设计产物
+  steps:
+  - 新建项目并输入 prompt
+  - 选定该 AMR 模型
+  - 运行生成
+  - 等待执行完成
+  expected: 设计文件出现在 Design Files 面板并正确预览渲染(非空白/非错误)
+  sources:
+  - 0.10.0-nightly P0-8 claude-sonnet-4.6 执行后没有产物输出
+- id: mc-retry-preserves-output
+  chain: generate
+  scope: per_model
+  severity: P0
+  title: 执行中途报错后重试不丢已有思考/产物
+  steps:
+  - 运行生成
+  - 制造或遇到中途报错(可用 mock/故障注入)
+  - 点击重试
+  expected: 重试后保留之前的思考与产物,不清空
+  sources:
+  - 0.10.0-nightly P0-11 执行一半出错重试以后思考及输出甚至产物全丢失
+- id: mc-preview-renders-correctly
+  chain: preview
+  scope: once
+  severity: P0
+  title: 生成文件预览正确渲染
+  steps:
+  - 生成出设计文件
+  - 打开预览
+  expected: 预览正常渲染,不是改坏/破版的状态
+  sources:
+  - 0.10.0-nightly P0-3 生成文件预览改坏了
+- id: mc-home-design-agent-complete
+  chain: home
+  scope: once
+  severity: P0
+  title: 首页 Design Agent 内容展示完整
+  steps:
+  - 打开首页
+  - 查看 Design Agent 区域
+  expected: 内容完整展示,无截断/缺失
+  sources:
+  - 0.10.0-nightly P0-1 首页 Design Agent 内容展示不全
+- id: mc-title-at-top
+  chain: preview
+  scope: once
+  severity: P0
+  title: 文案标题等内容位于顶部
+  steps:
+  - 生成含标题的设计
+  - 查看渲染
+  expected: 文案标题等内容出现在顶部正确位置
+  sources:
+  - 0.10.0-nightly P0-4 文案标题等内容没有在顶部
+  - 0.9.0 同类
+- id: mc-fork-from-here
+  chain: session
+  scope: once
+  severity: P0
+  title: fork from here 能进入新会话
+  steps:
+  - 在会话中点击 fork from here
+  expected: 创建并进入新会话(不是刷新一下没反应、停留在原会话)
+  sources:
+  - 0.10.0-nightly P0-7 fork from here 点击后页面刷新没反应,创建了新会话没进入
+- id: mc-comment-numbering-increments
+  chain: comment
+  scope: once
+  severity: P1
+  title: 评论序号正确递增不重复
+  steps:
+  - 在设计上添加多条评论
+  expected: 序号依次递增,不出现重复(如两个 2)
+  sources:
+  - 0.10.0-nightly P1-11 评论序号没有增加有2个2
+  - 0.9.0 评论序号跳变
+- id: mc-delete-element-confirm
+  chain: edit
+  scope: once
+  severity: P1
+  title: 删除元素有二次确认
+  steps:
+  - 编辑模式选中元素
+  - 点击删除
+  expected: 弹出二次确认而非直接删除;确认/取消按钮与文案完整可读
+  sources:
+  - 0.10.0-nightly P1-3 删除元素直接就删除了没做二次确认
+  - P1-2 删除元素样式优化
+- id: mc-no-blank-after-attach-delete-run
+  chain: chat
+  scope: once
+  severity: P1
+  title: 加多附件→删除→运行 不出现大面积空白
+  steps:
+  - 添加较多附件
+  - 删除部分附件
+  - 再运行
+  expected: 界面正常,不出现大面积空白
+  sources:
+  - 0.10.0-nightly P1-6 添加附件比较多删除以后再运行界面展示大面积空白
+- id: mc-comment-panel-no-blank
+  chain: comment
+  scope: once
+  severity: P1
+  title: comment 面板适配不出现大面积空白
+  steps:
+  - 打开 comment 面板
+  expected: 面板正确适配,无大面积空白
+  sources:
+  - 0.10.0-nightly P1-7 comment 面板没做好适配大面积空白
+- id: mc-mark-queue-no-blank
+  chain: mark
+  scope: once
+  severity: P1
+  title: mark 模式直接 queue 不出现大面积空白
+  steps:
+  - 进入 mark 模式
+  - 直接 queue
+  expected: 界面正常,无大面积空白
+  sources:
+  - 0.10.0-nightly P1-10 mark 模式直接 queue 也会出现大面积空白
+- id: mc-conversations-count-correct
+  chain: session
+  scope: once
+  severity: P1
+  title: 切换 message 后 conversations 面板数量正确
+  steps:
+  - 切换 message
+  expected: conversations 面板 message 数量展示正确
+  sources:
+  - 0.10.0-nightly P1-8 切换 message 后 conversations 面板 message 数量展示不对
+- id: mc-connectors-tab-input
+  chain: chat
+  scope: once
+  severity: P1
+  title: '@后切到 Connectors tab 输入框不悬空'
+  steps:
+  - 输入框输入 @
+  - 切换到 Connectors tab
+  expected: 输入框位置正常,不悬空
+  sources:
+  - 0.10.0-nightly P1-9 输入框输入@后切换到 Connectors tab 输入框悬空
+- id: mc-jump-to-latest-hideable
+  chain: chat
+  scope: once
+  severity: P1
+  title: Jump to latest 可隐藏不遮挡文案
+  steps:
+  - 滚动会话触发 Jump to latest
+  expected: Jump to latest 可隐藏,不遮挡文案
+  sources:
+  - 0.10.0-nightly P1-5 Jump to latest 隐藏不了遮挡文案
+- id: mc-rename-keeps-filename
+  chain: preview
+  scope: once
+  severity: P2
+  title: rename 时预览不误展示且原文件名不为空
+  steps:
+  - 点击 rename
+  expected: 不误进预览页;编辑态原文件名保留(非空)
+  sources:
+  - 0.10.0-nightly P2-4 点击 rename 预览页面展示出来了且编辑状态原文件名为空
+- id: mc-no-occlusion-toast-dropdown
+  chain: ui
+  scope: once
+  severity: P2
+  title: toast / 下拉窗 / 设计系统不被遮挡或暴露
+  steps:
+  - 点击 Copy path 看 toast
+  - 打开下拉窗
+  - 查看搜索框上方
+  expected: toast 不被遮挡;下拉窗文案不被遮挡;搜索框上方设计系统不暴露
+  sources:
+  - 0.10.0-nightly P2-3 Copy path toast 被遮挡
+  - P2-5 下拉窗文案被遮挡
+  - P2-6 搜索框上面设计系统暴露
+- id: mc-save-button-no-flicker
+  chain: ui
+  scope: once
+  severity: P2
+  title: 切换 tab 保存按钮不闪烁
+  steps:
+  - 切换 tab
+  expected: 保存按钮不闪烁
+  sources:
+  - 0.10.0-nightly P2-1 切换 tab 保存按钮闪烁
+- id: mc-error-frame-surfaces
+  chain: generate
+  scope: per_model
+  severity: P0
+  exec_dependent: true
+  error_path: true
+  title: 模型结构化 error frame 必须暴露为 error 事件(不被吞成 raw)
+  expected: opencode/qoder/codex 等输出 {type:error,...} 时,前端收到 error 事件并显示报错,不会静默丢失当作 raw
+  sources:
+  - 'test: apps/daemon/tests/json-event-stream.test.ts'
+  - qoder-stream.test.ts
+  - 对应人工 0.10.0 P0 执行报错类
+- id: mc-exit0-with-error-is-failed
+  chain: generate
+  scope: per_model
+  severity: P0
+  exec_dependent: true
+  error_path: true
+  title: agent 发完 error frame 后 exit 0,run 必须判 failed 而非 succeeded
+  expected: run.status=failed + AGENT_EXECUTION_FAILED;不能因为退出码 0 就当成功
+  sources:
+  - 'test: apps/daemon/tests/chat-route.test.ts:136'
+  - 人工 0.10.0 P0-8 执行后没有产物却像成功
+- id: mc-auth-error-classified
+  chain: amr
+  scope: per_model
+  severity: P0
+  exec_dependent: true
+  error_path: true
+  title: 模型/CLI 未登录的 auth 错误要被分类并给出指引
+  expected: stderr 'Authentication required' → AGENT_AUTH_REQUIRED,提示如何登录,而不是裸报错/静默
+  sources:
+  - 'test: apps/daemon/tests/chat-route.test.ts:183 (cursor-agent auth)'
+- id: mc-reconnect-not-fatal
+  chain: generate
+  scope: per_model
+  severity: P1
+  exec_dependent: true
+  error_path: true
+  title: codex 'Reconnecting 2/5' 等瞬时重连不能判致命
+  expected: 重连消息走 status 事件,run 之后正常完成,不被当 error 中断
+  sources:
+  - 'test: apps/daemon/tests/json-event-stream.test.ts:459'
+- id: mc-token-usage-accounting
+  chain: generate
+  scope: per_model
+  severity: P1
+  exec_dependent: true
+  error_path: false
+  title: 执行结束有正确的 token/用量统计
+  expected: step_finish 产出 usage(input/output/thought/cache 读写)+ 成本,供计费/Done 卡展示
+  sources:
+  - 'test: apps/daemon/tests/json-event-stream.test.ts:13'
+- id: mc-cancel-aborts-backend
+  chain: session
+  scope: once
+  severity: P1
+  exec_dependent: true
+  error_path: true
+  title: 取消/客户端断开要中止后端模型调用(不浪费 token)
+  expected: UI 取消或断连 → AbortSignal 触发,后端 fetch 中止,不继续跑 60-120s
+  sources:
+  - 'test: apps/daemon/tests/finalize-route-abort.test.ts:98'
+- id: mc-stuck-agent-killed
+  chain: session
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: true
+  title: 卡死的 agent 经 SIGTERM 宽限后强杀,run 标 canceled
+  expected: SIGTERM→宽限→SIGKILL 升级;ACP 会话发且只发一次 session/cancel
+  sources:
+  - 'test: apps/daemon/tests/runs.test.ts:67'
+  - acp.test.ts:205/256
+- id: mc-error-metadata-preserved
+  chain: session
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: true
+  title: run 失败时保留 errorCode/message/可重试标志
+  expected: statusBody 带 errorCode + retryable,驱动 UI 报错与 Retry 按钮
+  sources:
+  - 'test: apps/daemon/tests/runs.test.ts:6'
+- id: mc-stream-persist-preview
+  chain: generate
+  scope: per_model
+  severity: P0
+  exec_dependent: true
+  error_path: false
+  title: 真实执行:流式→落盘→预览渲染端到端
+  expected: 产物分多 chunk 流式也能落盘,iframe 预览渲染出内容
+  sources:
+  - 'test: apps/web/tests/real-daemon-run.test.ts'
+- id: mc-reload-midflight-restores
+  chain: generate
+  scope: once
+  severity: P1
+  exec_dependent: true
+  error_path: false
+  title: 生成中途刷新页面能恢复并最终拿到产物
+  expected: mid-flight reload 后产物仍生成落盘,工作区恢复到预览
+  sources:
+  - 'test: apps/web/tests/real-daemon-run.test.ts'
+- id: mc-empty-output-no-ghost
+  chain: generate
+  scope: per_model
+  severity: P1
+  exec_dependent: true
+  error_path: true
+  title: 空输出要干净失败,不留幽灵文件
+  expected: daemon 空输出 → 显示 'No output'/报错,不创建 phantom 文件,刷新后仍如此
+  sources:
+  - 'test: real-daemon-run.test.ts'
+  - api-empty-response.test.ts
+  - 人工 0.10.0 P0-8
+- id: mc-followup-turn-persists
+  chain: chat
+  scope: once
+  severity: P1
+  exec_dependent: true
+  error_path: false
+  title: 同项目内追问第二轮,两次产物都保留
+  expected: 第二个 prompt 后两个生成文件都在 files 列表
+  sources:
+  - 'test: real-daemon-run.test.ts'
+- id: mc-deck-pagination-direction
+  chain: preview
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: false
+  title: deck 上一页/下一页方向正确(不同向)
+  expected: prev 到上一张、next 到下一张;与缩放方向反的同类问题一并防
+  sources:
+  - 'test: apps/web/tests/app.test.ts'
+  - 人工 0.9.0 缩放方向反
+- id: mc-deck-per-tab-pagination
+  chain: preview
+  scope: once
+  severity: P2
+  exec_dependent: false
+  error_path: false
+  title: 多个 deck tab 各自保留分页位置
+  expected: 切 tab 后各自的幻灯片页码独立保留
+  sources:
+  - 'test: app.test.ts'
+- id: mc-manual-edit-persists-interactive
+  chain: edit
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: false
+  title: 手动编辑样式持久化且预览仍可交互
+  expected: inspector 改样式预览即时生效、刷新后保留;预览交互动作仍可用
+  sources:
+  - 'test: apps/web/tests/app-manual-edit.test.ts'
+- id: mc-reference-images-render
+  chain: preview
+  scope: once
+  severity: P2
+  exec_dependent: false
+  error_path: false
+  title: 上传的参考图在生成预览里正确渲染
+  expected: 图片 src 解析正确,无碎图
+  sources:
+  - 'test: app.test.ts'
+- id: mc-file-tab-restore-reload
+  chain: session
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: false
+  title: 刷新后工作区恢复到上次手动选中的文件 tab
+  expected: reload 后保持原 tab(不被产物 tab 顶替);切项目各自恢复各自 tab
+  sources:
+  - 'test: apps/web/tests/app-restoration.test.ts'
+- id: mc-design-files-upload-delete
+  chain: design_files
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: false
+  title: Design Files 上传图片开 tab/预览,删除后干净清理
+  expected: 上传→tab+预览;删除→列表与 tab 都清掉,无幽灵 tab
+  sources:
+  - 'test: apps/web/tests/app-design-files.test.ts'
+- id: mc-quick-switcher
+  chain: keyboard
+  scope: once
+  severity: P2
+  exec_dependent: false
+  error_path: false
+  title: Cmd/Ctrl+K 快速切换器筛选并激活文件
+  expected: 打开→筛选→方向键→Enter 激活;只列当前项目文件;reload 后仍可用
+  sources:
+  - 'test: apps/web/tests/workspace-keyboard-flows.test.ts'
+- id: mc-delete-confirm-cancel-keeps
+  chain: edit
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: false
+  title: 取消删除应保留文件/项目及其 tab
+  expected: 删除→确认弹窗→取消:文件/项目保留,tab 仍开
+  sources:
+  - 'test: project-management-flows.test.ts'
+  - 人工 0.10.0 P1-3 删除无二次确认
+- id: mc-attachment-remove-no-jank
+  chain: chat
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: false
+  title: 逐个移除附件不出现布局错乱/大面积空白
+  expected: 移除到空也保持干净布局,无孤立空盒;加→删→运行不空白
+  sources:
+  - 'feature: composer attachments'
+  - 人工 0.10.0 P1-6 加附件删除后大面积空白
+- id: mc-comment-attach-to-chat
+  chain: comment
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: false
+  title: 评论可作为结构化上下文 queue/send 进 chat
+  expected: 评论附件 chip 出现在 composer,空消息也能带 commentAttachments 发送
+  sources:
+  - 'test: app.test.ts'
+  - 'feature #3516 comment attachments'
+- id: mc-conversation-switch-restore
+  chain: session
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: false
+  title: 切换/刷新会话:历史保留、composer 可用、数量正确
+  expected: 两个会话切换+reload 后消息都在、composer 始终可用;conversations 数量展示正确
+  sources:
+  - 'test: app-restoration.test.ts'
+  - 人工 0.10.0 P1-8 会话数量不对
+- id: mc-byok-validate-key
+  chain: settings
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: true
+  title: BYOK key 测试连接:有效填充模型/无效报错;必填未满 save 禁用
+  expected: test 通过→绿勾+模型下拉;无效→红错+重试;字段不全 save 禁用
+  sources:
+  - 'test: apps/web/tests/settings-api-protocol.test.ts'
+  - 人工/新功能 BYOK 系列
+- id: mc-provider-ssrf-rejected
+  chain: provider
+  scope: once
+  severity: P1
+  exec_dependent: false
+  error_path: true
+  title: Provider 模型列举拒绝内网 IP(防 DNS rebinding SSRF),密钥不泄漏
+  expected: 私有 IP/DNS rebind → forbidden,不发外连;401/403 错误详情里不含 API key
+  sources:
+  - 'test: apps/daemon/tests/connection-test.test.ts:300/371'

--- a/validation/main-chain-suite.yaml
+++ b/validation/main-chain-suite.yaml
@@ -1,11 +1,16 @@
-# 主链路验证用例库 (main-chain validation suite)
+# main-chain validation suite
 #
-# open-design 的「每次 release 必须工作」回归契约 / 验收标准。
-# - 由 nexu-xray agent 自主验证读取(每个产品自带自己的验证契约,工具是通用 runner)。
-# - GROWS:每份人工验收 PDF 的 P0/P1 沉淀进来;改功能时同 PR 顺手更新对应 case。
-# - scope: per_model = 该 case 在 AMR 全模型下各跑一遍(见 amr_regression)。
-# - severity: P0 主链路阻断 / P1 高优 / P2 中 / P3 低。
-# - 两边(agent 结果 ↔ 人工验收)按 case `id` 对齐,算自主验证偏差率。
+# open-design's "must work every release" regression contract / acceptance criteria.
+# - Read by the nexu-xray autonomous-validation agent (each product ships its own contract;
+#   the tool is a generic runner).
+# - GROWS: every human acceptance doc's P0/P1 is sedimented in; update the relevant case in the
+#   same PR when a feature changes.
+# - scope: per_model = run this case once per model in the live AMR catalog (see amr_regression).
+# - severity: P0 main-chain blocker / P1 high / P2 medium / P3 low.
+# - Both sides (agent results <-> human acceptance) are aligned by case `id` to compute the
+#   autonomous-validation deviation rate.
+# - Note: case content (title/steps/expected) is in Chinese on purpose — it mirrors the Chinese
+#   UI and is transcribed from the team's Chinese acceptance docs.
 #
 version: 2
 product: nexu-io/open-design


### PR DESCRIPTION
Adds `validation/main-chain-suite.yaml` — open-design's **"must work every release" regression contract / acceptance criteria**, living alongside the product code.

## What it is
- **43 cases** (11 P0 / 26 P1 / 6 P2, 14 chains, 10 `per_model` × all AMR models), seeded from the 0.10.0 human acceptance + mining the source / e2e / daemon tests; each case cites its `sources` for traceability.
- The nexu-xray agent reads this contract from the repo it validates and runs each case **autonomously**; its results are aligned with the test team's human acceptance by case `id` to compute a **deviation rate** (R&D dashboard `/daily/?view=yang`, the "Agent autonomous validation vs human acceptance" card).

## Why it lives in the product repo
**Each product ships its own validation contract; the tool (nexu-xray) is a generic runner.** The contract belongs with the product code — owned by the product/QA team, updated in the same PR when a feature changes, and only ever grows (every human acceptance round is sedimented back into it).

## Format
YAML — readable by humans and agents, diff-friendly, supports comments, and lighter than JSON. Migrated from the nexu-xray tool repo's `corpus/main-chain-suite.json`; this is now the single source of truth.

See `validation/README.md`. Two new files only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)