### PR TITLE
[codex] Fix inspiration search focus ring

### DIFF
--- a/apps/web/src/styles/workspace/design-browser.css
+++ b/apps/web/src/styles/workspace/design-browser.css
@@ -464,6 +464,13 @@
   border-radius: var(--radius);
   background: color-mix(in srgb, var(--bg) 90%, transparent);
   color: var(--text-soft);
+  transition:
+    border-color 140ms cubic-bezier(0.23, 1, 0.32, 1),
+    box-shadow 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.db-browser-use-search:focus-within {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
 }
 .db-browser-use-search input {
   min-width: 0;
@@ -474,6 +481,10 @@
   font: inherit;
   font-size: 12px;
   line-height: 1.2;
+}
+.db-browser-use-search input:focus {
+  border: 0;
+  box-shadow: none;
 }
 .db-browser-use-search input::placeholder {
   color: var(--text-faint);


### PR DESCRIPTION
## Why

The Inspiration popover search field in the in-workspace Browser had the same focus-ring leak as the Reference Board search: the global `input:focus` shadow painted on the inner input only, so the visible highlight covered only part of the search field.

This PR moves the visible focus state to the `.db-browser-use-search` wrapper and suppresses the inherited inner input shadow.

## What users will see

Opening Browser → Inspiration and focusing the search field now highlights the full search box instead of only the inner text area.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Reported from the Browser → Inspiration popover: the focused search field only highlighted the inner input width. The fix is CSS-only and mirrors the Reference Board focus-ring behavior.

## Bug fix verification

- Test path that reproduces the bug: not added; this is a CSS focus-ring visual defect.
- Did the test go red on `main` and green on this branch? no automated red/green spec.
- Manual verification: inspected the reported Inspiration search style path and confirmed the inherited input focus shadow is now suppressed while the wrapper owns the full-width focus ring.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
