### PR TITLE
fix(web): render conversation count inline with the panel header title

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -1735,11 +1735,11 @@ export function ChatPane({
               <div className="chat-history-menu-head">
                 <span className="chat-history-menu-title">
                   {t('chat.conversationsHeading')}
-                </span>
-                <span className="chat-history-menu-count">
-                  {filteredConversations.length === conversations.length
-                    ? compactCount(conversations.length)
-                    : `${compactCount(filteredConversations.length)} / ${compactCount(conversations.length)}`}
+                  <span className="chat-history-menu-count">
+                    {filteredConversations.length === conversations.length
+                      ? `(${compactCount(conversations.length)})`
+                      : `(${compactCount(filteredConversations.length)} / ${compactCount(conversations.length)})`}
+                  </span>
                 </span>
                 {onNewConversation ? (
                   <button

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -2216,6 +2216,7 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   font-weight: 600;
 }
 .chat-history-menu-count {
+  margin-left: 4px;
   color: var(--text-faint);
   font-size: 10.5px;
   font-weight: 500;

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -2221,6 +2221,9 @@ body.entry-resizing { cursor: col-resize; user-select: none; }
   font-size: 10.5px;
   font-weight: 500;
   line-height: 1;
+  /* Nested in the uppercase title, but compactCount() suffixes (k/m) are
+     lowercase by design — opt this span back out of the inherited transform. */
+  text-transform: none;
 }
 .chat-history-search {
   display: flex;


### PR DESCRIPTION
Fixes #3848

## Why

While browsing a project's conversations panel I hit the same thing the reporter described: the count sits as its own faint element between the `Conversations` title and the `+ New` button, so it reads as a detached number rather than part of the header label. This is the small UI-polish bug the maintainer scoped in the issue thread — make the count read inline with the title.

## What users will see

In the chat conversations panel header, the count now reads inline with the title as `Conversations (6)` instead of a separate floating `6`. The `+ New` button stays aligned to the right. When a search filters the list, the inline count shows `(2 / 6)` (matched / total), same numbers as before, just parenthesized and bound to the title.

## Surface area

- [x] **UI** — conversations panel header (`apps/web/src/components/ChatPane.tsx`)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — none added; reuses the existing `chat.conversationsHeading` key
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Isolated render of the real `.chat-history-menu-head` markup with the actual `composio.css` rules (driving the full app to a multi-conversation project state for a one-line layout tweak was overkill, so this renders the exact header component + stylesheet):

![before/after](https://raw.githubusercontent.com/maxmilian/open-design/assets/issue-3848/before-after.png)

## Bug fix verification

This is a presentation-only layout change — the count value and its computation are unchanged; only the DOM nesting (count moved inside the title span) and the parenthesized formatting differ. There is no behavioral branch to encode as a red-then-green spec, so a falsifiable unit test wasn't cheap or meaningful here. Verified visually via the before/after above, and confirmed the existing `@open-design/web` suite stays green (no test asserts on this header's markup or count format).

## Validation

- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm guard` — pass (40/40, incl. CSS color policy)
- `pnpm --filter @open-design/web test` — 307 files / 3054 tests pass, 1 skipped
