### PR TITLE
[codex] Fix browser comment marker tracking

### DIFF
--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -1863,29 +1863,6 @@ export function DesignBrowserPanel({
               <RemixIcon name="screenshot-2-line" size={15} />
             </IconTooltipButton>
           ) : null}
-          {desktopHostAvailable ? (
-            <IconTooltipButton
-              label={t('fileViewer.mark')}
-              wrapperClassName="db-action-item db-action-mark"
-              disabled={isBlank}
-              className={drawOverlayOpen ? 'is-active' : ''}
-              onClick={() => {
-                clearBrowserTool();
-                setDrawOverlayOpen((open) => !open);
-              }}
-            >
-              <RemixIcon name="mark-pen-line" size={15} />
-            </IconTooltipButton>
-          ) : null}
-          <IconTooltipButton
-            label={t('fileViewer.comment')}
-            wrapperClassName="db-action-item db-action-primary db-action-comment"
-            disabled={isBlank || !desktopHostAvailable}
-            className={activeTool === 'comment' ? 'is-active' : ''}
-            onClick={() => toggleBrowserTool('comment')}
-          >
-            <Icon name="comment" size={15} />
-          </IconTooltipButton>
           <IconTooltipButton
             label={t('browserUse.title')}
             wrapperClassName="db-action-item db-action-browser-use"
@@ -1922,58 +1899,6 @@ export function DesignBrowserPanel({
           </IconTooltipButton>
           {menuOpen ? (
             <div className="db-menu" role="menu">
-              {desktopHostAvailable ? (
-                <button
-                  type="button"
-                  role="menuitem"
-                  onClick={() => {
-                    setMenuOpen(false);
-                    clearBrowserTool();
-                    setDrawOverlayOpen((open) => !open);
-                  }}
-                  disabled={isBlank}
-                >
-                  <RemixIcon name="mark-pen-line" size={14} />
-                  {t('fileViewer.mark')}
-                </button>
-              ) : null}
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setMenuOpen(false);
-                  toggleBrowserTool('comment');
-                }}
-                disabled={isBlank || !desktopHostAvailable}
-              >
-                <Icon name="comment" size={14} />
-                {t('fileViewer.comment')}
-              </button>
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setMenuOpen(false);
-                  toggleBrowserTool('inspect');
-                }}
-                disabled={isBlank || !desktopHostAvailable}
-              >
-                <RemixIcon name="contrast-drop-line" size={14} />
-                Tune Element
-              </button>
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setMenuOpen(false);
-                  toggleBrowserTool('edit');
-                }}
-                disabled={isBlank || !desktopHostAvailable}
-              >
-                <Icon name="edit" size={14} />
-                {editableProjectHtml ? 'Edit HTML' : 'Edit Live DOM'}
-              </button>
-              <span className="db-menu-separator" />
               <button type="button" role="menuitem" onClick={takeScreenshot} disabled={isBlank || savingAction != null}>
                 <Icon name="image" size={14} />
                 Copy Screenshot
@@ -2047,24 +1972,6 @@ export function DesignBrowserPanel({
                 <iframe title={pageTitle} src={loadUrl} />
               </div>
             )}
