### PR TITLE
feat(desktop): add hidden AMR profile menu

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1606,6 +1606,7 @@ function attachAgentStreamHandlers(
   prompt: string,
   cwd: string,
   model: string | undefined,
+  modelEnv: Record<string, string | undefined>,
   liveModelScope: string | null,
   send: (event: string, payload: unknown) => void,
   appendRawStdout?: (chunk: string) => void,
@@ -1647,7 +1648,7 @@ function attachAgentStreamHandlers(
       // concrete fallback id here too, otherwise Test connection deadlocks
       // on the same `session/set_model must be called before session/prompt`
       // error the chat-run path already handles.
-      model: resolveModelForAgent(def as never, model ?? null, process.env, liveModelScope),
+      model: resolveModelForAgent(def as never, model ?? null, modelEnv, liveModelScope),
       mcpServers: [],
       send,
     });
@@ -1713,7 +1714,6 @@ async function testAgentConnectionInternal(
     validateAgentCliEnv(input.agentCliEnv),
     input.agentId,
   );
-  const liveModelScope = input.agentId === 'amr' ? resolveAmrProfile(configuredAgentEnv) : null;
   const executableResolution = resolveAgentLaunch(def, configuredAgentEnv);
   const resolvedBin = executableResolution.selectedPath;
   if (!resolvedBin || !executableResolution.launchPath) {
@@ -1915,6 +1915,7 @@ async function testAgentConnectionInternal(
       undefined,
       { resolvedBin: executableResolution.selectedPath },
     );
+    const liveModelScope = input.agentId === 'amr' ? resolveAmrProfile(baseEnv) : null;
     const mmdRouteLaunchEnv = input.agentId === 'claude'
       ? await loadMmdRouteLaunchEnv(
           {
@@ -1987,6 +1988,7 @@ async function testAgentConnectionInternal(
       SMOKE_PROMPT,
       tempDir,
       input.model,
+      env,
       liveModelScope,
       sink.send,
       sink.appendRawStdout,

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -72,6 +72,7 @@ import {
   type ProviderTestRequest,
 } from '@open-design/contracts/api/connectionTest';
 import { googleGenerateContentUrl } from './google-models.js';
+import { resolveAmrProfile } from './integrations/vela.js';
 
 export { validateBaseUrl } from '@open-design/contracts/api/connectionTest';
 
@@ -1605,6 +1606,7 @@ function attachAgentStreamHandlers(
   prompt: string,
   cwd: string,
   model: string | undefined,
+  liveModelScope: string | null,
   send: (event: string, payload: unknown) => void,
   appendRawStdout?: (chunk: string) => void,
 ): AgentSpawnHandle {
@@ -1645,7 +1647,7 @@ function attachAgentStreamHandlers(
       // concrete fallback id here too, otherwise Test connection deadlocks
       // on the same `session/set_model must be called before session/prompt`
       // error the chat-run path already handles.
-      model: resolveModelForAgent(def as never, model ?? null),
+      model: resolveModelForAgent(def as never, model ?? null, process.env, liveModelScope),
       mcpServers: [],
       send,
     });
@@ -1711,6 +1713,7 @@ async function testAgentConnectionInternal(
     validateAgentCliEnv(input.agentCliEnv),
     input.agentId,
   );
+  const liveModelScope = input.agentId === 'amr' ? resolveAmrProfile(configuredAgentEnv) : null;
   const executableResolution = resolveAgentLaunch(def, configuredAgentEnv);
   const resolvedBin = executableResolution.selectedPath;
   if (!resolvedBin || !executableResolution.launchPath) {
@@ -1984,6 +1987,7 @@ async function testAgentConnectionInternal(
       SMOKE_PROMPT,
       tempDir,
       input.model,
+      liveModelScope,
       sink.send,
       sink.appendRawStdout,
     );

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -285,6 +285,7 @@ function rememberDetectedLiveModels(
   configuredEnv: Record<string, string>,
   agent: DetectedAgent,
 ): void {
+  if (def.id === 'amr' && agent.models.length === 0) return;
   const scope = def.id === 'amr'
     ? resolveAmrProfile({
         ...process.env,

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -1,6 +1,10 @@
 import { execAgentFile } from './invocation.js';
 import { AGENT_DEFS } from './registry.js';
-import { DEFAULT_MODEL_OPTION, rememberLiveModels } from './models.js';
+import {
+  DEFAULT_MODEL_OPTION,
+  getRememberedLiveModels,
+  rememberLiveModels,
+} from './models.js';
 import { applyAgentLaunchEnv, resolveAgentLaunch } from './launch.js';
 import { spawnEnvForAgent } from './env.js';
 import { probeAgentAuthStatus } from './auth.js';
@@ -26,6 +30,21 @@ type FetchedRuntimeModels = {
   models: RuntimeModelOption[];
   source: RuntimeModelSource;
 };
+
+function amrModelScopeFromEnv(env: NodeJS.ProcessEnv): string {
+  return resolveAmrProfile(env);
+}
+
+function withRememberedAmrModels(
+  def: RuntimeAgentDef,
+  env: NodeJS.ProcessEnv,
+  modelResult: FetchedRuntimeModels,
+): FetchedRuntimeModels {
+  if (def.id !== 'amr' || modelResult.models.length > 0) return modelResult;
+  const rememberedModels = getRememberedLiveModels(def.id, amrModelScopeFromEnv(env));
+  if (rememberedModels.length === 0) return modelResult;
+  return { models: rememberedModels, source: 'live' };
+}
 
 async function fetchModels(
   def: RuntimeAgentDef,
@@ -214,14 +233,15 @@ async function probe(
     fetchModels(def, launch.launchPath, probeEnv),
     probeAgentAuthStatus(def, launch.launchPath, probeEnv),
   ]);
+  const surfacedModelResult = withRememberedAmrModels(def, probeEnv, modelResult);
   if (caps) {
     agentCapabilities.set(def.id, caps);
   }
   const authDiagnostic = auth ? buildAuthDiagnostic(def, auth) : null;
   return {
     ...stripFns(def),
-    models: modelResult.models,
-    modelsSource: modelResult.source,
+    models: surfacedModelResult.models,
+    modelsSource: surfacedModelResult.source,
     available: true,
     path: launch.selectedPath,
     version: outcome.version,
@@ -287,7 +307,7 @@ function rememberDetectedLiveModels(
 ): void {
   if (def.id === 'amr' && agent.models.length === 0) return;
   const scope = def.id === 'amr'
-    ? resolveAmrProfile({
+    ? amrModelScopeFromEnv({
         ...process.env,
         ...(def.env || {}),
         ...configuredEnv,

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -6,6 +6,7 @@ import { spawnEnvForAgent } from './env.js';
 import { probeAgentAuthStatus } from './auth.js';
 import { agentCapabilities } from './capabilities.js';
 import { installMetaForAgent } from './metadata.js';
+import { resolveAmrProfile } from '../integrations/vela.js';
 import {
   buildAuthDiagnostic,
   buildExecutableDiagnostic,
@@ -279,6 +280,21 @@ async function safeProbe(
   }
 }
 
+function rememberDetectedLiveModels(
+  def: RuntimeAgentDef,
+  configuredEnv: Record<string, string>,
+  agent: DetectedAgent,
+): void {
+  const scope = def.id === 'amr'
+    ? resolveAmrProfile({
+        ...process.env,
+        ...(def.env || {}),
+        ...configuredEnv,
+      })
+    : null;
+  rememberLiveModels(agent.id, agent.models, scope);
+}
+
 export async function detectAgents(
   configuredEnvByAgent: Record<string, Record<string, string>> = {},
 ) {
@@ -288,8 +304,10 @@ export async function detectAgents(
   // Refresh the validation cache from whatever we just surfaced to the UI
   // so /api/chat can accept any model the user could have just picked,
   // including ones that only showed up after a CLI re-auth.
-  for (const agent of results) {
-    rememberLiveModels(agent.id, agent.models);
+  for (const [index, agent] of results.entries()) {
+    const def = AGENT_DEFS[index];
+    if (!def) continue;
+    rememberDetectedLiveModels(def, configuredEnvByAgent?.[def.id] ?? {}, agent);
   }
   return results;
 }
@@ -305,7 +323,7 @@ export async function* detectAgentsStream(
 ): AsyncGenerator<DetectedAgent> {
   const tagged = AGENT_DEFS.map((def, index) =>
     safeProbe(def, configuredEnvByAgent?.[def.id] ?? {}).then((agent) => {
-      rememberLiveModels(agent.id, agent.models);
+      rememberDetectedLiveModels(def, configuredEnvByAgent?.[def.id] ?? {}, agent);
       return { index, agent };
     }),
   );

--- a/apps/daemon/src/runtimes/models.ts
+++ b/apps/daemon/src/runtimes/models.ts
@@ -13,20 +13,26 @@ export const DEFAULT_MODEL_OPTION: RuntimeModelOption = {
 const liveModelCache = new Map<string, Set<string>>();
 const liveModelOrder = new Map<string, string[]>();
 
-export function rememberLiveModels(agentId: string, models: RuntimeModelOption[]) {
+function liveModelCacheKey(agentId: string, scope?: string | null): string {
+  const trimmedScope = typeof scope === 'string' ? scope.trim() : '';
+  return trimmedScope ? `${agentId}\0${trimmedScope}` : agentId;
+}
+
+export function rememberLiveModels(agentId: string, models: RuntimeModelOption[], scope?: string | null) {
   if (!Array.isArray(models)) return;
   const ids = models
     .map((m) => m && m.id)
     .filter((id) => typeof id === 'string');
+  const key = liveModelCacheKey(agentId, scope);
   liveModelCache.set(
-    agentId,
+    key,
     new Set(ids),
   );
-  liveModelOrder.set(agentId, ids);
+  liveModelOrder.set(key, ids);
 }
 
-export function getRememberedLiveModels(agentId: string): RuntimeModelOption[] {
-  const ids = liveModelOrder.get(agentId) ?? [];
+export function getRememberedLiveModels(agentId: string, scope?: string | null): RuntimeModelOption[] {
+  const ids = liveModelOrder.get(liveModelCacheKey(agentId, scope)) ?? [];
   return ids.map((id) => ({ id, label: id }));
 }
 
@@ -59,6 +65,7 @@ export function resolveModelForAgent(
   def: RuntimeAgentDef,
   resolved: string | null,
   env: Record<string, string | undefined> = process.env,
+  liveModelScope?: string | null,
 ): string | null {
   if (resolved && resolved !== 'default') return resolved;
   // Daemon-process env override (e.g. VELA_DEFAULT_MODEL for AMR). Lets an
@@ -70,7 +77,7 @@ export function resolveModelForAgent(
   }
   const fallbacks = Array.isArray(def.fallbackModels) ? def.fallbackModels : [];
   if (fallbacks.some((m) => m.id === 'default')) return resolved;
-  const liveModels = liveModelOrder.get(def.id) ?? [];
+  const liveModels = liveModelOrder.get(liveModelCacheKey(def.id, liveModelScope)) ?? [];
   const firstLive = liveModels[0];
   if (firstLive) return firstLive;
   if (fallbacks.length === 0) return resolved;

--- a/apps/daemon/src/runtimes/models.ts
+++ b/apps/daemon/src/runtimes/models.ts
@@ -43,9 +43,13 @@ export function preferFreshLiveModels(
   return freshModels.length > 0 ? freshModels : rememberedModels;
 }
 
-export function isKnownModel(def: RuntimeAgentDef, modelId: string | null | undefined) {
+export function isKnownModel(
+  def: RuntimeAgentDef,
+  modelId: string | null | undefined,
+  scope?: string | null,
+) {
   if (!modelId) return false;
-  const live = liveModelCache.get(def.id);
+  const live = liveModelCache.get(liveModelCacheKey(def.id, scope));
   if (live && live.has(modelId)) return true;
   if (Array.isArray(def.fallbackModels)) {
     return def.fallbackModels.some((m) => m.id === modelId);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -62,6 +62,7 @@ import {
   parseVelaLoginAttribution,
   readVelaCredentialRevision,
   readVelaLoginStatus,
+  resolveAmrProfile,
   spawnVelaLogin,
 } from './integrations/vela.js';
 import {
@@ -11970,9 +11971,10 @@ export async function startServer({
       } catch {
         liveModels = [];
       }
-      const rememberedLiveModels = getRememberedLiveModels(def.id);
+      const amrModelScope = resolveAmrProfile(modelProbeEnv ?? process.env);
+      const rememberedLiveModels = getRememberedLiveModels(def.id, amrModelScope);
       if (liveModels.length > 0) {
-        rememberLiveModels(def.id, liveModels);
+        rememberLiveModels(def.id, liveModels, amrModelScope);
       }
       liveModels = preferFreshLiveModels(liveModels, rememberedLiveModels);
       const liveModelIds = new Set(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11575,18 +11575,34 @@ export async function startServer({
       ...(run.analyticsTelemetry ?? {}),
       promptBuildEndAt: Date.now(),
     };
+    let configuredAgentEnv = {};
+    try {
+      const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+      configuredAgentEnv = agentCliEnvForAgent(appConfig.agentCliEnv, def.id);
+    } catch {
+      configuredAgentEnv = {};
+    }
     // Per-agent model + reasoning the user picked in the model menu.
     // Trust the value when it matches the most recent /api/agents listing
     // (live or fallback). Otherwise allow it through if it passes a
     // permissive sanitizer — that's the path for user-typed custom model
     // ids the CLI's listing didn't surface yet.
+    const requestedLiveModelScope = def.id === 'amr'
+      ? resolveAmrProfile({
+          ...process.env,
+          ...(def.env || {}),
+          ...configuredAgentEnv,
+        })
+      : null;
     let safeModel = resolveModelForAgent(
       def,
       typeof model === 'string'
-        ? isKnownModel(def, model)
+        ? isKnownModel(def, model, requestedLiveModelScope)
           ? model
           : sanitizeCustomModel(model)
         : null,
+      process.env,
+      requestedLiveModelScope,
     );
     const safeReasoning =
       typeof reasoning === 'string' && Array.isArray(def.reasoningOptions)
@@ -11905,14 +11921,6 @@ export async function startServer({
         ),
       );
       return design.runs.finish(run, 'failed', 1, null);
-    }
-
-    let configuredAgentEnv = {};
-    try {
-      const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
-      configuredAgentEnv = agentCliEnvForAgent(appConfig.agentCliEnv, def.id);
-    } catch {
-      configuredAgentEnv = {};
     }
 
     let mmdRouteLaunchEnv = null;

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -6,6 +6,7 @@ import { promises as dnsPromises } from 'node:dns';
 import { promises as fsp } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { Socks5ProxyAgent } from 'undici';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import * as platform from '@open-design/platform';
@@ -23,6 +24,7 @@ import {
 } from '../src/connectionTest.js';
 import { listProviderModels } from '../src/providerModels.js';
 import { startServer } from '../src/server.js';
+import { rememberLiveModels } from '../src/runtimes/models.js';
 
 type FetchInput = Parameters<typeof fetch>[0];
 type FetchInit = Parameters<typeof fetch>[1];
@@ -35,6 +37,7 @@ interface StartedServer {
 const realFetch = globalThis.fetch;
 let baseUrl: string;
 let server: http.Server;
+const FAKE_VELA_FIXTURE = path.resolve(process.cwd(), 'tests', 'fixtures', 'fake-vela.mjs');
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -1985,6 +1988,32 @@ describe('POST /api/test/connection provider mode', () => {
 });
 
 describe('POST /api/test/connection agent mode', () => {
+  it('uses the AMR profile-scoped remembered model during connection tests when no explicit model is selected', async () => {
+    rememberLiveModels('amr', [{ id: 'local-scoped-model', label: 'local-scoped-model' }], 'local');
+
+    await withFakeAgent(
+      'vela',
+      `void import(${JSON.stringify(pathToFileURL(FAKE_VELA_FIXTURE).href)});\n`,
+      async () => {
+        const result = await testAgentConnection({
+          agentId: 'amr',
+          agentCliEnv: {
+            amr: {
+              OPEN_DESIGN_AMR_PROFILE: 'local',
+            },
+          },
+        });
+
+        expect(result).toMatchObject({
+          ok: true,
+          kind: 'success',
+          agentName: 'AMR',
+          sample: 'Hello from fake vela.',
+        });
+      },
+    );
+  });
+
   it('reports success for a fake Codex agent response', async () => {
     await withFakeCodex(
       `

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2014,6 +2014,39 @@ describe('POST /api/test/connection agent mode', () => {
     );
   });
 
+  it('resolves the AMR connection-test scope from the merged launch env', async () => {
+    rememberLiveModels('amr', [{ id: 'local-env-model', label: 'local-env-model' }], 'local');
+    const previousProfile = process.env.OPEN_DESIGN_AMR_PROFILE;
+    process.env.OPEN_DESIGN_AMR_PROFILE = 'local';
+
+    try {
+      await withFakeAgent(
+        'vela',
+        `void import(${JSON.stringify(pathToFileURL(FAKE_VELA_FIXTURE).href)});\n`,
+        async () => {
+          const result = await testAgentConnection({
+            agentId: 'amr',
+            agentCliEnv: {
+              amr: {
+                VELA_BIN: '/tmp/fake-vela-bin',
+              },
+            },
+          });
+
+          expect(result).toMatchObject({
+            ok: true,
+            kind: 'success',
+            agentName: 'AMR',
+            sample: 'Hello from fake vela.',
+          });
+        },
+      );
+    } finally {
+      if (previousProfile === undefined) delete process.env.OPEN_DESIGN_AMR_PROFILE;
+      else process.env.OPEN_DESIGN_AMR_PROFILE = previousProfile;
+    }
+  });
+
   it('reports success for a fake Codex agent response', async () => {
     await withFakeCodex(
       `

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -8,6 +8,7 @@ import {
   assert, chmodSync, detectAgents, inspectAgentExecutableResolution, join, minimalAgentDef, mkdirSync, mkdtempSync, opencode, resolveAgentExecutable, rmSync, spawnEnvForAgent, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
 import { isCursorAuthFailureText } from '../../src/runtimes/auth.js';
+import { getRememberedLiveModels } from '../../src/runtimes/models.js';
 
 const fsTest = process.platform === 'win32' ? test.skip : test;
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
@@ -638,6 +639,71 @@ exit 0
       ]);
       assert.equal(amrAgent.models.some((model) => model.id === 'default'), false);
       assert.equal(amrAgent.models.some((model) => model.id === 'gpt-5.4-mini'), false);
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+fsTest('detectAgents preserves the scoped AMR cache when a later probe returns no models', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'od-detect-amr-empty-models-'));
+  try {
+    return await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'OD_RESOURCE_ROOT', 'VELA_OPENCODE_BIN'], async () => {
+      const fakeVela = join(root, 'vela');
+      const fakeOpenCode = join(root, 'opencode');
+      const modeFile = join(root, 'models-mode');
+      writeFileSync(modeFile, 'warm');
+      writeFileSync(
+        fakeVela,
+        `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "vela scoped-cache"; exit 0; fi
+if [ "$1" = "model" ] && [ "$2" = "list" ]; then
+  if [ "$(cat "${modeFile}")" = "empty" ]; then
+    echo '{"source":"remote","data":[]}'
+  else
+    echo '{"source":"remote","data":[{"id":"deepseek-v4-flash"}]}'
+  fi
+  exit 0
+fi
+exit 0
+`,
+      );
+      writeFileSync(fakeOpenCode, '#!/bin/sh\nexit 0\n');
+      chmodSync(fakeVela, 0o755);
+      chmodSync(fakeOpenCode, 0o755);
+      process.env.PATH = '';
+      process.env.OD_AGENT_HOME = join(root, 'empty-home');
+      delete process.env.OD_RESOURCE_ROOT;
+      delete process.env.VELA_OPENCODE_BIN;
+
+      await detectAgents({
+        amr: {
+          VELA_BIN: fakeVela,
+          VELA_OPENCODE_BIN: fakeOpenCode,
+          OPEN_DESIGN_AMR_PROFILE: 'prod',
+        },
+      });
+      assert.deepEqual(getRememberedLiveModels('amr', 'prod'), [
+        { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
+      ]);
+
+      writeFileSync(modeFile, 'empty');
+      const agents = await detectAgents({
+        amr: {
+          VELA_BIN: fakeVela,
+          VELA_OPENCODE_BIN: fakeOpenCode,
+          OPEN_DESIGN_AMR_PROFILE: 'prod',
+        },
+      });
+      const amrAgent = agents.find((agent) => agent.id === 'amr');
+
+      assert.ok(amrAgent);
+      assert.deepEqual(amrAgent.models, [
+        { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
+      ]);
+      assert.deepEqual(getRememberedLiveModels('amr', 'prod'), [
+        { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
+      ]);
     });
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/apps/daemon/tests/runtimes/resolve-model.test.ts
+++ b/apps/daemon/tests/runtimes/resolve-model.test.ts
@@ -70,6 +70,25 @@ describe('resolveModelForAgent', () => {
     ]);
   });
 
+  it('isolates remembered AMR live models by environment profile scope', () => {
+    const def = defWithId('amr', []);
+    rememberLiveModels(def.id, [
+      { id: 'prod-model', label: 'prod-model' },
+    ], 'prod');
+    rememberLiveModels(def.id, [
+      { id: 'test-model', label: 'test-model' },
+    ], 'test');
+
+    expect(getRememberedLiveModels(def.id, 'prod')).toEqual([
+      { id: 'prod-model', label: 'prod-model' },
+    ]);
+    expect(getRememberedLiveModels(def.id, 'test')).toEqual([
+      { id: 'test-model', label: 'test-model' },
+    ]);
+    expect(resolveModelForAgent(def, null, {}, 'prod')).toBe('prod-model');
+    expect(resolveModelForAgent(def, null, {}, 'test')).toBe('test-model');
+  });
+
   it('prefers remembered live models only when the fresh AMR catalog is empty', () => {
     const remembered = [
       { id: 'deepseek-v3.2', label: 'deepseek-v3.2' },

--- a/apps/daemon/tests/runtimes/resolve-model.test.ts
+++ b/apps/daemon/tests/runtimes/resolve-model.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getRememberedLiveModels,
+  isKnownModel,
   preferFreshLiveModels,
   rememberLiveModels,
   resolveModelForAgent,
@@ -85,6 +86,8 @@ describe('resolveModelForAgent', () => {
     expect(getRememberedLiveModels(def.id, 'test')).toEqual([
       { id: 'test-model', label: 'test-model' },
     ]);
+    expect(isKnownModel(def, 'prod-model', 'prod')).toBe(true);
+    expect(isKnownModel(def, 'prod-model', 'test')).toBe(false);
     expect(resolveModelForAgent(def, null, {}, 'prod')).toBe('prod-model');
     expect(resolveModelForAgent(def, null, {}, 'test')).toBe('test-model');
   });

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -223,7 +223,7 @@ export function createAmrEnvironmentProfileMenuItems(
 ): MenuItemConstructorOptions[] {
   return [
     {
-      label: "AMR Environment Profile",
+      label: "AMR Profile",
       submenu: AMR_ENVIRONMENT_PROFILES.map((profile) => ({
         label: profile,
         type: "radio" as const,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -81,6 +81,7 @@ const AMR_ENVIRONMENT_PROFILES = ["prod", "test", "local"] as const;
 const APP_CONFIG_CHANGED_IPC_CHANNEL = "od:app-config-changed";
 type AmrEnvironmentProfile = (typeof AMR_ENVIRONMENT_PROFILES)[number];
 type DesktopAppConfigPrefs = {
+  agentModels?: Record<string, { model?: string; reasoning?: string }>;
   agentCliEnv?: Record<string, Record<string, string>>;
   [key: string]: unknown;
 };
@@ -206,8 +207,13 @@ export function mergeAmrEnvironmentProfileConfig(
   if (!AMR_ENVIRONMENT_PROFILES.includes(profile)) {
     throw new Error(`Unsupported AMR Environment Profile: ${String(profile)}`);
   }
+  const nextAgentModels = { ...(config.agentModels ?? {}) };
+  delete nextAgentModels[AMR_PROFILE_AGENT_ID];
   return {
     ...config,
+    ...(Object.keys(nextAgentModels).length > 0
+      ? { agentModels: nextAgentModels }
+      : { agentModels: undefined }),
     agentCliEnv: {
       ...(config.agentCliEnv ?? {}),
       [AMR_PROFILE_AGENT_ID]: {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -207,13 +207,16 @@ export function mergeAmrEnvironmentProfileConfig(
   if (!AMR_ENVIRONMENT_PROFILES.includes(profile)) {
     throw new Error(`Unsupported AMR Environment Profile: ${String(profile)}`);
   }
+  const hadAmrModel = Object.prototype.hasOwnProperty.call(config.agentModels ?? {}, AMR_PROFILE_AGENT_ID);
   const nextAgentModels = { ...(config.agentModels ?? {}) };
   delete nextAgentModels[AMR_PROFILE_AGENT_ID];
   return {
     ...config,
     ...(Object.keys(nextAgentModels).length > 0
       ? { agentModels: nextAgentModels }
-      : { agentModels: undefined }),
+      : hadAmrModel
+        ? { agentModels: {} }
+        : {}),
     agentCliEnv: {
       ...(config.agentCliEnv ?? {}),
       [AMR_PROFILE_AGENT_ID]: {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto";
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { BrowserWindow, Menu, app, shell, type MenuItemConstructorOptions } from "electron";
+import { BrowserWindow, Menu, app, dialog, globalShortcut, shell, type MenuItemConstructorOptions } from "electron";
 
 import {
   APP_KEYS,
@@ -75,6 +75,14 @@ export {
 } from "./runtime.js";
 
 const TOOLS_DEV_PARENT_PID_ENV = SIDECAR_ENV.TOOLS_DEV_PARENT_PID;
+const AMR_PROFILE_ENV_KEY = "OPEN_DESIGN_AMR_PROFILE";
+const AMR_PROFILE_AGENT_ID = "amr";
+const AMR_ENVIRONMENT_PROFILES = ["prod", "test", "local"] as const;
+type AmrEnvironmentProfile = (typeof AMR_ENVIRONMENT_PROFILES)[number];
+type DesktopAppConfigPrefs = {
+  agentCliEnv?: Record<string, Record<string, string>>;
+  [key: string]: unknown;
+};
 
 // Argv prefix the preload uses to recover the OS locale main process
 // read at startup. The renderer wires `__od__.client.osLocale` from it.
@@ -182,9 +190,135 @@ function createWebDiscovery(runtime: SidecarRuntimeContext<SidecarStamp>): () =>
   };
 }
 
+export function normalizeAmrEnvironmentProfile(profile: unknown): AmrEnvironmentProfile {
+  if (typeof profile !== "string") return "prod";
+  const trimmed = profile.trim();
+  return AMR_ENVIRONMENT_PROFILES.includes(trimmed as AmrEnvironmentProfile)
+    ? (trimmed as AmrEnvironmentProfile)
+    : "prod";
+}
+
+export function mergeAmrEnvironmentProfileConfig(
+  config: DesktopAppConfigPrefs,
+  profile: AmrEnvironmentProfile,
+): DesktopAppConfigPrefs {
+  if (!AMR_ENVIRONMENT_PROFILES.includes(profile)) {
+    throw new Error(`Unsupported AMR Environment Profile: ${String(profile)}`);
+  }
+  return {
+    ...config,
+    agentCliEnv: {
+      ...(config.agentCliEnv ?? {}),
+      [AMR_PROFILE_AGENT_ID]: {
+        ...(config.agentCliEnv?.[AMR_PROFILE_AGENT_ID] ?? {}),
+        [AMR_PROFILE_ENV_KEY]: profile,
+      },
+    },
+  };
+}
+
+export function createAmrEnvironmentProfileMenuItems(
+  selectedProfile: AmrEnvironmentProfile,
+  onSelect: (profile: AmrEnvironmentProfile) => void,
+): MenuItemConstructorOptions[] {
+  return [
+    {
+      label: "AMR Environment Profile",
+      submenu: AMR_ENVIRONMENT_PROFILES.map((profile) => ({
+        label: profile,
+        type: "radio" as const,
+        checked: selectedProfile === profile,
+        click: () => onSelect(profile),
+      })),
+    },
+  ];
+}
+
+function appConfigUrl(baseUrl: string): string {
+  return new URL("/api/app-config", baseUrl).toString();
+}
+
+async function readAppConfigFromDaemon(baseUrl: string): Promise<DesktopAppConfigPrefs> {
+  const response = await fetch(appConfigUrl(baseUrl));
+  if (!response.ok) {
+    throw new Error(`GET /api/app-config failed with HTTP ${response.status}`);
+  }
+  const payload = await response.json() as { config?: DesktopAppConfigPrefs };
+  if (payload.config == null || typeof payload.config !== "object") {
+    throw new Error("GET /api/app-config returned an invalid config payload");
+  }
+  return payload.config;
+}
+
+async function writeAppConfigToDaemon(
+  baseUrl: string,
+  config: DesktopAppConfigPrefs,
+): Promise<DesktopAppConfigPrefs> {
+  const response = await fetch(appConfigUrl(baseUrl), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(config),
+  });
+  if (!response.ok) {
+    throw new Error(`PUT /api/app-config failed with HTTP ${response.status}`);
+  }
+  const payload = await response.json() as { config?: DesktopAppConfigPrefs };
+  if (payload.config == null || typeof payload.config !== "object") {
+    throw new Error("PUT /api/app-config returned an invalid config payload");
+  }
+  return payload.config;
+}
+
 function installDesktopMenu(
   runtime: SidecarRuntimeContext<SidecarStamp>,
+  options: Pick<DesktopMainOptions, "discoverDaemonUrl" | "discoverWebUrl"> = {},
 ): () => void {
+  let developMenuVisible = false;
+  let lastKnownAmrProfile: AmrEnvironmentProfile = "prod";
+
+  const showDevelopMenuError = (message: string, error: unknown): void => {
+    const detail = error instanceof Error ? error.message : String(error);
+    dialog.showErrorBox(message, detail);
+  };
+
+  const discoverAppConfigBaseUrl = async (): Promise<string> => {
+    const baseUrl =
+      (await options.discoverDaemonUrl?.()) ??
+      (await options.discoverWebUrl?.()) ??
+      (await createWebDiscovery(runtime)());
+    if (!baseUrl) {
+      throw new Error("daemon URL is unavailable");
+    }
+    return baseUrl;
+  };
+
+  const readCurrentAmrProfile = async (): Promise<AmrEnvironmentProfile> => {
+    const baseUrl = await discoverAppConfigBaseUrl();
+    const config = await readAppConfigFromDaemon(baseUrl);
+    return normalizeAmrEnvironmentProfile(config.agentCliEnv?.[AMR_PROFILE_AGENT_ID]?.[AMR_PROFILE_ENV_KEY]);
+  };
+
+  const writeCurrentAmrProfile = async (profile: AmrEnvironmentProfile): Promise<AmrEnvironmentProfile> => {
+    const baseUrl = await discoverAppConfigBaseUrl();
+    const config = await readAppConfigFromDaemon(baseUrl);
+    const nextConfig = mergeAmrEnvironmentProfileConfig(config, profile);
+    const writtenConfig = await writeAppConfigToDaemon(baseUrl, nextConfig);
+    return normalizeAmrEnvironmentProfile(
+      writtenConfig.agentCliEnv?.[AMR_PROFILE_AGENT_ID]?.[AMR_PROFILE_ENV_KEY],
+    );
+  };
+
+  const selectAmrProfile = (profile: AmrEnvironmentProfile): void => {
+    void writeCurrentAmrProfile(profile)
+      .then((writtenProfile) => {
+        lastKnownAmrProfile = writtenProfile;
+        rebuild();
+      })
+      .catch((error: unknown) => {
+        showDevelopMenuError("AMR Environment Profile switch failed", error);
+      });
+  };
+
   const exportDiagnostics = () => {
     const focused = BrowserWindow.getFocusedWindow();
     void exportDiagnosticsToFile(runtime, focused).catch((error: unknown) => {
@@ -244,6 +378,14 @@ function installDesktopMenu(
           { role: "togglefullscreen" },
         ],
       },
+      ...(developMenuVisible
+        ? [
+            {
+              label: "Develop",
+              submenu: createAmrEnvironmentProfileMenuItems(lastKnownAmrProfile, selectAmrProfile),
+            },
+          ]
+        : []),
       {
         label: "Window",
         submenu: [
@@ -292,7 +434,29 @@ function installDesktopMenu(
   };
 
   rebuild();
-  return () => undefined;
+  const accelerator = process.platform === "darwin" ? "Command+Option+Shift+D" : "Control+Alt+Shift+D";
+  const registered = globalShortcut.register(accelerator, () => {
+    if (developMenuVisible) {
+      developMenuVisible = false;
+      rebuild();
+      return;
+    }
+    void readCurrentAmrProfile()
+      .then((profile) => {
+        lastKnownAmrProfile = profile;
+        developMenuVisible = true;
+        rebuild();
+      })
+      .catch((error: unknown) => {
+        showDevelopMenuError("Develop menu unavailable", error);
+      });
+  });
+  if (!registered) {
+    showDevelopMenuError("Develop menu shortcut unavailable", new Error(`Failed to register ${accelerator}`));
+  }
+  return () => {
+    globalShortcut.unregister(accelerator);
+  };
 }
 
 const REGISTER_DESKTOP_AUTH_RETRY_DELAYS_MS = [120, 240, 480, 960, 1500];
@@ -471,7 +635,7 @@ export async function runDesktopMain(
     updater,
   });
   options.onDesktopReady?.({ show: () => desktop?.show() });
-  disposeMenu = installDesktopMenu(runtime);
+  disposeMenu = installDesktopMenu(runtime, options);
   removeDiagnosticsIpc = registerDesktopDiagnosticsIpc(runtime);
   updateScheduler = createDesktopUpdaterScheduler(updater, {
     backoffInitialMs: updater.config.checkBackoffInitialMs,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -78,6 +78,7 @@ const TOOLS_DEV_PARENT_PID_ENV = SIDECAR_ENV.TOOLS_DEV_PARENT_PID;
 const AMR_PROFILE_ENV_KEY = "OPEN_DESIGN_AMR_PROFILE";
 const AMR_PROFILE_AGENT_ID = "amr";
 const AMR_ENVIRONMENT_PROFILES = ["prod", "test", "local"] as const;
+const APP_CONFIG_CHANGED_IPC_CHANNEL = "od:app-config-changed";
 type AmrEnvironmentProfile = (typeof AMR_ENVIRONMENT_PROFILES)[number];
 type DesktopAppConfigPrefs = {
   agentCliEnv?: Record<string, Record<string, string>>;
@@ -312,6 +313,9 @@ function installDesktopMenu(
     void writeCurrentAmrProfile(profile)
       .then((writtenProfile) => {
         lastKnownAmrProfile = writtenProfile;
+        for (const window of BrowserWindow.getAllWindows()) {
+          window.webContents.send(APP_CONFIG_CHANGED_IPC_CHANNEL);
+        }
         rebuild();
       })
       .catch((error: unknown) => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -207,9 +207,16 @@ export function mergeAmrEnvironmentProfileConfig(
   if (!AMR_ENVIRONMENT_PROFILES.includes(profile)) {
     throw new Error(`Unsupported AMR Environment Profile: ${String(profile)}`);
   }
-  const hadAmrModel = Object.prototype.hasOwnProperty.call(config.agentModels ?? {}, AMR_PROFILE_AGENT_ID);
+  const currentProfile = normalizeAmrEnvironmentProfile(
+    config.agentCliEnv?.[AMR_PROFILE_AGENT_ID]?.[AMR_PROFILE_ENV_KEY],
+  );
+  const shouldClearAmrModel = currentProfile !== profile;
+  const hadAmrModel =
+    shouldClearAmrModel && Object.prototype.hasOwnProperty.call(config.agentModels ?? {}, AMR_PROFILE_AGENT_ID);
   const nextAgentModels = { ...(config.agentModels ?? {}) };
-  delete nextAgentModels[AMR_PROFILE_AGENT_ID];
+  if (shouldClearAmrModel) {
+    delete nextAgentModels[AMR_PROFILE_AGENT_ID];
+  }
   return {
     ...config,
     ...(Object.keys(nextAgentModels).length > 0

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -18,6 +18,8 @@ import type {
 const OPEN_DESIGN_HOST_GLOBAL: typeof import('@open-design/host').OPEN_DESIGN_HOST_GLOBAL = '__od__';
 const OPEN_DESIGN_HOST_VERSION: typeof import('@open-design/host').OPEN_DESIGN_HOST_VERSION = 2;
 const UPDATER_STATUS_EVENT = 'od:update:status-changed';
+const APP_CONFIG_CHANGED_IPC_CHANNEL = 'od:app-config-changed';
+const APP_CONFIG_CHANGED_EVENT = 'open-design:app-config-changed';
 
 // Mirror of the argv prefix used by main's `applyOsLocaleSwitch` and
 // runtime's `additionalArguments`. Duplicated literal on purpose: the
@@ -272,6 +274,10 @@ const updater = {
 };
 
 const osLocale = readOsLocaleFromArgv();
+
+ipcRenderer.on(APP_CONFIG_CHANGED_IPC_CHANNEL, () => {
+  window.dispatchEvent(new CustomEvent(APP_CONFIG_CHANGED_EVENT));
+});
 
 const hostBridge = {
   version: OPEN_DESIGN_HOST_VERSION,

--- a/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
+++ b/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
@@ -20,6 +20,15 @@ describe("AMR Environment Profile desktop menu helpers", () => {
     const result = mergeAmrEnvironmentProfileConfig(
       {
         agentId: "claude",
+        agentModels: {
+          amr: {
+            model: "deepseek-v4-flash",
+            reasoning: "default",
+          },
+          claude: {
+            model: "sonnet",
+          },
+        },
         agentCliEnv: {
           amr: {
             VELA_BIN: "/opt/open-design/vela",
@@ -37,6 +46,11 @@ describe("AMR Environment Profile desktop menu helpers", () => {
 
     expect(result).toEqual({
       agentId: "claude",
+      agentModels: {
+        claude: {
+          model: "sonnet",
+        },
+      },
       agentCliEnv: {
         amr: {
           VELA_BIN: "/opt/open-design/vela",
@@ -58,6 +72,28 @@ describe("AMR Environment Profile desktop menu helpers", () => {
           OPEN_DESIGN_AMR_PROFILE: "test",
         },
       },
+    });
+  });
+
+  it("drops agentModels when AMR was the only persisted model choice", () => {
+    expect(
+      mergeAmrEnvironmentProfileConfig(
+        {
+          agentModels: {
+            amr: {
+              model: "deepseek-v4-flash",
+            },
+          },
+        },
+        "test",
+      ),
+    ).toEqual({
+      agentCliEnv: {
+        amr: {
+          OPEN_DESIGN_AMR_PROFILE: "test",
+        },
+      },
+      agentModels: undefined,
     });
   });
 

--- a/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
+++ b/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
@@ -75,25 +75,34 @@ describe("AMR Environment Profile desktop menu helpers", () => {
     });
   });
 
-  it("drops agentModels when AMR was the only persisted model choice", () => {
-    expect(
-      mergeAmrEnvironmentProfileConfig(
-        {
-          agentModels: {
-            amr: {
-              model: "deepseek-v4-flash",
-            },
+  it("serializes an explicit empty agentModels map when AMR was the only persisted model choice", () => {
+    const result = mergeAmrEnvironmentProfileConfig(
+      {
+        agentModels: {
+          amr: {
+            model: "deepseek-v4-flash",
           },
         },
-        "test",
-      ),
-    ).toEqual({
+      },
+      "test",
+    );
+
+    expect(result).toEqual({
       agentCliEnv: {
         amr: {
           OPEN_DESIGN_AMR_PROFILE: "test",
         },
       },
-      agentModels: undefined,
+      agentModels: {},
+    });
+
+    expect(JSON.parse(JSON.stringify(result))).toEqual({
+      agentCliEnv: {
+        amr: {
+          OPEN_DESIGN_AMR_PROFILE: "test",
+        },
+      },
+      agentModels: {},
     });
   });
 

--- a/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
+++ b/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createAmrEnvironmentProfileMenuItems,
+  mergeAmrEnvironmentProfileConfig,
+  normalizeAmrEnvironmentProfile,
+} from "../../src/main/index.js";
+
+describe("AMR Environment Profile desktop menu helpers", () => {
+  it("normalizes missing or invalid profile values to prod", () => {
+    expect(normalizeAmrEnvironmentProfile(undefined)).toBe("prod");
+    expect(normalizeAmrEnvironmentProfile("")).toBe("prod");
+    expect(normalizeAmrEnvironmentProfile("staging")).toBe("prod");
+    expect(normalizeAmrEnvironmentProfile("local")).toBe("local");
+    expect(normalizeAmrEnvironmentProfile("test")).toBe("test");
+    expect(normalizeAmrEnvironmentProfile("prod")).toBe("prod");
+  });
+
+  it("merges the selected profile without deleting other app config env", () => {
+    const result = mergeAmrEnvironmentProfileConfig(
+      {
+        agentId: "claude",
+        agentCliEnv: {
+          amr: {
+            VELA_BIN: "/opt/open-design/vela",
+            VELA_LINK_URL: "https://amr.example.test/link",
+            OPEN_DESIGN_AMR_PROFILE: "prod",
+          },
+          claude: {
+            ANTHROPIC_BASE_URL: "https://claude.example.test",
+          },
+        },
+        customInstructions: "Keep failures visible.",
+      },
+      "local",
+    );
+
+    expect(result).toEqual({
+      agentId: "claude",
+      agentCliEnv: {
+        amr: {
+          VELA_BIN: "/opt/open-design/vela",
+          VELA_LINK_URL: "https://amr.example.test/link",
+          OPEN_DESIGN_AMR_PROFILE: "local",
+        },
+        claude: {
+          ANTHROPIC_BASE_URL: "https://claude.example.test",
+        },
+      },
+      customInstructions: "Keep failures visible.",
+    });
+  });
+
+  it("creates the AMR env section when the existing config has no agentCliEnv", () => {
+    expect(mergeAmrEnvironmentProfileConfig({}, "test")).toEqual({
+      agentCliEnv: {
+        amr: {
+          OPEN_DESIGN_AMR_PROFILE: "test",
+        },
+      },
+    });
+  });
+
+  it("builds radio menu items for prod, test, and local", () => {
+    const selected: string[] = [];
+    const [profileMenu] = createAmrEnvironmentProfileMenuItems("test", (profile) => {
+      selected.push(profile);
+    });
+
+    expect(profileMenu.label).toBe("AMR Environment Profile");
+    expect(profileMenu.submenu).toEqual([
+      expect.objectContaining({ label: "prod", type: "radio", checked: false }),
+      expect.objectContaining({ label: "test", type: "radio", checked: true }),
+      expect.objectContaining({ label: "local", type: "radio", checked: false }),
+    ]);
+
+    const localItem = Array.isArray(profileMenu.submenu)
+      ? profileMenu.submenu.find((item) => item.label === "local")
+      : null;
+    localItem?.click?.(undefined as never, undefined as never, undefined as never);
+    expect(selected).toEqual(["local"]);
+  });
+});

--- a/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
+++ b/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
@@ -67,7 +67,7 @@ describe("AMR Environment Profile desktop menu helpers", () => {
       selected.push(profile);
     });
 
-    expect(profileMenu.label).toBe("AMR Environment Profile");
+    expect(profileMenu.label).toBe("AMR Profile");
     expect(profileMenu.submenu).toEqual([
       expect.objectContaining({ label: "prod", type: "radio", checked: false }),
       expect.objectContaining({ label: "test", type: "radio", checked: true }),

--- a/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
+++ b/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
@@ -106,6 +106,43 @@ describe("AMR Environment Profile desktop menu helpers", () => {
     });
   });
 
+  it("preserves the saved AMR model when re-selecting the normalized current profile", () => {
+    const result = mergeAmrEnvironmentProfileConfig(
+      {
+        agentModels: {
+          amr: {
+            model: "deepseek-v4-flash",
+          },
+          claude: {
+            model: "sonnet",
+          },
+        },
+        agentCliEnv: {
+          amr: {
+            OPEN_DESIGN_AMR_PROFILE: " prod ",
+          },
+        },
+      },
+      "prod",
+    );
+
+    expect(result).toEqual({
+      agentModels: {
+        amr: {
+          model: "deepseek-v4-flash",
+        },
+        claude: {
+          model: "sonnet",
+        },
+      },
+      agentCliEnv: {
+        amr: {
+          OPEN_DESIGN_AMR_PROFILE: "prod",
+        },
+      },
+    });
+  });
+
   it("builds radio menu items for prod, test, and local", () => {
     const selected: string[] = [];
     const [profileMenu] = createAmrEnvironmentProfileMenuItems("test", (profile) => {

--- a/apps/desktop/tests/main/preload-host-boundary.test.ts
+++ b/apps/desktop/tests/main/preload-host-boundary.test.ts
@@ -30,6 +30,9 @@ describe("desktop preload host boundary", () => {
     expect(source).toContain("invokeUpdater('install'");
     expect(source).toContain("od:update:quit");
     expect(source).toContain("od:update:status-changed");
+    expect(source).toContain("od:app-config-changed");
+    expect(source).toContain("open-design:app-config-changed");
+    expect(source).toContain("window.dispatchEvent(new CustomEvent(APP_CONFIG_CHANGED_EVENT))");
     expect(source).not.toContain("@open-design/contracts");
     expect(source).not.toContain("exposeInMainWorld('electronAPI'");
     expect(source).not.toContain('exposeInMainWorld("__odDesktop"');

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -100,6 +100,7 @@ import { useI18n } from './i18n';
 import { liveArtifactTabId } from './types';
 import type {
   AgentInfo,
+  AgentModelChoice,
   ApiProtocol,
   AppConfig,
   AppVersionInfo,
@@ -114,6 +115,8 @@ import type {
 } from './types';
 
 const APP_CONFIG_CHANGED_EVENT = 'open-design:app-config-changed';
+const AMR_AGENT_ID = 'amr';
+const AMR_PROFILE_ENV_KEY = 'OPEN_DESIGN_AMR_PROFILE';
 
 export function shouldSyncMediaProvidersOnSave(
   mediaProviders: AppConfig['mediaProviders'],
@@ -133,6 +136,34 @@ function normalizeSavedComposioConfig(config: AppConfig['composio']): AppConfig[
     };
   }
   return { ...(config ?? {}) };
+}
+
+function amrProfileForConfig(config: AppConfig): string | null {
+  const profile = config.agentCliEnv?.[AMR_AGENT_ID]?.[AMR_PROFILE_ENV_KEY];
+  return typeof profile === 'string' && profile ? profile : null;
+}
+
+function sameAgentModelChoice(
+  left: AgentModelChoice | undefined,
+  right: AgentModelChoice | undefined,
+): boolean {
+  return (left?.model ?? null) === (right?.model ?? null)
+    && (left?.reasoning ?? null) === (right?.reasoning ?? null);
+}
+
+function clearStaleAmrModelChoiceOnProfileChange(
+  previous: AppConfig,
+  next: AppConfig,
+): AppConfig {
+  if (amrProfileForConfig(previous) === amrProfileForConfig(next)) return next;
+
+  const previousChoice = previous.agentModels?.[AMR_AGENT_ID];
+  const nextChoice = next.agentModels?.[AMR_AGENT_ID];
+  if (!nextChoice || !sameAgentModelChoice(previousChoice, nextChoice)) return next;
+
+  const nextAgentModels = { ...(next.agentModels ?? {}) };
+  delete nextAgentModels[AMR_AGENT_ID];
+  return { ...next, agentModels: nextAgentModels };
 }
 
 type ProjectListRequest = {
@@ -811,7 +842,10 @@ function AppInner() {
           daemonMediaProvidersLoaded,
         );
         const next = mergeDaemonMediaProviders(
-          mergeDaemonConfig(baseConfig, daemonConfig),
+          clearStaleAmrModelChoiceOnProfileChange(
+            baseConfig,
+            mergeDaemonConfig(baseConfig, daemonConfig),
+          ),
           daemonMediaProvidersLoaded,
         );
         const hasLocalComposioKey = Boolean(next.composio?.apiKey?.trim());
@@ -1124,7 +1158,10 @@ function AppInner() {
   const refreshAgents = useCallback(
     async (options?: { throwOnError?: boolean; agentCliEnv?: AppConfig['agentCliEnv'] }) => {
       if (options && Object.prototype.hasOwnProperty.call(options, 'agentCliEnv')) {
-        const nextConfig = { ...config, agentCliEnv: options.agentCliEnv ?? {} };
+        const nextConfig = clearStaleAmrModelChoiceOnProfileChange(config, {
+          ...config,
+          agentCliEnv: options.agentCliEnv ?? {},
+        });
         amrModelsRef.current = null;
         saveConfig(nextConfig);
         await syncConfigToDaemon(nextConfig);
@@ -1164,7 +1201,10 @@ function AppInner() {
   useEffect(() => {
     const handleAppConfigChanged = () => {
       void fetchDaemonConfig().then((daemonConfig) => {
-        const next = mergeDaemonConfig(latestPersistedConfigRef.current, daemonConfig);
+        const next = clearStaleAmrModelChoiceOnProfileChange(
+          latestPersistedConfigRef.current,
+          mergeDaemonConfig(latestPersistedConfigRef.current, daemonConfig),
+        );
         latestPersistedConfigRef.current = next;
         saveConfig(next);
         setConfig(next);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1168,6 +1168,7 @@ function AppInner() {
         latestPersistedConfigRef.current = next;
         saveConfig(next);
         setConfig(next);
+        amrModelsRef.current = null;
         void refreshAgents();
       });
     };

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -113,6 +113,8 @@ import type {
   SkillSummary,
 } from './types';
 
+const APP_CONFIG_CHANGED_EVENT = 'open-design:app-config-changed';
+
 export function shouldSyncMediaProvidersOnSave(
   mediaProviders: AppConfig['mediaProviders'],
   options?: { force?: boolean },
@@ -1158,6 +1160,20 @@ function AppInner() {
     },
     [beginAgentStreamRequest, config, isCurrentAgentStreamRequest],
   );
+
+  useEffect(() => {
+    const handleAppConfigChanged = () => {
+      void fetchDaemonConfig().then((daemonConfig) => {
+        const next = mergeDaemonConfig(latestPersistedConfigRef.current, daemonConfig);
+        latestPersistedConfigRef.current = next;
+        saveConfig(next);
+        setConfig(next);
+        void refreshAgents();
+      });
+    };
+    window.addEventListener(APP_CONFIG_CHANGED_EVENT, handleAppConfigChanged);
+    return () => window.removeEventListener(APP_CONFIG_CHANGED_EVENT, handleAppConfigChanged);
+  }, [refreshAgents]);
 
   const handleCreateProject = useCallback(
     async (

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -364,6 +364,7 @@ function AppInner() {
   const [daemonLive, setDaemonLive] = useState(false);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const amrModelsRef = useRef<AmrModelsResponse | null>(null);
+  const amrPollGenerationRef = useRef(0);
   const agentStreamRequestSeqRef = useRef(0);
   const [amrPollRestartToken, setAmrPollRestartToken] = useState(0);
   const [providerModelsCache, setProviderModelsCache] = useState<
@@ -439,6 +440,11 @@ function AppInner() {
 
   const isCurrentAgentStreamRequest = useCallback((requestId: number) => {
     return agentStreamRequestSeqRef.current === requestId;
+  }, []);
+
+  const restartAmrPolling = useCallback(() => {
+    amrPollGenerationRef.current += 1;
+    setAmrPollRestartToken((current) => current + 1);
   }, []);
 
   // v2 schema removed the standalone `app_launch` event; the initial
@@ -654,13 +660,23 @@ function AppInner() {
     if (!daemonLive) return;
     let cancelled = false;
     let timer: number | null = null;
+    const pollGeneration = amrPollGenerationRef.current + 1;
+    amrPollGenerationRef.current = pollGeneration;
     const pollDelayMs = 1_000;
     const maxPresetPolls = 10;
     let presetPolls = 0;
 
     const applyAmrModels = async () => {
       const result = await fetchAmrModels();
-      if (cancelled || !result || !Array.isArray(result.models) || result.models.length === 0) return;
+      if (
+        cancelled ||
+        amrPollGenerationRef.current !== pollGeneration ||
+        !result ||
+        !Array.isArray(result.models) ||
+        result.models.length === 0
+      ) {
+        return;
+      }
       amrModelsRef.current = result;
       setAgents((current) => mergeAmrModelsIntoAgents(current, result));
       const shouldPollPreset =
@@ -684,8 +700,8 @@ function AppInner() {
 
   const handleAmrLoginStatusChange = useCallback((status: VelaLoginStatus | null) => {
     if (status?.loggedIn !== true) return;
-    setAmrPollRestartToken((current) => current + 1);
-  }, []);
+    restartAmrPolling();
+  }, [restartAmrPolling]);
 
   // Bootstrap — detect daemon, then fan out independent fetches so each
   // entry-view tab can render the moment its own data lands. Earlier this
@@ -1209,12 +1225,13 @@ function AppInner() {
         saveConfig(next);
         setConfig(next);
         amrModelsRef.current = null;
+        restartAmrPolling();
         void refreshAgents();
       });
     };
     window.addEventListener(APP_CONFIG_CHANGED_EVENT, handleAppConfigChanged);
     return () => window.removeEventListener(APP_CONFIG_CHANGED_EVENT, handleAppConfigChanged);
-  }, [refreshAgents]);
+  }, [refreshAgents, restartAmrPolling]);
 
   const handleCreateProject = useCallback(
     async (

--- a/apps/web/src/components/AmrLoginPill.tsx
+++ b/apps/web/src/components/AmrLoginPill.tsx
@@ -20,7 +20,7 @@ import {
   amrLoginStatusEventReason,
   notifyAmrLoginStatusChanged,
 } from './amrLoginPolling';
-import { amrConsoleUrlForProfile } from '../runtime/amr-guidance';
+import { amrConsoleUrlForProfile, amrProfileBadgeLabel } from '../runtime/amr-guidance';
 
 interface AmrLoginPillProps {
   className?: string;
@@ -84,12 +84,6 @@ function closeAmrActivationWindowBestEffort(): boolean {
   }
 }
 
-function profileBadgeLabel(profile: string | undefined): string | null {
-  if (profile === 'test') return 'TEST';
-  if (profile === 'local') return 'LOCAL';
-  return null;
-}
-
 function classNames(...names: Array<string | false | null | undefined>): string {
   return names.filter(Boolean).join(' ');
 }
@@ -121,7 +115,7 @@ export function AmrAccountControl({
   const isSigningIn = status === 'signing-in';
   const isCanceled = status === 'canceled';
   const hasError = status === 'error';
-  const badgeLabel = showProfileBadge ? profileBadgeLabel(profile) : null;
+  const badgeLabel = showProfileBadge ? amrProfileBadgeLabel(profile) : null;
   const visibleBadgeLabel = isSignedIn ? badgeLabel : null;
   const resolvedConsoleUrl = consoleUrl ?? amrConsoleUrlForProfile(profile);
   const loginErrorText = errorMessage || t('settings.amrLoginErrorCompact');

--- a/apps/web/src/components/AmrLoginPill.tsx
+++ b/apps/web/src/components/AmrLoginPill.tsx
@@ -20,7 +20,7 @@ import {
   amrLoginStatusEventReason,
   notifyAmrLoginStatusChanged,
 } from './amrLoginPolling';
-import { AMR_CONSOLE_URL } from '../runtime/amr-guidance';
+import { amrConsoleUrlForProfile } from '../runtime/amr-guidance';
 
 interface AmrLoginPillProps {
   className?: string;
@@ -107,7 +107,7 @@ export function AmrAccountControl({
   hideSignedInStatus = false,
   signInLabel,
   showConsoleAction = false,
-  consoleUrl = AMR_CONSOLE_URL,
+  consoleUrl,
   showCancelSignInAction = false,
   onSignIn,
   onSignOut,
@@ -117,11 +117,13 @@ export function AmrAccountControl({
   cancelSignInDisabled = false,
 }: AmrAccountControlProps) {
   const { t } = useI18n();
-  const badgeLabel = showProfileBadge ? profileBadgeLabel(profile) : null;
   const isSignedIn = status === 'signed-in';
   const isSigningIn = status === 'signing-in';
   const isCanceled = status === 'canceled';
   const hasError = status === 'error';
+  const badgeLabel = showProfileBadge ? profileBadgeLabel(profile) : null;
+  const visibleBadgeLabel = isSignedIn ? badgeLabel : null;
+  const resolvedConsoleUrl = consoleUrl ?? amrConsoleUrlForProfile(profile);
   const loginErrorText = errorMessage || t('settings.amrLoginErrorCompact');
   const statusText = isSignedIn
     ? hideSignedInStatus
@@ -148,12 +150,17 @@ export function AmrAccountControl({
       aria-label={t('settings.amrAccountStatus')}
     >
       {statusText ? (
-        <span className="amr-account-control__status">{statusText}</span>
+        <span className="amr-account-control__status">
+          <span className="amr-account-control__status-text">{statusText}</span>
+          {visibleBadgeLabel ? (
+            <span className="amr-login-pill-badge">{visibleBadgeLabel}</span>
+          ) : null}
+        </span>
       ) : null}
       {isSignedIn && showConsoleAction ? (
         <a
           className="amr-account-control__action"
-          href={consoleUrl}
+          href={resolvedConsoleUrl}
           target="_blank"
           rel="noopener noreferrer"
           aria-label={t('settings.amrConsole')}
@@ -193,9 +200,6 @@ export function AmrAccountControl({
         >
           {signInLabel ?? t('settings.amrSignIn')}
         </button>
-      ) : null}
-      {badgeLabel ? (
-        <span className="amr-login-pill-badge">{badgeLabel}</span>
       ) : null}
       {hasError ? (
         <span className="amr-account-control__error" role="alert">

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -11,7 +11,7 @@ import { mergeProviderModelOptions, providerModelsCacheKey } from './SettingsDia
 import { apiProtocolLabel } from '../utils/apiProtocol';
 import { fetchProviderModels } from '../providers/provider-models';
 import { isMacPlatform } from '../utils/platform';
-import { AMR_CONSOLE_URL } from '../runtime/amr-guidance';
+import { amrConsoleUrlForProfile } from '../runtime/amr-guidance';
 
 interface Props {
   config: AppConfig;
@@ -148,6 +148,8 @@ export function AvatarMenu({
   const amrAvailable = installedAgents.some((a) => a.id === 'amr');
   const showAmrAccountShortcut =
     config.mode === 'daemon' && currentAgent?.id === 'amr' && amrAvailable;
+  const amrProfile = config.agentCliEnv?.amr?.OPEN_DESIGN_AMR_PROFILE;
+  const amrConsoleUrl = amrConsoleUrlForProfile(amrProfile);
 
   // Resolve the user's model + reasoning pick for the active agent. Falls
   // back to the agent's first declared option (`'default'`) when the user
@@ -262,7 +264,7 @@ export function AvatarMenu({
           {showAmrAccountShortcut ? (
             <a
               className="avatar-amr-account-link"
-              href={AMR_CONSOLE_URL}
+              href={amrConsoleUrl}
               target="_blank"
               rel="noopener noreferrer"
               onClick={() => setOpen(false)}

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -36,7 +36,7 @@ import { dayKey, dayLabel, exactDateTime, messageTime, relativeTimeLong, shortTi
 import { commentTargetDisplayName, commentsToAttachments, simplePositionLabel } from '../comments';
 import { AssistantMessage, type QuestionFormOpenRequest } from './AssistantMessage';
 import { AmrGuidance } from './AmrGuidance';
-import { AMR_RECHARGE_URL, resolveRunFailureUi } from '../runtime/amr-guidance';
+import { amrRechargeUrlForProfile, resolveRunFailureUi } from '../runtime/amr-guidance';
 import {
   ChatComposer,
   type ChatComposerHandle,
@@ -589,7 +589,10 @@ interface Props {
   backLabel?: string;
   projectHeader?: ReactNode;
   designSystemPicker?: ReactNode;
+  config?: AppConfig;
 }
+
+const AMR_PROFILE_ENV_KEY = 'OPEN_DESIGN_AMR_PROFILE';
 
 type Tab = 'chat' | 'comments';
 
@@ -731,9 +734,11 @@ export function ChatPane({
   backLabel,
   projectHeader,
   designSystemPicker,
+  config,
 }: Props) {
   const t = useT();
   const analytics = useAnalytics();
+  const amrProfile = config?.agentCliEnv?.amr?.[AMR_PROFILE_ENV_KEY] ?? null;
   const logRef = useRef<HTMLDivElement | null>(null);
   const chatLogScrollIdleTimerRef = useRef<number | null>(null);
   const historyWrapRef = useRef<HTMLDivElement | null>(null);
@@ -2033,7 +2038,7 @@ export function ChatPane({
                                   'chat_error_recharge',
                                 );
                                 window.open(
-                                  attributedAmrUrl(AMR_RECHARGE_URL, attribution),
+                                  attributedAmrUrl(amrRechargeUrlForProfile(amrProfile), attribution),
                                   '_blank',
                                   'noopener,noreferrer',
                                 );

--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -1824,6 +1824,7 @@ export function DesignSystemDetailView({
             messages={chatMessages}
             streaming={generationActive || saving || chatStreaming}
             error={chatError}
+            config={config}
             projectId={workspaceProjectId}
             projectFiles={workspaceProjectFiles}
             onEnsureProject={ensureWorkspaceProject}

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -218,6 +218,8 @@ interface Props {
   focusQuestionsRequest?: { nonce: number } | null;
 }
 
+const AMR_PROFILE_ENV_KEY = 'OPEN_DESIGN_AMR_PROFILE';
+
 interface SketchState {
   version: number;
   rawItems: unknown[];
@@ -427,6 +429,7 @@ export function FileWorkspace({
   focusQuestionsRequest = null,
 }: Props) {
   const t = useT();
+  const amrProfile = chatConfig?.agentCliEnv?.amr?.[AMR_PROFILE_ENV_KEY] ?? null;
   // The chat column only shows a compact Questions banner; the form itself
   // lives here, including after submission when a banner click can reopen the
   // answered preview.
@@ -2121,6 +2124,7 @@ export function FileWorkspace({
             onLaunchTerminalAuth={onLaunchTerminalAuth}
             amrAuthorizeSourceDetail="generation_preview_authorize_retry"
             amrRechargeSourceDetail="generation_preview_recharge"
+            amrProfile={amrProfile}
             amrGuidance={
               generationPreview.promoteAmrSwitch
                 && generationPreview.errorCode

--- a/apps/web/src/components/GenerationPreviewStage.tsx
+++ b/apps/web/src/components/GenerationPreviewStage.tsx
@@ -7,7 +7,7 @@ import {
   type TrackingAmrEntrySource,
 } from '../analytics/amr-attribution';
 import type { Dict } from '../i18n/types';
-import { AMR_RECHARGE_URL } from '../runtime/amr-guidance';
+import { amrRechargeUrlForProfile } from '../runtime/amr-guidance';
 import type { GenerationPreviewModel } from '../runtime/generation-preview';
 import { Icon } from './Icon';
 import styles from './GenerationPreviewStage.module.css';
@@ -21,6 +21,7 @@ type Props = {
   onLaunchTerminalAuth?: (() => void) | undefined;
   amrAuthorizeSourceDetail?: TrackingAmrEntrySource;
   amrRechargeSourceDetail?: TrackingAmrEntrySource;
+  amrProfile?: string | null;
   // "Switch to AMR" promotion card, pre-built by the parent and rendered under
   // the actions for the non-AMR auth/quota cases (see model.promoteAmrSwitch).
   amrGuidance?: ReactNode;
@@ -54,6 +55,7 @@ export function GenerationPreviewStage({
   onLaunchTerminalAuth,
   amrAuthorizeSourceDetail,
   amrRechargeSourceDetail,
+  amrProfile,
   amrGuidance,
 }: Props) {
   const t = useT();
@@ -193,7 +195,7 @@ export function GenerationPreviewStage({
                   amrRechargeSourceDetail ?? 'generation_preview_recharge',
                 );
                 window.open(
-                  attributedAmrUrl(AMR_RECHARGE_URL, attribution),
+                  attributedAmrUrl(amrRechargeUrlForProfile(amrProfile), attribution),
                   '_blank',
                   'noopener,noreferrer',
                 );

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5441,6 +5441,7 @@ export function ProjectView({
               messagesConversationId={messagesConversationId}
               onSelectConversation={handleSelectConversation}
               onDeleteConversation={handleDeleteConversation}
+              config={config}
               onOpenSettings={onOpenSettings}
               showByokRecoveryAction={
                 config.mode === 'api' &&

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1032,6 +1032,20 @@ export function SettingsDialog({
     };
   }, [initial.theme, initial.accentColor]);
 
+  useEffect(() => {
+    setCfg((current) => {
+      if (current.agentCliEnv === initial.agentCliEnv) return current;
+      return {
+        ...current,
+        agentCliEnv: initial.agentCliEnv,
+      };
+    });
+    autosaveLastSavedRef.current = {
+      ...autosaveLastSavedRef.current,
+      agentCliEnv: initial.agentCliEnv,
+    };
+  }, [initial.agentCliEnv]);
+
   // Revert the live theme preview to the most recently persisted appearance.
   // That is the initial appearance until autosave succeeds; after autosave,
   // closing Settings must not roll the document back to stale colors.

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -40,6 +40,7 @@ import {
   fetchVelaLoginStatus,
   type VelaLoginStatus,
 } from '../providers/daemon';
+import { amrProfileBadgeLabel } from '../runtime/amr-guidance';
 import { ExportDiagnosticsRow } from './ExportDiagnosticsButton';
 import { Icon } from './Icon';
 import {
@@ -3371,6 +3372,10 @@ export function SettingsDialog({
                             isAmrAgent && active && amrCardStatus?.loggedIn
                               ? amrCardStatus.user?.email || t('settings.amrSignedIn')
                               : '';
+                          const amrCardProfileBadge =
+                            isAmrAgent && active && amrCardStatus?.loggedIn
+                              ? amrProfileBadgeLabel(amrCardStatus.profile)
+                              : null;
                           const amrRevealPendingCancelAction =
                             isAmrAgent &&
                             active &&
@@ -3466,9 +3471,14 @@ export function SettingsDialog({
                                       ) : null}
                                       {amrCardEmail ? (
                                         <div className="agent-card-amr-email">
-                                          <span title={amrCardEmail}>
+                                          <span className="agent-card-amr-email-text" title={amrCardEmail}>
                                             {amrCardEmail}
                                           </span>
+                                          {amrCardProfileBadge ? (
+                                            <span className="agent-card-amr-profile-badge">
+                                              {amrCardProfileBadge}
+                                            </span>
+                                          ) : null}
                                         </div>
                                       ) : null}
                                       {!active && modelSummary ? (

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -838,6 +838,37 @@ export function updateAgentCliEnvValue(
   };
 }
 
+const AMR_PROFILE_AGENT_ID = 'amr';
+const AMR_PROFILE_ENV_KEY = 'OPEN_DESIGN_AMR_PROFILE';
+
+export function reconcileAmrProfileEnv(
+  currentAgentCliEnv: AppConfig['agentCliEnv'] | undefined,
+  nextInitialAgentCliEnv: AppConfig['agentCliEnv'] | undefined,
+): AppConfig['agentCliEnv'] | undefined {
+  const nextAmrProfile = nextInitialAgentCliEnv?.[AMR_PROFILE_AGENT_ID]?.[AMR_PROFILE_ENV_KEY];
+  const currentAmrProfile = currentAgentCliEnv?.[AMR_PROFILE_AGENT_ID]?.[AMR_PROFILE_ENV_KEY];
+  if (currentAmrProfile === nextAmrProfile) {
+    return currentAgentCliEnv;
+  }
+
+  const nextAgentCliEnv = { ...(currentAgentCliEnv ?? {}) };
+  const nextAmrEnv = { ...(nextAgentCliEnv[AMR_PROFILE_AGENT_ID] ?? {}) };
+
+  if (typeof nextAmrProfile === 'string' && nextAmrProfile.length > 0) {
+    nextAmrEnv[AMR_PROFILE_ENV_KEY] = nextAmrProfile;
+  } else {
+    delete nextAmrEnv[AMR_PROFILE_ENV_KEY];
+  }
+
+  if (Object.keys(nextAmrEnv).length > 0) {
+    nextAgentCliEnv[AMR_PROFILE_AGENT_ID] = nextAmrEnv;
+  } else {
+    delete nextAgentCliEnv[AMR_PROFILE_AGENT_ID];
+  }
+
+  return Object.keys(nextAgentCliEnv).length > 0 ? nextAgentCliEnv : {};
+}
+
 export function agentRefreshOptionsForConfig(cfg: AppConfig): AgentRefreshOptions {
   return {
     throwOnError: true,
@@ -1034,15 +1065,19 @@ export function SettingsDialog({
 
   useEffect(() => {
     setCfg((current) => {
-      if (current.agentCliEnv === initial.agentCliEnv) return current;
+      const nextAgentCliEnv = reconcileAmrProfileEnv(current.agentCliEnv, initial.agentCliEnv);
+      if (nextAgentCliEnv === current.agentCliEnv) return current;
       return {
         ...current,
-        agentCliEnv: initial.agentCliEnv,
+        agentCliEnv: nextAgentCliEnv,
       };
     });
     autosaveLastSavedRef.current = {
       ...autosaveLastSavedRef.current,
-      agentCliEnv: initial.agentCliEnv,
+      agentCliEnv: reconcileAmrProfileEnv(
+        autosaveLastSavedRef.current.agentCliEnv,
+        initial.agentCliEnv,
+      ),
     };
   }, [initial.agentCliEnv]);
 

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -84,6 +84,7 @@ import {
 } from '../state/maxTokens';
 import type {
   AgentInfo,
+  AgentModelChoice,
   ApiProtocol,
   ApiProtocolConfig,
   AppConfig,
@@ -841,6 +842,14 @@ export function updateAgentCliEnvValue(
 const AMR_PROFILE_AGENT_ID = 'amr';
 const AMR_PROFILE_ENV_KEY = 'OPEN_DESIGN_AMR_PROFILE';
 
+function sameAgentModelChoice(
+  left: AgentModelChoice | undefined,
+  right: AgentModelChoice | undefined,
+): boolean {
+  return (left?.model ?? null) === (right?.model ?? null)
+    && (left?.reasoning ?? null) === (right?.reasoning ?? null);
+}
+
 export function reconcileAmrProfileEnv(
   currentAgentCliEnv: AppConfig['agentCliEnv'] | undefined,
   nextInitialAgentCliEnv: AppConfig['agentCliEnv'] | undefined,
@@ -867,6 +876,31 @@ export function reconcileAmrProfileEnv(
   }
 
   return Object.keys(nextAgentCliEnv).length > 0 ? nextAgentCliEnv : {};
+}
+
+export function reconcileAmrModelChoice(
+  currentAgentModels: AppConfig['agentModels'] | undefined,
+  previousInitial: AppConfig,
+  nextInitial: AppConfig,
+): AppConfig['agentModels'] | undefined {
+  const previousAmrProfile = previousInitial.agentCliEnv?.[AMR_PROFILE_AGENT_ID]?.[AMR_PROFILE_ENV_KEY];
+  const nextAmrProfile = nextInitial.agentCliEnv?.[AMR_PROFILE_AGENT_ID]?.[AMR_PROFILE_ENV_KEY];
+  if (previousAmrProfile === nextAmrProfile) return currentAgentModels;
+
+  const previousChoice = previousInitial.agentModels?.[AMR_PROFILE_AGENT_ID];
+  const currentChoice = currentAgentModels?.[AMR_PROFILE_AGENT_ID];
+  if (!sameAgentModelChoice(currentChoice, previousChoice)) {
+    return currentAgentModels;
+  }
+
+  const nextChoice = nextInitial.agentModels?.[AMR_PROFILE_AGENT_ID];
+  const nextAgentModels = { ...(currentAgentModels ?? {}) };
+  if (nextChoice) {
+    nextAgentModels[AMR_PROFILE_AGENT_ID] = nextChoice;
+  } else {
+    delete nextAgentModels[AMR_PROFILE_AGENT_ID];
+  }
+  return Object.keys(nextAgentModels).length > 0 ? nextAgentModels : {};
 }
 
 export function agentRefreshOptionsForConfig(cfg: AppConfig): AgentRefreshOptions {
@@ -1045,6 +1079,7 @@ export function SettingsDialog({
   const [pendingMediaProviderEditIds, setPendingMediaProviderEditIds] = useState<
     ReadonlySet<string>
   >(() => new Set());
+  const previousInitialRef = useRef(initial);
   const lastSavedAppearanceRef = useRef({
     theme: initial.theme ?? 'system',
     accentColor: resolveAccentColor(initial.accentColor),
@@ -1064,12 +1099,20 @@ export function SettingsDialog({
   }, [initial.theme, initial.accentColor]);
 
   useEffect(() => {
+    const previousInitial = previousInitialRef.current;
     setCfg((current) => {
       const nextAgentCliEnv = reconcileAmrProfileEnv(current.agentCliEnv, initial.agentCliEnv);
-      if (nextAgentCliEnv === current.agentCliEnv) return current;
+      const nextAgentModels = reconcileAmrModelChoice(current.agentModels, previousInitial, initial);
+      if (
+        nextAgentCliEnv === current.agentCliEnv
+        && nextAgentModels === current.agentModels
+      ) {
+        return current;
+      }
       return {
         ...current,
         agentCliEnv: nextAgentCliEnv,
+        agentModels: nextAgentModels,
       };
     });
     autosaveLastSavedRef.current = {
@@ -1078,8 +1121,14 @@ export function SettingsDialog({
         autosaveLastSavedRef.current.agentCliEnv,
         initial.agentCliEnv,
       ),
+      agentModels: reconcileAmrModelChoice(
+        autosaveLastSavedRef.current.agentModels,
+        previousInitial,
+        initial,
+      ),
     };
-  }, [initial.agentCliEnv]);
+    previousInitialRef.current = initial;
+  }, [initial]);
 
   // Revert the live theme preview to the most recently persisted appearance.
   // That is the initial appearance until autosave succeeds; after autosave,

--- a/apps/web/src/components/workspace/SideChatTab.tsx
+++ b/apps/web/src/components/workspace/SideChatTab.tsx
@@ -132,10 +132,10 @@ export function SideChatTab({
       </div>
       <div className={styles.pane}>
         <ChatPane
-	          messages={controlledChat?.messages ?? chat.messages}
-	          streaming={controlledChat?.streaming ?? chat.streaming}
-	          loading={controlledChat?.loading ?? chat.loading}
-	          sendDisabled={controlledChat?.sendDisabled}
+          messages={controlledChat?.messages ?? chat.messages}
+          streaming={controlledChat?.streaming ?? chat.streaming}
+          loading={controlledChat?.loading ?? chat.loading}
+          sendDisabled={controlledChat?.sendDisabled}
           queuedItems={controlledChat?.queuedItems}
           onRemoveQueuedSend={controlledChat?.onRemoveQueuedSend}
           onUpdateQueuedSend={controlledChat?.onUpdateQueuedSend}
@@ -167,6 +167,7 @@ export function SideChatTab({
           onDeleteConversation={onDeleteConversation}
           onNewConversation={onNewConversation}
           researchAvailable={config.mode === 'daemon'}
+          config={config}
         />
       </div>
     </div>

--- a/apps/web/src/runtime/amr-guidance.ts
+++ b/apps/web/src/runtime/amr-guidance.ts
@@ -8,6 +8,17 @@
 export const AMR_CONSOLE_URL = 'https://open-design.ai/amr/wallet';
 export const AMR_RECHARGE_URL = AMR_CONSOLE_URL;
 
+const AMR_CONSOLE_URL_BY_PROFILE: Record<string, string> = {
+  prod: AMR_CONSOLE_URL,
+  test: 'https://vela.powerformer.net/wallet',
+  local: 'http://localhost:5173/wallet',
+};
+
+export function amrConsoleUrlForProfile(profile: string | null | undefined): string {
+  const normalized = profile?.trim() || 'prod';
+  return AMR_CONSOLE_URL_BY_PROFILE[normalized] ?? AMR_CONSOLE_URL;
+}
+
 // Codes that mean a non-AMR agent hit "the model service rejected or could not
 // serve the run" — auth missing/invalid, quota/rate exhausted, or the upstream
 // model endpoint was unavailable. These are the failures worth promoting AMR

--- a/apps/web/src/runtime/amr-guidance.ts
+++ b/apps/web/src/runtime/amr-guidance.ts
@@ -19,6 +19,12 @@ export function amrConsoleUrlForProfile(profile: string | null | undefined): str
   return AMR_CONSOLE_URL_BY_PROFILE[normalized] ?? AMR_CONSOLE_URL;
 }
 
+export function amrProfileBadgeLabel(profile: string | null | undefined): string | null {
+  if (profile === 'test') return 'TEST';
+  if (profile === 'local') return 'LOCAL';
+  return null;
+}
+
 // Codes that mean a non-AMR agent hit "the model service rejected or could not
 // serve the run" — auth missing/invalid, quota/rate exhausted, or the upstream
 // model endpoint was unavailable. These are the failures worth promoting AMR

--- a/apps/web/src/runtime/amr-guidance.ts
+++ b/apps/web/src/runtime/amr-guidance.ts
@@ -19,6 +19,10 @@ export function amrConsoleUrlForProfile(profile: string | null | undefined): str
   return AMR_CONSOLE_URL_BY_PROFILE[normalized] ?? AMR_CONSOLE_URL;
 }
 
+export function amrRechargeUrlForProfile(profile: string | null | undefined): string {
+  return amrConsoleUrlForProfile(profile);
+}
+
 export function amrProfileBadgeLabel(profile: string | null | undefined): string | null {
   if (profile === 'test') return 'TEST';
   if (profile === 'local') return 'LOCAL';

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1390,11 +1390,20 @@
   padding: 0 14px;
 }
 .agent-card-amr-auth .amr-account-control__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   max-width: 150px;
   overflow: hidden;
   color: var(--text-muted);
   font-size: 11px;
   font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.agent-card-amr-auth .amr-account-control__status-text {
+  min-width: 0;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1443,7 +1452,14 @@
   text-align: left;
 }
 .agent-card-amr-auth .amr-login-pill-badge {
-  display: none;
+  flex: 0 0 auto;
+  padding: 1px 5px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-radius: 999px;
+  color: var(--accent-strong);
+  font-size: 9px;
+  font-weight: 800;
+  line-height: 1.2;
 }
 .agent-model-row-head {
   font-size: 12px;

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -1329,6 +1329,10 @@
 }
 .agent-card-meta .muted { color: var(--text-soft); font-style: italic; }
 .agent-card-amr-email {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
   margin-top: 4px;
   color: var(--text-muted);
   font-size: 11px;
@@ -1339,10 +1343,20 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.agent-card-amr-email span {
+.agent-card-amr-email-text {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.agent-card-amr-profile-badge {
+  flex: 0 0 auto;
+  padding: 1px 5px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-radius: 999px;
+  color: var(--accent-strong);
+  font-size: 9px;
+  font-weight: 800;
+  line-height: 1.2;
 }
 .agent-card-model-summary {
   display: flex;

--- a/apps/web/tests/components/AmrLoginPill.test.tsx
+++ b/apps/web/tests/components/AmrLoginPill.test.tsx
@@ -142,7 +142,7 @@ describe('AmrLoginPill', () => {
     expect(screen.queryByText('LOCAL')).toBeNull();
   });
 
-  it('renders a TEST badge next to the signed-out action for the test profile', async () => {
+  it('does not render a profile badge for a signed-out test profile', async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse({
         body: { loggedIn: false, profile: 'test', user: null, configPath: '/x' },
@@ -152,7 +152,7 @@ describe('AmrLoginPill', () => {
     renderPill();
 
     expect(await screen.findByRole('button', { name: 'Sign in' })).toBeTruthy();
-    expect(screen.getByText('TEST')).toBeTruthy();
+    expect(screen.queryByText('TEST')).toBeNull();
   });
 
   it('renders daemon-reported in-flight login attempts as signing-in', async () => {
@@ -174,7 +174,7 @@ describe('AmrLoginPill', () => {
     expect(screen.queryByRole('button', { name: 'Sign in' })).toBeNull();
   });
 
-  it('renders a LOCAL badge next to the signed-out action for the local profile', async () => {
+  it('does not render a profile badge for a signed-out local profile', async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse({
         body: { loggedIn: false, profile: 'local', user: null, configPath: '/x' },
@@ -184,7 +184,53 @@ describe('AmrLoginPill', () => {
     renderPill();
 
     expect(await screen.findByRole('button', { name: 'Sign in' })).toBeTruthy();
+    expect(screen.queryByText('LOCAL')).toBeNull();
+  });
+
+  it('uses the test-profile AMR console URL for signed-in users', () => {
+    renderAccountControl({
+      status: 'signed-in',
+      email: 'leaf@example.com',
+      profile: 'test',
+      showProfileBadge: true,
+      showConsoleAction: true,
+    });
+
+    expect(screen.getByText('leaf@example.com')).toBeTruthy();
+    expect(screen.getByText('TEST')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'AMR Console' }).getAttribute('href')).toBe(
+      'https://vela.powerformer.net/wallet',
+    );
+  });
+
+  it('uses the local-profile AMR console URL for signed-in users', () => {
+    renderAccountControl({
+      status: 'signed-in',
+      email: 'leaf@example.com',
+      profile: 'local',
+      showProfileBadge: true,
+      showConsoleAction: true,
+    });
+
     expect(screen.getByText('LOCAL')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'AMR Console' }).getAttribute('href')).toBe(
+      'http://localhost:5173/wallet',
+    );
+  });
+
+  it('uses the production AMR console URL by default', () => {
+    renderAccountControl({
+      status: 'signed-in',
+      email: 'leaf@example.com',
+      profile: 'prod',
+      showProfileBadge: true,
+      showConsoleAction: true,
+    });
+
+    expect(screen.queryByText('PROD')).toBeNull();
+    expect(screen.getByRole('link', { name: 'AMR Console' }).getAttribute('href')).toBe(
+      'https://open-design.ai/amr/wallet',
+    );
   });
 
   it('renders a "Signed in" pill (with the Sign-out aria-label) when /status reports a logged-in user', async () => {

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -36,6 +36,9 @@ vi.mock('../../src/components/EntryView', () => ({
       <div data-testid="amr-model">
         {agents.find((agent) => agent.id === 'amr')?.models?.[0]?.id ?? 'none'}
       </div>
+      <div data-testid="config-amr-model">
+        {config.agentModels?.amr?.model ?? 'none'}
+      </div>
       <div data-testid="amr-profile">
         {config.agentCliEnv?.amr?.OPEN_DESIGN_AMR_PROFILE ?? 'none'}
       </div>
@@ -414,6 +417,7 @@ describe('App AMR polling', () => {
   it('refreshes renderer config and clears stale AMR models after a desktop app-config change event', async () => {
     mockedLoadConfig.mockReturnValue({
       ...baseConfig,
+      agentModels: { amr: { model: 'old-remote', reasoning: 'default' } },
       agentCliEnv: {
         amr: { OPEN_DESIGN_AMR_PROFILE: 'prod' },
       },
@@ -463,6 +467,9 @@ describe('App AMR polling', () => {
       expect(screen.getByTestId('amr-model').textContent).toBe('old-remote');
     });
     await waitFor(() => {
+      expect(screen.getByTestId('config-amr-model').textContent).toBe('old-remote');
+    });
+    await waitFor(() => {
       expect(screen.getByTestId('amr-profile').textContent).toBe('prod');
     });
 
@@ -470,6 +477,9 @@ describe('App AMR polling', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('amr-profile').textContent).toBe('local');
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('config-amr-model').textContent).toBe('none');
     });
     await waitFor(() => {
       expect(screen.getByTestId('amr-model').textContent).toBe('local-probe');

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -411,12 +411,18 @@ describe('App AMR polling', () => {
     expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
   });
 
-  it('refreshes renderer config and agents after a desktop app-config change event', async () => {
+  it('refreshes renderer config and clears stale AMR models after a desktop app-config change event', async () => {
     mockedLoadConfig.mockReturnValue({
       ...baseConfig,
       agentCliEnv: {
         amr: { OPEN_DESIGN_AMR_PROFILE: 'prod' },
       },
+    });
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'old-remote', label: 'old-remote' }],
     });
     mockedFetchDaemonConfig
       .mockResolvedValueOnce({})
@@ -429,9 +435,33 @@ describe('App AMR polling', () => {
       ...local,
       agentCliEnv: daemon?.agentCliEnv ?? local.agentCliEnv,
     }));
+    mockedFetchAgentsStream
+      .mockResolvedValueOnce([
+        {
+          id: 'amr',
+          name: 'AMR',
+          bin: 'vela',
+          available: true,
+          version: '1.0.0',
+          models: [],
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'amr',
+          name: 'AMR',
+          bin: 'vela',
+          available: true,
+          version: '1.0.0',
+          models: [{ id: 'local-probe', label: 'local-probe' }],
+        },
+      ]);
 
     render(<App />);
 
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('old-remote');
+    });
     await waitFor(() => {
       expect(screen.getByTestId('amr-profile').textContent).toBe('prod');
     });
@@ -442,7 +472,11 @@ describe('App AMR polling', () => {
       expect(screen.getByTestId('amr-profile').textContent).toBe('local');
     });
     await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('local-probe');
+    });
+    await waitFor(() => {
       expect(mockedFetchAgentsStream).toHaveBeenCalledTimes(2);
     });
+    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -25,14 +25,19 @@ vi.mock('../../src/router', () => ({
 vi.mock('../../src/components/EntryView', () => ({
   EntryView: ({
     agents,
+    config,
     onOpenSettings,
   }: {
     agents: Array<{ id: string; models?: Array<{ id: string }> }>;
+    config: AppConfig;
     onOpenSettings: () => void;
   }) => (
     <>
       <div data-testid="amr-model">
         {agents.find((agent) => agent.id === 'amr')?.models?.[0]?.id ?? 'none'}
+      </div>
+      <div data-testid="amr-profile">
+        {config.agentCliEnv?.amr?.OPEN_DESIGN_AMR_PROFILE ?? 'none'}
       </div>
       <button onClick={() => onOpenSettings()}>open settings</button>
     </>
@@ -404,5 +409,40 @@ describe('App AMR polling', () => {
       expect(screen.getByTestId('amr-model').textContent).toBe('new-probe');
     });
     expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes renderer config and agents after a desktop app-config change event', async () => {
+    mockedLoadConfig.mockReturnValue({
+      ...baseConfig,
+      agentCliEnv: {
+        amr: { OPEN_DESIGN_AMR_PROFILE: 'prod' },
+      },
+    });
+    mockedFetchDaemonConfig
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        agentCliEnv: {
+          amr: { OPEN_DESIGN_AMR_PROFILE: 'local' },
+        },
+      });
+    mockedMergeDaemonConfig.mockImplementation((local, daemon) => ({
+      ...local,
+      agentCliEnv: daemon?.agentCliEnv ?? local.agentCliEnv,
+    }));
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-profile').textContent).toBe('prod');
+    });
+
+    fireEvent(window, new CustomEvent('open-design:app-config-changed'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-profile').textContent).toBe('local');
+    });
+    await waitFor(() => {
+      expect(mockedFetchAgentsStream).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -188,6 +188,16 @@ const baseConfig: AppConfig = {
   agentCliEnv: {},
 };
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('App AMR polling', () => {
   beforeEach(() => {
     mockedDaemonIsLive.mockResolvedValue(true);
@@ -423,11 +433,17 @@ describe('App AMR polling', () => {
       },
     });
     mockedFetchAmrModels.mockReset();
-    mockedFetchAmrModels.mockResolvedValue({
-      source: 'remote',
-      refreshing: false,
-      models: [{ id: 'old-remote', label: 'old-remote' }],
-    });
+    mockedFetchAmrModels
+      .mockResolvedValueOnce({
+        source: 'remote',
+        refreshing: false,
+        models: [{ id: 'old-remote', label: 'old-remote' }],
+      })
+      .mockResolvedValueOnce({
+        source: 'remote',
+        refreshing: false,
+        models: [{ id: 'local-remote', label: 'local-remote' }],
+      });
     mockedFetchDaemonConfig
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({
@@ -482,11 +498,93 @@ describe('App AMR polling', () => {
       expect(screen.getByTestId('config-amr-model').textContent).toBe('none');
     });
     await waitFor(() => {
-      expect(screen.getByTestId('amr-model').textContent).toBe('local-probe');
+      expect(screen.getByTestId('amr-model').textContent).toBe('local-remote');
     });
     await waitFor(() => {
       expect(mockedFetchAgentsStream).toHaveBeenCalledTimes(2);
     });
-    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
+    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores stale in-flight AMR model polls after a desktop app-config change restarts polling', async () => {
+    const oldRemotePoll = deferred<Awaited<ReturnType<typeof fetchAmrModels>>>();
+    const localRemotePoll = deferred<Awaited<ReturnType<typeof fetchAmrModels>>>();
+    mockedLoadConfig.mockReturnValue({
+      ...baseConfig,
+      agentCliEnv: {
+        amr: { OPEN_DESIGN_AMR_PROFILE: 'prod' },
+      },
+    });
+    mockedFetchDaemonConfig
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        agentCliEnv: {
+          amr: { OPEN_DESIGN_AMR_PROFILE: 'local' },
+        },
+      });
+    mockedMergeDaemonConfig.mockImplementation((local, daemon) => ({
+      ...local,
+      agentCliEnv: daemon?.agentCliEnv ?? local.agentCliEnv,
+    }));
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels
+      .mockReturnValueOnce(oldRemotePoll.promise)
+      .mockReturnValueOnce(localRemotePoll.promise);
+    mockedFetchAgentsStream
+      .mockResolvedValueOnce([
+        {
+          id: 'amr',
+          name: 'AMR',
+          bin: 'vela',
+          available: true,
+          version: '1.0.0',
+          models: [],
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'amr',
+          name: 'AMR',
+          bin: 'vela',
+          available: true,
+          version: '1.0.0',
+          models: [{ id: 'local-probe', label: 'local-probe' }],
+        },
+      ]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent(window, new CustomEvent('open-design:app-config-changed'));
+
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+    });
+
+    localRemotePoll.resolve({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'local-remote', label: 'local-remote' }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-profile').textContent).toBe('local');
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('local-remote');
+    });
+
+    oldRemotePoll.resolve({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'old-remote', label: 'old-remote' }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('local-remote');
+    });
   });
 });

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -208,4 +208,35 @@ describe('AvatarMenu', () => {
       within(popover).getByRole('option', { name: /custom-codex-model/i }),
     ).toBeTruthy();
   });
+
+  it('routes the AMR account shortcut through the active AMR profile', () => {
+    renderMenu({
+      config: {
+        ...baseConfig,
+        agentId: 'amr',
+        agentCliEnv: {
+          amr: {
+            OPEN_DESIGN_AMR_PROFILE: 'test',
+          },
+        },
+      },
+      agents: [
+        {
+          id: 'amr',
+          name: 'Open Design AMR',
+          bin: 'vela',
+          available: true,
+          models: [{ id: 'default', label: 'Default (CLI config)' }],
+        },
+      ],
+    });
+
+    openMenu();
+
+    expect(
+      screen
+        .getByRole('link', { name: 'avatar.amrConsoleavatar.amrConsoleMeta' })
+        .getAttribute('href'),
+    ).toBe('https://vela.powerformer.net/wallet');
+  });
 });

--- a/apps/web/tests/components/ChatPane.conversation-title.test.tsx
+++ b/apps/web/tests/components/ChatPane.conversation-title.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatPane } from '../../src/components/ChatPane';
 import { trackRunFailedToastSurfaceView } from '../../src/analytics/events';
-import type { ChatMessage, Conversation } from '../../src/types';
+import type { AppConfig, ChatMessage, Conversation } from '../../src/types';
 
 vi.mock('../../src/i18n', () => ({
   useT: () => (key: string, vars?: Record<string, string | number>) => {
@@ -141,6 +141,46 @@ describe('ChatPane session switcher', () => {
       assistant_message_id: 'msg-amr-balance',
       run_id: 'run-amr-balance',
     });
+  });
+
+  it('opens the profile-scoped wallet from the AMR recharge action', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(
+      <ChatPane
+        messages={[
+          failedAssistantMessage({
+            id: 'msg-amr-balance',
+            runId: 'run-amr-balance',
+            code: 'AMR_INSUFFICIENT_BALANCE',
+            agentId: 'amr',
+          }),
+        ]}
+        streaming={false}
+        error={null}
+        projectId="project-1"
+        projectFiles={[]}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        onRetry={vi.fn()}
+        conversations={[conversation({ id: 'conv-1', title: 'Current' })]}
+        activeConversationId="conv-1"
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+        config={{ agentCliEnv: { amr: { OPEN_DESIGN_AMR_PROFILE: 'test' } } } as unknown as AppConfig}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('chat.amrError.rechargeCta'));
+
+    const [walletUrl, target, features] = openSpy.mock.calls[0] ?? [];
+    expect(target).toBe('_blank');
+    expect(features).toBe('noopener,noreferrer');
+    const parsedWalletUrl = new URL(String(walletUrl));
+    expect(`${parsedWalletUrl.origin}${parsedWalletUrl.pathname}`).toBe(
+      'https://vela.powerformer.net/wallet',
+    );
+    expect(parsedWalletUrl.searchParams.get('od_entry_source')).toBe('chat_error_recharge');
   });
 });
 

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -19,7 +19,7 @@ import {
   writeProjectTextFile,
   fetchProjectFolders,
 } from '../../src/providers/registry';
-import type { ChatMessage, ProjectFile, ProjectFolder } from '../../src/types';
+import type { AppConfig, ChatMessage, ProjectFile, ProjectFolder } from '../../src/types';
 
 vi.mock('../../src/components/AmrGuidance', () => ({
   AmrGuidance: ({
@@ -1301,6 +1301,7 @@ describe('FileWorkspace generation failure recovery', () => {
         isDeck={false}
         tabsState={{ tabs: ['generation'], active: 'generation' }}
         onTabsStateChange={vi.fn()}
+        chatConfig={{ agentCliEnv: { amr: { OPEN_DESIGN_AMR_PROFILE: 'local' } } } as unknown as AppConfig}
         messages={[failedAssistantMessage('AMR_INSUFFICIENT_BALANCE', 'amr', 'AMR balance empty')]}
         onRetry={onRetry}
       />,
@@ -1319,7 +1320,7 @@ describe('FileWorkspace generation failure recovery', () => {
     expect(features).toBe('noopener,noreferrer');
     const parsedWalletUrl = new URL(String(walletUrl));
     expect(`${parsedWalletUrl.origin}${parsedWalletUrl.pathname}`).toBe(
-      'https://open-design.ai/amr/wallet',
+      'http://localhost:5173/wallet',
     );
     expect(parsedWalletUrl.searchParams.get('od_origin')).toBe('open_design');
     expect(parsedWalletUrl.searchParams.get('od_entry_source')).toBe(

--- a/apps/web/tests/components/GenerationPreviewStage.test.tsx
+++ b/apps/web/tests/components/GenerationPreviewStage.test.tsx
@@ -154,6 +154,7 @@ describe('GenerationPreviewStage', () => {
       <GenerationPreviewStage
         model={failedModel('AMR_INSUFFICIENT_BALANCE', 'amr')}
         onRetry={vi.fn()}
+        amrProfile="test"
       />,
     );
     expect(markup).toContain('Account balance ran out');
@@ -161,6 +162,28 @@ describe('GenerationPreviewStage', () => {
     expect(markup).toContain('Top up AMR');
     // secondaryRetry surfaces the plain retry alongside the primary action.
     expect(markup).toContain('data-testid="generation-preview-retry"');
+  });
+
+  it('opens the profile-scoped wallet for the recharge action', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const container = render(failedModel('AMR_INSUFFICIENT_BALANCE', 'amr'), {
+      onRetry: vi.fn(),
+      amrProfile: 'local',
+    });
+    const button = container.querySelector<HTMLButtonElement>(
+      '[data-testid="generation-preview-recharge"]',
+    );
+    expect(button).not.toBeNull();
+    act(() => {
+      button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const [walletUrl, target, features] = openSpy.mock.calls[0] ?? [];
+    expect(target).toBe('_blank');
+    expect(features).toBe('noopener,noreferrer');
+    const parsedWalletUrl = new URL(String(walletUrl));
+    expect(`${parsedWalletUrl.origin}${parsedWalletUrl.pathname}`).toBe(
+      'http://localhost:5173/wallet',
+    );
   });
 
   it('renders the terminal sign-in action for an Antigravity auth failure', () => {

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -3523,7 +3523,11 @@ describe('SettingsDialog appearance interactions', () => {
         agentId: 'amr',
         theme: 'dark',
         agentCliEnv: {
-          amr: { OPEN_DESIGN_AMR_PROFILE: 'prod' },
+          codex: { CODEX_BIN: '/tmp/codex-dev' },
+          amr: {
+            OPEN_DESIGN_AMR_PROFILE: 'prod',
+            AMR_API_BASE_URL: 'https://draft.example.test',
+          },
         },
       },
       { initialSection: 'appearance', agents: [amrAgent, ...availableAgents] },
@@ -3537,7 +3541,10 @@ describe('SettingsDialog appearance interactions', () => {
           agentId: 'amr',
           theme: 'dark',
           agentCliEnv: {
-            amr: { OPEN_DESIGN_AMR_PROFILE: 'local' },
+            amr: {
+              OPEN_DESIGN_AMR_PROFILE: 'local',
+              AMR_API_BASE_URL: 'https://daemon.example.test',
+            },
           },
         }}
         agents={[amrAgent, ...availableAgents]}
@@ -3558,7 +3565,11 @@ describe('SettingsDialog appearance interactions', () => {
       expect.objectContaining({
         theme: 'light',
         agentCliEnv: {
-          amr: { OPEN_DESIGN_AMR_PROFILE: 'local' },
+          codex: { CODEX_BIN: '/tmp/codex-dev' },
+          amr: {
+            OPEN_DESIGN_AMR_PROFILE: 'local',
+            AMR_API_BASE_URL: 'https://draft.example.test',
+          },
         },
       }),
       {},

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -3515,6 +3515,55 @@ describe('SettingsDialog appearance interactions', () => {
     );
   });
 
+  it('reconciles the open settings draft when the parent agent CLI env changes', async () => {
+    const view = renderSettingsDialog(
+      {
+        mode: 'daemon',
+        agentId: 'amr',
+        theme: 'dark',
+        agentCliEnv: {
+          amr: { OPEN_DESIGN_AMR_PROFILE: 'prod' },
+        },
+      },
+      { initialSection: 'appearance' },
+    );
+
+    view.rerender(
+      <SettingsDialog
+        initial={{
+          ...baseConfig,
+          mode: 'daemon',
+          agentId: 'amr',
+          theme: 'dark',
+          agentCliEnv: {
+            amr: { OPEN_DESIGN_AMR_PROFILE: 'local' },
+          },
+        }}
+        agents={availableAgents}
+        daemonLive={true}
+        appVersionInfo={null}
+        initialSection="appearance"
+        onPersist={view.onPersist}
+        onPersistComposioKey={view.onPersistComposioKey}
+        onClose={view.onClose}
+        onRefreshAgents={view.onRefreshAgents}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Light' }));
+
+    await waitForPersist(
+      view.onPersist,
+      expect.objectContaining({
+        theme: 'light',
+        agentCliEnv: {
+          amr: { OPEN_DESIGN_AMR_PROFILE: 'local' },
+        },
+      }),
+      {},
+    );
+  });
+
   it('switches back to the default accent color and persists it explicitly', async () => {
     const { onPersist } = renderSettingsDialog(
       { mode: 'daemon', agentId: 'codex', theme: 'light', accentColor: '#2563eb' },

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -91,6 +91,7 @@ vi.mock('../../src/analytics/provider', () => ({
 
 import { SettingsDialog } from '../../src/components/SettingsDialog';
 import type { AgentRefreshOptions, SettingsSection } from '../../src/components/SettingsDialog';
+import { reconcileAmrModelChoice } from '../../src/components/SettingsDialog';
 import { reconcileAmrProfileEnv } from '../../src/components/SettingsDialog';
 import { I18nProvider } from '../../src/i18n';
 import { LOCALES } from '../../src/i18n/types';
@@ -3522,6 +3523,12 @@ describe('SettingsDialog appearance interactions', () => {
         mode: 'daemon',
         agentId: 'amr',
         theme: 'dark',
+        agentModels: {
+          amr: {
+            model: 'prod-only-model',
+            reasoning: 'default',
+          },
+        },
         agentCliEnv: {
           codex: { CODEX_BIN: '/tmp/codex-dev' },
           amr: {
@@ -3564,6 +3571,7 @@ describe('SettingsDialog appearance interactions', () => {
       view.onPersist,
       expect.objectContaining({
         theme: 'light',
+        agentModels: {},
         agentCliEnv: {
           codex: { CODEX_BIN: '/tmp/codex-dev' },
           amr: {
@@ -3574,6 +3582,42 @@ describe('SettingsDialog appearance interactions', () => {
       }),
       {},
     );
+  });
+
+  it('clears a stale AMR draft model when the external profile changes and the draft still matches the previous config', () => {
+    expect(
+      reconcileAmrModelChoice(
+        {
+          amr: {
+            model: 'prod-only-model',
+            reasoning: 'default',
+          },
+        },
+        {
+          ...baseConfig,
+          agentModels: {
+            amr: {
+              model: 'prod-only-model',
+              reasoning: 'default',
+            },
+          },
+          agentCliEnv: {
+            amr: {
+              OPEN_DESIGN_AMR_PROFILE: 'prod',
+            },
+          },
+        },
+        {
+          ...baseConfig,
+          agentModels: {},
+          agentCliEnv: {
+            amr: {
+              OPEN_DESIGN_AMR_PROFILE: 'local',
+            },
+          },
+        },
+      ),
+    ).toEqual({});
   });
 
   it('preserves unrelated draft env entries when reconciling the AMR profile', () => {

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -91,6 +91,7 @@ vi.mock('../../src/analytics/provider', () => ({
 
 import { SettingsDialog } from '../../src/components/SettingsDialog';
 import type { AgentRefreshOptions, SettingsSection } from '../../src/components/SettingsDialog';
+import { reconcileAmrProfileEnv } from '../../src/components/SettingsDialog';
 import { I18nProvider } from '../../src/i18n';
 import { LOCALES } from '../../src/i18n/types';
 import { MAX_MAX_TOKENS, MIN_MAX_TOKENS } from '../../src/state/maxTokens';
@@ -3525,7 +3526,7 @@ describe('SettingsDialog appearance interactions', () => {
           amr: { OPEN_DESIGN_AMR_PROFILE: 'prod' },
         },
       },
-      { initialSection: 'appearance' },
+      { initialSection: 'appearance', agents: [amrAgent, ...availableAgents] },
     );
 
     view.rerender(
@@ -3539,7 +3540,7 @@ describe('SettingsDialog appearance interactions', () => {
             amr: { OPEN_DESIGN_AMR_PROFILE: 'local' },
           },
         }}
-        agents={availableAgents}
+        agents={[amrAgent, ...availableAgents]}
         daemonLive={true}
         appVersionInfo={null}
         initialSection="appearance"
@@ -3562,6 +3563,32 @@ describe('SettingsDialog appearance interactions', () => {
       }),
       {},
     );
+  });
+
+  it('preserves unrelated draft env entries when reconciling the AMR profile', () => {
+    expect(
+      reconcileAmrProfileEnv(
+        {
+          codex: { CODEX_BIN: '/tmp/codex-dev' },
+          amr: {
+            OPEN_DESIGN_AMR_PROFILE: 'prod',
+            AMR_API_BASE_URL: 'https://draft.example.test',
+          },
+        },
+        {
+          amr: {
+            OPEN_DESIGN_AMR_PROFILE: 'local',
+            AMR_API_BASE_URL: 'https://daemon.example.test',
+          },
+        },
+      ),
+    ).toEqual({
+      codex: { CODEX_BIN: '/tmp/codex-dev' },
+      amr: {
+        OPEN_DESIGN_AMR_PROFILE: 'local',
+        AMR_API_BASE_URL: 'https://draft.example.test',
+      },
+    });
   });
 
   it('switches back to the default accent color and persists it explicitly', async () => {

--- a/apps/web/tests/components/workspace/SideChatTab.test.tsx
+++ b/apps/web/tests/components/workspace/SideChatTab.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SideChatTab } from '../../../src/components/workspace/SideChatTab';
+import type { AppConfig, Conversation } from '../../../src/types';
+
+const chatPaneMock = vi.fn((_: unknown) => <div data-testid="chat-pane" />);
+
+vi.mock('../../../src/i18n', () => ({
+  useT: () => (key: string) => key,
+}));
+
+vi.mock('../../../src/components/Icon', () => ({
+  Icon: () => <span data-testid="icon" />,
+}));
+
+vi.mock('../../../src/components/ChatPane', () => ({
+  ChatPane: (props: unknown) => chatPaneMock(props),
+}));
+
+vi.mock('../../../src/components/workspace/useConversationChat', () => ({
+  useConversationChat: () => ({
+    messages: [],
+    streaming: false,
+    loading: false,
+    error: null,
+    onSend: vi.fn(),
+    onStop: vi.fn(),
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  chatPaneMock.mockClear();
+});
+
+describe('SideChatTab', () => {
+  it('passes the live config through to ChatPane', () => {
+    const config = {
+      mode: 'daemon',
+      agentCliEnv: {
+        amr: { OPEN_DESIGN_AMR_PROFILE: 'test' },
+      },
+    } as unknown as AppConfig;
+    const conversations = [
+      {
+        id: 'conv-1',
+        title: 'Current',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        projectId: 'project-1',
+        messageCount: 0,
+        sessionMode: 'design',
+      },
+    ] as unknown as Conversation[];
+
+    render(
+      <SideChatTab
+        projectId="project-1"
+        conversationId="conv-1"
+        config={config}
+        agentsById={new Map()}
+        locale="en"
+        projectFiles={[]}
+        conversations={conversations}
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+      />,
+    );
+
+    expect(chatPaneMock).toHaveBeenCalled();
+    const firstCall = chatPaneMock.mock.calls[0];
+    expect(firstCall?.[0]).toEqual(
+      expect.objectContaining({
+        config,
+      }),
+    );
+  });
+});

--- a/apps/web/tests/runtime/amr-guidance.test.ts
+++ b/apps/web/tests/runtime/amr-guidance.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { resolveRunFailureUi } from '../../src/runtime/amr-guidance';
+import { amrRechargeUrlForProfile, resolveRunFailureUi } from '../../src/runtime/amr-guidance';
+
+describe('amrRechargeUrlForProfile', () => {
+  it('matches the selected AMR profile wallet origin', () => {
+    expect(amrRechargeUrlForProfile('prod')).toBe('https://open-design.ai/amr/wallet');
+    expect(amrRechargeUrlForProfile('test')).toBe('https://vela.powerformer.net/wallet');
+    expect(amrRechargeUrlForProfile('local')).toBe('http://localhost:5173/wallet');
+    expect(amrRechargeUrlForProfile(' unknown ')).toBe('https://open-design.ai/amr/wallet');
+  });
+});
 
 describe('resolveRunFailureUi', () => {
   it('promotes AMR (switch card) for non-AMR model/auth/quota errors', () => {

--- a/apps/web/tests/styles/amr-account-control.test.ts
+++ b/apps/web/tests/styles/amr-account-control.test.ts
@@ -19,11 +19,11 @@ function cssDeclarations(selector: string): string {
 }
 
 describe('AMR account control workspace styles', () => {
-  it('keeps settings startup errors visible while hiding profile badges', () => {
+  it('keeps settings startup errors and AMR profile badges visible', () => {
     const errorBlock = cssDeclarations('.agent-card-amr-auth .amr-account-control__error');
     const badgeBlock = cssDeclarations('.agent-card-amr-auth .amr-login-pill-badge');
 
     expect(errorBlock).not.toMatch(/(?:^|[;\n])\s*display:\s*none\s*;/);
-    expect(badgeBlock).toMatch(/(?:^|[;\n])\s*display:\s*none\s*;/);
+    expect(badgeBlock).not.toMatch(/(?:^|[;\n])\s*display:\s*none\s*;/);
   });
 });

--- a/specs/change/20260608-hidden-packaged-amr-profile-menu/spec.md
+++ b/specs/change/20260608-hidden-packaged-amr-profile-menu/spec.md
@@ -1,7 +1,7 @@
 ---
 id: 20260608-hidden-packaged-amr-profile-menu
 name: Hidden Packaged Amr Profile Menu
-status: planned
+status: implemented
 created: '2026-06-08'
 ---
 
@@ -422,15 +422,50 @@ Depends on: Step 1, Step 2, Step 3
 
 ### Progress
 
-- [ ] Step 1: Hidden Desktop Menu
-- [ ] Step 2: Profile Config Writes
-- [ ] Step 3: AMR Model Cache Isolation
-- [ ] Step 4: Validation Pass
+- [x] Step 1: Hidden Desktop Menu
+- [x] Step 2: Profile Config Writes
+- [x] Step 3: AMR Model Cache Isolation
+- [x] Step 4: Validation Pass
 
 ### Implementation
 
-<!-- Files created/modified, decisions made during coding, deviations from design -->
+- `apps/desktop/src/main/index.ts`
+  - Added a process-local hidden `Develop` menu toggled by
+    `Command+Option+Shift+D` on macOS and `Control+Alt+Shift+D` elsewhere.
+  - Added `Develop -> AMR Environment Profile -> prod/test/local` radio menu
+    items.
+  - Reads current profile from `/api/app-config` before showing the menu.
+  - Writes selected profile by merging
+    `agentCliEnv.amr.OPEN_DESIGN_AMR_PROFILE`, preserving other app config and
+    AMR env overrides.
+  - Surfaces daemon URL, read, write, invalid response, and shortcut
+    registration failures through native error dialogs.
+- `apps/desktop/tests/main/amr-environment-profile-menu.test.ts`
+  - Added focused helper coverage for profile normalization, config merge
+    preservation, missing env creation, and menu radio structure.
+- `apps/daemon/src/runtimes/models.ts`
+  - Added optional remembered live-model cache scope while preserving existing
+    agent-only behavior when no scope is supplied.
+- `apps/daemon/src/server.ts`
+  - Scoped AMR remembered live-model reads/writes by resolved AMR Environment
+    Profile during AMR run preflight.
+- `apps/daemon/tests/runtimes/resolve-model.test.ts`
+  - Added AMR profile-scoped remembered model isolation coverage.
 
 ### Verification
 
-<!-- How the feature was verified: tests written, manual testing steps, results -->
+- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/resolve-model.test.ts`
+  from `apps/daemon`: passed.
+- `pnpm exec vitest run -c vitest.config.ts tests/main/amr-environment-profile-menu.test.ts`
+  from `apps/desktop`: passed.
+- `pnpm --filter @open-design/daemon typecheck`: passed.
+- `pnpm --filter @open-design/desktop typecheck`: passed.
+- `pnpm typecheck`: passed.
+- `pnpm guard`: failed on the pre-existing `tools/pr/` top-level tools
+  allowlist violation. The initial sandbox run also failed before checks with
+  `listen EPERM` from `tsx`; the elevated rerun reached repository checks and
+  failed only on `tools/pr/`.
+- An accidental broad `pnpm --filter @open-design/daemon test --
+  tests/runtimes/resolve-model.test.ts` run invoked the wider daemon suite and
+  reported unrelated existing failures/timeouts; focused daemon coverage above
+  passed with the direct Vitest command.

--- a/specs/change/20260608-hidden-packaged-amr-profile-menu/spec.md
+++ b/specs/change/20260608-hidden-packaged-amr-profile-menu/spec.md
@@ -259,7 +259,7 @@ or the Vela / AMR CLI binary.
 - Selecting `prod` writes `OPEN_DESIGN_AMR_PROFILE: "prod"` explicitly instead
   of deleting the key.
 - The menu validates choices against `prod | test | local` before writing.
-- Menu structure is `Develop` -> `AMR Environment Profile` -> `prod`, `test`,
+- Menu structure is `Develop` -> `AMR Profile` -> `prod`, `test`,
   `local`.
 - This spec does not add updater, diagnostics, DevTools, feature flags, or
   other testing actions to `Develop`.
@@ -432,7 +432,7 @@ Depends on: Step 1, Step 2, Step 3
 - `apps/desktop/src/main/index.ts`
   - Added a process-local hidden `Develop` menu toggled by
     `Command+Option+Shift+D` on macOS and `Control+Alt+Shift+D` elsewhere.
-  - Added `Develop -> AMR Environment Profile -> prod/test/local` radio menu
+  - Added `Develop -> AMR Profile -> prod/test/local` radio menu
     items.
   - Reads current profile from `/api/app-config` before showing the menu.
   - Writes selected profile by merging

--- a/specs/change/20260608-hidden-packaged-amr-profile-menu/spec.md
+++ b/specs/change/20260608-hidden-packaged-amr-profile-menu/spec.md
@@ -1,0 +1,436 @@
+---
+id: 20260608-hidden-packaged-amr-profile-menu
+name: Hidden Packaged Amr Profile Menu
+status: planned
+created: '2026-06-08'
+---
+
+## Overview
+
+### Problem Statement
+
+Packaged Open Design needs a hidden desktop Develop menu for AMR testing.
+Testers should be able to switch the packaged runtime's AMR Environment
+Profile among `local`, `test`, and `prod` while reusing the same bundled Vela
+/ AMR CLI binary.
+
+### Goals
+
+- Add a hidden desktop Develop menu toggle for packaged testing.
+- Let the menu switch the AMR Environment Profile among `local`, `test`, and
+  `prod`.
+- Persist the selected profile through the existing app config path.
+- Preserve the bundled Vela / AMR CLI binary and other AMR env overrides.
+- Make failure visible when the menu cannot read or write configuration.
+
+### Non-Goals
+
+- Do not change the AMR CLI binary selection model.
+- Do not redefine Open Design release channels as AMR environments.
+- Do not change AMR account login semantics.
+- Do not add mock or placeholder profile behavior.
+
+### Success Criteria
+
+- A packaged desktop tester can reveal a hidden Develop menu and choose one of
+  `local`, `test`, or `prod`.
+- The selected profile is persisted in app config without deleting unrelated
+  `agentCliEnv` settings.
+- New AMR operations use the selected AMR Environment Profile.
+- The menu reports read/write failures instead of pretending the switch
+  succeeded.
+
+## Research
+
+### Existing System
+
+- The glossary defines **AMR Environment Profile** as the target AMR service
+  environment a packaged runtime is configured to use, and separates it from
+  release channel, account status, and app identity. Source:
+  `CONTEXT.md:75-77`.
+- The glossary states that AMR Environment Profile is independent from Open
+  Design release channel identity. Source: `CONTEXT.md:93-97`.
+- Desktop main already has a centralized native menu builder in
+  `installDesktopMenu`, with App/File, Edit, View, Window, and Help menus.
+  Source: `apps/desktop/src/main/index.ts:185-291`.
+- The View menu already exposes Electron's `toggleDevTools`; no separate
+  Develop menu exists in the current native template. Source:
+  `apps/desktop/src/main/index.ts:233-245`.
+- Packaged desktop passes a real daemon HTTP URL to desktop main through
+  `discoverDaemonUrl`; comments state Node-side fetch must target the daemon
+  sidecar HTTP URL, not the `od://app/` renderer URL. Source:
+  `apps/packaged/src/index.ts:148-156`.
+- `DesktopMainOptions` already models `discoverDaemonUrl` for packaged
+  main-process API calls. Source: `apps/desktop/src/main/index.ts:105-117`.
+- The daemon exposes `GET /api/app-config` and `PUT /api/app-config`, both
+  guarded by same-origin/local validation. Source:
+  `apps/daemon/src/server.ts:10193-10214`.
+- App config writes are serialized per data directory to avoid losing
+  concurrent read-modify-write updates. Source:
+  `apps/daemon/src/app-config.ts:528-535`.
+- `agentCliEnv` is the shared app-config shape for per-agent environment
+  settings. Source: `packages/contracts/src/api/app-config.ts:6,28-32`.
+- The app-config env allowlist permits AMR keys including
+  `OPEN_DESIGN_AMR_PROFILE` and other AMR overrides such as `VELA_BIN`,
+  `VELA_LINK_URL`, `VELA_RUNTIME_KEY`, and `VELA_OPENCODE_BIN`. Source:
+  `apps/daemon/src/app-config.ts:157-165`.
+- Packaged launch configuration already accepts AMR profile values
+  `prod | test | local`. Source: `apps/packaged/src/config.ts:21-22`.
+- Packaged config validation rejects unsupported packaged AMR profile values.
+  Source: `apps/packaged/src/config.ts:118-122`.
+- Packaged daemon spawn env forwards a baked packaged `amrProfile` as
+  `OPEN_DESIGN_AMR_PROFILE` when present. Source:
+  `apps/packaged/src/sidecars.ts:320-327`.
+- Runtime AMR profile resolution defaults to `prod`; allowed runtime values
+  are `prod`, `test`, and `local`; invalid values warn and fall back to
+  `prod`. Source: `apps/daemon/src/integrations/vela-profile.ts:1-16`.
+- AMR runtime env assembly maps `OPEN_DESIGN_AMR_PROFILE` into
+  Vela-facing profile env for AMR runs. Source:
+  `apps/daemon/src/runtimes/env.ts:88-98`.
+- The AMR model endpoint resolves its probe by reading app config inside the
+  request path, then builds a cache key that includes
+  `OPEN_DESIGN_AMR_PROFILE`, `VELA_PROFILE`, credentials, and launch path.
+  Source: `apps/daemon/src/server.ts:6454-6494`.
+- AMR status, login, and logout routes each read app config inside the route
+  handler before resolving AMR env. Source:
+  `apps/daemon/src/server.ts:6501-6527,6575-6591`.
+- New chat runs read app config before resolving the selected agent launch
+  env, then use that env for AMR model preflight and child process spawn.
+  Source: `apps/daemon/src/server.ts:11909-11963,12387-12398`.
+- AMR login status and logout resolve the active AMR profile from the merged
+  env supplied to the function. Source:
+  `apps/daemon/src/integrations/vela.ts:190-205,244-255`.
+- AMR model loading cache is keyed by caller-provided `cacheKey`; it keeps a
+  separate state per key. Source:
+  `apps/daemon/src/runtimes/amr-model-cache.ts:26-57,64-73`.
+- The generic remembered live-model cache is keyed only by `agentId`, not by
+  AMR Environment Profile. Source: `apps/daemon/src/runtimes/models.ts:8-30`.
+
+### Design Inputs
+
+- Handoff conclusion says no AMR runtime core change appears necessary; the
+  menu can override AMR profile through app config using
+  `agentCliEnv.amr.OPEN_DESIGN_AMR_PROFILE`. Source:
+  `/private/tmp/open-design-amr-profile-packaged-handoff.md`.
+- Handoff recommends desktop menu changes call daemon `GET /api/app-config`,
+  merge `agentCliEnv.amr.OPEN_DESIGN_AMR_PROFILE`, and then call
+  `PUT /api/app-config`; it explicitly recommends not writing
+  `app-config.json` directly from Electron main. Source:
+  `/private/tmp/open-design-amr-profile-packaged-handoff.md`.
+- Handoff notes `od config set agentCliEnv` replaces the whole top-level
+  `agentCliEnv` object, so callers must merge existing `agentCliEnv` before
+  writing. Source:
+  `/private/tmp/open-design-amr-profile-packaged-handoff.md`.
+
+### Constraints & Dependencies
+
+- The root repo guide requires reading module-level `AGENTS.md` files and
+  keeping packaged runtime paths namespace-scoped and independent from ports.
+  Source: `AGENTS.md` "Directory guide"; `apps/AGENTS.md` "Packaged runtime";
+  `apps/packaged/AGENTS.md` "Rules".
+- The repository values fast failure: required failed subprocesses, failed
+  network calls, and violated invariants should surface as clear errors rather
+  than fallback behavior. Source: `AGENTS.md` "Let It Crash / Fast Fail".
+- Regular validation before marking work ready includes at least
+  `pnpm guard`, `pnpm typecheck`, and package-scoped tests/builds matching
+  touched files. Source: `AGENTS.md` "Validation strategy".
+
+### Key References
+
+- `CONTEXT.md`
+- `/private/tmp/open-design-amr-profile-packaged-handoff.md`
+- `apps/desktop/src/main/index.ts`
+- `apps/packaged/src/index.ts`
+- `apps/packaged/src/config.ts`
+- `apps/packaged/src/sidecars.ts`
+- `apps/daemon/src/app-config.ts`
+- `apps/daemon/src/server.ts`
+- `apps/daemon/src/integrations/vela-profile.ts`
+- `apps/daemon/src/runtimes/env.ts`
+- `packages/contracts/src/api/app-config.ts`
+
+## Design
+
+### Design Summary
+
+Add the AMR Environment Profile switcher as a shared desktop main-process
+Develop menu capability. The menu is hidden by default and can be toggled by a
+desktop keyboard shortcut in both tools-dev and packaged desktop runs. The
+shared path keeps development and packaged testing on the same implementation
+surface instead of adding a packaged-only branch.
+
+The menu persists the selected profile through the daemon app-config API by
+merging `agentCliEnv.amr.OPEN_DESIGN_AMR_PROFILE` into the existing config.
+It does not change release channel identity, app identity, AMR account status,
+or the Vela / AMR CLI binary.
+
+### Design Decisions
+
+- Decision: Implement the hidden Develop menu as a shared desktop capability,
+  enabled in both tools-dev and packaged desktop runs, rather than a
+  packaged-only branch. Desktop main already centralizes native menu
+  construction, and packaged desktop already delegates host behavior to
+  `apps/desktop`; keeping one path reduces conditional behavior while allowing
+  development runs to test the feature directly. Source:
+  `apps/desktop/src/main/index.ts:185-291`;
+  `apps/packaged/AGENTS.md` "Owns"; `apps/AGENTS.md` "Active apps".
+- Decision: The menu changes only the **AMR Environment Profile**, not Open
+  Design release channel identity, app identity, AMR account status, or CLI
+  binary selection. Source: `CONTEXT.md:75-77,93-97`;
+  `apps/daemon/src/app-config.ts:157-165`.
+- Decision: The Develop menu visibility is process-local and resets to hidden
+  on desktop restart. The shortcut toggles only the current Electron process's
+  native menu template, keeping the entry as a temporary test surface rather
+  than a persisted user preference. Source:
+  `apps/desktop/src/main/index.ts:185-291`.
+- Decision: The reveal shortcut is `Cmd+Opt+Shift+D` on macOS. Source: user
+  decision, 2026-06-08.
+- Decision: Switching the AMR Environment Profile must not automatically
+  restart desktop or daemon, and normal use should not require a manual
+  restart. AMR status, login, logout, model loading, and new chat runs already
+  re-read app config in their request/run paths, and the AMR model loading
+  cache is profile-sensitive through its cache key. Source:
+  `apps/daemon/src/server.ts:6454-6494,6501-6527,6575-6591,11909-11963,12387-12398`;
+  `apps/daemon/src/runtimes/amr-model-cache.ts:26-57,64-73`.
+- Decision: Do not use restart as the fix for stale AMR model state. Add AMR
+  Environment Profile into the remembered live-model cache key, because the
+  current generic remembered model list is keyed only by `agentId`. Source:
+  `apps/daemon/src/runtimes/models.ts:8-30`;
+  `apps/daemon/src/server.ts:11973-12031`.
+- Decision: Successful profile switches should update native menu checked
+  state without a success dialog; failures should show a native error dialog.
+  The feature lives in Electron main's native menu surface, so success feedback
+  should stay in that surface and failures should remain visible. Source:
+  `apps/desktop/src/main/index.ts:185-291`; `AGENTS.md`
+  "Let It Crash / Fast Fail".
+- Decision: Treat daemon app config as the source of truth for the currently
+  selected AMR Environment Profile whenever the hidden Develop menu is shown or
+  rebuilt. Desktop memory is only a last-known UI state after successful reads
+  or writes. Source: `apps/daemon/src/server.ts:10193-10214`;
+  `apps/daemon/src/integrations/vela-profile.ts:1-16`.
+- Decision: Profile writes must be minimal merge updates that preserve the
+  rest of `agentCliEnv`. `agentCliEnv` stores all per-agent environment
+  settings, and AMR currently has other allowed keys that must survive a
+  profile switch. Source: `packages/contracts/src/api/app-config.ts:6,28-32`;
+  `apps/daemon/src/app-config.ts:157-165`;
+  `/private/tmp/open-design-amr-profile-packaged-handoff.md`.
+- Decision: The menu exposes only the explicit profiles `prod`, `test`, and
+  `local`; it does not expose a separate clear/default action. Runtime default
+  semantics already treat a missing profile as `prod`, and a hidden testing
+  menu benefits from an explicit selected value. Source:
+  `apps/daemon/src/integrations/vela-profile.ts:1-16`.
+- Decision: Name the hidden top-level menu `Develop`, but keep the first
+  version scoped to AMR Environment Profile switching only. Desktop already has
+  normal View and Help items for DevTools and diagnostics, so this change should
+  not become a general developer-tools menu. Source:
+  `apps/desktop/src/main/index.ts:233-287`.
+
+### Derived Rules
+
+- The hidden menu starts absent from the native menu template.
+- Pressing `Cmd+Opt+Shift+D` toggles the Develop menu visible/hidden for the
+  current desktop process.
+- The toggle state is not stored in `app-config.json`, packaged config, or
+  another preferences file.
+- On non-macOS platforms, use the Electron accelerator equivalent
+  `Ctrl+Alt+Shift+D` unless the platform prevents registering it.
+- After a successful profile switch, in-flight AMR runs or an already-running
+  `vela login` process are not migrated; the new profile applies to subsequent
+  AMR operations.
+- Manual restart is only an operator workaround for unrelated stuck state, not
+  part of the intended profile-switch workflow.
+- AMR remembered model state must be isolated by AMR Environment Profile; other
+  agents can keep their current agent-only cache behavior.
+- Profile choices are radio-style menu items for `local`, `test`, and `prod`.
+- After a successful switch, rebuild the menu so the selected profile is
+  checked.
+- On read/write failure, show a native error dialog and leave the last known
+  checked state unchanged.
+- Showing the Develop menu first reads `GET /api/app-config`; if the read
+  fails, show a native error dialog and keep the menu hidden.
+- Missing `agentCliEnv.amr.OPEN_DESIGN_AMR_PROFILE` displays as `prod`, matching
+  AMR runtime default semantics.
+- Writing a selected profile performs `GET /api/app-config`, merges
+  `agentCliEnv.amr.OPEN_DESIGN_AMR_PROFILE`, then sends `PUT /api/app-config`.
+- The write must preserve other AMR env keys, other agent env entries, and
+  unrelated app-config fields.
+- The menu implementation does not use a replace-whole-object config command
+  path for `agentCliEnv`.
+- Selecting `prod` writes `OPEN_DESIGN_AMR_PROFILE: "prod"` explicitly instead
+  of deleting the key.
+- The menu validates choices against `prod | test | local` before writing.
+- Menu structure is `Develop` -> `AMR Environment Profile` -> `prod`, `test`,
+  `local`.
+- This spec does not add updater, diagnostics, DevTools, feature flags, or
+  other testing actions to `Develop`.
+- This hidden native desktop testing affordance does not add a new web UI or
+  CLI surface.
+
+### System Structure
+
+- `apps/desktop/src/main/index.ts`
+  - owns the hidden menu state, shortcut registration, native menu rebuild, and
+    dialog errors.
+  - reads and writes app config through the daemon URL supplied by
+    `discoverDaemonUrl`, or the web/dev URL fallback where appropriate.
+- `apps/daemon/src/runtimes/models.ts`
+  - extends remembered live-model cache helpers to support an optional cache
+    scope for AMR Environment Profile while preserving current agent-only
+    behavior for non-AMR runtimes.
+- `apps/daemon/src/server.ts`
+  - passes AMR profile-aware cache scope when remembering or reading AMR live
+    model lists during run preflight.
+- Tests cover menu construction/toggle behavior, config merge behavior, and
+  AMR remembered model isolation by profile.
+
+### System Procedure
+
+```mermaid
+sequenceDiagram
+  participant Tester
+  participant Desktop as Electron desktop main
+  participant Daemon as Daemon app-config API
+  participant AMR as Later AMR operation
+
+  Tester->>Desktop: Cmd+Opt+Shift+D
+  Desktop->>Daemon: GET /api/app-config
+  alt config read succeeds
+    Daemon-->>Desktop: config
+    Desktop->>Desktop: show Develop menu with checked profile
+  else config read fails
+    Daemon-->>Desktop: error
+    Desktop->>Tester: native error dialog
+  end
+
+  Tester->>Desktop: select test/local/prod
+  Desktop->>Daemon: GET /api/app-config
+  Desktop->>Daemon: PUT merged agentCliEnv.amr.OPEN_DESIGN_AMR_PROFILE
+  alt write succeeds
+    Daemon-->>Desktop: merged config
+    Desktop->>Desktop: rebuild checked radio state
+  else write fails
+    Daemon-->>Desktop: error
+    Desktop->>Tester: native error dialog
+  end
+
+  Tester->>AMR: start later AMR status/login/models/run
+  AMR->>Daemon: existing AMR API/run path
+  Daemon->>Daemon: read app-config and build AMR env
+```
+
+### Interfaces / APIs
+
+- Existing daemon API only:
+  - `GET /api/app-config`
+  - `PUT /api/app-config`
+- Native menu labels:
+  - `Develop`
+  - `AMR Environment Profile`
+  - `prod`
+  - `test`
+  - `local`
+- Accelerators:
+  - macOS: `Command+Option+Shift+D`
+  - non-macOS: `Control+Alt+Shift+D`
+
+### Change Scope
+
+Impact Areas:
+
+- Desktop native menu behavior changes, but only behind a hidden shortcut.
+- Daemon runtime model-memory behavior changes for AMR profile isolation.
+- No database/schema changes.
+- No web UI, CLI command, route, contract, release-channel, or packaged
+  identity change.
+- No new i18n keys; native hidden testing menu labels can remain hardcoded.
+
+Planned File Changes:
+
+- `apps/desktop/src/main/index.ts`: add hidden Develop menu toggle, AMR profile
+  menu construction, app-config read/write helpers, and failure dialogs.
+- `apps/desktop/tests/main/*`: add or extend main-process tests for hidden menu
+  behavior and app-config merge preservation.
+- `apps/daemon/src/runtimes/models.ts`: add scoped remembered model cache keys.
+- `apps/daemon/src/server.ts`: use AMR profile-aware remembered model scope in
+  AMR run preflight.
+- `apps/daemon/tests/*`: add focused coverage for AMR remembered model
+  isolation by profile.
+
+### Edge Cases
+
+- Missing configured profile displays and writes as explicit `prod`.
+- Invalid profile values in app config display as `prod` to match runtime
+  default behavior, but the menu only writes valid `prod | test | local`.
+- Daemon URL unavailable, config read failure, and config write failure all
+  surface through native error dialogs.
+- Concurrent app-config changes are preserved by reading fresh config before
+  each write and letting daemon serialized writes handle overlap.
+- In-flight AMR runs and active `vela login` children keep their original env.
+- Stale remembered AMR model lists must not leak across profiles.
+
+### Verification Strategy
+
+- Run focused desktop main-process tests for menu toggle and config merge
+  behavior.
+- Run focused daemon tests for profile-scoped remembered model cache behavior.
+- Run package typechecks for touched desktop and daemon packages.
+- Before ready-for-PR, run repository baseline validation required by root
+  guidance: `pnpm guard` and `pnpm typecheck`.
+
+## Plan
+
+### Step 1: Hidden Desktop Menu
+
+Type: AFK
+Goal: Add the shared hidden Develop menu with process-local shortcut toggle and
+native error handling.
+Scope: Update desktop main menu construction, register the accelerator, read
+current profile from app config when revealing the menu, and add focused
+desktop tests for hidden/visible menu state and failed reads.
+Depends on: None
+
+### Step 2: Profile Config Writes
+
+Type: AFK
+Goal: Persist profile selections through a minimal app-config merge.
+Scope: Add desktop helper logic for read-merge-write profile updates, preserve
+other `agentCliEnv` entries, update checked radio state on success, and test
+merge preservation and write failure behavior.
+Depends on: Step 1
+
+### Step 3: AMR Model Cache Isolation
+
+Type: AFK
+Goal: Prevent stale remembered AMR model lists from leaking across AMR
+Environment Profiles.
+Scope: Extend remembered model cache helpers with an optional profile-aware
+scope, wire AMR run preflight to use the selected profile, preserve non-AMR
+agent-only behavior, and add daemon tests.
+Depends on: None
+
+### Step 4: Validation Pass
+
+Type: AFK
+Goal: Verify the complete change against focused tests and repo-level checks.
+Scope: Run focused desktop and daemon tests, package typechecks for touched
+packages, then `pnpm guard` and `pnpm typecheck`.
+Depends on: Step 1, Step 2, Step 3
+
+## Notes
+
+<!-- Optional sections — add what's relevant. -->
+
+### Progress
+
+- [ ] Step 1: Hidden Desktop Menu
+- [ ] Step 2: Profile Config Writes
+- [ ] Step 3: AMR Model Cache Isolation
+- [ ] Step 4: Validation Pass
+
+### Implementation
+
+<!-- Files created/modified, decisions made during coding, deviations from design -->
+
+### Verification
+
+<!-- How the feature was verified: tests written, manual testing steps, results -->


### PR DESCRIPTION
## Why

Packaged Open Design needs a hidden native testing affordance so testers can switch the AMR Environment Profile between `prod`, `test`, and `local` without changing the bundled Vela/AMR binary or release-channel identity.

This addresses packaged AMR validation pain: profile selection needs to persist through app config, preserve existing AMR env overrides, and fail visibly when the daemon config API cannot be read or written.

## What users will see

Testers can press `Command+Option+Shift+D` on macOS, or `Control+Alt+Shift+D` elsewhere, to reveal a hidden desktop `Develop` menu. The menu contains `AMR Profile` radio options for `prod`, `test`, and `local`. Selecting a profile updates app config for subsequent AMR operations. Failed reads/writes show a native error dialog.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [x] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a hidden native Electron menu behind a keyboard shortcut, and the implementation is covered with focused menu-template tests rather than a desktop screenshot harness in this turn.

## Bug fix verification

-

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/resolve-model.test.ts` from `apps/daemon` — passed
- `pnpm exec vitest run -c vitest.config.ts tests/main/amr-environment-profile-menu.test.ts` from `apps/desktop` — passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm --filter @open-design/desktop typecheck` — passed
- `pnpm typecheck` — passed
- `git diff --check` — passed
- `pnpm guard` — failed on the existing `tools/pr/` top-level tools allowlist violation. Initial sandbox run also failed before checks with `tsx` `listen EPERM`; elevated rerun reached repository checks and failed only on `tools/pr/`.

Additional note: an accidental broad `pnpm --filter @open-design/daemon test -- tests/runtimes/resolve-model.test.ts` invocation ran the wider daemon suite, reported unrelated failures/timeouts, and was terminated with `SIGTERM`. The direct focused Vitest command above passed.