### PR TITLE
Stabilize settings dialog e2e entry

### DIFF
--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -37,6 +37,10 @@ jobs:
       matrix:
         include:
           - name: entry-onboarding
+            smoke_command: >-
+              pnpm -C e2e exec playwright test -c playwright.config.ts
+              ui/critical-smoke.test.ts
+              --grep '\[P0\]'
             command: >-
               pnpm -C e2e exec playwright test -c playwright.config.ts
               ui/critical-smoke.test.ts
@@ -46,6 +50,10 @@ jobs:
               ui/api-empty-response.test.ts
               --grep '\[P0\]'
           - name: project-workspace
+            smoke_command: >-
+              pnpm -C e2e exec playwright test -c playwright.config.ts
+              ui/critical-smoke.test.ts
+              --grep '\[P0\]'
             command: >-
               pnpm -C e2e exec playwright test -c playwright.config.ts
               ui/app.test.ts
@@ -56,6 +64,10 @@ jobs:
               ui/workspace-keyboard-flows.test.ts
               --grep '\[P0\]'
           - name: runtime-recovery
+            smoke_command: >-
+              pnpm -C e2e exec playwright test -c playwright.config.ts
+              ui/critical-smoke.test.ts
+              --grep '\[P0\]'
             command: >-
               pnpm -C e2e exec playwright test -c playwright.config.ts
               ui/real-daemon-run.test.ts
@@ -64,6 +76,10 @@ jobs:
               ui/settings-local-cli-codex-fallback.test.ts
               --grep '\[P0\]'
           - name: settings-connectors
+            smoke_command: >-
+              pnpm -C e2e exec playwright test -c playwright.config.ts
+              ui/critical-smoke.test.ts
+              --grep '\[P0\] settings dialog'
             command: >-
               pnpm -C e2e exec playwright test -c playwright.config.ts
               ui/settings-api-protocol.test.ts
@@ -92,6 +108,9 @@ jobs:
 
       - name: Clean Playwright state
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
+
+      - name: Run UI shell smoke
+        run: ${{ matrix.smoke_command }}
 
       - name: Run UI P0 domain
         run: ${{ matrix.command }}

