### PR TITLE
fix(daemon): report Deliver-to-editor launch failures instead of swallowing them

### DIFF
--- a/apps/daemon/src/routes/host-tools.ts
+++ b/apps/daemon/src/routes/host-tools.ts
@@ -221,6 +221,39 @@ export async function resolveHostToolLaunchPlan(
   };
 }
 
+// Spawn a detached host-tool launch and wait for the OS to confirm it
+// actually started. Node emits `spawn` once the child is running and `error`
+// when the launch is refused (missing binary, quarantine, EACCES). The
+// `error` event arrives on a later tick, so the route must await this before
+// replying — otherwise it reports success for a launch the OS rejected and
+// the user sees nothing happen (#3871).
+export function launchHostTool(
+  command: string,
+  args: string[],
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  return new Promise((resolve) => {
+    // Detached so the daemon doesn't keep the child alive; same shape paseo
+    // uses (CLI shim, `open -a`, Explorer, xdg-open, etc.).
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: 'ignore',
+      shell: process.platform === 'win32',
+    });
+    let settled = false;
+    child.once('spawn', () => {
+      if (settled) return;
+      settled = true;
+      child.unref();
+      resolve({ ok: true });
+    });
+    child.once('error', (err) => {
+      if (settled) return;
+      settled = true;
+      resolve({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    });
+  });
+}
+
 export function applicableForPlatform(entry: CatalogueEntry, platform: Platform): boolean {
   if (platform === 'unknown') return false;
   if (entry.platforms && !entry.platforms.includes(platform)) return false;
@@ -309,21 +342,20 @@ export function registerHostToolsRoutes(app: Express, ctx: RegisterHostToolsRout
       if (!launchPlan.available || !launchPlan.command || !launchPlan.args) {
         return sendApiError(res, 409, 'EDITOR_NOT_AVAILABLE', `${entry.label} is not installed`);
       }
-      // Detached spawn so the daemon doesn't keep the child alive; same
-      // shape paseo uses. Each catalogue entry turns the project dir into
-      // the native argument shape it expects (CLI shim, `open -a`, Explorer,
-      // xdg-open, etc.).
-      const child = spawn(launchPlan.command, launchPlan.args, {
-        detached: true,
-        stdio: 'ignore',
-        shell: process.platform === 'win32',
-      });
-      child.on('error', () => {
-        // Swallow — best-effort; the client will see ok:true but the OS
-        // might still have refused (e.g. quarantine). Real diagnostic
-        // path is `od project open-in --debug`.
-      });
-      child.unref();
+      // Wait for the OS to confirm the launch before replying. Previously
+      // this returned ok:true synchronously and swallowed the child's `error`
+      // event, so a refused launch was reported as success and the user saw
+      // nothing happen — the web button only surfaces an error on a non-OK
+      // response (#3871).
+      const launch = await launchHostTool(launchPlan.command, launchPlan.args);
+      if (!launch.ok) {
+        return sendApiError(
+          res,
+          500,
+          'EDITOR_LAUNCH_FAILED',
+          `Failed to launch ${entry.label}: ${launch.error}`,
+        );
+      }
       const body: OpenProjectInEditorResponse = {
         ok: true,
         editorId,

--- a/apps/daemon/tests/host-tools-open-in-route.test.ts
+++ b/apps/daemon/tests/host-tools-open-in-route.test.ts
@@ -1,0 +1,111 @@
+// Route-level coverage for POST /api/projects/:id/open-in (#3871).
+//
+// The helper-level tests in host-tools-routes.test.ts pin launchHostTool's
+// contract, but not the route's translation of a refused launch into an HTTP
+// response — if the route regressed back to swallowing `!launch.ok` (or mapped
+// it to `200 { ok: true }`), those tests would stay green. Here the spawn is
+// mocked at the node:child_process boundary so the full route path runs, and
+// the assertions lock the observable behavior: HTTP status + error code/body.
+
+import { EventEmitter } from 'node:events';
+import type http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import express from 'express';
+import type { Response } from 'express';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { registerHostToolsRoutes } from '../src/routes/host-tools.js';
+import type { RegisterHostToolsRoutesDeps } from '../src/routes/host-tools.js';
+
+const spawnState = vi.hoisted(() => ({ fail: false, error: 'spawn cursor ENOENT' }));
+
+// Deterministic spawn: emits `error` or `spawn` on the next tick depending on
+// spawnState, so both launch outcomes are reachable on any CI platform.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(() => {
+      const child = new EventEmitter() as EventEmitter & { unref: () => void };
+      child.unref = () => {};
+      setImmediate(() => {
+        if (spawnState.fail) child.emit('error', new Error(spawnState.error));
+        else child.emit('spawn');
+      });
+      return child;
+    }),
+  };
+});
+
+// Make the $PATH probe succeed everywhere so resolveHostToolLaunchPlan
+// reports the editor as available and the route reaches the launch step.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, access: async () => undefined };
+});
+
+// Absolute baseDir short-circuits projectHostOpenDir, so resolveProjectDir is
+// never consulted and no real project layout is needed.
+const PROJECT_DIR = path.join(tmpdir(), 'od-3871-project');
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  registerHostToolsRoutes(app, {
+    db: {},
+    http: {
+      // Mirrors the compat shape of server.ts sendApiError: status + { error: { code, message } }.
+      sendApiError: (res: Response, status: number, code: string, message: string) =>
+        res.status(status).json({ error: { code, message } }),
+    },
+    paths: { PROJECTS_DIR: tmpdir() },
+    projectStore: {
+      getProject: (_db: unknown, id: string) =>
+        id === 'p1' ? { id, metadata: { baseDir: PROJECT_DIR } } : null,
+    },
+    projectFiles: { resolveProjectDir: () => PROJECT_DIR },
+  } as unknown as RegisterHostToolsRoutesDeps);
+  server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function postOpenIn(projectId: string) {
+  return fetch(`${baseUrl}/api/projects/${projectId}/open-in`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ editorId: 'cursor' }),
+  });
+}
+
+describe('POST /api/projects/:id/open-in launch reporting (#3871)', () => {
+  it('returns 500 EDITOR_LAUNCH_FAILED when the OS refuses the launch', async () => {
+    spawnState.fail = true;
+
+    const resp = await postOpenIn('p1');
+
+    expect(resp.status).toBe(500);
+    const body = (await resp.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('EDITOR_LAUNCH_FAILED');
+    expect(body.error.message).toContain('Failed to launch Cursor');
+    expect(body.error.message).toContain('spawn cursor ENOENT');
+  });
+
+  it('returns 200 ok:true once the OS confirms the launch', async () => {
+    spawnState.fail = false;
+
+    const resp = await postOpenIn('p1');
+
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toEqual({ ok: true, editorId: 'cursor', path: PROJECT_DIR });
+  });
+});

--- a/apps/daemon/tests/host-tools-routes.test.ts
+++ b/apps/daemon/tests/host-tools-routes.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   CATALOGUE,
   applicableForPlatform,
+  launchHostTool,
   resolveHostToolLaunchPlan,
 } from '../src/routes/host-tools.js';
 import type { CatalogueEntry, Platform } from '../src/routes/host-tools.js';
