### PR TITLE
Fix standalone HTML export for Vite artifacts

### DIFF
--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -715,7 +715,8 @@ async function resolveHtmlExportSource({
 }): Promise<{ html: string; relPath: string }> {
   if (!isViteDevHtmlEntry(html)) return { html, relPath };
 
-  const distRelPath = 'dist/index.html';
+  const ownerDir = nodePath.posix.dirname(relPath);
+  const distRelPath = ownerDir === '.' ? 'dist/index.html' : `${ownerDir}/dist/index.html`;
   try {
     const distMeta = await resolveProjectFilePath(projectsRoot, projectId, distRelPath, metadata);
     if (distMeta.size > MAX_INLINE_OWNER_BYTES || !distMeta.mime.startsWith('text/html')) {

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -657,9 +657,18 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
         };
       };
 
-      const rendered = await inlineRelativeAssets(
-        file.buffer.toString('utf8'),
+      const exportSource = await resolveHtmlExportSource({
+        projectId: req.params.id,
+        projectsRoot: PROJECTS_DIR,
         relPath,
+        html: file.buffer.toString('utf8'),
+        metadata: project?.metadata,
+        readProjectFile,
+        resolveProjectFilePath,
+      });
+      const rendered = await inlineRelativeAssets(
+        exportSource.html,
+        exportSource.relPath,
         fileReader,
       );
       // PR #1312 round-2 (lefarcen P2): top-level browser navigation to
@@ -685,6 +694,52 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
     }
   });
 
