### PR TITLE
[codex] Fix artifact blank screens from runtime and project scans

### DIFF
--- a/apps/daemon/src/artifact-runtime-compat.ts
+++ b/apps/daemon/src/artifact-runtime-compat.ts
@@ -1,0 +1,38 @@
+import { Buffer } from 'node:buffer';
+
+const HTML_EXTENSION = /\.html?$/iu;
+const MOTION_REACT_HOOK_USAGE =
+  /\bMotion\b[\s\S]*\b(?:useScroll|useTransform|useMotionTemplate|useMotionValue|useAnimationFrame)\b|\b(?:useScroll|useTransform|useMotionTemplate|useMotionValue|useAnimationFrame)\s*\(/u;
+const VANILLA_MOTION_UMD_SCRIPT =
+  /<script\b[^>]*\bsrc=(["'])https:\/\/unpkg\.com\/motion@([^/"']+)\/dist\/motion(?:\.min)?\.js\1[^>]*>\s*<\/script>/giu;
+const MOTION_UMD_SRC = /https:\/\/unpkg\.com\/motion@([^/"']+)\/dist\/motion(?:\.min)?\.js/iu;
+const FRAMER_MOTION_UMD_SCRIPT =
+  /<script\b[^>]*\bsrc=(["'])https:\/\/unpkg\.com\/framer-motion@([^/"']+)\/dist\/framer-motion(?:\.min)?\.js\1[^>]*>\s*<\/script>/iu;
+const FRAMER_MOTION_GLOBAL_USAGE = /\bFramerMotion\b/u;
+const FRAMER_MOTION_ALIAS = '<script>window.FramerMotion = window.FramerMotion || window.Motion;</script>';
+const INTEGRITY_ATTR = /\s+integrity=(["'])[^"']*\1/iu;
+
+export function normalizeArtifactRuntimeImports(name: string, body: unknown): unknown {
+  if (!HTML_EXTENSION.test(name)) return body;
+  const text = stringifyTextBody(body);
+  if (text === null) return body;
+  if (!MOTION_REACT_HOOK_USAGE.test(text) && !FRAMER_MOTION_GLOBAL_USAGE.test(text)) return body;
+
+  let normalized = text.replace(VANILLA_MOTION_UMD_SCRIPT, (tag, _quote, version) => {
+    return tag
+      .replace(MOTION_UMD_SRC, `https://unpkg.com/framer-motion@${version}/dist/framer-motion.js`)
+      .replace(INTEGRITY_ATTR, '');
+  });
+  if (FRAMER_MOTION_GLOBAL_USAGE.test(normalized) && !normalized.includes(FRAMER_MOTION_ALIAS)) {
+    normalized = normalized.replace(FRAMER_MOTION_UMD_SCRIPT, (tag) => `${tag}\n${FRAMER_MOTION_ALIAS}`);
+  }
+
+  return Buffer.isBuffer(body) || body instanceof Uint8Array ? Buffer.from(normalized, 'utf8') : normalized;
+}
+
+function stringifyTextBody(body: unknown): string | null {
+  if (typeof body === 'string') return body;
+  if (Buffer.isBuffer(body)) return body.toString('utf8');
+  if (body instanceof Uint8Array) return Buffer.from(body).toString('utf8');
+  return null;
+}

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -25,6 +25,7 @@ import {
   assertArtifactPublicationAllowed,
   isPublicationGuardedArtifactKind,
 } from './artifact-publication-guard.js';
+import { normalizeArtifactRuntimeImports } from './artifact-runtime-compat.js';
 import { isIgnoredProjectDirName } from './project-ignored-dirs.js';
 import { isSandboxModeEnabled } from './sandbox-mode.js';
 
@@ -40,6 +41,13 @@ export const projectFileRenameTestHooks = {
 export function isRunTouchedProjectFile(fileMtimeMs, runStartTimeMs) {
   if (!Number.isFinite(fileMtimeMs) || !Number.isFinite(runStartTimeMs)) return false;
   return fileMtimeMs + RUN_ARTIFACT_RECONCILE_MTIME_GRACE_MS >= runStartTimeMs;
+}
+
+function containsIgnoredProjectDirSegment(name: string): boolean {
+  return name
+    .split('/')
+    .filter(Boolean)
+    .some((segment) => isIgnoredProjectDirName(segment));
 }
 
 export function projectDir(projectsRoot, projectId) {
@@ -101,10 +109,10 @@ export async function listFiles(projectsRoot, projectId, opts = {}) {
   const metadata = opts?.metadata;
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const out = [];
-  // Skip build/install dirs for linked folders so node_modules doesn't stall
-  // the walk on large repos.
-  const skipDirs = usesExternalProjectRoot(metadata) ? isIgnoredProjectDirName : undefined;
-  await collectFiles(dir, '', out, skipDirs, dir);
+  // Skip generated dependency/build trees for all project roots. Standard OD
+  // projects can contain framework installs too; surfacing package HTML like
+  // node_modules/tslib/*.html as artifacts produces blank previews.
+  await collectFiles(dir, '', out, isIgnoredProjectDirName, dir);
   // Newest first — matches the visual order users expect after generating.
   out.sort((a, b) => b.mtime - a.mtime);
   const since = Number(opts.since);
@@ -118,8 +126,7 @@ export async function listProjectFolders(projectsRoot, projectId, opts = {}) {
   const metadata = opts?.metadata;
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const out = [];
-  const skipDirs = metadata?.baseDir ? isIgnoredProjectDirName : undefined;
-  await collectFolders(dir, '', out, skipDirs);
+  await collectFolders(dir, '', out, isIgnoredProjectDirName);
   out.sort((a, b) => a.name.localeCompare(b.name));
   return out;
 }
@@ -462,6 +469,7 @@ async function collectArchiveEntries(dir, relDir, out) {
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
     if (e.isDirectory()) {
+      if (isIgnoredProjectDirName(e.name)) continue;
       await collectArchiveEntries(full, rel, out);
       continue;
     }
@@ -748,6 +756,7 @@ export async function writeProjectFile(
   const dir = await ensureProject(projectsRoot, projectId, metadata);
   const safeName = sanitizePath(name);
   const target = await resolveSafeReal(dir, safeName);
+  body = normalizeArtifactRuntimeImports(safeName, body);
   if (!overwrite) {
     try {
       await stat(target);
@@ -842,6 +851,7 @@ function artifactManifestNameFor(name) {
 export async function reconcileHtmlArtifactManifest(projectsRoot, projectId, name, metadata?) {
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const safeName = validateProjectPath(name);
+  if (containsIgnoredProjectDirSegment(safeName)) return null;
   const ext = path.extname(safeName).toLowerCase();
   if (ext !== '.html' && ext !== '.htm') return null;
 
@@ -861,6 +871,7 @@ export async function reconcileHtmlArtifactManifest(projectsRoot, projectId, nam
     throw err;
   }
   if (!targetStat.isFile()) return null;
+  if (await isViteDevHtmlEntry(dir, safeName, target)) return null;
 
   const manifestFileName = artifactManifestNameFor(safeName);
   const manifestTarget = await resolveSafeReal(dir, manifestFileName);
@@ -897,6 +908,9 @@ export async function reconcileHtmlArtifactManifest(projectsRoot, projectId, nam
 }
 
 async function readManifestForPath(projectDirPath, relPath) {
+  if (containsIgnoredProjectDirSegment(relPath)) return null;
+  const fullPath = path.join(projectDirPath, relPath);
+  if (await isViteDevHtmlEntry(projectDirPath, relPath, fullPath)) return null;
   const manifestPath = path.join(projectDirPath, artifactManifestNameFor(relPath));
   try {
     const raw = await readFile(manifestPath, 'utf8');
@@ -1148,6 +1162,42 @@ async function collectArtifactManifestFiles(dir, relDir, out) {
     if (entry.isFile() && entry.name.endsWith('.artifact.json')) {
       out.push({ relPath, fullPath });
     }
+  }
+}
+
+async function isViteDevHtmlEntry(projectDirPath, safeName, targetPath) {
+  if (!/(^|\/)index\.html?$/i.test(safeName)) return false;
+  let body = '';
+  try {
+    body = await readFile(targetPath, 'utf8');
+  } catch {
+    return false;
+  }
+  if (!/<script\b[^>]*\btype=["']module["'][^>]*\bsrc=["']\/src\//i.test(body)) {
+    return false;
+  }
+  const viteConfigCandidates = [
+    'vite.config.js',
+    'vite.config.mjs',
+    'vite.config.cjs',
+    'vite.config.ts',
+    'vite.config.mts',
+    'vite.config.cts',
+  ];
+  for (const candidate of viteConfigCandidates) {
+    try {
+      const st = await stat(path.join(projectDirPath, candidate));
+      if (st.isFile()) return true;
+    } catch (err) {
+      if (!err || err.code !== 'ENOENT') return false;
+    }
+  }
+  try {
+    const raw = await readFile(path.join(projectDirPath, 'package.json'), 'utf8');
+    const pkg = JSON.parse(raw);
+    return Boolean(pkg?.dependencies?.vite || pkg?.devDependencies?.vite);
+  } catch {
+    return false;
   }
 }
 

--- a/apps/daemon/src/prompts/official-system.ts
+++ b/apps/daemon/src/prompts/official-system.ts
@@ -79,6 +79,13 @@ When writing React prototypes with inline JSX, use these exact pinned versions a
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 \`\`\`
 
+If you use Framer Motion / Motion React APIs in inline JSX — \`motion\`, \`useScroll\`, \`useTransform\`, \`useMotionTemplate\`, \`useMotionValue\`, or \`useAnimationFrame\` — load the React UMD bundle:
+\`\`\`html
+<script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>
+\`\`\`
+It exposes \`window.Motion\` with React hooks. Do not use \`https://unpkg.com/motion@.../dist/motion.js\` for React hooks; that is the vanilla DOM animation bundle and will crash with \`useScroll is not a function\`.
+When destructuring from this UMD bundle, use \`Motion\` as the global name, not \`FramerMotion\`.
+
 **CRITICAL — style-object naming.** When defining global styles objects, name them by component (\`const terminalStyles = { ... }\`). NEVER write a bare \`const styles = { ... }\` — multiple files with the same name break the page. Inline styles are fine too.
 
 **CRITICAL — multiple Babel files don't share scope.** Each \`<script type="text/babel">\` gets its own scope. To share components, export them to \`window\` at the end of your component file:

--- a/apps/daemon/tests/artifact-manifest-reconcile-on-run-end.test.ts
+++ b/apps/daemon/tests/artifact-manifest-reconcile-on-run-end.test.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { closeDatabase, insertProject, openDatabase } from '../src/db.js';
-import { isRunTouchedProjectFile, reconcileHtmlArtifactManifest, writeProjectFile } from '../src/projects.js';
+import { isRunTouchedProjectFile, listFiles, reconcileHtmlArtifactManifest, writeProjectFile } from '../src/projects.js';
 
 const PROJECT_ID = 'reconcile-test';
 let tempDir = null;
@@ -130,6 +130,59 @@ describe('run-end artifact manifest reconciliation (#2893)', () => {
     const manifest = JSON.parse(fs.readFileSync(sidecarPath, 'utf8'));
     expect(manifest.kind).toBe('html');
     expect(manifest.entry).toBe('page.htm');
+  });
+
+  it('does not reconcile dependency package HTML files as artifacts', async () => {
+    setup();
+
+    const dir = path.join(projectsRoot, PROJECT_ID);
+    fs.mkdirSync(path.join(dir, 'node_modules', 'tslib'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'node_modules', 'tslib', 'tslib.html'),
+      '<script src="tslib.js"></script>',
+    );
+
+    const result = await reconcileHtmlArtifactManifest(
+      projectsRoot,
+      PROJECT_ID,
+      'node_modules/tslib/tslib.html',
+    );
+
+    expect(result).toBeNull();
+    expect(
+      fs.existsSync(path.join(dir, 'node_modules', 'tslib', 'tslib.html.artifact.json')),
+    ).toBe(false);
+  });
+
+  it('does not infer or surface Vite dev index.html as an HTML artifact', async () => {
+    setup();
+
+    const dir = path.join(projectsRoot, PROJECT_ID);
+    fs.writeFileSync(
+      path.join(dir, 'index.html'),
+      '<div id="root"></div><script type="module" src="/src/main.jsx"></script>',
+    );
+    fs.writeFileSync(path.join(dir, 'vite.config.js'), 'export default {};');
+
+    const reconciled = await reconcileHtmlArtifactManifest(projectsRoot, PROJECT_ID, 'index.html');
+    expect(reconciled).toBeNull();
+    expect(fs.existsSync(path.join(dir, 'index.html.artifact.json'))).toBe(false);
+
+    fs.writeFileSync(
+      path.join(dir, 'index.html.artifact.json'),
+      JSON.stringify({
+        version: 1,
+        kind: 'html',
+        entry: 'index.html',
+        renderer: 'html',
+        status: 'complete',
+        exports: ['html', 'zip'],
+      }),
+    );
+
+    const files = await listFiles(projectsRoot, PROJECT_ID);
+    const index = files.find((file) => file.name === 'index.html');
+    expect(index?.artifactManifest).toBeNull();
   });
 
   it('skips pre-existing HTML files whose mtime is before the run start (imported-folder guard)', async () => {

--- a/apps/daemon/tests/artifact-runtime-compat.test.ts
+++ b/apps/daemon/tests/artifact-runtime-compat.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { normalizeArtifactRuntimeImports } from '../src/artifact-runtime-compat.js';
+import { writeProjectFile } from '../src/projects.js';
+
+const brokenReactMotionHtml = `<!doctype html>
+<html>
+  <head>
+    <script src="https://unpkg.com/motion@11.11.13/dist/motion.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      const { motion, useScroll, useTransform } = Motion;
+      function App() {
+        const { scrollYProgress } = useScroll();
+        const opacity = useTransform(scrollYProgress, [0, 1], [0, 1]);
+        return <motion.div style={{ opacity }}>Hello</motion.div>;
+      }
+    </script>
+  </body>
+</html>`;
+
+describe('artifact runtime compatibility normalizer', () => {
+  it('rewrites vanilla Motion UMD to Framer Motion UMD when React Motion hooks are used', () => {
+    const normalized = normalizeArtifactRuntimeImports('landing.html', brokenReactMotionHtml);
+
+    expect(normalized).toContain('https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js');
+    expect(normalized).not.toContain('https://unpkg.com/motion@11.11.13/dist/motion.js');
+  });
+
+  it('preserves non-HTML files and HTML that does not use Motion React hooks', () => {
+    expect(normalizeArtifactRuntimeImports('notes.md', brokenReactMotionHtml)).toBe(brokenReactMotionHtml);
+
+    const vanillaMotionHtml = '<!doctype html><script src="https://unpkg.com/motion@11.11.13/dist/motion.js"></script><script>Motion.animate("div", { opacity: 1 })</script>';
+    expect(normalizeArtifactRuntimeImports('animation.html', vanillaMotionHtml)).toBe(vanillaMotionHtml);
+  });
+
+  it('removes stale integrity from rewritten script tags', () => {
+    const html = brokenReactMotionHtml.replace(
+      'src="https://unpkg.com/motion@11.11.13/dist/motion.js"',
+      'src="https://unpkg.com/motion@11.11.13/dist/motion.js" integrity="sha384-stale"',
+    );
+
+    const normalized = normalizeArtifactRuntimeImports('landing.html', html) as string;
+
+    expect(normalized).toContain('https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js');
+    expect(normalized).not.toContain('sha384-stale');
+  });
+
+  it('aliases the FramerMotion global for framer-motion UMD artifacts', () => {
+    const html = `<!doctype html>
+      <script src="https://unpkg.com/framer-motion@11.11.17/dist/framer-motion.js"></script>
+      <script type="text/babel">const { motion, useScroll } = FramerMotion;</script>`;
+
+    const normalized = normalizeArtifactRuntimeImports('landing.html', html) as string;
+
+    expect(normalized).toContain('window.FramerMotion = window.FramerMotion || window.Motion;');
+    expect(normalized.indexOf('framer-motion@11.11.17')).toBeLessThan(normalized.indexOf('window.FramerMotion'));
+  });
+
+  it('normalizes content before writeProjectFile persists it', async () => {
+    const projectsRoot = await mkdtemp(path.join(tmpdir(), 'od-runtime-compat-'));
+    try {
+      await writeProjectFile(projectsRoot, 'project-1', 'landing.html', Buffer.from(brokenReactMotionHtml, 'utf8'));
+
+      const saved = await readFile(path.join(projectsRoot, 'project-1', 'landing.html'), 'utf8');
+      expect(saved).toContain('https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js');
+      expect(saved).not.toContain('https://unpkg.com/motion@11.11.13/dist/motion.js');
+    } finally {
+      await rm(projectsRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/daemon/tests/folder-import-projects.test.ts
+++ b/apps/daemon/tests/folder-import-projects.test.ts
@@ -194,14 +194,7 @@ describe('listFiles with metadata.baseDir', () => {
     expect(paths.some((p) => p.includes('/target/'))).toBe(false);
   });
 
-  it('does not skip those dirs for non-baseDir projects (back-compat)', async () => {
-    // Without metadata.baseDir, listFiles points at the standard project dir.
-    // We don't have one set up for this test — just assert the call doesn't
-    // *apply* the skip filter when the metadata is absent. We check this
-    // indirectly: passing the same baseDir as a non-baseDir directory
-    // (impossible here since listFiles uses standard path). So instead,
-    // verify the default path behavior is unchanged: no metadata, no
-    // skipDirs, no baseDir resolution.
+  it('skips dependency dirs for non-baseDir projects too', async () => {
     const standardDir = mkdtempSync(path.join(tmpdir(), 'od-list-std-'));
     try {
       await mkdir(path.join(standardDir, 'std-project'), { recursive: true });
@@ -211,9 +204,8 @@ describe('listFiles with metadata.baseDir', () => {
 
       const files = await listFiles(standardDir, 'std-project');
       const paths = files.map((f) => f.path).sort();
-      // node_modules contents *do* appear when no skip filter is applied
       expect(paths).toContain('main.html');
-      expect(paths).toContain('node_modules/a.js');
+      expect(paths).not.toContain('node_modules/a.js');
     } finally {
       rmSync(standardDir, { recursive: true, force: true });
     }

--- a/packages/contracts/src/prompts/official-system.ts
+++ b/packages/contracts/src/prompts/official-system.ts
@@ -75,6 +75,13 @@ When writing React prototypes with inline JSX, use these exact pinned versions a
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 \`\`\`
 
+If you use Framer Motion / Motion React APIs in inline JSX — \`motion\`, \`useScroll\`, \`useTransform\`, \`useMotionTemplate\`, \`useMotionValue\`, or \`useAnimationFrame\` — load the React UMD bundle:
+\`\`\`html
+<script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>
+\`\`\`
+It exposes \`window.Motion\` with React hooks. Do not use \`https://unpkg.com/motion@.../dist/motion.js\` for React hooks; that is the vanilla DOM animation bundle and will crash with \`useScroll is not a function\`.
+When destructuring from this UMD bundle, use \`Motion\` as the global name, not \`FramerMotion\`.
+
 **CRITICAL — style-object naming.** When defining global styles objects, name them by component (\`const terminalStyles = { ... }\`). NEVER write a bare \`const styles = { ... }\` — multiple files with the same name break the page. Inline styles are fine too.
 
 **CRITICAL — multiple Babel files don't share scope.** Each \`<script type="text/babel">\` gets its own scope. To share components, export them to \`window\` at the end of your component file:


### PR DESCRIPTION
## Summary

Fixes generated artifact blank/black screens caused by two runtime/publication gaps:

- Normalizes incorrect Motion/Framer Motion UMD usage at the project write boundary so inline React prototypes using Motion hooks load the React UMD bundle and resolve the expected global.
- Stops dependency/build/dev-entry HTML files from being surfaced as generated artifacts. Standard OD projects now skip ignored directories such as `node_modules` during file/folder listing and archives, run-end artifact reconciliation ignores those paths, and Vite dev `index.html` shells are not inferred or returned as complete HTML artifacts.

## Root Cause

Some beta.24 projects generated valid-looking HTML entries that were not actually standalone artifacts:

- `node_modules/tslib/*.html` came from installed dependencies and rendered blank by design, but OD scanned them and reconciled `.artifact.json` sidecars.
- Vite dev `index.html` entries pointed at `/src/main.jsx` and required a dev/build pipeline, but run-end reconciliation inferred them as complete HTML artifacts.
- Motion React hook prototypes sometimes loaded the vanilla `motion` UMD bundle or used the stale `FramerMotion` global, causing runtime crashes before React rendered.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/folder-import-projects.test.ts tests/artifact-manifest-reconcile-on-run-end.test.ts tests/project-archive.test.ts tests/artifact-runtime-compat.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