@@ -59,5 +60,26 @@ describe('platform gate — Warp is darwin-only, cross-platform tools stay avail
   it('cursor remains applicable on darwin (regression guard — no platforms restriction)', () => {
     const cursor = CATALOGUE.find((e: CatalogueEntry) => e.id === 'cursor')!;
     expect(applicableForPlatform(cursor, 'darwin' as Platform)).toBe(true);
+  });
+});
+
+describe('host tools launch reporting (#3871)', () => {
+  it('reports ok once the OS confirms the process spawned', async () => {
+    // process.execPath (the running node binary) always spawns, so this
+    // exercises the success path without depending on an installed editor.
+    const result = await launchHostTool(process.execPath, ['--version']);
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('surfaces the launch failure instead of swallowing it', async () => {
+    // shell:true on win32 runs the command through cmd.exe, which exits
+    // non-zero rather than emitting an `error` event for a missing binary.
+    if (process.platform === 'win32') return;
+
+    const result = await launchHostTool('open-design-nonexistent-editor-3871', []);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeTruthy();
   });
 });


### PR DESCRIPTION
Fixes #3871

## Why

A user reported (Discord `#中文区`) that clicking **Deliver to VS Code** does nothing — no handoff and no error. I traced the handoff path and it matches @lefarcen's diagnosis on the issue: `POST /api/projects/:id/open-in` reports success for a launch the OS actually refused, so the front-end never has anything to surface.

In `apps/daemon/src/routes/host-tools.ts` the route spawned the editor detached, attached an `error` listener that **swallowed** the failure, and then sent `{ ok: true }` **synchronously** — before the child's `error` event can even fire (it arrives on a later tick). The web button only shows an error on a non-OK response (`openProjectInEditor` throws on `!resp.ok`, `HandoffButton` renders it via `setError` + `role="alert"`), so a refused launch is silently reported as success.

## What users will see

When a Deliver-to-editor launch is refused by the OS (e.g. the binary passed the PATH probe but the OS blocks it — quarantine, `EACCES`), the handoff menu now shows an actionable inline error (`Failed to launch <Editor>: <reason>`) instead of appearing to do nothing. The success path is unchanged.

No UI was added — this reuses the existing `HandoffButton` error surface; the fix is daemon-side.

## Surface area

- [x] **Default behavior change** — the `/api/projects/:id/open-in` endpoint now returns a non-OK error when the OS refuses the launch (previously it always returned `{ ok: true }`). This is the bug fix itself; the success response shape is unchanged and no `packages/contracts` types changed (the failure reuses the existing API error envelope).
- [ ] UI / Keyboard shortcut / CLI / API contract shape / Extension point / i18n / New dependency

## Screenshots

N/A — no new UI. The error is rendered by the existing `HandoffButton` alert surface; only the daemon's failure-reporting changed.

## Bug fix verification

- **Red-spec test path:** `apps/daemon/tests/host-tools-routes.test.ts` → `host tools launch reporting (#3871)`.
- **Did it go red on `main` and green on the branch?** Yes. The fix extracts the spawn into a named helper, `launchHostTool`, whose invariant is "resolve `{ ok: false }` when the OS refuses the launch." The red spec spawns a non-existent binary and asserts `ok === false`; the old code path had no failure-reporting (it swallowed `error` and always returned `ok: true`), so the spec fails without this change and passes with it. A companion test asserts the success path still reports `ok: true`.
- **Why a helper-level spec rather than an HTTP-boundary e2e:** forcing a *real* spawn failure through the full `tools-dev` smoke daemon isn't deterministically arrangeable without mocking the OS spawn (an editor would have to pass the PATH probe yet fail to launch). Per AGENTS.md → Bug follow-up workflow ("let the fix read as an invariant" + the cheap-red-spec escape hatch), I encoded the invariant on the extracted helper and kept the route wiring a trivial, type-checked `if (!launch.ok) return sendApiError(...)`.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (clean, all workspace packages)
- Changed-area suite `apps/daemon/tests/host-tools-routes.test.ts` — pass (4/4).
- Full `pnpm --filter @open-design/daemon test` — pass (4237 passed). A first run showed one failure in an unrelated file that this PR does not touch; it passed on a clean re-run, i.e. a pre-existing flake, not a regression from this change.

## Scope

- Intentionally **not** changed: editor *detection* (PR #2494 already handled the zero-editor Finder/Explorer fallback) — this PR is only about reporting launch failures for an editor that *is* detected.
- Intentionally **not** added: exit-code inspection. The fix reports the OS-level launch refusal (`spawn`/`error`), which is the reported symptom. Surfacing non-zero *exit* of a detached launcher (e.g. `open -a` failing after a successful spawn) would need a settle timer and is a separate, riskier change — left as a possible follow-up.
- The route's `!launch.ok → 500 EDITOR_LAUNCH_FAILED` wiring is a trivial, type-checked mapping and is exercised through the extracted helper rather than a full-server route spec — a route-level launch-failure spec would need global `fs`/`child_process` mocks inside the smoke daemon plus a platform-stable editor, which isn't worth the harness fragility here.

## Known limitation (Windows)

On win32 the spawn keeps `shell: true` (required so `.cmd`/`.bat` editor shims like `code.cmd` launch at all). Under `cmd.exe` a refused/missing command spawns the shell successfully and then exits non-zero rather than emitting an `error` event, so this fix surfaces launch failures on **macOS/Linux** but not Windows. A Windows-specific path (e.g. inspecting the shell exit code without hanging on long-lived GUI launchers) is a separate follow-up; the `available` PATH probe already guards the most common missing-binary case there.
