### PR TITLE
fix(web): align composer footer controls to one height

### DIFF
--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -1575,13 +1575,16 @@
 .chat-composer-fixed-layer .composer-send {
   border-radius: var(--radius-sm);
 }
-.app .composer-row .icon-btn {
-  width: 28px;
-  height: 28px;
-}
+.app .composer-row .icon-btn,
 .chat-composer-fixed-layer .composer-row .icon-btn {
+  /* Clear the 32px min-width/min-height that leaks from chat.css's base
+     `.composer-row .icon-btn`; without these, width/height: 28px is floored
+     back up to 32px and the + drifts taller than the rest of the toolbar. */
   width: 28px;
   height: 28px;
+  min-width: 28px;
+  min-height: 28px;
+  box-sizing: border-box;
 }
 .app .composer-send {
   height: 28px;
@@ -1593,12 +1596,28 @@
   box-shadow: none;
 }
 .chat-composer-fixed-layer .composer-send {
-  height: 30px;
-  min-height: 30px;
+  height: 28px;
+  min-height: 28px;
   padding: 0 12px;
   font-size: 12.5px;
   font-weight: 600;
   box-shadow: none;
+}
+/* The session-mode ("Design"/CLI) toggle and the agent avatar are authored in
+   their own components and default to 32px. The composer now mounts under
+   .chat-composer-fixed-layer (a body-level portal), so chat.css's .app-scoped
+   normalization never reaches them and they drift taller than the + and the
+   working-dir pill. Pin both to the same 28px control height here — this is the
+   last-loaded stylesheet, so it wins — so the toolbar reads as one row. */
+.app .composer-row .session-mode-toggle,
+.app .composer-row .session-mode-toggle__trigger,
+.app .composer-row .avatar-agent-trigger,
+.chat-composer-fixed-layer .composer-row .session-mode-toggle,
+.chat-composer-fixed-layer .composer-row .session-mode-toggle__trigger,
+.chat-composer-fixed-layer .composer-row .avatar-agent-trigger {
+  height: 28px;
+  min-height: 28px;
+  box-sizing: border-box;
 }
 .app .composer-send:disabled {
   background: var(--bg-subtle);

--- a/e2e/ui/composer-toolbar-alignment.test.ts
+++ b/e2e/ui/composer-toolbar-alignment.test.ts
@@ -1,0 +1,135 @@
+// Composer footer toolbar alignment.
+//
+// The composer's bottom row mixes five controls authored in five different
+// components — the + icon (.icon-btn), the working-dir pill
+// (.working-dir-pill-trigger), the agent avatar (.avatar-agent-trigger), the
+// session-mode "Design"/CLI toggle (.session-mode-toggle__trigger) and Send
+// (.composer-send). The composer mounts under `.chat-composer-fixed-layer` (a
+// body-level portal), so the `.app`-scoped "one control system" normalization
+// in chat.css never reached it and the controls drifted to 28/30/32px. Even
+// though the row centers them, the differing heights left the pills and Send
+// visibly misaligned against the left buttons.
+//
+// This spec is the regression boundary: every interactive control in the
+// composer row must share one height and one vertical center so the toolbar
+// reads as a single row.
+
+import { randomUUID } from 'node:crypto';
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+const STORAGE_KEY = 'open-design:config';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-5',
+        agentId: 'mock',
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        agentModels: {},
+      }),
+    );
+  }, STORAGE_KEY);
+
+  await page.route('**/api/app-config', async (route) => {
+    await route.fulfill({
+      json: {
+        config: {
+          onboardingCompleted: true,
+          agentId: 'mock',
+          skillId: null,
+          designSystemId: null,
+          agentModels: {},
+          agentCliEnv: {},
+        },
+      },
+    });
+  });
+
+  await page.route('**/api/agents', async (route) => {
+    await route.fulfill({
+      json: {
+        agents: [
+          {
+            id: 'mock',
+            name: 'Mock Agent',
+            bin: 'mock-agent',
+            available: true,
+            version: 'test',
+            models: [{ id: 'default', label: 'Default' }],
+          },
+        ],
+      },
+    });
+  });
+});
+
+test('[P1] composer footer controls share one height and baseline', async ({ page }) => {
+  await page.goto('/');
+  await createProject(page, 'Composer toolbar alignment');
+  await expect(page).toHaveURL(/\/projects\//);
+  await expect(page.getByTestId('chat-composer')).toBeVisible();
+  await expect(page.getByTestId('chat-send')).toBeVisible();
+
+  const metrics = await page.evaluate(() => {
+    const row = document.querySelector('.composer-row');
+    if (!row) return { error: 'no .composer-row' as const };
+    const selectors = [
+      '.icon-btn',
+      '.working-dir-pill-trigger',
+      '.avatar-agent-trigger',
+      '.session-mode-toggle__trigger',
+      '.composer-send',
+    ];
+    const controls: Array<{ sel: string; height: number; center: number }> = [];
+    for (const sel of selectors) {
+      const el = row.querySelector(sel);
+      if (!el) continue;
+      const r = el.getBoundingClientRect();
+      controls.push({ sel, height: r.height, center: r.top + r.height / 2 });
+    }
+    return { controls };
+  });
+
+  if ('error' in metrics) throw new Error(metrics.error);
+  const { controls } = metrics;
+
+  // The toolbar should never collapse to a single control; if it does, the
+  // selectors below are stale and the height assertion is meaningless.
+  expect(controls.length).toBeGreaterThanOrEqual(4);
+
+  const heights = controls.map((c) => c.height);
+  const centers = controls.map((c) => c.center);
+  const spread = (xs: number[]) => Math.max(...xs) - Math.min(...xs);
+
+  // One control system: identical heights. On main these drift (e.g. the +
+  // at 32px, the working-dir pill at 28px, Send at 30px) and this fails.
+  expect(spread(heights), `control heights: ${JSON.stringify(controls)}`).toBeLessThanOrEqual(1);
+  // ...and a shared vertical center so nothing rides high or low in the row.
+  expect(spread(centers), `control centers: ${JSON.stringify(controls)}`).toBeLessThanOrEqual(1);
+});
+
+async function createProject(page: Page, projectName: string): Promise<void> {
+  const response = await page.request.post('/api/projects', {
+    data: {
+      id: randomUUID(),
+      name: projectName,
+      skillId: null,
+      designSystemId: null,
+      metadata: { kind: 'prototype', nameSource: 'user' },
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const body = (await response.json()) as {
+    project: { id: string };
+    conversationId: string;
+  };
+  await page.goto(`/projects/${body.project.id}/conversations/${body.conversationId}`);
+}


### PR DESCRIPTION
## Why

A teammate flagged on `origin/main` that the composer's bottom toolbar looks off: the **Local storage** pill, the session-mode **Design**/CLI toggle and **Send** don't line up with the left buttons. I traced it to a real layout regression rather than a one-off rendering glitch, so this fixes the root cause.

The composer was relocated into `.chat-composer-fixed-layer` — a body-level portal that is **not** a descendant of `.app`. The "one control system" height normalization authored in `chat.css` is `.app .composer-row`-scoped, so it never reaches the live composer. `routines.css` (loaded later) only patched some of the controls for the fixed-layer host, and inconsistently, so the five controls drifted apart:

| control | height on main |
|---|---|
| `+` icon (`.icon-btn`) | **32px** (`height:28` floored back up by a leaking `min-width/min-height:32` from chat.css) |
| working-dir pill (`.working-dir-pill-trigger`) | 28px |
| agent avatar (`.avatar-agent-trigger`) | 32px |
| session-mode toggle (`.session-mode-toggle__trigger`) | 32px |
| Send (`.composer-send`) | 30px |

They stay vertically centered (centers all match), so the misalignment is purely the **differing heights** — the pills and Send have different top/bottom edges than the left buttons.

## What users will see

In the chat composer's bottom toolbar, the **Local storage** pill, the **Design**/CLI mode toggle and the **Send** button are now the same height as the `+` button on the left, so the whole row reads as one aligned strip instead of controls of three slightly different sizes.

## Surface area

- [x] **UI** — composer footer toolbar control sizing in `apps/web`
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change

## Screenshots

Before vs after (composer footer row), captured against the running web app with a mock agent:

- **Before:** heights `[+ 32, Local storage 28, avatar 32, Design 32, Send 30]` — the Local storage pill and Send sit visibly shorter than the rest.
- **After:** all five controls `28px` — uniform height, shared baseline.

Concretely the regression test measures, on `main`: `[{icon-btn:32},{working-dir:28},{avatar:32},{session-mode:32},{send:30}]` (height spread 4px) → on this branch all `28` (spread 0).

## Bug fix verification

- Test path: `e2e/ui/composer-toolbar-alignment.test.ts`
- Red on `main` / green on this branch? **yes** — red on main with `Expected: <= 1 / Received: 4` (height spread), green here.

## Validation

- `pnpm guard` — pass (40/40)
- `pnpm typecheck` — pass (all packages)
- `pnpm --filter @open-design/e2e typecheck` — pass
- `pnpm --dir e2e exec playwright test ui/composer-toolbar-alignment.test.ts` — 1 passed; confirmed it fails on `main` (heights 32/28/32/32/30) and passes here (all 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)