### PR TITLE
fix(daemon): pass Grok Build prompts via files

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -57,6 +57,7 @@ import { aihubmixHeaders } from './aihubmix.js';
 import type { AgentCliEnvPrefs } from './app-config.js';
 import type { RuntimeAgentDef } from './runtimes/types.js';
 import { resolveModelForAgent } from './runtimes/models.js';
+import { preparePromptFileForAgent, type PreparedPromptFile } from './runtimes/prompt-file.js';
 import {
   isBlockedExternalApiHostname,
   isLoopbackApiHost,
@@ -1728,6 +1729,7 @@ async function testAgentConnectionInternal(
   let child: AgentChild | null = null;
   let childExit: Promise<AgentChildExit> | null = null;
   let childClosed = false;
+  let promptFile: PreparedPromptFile | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let abortHandler: (() => void) | null = null;
   const sink = createAgentSink();
@@ -1877,12 +1879,16 @@ async function testAgentConnectionInternal(
   try {
     let args: string[];
     try {
+      promptFile = await preparePromptFileForAgent(def, SMOKE_PROMPT, 'connection-test');
       args = def.buildArgs(
         SMOKE_PROMPT,
         [],
         [],
         { model: input.model ?? null, reasoning: input.reasoning ?? null },
-        { cwd: tempDir },
+        {
+          cwd: tempDir,
+          ...(promptFile ? { promptFilePath: promptFile.path } : {}),
+        },
       );
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
@@ -2241,6 +2247,9 @@ async function testAgentConnectionInternal(
       .catch(() => {
         // Best-effort cleanup; the OS reaps /tmp eventually.
       });
+    await promptFile?.cleanup().catch(() => {
+      // Best-effort cleanup; the OS reaps /tmp eventually.
+    });
   }
 }
 

--- a/apps/daemon/src/runtimes/defs/grok-build.ts
+++ b/apps/daemon/src/runtimes/defs/grok-build.ts
@@ -1,5 +1,26 @@
-import { parseLineSeparatedModels, DEFAULT_MODEL_OPTION } from './shared.js';
+import { DEFAULT_MODEL_OPTION } from './shared.js';
+import type { RuntimeModelOption } from '../types.js';
 import type { RuntimeAgentDef } from '../types.js';
+
+const GROK_MODEL_ID_RE = /^\*?\s*-?\s*(grok-[a-z0-9][a-z0-9._-]*)(?:\s+\(default\))?\s*$/i;
+
+export function parseGrokBuildModels(stdout: string): RuntimeModelOption[] {
+  const seen = new Set<string>();
+  const out: RuntimeModelOption[] = [DEFAULT_MODEL_OPTION];
+  for (const rawLine of String(stdout || '').split('\n')) {
+    const match = rawLine.trim().match(GROK_MODEL_ID_RE);
+    const id = match?.[1];
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, label: id });
+  }
+  return out;
+}
+
+function grokModelSupportsReasoningEffort(model: string | null | undefined): boolean {
+  if (!model || model === DEFAULT_MODEL_OPTION.id || model === 'grok-build') return false;
+  return /reasoning/i.test(model);
+}
 
 // xAI's first-party CLI agent — https://x.ai/cli — distributed as the
 // `grok` binary. Installed via `curl -fsSL https://x.ai/cli/install.sh | bash`,
@@ -29,14 +50,13 @@ export const grokBuildAgentDef = {
   bin: 'grok',
   versionArgs: ['--version'],
   helpArgs: ['-p', '--help'],
-  // `grok models` prints one model id per line, plus a `Default model:`
-  // header line that parseLineSeparatedModels strips because it isn't
-  // an id token. Falls back to the static list below when probing fails
-  // (no SuperGrok Heavy entitlement on this machine, network blip, etc.).
+  // `grok models` prints status/header lines plus bullet-prefixed model ids.
+  // Keep only concrete `grok-*` ids so UI pickers don't show prose such as
+  // "You are logged in with grok.com" as selectable model names.
   listModels: {
     args: ['models'],
     timeoutMs: 10_000,
-    parse: parseLineSeparatedModels,
+    parse: parseGrokBuildModels,
   },
   fallbackModels: [
     DEFAULT_MODEL_OPTION,
@@ -63,7 +83,7 @@ export const grokBuildAgentDef = {
     if (options.model && options.model !== DEFAULT_MODEL_OPTION.id) {
       args.push('--model', options.model);
     }
-    if (options.reasoning) {
+    if (options.reasoning && grokModelSupportsReasoningEffort(options.model)) {
       args.push('--effort', options.reasoning);
     }
     return args;

--- a/apps/daemon/src/runtimes/defs/grok-build.ts
+++ b/apps/daemon/src/runtimes/defs/grok-build.ts
@@ -12,8 +12,11 @@ import type { RuntimeAgentDef } from '../types.js';
 // --oauth` and the resulting `~/.grok/auth.json` is what every spawned
 // invocation reads.
 //
-// Headless mode follows Claude Code's pattern (`-p <PROMPT>` for single-
-// turn, `--output-format streaming-json` for structured streaming), but
+// Headless mode uses `--prompt-file <PATH>` because recent Grok CLI builds
+// require `-p/--single` to receive the prompt as an argv value and no longer
+// read piped stdin. OD's composed prompts often exceed safe argv limits, so
+// the daemon stages the prompt in a temp file and passes that path here. The
+// CLI also exposes `--output-format streaming-json`, but
 // the streaming-json schema is xAI-specific and we do not yet have a
 // daemon-side parser for it. To ship the runtime now and let users at
 // least chat with grok inside OD, this defaults to `plain` streamFormat
@@ -49,10 +52,14 @@ export const grokBuildAgentDef = {
       label: 'grok-4.20-multi-agent (xAI · orchestration)',
     },
   ],
-  // Grok Build CLI v0.1.212 enforces `-p, --single <PROMPT>` as value-
-  // required — stdin piping no longer satisfies it. Inline the prompt.
-  buildArgs: (prompt, _imagePaths, _extra = [], options = {}) => {
-    const args = ['-p', prompt];
+  // Grok Build CLI v0.1.212+ enforces `-p, --single <PROMPT>` as value-
+  // required, while normal OD composed prompts exceed safe argv budgets.
+  // Use the CLI's explicit prompt-file transport instead.
+  buildArgs: (_prompt, _imagePaths, _extra = [], options = {}, runtimeContext = {}) => {
+    if (!runtimeContext.promptFilePath) {
+      throw new Error('grok-build requires runtimeContext.promptFilePath');
+    }
+    const args = ['--prompt-file', runtimeContext.promptFilePath];
     if (options.model && options.model !== DEFAULT_MODEL_OPTION.id) {
       args.push('--model', options.model);
     }
@@ -68,21 +75,8 @@ export const grokBuildAgentDef = {
     { id: 'xhigh', label: 'xhigh' },
     { id: 'max', label: 'max' },
   ],
+  promptViaFile: true,
   promptViaStdin: false,
-  // Guard against prompts that would blow Windows' ~32 KB CreateProcess
-  // limit (or Linux MAX_ARG_STRLEN on extreme edges) before spawn. Same
-  // shape as the DeepSeek adapter — the previous stdin path is gone (CLI
-  // 0.1.212 enforces `-p <value>`), so the composed prompt now rides
-  // argv and a sufficiently large one — system text + history + skills/
-  // design-system content + user message — could surface as a generic
-  // spawn ENAMETOOLONG / E2BIG instead of a Grok-specific, user-
-  // actionable message. The /api/chat spawn path checks this byte
-  // budget against the composed prompt and emits AGENT_PROMPT_TOO_LARGE
-  // ("reduce skills/design-system context, or pick an adapter with
-  // stdin support") before calling `spawn`. 30_000 bytes leaves ~2.7 KB
-  // of argv headroom under the Windows command-line limit for `-p
-  // --model <id> --effort <level>` and internal quoting.
-  maxPromptArgBytes: 30_000,
   streamFormat: 'plain',
   installUrl: 'https://x.ai/cli',
   docsUrl: 'https://x.ai/cli',

--- a/apps/daemon/src/runtimes/prompt-budget.ts
+++ b/apps/daemon/src/runtimes/prompt-budget.ts
@@ -10,12 +10,6 @@ function promptArgvBudgetMessage(
       'Reduce the selected skills/design-system context or conversation length, or use DeepSeek through an API/provider model connection for large contexts. Pick a stdin-capable adapter when the prompt must include large local context.'
     );
   }
-  if (def.id === 'grok-build') {
-    return (
-      `${def.name} requires the prompt as the value of -p / --single (xAI CLI 0.1.212+ no longer reads piped stdin), and this run's composed prompt exceeds the safe size (${bytes} > ${def.maxPromptArgBytes} bytes). ` +
-      'Reduce the selected skills/design-system context or conversation length, or pick an adapter with stdin support (e.g. claude, codex, hermes) when the prompt must include large local context.'
-    );
-  }
   return (
     `${def.name} requires the prompt as a command-line argument and this run's composed prompt exceeds the safe size (${bytes} > ${def.maxPromptArgBytes} bytes). ` +
     'Reduce the selected skills/design-system context, shorten the conversation, or pick an adapter with stdin support.'

--- a/apps/daemon/src/runtimes/prompt-file.ts
+++ b/apps/daemon/src/runtimes/prompt-file.ts
@@ -1,0 +1,29 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { RuntimeAgentDef } from './types.js';
+
+export type PreparedPromptFile = {
+  path: string;
+  cleanup: () => Promise<void>;
+};
+
+export async function preparePromptFileForAgent(
+  def: RuntimeAgentDef | null | undefined,
+  prompt: string,
+  label: string,
+): Promise<PreparedPromptFile | null> {
+  if (!def?.promptViaFile) return null;
+
+  const safeLabel = label.replace(/[^a-zA-Z0-9_.-]/g, '-').slice(0, 80) || 'prompt';
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), `od-${def.id}-${safeLabel}-`));
+  const filePath = path.join(dir, 'prompt.md');
+  await fs.writeFile(filePath, prompt, { encoding: 'utf8', mode: 0o600 });
+
+  return {
+    path: filePath,
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -43,6 +43,11 @@ export type RuntimeContext = {
   // ~/.gemini/antigravity-cli/settings.json). Tests pass a temp path
   // so unit assertions against buildArgs do not touch the real home dir.
   antigravitySettingsPath?: string;
+  // Daemon-owned path to a temp file containing the composed prompt.
+  // Adapters with `promptViaFile: true` read this instead of receiving
+  // the prompt via argv or stdin. The daemon creates the file before
+  // buildArgs and removes it after the child exits.
+  promptFilePath?: string;
   // Resume-capable adapters (resumesSessionViaCli) read these to decide
   // whether to continue the CLI's own session. `resumeSessionId` is the
   // stored id for this (conversation, agent) when a prior session exists;
@@ -103,6 +108,11 @@ export type RuntimeAgentDef = {
   versionProbeTimeoutMs?: number;
   helpArgs?: string[];
   capabilityFlags?: Record<string, string>;
+  // Adapter reads the composed prompt from a daemon-created temp file.
+  // This is intentionally opt-in: stdin-capable adapters keep using
+  // `promptViaStdin`, and argv-only adapters keep their argv budget guard
+  // unless their CLI exposes an explicit prompt-file flag.
+  promptViaFile?: boolean;
   promptViaStdin?: boolean;
   // Format for the user prompt fed via stdin. Default is plain text (the
   // entire prompt buffer goes in raw, then stdin is closed). When set to

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -53,6 +53,7 @@ import {
   resolveModelForAgent,
 } from './runtimes/models.js';
 import { loadMmdRouteLaunchEnv } from './runtimes/mmd-routes.js';
+import { preparePromptFileForAgent } from './runtimes/prompt-file.js';
 import {
   cancelVelaLogin,
   forgetVelaLogin,
@@ -12115,6 +12116,10 @@ export async function startServer({
       def.id === 'antigravity'
         ? path.join(os.tmpdir(), `od-agy-${run.id}.log`)
         : undefined;
+    const promptFile = await preparePromptFileForAgent(def, composed, run.id);
+    const cleanupPromptFile = () => {
+      if (promptFile) promptFile.cleanup().catch(() => {});
+    };
 
     // Serialize antigravity spawns whose buildArgs writes a concrete
     // model into settings.json. Two concurrent runs with different
@@ -12138,19 +12143,26 @@ export async function startServer({
       antigravityModelLockRelease = await acquireAntigravityModelLock();
     }
 
-    const args = def.buildArgs(
-      composed,
-      safeImages,
-      extraAllowedDirs,
-      agentOptions,
-      {
-        cwd: effectiveCwd,
-        hasPriorAssistantTurn,
-        agentLogFilePath,
-        resumeSessionId: agentResumeCtx.resumeSessionId,
-        newSessionId: agentResumeCtx.newSessionId,
-      },
-    );
+    let args;
+    try {
+      args = def.buildArgs(
+        composed,
+        safeImages,
+        extraAllowedDirs,
+        agentOptions,
+        {
+          cwd: effectiveCwd,
+          hasPriorAssistantTurn,
+          agentLogFilePath,
+          promptFilePath: promptFile?.path,
+          resumeSessionId: agentResumeCtx.resumeSessionId,
+          newSessionId: agentResumeCtx.newSessionId,
+        },
+      );
+    } catch (err) {
+      cleanupPromptFile();
+      throw err;
+    }
     // Second-pass budget check that knows about the Windows `.cmd` shim
     // wrap. The pre-buildArgs `checkPromptArgvBudget` only looks at the
     // raw composed prompt; on Windows an npm-installed adapter resolves
@@ -12167,6 +12179,7 @@ export async function startServer({
       args,
     );
     if (cmdShimBudgetError) {
+      cleanupPromptFile();
       design.runs.emit(
         run,
         'error',
@@ -12194,6 +12207,7 @@ export async function startServer({
       args,
     );
     if (directExeBudgetError) {
+      cleanupPromptFile();
       design.runs.emit(
         run,
         'error',
@@ -12423,6 +12437,7 @@ export async function startServer({
     // spawn(def.bin) — that fallback re-introduces the exact ENOENT symptom
     // from issue #10.
     if (!resolvedBin || !agentLaunch.launchPath) {
+      cleanupPromptFile();
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
       send('error', createSseErrorPayload(
@@ -12446,6 +12461,7 @@ export async function startServer({
     if (def.id === 'amr') {
       const loginStatus = readVelaLoginStatus(agentSpawnEnv, configuredAgentEnv);
       if (!loginStatus.loggedIn) {
+        cleanupPromptFile();
         revokeToolToken('child_exit');
         unregisterChatAgentEventSink();
         sendAmrAccountFailure({
@@ -12468,6 +12484,7 @@ export async function startServer({
         : {}),
     };
     if (run.cancelRequested || design.runs.isTerminal(run.status)) {
+      cleanupPromptFile();
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
       return;
@@ -12624,6 +12641,7 @@ export async function startServer({
         writePromptToChildStdin = true;
       }
     } catch (err) {
+      cleanupPromptFile();
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
       send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', `spawn failed: ${err.message}`));
@@ -13254,6 +13272,7 @@ export async function startServer({
 
     child.on('error', (err) => {
       clearInactivityWatchdog();
+      cleanupPromptFile();
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
       send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err.message));
@@ -13619,6 +13638,7 @@ export async function startServer({
         if (agentLogFilePath) {
           fs.promises.unlink(agentLogFilePath).catch(() => {});
         }
+        cleanupPromptFile();
       }
     });
     if (writePromptToChildStdin && child.stdin) {

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -795,14 +795,31 @@ test('grok-build uses --prompt-file and never embeds the prompt in argv or stdin
     promptFilePath,
     '--model',
     'grok-4.3',
-    '--effort',
-    'high',
   ]);
   assert.equal(args.includes(prompt), false);
   assert.equal(args.includes('-'), false);
   assert.equal(args.includes('-p'), false);
   assert.equal(args.includes('--single'), false);
   assert.equal(args.filter((entry) => entry === '--prompt-file').length, 1);
+});
+
+test('grok-build omits effort for default/build models but keeps it for reasoning models', () => {
+  const promptFilePath = '/tmp/od-grok-prompt/prompt.md';
+  const defaultArgs = grokBuild.buildArgs('', [], [], { model: 'default', reasoning: 'high' }, { promptFilePath });
+  assert.equal(defaultArgs.includes('--effort'), false);
+
+  const buildArgs = grokBuild.buildArgs('', [], [], { model: 'grok-build', reasoning: 'high' }, { promptFilePath });
+  assert.equal(buildArgs.includes('--effort'), false);
+
+  const reasoningArgs = grokBuild.buildArgs('', [], [], { model: 'grok-4.20-reasoning', reasoning: 'high' }, { promptFilePath });
+  assert.deepEqual(reasoningArgs, [
+    '--prompt-file',
+    promptFilePath,
+    '--model',
+    'grok-4.20-reasoning',
+    '--effort',
+    'high',
+  ]);
 });
 
 test('grok-build requires a daemon-provided prompt file path', () => {

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -777,27 +777,39 @@ test('codex buildArgs omits model_reasoning_effort when reasoning is "default"',
   );
 });
 
-test('grok-build inlines the prompt as -p <value> and never falls back to stdin sentinels', () => {
+test('grok-build uses --prompt-file and never embeds the prompt in argv or stdin', () => {
   const prompt = 'summarize the current page layout';
+  const promptFilePath = '/tmp/od-grok-prompt/prompt.md';
   const args = grokBuild.buildArgs(
     prompt,
     [],
     [],
     { model: 'grok-4.3', reasoning: 'high' },
-    { cwd: '/tmp/od-project' },
+    { cwd: '/tmp/od-project', promptFilePath },
   );
 
+  assert.equal(grokBuild.promptViaFile, true);
   assert.equal(grokBuild.promptViaStdin, false);
   assert.deepEqual(args, [
-    '-p',
-    prompt,
+    '--prompt-file',
+    promptFilePath,
     '--model',
     'grok-4.3',
     '--effort',
     'high',
   ]);
+  assert.equal(args.includes(prompt), false);
   assert.equal(args.includes('-'), false);
-  assert.equal(args.filter((entry) => entry === '-p').length, 1);
+  assert.equal(args.includes('-p'), false);
+  assert.equal(args.includes('--single'), false);
+  assert.equal(args.filter((entry) => entry === '--prompt-file').length, 1);
+});
+
+test('grok-build requires a daemon-provided prompt file path', () => {
+  assert.throws(
+    () => grokBuild.buildArgs('hi', [], [], {}, { cwd: '/tmp/od-project' }),
+    /promptFilePath/,
+  );
 });
 
 test('claude flags promptViaStdin and never embeds the prompt in argv', () => {

--- a/apps/daemon/tests/runtimes/helpers/test-helpers.ts
+++ b/apps/daemon/tests/runtimes/helpers/test-helpers.ts
@@ -96,13 +96,6 @@ export const deepseekMaxPromptArgBytes = (() => {
   );
   return deepseek.maxPromptArgBytes;
 })();
-export const grokBuildMaxPromptArgBytes = (() => {
-  assert.ok(
-    grokBuild.maxPromptArgBytes !== undefined,
-    'grok-build must define maxPromptArgBytes for argv budget tests',
-  );
-  return grokBuild.maxPromptArgBytes;
-})();
 const originalDisablePlugins = process.env.OD_CODEX_DISABLE_PLUGINS;
 const originalPath = process.env.PATH;
 const originalHome = process.env.HOME;

--- a/apps/daemon/tests/runtimes/prompt-budget.test.ts
+++ b/apps/daemon/tests/runtimes/prompt-budget.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import {
-  assert, checkPromptArgvBudget, checkWindowsCmdShimCommandLineBudget, checkWindowsDirectExeCommandLineBudget, claude, deepseek, deepseekMaxPromptArgBytes, grokBuild, grokBuildMaxPromptArgBytes, vibe,
+  assert, checkPromptArgvBudget, checkWindowsCmdShimCommandLineBudget, checkWindowsDirectExeCommandLineBudget, claude, deepseek, deepseekMaxPromptArgBytes, grokBuild, vibe,
 } from './helpers/test-helpers.js';
 import type { TestAgentDef } from './helpers/test-helpers.js';
 
@@ -107,62 +107,10 @@ test('checkPromptArgvBudget gives DeepSeek-specific guidance for large contexts'
   assert.match(flagged.message, /stdin-capable adapter/);
 });
 
-// Grok Build CLI 0.1.212+ enforces `-p, --single <PROMPT>` as value-
-// required, so the prompt rides argv just like DeepSeek. Pin the budget
-// field and the byte-vs-codepoint guard so a future runtime-def edit
-// can't silently drop the guard or let it drift over the Windows
-// CreateProcess limit.
-test('grok-build declares a conservative argv-byte budget for the prompt', () => {
-  assert.equal(
-    typeof grokBuildMaxPromptArgBytes,
-    'number',
-    'grok-build must set maxPromptArgBytes so the spawn path can pre-flight oversized prompts before hitting CreateProcess / E2BIG',
-  );
-  assert.ok(
-    grokBuildMaxPromptArgBytes > 0 && grokBuildMaxPromptArgBytes < 32_768,
-    `grokBuildMaxPromptArgBytes must stay strictly under the Windows CreateProcess limit (~32 KB); got ${grokBuildMaxPromptArgBytes}`,
-  );
-});
-
-test('checkPromptArgvBudget flags oversized Grok Build prompts and lets short prompts through', () => {
-  const oversized = 'x'.repeat(grokBuildMaxPromptArgBytes + 1);
-  const flagged = checkPromptArgvBudget(grokBuild, oversized);
-  assert.ok(flagged, 'oversized prompts must trip the argv-byte guard');
-  assert.equal(flagged.code, 'AGENT_PROMPT_TOO_LARGE');
-  assert.equal(flagged.limit, grokBuildMaxPromptArgBytes);
-  assert.equal(flagged.bytes, grokBuildMaxPromptArgBytes + 1);
-  assert.match(flagged.message, /Grok Build/);
-  assert.match(flagged.message, /-p \/ --single/);
-  assert.match(flagged.message, /stdin/);
-
-  // Happy path: chat must keep working for normal-sized prompts.
-  assert.equal(checkPromptArgvBudget(grokBuild, 'hello'), null);
-
-  // Exact-budget edge: at-limit prompts pass; guard fires only on strict
-  // overrun.
-  const atLimit = 'x'.repeat(grokBuildMaxPromptArgBytes);
-  assert.equal(checkPromptArgvBudget(grokBuild, atLimit), null);
-
-  // Multi-byte UTF-8 (CJK = 3 bytes) must be byte-counted, not code-
-  // point-counted — mirrors the DeepSeek byte-count regression guard.
-  const cjkOversized = '汉'.repeat(
-    Math.ceil(grokBuildMaxPromptArgBytes / 3) + 1,
-  );
-  const cjkFlagged = checkPromptArgvBudget(grokBuild, cjkOversized);
-  assert.ok(cjkFlagged, 'byte-counted UTF-8 prompts must also trip the guard');
-  assert.equal(cjkFlagged.code, 'AGENT_PROMPT_TOO_LARGE');
-});
-
-test('checkPromptArgvBudget gives Grok-Build-specific guidance for large contexts', () => {
-  const oversized = 'x'.repeat(grokBuildMaxPromptArgBytes + 1);
-  const flagged = checkPromptArgvBudget(grokBuild, oversized);
-
-  assert.ok(flagged, 'oversized Grok Build prompts must return a diagnostic');
-  assert.match(flagged.message, /Grok Build/);
-  assert.match(flagged.message, /-p \/ --single/);
-  assert.match(flagged.message, /xAI CLI 0\.1\.212\+/);
-  assert.match(flagged.message, /no longer reads piped stdin/);
-  assert.match(flagged.message, /stdin support/);
+test('checkPromptArgvBudget is a no-op for Grok Build because it uses prompt files', () => {
+  assert.equal(grokBuild.promptViaFile, true);
+  assert.equal(grokBuild.maxPromptArgBytes, undefined);
+  assert.equal(checkPromptArgvBudget(grokBuild, 'x'.repeat(100_000)), null);
 });
 
 // Adapters that ship the prompt over stdin (every other code agent

--- a/apps/daemon/tests/runtimes/prompt-file.test.ts
+++ b/apps/daemon/tests/runtimes/prompt-file.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { dirname } from 'node:path';
+import { assert, minimalAgentDef } from './helpers/test-helpers.js';
+import { preparePromptFileForAgent } from '../../src/runtimes/prompt-file.js';
+
+test('preparePromptFileForAgent writes prompt content and cleans up for prompt-file adapters', async () => {
+  const prompt = 'large composed prompt\nwith unicode: 汉字';
+  const agent = minimalAgentDef({
+    id: 'prompt-file-agent',
+    name: 'Prompt File Agent',
+    bin: 'prompt-file-agent',
+    promptViaFile: true,
+  });
+
+  const prepared = await preparePromptFileForAgent(agent, prompt, 'label with spaces');
+  assert.ok(prepared, 'prompt-file agents should receive a prepared file');
+  assert.equal(await fs.readFile(prepared.path, 'utf8'), prompt);
+
+  const stat = await fs.stat(prepared.path);
+  assert.equal(stat.isFile(), true);
+
+  const dir = dirname(prepared.path);
+  await prepared.cleanup();
+  await assert.rejects(() => fs.stat(dir), /ENOENT/);
+});
+
+test('preparePromptFileForAgent is a no-op unless promptViaFile is enabled', async () => {
+  const agent = minimalAgentDef({
+    id: 'stdin-agent',
+    name: 'Stdin Agent',
+    bin: 'stdin-agent',
+    promptViaStdin: true,
+  });
+
+  assert.equal(await preparePromptFileForAgent(agent, 'prompt', 'label'), null);
+});

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import {
-  AGENT_DEFS, assert, chmodSync, codex, cursorAgent, detectAgents, join, mkdtempSync, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
+  AGENT_DEFS, assert, chmodSync, codex, cursorAgent, detectAgents, grokBuild, join, mkdtempSync, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
 import { codexNeedsDangerFullAccessSandbox } from '../../src/runtimes/defs/codex.js';
 import { readLocalAgentProfileDefs } from '../../src/runtimes/registry.js';
@@ -458,6 +458,26 @@ test('cursor-agent parses live model ids separately from display labels', () => 
     { id: 'auto', label: 'Auto' },
     { id: 'composer-2.5', label: 'Composer 2.5 (current)' },
     { id: 'grok-4.3', label: 'Grok 4.3 1M' },
+  ]);
+});
+
+test('grok-build filters login headers from live model discovery output', () => {
+  assert.ok(grokBuild.listModels, 'grok-build must define live model discovery');
+  const parsed = grokBuild.listModels.parse([
+    'You are logged in with grok.com.',
+    '',
+    'Default model: grok-build',
+    '',
+    'Available models:',
+    '',
+    '- grok-composer-2.5-fast',
+    '* grok-build (default)',
+  ].join('\n'));
+
+  assert.deepEqual(parsed, [
+    { id: 'default', label: 'Default (CLI config)' },
+    { id: 'grok-composer-2.5-fast', label: 'grok-composer-2.5-fast' },
+    { id: 'grok-build', label: 'grok-build' },
   ]);
 });
 

--- a/apps/web/src/artifacts/recover.ts
+++ b/apps/web/src/artifacts/recover.ts
@@ -66,3 +66,9 @@ export function recoverHtmlArtifactFromPrecedingDocument({
   const candidate = beforeArtifact.slice(htmlStart, htmlClose + closeMatch[0].length).trim();
   return validateHtmlArtifact(candidate).ok ? candidate : null;
 }
+
+export function recoverStandaloneHtmlDocument(sourceText: string | null | undefined): string | null {
+  const candidate = String(sourceText || '').replace(/^﻿/, '').trim();
+  if (!/<\/html\s*>$/i.test(candidate)) return null;
+  return validateHtmlArtifact(candidate).ok ? candidate : null;
+}

--- a/apps/web/src/artifacts/recover.ts
+++ b/apps/web/src/artifacts/recover.ts
@@ -1,0 +1,68 @@
+import { validateHtmlArtifact } from './validate';
+
+type RecoverHtmlArtifactInput = {
+  artifactHtml: string;
+  identifier?: string;
+  sourceText?: string;
+};
+
+const HTML_OPEN_RE = /<html\b/gi;
+const HTML_CLOSE_RE = /<\/html\s*>/gi;
+const ADJACENT_DOCTYPE_RE = /<!doctype\s+html\b[^>]*>\s*$/i;
+
+function findLastArtifactOpen(sourceText: string, identifier?: string): number {
+  if (!identifier) return sourceText.lastIndexOf('<artifact');
+
+  const escapedIdentifier = identifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const taggedOpenRe = new RegExp(
+    `<artifact\\b(?=[^>]*\\bidentifier\\s*=\\s*(?:"${escapedIdentifier}"|'${escapedIdentifier}'))[^>]*>`,
+    'gi',
+  );
+  let last = -1;
+  let match: RegExpExecArray | null;
+  while ((match = taggedOpenRe.exec(sourceText)) !== null) {
+    last = match.index;
+  }
+  return last !== -1 ? last : sourceText.lastIndexOf('<artifact');
+}
+
+function lastIndexOfRegex(re: RegExp, text: string): number {
+  re.lastIndex = 0;
+  let last = -1;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    last = match.index;
+  }
+  return last;
+}
+
+export function recoverHtmlArtifactFromPrecedingDocument({
+  artifactHtml,
+  identifier,
+  sourceText,
+}: RecoverHtmlArtifactInput): string | null {
+  if (!sourceText) return null;
+  if (validateHtmlArtifact(artifactHtml).ok) return null;
+
+  const artifactOpen = findLastArtifactOpen(sourceText, identifier);
+  if (artifactOpen === -1) return null;
+
+  const beforeArtifact = sourceText.slice(0, artifactOpen);
+  if (!/<\/html\s*>\s*$/i.test(beforeArtifact)) return null;
+
+  const htmlOpenStart = lastIndexOfRegex(HTML_OPEN_RE, beforeArtifact);
+  const htmlClose = lastIndexOfRegex(HTML_CLOSE_RE, beforeArtifact);
+  if (htmlOpenStart === -1 || htmlClose === -1 || htmlClose < htmlOpenStart) return null;
+
+  const closeMatch = beforeArtifact.slice(htmlClose).match(/^<\/html\s*>/i);
+  if (!closeMatch) return null;
+
+  const beforeHtmlOpen = beforeArtifact.slice(0, htmlOpenStart);
+  const adjacentDoctype = beforeHtmlOpen.match(ADJACENT_DOCTYPE_RE);
+  const htmlStart = adjacentDoctype
+    ? htmlOpenStart - adjacentDoctype[0].length
+    : htmlOpenStart;
+
+  const candidate = beforeArtifact.slice(htmlStart, htmlClose + closeMatch[0].length).trim();
+  return validateHtmlArtifact(candidate).ok ? candidate : null;
+}

--- a/apps/web/src/artifacts/recover.ts
+++ b/apps/web/src/artifacts/recover.ts
@@ -9,6 +9,7 @@ type RecoverHtmlArtifactInput = {
 const HTML_OPEN_RE = /<html\b/gi;
 const HTML_CLOSE_RE = /<\/html\s*>/gi;
 const ADJACENT_DOCTYPE_RE = /<!doctype\s+html\b[^>]*>\s*$/i;
+const HTML_FENCE_RE = /```(?:html|HTML)\s*\n([\s\S]*?)\n```/g;
 
 function findLastArtifactOpen(sourceText: string, identifier?: string): number {
   if (!identifier) return sourceText.lastIndexOf('<artifact');
@@ -71,4 +72,20 @@ export function recoverStandaloneHtmlDocument(sourceText: string | null | undefi
   const candidate = String(sourceText || '').replace(/^﻿/, '').trim();
   if (!/<\/html\s*>$/i.test(candidate)) return null;
   return validateHtmlArtifact(candidate).ok ? candidate : null;
+}
+
+export function recoverHtmlDocumentFromMarkdownFence(sourceText: string | null | undefined): string | null {
+  const text = String(sourceText || '');
+  HTML_FENCE_RE.lastIndex = 0;
+  let recovered: string | null = null;
+  let count = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HTML_FENCE_RE.exec(text)) !== null) {
+    const candidate = (match[1] || '').replace(/^﻿/, '').trim();
+    if (!/<\/html\s*>$/i.test(candidate)) continue;
+    if (!validateHtmlArtifact(candidate).ok) continue;
+    recovered = candidate;
+    count += 1;
+  }
+  return count === 1 ? recovered : null;
 }

--- a/apps/web/src/artifacts/strip.ts
+++ b/apps/web/src/artifacts/strip.ts
@@ -1,5 +1,9 @@
 import { computeSkipRanges, isRealArtifactOpenAt, rangeContains, type Range } from './markdown-context';
-import { recoverHtmlDocumentFromMarkdownFence, recoverStandaloneHtmlDocument } from './recover';
+import {
+  recoverHtmlArtifactFromPrecedingDocument,
+  recoverHtmlDocumentFromMarkdownFence,
+  recoverStandaloneHtmlDocument,
+} from './recover';
 
 const OPEN = '<artifact';
 const CLOSE = '</artifact>';
@@ -88,6 +92,46 @@ function findSingleRecoverableHtmlFence(content: string): MarkdownFenceRange | n
   return count === 1 ? recovered : null;
 }
 
+function findRecoverablePrecedingHtmlArtifact(sourceText: string): string | null {
+  const { ranges: baseRanges, unclosedFenceStart } = computeSkipRanges(sourceText);
+  const ranges: Range[] =
+    unclosedFenceStart !== null ? [...baseRanges, [unclosedFenceStart, sourceText.length]] : baseRanges;
+
+  let from = 0;
+  while (from <= sourceText.length) {
+    const open = findRealOpen(sourceText, from, ranges);
+    if (open === -1) return null;
+
+    const closeTag = sourceText.indexOf('>', open);
+    if (closeTag === -1) return null;
+
+    const end = findUnskipped(sourceText, CLOSE, closeTag, ranges);
+    if (end === -1) return null;
+
+    const attrs = parseArtifactAttrs(sourceText.slice(open, closeTag));
+    const recovered = recoverHtmlArtifactFromPrecedingDocument({
+      artifactHtml: sourceText.slice(closeTag + 1, end),
+      identifier: attrs['identifier'],
+      sourceText,
+    });
+    if (recovered) return recovered;
+
+    from = end + CLOSE.length;
+  }
+
+  return null;
+}
+
+function stripRecoverablePrecedingHtml(content: string, sourceText: string): string | null {
+  const recovered = findRecoverablePrecedingHtmlArtifact(sourceText);
+  if (!recovered) return null;
+
+  const start = content.lastIndexOf(recovered);
+  if (start === -1) return null;
+
+  return `${content.slice(0, start)}${content.slice(start + recovered.length)}`.trim();
+}
+
 /**
  * Display-only cleanup for Grok Build's fallback artifact shape.
  *
@@ -98,7 +142,10 @@ function findSingleRecoverableHtmlFence(content: string): MarkdownFenceRange | n
  * It must never be used to rewrite `message.content`, because that content is
  * the canonical transcript for future agent turns and forked conversations.
  */
-export function stripRecoveredHtmlFallbackForDisplay(content: string): string {
+export function stripRecoveredHtmlFallbackForDisplay(content: string, sourceText = content): string {
+  const withoutPrecedingDocument = stripRecoverablePrecedingHtml(content, sourceText);
+  if (withoutPrecedingDocument !== null) return withoutPrecedingDocument;
+
   if (recoverStandaloneHtmlDocument(content)) return '';
 
   const fence = findSingleRecoverableHtmlFence(content);

--- a/apps/web/src/artifacts/strip.ts
+++ b/apps/web/src/artifacts/strip.ts
@@ -1,7 +1,15 @@
 import { computeSkipRanges, isRealArtifactOpenAt, rangeContains, type Range } from './markdown-context';
+import { recoverHtmlDocumentFromMarkdownFence, recoverStandaloneHtmlDocument } from './recover';
 
 const OPEN = '<artifact';
 const CLOSE = '</artifact>';
+const HTML_FENCE_RE = /```(?:html|HTML)\s*\n([\s\S]*?)\n```/g;
+
+type MarkdownFenceRange = {
+  start: number;
+  end: number;
+  html: string;
+};
 
 function findUnskipped(content: string, needle: string, fromIndex: number, ranges: ReadonlyArray<Range>): number {
   let from = fromIndex;
@@ -62,6 +70,40 @@ export function stripArtifact(content: string): string {
   const end = findUnskipped(content, CLOSE, closeTag, ranges);
   if (end === -1) return content;
   return (content.slice(0, open) + content.slice(end + CLOSE.length)).trim();
+}
+
+function findSingleRecoverableHtmlFence(content: string): MarkdownFenceRange | null {
+  HTML_FENCE_RE.lastIndex = 0;
+  let recovered: MarkdownFenceRange | null = null;
+  let count = 0;
+  let match: RegExpExecArray | null = HTML_FENCE_RE.exec(content);
+  while (match !== null) {
+    const html = (match[1] || '').replace(/^﻿/, '').trim();
+    if (recoverHtmlDocumentFromMarkdownFence(match[0]) === html) {
+      recovered = { start: match.index, end: match.index + match[0].length, html };
+      count += 1;
+    }
+    match = HTML_FENCE_RE.exec(content);
+  }
+  return count === 1 ? recovered : null;
+}
+
+/**
+ * Display-only cleanup for Grok Build's fallback artifact shape.
+ *
+ * Some Grok runs emit a complete HTML document as a standalone response or as a
+ * single ```html fenced block instead of using the `<artifact>` protocol. The
+ * ProjectView recovery path persists those documents as `response.html`; this
+ * helper only removes the duplicate raw document from the rendered chat bubble.
+ * It must never be used to rewrite `message.content`, because that content is
+ * the canonical transcript for future agent turns and forked conversations.
+ */
+export function stripRecoveredHtmlFallbackForDisplay(content: string): string {
+  if (recoverStandaloneHtmlDocument(content)) return '';
+
+  const fence = findSingleRecoverableHtmlFence(content);
+  if (!fence) return content;
+  return `${content.slice(0, fence.start)}${content.slice(fence.end)}`.trim();
 }
 
 function parseArtifactAttrs(raw: string): Record<string, string> {

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -1907,7 +1907,7 @@ function ProseBlock({
   const t = useT();
   const cleaned = useMemo(() => {
     const stripped = stripArtifact(text);
-    return hideRecoveredHtmlFallback ? stripRecoveredHtmlFallbackForDisplay(stripped) : stripped;
+    return hideRecoveredHtmlFallback ? stripRecoveredHtmlFallbackForDisplay(stripped, text) : stripped;
   }, [hideRecoveredHtmlFallback, text]);
   // While the latest turn is still streaming a not-yet-closed question-form,
   // drop the partial `<question-form>{…` markup from the prose so the chat

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -34,7 +34,7 @@ import {
   type QuestionForm,
 } from "../artifacts/question-form";
 import { parseSubmittedAnswers } from "./QuestionForm";
-import { splitStreamingArtifact, stripArtifact } from "../artifacts/strip";
+import { splitStreamingArtifact, stripArtifact, stripRecoveredHtmlFallbackForDisplay } from "../artifacts/strip";
 import {
   getPluginFolderCandidates,
   type PluginFolderCandidate,
@@ -633,6 +633,7 @@ function AssistantMessageImpl({
               <ProseBlock
                 key={i}
                 text={b.text}
+                hideRecoveredHtmlFallback={message.agentId === "grok-build" && !streaming}
                 assistantMessageId={message.id}
                 isLastAssistant={!!isLast}
                 streaming={streaming}
@@ -1878,6 +1879,7 @@ function hasPluginFinalActionHint(content: string): boolean {
 
 function ProseBlock({
   text,
+  hideRecoveredHtmlFallback,
   assistantMessageId,
   isLastAssistant,
   streaming,
@@ -1890,6 +1892,7 @@ function ProseBlock({
   onRequestOpenFile,
 }: {
   text: string;
+  hideRecoveredHtmlFallback?: boolean;
   assistantMessageId: string;
   isLastAssistant: boolean;
   streaming: boolean;
@@ -1902,7 +1905,10 @@ function ProseBlock({
   onRequestOpenFile?: (name: string) => void;
 }) {
   const t = useT();
-  const cleaned = useMemo(() => stripArtifact(text), [text]);
+  const cleaned = useMemo(() => {
+    const stripped = stripArtifact(text);
+    return hideRecoveredHtmlFallback ? stripRecoveredHtmlFallbackForDisplay(stripped) : stripped;
+  }, [hideRecoveredHtmlFallback, text]);
   // While the latest turn is still streaming a not-yet-closed question-form,
   // drop the partial `<question-form>{…` markup from the prose so the chat
   // doesn't flash raw JSON; we surface a banner for it instead. The actual

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -14,7 +14,7 @@ import { AnimatePresence } from 'motion/react';
 import { createHtmlArtifactManifest, inferLegacyManifest } from '../artifacts/manifest';
 import { resolveHtmlPointerArtifactTarget } from '../artifacts/pointer';
 import { validateHtmlArtifact } from '../artifacts/validate';
-import { recoverHtmlArtifactFromPrecedingDocument } from '../artifacts/recover';
+import { recoverHtmlArtifactFromPrecedingDocument, recoverStandaloneHtmlDocument } from '../artifacts/recover';
 import { createArtifactParser } from '../artifacts/parser';
 import {
   findFirstQuestionForm,
@@ -1746,6 +1746,17 @@ export function ProjectView({
     [project.id, project.designSystemId, project.skillId, requestOpenFile],
   );
 
+  const artifactFromStandaloneHtml = useCallback((sourceText: string): Artifact | null => {
+    const html = recoverStandaloneHtmlDocument(sourceText);
+    if (!html) return null;
+    return {
+      identifier: 'response',
+      artifactType: 'text/html',
+      title: 'Response',
+      html,
+    };
+  }, []);
+
   // Set of project file names that the chat surface uses to decide whether
   // a tool card's path is openable as a tab. Recomputed on every file-list
   // change; tool cards just read from the set.
@@ -2621,10 +2632,13 @@ export function ProjectView({
                 // fall back to the current list for legacy messages.
                 const beforeFileNames = new Set(preTurn ?? nextFiles.map((f) => f.name));
                 let recoveredExistingArtifact: ProjectFile | null = null;
-                if (parsedArtifact?.html) {
+                const artifactToPersist = parsedArtifact?.html
+                  ? parsedArtifact
+                  : artifactFromStandaloneHtml(replayedContent);
+                if (artifactToPersist?.html) {
                   const runStartedAt = status.createdAt || message.startedAt || message.createdAt;
                   recoveredExistingArtifact = findExistingArtifactProjectFile(
-                    parsedArtifact,
+                    artifactToPersist,
                     nextFiles,
                     { minMtime: runStartedAt },
                   );
@@ -2632,7 +2646,7 @@ export function ProjectView({
                     savedArtifactRef.current = recoveredExistingArtifact.name;
                     requestOpenFile(recoveredExistingArtifact.name);
                   } else {
-                    await persistArtifact(parsedArtifact, nextFiles, replayedContent);
+                    await persistArtifact(artifactToPersist, nextFiles, replayedContent);
                     nextFiles = await refreshProjectFiles();
                   }
                 }
@@ -3325,8 +3339,12 @@ export function ProjectView({
           // chips.
           void (async () => {
             let nextFiles = await refreshProjectFiles();
-            if (parsedArtifact?.html) {
-              await persistArtifact(parsedArtifact, nextFiles, streamedText || fullText);
+            const finalText = streamedText || fullText;
+            const artifactToPersist = parsedArtifact?.html
+              ? parsedArtifact
+              : artifactFromStandaloneHtml(finalText);
+            if (artifactToPersist?.html) {
+              await persistArtifact(artifactToPersist, nextFiles, finalText);
               nextFiles = await refreshProjectFiles();
             }
             const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -14,6 +14,7 @@ import { AnimatePresence } from 'motion/react';
 import { createHtmlArtifactManifest, inferLegacyManifest } from '../artifacts/manifest';
 import { resolveHtmlPointerArtifactTarget } from '../artifacts/pointer';
 import { validateHtmlArtifact } from '../artifacts/validate';
+import { recoverHtmlArtifactFromPrecedingDocument } from '../artifacts/recover';
 import { createArtifactParser } from '../artifacts/parser';
 import {
   findFirstQuestionForm,
@@ -1637,7 +1638,13 @@ export function ProjectView({
   }, []);
 
   const persistArtifact = useCallback(
-    async (art: Artifact, projectFilesSnapshot?: ProjectFile[]) => {
+    async (art: Artifact, projectFilesSnapshot?: ProjectFile[], sourceText?: string) => {
+      const recoveredHtml = recoverHtmlArtifactFromPrecedingDocument({
+        artifactHtml: art.html,
+        identifier: art.identifier,
+        sourceText,
+      });
+      const artifactToPersist = recoveredHtml ? { ...art, html: recoveredHtml } : art;
       const baseName = artifactBaseNameFor(art);
       const ext = artifactExtensionFor(art);
       // Pick a name that doesn't collide with an existing project file.
@@ -1653,7 +1660,7 @@ export function ProjectView({
       }
       if (ext === '.html') {
         const pointerTarget = resolveHtmlPointerArtifactTarget({
-          content: art.html,
+          content: artifactToPersist.html,
           candidateFileName: fileName,
           projectFiles: currentProjectFiles,
         });
@@ -1670,7 +1677,7 @@ export function ProjectView({
       // when only Edit-tool changes happened this turn. Without this guard,
       // such content lands as a phantom HTML file in the project panel.
       if (ext === '.html') {
-        const validation = validateHtmlArtifact(art.html);
+        const validation = validateHtmlArtifact(artifactToPersist.html);
         if (!validation.ok) {
           setError(`Refused to save artifact "${art.identifier || art.title || 'untitled'}": ${validation.reason}`);
           return;
@@ -1702,7 +1709,7 @@ export function ProjectView({
                 designSystemId: project.designSystemId,
               },
             });
-      const file = await writeProjectTextFile(project.id, fileName, art.html, {
+      const file = await writeProjectTextFile(project.id, fileName, artifactToPersist.html, {
         artifactManifest: manifest ?? undefined,
       });
       if (file) {
@@ -2625,7 +2632,7 @@ export function ProjectView({
                     savedArtifactRef.current = recoveredExistingArtifact.name;
                     requestOpenFile(recoveredExistingArtifact.name);
                   } else {
-                    await persistArtifact(parsedArtifact, nextFiles);
+                    await persistArtifact(parsedArtifact, nextFiles, replayedContent);
                     nextFiles = await refreshProjectFiles();
                   }
                 }
@@ -3319,7 +3326,7 @@ export function ProjectView({
           void (async () => {
             let nextFiles = await refreshProjectFiles();
             if (parsedArtifact?.html) {
-              await persistArtifact(parsedArtifact, nextFiles);
+              await persistArtifact(parsedArtifact, nextFiles, streamedText || fullText);
               nextFiles = await refreshProjectFiles();
             }
             const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -14,7 +14,7 @@ import { AnimatePresence } from 'motion/react';
 import { createHtmlArtifactManifest, inferLegacyManifest } from '../artifacts/manifest';
 import { resolveHtmlPointerArtifactTarget } from '../artifacts/pointer';
 import { validateHtmlArtifact } from '../artifacts/validate';
-import { recoverHtmlArtifactFromPrecedingDocument, recoverStandaloneHtmlDocument } from '../artifacts/recover';
+import { recoverHtmlArtifactFromPrecedingDocument, recoverHtmlDocumentFromMarkdownFence, recoverStandaloneHtmlDocument } from '../artifacts/recover';
 import { createArtifactParser } from '../artifacts/parser';
 import {
   findFirstQuestionForm,
@@ -1747,7 +1747,8 @@ export function ProjectView({
   );
 
   const artifactFromStandaloneHtml = useCallback((sourceText: string): Artifact | null => {
-    const html = recoverStandaloneHtmlDocument(sourceText);
+    const html = recoverStandaloneHtmlDocument(sourceText)
+      ?? recoverHtmlDocumentFromMarkdownFence(sourceText);
     if (!html) return null;
     return {
       identifier: 'response',

--- a/apps/web/tests/artifacts/recover.test.ts
+++ b/apps/web/tests/artifacts/recover.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { recoverHtmlArtifactFromPrecedingDocument } from '../../src/artifacts/recover';
+import { recoverHtmlArtifactFromPrecedingDocument, recoverStandaloneHtmlDocument } from '../../src/artifacts/recover';
 
 const completeHtml = '<!doctype html><html><head><title>Demo</title></head><body><main><h1>Recovered artifact</h1></main></body></html>';
 
@@ -58,5 +58,27 @@ describe('recoverHtmlArtifactFromPrecedingDocument', () => {
       identifier: 'demo',
       sourceText,
     })).toBe(html);
+  });
+});
+
+describe('recoverStandaloneHtmlDocument', () => {
+  it('recovers a response that is itself a complete HTML document', () => {
+    expect(recoverStandaloneHtmlDocument(`\n${completeHtml}\n`)).toBe(completeHtml);
+  });
+
+  it('does not recover HTML embedded in prose', () => {
+    expect(recoverStandaloneHtmlDocument(`Here is the page:\n${completeHtml}`)).toBeNull();
+  });
+
+  it('does not recover a document followed by trailing prose', () => {
+    expect(recoverStandaloneHtmlDocument(`${completeHtml}\nI also updated the layout.`)).toBeNull();
+  });
+
+  it('does not recover partial snippets', () => {
+    expect(recoverStandaloneHtmlDocument('<main><h1>Snippet</h1></main>')).toBeNull();
+  });
+
+  it('does not recover document-shaped output missing a closing html tag', () => {
+    expect(recoverStandaloneHtmlDocument('<!doctype html><html><body><main><h1>Missing close</h1></main></body>')).toBeNull();
   });
 });

--- a/apps/web/tests/artifacts/recover.test.ts
+++ b/apps/web/tests/artifacts/recover.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { recoverHtmlArtifactFromPrecedingDocument, recoverStandaloneHtmlDocument } from '../../src/artifacts/recover';
+import { recoverHtmlArtifactFromPrecedingDocument, recoverHtmlDocumentFromMarkdownFence, recoverStandaloneHtmlDocument } from '../../src/artifacts/recover';
 
 const completeHtml = '<!doctype html><html><head><title>Demo</title></head><body><main><h1>Recovered artifact</h1></main></body></html>';
 
@@ -80,5 +80,33 @@ describe('recoverStandaloneHtmlDocument', () => {
 
   it('does not recover document-shaped output missing a closing html tag', () => {
     expect(recoverStandaloneHtmlDocument('<!doctype html><html><body><main><h1>Missing close</h1></main></body>')).toBeNull();
+  });
+});
+
+describe('recoverHtmlDocumentFromMarkdownFence', () => {
+  it('recovers a single complete html fenced code block from prose', () => {
+    expect(recoverHtmlDocumentFromMarkdownFence([
+      '明白了，这是落地页原型。',
+      '',
+      '```html',
+      completeHtml,
+      '```',
+    ].join('\n'))).toBe(completeHtml);
+  });
+
+  it('does not recover non-html fences or partial html snippets', () => {
+    expect(recoverHtmlDocumentFromMarkdownFence(['```ts', completeHtml, '```'].join('\n'))).toBeNull();
+    expect(recoverHtmlDocumentFromMarkdownFence('```html\n<main><h1>Snippet</h1></main>\n```')).toBeNull();
+  });
+
+  it('does not guess when multiple complete html fences are present', () => {
+    expect(recoverHtmlDocumentFromMarkdownFence([
+      '```html',
+      completeHtml,
+      '```',
+      '```html',
+      completeHtml.replace('Demo', 'Second'),
+      '```',
+    ].join('\n'))).toBeNull();
   });
 });

--- a/apps/web/tests/artifacts/recover.test.ts
+++ b/apps/web/tests/artifacts/recover.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { recoverHtmlArtifactFromPrecedingDocument } from '../../src/artifacts/recover';
+
+const completeHtml = '<!doctype html><html><head><title>Demo</title></head><body><main><h1>Recovered artifact</h1></main></body></html>';
+
+describe('recoverHtmlArtifactFromPrecedingDocument', () => {
+  it('recovers a complete HTML document emitted immediately before a prose artifact tag', () => {
+    const sourceText = [
+      'Here is the prototype:',
+      completeHtml,
+      '<artifact identifier="clay-code-longform" type="text/html" title="Clay & Code">',
+      '(The complete document above is the delivered artifact.)',
+      '</artifact>',
+    ].join('\n');
+
+    expect(recoverHtmlArtifactFromPrecedingDocument({
+      artifactHtml: '(The complete document above is the delivered artifact.)',
+      identifier: 'clay-code-longform',
+      sourceText,
+    })).toBe(completeHtml);
+  });
+
+  it('does not recover when the artifact body is already valid HTML', () => {
+    expect(recoverHtmlArtifactFromPrecedingDocument({
+      artifactHtml: completeHtml,
+      identifier: 'demo',
+      sourceText: `${completeHtml}\n<artifact identifier="demo">ignored</artifact>`,
+    })).toBeNull();
+  });
+
+  it('does not recover non-adjacent prior HTML', () => {
+    expect(recoverHtmlArtifactFromPrecedingDocument({
+      artifactHtml: 'summary only',
+      identifier: 'demo',
+      sourceText: `${completeHtml}\nThis is an explanation.\n<artifact identifier="demo">summary only</artifact>`,
+    })).toBeNull();
+  });
+
+  it('recovers the immediately preceding html document instead of an earlier doctype document', () => {
+    const oldHtml = '<!doctype html><html><head><title>Old</title></head><body><main><h1>Old document</h1></main></body></html>';
+    const newHtml = '<html><head><title>New</title></head><body><main><h1>New document</h1></main></body></html>';
+    const sourceText = `${oldHtml}\nExplanation between drafts.\n${newHtml}\n<artifact identifier="demo" type="text/html">summary only</artifact>`;
+
+    expect(recoverHtmlArtifactFromPrecedingDocument({
+      artifactHtml: 'summary only',
+      identifier: 'demo',
+      sourceText,
+    })).toBe(newHtml);
+  });
+
+  it('ignores a stray doctype mention before the immediately preceding html document', () => {
+    const html = '<html><head><title>Final</title></head><body><main><h1>Final document</h1></main></body></html>';
+    const sourceText = `Mention <!doctype html> in prose.\n${html}\n<artifact identifier="demo" type="text/html">summary only</artifact>`;
+
+    expect(recoverHtmlArtifactFromPrecedingDocument({
+      artifactHtml: 'summary only',
+      identifier: 'demo',
+      sourceText,
+    })).toBe(html);
+  });
+});

--- a/apps/web/tests/artifacts/strip.test.ts
+++ b/apps/web/tests/artifacts/strip.test.ts
@@ -203,6 +203,18 @@ describe('stripRecoveredHtmlFallbackForDisplay', () => {
     expect(stripRecoveredHtmlFallbackForDisplay(input)).toBe('Done — saved as an artifact.');
   });
 
+  it('removes a recovered preceding HTML document using original artifact context', () => {
+    const original = [
+      'Done — saved as an artifact.',
+      '',
+      completeHtml,
+      '<artifact identifier="demo" type="text/html" title="Demo">summary only</artifact>',
+    ].join('\n');
+    const stripped = stripArtifact(original);
+
+    expect(stripRecoveredHtmlFallbackForDisplay(stripped, original)).toBe('Done — saved as an artifact.');
+  });
+
   it('leaves partial snippets unchanged', () => {
     const input = '```html\n<main><h1>Snippet</h1></main>\n```';
     expect(stripRecoveredHtmlFallbackForDisplay(input)).toBe(input);

--- a/apps/web/tests/artifacts/strip.test.ts
+++ b/apps/web/tests/artifacts/strip.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { splitStreamingArtifact, stripArtifact } from '../../src/artifacts/strip';
+import { splitStreamingArtifact, stripArtifact, stripRecoveredHtmlFallbackForDisplay } from '../../src/artifacts/strip';
+
+const completeHtml = '<!doctype html><html><head><title>X</title></head><body><h1>X</h1></body></html>';
 
 describe('stripArtifact', () => {
   it('removes a real artifact tag and its body from prose', () => {
@@ -188,5 +190,26 @@ describe('splitStreamingArtifact', () => {
     const { head, live } = splitStreamingArtifact(input);
     expect(head).toBe(input);
     expect(live).toBeNull();
+  });
+});
+
+describe('stripRecoveredHtmlFallbackForDisplay', () => {
+  it('removes a standalone complete HTML response for display only', () => {
+    expect(stripRecoveredHtmlFallbackForDisplay(`\n${completeHtml}\n`)).toBe('');
+  });
+
+  it('removes a single complete html fence while preserving prose', () => {
+    const input = ['Done — saved as an artifact.', '', '```html', completeHtml, '```'].join('\n');
+    expect(stripRecoveredHtmlFallbackForDisplay(input)).toBe('Done — saved as an artifact.');
+  });
+
+  it('leaves partial snippets unchanged', () => {
+    const input = '```html\n<main><h1>Snippet</h1></main>\n```';
+    expect(stripRecoveredHtmlFallbackForDisplay(input)).toBe(input);
+  });
+
+  it('leaves multiple complete html fences unchanged instead of guessing', () => {
+    const input = ['```html', completeHtml, '```', '```html', completeHtml, '```'].join('\n');
+    expect(stripRecoveredHtmlFallbackForDisplay(input)).toBe(input);
   });
 });


### PR DESCRIPTION
## Why

I hit this while verifying the Grok Build local CLI adapter from Open Design: direct `grok --prompt-file` worked, but an OD chat run failed before spawn with `AGENT_PROMPT_TOO_LARGE` because Grok's previous `-p <prompt>` path carried the full composed prompt in argv.

After testing the fixed path in the web UI, Grok also exposed a second compatibility issue: it can emit a complete HTML document first, then append `<artifact ...>` after `</html>` with prose inside the artifact body. The web artifact parser correctly rejected that prose as non-HTML, but the user still got a failed save despite the full document being present immediately above the tag.

## What users will see

Grok Build runs from Open Design now launch successfully with normal composed prompts instead of failing with a prompt-too-large error. If Grok places the artifact wrapper after a complete HTML document, Open Design recovers the immediately preceding document instead of trying to save the prose wrapper body.

Other local CLI agents keep their existing prompt transport behavior.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — behavior fix only; no new UI entry point.

## Bug fix verification

- Test paths:
  - `apps/daemon/tests/runtimes/agent-args.test.ts`
  - `apps/daemon/tests/runtimes/prompt-budget.test.ts`
  - `apps/daemon/tests/runtimes/prompt-file.test.ts`
  - `apps/web/tests/artifacts/recover.test.ts`
- Did the test go red on `main` and green on this branch? No; I verified the shipped failure with an OD Grok smoke run on the pre-fix code (`AGENT_PROMPT_TOO_LARGE`, 78115 > 30000) and reproduced the wrapper-after-HTML shape from the user report in a focused web artifact recovery test.
- Additional verification: `od run redesign --agent grok-build --model default --message 'Reply with exactly: GROK_OD_OK' --follow --json` succeeded and streamed `GROK_OD_OK`.

## Validation

- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm install`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm --filter @open-design/daemon build`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm exec vitest run -c vitest.config.ts tests/runtimes/agent-args.test.ts tests/runtimes/prompt-budget.test.ts tests/runtimes/prompt-file.test.ts --reporter verbose` (from `apps/daemon`)
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm exec vitest run -c vitest.config.ts tests/artifacts/recover.test.ts tests/artifacts/parser.test.ts --reporter verbose` (from `apps/web`)
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm --filter @open-design/web typecheck`
- Grok OD smoke: `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm --filter @open-design/daemon exec od run redesign --daemon-url http://127.0.0.1:17456 --path "/var/folders/0h/q1vd77ss5_56tt8c0q7mhdh00000gn/T/opencode/grok-smoke-project" --agent grok-build --model default --message 'Reply with exactly: GROK_OD_OK' --follow --json`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm guard`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm typecheck`
