### PR TITLE
[codex] Fix design system modal layering

### DIFF
--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -1299,7 +1299,7 @@
 .ds-modal-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 900;
+  z-index: 1700;
   background: rgba(28, 27, 26, 0.42);
   backdrop-filter: blur(2px);
   -webkit-app-region: no-drag;

--- a/apps/web/tests/styles/design-system-modal-layer.test.ts
+++ b/apps/web/tests/styles/design-system-modal-layer.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { readExpandedIndexCss } from '../helpers/read-expanded-css';
+
+const expandedIndexCss = readExpandedIndexCss();
+
+function cssBlock(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(css);
+  if (!match) throw new Error(`Missing CSS block for ${selector}`);
+  return match[1] ?? '';
+}
+
+function ruleValue(block: string, property: string): string {
+  const match = new RegExp(`(?:^|;)\\s*${property}:\\s*([^;]+);`).exec(block);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('design system modal layering', () => {
+  it('keeps preview modals above composer floating controls', () => {
+    const backdrop = cssBlock(expandedIndexCss, '.ds-modal-backdrop');
+    const composerPopover = cssBlock(
+      expandedIndexCss,
+      '.split-chat-slot:has(.session-mode-toggle__popover),\n.split-chat-slot > .pane:has(.session-mode-toggle__popover),\n.composer:has(.session-mode-toggle__popover)',
+    );
+
+    expect(Number(ruleValue(backdrop, 'z-index'))).toBeGreaterThan(
+      Number(ruleValue(composerPopover, 'z-index')),
+    );
+  });
+});


### PR DESCRIPTION
## Why

This is a follow-up to the project-instructions cleanup PR. While checking the design system details preview, the bottom-left chat composer could still float above the preview modal in project views.

The root cause is that `.ds-modal-backdrop` used `z-index: 900`, while composer floating controls can rise to `z-index: 1500` when their popover state is active.

## What users will see

Opening a design system or plugin rich preview modal now places the modal and dimmed backdrop above the chat composer, so the lower-left input no longer appears on top of the modal.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Browser verification on the branch loaded CSSOM showed:

- `.composer:has(.session-mode-toggle__popover)` → `z-index: 1500`
- `.ds-modal-backdrop` → `z-index: 1700`

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/design-system-modal-layer.test.ts`
- Did the test go red on `main` and green on this branch? Not run separately on `main`; the assertion compares modal and composer z-index values and would fail against the previous `900` vs `1500` values.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/DesignSystemPreviewModal.layering.test.tsx tests/styles/design-system-modal-layer.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- Browser CSSOM check on `http://127.0.0.1:17623/` with isolated `ds-modal-check` namespace
