### PR TITLE
[codex] Fix onboarding AMR login cancel

### DIFF
--- a/apps/web/src/components/AmrLoginPill.tsx
+++ b/apps/web/src/components/AmrLoginPill.tsx
@@ -73,7 +73,7 @@ export interface AmrAccountControlProps {
 
 const AMR_CANCELED_RESET_MS = 1500;
 
-function closeAmrActivationWindowBestEffort(): boolean {
+export function closeAmrActivationWindowBestEffort(): boolean {
   if (typeof window === 'undefined') return false;
   if (window.opener == null) return false;
   try {

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1440,12 +1440,26 @@ function OnboardingView({
     setAmrLoginPending(true);
     try {
       const currentStatus = await fetchVelaLoginStatus();
+      if (amrLoginPollCancelledRef.current) return;
       if (currentStatus) setAmrStatus(currentStatus);
       if (currentStatus?.loggedIn) {
         setStep((current) => current + 1);
         return;
       }
+      if (amrLoginPollCancelledRef.current) return;
       const loginResult = await startVelaLogin(attribution);
+      if (amrLoginPollCancelledRef.current) {
+        if (loginResult.ok || loginResult.alreadyRunning) {
+          const cancelResult = await cancelVelaLogin();
+          closeAmrActivationWindowBestEffort();
+          if (!cancelResult.ok) {
+            setAmrLoginError(t('settings.amrLoginErrorCompact'));
+            return;
+          }
+          notifyAmrLoginStatusChanged('login-canceled');
+        }
+        return;
+      }
       if (!loginResult.ok && !loginResult.alreadyRunning) {
         setAmrLoginError(loginResult.error || t('settings.amrLoginErrorCompact'));
         return;

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -126,7 +126,9 @@ import {
 import {
   AMR_LOGIN_POLL_INTERVAL_MS,
   amrLoginPollOutcome,
+  notifyAmrLoginStatusChanged,
 } from './amrLoginPolling';
+import { closeAmrActivationWindowBestEffort } from './AmrLoginPill';
 import { AnimatePresence } from 'motion/react';
 import { renderModelOptions } from './modelOptions';
 import {
@@ -918,6 +920,7 @@ function OnboardingView({
   const [cliScanStatus, setCliScanStatus] = useState<'idle' | 'scanning' | 'done'>('idle');
   const [amrStatus, setAmrStatus] = useState<VelaLoginStatus | null>(null);
   const [amrLoginPending, setAmrLoginPending] = useState(false);
+  const [amrLoginCancelPending, setAmrLoginCancelPending] = useState(false);
   const [newsletterSubmitting, setNewsletterSubmitting] = useState(false);
   const [amrLoginError, setAmrLoginError] = useState<string | null>(null);
   const [visibleAgentIds, setVisibleAgentIds] = useState<string[]>([]);
@@ -1069,6 +1072,7 @@ function OnboardingView({
     if (runtime === 'amr') return;
     amrLoginPollCancelledRef.current = true;
     setAmrLoginPending(false);
+    setAmrLoginCancelPending(false);
   }, [runtime]);
 
   // Onboarding step exposure. Design-system intake used to live here
@@ -1430,7 +1434,7 @@ function OnboardingView({
   async function handleAmrSignInToContinue(
     attribution?: AmrEntryAttribution | null,
   ) {
-    if (amrLoginPending) return;
+    if (amrLoginPending || amrLoginCancelPending) return;
     amrLoginPollCancelledRef.current = false;
     setAmrLoginError(null);
     setAmrLoginPending(true);
@@ -1452,6 +1456,27 @@ function OnboardingView({
     } finally {
       setAmrLoginPending(false);
     }
+  }
+
+  async function handleCancelAmrLogin() {
+    if (!amrLoginPending || amrLoginCancelPending) return;
+    amrLoginPollCancelledRef.current = true;
+    setAmrLoginError(null);
+    setAmrLoginCancelPending(true);
+    setAmrStatus((current) => (
+      current
+        ? { ...current, loggedIn: false, loginInFlight: false, user: null }
+        : current
+    ));
+    setAmrLoginPending(false);
+    const result = await cancelVelaLogin();
+    closeAmrActivationWindowBestEffort();
+    setAmrLoginCancelPending(false);
+    if (!result.ok) {
+      setAmrLoginError(t('settings.amrLoginErrorCompact'));
+      return;
+    }
+    notifyAmrLoginStatusChanged('login-canceled');
   }
 
   async function pollAmrLoginCompletion(): Promise<boolean> {
@@ -1967,11 +1992,21 @@ function OnboardingView({
             >
               {step === 0 ? t('settings.onboardingSkip') : t('settings.onboardingBack')}
             </button>
+            {step === 0 && amrLoginPending ? (
+              <button
+                type="button"
+                className="onboarding-view__secondary"
+                onClick={handleCancelAmrLogin}
+                disabled={amrLoginCancelPending}
+              >
+                {t('settings.amrCancelSignIn')}
+              </button>
+            ) : null}
             <button
               type="button"
               className="onboarding-view__primary"
               onClick={handlePrimaryAction}
-              disabled={amrLoginPending || newsletterSubmitting}
+              disabled={amrLoginPending || amrLoginCancelPending || newsletterSubmitting}
               aria-busy={newsletterSubmitting ? true : undefined}
             >
               <span>{primaryActionLabel}</span>

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -2453,8 +2453,8 @@
   grid-row: 1;
   display: grid;
   min-width: 0;
-  width: min(100%, 430px);
-  justify-self: start;
+  width: 100%;
+  justify-self: stretch;
 }
 
 .onboarding-view__benefit-aside .onboarding-view__benefit-stack {
@@ -2560,8 +2560,10 @@
 }
 
 .onboarding-view__benefit-aside .onboarding-view__benefits {
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 7px;
+  width: 100%;
+  max-width: 100%;
 }
 
 .onboarding-view__benefit-aside

--- a/apps/web/tests/styles/onboarding-layout.test.ts
+++ b/apps/web/tests/styles/onboarding-layout.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const entryLayoutCss = readFileSync(
+  new URL('../../src/styles/home/entry-layout.css', import.meta.url),
+  'utf8',
+);
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(entryLayoutCss)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+describe('onboarding layout styles', () => {
+  it('lets AMR benefit chips wrap inside the featured card', () => {
+    const asideBlock = cssDeclarations('.onboarding-view__benefit-aside');
+    const benefitsBlock = cssDeclarations(
+      '.onboarding-view__benefit-aside .onboarding-view__benefits',
+    );
+
+    expect(asideBlock).toMatch(/(?:^|[;\n])\s*width:\s*100%\s*;/);
+    expect(asideBlock).toMatch(/(?:^|[;\n])\s*justify-self:\s*stretch\s*;/);
+    expect(benefitsBlock).toMatch(/(?:^|[;\n])\s*flex-wrap:\s*wrap\s*;/);
+    expect(benefitsBlock).not.toMatch(/(?:^|[;\n])\s*flex-wrap:\s*nowrap\s*;/);
+  });
+});

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -20,7 +20,10 @@ type OnboardingConfig = {
 declare global {
   interface Window {
     __amrOnboardingCancelCalls?: number;
+    __amrOnboardingDelayNextSignedOutStatus?: boolean;
     __amrOnboardingLoginCalls?: number;
+    __amrOnboardingSlowStatusResolved?: boolean;
+    __amrOnboardingStatusCalls?: number;
   }
 }
 
@@ -139,6 +142,40 @@ test('[P0] onboarding lets the user cancel an incomplete AMR sign-in and retry',
 
   await expect.poll(() => page.evaluate(() => window.__amrOnboardingLoginCalls ?? 0)).toBe(2);
   await expect(page.getByRole('button', { name: /Cancel sign-in/i })).toBeVisible();
+});
+
+test('[P0] onboarding cancel during a slow AMR status check does not start login', async ({ page }) => {
+  const config = await wireOnboardingMocks(page, {
+    amrAvailable: true,
+    initialLoggedIn: false,
+    keepAmrLoginIncomplete: true,
+    delaySignedOutStatusMs: 350,
+  });
+
+  await seedOnboardingConfig(page, config);
+  await gotoOnboarding(page);
+  await expect
+    .poll(() => page.evaluate(() => window.__amrOnboardingStatusCalls ?? 0))
+    .toBeGreaterThanOrEqual(1);
+
+  await page.evaluate(() => {
+    window.__amrOnboardingDelayNextSignedOutStatus = true;
+    window.__amrOnboardingSlowStatusResolved = false;
+  });
+  await page.getByRole('button', { name: /sign in to continue/i }).click();
+
+  const cancelSignIn = page.getByRole('button', { name: /Cancel sign-in/i });
+  await expect(cancelSignIn).toBeVisible();
+  await cancelSignIn.click();
+
+  await expect(page.getByRole('button', { name: /sign in to continue/i })).toBeVisible();
+  await expect.poll(() => page.evaluate(() => window.__amrOnboardingCancelCalls ?? 0)).toBe(1);
+  await expect
+    .poll(() => page.evaluate(() => window.__amrOnboardingSlowStatusResolved ?? false))
+    .toBe(true);
+  await page.waitForTimeout(250);
+  await expect(page.getByRole('button', { name: /Signing in/i })).toHaveCount(0);
+  await expect.poll(() => page.evaluate(() => window.__amrOnboardingLoginCalls ?? 0)).toBe(0);
 });
 
 test('[P0] onboarding AMR card lets the user pick a live runtime model before continuing', async ({ page }) => {
@@ -322,6 +359,7 @@ async function wireOnboardingMocks(
     initialLoggedIn: boolean;
     failFirstStatusPollAfterLogin?: boolean;
     keepAmrLoginIncomplete?: boolean;
+    delaySignedOutStatusMs?: number;
     amrModels?: Array<{ id: string; label: string }>;
     codexModels?: Array<{ id: string; label: string }>;
   },
@@ -343,6 +381,7 @@ async function wireOnboardingMocks(
 
   let loggedIn = options.initialLoggedIn;
   let loginInFlight = false;
+  let statusCalls = 0;
   let statusCallsAfterLogin = 0;
   let loginCalls = 0;
   let cancelCalls = 0;
@@ -398,6 +437,24 @@ async function wireOnboardingMocks(
   });
 
   await page.route('**/api/integrations/vela/status', async (route) => {
+    statusCalls += 1;
+    await page.evaluate((calls) => {
+      window.__amrOnboardingStatusCalls = calls;
+    }, statusCalls);
+    const shouldDelaySignedOutStatus =
+      !loggedIn
+      && typeof options.delaySignedOutStatusMs === 'number'
+      && options.delaySignedOutStatusMs > 0
+      && await page.evaluate(() => {
+        if (!window.__amrOnboardingDelayNextSignedOutStatus) return false;
+        window.__amrOnboardingDelayNextSignedOutStatus = false;
+        return true;
+      });
+    if (shouldDelaySignedOutStatus) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, options.delaySignedOutStatusMs),
+      );
+    }
     if (loggedIn) {
       statusCallsAfterLogin += 1;
       if (options.failFirstStatusPollAfterLogin && statusCallsAfterLogin === 1) {
@@ -426,6 +483,11 @@ async function wireOnboardingMocks(
             user: null,
           },
     });
+    if (shouldDelaySignedOutStatus) {
+      await page.evaluate(() => {
+        window.__amrOnboardingSlowStatusResolved = true;
+      });
+    }
   });
 
   await page.route('**/api/integrations/vela/login', async (route) => {

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -17,6 +17,13 @@ type OnboardingConfig = {
   agentModels: Record<string, { model: string; reasoning: string }>;
 };
 
+declare global {
+  interface Window {
+    __amrOnboardingCancelCalls?: number;
+    __amrOnboardingLoginCalls?: number;
+  }
+}
+
 test.describe.configure({ timeout: 30_000 });
 
 test('[P0] onboarding lets AMR Cloud sign in and complete setup after the login poll succeeds', async ({ page }) => {
@@ -104,6 +111,34 @@ test('[P0] onboarding recovers from a transient AMR status failure and still con
   await page.getByRole('button', { name: /sign in to continue/i }).click();
 
   await expect(page.getByRole('button', { name: /Continue/i })).toBeVisible({ timeout: 12_000 });
+});
+
+test('[P0] onboarding lets the user cancel an incomplete AMR sign-in and retry', async ({ page }) => {
+  const config = await wireOnboardingMocks(page, {
+    amrAvailable: true,
+    initialLoggedIn: false,
+    keepAmrLoginIncomplete: true,
+  });
+
+  await seedOnboardingConfig(page, config);
+  await gotoOnboarding(page);
+
+  await page.getByRole('button', { name: /sign in to continue/i }).click();
+
+  await expect(page.getByRole('button', { name: /Signing in/i })).toBeVisible();
+  const cancelSignIn = page.getByRole('button', { name: /Cancel sign-in/i });
+  await expect(cancelSignIn).toBeVisible();
+  await cancelSignIn.click();
+
+  await expect(page.getByRole('button', { name: /sign in to continue/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Signing in/i })).toHaveCount(0);
+  await expect.poll(() => page.evaluate(() => window.__amrOnboardingCancelCalls ?? 0)).toBe(1);
+  await expect.poll(() => page.evaluate(() => window.__amrOnboardingLoginCalls ?? 0)).toBe(1);
+
+  await page.getByRole('button', { name: /sign in to continue/i }).click();
+
+  await expect.poll(() => page.evaluate(() => window.__amrOnboardingLoginCalls ?? 0)).toBe(2);
+  await expect(page.getByRole('button', { name: /Cancel sign-in/i })).toBeVisible();
 });
 
 test('[P0] onboarding AMR card lets the user pick a live runtime model before continuing', async ({ page }) => {
@@ -286,6 +321,7 @@ async function wireOnboardingMocks(
     amrAvailable: boolean;
     initialLoggedIn: boolean;
     failFirstStatusPollAfterLogin?: boolean;
+    keepAmrLoginIncomplete?: boolean;
     amrModels?: Array<{ id: string; label: string }>;
     codexModels?: Array<{ id: string; label: string }>;
   },
@@ -306,7 +342,10 @@ async function wireOnboardingMocks(
   };
 
   let loggedIn = options.initialLoggedIn;
+  let loginInFlight = false;
   let statusCallsAfterLogin = 0;
+  let loginCalls = 0;
+  let cancelCalls = 0;
 
   await page.route('**/api/health', async (route) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
@@ -374,12 +413,14 @@ async function wireOnboardingMocks(
       json: loggedIn
         ? {
             loggedIn: true,
+            loginInFlight: false,
             profile: 'local',
             configPath: '/tmp/.amr/config.json',
             user: { id: 'user-1', email: 'onboarding@example.com', plan: 'free' },
           }
         : {
             loggedIn: false,
+            loginInFlight,
             profile: 'local',
             configPath: '/tmp/.amr/config.json',
             user: null,
@@ -388,11 +429,28 @@ async function wireOnboardingMocks(
   });
 
   await page.route('**/api/integrations/vela/login', async (route) => {
-    loggedIn = true;
+    loginCalls += 1;
+    loginInFlight = true;
+    if (!options.keepAmrLoginIncomplete) {
+      loggedIn = true;
+      loginInFlight = false;
+    }
+    await page.evaluate((calls) => {
+      window.__amrOnboardingLoginCalls = calls;
+    }, loginCalls);
     await route.fulfill({
       status: 202,
       json: { pid: 4242, startedAt: new Date().toISOString(), profile: 'local' },
     });
+  });
+
+  await page.route('**/api/integrations/vela/login/cancel', async (route) => {
+    cancelCalls += 1;
+    loginInFlight = false;
+    await page.evaluate((calls) => {
+      window.__amrOnboardingCancelCalls = calls;
+    }, cancelCalls);
+    await route.fulfill({ json: { canceled: true, pids: [4242] } });
   });
 
   return config;


### PR DESCRIPTION
Refs ONB-001

## Why

This PR addresses an onboarding bug found while reviewing the AMR authorization flow. If a user starts AMR sign-in from onboarding and then closes or abandons the external authorization window, onboarding can remain stuck in the signing-in state and the primary action cannot restart `vela login`.

It also fixes a visible English-layout issue on the same onboarding step: the AMR benefit chips were forced into a single row and clipped at the right edge.

## What users will see

Onboarding → Connect now shows a `Cancel sign-in` action while AMR sign-in is pending. Canceling returns the user to the same onboarding step and restores `Sign in to continue`, so clicking it again starts a fresh AMR login attempt.

English AMR benefit chips wrap inside the featured AMR card instead of being clipped.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Verified locally with the Codex in-app Browser at `/onboarding`: AMR benefit chips wrap, `Cancel sign-in` appears during pending AMR login, cancel restores `Sign in to continue`, and retry enters pending again. No persistent image artifact is attached to this draft PR.

## Bug fix verification

- Test path that reproduces the bug: `e2e/ui/amr-onboarding.test.ts` → `[P0] onboarding lets the user cancel an incomplete AMR sign-in and retry`
- Did the test go red on `main` and green on this branch? Not run red on `main`; the test is new and covers the missing cancel/retry behavior. It passes on this branch.
- Additional verification: in-app Browser manual verification using a long-running mock `vela login` confirmed pending → cancel → restored sign-in → retry pending, and confirmed English AMR chips are not clipped.

## Validation

- `corepack pnpm --filter @open-design/web test -- EntryShell`
- `PATH="/tmp/od-corepack-pnpm-shim:$PATH" OD_PORT=18456 OD_WEB_PORT=18573 OD_E2E_NAMESPACE=onb-001-pr OD_E2E_DATA_DIR='ui/.od-data/onb-001-pr' corepack pnpm exec playwright test -c playwright.config.ts ui/amr-onboarding.test.ts` from `e2e/`
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm guard`
- `PATH="/tmp/od-corepack-pnpm-shim:$PATH" corepack pnpm typecheck`
- Codex in-app Browser verification at `http://127.0.0.1:20573/onboarding` with mock AMR login pending flow
