### PR TITLE
Fix home @ picker catalog results

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -283,6 +283,8 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
   const [mentionTrigger, setMentionTrigger] = useState<{ query: string } | null>(null);
   const [caretRect, setCaretRect] = useState<CaretRect | null>(null);
   const editorRef = useRef<LexicalComposerInputHandle | null>(null);
+  const promptEditorRef = useRef<HTMLDivElement | null>(null);
+  const mentionPickerRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const shortcutsMenuRef = useRef<HTMLDivElement>(null);
   const canSubmit = (prompt.trim().length > 0 || stagedFiles.length > 0) && !submitDisabled;
@@ -308,16 +310,16 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
   const pluginMatches = useMemo(
     () =>
       mentionActive
-        ? pluginOptions.filter((plugin) => pluginMatchesQuery(plugin, mentionQuery)).slice(0, 6)
+        ? pluginOptions.filter((plugin) => pluginMatchesQuery(plugin, mentionQuery, locale))
         : [],
-    [mentionActive, mentionQuery, pluginOptions],
+    [locale, mentionActive, mentionQuery, pluginOptions],
   );
   const skillMatches = useMemo(
     () =>
       mentionActive
-        ? skillOptions.filter((skill) => skillMatchesQuery(skill, mentionQuery)).slice(0, 6)
+        ? skillOptions.filter((skill) => skillMatchesQuery(skill, mentionQuery, locale))
         : [],
-    [mentionActive, mentionQuery, skillOptions],
+    [locale, mentionActive, mentionQuery, skillOptions],
   );
   const mcpMatches = useMemo(
     () =>
@@ -529,6 +531,38 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
 
   useEffect(() => {
     if (!pickerOpen) setHoveredPlugin(null);
+  }, [pickerOpen]);
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const isInsideMentionSurface = (target: EventTarget | null) => {
+      if (!(target instanceof Node)) return false;
+      return (
+        promptEditorRef.current?.contains(target) ||
+        mentionPickerRef.current?.contains(target)
+      );
+    };
+    const closePicker = () => {
+      setMentionTrigger(null);
+      setMentionTab('all');
+    };
+    const closeOnOutsidePointer = (event: PointerEvent) => {
+      if (!isInsideMentionSurface(event.target)) closePicker();
+    };
+    const closeOnOutsideMouse = (event: MouseEvent) => {
+      if (!isInsideMentionSurface(event.target)) closePicker();
+    };
+    const closeOnOutsideFocus = (event: FocusEvent) => {
+      if (!isInsideMentionSurface(event.target)) closePicker();
+    };
+    document.addEventListener('pointerdown', closeOnOutsidePointer, true);
+    document.addEventListener('mousedown', closeOnOutsideMouse, true);
+    document.addEventListener('focusin', closeOnOutsideFocus);
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsidePointer, true);
+      document.removeEventListener('mousedown', closeOnOutsideMouse, true);
+      document.removeEventListener('focusin', closeOnOutsideFocus);
+    };
   }, [pickerOpen]);
 
   useEffect(() => {
@@ -1018,7 +1052,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
           </div>
         ) : null}
         <div className="home-hero__prompt-surface">
-          <div className="home-hero__prompt-editor home-hero__lexical">
+          <div ref={promptEditorRef} className="home-hero__prompt-editor home-hero__lexical">
             <LexicalComposerInput
               ref={editorRef}
               testId="home-hero-input"
@@ -1058,6 +1092,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
         </div>
         <CaretFloatingLayer caret={caretRect} open={pickerOpen}>
           <div
+            ref={mentionPickerRef}
             id="home-hero-context-picker"
             className="home-hero__plugin-picker home-hero__plugin-picker--floating"
             role="listbox"
@@ -2244,14 +2279,16 @@ function fileMatchesQuery(file: File, query: string): boolean {
     .includes(q);
 }
 
