### PR TITLE
[codex] Stabilize mention popover height

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1056,89 +1056,91 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
                 </button>
               ))}
             </div>
-            {visibleLoading && visiblePickerOptions.length === 0 ? (
-              <div className="home-hero__plugin-picker-empty">{t('homeHero.loadingContext')}</div>
-            ) : null}
-            {!visibleLoading && visiblePickerOptions.length === 0 ? (
-              <div className="home-hero__plugin-picker-empty">
-                {mentionQuery ? (
-                  <>{t('homeHero.noResults', { query: mentionQuery })}</>
-                ) : (
-                  <>{t('homeHero.searchPrompt')}</>
-                )}
-              </div>
-            ) : null}
-            {visibleSections.map((section) => (
-              <div key={section.id} className="home-hero__mention-section">
-                <div className="home-hero__mention-section-label">{section.label}</div>
-                {section.options.map((item) => {
-                  const optionIndex = optionRenderIndex;
-                  optionRenderIndex += 1;
-                  return (
-                    <button
-                      key={item.id}
-                      id={`home-hero-option-${optionIndex}`}
-                      type="button"
-                      role="option"
-                      aria-selected={optionIndex === selectedIndex}
-                      className={`home-hero__plugin-option${
-                        optionIndex === selectedIndex ? ' is-active' : ''
-                      }`}
-                      onMouseEnter={() => {
-                        setSelectedIndex(optionIndex);
-                        setHoveredPlugin(item.pluginRecord ?? null);
-                      }}
-                      onMouseDown={(event) => {
-                        event.preventDefault();
-                        if (!item.disabled) item.onPick();
-                      }}
-                      disabled={item.disabled}
-                    >
-                      <span className="home-hero__plugin-option-icon" aria-hidden>
-                        <Icon name={item.icon} size={13} />
-                      </span>
-                      <span className="home-hero__plugin-option-main">
-                        <span>{item.title}</span>
-                        <span>{item.description}</span>
-                      </span>
-                      <span className="home-hero__plugin-option-meta">
-                        {item.meta}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            ))}
-            {hoveredPlugin ? (
-              <div
-                className="home-hero__plugin-hover-card"
-                data-testid="home-hero-plugin-hover-card"
-              >
-                <div>
-                  <span className="home-hero__plugin-hover-kicker">
-                    {getPluginSourceLabel(hoveredPlugin)}
-                  </span>
-                  <strong>{localizePluginTitle(locale, hoveredPlugin)}</strong>
-                  <p>{localizePluginDescription(locale, hoveredPlugin) || hoveredPlugin.id}</p>
+            <div className="home-hero__plugin-picker-results">
+              {visibleLoading && visiblePickerOptions.length === 0 ? (
+                <div className="home-hero__plugin-picker-empty">{t('homeHero.loadingContext')}</div>
+              ) : null}
+              {!visibleLoading && visiblePickerOptions.length === 0 ? (
+                <div className="home-hero__plugin-picker-empty">
+                  {mentionQuery ? (
+                    <>{t('homeHero.noResults', { query: mentionQuery })}</>
+                  ) : (
+                    <>{t('homeHero.searchPrompt')}</>
+                  )}
                 </div>
-                <div className="home-hero__plugin-hover-meta">
-                  <span>{t('homeHero.parameters', { n: (hoveredPlugin.manifest?.od?.inputs ?? []).length })}</span>
-                  {getPluginQueryPreview(hoveredPlugin) ? (
-                    <span>{getPluginQueryPreview(hoveredPlugin)}</span>
-                  ) : null}
+              ) : null}
+              {visibleSections.map((section) => (
+                <div key={section.id} className="home-hero__mention-section">
+                  <div className="home-hero__mention-section-label">{section.label}</div>
+                  {section.options.map((item) => {
+                    const optionIndex = optionRenderIndex;
+                    optionRenderIndex += 1;
+                    return (
+                      <button
+                        key={item.id}
+                        id={`home-hero-option-${optionIndex}`}
+                        type="button"
+                        role="option"
+                        aria-selected={optionIndex === selectedIndex}
+                        className={`home-hero__plugin-option${
+                          optionIndex === selectedIndex ? ' is-active' : ''
+                        }`}
+                        onMouseEnter={() => {
+                          setSelectedIndex(optionIndex);
+                          setHoveredPlugin(item.pluginRecord ?? null);
+                        }}
+                        onMouseDown={(event) => {
+                          event.preventDefault();
+                          if (!item.disabled) item.onPick();
+                        }}
+                        disabled={item.disabled}
+                      >
+                        <span className="home-hero__plugin-option-icon" aria-hidden>
+                          <Icon name={item.icon} size={13} />
+                        </span>
+                        <span className="home-hero__plugin-option-main">
+                          <span>{item.title}</span>
+                          <span>{item.description}</span>
+                        </span>
+                        <span className="home-hero__plugin-option-meta">
+                          {item.meta}
+                        </span>
+                      </button>
+                    );
+                  })}
                 </div>
-                <button
-                  type="button"
-                  onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => {
-                    dismissMentionPicker();
-                    onOpenPluginDetails(hoveredPlugin);
-                  }}
+              ))}
+              {hoveredPlugin ? (
+                <div
+                  className="home-hero__plugin-hover-card"
+                  data-testid="home-hero-plugin-hover-card"
                 >
-                  {t('homeHero.details')}
-                </button>
-              </div>
-            ) : null}
+                  <div>
+                    <span className="home-hero__plugin-hover-kicker">
+                      {getPluginSourceLabel(hoveredPlugin)}
+                    </span>
+                    <strong>{localizePluginTitle(locale, hoveredPlugin)}</strong>
+                    <p>{localizePluginDescription(locale, hoveredPlugin) || hoveredPlugin.id}</p>
+                  </div>
+                  <div className="home-hero__plugin-hover-meta">
+                    <span>{t('homeHero.parameters', { n: (hoveredPlugin.manifest?.od?.inputs ?? []).length })}</span>
+                    {getPluginQueryPreview(hoveredPlugin) ? (
+                      <span>{getPluginQueryPreview(hoveredPlugin)}</span>
+                    ) : null}
+                  </div>
+                  <button
+                    type="button"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => {
+                      dismissMentionPicker();
+                      onOpenPluginDetails(hoveredPlugin);
+                    }}
+                  >
+                    {t('homeHero.details')}
+                  </button>
+                </div>
+              ) : null}
+            </div>
           </div>
         </CaretFloatingLayer>
         <div className="home-hero__input-foot">

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -636,7 +636,7 @@
   flex-direction: column;
   gap: 3px;
   max-height: 280px;
-  overflow: auto;
+  overflow: hidden;
   padding: 6px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -653,7 +653,16 @@
   right: auto;
   top: auto;
   width: 100%;
+  height: var(--cfl-max-h, 60vh);
   max-height: var(--cfl-max-h, 60vh);
+}
+.home-hero__plugin-picker-results {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  overflow-y: auto;
 }
 .home-hero__plugin-hover-card {
   display: grid;

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -30,6 +30,7 @@
   flex-direction: column;
   width: 100%;
   max-width: 100%;
+  height: var(--cfl-max-h, 460px);
   max-height: var(--cfl-max-h, 460px);
   background: var(--bg-panel);
   border: 1px solid var(--border);

--- a/apps/web/tests/styles/home-hero-compact-controls.test.ts
+++ b/apps/web/tests/styles/home-hero-compact-controls.test.ts
@@ -9,8 +9,9 @@ const homeHeroCss = readFileSync(
 function cssDeclarations(selector: string): string {
   const blocks: string[] = [];
   const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = homeHeroCss.replace(/\/\*[\s\S]*?\*\//g, '');
   let match: RegExpExecArray | null;
-  while ((match = rulePattern.exec(homeHeroCss)) !== null) {
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
     const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
     if (selectors.includes(selector)) blocks.push(match[2] ?? '');
   }
@@ -26,6 +27,20 @@ function ruleValue(block: string, property: string): string {
 }
 
 describe('HomeHero compact composer controls', () => {
+  it('keeps the floating @ picker shell stable while result tabs change', () => {
+    const floatingPicker = cssDeclarations(
+      '.caret-floating-layer .home-hero__plugin-picker--floating',
+    );
+    const picker = cssDeclarations('.home-hero__plugin-picker');
+    const results = cssDeclarations('.home-hero__plugin-picker-results');
+
+    expect(ruleValue(floatingPicker, 'height')).toBe('var(--cfl-max-h, 60vh)');
+    expect(ruleValue(floatingPicker, 'max-height')).toBe('var(--cfl-max-h, 60vh)');
+    expect(ruleValue(picker, 'overflow')).toBe('hidden');
+    expect(ruleValue(results, 'flex')).toBe('1 1 auto');
+    expect(ruleValue(results, 'overflow-y')).toBe('auto');
+  });
+
   it('keeps the session mode and execution buttons compact in the hero', () => {
     const modeTrigger = cssDeclarations(
       '.home-hero__foot-right .session-mode-toggle__trigger',

--- a/apps/web/tests/styles/mention-popover.test.ts
+++ b/apps/web/tests/styles/mention-popover.test.ts
@@ -26,6 +26,16 @@ function ruleValue(block: string, property: string): string {
 }
 
 describe('mention popover styles', () => {
+  it('keeps the panel height stable while tabs swap between long and short results', () => {
+    const popover = cssBlock('.mention-popover');
+    const results = cssBlock('.mention-results');
+
+    expect(ruleValue(popover, 'height')).toBe('var(--cfl-max-h, 460px)');
+    expect(ruleValue(popover, 'max-height')).toBe('var(--cfl-max-h, 460px)');
+    expect(ruleValue(results, 'flex')).toBe('1 1 auto');
+    expect(ruleValue(results, 'overflow-y')).toBe('auto');
+  });
+
   it('wraps category tabs inside the panel without clipping labels', () => {
     const tabs = cssBlock('.mention-tabs');
     const tab = cssBlock('.mention-tab');


### PR DESCRIPTION
## Why

The project chat composer and home composer `@` mention menus changed height when switching between long result tabs and short or empty tabs. The top edge stayed anchored, so the bottom edge jumped and made the menu feel unstable while browsing mention categories.

This PR fixes that bug by keeping each mention popover shell at the floating layer height for the lifetime of the open menu, while the results area remains the scroll container.

## What users will see

When users open the `@` menu in either the home composer or the project composer and switch between Design files, Plugins, Skills, MCP, and Connectors, the menu frame keeps the same size. Long lists scroll internally; short lists and empty states leave stable whitespace inside the panel instead of shrinking the whole popover.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No static screenshot attached. Browser verification measured the live popovers before and after switching tabs:

- Project composer: All, MCP, and Connectors each stayed at `460px` height with the same top and bottom coordinates.
- Home composer: All, MCP, and Connectors each stayed at `289.922px` height with the same top and bottom coordinates in the tested viewport.

## Bug fix verification

- Test paths that reproduce the layout contract:
  - `apps/web/tests/styles/mention-popover.test.ts`
  - `apps/web/tests/styles/home-hero-compact-controls.test.ts`
- Did the test go red on `main` and green on this branch? No; this was locked with focused CSS contract regressions because the behavior is a layout stability issue best observed in-browser.
- Additional verification: opened the project composer and home composer locally, typed `@`, switched All → MCP → Connectors, and confirmed the popovers kept unchanged top/bottom coordinates while results scrolled internally.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web test -- tests/styles/mention-popover.test.ts`
- `pnpm exec vitest run -c vitest.config.ts tests/styles/home-hero-compact-controls.test.ts tests/components/HomeHero.plugin-picker.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- Browser verification against `pnpm tools-dev run web --namespace codex-ee6d --daemon-port 17456 --web-port 17573`
