### PR TITLE
fix(web): keep screenshot capture from grabbing the hover tooltip

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -7219,6 +7219,14 @@ function HtmlViewer({
     setDeployMenuOpen((v) => !v);
   };
   const captureExportImageSnapshot = useCallback(async () => {
+    // The host compositor grabs on-screen pixels, so any transient hover chrome
+    // over the preview leaks into the capture. The screenshot control's own
+    // tooltip is already dismissed by TooltipLayer's pointerdown/click listener,
+    // but that setState(null) has not repainted yet when capture starts. Wait
+    // two frames so the dismissal commits first — mirrors the double-rAF guard
+    // in the browser screenshot flow (DesignBrowserPanel).
+    await waitForAnimationFrame();
+    await waitForAnimationFrame();
     // Prefer the desktop compositor screenshot of the visible preview region:
     // it returns the real rendered pixels (fonts, external CSS, gradients,
     // images) and is never tainted, so it cannot produce the black/blank frames

--- a/apps/web/tests/components/file-viewer-screenshot-tooltip.test.tsx
+++ b/apps/web/tests/components/file-viewer-screenshot-tooltip.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectFile } from '../../src/types';
+
+const { captureHostIframeSnapshotMock, copyImageDataUrlToClipboardMock } = vi.hoisted(() => ({
+  captureHostIframeSnapshotMock: vi.fn(),
+  copyImageDataUrlToClipboardMock: vi.fn(),
+}));
+
+vi.mock('../../src/runtime/exports', async () => {
+  const actual = await vi.importActual<typeof import('../../src/runtime/exports')>(
+    '../../src/runtime/exports',
+  );
+  return {
+    ...actual,
+    captureHostIframeSnapshot: captureHostIframeSnapshotMock,
+    copyImageDataUrlToClipboard: copyImageDataUrlToClipboardMock,
+  };
+});
+
+import { FileViewer } from '../../src/components/FileViewer';
+import { TooltipLayer } from '../../src/components/TooltipLayer';
+
+function htmlFile(): ProjectFile {
+  return {
+    name: 'workspace.html',
+    path: 'workspace.html',
+    type: 'file',
+    size: 1024,
+    mtime: 1710000000,
+    kind: 'html',
+    mime: 'text/html',
+    artifactManifest: {
+      version: 1,
+      kind: 'html',
+      title: 'Workspace',
+      entry: 'workspace.html',
+      renderer: 'html',
+      exports: ['html'],
+    },
+  };
+}
+
+describe('FileViewer screenshot tooltip guard', () => {
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('clears the hover tooltip before the host compositor capture grabs the frame', async () => {
+    captureHostIframeSnapshotMock.mockResolvedValue({
+      dataUrl: 'data:image/png;base64,ok',
+      w: 800,
+      h: 600,
+    });
+    copyImageDataUrlToClipboardMock.mockResolvedValue('copied');
+
+    const rafQueue: FrameRequestCallback[] = [];
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    const flushFrame = async () => {
+      const callbacks = rafQueue.splice(0);
+      for (const cb of callbacks) cb(0);
+      await Promise.resolve();
+    };
+
+    // TooltipLayer is an app-level component that portals the active tooltip
+    // into <body>; mount it so the screenshot button's hover tooltip is real.
+    render(
+      <>
+        <TooltipLayer />
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlFile()}
+          liveHtml="<html><body><main>Workspace</main></body></html>"
+        />
+      </>,
+    );
+
+    const button = screen.getByTestId('screenshot-copy-button');
+    fireEvent.pointerOver(button);
+    expect(document.body.querySelector('.od-tooltip-layer')).not.toBeNull();
+
+    fireEvent.click(button);
+    await Promise.resolve();
+
+    // The capture must not grab the frame until the dismissed tooltip has had a
+    // chance to repaint away — i.e. not before any animation frame has elapsed.
+    expect(captureHostIframeSnapshotMock).not.toHaveBeenCalled();
+
+    await flushFrame();
+    await flushFrame();
+
+    await waitFor(() => {
+      expect(captureHostIframeSnapshotMock).toHaveBeenCalled();
+    });
+    // By the time the frame is captured, the tooltip is gone from the DOM.
+    expect(document.body.querySelector('.od-tooltip-layer')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #3881

## Why

The screenshot control is self-polluting: its hover tooltip (`截图`) can be captured inside the resulting screenshot, so users get a broken-looking asset and have to retake or crop it. This scratches the itch from #3881 — a confirmed tooltip-timing bug in the screenshot path.

The tooltip *is* already dismissed on `pointerdown` (`TooltipLayer` → `hideTooltipForActivation` → `setState(null)`), but the dismissal hasn't repainted before `captureExportImageSnapshot()` takes its preferred path — `captureHostIframeSnapshot()`, which grabs the on-screen desktop-compositor pixels — so the still-painted tooltip leaks into the frame. The same class of race is already handled in the browser screenshot flow (`DesignBrowserPanel`), which waits two animation frames for transient chrome to disappear before capture.

## What users will see

Taking a screenshot from the file preview no longer captures the screenshot button's own `截图` hover tooltip. The captured image shows clean content.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — screenshot/image-export captures no longer include transient hover chrome; the captured pixels change for all users (bug fix).
- [ ] **None**

## Screenshots

The bug repro image is in #3881 (tooltip visible in the captured frame). The fix is a capture-timing guard — the leak depends on the compositor grabbing a frame mid-repaint, which isn't deterministically reproducible in a still — so it is verified by an automated red/green test instead (see below) rather than a before/after screenshot.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/file-viewer-screenshot-tooltip.test.tsx`
- Did the test go red before the source change and green after? **yes** — with the two `waitForAnimationFrame()` lines removed, `captureHostIframeSnapshot` is called synchronously before any animation frame and the test fails; with the guard in place it passes.

## Validation

- `pnpm guard` — pass (40/40)
- `pnpm typecheck` — pass (all packages)
- `pnpm --filter @open-design/web test` — pass (310 files, 3066 tests, 1 skipped), including the new test