### PR TITLE
fix(web): hide external browser annotation tools

### DIFF
--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -1863,29 +1863,6 @@ export function DesignBrowserPanel({
               <RemixIcon name="screenshot-2-line" size={15} />
             </IconTooltipButton>
           ) : null}
-          {desktopHostAvailable ? (
-            <IconTooltipButton
-              label={t('fileViewer.mark')}
-              wrapperClassName="db-action-item db-action-mark"
-              disabled={isBlank}
-              className={drawOverlayOpen ? 'is-active' : ''}
-              onClick={() => {
-                clearBrowserTool();
-                setDrawOverlayOpen((open) => !open);
-              }}
-            >
-              <RemixIcon name="mark-pen-line" size={15} />
-            </IconTooltipButton>
-          ) : null}
-          <IconTooltipButton
-            label={t('fileViewer.comment')}
-            wrapperClassName="db-action-item db-action-primary db-action-comment"
-            disabled={isBlank || !desktopHostAvailable}
-            className={activeTool === 'comment' ? 'is-active' : ''}
-            onClick={() => toggleBrowserTool('comment')}
-          >
-            <Icon name="comment" size={15} />
-          </IconTooltipButton>
           <IconTooltipButton
             label={t('browserUse.title')}
             wrapperClassName="db-action-item db-action-browser-use"
@@ -1922,58 +1899,6 @@ export function DesignBrowserPanel({
           </IconTooltipButton>
           {menuOpen ? (
             <div className="db-menu" role="menu">
-              {desktopHostAvailable ? (
-                <button
-                  type="button"
-                  role="menuitem"
-                  onClick={() => {
-                    setMenuOpen(false);
-                    clearBrowserTool();
-                    setDrawOverlayOpen((open) => !open);
-                  }}
-                  disabled={isBlank}
-                >
-                  <RemixIcon name="mark-pen-line" size={14} />
-                  {t('fileViewer.mark')}
-                </button>
-              ) : null}
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setMenuOpen(false);
-                  toggleBrowserTool('comment');
-                }}
-                disabled={isBlank || !desktopHostAvailable}
-              >
-                <Icon name="comment" size={14} />
-                {t('fileViewer.comment')}
-              </button>
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setMenuOpen(false);
-                  toggleBrowserTool('inspect');
-                }}
-                disabled={isBlank || !desktopHostAvailable}
-              >
-                <RemixIcon name="contrast-drop-line" size={14} />
-                Tune Element
-              </button>
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  setMenuOpen(false);
-                  toggleBrowserTool('edit');
-                }}
-                disabled={isBlank || !desktopHostAvailable}
-              >
-                <Icon name="edit" size={14} />
-                {editableProjectHtml ? 'Edit HTML' : 'Edit Live DOM'}
-              </button>
-              <span className="db-menu-separator" />
               <button type="button" role="menuitem" onClick={takeScreenshot} disabled={isBlank || savingAction != null}>
                 <Icon name="image" size={14} />
                 Copy Screenshot
@@ -2047,24 +1972,6 @@ export function DesignBrowserPanel({
                 <iframe title={pageTitle} src={loadUrl} />
               </div>
             )}
