### PR TITLE
fix(web): interrupt the active run when sending a queued chat now

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -2816,6 +2816,7 @@ function QueuedSendStrip({
                   data-tooltip={t('chat.send')}
                   data-tooltip-placement="top"
                   aria-label={t('chat.send')}
+                  data-testid="chat-queued-send-now"
                   onClick={() => onSendNow?.(item.id)}
                   disabled={!onSendNow}
                 >

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3666,6 +3666,37 @@ export function ProjectView({
     ],
   );
 
+  // Cancel every in-flight run for the current conversation (the user's own
+  // streaming turn plus any reattached runs), mark their assistant messages
+  // canceled, and drop the streaming state. Defined here — ahead of the
+  // queued-send handlers — because "send now" interrupts the active run to
+  // make room for the prioritized send.
+  const handleStop = useCallback(() => {
+    const stoppedAt = Date.now();
+    cancelSendTextBuffer(true);
+    cancelReattachTextBuffers(true);
+    cancelRef.current?.abort();
+    cancelRef.current = null;
+    for (const controller of reattachCancelControllersRef.current.values()) {
+      controller.abort();
+    }
+    reattachCancelControllersRef.current.clear();
+    abortRef.current?.abort();
+    abortRef.current = null;
+    for (const controller of reattachControllersRef.current.values()) {
+      controller.abort();
+    }
+    reattachControllersRef.current.clear();
+    setStreaming(false);
+    streamingConversationIdRef.current = null;
+    setStreamingConversationId(null);
+    setMessages((curr) => {
+      const { messages: next, finalized } = finalizeActiveAssistantMessagesOnStop(curr, stoppedAt);
+      for (const message of finalized) persistMessage(message, { telemetryFinalized: true });
+      return next;
+    });
+  }, [cancelSendTextBuffer, cancelReattachTextBuffers, persistMessage]);
+
   // Flip the deck preview to the slide a queued send's marked element lives on
   // the moment that send starts processing. No-op for plain prompts or marks
   // without a slide index; FileWorkspace/FileViewer ignore it unless the named
@@ -3680,7 +3711,14 @@ export function ProjectView({
     const item = queuedChatSendsRef.current.find((candidate) => candidate.id === id);
     if (!item) return;
     if (currentConversationBusy) {
+      // "Send now" while the agent is still working: the user has explicitly
+      // chosen this turn over the in-flight one, so interrupt the running run
+      // and move this item to the front. Stopping flips the conversation out
+      // of its busy state, and the auto-start effect below then flushes the
+      // now-first queued send — reusing the same path as a natural completion,
+      // so runs never overlap.
       prioritizeQueuedChatSend(id);
+      handleStop();
       return;
     }
     void (async () => {
@@ -3693,7 +3731,7 @@ export function ProjectView({
       );
       if (started) removeQueuedChatSend(id);
     })();
-  }, [armSlideNavForQueuedSend, currentConversationBusy, handleSend, prioritizeQueuedChatSend, removeQueuedChatSend]);
+  }, [armSlideNavForQueuedSend, currentConversationBusy, handleSend, handleStop, prioritizeQueuedChatSend, removeQueuedChatSend]);
 
   useEffect(() => {
     if (currentConversationBusy) {
@@ -4291,32 +4329,6 @@ export function ProjectView({
     },
     [currentConversationActionDisabled, handleSend],
   );
-
-  const handleStop = useCallback(() => {
-    const stoppedAt = Date.now();
-    cancelSendTextBuffer(true);
-    cancelReattachTextBuffers(true);
-    cancelRef.current?.abort();
-    cancelRef.current = null;
-    for (const controller of reattachCancelControllersRef.current.values()) {
-      controller.abort();
-    }
-    reattachCancelControllersRef.current.clear();
-    abortRef.current?.abort();
-    abortRef.current = null;
-    for (const controller of reattachControllersRef.current.values()) {
-      controller.abort();
-    }
-    reattachControllersRef.current.clear();
-    setStreaming(false);
-    streamingConversationIdRef.current = null;
-    setStreamingConversationId(null);
-    setMessages((curr) => {
-      const { messages: next, finalized } = finalizeActiveAssistantMessagesOnStop(curr, stoppedAt);
-      for (const message of finalized) persistMessage(message, { telemetryFinalized: true });
-      return next;
-    });
-  }, [cancelSendTextBuffer, cancelReattachTextBuffers, persistMessage]);
 
   const handleNewConversation = useCallback(async () => {
     if (creatingConversationRef.current) return;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2637,13 +2637,12 @@ export function ProjectView({
               textBuffer.cancel();
               unregisterTextBuffer();
               // A reattached run interrupted by a "send now" still receives a
-              // late onDone from the daemon. Capture ownership before
-              // clearCurrentRunStreamingMarker clears the refs so its
-              // completion-only side effects (artifact persist, produced-file
-              // attachment) don't run over the replacement run that now owns
-              // the conversation.
-              const isCurrentRun =
-                abortRef.current === controller && cancelRef.current === cancelController;
+              // late onDone from the daemon. Skip its completion side effects
+              // (artifact persist, produced-file attachment) when a newer run
+              // owns the active slot. See the streamViaDaemon onDone for the
+              // ownership rationale.
+              const runMayFinalize =
+                abortRef.current === null || abortRef.current === controller;
               for (const ev of parser.flush()) {
                 if (ev.type === 'artifact:end') {
                   parsedArtifact = parsedArtifact
@@ -2672,7 +2671,7 @@ export function ProjectView({
               reattachControllersRef.current.delete(runId);
               reattachCancelControllersRef.current.delete(runId);
               clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
-              if (!isCurrentRun) return;
+              if (!runMayFinalize) return;
               void (async () => {
                 const preTurn = message.preTurnFileNames;
                 let nextFiles = await refreshProjectFiles();
@@ -2719,12 +2718,12 @@ export function ProjectView({
               const errorCode = (err as Error & { code?: string }).code;
               // A superseded reattached run must not paint a global failure
               // banner or re-finalize its message over the replacement run.
-              const isCurrentRun =
-                abortRef.current === controller && cancelRef.current === cancelController;
+              const runMayFinalize =
+                abortRef.current === null || abortRef.current === controller;
               textBuffer.flush();
               textBuffer.cancel();
               unregisterTextBuffer();
-              if (isCurrentRun) {
+              if (runMayFinalize) {
                 setError(err.message);
                 appendAssistantErrorEvent(message.id, err.message, errorCode);
                 updateMessageById(
@@ -2775,9 +2774,9 @@ export function ProjectView({
             // Skip AbortError (expected on interrupt) and any error from a run
             // that has already been superseded — only the run still holding the
             // active controllers may surface a global failure here.
-            const isCurrentRun =
-              abortRef.current === controller && cancelRef.current === cancelController;
-            if ((err as Error).name !== 'AbortError' && isCurrentRun) {
+            const runMayFinalize =
+              abortRef.current === null || abortRef.current === controller;
+            if ((err as Error).name !== 'AbortError' && runMayFinalize) {
               const msg = err instanceof Error ? err.message : String(err);
               setError(msg);
               appendAssistantErrorEvent(message.id, msg);
@@ -3328,9 +3327,17 @@ export function ProjectView({
           }));
         },
         onDone: (fullText = '') => {
-          const isCurrentRun =
-            abortRef.current === controller && cancelRef.current === cancelController;
-          if (!isCurrentRun) {
+          // The daemon delivers onDone even for a canceled run, so a run
+          // superseded by a "send now" interrupt can still land here and must
+          // not apply its completion side effects over the replacement. A run
+          // may finalize when no *newer* run owns the active slot: either this
+          // run still holds it, or the slot is null because this run's own
+          // terminal onRunStatus already cleared it (the normal success path —
+          // onRunStatus fires before onDone). A live replacement leaves abortRef
+          // pointing at a different controller.
+          const runMayFinalize =
+            abortRef.current === null || abortRef.current === controller;
+          if (!runMayFinalize) {
             textBuffer.cancel();
             cancelSendTextBuffer();
             return;
@@ -3442,15 +3449,15 @@ export function ProjectView({
           // A run superseded by a "send now" interrupt can still surface a
           // late disconnect error (e.g. a canceled stream that lost its
           // terminal SSE). It must not paint a global failure banner or
-          // re-finalize its already-canceled assistant message over the
-          // replacement run that now owns the conversation. Capture ownership
-          // before clearCurrentRunStreamingMarker clears the active refs.
-          const isCurrentRun =
-            abortRef.current === controller && cancelRef.current === cancelController;
+          // re-finalize its already-canceled assistant message when a newer run
+          // owns the active slot. See the onDone above for the ownership
+          // rationale.
+          const runMayFinalize =
+            abortRef.current === null || abortRef.current === controller;
           textBuffer.flush();
           textBuffer.cancel();
           cancelSendTextBuffer();
-          if (isCurrentRun) {
+          if (runMayFinalize) {
             setError(err.message);
             appendAssistantErrorEvent(assistantId, err.message, errorCode);
             updateAssistant((prev) => ({
@@ -3553,8 +3560,8 @@ export function ProjectView({
           },
           onRunStatus: (runStatus) => {
             const endedAt = isTerminalRunStatus(runStatus) ? Date.now() : undefined;
-            const isCurrentRun =
-              abortRef.current === controller && cancelRef.current === cancelController;
+            const runMayFinalize =
+              abortRef.current === null || abortRef.current === controller;
             updateMessageById(
               assistantId,
               (prev) => ({
@@ -3565,7 +3572,7 @@ export function ProjectView({
               true,
               runStatus === 'canceled' ? { telemetryFinalized: true } : undefined,
             );
-            if (!isCurrentRun) return;
+            if (!runMayFinalize) return;
             updateConversationLatestRun(runStatus, endedAt);
             if (isTerminalRunStatus(runStatus)) {
               clearCurrentRunStreamingMarker(runConversationId, controller, cancelController);

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2242,8 +2242,9 @@ export function ProjectView({
     controller: AbortController,
     cancelController: AbortController,
   ) => {
-    if (!clearActiveRunRefs(conversationId, controller, cancelController)) return;
+    if (!clearActiveRunRefs(conversationId, controller, cancelController)) return false;
     clearStreamingMarker(conversationId);
+    return true;
   }, [clearActiveRunRefs, clearStreamingMarker]);
 
   const handleAssistantFeedback = useCallback(
@@ -3348,8 +3349,12 @@ export function ProjectView({
             if (runCommentAttachments.length > 0) {
               void patchAttachedStatuses(runCommentAttachments, 'failed');
             }
-            clearCurrentRunStreamingMarker(runConversationId, controller, cancelController);
-            updateConversationLatestRun('failed', endedAt);
+            const ownsCurrentRun = clearCurrentRunStreamingMarker(
+              runConversationId,
+              controller,
+              cancelController,
+            );
+            if (ownsCurrentRun) updateConversationLatestRun('failed', endedAt);
             void refreshProjectFiles();
             onProjectsRefresh();
             return;
@@ -3367,8 +3372,12 @@ export function ProjectView({
           if (runCommentAttachments.length > 0) {
             void patchAttachedStatuses(runCommentAttachments, 'needs_review');
           }
-          clearCurrentRunStreamingMarker(runConversationId, controller, cancelController);
-          updateConversationLatestRun(finalRunStatus ?? 'succeeded', endedAt);
+          const ownsCurrentRun = clearCurrentRunStreamingMarker(
+            runConversationId,
+            controller,
+            cancelController,
+          );
+          if (ownsCurrentRun) updateConversationLatestRun(finalRunStatus ?? 'succeeded', endedAt);
           // Refetch the file list directly (rather than just bumping the
           // refresh signal) so we can diff against the pre-turn snapshot
           // and attach the new files to the assistant message as download
@@ -3418,8 +3427,12 @@ export function ProjectView({
           if (runCommentAttachments.length > 0) {
             void patchAttachedStatuses(runCommentAttachments, 'failed');
           }
-          clearCurrentRunStreamingMarker(runConversationId, controller, cancelController);
-          updateConversationLatestRun('failed', endedAt);
+          const ownsCurrentRun = clearCurrentRunStreamingMarker(
+            runConversationId,
+            controller,
+            cancelController,
+          );
+          if (ownsCurrentRun) updateConversationLatestRun('failed', endedAt);
           setMessages((curr) => {
             const finalized = curr.find((m) => m.id === assistantId);
             if (finalized) persistMessage(finalized, { telemetryFinalized: true });

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1005,6 +1005,13 @@ export function ProjectView({
   >(null);
   const abortRef = useRef<AbortController | null>(null);
   const cancelRef = useRef<AbortController | null>(null);
+  // Runs explicitly superseded by a "send now" interrupt. Their abort
+  // controller is recorded here synchronously — before handleStop() clears the
+  // active refs — so the run's late terminal callbacks (which the daemon still
+  // delivers for a canceled run) can be recognized as stale and skip every
+  // current-run side effect, independent of abortRef churn. A WeakSet so a
+  // finished run's controller is collected once nothing else references it.
+  const supersededRunsRef = useRef<WeakSet<AbortController>>(new WeakSet());
   const streamingConversationIdRef = useRef<string | null>(null);
   const [queuedChatSends, setQueuedChatSends] = useState<QueuedChatSend[]>([]);
   const queuedChatSendsRef = useRef<QueuedChatSend[]>([]);
@@ -2633,16 +2640,22 @@ export function ProjectView({
               textBuffer.appendEvent(ev);
             },
             onDone: () => {
-              textBuffer.flush();
+              // A reattached run interrupted by a "send now" still receives a
+              // late onDone from the daemon. Decide ownership first, then bail
+              // BEFORE any current-run side effect (committing buffered text,
+              // repainting the artifact preview via setArtifact, re-finalizing
+              // the message) — only release this run's bookkeeping. See the
+              // streamViaDaemon onDone for the ownership rationale.
+              const runMayFinalize =
+                !supersededRunsRef.current.has(controller);
+              if (runMayFinalize) textBuffer.flush();
               textBuffer.cancel();
               unregisterTextBuffer();
-              // A reattached run interrupted by a "send now" still receives a
-              // late onDone from the daemon. Skip its completion side effects
-              // (artifact persist, produced-file attachment) when a newer run
-              // owns the active slot. See the streamViaDaemon onDone for the
-              // ownership rationale.
-              const runMayFinalize =
-                abortRef.current === null || abortRef.current === controller;
+              completedReattachRunsRef.current.add(runId);
+              reattachControllersRef.current.delete(runId);
+              reattachCancelControllersRef.current.delete(runId);
+              clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
+              if (!runMayFinalize) return;
               for (const ev of parser.flush()) {
                 if (ev.type === 'artifact:end') {
                   parsedArtifact = parsedArtifact
@@ -2667,11 +2680,6 @@ export function ProjectView({
                 true,
                 { telemetryFinalized: true },
               );
-              completedReattachRunsRef.current.add(runId);
-              reattachControllersRef.current.delete(runId);
-              reattachCancelControllersRef.current.delete(runId);
-              clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
-              if (!runMayFinalize) return;
               void (async () => {
                 const preTurn = message.preTurnFileNames;
                 let nextFiles = await refreshProjectFiles();
@@ -2719,7 +2727,7 @@ export function ProjectView({
               // A superseded reattached run must not paint a global failure
               // banner or re-finalize its message over the replacement run.
               const runMayFinalize =
-                abortRef.current === null || abortRef.current === controller;
+                !supersededRunsRef.current.has(controller);
               textBuffer.flush();
               textBuffer.cancel();
               unregisterTextBuffer();
@@ -2772,10 +2780,10 @@ export function ProjectView({
         })
           .catch((err) => {
             // Skip AbortError (expected on interrupt) and any error from a run
-            // that has already been superseded — only the run still holding the
-            // active controllers may surface a global failure here.
+            // that was tagged superseded by a send-now interrupt — it must not
+            // surface a global failure over the replacement.
             const runMayFinalize =
-              abortRef.current === null || abortRef.current === controller;
+              !supersededRunsRef.current.has(controller);
             if ((err as Error).name !== 'AbortError' && runMayFinalize) {
               const msg = err instanceof Error ? err.message : String(err);
               setError(msg);
@@ -3330,13 +3338,12 @@ export function ProjectView({
           // The daemon delivers onDone even for a canceled run, so a run
           // superseded by a "send now" interrupt can still land here and must
           // not apply its completion side effects over the replacement. A run
-          // may finalize when no *newer* run owns the active slot: either this
-          // run still holds it, or the slot is null because this run's own
-          // terminal onRunStatus already cleared it (the normal success path —
-          // onRunStatus fires before onDone). A live replacement leaves abortRef
-          // pointing at a different controller.
+          // may finalize unless it was tagged superseded at interrupt time
+          // (recorded before handleStop cleared the refs), which is reliable
+          // even before the replacement send attaches — unlike abortRef, whose
+          // terminal onRunStatus / handleStop churn make it ambiguous here.
           const runMayFinalize =
-            abortRef.current === null || abortRef.current === controller;
+            !supersededRunsRef.current.has(controller);
           if (!runMayFinalize) {
             textBuffer.cancel();
             cancelSendTextBuffer();
@@ -3449,11 +3456,10 @@ export function ProjectView({
           // A run superseded by a "send now" interrupt can still surface a
           // late disconnect error (e.g. a canceled stream that lost its
           // terminal SSE). It must not paint a global failure banner or
-          // re-finalize its already-canceled assistant message when a newer run
-          // owns the active slot. See the onDone above for the ownership
-          // rationale.
+          // re-finalize its already-canceled assistant message once it was
+          // tagged superseded. See the onDone above for the ownership rationale.
           const runMayFinalize =
-            abortRef.current === null || abortRef.current === controller;
+            !supersededRunsRef.current.has(controller);
           textBuffer.flush();
           textBuffer.cancel();
           cancelSendTextBuffer();
@@ -3561,7 +3567,7 @@ export function ProjectView({
           onRunStatus: (runStatus) => {
             const endedAt = isTerminalRunStatus(runStatus) ? Date.now() : undefined;
             const runMayFinalize =
-              abortRef.current === null || abortRef.current === controller;
+              !supersededRunsRef.current.has(controller);
             updateMessageById(
               assistantId,
               (prev) => ({
@@ -3784,6 +3790,16 @@ export function ProjectView({
       // of its busy state, and the auto-start effect below then flushes the
       // now-first queued send — reusing the same path as a natural completion,
       // so runs never overlap.
+      //
+      // Record the runs we're superseding BEFORE handleStop() clears the active
+      // refs. The daemon still delivers a late terminal callback for the
+      // canceled run; tagging its controller here lets those callbacks be
+      // recognized as stale and skip every current-run side effect, even if the
+      // replacement send hasn't attached yet.
+      if (abortRef.current) supersededRunsRef.current.add(abortRef.current);
+      for (const controller of reattachControllersRef.current.values()) {
+        supersededRunsRef.current.add(controller);
+      }
       prioritizeQueuedChatSend(id);
       handleStop();
       return;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3308,6 +3308,13 @@ export function ProjectView({
           }));
         },
         onDone: (fullText = '') => {
+          const isCurrentRun =
+            abortRef.current === controller && cancelRef.current === cancelController;
+          if (!isCurrentRun) {
+            textBuffer.cancel();
+            cancelSendTextBuffer();
+            return;
+          }
           textBuffer.flush();
           textBuffer.cancel();
           cancelSendTextBuffer();

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -855,6 +855,12 @@ export function ProjectView({
   // attach the runId to.
   const [messagesInitialized, setMessagesInitialized] = useState(false);
   const [previewComments, setPreviewComments] = useState<PreviewComment[]>([]);
+  // Mirror so the send-now interrupt path can read the current statuses
+  // synchronously without re-creating its callback on every comment change.
+  const previewCommentsRef = useRef<PreviewComment[]>([]);
+  useEffect(() => {
+    previewCommentsRef.current = previewComments;
+  }, [previewComments]);
   const [attachedComments, setAttachedComments] = useState<PreviewComment[]>([]);
   const [streaming, setStreaming] = useState(false);
   const [streamingConversationId, setStreamingConversationId] = useState<string | null>(null);
@@ -3800,6 +3806,25 @@ export function ProjectView({
       for (const controller of reattachControllersRef.current.values()) {
         supersededRunsRef.current.add(controller);
       }
+      // The interrupted turn moved its preview-comment attachments to
+      // 'applying' when it started; since we now suppress its terminal
+      // callbacks, reset them to 'open' here so they don't stay stuck as
+      // "applying" after the replacement send takes over.
+      const stuckApplying = previewCommentsRef.current.filter(
+        (comment) => comment.status === 'applying',
+      );
+      if (stuckApplying.length > 0) {
+        setPreviewComments((current) =>
+          current.map((comment) =>
+            comment.status === 'applying' ? { ...comment, status: 'open' } : comment,
+          ),
+        );
+        void Promise.all(
+          stuckApplying.map((comment) =>
+            patchPreviewCommentStatus(project.id, comment.conversationId, comment.id, 'open'),
+          ),
+        ).catch(() => {});
+      }
       prioritizeQueuedChatSend(id);
       handleStop();
       return;
@@ -3814,7 +3839,7 @@ export function ProjectView({
       );
       if (started) removeQueuedChatSend(id);
     })();
-  }, [armSlideNavForQueuedSend, currentConversationBusy, handleSend, handleStop, prioritizeQueuedChatSend, removeQueuedChatSend]);
+  }, [armSlideNavForQueuedSend, currentConversationBusy, handleSend, handleStop, prioritizeQueuedChatSend, project.id, removeQueuedChatSend]);
 
   useEffect(() => {
     if (currentConversationBusy) {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3412,20 +3412,30 @@ export function ProjectView({
         onError: (err: Error) => {
           const endedAt = Date.now();
           const errorCode = (err as Error & { code?: string }).code;
+          // A run superseded by a "send now" interrupt can still surface a
+          // late disconnect error (e.g. a canceled stream that lost its
+          // terminal SSE). It must not paint a global failure banner or
+          // re-finalize its already-canceled assistant message over the
+          // replacement run that now owns the conversation. Capture ownership
+          // before clearCurrentRunStreamingMarker clears the active refs.
+          const isCurrentRun =
+            abortRef.current === controller && cancelRef.current === cancelController;
           textBuffer.flush();
           textBuffer.cancel();
           cancelSendTextBuffer();
-          setError(err.message);
-          appendAssistantErrorEvent(assistantId, err.message, errorCode);
-          updateAssistant((prev) => ({
-            ...prev,
-            endedAt,
-            runStatus: config.mode === 'api' || prev.runId || isActiveRunStatus(prev.runStatus)
-              ? 'failed'
-              : prev.runStatus,
-          }));
-          if (runCommentAttachments.length > 0) {
-            void patchAttachedStatuses(runCommentAttachments, 'failed');
+          if (isCurrentRun) {
+            setError(err.message);
+            appendAssistantErrorEvent(assistantId, err.message, errorCode);
+            updateAssistant((prev) => ({
+              ...prev,
+              endedAt,
+              runStatus: config.mode === 'api' || prev.runId || isActiveRunStatus(prev.runStatus)
+                ? 'failed'
+                : prev.runStatus,
+            }));
+            if (runCommentAttachments.length > 0) {
+              void patchAttachedStatuses(runCommentAttachments, 'failed');
+            }
           }
           const ownsCurrentRun = clearCurrentRunStreamingMarker(
             runConversationId,

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3808,15 +3808,25 @@ export function ProjectView({
       }
       // The interrupted turn moved its preview-comment attachments to
       // 'applying' when it started; since we now suppress its terminal
-      // callbacks, reset them to 'open' here so they don't stay stuck as
-      // "applying" after the replacement send takes over.
+      // callbacks, reset them to 'open' so they don't stay stuck mid-apply.
+      // Reset ONLY the in-flight run's comments: queued sends (including the
+      // one being prioritized) also hold their attachments in 'applying', and
+      // those must stay reserved — the replacement run re-applies them. The
+      // in-flight run's comments are exactly the 'applying' ones not owned by
+      // any queued send.
+      const queuedCommentIds = new Set(
+        queuedChatSendsRef.current.flatMap((send) =>
+          send.commentAttachments.map((attachment) => attachment.id),
+        ),
+      );
       const stuckApplying = previewCommentsRef.current.filter(
-        (comment) => comment.status === 'applying',
+        (comment) => comment.status === 'applying' && !queuedCommentIds.has(comment.id),
       );
       if (stuckApplying.length > 0) {
+        const resetIds = new Set(stuckApplying.map((comment) => comment.id));
         setPreviewComments((current) =>
           current.map((comment) =>
-            comment.status === 'applying' ? { ...comment, status: 'open' } : comment,
+            resetIds.has(comment.id) ? { ...comment, status: 'open' } : comment,
           ),
         );
         void Promise.all(

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2227,11 +2227,24 @@ export function ProjectView({
     cancelController: AbortController,
   ) => {
     if (!shouldClearActiveRunRefs(streamingConversationIdRef.current, conversationId)) {
-      return;
+      return false;
     }
-    if (abortRef.current === controller) abortRef.current = null;
-    if (cancelRef.current === cancelController) cancelRef.current = null;
+    if (abortRef.current !== controller || cancelRef.current !== cancelController) {
+      return false;
+    }
+    abortRef.current = null;
+    cancelRef.current = null;
+    return true;
   }, []);
+
+  const clearCurrentRunStreamingMarker = useCallback((
+    conversationId: string,
+    controller: AbortController,
+    cancelController: AbortController,
+  ) => {
+    if (!clearActiveRunRefs(conversationId, controller, cancelController)) return;
+    clearStreamingMarker(conversationId);
+  }, [clearActiveRunRefs, clearStreamingMarker]);
 
   const handleAssistantFeedback = useCallback(
     (assistantMessage: ChatMessage, change: ChatMessageFeedbackChange) => {
@@ -2649,8 +2662,7 @@ export function ProjectView({
               completedReattachRunsRef.current.add(runId);
               reattachControllersRef.current.delete(runId);
               reattachCancelControllersRef.current.delete(runId);
-              clearActiveRunRefs(reattachConversationId, controller, cancelController);
-              clearStreamingMarker(reattachConversationId);
+              clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
               void (async () => {
                 const preTurn = message.preTurnFileNames;
                 let nextFiles = await refreshProjectFiles();
@@ -2712,8 +2724,7 @@ export function ProjectView({
               completedReattachRunsRef.current.add(runId);
               reattachControllersRef.current.delete(runId);
               reattachCancelControllersRef.current.delete(runId);
-              clearActiveRunRefs(reattachConversationId, controller, cancelController);
-              clearStreamingMarker(reattachConversationId);
+              clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
               persistNow({ telemetryFinalized: true });
             },
           },
@@ -2734,8 +2745,7 @@ export function ProjectView({
               completedReattachRunsRef.current.add(runId);
               reattachControllersRef.current.delete(runId);
               reattachCancelControllersRef.current.delete(runId);
-              clearActiveRunRefs(reattachConversationId, controller, cancelController);
-              clearStreamingMarker(reattachConversationId);
+              clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
               persistNow({ telemetryFinalized: true });
             }
           },
@@ -2787,6 +2797,7 @@ export function ProjectView({
     markStreamingConversation,
     clearStreamingMarker,
     clearActiveRunRefs,
+    clearCurrentRunStreamingMarker,
     refreshProjectFiles,
     persistArtifact,
     requestOpenFile,
@@ -3337,8 +3348,7 @@ export function ProjectView({
             if (runCommentAttachments.length > 0) {
               void patchAttachedStatuses(runCommentAttachments, 'failed');
             }
-            clearActiveRunRefs(runConversationId, controller, cancelController);
-            clearStreamingMarker(runConversationId);
+            clearCurrentRunStreamingMarker(runConversationId, controller, cancelController);
             updateConversationLatestRun('failed', endedAt);
             void refreshProjectFiles();
             onProjectsRefresh();
@@ -3357,8 +3367,7 @@ export function ProjectView({
           if (runCommentAttachments.length > 0) {
             void patchAttachedStatuses(runCommentAttachments, 'needs_review');
           }
-          clearActiveRunRefs(runConversationId, controller, cancelController);
-          clearStreamingMarker(runConversationId);
+          clearCurrentRunStreamingMarker(runConversationId, controller, cancelController);
           updateConversationLatestRun(finalRunStatus ?? 'succeeded', endedAt);
           // Refetch the file list directly (rather than just bumping the
           // refresh signal) so we can diff against the pre-turn snapshot
@@ -3409,8 +3418,7 @@ export function ProjectView({
           if (runCommentAttachments.length > 0) {
             void patchAttachedStatuses(runCommentAttachments, 'failed');
           }
-          clearActiveRunRefs(runConversationId, controller, cancelController);
-          clearStreamingMarker(runConversationId);
+          clearCurrentRunStreamingMarker(runConversationId, controller, cancelController);
           updateConversationLatestRun('failed', endedAt);
           setMessages((curr) => {
             const finalized = curr.find((m) => m.id === assistantId);
@@ -3495,6 +3503,8 @@ export function ProjectView({
           },
           onRunStatus: (runStatus) => {
             const endedAt = isTerminalRunStatus(runStatus) ? Date.now() : undefined;
+            const isCurrentRun =
+              abortRef.current === controller && cancelRef.current === cancelController;
             updateMessageById(
               assistantId,
               (prev) => ({
@@ -3505,10 +3515,10 @@ export function ProjectView({
               true,
               runStatus === 'canceled' ? { telemetryFinalized: true } : undefined,
             );
+            if (!isCurrentRun) return;
             updateConversationLatestRun(runStatus, endedAt);
             if (isTerminalRunStatus(runStatus)) {
-              clearActiveRunRefs(runConversationId, controller, cancelController);
-              clearStreamingMarker(runConversationId);
+              clearCurrentRunStreamingMarker(runConversationId, controller, cancelController);
             }
           },
           onRunEventId: (lastRunEventId) => {
@@ -3660,7 +3670,7 @@ export function ProjectView({
       updateMessageById,
       markStreamingConversation,
       clearStreamingMarker,
-      clearActiveRunRefs,
+      clearCurrentRunStreamingMarker,
       onProjectsRefresh,
       onProjectChange,
     ],

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2636,6 +2636,14 @@ export function ProjectView({
               textBuffer.flush();
               textBuffer.cancel();
               unregisterTextBuffer();
+              // A reattached run interrupted by a "send now" still receives a
+              // late onDone from the daemon. Capture ownership before
+              // clearCurrentRunStreamingMarker clears the refs so its
+              // completion-only side effects (artifact persist, produced-file
+              // attachment) don't run over the replacement run that now owns
+              // the conversation.
+              const isCurrentRun =
+                abortRef.current === controller && cancelRef.current === cancelController;
               for (const ev of parser.flush()) {
                 if (ev.type === 'artifact:end') {
                   parsedArtifact = parsedArtifact
@@ -2664,6 +2672,7 @@ export function ProjectView({
               reattachControllersRef.current.delete(runId);
               reattachCancelControllersRef.current.delete(runId);
               clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
+              if (!isCurrentRun) return;
               void (async () => {
                 const preTurn = message.preTurnFileNames;
                 let nextFiles = await refreshProjectFiles();
@@ -2708,20 +2717,26 @@ export function ProjectView({
             },
             onError: (err) => {
               const errorCode = (err as Error & { code?: string }).code;
+              // A superseded reattached run must not paint a global failure
+              // banner or re-finalize its message over the replacement run.
+              const isCurrentRun =
+                abortRef.current === controller && cancelRef.current === cancelController;
               textBuffer.flush();
               textBuffer.cancel();
               unregisterTextBuffer();
-              setError(err.message);
-              appendAssistantErrorEvent(message.id, err.message, errorCode);
-              updateMessageById(
-                message.id,
-                (prev) => ({
-                  ...prev,
-                  runStatus: 'failed',
-                  endedAt: prev.endedAt ?? Date.now(),
-                }),
-                true,
-              );
+              if (isCurrentRun) {
+                setError(err.message);
+                appendAssistantErrorEvent(message.id, err.message, errorCode);
+                updateMessageById(
+                  message.id,
+                  (prev) => ({
+                    ...prev,
+                    runStatus: 'failed',
+                    endedAt: prev.endedAt ?? Date.now(),
+                  }),
+                  true,
+                );
+              }
               completedReattachRunsRef.current.add(runId);
               reattachControllersRef.current.delete(runId);
               reattachCancelControllersRef.current.delete(runId);
@@ -2757,7 +2772,12 @@ export function ProjectView({
           },
         })
           .catch((err) => {
-            if ((err as Error).name !== 'AbortError') {
+            // Skip AbortError (expected on interrupt) and any error from a run
+            // that has already been superseded — only the run still holding the
+            // active controllers may surface a global failure here.
+            const isCurrentRun =
+              abortRef.current === controller && cancelRef.current === cancelController;
+            if ((err as Error).name !== 'AbortError' && isCurrentRun) {
               const msg = err instanceof Error ? err.message : String(err);
               setError(msg);
               appendAssistantErrorEvent(message.id, msg);

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -1021,6 +1021,46 @@ describe('ProjectView conversation run isolation', () => {
     expect(screen.getByTestId('conversation-latest-runs').textContent).toContain('conv-a:running');
   });
 
+  it('does not surface a stale failure banner when an interrupted reattached run errors late', async () => {
+    // conv-a starts with a reattached run in flight (the screenshot scenario:
+    // the agent was already streaming when the user queued a turn).
+    let reattachHandlers: { onError: (err: Error) => void } | null = null;
+    reattachDaemonRun.mockImplementation(async (input: unknown) => {
+      reattachHandlers = (input as { handlers: { onError: (err: Error) => void } }).handlers;
+      return new Promise<void>(() => {});
+    });
+    streamViaDaemon.mockImplementation(async (input: unknown) => {
+      const options = input as {
+        onRunCreated?: (runId: string) => void;
+        onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
+      };
+      options.onRunCreated?.('run-replacement');
+      options.onRunStatus?.('running');
+    });
+
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
+
+    fireEvent.click(screen.getByTestId('send-message'));
+    await waitFor(() => expect(screen.getByTestId('send-queued-0').textContent).toBe('hello from b'));
+
+    // Interrupt the reattached run; the queued send flushes as the replacement.
+    fireEvent.click(screen.getByTestId('send-queued-0'));
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('streaming-state').textContent).toBe('streaming');
+
+    // The superseded reattached run errors late (lost terminal SSE). It must
+    // not paint a global failure banner over the live replacement run.
+    await act(async () => {
+      reattachHandlers?.onError(new Error('daemon stream disconnected before run completed'));
+    });
+
+    expect(screen.getByTestId('chat-error').textContent).toBe('');
+    expect(screen.getByTestId('streaming-state').textContent).toBe('streaming');
+  });
+
   it('auto-starts queued sends one at a time after the active run completes', async () => {
     let finishReattach: (() => void) | null = null;
     let reattachHandlers: { onDone: () => void } | null = null;

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -818,7 +818,7 @@ describe('ProjectView conversation run isolation', () => {
     );
   });
 
-  it('does not overlap active runs when send-now is clicked for a queued item', async () => {
+  it('interrupts the active run and flushes the prioritized queued send when send-now is clicked while busy', async () => {
     let finishReattach: (() => void) | null = null;
     let reattachHandlers: { onDone: () => void } | null = null;
     reattachDaemonRun.mockImplementation(async (input: unknown) => {
@@ -837,15 +837,25 @@ describe('ProjectView conversation run isolation', () => {
     fireEvent.click(screen.getByTestId('send-message-alt'));
 
     await waitFor(() => expect(screen.getByTestId('send-queued-1')).toBeTruthy());
-    fireEvent.click(screen.getByTestId('send-queued-1'));
-
     expect(streamViaDaemon).not.toHaveBeenCalled();
 
-    await act(async () => {
-      reattachHandlers?.onDone();
-      finishReattach?.();
-    });
+    // Send-now on the second queued item while the conversation is still
+    // busy. The chosen UX is "interrupt the running turn and send this item
+    // now" — so this must stop the in-flight run and flush the prioritized
+    // send WITHOUT waiting for the active run to finish on its own. Stopping
+    // first keeps runs from overlapping. The reattach promise is never
+    // resolved here on purpose: a regression that only reorders the queue
+    // (without stopping) would leave the conversation busy forever and never
+    // call streamViaDaemon.
+    fireEvent.click(screen.getByTestId('send-queued-1'));
 
+    // The in-flight turn is canceled (interrupted), not left running.
+    await waitFor(() =>
+      expect(screen.getByTestId('assistant-summary').textContent).toContain('canceled'),
+    );
+
+    // ...and the prioritized queued send flushes immediately afterward, with
+    // no manual completion of the reattach run.
     await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
     const payload = streamViaDaemon.mock.calls[0]?.[0] as {
       history?: Array<{ role: string; content: string }>;

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -1061,6 +1061,54 @@ describe('ProjectView conversation run isolation', () => {
     expect(screen.getByTestId('streaming-state').textContent).toBe('streaming');
   });
 
+  it('runs a normal run completion even after its terminal status cleared the active refs', async () => {
+    // The daemon emits the terminal onRunStatus *before* onDone, and that
+    // terminal status clears the run's active refs. onDone must still apply the
+    // normal completion flow (file refresh, artifact/produced-file attach) — the
+    // superseded-run guard must not mistake a cleared slot for a takeover.
+    conversationAMessages = [];
+    const daemonRuns: Array<{
+      handlers: { onDone: (fullText?: string) => void };
+      onRunCreated?: (runId: string) => void;
+      onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
+    }> = [];
+    streamViaDaemon.mockImplementation(async (input: unknown) => {
+      const options = input as {
+        handlers: { onDone: (fullText?: string) => void };
+        onRunCreated?: (runId: string) => void;
+        onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
+      };
+      daemonRuns.push(options);
+      options.onRunCreated?.(`run-${daemonRuns.length}`);
+      options.onRunStatus?.('running');
+    });
+
+    renderProjectView(
+      config,
+      project,
+      [{ id: 'agent-1', name: 'OpenCode', bin: 'opencode', available: true, models: [] }],
+    );
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false));
+
+    fireEvent.click(screen.getByTestId('send-message'));
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+
+    fetchProjectFiles.mockClear();
+
+    await act(async () => {
+      // Terminal status first (clears the active refs), then onDone.
+      daemonRuns[0]?.onRunStatus?.('succeeded');
+      daemonRuns[0]?.handlers.onDone('completed output');
+    });
+
+    // The completion flow ran: it refetches the file list to attach produced
+    // files, and the conversation's latest run reflects success.
+    await waitFor(() => expect(fetchProjectFiles).toHaveBeenCalled());
+    expect(screen.getByTestId('conversation-latest-runs').textContent).toContain('conv-a:succeeded');
+  });
+
   it('auto-starts queued sends one at a time after the active run completes', async () => {
     let finishReattach: (() => void) | null = null;
     let reattachHandlers: { onDone: () => void } | null = null;

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -276,6 +276,11 @@ vi.mock('../../src/components/ChatPane', () => ({
         <output data-testid="active-conversation">{activeConversationId}</output>
         <output data-testid="streaming-state">{streaming ? 'streaming' : 'idle'}</output>
         <output data-testid="chat-error">{error}</output>
+        <output data-testid="conversation-latest-runs">
+          {conversations
+            .map((conversation) => `${conversation.id}:${conversation.latestRun?.status ?? ''}`)
+            .join('\n')}
+        </output>
         <output data-testid="assistant-events">
           {(messages ?? [])
             .filter((message) => message.role === 'assistant')
@@ -863,7 +868,7 @@ describe('ProjectView conversation run isolation', () => {
     expect(payload.history?.at(-1)).toMatchObject({ role: 'user', content: 'hello from c' });
   });
 
-  it('keeps the replacement run streaming when the interrupted run reports canceled late', async () => {
+  it('keeps the replacement run active when the interrupted run reports canceled and done late', async () => {
     const queuedSend = {
       id: 'queued-1',
       conversationId: 'conv-a',
@@ -877,18 +882,20 @@ describe('ProjectView conversation run isolation', () => {
       JSON.stringify([queuedSend]),
     );
 
-    const interruptedRunStatuses: Array<(status: NonNullable<ChatMessage['runStatus']>) => void> = [];
-    reattachDaemonRun.mockImplementation(async (input: unknown) => {
-      const onRunStatus = (input as {
-        onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
-      }).onRunStatus;
-      if (onRunStatus) interruptedRunStatuses.push(onRunStatus);
-      return new Promise<void>(() => {});
-    });
+    conversationAMessages = [];
+    const daemonRuns: Array<{
+      handlers: { onDone: (fullText?: string) => void };
+      onRunCreated?: (runId: string) => void;
+      onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
+    }> = [];
     streamViaDaemon.mockImplementation(async (input: unknown) => {
       const options = input as {
+        handlers: { onDone: (fullText?: string) => void };
+        onRunCreated?: (runId: string) => void;
         onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
       };
+      daemonRuns.push(options);
+      options.onRunCreated?.(`run-${daemonRuns.length}`);
       options.onRunStatus?.('running');
     });
 
@@ -899,17 +906,30 @@ describe('ProjectView conversation run isolation', () => {
     );
 
     await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false));
+
+    fireEvent.click(screen.getByTestId('send-message'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
     await waitFor(() => expect(screen.getByTestId('send-queued-0')).toBeTruthy());
 
     fireEvent.click(screen.getByTestId('send-queued-0'));
 
-    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
-    interruptedRunStatuses[0]?.('canceled');
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(screen.getByTestId('conversation-latest-runs').textContent).toContain('conv-a:running'),
+    );
+
+    await act(async () => {
+      daemonRuns[0]?.onRunStatus?.('canceled');
+      daemonRuns[0]?.handlers.onDone('interrupted done');
+    });
 
     await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
     expect(screen.getByTestId('workspace-streaming-state').textContent).toBe('streaming');
-    expect(streamViaDaemon).toHaveBeenCalledWith(expect.objectContaining({
+    expect(screen.getByTestId('conversation-latest-runs').textContent).toContain('conv-a:running');
+    expect(streamViaDaemon).toHaveBeenLastCalledWith(expect.objectContaining({
       conversationId: 'conv-a',
       history: expect.arrayContaining([
         expect.objectContaining({ role: 'user', content: 'hello from c' }),

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -1151,6 +1151,53 @@ describe('ProjectView conversation run isolation', () => {
     expect(fetchProjectFiles).not.toHaveBeenCalled();
   });
 
+  it('clears stuck applying comment status when send-now interrupts a comment-bearing turn', async () => {
+    fetchPreviewComments.mockResolvedValue([previewComment]);
+    streamViaDaemon.mockImplementation(async (input: unknown) => {
+      const options = input as {
+        onRunCreated?: (runId: string) => void;
+        onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
+      };
+      options.onRunCreated?.('run-replacement');
+      options.onRunStatus?.('running');
+    });
+
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
+
+    // Attach a comment and send while busy: the turn is queued and its comment
+    // attachment is moved to 'applying'.
+    fireEvent.click(screen.getByTestId('attach-first-comment'));
+    await waitFor(() => expect(screen.getByTestId('attached-comment-count').textContent).toBe('1'));
+    fireEvent.click(screen.getByTestId('send-message'));
+    await waitFor(() =>
+      expect(patchPreviewCommentStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        previewComment.id,
+        'applying',
+      ),
+    );
+    await waitFor(() => expect(screen.getByTestId('send-queued-0')).toBeTruthy());
+
+    patchPreviewCommentStatus.mockClear();
+
+    // Send-now interrupts the in-flight turn; the stuck 'applying' comment must
+    // be reset to 'open' rather than left mid-apply forever.
+    fireEvent.click(screen.getByTestId('send-queued-0'));
+
+    await waitFor(() =>
+      expect(patchPreviewCommentStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        previewComment.id,
+        'open',
+      ),
+    );
+  });
+
   it('auto-starts queued sends one at a time after the active run completes', async () => {
     let finishReattach: (() => void) | null = null;
     let reattachHandlers: { onDone: () => void } | null = null;

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -22,6 +22,7 @@ const fetchProjectFiles = vi.fn();
 const fetchLiveArtifacts = vi.fn();
 const fetchSkill = vi.fn();
 const fetchDesignSystem = vi.fn();
+const patchPreviewCommentStatus = vi.fn();
 const getTemplate = vi.fn();
 const fetchChatRunStatus = vi.fn();
 const listActiveChatRuns = vi.fn();
@@ -79,7 +80,7 @@ vi.mock('../../src/providers/registry', () => ({
   fetchLiveArtifacts: (...args: unknown[]) => fetchLiveArtifacts(...args),
   fetchProjectFiles: (...args: unknown[]) => fetchProjectFiles(...args),
   fetchSkill: (...args: unknown[]) => fetchSkill(...args),
-  patchPreviewCommentStatus: vi.fn(),
+  patchPreviewCommentStatus: (...args: unknown[]) => patchPreviewCommentStatus(...args),
   upsertPreviewComment: vi.fn(),
   writeProjectTextFile: vi.fn(),
 }));
@@ -868,7 +869,7 @@ describe('ProjectView conversation run isolation', () => {
     expect(payload.history?.at(-1)).toMatchObject({ role: 'user', content: 'hello from c' });
   });
 
-  it('keeps the replacement run active when the interrupted run reports canceled and done late', async () => {
+  it('ignores completion side effects when the interrupted run reports canceled and done late', async () => {
     const queuedSend = {
       id: 'queued-1',
       conversationId: 'conv-a',
@@ -883,6 +884,7 @@ describe('ProjectView conversation run isolation', () => {
     );
 
     conversationAMessages = [];
+    fetchPreviewComments.mockResolvedValue([previewComment]);
     const daemonRuns: Array<{
       handlers: { onDone: (fullText?: string) => void };
       onRunCreated?: (runId: string) => void;
@@ -908,6 +910,9 @@ describe('ProjectView conversation run isolation', () => {
     await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
     await waitFor(() => expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false));
 
+    fireEvent.click(screen.getByTestId('attach-first-comment'));
+    await waitFor(() => expect(screen.getByTestId('attached-comment-count').textContent).toBe('1'));
+
     fireEvent.click(screen.getByTestId('send-message'));
 
     await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
@@ -920,15 +925,33 @@ describe('ProjectView conversation run isolation', () => {
     await waitFor(() =>
       expect(screen.getByTestId('conversation-latest-runs').textContent).toContain('conv-a:running'),
     );
+    await waitFor(() =>
+      expect(patchPreviewCommentStatus).toHaveBeenCalledWith(
+        'project-1',
+        'conv-a',
+        previewComment.id,
+        'applying',
+      ),
+    );
+    patchPreviewCommentStatus.mockClear();
+    fetchProjectFiles.mockClear();
 
     await act(async () => {
       daemonRuns[0]?.onRunStatus?.('canceled');
       daemonRuns[0]?.handlers.onDone('interrupted done');
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
     });
 
     await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
     expect(screen.getByTestId('workspace-streaming-state').textContent).toBe('streaming');
     expect(screen.getByTestId('conversation-latest-runs').textContent).toContain('conv-a:running');
+    expect(patchPreviewCommentStatus).not.toHaveBeenCalledWith(
+      'project-1',
+      'conv-a',
+      previewComment.id,
+      'needs_review',
+    );
+    expect(fetchProjectFiles).not.toHaveBeenCalled();
     expect(streamViaDaemon).toHaveBeenLastCalledWith(expect.objectContaining({
       conversationId: 'conv-a',
       history: expect.arrayContaining([

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -937,6 +937,67 @@ describe('ProjectView conversation run isolation', () => {
     }));
   });
 
+  it('does not surface a stale failure banner when the interrupted run errors late', async () => {
+    const queuedSend = {
+      id: 'queued-1',
+      conversationId: 'conv-a',
+      prompt: 'hello from c',
+      attachments: [],
+      commentAttachments: [],
+      createdAt: 1,
+    };
+    window.localStorage.setItem(
+      'od:chat-queued-sends:project-1:v1',
+      JSON.stringify([queuedSend]),
+    );
+
+    conversationAMessages = [];
+    const daemonRuns: Array<{
+      handlers: { onDone: (fullText?: string) => void; onError: (err: Error) => void };
+      onRunCreated?: (runId: string) => void;
+      onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
+    }> = [];
+    streamViaDaemon.mockImplementation(async (input: unknown) => {
+      const options = input as {
+        handlers: { onDone: (fullText?: string) => void; onError: (err: Error) => void };
+        onRunCreated?: (runId: string) => void;
+        onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
+      };
+      daemonRuns.push(options);
+      options.onRunCreated?.(`run-${daemonRuns.length}`);
+      options.onRunStatus?.('running');
+    });
+
+    renderProjectView(
+      config,
+      project,
+      [{ id: 'agent-1', name: 'OpenCode', bin: 'opencode', available: true, models: [] }],
+    );
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false));
+
+    fireEvent.click(screen.getByTestId('send-message'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByTestId('send-queued-0')).toBeTruthy());
+
+    // Interrupt: send-now stops the first run and flushes the queued send.
+    fireEvent.click(screen.getByTestId('send-queued-0'));
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
+
+    // The superseded run loses its terminal SSE and surfaces a late error. It
+    // must not paint a global failure banner over the live replacement run.
+    await act(async () => {
+      daemonRuns[0]?.handlers.onError(new Error('daemon stream disconnected before run completed'));
+    });
+
+    expect(screen.getByTestId('chat-error').textContent).toBe('');
+    expect(screen.getByTestId('streaming-state').textContent).toBe('streaming');
+    expect(screen.getByTestId('conversation-latest-runs').textContent).toContain('conv-a:running');
+  });
+
   it('auto-starts queued sends one at a time after the active run completes', async () => {
     let finishReattach: (() => void) | null = null;
     let reattachHandlers: { onDone: () => void } | null = null;

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -1109,6 +1109,48 @@ describe('ProjectView conversation run isolation', () => {
     expect(screen.getByTestId('conversation-latest-runs').textContent).toContain('conv-a:succeeded');
   });
 
+  it('skips an interrupted reattached run\'s completion side effects when it finishes late', async () => {
+    // The interrupted run is tagged superseded synchronously at send-now time
+    // (before handleStop clears the refs), so its late onDone — which the
+    // daemon still delivers for the canceled run — must not run the completion
+    // flow (file refresh, artifact persist, produced-file attach) even though
+    // it could land before the replacement send attaches.
+    let reattachHandlers: { onDone: () => void } | null = null;
+    reattachDaemonRun.mockImplementation(async (input: unknown) => {
+      reattachHandlers = (input as { handlers: { onDone: () => void } }).handlers;
+      return new Promise<void>(() => {});
+    });
+    streamViaDaemon.mockImplementation(async (input: unknown) => {
+      const options = input as {
+        onRunCreated?: (runId: string) => void;
+        onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
+      };
+      options.onRunCreated?.('run-replacement');
+      options.onRunStatus?.('running');
+    });
+
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
+
+    fireEvent.click(screen.getByTestId('send-message'));
+    await waitFor(() => expect(screen.getByTestId('send-queued-0').textContent).toBe('hello from b'));
+
+    fireEvent.click(screen.getByTestId('send-queued-0'));
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+
+    fetchProjectFiles.mockClear();
+
+    // The superseded reattached run finishes late.
+    await act(async () => {
+      reattachHandlers?.onDone();
+    });
+
+    // Its completion side effects (which refetch the file list) did not run.
+    expect(fetchProjectFiles).not.toHaveBeenCalled();
+  });
+
   it('auto-starts queued sends one at a time after the active run completes', async () => {
     let finishReattach: (() => void) | null = null;
     let reattachHandlers: { onDone: () => void } | null = null;

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -1151,7 +1151,7 @@ describe('ProjectView conversation run isolation', () => {
     expect(fetchProjectFiles).not.toHaveBeenCalled();
   });
 
-  it('clears stuck applying comment status when send-now interrupts a comment-bearing turn', async () => {
+  it('does not reset a queued send\'s own comment status when send-now flushes it', async () => {
     fetchPreviewComments.mockResolvedValue([previewComment]);
     streamViaDaemon.mockImplementation(async (input: unknown) => {
       const options = input as {
@@ -1168,7 +1168,7 @@ describe('ProjectView conversation run isolation', () => {
     await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
 
     // Attach a comment and send while busy: the turn is queued and its comment
-    // attachment is moved to 'applying'.
+    // attachment is reserved as 'applying'.
     fireEvent.click(screen.getByTestId('attach-first-comment'));
     await waitFor(() => expect(screen.getByTestId('attached-comment-count').textContent).toBe('1'));
     fireEvent.click(screen.getByTestId('send-message'));
@@ -1184,17 +1184,18 @@ describe('ProjectView conversation run isolation', () => {
 
     patchPreviewCommentStatus.mockClear();
 
-    // Send-now interrupts the in-flight turn; the stuck 'applying' comment must
-    // be reset to 'open' rather than left mid-apply forever.
+    // Send-now flushes that queued comment-bearing item. Its comment belongs to
+    // the send being dispatched (the replacement re-applies it), so the
+    // interrupt's stale-comment cleanup must NOT reset it to 'open' — that would
+    // race the replacement's 'applying' write and reopen a reserved comment.
     fireEvent.click(screen.getByTestId('send-queued-0'));
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalled());
 
-    await waitFor(() =>
-      expect(patchPreviewCommentStatus).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        previewComment.id,
-        'open',
-      ),
+    expect(patchPreviewCommentStatus).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      previewComment.id,
+      'open',
     );
   });
 

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -863,6 +863,60 @@ describe('ProjectView conversation run isolation', () => {
     expect(payload.history?.at(-1)).toMatchObject({ role: 'user', content: 'hello from c' });
   });
 
+  it('keeps the replacement run streaming when the interrupted run reports canceled late', async () => {
+    const queuedSend = {
+      id: 'queued-1',
+      conversationId: 'conv-a',
+      prompt: 'hello from c',
+      attachments: [],
+      commentAttachments: [],
+      createdAt: 1,
+    };
+    window.localStorage.setItem(
+      'od:chat-queued-sends:project-1:v1',
+      JSON.stringify([queuedSend]),
+    );
+
+    const interruptedRunStatuses: Array<(status: NonNullable<ChatMessage['runStatus']>) => void> = [];
+    reattachDaemonRun.mockImplementation(async (input: unknown) => {
+      const onRunStatus = (input as {
+        onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
+      }).onRunStatus;
+      if (onRunStatus) interruptedRunStatuses.push(onRunStatus);
+      return new Promise<void>(() => {});
+    });
+    streamViaDaemon.mockImplementation(async (input: unknown) => {
+      const options = input as {
+        onRunStatus?: (status: NonNullable<ChatMessage['runStatus']>) => void;
+      };
+      options.onRunStatus?.('running');
+    });
+
+    renderProjectView(
+      config,
+      project,
+      [{ id: 'agent-1', name: 'OpenCode', bin: 'opencode', available: true, models: [] }],
+    );
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
+    await waitFor(() => expect(screen.getByTestId('send-queued-0')).toBeTruthy());
+
+    fireEvent.click(screen.getByTestId('send-queued-0'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    interruptedRunStatuses[0]?.('canceled');
+
+    await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
+    expect(screen.getByTestId('workspace-streaming-state').textContent).toBe('streaming');
+    expect(streamViaDaemon).toHaveBeenCalledWith(expect.objectContaining({
+      conversationId: 'conv-a',
+      history: expect.arrayContaining([
+        expect.objectContaining({ role: 'user', content: 'hello from c' }),
+      ]),
+    }));
+  });
+
   it('auto-starts queued sends one at a time after the active run completes', async () => {
     let finishReattach: (() => void) | null = null;
     let reattachHandlers: { onDone: () => void } | null = null;

--- a/e2e/lib/fake-agents.ts
+++ b/e2e/lib/fake-agents.ts
@@ -137,6 +137,14 @@ if (process.stdin.isTTY || agentId === 'deepseek') {
 async function emitRun(promptText) {
   if (emitted) return;
   emitted = true;
+  if (promptText.includes('Hold the daemon run open until canceled')) {
+    // Stay running (busy) without ever emitting a terminal result, so a test
+    // can queue a follow-up turn and interrupt it via send-now. Keep the event
+    // loop alive indefinitely; the daemon kills this child (SIGTERM) when the
+    // run is canceled.
+    setInterval(() => {}, 1 << 30);
+    return;
+  }
   if (promptText.includes('Return an intentional daemon smoke failure')) {
     emitFailure();
     return;

--- a/e2e/tests/dialog/send-now-interrupt.test.ts
+++ b/e2e/tests/dialog/send-now-interrupt.test.ts
@@ -1,0 +1,199 @@
+// @vitest-environment node
+
+// Send-now interrupt — the queued-send "send now" affordance.
+//
+// While a run is streaming, typing another turn queues it. Clicking the
+// queued item's send-now (↩) arrow must interrupt the in-flight run and
+// dispatch the queued turn immediately, instead of silently waiting for the
+// current run to finish. This spec drives the real browser UI against a real
+// daemon + fake agent: it starts a held (never-finishing) run, queues a second
+// turn, clicks send-now, and asserts the held run is canceled and the queued
+// turn dispatches as a fresh run.
+
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+
+import { chromium, expect as playwrightExpect, type Browser, type Page } from '@playwright/test';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { createFakeAgentRuntimes } from '@/fake-agents';
+import { requestJson } from '@/vitest/http';
+import { waitForRunTerminal } from '@/vitest/runs';
+import { createSmokeSuite } from '@/vitest/smoke-suite';
+
+const HELD_PROMPT = 'Hold the daemon run open until canceled for the send-now smoke';
+const QUEUED_PROMPT = 'Create a deterministic smoke artifact';
+const STORAGE_KEY = 'open-design:config';
+
+type ProjectResponse = {
+  conversationId: string;
+  project: { id: string; name: string };
+};
+
+describe('dialog send-now interrupt', () => {
+  let browser: Browser | null = null;
+
+  afterEach(async () => {
+    await browser?.close();
+    browser = null;
+  });
+
+  test('interrupts the in-flight run and dispatches the queued turn when send-now is clicked', async () => {
+    const suite = await createSmokeSuite('dialog-send-now-interrupt');
+
+    await suite.with.toolsDev(async ({ webUrl }) => {
+      const fakeAgents = await createFakeAgentRuntimes({
+        root: join(suite.scratchDir, 'fake-agents'),
+        runtimeIds: ['codex'],
+      });
+
+      await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
+        body: {
+          agentCliEnv: { codex: fakeAgents.codex.env },
+          agentId: 'codex',
+          agentModels: { codex: { model: 'default', reasoning: 'default' } },
+          designSystemId: null,
+          onboardingCompleted: true,
+          privacyDecisionAt: 1,
+          skillId: null,
+          telemetry: { artifactManifest: true, content: false, metrics: false },
+        },
+        method: 'PUT',
+      });
+
+      const project = await requestJson<ProjectResponse>(webUrl, '/api/projects', {
+        body: {
+          designSystemId: null,
+          id: randomUUID(),
+          metadata: { kind: 'prototype' },
+          name: 'Dialog send-now interrupt project',
+          pendingPrompt: null,
+          skillId: null,
+        },
+      });
+
+      browser = await chromium.launch();
+      const context = await browser.newContext({ baseURL: webUrl });
+      await context.addInitScript(({ key, codexEnv }) => {
+        window.localStorage.setItem(
+          key,
+          JSON.stringify({
+            mode: 'daemon',
+            apiKey: '',
+            baseUrl: 'https://api.anthropic.com',
+            model: 'claude-sonnet-4-5',
+            agentId: 'codex',
+            skillId: null,
+            designSystemId: null,
+            onboardingCompleted: true,
+            privacyDecisionAt: 1,
+            agentModels: { codex: { model: 'default', reasoning: 'default' } },
+            agentCliEnv: { codex: codexEnv },
+            telemetry: { metrics: false, content: false, artifactManifest: true },
+          }),
+        );
+      }, { key: STORAGE_KEY, codexEnv: fakeAgents.codex.env });
+
+      const page = await context.newPage();
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await waitForLoadingToClear(page);
+      const target = `/projects/${encodeURIComponent(project.project.id)}/conversations/${encodeURIComponent(project.conversationId)}`;
+      await page.goto(target, { waitUntil: 'domcontentloaded' });
+      await expectWorkspaceReady(page);
+
+      // Start a run that never finishes on its own — the conversation stays busy.
+      const heldRunId = await sendComposerTurn(page, HELD_PROMPT);
+      await waitForRunStatusIs(webUrl, heldRunId, 'running');
+
+      // Type a second turn while busy; it is queued (no new run yet).
+      await queueComposerTurn(page, QUEUED_PROMPT);
+      await playwrightExpect(page.getByTestId('chat-queued-send-strip')).toBeVisible();
+
+      // Click send-now on the queued item: the held run must be canceled and
+      // the queued turn dispatched as a brand-new run.
+      const newRunResponse = page.waitForResponse(
+        (response) =>
+          new URL(response.url()).pathname === '/api/runs'
+          && response.request().method() === 'POST',
+        { timeout: 15_000 },
+      );
+      await page.getByTestId('chat-queued-send-now').click();
+
+      // The interrupted run reaches a terminal (canceled) status.
+      const terminal = await waitForRunTerminal(webUrl, heldRunId);
+      expect(terminal.status).toBe('canceled');
+
+      // ...and a fresh run was dispatched for the queued turn.
+      const dispatched = await newRunResponse;
+      expect(dispatched.ok()).toBe(true);
+      const { runId: queuedRunId } = (await dispatched.json()) as { runId: string };
+      expect(queuedRunId).not.toBe(heldRunId);
+
+      // The queued strip drains once its only item has been dispatched.
+      await playwrightExpect(page.getByTestId('chat-queued-send-strip')).toHaveCount(0);
+    });
+  }, 180_000);
+});
+
+async function expectWorkspaceReady(page: Page) {
+  await waitForLoadingToClear(page);
+  const privacyDialog = page.getByRole('region', { name: 'Help us improve Open Design' });
+  if (await privacyDialog.isVisible().catch(() => false)) {
+    await privacyDialog.getByRole('button', { name: /don't share|not now/i }).click();
+    await playwrightExpect(privacyDialog).toHaveCount(0);
+  }
+  await playwrightExpect(page).toHaveURL(/\/projects\//);
+  await playwrightExpect(page.getByTestId('chat-composer')).toBeVisible();
+  await playwrightExpect(page.getByTestId('chat-composer-input')).toBeVisible();
+  await playwrightExpect(page.getByTestId('file-workspace')).toBeVisible();
+}
+
+async function waitForLoadingToClear(page: Page) {
+  const loading = page.getByText('Loading Open Design…');
+  await loading.waitFor({ state: 'detached', timeout: 10_000 }).catch(() => {});
+}
+
+// Send a turn that starts a run immediately (conversation idle). Returns the runId.
+async function sendComposerTurn(page: Page, prompt: string): Promise<string> {
+  const input = page.getByTestId('chat-composer-input');
+  await playwrightExpect(input).toBeVisible({ timeout: 5_000 });
+  await input.click();
+  await input.fill(prompt);
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      new URL(response.url()).pathname === '/api/runs'
+      && response.request().method() === 'POST',
+    { timeout: 10_000 },
+  );
+  await page.getByTestId('chat-send').click();
+  const response = await responsePromise;
+  expect(response.ok()).toBe(true);
+  const { runId } = (await response.json()) as { runId: string };
+  return runId;
+}
+
+// Type and submit a turn while the conversation is busy; it is queued, so no
+// POST /api/runs fires. The send button is shown (not Stop) because the
+// composer has content.
+async function queueComposerTurn(page: Page, prompt: string) {
+  const input = page.getByTestId('chat-composer-input');
+  await input.click();
+  await input.fill(prompt);
+  await playwrightExpect(page.getByTestId('chat-send')).toBeEnabled();
+  await page.getByTestId('chat-send').click();
+}
+
+async function waitForRunStatusIs(webUrl: string, runId: string, status: string) {
+  await playwrightExpect
+    .poll(
+      async () => {
+        const run = await requestJson<{ status: string }>(
+          webUrl,
+          `/api/runs/${encodeURIComponent(runId)}`,
+        );
+        return run.status;
+      },
+      { timeout: 15_000 },
+    )
+    .toBe(status);
+}


### PR DESCRIPTION
## Why

Reported from the desktop app: while the agent was still working ("准备中…"), a chat message typed into the composer got queued (the expected busy-state behavior), but clicking the **↩ "send now"** up-arrow on that queued item did nothing — the message just sat there until the in-flight turn finished on its own. The user read this as "queue 的发送失效了" (queued send is broken).

Root cause: `sendQueuedChatSendNow` only called `prioritizeQueuedChatSend` while the conversation was busy — it moved the item to the front of the queue and returned. For the common single queued item, reordering a one-item list is a complete no-op, so an explicit "send" affordance silently did nothing.

Product decision (confirmed with product): "send now" should mean *send now* — interrupt the running turn rather than wait it out.

## What users will see

When the agent is busy and you click the **↩ send-now** arrow on a queued message, Open Design now stops the in-flight turn and immediately sends that queued message. Previously the button appeared to do nothing until the current turn finished. Behavior when the conversation is idle is unchanged (the item sends directly).

## Surface area

- [x] **UI** — changes the behavior of the queued-send "send now" control in the chat composer (`apps/web`)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — N/A: queuing is a web-UI-only interaction (typing while a run streams); there is no `od` surface for it, so there is nothing to mirror.
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — "send now" on a queued item now interrupts the active run instead of waiting for it to finish.
- [ ] **None**

## Screenshots

This changes the behavior of an existing control rather than adding a new entry point. The control is the **↩ up-arrow** on a queued item in the "已排队 / 待发送" strip above the composer (visible whenever a send is queued during a run). Before: clicking it left the item queued until the active run ended. After: clicking it stops the active run and sends the item.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ProjectView.run-isolation.test.tsx` → `interrupts the active run and flushes the prioritized queued send when send-now is clicked while busy`
- Did the test go red on `main` and green on this branch? **yes** — verified by stashing the source change (red: the active run stays running and `streamViaDaemon` is never called) and restoring it (green: the run is canceled and the prioritized send flushes).
- The test asserts the in-flight assistant turn is `canceled` and the prioritized queued send flushes through `streamViaDaemon` **without** any manual completion of the active run — a reorder-only regression would leave the conversation busy forever and never flush.

## Implementation note

The fix reuses existing machinery rather than adding a parallel send path: stopping the run flips the conversation out of its busy state, and the existing auto-start effect then flushes the now-first queued send through the same path as a natural completion — so runs still never overlap (stop happens first). `handleStop` was moved ahead of the queued-send handlers so `sendQueuedChatSendNow` can call it.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/web test tests/components/ProjectView.run-isolation.test.tsx tests/components/ProjectView.run-cleanup.test.tsx` — 47 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)