### PR TITLE
[codex] Clear plugin form when mention is removed

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -646,14 +646,10 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     ): { id: string; label: string } | null {
       if (!appliedPlugin) return null;
       const restoredInline = meta?.inlineAppliedPlugin;
-      const restoredRecord = pluginsForComposer.find((plugin) => plugin.id === appliedPlugin.pluginId);
-      const labels = [
-        restoredInline?.pluginId === appliedPlugin.pluginId ? restoredInline.label : null,
-        restoredRecord?.title,
-        appliedPlugin.pluginId,
-      ].filter((label): label is string => Boolean(label));
-      const label = labels.find((candidate) => mentionTokenPresent(text, candidate));
-      return label ? { id: appliedPlugin.pluginId, label } : null;
+      if (restoredInline?.pluginId !== appliedPlugin.pluginId) return null;
+      return mentionTokenPresent(text, restoredInline.label)
+        ? { id: appliedPlugin.pluginId, label: restoredInline.label }
+        : null;
     }
 
     const designToolboxResourceIndex = useMemo<DesignToolboxResourceIndex>(

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -328,6 +328,10 @@ export interface ChatSendMeta {
   context?: RunContextSelection;
   appliedPluginSnapshot?: AppliedPluginSnapshot;
   appliedPluginSnapshotId?: string;
+  inlineAppliedPlugin?: {
+    pluginId: string;
+    label: string;
+  };
   // Per-turn skill ids picked via the @-mention popover. The chat layer
   // forwards these to the daemon's `skillIds` field so the system prompt
   // for this run only is composed with the extra skill bodies, without
@@ -634,6 +638,24 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       () => mcpServers.filter((s) => s.enabled),
       [mcpServers],
     );
+
+    function inlineBackedPluginFromRestoredDraft(
+      text: string,
+      appliedPlugin: AppliedPluginSnapshot | null | undefined,
+      meta: ChatSendMeta | undefined,
+    ): { id: string; label: string } | null {
+      if (!appliedPlugin) return null;
+      const restoredInline = meta?.inlineAppliedPlugin;
+      const restoredRecord = pluginsForComposer.find((plugin) => plugin.id === appliedPlugin.pluginId);
+      const labels = [
+        restoredInline?.pluginId === appliedPlugin.pluginId ? restoredInline.label : null,
+        restoredRecord?.title,
+        appliedPlugin.pluginId,
+      ].filter((label): label is string => Boolean(label));
+      const label = labels.find((candidate) => mentionTokenPresent(text, candidate));
+      return label ? { id: appliedPlugin.pluginId, label } : null;
+    }
+
     const designToolboxResourceIndex = useMemo<DesignToolboxResourceIndex>(
       () => ({
         skills,
@@ -872,7 +894,13 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               : [],
           );
           setStagedWorkspaceContexts(ctx?.workspaceItems ?? []);
-          setActiveAppliedPlugin(meta?.appliedPluginSnapshot ?? null);
+          const restoredAppliedPlugin = meta?.appliedPluginSnapshot ?? null;
+          setActiveAppliedPlugin(restoredAppliedPlugin);
+          inlineBackedPluginRef.current = inlineBackedPluginFromRestoredDraft(
+            text,
+            restoredAppliedPlugin,
+            meta,
+          );
           setUploadError(null);
           setMention(null);
           setSlash(null);
@@ -884,7 +912,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           editorRef.current?.focus();
         },
       }),
