### PR TITLE
fix: prevent horizontal overflow on home page

### DIFF
--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -704,6 +704,7 @@
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
+  overflow-x: clip;
   background: var(--bg);
   padding: 0;
   /* Used by descendants (e.g. the plugins-home Scenario row) to


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #3910 

## Why

This PR addresses a layout regression on the Home page where a spurious horizontal scrollbar appears at the bottom of the window, even though the content already fits within the available viewport. 

The root scroller (`.entry-main--scroll`) was missing an `overflow-x` guard. Because of this, any descendant elements that marginally exceeded the 1440px cap—such as `100vw` backgrounds, max-content rows, or chip strips with horizontal overflow—caused the entire page layout to leak out and expose a bottom scrollbar. Adding `overflow-x: clip` prevents the leak while preserving `position: sticky` child elements like the topbar.

## What users will see

Users will no longer see a spurious horizontal scrollbar at the bottom of the Home page, restoring a stable and visually polished layout that is locked horizontally.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

<!-- Please drop your before/after recording or screenshots here! -->

## Bug fix verification

- Test path that reproduces the bug: N/A - pure visual CSS layout regression.
- Did the test go red on `main` and green on this branch? (yes / no): N/A
- If a red spec wasn't cheap to write, explain why and what verification you did instead: Wrote a CSS rule (`overflow-x: clip;`) to bound the horizontal width of `.entry-main--scroll`. Tested visually in the browser across viewport bounds above and below the inner max-width breakpoint to ensure horizontal scroll leak is patched without breaking the sticky layout logic.

## Validation

- Ran `pnpm tools-dev` and performed a visual verification of the Home page layout ensuring the horizontal scrollbar is permanently removed and the topbar remains correctly positioned.
- `pnpm guard` + `pnpm typecheck`
- `pnpm --filter @open-design/web test`
