### PR TITLE
Fix mention picker tab wrapping

### DIFF
--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -43,13 +43,18 @@
   display: flex;
   align-items: center;
   align-content: flex-start;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 4px;
   min-height: 0;
   padding: 6px;
   background: var(--bg-subtle);
   border-bottom: 1px solid var(--border-soft);
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+}
+.mention-tabs::-webkit-scrollbar {
+  display: none;
 }
 .mention-tab {
   flex: 0 0 auto;

--- a/apps/web/tests/styles/mention-popover.test.ts
+++ b/apps/web/tests/styles/mention-popover.test.ts
@@ -36,13 +36,16 @@ describe('mention popover styles', () => {
     expect(ruleValue(results, 'overflow-y')).toBe('auto');
   });
 
-  it('wraps category tabs inside the panel without clipping labels', () => {
+  it('keeps category tabs on one line without clipping labels', () => {
     const tabs = cssBlock('.mention-tabs');
     const tab = cssBlock('.mention-tab');
 
-    expect(ruleValue(tabs, 'flex-wrap')).toBe('wrap');
-    expect(ruleValue(tabs, 'overflow')).toBe('hidden');
+    expect(ruleValue(tabs, 'flex-wrap')).toBe('nowrap');
+    expect(ruleValue(tabs, 'overflow-x')).toBe('auto');
+    expect(ruleValue(tabs, 'overflow-y')).toBe('hidden');
+    expect(ruleValue(tabs, 'scrollbar-width')).toBe('none');
     expect(ruleValue(tab, 'flex')).toBe('0 0 auto');
+    expect(ruleValue(tab, 'min-inline-size')).toBe('max-content');
     expect(ruleValue(tab, 'white-space')).toBe('nowrap');
   });
 


### PR DESCRIPTION
## Summary
- keep mention picker category tabs on a single row
- allow the tab rail to scroll horizontally instead of wrapping labels
- update the mention popover style coverage for the new no-wrap contract

Fixes #3890.

## Surface area
- [x] UI
- [ ] Daemon/runtime
- [ ] Docs
- [ ] Tests only

## Tests
- node lightweight CSS assertion for mention tab rules
- git diff --check

Note: the focused Vitest command could not run locally in this fresh worktree because node_modules is not installed; relying on CI for the full test run.