### PR TITLE
[codex] Promote OpenCode role marker ACP errors

### DIFF
--- a/apps/daemon/src/acp.ts
+++ b/apps/daemon/src/acp.ts
@@ -158,6 +158,33 @@ function rpcErrorRetryable(data: unknown): boolean | undefined {
   return typeof details?.retryable === 'boolean' ? details.retryable : undefined;
 }
 
+function promotedOpenCodeSessionErrorPayload(data: unknown, fallbackMessage: string) {
+  const details = asObject(data);
+  if (
+    details?.kind !== 'opencode_session_error' ||
+    details.source !== 'opencode' ||
+    details.code !== 'ROLE_MARKER_HALLUCINATION'
+  ) {
+    return null;
+  }
+  const message =
+    typeof details.message === 'string' && details.message.trim()
+      ? details.message.trim()
+      : fallbackMessage;
+  return {
+    message,
+    error: {
+      code: 'ROLE_MARKER_HALLUCINATION',
+      message,
+      retryable: typeof details.retryable === 'boolean' ? details.retryable : true,
+      details: {
+        ...details,
+        promoted_by: 'open_design_acp',
+      },
+    },
+  };
+}
+
 interface FormattedUsage {
   input_tokens?: number;
   output_tokens?: number;
@@ -749,6 +776,15 @@ export function attachAcpSession({
     );
   };
 
+  const failWithPayload = (payload: unknown) => {
+    if (finished) return;
+    finished = true;
+    fatal = true;
+    clearStageTimer();
+    send('error', payload);
+    if (!child.killed) child.kill('SIGTERM');
+  };
+
   const fail = (
     message: string,
     options: { forceModelUnavailable?: boolean; details?: unknown; retryable?: boolean } = {},
@@ -856,6 +892,11 @@ export function attachAcpSession({
         return;
       }
       const details = rpcErrorData(obj);
+      const promotedPayload = promotedOpenCodeSessionErrorPayload(details, rpcErr);
+      if (promotedPayload) {
+        failWithPayload(promotedPayload);
+        return;
+      }
       const retryable = rpcErrorRetryable(details);
       fail(rpcErr, {
         details,

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -721,6 +721,53 @@ test('attachAcpSession still fails an AMR turn that produces no text and no tool
   );
 });
 
+test('attachAcpSession promotes allowlisted OpenCode role-marker ACP errors', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  const details = {
+    kind: 'opencode_session_error',
+    source: 'opencode',
+    code: 'ROLE_MARKER_HALLUCINATION',
+    upstream_name: 'RoleMarkerHallucinationError',
+    message: 'Model emitted fabricated role marker ("## user"). Response was truncated to prevent unauthorized instruction injection.',
+    marker: '## user',
+    retryable: true,
+  };
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpError(child, 3, {
+    code: -32600,
+    message: 'OpenCode session failed: ROLE_MARKER_HALLUCINATION',
+    data: details,
+  });
+
+  const errorEvents = events.filter((entry) => entry.event === 'error');
+  assert.equal(errorEvents.length, 1);
+  assert.deepEqual(errorEvents[0]?.payload, {
+    message: details.message,
+    error: {
+      code: 'ROLE_MARKER_HALLUCINATION',
+      message: details.message,
+      retryable: true,
+      details: {
+        ...details,
+        promoted_by: 'open_design_acp',
+      },
+    },
+  });
+});
+
 test('attachAcpSession preserves structured OpenCode session error details from ACP failures', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];
@@ -737,6 +784,7 @@ test('attachAcpSession preserves structured OpenCode session error details from 
   const details = {
     kind: 'opencode_session_error',
     source: 'opencode',
+    code: 'SOME_UNKNOWN_UPSTREAM_ERROR',
     message: 'Not Found',
     statusCode: 404,
     retryable: false,

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -334,6 +334,8 @@ function readBooleanField(record: Record<string, unknown> | null, key: string): 
 }
 
 interface OpenCodeSessionErrorDetails {
+  source: string | null;
+  code: string | null;
   message: string | null;
   statusCode: number | null;
   retryable: boolean | null;
@@ -350,6 +352,8 @@ function normalizeOpenCodeSessionErrorDetails(value: unknown): OpenCodeSessionEr
   if (!isRecord(value) || value.kind !== 'opencode_session_error') return null;
   const statusCode = readNumberField(value, 'statusCode');
   return {
+    source: readStringField(value, 'source'),
+    code: readStringField(value, 'code'),
     message: readStringField(value, 'message'),
     statusCode,
     retryable: readBooleanField(value, 'retryable') ?? inferOpenCodeRetryable(statusCode),
@@ -388,6 +392,9 @@ function formatOpenCodeSessionError(value: unknown): string | null {
   if (!details) return null;
   const statusCode = details.statusCode;
   const message = details.message;
+  if (details.source === 'opencode' && details.code === 'ROLE_MARKER_HALLUCINATION') {
+    return message;
+  }
   if (statusCode === 404) {
     return 'The model service returned 404 Not Found for the configured runtime endpoint. Check the AMR Link URL or model route.';
   }
@@ -456,6 +463,8 @@ function legacyOpenCodeSessionErrorDetails(text: string): OpenCodeSessionErrorDe
   const statusCode = readNumberField(data, 'statusCode');
   const retryable = readBooleanField(data, 'isRetryable') ?? inferOpenCodeRetryable(statusCode);
   return {
+    source: null,
+    code: null,
     message: readStringField(data, 'message') ?? readStringField(error, 'message'),
     statusCode,
     retryable,

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -643,6 +643,67 @@ describe('streamViaDaemon', () => {
     expect(handlers.onDone).not.toHaveBeenCalled();
   });
 
+  it('renders promoted OpenCode role-marker errors without OpenCode-session prefixing', async () => {
+    const handlers = createDaemonHandlers();
+    const message =
+      'Model emitted fabricated role marker ("## user"). Response was truncated to prevent unauthorized instruction injection.';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(jsonResponse({ runId: 'run-1' }))
+        .mockResolvedValueOnce(
+          sseResponse(
+            [
+              'event: error',
+              `data: ${JSON.stringify({
+                message,
+                error: {
+                  code: 'ROLE_MARKER_HALLUCINATION',
+                  message,
+                  retryable: true,
+                  details: {
+                    kind: 'opencode_session_error',
+                    source: 'opencode',
+                    code: 'ROLE_MARKER_HALLUCINATION',
+                    upstream_name: 'RoleMarkerHallucinationError',
+                    message,
+                    marker: '## user',
+                    retryable: true,
+                    promoted_by: 'open_design_acp',
+                  },
+                },
+              })}`,
+              '',
+              '',
+            ].join('\n'),
+          ),
+        ),
+    );
+
+    await streamViaDaemon({
+      agentId: 'amr',
+      history: [{ id: '1', role: 'user', content: 'hello' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+    });
+
+    expect(handlers.onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message,
+        code: 'ROLE_MARKER_HALLUCINATION',
+        details: expect.objectContaining({
+          kind: 'opencode_session_error',
+          code: 'ROLE_MARKER_HALLUCINATION',
+          marker: '## user',
+        }),
+      }),
+    );
+    const renderedMessage = (handlers.onError.mock.calls[0]?.[0] as Error).message;
+    expect(renderedMessage).not.toContain('OpenCode session failed');
+    expect(handlers.onDone).not.toHaveBeenCalled();
+  });
+
   it('renders structured retry-exhausted provider errors from responseBodyPreview', async () => {
     const handlers = createDaemonHandlers();
     const responseBodyPreview = JSON.stringify({


### PR DESCRIPTION
## Why

This PR implements the Open Design side of the upstream structured-error handoff for OpenCode role-marker guard failures. Vela is expected to preserve the upstream `RoleMarkerHallucinationError` as ACP JSON-RPC `error.data`; Open Design should then treat that exact allowlisted shape as a first-class run error instead of downgrading it to `AGENT_EXECUTION_FAILED`.

The pain being addressed is user-facing error ambiguity: a fabricated role marker safety stop is retryable and specific, but today the ACP bridge wraps it as a generic agent execution failure once it reaches Open Design. The web client also needs to preserve that sanitized role-marker message as-is instead of reformatting it with the generic OpenCode session prefix.

## What users will see

When an ACP-backed OpenCode run reports the structured role-marker safety error, the run error now appears as `ROLE_MARKER_HALLUCINATION` with the upstream sanitized message and retryable flag, rather than a generic JSON-RPC `AGENT_EXECUTION_FAILED` message or an extra `OpenCode session failed:` prefix.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

- Test path that reproduces the daemon promotion bug: `apps/daemon/tests/acp.test.ts`
- Test path that reproduces the web reformatting bug: `apps/web/tests/providers/sse.test.ts`
- Did the tests go red on `main` and green on this branch? yes — the new ACP role-marker promotion test failed before the daemon helper because the payload remained `AGENT_EXECUTION_FAILED`; the new web SSE test failed before the formatter fix because the message gained an `OpenCode session failed:` prefix. Both pass on this branch.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/acp.test.ts --maxWorkers=1`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/providers/sse.test.ts --maxWorkers=1`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`