+}
+
+async function resolveHtmlExportSource({
+  projectId,
+  projectsRoot,
+  relPath,
+  html,
+  metadata,
+  readProjectFile,
+  resolveProjectFilePath,
+}: {
+  projectId: string;
+  projectsRoot: string;
+  relPath: string;
+  html: string;
+  metadata: unknown;
+  readProjectFile: (projectsRoot: string, projectId: string, relPath: string, metadata?: unknown) => Promise<{ buffer: Buffer }>;
+  resolveProjectFilePath: (projectsRoot: string, projectId: string, relPath: string, metadata?: unknown) => Promise<{ size: number; mime: string }>;
+}): Promise<{ html: string; relPath: string }> {
+  if (!isViteDevHtmlEntry(html)) return { html, relPath };
+
+  const distRelPath = 'dist/index.html';
+  try {
+    const distMeta = await resolveProjectFilePath(projectsRoot, projectId, distRelPath, metadata);
+    if (distMeta.size > MAX_INLINE_OWNER_BYTES || !distMeta.mime.startsWith('text/html')) {
+      return { html, relPath };
+    }
+    const distFile = await readProjectFile(projectsRoot, projectId, distRelPath, metadata);
+    return {
+      html: rewriteViteDistRootAssetUrls(distFile.buffer.toString('utf8')),
+      relPath: distRelPath,
+    };
+  } catch {
+    return { html, relPath };
+  }
+}
+
+function isViteDevHtmlEntry(html: string): boolean {
+  return /<script\b[^>]*\btype\s*=\s*["']module["'][^>]*\bsrc\s*=\s*["']\/src\/[^"']+["'][^>]*>\s*<\/script>/i.test(html);
+}
+
+function rewriteViteDistRootAssetUrls(html: string): string {
+  return html.replace(
+    /\b(href|src)\s*=\s*(["'])\/assets\//gi,
+    (_match, attr: string, quote: string) => `${attr}=${quote}assets/`,
+  );
 }
 
 function buildProjectExportManifestResponse({

--- a/apps/daemon/src/project-routes.ts
+++ b/apps/daemon/src/project-routes.ts
@@ -1920,7 +1920,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
     relPath: string,
     metadata?: unknown,
     beforeSend?: (mime: string) => void,
-    transformFile?: (file: { mime: string; buffer: Buffer }) => Buffer | string,
+    transformFile?: (file: { mime: string; buffer: Buffer }) => Buffer | string | Promise<Buffer | string>,
   ) {
     const meta = await resolveProjectFilePath(
       PROJECTS_DIR,
@@ -1975,7 +1975,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
     }
 
     const file = await readProjectFile(PROJECTS_DIR, projectId, relPath, metadata);
-    res.type(file.mime).send(transformFile ? transformFile(file) : file.buffer);
+    res.type(file.mime).send(transformFile ? await transformFile(file) : file.buffer);
   }
 
   function previewFilePathForProject(project: any, queryFile: unknown): string {
@@ -1988,6 +1988,46 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
 
   function encodeProjectPathForUrl(filePath: string): string {
     return filePath.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+  }
+
+  async function maybeResolveVitePreviewHtml({
+    file,
+    projectId,
+    relPath,
+    metadata,
+    projectsRoot,
+    readProjectFile,
+  }: {
+    file: { mime: string; buffer: Buffer };
+    projectId: string;
+    relPath: string;
+    metadata?: unknown;
+    projectsRoot: string;
+    readProjectFile: (projectsRoot: string, projectId: string, relPath: string, metadata?: unknown) => Promise<{ buffer: Buffer }>;
+  }): Promise<Buffer | string> {
+    if (!/^text\/html(?:;|$)/i.test(file.mime)) return file.buffer;
+    const html = file.buffer.toString('utf8');
+    if (!isViteDevHtmlEntry(html)) return file.buffer;
+
+    const ownerDir = path.posix.dirname(relPath);
+    const distRelPath = ownerDir === '.' ? 'dist/index.html' : `${ownerDir}/dist/index.html`;
+    try {
+      const distFile = await readProjectFile(projectsRoot, projectId, distRelPath, metadata);
+      return rewriteViteDistAssetUrlsForPreview(distFile.buffer.toString('utf8'));
+    } catch {
+      return file.buffer;
+    }
+  }
+
+  function isViteDevHtmlEntry(html: string): boolean {
+    return /<script\b[^>]*\btype\s*=\s*["']module["'][^>]*\bsrc\s*=\s*["']\/src\/[^"']+["'][^>]*>\s*<\/script>/i.test(html);
+  }
+
+  function rewriteViteDistAssetUrlsForPreview(html: string): string {
+    return html.replace(
+      /\b(href|src)\s*=\s*(["'])\/assets\//gi,
+      (_match, attr: string, quote: string) => `${attr}=${quote}dist/assets/`,
+    );
   }
 
   // Project files. Each project owns a flat folder under .od/projects/<id>/
@@ -2177,6 +2217,14 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
         relPath,
         project.metadata,
         () => setProjectPreviewHeaders(res),
+        async (file) => maybeResolveVitePreviewHtml({
+          file,
+          projectId: project.id,
+          relPath,
+          metadata: project.metadata,
+          projectsRoot: PROJECTS_DIR,
+          readProjectFile,
+        }),
       );
     } catch (err: any) {
       const status = err && err.code === 'ENOENT' ? 404 : 400;
@@ -2223,14 +2271,22 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
         relPath,
         project?.metadata,
         undefined,
-        (file) => {
+        async (file) => {
+          let transformed = await maybeResolveVitePreviewHtml({
+            file,
+            projectId,
+            relPath,
+            metadata: project?.metadata,
+            projectsRoot: PROJECTS_DIR,
+            readProjectFile,
+          });
           if (
             (wantsUrlPreviewScrollBridge(req.query.odPreviewBridge) ||
               wantsUrlPreviewSelectionBridge(req.query.odPreviewBridge) ||
               wantsUrlPreviewSnapshotBridge(req.query.odPreviewBridge)) &&
             /^text\/html(?:;|$)/i.test(file.mime)
           ) {
-            let html = file.buffer.toString('utf8');
+            let html = Buffer.isBuffer(transformed) ? transformed.toString('utf8') : transformed;
             if (wantsUrlPreviewScrollBridge(req.query.odPreviewBridge)) {
               html = injectUrlPreviewBridge(html, 'scroll');
             }
@@ -2240,9 +2296,9 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
             if (wantsUrlPreviewSnapshotBridge(req.query.odPreviewBridge)) {
               html = injectUrlPreviewBridge(html, 'snapshot');
             }
-            return html;
+            transformed = html;
           }
-          return file.buffer;
+          return transformed;
         },
       );
     } catch (err: any) {

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -628,6 +628,35 @@ describe('GET /api/projects/:id/export/*?inline=1 route', () => {
     expect(body).toContain('data-od-inline-asset="assets/app.css"');
   });
 
+  it('exports a nested Vite dev HTML entry through its sibling built dist artifact', async () => {
+    const dir = path.join(projectsRoot, projectId, 'pages');
+    await mkdir(path.join(dir, 'dist', 'assets'), { recursive: true });
+    await writeFile(
+      path.join(dir, 'nested-vite.html'),
+      '<!doctype html><html><head><script type="module" src="/src/main.tsx"></script></head><body><div id="root"></div></body></html>',
+    );
+    await writeFile(
+      path.join(dir, 'dist', 'index.html'),
+      '<!doctype html><html><head>' +
+        '<script type="module" crossorigin src="/assets/nested.js"></script>' +
+        '<link rel="stylesheet" crossorigin href="/assets/nested.css">' +
+        '</head><body><div id="root"></div></body></html>',
+    );
+    await writeFile(path.join(dir, 'dist', 'assets', 'nested.js'), 'window.NESTED_VITE_EXPORT_OK = true;');
+    await writeFile(path.join(dir, 'dist', 'assets', 'nested.css'), 'body{background:#abcdef}');
+
+    const res = await fetch(exportUrl('pages/nested-vite.html'));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+
+    expect(body).toContain('window.NESTED_VITE_EXPORT_OK = true;');
+    expect(body).toContain('body{background:#abcdef}');
+    expect(body).not.toContain('/src/main.tsx');
+    expect(body).not.toContain('/assets/nested.js');
+    expect(body).not.toContain('/assets/nested.css');
+    expect(body).toContain('data-od-inline-asset="assets/nested.css"');
+  });
+
   it('sends Content-Security-Policy: sandbox allow-scripts to block daemon-origin privilege escalation', async () => {
     // PR #1312 round-2 review (lefarcen P2 @ import-export-routes.ts:423):
     // top-level browser navigation to the export URL sends no Origin

--- a/apps/daemon/tests/export-inline-route.test.ts
+++ b/apps/daemon/tests/export-inline-route.test.ts
@@ -599,6 +599,35 @@ describe('GET /api/projects/:id/export/*?inline=1 route', () => {
     expect(body).not.toContain('src="../shared/util.js"');
   });
 
+  it('exports a Vite dev HTML entry through the built dist artifact for offline HTML downloads', async () => {
+    const dir = path.join(projectsRoot, projectId);
+    await mkdir(path.join(dir, 'dist', 'assets'), { recursive: true });
+    await writeFile(
+      path.join(dir, 'vite-entry.html'),
+      '<!doctype html><html><head><script type="module" src="/src/main.tsx"></script></head><body><div id="root"></div></body></html>',
+    );
+    await writeFile(
+      path.join(dir, 'dist', 'index.html'),
+      '<!doctype html><html><head>' +
+        '<script type="module" crossorigin src="/assets/app.js"></script>' +
+        '<link rel="stylesheet" crossorigin href="/assets/app.css">' +
+        '</head><body><div id="root"></div></body></html>',
+    );
+    await writeFile(path.join(dir, 'dist', 'assets', 'app.js'), 'window.VITE_EXPORT_OK = true;');
+    await writeFile(path.join(dir, 'dist', 'assets', 'app.css'), 'body{background:#123456}');
+
+    const res = await fetch(exportUrl('vite-entry.html'));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+
+    expect(body).toContain('window.VITE_EXPORT_OK = true;');
+    expect(body).toContain('body{background:#123456}');
+    expect(body).not.toContain('/src/main.tsx');
+    expect(body).not.toContain('/assets/app.js');
+    expect(body).not.toContain('/assets/app.css');
+    expect(body).toContain('data-od-inline-asset="assets/app.css"');
+  });
+
   it('sends Content-Security-Policy: sandbox allow-scripts to block daemon-origin privilege escalation', async () => {
     // PR #1312 round-2 review (lefarcen P2 @ import-export-routes.ts:423):
     // top-level browser navigation to the export URL sends no Origin

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -178,6 +178,20 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
       path.join(dir, 'snapshot-bridged.html'),
       Buffer.from('<html><body><script data-od-url-snapshot-bridge></script><main>Preview</main></body></html>'),
     );
+    await mkdir(path.join(dir, 'dist', 'assets'), { recursive: true });
+    await writeFile(
+      path.join(dir, 'vite-entry.html'),
+      Buffer.from('<!doctype html><html><head><script type="module" src="/src/main.tsx"></script></head><body><div id="root"></div></body></html>'),
+    );
+    await writeFile(
+      path.join(dir, 'dist', 'index.html'),
+      Buffer.from(
+        '<!doctype html><html><head>' +
+          '<script type="module" crossorigin src="/assets/app.js"></script>' +
+          '<link rel="stylesheet" crossorigin href="/assets/app.css">' +
+          '</head><body><div id="root"></div></body></html>',
+      ),
+    );
   });
 
   afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
@@ -281,6 +295,18 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(html).toContain("type: 'od:snapshot:result'");
     expect(html).not.toContain('data-od-url-scroll-bridge');
     expect(html).not.toContain('data-od-url-selection-bridge');
+  });
+
+  it('serves built dist HTML for Vite dev entries so previews do not load /src from daemon root', async () => {
+    const res = await fetch(rawUrl('vite-entry.html'));
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).not.toContain('/src/main.tsx');
+    expect(html).not.toContain('src="/assets/app.js"');
+    expect(html).not.toContain('href="/assets/app.css"');
+    expect(html).toContain('src="dist/assets/app.js"');
+    expect(html).toContain('href="dist/assets/app.css"');
   });
 
   it('injects scroll and selection URL preview bridges together', async () => {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -62,10 +62,10 @@ import {
 import type { ProjectFilePreview } from '../providers/registry';
 import {
   downloadImageDataUrl,
-  exportAsHtml,
   exportAsJsx,
   exportAsMd,
   exportAsPdf,
+  exportProjectAsHtml,
   exportProjectAsPdf,
   exportProjectAsZip,
   copyImageDataUrlToClipboard,
@@ -8385,7 +8385,12 @@ function HtmlViewer({
                     role="menuitem"
                     onClick={() => {
                       setDownloadMenuOpen(false);
-                      fireShareExport('html', () => exportAsHtml(source ?? '', exportTitle));
+                      fireShareExport('html', () => exportProjectAsHtml({
+                        projectId,
+                        filePath: file.name,
+                        fallbackHtml: source ?? '',
+                        fallbackTitle: exportTitle,
+                      }));
                     }}
                   >
                     <span className="share-menu-icon"><RemixIcon name="file-code-line" size={15} /></span>

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -56,6 +56,29 @@ export function exportAsHtml(html: string, title: string): void {
   triggerDownload(blob, `${safeFilename(title, 'artifact')}.html`);
 }
 
+export async function exportProjectAsHtml(opts: {
+  projectId: string;
+  filePath: string;
+  fallbackHtml: string;
+  fallbackTitle: string;
+}): Promise<void> {
+  const segments = opts.filePath
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+  const url = `/api/projects/${encodeURIComponent(opts.projectId)}/export/${segments}?inline=1`;
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error(`html export request failed (${resp.status})`);
+    const blob = await resp.blob();
+    triggerDownload(blob, `${safeFilename(opts.fallbackTitle, 'artifact')}.html`);
+  } catch (err) {
+    console.warn('[exportProjectAsHtml] falling back to source HTML export:', err);
+    exportAsHtml(opts.fallbackHtml, opts.fallbackTitle);
+  }
+}
+
 // A file is treated as a preview-chrome wrapper only when it lives inside
 // a frames/ or device-frames/ directory, or its filename is an unambiguous
 // wrapper template (browser-chrome.html, device-frame.html).  Filenames

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -10,6 +10,7 @@ import {
   exportAsImage,
   exportAsMd,
   exportAsPdf,
+  exportProjectAsHtml,
   exportProjectAsPdf,
   openSandboxedPreviewInNewTab,
   prepareImageExportTarget,
@@ -234,6 +235,76 @@ describe('exportProjectAsPdf', () => {
 
     expect(result).toBe('fallback');
     expect(fallback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('exportProjectAsHtml', () => {
+  let capturedBlob: Blob | undefined;
+  let capturedFilename: string | undefined;
+
+  beforeEach(() => {
+    capturedBlob = undefined;
+    capturedFilename = undefined;
+    vi.stubGlobal('URL', {
+      createObjectURL: (blob: Blob) => {
+        capturedBlob = blob;
+        return 'blob:test';
+      },
+      revokeObjectURL: () => {},
+    });
+    vi.stubGlobal('document', {
+      createElement: () => {
+        const anchor = { href: '', click: () => {} } as { href: string; download?: string; click: () => void };
+        Object.defineProperty(anchor, 'download', {
+          set(value: string) {
+            capturedFilename = value;
+          },
+          get() {
+            return capturedFilename ?? '';
+          },
+        });
+        return anchor;
+      },
+      body: { appendChild: () => {}, removeChild: () => {} },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('downloads daemon-inlined project HTML instead of the raw source body', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('<!doctype html><p>inlined</p>', {
+      headers: { 'content-type': 'text/html' },
+      status: 200,
+    })));
+
+    await exportProjectAsHtml({
+      projectId: 'proj 1',
+      filePath: 'screens/main page.html',
+      fallbackHtml: '<script type="module" src="/src/main.tsx"></script>',
+      fallbackTitle: 'Main Page',
+    });
+
+    expect(fetch).toHaveBeenCalledWith('/api/projects/proj%201/export/screens/main%20page.html?inline=1');
+    expect(capturedFilename).toBe('Main-Page.html');
+    expect(await capturedBlob!.text()).toBe('<!doctype html><p>inlined</p>');
+  });
+
+  it('falls back to the source HTML export when the daemon inline endpoint fails', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 500 })));
+
+    await exportProjectAsHtml({
+      projectId: 'proj-1',
+      filePath: 'index.html',
+      fallbackHtml: '<main>fallback</main>',
+      fallbackTitle: 'Fallback',
+    });
+
+    expect(capturedFilename).toBe('Fallback.html');
+    expect(await capturedBlob!.text()).toContain('<main>fallback</main>');
   });
 });
 


### PR DESCRIPTION
## Summary
- Detect Vite dev HTML entries and export the built dist artifact instead of the raw /src entry
- Rewrite dist asset URLs for preview/raw routes so generated HTML does not black-screen in iframes
- Route HTML downloads through the daemon inline export endpoint with source fallback

## Validation
- pnpm --filter @open-design/daemon exec tsc -p tsconfig.json --noEmit
- pnpm --filter @open-design/web exec tsc -p tsconfig.json --noEmit
- pnpm exec vitest run -c vitest.config.ts tests/export-inline-route.test.ts
- pnpm exec vitest run -c vitest.config.ts tests/project-file-range.test.ts
- pnpm exec vitest run -c vitest.config.ts tests/runtime/exports.test.ts
- git diff --check

Note: dependency-based validation was run in the original worktree where node_modules are installed; the clean PR worktree was used only to cherry-pick and push the isolated commit.