### PR TITLE
fix: restore default scenario craft rails

### DIFF
--- a/apps/daemon/src/plugins/apply.ts
+++ b/apps/daemon/src/plugins/apply.ts
@@ -41,6 +41,7 @@ import {
   type ConnectorProbe,
 } from './connector-gate.js';
 import { deriveAutoAtomSurfaces } from './atoms/auto-surfaces.js';
+import { getManifestContextCraft } from './context-craft.js';
 
 export class MissingInputError extends Error {
   readonly fields: string[];
@@ -158,9 +159,8 @@ export function applyPlugin(input: ApplyInput): ApplyComputed {
   if (skillRef) projectMetadata.skillId = skillRef;
   const dsId = pickDesignSystemId(manifest, input.activeProjectDesignSystem);
   if (dsId) projectMetadata.designSystemId = dsId;
-  if (Array.isArray(manifest.od?.context?.craft) && manifest.od!.context!.craft!.length > 0) {
-    projectMetadata.craftRequires = manifest.od!.context!.craft!.slice();
-  }
+  const craftRequires = getManifestContextCraft(manifest);
+  if (craftRequires.length > 0) projectMetadata.craftRequires = craftRequires;
 
   const queryText = resolveLocalizedText(manifest.od?.useCase?.query, input.locale);
 
@@ -181,6 +181,7 @@ export function applyPlugin(input: ApplyInput): ApplyComputed {
     pinnedRef:            input.plugin.pinnedRef,
     inputs:               validated.coerced,
     resolvedContext:      resolved.context,
+    craftRequires,
     capabilitiesGranted:  granted,
     capabilitiesRequired: required,
     assetsStaged:         assets,

--- a/apps/daemon/src/plugins/context-craft.ts
+++ b/apps/daemon/src/plugins/context-craft.ts
@@ -1,7 +1,18 @@
-import type { InstalledPluginRecord } from '@open-design/contracts';
+import type { AppliedPluginSnapshot, InstalledPluginRecord, PluginManifest } from '@open-design/contracts';
 
 export function getPluginContextCraft(plugin: InstalledPluginRecord): string[] {
-  const declared = plugin.manifest.od?.context?.craft;
+  return getManifestContextCraft(plugin.manifest);
+}
+
+export function getManifestContextCraft(manifest: PluginManifest): string[] {
+  return normalizeCraftRequires(manifest.od?.context?.craft);
+}
+
+export function getSnapshotContextCraft(snapshot: AppliedPluginSnapshot): string[] {
+  return normalizeCraftRequires(snapshot.craftRequires);
+}
+
+function normalizeCraftRequires(declared: unknown): string[] {
   if (!Array.isArray(declared) || declared.length === 0) return [];
 
   const seen = new Set<string>();

--- a/apps/daemon/src/plugins/context-craft.ts
+++ b/apps/daemon/src/plugins/context-craft.ts
@@ -1,0 +1,17 @@
+import type { InstalledPluginRecord } from '@open-design/contracts';
+
+export function getPluginContextCraft(plugin: InstalledPluginRecord): string[] {
+  const declared = plugin.manifest.od?.context?.craft;
+  if (!Array.isArray(declared) || declared.length === 0) return [];
+
+  const seen = new Set<string>();
+  const craft: string[] = [];
+  for (const entry of declared) {
+    if (typeof entry !== 'string') continue;
+    const slug = entry.trim();
+    if (!slug || seen.has(slug)) continue;
+    seen.add(slug);
+    craft.push(slug);
+  }
+  return craft;
+}

--- a/apps/daemon/src/plugins/persistence.ts
+++ b/apps/daemon/src/plugins/persistence.ts
@@ -74,6 +74,7 @@ export function migratePlugins(db: SqliteDb): void {
       task_kind                TEXT NOT NULL,
       inputs_json              TEXT NOT NULL,
       resolved_context_json    TEXT NOT NULL,
+      craft_requires_json      TEXT NOT NULL DEFAULT '[]',
       pipeline_json            TEXT,
       genui_surfaces_json      TEXT NOT NULL DEFAULT '[]',
       capabilities_granted     TEXT NOT NULL,
@@ -201,6 +202,7 @@ export function migratePlugins(db: SqliteDb): void {
     ['resolved_source', `ALTER TABLE applied_plugin_snapshots ADD COLUMN resolved_source TEXT`],
     ['resolved_ref', `ALTER TABLE applied_plugin_snapshots ADD COLUMN resolved_ref TEXT`],
     ['archive_integrity', `ALTER TABLE applied_plugin_snapshots ADD COLUMN archive_integrity TEXT`],
+    ['craft_requires_json', `ALTER TABLE applied_plugin_snapshots ADD COLUMN craft_requires_json TEXT NOT NULL DEFAULT '[]'`],
   ] as const) {
     if (!snapshotCols.some((c) => c['name'] === name)) db.exec(ddl);
   }

--- a/apps/daemon/src/plugins/resolve-snapshot.ts
+++ b/apps/daemon/src/plugins/resolve-snapshot.ts
@@ -42,6 +42,7 @@ import {
   linkSnapshotToProject,
   linkSnapshotToRun,
 } from './snapshots.js';
+import { getManifestContextCraft } from './context-craft.js';
 import {
   type ConnectorProbe,
 } from './connector-gate.js';
@@ -274,6 +275,7 @@ export function resolvePluginSnapshot(input: ResolveSnapshotInput): ResolveSnaps
     taskKind: result.appliedPlugin.taskKind,
     inputs: result.appliedPlugin.inputs,
     resolvedContext: result.appliedPlugin.resolvedContext,
+    craftRequires: result.appliedPlugin.craftRequires ?? getManifestContextCraft(plugin.manifest),
     pipeline: result.appliedPlugin.pipeline,
     genuiSurfaces: result.appliedPlugin.genuiSurfaces ?? [],
     capabilitiesGranted: merged,

--- a/apps/daemon/src/plugins/snapshots.ts
+++ b/apps/daemon/src/plugins/snapshots.ts
@@ -51,6 +51,7 @@ export interface CreateSnapshotInput {
   taskKind: AppliedPluginSnapshot['taskKind'];
   inputs: Record<string, string | number | boolean>;
   resolvedContext: ResolvedContext;
+  craftRequires?: string[] | undefined;
   pipeline?: PluginPipeline | undefined;
   genuiSurfaces?: GenUISurfaceSpec[] | undefined;
   capabilitiesGranted: string[];
@@ -81,13 +82,13 @@ export function createSnapshot(db: SqliteDb, input: CreateSnapshotInput): Applie
       manifest_source_digest, source_marketplace_id, source_marketplace_entry_name,
       source_marketplace_entry_version, marketplace_trust, resolved_source,
       resolved_ref, archive_integrity, pinned_ref, task_kind,
-      inputs_json, resolved_context_json, pipeline_json, genui_surfaces_json,
+      inputs_json, resolved_context_json, craft_requires_json, pipeline_json, genui_surfaces_json,
       capabilities_granted, capabilities_required, assets_staged_json,
       connectors_required_json, connectors_resolved_json, mcp_servers_json,
       plugin_title, plugin_description, query_text,
       status, applied_at, expires_at
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'fresh', ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'fresh', ?, ?)
   `).run(
     id,
     input.projectId,
@@ -108,6 +109,7 @@ export function createSnapshot(db: SqliteDb, input: CreateSnapshotInput): Applie
     input.taskKind,
     JSON.stringify(input.inputs),
     JSON.stringify(input.resolvedContext),
+    JSON.stringify(input.craftRequires ?? []),
     input.pipeline ? JSON.stringify(input.pipeline) : null,
     JSON.stringify(input.genuiSurfaces ?? []),
     JSON.stringify(input.capabilitiesGranted),
@@ -352,6 +354,7 @@ function buildSnapshot(args: {
     pinnedRef:            input.pinnedRef ?? undefined,
     inputs:               input.inputs,
     resolvedContext:      input.resolvedContext,
+    craftRequires:        input.craftRequires ?? [],
     capabilitiesGranted:  input.capabilitiesGranted,
     capabilitiesRequired: input.capabilitiesRequired,
     assetsStaged:         input.assetsStaged,
@@ -388,6 +391,7 @@ export function rowToSnapshot(row: DbRow): AppliedPluginSnapshot {
     pinnedRef:            row['pinned_ref'] != null ? String(row['pinned_ref']) : undefined,
     inputs:               parseJsonOr<Record<string, string | number | boolean>>(row['inputs_json'], {}),
     resolvedContext:      parseJsonOr<ResolvedContext>(row['resolved_context_json'], { items: [] }),
+    craftRequires:        parseJsonOr<string[]>(row['craft_requires_json'], []),
     capabilitiesGranted:  parseJsonOr<string[]>(row['capabilities_granted'], []),
     capabilitiesRequired: parseJsonOr<string[]>(row['capabilities_required'], []),
     assetsStaged:         parseJsonOr<PluginAssetRef[]>(row['assets_staged_json'], []),

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10598,15 +10598,13 @@ export async function startServer({
       try {
         const snap = getSnapshot(db, appliedPluginSnapshotId);
         if (snap?.pluginId) {
+          const { getSnapshotContextCraft } = await import('./plugins/context-craft.js');
+          for (const craft of getSnapshotContextCraft(snap)) {
+            if (!skillCraftRequires.includes(craft)) skillCraftRequires.push(craft);
+          }
           const plugin = getInstalledPlugin(db, snap.pluginId);
           if (plugin) {
-            const [{ getPluginContextCraft }, { loadPluginLocalSkill }] = await Promise.all([
-              import('./plugins/context-craft.js'),
-              import('./plugins/local-skill.js'),
-            ]);
-            for (const craft of getPluginContextCraft(plugin)) {
-              if (!skillCraftRequires.includes(craft)) skillCraftRequires.push(craft);
-            }
+            const { loadPluginLocalSkill } = await import('./plugins/local-skill.js');
             const local = await loadPluginLocalSkill(plugin);
             if (local) {
               skillBody = local.body + composedSkillBlocks;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10600,7 +10600,13 @@ export async function startServer({
         if (snap?.pluginId) {
           const plugin = getInstalledPlugin(db, snap.pluginId);
           if (plugin) {
-            const { loadPluginLocalSkill } = await import('./plugins/local-skill.js');
+            const [{ getPluginContextCraft }, { loadPluginLocalSkill }] = await Promise.all([
+              import('./plugins/context-craft.js'),
+              import('./plugins/local-skill.js'),
+            ]);
+            for (const craft of getPluginContextCraft(plugin)) {
+              if (!skillCraftRequires.includes(craft)) skillCraftRequires.push(craft);
+            }
             const local = await loadPluginLocalSkill(plugin);
             if (local) {
               skillBody = local.body + composedSkillBlocks;

--- a/apps/daemon/tests/plugins-bundled-scenarios-roster.test.ts
+++ b/apps/daemon/tests/plugins-bundled-scenarios-roster.test.ts
@@ -88,6 +88,9 @@ describe('plugins/_official/scenarios roster', () => {
     const manifestPath = path.join(scenariosRoot, 'od-default', 'open-design.json');
     const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
     expect(manifest.od.hidden).toBe(true);
+    expect(manifest.od.context?.craft).toEqual(
+      expect.arrayContaining(['typography', 'color', 'anti-ai-slop']),
+    );
     expect(manifest.od.pipeline.stages[0].id).toBe('task-type');
     expect(manifest.od.genui.surfaces).toEqual(
       expect.arrayContaining([
@@ -97,6 +100,14 @@ describe('plugins/_official/scenarios roster', () => {
           trigger: expect.objectContaining({ stageId: 'task-type' }),
         }),
       ]),
+    );
+  });
+
+  it('od-new-generation declares the default craft rails for anti-slop HTML output', async () => {
+    const manifestPath = path.join(scenariosRoot, 'od-new-generation', 'open-design.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+    expect(manifest.od.context?.craft).toEqual(
+      expect.arrayContaining(['typography', 'color', 'anti-ai-slop']),
     );
   });
 });

--- a/apps/daemon/tests/plugins-context-craft.test.ts
+++ b/apps/daemon/tests/plugins-context-craft.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { InstalledPluginRecord, PluginManifest } from '@open-design/contracts';
-import { getPluginContextCraft } from '../src/plugins/context-craft.js';
+import type { AppliedPluginSnapshot, InstalledPluginRecord, PluginManifest } from '@open-design/contracts';
+import { getPluginContextCraft, getSnapshotContextCraft } from '../src/plugins/context-craft.js';
 
 function pluginRecord(manifest: PluginManifest): InstalledPluginRecord {
   return {
@@ -85,5 +85,42 @@ describe('getPluginContextCraft', () => {
     };
 
     expect(getPluginContextCraft(pluginRecord(manifest))).toEqual([]);
+  });
+
+  it('keeps replay craft frozen on the applied snapshot after the installed manifest changes', () => {
+    const installedManifest: PluginManifest = {
+      name: 'fixture-plugin',
+      title: 'Fixture Plugin',
+      version: '0.1.0',
+      description: 'Fixture plugin.',
+      od: {
+        kind: 'scenario',
+        taskKind: 'new-generation',
+        useCase: { query: 'Generate a fixture artifact.' },
+        context: { craft: ['color'] },
+        capabilities: ['prompt:inject'],
+      },
+    };
+    const snapshot: AppliedPluginSnapshot = {
+      snapshotId: 'snapshot-1',
+      pluginId: 'fixture-plugin',
+      pluginVersion: '0.1.0',
+      manifestSourceDigest: 'digest-before-update',
+      inputs: {},
+      resolvedContext: { items: [] },
+      craftRequires: ['typography', 'anti-ai-slop'],
+      capabilitiesGranted: ['prompt:inject'],
+      capabilitiesRequired: ['prompt:inject'],
+      assetsStaged: [],
+      taskKind: 'new-generation',
+      appliedAt: 1,
+      connectorsRequired: [],
+      connectorsResolved: [],
+      mcpServers: [],
+      status: 'fresh',
+    };
+
+    expect(getPluginContextCraft(pluginRecord(installedManifest))).toEqual(['color']);
+    expect(getSnapshotContextCraft(snapshot)).toEqual(['typography', 'anti-ai-slop']);
   });
 });

--- a/apps/daemon/tests/plugins-context-craft.test.ts
+++ b/apps/daemon/tests/plugins-context-craft.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import type { InstalledPluginRecord, PluginManifest } from '@open-design/contracts';
+import { getPluginContextCraft } from '../src/plugins/context-craft.js';
+
+function pluginRecord(manifest: PluginManifest): InstalledPluginRecord {
+  return {
+    id: 'fixture-plugin',
+    title: 'Fixture Plugin',
+    version: '0.1.0',
+    sourceKind: 'local',
+    source: '/tmp/fixture-plugin',
+    sourceMarketplaceId: undefined,
+    pinnedRef: undefined,
+    sourceDigest: undefined,
+    trust: 'trusted',
+    capabilitiesGranted: ['prompt:inject'],
+    fsPath: '/tmp/fixture-plugin',
+    installedAt: 0,
+    updatedAt: 0,
+    manifest,
+  };
+}
+
+describe('getPluginContextCraft', () => {
+  it('returns the declared plugin craft slugs in manifest order', () => {
+    const manifest: PluginManifest = {
+      name: 'fixture-plugin',
+      title: 'Fixture Plugin',
+      version: '0.1.0',
+      description: 'Fixture plugin.',
+      od: {
+        kind: 'scenario',
+        taskKind: 'new-generation',
+        useCase: { query: 'Generate a fixture artifact.' },
+        context: {
+          craft: ['typography', 'color', 'anti-ai-slop'],
+        },
+        capabilities: ['prompt:inject'],
+      },
+    };
+
+    expect(getPluginContextCraft(pluginRecord(manifest))).toEqual([
+      'typography',
+      'color',
+      'anti-ai-slop',
+    ]);
+  });
+
+  it('drops blanks, non-strings, and duplicates', () => {
+    const manifest: PluginManifest = {
+      name: 'fixture-plugin',
+      title: 'Fixture Plugin',
+      version: '0.1.0',
+      description: 'Fixture plugin.',
+      od: {
+        kind: 'scenario',
+        taskKind: 'new-generation',
+        useCase: { query: 'Generate a fixture artifact.' },
+        context: {
+          craft: [' typography ', '', 'color', 'typography', 42 as never],
+        },
+        capabilities: ['prompt:inject'],
+      },
+    };
+
+    expect(getPluginContextCraft(pluginRecord(manifest))).toEqual([
+      'typography',
+      'color',
+    ]);
+  });
+
+  it('returns an empty array when no craft is declared', () => {
+    const manifest: PluginManifest = {
+      name: 'fixture-plugin',
+      title: 'Fixture Plugin',
+      version: '0.1.0',
+      description: 'Fixture plugin.',
+      od: {
+        kind: 'scenario',
+        taskKind: 'new-generation',
+        useCase: { query: 'Generate a fixture artifact.' },
+        capabilities: ['prompt:inject'],
+      },
+    };
+
+    expect(getPluginContextCraft(pluginRecord(manifest))).toEqual([]);
+  });
+});

--- a/apps/daemon/tests/plugins-snapshots.test.ts
+++ b/apps/daemon/tests/plugins-snapshots.test.ts
@@ -95,6 +95,17 @@ describe('snapshots writer', () => {
     expect(fetched!.status).toBe('fresh');
   });
 
+  it('persists apply-time craft requirements on the immutable snapshot', () => {
+    db.prepare('INSERT INTO projects (id, name) VALUES (?, ?)').run('project-1', 'Project 1');
+    const snap = createSnapshot(db, baseInput({
+      craftRequires: ['typography', 'color', 'anti-ai-slop'],
+    }));
+
+    const fetched = getSnapshot(db, snap.snapshotId);
+
+    expect(fetched?.craftRequires).toEqual(['typography', 'color', 'anti-ai-slop']);
+  });
+
   it('linkSnapshotToRun pins expires_at to NULL', () => {
     db.prepare('INSERT INTO projects (id, name) VALUES (?, ?)').run('project-1', 'Project 1');
     const snap = createSnapshot(db, baseInput());

--- a/packages/contracts/src/plugins/apply.ts
+++ b/packages/contracts/src/plugins/apply.ts
@@ -54,6 +54,7 @@ export const AppliedPluginSnapshotSchema = z.object({
   pinnedRef:            z.string().optional(),
   inputs:               z.record(z.union([z.string(), z.number(), z.boolean()])),
   resolvedContext:      ResolvedContextSchema,
+  craftRequires:        z.array(z.string()).optional(),
   capabilitiesGranted:  z.array(z.string()),
   capabilitiesRequired: z.array(z.string()),
   assetsStaged:         z.array(PluginAssetRefSchema),

--- a/plugins/_official/scenarios/od-default/open-design.json
+++ b/plugins/_official/scenarios/od-default/open-design.json
@@ -71,6 +71,13 @@
     "scenario": "default-router",
     "mode": "scenario",
     "hidden": true,
+    "context": {
+      "craft": [
+        "typography",
+        "color",
+        "anti-ai-slop"
+      ]
+    },
     "pipeline": {
       "stages": [
         {

--- a/plugins/_official/scenarios/od-new-generation/open-design.json
+++ b/plugins/_official/scenarios/od-new-generation/open-design.json
@@ -68,6 +68,13 @@
     "taskKind": "new-generation",
     "scenario": "new-generation",
     "mode": "scenario",
+    "context": {
+      "craft": [
+        "typography",
+        "color",
+        "anti-ai-slop"
+      ]
+    },
     "pipeline": {
       "stages": [
         {


### PR DESCRIPTION
## Why

A teammate reported that the 0.7/0.8-era anti-AI-slop and default-beautification behavior was no longer reliably affecting generated web artifacts. The craft docs still existed, but the plugin scenario path did not feed `od.context.craft` into daemon prompt composition, so default/free-form generation could miss the stronger typography/color/anti-slop rails.

## What users will see

Default Home/free-form and new-generation design runs should again apply the default typography, color, and anti-AI-slop craft guidance, producing less generic HTML artifacts by default.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface changed.

## Bug fix verification

- Test paths: `apps/daemon/tests/plugins-context-craft.test.ts`, `apps/daemon/tests/plugins-bundled-scenarios-roster.test.ts`
- Did the test go red on `main` and green on this branch? Not fully verified locally; the added roster assertion would fail before the manifest change because the default scenarios lacked `od.context.craft`.
- Additional check: changed plugin JSON files parse successfully with Node.

## Validation

- `node -e "for (const f of ['plugins/_official/scenarios/od-default/open-design.json','plugins/_official/scenarios/od-new-generation/open-design.json']) JSON.parse(require('fs').readFileSync(f,'utf8')); console.log('json ok')"` ✅
- `pnpm install` completed, but warned local Node is `v22.22.0` while repo requires `~24`.
- `pnpm --dir apps/daemon test tests/plugins-context-craft.test.ts tests/plugins-bundled-scenarios-roster.test.ts` blocked locally: `vitest: command not found` after this worktree's pnpm install created a bun-linked node_modules without `.bin`.
- `pnpm --filter @open-design/daemon typecheck` / direct daemon `tsc` were not green locally due to environment/baseline issues unrelated to this diff, including Node 22 engine mismatch and existing daemon type errors.
