### PR TITLE
fix(daemon): stabilize HyperFrames render handoff

### DIFF
--- a/apps/daemon/src/media.ts
+++ b/apps/daemon/src/media.ts
@@ -699,6 +699,12 @@ export async function generateMedia(args: {
     if (err instanceof StubProviderDisabledError) {
       throw err;
     }
+    // HyperFrames is a local render, not a remote provider. Falling back
+    // to a stub here hides actionable composition/preflight failures and
+    // can make the agent retry or narrate a fake MP4 as success.
+    if (def.provider === 'hyperframes') {
+      throw err;
+    }
     // A real provider failed (network blip, 4xx, missing key, …). We
     // still want to fall back to a stub so the agent's chat loop
     // doesn't dead-end — but only when stubs are allowed for this
@@ -3600,15 +3606,24 @@ async function renderHyperFramesViaCli(ctx: MediaContext, projectDir: string, on
   if (!compStat.isDirectory()) {
     throw new Error(`compositionDir is not a directory: ${compRel}`);
   }
-  const indexStat = await stat(path.join(compAbs, 'index.html')).catch(
-    () => null,
+  await assertHyperFramesCompositionFile(
+    compAbs,
+    compRel,
+    'hyperframes.json',
+    'Run `npx hyperframes init "$OD_PROJECT_DIR/$COMP_REL" --example blank --skip-skills --non-interactive` before editing the composition.',
   );
-  if (!indexStat || !indexStat.isFile()) {
-    throw new Error(
-      `compositionDir is missing index.html: ${compRel}. The agent must ` +
-        'write index.html (with window.__timelines registration) before dispatch.',
-    );
-  }
+  await assertHyperFramesCompositionFile(
+    compAbs,
+    compRel,
+    'meta.json',
+    'Run `npx hyperframes init` so the renderer has duration/scene metadata before dispatch.',
+  );
+  await assertHyperFramesCompositionFile(
+    compAbs,
+    compRel,
+    'index.html',
+    'The agent must write index.html (with window.__timelines registration) before dispatch.',
+  );
 
   const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'open-design-hf-'));
   const tmpOutput = path.join(tmpRoot, 'render.mp4');
@@ -3632,6 +3647,20 @@ async function renderHyperFramesViaCli(ctx: MediaContext, projectDir: string, on
     throw new Error(`hyperframes render failed: ${truncate(message, 480)}`);
   } finally {
     await rm(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+async function assertHyperFramesCompositionFile(
+  compAbs: string,
+  compRel: string,
+  fileName: string,
+  guidance: string,
+): Promise<void> {
+  const fileStat = await stat(path.join(compAbs, fileName)).catch(() => null);
+  if (!fileStat || !fileStat.isFile()) {
+    throw new Error(
+      `compositionDir is missing ${fileName}: ${compRel}. ${guidance}`,
+    );
   }
 }
 

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -395,11 +395,13 @@ path is given.
    metadata doesn't carry.
 
    For \`hyperframes-html\`, the discovery turn is the last turn before
-   you start authoring. Once the user answers, write the composition
-   files into \`.hyperframes-cache/\` and run \`npx hyperframes render\`
-   immediately — do not add a second "plan" or "environment check"
-   message first, and do not call \`"$OD_NODE_BIN" "$OD_BIN" media generate\` (that path is
-   intentionally rejected for this model).
+   you start authoring. Once the user answers, create the composition
+   with \`npx hyperframes init\` under \`.hyperframes-cache/\`, edit the
+   generated \`index.html\`, and dispatch through
+   \`"$OD_NODE_BIN" "$OD_BIN" media generate --surface video --model hyperframes-html --composition-dir <rel>\`.
+   Do not run \`npx hyperframes render\` yourself; Chrome-bound rendering
+   must happen in the daemon process. Do not add a second "plan" or
+   "environment check" message first.
 3. **Generate by shell, reply in one short message.** When you invoke
    \`"$OD_NODE_BIN" "$OD_BIN" media generate\`, do it inside a clearly-labelled tool call.
    After the command completes, reply with **one brief message** (2–3 sentences max):

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -1159,7 +1159,7 @@ function renderMetadataBlock(
     ));
     if (metadata.videoModel === 'hyperframes-html') {
       lines.push(
-        'Special case: `hyperframes-html` is a local HTML-to-MP4 renderer, not a photoreal text-to-video model. Treat it like a motion design renderer, ask at most one clarifying question, then dispatch immediately.',
+        'Special case: `hyperframes-html` is a local HTML-to-MP4 renderer, not a photoreal text-to-video model. Treat it like a motion design renderer, ask at most one clarifying question, then create a HyperFrames composition with `npx hyperframes init` under `.hyperframes-cache/`, edit `index.html`, and dispatch via `"$OD_NODE_BIN" "$OD_BIN" media generate --surface video --model hyperframes-html --composition-dir <rel>`. Do not run `npx hyperframes render` yourself.',
       );
     }
   }

--- a/apps/daemon/tests/media-hyperframes.test.ts
+++ b/apps/daemon/tests/media-hyperframes.test.ts
@@ -1,0 +1,65 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { generateMedia } from '../src/media.js';
+
+describe('hyperframes-html media renderer preflight', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  const originalAllowStubs = process.env.OD_MEDIA_ALLOW_STUBS;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-hyperframes-media-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    await mkdir(path.join(projectsRoot, 'project-1'), { recursive: true });
+    process.env.OD_MEDIA_ALLOW_STUBS = '1';
+  });
+
+  afterEach(async () => {
+    if (originalAllowStubs == null) {
+      delete process.env.OD_MEDIA_ALLOW_STUBS;
+    } else {
+      process.env.OD_MEDIA_ALLOW_STUBS = originalAllowStubs;
+    }
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('rejects incomplete composition dirs instead of falling back to a stub', async () => {
+    const compRel = '.hyperframes-cache/incomplete';
+    const compDir = path.join(projectsRoot, 'project-1', compRel);
+    await mkdir(compDir, { recursive: true });
+    await writeFile(path.join(compDir, 'index.html'), '<!doctype html><div id="root"></div>', 'utf8');
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'video',
+      model: 'hyperframes-html',
+      output: 'test.mp4',
+      compositionDir: compRel,
+    })).rejects.toThrow(/compositionDir is missing hyperframes\.json/);
+  });
+
+  it('requires meta.json before spawning the local renderer', async () => {
+    const compRel = '.hyperframes-cache/no-meta';
+    const compDir = path.join(projectsRoot, 'project-1', compRel);
+    await mkdir(compDir, { recursive: true });
+    await writeFile(path.join(compDir, 'hyperframes.json'), '{}', 'utf8');
+    await writeFile(path.join(compDir, 'index.html'), '<!doctype html><div id="root"></div>', 'utf8');
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'video',
+      model: 'hyperframes-html',
+      output: 'test.mp4',
+      compositionDir: compRel,
+    })).rejects.toThrow(/compositionDir is missing meta\.json/);
+  });
+});

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -38,7 +38,12 @@ const hyperframesSkillPath = path.join(
   repoRoot,
   'design-templates/hyperframes/SKILL.md',
 );
+const officialHyperframesSkillPath = path.join(
+  repoRoot,
+  'plugins/_official/examples/hyperframes/SKILL.md',
+);
 const hyperframesSkillMarkdown = readFileSync(hyperframesSkillPath, 'utf8');
+const officialHyperframesSkillMarkdown = readFileSync(officialHyperframesSkillPath, 'utf8');
 const hyperframesSkillBody = [
   `> **Skill root (absolute):** \`${hyperframesRoot}\``,
   '>',
@@ -234,6 +239,18 @@ describe('composeSystemPrompt', () => {
     expect(prompt).toContain('media generate --surface video --model hyperframes-html --composition-dir <rel>');
     expect(prompt).toContain('Do not run `npx hyperframes render` yourself');
     expect(prompt).not.toContain('intentionally rejected for this model');
+    expect(prompt).not.toContain('AGENT_RENDERED');
+    expect(prompt).not.toContain('rendered by you directly via npx');
+  });
+
+  it('keeps both hyperframes skill copies aligned with the daemon render handoff', () => {
+    for (const markdown of [hyperframesSkillMarkdown, officialHyperframesSkillMarkdown]) {
+      expect(markdown).toContain('media generate --surface video --model hyperframes-html --composition-dir <rel>');
+      expect(markdown).toContain('Do not run `npx hyperframes render`');
+      expect(markdown).not.toContain('AGENT_RENDERED');
+      expect(markdown).not.toContain('rendered by you directly via npx');
+      expect(markdown).not.toContain('dispatcher path returns a 400');
+    }
   });
 
   it('does not add the responsive web contract to deck metadata without platform fields', () => {

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -231,6 +231,9 @@ describe('composeSystemPrompt', () => {
     expect(prompt).toContain('## Active skill — hyperframes');
     expect(prompt).toContain('**Pre-flight (do this before any other tool):**');
     expect(prompt).toContain('`references/html-in-canvas.md`');
+    expect(prompt).toContain('media generate --surface video --model hyperframes-html --composition-dir <rel>');
+    expect(prompt).toContain('Do not run `npx hyperframes render` yourself');
+    expect(prompt).not.toContain('intentionally rejected for this model');
   });
 
   it('does not add the responsive web contract to deck metadata without platform fields', () => {

--- a/design-templates/hyperframes/SKILL.md
+++ b/design-templates/hyperframes/SKILL.md
@@ -127,11 +127,11 @@ The lighter HF subcommands you CAN still run from your own shell
 - `npx hyperframes tts <text>` — generate narration
 
 Reserve the daemon dispatch for `render`/`inspect`/`preview` (anything
-Chrome-bound).
-
-**Do NOT** call `"$OD_NODE_BIN" "$OD_BIN" media generate --model hyperframes-html` — that
-dispatcher path returns a 400 (`AGENT_RENDERED`) on purpose. HyperFrames
-is rendered by you directly via npx.
+Chrome-bound). After authoring the composition under `.hyperframes-cache/`,
+render it by calling `"$OD_NODE_BIN" "$OD_BIN" media generate --surface video --model hyperframes-html --composition-dir <rel>`.
+The daemon runs the Chrome-bound HyperFrames render outside your shell
+sandbox and streams progress back to you. Do not run `npx hyperframes render`
+yourself.
 
 **Do NOT** drop `hyperframes.json` / `meta.json` / `index.html` in the
 project root; OD's file listing scans recursively and the user would see

--- a/plugins/_official/examples/hyperframes/SKILL.md
+++ b/plugins/_official/examples/hyperframes/SKILL.md
@@ -127,11 +127,11 @@ The lighter HF subcommands you CAN still run from your own shell
 - `npx hyperframes tts <text>` — generate narration
 
 Reserve the daemon dispatch for `render`/`inspect`/`preview` (anything
-Chrome-bound).
-
-**Do NOT** call `"$OD_NODE_BIN" "$OD_BIN" media generate --model hyperframes-html` — that
-dispatcher path returns a 400 (`AGENT_RENDERED`) on purpose. HyperFrames
-is rendered by you directly via npx.
+Chrome-bound). After authoring the composition under `.hyperframes-cache/`,
+render it by calling `"$OD_NODE_BIN" "$OD_BIN" media generate --surface video --model hyperframes-html --composition-dir <rel>`.
+The daemon runs the Chrome-bound HyperFrames render outside your shell
+sandbox and streams progress back to you. Do not run `npx hyperframes render`
+yourself.
 
 **Do NOT** drop `hyperframes.json` / `meta.json` / `index.html` in the
 project root; OD's file listing scans recursively and the user would see


### PR DESCRIPTION
## Why

QA recvlPQ19CcxMi reports frequent retry/error behavior when running HyperFrames video generation and related generated artifact flows. The HyperFrames prompt contract had drifted: one section told agents to use the daemon `media generate` handoff, while the workflow rules still told them to run `npx hyperframes render` directly and said `media generate` was rejected. That made agents more likely to take the sandboxed Chrome path or keep retrying a bad handoff.

This also hardens the daemon side so local HyperFrames composition/render failures stay actionable instead of being converted into stub fallback output.

## What users will see

HyperFrames video generation should be more stable: agents are instructed to scaffold under `.hyperframes-cache/`, dispatch through `od media generate --model hyperframes-html --composition-dir <rel>`, and stop if the local composition is incomplete. When required files are missing, the error names the missing file instead of falling through to retry/fake output.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — daemon prompt/render behavior only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/media-hyperframes.test.ts`, `apps/daemon/tests/prompts/system.test.ts`
- Did the test go red on `main` and green on this branch? The prompt drift assertion would fail on `main`; the new HyperFrames preflight/stub-fallback coverage is green on this branch.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/media-hyperframes.test.ts tests/prompts/system.test.ts tests/pi-rpc.test.ts tests/runs.test.ts`
- `pnpm --filter @open-design/daemon typecheck` (passes; local shell is Node 22 so pnpm prints the repo's Node ~24 engine warning)
- `pnpm guard` (passes; same Node 22 engine warning)
- LSP diagnostics unavailable locally: `typescript-language-server` is not installed.
