### PR TITLE
fix(daemon): reject unknown startup commands

### DIFF
--- a/apps/daemon/src/daemon-startup.ts
+++ b/apps/daemon/src/daemon-startup.ts
@@ -28,6 +28,13 @@ export type DaemonCliStartupParseResult =
   | { ok: false; kind: 'help' }
   | { ok: false; kind: 'error'; message: string };
 
+function requiredOptionValue(flag: string, value: string | undefined, label: string): string | DaemonCliStartupParseResult {
+  if (value == null || value.startsWith('-')) {
+    return { ok: false, kind: 'error', message: `${flag} requires ${label}` };
+  }
+  return value;
+}
+
 export function parseDaemonCliStartupArgs(
   argv: string[],
   env: NodeJS.ProcessEnv = process.env,
@@ -40,16 +47,16 @@ export function parseDaemonCliStartupArgs(
     const a = argv[i];
     if (a == null) continue;
     if (a === '-p' || a === '--port') {
-      const next = argv[++i];
-      if (next == null) return { ok: false, kind: 'error', message: `${a} requires a port` };
+      const next = requiredOptionValue(a, argv[++i], 'a port');
+      if (typeof next !== 'string') return next;
       const parsedPort = Number(next);
       if (!Number.isInteger(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
         return { ok: false, kind: 'error', message: `invalid port: ${next}` };
       }
       port = parsedPort;
     } else if (a === '--host') {
-      const next = argv[++i];
-      if (next == null) return { ok: false, kind: 'error', message: '--host requires an address' };
+      const next = requiredOptionValue(a, argv[++i], 'an address');
+      if (typeof next !== 'string') return next;
       host = next;
     } else if (a === '--no-open') {
       open = false;

--- a/apps/daemon/src/daemon-startup.ts
+++ b/apps/daemon/src/daemon-startup.ts
@@ -17,6 +17,54 @@ type DaemonRuntimeOptions = Omit<StartServerOptions, 'returnServer'> & {
   logListening?: boolean;
 };
 
+export type DaemonCliStartupConfig = {
+  host: string;
+  open: boolean;
+  port: number;
+};
+
+export type DaemonCliStartupParseResult =
+  | { ok: true; config: DaemonCliStartupConfig }
+  | { ok: false; kind: 'help' }
+  | { ok: false; kind: 'error'; message: string };
+
+export function parseDaemonCliStartupArgs(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): DaemonCliStartupParseResult {
+  let port = Number(env.OD_PORT) || 7456;
+  let host = env.OD_BIND_HOST || '127.0.0.1';
+  let open = true;
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a == null) continue;
+    if (a === '-p' || a === '--port') {
+      const next = argv[++i];
+      if (next == null) return { ok: false, kind: 'error', message: `${a} requires a port` };
+      const parsedPort = Number(next);
+      if (!Number.isInteger(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
+        return { ok: false, kind: 'error', message: `invalid port: ${next}` };
+      }
+      port = parsedPort;
+    } else if (a === '--host') {
+      const next = argv[++i];
+      if (next == null) return { ok: false, kind: 'error', message: '--host requires an address' };
+      host = next;
+    } else if (a === '--no-open') {
+      open = false;
+    } else if (a === '-h' || a === '--help') {
+      return { ok: false, kind: 'help' };
+    } else if (a.startsWith('-')) {
+      return { ok: false, kind: 'error', message: `unknown option: ${a}` };
+    } else {
+      return { ok: false, kind: 'error', message: `unknown command: od ${a}` };
+    }
+  }
+
+  return { ok: true, config: { host, open, port } };
+}
+
 export async function closeHttpServer(
   server: Server,
   { closeTimeoutMs = 5_000, idleCloseMs = 1_000 } = {},
@@ -87,24 +135,17 @@ export async function startDaemonRuntime(options: DaemonRuntimeOptions = {}): Pr
 }
 
 export async function runDaemonCliStartup(argv: string[], options: { printHelp?: () => void } = {}): Promise<void> {
-  let port = Number(process.env.OD_PORT) || 7456;
-  let host = process.env.OD_BIND_HOST || '127.0.0.1';
-  let open = true;
-
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i];
-    if (a === '-p' || a === '--port') {
-      port = Number(argv[++i]);
-    } else if (a === '--host') {
-      const next = argv[++i];
-      if (next != null) host = next;
-    } else if (a === '--no-open') {
-      open = false;
-    } else if (a === '-h' || a === '--help') {
+  const parsed = parseDaemonCliStartupArgs(argv);
+  if (!parsed.ok) {
+    if (parsed.kind === 'error') {
+      console.error(parsed.message);
       options.printHelp?.();
-      return;
+      process.exit(2);
     }
+    options.printHelp?.();
+    return;
   }
+  const { host, open, port } = parsed.config;
 
   const runtime = await startDaemonRuntime({
     host,

--- a/apps/daemon/tests/daemon-startup.test.ts
+++ b/apps/daemon/tests/daemon-startup.test.ts
@@ -40,4 +40,17 @@ describe('daemon startup CLI parsing', () => {
       message: 'unknown option: --url',
     });
   });
+
+  it('rejects flag-shaped values for required daemon startup options', () => {
+    expect(parseDaemonCliStartupArgs(['--host', '--no-open'], {})).toEqual({
+      ok: false,
+      kind: 'error',
+      message: '--host requires an address',
+    });
+    expect(parseDaemonCliStartupArgs(['--port', '--no-open'], {})).toEqual({
+      ok: false,
+      kind: 'error',
+      message: '--port requires a port',
+    });
+  });
 });

--- a/apps/daemon/tests/daemon-startup.test.ts
+++ b/apps/daemon/tests/daemon-startup.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseDaemonCliStartupArgs } from '../src/daemon-startup.js';
+
+describe('daemon startup CLI parsing', () => {
+  it('parses the documented daemon startup flags', () => {
+    expect(parseDaemonCliStartupArgs(['--host', '0.0.0.0', '--port', '8123', '--no-open'], {})).toEqual({
+      ok: true,
+      config: {
+        host: '0.0.0.0',
+        open: false,
+        port: 8123,
+      },
+    });
+  });
+
+  it('uses environment defaults when startup flags are omitted', () => {
+    expect(parseDaemonCliStartupArgs([], { OD_BIND_HOST: '127.0.0.2', OD_PORT: '7345' })).toEqual({
+      ok: true,
+      config: {
+        host: '127.0.0.2',
+        open: true,
+        port: 7345,
+      },
+    });
+  });
+
+  it('rejects browser snapshot instead of treating it as daemon startup', () => {
+    expect(parseDaemonCliStartupArgs(['browser', 'snapshot', '--url', 'https://example.test/'], {})).toEqual({
+      ok: false,
+      kind: 'error',
+      message: 'unknown command: od browser',
+    });
+  });
+
+  it('rejects unknown daemon startup options', () => {
+    expect(parseDaemonCliStartupArgs(['--url', 'https://example.test/'], {})).toEqual({
+      ok: false,
+      kind: 'error',
+      message: 'unknown option: --url',
+    });
+  });
+});

--- a/apps/daemon/tests/skills.test.ts
+++ b/apps/daemon/tests/skills.test.ts
@@ -179,6 +179,7 @@ describe('listSkills', () => {
     expect(skill.body).toContain('`daemon-cli.mjs browser snapshot`');
     expect(skill.body).toContain('misinterpreted as daemon startup');
     expect(skill.body).toContain('trap cleanup_agent_browser EXIT INT TERM');
+    expect(skill.body).toContain('pkill -f -- "--user-data-dir=${CHROME_USER_DATA_DIR}"');
   });
 
   it('includes the DCF valuation, X research, and Last30Days research skills', async () => {

--- a/apps/daemon/tests/skills.test.ts
+++ b/apps/daemon/tests/skills.test.ts
@@ -176,6 +176,9 @@ describe('listSkills', () => {
     expect(skill.body).toContain('Chrome crashed before CDP became available');
     expect(skill.body).toContain('command -v agent-browser');
     expect(skill.body).toContain('Open Design Smoke Path');
+    expect(skill.body).toContain('`daemon-cli.mjs browser snapshot`');
+    expect(skill.body).toContain('misinterpreted as daemon startup');
+    expect(skill.body).toContain('trap cleanup_agent_browser EXIT INT TERM');
   });
 
   it('includes the DCF valuation, X research, and Last30Days research skills', async () => {

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -177,7 +177,7 @@ finishing the task. Prefer a shell trap around the whole smoke script:
 ```bash
 CHROME_USER_DATA_DIR=/tmp/od-agent-browser-chrome
 cleanup_agent_browser() {
-  pkill -f "--user-data-dir=${CHROME_USER_DATA_DIR}" 2>/dev/null || true
+  pkill -f -- "--user-data-dir=${CHROME_USER_DATA_DIR}" 2>/dev/null || true
 }
 trap cleanup_agent_browser EXIT INT TERM
 ```

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -115,6 +115,13 @@ screenshots.
 `agent-browser open` before `agent-browser connect`; doing so can make the CLI
 auto-launch Chrome and re-enter the crash path.
 
+Do not run Open Design's own daemon CLI as a browser automation tool. Commands
+such as `od browser snapshot`, `daemon-cli.mjs browser snapshot`, or
+`$OD_NODE_BIN $OD_BIN browser snapshot` are not valid browser tools; they can be
+misinterpreted as daemon startup and open an internal `127.0.0.1:<port>` service
+in the system browser. Use the external `agent-browser` CLI attached to CDP
+instead.
+
 Use this sequence:
 
 ```bash
@@ -164,13 +171,24 @@ export HOME=/tmp/agent-browser-home
 export AGENT_BROWSER_SESSION=od-local-preview
 ```
 
+When you start a temporary Chrome profile for this smoke path, close it before
+finishing the task. Prefer a shell trap around the whole smoke script:
+
+```bash
+CHROME_USER_DATA_DIR=/tmp/od-agent-browser-chrome
+cleanup_agent_browser() {
+  pkill -f "--user-data-dir=${CHROME_USER_DATA_DIR}" 2>/dev/null || true
+}
+trap cleanup_agent_browser EXIT INT TERM
+```
+
 With the Open Design preview at `http://127.0.0.1:17573/`, run:
 
 ```bash
 if ! curl -fsS http://127.0.0.1:9223/json/version | rg -q webSocketDebuggerUrl; then
   open -na "Google Chrome" --args \
     --remote-debugging-port=9223 \
-    --user-data-dir=/tmp/od-agent-browser-chrome \
+    --user-data-dir="$CHROME_USER_DATA_DIR" \
     --no-first-run \
     --no-default-browser-check
 


### PR DESCRIPTION
## Why

I hit a packaged Open Design Beta run where an agent attempted `daemon-cli.mjs browser snapshot ...`. Because `browser` is not an `od` subcommand, the daemon CLI fell through to normal daemon startup, opened the internal `http://127.0.0.1:7456/` URL in the system browser, and left the local service running.

This fixes that bug by making daemon startup argument parsing strict: unknown commands and unknown options fail fast instead of starting the daemon with the default auto-open behavior.

## What users will see

Invalid commands such as `od browser snapshot ...` now print `unknown command: od browser` and exit instead of launching Open Design and opening `127.0.0.1:7456` in the system browser. The agent-browser skill also now explicitly tells agents to use the external `agent-browser` CLI and to clean up temporary Chrome profiles.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; CLI/skill behavior only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/daemon-startup.test.ts`
- Did the test go red on `main` and green on this branch? No. I did not run the new test against `main`; the behavior was verified directly from the previous parser logic and with a CLI smoke on this branch.
- Additional verification: `node apps/daemon/dist/cli.js browser snapshot --url https://example.test/ --path browser/snapshot.json --timeout 180000` now exits quickly with `unknown command: od browser` instead of starting the daemon.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/daemon-startup.test.ts tests/skills.test.ts`
- `node apps/daemon/dist/cli.js browser snapshot --url https://example.test/ --path browser/snapshot.json --timeout 180000`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`

Note: validation ran under Node `v22.22.0`, so pnpm emitted engine warnings because the repo expects Node `~24`.