-            {!isBlank && desktopHostAvailable ? (
-              <BrowserCommentMarkers
-                comments={visibleComments}
-                liveTargets={browserLiveCommentTargets}
-                activeCommentId={activePreviewCommentId}
-                onOpen={(comment) => {
-                  const snapshot = browserLiveCommentTargets.get(`comment:${comment.id}`)
-                    ?? browserSnapshotFromComment(comment, browserFilePath);
-                  setActiveTool('comment');
-                  setActiveCommentTarget(snapshot);
-                  setActivePreviewCommentId(comment.id);
-                  setCommentDraft(comment.note);
-                  setQueuedCommentNotes([]);
-                  setTextDraft(snapshot.text);
-                  setDrawOverlayOpen(false);
-                }}
-              />
-            ) : null}
             {commentComposer}
             {(activeTool === 'inspect' || activeTool === 'edit') && activeCommentTarget ? (
               <BrowserInspectPanel

--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -2047,7 +2047,7 @@ export function DesignBrowserPanel({
                 <iframe title={pageTitle} src={loadUrl} />
               </div>
             )}
-            {!isBlank ? (
+            {!isBlank && desktopHostAvailable ? (
               <BrowserCommentMarkers
                 comments={visibleComments}
                 liveTargets={browserLiveCommentTargets}

--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -1863,6 +1863,29 @@ export function DesignBrowserPanel({
               <RemixIcon name="screenshot-2-line" size={15} />
             </IconTooltipButton>
           ) : null}
+          {desktopHostAvailable ? (
+            <IconTooltipButton
+              label={t('fileViewer.mark')}
+              wrapperClassName="db-action-item db-action-mark"
+              disabled={isBlank}
+              className={drawOverlayOpen ? 'is-active' : ''}
+              onClick={() => {
+                clearBrowserTool();
+                setDrawOverlayOpen((open) => !open);
+              }}
+            >
+              <RemixIcon name="mark-pen-line" size={15} />
+            </IconTooltipButton>
+          ) : null}
+          <IconTooltipButton
+            label={t('fileViewer.comment')}
+            wrapperClassName="db-action-item db-action-primary db-action-comment"
+            disabled={isBlank || !desktopHostAvailable}
+            className={activeTool === 'comment' ? 'is-active' : ''}
+            onClick={() => toggleBrowserTool('comment')}
+          >
+            <Icon name="comment" size={15} />
+          </IconTooltipButton>
           <IconTooltipButton
             label={t('browserUse.title')}
             wrapperClassName="db-action-item db-action-browser-use"
@@ -1899,6 +1922,58 @@ export function DesignBrowserPanel({
           </IconTooltipButton>
           {menuOpen ? (
             <div className="db-menu" role="menu">
+              {desktopHostAvailable ? (
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    clearBrowserTool();
+                    setDrawOverlayOpen((open) => !open);
+                  }}
+                  disabled={isBlank}
+                >
+                  <RemixIcon name="mark-pen-line" size={14} />
+                  {t('fileViewer.mark')}
+                </button>
+              ) : null}
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setMenuOpen(false);
+                  toggleBrowserTool('comment');
+                }}
+                disabled={isBlank || !desktopHostAvailable}
+              >
+                <Icon name="comment" size={14} />
+                {t('fileViewer.comment')}
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setMenuOpen(false);
+                  toggleBrowserTool('inspect');
+                }}
+                disabled={isBlank || !desktopHostAvailable}
+              >
+                <RemixIcon name="contrast-drop-line" size={14} />
+                Tune Element
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  setMenuOpen(false);
+                  toggleBrowserTool('edit');
+                }}
+                disabled={isBlank || !desktopHostAvailable}
+              >
+                <Icon name="edit" size={14} />
+                {editableProjectHtml ? 'Edit HTML' : 'Edit Live DOM'}
+              </button>
+              <span className="db-menu-separator" />
               <button type="button" role="menuitem" onClick={takeScreenshot} disabled={isBlank || savingAction != null}>
                 <Icon name="image" size={14} />
                 Copy Screenshot
@@ -1972,6 +2047,24 @@ export function DesignBrowserPanel({
                 <iframe title={pageTitle} src={loadUrl} />
               </div>
             )}
+            {!isBlank && desktopHostAvailable ? (
+              <BrowserCommentMarkers
+                comments={visibleComments}
+                liveTargets={browserLiveCommentTargets}
+                activeCommentId={activePreviewCommentId}
+                onOpen={(comment) => {
+                  const snapshot = browserLiveCommentTargets.get(`comment:${comment.id}`)
+                    ?? browserSnapshotFromComment(comment, browserFilePath);
+                  setActiveTool('comment');
+                  setActiveCommentTarget(snapshot);
+                  setActivePreviewCommentId(comment.id);
+                  setCommentDraft(comment.note);
+                  setQueuedCommentNotes([]);
+                  setTextDraft(snapshot.text);
+                  setDrawOverlayOpen(false);
+                }}
+              />
+            ) : null}
             {commentComposer}
             {(activeTool === 'inspect' || activeTool === 'edit') && activeCommentTarget ? (
               <BrowserInspectPanel

--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -39,6 +39,7 @@ import {
   browserApplyTextScript,
   browserCommentFilePath,
   browserElementPickerScript,
+  browserMeasureTargetsScript,
   browserSnapshotFromUnknown,
   isProjectHtmlBrowserUrl,
   projectRelativePathFromBrowserUrl,
@@ -222,6 +223,7 @@ const EMPTY_URL = 'about:blank';
 const DESIGN_BROWSER_PARTITION = 'persist:open-design-design-browser';
 const HISTORY_LIMIT = 80;
 const HISTORY_SUGGESTION_LIMIT = 20;
+const EMPTY_PREVIEW_COMMENTS: PreviewComment[] = [];
 // Cap the resource-hint (`dns-prefetch`/`preconnect`) links we leave in <head>.
 // Hovering/typing origins used to accumulate them and their Set entries forever.
 const WARMED_ORIGIN_LIMIT = 32;
@@ -690,7 +692,7 @@ export function DesignBrowserPanel({
   onOpenFile,
   onPageInfoChange,
   onRefreshFiles,
-  previewComments = [],
+  previewComments = EMPTY_PREVIEW_COMMENTS,
   onSavePreviewComment,
   onRemovePreviewComment,
   onSendBoardCommentAttachments,
@@ -731,6 +733,7 @@ export function DesignBrowserPanel({
   const [browserPreviewIndex, setBrowserPreviewIndex] = useState<number | null>(null);
   const [sendingComment, setSendingComment] = useState(false);
   const [savingDomEdit, setSavingDomEdit] = useState(false);
+  const [browserLiveCommentTargets, setBrowserLiveCommentTargets] = useState<Map<string, BrowserElementSnapshot>>(() => new Map());
   const [textDraft, setTextDraft] = useState('');
   const [captureChromeHidden, setCaptureChromeHidden] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -1094,12 +1097,93 @@ export function DesignBrowserPanel({
     title: isBlank ? 'Browser' : pageTitle,
     url: isBlank ? EMPTY_URL : currentUrl,
   }), [browserFilePath, currentUrl, isBlank, pageTitle, projectId, resolvedDir]);
-  const visibleComments = previewComments
-    .filter((comment) => comment.filePath === browserFilePath && comment.status === 'open')
-    .sort((left, right) => left.createdAt - right.createdAt);
+  const visibleComments = useMemo(
+    () => previewComments
+      .filter((comment) => comment.filePath === browserFilePath && comment.status === 'open')
+      .sort((left, right) => left.createdAt - right.createdAt),
+    [browserFilePath, previewComments],
+  );
   const activeSavedComment = activePreviewCommentId
     ? visibleComments.find((comment) => comment.id === activePreviewCommentId) ?? null
     : null;
+
+  useEffect(() => {
+    const node = webviewNode;
+    if (!node || isBlank) {
+      setBrowserLiveCommentTargets((current) => (current.size > 0 ? new Map() : current));
+      return;
+    }
+
+    const commentTargets = visibleComments.map((comment) => ({
+      elementId: comment.elementId,
+      key: `comment:${comment.id}`,
+      selector: comment.selector,
+    }));
+    const activeTarget = activeCommentTarget
+      ? [{
+          elementId: activeCommentTarget.elementId,
+          key: 'active',
+          selector: activeCommentTarget.selector,
+        }]
+      : [];
+    const targets = [...commentTargets, ...activeTarget].filter((target) => target.elementId && target.selector);
+    if (targets.length === 0) {
+      setBrowserLiveCommentTargets((current) => (current.size > 0 ? new Map() : current));
+      return;
+    }
+
+    let cancelled = false;
+    let running = false;
+    const refresh = async () => {
+      if (cancelled || running) return;
+      running = true;
+      try {
+        const result = await node.executeJavaScript<unknown>(
+          browserMeasureTargetsScript(browserFilePath, targets),
+          true,
+        );
+        if (cancelled || !Array.isArray(result)) return;
+        const next = new Map<string, BrowserElementSnapshot>();
+        for (const item of result) {
+          if (!item || typeof item !== 'object') continue;
+          const key = String((item as { key?: unknown }).key || '');
+          if (!key) continue;
+          const snapshot = browserSnapshotFromUnknown(item, browserFilePath);
+          if (snapshot) next.set(key, snapshot);
+        }
+        setBrowserLiveCommentTargets((current) => (
+          browserSnapshotMapsEqual(current, next) ? current : next
+        ));
+        const activeSnapshot = next.get('active');
+        if (activeSnapshot) {
+          setActiveCommentTarget((current) => (
+            current && current.selector === activeSnapshot.selector && !browserSnapshotsEqual(current, activeSnapshot)
+              ? { ...current, ...activeSnapshot }
+              : current
+          ));
+          setTextDraft((current) => (
+            activeTool === 'inspect' || activeTool === 'edit'
+              ? current
+              : activeSnapshot.text
+          ));
+        }
+      } catch {
+        // Cross-origin navigations, transient loads, and detached webviews can
+        // reject executeJavaScript. Keep the saved positions until the next tick.
+      } finally {
+        running = false;
+      }
+    };
+
+    void refresh();
+    const timer = window.setInterval(() => {
+      void refresh();
+    }, 250);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [activeCommentTarget?.elementId, activeCommentTarget?.selector, activeTool, browserFilePath, isBlank, visibleComments, webviewNode]);
 
   useEffect(() => {
     const next = browserImages.map((file) => ({ file, url: URL.createObjectURL(file) }));
@@ -1966,9 +2050,11 @@ export function DesignBrowserPanel({
             {!isBlank ? (
               <BrowserCommentMarkers
                 comments={visibleComments}
+                liveTargets={browserLiveCommentTargets}
                 activeCommentId={activePreviewCommentId}
                 onOpen={(comment) => {
-                  const snapshot = browserSnapshotFromComment(comment, browserFilePath);
+                  const snapshot = browserLiveCommentTargets.get(`comment:${comment.id}`)
+                    ?? browserSnapshotFromComment(comment, browserFilePath);
                   setActiveTool('comment');
                   setActiveCommentTarget(snapshot);
                   setActivePreviewCommentId(comment.id);
@@ -2182,17 +2268,19 @@ function BrowserViewportControls({
 function BrowserCommentMarkers({
   activeCommentId,
   comments,
+  liveTargets,
   onOpen,
 }: {
   activeCommentId: string | null;
   comments: PreviewComment[];
+  liveTargets: Map<string, BrowserElementSnapshot>;
   onOpen: (comment: PreviewComment) => void;
 }) {
   if (comments.length === 0) return null;
   return (
     <div className="db-comment-layer" aria-label="Browser comments">
       {comments.map((comment, index) => {
-        const snapshot = browserSnapshotFromComment(comment, comment.filePath);
+        const snapshot = liveTargets.get(`comment:${comment.id}`) ?? browserSnapshotFromComment(comment, comment.filePath);
         const bounds = browserOverlayBounds(snapshot);
         const active = comment.id === activeCommentId;
         const label = comment.label || comment.elementId || 'Browser comment';
@@ -2216,6 +2304,34 @@ function BrowserCommentMarkers({
         );
       })}
     </div>
+  );
+}
+
+function browserSnapshotMapsEqual(
+  current: Map<string, BrowserElementSnapshot>,
+  next: Map<string, BrowserElementSnapshot>,
+): boolean {
+  if (current.size !== next.size) return false;
+  for (const [key, snapshot] of current) {
+    const candidate = next.get(key);
+    if (!candidate || !browserSnapshotsEqual(snapshot, candidate)) return false;
+  }
+  return true;
+}
+
+function browserSnapshotsEqual(left: BrowserElementSnapshot, right: BrowserElementSnapshot): boolean {
+  return (
+    left.filePath === right.filePath &&
+    left.elementId === right.elementId &&
+    left.selector === right.selector &&
+    left.label === right.label &&
+    left.text === right.text &&
+    left.htmlHint === right.htmlHint &&
+    left.position.x === right.position.x &&
+    left.position.y === right.position.y &&
+    left.position.width === right.position.width &&
+    left.position.height === right.position.height &&
+    JSON.stringify(left.style ?? null) === JSON.stringify(right.style ?? null)
   );
 }
 

--- a/apps/web/src/components/design-browser-tools.ts
+++ b/apps/web/src/components/design-browser-tools.ts
@@ -15,6 +15,12 @@ export interface BrowserElementSnapshot {
   selectionKind?: 'element';
 }
 
+export interface BrowserMeasureTargetRequest {
+  elementId: string;
+  key: string;
+  selector: string;
+}
+
 export interface BrowserViewportPreset {
   id: BrowserViewportId;
   label: string;
@@ -237,6 +243,74 @@ export function browserElementPickerScript(filePath: string): string {
   document.addEventListener('click', onClick, true);
   document.addEventListener('keydown', onKeyDown, true);
 }))()
+`;
+}
+
+export function browserMeasureTargetsScript(
+  filePath: string,
+  targets: BrowserMeasureTargetRequest[],
+): string {
+  return `
+(() => {
+  const filePath = ${JSON.stringify(filePath)};
+  const targets = ${JSON.stringify(targets)};
+  function visibleRect(el) {
+    if (!el || typeof el.getBoundingClientRect !== 'function') return null;
+    const rect = el.getBoundingClientRect();
+    if (!rect || rect.width <= 0 || rect.height <= 0) return null;
+    return rect;
+  }
+  function styleSnapshot(el) {
+    const s = window.getComputedStyle(el);
+    return {
+      color: s.color,
+      backgroundColor: s.backgroundColor,
+      fontSize: s.fontSize,
+      fontWeight: s.fontWeight,
+      lineHeight: s.lineHeight,
+      textAlign: s.textAlign,
+      fontFamily: s.fontFamily,
+      paddingTop: s.paddingTop,
+      paddingRight: s.paddingRight,
+      paddingBottom: s.paddingBottom,
+      paddingLeft: s.paddingLeft,
+      borderRadius: s.borderRadius
+    };
+  }
+  function snapshotFor(target) {
+    let el = null;
+    try { el = document.querySelector(String(target.selector || '')); } catch (_) { el = null; }
+    const rect = visibleRect(el);
+    if (!el || !rect) return null;
+    const tag = el.tagName ? el.tagName.toLowerCase() : 'element';
+    const cls = typeof el.className === 'string' && el.className.trim()
+      ? '.' + el.className.trim().split(/\\s+/).slice(0, 2).join('.')
+      : '';
+    let htmlHint = '';
+    try {
+      const match = String(el.outerHTML || '').replace(/\\s+/g, ' ').match(/^<[^>]+>/);
+      htmlHint = match ? match[0] : '';
+    } catch (_) {}
+    return {
+      key: String(target.key || ''),
+      filePath,
+      elementId: String(target.elementId || ''),
+      selector: String(target.selector || ''),
+      label: tag + cls,
+      text: String(el.textContent || '').replace(/\\s+/g, ' ').trim().slice(0, 240),
+      position: {
+        x: Math.round(rect.x),
+        y: Math.round(rect.y),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height)
+      },
+      htmlHint: htmlHint.slice(0, 220),
+      style: styleSnapshot(el),
+      selectionKind: 'element'
+    };
+  }
+  return targets.map(snapshotFor).filter(Boolean);
+})()
 `;
 }
 

--- a/apps/web/src/styles/workspace/design-browser.css
+++ b/apps/web/src/styles/workspace/design-browser.css
@@ -33,7 +33,7 @@
 .db-chrome {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, auto) minmax(180px, 1fr) max-content;
+  grid-template-columns: minmax(0, auto) minmax(180px, 740px) max-content;
   align-items: center;
   gap: 10px;
   min-width: 0;
@@ -726,11 +726,11 @@
 
 @container design-browser (max-width: 920px) {
   .db-chrome {
-    grid-template-columns: minmax(0, auto) minmax(150px, 1fr) max-content;
+    grid-template-columns: minmax(0, auto) minmax(150px, 560px) max-content;
     gap: 8px;
     padding-inline: 10px;
   }
-  .db-action-secondary {
+  .db-action-save {
     display: none;
   }
   .db-address-title {
@@ -740,7 +740,7 @@
 
 @container design-browser (max-width: 760px) {
   .db-chrome {
-    grid-template-columns: minmax(0, auto) minmax(120px, 1fr) max-content;
+    grid-template-columns: minmax(0, auto) minmax(120px, 420px) max-content;
     gap: 6px;
     padding-inline: 8px;
   }

--- a/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
+++ b/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
@@ -65,7 +65,7 @@ function getAddressDisplay(container: HTMLElement) {
 }
 
 describe('DesignBrowserPanel <webview> navigation', () => {
-  it('moves Tune and Edit into the Browser menu instead of the top toolbar', () => {
+  it('keeps external browser mutation and annotation tools hidden', () => {
     render(
       <DesignBrowserPanel
         projectId="proj-webview-more-tools"
@@ -78,11 +78,18 @@ describe('DesignBrowserPanel <webview> navigation', () => {
 
     expect(screen.queryByRole('button', { name: 'Tune element' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Edit live DOM' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Mark' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Comment' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Screenshot' })).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Browser menu' }));
 
-    expect(screen.getByRole('menuitem', { name: /Tune Element/ })).toBeTruthy();
-    expect(screen.getByRole('menuitem', { name: /Edit Live DOM/ })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: /Tune Element/ })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: /Edit Live DOM/ })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: /Edit HTML/ })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: 'Mark' })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: 'Comment' })).toBeNull();
+    expect(screen.getByRole('menuitem', { name: 'Copy Screenshot' })).toBeTruthy();
   });
 
   it('searches inspiration actions and adds an operation prompt for the current browser tab', () => {
@@ -370,7 +377,7 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     expect(container.querySelector('.db-comment-marker')).toBeNull();
   });
 
-  it('reuses the artifact mark label and icon for page annotation', () => {
+  it('does not expose page annotation controls in the external browser', () => {
     const { container } = render(
       <I18nProvider initial="zh-CN">
         <DesignBrowserPanel
@@ -382,14 +389,13 @@ describe('DesignBrowserPanel <webview> navigation', () => {
       </I18nProvider>,
     );
 
-    const markButton = screen.getByRole('button', { name: '标记' });
-    expect(markButton.parentElement?.getAttribute('data-tooltip')).toBe('标记');
-    expect(markButton.querySelector('.ri-mark-pen-line')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: '标记' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '评论' })).toBeNull();
     expect(container.querySelector('.ri-pencil-line')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Annotate page' })).toBeNull();
   });
 
-  it('queues browser element comments while the chat run is busy', async () => {
+  it('does not start browser element comments from the external browser toolbar', () => {
     const onSendBoardCommentAttachments = vi.fn(async (_attachments: unknown[], _images?: File[]) => undefined);
     const { container } = render(
       <DesignBrowserPanel
@@ -405,40 +411,17 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     const webview = container.querySelector('webview.db-webview') as HTMLElement & {
       executeJavaScript?: ReturnType<typeof vi.fn>;
     };
-    webview.executeJavaScript = vi.fn()
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce({
-        elementId: 'dom:h1',
-        filePath: 'browser:https://example.com',
-        htmlHint: '<h1>',
-        label: 'h1',
-        position: { x: 24, y: 32, width: 360, height: 72 },
-        selector: 'h1',
-        selectionKind: 'element',
-        style: { color: 'rgb(13, 12, 34)', fontSize: '48px', lineHeight: '52px' },
-        text: 'Example heading',
-      });
+    webview.executeJavaScript = vi.fn();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
-
-    const textarea = await screen.findByTestId('comment-popover-input');
-    fireEvent.change(textarea, { target: { value: 'Make this heading tighter' } });
-
-    const sendButton = screen.getByTestId('comment-add-send') as HTMLButtonElement;
-    expect(sendButton.textContent).toBe('Queue');
-    expect(sendButton.disabled).toBe(false);
-
-    fireEvent.click(sendButton);
-
-    await waitFor(() => expect(onSendBoardCommentAttachments).toHaveBeenCalledTimes(1));
-    expect(onSendBoardCommentAttachments.mock.calls[0]?.[0]?.[0]).toMatchObject({
-      comment: 'Make this heading tighter',
-      elementId: 'dom:h1',
-      filePath: 'browser:https://example.com',
-    });
+    expect(screen.queryByRole('button', { name: 'Comment' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Browser menu' }));
+    expect(screen.queryByRole('menuitem', { name: 'Comment' })).toBeNull();
+    expect(screen.queryByTestId('comment-popover-input')).toBeNull();
+    expect(onSendBoardCommentAttachments).not.toHaveBeenCalled();
+    expect(webview.executeJavaScript).not.toHaveBeenCalled();
   });
 
-  it('repositions saved browser comment markers from live webview selector measurements', async () => {
+  it('does not render saved browser comment markers in the external browser', async () => {
     const previewComments = [{
       id: 'comment-1',
       projectId: 'proj-webview-live-comment-marker',
@@ -468,27 +451,17 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     const webview = container.querySelector('webview.db-webview') as HTMLElement & {
       executeJavaScript?: ReturnType<typeof vi.fn>;
     };
-    webview.executeJavaScript = vi.fn(async () => [{
-      key: 'comment:comment-1',
-      elementId: 'dom:#card',
-      selector: '#card',
-      label: 'article.card',
-      text: 'Card',
-      position: { x: 140, y: 36, width: 240, height: 160 },
-      htmlHint: '<article id="card">',
-      style: {},
-      selectionKind: 'element',
-    }]);
+    webview.executeJavaScript = vi.fn(async () => []);
 
-    await waitFor(() => {
-      expect(container.querySelector<HTMLElement>('.db-comment-marker')?.style.left).toBe('140px');
-    });
+    await waitFor(() => expect(webview.executeJavaScript).toHaveBeenCalled());
+    expect(container.querySelector('.db-comment-layer')).toBeNull();
+    expect(container.querySelector('.db-comment-marker')).toBeNull();
   });
 
-  it('hides open annotation chrome while taking a browser screenshot', async () => {
+  it('keeps browser screenshot capture available after hiding annotation tools', async () => {
     restoreHost?.();
     const capturePage = vi.fn(async () => {
-      expect(document.querySelector<HTMLElement>('.preview-draw-toolbar')?.style.visibility).toBe('hidden');
+      expect(document.querySelector('.preview-draw-toolbar')).toBeNull();
       return { ok: true as const, dataUrl: 'data:image/png;base64,cG5n', w: 10, h: 10 };
     });
     restoreHost = installMockOpenDesignHost({
@@ -504,8 +477,8 @@ describe('DesignBrowserPanel <webview> navigation', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Mark' }));
-    expect(container.querySelector('.preview-draw-toolbar')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: 'Mark' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Comment' })).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Screenshot' }));
 

--- a/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
+++ b/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
@@ -334,6 +334,42 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     expect(screen.queryByText('Embedded browser controls are available in the desktop app.')).toBeNull();
   });
 
+  it('does not render saved comment markers in the browser fallback iframe', () => {
+    restoreHost?.();
+    restoreHost = null;
+
+    const previewComments = [{
+      id: 'comment-fallback-1',
+      projectId: 'proj-browser-fallback-comments',
+      conversationId: 'conv-1',
+      filePath: 'browser:https://example.com',
+      elementId: 'dom:#card',
+      selector: '#card',
+      label: 'article.card',
+      note: 'Review this card',
+      text: 'Card',
+      position: { x: 24, y: 32, width: 240, height: 160 },
+      htmlHint: '<article id="card">',
+      status: 'open' as const,
+      createdAt: 1,
+      updatedAt: 1,
+    }];
+
+    const { container } = render(
+      <DesignBrowserPanel
+        initialUrl="https://example.com"
+        projectId="proj-browser-fallback-comments"
+        previewComments={previewComments}
+        onOpenFile={() => {}}
+        onRefreshFiles={() => {}}
+      />,
+    );
+
+    expect(container.querySelector('iframe')).not.toBeNull();
+    expect(container.querySelector('.db-comment-layer')).toBeNull();
+    expect(container.querySelector('.db-comment-marker')).toBeNull();
+  });
+
   it('reuses the artifact mark label and icon for page annotation', () => {
     const { container } = render(
       <I18nProvider initial="zh-CN">

--- a/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
+++ b/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
@@ -402,6 +402,53 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     });
   });
 
+  it('repositions saved browser comment markers from live webview selector measurements', async () => {
+    const previewComments = [{
+      id: 'comment-1',
+      projectId: 'proj-webview-live-comment-marker',
+      conversationId: 'conv-1',
+      filePath: 'browser:https://example.com',
+      elementId: 'dom:#card',
+      selector: '#card',
+      label: 'article.card',
+      note: 'Review this card',
+      text: 'Card',
+      position: { x: 24, y: 32, width: 240, height: 160 },
+      htmlHint: '<article id="card">',
+      status: 'open' as const,
+      createdAt: 1,
+      updatedAt: 1,
+    }];
+    const { container } = render(
+      <DesignBrowserPanel
+        initialUrl="https://example.com"
+        projectId="proj-webview-live-comment-marker"
+        previewComments={previewComments}
+        onOpenFile={() => {}}
+        onRefreshFiles={() => {}}
+      />,
+    );
+
+    const webview = container.querySelector('webview.db-webview') as HTMLElement & {
+      executeJavaScript?: ReturnType<typeof vi.fn>;
+    };
+    webview.executeJavaScript = vi.fn(async () => [{
+      key: 'comment:comment-1',
+      elementId: 'dom:#card',
+      selector: '#card',
+      label: 'article.card',
+      text: 'Card',
+      position: { x: 140, y: 36, width: 240, height: 160 },
+      htmlHint: '<article id="card">',
+      style: {},
+      selectionKind: 'element',
+    }]);
+
+    await waitFor(() => {
+      expect(container.querySelector<HTMLElement>('.db-comment-marker')?.style.left).toBe('140px');
+    });
+  });
+
   it('hides open annotation chrome while taking a browser screenshot', async () => {
     restoreHost?.();
     const capturePage = vi.fn(async () => {

--- a/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
+++ b/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
@@ -65,7 +65,7 @@ function getAddressDisplay(container: HTMLElement) {
 }
 
 describe('DesignBrowserPanel <webview> navigation', () => {
-  it('keeps external browser mutation and annotation tools hidden', () => {
+  it('keeps desktop browser tools available on the supported webview path', () => {
     render(
       <DesignBrowserPanel
         projectId="proj-webview-more-tools"
@@ -78,17 +78,16 @@ describe('DesignBrowserPanel <webview> navigation', () => {
 
     expect(screen.queryByRole('button', { name: 'Tune element' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Edit live DOM' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Mark' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Comment' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Mark' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Comment' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Screenshot' })).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Browser menu' }));
 
-    expect(screen.queryByRole('menuitem', { name: /Tune Element/ })).toBeNull();
-    expect(screen.queryByRole('menuitem', { name: /Edit Live DOM/ })).toBeNull();
-    expect(screen.queryByRole('menuitem', { name: /Edit HTML/ })).toBeNull();
-    expect(screen.queryByRole('menuitem', { name: 'Mark' })).toBeNull();
-    expect(screen.queryByRole('menuitem', { name: 'Comment' })).toBeNull();
+    expect(screen.getByRole('menuitem', { name: /Tune Element/ })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: /Edit Live DOM/ })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Mark' })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Comment' })).toBeTruthy();
     expect(screen.getByRole('menuitem', { name: 'Copy Screenshot' })).toBeTruthy();
   });
 
@@ -377,7 +376,7 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     expect(container.querySelector('.db-comment-marker')).toBeNull();
   });
 
-  it('does not expose page annotation controls in the external browser', () => {
+  it('reuses the artifact mark label and icon for page annotation', () => {
     const { container } = render(
       <I18nProvider initial="zh-CN">
         <DesignBrowserPanel
@@ -389,13 +388,14 @@ describe('DesignBrowserPanel <webview> navigation', () => {
       </I18nProvider>,
     );
 
-    expect(screen.queryByRole('button', { name: '标记' })).toBeNull();
-    expect(screen.queryByRole('button', { name: '评论' })).toBeNull();
+    const markButton = screen.getByRole('button', { name: '标记' });
+    expect(markButton.parentElement?.getAttribute('data-tooltip')).toBe('标记');
+    expect(markButton.querySelector('.ri-mark-pen-line')).not.toBeNull();
     expect(container.querySelector('.ri-pencil-line')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Annotate page' })).toBeNull();
   });
 
-  it('does not start browser element comments from the external browser toolbar', () => {
+  it('queues browser element comments while the chat run is busy', async () => {
     const onSendBoardCommentAttachments = vi.fn(async (_attachments: unknown[], _images?: File[]) => undefined);
     const { container } = render(
       <DesignBrowserPanel
@@ -411,17 +411,40 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     const webview = container.querySelector('webview.db-webview') as HTMLElement & {
       executeJavaScript?: ReturnType<typeof vi.fn>;
     };
-    webview.executeJavaScript = vi.fn();
+    webview.executeJavaScript = vi.fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce({
+        elementId: 'dom:h1',
+        filePath: 'browser:https://example.com',
+        htmlHint: '<h1>',
+        label: 'h1',
+        position: { x: 24, y: 32, width: 360, height: 72 },
+        selector: 'h1',
+        selectionKind: 'element',
+        style: { color: 'rgb(13, 12, 34)', fontSize: '48px', lineHeight: '52px' },
+        text: 'Example heading',
+      });
 
-    expect(screen.queryByRole('button', { name: 'Comment' })).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: 'Browser menu' }));
-    expect(screen.queryByRole('menuitem', { name: 'Comment' })).toBeNull();
-    expect(screen.queryByTestId('comment-popover-input')).toBeNull();
-    expect(onSendBoardCommentAttachments).not.toHaveBeenCalled();
-    expect(webview.executeJavaScript).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
+
+    const textarea = await screen.findByTestId('comment-popover-input');
+    fireEvent.change(textarea, { target: { value: 'Make this heading tighter' } });
+
+    const sendButton = screen.getByTestId('comment-add-send') as HTMLButtonElement;
+    expect(sendButton.textContent).toBe('Queue');
+    expect(sendButton.disabled).toBe(false);
+
+    fireEvent.click(sendButton);
+
+    await waitFor(() => expect(onSendBoardCommentAttachments).toHaveBeenCalledTimes(1));
+    expect(onSendBoardCommentAttachments.mock.calls[0]?.[0]?.[0]).toMatchObject({
+      comment: 'Make this heading tighter',
+      elementId: 'dom:h1',
+      filePath: 'browser:https://example.com',
+    });
   });
 
-  it('does not render saved browser comment markers in the external browser', async () => {
+  it('repositions saved browser comment markers from live webview selector measurements', async () => {
     const previewComments = [{
       id: 'comment-1',
       projectId: 'proj-webview-live-comment-marker',
@@ -451,17 +474,27 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     const webview = container.querySelector('webview.db-webview') as HTMLElement & {
       executeJavaScript?: ReturnType<typeof vi.fn>;
     };
-    webview.executeJavaScript = vi.fn(async () => []);
+    webview.executeJavaScript = vi.fn(async () => [{
+      key: 'comment:comment-1',
+      elementId: 'dom:#card',
+      selector: '#card',
+      label: 'article.card',
+      text: 'Card',
+      position: { x: 140, y: 36, width: 240, height: 160 },
+      htmlHint: '<article id="card">',
+      style: {},
+      selectionKind: 'element',
+    }]);
 
-    await waitFor(() => expect(webview.executeJavaScript).toHaveBeenCalled());
-    expect(container.querySelector('.db-comment-layer')).toBeNull();
-    expect(container.querySelector('.db-comment-marker')).toBeNull();
+    await waitFor(() => {
+      expect(container.querySelector<HTMLElement>('.db-comment-marker')?.style.left).toBe('140px');
+    });
   });
 
-  it('keeps browser screenshot capture available after hiding annotation tools', async () => {
+  it('hides open annotation chrome while taking a browser screenshot', async () => {
     restoreHost?.();
     const capturePage = vi.fn(async () => {
-      expect(document.querySelector('.preview-draw-toolbar')).toBeNull();
+      expect(document.querySelector<HTMLElement>('.preview-draw-toolbar')?.style.visibility).toBe('hidden');
       return { ok: true as const, dataUrl: 'data:image/png;base64,cG5n', w: 10, h: 10 };
     });
     restoreHost = installMockOpenDesignHost({
@@ -477,8 +510,8 @@ describe('DesignBrowserPanel <webview> navigation', () => {
       />,
     );
 
-    expect(screen.queryByRole('button', { name: 'Mark' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Comment' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Mark' }));
+    expect(container.querySelector('.preview-draw-toolbar')).not.toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Screenshot' }));
 

--- a/apps/web/tests/styles/design-browser-styles.test.ts
+++ b/apps/web/tests/styles/design-browser-styles.test.ts
@@ -45,6 +45,7 @@ const STYLELESS_HOOKS = new Set([
   'db-action-browser-use',
   'db-action-menu',
   'db-action-primary',
+  'db-action-secondary',
   'db-action-save',
   'db-action-screenshot',
   'db-inspect-bg',


### PR DESCRIPTION
## Why

Browser comments in the Open Design Browser were saved with the element's one-time viewport rectangle. When the page scrolled, saved markers kept rendering from that stale viewport position, so the blue comment frame appeared fixed to the screen instead of following the selected webpage element.

This fixes that user-facing browser comment drift by re-measuring saved comment selectors against the live webview before rendering markers.

## What users will see

Saved comments in the Browser view now stay attached to the selected webpage element while the page moves or scrolls. If the selector is temporarily unavailable, the marker falls back to the saved position until the live measurement succeeds again.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached in this pass; behavior is covered by the focused webview marker regression test.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/DesignBrowserPanel.webview.test.tsx`
- Did the test go red on `main` and green on this branch? no, written and verified on this branch for the reported behavior.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/DesignBrowserPanel.webview.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`