### PR TITLE
fix(web): flatten the composer footer into one tidy inset card

### DIFF
--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -933,8 +933,11 @@
 }
 /* When the chat pane is narrow, compact the footer cluster: tighten the
    model chip + mode toggle, collapse the mode label, and make send/stop
-   icon-only — so the action buttons never overflow or deform. */
-@container (max-width: 430px) {
+   icon-only — so the action buttons never overflow or deform. The threshold
+   sits below the fixed-layer composer-shell's padded content width (its 8px
+   side padding shrinks the queried container width) so the "Design"/"Send"
+   labels stay until the pane is genuinely too tight. */
+@container (max-width: 414px) {
   .composer-row .inline-switcher__chip { padding: 0 7px 0 5px; gap: 5px; }
   /* Hide ONLY the trigger's label — the popover options share this class
      and must keep their labels ("Ask" / "Design") visible. */

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -933,11 +933,12 @@
 }
 /* When the chat pane is narrow, compact the footer cluster: tighten the
    model chip + mode toggle, collapse the mode label, and make send/stop
-   icon-only — so the action buttons never overflow or deform. The threshold
-   sits below the fixed-layer composer-shell's padded content width (its 8px
-   side padding shrinks the queried container width) so the "Design"/"Send"
-   labels stay until the pane is genuinely too tight. */
-@container (max-width: 414px) {
+   icon-only — so the action buttons never overflow or deform. This @container
+   block is shared by every `.composer-shell` (chat footer, comment composer,
+   …), so the breakpoint stays generic; the fixed-layer footer keeps its side
+   inset via child margins rather than shell padding, leaving this width — and
+   every other composer's collapse behavior — untouched. */
+@container (max-width: 430px) {
   .composer-row .inline-switcher__chip { padding: 0 7px 0 5px; gap: 5px; }
   /* Hide ONLY the trigger's label — the popover options share this class
      and must keep their labels ("Ask" / "Design") visible. */

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -1512,7 +1512,11 @@
   box-shadow: var(--shadow-sm);
 }
 .chat-composer-fixed-layer .composer-shell {
-  padding: 0;
+  /* Even inset so the staged-context chips, the input box and the toolbar all
+     sit off the card's rounded frame (incl. a side margin on + and Send).
+     Horizontal padding narrows the @container width that drives the toolbar
+     label-collapse, so its breakpoint is lowered to match (see chat.css). */
+  padding: 6px 8px;
   border-color: var(--border);
   border-radius: var(--radius-md);
   box-shadow: none;
@@ -1534,6 +1538,13 @@
 .chat-composer-fixed-layer .composer.drag-active .composer-shell {
   border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 9%, transparent);
+}
+/* Keep the typing area a clean white field with a soft border so it reads as
+   the one input surface inside the tinted card — the resting border replaces
+   the removed toolbar divider as the only separator in the footer. */
+.chat-composer-fixed-layer .composer-input-wrap {
+  background: var(--bg-panel);
+  border-color: var(--border-soft);
 }
 .app .composer textarea {
   min-height: 56px;
@@ -1558,8 +1569,14 @@
   gap: 6px;
 }
 .chat-composer-fixed-layer .composer-row {
-  min-height: 32px;
-  padding-top: 2px;
+  /* Match the 28px control height exactly — the old 32px min-height left 4px
+     of dead space that made the footer band feel too tall. */
+  min-height: 28px;
+  /* No divider above the toolbar: the white input box already separates it
+     from the textarea, so the extra border-top + its 2px spacing just stacked
+     another line into the footer. Drop both so the card reads as fewer layers. */
+  padding-top: 0;
+  border-top: none;
 }
 .app .composer-row .icon-btn,
 .app .composer-import,

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -1512,14 +1512,21 @@
   box-shadow: var(--shadow-sm);
 }
 .chat-composer-fixed-layer .composer-shell {
-  /* Even inset so the staged-context chips, the input box and the toolbar all
-     sit off the card's rounded frame (incl. a side margin on + and Send).
-     Horizontal padding narrows the @container width that drives the toolbar
-     label-collapse, so its breakpoint is lowered to match (see chat.css). */
-  padding: 6px 8px;
+  /* Vertical breathing room only. The side inset is applied as a margin on the
+     children below instead of horizontal padding here, so the shell's
+     content-box width — which is what the shared label-collapse @container in
+     chat.css measures — stays full and that breakpoint can remain generic. */
+  padding: 6px 0;
   border-color: var(--border);
   border-radius: var(--radius-md);
   box-shadow: none;
+}
+/* Inset the staged chips, the input field and the toolbar off the card's
+   rounded frame (giving + and Send a real side margin) without shrinking the
+   @container width — see the .composer-shell padding note above. */
+.chat-composer-fixed-layer .composer-shell > * {
+  margin-left: 8px;
+  margin-right: 8px;
 }
 .app .composer-shell:focus-within {
   border-color: color-mix(in srgb, var(--accent) 34%, var(--border-strong));

--- a/e2e/ui/composer-footer-card.test.ts
+++ b/e2e/ui/composer-footer-card.test.ts
@@ -1,0 +1,130 @@
+// Composer footer card layering + inset.
+//
+// Follow-up to the alignment fix (#3949). The composer mounts under
+// `.chat-composer-fixed-layer`, whose shell had `padding: 0`, so the staged
+// chips, the input field, and the toolbar all hugged the card's rounded frame
+// — the + and Send buttons sat flush against the left/right edges with no
+// margin, and a redundant toolbar divider stacked an extra line into the
+// footer. This spec pins the polished card: every edge gets an even inset and
+// the divider is gone, so the footer reads as one tidy card.
+//
+// These invariants are pane-width independent (they follow from the shell's
+// fixed padding and the removed border), so they don't depend on the e2e
+// viewport width the way label-collapse would.
+
+import { randomUUID } from 'node:crypto';
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+const STORAGE_KEY = 'open-design:config';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-5',
+        agentId: 'mock',
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        agentModels: {},
+      }),
+    );
+  }, STORAGE_KEY);
+
+  await page.route('**/api/app-config', async (route) => {
+    await route.fulfill({
+      json: {
+        config: {
+          onboardingCompleted: true,
+          agentId: 'mock',
+          skillId: null,
+          designSystemId: null,
+          agentModels: {},
+          agentCliEnv: {},
+        },
+      },
+    });
+  });
+
+  await page.route('**/api/agents', async (route) => {
+    await route.fulfill({
+      json: {
+        agents: [
+          {
+            id: 'mock',
+            name: 'Mock Agent',
+            bin: 'mock-agent',
+            available: true,
+            version: 'test',
+            models: [{ id: 'default', label: 'Default' }],
+          },
+        ],
+      },
+    });
+  });
+});
+
+test('[P1] composer footer sits inset inside the card with no toolbar divider', async ({ page }) => {
+  await page.goto('/');
+  await createProject(page, 'Composer footer card');
+  await expect(page).toHaveURL(/\/projects\//);
+  await expect(page.getByTestId('chat-composer')).toBeVisible();
+  await expect(page.getByTestId('chat-send')).toBeVisible();
+
+  const m = await page.evaluate(() => {
+    const rect = (sel: string) => {
+      const el = document.querySelector(sel);
+      return el ? el.getBoundingClientRect() : null;
+    };
+    const shell = rect('.composer-shell');
+    const send = rect('.composer-row .composer-send');
+    const plus = rect('.composer-row .icon-btn');
+    const input = rect('.composer-input-wrap');
+    const row = document.querySelector('.composer-row');
+    const rowBorderTop = row ? getComputedStyle(row).borderTopWidth : null;
+    if (!shell || !send || !plus || !input) return { error: 'missing composer parts' as const };
+    return {
+      sendRightInset: shell.right - send.right,
+      plusLeftInset: plus.left - shell.left,
+      inputLeftInset: input.left - shell.left,
+      inputRightInset: shell.right - input.right,
+      rowBorderTop,
+    };
+  });
+
+  if ('error' in m) throw new Error(m.error);
+
+  // The + and Send must not hug the card frame — they get a real side margin.
+  // On main (shell padding: 0) these are ~1px and this fails.
+  expect(m.sendRightInset, JSON.stringify(m)).toBeGreaterThanOrEqual(5);
+  expect(m.plusLeftInset, JSON.stringify(m)).toBeGreaterThanOrEqual(5);
+  // Input field inset evenly from both sides.
+  expect(Math.abs(m.inputLeftInset - m.inputRightInset), JSON.stringify(m)).toBeLessThanOrEqual(1);
+  expect(m.inputLeftInset, JSON.stringify(m)).toBeGreaterThanOrEqual(5);
+  // No divider line above the toolbar — the white input field is the only
+  // separator now. On main this is "1px"; here it must be "0px".
+  expect(m.rowBorderTop, JSON.stringify(m)).toBe('0px');
+});
+
+async function createProject(page: Page, projectName: string): Promise<void> {
+  const response = await page.request.post('/api/projects', {
+    data: {
+      id: randomUUID(),
+      name: projectName,
+      skillId: null,
+      designSystemId: null,
+      metadata: { kind: 'prototype', nameSource: 'user' },
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const body = (await response.json()) as {
+    project: { id: string };
+    conversationId: string;
+  };
+  await page.goto(`/projects/${body.project.id}/conversations/${body.conversationId}`);
+}


### PR DESCRIPTION
## Why

Follow-up polish to the alignment fix (#3949). While verifying that PR locally we noticed the composer footer reads as too many stacked layers: the composer mounts under `.chat-composer-fixed-layer`, whose shell had `padding: 0`, so the staged-context chips, the input field and the toolbar all hugged the card's rounded frame. On top of that the footer carried a redundant toolbar divider, a tinted outer card wrapping a separate inner box, and the `+` / `Send` buttons sat flush against the card edges with no side margin. The toolbar band also felt too tall.

## What users will see

The chat composer now reads as one tidy card instead of box-in-box:
- The typing area is a clean **white field** with a soft border — clearly the input surface inside the tinted card.
- The thin **divider line above the toolbar is gone**; the white field is the only separator.
- The chips, input and toolbar are **evenly inset** from the card frame, so `+` and `Send` have a real side margin instead of touching the edges.
- The bottom toolbar band is **tighter** (no more dead vertical space).
- The `Design` / `Send` text labels still show at the default pane width.

## Surface area

- [x] **UI** — composer footer card styling in `apps/web`
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change

## Screenshots

Composer footer, default chat-pane width (mock agent):

- **Before:** tinted card wrapping a separate inner box, a divider line above the toolbar, and `+` / `Send` flush against the card edges (~1px). Footer band tall.
- **After:** single tinted card, white input field with a soft border, no divider, `+` and `Send` inset ~9px from the edges, tighter footer.

(Captured locally via Playwright against the running web app.)

## Bug fix verification

- Test path: `e2e/ui/composer-footer-card.test.ts`
- Red on `main` / green on this branch? **yes** — red on main with `{"sendRightInset":1,"plusLeftInset":1,"inputLeftInset":1,"inputRightInset":1,"rowBorderTop":"1px"}` (fails `>= 5` and `== 0px`), green here (insets ~8-9px, border `0px`). The spec asserts pane-width-independent invariants (insets + removed divider), not the label-collapse which depends on viewport width.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (web)
- `pnpm --dir e2e exec playwright test ui/composer-footer-card.test.ts` — 1 passed; confirmed red on `main`, green here

🤖 Generated with [Claude Code](https://claude.com/claude-code)