### PR TITLE
Consolidate E2E agents route fixtures

### DIFF
--- a/e2e/lib/playwright/mock-factory.ts
+++ b/e2e/lib/playwright/mock-factory.ts
@@ -95,7 +95,7 @@ export async function fulfillAgentsRoute(
 
   const url = new URL(route.request().url());
   if (url.pathname !== '/api/agents') {
-    await route.continue();
+    await route.fallback();
     return;
   }
 

--- a/e2e/lib/playwright/mock-factory.ts
+++ b/e2e/lib/playwright/mock-factory.ts
@@ -94,6 +94,11 @@ export async function fulfillAgentsRoute(
   }
 
   const url = new URL(route.request().url());
+  if (url.pathname !== '/api/agents') {
+    await route.continue();
+    return;
+  }
+
   if (url.searchParams.get('stream') !== '1') {
     await route.fulfill({ json: { agents } });
     return;

--- a/e2e/ui/app-design-files.test.ts
+++ b/e2e/ui/app-design-files.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { ensureRailOpen } from '@/playwright/rail';
+import { routeAgents } from '@/playwright/mock-factory';
 import type { Locator, Page, Request, Response } from '@playwright/test';
 import { automatedUiScenarios } from '@/playwright/resources';
 import type { UiScenario } from '@/playwright/resources';
@@ -65,24 +66,22 @@ const CRITICAL_DESIGN_FILE_SCENARIO_IDS = new Set([
   'design-files-tab-persistence',
 ]);
 
+async function routeMockAgents(page: Page) {
+  await routeAgents(page, [
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
+}
+
 for (const entry of automatedUiScenarios().filter((scenario) => designFileFlows.has(scenario.flow ?? ''))) {
   test(`[${designFileScenarioPriority(entry)}]${criticalDesignFileScenarioTag(entry)} ${entry.id}: ${entry.title}`, async ({ page }) => {
-    await page.route('**/api/agents', async (route) => {
-      await route.fulfill({
-        json: {
-          agents: [
-            {
-              id: 'mock',
-              name: 'Mock Agent',
-              bin: 'mock-agent',
-              available: true,
-              version: 'test',
-              models: [{ id: 'default', label: 'Default' }],
-            },
-          ],
-        },
-      });
-    });
+    await routeMockAgents(page);
 
     await gotoEntryHome(page);
     await createProject(page, entry);
@@ -433,22 +432,7 @@ async function runDesignFilesDeleteFlow(page: Page) {
 }
 
 test('design files batch delete removes only the selected files and clears the bulk action state', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
   page.on('dialog', async (dialog) => {
     await dialog.accept();

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { ensureRailOpen } from '@/playwright/rail';
+import { routeAgents } from '@/playwright/mock-factory';
 import type { Page } from '@playwright/test';
 import { T } from '@/timeouts';
 
@@ -313,22 +314,16 @@ test('[P0] @critical HTML preview stays rendered after switching from Preview to
 });
 
 async function routeMockAgents(page: Page) {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeAgents(page, [
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
 }
 
 async function createEmptyProject(page: Page, name: string): Promise<string> {

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { ensureRailOpen } from '@/playwright/rail';
+import { routeAgents } from '@/playwright/mock-factory';
 import type { Dialog, Locator, Page, Request, Response } from '@playwright/test';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -93,22 +94,7 @@ for (const entry of automatedUiScenarios().filter(
   (scenario) => !APP_OWNED_SCENARIO_FLOWS.has(scenario.flow ?? ''),
 )) {
   test(`[${scenarioPriority(entry)}]${criticalScenarioTag(entry)} ${entry.id}: ${entry.title}`, async ({ page }) => {
-    await page.route('**/api/agents', async (route) => {
-      await route.fulfill({
-        json: {
-          agents: [
-            {
-              id: 'mock',
-              name: 'Mock Agent',
-              bin: 'mock-agent',
-              available: true,
-              version: 'test',
-              models: [{ id: 'default', label: 'Default' }],
-            },
-          ],
-        },
-      });
-    });
+    await routeMockAgents(page);
 
     if (entry.flow === 'example-use-prompt') {
       const exampleSummary = {
@@ -579,22 +565,16 @@ test('[P0] sending preview comments opens the refreshed follow-up artifact', asy
 });
 
 async function routeMockAgents(page: Page) {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeAgents(page, [
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
 }
 
 function scenarioPriority(entry: UiScenario): 'P0' | 'P1' | 'P2' {

--- a/e2e/ui/automations-page.test.ts
+++ b/e2e/ui/automations-page.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { ensureRailOpen } from '@/playwright/rail';
+import { routeAgents } from '@/playwright/mock-factory';
 import type { Page } from '@playwright/test';
 
 const STORAGE_KEY = 'open-design:config';
@@ -39,22 +40,16 @@ async function seedAutomationsBase(page: Page) {
     });
   });
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'codex',
-            name: 'Codex CLI',
-            bin: 'codex',
-            available: true,
-            version: '0.130.0',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeAgents(page, [
+    {
+      id: 'codex',
+      name: 'Codex CLI',
+      bin: 'codex',
+      available: true,
+      version: '0.130.0',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
 
   await page.route('**/api/plugins', async (route) => {
     await route.fulfill({

--- a/e2e/ui/chat-design-system-switch.test.ts
+++ b/e2e/ui/chat-design-system-switch.test.ts
@@ -10,6 +10,7 @@
 import { randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
+import { routeAgents } from '@/playwright/mock-factory';
 
 const STORAGE_KEY = 'open-design:config';
 
@@ -63,22 +64,16 @@ test.beforeEach(async ({ page }) => {
     });
   });
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeAgents(page, [
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
 
   await page.route('**/api/design-systems', async (route) => {
     await route.fulfill({ json: { designSystems: DESIGN_SYSTEMS } });

--- a/e2e/ui/chat-todo-autoscroll.test.ts
+++ b/e2e/ui/chat-todo-autoscroll.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
+import { routeAgents } from '@/playwright/mock-factory';
 
 // Verifies that the chat-log stays pinned to the bottom when the PinnedTodoSlot
 // grows (scenario A) and that a deliberate scroll-up is not overridden by a
@@ -54,22 +55,16 @@ async function seedAppConfig(page: Page) {
     });
   });
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeAgents(page, [
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
 }
 
 // Seed a project + conversation + messages via the daemon HTTP API, then

--- a/e2e/ui/critique-theater.test.ts
+++ b/e2e/ui/critique-theater.test.ts
@@ -38,6 +38,7 @@
 
 import { expect, test } from '@playwright/test';
 import type { Page, Route } from '@playwright/test';
+import { routeAgents } from '@/playwright/mock-factory';
 
 const STORAGE_KEY = 'open-design:config';
 
@@ -124,22 +125,16 @@ async function bootAppWithCritiqueEnabled(page: Page): Promise<void> {
 }
 
 async function stubAgents(page: Page): Promise<void> {
-  await page.route('**/api/agents', async (route: Route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeAgents(page, [
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
 }
 
 async function stubProjectEvents(page: Page, frames: CritiqueFrame[]): Promise<void> {

--- a/e2e/ui/design-files-view-state-persist.test.ts
+++ b/e2e/ui/design-files-view-state-persist.test.ts
@@ -18,6 +18,7 @@
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { ensureRailOpen } from '@/playwright/rail';
+import { routeAgents } from '@/playwright/mock-factory';
 
 // Matches the constant in DesignFilesPanel.tsx
 const VIEW_STATE_KEY_PREFIX = 'od:design-files:view-state:v1:';
@@ -75,22 +76,16 @@ test.beforeEach(async ({ page }) => {
     });
   });
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeAgents(page, [
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
 });
 
 // ---------------------------------------------------------------------------

--- a/e2e/ui/entry-configuration-flows.test.ts
+++ b/e2e/ui/entry-configuration-flows.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { ensureRailOpen } from '@/playwright/rail';
+import { routeAgents } from '@/playwright/mock-factory';
 import type { Locator, Page } from '@playwright/test';
 
 const STORAGE_KEY = 'open-design:config';
@@ -81,22 +82,16 @@ test.beforeEach(async ({ page }) => {
     );
   }, STORAGE_KEY);
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeAgents(page, [
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
 });
 
 test('[P1] prompt template retry preserves the edited body in project metadata', async ({ page }) => {

--- a/e2e/ui/entry-topbar.test.ts
+++ b/e2e/ui/entry-topbar.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { ensureRailOpen } from '@/playwright/rail';
+import { routeAgents } from '@/playwright/mock-factory';
 import type { Page } from '@playwright/test';
 
 const STORAGE_KEY = 'open-design:config';
@@ -52,31 +53,25 @@ test.beforeEach(async ({ page }) => {
     });
   });
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'codex',
-            name: 'Codex CLI',
-            bin: 'codex',
-            available: true,
-            version: '0.80.0',
-            path: '/usr/local/bin/codex',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeAgents(page, [
+    {
+      id: 'codex',
+      name: 'Codex CLI',
+      bin: 'codex',
+      available: true,
+      version: '0.80.0',
+      path: '/usr/local/bin/codex',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
 
   await page.route('**/api/app-config', async (route) => {
     if (route.request().method() !== 'GET') {

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
+import { routeAgents } from '@/playwright/mock-factory';
 
 test.describe.configure({ timeout: 30_000 });
 
@@ -299,31 +300,25 @@ test.beforeEach(async ({ page }) => {
     });
   });
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'codex',
-            name: 'Codex CLI',
-            bin: 'codex',
-            available: true,
-            version: '0.80.0',
-            path: '/usr/local/bin/codex',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeAgents(page, [
+    {
+      id: 'codex',
+      name: 'Codex CLI',
+      bin: 'codex',
+      available: true,
+      version: '0.80.0',
+      path: '/usr/local/bin/codex',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
 
   await page.route('**/api/app-config', async (route) => {
     if (route.request().method() !== 'GET') {

--- a/e2e/ui/settings-memory-routines.test.ts
+++ b/e2e/ui/settings-memory-routines.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { ensureRailOpen } from '@/playwright/rail';
+import { routeAgents } from '@/playwright/mock-factory';
 import type { Page } from '@playwright/test';
 import { openSettingsDialog } from '../lib/playwright/amr.js';
 
@@ -40,22 +41,16 @@ async function seedSettingsBase(page: Page) {
     });
   });
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'codex',
-            name: 'Codex CLI',
-            bin: 'codex',
-            available: true,
-            version: '0.130.0',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeAgents(page, [
+    {
+      id: 'codex',
+      name: 'Codex CLI',
+      bin: 'codex',
+      available: true,
+      version: '0.130.0',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
 }
 
 async function waitForLoadingToClear(page: Page) {


### PR DESCRIPTION
## Summary
- reuse the shared `routeAgents` helper across more E2E specs that previously hand-rolled `/api/agents` responses
- narrow the shared agents route fulfillment to the exact `/api/agents` pathname so nested agent endpoints can keep their own mocks
- reduce duplicated mock shape across app, design-files, entry, home rail, memory, automation, and related specs

## Verification
- `pnpm -C e2e run typecheck`
- `pnpm -C e2e exec playwright test -c playwright.config.ts ui/app.test.ts ui/app-design-files.test.ts ui/app-manual-edit.test.ts ui/entry-configuration-flows.test.ts ui/entry-topbar.test.ts ui/home-hero-rail.test.ts ui/settings-memory-routines.test.ts ui/automations-page.test.ts --project=chromium --grep "\[P0\]|design files batch|home topbar execution pill|home hero rail switches non-media|renders the new Memory information|Automations page.*renders the page hero"`

## Notes
- This stacks on #3904.
- A broader exploratory P1 run still shows several existing UI expectation mismatches unrelated to the agents fixture change; those should be handled separately rather than folded into this fixture cleanup.