### PR TITLE
Allow release-stable preflight dry runs

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -15,6 +15,15 @@ on:
         description: "Required when channel=stable: exact validated nightly version to promote, for example 0.5.1.nightly.3."
         required: false
         type: string
+      release_version:
+        description: "Stable base version to publish, for example 0.5.1. Required when ref is not release/vX.Y.Z."
+        required: false
+        type: string
+      dry_run:
+        description: "Validate release inputs and read-only remote gates without building or publishing."
+        required: false
+        type: boolean
+        default: false
       ref:
         description: "Optional git ref (branch/tag/SHA) to build. Empty builds the ref this workflow was dispatched on."
         required: false
@@ -32,6 +41,16 @@ on:
         required: false
         type: string
         default: ""
+      release_version:
+        description: "Stable base version to publish. Required when ref is not release/vX.Y.Z."
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Validate release inputs and read-only remote gates without building or publishing."
+        required: false
+        type: boolean
+        default: false
       ref:
         description: "Optional git ref (branch/tag/SHA) to build. Empty builds the caller's ref."
         required: false
@@ -50,6 +69,9 @@ on:
       commit:
         description: "The commit SHA that was built."
         value: ${{ jobs.metadata.outputs.commit }}
+      dry_run:
+        description: "Whether this run stopped after metadata/preflight validation."
+        value: ${{ jobs.metadata.outputs.dry_run }}
       previous_commit:
         description: "Commit SHA of the previously published nightly (changelog baseline); empty on cold start."
         value: ${{ jobs.metadata.outputs.previous_commit }}
@@ -74,7 +96,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: open-design-release-stable-${{ inputs.channel }}
+  group: open-design-release-stable-${{ inputs.channel }}-${{ inputs.dry_run && 'dry-run' || 'publish' }}
   cancel-in-progress: false
 
 env:
@@ -102,14 +124,17 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       GITHUB_REPOSITORY: ${{ github.repository }}
       OPEN_DESIGN_NIGHTLY_METADATA_URL: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}/nightly/latest/metadata.json
+      OPEN_DESIGN_RELEASE_DRY_RUN: ${{ inputs.dry_run }}
       OPEN_DESIGN_RELEASE_CHANNEL: ${{ inputs.channel }}
       OPEN_DESIGN_RELEASES_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
       OPEN_DESIGN_STABLE_NIGHTLY_VERSION: ${{ inputs.nightly_version }}
+      OPEN_DESIGN_STABLE_VERSION: ${{ inputs.release_version }}
     outputs:
       base_version: ${{ steps.stable.outputs.base_version }}
       branch: ${{ steps.stable.outputs.branch }}
       channel: ${{ steps.stable.outputs.channel }}
       commit: ${{ steps.stable.outputs.commit }}
+      dry_run: ${{ steps.stable.outputs.dry_run }}
       github_release_enabled: ${{ steps.stable.outputs.github_release_enabled }}
       linux_namespace: ${{ steps.stable.outputs.linux_namespace }}
       mac_intel_namespace: ${{ steps.stable.outputs.mac_intel_namespace }}
@@ -161,6 +186,7 @@ jobs:
         run: node --experimental-strip-types ./scripts/release-stable.ts
 
       - name: Validate R2 release access
+        if: ${{ steps.stable.outputs.dry_run != 'true' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_RELEASES_SK }}
@@ -176,6 +202,7 @@ jobs:
   verify:
     name: Verify build (typecheck + tests)
     needs: metadata
