### PR TITLE
fix(web): show every staged design file in the Home @ picker

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -162,6 +162,13 @@ interface Props {
 
 type HomeMentionTab = 'all' | 'files' | 'plugins' | 'skills' | 'mcp' | 'connectors';
 
+// In the combined "All" overview, every surface is capped to a handful of top
+// matches so no single section floods the picker. The dedicated "Design files"
+// tab is exempt: staged files are the user's own finite content, so that tab
+// lists every match (the results panel scrolls) and its count reflects the true
+// total rather than the truncated preview.
+const HOME_MENTION_ALL_TAB_PREVIEW = 6;
+
 interface HomeMentionOption {
   id: string;
   icon: IconName;
@@ -295,7 +302,6 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
         ? stagedFiles
             .map((file, index) => ({ file, index }))
             .filter(({ file }) => fileMatchesQuery(file, mentionQuery))
-            .slice(0, 6)
         : [],
     [mentionActive, mentionQuery, stagedFiles],
   );
@@ -346,7 +352,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
       ? {
           id: 'files',
           label: t('chat.mentionSectionFiles'),
-          options: fileMatches.map(({ file, index }) => ({
+          options: (mentionTab === 'files' ? fileMatches : fileMatches.slice(0, HOME_MENTION_ALL_TAB_PREVIEW)).map(({ file, index }) => ({
             id: `file-${index}-${file.name}`,
             icon: isImageFile(file) ? 'image' : 'file',
             title: file.name,

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -335,7 +335,11 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
   );
   const pickerOpen = mentionActive;
   const tabs: Array<{ id: HomeMentionTab; label: string; count: number }> = [
-    { id: 'all', label: t('common.all'), count: fileMatches.length + pluginMatches.length + skillMatches.length + mcpMatches.length + connectorMatches.length },
+    // The All overview previews at most HOME_MENTION_ALL_TAB_PREVIEW files, so
+    // its badge counts the previewed slice — not the full staged total — to keep
+    // the count aligned with what that tab actually renders. The dedicated files
+    // tab below lists every match and reports the true total.
+    { id: 'all', label: t('common.all'), count: Math.min(fileMatches.length, HOME_MENTION_ALL_TAB_PREVIEW) + pluginMatches.length + skillMatches.length + mcpMatches.length + connectorMatches.length },
     { id: 'files', label: t('chat.mentionTabFiles'), count: fileMatches.length },
     { id: 'plugins', label: t('entry.navPlugins'), count: pluginMatches.length },
     { id: 'skills', label: t('homeHero.skills'), count: skillMatches.length },

--- a/apps/web/tests/components/HomeView.mention-files-cap.test.tsx
+++ b/apps/web/tests/components/HomeView.mention-files-cap.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+// Red spec for the Home "@" picker capping staged design files at 6.
+//
+// Repro: a user stages more than six design files, then opens the context
+// picker. On `origin/main` the "Design files" surface ran the staged files
+// through `.slice(0, 6)` BEFORE both the tab count and the rendered list, so
+// the tab badge read "6" and only six files were ever pickable — the 7th+
+// upload was unreachable through the picker. The dedicated Design files tab
+// must instead list every staged match and report the true total.
+
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { HomeView } from '../../src/components/HomeView';
+import { setHomeHeroPrompt } from '../helpers/home-hero-lexical';
+
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function stubContextFetch() {
+  const fetchMock = vi.fn<typeof fetch>(async (url) => {
+    if (typeof url === 'string' && url === '/api/plugins') {
+      return new Response(JSON.stringify({ plugins: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (typeof url === 'string' && url === '/api/mcp/servers') {
+      return new Response(JSON.stringify({ servers: [], templates: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('HomeView design-files mention picker', () => {
+  it('lists every staged design file and counts the true total when more than six are uploaded', async () => {
+    stubContextFetch();
+
+    const files = Array.from(
+      { length: 7 },
+      (_, i) => new File(['x'], `design-${i + 1}.png`, { type: 'image/png' }),
+    );
+
+    render(
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />,
+    );
+
+    const input = await screen.findByTestId('home-hero-input');
+    // Stage all seven uploads in one paste (Lexical's PastePlugin reads
+    // `clipboardData.files`).
+    fireEvent.paste(input, {
+      clipboardData: {
+        files,
+        items: files.map((file) => ({ kind: 'file', getAsFile: () => file })),
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText('design-1.png')).toBeTruthy());
+
+    // Open the context picker with a query that matches every staged file.
+    setHomeHeroPrompt('@design');
+    await settle();
+
+    // The "Design files" tab badge must report the true number staged (7),
+    // not the truncated preview (6).
+    const filesTab = await screen.findByRole('tab', { name: /design files/i });
+    expect(filesTab.textContent).toContain('7');
+
+    // Switching to the dedicated Design files tab must surface every match,
+    // including the 7th upload that the old `.slice(0, 6)` dropped.
+    fireEvent.click(filesTab);
+    await settle();
+
+    const picker = screen.getByTestId('home-hero-plugin-picker');
+    for (let i = 1; i <= 7; i += 1) {
+      expect(within(picker).getByText(`design-${i}.png`)).toBeTruthy();
+    }
+  });
+});

--- a/apps/web/tests/components/HomeView.mention-files-cap.test.tsx
+++ b/apps/web/tests/components/HomeView.mention-files-cap.test.tsx
@@ -97,4 +97,47 @@ describe('HomeView design-files mention picker', () => {
       expect(within(picker).getByText(`design-${i}.png`)).toBeTruthy();
     }
   });
+
+  it('keeps the All overview count aligned with its preview-sized render', async () => {
+    stubContextFetch();
+
+    const files = Array.from(
+      { length: 7 },
+      (_, i) => new File(['x'], `design-${i + 1}.png`, { type: 'image/png' }),
+    );
+
+    render(
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />,
+    );
+
+    const input = await screen.findByTestId('home-hero-input');
+    fireEvent.paste(input, {
+      clipboardData: {
+        files,
+        items: files.map((file) => ({ kind: 'file', getAsFile: () => file })),
+      },
+    });
+    await waitFor(() => expect(screen.getByText('design-1.png')).toBeTruthy());
+
+    setHomeHeroPrompt('@design');
+    await settle();
+
+    // The default All overview previews only the first six files, so its badge
+    // must read 6 — not the full 7 — and exactly six file options render. This
+    // prevents the count/content mismatch from relocating to the All tab.
+    const allTab = await screen.findByRole('tab', { name: /^all/i });
+    expect(allTab.textContent).toContain('6');
+    expect(allTab.textContent).not.toContain('7');
+
+    const picker = screen.getByTestId('home-hero-plugin-picker');
+    const shown = Array.from({ length: 7 }, (_, i) => `design-${i + 1}.png`).filter(
+      (name) => within(picker).queryByText(name) !== null,
+    );
+    expect(shown).toHaveLength(6);
+  });
 });


### PR DESCRIPTION
## Why

A teammate hit this on `origin/main`: after staging more than six design files on the Home screen, opening the `@` context picker showed only six of them and the **Design files** tab badge was stuck at `6`, no matter how many were actually uploaded. The 7th and later uploads were simply unreachable through the picker — you couldn't `@`-mention a file you had just attached.

The cause is in `HomeHero`: staged files were run through `.slice(0, 6)` *before* feeding both the tab count and the rendered list, so the truncation silently doubled as the count source.

## What users will see

On Home, type `@` after uploading several design files:

- The **Design files** tab now shows the real number of staged files (e.g. `7`), not a capped `6`.
- Opening the dedicated **Design files** tab lists **every** staged file; the panel scrolls if there are many.
- The combined **All** overview still previews the first six files per surface, so no single section floods the picker.

Catalog surfaces (Plugins / Skills / MCP / Connectors) are unchanged — those are searchable catalogs where a top-N suggestion list is intended; staged files are the user's own finite content.

## Surface area

- [x] **UI** — Home `@` context picker (`apps/web/src/components/HomeHero.tsx`)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**

## Screenshots

Entry point is the Home composer `@` picker → **Design files** tab. Before: tab reads `Design files 6` and lists 6 of N staged uploads. After: tab reads the true total and the dedicated tab lists all of them (scrollable).

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/HomeView.mention-files-cap.test.tsx`
- Did the test go red on `main` and green on this branch? **yes** — on `main` it fails with `expected 'Design files6' to contain '7'`; green on this branch.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run tests/components/HomeView.mention-files-cap.test.tsx tests/components/HomeView.context-picker.test.tsx tests/components/HomeHero.plugin-picker.test.tsx` — 18 passed
