### PR TITLE
fix(daemon): classify Claude mid-stream socket drops as retryable

### DIFF
--- a/apps/daemon/src/claude-diagnostics.ts
+++ b/apps/daemon/src/claude-diagnostics.ts
@@ -42,11 +42,14 @@ function withContext(
 ): ClaudeCliDiagnostic {
   const configDir = envValue(input.env, 'CLAUDE_CONFIG_DIR');
   const baseUrl = envValue(input.env, 'ANTHROPIC_BASE_URL');
+  const runtimeLabel = selectedClaudeCompatibleRuntime(input) === 'openclaude'
+    ? 'OpenClaude'
+    : 'Claude Code';
   const diagnosticTail = redactSecrets(body(input)).replace(/\s+/g, ' ').trim().slice(-240);
   const context: string[] = [message, detail];
   if (diagnosticTail) context.push(`Claude output: ${diagnosticTail}`);
   if (configDir) context.push(`Effective CLAUDE_CONFIG_DIR: ${configDir}.`);
-  if (baseUrl) context.push('ANTHROPIC_BASE_URL is set for this Claude Code process.');
+  if (baseUrl) context.push(`ANTHROPIC_BASE_URL is set for this ${runtimeLabel} process.`);
   return {
     message: redactSecrets(message),
     detail: redactSecrets(context.filter(Boolean).join(' ')),
@@ -75,6 +78,8 @@ export function diagnoseClaudeCliFailure(
   const hasConfigDir = envValue(input.env, 'CLAUDE_CONFIG_DIR') !== null;
   const runtime = selectedClaudeCompatibleRuntime(input);
   const isOpenClaude = runtime === 'openclaude';
+  const runtimeLabel = isOpenClaude ? 'OpenClaude' : 'Claude Code';
+  const defaultEndpointLabel = isOpenClaude ? 'its configured endpoint' : 'the Anthropic API';
 
   const customEndpointConnectionFailure =
     hasCustomBaseUrl &&
@@ -110,14 +115,17 @@ export function diagnoseClaudeCliFailure(
     /\bconnection (error|reset|closed)\b/i.test(text);
   if (connectionDropped) {
     if (hasCustomBaseUrl) {
+      const customEndpointFallback = isOpenClaude
+        ? 'check the OpenClaude endpoint configuration.'
+        : 'remove ANTHROPIC_BASE_URL to retry with standard Claude Code auth.';
       return withContext(
-        'Claude Code lost its connection to the configured custom Anthropic endpoint before the response finished.',
-        'The connection to ANTHROPIC_BASE_URL was closed mid-stream — often a proxy or relay that drops long-lived streaming requests, and most likely on large generations. Retry; if it keeps happening, raise the proxy idle/stream timeout, or remove ANTHROPIC_BASE_URL to retry with standard Claude Code auth.',
+        `${runtimeLabel} lost its connection to the configured custom Anthropic endpoint before the response finished.`,
+        `The connection to ANTHROPIC_BASE_URL was closed mid-stream — often a proxy or relay that drops long-lived streaming requests, and most likely on large generations. Retry; if it keeps happening, raise the proxy idle/stream timeout, or ${customEndpointFallback}`,
         input,
       );
     }
     return withContext(
-      'Claude Code lost its connection to the Anthropic API before the response finished.',
+      `${runtimeLabel} lost its connection to ${defaultEndpointLabel} before the response finished.`,
       'The network connection was closed mid-response — common on unstable networks, VPNs, or proxies that drop long-lived streaming requests, and most likely on large generations. Retry the request.',
       input,
     );

--- a/apps/daemon/src/claude-diagnostics.ts
+++ b/apps/daemon/src/claude-diagnostics.ts
@@ -89,6 +89,40 @@ export function diagnoseClaudeCliFailure(
     );
   }
 
+  // A connection that *was established* and then dropped mid-response. This is
+  // distinct from the `connection refused` case above (which never connects):
+  // the Anthropic SDK / undici reports a premature close as "the socket
+  // connection was closed unexpectedly", "socket hang up", ECONNRESET,
+  // "fetch failed", etc. It is transient and worth retrying, and it shows up
+  // most on long, large generations whose streaming response outlives a flaky
+  // hop (VPN, corporate proxy, or a self-hosted ANTHROPIC_BASE_URL relay that
+  // caps streaming-request duration).
+  const connectionDropped =
+    /socket connection was closed/i.test(text) ||
+    /closed unexpectedly/i.test(text) ||
+    /socket hang up/i.test(text) ||
+    /econnreset/i.test(text) ||
+    /epipe/i.test(text) ||
+    /und_err_socket/i.test(text) ||
+    /premature close/i.test(text) ||
+    /other side closed/i.test(text) ||
+    /fetch failed/i.test(text) ||
+    /\bconnection (error|reset|closed)\b/i.test(text);
+  if (connectionDropped) {
+    if (hasCustomBaseUrl) {
+      return withContext(
+        'Claude Code lost its connection to the configured custom Anthropic endpoint before the response finished.',
+        'The connection to ANTHROPIC_BASE_URL was closed mid-stream — often a proxy or relay that drops long-lived streaming requests, and most likely on large generations. Retry; if it keeps happening, raise the proxy idle/stream timeout, or remove ANTHROPIC_BASE_URL to retry with standard Claude Code auth.',
+        input,
+      );
+    }
+    return withContext(
+      'Claude Code lost its connection to the Anthropic API before the response finished.',
+      'The network connection was closed mid-response — common on unstable networks, VPNs, or proxies that drop long-lived streaming requests, and most likely on large generations. Retry the request.',
+      input,
+    );
+  }
+
   const authFailure =
     /\b401\b/.test(text) ||
     /apikeysource["'\s:]+none/i.test(text) ||

--- a/apps/daemon/src/claude-diagnostics.ts
+++ b/apps/daemon/src/claude-diagnostics.ts
@@ -94,19 +94,27 @@ export function diagnoseClaudeCliFailure(
     );
   }
 
-  // A connection that *was established* and then dropped mid-response. This is
-  // distinct from the `connection refused` case above (which never connects):
-  // the Anthropic SDK / undici reports a premature close as "the socket
-  // connection was closed unexpectedly", "socket hang up", ECONNRESET,
-  // "fetch failed", etc. It is transient and worth retrying, and it shows up
-  // most on long, large generations whose streaming response outlives a flaky
-  // hop (VPN, corporate proxy, or a self-hosted ANTHROPIC_BASE_URL relay that
-  // caps streaming-request duration).
+  // A connection that *was established* and then dropped (or kept resetting),
+  // distinct from the `connection refused` case above (which never connects).
+  // The exact text has several faces depending on where the failure lands;
+  // these were captured by driving the real Claude Code CLI (2.1.168) against
+  // a flaky local hop:
+  //   - SSE stream cut after it started  -> "API Error: The socket connection
+  //     was closed unexpectedly. ... pass verbose: true ..."
+  //   - TLS tunnel reset                 -> "API Error: Unable to connect to
+  //     API (ECONNRESET)"
+  // Both are transient and worth retrying; the CLI retries internally for a
+  // minute or more before surfacing them, which is why long runs appear to
+  // "abort after a while". Most visible on large generations whose streaming
+  // response outlives a flaky hop (VPN, GFW/relay, corporate proxy, or a
+  // self-hosted ANTHROPIC_BASE_URL relay that caps streaming-request duration).
   const connectionDropped =
     /socket connection was closed/i.test(text) ||
     /closed unexpectedly/i.test(text) ||
+    /unable to connect to api/i.test(text) ||
     /socket hang up/i.test(text) ||
     /econnreset/i.test(text) ||
+    /etimedout/i.test(text) ||
     /epipe/i.test(text) ||
     /und_err_socket/i.test(text) ||
     /premature close/i.test(text) ||

--- a/apps/daemon/src/claude-diagnostics.ts
+++ b/apps/daemon/src/claude-diagnostics.ts
@@ -16,6 +16,13 @@ export interface ClaudeCliDiagnostic {
   message: string;
   detail: string;
   retryable: boolean;
+  /**
+   * Stable `ApiErrorCode` for this failure class, when one is more specific
+   * than the generic `AGENT_EXECUTION_FAILED`. Lets the web map the code to a
+   * localized message and lets triage count failures by class. Omitted for
+   * branches that have no dedicated code yet.
+   */
+  code?: string;
 }
 
 function envValue(
@@ -39,6 +46,7 @@ function withContext(
   message: string,
   detail: string,
   input: ClaudeCliDiagnosticInput,
+  code?: string,
 ): ClaudeCliDiagnostic {
   const configDir = envValue(input.env, 'CLAUDE_CONFIG_DIR');
   const baseUrl = envValue(input.env, 'ANTHROPIC_BASE_URL');
@@ -54,6 +62,7 @@ function withContext(
     message: redactSecrets(message),
     detail: redactSecrets(context.filter(Boolean).join(' ')),
     retryable: true,
+    ...(code ? { code } : {}),
   };
 }
 
@@ -130,12 +139,14 @@ export function diagnoseClaudeCliFailure(
         `${runtimeLabel} lost its connection to the configured custom Anthropic endpoint before the response finished.`,
         `The connection to ANTHROPIC_BASE_URL was closed mid-stream — often a proxy or relay that drops long-lived streaming requests, and most likely on large generations. Retry; if it keeps happening, raise the proxy idle/stream timeout, or ${customEndpointFallback}`,
         input,
+        'AGENT_CONNECTION_DROPPED',
       );
     }
     return withContext(
       `${runtimeLabel} lost its connection to ${defaultEndpointLabel} before the response finished.`,
       'The network connection was closed mid-response — common on unstable networks, VPNs, or proxies that drop long-lived streaming requests, and most likely on large generations. Retry the request.',
       input,
+      'AGENT_CONNECTION_DROPPED',
     );
   }
 

--- a/apps/daemon/src/claude-diagnostics.ts
+++ b/apps/daemon/src/claude-diagnostics.ts
@@ -101,8 +101,8 @@ export function diagnoseClaudeCliFailure(
   // a flaky local hop:
   //   - SSE stream cut after it started  -> "API Error: The socket connection
   //     was closed unexpectedly. ... pass verbose: true ..."
-  //   - TLS tunnel reset                 -> "API Error: Unable to connect to
-  //     API (ECONNRESET)"
+  //   - TLS tunnel reset/timeout         -> "API Error: Unable to connect to
+  //     API (ECONNRESET)" / "API Error: Unable to connect to API (ETIMEDOUT)"
   // Both are transient and worth retrying; the CLI retries internally for a
   // minute or more before surfacing them, which is why long runs appear to
   // "abort after a while". Most visible on large generations whose streaming
@@ -111,7 +111,7 @@ export function diagnoseClaudeCliFailure(
   const connectionDropped =
     /socket connection was closed/i.test(text) ||
     /closed unexpectedly/i.test(text) ||
-    /unable to connect to api/i.test(text) ||
+    /unable to connect to api \((econnreset|etimedout)\)/i.test(text) ||
     /socket hang up/i.test(text) ||
     /econnreset/i.test(text) ||
     /etimedout/i.test(text) ||

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13504,7 +13504,10 @@ export async function startServer({
         );
         if (diagnostic) {
           send('error', createSseErrorPayload(
-            serviceCode ?? 'AGENT_EXECUTION_FAILED',
+            // A diagnostic that named its own failure class (e.g.
+            // AGENT_CONNECTION_DROPPED) wins over the generic service-failure
+            // sniff so the UI can localize by code and triage can count it.
+            diagnostic.code ?? serviceCode ?? 'AGENT_EXECUTION_FAILED',
             diagnostic.message,
             { retryable: diagnostic.retryable, details: { detail: diagnostic.detail } },
           ));

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13048,17 +13048,33 @@ export async function startServer({
             agentStdoutTail,
             agentStderrTail,
           ].join('\n');
-          agentStreamError = rewriteKnownAgentStreamError(
-            agentId,
-            message,
-            failureText,
-          );
           clearInactivityWatchdog();
+          // Claude surfaces a connection drop / reset as an in-stream `error`
+          // frame (assistant `error:"unknown"` + the raw SDK string), which
+          // would otherwise reach the UI verbatim as a non-retryable
+          // AGENT_EXECUTION_FAILED. Run the same per-agent diagnostic used at
+          // child-exit so this path emits the specific class
+          // (AGENT_CONNECTION_DROPPED) — retryable, with copy the web can
+          // localize and triage can count by code.
+          const diagnostic = diagnoseClaudeCliFailure({
+            agentId: def.id,
+            exitCode: 1,
+            stderrTail: agentStderrTail,
+            stdoutTail: failureText,
+            env: spawnedAgentEnv,
+            resolvedBin: agentLaunch.selectedPath,
+          });
           const serviceCode = classifyAgentServiceFailure(failureText);
+          agentStreamError = diagnostic?.message
+            ?? rewriteKnownAgentStreamError(agentId, message, failureText);
           send('error', createSseErrorPayload(
-            serviceCode ?? 'AGENT_EXECUTION_FAILED',
+            diagnostic?.code ?? serviceCode ?? 'AGENT_EXECUTION_FAILED',
             agentStreamError,
-            { retryable: serviceCode === 'AGENT_AUTH_REQUIRED' || serviceCode === 'RATE_LIMITED' },
+            {
+              retryable: diagnostic?.retryable
+                ?? (serviceCode === 'AGENT_AUTH_REQUIRED' || serviceCode === 'RATE_LIMITED'),
+              ...(diagnostic ? { details: { detail: diagnostic.detail } } : {}),
+            },
           ));
           return;
         }

--- a/apps/daemon/tests/claude-diagnostics.test.ts
+++ b/apps/daemon/tests/claude-diagnostics.test.ts
@@ -217,6 +217,24 @@ describe('diagnoseClaudeCliFailure', () => {
     expect(diagnostic?.retryable).toBe(true);
   });
 
+  // Captured verbatim from the real Claude Code CLI (2.1.168, official auth,
+  // no ANTHROPIC_BASE_URL) driven through a local proxy that reset the TLS
+  // tunnel mid-stream. The CLI retried internally for ~3 minutes, then emitted
+  // this on stdout as a result frame with is_error:true and exited 1.
+  it('classifies the real "Unable to connect to API (ECONNRESET)" transcript', () => {
+    const diagnostic = diagnoseClaudeCliFailure({
+      agentId: 'claude',
+      exitCode: 1,
+      stdoutTail:
+        '{"type":"result","subtype":"success","is_error":true,"result":"API Error: Unable to connect to API (ECONNRESET)","stop_reason":"stop_sequence"}',
+      env: {},
+    });
+
+    expect(diagnostic?.message).toContain('lost its connection to the Anthropic API');
+    expect(diagnostic?.detail).not.toContain('/login');
+    expect(diagnostic?.retryable).toBe(true);
+  });
+
   it('classifies ECONNRESET and socket hang up as connection drops', () => {
     for (const tail of ['Error: socket hang up', 'read ECONNRESET', 'TypeError: fetch failed']) {
       const diagnostic = diagnoseClaudeCliFailure({

--- a/apps/daemon/tests/claude-diagnostics.test.ts
+++ b/apps/daemon/tests/claude-diagnostics.test.ts
@@ -184,4 +184,45 @@ describe('diagnoseClaudeCliFailure', () => {
     expect(diagnostic?.detail).not.toContain('b'.repeat(80));
     expect(diagnostic?.detail).toContain('x-api-key: [REDACTED:api_key_header]');
   });
+
+  it('maps mid-stream socket drops to a retryable connection diagnostic', () => {
+    const diagnostic = diagnoseClaudeCliFailure({
+      agentId: 'claude',
+      exitCode: 1,
+      stderrTail:
+        'API Error: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()',
+      env: {},
+    });
+
+    expect(diagnostic?.message).toContain('lost its connection');
+    expect(diagnostic?.message).toContain('Anthropic API');
+    expect(diagnostic?.detail).toContain('Retry');
+    expect(diagnostic?.detail).not.toContain('/login');
+    expect(diagnostic?.retryable).toBe(true);
+  });
+
+  it('classifies ECONNRESET and socket hang up as connection drops', () => {
+    for (const tail of ['Error: socket hang up', 'read ECONNRESET', 'TypeError: fetch failed']) {
+      const diagnostic = diagnoseClaudeCliFailure({
+        agentId: 'claude',
+        exitCode: 1,
+        stderrTail: tail,
+        env: {},
+      });
+      expect(diagnostic?.message, tail).toContain('lost its connection');
+    }
+  });
+
+  it('points socket drops at the proxy when a custom endpoint is configured', () => {
+    const diagnostic = diagnoseClaudeCliFailure({
+      agentId: 'claude',
+      exitCode: 1,
+      stderrTail: 'API Error: The socket connection was closed unexpectedly.',
+      env: { ANTHROPIC_BASE_URL: 'https://relay.example.com' },
+    });
+
+    expect(diagnostic?.message).toContain('custom Anthropic endpoint');
+    expect(diagnostic?.detail).toContain('ANTHROPIC_BASE_URL');
+    expect(diagnostic?.detail).toContain('timeout');
+  });
 });

--- a/apps/daemon/tests/claude-diagnostics.test.ts
+++ b/apps/daemon/tests/claude-diagnostics.test.ts
@@ -201,6 +201,22 @@ describe('diagnoseClaudeCliFailure', () => {
     expect(diagnostic?.retryable).toBe(true);
   });
 
+  it('uses OpenClaude copy for OpenClaude mid-stream socket drops', () => {
+    const diagnostic = diagnoseClaudeCliFailure({
+      agentId: 'claude',
+      exitCode: 1,
+      stderrTail: 'API Error: The socket connection was closed unexpectedly.',
+      env: {},
+      resolvedBin: '/usr/local/bin/openclaude',
+    });
+
+    expect(diagnostic?.message).toContain('OpenClaude lost its connection');
+    expect(diagnostic?.message).toContain('its configured endpoint');
+    expect(diagnostic?.detail).not.toContain('Claude Code');
+    expect(diagnostic?.detail).not.toContain('Anthropic API');
+    expect(diagnostic?.retryable).toBe(true);
+  });
+
   it('classifies ECONNRESET and socket hang up as connection drops', () => {
     for (const tail of ['Error: socket hang up', 'read ECONNRESET', 'TypeError: fetch failed']) {
       const diagnostic = diagnoseClaudeCliFailure({
@@ -224,5 +240,21 @@ describe('diagnoseClaudeCliFailure', () => {
     expect(diagnostic?.message).toContain('custom Anthropic endpoint');
     expect(diagnostic?.detail).toContain('ANTHROPIC_BASE_URL');
     expect(diagnostic?.detail).toContain('timeout');
+  });
+
+  it('uses OpenClaude copy for OpenClaude custom endpoint socket drops', () => {
+    const diagnostic = diagnoseClaudeCliFailure({
+      agentId: 'claude',
+      exitCode: 1,
+      stderrTail: 'API Error: The socket connection was closed unexpectedly.',
+      env: { ANTHROPIC_BASE_URL: 'https://relay.example.com' },
+      resolvedBin: '/usr/local/bin/openclaude',
+    });
+
+    expect(diagnostic?.message).toContain('OpenClaude lost its connection');
+    expect(diagnostic?.message).toContain('custom Anthropic endpoint');
+    expect(diagnostic?.detail).toContain('ANTHROPIC_BASE_URL');
+    expect(diagnostic?.detail).toContain('OpenClaude endpoint configuration');
+    expect(diagnostic?.detail).not.toContain('Claude Code');
   });
 });

--- a/apps/daemon/tests/claude-diagnostics.test.ts
+++ b/apps/daemon/tests/claude-diagnostics.test.ts
@@ -199,6 +199,7 @@ describe('diagnoseClaudeCliFailure', () => {
     expect(diagnostic?.detail).toContain('Retry');
     expect(diagnostic?.detail).not.toContain('/login');
     expect(diagnostic?.retryable).toBe(true);
+    expect(diagnostic?.code).toBe('AGENT_CONNECTION_DROPPED');
   });
 
   it('uses OpenClaude copy for OpenClaude mid-stream socket drops', () => {
@@ -233,6 +234,7 @@ describe('diagnoseClaudeCliFailure', () => {
     expect(diagnostic?.message).toContain('lost its connection to the Anthropic API');
     expect(diagnostic?.detail).not.toContain('/login');
     expect(diagnostic?.retryable).toBe(true);
+    expect(diagnostic?.code).toBe('AGENT_CONNECTION_DROPPED');
   });
 
   it('does not classify generic first-connect API failures as mid-stream drops', () => {

--- a/apps/daemon/tests/claude-diagnostics.test.ts
+++ b/apps/daemon/tests/claude-diagnostics.test.ts
@@ -235,6 +235,18 @@ describe('diagnoseClaudeCliFailure', () => {
     expect(diagnostic?.retryable).toBe(true);
   });
 
+  it('does not classify generic first-connect API failures as mid-stream drops', () => {
+    const diagnostic = diagnoseClaudeCliFailure({
+      agentId: 'claude',
+      exitCode: 1,
+      stdoutTail:
+        '{"type":"result","subtype":"success","is_error":true,"result":"API Error: Unable to connect to API (ENOTFOUND)","stop_reason":"stop_sequence"}',
+      env: {},
+    });
+
+    expect(diagnostic).toBeNull();
+  });
+
   it('classifies ECONNRESET and socket hang up as connection drops', () => {
     for (const tail of ['Error: socket hang up', 'read ECONNRESET', 'TypeError: fetch failed']) {
       const diagnostic = diagnoseClaudeCliFailure({

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -13,6 +13,7 @@ export const ar: Dict = {
   'chat.amrError.rechargeCta': 'شحن AMR',
   'chat.antigravityError.launchTerminalCta': 'تسجيل الدخول عبر الطرفية',
   'chat.antigravityError.launchSwitchModelCta': 'تبديل النموذج في الطرفية',
+  'chat.connectionDropped': 'انقطع الاتصال بخدمة النموذج قبل اكتمال الاستجابة — عادةً بسبب شبكة أو وكيل (proxy) غير مستقر. يرجى إعادة المحاولة.',
   'common.cancel': 'إلغاء',
   'common.save': 'حفظ',
   'common.close': 'إغلاق',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -13,6 +13,7 @@ export const de: Dict = {
   'chat.amrError.rechargeCta': 'AMR aufladen',
   'chat.antigravityError.launchTerminalCta': 'Über Terminal anmelden',
   'chat.antigravityError.launchSwitchModelCta': 'Modell im Terminal wechseln',
+  'chat.connectionDropped': 'Die Verbindung zum Modelldienst wurde vor dem Ende der Antwort unterbrochen – meist ein instabiles Netzwerk oder ein Proxy. Bitte erneut versuchen.',
   'common.cancel': 'Abbrechen',
   'common.save': 'Speichern',
   'common.close': 'Schließen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -13,6 +13,7 @@ export const en: Dict = {
   'chat.amrError.rechargeCta': 'Top up AMR',
   'chat.antigravityError.launchTerminalCta': 'Sign in via terminal',
   'chat.antigravityError.launchSwitchModelCta': 'Switch model in terminal',
+  'chat.connectionDropped': 'The connection to the model service dropped before the response finished — usually an unstable network or proxy. Please retry.',
   'common.cancel': 'Cancel',
   'common.save': 'Save',
   'common.close': 'Close',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -13,6 +13,7 @@ export const esES: Dict = {
   'chat.amrError.rechargeCta': 'Recargar AMR',
   'chat.antigravityError.launchTerminalCta': 'Iniciar sesión desde el terminal',
   'chat.antigravityError.launchSwitchModelCta': 'Cambiar de modelo en el terminal',
+  'chat.connectionDropped': 'La conexión con el servicio del modelo se interrumpió antes de terminar la respuesta, normalmente por una red o un proxy inestables. Vuelve a intentarlo.',
   'common.cancel': 'Cancelar',
   'common.save': 'Guardar',
   'common.close': 'Cerrar',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -13,6 +13,7 @@ export const fa: Dict = {
   'chat.amrError.rechargeCta': 'شارژ AMR',
   'chat.antigravityError.launchTerminalCta': 'ورود از طریق ترمینال',
   'chat.antigravityError.launchSwitchModelCta': 'تغییر مدل در ترمینال',
+  'chat.connectionDropped': 'اتصال به سرویس مدل پیش از پایان پاسخ قطع شد — معمولاً به دلیل شبکه یا پراکسی ناپایدار. لطفاً دوباره تلاش کنید.',
   'common.cancel': 'لغو',
   'common.save': 'ذخیره',
   'common.close': 'بستن',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -13,6 +13,7 @@ export const fr: Dict = {
   'chat.amrError.rechargeCta': 'Recharger AMR',
   'chat.antigravityError.launchTerminalCta': 'Se connecter via le terminal',
   'chat.antigravityError.launchSwitchModelCta': 'Changer de modèle dans le terminal',
+  'chat.connectionDropped': 'La connexion au service de modèle a été interrompue avant la fin de la réponse — généralement un réseau ou un proxy instable. Veuillez réessayer.',
   'common.cancel': 'Annuler',
   'common.save': 'Enregistrer',
   'common.close': 'Fermer',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -13,6 +13,7 @@ export const hu: Dict = {
   'chat.amrError.rechargeCta': 'AMR feltöltése',
   'chat.antigravityError.launchTerminalCta': 'Bejelentkezés terminálon keresztül',
   'chat.antigravityError.launchSwitchModelCta': 'Modellváltás a terminálban',
+  'chat.connectionDropped': 'A modellszolgáltatáshoz való kapcsolat megszakadt a válasz befejezése előtt – általában instabil hálózat vagy proxy miatt. Kérjük, próbáld újra.',
   'common.cancel': 'Mégse',
   'common.save': 'Mentés',
   'common.close': 'Bezárás',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -13,6 +13,7 @@ export const id: Dict = {
   'chat.amrError.rechargeCta': 'Isi ulang AMR',
   'chat.antigravityError.launchTerminalCta': 'Masuk melalui terminal',
   'chat.antigravityError.launchSwitchModelCta': 'Ganti model di terminal',
+  'chat.connectionDropped': 'Koneksi ke layanan model terputus sebelum respons selesai — biasanya karena jaringan atau proxy yang tidak stabil. Silakan coba lagi.',
   'common.cancel': 'Batal',
   'common.save': 'Simpan',
   'common.close': 'Tutup',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -13,6 +13,7 @@ export const it: Dict = {
   'chat.amrError.rechargeCta': 'Ricarica AMR',
   'chat.antigravityError.launchTerminalCta': 'Accedi tramite terminale',
   'chat.antigravityError.launchSwitchModelCta': 'Cambia modello nel terminale',
+  'chat.connectionDropped': 'La connessione al servizio del modello è caduta prima del completamento della risposta, di solito a causa di una rete o di un proxy instabili. Riprova.',
   'common.cancel': 'Annulla',
   'common.save': 'Salva',
   'common.close': 'Chiudi',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -13,6 +13,7 @@ export const ja: Dict = {
   'chat.amrError.rechargeCta': 'AMR にチャージ',
   'chat.antigravityError.launchTerminalCta': 'ターミナルでサインイン',
   'chat.antigravityError.launchSwitchModelCta': 'ターミナルでモデルを切り替え',
+  'chat.connectionDropped': '応答が完了する前にモデルサービスへの接続が切断されました。多くはネットワークやプロキシの不安定が原因です。再試行してください。',
   'common.cancel': 'キャンセル',
   'common.save': '保存',
   'common.close': '閉じる',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -13,6 +13,7 @@ export const ko: Dict = {
   'chat.amrError.rechargeCta': 'AMR 충전',
   'chat.antigravityError.launchTerminalCta': '터미널에서 로그인',
   'chat.antigravityError.launchSwitchModelCta': '터미널에서 모델 전환',
+  'chat.connectionDropped': '응답이 끝나기 전에 모델 서비스 연결이 끊겼습니다. 대개 불안정한 네트워크나 프록시가 원인입니다. 다시 시도해 주세요.',
   'common.cancel': '취소',
   'common.save': '저장',
   'common.close': '닫기',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -13,6 +13,7 @@ export const pl: Dict = {
   'chat.amrError.rechargeCta': 'Doładuj AMR',
   'chat.antigravityError.launchTerminalCta': 'Zaloguj się przez terminal',
   'chat.antigravityError.launchSwitchModelCta': 'Zmień model w terminalu',
+  'chat.connectionDropped': 'Połączenie z usługą modelu zostało przerwane przed zakończeniem odpowiedzi — zwykle z powodu niestabilnej sieci lub serwera proxy. Spróbuj ponownie.',
   'common.cancel': 'Anuluj',
   'common.save': 'Zapisz',
   'common.close': 'Zamknij',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -13,6 +13,7 @@ export const ptBR: Dict = {
   'chat.amrError.rechargeCta': 'Recarregar AMR',
   'chat.antigravityError.launchTerminalCta': 'Entrar pelo terminal',
   'chat.antigravityError.launchSwitchModelCta': 'Alternar modelo no terminal',
+  'chat.connectionDropped': 'A conexão com o serviço do modelo caiu antes de a resposta terminar — geralmente uma rede ou proxy instável. Tente novamente.',
   'common.cancel': 'Cancelar',
   'common.save': 'Salvar',
   'common.close': 'Fechar',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -13,6 +13,7 @@ export const ru: Dict = {
   'chat.amrError.rechargeCta': 'Пополнить AMR',
   'chat.antigravityError.launchTerminalCta': 'Войти через терминал',
   'chat.antigravityError.launchSwitchModelCta': 'Сменить модель в терминале',
+  'chat.connectionDropped': 'Соединение с сервисом модели прервалось до завершения ответа — обычно из-за нестабильной сети или прокси. Повторите попытку.',
   'common.cancel': 'Отмена',
   'common.save': 'Сохранить',
   'common.close': 'Закрыть',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -13,6 +13,7 @@ export const th: Dict = {
   'chat.amrError.rechargeCta': 'เติมเงิน AMR',
   'chat.antigravityError.launchTerminalCta': 'ลงชื่อเข้าใช้ผ่านเทอร์มินัล',
   'chat.antigravityError.launchSwitchModelCta': 'สลับโมเดลในเทอร์มินัล',
+  'chat.connectionDropped': 'การเชื่อมต่อกับบริการโมเดลหลุดก่อนที่การตอบกลับจะเสร็จสิ้น — มักเกิดจากเครือข่ายหรือพร็อกซีที่ไม่เสถียร โปรดลองอีกครั้ง',
   'common.cancel': 'ยกเลิก',
   'common.save': 'บันทึก',
   'common.close': 'ปิด',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -13,6 +13,7 @@ export const tr: Dict = {
   'chat.amrError.rechargeCta': 'AMR bakiyesi yükle',
   'chat.antigravityError.launchTerminalCta': 'Terminal üzerinden giriş yap',
   'chat.antigravityError.launchSwitchModelCta': 'Terminalde modeli değiştir',
+  'chat.connectionDropped': 'Yanıt tamamlanmadan model hizmetiyle bağlantı koptu — genellikle kararsız bir ağ veya proxy nedeniyle. Lütfen yeniden deneyin.',
   'common.cancel': 'İptal et',
   'common.save': 'Kaydet',
   'common.close': 'Kapat',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -13,6 +13,7 @@ export const uk: Dict = {
   'chat.amrError.rechargeCta': 'Поповнити AMR',
   'chat.antigravityError.launchTerminalCta': 'Увійти через термінал',
   'chat.antigravityError.launchSwitchModelCta': 'Змінити модель у терміналі',
+  'chat.connectionDropped': 'З’єднання зі службою моделі обірвалося до завершення відповіді — зазвичай через нестабільну мережу або проксі. Повторіть спробу.',
   'common.cancel': 'Скасувати',
   'common.save': 'Зберегти',
   'common.close': 'Закрити',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -13,6 +13,7 @@ export const zhCN: Dict = {
   'chat.amrError.rechargeCta': '为 AMR 充值',
   'chat.antigravityError.launchTerminalCta': '在终端中登录',
   'chat.antigravityError.launchSwitchModelCta': '在终端中切换模型',
+  'chat.connectionDropped': '与模型服务的连接在响应完成前中断了——通常是网络或代理不稳定。请重试。',
   'common.cancel': '取消',
   'common.save': '保存',
   'common.close': '关闭',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -13,6 +13,7 @@ export const zhTW: Dict = {
   'chat.amrError.rechargeCta': '為 AMR 儲值',
   'chat.antigravityError.launchTerminalCta': '透過終端機登入',
   'chat.antigravityError.launchSwitchModelCta': '在終端機中切換模型',
+  'chat.connectionDropped': '與模型服務的連線在回應完成前中斷了——通常是網路或代理不穩定。請重試。',
   'common.cancel': '取消',
   'common.save': '儲存',
   'common.close': '關閉',

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1973,6 +1973,7 @@ export interface Dict {
   'chat.amrError.rechargeCta': string;
   'chat.antigravityError.launchTerminalCta': string;
   'chat.antigravityError.launchSwitchModelCta': string;
+  'chat.connectionDropped': string;
   'chat.tabComments': string;
   'chat.commentsSoon': string;
   'chat.comments.attached': string;

--- a/apps/web/src/runtime/amr-guidance.ts
+++ b/apps/web/src/runtime/amr-guidance.ts
@@ -53,6 +53,7 @@ export type RunFailurePrimaryAction =
 export type RunFailureMessageKey =
   | 'chat.amrError.authMessage'
   | 'chat.amrError.balanceMessage'
+  | 'chat.connectionDropped'
   | null;
 
 export interface RunFailureUi {
@@ -127,6 +128,18 @@ export function resolveRunFailureUi(
         showSwitchCard: false,
       };
     }
+  }
+  // Agent-neutral: a mid-response connection drop (any agent) gets a clear,
+  // localized "lost connection — retry" message instead of the raw SDK string.
+  // Not an AMR-promotable case: the break is the user's own network path, which
+  // switching model service wouldn't fix.
+  if (code === 'AGENT_CONNECTION_DROPPED') {
+    return {
+      primaryAction: 'retry',
+      messageKey: 'chat.connectionDropped',
+      secondaryRetry: false,
+      showSwitchCard: false,
+    };
   }
   const promote = typeof code === 'string' && PROMOTE_AMR_CODES.has(code);
   return {

--- a/apps/web/tests/runtime/amr-guidance.test.ts
+++ b/apps/web/tests/runtime/amr-guidance.test.ts
@@ -23,6 +23,18 @@ describe('resolveRunFailureUi', () => {
     expect(resolveRunFailureUi('AGENT_UNAVAILABLE', 'codex').showSwitchCard).toBe(false);
   });
 
+  it('localizes a mid-stream connection drop for any agent, no AMR promotion', () => {
+    for (const agent of ['claude', 'codex', null]) {
+      const ui = resolveRunFailureUi('AGENT_CONNECTION_DROPPED', agent);
+      expect(ui).toMatchObject({
+        primaryAction: 'retry',
+        messageKey: 'chat.connectionDropped',
+        secondaryRetry: false,
+        showSwitchCard: false,
+      });
+    }
+  });
+
   it('offers authorize-and-retry for an unauthorized AMR run (no card)', () => {
     const ui = resolveRunFailureUi('AMR_AUTH_REQUIRED', 'amr');
     expect(ui).toMatchObject({

--- a/e2e/lib/fake-agents.ts
+++ b/e2e/lib/fake-agents.ts
@@ -149,6 +149,10 @@ async function emitRun(promptText) {
     emitServiceFailure(503);
     return;
   }
+  if (promptText.includes('Return a daemon socket-drop failure')) {
+    emitSocketDropFailure();
+    return;
+  }
   if (promptText.includes('Return an empty daemon smoke response')) {
     emitEmptySuccess();
     return;
@@ -413,6 +417,57 @@ function emitServiceFailure(statusCode) {
       process.exitCode = 1;
       exitSoon(1);
   }
+}
+
+// Reproduces a connection that dropped mid-response. This shape is NOT guessed:
+// it was captured by pointing the real Claude Code CLI (2.1.168) at a fake
+// Anthropic endpoint that accepts the request, starts streaming, then destroys
+// the TCP socket. The real CLI exhausts its internal retries and then, on
+// STDOUT (not stderr), emits the SDK error as a synthetic assistant text block
+// plus a result frame carrying is_error:true with subtype "success", and exits
+// 1. The daemon's claude diagnostic reads the stdout tail and classifies it as
+// a retryable connection drop.
+//
+// Only claude is modeled here: the daemon connection-drop diagnostic is
+// claude-specific, and the real Codex CLI fails this class differently (it
+// streams "Reconnecting... N/5" and a turn.failed event over its own
+// transport), so a faithful Codex case belongs with Codex-specific handling,
+// not this claude reproduction.
+function emitSocketDropFailure() {
+  const sdkError =
+    'API Error: The socket connection was closed unexpectedly. For more information, pass \`verbose: true\` in the second argument to fetch()';
+  if (agentId === 'claude') {
+    writeJson({ type: 'system', subtype: 'init', model: 'fake-claude', session_id: 'fake-session' });
+    writeJson({
+      type: 'assistant',
+      message: {
+        id: 'msg-1',
+        model: '<synthetic>',
+        role: 'assistant',
+        stop_reason: 'stop_sequence',
+        content: [{ type: 'text', text: sdkError }],
+      },
+      error: 'unknown',
+    });
+    writeJson({
+      type: 'result',
+      subtype: 'success',
+      is_error: true,
+      result: sdkError,
+      stop_reason: 'stop_sequence',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: { input_tokens: 0, output_tokens: 0 },
+    });
+    process.exitCode = 1;
+    exitSoon(1);
+    return;
+  }
+  // Other runtimes are not the subject of the claude connection diagnostic;
+  // surface a generic non-zero exit carrying the same SDK error text.
+  process.stderr.write(sdkError + '\\n');
+  process.exitCode = 1;
+  exitSoon(1);
 }
 
 function emitEmptySuccess() {

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -114,6 +114,21 @@ test('[P0] real daemon run surfaces process/parser errors in chat', async ({ pag
   await expect(page.locator('.msg.error')).toContainText('intentional fake codex failure');
 });
 
+test('[P0] real daemon run classifies a Claude mid-stream socket drop as a retryable connection error', async ({ page }) => {
+  await page.goto('/');
+  await createProject(page, 'Daemon socket-drop smoke', 'claude');
+  await expectWorkspaceReady(page);
+
+  await sendPrompt(page, 'Return a daemon socket-drop failure');
+
+  // The raw SDK error ("The socket connection was closed unexpectedly") is
+  // replaced by the daemon's classified, human-readable connection diagnostic
+  // instead of being echoed verbatim into an error bubble.
+  await expect(page.locator('.msg.error')).toContainText('lost its connection to the Anthropic API', {
+    timeout: 15_000,
+  });
+});
+
 test('[P0] real daemon run supports a follow-up turn in the same project', async ({ page }) => {
   await page.goto('/');
   await createProject(page, 'Daemon follow-up smoke');

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -122,9 +122,10 @@ test('[P0] real daemon run classifies a Claude mid-stream socket drop as a retry
   await sendPrompt(page, 'Return a daemon socket-drop failure');
 
   // The raw SDK error ("The socket connection was closed unexpectedly") is
-  // replaced by the daemon's classified, human-readable connection diagnostic
-  // instead of being echoed verbatim into an error bubble.
-  await expect(page.locator('.msg.error')).toContainText('lost its connection to the Anthropic API', {
+  // classified as AGENT_CONNECTION_DROPPED and the error card shows the
+  // localized chat.connectionDropped copy (en locale here) instead of echoing
+  // the raw SDK string verbatim.
+  await expect(page.locator('.msg.error')).toContainText('connection to the model service dropped', {
     timeout: 15_000,
   });
 });

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -13,6 +13,14 @@ export const API_ERROR_CODES = [
   'AGENT_UNAVAILABLE',
   'AGENT_AUTH_REQUIRED',
   'AGENT_EXECUTION_FAILED',
+  // The agent's connection to its model provider was established and then
+  // dropped or kept resetting mid-response (e.g. "socket connection was closed
+  // unexpectedly", ECONNRESET, "Unable to connect to API", ETIMEDOUT). Distinct
+  // from a refused connection that never opened. Transient and retryable;
+  // surfaced by the daemon's per-agent failure diagnostics so the UI can show a
+  // localized, human-readable reason instead of the raw SDK string, and so
+  // triage can count this failure class by code.
+  'AGENT_CONNECTION_DROPPED',
   'AGENT_PROMPT_TOO_LARGE',
   'AMR_MODEL_UNAVAILABLE',
   'AMR_AUTH_REQUIRED',


### PR DESCRIPTION
<!-- Fixes presentation of a real upstream failure; doesn't close a tracked issue. -->

## Why

- **Use case:** Teammates on official Claude Code (no custom endpoint) frequently see runs "abort after a minute or so" with a cryptic `API Error: The socket connection was closed unexpectedly. For more information, pass verbose: true in the second argument to fetch()`. I traced where that string comes from and how Open Design surfaces it.
- **Pain:** That string is the raw `@anthropic-ai/sdk` (undici) error for a connection that was established and then dropped/reset mid-response. Open Design relayed it verbatim as a non-retryable `AGENT_EXECUTION_FAILED`. It is transient (the CLI retries internally for 1–3 min before giving up, which is the "abort after a while" symptom) and most visible on long generations, whose multi-minute streaming response is far more exposed to a flaky hop than a short chat turn.

## What users will see

When Claude loses its connection mid-response, the error card now shows a clear, **localized, retryable** message — in zh-CN: “与模型服务的连接在响应完成前中断了——通常是网络或代理不稳定。请重试。” (English: "The connection to the model service dropped before the response finished — usually an unstable network or proxy. Please retry.") — instead of the raw English SDK string. The Retry button is unchanged. The full technical detail stays available via the copy-diagnostic affordance.

## What this PR does

1. **Classify the failure class.** `diagnoseClaudeCliFailure` gains a connection-drop branch matching the real signatures (captured from the live CLI): `socket connection was closed unexpectedly`, `Unable to connect to API (ECONNRESET|ETIMEDOUT)`, `socket hang up`, `fetch failed`, etc. — distinct from the existing connection-refused (never-connected) case.
2. **Stable, machine-readable code.** New `AGENT_CONNECTION_DROPPED` in `packages/contracts`. The daemon stamps it on the run, so the web can localize by code and triage can count this class via `run_finished.error_code` / `routine_runs.error_code` instead of regex-matching prose.
3. **Fix the layer that actually fires (the key correction).** Real Claude reports this as an in-stream `error` frame (assistant `error:"unknown"` + the raw SDK string), which `claude-stream.ts` turns into a `type:'error'` event. The daemon's stream-error handler was sending that raw string verbatim and setting `agentStreamError`, so the child-exit diagnostic was skipped entirely. The diagnostic now runs in the **stream-error handler**, which is where the real failure surfaces. (Found only by running the end-to-end test locally — unit tests passed because they call the function directly and bypass this path.)
4. **Localize.** `resolveRunFailureUi` maps `AGENT_CONNECTION_DROPPED` (any agent) → `chat.connectionDropped`, added to `types.ts` and all 19 locale bundles.
5. **Faithful repro in the fake CLI.** The fake-agent `Return a daemon socket-drop failure` mode was modeled from the real Claude CLI 2.1.168 output (error on stdout as a synthetic `assistant` block + `result{is_error:true}`, exit 1, empty stderr), not guessed. Codex is intentionally out of scope (it fails this class differently — `Reconnecting... N/5` + `turn.failed` over its own transport — and the diagnostic is Claude-specific).

## Surface area

- [x] **API / contract** — new `AGENT_CONNECTION_DROPPED` in `packages/contracts/src/errors.ts`
- [x] **i18n keys** — new `chat.connectionDropped` in `types.ts` + all 19 locale bundles
- [x] **Default behavior change** — the connection-drop error card copy changes (raw SDK string → localized, retryable message)

## Screenshots

The change is the text of an existing error card. Verified live via Playwright (see below); the card renders the localized `chat.connectionDropped` copy with a Retry button.

## Bug fix verification

- **Red spec:** `apps/daemon/tests/claude-diagnostics.test.ts` — connection-drop cases (the exact reported `socket connection was closed` string and the real `Unable to connect to API (ECONNRESET)` transcript) return `null` on `main` (unclassified) and the localized class on this branch. 21 passing.
- **Reproduced against the real CLI (no Open Design):** drove real Claude Code 2.1.168 (official auth, no `ANTHROPIC_BASE_URL`) through a local proxy that resets the TLS tunnel mid-stream → exit 1, `result{is_error:true}` carrying `Unable to connect to API (ECONNRESET)` after ~3 min of internal retries.
- **End-to-end on a real daemon + browser (this machine):**
  - Headless: the daemon now emits `{ code: "AGENT_CONNECTION_DROPPED", retryable: true, message: "…lost its connection to the Anthropic API…", details.detail: … }` (before this fix it emitted raw `AGENT_EXECUTION_FAILED` / non-retryable).
  - Playwright `e2e/ui/real-daemon-run.test.ts` (new `[P0]` case): real daemon + fake-Claude socket-drop → the error card shows the localized `chat.connectionDropped` copy. **1 passed.**

## Validation

- `pnpm --filter @open-design/daemon typecheck` → pass
- `pnpm --filter @open-design/web typecheck` → pass (validates all 19 locales + the message-key union)
- `pnpm --filter @open-design/daemon exec vitest run claude-diagnostics` → 21 passed
- `pnpm --filter @open-design/web exec vitest run runtime/amr-guidance` → 10 passed
- `pnpm guard` → pass
- Playwright `ui/real-daemon-run.test.ts -g "mid-stream socket drop"` → 1 passed (run locally)

## Note

This makes the upstream connection drop legible, retryable, and countable; it does not change the network path to the provider. The actual cure for the affected machines is a stable connection to Anthropic — the diagnostic now says so instead of dumping a raw SDK string.
