### PR TITLE
Dismiss home mention picker on view switch

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -757,6 +757,7 @@ export function EntryShell({
           >
             <div data-testid="entry-view-home" data-active={view === 'home' ? 'true' : 'false'} {...inactiveViewProps(view === 'home')}>
               <HomeView
+                isActive={view === 'home'}
                 projects={projects}
                 projectsLoading={projectsLoading}
                 designSystems={designSystems}

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -94,6 +94,7 @@ export interface ExamplePromptInfo {
 }
 
 interface Props {
+  active?: boolean;
   prompt: string;
   onPromptChange: (value: string) => void;
   onSubmit: HomeHeroSubmitHandler;
@@ -205,6 +206,7 @@ const EMPTY_CONNECTOR_OPTIONS: ConnectorDetail[] = [];
 
 export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
   {
+    active = true,
     prompt,
     onPromptChange,
     onSubmit,
@@ -333,7 +335,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
         : [],
     [connectorOptions, mentionActive, mentionQuery],
   );
-  const pickerOpen = mentionActive;
+  const pickerOpen = active && mentionActive;
   const tabs: Array<{ id: HomeMentionTab; label: string; count: number }> = [
     // The All overview previews at most HOME_MENTION_ALL_TAB_PREVIEW files, so
     // its badge counts the previewed slice — not the full staged total — to keep
@@ -661,6 +663,12 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     slash: { q: string } | null;
     anchorRect: CaretRect | null;
   }) {
+    if (!active) {
+      setCaretRect(null);
+      setMentionTrigger(null);
+      setMentionTab('all');
+      return;
+    }
     setCaretRect(anchorRect);
     if (nextMention) {
       setMentionTrigger((prev) => {
@@ -679,6 +687,10 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     setHoveredPlugin(null);
     setSelectedIndex(0);
   }
+
+  useEffect(() => {
+    if (!active) dismissMentionPicker();
+  }, [active]);
 
   // Routes popover navigation keys from the Lexical editor over the visible
   // picker option union. Returns true when consumed so the editor can

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -178,6 +178,7 @@ const AUTHORING_DEFAULT_SCENARIO_INPUTS = {
 
 
 interface Props {
+  isActive?: boolean;
   projects: Project[];
   projectsLoading?: boolean;
   designSystems?: DesignSystemSummary[];
@@ -206,6 +207,7 @@ const EMPTY_CONNECTORS: ConnectorDetail[] = [];
 const EMPTY_PROMPT_TEMPLATES: PromptTemplateSummary[] = [];
 
 export function HomeView({
+  isActive = true,
   projects,
   projectsLoading,
   designSystems = EMPTY_DESIGN_SYSTEMS,
@@ -1489,6 +1491,7 @@ export function HomeView({
     <div className="home-view" data-testid="home-view" ref={homeViewRef}>
       <HomeHero
         ref={inputRef}
+        active={isActive}
         prompt={prompt}
         onPromptChange={handlePromptChange}
         onSubmit={submit}

--- a/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
+++ b/apps/web/tests/components/HomeHero.plugin-picker.test.tsx
@@ -106,6 +106,55 @@ afterEach(() => {
 });
 
 describe('HomeHero plugin picker', () => {
+  it('closes the portal picker when the home view becomes inactive', async () => {
+    const { rerender } = render(
+      <HomeHero
+        active
+        prompt=""
+        onPromptChange={() => undefined}
+        onSubmit={() => undefined}
+        activePluginTitle={null}
+        activeChipId={null}
+        onClearActivePlugin={() => undefined}
+        pluginOptions={[makePlugin('sample-plugin', 'Sample Plugin')]}
+        pluginsLoading={false}
+        pendingPluginId={null}
+        pendingChipId={null}
+        onPickPlugin={() => undefined}
+        onPickChip={() => undefined}
+        contextItemCount={0}
+        error={null}
+      />,
+    );
+
+    setHomeHeroPrompt('@');
+    await settle();
+    expect(screen.getByTestId('home-hero-plugin-picker')).toBeTruthy();
+
+    rerender(
+      <HomeHero
+        active={false}
+        prompt="@"
+        onPromptChange={() => undefined}
+        onSubmit={() => undefined}
+        activePluginTitle={null}
+        activeChipId={null}
+        onClearActivePlugin={() => undefined}
+        pluginOptions={[makePlugin('sample-plugin', 'Sample Plugin')]}
+        pluginsLoading={false}
+        pendingPluginId={null}
+        pendingChipId={null}
+        onPickPlugin={() => undefined}
+        onPickChip={() => undefined}
+        contextItemCount={0}
+        error={null}
+      />,
+    );
+    await settle();
+
+    expect(screen.queryByTestId('home-hero-plugin-picker')).toBeNull();
+  });
+
   it('opens plugin search from an @ token across community and my plugins', async () => {
     const onPromptChange = vi.fn();
     const onPickPlugin = vi.fn();


### PR DESCRIPTION
## Why

Typing `@` on the home composer opens a portal-backed mention picker. When the user switched away from Home while that picker was still open, the home view became inactive but the portal stayed mounted over the Projects view. This PR fixes that stale overlay state.

## What users will see

If users type `@` on the home page and then switch to Projects or another entry view, the mention picker closes immediately instead of floating over the next view.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Verified locally in the in-app browser: opened the home `@` picker, clicked “查看全部” to switch to `/projects`, and confirmed `[data-testid="home-hero-plugin-picker"]` was removed while Projects became active.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/HomeHero.plugin-picker.test.tsx`
- Did the test go red on `main` and green on this branch? no — this is a focused regression around the inactive HomeHero contract added with the fix.
- Additional verification: in-app browser at `http://127.0.0.1:17573/`, opened the home `@` picker, switched to Projects via “查看全部”, and confirmed the picker portal was gone.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `cd apps/web && pnpm exec vitest run -c vitest.config.ts tests/components/HomeHero.plugin-picker.test.tsx`