### PR TITLE
feat(daemon): add Codebuddy Code CLI agent adapter

### DIFF
--- a/apps/daemon/src/runtimes/defs/codebuddy.ts
+++ b/apps/daemon/src/runtimes/defs/codebuddy.ts
@@ -63,8 +63,11 @@ export const codebuddyAgentDef = {
     // Codebuddy CLI does not ship a `models` subcommand; the supported model
     // ids are advertised in `--help` output. Fallback list above covers the
     // current set; users can type custom ids through the "Custom" input.
+    // Codebuddy CLI --effort supports exactly these 6 levels:
+    //   minimal, low, medium, high, xhigh, max
+    // No "default" level — omitting --effort entirely lets Codebuddy use
+    // its own default, which is modelled by an empty reasoning selection.
     reasoningOptions: [
-      { id: 'default', label: 'Default' },
       { id: 'minimal', label: 'Minimal' },
       { id: 'low', label: 'Low' },
       { id: 'medium', label: 'Medium' },

--- a/apps/daemon/src/runtimes/defs/codebuddy.ts
+++ b/apps/daemon/src/runtimes/defs/codebuddy.ts
@@ -1,0 +1,110 @@
+import { agentCapabilities } from '../capabilities.js';
+import { DEFAULT_MODEL_OPTION } from './shared.js';
+import type { RuntimeAgentDef } from '../types.js';
+
+// Codebuddy Code (https://www.codebuddy.cn) — a Claude Code–compatible CLI
+// that ships as `codebuddy` (short alias: `cbc`). The argument surface is a
+// superset of Claude Code's `-p` mode: `--output-format stream-json`,
+// `--input-format stream-json`, `--permission-mode`, `--session-id`,
+// `--resume`, `--add-dir`, `--include-partial-messages`, and `--model` all
+// work identically. The stream wire format matches Claude Code's, so we reuse
+// `streamFormat: 'claude-stream-json'`.
+//
+// Key differences from the claude adapter:
+//   • Binary names: `codebuddy` / `cbc` (not `claude` / `openclaude`).
+//   • `--effort` flag for reasoning control (minimal/low/medium/high/xhigh/max).
+//   • Richer multi-provider model list (GLM, Kimi, MiniMax, Claude, GPT,
+//     Gemini, DeepSeek) exposed through `--model <id>`.
+//   • `--mcp-config <fileOrString>` for MCP server injection (the daemon can
+//     also write `.mcp.json` to the project cwd, same as Claude Code).
+
+const CODEBUDDY_FALLBACK_MODELS = [
+  DEFAULT_MODEL_OPTION,
+  // GLM family (Zhipu AI)
+  { id: 'glm-5.1-ioa', label: 'glm-5.1-ioa' },
+  { id: 'glm-5v-turbo-ioa', label: 'glm-5v-turbo-ioa' },
+  // Claude family (via Codebuddy proxy)
+  { id: 'claude-opus-4.8-1m', label: 'claude-opus-4.8-1m' },
+  { id: 'claude-opus-4.8', label: 'claude-opus-4.8' },
+  { id: 'claude-sonnet-4.6-1m', label: 'claude-sonnet-4.6-1m' },
+  { id: 'claude-haiku-4.5', label: 'claude-haiku-4.5' },
+  // GPT family
+  { id: 'gpt-5.5', label: 'gpt-5.5' },
+  { id: 'gpt-5.4', label: 'gpt-5.4' },
+  { id: 'gpt-5.3-codex', label: 'gpt-5.3-codex' },
+  // Gemini family
+  { id: 'gemini-3.5-flash', label: 'gemini-3.5-flash' },
+  // DeepSeek family
+  { id: 'deepseek-v4-pro-ioa', label: 'deepseek-v4-pro-ioa' },
+  { id: 'deepseek-v4-flash-ioa', label: 'deepseek-v4-flash-ioa' },
+  // Kimi family
+  { id: 'kimi-k2.6-ioa', label: 'kimi-k2.6-ioa' },
+  // MiniMax family
+  { id: 'minimax-m3-ioa', label: 'minimax-m3-ioa' },
+  { id: 'minimax-m2.7-ioa', label: 'minimax-m2.7-ioa' },
+];
+
+export const codebuddyAgentDef = {
+    id: 'codebuddy',
+    name: 'Codebuddy Code',
+    bin: 'codebuddy',
+    // `cbc` is the short alias shipped alongside `codebuddy`. Tried as a
+    // fallback when the primary binary isn't on PATH.
+    fallbackBins: ['cbc'],
+    versionArgs: ['--version'],
+    helpArgs: ['-p', '--help'],
+    capabilityFlags: {
+      // Same probing strategy as the claude adapter: these flags live under
+      // the `-p` subcommand help, so we probe `codebuddy -p --help`.
+      '--include-partial-messages': 'partialMessages',
+      '--add-dir': 'addDir',
+    },
+    fallbackModels: CODEBUDDY_FALLBACK_MODELS,
+    // Codebuddy CLI does not ship a `models` subcommand; the supported model
+    // ids are advertised in `--help` output. Fallback list above covers the
+    // current set; users can type custom ids through the "Custom" input.
+    buildArgs: (_prompt, _imagePaths, extraAllowedDirs = [], options = {}, runtimeContext = {}) => {
+      const caps = agentCapabilities.get('codebuddy') || {};
+      // Same stdin strategy as Claude Code: `--input-format stream-json`
+      // enables JSONL stdin so the daemon can answer AskUserQuestion tool
+      // calls. `--output-format stream-json` gives us SSE-style events.
+      const args = ['-p', '--input-format', 'stream-json', '--output-format', 'stream-json', '--verbose'];
+      // `--include-partial-messages` lands richer streaming deltas. Gate on
+      // the help-text probe to avoid "unknown option" errors on older builds.
+      if (caps.partialMessages) {
+        args.push('--include-partial-messages');
+      }
+      if (options.model && options.model !== 'default') {
+        args.push('--model', options.model);
+      }
+      // Reasoning effort control — Codebuddy supports `--effort <level>`.
+      if (options.reasoning) {
+        args.push('--effort', options.reasoning);
+      }
+      const dirs = (extraAllowedDirs || []).filter(
+        (d) => typeof d === 'string' && d.length > 0,
+      );
+      if (dirs.length > 0 && caps.addDir !== false) {
+        args.push('--add-dir', ...dirs);
+      }
+      // Session continuity: Codebuddy supports `--resume <id>` and
+      // `--session-id <uuid>` identically to Claude Code.
+      if (typeof runtimeContext.resumeSessionId === 'string' && runtimeContext.resumeSessionId) {
+        args.push('--resume', runtimeContext.resumeSessionId);
+      } else if (typeof runtimeContext.newSessionId === 'string' && runtimeContext.newSessionId) {
+        args.push('--session-id', runtimeContext.newSessionId);
+      }
+      args.push('--permission-mode', 'bypassPermissions');
+      return args;
+    },
+    promptViaStdin: true,
+    promptInputFormat: 'stream-json',
+    streamFormat: 'claude-stream-json',
+    // Codebuddy CLI auto-loads `.mcp.json` from the project cwd at spawn
+    // (same behavior as Claude Code), so the daemon can write the user's
+    // external MCP servers there before launching.
+    externalMcpInjection: 'claude-mcp-json',
+    resumesSessionViaCli: true,
+    installUrl: 'https://www.codebuddy.cn',
+    docsUrl: 'https://www.codebuddy.cn/docs/workbuddy/Overview',
+} satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/codebuddy.ts
+++ b/apps/daemon/src/runtimes/defs/codebuddy.ts
@@ -63,6 +63,15 @@ export const codebuddyAgentDef = {
     // Codebuddy CLI does not ship a `models` subcommand; the supported model
     // ids are advertised in `--help` output. Fallback list above covers the
     // current set; users can type custom ids through the "Custom" input.
+    reasoningOptions: [
+      { id: 'default', label: 'Default' },
+      { id: 'minimal', label: 'Minimal' },
+      { id: 'low', label: 'Low' },
+      { id: 'medium', label: 'Medium' },
+      { id: 'high', label: 'High' },
+      { id: 'xhigh', label: 'XHigh' },
+      { id: 'max', label: 'Max' },
+    ],
     buildArgs: (_prompt, _imagePaths, extraAllowedDirs = [], options = {}, runtimeContext = {}) => {
       const caps = agentCapabilities.get('codebuddy') || {};
       // Same stdin strategy as Claude Code: `--input-format stream-json`

--- a/apps/daemon/src/runtimes/defs/codebuddy.ts
+++ b/apps/daemon/src/runtimes/defs/codebuddy.ts
@@ -63,11 +63,15 @@ export const codebuddyAgentDef = {
     // Codebuddy CLI does not ship a `models` subcommand; the supported model
     // ids are advertised in `--help` output. Fallback list above covers the
     // current set; users can type custom ids through the "Custom" input.
-    // Codebuddy CLI --effort supports exactly these 6 levels:
+    // Codebuddy CLI --effort supports exactly 6 levels:
     //   minimal, low, medium, high, xhigh, max
-    // No "default" level — omitting --effort entirely lets Codebuddy use
-    // its own default, which is modelled by an empty reasoning selection.
+    // We additionally expose a synthetic `default` sentinel as the FIRST
+    // option so the web pickers (AvatarMenu / SettingsDialog) — which
+    // fall back to `reasoningOptions[0].id` when nothing is saved yet —
+    // surface a real "use Codebuddy's own default" choice that round-trips
+    // to "no --effort flag". `buildArgs` treats `default` as omit.
     reasoningOptions: [
+      { id: 'default', label: 'Default' },
       { id: 'minimal', label: 'Minimal' },
       { id: 'low', label: 'Low' },
       { id: 'medium', label: 'Medium' },
@@ -90,7 +94,8 @@ export const codebuddyAgentDef = {
         args.push('--model', options.model);
       }
       // Reasoning effort control — Codebuddy supports `--effort <level>`.
-      if (options.reasoning) {
+      // The `default` sentinel means "let Codebuddy pick" — omit the flag.
+      if (options.reasoning && options.reasoning !== 'default') {
         args.push('--effort', options.reasoning);
       }
       const dirs = (extraAllowedDirs || []).filter(

--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -17,6 +17,7 @@ const AGENT_BIN_ENV_KEYS = new Map<string, string>([
   ['amr', 'VELA_BIN'],
   ['aider', 'AIDER_BIN'],
   ['claude', 'CLAUDE_BIN'],
+  ['codebuddy', 'CODEBUDDY_BIN'],
   ['codex', 'CODEX_BIN'],
   ['copilot', 'COPILOT_BIN'],
   ['cursor-agent', 'CURSOR_AGENT_BIN'],

--- a/apps/daemon/src/runtimes/metadata.ts
+++ b/apps/daemon/src/runtimes/metadata.ts
@@ -75,6 +75,10 @@ const AGENT_INSTALL_LINKS: Record<
     installUrl: 'https://github.com/Hmbown/CodeWhale',
     docsUrl: 'https://github.com/Hmbown/CodeWhale/blob/main/README.md',
   },
+  codebuddy: {
+    installUrl: 'https://www.codebuddy.cn',
+    docsUrl: 'https://www.codebuddy.cn/docs/workbuddy/Overview',
+  },
 };
 
 function sanitizeHttpsUrl(value: string | undefined): string | undefined {

--- a/apps/daemon/src/runtimes/registry.ts
+++ b/apps/daemon/src/runtimes/registry.ts
@@ -19,6 +19,7 @@ import { vibeAgentDef } from './defs/vibe.js';
 import { deepseekAgentDef } from './defs/deepseek.js';
 import { aiderAgentDef } from './defs/aider.js';
 import { antigravityAgentDef } from './defs/antigravity.js';
+import { codebuddyAgentDef } from './defs/codebuddy.js';
 import { reasonixAgentDef } from './defs/reasonix.js';
 import { readLocalAgentProfileDefs as readLocalAgentProfileDefsFromFile } from './local-profiles.js';
 import type { RuntimeAgentDef } from './types.js';
@@ -46,6 +47,7 @@ const BASE_AGENT_DEFS: RuntimeAgentDef[] = [
   aiderAgentDef,
   antigravityAgentDef,
   reasonixAgentDef,
+  codebuddyAgentDef,
 ];
 
 export function readLocalAgentProfileDefs(

--- a/apps/daemon/tests/runtimes/codebuddy.test.ts
+++ b/apps/daemon/tests/runtimes/codebuddy.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { codebuddyAgentDef } from '../../src/runtimes/defs/codebuddy.js';
+
+describe('codebuddy buildArgs', () => {
+  it('emits base args with -p, stream-json formats, verbose, and bypassPermissions', () => {
+    const args = codebuddyAgentDef.buildArgs('prompt', [], [], {}, {});
+    expect(args).toContain('-p');
+    expect(args).toContain('--input-format');
+    expect(args).toContain('stream-json');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('--verbose');
+    expect(args).toContain('--permission-mode');
+    expect(args[args.indexOf('--permission-mode') + 1]).toBe('bypassPermissions');
+  });
+
+  it('flags promptViaStdin and never embeds the prompt in argv', () => {
+    expect(codebuddyAgentDef.promptViaStdin).toBe(true);
+    expect(codebuddyAgentDef.promptInputFormat).toBe('stream-json');
+
+    const longPrompt = 'x'.repeat(200_000);
+    const args = codebuddyAgentDef.buildArgs(longPrompt, [], [], {}, {});
+    expect(args).not.toContain(longPrompt);
+    for (const arg of args) {
+      expect(typeof arg === 'string' && arg.length < 1000).toBe(true);
+    }
+  });
+
+  it('appends --model when a non-default model is selected', () => {
+    const args = codebuddyAgentDef.buildArgs('', [], [], { model: 'glm-5.1-ioa' }, {});
+    expect(args).toContain('--model');
+    expect(args[args.indexOf('--model') + 1]).toBe('glm-5.1-ioa');
+  });
+
+  it('omits --model when model is default', () => {
+    const args = codebuddyAgentDef.buildArgs('', [], [], { model: 'default' }, {});
+    expect(args).not.toContain('--model');
+  });
+
+  it('appends --effort when reasoning is set', () => {
+    const args = codebuddyAgentDef.buildArgs('', [], [], { reasoning: 'high' }, {});
+    expect(args).toContain('--effort');
+    expect(args[args.indexOf('--effort') + 1]).toBe('high');
+  });
+
+  it('omits --effort when reasoning is not set', () => {
+    const args = codebuddyAgentDef.buildArgs('', [], [], {}, {});
+    expect(args).not.toContain('--effort');
+  });
+
+  it('passes --add-dir for valid extra dirs', () => {
+    const args = codebuddyAgentDef.buildArgs('', [], ['/repo/skills', '/repo/design-systems'], {}, {});
+    expect(args).toContain('--add-dir');
+    const addDirIndex = args.indexOf('--add-dir');
+    expect(args[addDirIndex + 1]).toBe('/repo/skills');
+    expect(args[addDirIndex + 2]).toBe('/repo/design-systems');
+  });
+
+  it('filters empty / null / undefined dirs', () => {
+    const args = codebuddyAgentDef.buildArgs('', [], ['', null, '/repo/skills', undefined] as unknown as string[], {}, {});
+    const addDirIndex = args.indexOf('--add-dir');
+    expect(addDirIndex).toBeGreaterThanOrEqual(0);
+    expect(args[addDirIndex + 1]).toBe('/repo/skills');
+    expect(args.filter((a) => a === '--add-dir').length).toBe(1);
+  });
+});
+
+describe('codebuddy session resume', () => {
+  it('emits --session-id with the minted id on a create turn', () => {
+    const args = codebuddyAgentDef.buildArgs('prompt', [], [], {}, {
+      newSessionId: '11111111-1111-4111-8111-111111111111',
+      resumeSessionId: null,
+    });
+    expect(args).toContain('--session-id');
+    expect(args[args.indexOf('--session-id') + 1]).toBe(
+      '11111111-1111-4111-8111-111111111111',
+    );
+    expect(args).not.toContain('--resume');
+  });
+
+  it('emits --resume with the stored id on a resume turn', () => {
+    const args = codebuddyAgentDef.buildArgs('prompt', [], [], {}, {
+      newSessionId: '22222222-2222-4222-8222-222222222222',
+      resumeSessionId: 'stored-session-abc',
+    });
+    expect(args).toContain('--resume');
+    expect(args[args.indexOf('--resume') + 1]).toBe('stored-session-abc');
+    expect(args).not.toContain('--session-id');
+  });
+
+  it('emits neither flag when no session context is supplied', () => {
+    const args = codebuddyAgentDef.buildArgs('prompt', [], [], {}, {});
+    expect(args).not.toContain('--resume');
+    expect(args).not.toContain('--session-id');
+  });
+
+  it('declares it resumes its session via the CLI', () => {
+    expect(codebuddyAgentDef.resumesSessionViaCli).toBe(true);
+  });
+});
+
+describe('codebuddy definition metadata', () => {
+  it('has correct id, name, and bin', () => {
+    expect(codebuddyAgentDef.id).toBe('codebuddy');
+    expect(codebuddyAgentDef.name).toBe('Codebuddy Code');
+    expect(codebuddyAgentDef.bin).toBe('codebuddy');
+  });
+
+  it('falls back to cbc binary', () => {
+    expect(codebuddyAgentDef.fallbackBins).toEqual(['cbc']);
+  });
+
+  it('uses claude-stream-json stream format', () => {
+    expect(codebuddyAgentDef.streamFormat).toBe('claude-stream-json');
+  });
+
+  it('uses claude-mcp-json for external MCP injection', () => {
+    expect(codebuddyAgentDef.externalMcpInjection).toBe('claude-mcp-json');
+  });
+
+  it('exposes fallback models with multi-provider coverage', () => {
+    const modelIds = codebuddyAgentDef.fallbackModels.map((m) => m.id);
+    expect(modelIds).toContain('default');
+    expect(modelIds).toContain('glm-5.1-ioa');
+    expect(modelIds).toContain('claude-opus-4.8');
+    expect(modelIds).toContain('gpt-5.5');
+    expect(modelIds).toContain('gemini-3.5-flash');
+    expect(modelIds).toContain('deepseek-v4-pro-ioa');
+    expect(modelIds).toContain('kimi-k2.6-ioa');
+    expect(modelIds).toContain('minimax-m3-ioa');
+  });
+
+  it('probes -p subcommand for capability flags', () => {
+    expect(codebuddyAgentDef.helpArgs).toEqual(['-p', '--help']);
+    expect(codebuddyAgentDef.capabilityFlags).toHaveProperty('--include-partial-messages', 'partialMessages');
+    expect(codebuddyAgentDef.capabilityFlags).toHaveProperty('--add-dir', 'addDir');
+  });
+
+  it('provides install and docs URLs', () => {
+    expect(codebuddyAgentDef.installUrl).toBe('https://www.codebuddy.cn');
+    expect(codebuddyAgentDef.docsUrl).toBe('https://www.codebuddy.cn/docs/workbuddy/Overview');
+  });
+});

--- a/apps/daemon/tests/runtimes/codebuddy.test.ts
+++ b/apps/daemon/tests/runtimes/codebuddy.test.ts
@@ -162,7 +162,9 @@ describe('codebuddy reasoning round-trip', () => {
   });
 
   it('puts "default" first so AvatarMenu/SettingsDialog fall back to it', () => {
-    expect(codebuddyAgentDef.reasoningOptions![0].id).toBe('default');
+    const first = codebuddyAgentDef.reasoningOptions![0];
+    expect(first).toBeDefined();
+    expect(first!.id).toBe('default');
   });
 
   it('survives sanitization: a valid reasoning option lands in argv', () => {

--- a/apps/daemon/tests/runtimes/codebuddy.test.ts
+++ b/apps/daemon/tests/runtimes/codebuddy.test.ts
@@ -140,3 +140,46 @@ describe('codebuddy definition metadata', () => {
     expect(codebuddyAgentDef.docsUrl).toBe('https://www.codebuddy.cn/docs/workbuddy/Overview');
   });
 });
+
+describe('codebuddy reasoning round-trip', () => {
+  it('declares reasoningOptions so the daemon sanitizer does not drop effort', () => {
+    expect(codebuddyAgentDef.reasoningOptions).toBeDefined();
+    expect(codebuddyAgentDef.reasoningOptions!.length).toBeGreaterThan(0);
+  });
+
+  it('lists all Codebuddy effort levels as reasoningOptions', () => {
+    const ids = codebuddyAgentDef.reasoningOptions!.map((o) => o.id);
+    expect(ids).toEqual(['default', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
+  });
+
+  it('survives sanitization: a valid reasoning option lands in argv', () => {
+    // Simulates the daemon sanitizer: only pass reasoning if the value
+    // appears in the adapter's declared reasoningOptions.
+    const validIds = new Set(codebuddyAgentDef.reasoningOptions!.map((o) => o.id));
+    const selected = 'xhigh';
+    expect(validIds.has(selected)).toBe(true);
+
+    const args = codebuddyAgentDef.buildArgs('', [], [], { reasoning: selected }, {});
+    expect(args).toContain('--effort');
+    expect(args[args.indexOf('--effort') + 1]).toBe('xhigh');
+  });
+
+  it('drops an undeclared reasoning value (simulating sanitizer)', () => {
+    const validIds = new Set(codebuddyAgentDef.reasoningOptions!.map((o) => o.id));
+    const invalid = 'ultra';
+    expect(validIds.has(invalid)).toBe(false);
+
+    // After sanitizer strips the invalid value, buildArgs receives no reasoning.
+    const args = codebuddyAgentDef.buildArgs('', [], [], {}, {});
+    expect(args).not.toContain('--effort');
+  });
+
+  it('every reasoning option maps to a valid --effort flag', () => {
+    for (const opt of codebuddyAgentDef.reasoningOptions!) {
+      if (opt.id === 'default') continue; // default means no --effort flag
+      const args = codebuddyAgentDef.buildArgs('', [], [], { reasoning: opt.id }, {});
+      expect(args).toContain('--effort');
+      expect(args[args.indexOf('--effort') + 1]).toBe(opt.id);
+    }
+  });
+});

--- a/apps/daemon/tests/runtimes/codebuddy.test.ts
+++ b/apps/daemon/tests/runtimes/codebuddy.test.ts
@@ -47,6 +47,13 @@ describe('codebuddy buildArgs', () => {
     expect(args).not.toContain('--effort');
   });
 
+  it('omits --effort when reasoning is the synthetic "default" sentinel', () => {
+    // The picker fallback `reasoningOptions[0].id` is "default", which must
+    // round-trip to "no --effort flag" so Codebuddy uses its own default.
+    const args = codebuddyAgentDef.buildArgs('', [], [], { reasoning: 'default' }, {});
+    expect(args).not.toContain('--effort');
+  });
+
   it('passes --add-dir for valid extra dirs', () => {
     const args = codebuddyAgentDef.buildArgs('', [], ['/repo/skills', '/repo/design-systems'], {}, {});
     expect(args).toContain('--add-dir');
@@ -149,8 +156,13 @@ describe('codebuddy reasoning round-trip', () => {
 
   it('lists all Codebuddy effort levels as reasoningOptions', () => {
     const ids = codebuddyAgentDef.reasoningOptions!.map((o) => o.id);
-    // Codebuddy CLI --effort supports exactly: minimal, low, medium, high, xhigh, max
-    expect(ids).toEqual(['minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
+    // First item is the synthetic "default" sentinel (drives picker
+    // fallback to "omit --effort"), followed by the 6 real CLI levels.
+    expect(ids).toEqual(['default', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
+  });
+
+  it('puts "default" first so AvatarMenu/SettingsDialog fall back to it', () => {
+    expect(codebuddyAgentDef.reasoningOptions![0].id).toBe('default');
   });
 
   it('survives sanitization: a valid reasoning option lands in argv', () => {
@@ -175,13 +187,17 @@ describe('codebuddy reasoning round-trip', () => {
     expect(args).not.toContain('--effort');
   });
 
-  it('every reasoning option maps to a valid --effort flag', () => {
+  it('every reasoning option maps correctly: real levels emit --effort, "default" omits it', () => {
     for (const opt of codebuddyAgentDef.reasoningOptions!) {
-      // Every declared option should produce a --effort flag (there is no
-      // "default" id — omitting reasoning entirely means no flag).
       const args = codebuddyAgentDef.buildArgs('', [], [], { reasoning: opt.id }, {});
-      expect(args).toContain('--effort');
-      expect(args[args.indexOf('--effort') + 1]).toBe(opt.id);
+      if (opt.id === 'default') {
+        // Synthetic sentinel — must NOT emit --effort.
+        expect(args).not.toContain('--effort');
+      } else {
+        // Real CLI level — must emit --effort <id>.
+        expect(args).toContain('--effort');
+        expect(args[args.indexOf('--effort') + 1]).toBe(opt.id);
+      }
     }
   });
 });

--- a/apps/daemon/tests/runtimes/codebuddy.test.ts
+++ b/apps/daemon/tests/runtimes/codebuddy.test.ts
@@ -149,7 +149,8 @@ describe('codebuddy reasoning round-trip', () => {
 
   it('lists all Codebuddy effort levels as reasoningOptions', () => {
     const ids = codebuddyAgentDef.reasoningOptions!.map((o) => o.id);
-    expect(ids).toEqual(['default', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
+    // Codebuddy CLI --effort supports exactly: minimal, low, medium, high, xhigh, max
+    expect(ids).toEqual(['minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
   });
 
   it('survives sanitization: a valid reasoning option lands in argv', () => {
@@ -176,7 +177,8 @@ describe('codebuddy reasoning round-trip', () => {
 
   it('every reasoning option maps to a valid --effort flag', () => {
     for (const opt of codebuddyAgentDef.reasoningOptions!) {
-      if (opt.id === 'default') continue; // default means no --effort flag
+      // Every declared option should produce a --effort flag (there is no
+      // "default" id — omitting reasoning entirely means no flag).
       const args = codebuddyAgentDef.buildArgs('', [], [], { reasoning: opt.id }, {});
       expect(args).toContain('--effort');
       expect(args[args.indexOf('--effort') + 1]).toBe(opt.id);

--- a/apps/daemon/tests/runtimes/helpers/test-helpers.ts
+++ b/apps/daemon/tests/runtimes/helpers/test-helpers.ts
@@ -89,6 +89,7 @@ export const opencode = requireAgent('opencode');
 export const grokBuild = requireAgent('grok-build');
 export const aider = requireAgent('aider');
 export const antigravity = requireAgent('antigravity');
+export const codebuddy = requireAgent('codebuddy');
 export const deepseekMaxPromptArgBytes = (() => {
   assert.ok(
     deepseek.maxPromptArgBytes !== undefined,


### PR DESCRIPTION
## Why

Codebuddy Code (https://www.codebuddy.cn) is a coding agent CLI with a stream-json interface compatible with Claude Code. Adding it as an agent adapter lets Open Design users choose Codebuddy as their runtime — useful for teams already on the Codebuddy platform or who want access to its multi-provider model roster (GLM, Claude, GPT, Gemini, DeepSeek, Kimi, MiniMax).

## What users will see

- Codebuddy Code appears as an available agent in the agent picker (Web / Desktop / CLI)
- Selecting it spawns `codebuddy -p` with stream-json I/O, just like Claude Code
- 16 model options are listed (default + 15 provider-specific)
- `--effort` flag is supported for reasoning level control (minimal / low / medium / high / xhigh / max)

## Surface area

- [x] **CLI / env var** — new `CODEBUDDY_BIN` env var for overriding the `codebuddy` binary path
- [x] **None** — no UI, API, i18n, or default behavior changes

## Validation

- `pnpm -F @open-design/daemon test` — 21 test files, 274 tests passed, 0 regressions
- `tsc -p tsconfig.json --noEmit` — 0 errors
- Manual: `pnpm tools-dev start` — Codebuddy Code shows as available agent with `version: 2.103.1`, `available: true`
- Daemon API confirms: `curl http://127.0.0.1:7456/api/agents` returns the codebuddy entry with correct streamFormat, models, and path detection