-function pluginMatchesQuery(plugin: InstalledPluginRecord, query: string): boolean {
+function pluginMatchesQuery(plugin: InstalledPluginRecord, query: string, locale: Locale): boolean {
   const q = query.trim().toLowerCase();
   if (!q) return true;
   return [
     plugin.title,
+    localizePluginTitle(locale, plugin),
     plugin.id,
     plugin.sourceKind,
     plugin.manifest?.description ?? '',
+    localizePluginDescription(locale, plugin),
     ...(plugin.manifest?.tags ?? []),
   ]
     .join(' ')
@@ -2259,13 +2296,15 @@ function pluginMatchesQuery(plugin: InstalledPluginRecord, query: string): boole
     .includes(q);
 }
 
-function skillMatchesQuery(skill: SkillSummary, query: string): boolean {
+function skillMatchesQuery(skill: SkillSummary, query: string, locale: Locale): boolean {
   const q = query.trim().toLowerCase();
   if (!q) return true;
   return [
     skill.id,
     skill.name,
+    localizeSkillName(locale, skill),
     skill.description,
+    localizeSkillDescription(locale, skill),
     skill.mode,
     skill.surface ?? '',
     ...skill.triggers,

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -728,27 +728,38 @@
   color: var(--accent);
 }
 .home-hero__mention-tabs {
+  flex: 0 0 auto;
   display: flex;
-  gap: 4px;
+  align-items: center;
+  gap: 2px;
+  min-height: 44px;
   padding: 2px;
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-sm);
   background: var(--bg-subtle);
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
 }
+.home-hero__mention-tabs::-webkit-scrollbar { display: none; }
 .home-hero__mention-tab {
   appearance: none;
+  flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 5px;
-  min-width: 0;
-  padding: 5px 8px;
+  min-inline-size: max-content;
+  padding: 5px 6px;
   border: 1px solid transparent;
   border-radius: calc(var(--radius-sm) - 1px);
   background: transparent;
   color: var(--text-muted);
   font: inherit;
   font-size: 11.5px;
+  white-space: nowrap;
   cursor: pointer;
 }
 .home-hero__mention-tab.is-active {

--- a/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
+++ b/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { KEY_ENTER_COMMAND } from 'lexical';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -12,6 +12,7 @@ import type {
   TrustTier,
 } from '@open-design/contracts';
 import { HomeHero } from '../../src/components/HomeHero';
+import { I18nProvider } from '../../src/i18n';
 import {
   getHomeHeroEditor,
   setHomeHeroPrompt,
@@ -146,6 +147,177 @@ describe('HomeHero plugin picker', () => {
       expect.objectContaining({ id: 'sample-user-plugin' }),
       'Make @Sample User Plugin ',
     );
+  });
+
+  it('does not truncate home @ plugin results to six entries', async () => {
+    const pluginOptions = Array.from({ length: 9 }, (_, index) =>
+      makePlugin(`catalog-plugin-${index}`, `Catalog Plugin ${index + 1}`),
+    );
+    render(
+      <HomeHero
+        prompt=""
+        onPromptChange={() => undefined}
+        onSubmit={() => undefined}
+        activePluginTitle={null}
+        activeChipId={null}
+        onClearActivePlugin={() => undefined}
+        pluginOptions={pluginOptions}
+        pluginsLoading={false}
+        pendingPluginId={null}
+        pendingChipId={null}
+        onPickPlugin={() => undefined}
+        onPickChip={() => undefined}
+        contextItemCount={0}
+        error={null}
+      />,
+    );
+
+    setHomeHeroPrompt('@catalog');
+    await settle();
+
+    const picker = screen.getByTestId('home-hero-plugin-picker');
+    expect(within(picker).getAllByRole('option')).toHaveLength(9);
+    expect(within(picker).getByText('Catalog Plugin 9')).toBeTruthy();
+    expect(within(picker).getByRole('tab', { name: /plugins/i }).textContent).toContain('9');
+  });
+
+  it('matches localized plugin and skill text in the home @ picker', async () => {
+    const localizedPlugin = makePlugin('localized-plugin', 'Localized Plugin');
+    localizedPlugin.manifest.title_i18n = { 'zh-CN': '官方看板' };
+    localizedPlugin.manifest.description_i18n = { 'zh-CN': '内置官方插件。' };
+    const localizedSkill = makeSkill('localized-skill', 'localized-skill');
+    localizedSkill.displayName = { 'zh-CN': '杂志文章' };
+    localizedSkill.descriptionI18n = { 'zh-CN': '中文能力描述' };
+    const { rerender } = render(
+      <I18nProvider initial="zh-CN">
+        <HomeHero
+          prompt=""
+          onPromptChange={() => undefined}
+          onSubmit={() => undefined}
+          activePluginTitle={null}
+          activeChipId={null}
+          onClearActivePlugin={() => undefined}
+          pluginOptions={[localizedPlugin]}
+          pluginsLoading={false}
+          skillOptions={[localizedSkill]}
+          skillsLoading={false}
+          pendingPluginId={null}
+          pendingChipId={null}
+          onPickPlugin={() => undefined}
+          onPickSkill={() => undefined}
+          onPickChip={() => undefined}
+          contextItemCount={0}
+          error={null}
+        />
+      </I18nProvider>,
+    );
+
+    setHomeHeroPrompt('@看板');
+    await settle();
+
+    expect(screen.getByRole('option', { name: /官方看板/i })).toBeTruthy();
+
+    rerender(
+      <I18nProvider initial="zh-CN">
+        <HomeHero
+          prompt=""
+          onPromptChange={() => undefined}
+          onSubmit={() => undefined}
+          activePluginTitle={null}
+          activeChipId={null}
+          onClearActivePlugin={() => undefined}
+          pluginOptions={[localizedPlugin]}
+          pluginsLoading={false}
+          skillOptions={[localizedSkill]}
+          skillsLoading={false}
+          pendingPluginId={null}
+          pendingChipId={null}
+          onPickPlugin={() => undefined}
+          onPickSkill={() => undefined}
+          onPickChip={() => undefined}
+          contextItemCount={0}
+          error={null}
+        />
+      </I18nProvider>,
+    );
+
+    setHomeHeroPrompt('@中文能力');
+    await settle();
+
+    expect(screen.getByRole('option', { name: /杂志文章/i })).toBeTruthy();
+  });
+
+  it('closes the home @ picker when focus moves outside the composer', async () => {
+    render(
+      <>
+        <HomeHero
+          prompt=""
+          onPromptChange={() => undefined}
+          onSubmit={() => undefined}
+          activePluginTitle={null}
+          activeChipId={null}
+          onClearActivePlugin={() => undefined}
+          pluginOptions={[makePlugin('sample-plugin', 'Sample Plugin')]}
+          pluginsLoading={false}
+          pendingPluginId={null}
+          pendingChipId={null}
+          onPickPlugin={() => undefined}
+          onPickChip={() => undefined}
+          contextItemCount={0}
+          error={null}
+        />
+        <button type="button" data-testid="outside-control">Outside</button>
+      </>,
+    );
+
+    setHomeHeroPrompt('@sample');
+    await settle();
+
+    expect(screen.getByTestId('home-hero-plugin-picker')).toBeTruthy();
+
+    fireEvent.mouseDown(screen.getByTestId('outside-control'));
+    fireEvent.focusIn(screen.getByTestId('outside-control'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('home-hero-plugin-picker')).toBeNull();
+    });
+  });
+
+  it('keeps the home @ picker open while interacting with its tabs', async () => {
+    render(
+      <HomeHero
+        prompt=""
+        onPromptChange={() => undefined}
+        onSubmit={() => undefined}
+        activePluginTitle={null}
+        activeChipId={null}
+        onClearActivePlugin={() => undefined}
+        pluginOptions={[makePlugin('sample-plugin', 'Sample Plugin')]}
+        pluginsLoading={false}
+        skillOptions={[makeSkill('sample-skill', 'Sample Skill')]}
+        skillsLoading={false}
+        pendingPluginId={null}
+        pendingChipId={null}
+        onPickPlugin={() => undefined}
+        onPickSkill={() => undefined}
+        onPickChip={() => undefined}
+        contextItemCount={0}
+        error={null}
+      />,
+    );
+
+    setHomeHeroPrompt('@sample');
+    await settle();
+
+    const picker = screen.getByTestId('home-hero-plugin-picker');
+    const skillsTab = within(picker).getByRole('tab', { name: /skills/i });
+    fireEvent.pointerDown(skillsTab);
+    fireEvent.click(skillsTab);
+
+    await settle();
+
+    expect(screen.getByTestId('home-hero-plugin-picker')).toBeTruthy();
+    expect(within(screen.getByTestId('home-hero-plugin-picker')).getByRole('tab', { name: /skills/i }).getAttribute('aria-selected')).toBe('true');
   });
 
   it('renders selected @ plugins inside the prompt as mention pills', async () => {


### PR DESCRIPTION
## Why

The home prompt's `@` picker still behaved differently from the Settings/Plugins catalog path after the catalog fix: official plugins and skills were capped to a small visible set, localized Chinese names/descriptions were not searchable from the home picker, and the picker UI stayed open after focus moved elsewhere. While validating the release branch, the homepage path was the remaining user-facing surface that made official plugin/skill availability look incomplete.

This PR fixes the homepage picker so the same catalog is actually discoverable from the first-run creation surface, and cleans up the adjacent popover usability issues reported during acceptance.

## What users will see

Typing `@` in the home prompt now shows the full matched plugin and skill catalog instead of only six items. Searches also match localized plugin and skill titles/descriptions, so Chinese queries such as `看板` or localized skill descriptions can find the expected entries.

The picker tabs stay on one line (`Design files` no longer wraps), and the picker closes when users click or focus outside the composer/picker while remaining open for tab and option interactions inside the picker.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Home `@` picker after the fix: full matched catalog counts are visible (`All 672`, `Plugins 400`, `Skills 272`) and `Design files` stays on one line.

![Home @ picker full catalog and single-line tabs](https://raw.githubusercontent.com/nexu-io/open-design/e9ce2a402a65ec5ebcfcb6a95a3133799b85aa1c/.github/validation/home-at-picker-verified.png)

After clicking outside the picker, it closes while the prompt content remains intact.

![Home @ picker closes on outside focus](https://raw.githubusercontent.com/nexu-io/open-design/e9ce2a402a65ec5ebcfcb6a95a3133799b85aa1c/.github/validation/home-at-picker-closed-on-blur.png)

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/HomeHero.plugin-picker.test.tsx`
- Did the test go red on `main` and green on this branch? No automated red run on `main` in this turn. I reproduced the issue in-browser on `release/v0.10.0` first, then added regression coverage for the six-item truncation, localized matching, outside-focus close behavior, and in-picker tab interaction. The focused test suite is green on this branch.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/HomeHero.plugin-picker.test.tsx`
- Browser/in-app browser E2E on `http://127.0.0.1:22573/`:
  - Opened home prompt and typed `@`.
  - Verified full picker counts: `All 672`, `Plugins 400`, `Skills 272`.
  - Verified `Design files` tab remains single-line and all tabs fit in the picker.
  - Clicked outside the picker and verified it closes (`pickerVisible: false`).
