### PR TITLE
Handle broken plugin detail posters

### DIFF
--- a/apps/web/src/components/plugin-details/PluginMediaDetail.tsx
+++ b/apps/web/src/components/plugin-details/PluginMediaDetail.tsx
@@ -79,6 +79,7 @@ export function PluginMediaDetail({
 }: Props) {
   const t = useT();
   const [copied, setCopied] = useState(false);
+  const [posterLoadFailed, setPosterLoadFailed] = useState(false);
 
   const manifest: PluginManifest = record.manifest ?? ({} as PluginManifest);
   const od = manifest.od ?? {};
@@ -86,12 +87,17 @@ export function PluginMediaDetail({
   const query = resolvePluginQueryFallback(od.useCase?.query);
   const media = useMemo(() => readMedia(record), [record]);
   const hasAsset = Boolean(media.poster || media.videoUrl || media.audioUrl);
+  const showPoster = Boolean(media.poster && !posterLoadFailed);
 
   // Reset transient state when the active record swaps so the next
   // open never inherits the previous plugin's copied flag.
   useEffect(() => {
     setCopied(false);
   }, [record.id]);
+
+  useEffect(() => {
+    setPosterLoadFailed(false);
+  }, [media.poster, record.id]);
 
   function handleCopy() {
     if (!query) return;
@@ -126,13 +132,14 @@ export function PluginMediaDetail({
         />
       ) : media.isAudio && media.audioUrl ? (
         <div className="plugin-media-stage__audio">
-          {media.poster ? (
+          {showPoster ? (
             <img
               className="plugin-media-stage__audio-poster"
-              src={media.poster}
+              src={media.poster ?? undefined}
               alt={record.title}
               referrerPolicy="no-referrer"
               loading="lazy"
+              onError={() => setPosterLoadFailed(true)}
             />
           ) : (
             <div
@@ -149,14 +156,19 @@ export function PluginMediaDetail({
             preload="none"
           />
         </div>
-      ) : media.poster ? (
+      ) : showPoster ? (
         <img
           className="plugin-media-stage__image"
-          src={media.poster}
+          src={media.poster ?? undefined}
           alt={record.title}
           loading="lazy"
           referrerPolicy="no-referrer"
+          onError={() => setPosterLoadFailed(true)}
         />
+      ) : media.poster ? (
+        <div className="plugin-media-stage__empty">
+          {t('fileViewer.previewUnavailable')}
+        </div>
       ) : null}
     </div>
   );

--- a/apps/web/tests/components/PluginMediaDetail.poster-fallback.test.tsx
+++ b/apps/web/tests/components/PluginMediaDetail.poster-fallback.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import type { InstalledPluginRecord } from '@open-design/contracts';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { I18nProvider } from '../../src/i18n';
+import { PluginMediaDetail } from '../../src/components/plugin-details/PluginMediaDetail';
+
+function makeRecord(
+  poster: string,
+  preview: Record<string, unknown> = { type: 'image' },
+): InstalledPluginRecord {
+  return {
+    id: 'broken-poster-plugin',
+    title: 'Broken Poster Plugin',
+    version: '0.1.0',
+    sourceKind: 'bundled',
+    source: '/tmp',
+    trust: 'bundled',
+    capabilitiesGranted: [],
+    manifest: {
+      name: 'broken-poster-plugin',
+      version: '0.1.0',
+      title: 'Broken Poster Plugin',
+      od: {
+        kind: 'scenario',
+        preview: { poster, ...preview },
+      },
+    },
+    fsPath: '/tmp',
+    installedAt: 0,
+    updatedAt: 0,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('PluginMediaDetail poster fallback', () => {
+  it('removes a broken poster image from the detail stage', () => {
+    const { container } = render(
+      <I18nProvider>
+        <PluginMediaDetail
+          record={makeRecord('https://example.invalid/poster.png')}
+          onClose={() => {}}
+          onUse={() => {}}
+        />
+      </I18nProvider>,
+    );
+
+    const img = container.querySelector('img.plugin-media-stage__image');
+    expect(img).not.toBeNull();
+
+    fireEvent.error(img as HTMLImageElement);
+
+    expect(container.querySelector('img.plugin-media-stage__image')).toBeNull();
+    expect(container.querySelector('.plugin-media-stage__empty')).not.toBeNull();
+  });
+
+  it('tries a new poster URL after a previous poster failed', () => {
+    const { container, rerender } = render(
+      <I18nProvider>
+        <PluginMediaDetail
+          record={makeRecord('https://example.invalid/poster.png')}
+          onClose={() => {}}
+          onUse={() => {}}
+        />
+      </I18nProvider>,
+    );
+
+    fireEvent.error(
+      container.querySelector('img.plugin-media-stage__image') as HTMLImageElement,
+    );
+    expect(container.querySelector('.plugin-media-stage__empty')).not.toBeNull();
+
+    rerender(
+      <I18nProvider>
+        <PluginMediaDetail
+          record={makeRecord('https://example.invalid/recovered.png')}
+          onClose={() => {}}
+          onUse={() => {}}
+        />
+      </I18nProvider>,
+    );
+
+    const recovered = container.querySelector('img.plugin-media-stage__image');
+    expect(recovered).not.toBeNull();
+    expect((recovered as HTMLImageElement).src).toContain('recovered.png');
+  });
+
+  it('keeps the audio player available when an audio poster fails', () => {
+    const { container } = render(
+      <I18nProvider>
+        <PluginMediaDetail
+          record={makeRecord('https://example.invalid/poster.png', {
+            type: 'audio',
+            audio: 'https://example.invalid/clip.mp3',
+          })}
+          onClose={() => {}}
+          onUse={() => {}}
+        />
+      </I18nProvider>,
+    );
+
+    const poster = container.querySelector(
+      'img.plugin-media-stage__audio-poster',
+    );
+    expect(poster).not.toBeNull();
+
+    fireEvent.error(poster as HTMLImageElement);
+
+    expect(
+      container.querySelector('img.plugin-media-stage__audio-poster'),
+    ).toBeNull();
+    expect(
+      container.querySelector('.plugin-media-stage__audio-glyph'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('audio.plugin-media-stage__audio-player'),
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- hide plugin detail poster images after the browser reports a load error
- fall back to the existing unavailable/glyph states instead of leaving a broken image visible
- add regression coverage for image posters, recovered poster URLs, and audio poster fallback

Fixes #3894

## Surface area
- [x] UI
- [ ] Daemon/runtime
- [ ] Docs
- [ ] Tests only

## Validation
- `git diff --check`
- lightweight static assertions for the poster error/fallback paths

Note: the focused Vitest command could not run locally in this fresh worktree because node_modules is not installed; relying on CI for the full test run.