--- a/e2e/lib/playwright/amr.ts
+++ b/e2e/lib/playwright/amr.ts
@@ -31,6 +31,7 @@ export async function expectWorkspaceReady(page: Page) {
 }
 
 export async function openSettingsDialog(page: Page) {
+  await waitForLoadingToClear(page);
   await dismissPrivacyDialog(page);
   const settingsTrigger = page.getByTestId('entry-settings-menu-trigger');
   if (await settingsTrigger.isVisible({ timeout: 1_000 }).catch(() => false)) {
@@ -39,7 +40,10 @@ export async function openSettingsDialog(page: Page) {
     await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).first().click();
   }
   const dialog = page.getByRole('dialog');
-  const menu = page.getByRole('menu');
+  const menu = page
+    .getByTestId('entry-settings-menu')
+    .or(page.getByRole('menu', { name: SETTINGS_MENU_LABEL }))
+    .first();
   await expect
     .poll(async () => {
       if (await dialog.isVisible().catch(() => false)) return 'dialog';
@@ -48,7 +52,12 @@ export async function openSettingsDialog(page: Page) {
     })
     .not.toBe('pending');
   if (await menu.isVisible().catch(() => false)) {
-    await menu.getByRole('menuitem', { name: SETTINGS_MENU_LABEL }).click();
+    const settingsItem = menu
+      .getByRole('menuitem', { name: SETTINGS_MENU_LABEL })
+      .or(menu.getByRole('button', { name: SETTINGS_MENU_LABEL }))
+      .first();
+    await expect(settingsItem).toBeVisible({ timeout: 10_000 });
+    await settingsItem.click();
   }
   await expect(dialog).toBeVisible({ timeout: 10_000 });
   return dialog;

--- a/e2e/ui/amr-login-pill.test.ts
+++ b/e2e/ui/amr-login-pill.test.ts
@@ -13,10 +13,10 @@
 
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
+import { openSettingsDialog as openEntrySettingsDialog } from '../lib/playwright/amr.js';
 
 const STORAGE_KEY = 'open-design:config';
 const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定/i;
-const SETTINGS_MENU_LABEL = /^Settings$|^设置$|^設定$/i;
 
 test.describe.configure({ timeout: 30_000 });
 
@@ -35,21 +35,7 @@ async function gotoEntryHome(page: Page) {
 }
 
 async function openSettingsDialog(page: Page) {
-  await waitForLoadingToClear(page);
-  // The entry "Open settings" button may either:
-  //   (a) open a popover menu containing a "Settings" item that opens the
-  //       dialog (older UI), or
-  //   (b) open the Settings dialog directly (current UI as of this PR).
-  // Try the menu-first path, fall through to the direct dialog if no
-  // menu materialises within a short window.
-  await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).click();
-  const menu = page.getByRole('menu');
-  if (await menu.isVisible({ timeout: 1_000 }).catch(() => false)) {
-    await menu.getByRole('button', { name: SETTINGS_MENU_LABEL }).click();
-  }
-  const dialog = page.getByRole('dialog');
-  await expect(dialog).toBeVisible({ timeout: 10_000 });
-  return dialog;
+  return openEntrySettingsDialog(page);
 }
 
 interface VelaMockState {
@@ -64,29 +50,44 @@ async function wireDaemonMocks(page: Page, state: VelaMockState) {
     await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
   });
 
-  await page.route('**/api/agents', async (route) => {
+  await page.route('**/api/agents**', async (route) => {
     // Only AMR present — keeps the card layout deterministic regardless
     // of whatever else `runtimes/registry.ts` later adds.
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'amr',
-            name: 'AMR (vela)',
-            bin: 'vela',
-            versionArgs: ['--version'],
-            available: true,
-            authStatus: null,
-            modelsSource: 'fallback',
-            models: [
-              { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini (openrouter · default)' },
-            ],
-            path: '/usr/local/bin/vela',
-            version: null,
-          },
-        ],
-      },
-    });
+    const agent = {
+      id: 'amr',
+      name: 'AMR (vela)',
+      bin: 'vela',
+      versionArgs: ['--version'],
+      available: true,
+      authStatus: null,
+      modelsSource: 'fallback',
+      models: [
+        { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini (openrouter · default)' },
+      ],
+      path: '/usr/local/bin/vela',
+      version: null,
+    };
+    const url = new URL(route.request().url());
+    if (url.searchParams.get('stream') === '1') {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-cache',
+        },
+        body: [
+          'event: agent',
+          `data: ${JSON.stringify(agent)}`,
+          '',
+          'event: done',
+          'data: {}',
+          '',
+          '',
+        ].join('\n'),
+      });
+      return;
+    }
+    await route.fulfill({ json: { agents: [agent] } });
   });
 
   await page.route('**/api/integrations/vela/status', async (route) => {

--- a/e2e/ui/settings-api-protocol.test.ts
+++ b/e2e/ui/settings-api-protocol.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
 import type { Locator, Page, Route } from '@playwright/test';
+import { openSettingsDialog } from '../lib/playwright/amr.js';
 
 const STORAGE_KEY = 'open-design:config';
 const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定|Account & settings/i;
-const SETTINGS_MENU_LABEL = /Settings|设置|設定/i;
 const LOCAL_CLI_LABEL = /Local CLI|本机 CLI|本地 CLI/i;
 const MODEL_POPOVER_SELECTOR = '.model-select-searchable__popover';
 
@@ -24,22 +24,7 @@ async function gotoEntryHome(page: Page) {
 }
 
 async function openSettingsDialogFromEntry(page: Page) {
-  await waitForLoadingToClear(page);
-  await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).first().click();
-  const dialog = page.locator('.modal-settings[role="dialog"]');
-  const menu = page.getByRole('menu');
-  await expect
-    .poll(async () => {
-      if (await dialog.isVisible().catch(() => false)) return 'dialog';
-      if (await menu.isVisible().catch(() => false)) return 'menu';
-      return 'pending';
-    })
-    .not.toBe('pending');
-  if (await menu.isVisible().catch(() => false)) {
-    await menu.getByRole('menuitem', { name: SETTINGS_MENU_LABEL }).click();
-  }
-  await expect(dialog).toBeVisible();
-  return dialog;
+  return openSettingsDialog(page);
 }
 
 async function openExecutionSettings(

--- a/e2e/ui/settings-connectors-auth-happy-path.test.ts
+++ b/e2e/ui/settings-connectors-auth-happy-path.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
+import { openSettingsDialog } from '../lib/playwright/amr.js';
 
 const STORAGE_KEY = 'open-design:config';
 const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定|Account & settings/i;
-const SETTINGS_MENU_LABEL = /Settings|设置|設定/i;
 
 test.describe.configure({ timeout: 30_000 });
 
@@ -74,15 +74,7 @@ async function gotoEntryHome(page: Page) {
 }
 
 async function openSettingsDialogFromEntry(page: Page) {
-  await waitForLoadingToClear(page);
-  await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).click();
-  const menu = page.getByRole('menu');
-  if (await menu.isVisible({ timeout: 1_000 }).catch(() => false)) {
-    await menu.getByRole('menuitem', { name: SETTINGS_MENU_LABEL }).click();
-  }
-  const dialog = page.getByRole('dialog');
-  await expect(dialog).toBeVisible();
-  return dialog;
+  return openSettingsDialog(page);
 }
 
 async function openConnectorsSettings(

--- a/e2e/ui/settings-connectors-auth-recovery.test.ts
+++ b/e2e/ui/settings-connectors-auth-recovery.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
+import { openSettingsDialog } from '../lib/playwright/amr.js';
 
 const STORAGE_KEY = 'open-design:config';
 const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定|Account & settings/i;
-const SETTINGS_MENU_LABEL = /Settings|设置|設定/i;
 
 test.describe.configure({ timeout: 30_000 });
 
@@ -95,15 +95,7 @@ async function gotoEntryHome(page: Page) {
 }
 
 async function openSettingsDialogFromEntry(page: Page) {
-  await waitForLoadingToClear(page);
-  await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).click();
-  const menu = page.getByRole('menu');
-  if (await menu.isVisible({ timeout: 1_000 }).catch(() => false)) {
-    await menu.getByRole('menuitem', { name: SETTINGS_MENU_LABEL }).click();
-  }
-  const dialog = page.getByRole('dialog');
-  await expect(dialog).toBeVisible();
-  return dialog;
+  return openSettingsDialog(page);
 }
 
 async function openConnectorsSettings(

--- a/e2e/ui/settings-design-systems.test.ts
+++ b/e2e/ui/settings-design-systems.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
 import type { Page, Route } from '@playwright/test';
+import { openSettingsDialog } from '../lib/playwright/amr.js';
 
 const STORAGE_KEY = 'open-design:config';
-const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定/i;
 
 type DesignSystemFixture = {
   id: string;
@@ -183,9 +183,7 @@ async function routeBootstrapApis(
 
 async function openDesignSystemsSettings(page: Page) {
   await gotoEntryHome(page);
-  await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).click();
-  const dialog = page.getByRole('dialog');
-  await expect(dialog).toBeVisible();
+  const dialog = await openSettingsDialog(page);
   await dialog.getByRole('button', { name: /Design systems|设计系统|設計系統/i }).click();
   await expect(dialog.getByRole('heading', { name: /Design systems|设计系统|設計系統/i })).toBeVisible();
   return dialog;

--- a/e2e/ui/settings-hover-contrast.test.ts
+++ b/e2e/ui/settings-hover-contrast.test.ts
@@ -1,9 +1,8 @@
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
+import { openSettingsDialog } from '../lib/playwright/amr.js';
 
 const STORAGE_KEY = 'open-design:config';
-const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定/i;
-const SETTINGS_MENU_LABEL = /^Settings$|^设置$|^設定$/i;
 
 // WCAG AA threshold for normal text. We assert against this rather than AAA
 // because the codebase has historically targeted AA for muted-on-subtle
@@ -39,12 +38,7 @@ async function openSettings(page: Page, theme: Theme) {
 
   await page.emulateMedia({ colorScheme: theme });
   await page.goto('/');
-  await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).click();
-  const menu = page.getByRole('menu');
-  if (await menu.isVisible().catch(() => false)) {
-    await menu.getByRole('button', { name: SETTINGS_MENU_LABEL }).click();
-  }
-  await expect(page.getByRole('dialog')).toBeVisible();
+  await openSettingsDialog(page);
 }
 
 /**

--- a/e2e/ui/settings-local-cli-codex-fallback.test.ts
+++ b/e2e/ui/settings-local-cli-codex-fallback.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import type { Page, Route } from '@playwright/test';
+import { openSettingsDialog } from '../lib/playwright/amr.js';
 
 const STORAGE_KEY = 'open-design:config';
 const LOCALE_KEY = 'open-design:locale';
 const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定|Account & settings/i;
-const SETTINGS_MENU_LABEL = /Settings|设置|設定/i;
 const LOCAL_CLI_LABEL = /Local CLI|本机 CLI|本地 CLI/i;
 
 test.describe.configure({ timeout: 30_000 });
@@ -155,21 +155,7 @@ async function openLocalCliSettings(
   });
 
   await gotoEntryHome(page);
-  await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).first().click();
-  const dialog = page.locator('.modal-settings[role="dialog"]');
-  const menu = page.getByRole('menu');
-  await expect
-    .poll(async () => {
-      if (await dialog.isVisible().catch(() => false)) return 'dialog';
-      if (await menu.isVisible().catch(() => false)) return 'menu';
-      return 'pending';
-    })
-    .not.toBe('pending');
-  if (await menu.isVisible().catch(() => false)) {
-    await menu.getByRole('menuitem', { name: SETTINGS_MENU_LABEL }).click();
-  }
-
-  await expect(dialog).toBeVisible();
+  const dialog = await openSettingsDialog(page);
   await dialog.getByRole('tab', { name: LOCAL_CLI_LABEL }).click();
   const codexCard = dialog
     .locator('[data-testid="settings-agent-select-codex"], .agent-card-select', {

--- a/e2e/ui/settings-media-providers.test.ts
+++ b/e2e/ui/settings-media-providers.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
 import { ensureRailOpen } from '@/playwright/rail';
 import type { Page, Route } from '@playwright/test';
+import { openSettingsDialog } from '../lib/playwright/amr.js';
 
 const STORAGE_KEY = 'open-design:config';
-const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定/i;
 
 function baseConfig(): Record<string, unknown> {
   return {
@@ -137,9 +137,7 @@ async function openMediaSettings(page: Page) {
 }
 
 async function openMediaSettingsFromCurrentPage(page: Page) {
-  await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).click();
-  const dialog = page.getByRole('dialog');
-  await expect(dialog).toBeVisible();
+  const dialog = await openSettingsDialog(page);
   await dialog.getByRole('button', { name: /^Media providers$/ }).click();
   await expect(dialog.getByRole('heading', { name: 'Media providers' })).toBeVisible();
   return dialog;

--- a/e2e/ui/settings-memory-routines.test.ts
+++ b/e2e/ui/settings-memory-routines.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { ensureRailOpen } from '@/playwright/rail';
 import type { Page } from '@playwright/test';
+import { openSettingsDialog } from '../lib/playwright/amr.js';
 
 const STORAGE_KEY = 'open-design:config';
 const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定/i;
-const SETTINGS_MENU_LABEL = /^Settings$|^设置$|^設定$/i;
 
 test.describe.configure({ timeout: 30_000 });
 
@@ -74,14 +74,7 @@ async function gotoEntryHome(page: Page) {
 
 async function openSettings(page: Page) {
   await gotoEntryHome(page);
-  await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).click();
-  const menu = page.getByRole('menu');
-  if (await menu.isVisible().catch(() => false)) {
-    await menu.getByRole('button', { name: SETTINGS_MENU_LABEL }).click();
-  }
-  const dialog = page.getByRole('dialog');
-  await expect(dialog).toBeVisible();
-  return dialog;
+  return openSettingsDialog(page);
 }
 
 async function openMemorySettings(page: Page) {


### PR DESCRIPTION
## Summary
- centralize settings dialog opening through the shared Playwright AMR helper
- handle the entry settings menu before the modal opens, including nested menu cases
- scope the menu locator so nested language menus do not make the helper miss the visible Settings menu
- reuse the shared settings helper across settings API/connectors/local CLI/memory/media/design-system/AMR/contrast tests
- add a shell smoke step before each `ui-extended-main` P0 domain so common entry/settings/project-shell failures stop before fanning out into many dependent cases
- stabilize the AMR login pill test agents mock for streaming `/api/agents?stream=1`

## Verification
- pnpm -C e2e run typecheck
- docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12 .github/workflows/ui-extended-main.yml
- pnpm -C e2e exec playwright test -c playwright.config.ts ui/critical-smoke.test.ts ui/settings-api-protocol.test.ts ui/settings-connectors-auth-happy-path.test.ts ui/settings-connectors-auth-recovery.test.ts ui/settings-local-cli-codex-fallback.test.ts --project=chromium --grep "\[P0\]"
- pnpm -C e2e exec playwright test -c playwright.config.ts ui/amr-login-pill.test.ts --project=chromium --grep "AMR card authorizes"
- pnpm -C e2e exec playwright test -c playwright.config.ts ui/amr-login-pill.test.ts ui/settings-hover-contrast.test.ts ui/settings-media-providers.test.ts ui/settings-design-systems.test.ts ui/settings-memory-routines.test.ts --project=chromium --grep "AMR card authorizes|contrast|autosaves media provider|imports a local design system|renders the new Memory"