### PR TITLE
fix(browser): prevent screenshot tooltip from being captured

### DIFF
--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -1255,13 +1255,14 @@ export function DesignBrowserPanel({
       // Hide any visible tooltip so it cannot bleed into the host compositor
       // capture. Tooltip state updates are async React renders, so we also
       // remove it from the DOM directly before the compositor fires.
-      // Gate on computed visibility so we don't accidentally flip a
-      // pre-positioned hidden node to visible in the finally block.
+      // Track whether we actually hid it so the finally block only
+      // restores a node we touched, avoiding exposing a pre-hidden tooltip.
       tooltipLayer = document.querySelector('.od-tooltip-layer');
       if (tooltipLayer) {
         const computedVisibility = window.getComputedStyle(tooltipLayer).visibility;
         if (computedVisibility === 'visible') {
           tooltipLayer.style.visibility = 'hidden';
+          (tooltipLayer as any).__od_hiddenByScreenshot = True;
         }
       }
 
@@ -1290,9 +1291,10 @@ export function DesignBrowserPanel({
       setStatusMessage(error instanceof Error ? error.message : 'Screenshot failed');
     } finally {
       if (tooltipLayer) {
-        const computedVisibility = window.getComputedStyle(tooltipLayer).visibility;
-        if (computedVisibility === 'hidden') {
+        const marker = (tooltipLayer as any).__od_hiddenByScreenshot;
+        if (marker) {
           tooltipLayer.style.visibility = '';
+          delete (tooltipLayer as any).__od_hiddenByScreenshot;
         }
       }
       setCaptureChromeHidden(false);

--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -1247,12 +1247,19 @@ export function DesignBrowserPanel({
       return;
     }
     setSavingAction('screenshot');
-    // Close the dropdown first so it cannot appear in a host compositor capture
-    // (which screenshots the on-screen window region, not the guest surface).
     setMenuOpen(false);
     if (drawOverlayOpen) flushSync(() => setCaptureChromeHidden(true));
+
+    let tooltipLayer: HTMLElement | null = null;
     try {
-      // Let the dropdown unmount + repaint before the compositor capture.
+      // Hide any visible tooltip so it cannot bleed into the host compositor
+      // capture. Tooltip state updates are async React renders, so we also
+      // remove it from the DOM directly before the compositor fires.
+      tooltipLayer = document.querySelector('.od-tooltip-layer');
+      if (tooltipLayer) {
+        tooltipLayer.style.visibility = 'hidden';
+      }
+
       await new Promise<void>((resolve) =>
         requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
       );
@@ -1277,6 +1284,9 @@ export function DesignBrowserPanel({
     } catch (error) {
       setStatusMessage(error instanceof Error ? error.message : 'Screenshot failed');
     } finally {
+      if (tooltipLayer) {
+        tooltipLayer.style.visibility = '';
+      }
       setCaptureChromeHidden(false);
       setSavingAction(null);
       setMenuOpen(false);

--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -1255,9 +1255,14 @@ export function DesignBrowserPanel({
       // Hide any visible tooltip so it cannot bleed into the host compositor
       // capture. Tooltip state updates are async React renders, so we also
       // remove it from the DOM directly before the compositor fires.
+      // Gate on computed visibility so we don't accidentally flip a
+      // pre-positioned hidden node to visible in the finally block.
       tooltipLayer = document.querySelector('.od-tooltip-layer');
       if (tooltipLayer) {
-        tooltipLayer.style.visibility = 'hidden';
+        const computedVisibility = window.getComputedStyle(tooltipLayer).visibility;
+        if (computedVisibility === 'visible') {
+          tooltipLayer.style.visibility = 'hidden';
+        }
       }
 
       await new Promise<void>((resolve) =>
@@ -1285,7 +1290,10 @@ export function DesignBrowserPanel({
       setStatusMessage(error instanceof Error ? error.message : 'Screenshot failed');
     } finally {
       if (tooltipLayer) {
-        tooltipLayer.style.visibility = '';
+        const computedVisibility = window.getComputedStyle(tooltipLayer).visibility;
+        if (computedVisibility === 'hidden') {
+          tooltipLayer.style.visibility = '';
+        }
       }
       setCaptureChromeHidden(false);
       setSavingAction(null);

--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -1262,7 +1262,7 @@ export function DesignBrowserPanel({
         const computedVisibility = window.getComputedStyle(tooltipLayer).visibility;
         if (computedVisibility === 'visible') {
           tooltipLayer.style.visibility = 'hidden';
-          (tooltipLayer as any).__od_hiddenByScreenshot = True;
+          (tooltipLayer as any).__od_hiddenByScreenshot = true;
         }
       }
 


### PR DESCRIPTION
Closes #3881

The browser screenshot action could capture its own hover tooltip because the TooltipLayer hide is an async React state update, so the tooltip portal node could still be on-screen when the host compositor capture fires.

In `takeScreenshot()`, detect the visible `.od-tooltip-layer` before the capture RAF + IPC window, set `visibility: hidden` on it, and restore visibility in `finally`. This is a single concern fix scoped to the screenshot flow only.


## Why
Users taking screenshots see the control tooltip baked into the image because
the tooltip DOM node is still present when the host compositor capture fires.
The tooltip hide is an async React state update, so the portal node can still
be on-screen when capture triggers.

## Surface area
- UI (screenshot capture path only)

## Validation
- Hovered the screenshot button to show the tooltip, clicked capture, confirmed
  the tooltip is not present in the resulting image.
- Confirmed normal tooltip behavior is unaffected for other buttons.
- Confirmed the capture still works when no tooltip is visible.