+    if: ${{ needs.metadata.outputs.dry_run != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -828,6 +855,7 @@ jobs:
       ${{
         always() &&
         !cancelled() &&
+        needs.metadata.outputs.dry_run != 'true' &&
         needs.metadata.result == 'success' &&
         needs.verify.result == 'success' &&
         needs.build_mac.result == 'success' &&
@@ -1032,12 +1060,13 @@ jobs:
   cleanup_partial_release_assets:
     name: Cleanup unpublished release asset artifacts
     needs:
+      - metadata
       - build_mac
       - build_mac_intel
       - build_win
       - build_linux
       - publish
-    if: ${{ always() && needs.publish.result != 'success' }}
+    if: ${{ always() && needs.metadata.outputs.dry_run != 'true' && needs.publish.result != 'success' }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -46,6 +46,26 @@ function sectionBetween(content: string, start: string, end: string): string {
   return content.slice(startIndex, endIndex);
 }
 
+async function runReleaseStableForFailure(env: Record<string, string>): Promise<string> {
+  try {
+    await execFileAsync(process.execPath, ["--experimental-strip-types", releaseStableScriptPath], {
+      cwd: workspaceRoot,
+      env: {
+        ...process.env,
+        GITHUB_REPOSITORY: "nexu-io/open-design",
+        GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+        OPEN_DESIGN_RELEASE_CHANNEL: "stable",
+        ...env,
+      },
+    });
+  } catch (error) {
+    const failed = error as { stderr?: string; stdout?: string };
+    return `${failed.stdout ?? ""}${failed.stderr ?? ""}`;
+  }
+
+  throw new Error("release-stable script unexpectedly succeeded");
+}
+
 describe("packaged smoke workflow", () => {
   it("[P2] keeps packaged smoke outside the main CI gate", async () => {
     const workflow = await readFile(ciWorkflowPath, "utf8");
@@ -160,6 +180,76 @@ describe("packaged smoke workflow", () => {
     const betaBuildScript = await readFile(releaseBetaPosixBuildScriptPath, "utf8");
     expect(betaBuildScript).toContain("OD_PACKAGED_E2E_RELEASE_CHANNEL=beta");
     expect(betaBuildScript).toContain('OD_PACKAGED_E2E_RELEASE_VERSION="$RELEASE_VERSION"');
+  });
+
+  it("[P2] lets stable release dispatch use an explicit version when ref is not a release branch", async () => {
+    const [workflow, script] = await Promise.all([
+      readFile(releaseStableWorkflowPath, "utf8"),
+      readFile(releaseStableScriptPath, "utf8"),
+    ]);
+
+    expect(workflow).toContain("release_version:");
+    expect(workflow).toContain("Required when ref is not release/vX.Y.Z");
+    expect(workflow).toContain("OPEN_DESIGN_STABLE_VERSION: ${{ inputs.release_version }}");
+
+    expect(script).toContain("const stableReleaseBranchPattern = /^release\\/v(\\d+\\.\\d+\\.\\d+)$/;");
+    expect(script).toContain("function resolveStableBaseVersion");
+    expect(script).toContain("release-stable requires either a release/vX.Y.Z branch or OPEN_DESIGN_STABLE_VERSION");
+    expect(script).toContain("OPEN_DESIGN_STABLE_VERSION ${inputVersion.value} must match release branch version");
+    expect(script).toContain(
+      '${stableBaseVersion.source ?? "release base"} version ${stableBaseVersion.value} must match apps/packaged/package.json version',
+    );
+    expect(script).not.toContain("release-stable can only run from release/vX.Y.Z branches");
+  });
+
+  it("[P2] rejects stable release runs without a release branch or explicit version", async () => {
+    const output = await runReleaseStableForFailure({
+      GITHUB_REF_NAME: "main",
+      OPEN_DESIGN_STABLE_VERSION: "",
+    });
+
+    expect(output).toContain("release-stable requires either a release/vX.Y.Z branch or OPEN_DESIGN_STABLE_VERSION");
+  });
+
+  it("[P2] rejects conflicting stable release branch and explicit version inputs", async () => {
+    const output = await runReleaseStableForFailure({
+      GITHUB_REF_NAME: "release/v0.10.0",
+      OPEN_DESIGN_STABLE_VERSION: "0.10.1",
+    });
+
+    expect(output).toContain("OPEN_DESIGN_STABLE_VERSION 0.10.1 must match release branch version 0.10.0");
+  });
+
+  it("[P2] supports release dry-run preflight without build or publish side effects", async () => {
+    const [workflow, script] = await Promise.all([
+      readFile(releaseStableWorkflowPath, "utf8"),
+      readFile(releaseStableScriptPath, "utf8"),
+    ]);
+
+    expect(workflow).toContain("dry_run:");
+    expect(workflow).toContain("Validate release inputs and read-only remote gates without building or publishing.");
+    expect(workflow).toContain(
+      "group: open-design-release-stable-${{ inputs.channel }}-${{ inputs.dry_run && 'dry-run' || 'publish' }}",
+    );
+    expect(workflow).toContain("OPEN_DESIGN_RELEASE_DRY_RUN: ${{ inputs.dry_run }}");
+    expect(workflow).toContain("dry_run: ${{ steps.stable.outputs.dry_run }}");
+    expect(workflow).toContain("if: ${{ steps.stable.outputs.dry_run != 'true' }}");
+    expect(workflow).toContain("if: ${{ needs.metadata.outputs.dry_run != 'true' }}");
+    expect(workflow).toContain("needs.metadata.outputs.dry_run != 'true' &&");
+
+    expect(script).toContain("function parseBooleanInput");
+    expect(script).toContain('parseBooleanInput(process.env.OPEN_DESIGN_RELEASE_DRY_RUN, "OPEN_DESIGN_RELEASE_DRY_RUN")');
+    expect(script).toContain('setOutput("dry_run", dryRun ? "true" : "false");');
+  });
+
+  it("[P2] rejects invalid release dry-run values before remote checks", async () => {
+    const output = await runReleaseStableForFailure({
+      GITHUB_REF_NAME: "release/v0.10.0",
+      OPEN_DESIGN_RELEASE_DRY_RUN: "maybe",
+      OPEN_DESIGN_STABLE_VERSION: "",
+    });
+
+    expect(output).toContain("OPEN_DESIGN_RELEASE_DRY_RUN must be true or false; got maybe");
   });
 
   it("keeps both beta release lanes on the shared payload-aware metadata surface", async () => {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -64,6 +65,24 @@ async function runReleaseStableForFailure(env: Record<string, string>): Promise<
   }
 
   throw new Error("release-stable script unexpectedly succeeded");
+}
+
+async function writeFakeGhBin(binDir: string, releases: unknown[]): Promise<void> {
+  const ghPath = join(binDir, "gh");
+  await writeFile(
+    ghPath,
+    `#!/usr/bin/env node
+if (process.argv[2] === "api" && /^repos\\/[^/]+\\/[^/]+\\/releases\\?/.test(process.argv[3] ?? "")) {
+  const url = new URL(process.argv[3], "https://api.github.com/");
+  const page = url.searchParams.get("page") ?? "1";
+  process.stdout.write(JSON.stringify(page === "1" ? ${JSON.stringify(releases)} : []));
+  process.exit(0);
+}
+console.error("unexpected gh invocation: " + process.argv.slice(2).join(" "));
+process.exit(1);
+`,
+  );
+  await chmod(ghPath, 0o755);
 }
 
 describe("packaged smoke workflow", () => {
@@ -240,6 +259,47 @@ describe("packaged smoke workflow", () => {
     expect(script).toContain("function parseBooleanInput");
     expect(script).toContain('parseBooleanInput(process.env.OPEN_DESIGN_RELEASE_DRY_RUN, "OPEN_DESIGN_RELEASE_DRY_RUN")');
     expect(script).toContain('setOutput("dry_run", dryRun ? "true" : "false");');
+  });
+
+  it("[P2] validates stable dry-run nightly metadata from a non-release ref", async () => {
+    const objects: Record<string, unknown> = {};
+    const fixture = await startStableNightlyMetadataServer(objects);
+    objects["nightly/versions/0.10.0.nightly.12/metadata.json"] = stableNightlyMetadataFixture(
+      "0.10.0",
+      "0.10.0.nightly.12",
+      fixture.origin,
+    );
+    const runnerTemp = await mkdtemp(join(tmpdir(), "od-release-stable-dry-run-"));
+
+    try {
+      await mkdir(join(runnerTemp, "bin"), { recursive: true });
+      await writeFakeGhBin(join(runnerTemp, "bin"), []);
+
+      const result = await execFileAsync(process.execPath, ["--experimental-strip-types", releaseStableScriptPath], {
+        cwd: workspaceRoot,
+        env: {
+          ...process.env,
+          GITHUB_REF_NAME: "main",
+          GITHUB_REPOSITORY: "nexu-io/open-design",
+          GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+          NODE_TLS_REJECT_UNAUTHORIZED: "0",
+          OPEN_DESIGN_RELEASE_CHANNEL: "stable",
+          OPEN_DESIGN_RELEASE_DRY_RUN: "true",
+          OPEN_DESIGN_RELEASES_PUBLIC_ORIGIN: fixture.origin,
+          OPEN_DESIGN_STABLE_NIGHTLY_VERSION: "0.10.0.nightly.12",
+          OPEN_DESIGN_STABLE_VERSION: "0.10.0",
+          PATH: `${join(runnerTemp, "bin")}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(result.stdout).toContain("[release-stable] validated nightly: 0.10.0.nightly.12");
+      expect(result.stdout).toContain("[release-stable] channel: stable");
+      expect(result.stdout).toContain("[release-stable] dry run: true");
+      expect(result.stdout).toContain("[release-stable] version tag: open-design-v0.10.0");
+    } finally {
+      await fixture.close();
+      await rm(runnerTemp, { force: true, recursive: true });
+    }
   });
 
   it("[P2] rejects invalid release dry-run values before remote checks", async () => {
@@ -966,6 +1026,111 @@ function expectReleaseLinuxSmokePreservesEvidenceBeforeApt(workflow: string, ste
   expect(reportDirIndex).toBeLessThan(aptIndex);
 }
 
+async function startStableNightlyMetadataServer(objects: Record<string, unknown>): Promise<{
+  close: () => Promise<void>;
+  origin: string;
+}> {
+  const server = createHttpsServer(
+    {
+      cert: stableNightlyMetadataCert,
+      key: stableNightlyMetadataKey,
+    },
+    (request, response) => {
+      const objectKey = decodeURIComponent(new URL(request.url ?? "/", "https://127.0.0.1").pathname.replace(/^\/+/, ""));
+      if (request.method !== "GET" || !(objectKey in objects)) {
+        response.statusCode = 404;
+        response.end("not found");
+        return;
+      }
+
+      response.setHeader("content-type", "application/json; charset=utf-8");
+      response.end(JSON.stringify(objects[objectKey]));
+    },
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  if (address == null || typeof address === "string") {
+    throw new Error("stable nightly metadata server did not bind to a TCP port");
+  }
+
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error == null ? resolve() : reject(error)));
+      }),
+    origin: `https://127.0.0.1:${address.port}`,
+  };
+}
+
+function stableNightlyMetadataFixture(baseVersion: string, nightlyVersion: string, publicOrigin: string): Record<string, unknown> {
+  const versionPrefix = `nightly/versions/${nightlyVersion}`;
+  const versionUrl = `${publicOrigin}/${versionPrefix}`;
+  const artifact = (name: string) => ({
+    sha256Url: `${versionUrl}/${name}.sha256`,
+    url: `${versionUrl}/${name}`,
+  });
+
+  return {
+    baseVersion,
+    channel: "nightly",
+    github: {
+      branch: `release/v${baseVersion}`,
+      commit: "0123456789abcdef0123456789abcdef01234567",
+      repository: "nexu-io/open-design",
+      workflow: "release-stable",
+    },
+    nightlyNumber: 12,
+    nightlyVersion,
+    platforms: {
+      mac: {
+        arch: "arm64",
+        artifacts: {
+          dmg: artifact("Open Design.dmg"),
+          zip: artifact("Open Design-mac-arm64.zip"),
+        },
+        enabled: true,
+        signed: true,
+      },
+      macIntel: {
+        arch: "x64",
+        artifacts: {
+          dmg: artifact("Open Design Intel.dmg"),
+          zip: artifact("Open Design-mac-x64.zip"),
+        },
+        enabled: true,
+        signed: true,
+      },
+      win: {
+        arch: "x64",
+        artifacts: {
+          installer: artifact("Open Design Setup.exe"),
+        },
+        enabled: true,
+      },
+    },
+    r2: {
+      report: {
+        type: "zip",
+        url: `${versionUrl}/report.zip`,
+      },
+      reportZipUrl: `${versionUrl}/report.zip`,
+      versionMetadataUrl: `${versionUrl}/metadata.json`,
+      versionPrefix,
+    },
+    releaseVersion: nightlyVersion,
+    signed: true,
+    stableVersion: baseVersion,
+  };
+}
+
 async function startReleaseMetadataObjectStore(objects: Record<string, unknown>): Promise<{
   bucket: string;
   close: () => Promise<void>;
@@ -1043,3 +1208,52 @@ async function handleReleaseMetadataObjectStoreRequest(
   response.statusCode = 405;
   response.end("method not allowed");
 }
+
+const stableNightlyMetadataKey = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC1hoV1GwxqTYdO
+Zs0pY5hnp8BtTwdF6dWsXoFWYw9IPpBTmyNeleRcLtrht/oc5oRS05tC97qmb5eL
+RigyXUmwrpt/VjJ7ursDa3qGnljkqVxqBkRAUdXBMCVPkMogKWvJy/S61Vthvf7K
+K5HhofwcuPPvRBdhdZgtw/7nZY49HYutd7wP/U7iqCYBMpWr0I29jSs1S2xY9fH8
+ih/exDGe3PHm8yQao4pHUUFVXoAI5w6tYsmNep6b+5NYPHnHSaXd7h5gaF+nIJE4
+78jgRQHKjQ2iNf/53/o/d5SAMb/9lZ7stNT8RIFOJUz1IP8Zsz3VKwAvXKXZDObr
+0MS4JrPdAgMBAAECggEATcF0HD/8VvKjsU0ut3pud4QvVINEGcn6mY2XuFHRY4BN
+IUr0YRkyytvVLVe5vrRtXO9Ac/Sakp19XA6uvDgijxiUCfz5ve80GVhqEQz2BeiX
+6eCKTsTfG5QMf2MFebZUcgm36Gno7VrNr3rvT6erzv/YmZZgr4IIMB5i62qgfYOY
+ABSg6b223RSVeZXNvWxovKycBUUa26lrzRu5jpuexjAccmgbiE86exhzW7FK2zjZ
+XH8rOxSDJ49+ipPOGsJ+rZMdtvHq6BO/QU4O9IkBLNuHAIbr/WcjBgnAPskQTrOM
+i3vWqPNVw3tPjBWCOtzy0UllG0L5Sxnx5cceFvL9HwKBgQDieIaM89In+VETI+x4
+aUmQXxVcisZR0FWQytl+XbWe4T1zxEj4fFjd/phgv0M60599/mwCCGrImxKM8cnb
+mjxv2FX+or9+2IFpaSOi+Qj6/IxcTTWoMU0t4AQjOgbRf3iBpVz6JysnKKpqqukT
+GGOnzGWz0gFmDAqKm0zkGy7czwKBgQDNMb6hrSGobMRlCndgx//w/SdDq/IqAbIS
+QyAvYgNuOXV3J4sD2Z1TwYxZM2Oq5rhOPfZr8SnqM7d+LknLPiGMKV7z6vL/BOu8
+ZB5+EmMZwqNmSOMaFZM+77OC/zxDCznqTm4N5vDdg+6SByCtuyCm+Jraj0PtHtkD
+krdWqBfHkwKBgDpTzluZJGQ1OyNR2kJ843xycL7/4uoJXTBIflGkcvVzj280e5K7
+++tY+gfY2sjY3jgGAe1YG6CFB/cTAukzRSONNUC6y9Uwj8wFTy9XMm/qAYB4RjyG
+Thllm8sy07S7Pt8tJtAqrFuOhq2oTRUk7+20n/D7Qm705PYj317UfXJTAoGABdYM
+XfzWoDu3ukf57T7DAM+ydjJFyPwTXIGcQLzA7DmmJaVyRsHBv8gZfdAAXbQCOfd5
+MsjBMHAYH/ahEq7JtXrXwIhGMQqqycjvNRbAytLGYvpfuzYx4fBfYrJvvFhtZUSl
+zK9s2mAOQQkC3O4dl6IqhVzdybi+42Mg484UHxECgYEAht1ef0Gc6RKZpmqttlZJ
+1G4lsR1Aws3dintACs8lza5aaufrY07gF8z3rkW6tPGEWfol3CYOT2U5UiUw+iKG
+F/Pa3L5wCxuRKKWx0ip0PFhDPrpWfVCm2CLlUlZLEjpmF2iUZgmkaScjYqG8R16a
+C8cywTs1ku5aYIaN8YcAigI=
+-----END PRIVATE KEY-----`;
+
+const stableNightlyMetadataCert = `-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIUbNGmwcWmZP5tw6gm8s2RXzWJv+IwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJMTI3LjAuMC4xMB4XDTI2MDYwODA0MDczNVoXDTI2MDYw
+OTA0MDczNVowFDESMBAGA1UEAwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAtYaFdRsMak2HTmbNKWOYZ6fAbU8HRenVrF6BVmMPSD6Q
+U5sjXpXkXC7a4bf6HOaEUtObQve6pm+Xi0YoMl1JsK6bf1Yye7q7A2t6hp5Y5Klc
+agZEQFHVwTAlT5DKIClrycv0utVbYb3+yiuR4aH8HLjz70QXYXWYLcP+52WOPR2L
+rXe8D/1O4qgmATKVq9CNvY0rNUtsWPXx/Iof3sQxntzx5vMkGqOKR1FBVV6ACOcO
+rWLJjXqem/uTWDx5x0ml3e4eYGhfpyCROO/I4EUByo0NojX/+d/6P3eUgDG//ZWe
+7LTU/ESBTiVM9SD/GbM91SsAL1yl2Qzm69DEuCaz3QIDAQABo1MwUTAdBgNVHQ4E
+FgQU8Z0Oy/q8fAqp9005cn2sW4K6oB4wHwYDVR0jBBgwFoAU8Z0Oy/q8fAqp9005
+cn2sW4K6oB4wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAlJTb
+7zi4FKJqYuXZ9YWmV96Ri+vBcNfO2dwKBxFtJXm0Ai2Q4ruutuFPYwY6UYGTN5gC
+HJ0/WxuPK5ftAE6UU+Mghu0dJlH+gWmOq5cDyhYdnEi8R6z5AsPtPEYlkkIvhUO1
+k1BtCP0h4Kh8fuaILGuXQNOaKizIWF2lEEHfCmvKhgOF6dKWs38zdetFQCLRIaHg
+ZyGlUhPCUbKdTiBJuCGaDKzeEAlC8dsar2zjg9CVue7w3CaamQpjnV0d2IHJiVAH
+QONQvdtLnZ6GeNPe06oBrq7R9SL5/tkqgSq8lCrDE6jFZnfXNMdDmZY3wTcFcdyG
+yW/DsIUs5ZzcHza5rw==
+-----END CERTIFICATE-----`;

--- a/scripts/release-stable.ts
+++ b/scripts/release-stable.ts
@@ -23,6 +23,7 @@ type GitHubRelease = {
 
 type ParsedStableVersion = {
   parsed: [number, number, number];
+  source?: string;
   value: string;
 };
 
@@ -59,11 +60,55 @@ function parseChannel(value: string | undefined): ReleaseChannel {
   fail(`OPEN_DESIGN_RELEASE_CHANNEL must be stable or nightly; got ${value}`);
 }
 
+function parseBooleanInput(value: string | undefined, name: string): boolean {
+  if (value == null || value.length === 0 || value === "false") return false;
+  if (value === "true") return true;
+  fail(`${name} must be true or false; got ${value}`);
+}
+
 function parseStableVersion(value: string): [number, number, number] | null {
   const match = stableVersionPattern.exec(value);
   if (match == null) return null;
 
   return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function parseStableVersionInput(value: string | undefined, sourceName: string): ParsedStableVersion | null {
+  const trimmed = value?.trim() ?? "";
+  if (trimmed.length === 0) return null;
+
+  const parsed = parseStableVersion(trimmed);
+  if (parsed == null) {
+    fail(`${sourceName} must be a stable x.y.z version; got ${trimmed}`);
+  }
+
+  return { parsed, source: sourceName, value: trimmed };
+}
+
+function resolveStableBaseVersion(branch: string, inputValue: string | undefined): ParsedStableVersion {
+  const branchMatch = stableReleaseBranchPattern.exec(branch);
+  const branchVersion =
+    branchMatch?.[1] == null
+      ? null
+      : ({
+          parsed: parseStableVersion(branchMatch[1]) ?? fail(`invalid release branch version: ${branchMatch[1]}`),
+          source: "GITHUB_REF_NAME",
+          value: branchMatch[1],
+        } satisfies ParsedStableVersion);
+  const inputVersion = parseStableVersionInput(inputValue, "OPEN_DESIGN_STABLE_VERSION");
+
+  if (branchVersion != null) {
+    if (inputVersion != null && inputVersion.value !== branchVersion.value) {
+      fail(
+        `OPEN_DESIGN_STABLE_VERSION ${inputVersion.value} must match release branch version ${branchVersion.value} when both are provided`,
+      );
+    }
+    return branchVersion;
+  }
+
+  if (inputVersion != null) return inputVersion;
+
+  fail("release-stable requires either a release/vX.Y.Z branch or OPEN_DESIGN_STABLE_VERSION");
 }
 
 function compareVersions(left: [number, number, number], right: [number, number, number]): number {
@@ -450,18 +495,17 @@ function setOutput(name: string, value: string): void {
 
 const repository = process.env.GITHUB_REPOSITORY ?? fail("GITHUB_REPOSITORY is required");
 const channel = parseChannel(process.env.OPEN_DESIGN_RELEASE_CHANNEL);
+const dryRun = parseBooleanInput(process.env.OPEN_DESIGN_RELEASE_DRY_RUN, "OPEN_DESIGN_RELEASE_DRY_RUN");
 const namespaces = releaseNamespaces(channel);
 const packagedVersion = await readPackagedVersion();
-const packagedParsed = parseStableVersion(packagedVersion) ?? fail(`invalid packaged version: ${packagedVersion}`);
 const commit = process.env.GITHUB_SHA ?? "";
 const branch = process.env.GITHUB_REF_NAME ?? "";
-const branchMatch = stableReleaseBranchPattern.exec(branch);
-if (branchMatch?.[1] == null) {
-  fail(`release-stable can only run from release/vX.Y.Z branches; got ${branch || "(empty)"}`);
-}
-const branchVersion = branchMatch[1];
-if (branchVersion !== packagedVersion) {
-  fail(`release branch version ${branchVersion} must match apps/packaged/package.json version ${packagedVersion}`);
+const stableBaseVersion = resolveStableBaseVersion(branch, process.env.OPEN_DESIGN_STABLE_VERSION);
+const packagedParsed = stableBaseVersion.parsed;
+if (stableBaseVersion.value !== packagedVersion) {
+  fail(
+    `${stableBaseVersion.source ?? "release base"} version ${stableBaseVersion.value} must match apps/packaged/package.json version ${packagedVersion}`,
+  );
 }
 
 const releases = await fetchReleases(repository);
@@ -550,6 +594,7 @@ console.log(`[release-stable] channel: ${channel}`);
 console.log(`[release-stable] base version: ${packagedVersion}`);
 console.log(`[release-stable] release version: ${releaseVersion}`);
 console.log(`[release-stable] namespace: ${namespaces.mac}`);
+console.log(`[release-stable] dry run: ${String(dryRun)}`);
 if (channel === "stable") console.log(`[release-stable] version tag: ${versionTag}`);
 console.log(`[release-stable] state source: ${stateSource}`);
 if (latestStable != null) console.log(`[release-stable] previous stable: ${latestStable.value}`);
@@ -558,6 +603,7 @@ setOutput("base_version", packagedVersion);
 setOutput("branch", branch);
 setOutput("channel", channel);
 setOutput("commit", commit);
+setOutput("dry_run", dryRun ? "true" : "false");
 setOutput("github_release_enabled", channel === "stable" ? "true" : "false");
 setOutput("linux_namespace", namespaces.linux);
 setOutput("mac_intel_namespace", namespaces.macIntel);

--- a/scripts/release-stable.ts
+++ b/scripts/release-stable.ts
@@ -577,8 +577,9 @@ if (channel === "nightly") {
   releaseName = `Open Design Nightly ${releaseVersion}`;
   console.log(`[release-stable] latest nightly: ${latestNightly.nightlyVersion}`);
 } else {
+  const stableReleaseBranch = `release/v${stableBaseVersion.value}`;
   const stableNightly = await validateStableNightlyMetadata({
-    branch,
+    branch: stableReleaseBranch,
     commit,
     nightlyVersionInput: process.env.OPEN_DESIGN_STABLE_NIGHTLY_VERSION,
     packagedVersion,


### PR DESCRIPTION
## Why

Release validation currently depends on dispatching from a `release/vX.Y.Z` branch and quickly moves into build/publish-side effects. This PR adds a safer preflight path for release operators who need to validate release metadata inputs from a non-release branch before changing or promoting release state.

The pain addressed is release workflow risk: operators can now verify the same version-source, GitHub Release, and nightly metadata gates without writing R2 probe objects, building installers, uploading artifacts, or creating GitHub releases.

## What users will see

Maintainers running `release-stable` manually will see two additional workflow inputs:

- `release_version`, used as the stable base version when the checked-out ref is not `release/vX.Y.Z`.
- `dry_run`, which runs metadata/preflight validation and skips build/publish jobs.

`release/vX.Y.Z` remains the preferred version source. If both branch version and `release_version` are provided, they must match.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — release workflow only.

## Bug fix verification

N/A — release workflow hardening, not a product bug fix.

## Validation

- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts`
- `pnpm exec tsc -p scripts/tsconfig.json --noEmit`
- `git diff --check`
- `pnpm guard`
- `pnpm typecheck`
- GitHub Actions dry-run: https://github.com/nexu-io/open-design/actions/runs/27114999704
  - `channel=nightly`
  - `release_version=0.10.0`
  - `dry_run=true`
  - metadata succeeded, R2 access probe skipped, verify/build/publish/cleanup skipped