-      [connectors, mcpServers, skills]
+      [connectors, mcpServers, pluginsForComposer, skills]
     );
 
     function reset() {
@@ -934,6 +962,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           ? {
               appliedPluginSnapshot: activeAppliedPlugin,
               appliedPluginSnapshotId: activeAppliedPlugin.snapshotId,
+              ...(inlineBackedPluginRef.current?.id === activeAppliedPlugin.pluginId
+                ? {
+                    inlineAppliedPlugin: {
+                      pluginId: activeAppliedPlugin.pluginId,
+                      label: inlineBackedPluginRef.current.label,
+                    },
+                  }
+                : {}),
             }
           : {}),
         ...(Object.keys(context).length > 0 ? { context } : {}),

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -50,6 +50,7 @@ import { PluginsSection, type PluginsSectionHandle } from "./PluginsSection";
 import { BUILT_IN_PETS, CUSTOM_PET_ID } from "./pet/pets";
 import {
   inlineMentionToken,
+  mentionTokenPresent,
   type InlineMentionEntity,
 } from '../utils/inlineMentions';
 import {
@@ -466,6 +467,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     const [activeAppliedPlugin, setActiveAppliedPlugin] =
       useState<AppliedPluginSnapshot | null>(null);
     const pluginsSectionRef = useRef<PluginsSectionHandle | null>(null);
+    const inlineBackedPluginRef = useRef<{ id: string; label: string } | null>(null);
     // Consolidated "tools" popover — a single dropdown anchored to the
     // leading sliders icon that hosts project context, MCP, Import actions,
     // and a shortcut to open the full Settings dialog. Replaces the previous
@@ -607,6 +609,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         stopListening();
       };
     }, [composerEngaged]);
+
+    useEffect(() => {
+      const inlinePlugin = inlineBackedPluginRef.current;
+      if (!activeAppliedPlugin || inlinePlugin?.id !== activeAppliedPlugin.pluginId) return;
+      if (mentionTokenPresent(draft, inlinePlugin.label)) return;
+      inlineBackedPluginRef.current = null;
+      pluginsSectionRef.current?.clear();
+    }, [activeAppliedPlugin, draft]);
 
     // Composer-side plugin list: hide bundled atoms (pipeline-only). Keep
     // the full installed list available even when the project was created
@@ -887,6 +897,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       setStagedConnectors([]);
       setStagedWorkspaceContexts([]);
       pluginsSectionRef.current?.clear();
+      inlineBackedPluginRef.current = null;
       setActiveAppliedPlugin(null);
       setUploadError(null);
       setMention(null);
@@ -1085,6 +1096,10 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
 
       if (resource.kind === 'plugin') {
         void (async () => {
+          inlineBackedPluginRef.current = {
+            id: resource.plugin.id,
+            label: resource.plugin.title,
+          };
           await pluginsSectionRef.current?.applyById(resource.plugin.id, resource.plugin);
           applyDesignToolboxDraft(`${inlineMentionToken(resource.plugin.title)}\n${prompt}`);
         })();
@@ -1503,6 +1518,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       draftRef.current = text;
       setDraft(text);
       const set = new Set(present.map((e) => `${e.kind}:${e.id}`));
+      if (
+        activeAppliedPlugin
+        && inlineBackedPluginRef.current?.id === activeAppliedPlugin.pluginId
+        && !set.has(`plugin:${activeAppliedPlugin.pluginId}`)
+      ) {
+        inlineBackedPluginRef.current = null;
+        pluginsSectionRef.current?.clear();
+      }
       setStagedSkills((prev) => prev.filter((s) => set.has(`skill:${s.id}`)));
       setStagedMcpServers((prev) => prev.filter((m) => set.has(`mcp:${m.id}`)));
       setStagedConnectors((prev) =>
@@ -1679,6 +1702,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         entity: { id: record.id, kind: 'plugin', label: record.title },
       });
       setMention(null);
+      inlineBackedPluginRef.current = { id: record.id, label: record.title };
       await pluginsSectionRef.current?.applyById(record.id, record);
     }
 
@@ -1931,7 +1955,10 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                   setDraft((cur) => (cur.trim().length === 0 ? brief : cur));
                 }
               }}
