### PR TITLE
[codex] Fix reference search focus ring

### DIFF
--- a/apps/web/src/styles/workspace/design-browser.css
+++ b/apps/web/src/styles/workspace/design-browser.css
@@ -944,10 +944,13 @@
   border: 1px solid var(--border);
   border-radius: 10px;
   background: var(--bg-panel);
-  transition: border-color 140ms cubic-bezier(0.23, 1, 0.32, 1);
+  transition:
+    border-color 140ms cubic-bezier(0.23, 1, 0.32, 1),
+    box-shadow 140ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .db-reference-search:focus-within {
   border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
 }
 .db-reference-search-icon {
   display: inline-flex;
@@ -961,6 +964,10 @@
   color: var(--text);
   font-size: 13px;
   outline: none;
+}
+.db-reference-search input:focus {
+  border: 0;
+  box-shadow: none;
 }
 .db-reference-search input::placeholder {
   color: var(--text-soft);


### PR DESCRIPTION
## Why

While checking the in-workspace Open Design Browser, the Reference Board search focus highlight only painted around the inner input text area instead of the full search field. The global `input:focus` shadow was leaking through the local search control, so the visible focus state looked clipped and misaligned.

This PR keeps the Reference Board search focus state on the outer container, where the icon, padding, and input all read as one control.

## What users will see

In a new Browser tab, focusing `Search references...` now highlights the full search box instead of only the inner input area.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Verified locally with the in-app Browser. The focused Reference Board search input now reports `inputBoxShadow: none` and the outer `.db-reference-search` owns the full-width focus shadow.

## Bug fix verification

- Test path that reproduces the bug: not added; this is a CSS focus-ring visual defect where the cheapest reliable verification is browser rendering.
- Did the test go red on `main` and green on this branch? no automated red/green spec.
- Manual verification: opened a project in `pnpm tools-dev run web --namespace verify-88bd --daemon-port 18456 --web-port 18573`, created a Browser tab, focused `Search references...`, and confirmed the computed focus shadow moved from the inner input to the outer search container.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
