### PR TITLE
test(e2e): mock streamed agents in main P0 flows

### DIFF
--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { ensureRailOpen } from '@/playwright/rail';
-import type { Locator, Page, Request } from '@playwright/test';
+import type { Locator, Page, Request, Route } from '@playwright/test';
 
 const STORAGE_KEY = 'open-design:config';
 const ACTIVE_ARTIFACT_PREVIEW_SELECTOR = '[data-testid="artifact-preview-frame"]:visible, [data-testid="artifact-preview-frame-url-load"]:visible, [data-testid="artifact-preview-frame-srcdoc"]:visible, [data-testid="live-artifact-preview-frame"]:visible';
@@ -111,14 +111,37 @@ test.beforeEach(async ({ page }) => {
     });
   });
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: AGENTS,
-      },
-    });
+  await page.route('**/api/agents**', async (route) => {
+    await fulfillAgentsRoute(route, AGENTS);
   });
 });
+
+async function fulfillAgentsRoute(route: Route, agents: typeof AGENTS) {
+  const url = new URL(route.request().url());
+  if (url.searchParams.get('stream') === '1') {
+    const body = [
+      ...agents.flatMap((agent) => [
+        'event: agent',
+        `data: ${JSON.stringify(agent)}`,
+        '',
+      ]),
+      'event: done',
+      'data: {}',
+      '',
+      '',
+    ].join('\n');
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+      },
+      body,
+    });
+    return;
+  }
+  await route.fulfill({ json: { agents } });
+}
 
 function artifactPreview(page: Page) {
   return page.locator(ACTIVE_ARTIFACT_PREVIEW_SELECTOR).first();
@@ -463,15 +486,12 @@ test('[P0] project instructions flow into the next API run as project-level syst
 });
 
 test('[P0] project detail avatar menu lets the user switch Local CLI agents and models', async ({ page }) => {
+  test.setTimeout(60_000);
   await page.goto('/');
   await createProject(page, 'Header agent switch');
   await expectWorkspaceReady(page);
 
-  const trigger = page.locator('.avatar-menu .avatar-agent-trigger');
-  await trigger.click();
-  const menu = page.locator('.avatar-popover[role="dialog"]');
-  await expect(menu).toBeVisible();
-  const claudeButton = menu.getByTestId('avatar-agent-option-claude');
+  const { menu, claudeButton } = await openAvatarAgentMenu(page);
   await expect(claudeButton).toBeVisible();
   await claudeButton.click();
 
@@ -485,6 +505,7 @@ test('[P0] project detail avatar menu lets the user switch Local CLI agents and 
 });
 
 test('[P0] project detail agent and model switches carry into the next daemon run request', async ({ page }) => {
+  test.setTimeout(60_000);
   const runRequestBodies: Array<Record<string, unknown>> = [];
   await page.route('**/api/runs', async (route) => {
     const raw = route.request().postData();
@@ -507,11 +528,8 @@ test('[P0] project detail agent and model switches carry into the next daemon ru
   await createProject(page, 'Header agent switch run context');
   await expectWorkspaceReady(page);
 
-  const trigger = page.locator('.avatar-menu .avatar-agent-trigger');
-  await trigger.click();
-  const menu = page.locator('.avatar-popover[role="dialog"]');
-  await expect(menu).toBeVisible();
-  await menu.getByTestId('avatar-agent-option-claude').click();
+  const { menu, claudeButton } = await openAvatarAgentMenu(page);
+  await claudeButton.click();
   const modelSelect = menu.locator('.avatar-model-section [role=\"combobox\"]').first();
   await modelSelect.click();
   await page.getByRole('option', { name: /^Sonnet \(alias\)$/i }).click();
@@ -1473,6 +1491,32 @@ async function openEntrySettingsDialog(page: Page, sectionName?: RegExp | string
     await settingsDialog.getByRole('button', { name: sectionName }).click();
   }
   return settingsDialog;
+}
+
+async function openAvatarAgentMenu(page: Page): Promise<{
+  menu: Locator;
+  claudeButton: Locator;
+}> {
+  const trigger = page.locator('.avatar-menu .avatar-agent-trigger');
+  await trigger.click();
+  const menu = page.locator('.avatar-popover[role="dialog"]');
+  await expect(menu).toBeVisible();
+
+  const claudeButton = menu
+    .locator('[data-testid="avatar-agent-option-claude"], .avatar-item', {
+      hasText: /Claude Code/i,
+    })
+    .first();
+  if (!(await claudeButton.isVisible().catch(() => false))) {
+    const localCliOption = menu.getByRole('button', {
+      name: /Local CLI|本机 CLI|本地 CLI|Use local/i,
+    });
+    if (await localCliOption.isVisible().catch(() => false)) {
+      await localCliOption.click();
+    }
+  }
+  await expect(claudeButton).toBeVisible({ timeout: 20_000 });
+  return { menu, claudeButton };
 }
 
 async function expectWorkspaceReady(page: Page) {

--- a/e2e/ui/settings-api-protocol.test.ts
+++ b/e2e/ui/settings-api-protocol.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import type { Locator, Page } from '@playwright/test';
+import type { Locator, Page, Route } from '@playwright/test';
 
 const STORAGE_KEY = 'open-design:config';
 const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定|Account & settings/i;
@@ -26,7 +26,7 @@ async function gotoEntryHome(page: Page) {
 async function openSettingsDialogFromEntry(page: Page) {
   await waitForLoadingToClear(page);
   await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).first().click();
-  const dialog = page.getByRole('dialog');
+  const dialog = page.locator('.modal-settings[role="dialog"]');
   const menu = page.getByRole('menu');
   await expect
     .poll(async () => {
@@ -117,12 +117,49 @@ async function openExecutionSettingsWithAgents(
   await page.route('**/api/health', async (route) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
   });
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({ json: { agents } });
+  await page.route('**/api/agents**', async (route) => {
+    await fulfillAgentsRoute(route, agents);
   });
 
   await gotoEntryHome(page);
   await openSettingsDialogFromEntry(page);
+}
+
+async function fulfillAgentsRoute(
+  route: Route,
+  agents: Array<{
+    id: string;
+    name: string;
+    bin: string;
+    available: boolean;
+    version?: string | null;
+    models?: Array<{ id: string; label: string }>;
+  }>,
+) {
+  const url = new URL(route.request().url());
+  if (url.searchParams.get('stream') === '1') {
+    const body = [
+      ...agents.flatMap((agent) => [
+        'event: agent',
+        `data: ${JSON.stringify(agent)}`,
+        '',
+      ]),
+      'event: done',
+      'data: {}',
+      '',
+      '',
+    ].join('\n');
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+      },
+      body,
+    });
+    return;
+  }
+  await route.fulfill({ json: { agents } });
 }
 
 test('[P1] legacy known OpenAI provider switches to the matching Anthropic preset', async ({ page }) => {
@@ -437,6 +474,7 @@ test('[P0] BYOK fetched models are searchable inside the Settings model dropdown
 });
 
 test('[P0] saving Local CLI updates the entry status pill with the selected agent', async ({ page }) => {
+  test.setTimeout(60_000);
   await openExecutionSettingsWithAgents(
     page,
     {
@@ -478,7 +516,9 @@ test('[P0] saving Local CLI updates the entry status pill with the selected agen
   const dialog = page.getByRole('dialog');
 
   await dialog.getByRole('tab', { name: LOCAL_CLI_LABEL }).click();
-  await dialog.getByTestId('settings-agent-select-codex').click();
+  const codexAgent = dialog.getByTestId('settings-agent-select-codex');
+  await expect(codexAgent).toBeVisible();
+  await codexAgent.click();
   await expect.poll(async () => readSavedConfig(page)).toMatchObject({
     mode: 'daemon',
     agentId: 'codex',

--- a/e2e/ui/settings-local-cli-codex-fallback.test.ts
+++ b/e2e/ui/settings-local-cli-codex-fallback.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import type { Page } from '@playwright/test';
+import type { Page, Route } from '@playwright/test';
 
 const STORAGE_KEY = 'open-design:config';
 const LOCALE_KEY = 'open-design:locale';
@@ -141,8 +141,8 @@ async function openLocalCliSettings(
     });
   });
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({ json: { agents } });
+  await page.route('**/api/agents**', async (route) => {
+    await fulfillAgentsRoute(route, agents);
   });
 
   await page.route('**/api/test/connection', async (route) => {
@@ -156,7 +156,7 @@ async function openLocalCliSettings(
 
   await gotoEntryHome(page);
   await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).first().click();
-  const dialog = page.getByRole('dialog');
+  const dialog = page.locator('.modal-settings[role="dialog"]');
   const menu = page.getByRole('menu');
   await expect
     .poll(async () => {
@@ -171,8 +171,12 @@ async function openLocalCliSettings(
 
   await expect(dialog).toBeVisible();
   await dialog.getByRole('tab', { name: LOCAL_CLI_LABEL }).click();
-  const codexCard = dialog.getByTestId('settings-agent-select-codex');
-  await expect(codexCard).toBeVisible();
+  const codexCard = dialog
+    .locator('[data-testid="settings-agent-select-codex"], .agent-card-select', {
+      hasText: /Codex CLI/i,
+    })
+    .first();
+  await expect(codexCard).toBeVisible({ timeout: 20_000 });
   await codexCard.click();
   await dialog.getByTestId('settings-cli-env').evaluate((details) => {
     if (details instanceof HTMLDetailsElement) details.open = true;
@@ -183,8 +187,36 @@ async function openLocalCliSettings(
   return dialog;
 }
 
+async function fulfillAgentsRoute(route: Route, agents: AgentFixture[]) {
+  const url = new URL(route.request().url());
+  if (url.searchParams.get('stream') === '1') {
+    const body = [
+      ...agents.flatMap((agent) => [
+        'event: agent',
+        `data: ${JSON.stringify(agent)}`,
+        '',
+      ]),
+      'event: done',
+      'data: {}',
+      '',
+      '',
+    ].join('\n');
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+      },
+      body,
+    });
+    return;
+  }
+  await route.fulfill({ json: { agents } });
+}
+
 test.describe('Settings Local CLI Codex fallback UX', () => {
   test('[P0] shows fallback repair actions and can replace the saved path with the detected Codex binary', async ({ page }) => {
+    test.setTimeout(60_000);
     const configuredPath = '/bad/codex';
     const detectedPath = '/usr/local/bin/codex';
     let lastRequest: Record<string, unknown> | null = null;
@@ -246,6 +278,7 @@ test.describe('Settings Local CLI Codex fallback UX', () => {
   });
 
   test('[P0] can clear an unusable custom Codex path after a fallback_failed test result', async ({ page }) => {
+    test.setTimeout(60_000);
     const configuredPath = '/Applications/Codex.app/Contents/Resources/codex';
     const detectedPath = '/opt/homebrew/bin/codex';
 


### PR DESCRIPTION
## Summary
- mock `/api/agents?stream=1` with SSE agent events in affected P0 UI tests
- keep JSON `/api/agents` responses for non-stream callers
- make settings/avatar agent selection assertions wait for the mocked Codex/Claude entries

## Verification
- `pnpm --filter @open-design/e2e exec playwright test ui/settings-api-protocol.test.ts --project=chromium -g "saving Local CLI"`
- `pnpm --filter @open-design/e2e exec playwright test ui/settings-local-cli-codex-fallback.test.ts --project=chromium -g "fallback repair|clear an unusable"`
- `pnpm --filter @open-design/e2e exec playwright test ui/project-management-flows.test.ts --project=chromium -g "avatar menu lets|agent and model switches"`
- `pnpm -C e2e exec playwright test -c playwright.config.ts ui/settings-api-protocol.test.ts ui/settings-connectors-auth-happy-path.test.ts ui/settings-connectors-auth-recovery.test.ts --grep '\\[P0\\]'`