### PR TITLE
[codex] Filter AMR OpenCode bootstrap stderr

### DIFF
--- a/apps/daemon/src/amr-stderr-filter.ts
+++ b/apps/daemon/src/amr-stderr-filter.ts
@@ -1,0 +1,73 @@
+// Daemon-side compatibility guard for older Vela/OpenCode stderr behavior.
+// These lifecycle lines are not failures and should not become structured
+// error events in Open Design. Real AMR/OpenCode failures should continue to
+// arrive structured from Vela where possible; this filter only keeps known
+// bootstrap noise out of user-visible and persisted stderr surfaces.
+function isAmrOpenCodeBootstrapStderrLine(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    /^Performing one time database migration, may take a few minutes\.\.\.$/i.test(trimmed) ||
+    /^sqlite-migration:(?:done|\d+(?:\.\d+)?%?)$/i.test(trimmed) ||
+    /^Database migration complete\.?$/i.test(trimmed) ||
+    /^Warning:\s*OPENCODE_SERVER_PASSWORD is not set;\s*server is unsecured\.?$/i.test(trimmed) ||
+    /^opencode server listening on http:\/\/127\.0\.0\.1:\d+\/?$/i.test(trimmed)
+  );
+}
+
+function coerceStderrChunk(chunk: unknown): string {
+  if (chunk === null || chunk === undefined) return '';
+  return typeof chunk === 'string' ? chunk : String(chunk);
+}
+
+export function createAgentStderrVisibilityFilter(agentId: string | undefined) {
+  if (agentId !== 'amr') {
+    return {
+      write(chunk: unknown): string {
+        return coerceStderrChunk(chunk);
+      },
+      flush(): string {
+        return '';
+      },
+    };
+  }
+
+  let pendingLine = '';
+
+  const nextLineBreakIndex = (text: string): number => {
+    const newline = text.indexOf('\n');
+    const carriage = text.indexOf('\r');
+    if (newline === -1) return carriage;
+    if (carriage === -1) return newline;
+    return Math.min(newline, carriage);
+  };
+
+  const emitIfVisible = (line: string, separator = ''): string =>
+    isAmrOpenCodeBootstrapStderrLine(line) ? '' : `${line}${separator}`;
+
+  return {
+    write(chunk: unknown): string {
+      pendingLine += coerceStderrChunk(chunk);
+      let output = '';
+      while (pendingLine.length > 0) {
+        const lineBreakIndex = nextLineBreakIndex(pendingLine);
+        if (lineBreakIndex === -1) break;
+        const line = pendingLine.slice(0, lineBreakIndex);
+        let separator = pendingLine[lineBreakIndex] ?? '';
+        let nextIndex = lineBreakIndex + 1;
+        if (separator === '\r' && pendingLine[nextIndex] === '\n') {
+          separator = '\r\n';
+          nextIndex += 1;
+        }
+        pendingLine = pendingLine.slice(nextIndex);
+        output += emitIfVisible(line, separator);
+      }
+      return output;
+    },
+    flush(): string {
+      if (!pendingLine) return '';
+      const output = emitIfVisible(pendingLine);
+      pendingLine = '';
+      return output;
+    },
+  };
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -227,6 +227,7 @@ import {
   cursorAuthGuidance,
 } from './runtimes/auth.js';
 import { readOpenCodeServiceFailure } from './runtimes/opencode-log.js';
+import { createAgentStderrVisibilityFilter } from './amr-stderr-filter.js';
 import { createQoderStreamHandler } from './qoder-stream.js';
 import { subscribe as subscribeFileEvents } from './project-watchers.js';
 import { renderDesignSystemPreview } from './design-system-preview.js';
@@ -12529,6 +12530,19 @@ export async function startServer({
     let spawnedAgentEnv = null;
     let agentStdoutTail = '';
     let agentStderrTail = '';
+    const agentStderrFilter = createAgentStderrVisibilityFilter(agentId);
+    const emitVisibleAgentStderr = (chunk: unknown) => {
+      const visibleChunk = agentStderrFilter.write(chunk);
+      if (!visibleChunk) return;
+      agentStderrTail = `${agentStderrTail}${visibleChunk}`.slice(-2000);
+      send('stderr', { chunk: visibleChunk });
+    };
+    const flushVisibleAgentStderr = () => {
+      const visibleChunk = agentStderrFilter.flush();
+      if (!visibleChunk) return;
+      agentStderrTail = `${agentStderrTail}${visibleChunk}`.slice(-2000);
+      send('stderr', { chunk: visibleChunk });
+    };
     try {
       // Prompt delivery via stdin is now the universal default. This bypasses
       // both the cmd.exe 8KB limit and the CreateProcess 32KB limit.
@@ -12817,9 +12831,10 @@ export async function startServer({
         // is owned solely by the orchestrator's awaited result below.
         child.stderr.on('data', (chunk) => {
           noteAgentActivity();
-          send('stderr', { chunk });
+          emitVisibleAgentStderr(chunk);
         });
         child.on('error', (err) => {
+          flushVisibleAgentStderr();
           send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err.message));
         });
 
@@ -12828,7 +12843,10 @@ export async function startServer({
         // flow. Without this the orchestrator can't tell a non-zero exit
         // apart from a clean ship and may misclassify failures.
         const childExitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-          child.once('close', (code, signal) => resolve({ code, signal }));
+          child.once('close', (code, signal) => {
+            flushVisibleAgentStderr();
+            resolve({ code, signal });
+          });
         });
         try {
           const orchestratorResult = await runOrchestrator({
@@ -12871,6 +12889,7 @@ export async function startServer({
             design.runs.finish(run, 'failed', 1, null);
           }
         } catch (err) {
+          flushVisibleAgentStderr();
           send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err instanceof Error ? err.message : String(err)));
           design.runs.finish(run, 'failed', 1, null);
         } finally {
@@ -13016,6 +13035,7 @@ export async function startServer({
     const sendAgentEvent = (ev) => {
       if (ev?.type === 'error') {
         if (agentStreamError) return;
+        flushVisibleAgentStderr();
         const failureText = [
           String(ev.message || 'Agent stream error'),
           typeof ev.raw === 'string' ? ev.raw : '',
@@ -13073,6 +13093,7 @@ export async function startServer({
       const claude = createClaudeStreamHandler((ev) => {
         if (ev?.type === 'error') {
           if (agentStreamError) return;
+          flushVisibleAgentStderr();
           const message = String((ev as any).message || 'Claude Code stream error');
           const failureText = [
             message,
@@ -13171,6 +13192,7 @@ export async function startServer({
             sendAgentEvent(payload);
           } else if (channel === 'error') {
             if (agentStreamError) return;
+            flushVisibleAgentStderr();
             agentStreamError = String(payload?.message || 'Pi session error');
             const piErrorCode = typeof payload?.code === 'string' ? payload.code : null;
             if (piErrorCode) {
@@ -13209,6 +13231,7 @@ export async function startServer({
           }
           noteAgentActivity();
           if (event === 'agent') noteFirstTokenFromAgentEvent(data);
+          if (event === 'error') flushVisibleAgentStderr();
           if (def.id === 'amr' && event === 'error') {
             const failure = classifyAmrAccountFailure(
               [
@@ -13284,13 +13307,13 @@ export async function startServer({
     run.acpSession = acpSession;
     child.stderr.on('data', (chunk) => {
       noteAgentActivity();
-      agentStderrTail = `${agentStderrTail}${chunk}`.slice(-2000);
-      send('stderr', { chunk });
+      emitVisibleAgentStderr(chunk);
     });
 
     child.on('error', (err) => {
       clearInactivityWatchdog();
       cleanupPromptFile();
+      flushVisibleAgentStderr();
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
       send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err.message));
@@ -13299,6 +13322,7 @@ export async function startServer({
     child.on('close', async (code, signal) => {
       try {
       clearInactivityWatchdog();
+      flushVisibleAgentStderr();
       if (watchdogRetryRestarted) {
         // The inactivity watchdog already failed this attempt and the same-run
         // retry restarted on a fresh child. Finalization and event-sink / run-

--- a/apps/daemon/tests/amr-stderr-filter.test.ts
+++ b/apps/daemon/tests/amr-stderr-filter.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { createAgentStderrVisibilityFilter } from '../src/amr-stderr-filter.js';
+
+describe('AMR stderr visibility filter', () => {
+  it('treats OpenCode bootstrap stderr as lifecycle noise while preserving real AMR diagnostics', () => {
+    const filter = createAgentStderrVisibilityFilter('amr');
+
+    const visible = [
+      filter.write('Performing one time database migration, may take a few minutes...\n'),
+      filter.write('sqlite-migration:42%\r'),
+      filter.write('sqlite-migration:done\n'),
+      filter.write('Database migration complete.\n'),
+      filter.write('Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.\n'),
+      filter.write('opencode server listening on http://127.0.0.1:54321\n'),
+      filter.write('real AMR diagnostic before ACP\n'),
+      filter.write('real AMR diagnostic without newline'),
+      filter.flush(),
+    ].join('');
+
+    expect(visible).toBe(
+      'real AMR diagnostic before ACP\nreal AMR diagnostic without newline',
+    );
+  });
+
+  it('filters bootstrap lines split across chunks', () => {
+    const filter = createAgentStderrVisibilityFilter('amr');
+
+    const visible = [
+      filter.write('opencode server listening on http://127.'),
+      filter.write('0.0.1:54321\nreal diagnostic\n'),
+      filter.flush(),
+    ].join('');
+
+    expect(visible).toBe('real diagnostic\n');
+  });
+
+  it('preserves sqlite migration diagnostics that are not known progress lines', () => {
+    const filter = createAgentStderrVisibilityFilter('amr');
+
+    const visible = [
+      filter.write('sqlite-migration:42\n'),
+      filter.write('sqlite-migration:42.5%\n'),
+      filter.write('sqlite-migration: failed to open migration file\n'),
+      filter.write('sqlite-migration:error: locked database\n'),
+      filter.flush(),
+    ].join('');
+
+    expect(visible).toBe(
+      'sqlite-migration: failed to open migration file\n' +
+        'sqlite-migration:error: locked database\n',
+    );
+  });
+
+  it('handles empty, nullish, and control-character chunks without fabricating stderr', () => {
+    const filter = createAgentStderrVisibilityFilter('amr');
+
+    const visible = [
+      filter.write(''),
+      filter.write(null),
+      filter.write(undefined),
+      filter.write('\0'),
+      filter.write('\n'),
+      filter.write('diagnostic with nul \0 byte'),
+      filter.flush(),
+    ].join('');
+
+    expect(visible).toBe('\0\ndiagnostic with nul \0 byte');
+  });
+
+  it('does not hide non-AMR stderr', () => {
+    const filter = createAgentStderrVisibilityFilter('opencode');
+
+    const visible = filter.write(
+      [
+        'Performing one time database migration, may take a few minutes...',
+        'sqlite-migration:done',
+        'opencode server listening on http://127.0.0.1:54321',
+        'real diagnostic',
+      ].join('\n'),
+    );
+
+    expect(visible).toContain('Performing one time database migration');
+    expect(visible).toContain('sqlite-migration:done');
+    expect(visible).toContain('opencode server listening');
+    expect(visible).toContain('real diagnostic');
+    expect(filter.flush()).toBe('');
+  });
+
+  it('does not stringify nullish chunks for non-AMR stderr', () => {
+    const filter = createAgentStderrVisibilityFilter('opencode');
+
+    expect(filter.write(null)).toBe('');
+    expect(filter.write(undefined)).toBe('');
+  });
+});


### PR DESCRIPTION
## Why

AMR runs launch Vela as `vela agent run --runtime opencode`. Older Vela/OpenCode behavior can write normal private-server bootstrap lifecycle lines to stderr, including sqlite migration progress, unsecured-password warnings, and `opencode server listening` messages.

Those lines are not failures, but Open Design persists and replays daemon stderr through run SSE, reattach, and event logs. This PR adds a narrow daemon-side compatibility guard so expected AMR/OpenCode bootstrap noise does not look like service restarts or user-actionable errors in Open Design while the upstream Vela output-contract fix lands separately.

## What users will see

AMR runs no longer show known OpenCode bootstrap/private-server lifecycle lines in run stderr surfaces. Real AMR stderr diagnostics still appear normally.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — daemon stderr filtering only; no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/amr-stderr-filter.test.ts`
- Did the test go red on `main` and green on this branch? No. The regression is encoded as a focused filter contract test rather than a full daemon SSE integration because the known symptom is the daemon stderr visibility boundary.
- Verification confirms known AMR/OpenCode lifecycle lines are filtered, real diagnostics are preserved, split stderr chunks are handled, and non-AMR stderr is not filtered.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/amr-stderr-filter.test.ts --reporter verbose`
- `corepack pnpm --filter @open-design/daemon build`
- `corepack pnpm guard`
- `corepack pnpm --filter @open-design/contracts build && corepack pnpm --filter @open-design/registry-protocol build && corepack pnpm --dir apps/daemon exec tsc -p tsconfig.json --noEmit && corepack pnpm --dir apps/daemon exec tsc -p tsconfig.tests.json --noEmit`
