### PR TITLE
[codex] Clean object manifest pending reasons

### DIFF
--- a/apps/daemon/src/trace-object-manifest.ts
+++ b/apps/daemon/src/trace-object-manifest.ts
@@ -650,7 +650,7 @@ export async function buildTraceObjectManifests(
       ...mergeSourceDigest(entry, sources[index]!),
       status: 'unavailable' as const,
       stored_in_open_design: false,
-      reason: entry.reason ?? 'relay_authorization_pending',
+      ...(entry.reason ? { reason: entry.reason } : {}),
     })));
   }
 

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -621,6 +621,11 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(4);
     expect(fetchSpy.mock.calls[0]![0]).toContain('/api/langfuse');
+    const registrationBody = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string).batch as any[];
+    const registrationTrace = registrationBody[0].body;
+    expect(registrationTrace.metadata.attachment_manifest[0]).not.toHaveProperty('reason');
+    expect(registrationTrace.metadata.artifact_manifest[0]).not.toHaveProperty('reason');
+    expect(registrationTrace.metadata.input_text_snapshot_manifest[0]).not.toHaveProperty('reason');
     expect(fetchSpy.mock.calls[1]![0]).toContain('/api/objects/authorize');
     expect(fetchSpy.mock.calls[2]![0]).toContain('/api/objects/batch');
     expect(fetchSpy.mock.calls[3]![0]).toContain('/api/langfuse');
@@ -644,6 +649,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
       access_scope: 'project',
       sensitivity: 'private',
     });
+    expect(trace.metadata.attachment_manifest[0]).not.toHaveProperty('reason');
     expect(trace.metadata.artifact_manifest[0]).toMatchObject({
       object_class: 'artifact',
       status: 'ok',
@@ -651,12 +657,14 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
       source: 'agent_generated',
       retention_policy: 'observability_90d',
     });
+    expect(trace.metadata.artifact_manifest[0]).not.toHaveProperty('reason');
     expect(trace.metadata.input_text_snapshot_manifest[0]).toMatchObject({
       object_class: 'input_text_snapshot',
       status: 'ok',
       stored_in_open_design: true,
       source: 'user_prompt',
     });
+    expect(trace.metadata.input_text_snapshot_manifest[0]).not.toHaveProperty('reason');
     expect(JSON.stringify(trace.metadata)).toContain(
       'od://objects/workspaces/unknown/projects/proj-1/runs/run-id-1',
     );

--- a/apps/daemon/tests/trace-object-manifest.test.ts
+++ b/apps/daemon/tests/trace-object-manifest.test.ts
@@ -179,6 +179,43 @@ describe('buildTraceObjectManifests', () => {
       extension: 'html',
       stored_in_open_design: true,
     });
+    expect(manifests?.attachmentManifest?.[0]).not.toHaveProperty('reason');
+    expect(manifests?.artifactManifest?.[0]).not.toHaveProperty('reason');
+  });
+
+  it('does not put pending authorization reasons into registration-only manifests', async () => {
+    const projectsRoot = path.join(dataDir, 'projects');
+    const projectDir = path.join(projectsRoot, 'proj-1');
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(path.join(projectDir, 'artifact.txt'), 'release artifact');
+
+    const manifests = await buildTraceObjectManifests({
+      installationId: 'install-1',
+      projectId: 'proj-1',
+      runId: 'run-1',
+      projectsRoot,
+      artifacts: [
+        { summary: { slug: 'artifact.txt', type: 'text', sizeBytes: 'release artifact'.length } },
+      ],
+      prompt: 'prompt',
+      prefs: { metrics: true, content: true, artifactManifest: true },
+      fetchImpl: vi.fn() as any,
+      env: {
+        NODE_ENV: 'test',
+        OPEN_DESIGN_OBJECT_RELAY_URL: 'https://telemetry.open-design.ai/api/objects/batch',
+      },
+      uploadMode: 'manifest-only',
+      now: () => new Date('2026-06-08T00:00:00.000Z'),
+    });
+
+    expect(manifests?.completeness).toBe('partial');
+    expect(manifests?.artifactManifest?.[0]).toMatchObject({
+      status: 'unavailable',
+      stored_in_open_design: false,
+      size_bytes: 'release artifact'.length,
+      sha256: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+    });
+    expect(manifests?.artifactManifest?.[0]).not.toHaveProperty('reason');
   });
 
   it('splits relay uploads at the worker object count cap', async () => {


### PR DESCRIPTION
## Why

While validating the trace object upload flow, successful R2 uploads still showed a stale `reason: relay_authorization_pending` in Langfuse manifests. That made the observability result look partially pending even when the object was already uploaded and verified.

This PR removes the default pending reason from registration-only manifests so the later successful manifest does not carry misleading failure context forward. Real source/read failures still keep their explicit reason.

## What users will see

No UI change. Langfuse object manifests for successful uploads are easier to read: `status: ok` entries no longer show a pending authorization reason.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/trace-object-manifest.test.ts`, `apps/daemon/tests/langfuse-bridge.test.ts`
- Did the test go red on `main` and green on this branch? No. This is a narrow follow-up from manual Langfuse/R2 validation; the new assertions lock the cleaned manifest behavior.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/trace-object-manifest.test.ts`
- `pnpm --filter @open-design/daemon exec vitest run tests/langfuse-bridge.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