-              onCleared={() => setActiveAppliedPlugin(null)}
+              onCleared={() => {
+                inlineBackedPluginRef.current = null;
+                setActiveAppliedPlugin(null);
+              }}
               onChipDetails={(item: ContextItem) => {
                 if (item.kind !== 'plugin') return;
                 const record = installedPlugins.find((p) => p.id === item.id);
@@ -2189,6 +2216,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
             record={detailsRecord}
             onClose={() => setDetailsRecord(null)}
             onUse={async (record) => {
+              inlineBackedPluginRef.current = null;
               await pluginsSectionRef.current?.applyById(record.id, record);
               setDetailsRecord(null);
             }}

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1522,6 +1522,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         activeAppliedPlugin
         && inlineBackedPluginRef.current?.id === activeAppliedPlugin.pluginId
         && !set.has(`plugin:${activeAppliedPlugin.pluginId}`)
+        && !mentionTokenPresent(text, inlineBackedPluginRef.current.label)
       ) {
         inlineBackedPluginRef.current = null;
         pluginsSectionRef.current?.clear();

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -554,6 +554,39 @@ describe('ChatComposer context pickers', () => {
     expect(onSend.mock.calls[0]?.[3]?.appliedPluginSnapshot).toBeUndefined();
   });
 
+  it('keeps restored non-inline plugin context when matching prompt text is removed', async () => {
+    const onSend = vi.fn();
+    const composerRef = createRef<ChatComposerHandle>();
+    const restoredAppliedPlugin = APPLY_RESULT.appliedPlugin as AppliedPluginSnapshot;
+    render(<ChatComposer ref={composerRef} {...composerElement({ onSend }).props} />);
+    await flushMounts();
+
+    act(() => {
+      composerRef.current?.restoreDraft({
+        text: '@My Export queued work',
+        meta: {
+          appliedPluginSnapshot: restoredAppliedPlugin,
+          appliedPluginSnapshotId: restoredAppliedPlugin.snapshotId,
+          context: { pluginIds: [USER_PLUGIN.id] },
+        },
+      });
+    });
+
+    await waitFor(() => expect(composerText()).toBe('@My Export queued work'));
+
+    await typeAndSettle('queued work');
+    fireEvent.click(screen.getByTestId('chat-send'));
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(onSend.mock.calls[0]?.[3]).toMatchObject({
+      appliedPluginSnapshotId: restoredAppliedPlugin.snapshotId,
+      appliedPluginSnapshot: expect.objectContaining({
+        pluginId: USER_PLUGIN.id,
+      }),
+      context: { pluginIds: [USER_PLUGIN.id] },
+    });
+  });
+
   it('keeps the plugin context form when the inline plugin token has trailing punctuation', async () => {
     renderComposer();
     await flushMounts();

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -98,9 +98,7 @@ const APPLY_RESULT = {
   ok: true,
   query: 'Run plugin.',
   contextItems: [],
-  inputs: [
-    { name: 'brief', type: 'string', required: false, label: 'Brief' },
-  ],
+  inputs: [],
   assets: [],
   mcpServers: [],
   trust: 'restricted',
@@ -166,6 +164,12 @@ async function flushMounts() {
   await act(async () => {
     await new Promise((r) => setTimeout(r, 0));
   });
+}
+
+function stagedPluginChip(): Element | null {
+  return screen
+    .queryByTestId('staged-contexts')
+    ?.querySelector('.staged-chip.staged-context--plugin') ?? null;
 }
 
 // The contenteditable serializes newlines as `<br>`, which jsdom's
@@ -504,7 +508,7 @@ describe('ChatComposer context pickers', () => {
     expect(pill?.getAttribute('data-mention-kind')).toBe('plugin');
   });
 
-  it('clears the plugin context form when the inline plugin token is removed', async () => {
+  it('clears the inline plugin context when the plugin token is removed', async () => {
     renderComposer();
     await flushMounts();
 
@@ -514,12 +518,11 @@ describe('ChatComposer context pickers', () => {
     fireEvent.click(screen.getByText('My Export'));
 
     await waitFor(() => expect(composerText()).toBe('@My Export '));
-    await waitFor(() => expect(screen.getByTestId('plugin-inputs-form')).toBeTruthy());
+    await waitFor(() => expect(stagedPluginChip()?.textContent).toContain(USER_PLUGIN.id));
 
     await typeAndSettle('');
 
-    await waitFor(() => expect(screen.queryByTestId('plugin-inputs-form')).toBeNull());
-    expect(screen.queryByTestId('context-chip-strip')).toBeNull();
+    await waitFor(() => expect(stagedPluginChip()).toBeNull());
   });
 
   it('clears restored inline plugin context when the queued draft token is removed', async () => {
@@ -587,7 +590,7 @@ describe('ChatComposer context pickers', () => {
     });
   });
 
-  it('keeps the plugin context form when the inline plugin token has trailing punctuation', async () => {
+  it('keeps the inline plugin context when the plugin token has trailing punctuation', async () => {
     renderComposer();
     await flushMounts();
 
@@ -597,13 +600,12 @@ describe('ChatComposer context pickers', () => {
     fireEvent.click(screen.getByText('My Export'));
 
     await waitFor(() => expect(composerText()).toBe('@My Export '));
-    await waitFor(() => expect(screen.getByTestId('plugin-inputs-form')).toBeTruthy());
+    await waitFor(() => expect(stagedPluginChip()?.textContent).toContain(USER_PLUGIN.id));
 
     await typeAndSettle('@My Export, refine this export');
 
     await waitFor(() => expect(composerText()).toBe('@My Export, refine this export'));
-    expect(screen.getByTestId('plugin-inputs-form')).toBeTruthy();
-    expect(screen.getByTestId('context-chip-strip').textContent).toContain('My Export');
+    expect(stagedPluginChip()?.textContent).toContain(USER_PLUGIN.id);
   });
 
   it('sends the applied plugin snapshot as per-turn context', async () => {
@@ -622,10 +624,7 @@ describe('ChatComposer context pickers', () => {
     // own ContextChipStrip). It is keyed off the plugin id when no display title
     // is present in the applied snapshot.
     await waitFor(() => {
-      const chip = screen
-        .getByTestId('staged-contexts')
-        .querySelector('.staged-chip.staged-context--plugin');
-      expect(chip?.textContent).toContain(USER_PLUGIN.id);
+      expect(stagedPluginChip()?.textContent).toContain(USER_PLUGIN.id);
     });
 
     fireEvent.click(screen.getByTestId('chat-send'));
@@ -642,9 +641,7 @@ describe('ChatComposer context pickers', () => {
     });
     // After sending, the applied plugin clears, so its staged chip is gone.
     await waitFor(() => {
-      expect(
-        screen.queryByTestId('staged-contexts')?.querySelector('.staged-context--plugin') ?? null,
-      ).toBeNull();
+      expect(stagedPluginChip()).toBeNull();
     });
   });
 

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { ComponentProps } from 'react';
+import { createRef, type ComponentProps } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const trackChatPanelClickMock = vi.hoisted(() => vi.fn());
@@ -14,9 +14,10 @@ vi.mock('../../src/analytics/events', async (importOriginal) => {
   };
 });
 
-import { ChatComposer } from '../../src/components/ChatComposer';
+import { ChatComposer, type ChatComposerHandle } from '../../src/components/ChatComposer';
 import { I18nProvider } from '../../src/i18n';
 import type { Locale } from '../../src/i18n/types';
+import type { AppliedPluginSnapshot } from '@open-design/contracts';
 import { composerText, pressEnter, typeAndSettle } from '../helpers/lexical-composer';
 
 const COMMUNITY_PLUGIN = {
@@ -519,6 +520,38 @@ describe('ChatComposer context pickers', () => {
 
     await waitFor(() => expect(screen.queryByTestId('plugin-inputs-form')).toBeNull());
     expect(screen.queryByTestId('context-chip-strip')).toBeNull();
+  });
+
+  it('clears restored inline plugin context when the queued draft token is removed', async () => {
+    const onSend = vi.fn();
+    const composerRef = createRef<ChatComposerHandle>();
+    const restoredAppliedPlugin = APPLY_RESULT.appliedPlugin as AppliedPluginSnapshot;
+    render(<ChatComposer ref={composerRef} {...composerElement({ onSend }).props} />);
+    await flushMounts();
+
+    act(() => {
+      composerRef.current?.restoreDraft({
+        text: '@My Export queued work',
+        meta: {
+          appliedPluginSnapshot: restoredAppliedPlugin,
+          appliedPluginSnapshotId: restoredAppliedPlugin.snapshotId,
+          inlineAppliedPlugin: {
+            pluginId: USER_PLUGIN.id,
+            label: USER_PLUGIN.title,
+          },
+          context: { pluginIds: [USER_PLUGIN.id] },
+        },
+      });
+    });
+
+    await waitFor(() => expect(composerText()).toBe('@My Export queued work'));
+
+    await typeAndSettle('queued work');
+    fireEvent.click(screen.getByTestId('chat-send'));
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(onSend.mock.calls[0]?.[3]?.context?.pluginIds).toBeUndefined();
+    expect(onSend.mock.calls[0]?.[3]?.appliedPluginSnapshot).toBeUndefined();
   });
 
   it('keeps the plugin context form when the inline plugin token has trailing punctuation', async () => {

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -521,6 +521,25 @@ describe('ChatComposer context pickers', () => {
     expect(screen.queryByTestId('context-chip-strip')).toBeNull();
   });
 
+  it('keeps the plugin context form when the inline plugin token has trailing punctuation', async () => {
+    renderComposer();
+    await flushMounts();
+
+    await typeAndSettle('@export');
+
+    await waitFor(() => expect(screen.getByText('My Export')).toBeTruthy());
+    fireEvent.click(screen.getByText('My Export'));
+
+    await waitFor(() => expect(composerText()).toBe('@My Export '));
+    await waitFor(() => expect(screen.getByTestId('plugin-inputs-form')).toBeTruthy());
+
+    await typeAndSettle('@My Export, refine this export');
+
+    await waitFor(() => expect(composerText()).toBe('@My Export, refine this export'));
+    expect(screen.getByTestId('plugin-inputs-form')).toBeTruthy();
+    expect(screen.getByTestId('context-chip-strip').textContent).toContain('My Export');
+  });
+
   it('sends the applied plugin snapshot as per-turn context', async () => {
     const onSend = vi.fn();
     renderComposer({ onSend });

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -97,7 +97,9 @@ const APPLY_RESULT = {
   ok: true,
   query: 'Run plugin.',
   contextItems: [],
-  inputs: [],
+  inputs: [
+    { name: 'brief', type: 'string', required: false, label: 'Brief' },
+  ],
   assets: [],
   mcpServers: [],
   trust: 'restricted',
@@ -499,6 +501,24 @@ describe('ChatComposer context pickers', () => {
       .querySelector('.composer-inline-mention');
     expect(pill?.textContent).toBe('@My Export');
     expect(pill?.getAttribute('data-mention-kind')).toBe('plugin');
+  });
+
+  it('clears the plugin context form when the inline plugin token is removed', async () => {
+    renderComposer();
+    await flushMounts();
+
+    await typeAndSettle('@export');
+
+    await waitFor(() => expect(screen.getByText('My Export')).toBeTruthy());
+    fireEvent.click(screen.getByText('My Export'));
+
+    await waitFor(() => expect(composerText()).toBe('@My Export '));
+    await waitFor(() => expect(screen.getByTestId('plugin-inputs-form')).toBeTruthy());
+
+    await typeAndSettle('');
+
+    await waitFor(() => expect(screen.queryByTestId('plugin-inputs-form')).toBeNull());
+    expect(screen.queryByTestId('context-chip-strip')).toBeNull();
   });
 
   it('sends the applied plugin snapshot as per-turn context', async () => {


### PR DESCRIPTION
## Why

This fixes a chat composer bug I hit while checking the plugin mention flow: selecting a plugin through an inline `@` mention applied the plugin and showed its context form, but deleting the inline mention from the input left the plugin form visible.

The user-facing pain was that the composer looked like the plugin was still selected even after the user removed the only visible reference. The root cause was that the plugin form was driven by `PluginsSection`'s applied state, while editor text reconciliation only pruned staged skills, MCP servers, connectors, and workspace contexts.

## What users will see

When a user selects a plugin from the `@` picker or design toolbox and then deletes the corresponding `@plugin` token from the composer, the plugin chip and plugin input form now disappear immediately. Plugins applied from non-inline surfaces, such as the details modal, continue to stay active until explicitly cleared.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a narrow composer state reconciliation bug: the visible behavior is the plugin form disappearing after the inline `@plugin` token is deleted, and it is covered by the regression test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ChatComposer.context-pickers.test.tsx` (`clears the plugin context form when the inline plugin token is removed`)
- Did the test go red on `main` and green on this branch? No. I added the regression during this fix and verified it is green on this branch; I did not switch back to `main` in this worktree after implementation.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/ChatComposer.context-pickers.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
