### PR TITLE
fix(web): constrain onboarding dropdowns

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -10,9 +10,11 @@
 
 import {
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type Dispatch,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
@@ -2487,7 +2489,7 @@ type OnboardingDropdownProps =
       multiple: true;
     });
 
-function OnboardingDropdown(props: OnboardingDropdownProps) {
+export function OnboardingDropdown(props: OnboardingDropdownProps) {
   const {
     label,
     placeholder,
@@ -2497,6 +2499,8 @@ function OnboardingDropdown(props: OnboardingDropdownProps) {
     multiple = false,
   } = props;
   const [open, setOpen] = useState(false);
+  const [resolvedPlacement, setResolvedPlacement] = useState(placement);
+  const [menuMaxHeight, setMenuMaxHeight] = useState(240);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const selectedValues = Array.isArray(value) ? value : value ? [value] : [];
   const selectedOptions = options.filter((option) => selectedValues.includes(option.value));
@@ -2505,6 +2509,36 @@ function OnboardingDropdown(props: OnboardingDropdownProps) {
   const selectedLabel = multiple
     ? selectedOptions.map((option) => option.label).join(', ')
     : selectedOption?.label;
+  const triggerLabel = selectedLabel || placeholder;
+
+  useLayoutEffect(() => {
+    if (!open) return;
+
+    function measureMenu() {
+      const root = rootRef.current;
+      if (!root) return;
+
+      const rect = root.getBoundingClientRect();
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 720;
+      const spaceBelow = viewportHeight - rect.bottom;
+      const spaceAbove = rect.top;
+      const nextPlacement =
+        placement === 'top' || (spaceBelow < 260 && spaceAbove > spaceBelow)
+          ? 'top'
+          : 'bottom';
+      const availableSpace = nextPlacement === 'top' ? spaceAbove : spaceBelow;
+      setResolvedPlacement(nextPlacement);
+      setMenuMaxHeight(Math.max(48, Math.min(240, availableSpace - 16)));
+    }
+
+    measureMenu();
+    window.addEventListener('resize', measureMenu);
+    window.addEventListener('scroll', measureMenu, true);
+    return () => {
+      window.removeEventListener('resize', measureMenu);
+      window.removeEventListener('scroll', measureMenu, true);
+    };
+  }, [open, placement, options.length]);
 
   useEffect(() => {
     if (!open) return;
@@ -2530,7 +2564,12 @@ function OnboardingDropdown(props: OnboardingDropdownProps) {
   }, [open]);
 
   return (
-    <div className="onboarding-view__select-field" data-placement={placement} ref={rootRef}>
+    <div
+      className="onboarding-view__select-field"
+      data-placement={resolvedPlacement}
+      data-open={open || undefined}
+      ref={rootRef}
+    >
       <span className="onboarding-view__select-label">{label}</span>
       <button
         type="button"
@@ -2539,9 +2578,10 @@ function OnboardingDropdown(props: OnboardingDropdownProps) {
         }`}
         aria-haspopup="listbox"
         aria-expanded={open}
+        title={triggerLabel}
         onClick={() => setOpen((current) => !current)}
       >
-        <span>{selectedLabel || placeholder}</span>
+        <span>{triggerLabel}</span>
         <Icon name="chevron-down" size={16} />
       </button>
       {open ? (
@@ -2550,6 +2590,7 @@ function OnboardingDropdown(props: OnboardingDropdownProps) {
           role="listbox"
           aria-label={label}
           aria-multiselectable={multiple || undefined}
+          style={{ '--onboarding-select-menu-max-height': `${menuMaxHeight}px` } as CSSProperties}
         >
           {options.map((option) => {
             const selected = selectedValues.includes(option.value);

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1700,17 +1700,20 @@
   gap: 18px;
   width: min(860px, 100%);
   min-width: 0;
+  overflow: visible;
 }
 
 .onboarding-view__panel {
   display: grid;
   gap: 18px;
   min-height: 0;
+  min-width: 0;
   padding: 0;
   border: 0;
   border-radius: 0;
   background: transparent;
   box-shadow: none;
+  overflow: visible;
 }
 
 .onboarding-view__design-system-create {
@@ -3151,11 +3154,13 @@
 .onboarding-view__setup-panel {
   display: grid;
   gap: 14px;
+  min-width: 0;
   padding: 14px;
   border: 1px solid color-mix(in srgb, var(--border) 82%, var(--accent) 18%);
   border-radius: 8px;
   background: color-mix(in srgb, var(--bg-panel) 97%, var(--accent) 3%);
   box-shadow: var(--shadow-xs);
+  overflow: visible;
 }
 
 .onboarding-view__setup-head {
@@ -3163,6 +3168,11 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 14px;
+  min-width: 0;
+}
+
+.onboarding-view__setup-head > div:first-child {
+  min-width: 0;
 }
 
 .onboarding-view__setup-head strong {
@@ -3370,6 +3380,7 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 8px;
+  min-width: 0;
 }
 
 .onboarding-view__field-row button {
@@ -3593,6 +3604,10 @@
   min-width: 0;
 }
 
+.onboarding-view__select-field[data-open='true'] {
+  z-index: 45;
+}
+
 .onboarding-view__select-label {
   color: var(--text-strong);
   font-size: 12px;
@@ -3617,6 +3632,14 @@
   cursor: pointer;
   box-shadow: var(--shadow-xs);
   transition: background-color 160ms cubic-bezier(0.23, 1, 0.32, 1), border-color 160ms cubic-bezier(0.23, 1, 0.32, 1), color 160ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 160ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.onboarding-view__select-trigger > span {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .onboarding-view__select-trigger svg {
@@ -3652,14 +3675,18 @@
 
 .onboarding-view__select-menu {
   position: absolute;
-  z-index: 20;
+  z-index: 50;
   top: calc(100% + 6px);
   left: 0;
   right: 0;
   display: grid;
   gap: 2px;
-  max-height: 240px;
+  max-height: min(
+    var(--onboarding-select-menu-max-height, 240px),
+    max(48px, min(240px, calc(100vh - 120px)))
+  );
   overflow-y: auto;
+  overflow-x: hidden;
   overscroll-behavior: contain;
   padding: 6px;
   border: 1px solid color-mix(in srgb, var(--border) 82%, var(--accent) 18%);
@@ -3690,6 +3717,14 @@
   font-size: 13px;
   text-align: left;
   cursor: pointer;
+}
+
+.onboarding-view__select-option > span {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .onboarding-view__select-option:hover {
@@ -3811,6 +3846,22 @@
   }
 }
 
+@media (max-width: 900px) {
+  .onboarding-view {
+    width: min(820px, 100%);
+    padding: 34px 28px 36px;
+  }
+
+  .onboarding-view__hero h1 {
+    font-size: 42px;
+  }
+
+  .onboarding-view__alternatives,
+  .onboarding-view__ds-points {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 760px) {
   .entry-shell--onboarding {
     padding: 0;
@@ -3837,10 +3888,6 @@
   }
 
   .onboarding-view__steps {
-    grid-template-columns: 1fr;
-  }
-
-  .onboarding-view__ds-points {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { OnboardingDropdown } from '../../src/components/EntryShell';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('OnboardingDropdown', () => {
+  it('renders a custom listbox instead of a native select', () => {
+    render(
+      <OnboardingDropdown
+        label="Model"
+        placeholder="Select a model"
+        value="claude-sonnet-4-5"
+        options={[
+          { value: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+          { value: 'gpt-5', label: 'GPT-5' },
+        ]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(document.querySelector('select')).toBeNull();
+
+    const trigger = screen.getByRole('button', { name: /Claude Sonnet 4.5/ });
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(trigger);
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('listbox', { name: 'Model' })).toBeTruthy();
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+  });
+
+  it('flips upward near the viewport bottom and caps menu height', () => {
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 420,
+    });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: HTMLElement,
+    ) {
+      if (this.classList.contains('onboarding-view__select-field')) {
+        return {
+          x: 0,
+          y: 330,
+          width: 320,
+          height: 42,
+          top: 330,
+          right: 320,
+          bottom: 372,
+          left: 0,
+          toJSON: () => ({}),
+        };
+      }
+      return {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      };
+    });
+
+    render(
+      <OnboardingDropdown
+        label="Model"
+        placeholder="Select a model"
+        value="model-1"
+        options={Array.from({ length: 30 }, (_, index) => ({
+          value: `model-${index + 1}`,
+          label: `Very long Windows model option ${index + 1}`,
+        }))}
+        onChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Very long Windows model option 1/ }));
+
+    const listbox = screen.getByRole('listbox', { name: 'Model' });
+    expect(listbox.parentElement?.getAttribute('data-placement')).toBe('top');
+    expect(listbox.style.getPropertyValue('--onboarding-select-menu-max-height')).toBe('240px');
+  });
+});


### PR DESCRIPTION
## Why

QA reported recvlVk3NdCtho: the Onboarding model picker could appear like a giant native/system list on Windows and crowd the AMR / Local CLI / BYOK setup areas in narrow or short desktop windows. This fixes the onboarding dropdown and layout guardrails so model/provider lists stay inside the viewport and card content does not overflow.

## What users will see

Onboarding model/provider dropdowns remain custom in-app menus. Long model lists scroll inside the dropdown, flip upward when near the bottom of the window, and avoid covering most of the onboarding page. AMR, Local CLI, and BYOK setup cards fit better on narrow Windows-sized viewports.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not captured locally; this addresses the Windows QA screenshot in recvlVk3NdCtho by keeping onboarding dropdowns custom, bounded, and scrollable.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx`
- Did the test go red on `main` and green on this branch? No — current `main` already has a custom dropdown, so the added regression test locks the no-native-select behavior and viewport flip/max-height guardrails that prevent this QA class from returning.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/EntryShell.onboarding-dropdown.test.tsx` ✅
- `pnpm --filter @open-design/web typecheck` ✅
- `pnpm guard` ⚠️ fails on current `origin/main` baseline: `Tools layout violations found: tools/pr/ -> tools/ top-level entries are allowlisted; expected only AGENTS.md, dev/, pack/, and serve/`
- `pnpm --filter @open-design/web test` ⚠️ 3055 passed / 2 failed on current `origin/main` baseline with jsdom canvas/timeouts in `DesignBrowserPanel.webview.test.tsx` and `FileViewer.test.tsx`

Note: local Node is v22.22.0, so pnpm prints engine warnings for the repo's Node ~24 target.
