### PR TITLE
Fix staged attachment e2e selectors

### DIFF
--- a/e2e/ui/app-restoration.test.ts
+++ b/e2e/ui/app-restoration.test.ts
@@ -18,6 +18,12 @@ function artifactPreviewFrame(page: Page) {
   return page.frameLocator(ACTIVE_ARTIFACT_PREVIEW_SELECTOR);
 }
 
+function stagedAttachmentName(page: Page, name: string): Locator {
+  return page
+    .locator('[data-testid="staged-attachments"], [data-testid="staged-contexts"]')
+    .getByText(name, { exact: true });
+}
+
 test.beforeEach(async ({ page }) => {
   await page.addInitScript((key) => {
     window.localStorage.setItem(
@@ -804,14 +810,14 @@ test('[P0] switching between conversations keeps staged attachments UI available
     buffer: Buffer.from('First conversation staged attachment.\n', 'utf8'),
   });
   await expect((await firstUploadResponse).ok()).toBeTruthy();
-  await expect(page.getByTestId('staged-attachments')).toContainText('first-draft-attachment.txt');
+  await expect(stagedAttachmentName(page, 'first-draft-attachment.txt')).toBeVisible();
 
   await startNewConversation(page);
   await expect(page.getByTestId('chat-composer-input')).toBeVisible();
   await expect(page.getByTestId('chat-composer-input')).toHaveText('');
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
-  await expect(page.getByTestId('staged-attachments')).toHaveCount(0);
+  await expect(stagedAttachmentName(page, 'first-draft-attachment.txt')).toHaveCount(0);
 
   const secondUploadResponse = page.waitForResponse(
     (resp: Response) => resp.url().includes('/upload') && resp.request().method() === 'POST',
@@ -823,7 +829,7 @@ test('[P0] switching between conversations keeps staged attachments UI available
     buffer: Buffer.from('Second conversation staged attachment.\n', 'utf8'),
   });
   await expect((await secondUploadResponse).ok()).toBeTruthy();
-  await expect(page.getByTestId('staged-attachments')).toContainText('second-draft-attachment.txt');
+  await expect(stagedAttachmentName(page, 'second-draft-attachment.txt')).toBeVisible();
 
   await page.getByTestId('conversation-history-trigger').click();
   const historyList = page.getByTestId('conversation-list');
@@ -929,7 +935,7 @@ test('[P0] reloading an older conversation route keeps the composer available af
     buffer: Buffer.from('Attachment that should survive a reload.\n', 'utf8'),
   });
   await expect((await uploadResponse).ok()).toBeTruthy();
-  await expect(page.getByTestId('staged-attachments')).toContainText('reload-staged-attachment.txt');
+  await expect(stagedAttachmentName(page, 'reload-staged-attachment.txt')).toBeVisible();
 
   await page.reload();
   await expect(page.getByTestId('chat-composer')).toBeVisible();
@@ -2914,8 +2920,7 @@ async function runFileMentionFlow(
   await expect(page.getByTestId('mention-popover')).toBeVisible();
   await page.getByTestId('mention-popover').getByRole('button', { name: /reference\.txt/i }).click();
   await expect(page.getByTestId('chat-composer-input')).toHaveText('Review @reference.txt ');
-  await expect(page.getByTestId('staged-attachments')).toBeVisible();
-  await expect(page.getByTestId('staged-attachments').getByText('reference.txt', { exact: true })).toBeVisible();
+  await expect(stagedAttachmentName(page, 'reference.txt')).toBeVisible();
   await expect(page.getByTestId('chat-send')).toBeEnabled();
 }
 
@@ -2959,10 +2964,7 @@ async function runFileUploadSendFlow(
   });
   await expect((await uploadResponse).ok()).toBeTruthy();
 
-  await expect(page.getByTestId('staged-attachments')).toBeVisible();
-  await expect(
-    page.getByTestId('staged-attachments').getByText('reference.txt', { exact: true }),
-  ).toBeVisible();
+  await expect(stagedAttachmentName(page, 'reference.txt')).toBeVisible();
   await expect(page.getByText('reference.txt', { exact: true })).toBeVisible();
 
   await sendPrompt(page, entry.prompt);

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -29,6 +29,12 @@ function artifactPreviewFrame(page: Page) {
   return page.frameLocator(ACTIVE_ARTIFACT_PREVIEW_SELECTOR);
 }
 
+function stagedAttachmentName(page: Page, name: string): Locator {
+  return page
+    .locator('[data-testid="staged-attachments"], [data-testid="staged-contexts"]')
+    .getByText(name, { exact: true });
+}
+
 test.beforeEach(async ({ page }) => {
   await page.addInitScript((key) => {
     window.localStorage.setItem(
@@ -1560,8 +1566,7 @@ async function runFileMentionFlow(
   await expect(page.getByTestId('mention-popover')).toBeVisible();
   await page.getByTestId('mention-popover').getByRole('button', { name: /reference\.txt/i }).click();
   await expect(page.getByTestId('chat-composer-input')).toHaveText('Review @reference.txt ');
-  await expect(page.getByTestId('staged-attachments')).toBeVisible();
-  await expect(page.getByTestId('staged-attachments').getByText('reference.txt', { exact: true })).toBeVisible();
+  await expect(stagedAttachmentName(page, 'reference.txt')).toBeVisible();
   await expect(page.getByTestId('chat-send')).toBeEnabled();
 
   const runRequestPromise = page.waitForRequest(isCreateRunRequest);
@@ -1619,10 +1624,7 @@ async function runFileUploadSendFlow(
   });
   await expect((await uploadResponse).ok()).toBeTruthy();
 
-  await expect(page.getByTestId('staged-attachments')).toBeVisible();
-  await expect(
-    page.getByTestId('staged-attachments').getByText('reference.txt', { exact: true }),
-  ).toBeVisible();
+  await expect(stagedAttachmentName(page, 'reference.txt')).toBeVisible();
   await expect(page.getByText('reference.txt', { exact: true })).toBeVisible();
 
   await sendPrompt(page, entry.prompt);


### PR DESCRIPTION
## Summary
- Update staged attachment assertions to support the new staged context row introduced by the composer UI refresh
- Keep compatibility with the old `staged-attachments` container where it still appears
- Assert attachment names directly instead of requiring the removed standalone staged attachment row

## Validation
- pnpm --filter @open-design/e2e exec playwright test ui/app.test.ts --project=chromium -g "file-upload-send"
- pnpm --filter @open-design/e2e exec playwright test ui/app-restoration.test.ts --project=chromium -g "staged attachments UI available|after staging attachments"
- git diff --check

Note: Playwright validation was run in the original worktree with installed dependencies; this PR branch was created in a clean worktree from latest `origin/main`.