-            {!isBlank && desktopHostAvailable ? (
-              <BrowserCommentMarkers
-                comments={visibleComments}
-                liveTargets={browserLiveCommentTargets}
-                activeCommentId={activePreviewCommentId}
-                onOpen={(comment) => {
-                  const snapshot = browserLiveCommentTargets.get(`comment:${comment.id}`)
-                    ?? browserSnapshotFromComment(comment, browserFilePath);
-                  setActiveTool('comment');
-                  setActiveCommentTarget(snapshot);
-                  setActivePreviewCommentId(comment.id);
-                  setCommentDraft(comment.note);
-                  setQueuedCommentNotes([]);
-                  setTextDraft(snapshot.text);
-                  setDrawOverlayOpen(false);
-                }}
-              />
-            ) : null}
             {commentComposer}
             {(activeTool === 'inspect' || activeTool === 'edit') && activeCommentTarget ? (
               <BrowserInspectPanel

--- a/apps/web/src/components/DesignBrowserPanel.tsx
+++ b/apps/web/src/components/DesignBrowserPanel.tsx
@@ -1114,11 +1114,6 @@ export function DesignBrowserPanel({
       return;
     }
 
-    const commentTargets = visibleComments.map((comment) => ({
-      elementId: comment.elementId,
-      key: `comment:${comment.id}`,
-      selector: comment.selector,
-    }));
     const activeTarget = activeCommentTarget
       ? [{
           elementId: activeCommentTarget.elementId,
@@ -1126,7 +1121,7 @@ export function DesignBrowserPanel({
           selector: activeCommentTarget.selector,
         }]
       : [];
-    const targets = [...commentTargets, ...activeTarget].filter((target) => target.elementId && target.selector);
+    const targets = activeTarget.filter((target) => target.elementId && target.selector);
     if (targets.length === 0) {
       setBrowserLiveCommentTargets((current) => (current.size > 0 ? new Map() : current));
       return;
@@ -1183,7 +1178,7 @@ export function DesignBrowserPanel({
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [activeCommentTarget?.elementId, activeCommentTarget?.selector, activeTool, browserFilePath, isBlank, visibleComments, webviewNode]);
+  }, [activeCommentTarget?.elementId, activeCommentTarget?.selector, activeTool, browserFilePath, isBlank, webviewNode]);
 
   useEffect(() => {
     const next = browserImages.map((file) => ({ file, url: URL.createObjectURL(file) }));

--- a/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
+++ b/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
@@ -453,7 +453,11 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     };
     webview.executeJavaScript = vi.fn(async () => []);
 
-    await waitFor(() => expect(webview.executeJavaScript).toHaveBeenCalled());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(webview.executeJavaScript).not.toHaveBeenCalled();
     expect(container.querySelector('.db-comment-layer')).toBeNull();
     expect(container.querySelector('.db-comment-marker')).toBeNull();
   });

--- a/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
+++ b/apps/web/tests/components/DesignBrowserPanel.webview.test.tsx
@@ -65,7 +65,7 @@ function getAddressDisplay(container: HTMLElement) {
 }
 
 describe('DesignBrowserPanel <webview> navigation', () => {
-  it('keeps desktop browser tools available on the supported webview path', () => {
+  it('keeps external browser mutation and annotation tools hidden', () => {
     render(
       <DesignBrowserPanel
         projectId="proj-webview-more-tools"
@@ -78,16 +78,17 @@ describe('DesignBrowserPanel <webview> navigation', () => {
 
     expect(screen.queryByRole('button', { name: 'Tune element' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Edit live DOM' })).toBeNull();
-    expect(screen.getByRole('button', { name: 'Mark' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Comment' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Mark' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Comment' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Screenshot' })).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Browser menu' }));
 
-    expect(screen.getByRole('menuitem', { name: /Tune Element/ })).toBeTruthy();
-    expect(screen.getByRole('menuitem', { name: /Edit Live DOM/ })).toBeTruthy();
-    expect(screen.getByRole('menuitem', { name: 'Mark' })).toBeTruthy();
-    expect(screen.getByRole('menuitem', { name: 'Comment' })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: /Tune Element/ })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: /Edit Live DOM/ })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: /Edit HTML/ })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: 'Mark' })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: 'Comment' })).toBeNull();
     expect(screen.getByRole('menuitem', { name: 'Copy Screenshot' })).toBeTruthy();
   });
 
@@ -376,7 +377,7 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     expect(container.querySelector('.db-comment-marker')).toBeNull();
   });
 
-  it('reuses the artifact mark label and icon for page annotation', () => {
+  it('does not expose page annotation controls in the external browser', () => {
     const { container } = render(
       <I18nProvider initial="zh-CN">
         <DesignBrowserPanel
@@ -388,14 +389,13 @@ describe('DesignBrowserPanel <webview> navigation', () => {
       </I18nProvider>,
     );
 
-    const markButton = screen.getByRole('button', { name: '标记' });
-    expect(markButton.parentElement?.getAttribute('data-tooltip')).toBe('标记');
-    expect(markButton.querySelector('.ri-mark-pen-line')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: '标记' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '评论' })).toBeNull();
     expect(container.querySelector('.ri-pencil-line')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Annotate page' })).toBeNull();
   });
 
-  it('queues browser element comments while the chat run is busy', async () => {
+  it('does not start browser element comments from the external browser toolbar', () => {
     const onSendBoardCommentAttachments = vi.fn(async (_attachments: unknown[], _images?: File[]) => undefined);
     const { container } = render(
       <DesignBrowserPanel
@@ -411,40 +411,17 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     const webview = container.querySelector('webview.db-webview') as HTMLElement & {
       executeJavaScript?: ReturnType<typeof vi.fn>;
     };
-    webview.executeJavaScript = vi.fn()
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce({
-        elementId: 'dom:h1',
-        filePath: 'browser:https://example.com',
-        htmlHint: '<h1>',
-        label: 'h1',
-        position: { x: 24, y: 32, width: 360, height: 72 },
-        selector: 'h1',
-        selectionKind: 'element',
-        style: { color: 'rgb(13, 12, 34)', fontSize: '48px', lineHeight: '52px' },
-        text: 'Example heading',
-      });
+    webview.executeJavaScript = vi.fn();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Comment' }));
-
-    const textarea = await screen.findByTestId('comment-popover-input');
-    fireEvent.change(textarea, { target: { value: 'Make this heading tighter' } });
-
-    const sendButton = screen.getByTestId('comment-add-send') as HTMLButtonElement;
-    expect(sendButton.textContent).toBe('Queue');
-    expect(sendButton.disabled).toBe(false);
-
-    fireEvent.click(sendButton);
-
-    await waitFor(() => expect(onSendBoardCommentAttachments).toHaveBeenCalledTimes(1));
-    expect(onSendBoardCommentAttachments.mock.calls[0]?.[0]?.[0]).toMatchObject({
-      comment: 'Make this heading tighter',
-      elementId: 'dom:h1',
-      filePath: 'browser:https://example.com',
-    });
+    expect(screen.queryByRole('button', { name: 'Comment' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Browser menu' }));
+    expect(screen.queryByRole('menuitem', { name: 'Comment' })).toBeNull();
+    expect(screen.queryByTestId('comment-popover-input')).toBeNull();
+    expect(onSendBoardCommentAttachments).not.toHaveBeenCalled();
+    expect(webview.executeJavaScript).not.toHaveBeenCalled();
   });
 
-  it('repositions saved browser comment markers from live webview selector measurements', async () => {
+  it('does not render saved browser comment markers in the external browser', async () => {
     const previewComments = [{
       id: 'comment-1',
       projectId: 'proj-webview-live-comment-marker',
@@ -474,27 +451,17 @@ describe('DesignBrowserPanel <webview> navigation', () => {
     const webview = container.querySelector('webview.db-webview') as HTMLElement & {
       executeJavaScript?: ReturnType<typeof vi.fn>;
     };
-    webview.executeJavaScript = vi.fn(async () => [{
-      key: 'comment:comment-1',
-      elementId: 'dom:#card',
-      selector: '#card',
-      label: 'article.card',
-      text: 'Card',
-      position: { x: 140, y: 36, width: 240, height: 160 },
-      htmlHint: '<article id="card">',
-      style: {},
-      selectionKind: 'element',
-    }]);
+    webview.executeJavaScript = vi.fn(async () => []);
 
-    await waitFor(() => {
-      expect(container.querySelector<HTMLElement>('.db-comment-marker')?.style.left).toBe('140px');
-    });
+    await waitFor(() => expect(webview.executeJavaScript).toHaveBeenCalled());
+    expect(container.querySelector('.db-comment-layer')).toBeNull();
+    expect(container.querySelector('.db-comment-marker')).toBeNull();
   });
 
-  it('hides open annotation chrome while taking a browser screenshot', async () => {
+  it('keeps browser screenshot capture available after hiding annotation tools', async () => {
     restoreHost?.();
     const capturePage = vi.fn(async () => {
-      expect(document.querySelector<HTMLElement>('.preview-draw-toolbar')?.style.visibility).toBe('hidden');
+      expect(document.querySelector('.preview-draw-toolbar')).toBeNull();
       return { ok: true as const, dataUrl: 'data:image/png;base64,cG5n', w: 10, h: 10 };
     });
     restoreHost = installMockOpenDesignHost({
@@ -510,8 +477,8 @@ describe('DesignBrowserPanel <webview> navigation', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Mark' }));
-    expect(container.querySelector('.preview-draw-toolbar')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: 'Mark' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Comment' })).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Screenshot' }));
 


### PR DESCRIPTION
## Why

#3887 was merged, but the latest `main` still restores the external Browser Mark/Comment/Tune/Edit controls. These controls imply the app can annotate or mutate arbitrary external pages, while the intended external Browser behavior is screenshot-only plus non-mutating utility actions.

## What users will see

In the external Browser toolbar, users will see Screenshot, Browser Use, and the More menu. Mark, Comment, Tune Element, and Edit HTML / Edit Live DOM are hidden. The More menu still keeps Copy Screenshot, Hard Reload, Copy URL, Open in Browser, Save Page Brief, and clearing actions. Generated artifact previews are unchanged.

## Surface area

- [x] Web UI
- [ ] Daemon / CLI
- [ ] Desktop shell
- [ ] Packages / contracts
- [ ] Docs

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/DesignBrowserPanel.webview.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm tools-dev inspect desktop screenshot --namespace main-latest --path /tmp/open-design-current-toolbar.png`