### PR TITLE
[codex] Load local env for tools-dev telemetry

### DIFF
--- a/apps/daemon/src/analytics.ts
+++ b/apps/daemon/src/analytics.ts
@@ -24,6 +24,7 @@ import {
   EVENT_SCHEMA_VERSION,
 } from '@open-design/contracts/analytics';
 import { readAppConfig } from './app-config.js';
+import { readTelemetryEnvironment } from './telemetry-environment.js';
 
 const DEFAULT_HOST = 'https://us.i.posthog.com';
 
@@ -79,6 +80,7 @@ function headerString(req: Request, name: string): string | null {
 export interface PosthogConfig {
   key: string;
   host: string;
+  env: string;
 }
 
 export function readPosthogConfig(
@@ -87,7 +89,7 @@ export function readPosthogConfig(
   const key = env.POSTHOG_KEY?.trim();
   if (!key) return null;
   const host = (env.POSTHOG_HOST?.trim() || DEFAULT_HOST).replace(/\/+$/, '');
-  return { key, host };
+  return { key, host, env: readTelemetryEnvironment(env) };
 }
 
 // Baseline wire response for GET /api/analytics/config — checks only the
@@ -97,8 +99,9 @@ export function readPublicConfigResponse(
   env: NodeJS.ProcessEnv = process.env,
 ): AnalyticsConfigResponse {
   const cfg = readPosthogConfig(env);
-  if (!cfg) return { enabled: false, key: null, host: null };
-  return { enabled: true, key: cfg.key, host: cfg.host };
+  const telemetryEnv = cfg?.env ?? readTelemetryEnvironment(env);
+  if (!cfg) return { enabled: false, env: telemetryEnv, key: null, host: null };
+  return { enabled: true, env: cfg.env, key: cfg.key, host: cfg.host };
 }
 
 export interface AnalyticsService {
@@ -189,6 +192,7 @@ export function createAnalyticsService(args: {
               ...properties,
               event_id: insertId,
               event_schema_version: EVENT_SCHEMA_VERSION,
+              env: cfg.env,
               ui_version: appVersion,
               app_version: appVersion,
               session_id: context.sessionId,
@@ -237,6 +241,7 @@ export function createAnalyticsService(args: {
             ...properties,
             event_id: resolvedInsertId,
             event_schema_version: EVENT_SCHEMA_VERSION,
+            env: cfg.env,
             ui_version: appVersion,
             app_version: appVersion,
             device_id: resolvedDistinctId,

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -30,6 +30,7 @@ import type {
   RunTimingAnalytics,
 } from './run-analytics-observability.js';
 import type { RunFailureClassification } from './run-failure-classification.js';
+import { readTelemetryEnvironment } from './telemetry-environment.js';
 
 // Langfuse US region: confirmed by an end-to-end smoke on 2026-05-07 — the
 // project's keys authenticate against `us.cloud.langfuse.com` only. EU host
@@ -1103,6 +1104,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   // keys best). All entries are anonymous — no PII, no credentials.
   const traceMetadata: Record<string, unknown> = {
     success,
+    env: readTelemetryEnvironment(),
     status: ctx.run.status,
     error: ctx.run.error ?? undefined,
     error_code: ctx.run.errorCode,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5554,6 +5554,7 @@ export async function startServer({
           : null;
       res.json({
         enabled: consentGranted,
+        env: baseline.env,
         key: baseline.key,
         host: baseline.host,
         installationId,
@@ -5564,6 +5565,7 @@ export async function startServer({
       // valuable signal in a degraded-state scenario.
       res.json({
         enabled: false,
+        env: baseline.env,
         key: baseline.key,
         host: baseline.host,
         installationId: null,

--- a/apps/daemon/src/telemetry-environment.ts
+++ b/apps/daemon/src/telemetry-environment.ts
@@ -1,0 +1,14 @@
+const DEFAULT_TELEMETRY_ENV = 'development';
+
+export function readTelemetryEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const explicit =
+    env.OD_TELEMETRY_ENV?.trim() ||
+    env.OPEN_DESIGN_ENV?.trim() ||
+    env.POSTHOG_ENV?.trim() ||
+    env.LANGFUSE_ENVIRONMENT?.trim();
+  if (explicit) return explicit;
+  if (env.NODE_ENV === 'production') return 'production';
+  return DEFAULT_TELEMETRY_ENV;
+}

--- a/apps/daemon/tests/analytics-env.test.ts
+++ b/apps/daemon/tests/analytics-env.test.ts
@@ -1,0 +1,74 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+const posthogCapture = vi.hoisted(() => vi.fn());
+const posthogShutdown = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock('posthog-node', () => ({
+  PostHog: vi.fn(function PostHogMock() {
+    return {
+      capture: posthogCapture,
+      on: vi.fn(),
+      shutdown: posthogShutdown,
+    };
+  }),
+}));
+
+describe('analytics telemetry environment', () => {
+  it('exposes the telemetry env in public analytics config', async () => {
+    const { readPublicConfigResponse } = await import('../src/analytics.js');
+
+    expect(readPublicConfigResponse({
+      POSTHOG_KEY: 'phc_test',
+      OD_TELEMETRY_ENV: 'local_development',
+    })).toMatchObject({
+      enabled: true,
+      env: 'local_development',
+      key: 'phc_test',
+    });
+  });
+
+  it('stamps daemon PostHog captures with env', async () => {
+    posthogCapture.mockReset();
+    const dataDir = await mkdtemp(path.join(tmpdir(), 'od-analytics-env-'));
+    await writeFile(path.join(dataDir, 'app-config.json'), JSON.stringify({
+      installationId: 'install-1',
+      telemetry: { metrics: true },
+    }));
+    const { createAnalyticsService } = await import('../src/analytics.js');
+    const analytics = createAnalyticsService({
+      dataDir,
+      env: {
+        POSTHOG_KEY: 'phc_test',
+        OD_TELEMETRY_ENV: 'local_development',
+      },
+    });
+
+    analytics.capture({
+      eventName: 'unit_event',
+      appVersion: '1.2.3',
+      context: {
+        deviceId: 'device-1',
+        sessionId: 'session-1',
+        clientType: 'web',
+        locale: 'en',
+        requestId: null,
+      },
+      insertId: 'insert-1',
+      properties: {},
+    });
+
+    await vi.waitFor(() => {
+      expect(posthogCapture).toHaveBeenCalled();
+    });
+    expect(posthogCapture.mock.calls[0]?.[0]).toMatchObject({
+      event: 'unit_event',
+      properties: {
+        env: 'local_development',
+      },
+    });
+  });
+});

--- a/apps/daemon/tests/langfuse-env.test.ts
+++ b/apps/daemon/tests/langfuse-env.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { buildTracePayload } from '../src/langfuse-trace.js';
+
+const ORIGINAL_OD_TELEMETRY_ENV = process.env.OD_TELEMETRY_ENV;
+
+afterEach(() => {
+  if (ORIGINAL_OD_TELEMETRY_ENV === undefined) {
+    delete process.env.OD_TELEMETRY_ENV;
+  } else {
+    process.env.OD_TELEMETRY_ENV = ORIGINAL_OD_TELEMETRY_ENV;
+  }
+});
+
+describe('langfuse telemetry environment', () => {
+  it('stamps trace metadata with env', () => {
+    process.env.OD_TELEMETRY_ENV = 'local_development';
+
+    const batch = buildTracePayload({
+      installationId: 'install-1',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      agentId: 'codex',
+      run: {
+        runId: 'run-1',
+        status: 'succeeded',
+        startedAt: Date.now() - 1000,
+        endedAt: Date.now(),
+      },
+      message: {
+        messageId: 'message-1',
+        prompt: 'Build a page',
+        output: 'Done',
+      },
+      artifacts: [],
+      eventsSummary: {
+        toolCalls: 0,
+        errors: 0,
+        durationMs: 1000,
+      },
+      prefs: {
+        metrics: true,
+        content: true,
+      },
+    });
+
+    expect((batch[0] as any).body.metadata.env).toBe('local_development');
+  });
+});

--- a/apps/web/src/analytics/client.ts
+++ b/apps/web/src/analytics/client.ts
@@ -115,6 +115,7 @@ export function bootstrapExceptionTracking(context: AnalyticsContext): Promise<v
         clearExceptionTrackingContext();
         return;
       }
+      const telemetryEnv = cfg.env || 'unknown';
       const distinctId =
         (typeof cfg.installationId === 'string' && cfg.installationId) ||
         context.anonymousId;
@@ -124,6 +125,7 @@ export function bootstrapExceptionTracking(context: AnalyticsContext): Promise<v
         distinctId,
         appVersion: context.appVersion,
         sessionId: context.sessionId,
+        telemetryEnv,
       });
     } catch {
       // Network failure / endpoint unavailable — leave the buffer in
@@ -151,6 +153,7 @@ export async function getAnalyticsClient(
       if (!res.ok) return null;
       const cfg = (await res.json()) as AnalyticsConfigResponse;
       if (!cfg.enabled || !cfg.key || !cfg.host) return null;
+      const telemetryEnv = cfg.env || 'unknown';
       const distinctId =
         (typeof cfg.installationId === 'string' && cfg.installationId) ||
         context.anonymousId;
@@ -252,6 +255,7 @@ export async function getAnalyticsClient(
         loaded: (instance) => {
           lastRegisterPayload = {
             event_schema_version: EVENT_SCHEMA_VERSION,
+            env: telemetryEnv,
             ui_version: context.appVersion,
             app_version: context.appVersion,
             client_type: context.clientType,
@@ -274,6 +278,7 @@ export async function getAnalyticsClient(
             distinctId,
             appVersion: context.appVersion,
             sessionId: context.sessionId,
+            telemetryEnv,
           });
         },
       });

--- a/apps/web/src/analytics/error-tracking.ts
+++ b/apps/web/src/analytics/error-tracking.ts
@@ -41,6 +41,7 @@ interface ExceptionTrackingContext {
   distinctId: string;
   appVersion?: string;
   sessionId?: string;
+  telemetryEnv?: string;
 }
 
 interface BufferedSafetyEvent {
@@ -177,6 +178,7 @@ function dispatch(item: BufferedSafetyEvent): void {
     properties: {
       ...item.body.properties,
       $lib: 'web/error-tracking',
+      ...(context.telemetryEnv ? { env: context.telemetryEnv } : {}),
       ...(context.appVersion ? { app_version: context.appVersion, ui_version: context.appVersion } : {}),
       ...(context.sessionId ? { session_id: context.sessionId } : {}),
     },

--- a/apps/web/tests/analytics-session-replay.test.ts
+++ b/apps/web/tests/analytics-session-replay.test.ts
@@ -30,6 +30,7 @@ interface InitConfig {
 }
 
 let lastInitConfig: InitConfig | null = null;
+let lastRegisterPayload: Record<string, unknown> | null = null;
 
 vi.mock('posthog-js', () => {
   const stub = {
@@ -41,7 +42,9 @@ vi.mock('posthog-js', () => {
       loaded?.(stub);
       return stub;
     },
-    register: () => undefined,
+    register: (payload: Record<string, unknown>) => {
+      lastRegisterPayload = payload;
+    },
     opt_in_capturing: () => undefined,
     opt_out_capturing: () => undefined,
     reset: () => undefined,
@@ -55,6 +58,7 @@ describe('PostHog session replay configuration', () => {
 
   beforeEach(() => {
     lastInitConfig = null;
+    lastRegisterPayload = null;
     vi.resetModules();
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url =
@@ -67,6 +71,7 @@ describe('PostHog session replay configuration', () => {
         return new Response(
           JSON.stringify({
             enabled: true,
+            env: 'local_development',
             key: 'phc_test_key',
             host: 'https://us.i.posthog.com',
             installationId: 'install-123',
@@ -116,5 +121,12 @@ describe('PostHog session replay configuration', () => {
     const config = await initClient();
     expect(config?.session_recording?.blockSelector).toBe('iframe');
     expect(config?.session_recording?.recordCrossOriginIframes).toBe(false);
+  });
+
+  it('registers the daemon-provided telemetry environment', async () => {
+    await initClient();
+    expect(lastRegisterPayload).toMatchObject({
+      env: 'local_development',
+    });
   });
 });

--- a/packages/contracts/src/analytics/public-params.ts
+++ b/packages/contracts/src/analytics/public-params.ts
@@ -15,6 +15,7 @@ export interface AnalyticsPublicParams {
   event_id: string;
   request_id?: string;
   event_schema_version: number;
+  env: string;
   ui_version: string;
   session_id: string;
   // v2 rename: was `anonymous_id` in schema v1. The value is still the
@@ -80,6 +81,7 @@ export const ANALYTICS_HEADER_REQUEST_ID = 'x-od-analytics-request-id';
 //   identity PostHog already saw on prior runs.
 export interface AnalyticsConfigResponse {
   enabled: boolean;
+  env: string;
   key: string | null;
   host: string | null;
   installationId?: string | null;

--- a/tools/dev/src/index.ts
+++ b/tools/dev/src/index.ts
@@ -42,6 +42,7 @@ import {
   resolveStopApps,
   resolveTargetApps,
   resolveToolDevConfig,
+  WORKSPACE_ROOT,
   type ToolDevAppName,
   type ToolDevConfig,
   type ToolDevOptions,
@@ -64,6 +65,7 @@ import {
   waitForWebRuntime,
 } from "./sidecar-client.js";
 import { ensureDaemonGateForDesktop } from "./desktop-auth-gate.js";
+import { loadWorkspaceLocalEnv } from "./local-env.js";
 import { resolveSharedPortsFromRunningState } from "./shared-ports.js";
 
 type CliOptions = ToolDevOptions & {
@@ -88,6 +90,8 @@ function exitWithError(error: unknown): never {
 
 process.on("uncaughtException", exitWithError);
 process.on("unhandledRejection", exitWithError);
+
+loadWorkspaceLocalEnv({ workspaceRoot: WORKSPACE_ROOT });
 
 function printJson(payload: unknown): void {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);

--- a/tools/dev/src/local-env.ts
+++ b/tools/dev/src/local-env.ts
@@ -1,0 +1,92 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+export const LOCAL_ENV_FILE_NAME = ".env.local";
+export const LOCAL_DEVELOPMENT_TELEMETRY_ENV = "local_development";
+export const TELEMETRY_ENV_KEY = "OD_TELEMETRY_ENV";
+
+export interface LoadWorkspaceLocalEnvResult {
+  envPath: string;
+  loaded: boolean;
+  keys: string[];
+}
+
+export function loadWorkspaceLocalEnv(options: {
+  workspaceRoot: string;
+  env?: NodeJS.ProcessEnv;
+}): LoadWorkspaceLocalEnvResult {
+  const env = options.env ?? process.env;
+  const envPath = path.join(options.workspaceRoot, LOCAL_ENV_FILE_NAME);
+  if (!existsSync(envPath)) return { envPath, loaded: false, keys: [] };
+
+  const parsed = parseDotEnvLocal(readFileSync(envPath, "utf8"));
+  for (const [key, value] of Object.entries(parsed)) {
+    env[key] = value;
+  }
+  if (env[TELEMETRY_ENV_KEY] == null || env[TELEMETRY_ENV_KEY]?.trim() === "") {
+    env[TELEMETRY_ENV_KEY] = LOCAL_DEVELOPMENT_TELEMETRY_ENV;
+  }
+  return { envPath, loaded: true, keys: Object.keys(parsed).sort() };
+}
+
+export function parseDotEnvLocal(content: string): Record<string, string> {
+  const parsed: Record<string, string> = Object.create(null);
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const normalized = line.startsWith("export ") ? line.slice("export ".length).trimStart() : line;
+    const equalsIndex = normalized.indexOf("=");
+    if (equalsIndex <= 0) continue;
+
+    const key = normalized.slice(0, equalsIndex).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+
+    const rawValue = normalized.slice(equalsIndex + 1).trim();
+    parsed[key] = parseDotEnvValue(rawValue);
+  }
+  return parsed;
+}
+
+function parseDotEnvValue(rawValue: string): string {
+  if (rawValue.startsWith("\"") || rawValue.startsWith("'")) {
+    return parseQuotedValue(rawValue);
+  }
+  return stripInlineComment(rawValue).trim();
+}
+
+function parseQuotedValue(rawValue: string): string {
+  const quote = rawValue[0]!;
+  let escaped = false;
+  let value = "";
+  for (let i = 1; i < rawValue.length; i += 1) {
+    const char = rawValue[i]!;
+    if (escaped) {
+      value += quote === "\"" ? decodeEscape(char) : char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === quote) return value;
+    value += char;
+  }
+  return value;
+}
+
+function decodeEscape(char: string): string {
+  if (char === "n") return "\n";
+  if (char === "r") return "\r";
+  if (char === "t") return "\t";
+  return char;
+}
+
+function stripInlineComment(value: string): string {
+  for (let i = 0; i < value.length; i += 1) {
+    if (value[i] !== "#") continue;
+    if (i === 0 || /\s/.test(value[i - 1]!)) return value.slice(0, i);
+  }
+  return value;
+}

--- a/tools/dev/tests/local-env.test.ts
+++ b/tools/dev/tests/local-env.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  LOCAL_DEVELOPMENT_TELEMETRY_ENV,
+  loadWorkspaceLocalEnv,
+  parseDotEnvLocal,
+  TELEMETRY_ENV_KEY,
+} from "../src/local-env.js";
+
+describe("tools-dev local env loading", () => {
+  it("parses common .env.local assignment forms", () => {
+    assert.deepEqual({ ...parseDotEnvLocal([
+      "# comment",
+      "POSTHOG_KEY=phc_local",
+      "POSTHOG_HOST=https://us.i.posthog.com # trailing comment",
+      "export LANGFUSE_PUBLIC_KEY=\"pk local\"",
+      "LANGFUSE_SECRET_KEY='sk#local'",
+      "BAD-KEY=ignored",
+      "",
+    ].join("\n")) }, {
+      POSTHOG_KEY: "phc_local",
+      POSTHOG_HOST: "https://us.i.posthog.com",
+      LANGFUSE_PUBLIC_KEY: "pk local",
+      LANGFUSE_SECRET_KEY: "sk#local",
+    });
+  });
+
+  it("loads workspace .env.local over the parent environment and marks telemetry as local dev", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "od-local-env-"));
+    await writeFile(path.join(workspaceRoot, ".env.local"), [
+      "POSTHOG_KEY=phc_from_file",
+      "LANGFUSE_PUBLIC_KEY=pk_from_file",
+    ].join("\n"));
+    const env: NodeJS.ProcessEnv = { POSTHOG_KEY: "phc_from_parent" };
+
+    const result = loadWorkspaceLocalEnv({ workspaceRoot, env });
+
+    assert.equal(result.loaded, true);
+    assert.equal(env.POSTHOG_KEY, "phc_from_file");
+    assert.equal(env.LANGFUSE_PUBLIC_KEY, "pk_from_file");
+    assert.equal(env[TELEMETRY_ENV_KEY], LOCAL_DEVELOPMENT_TELEMETRY_ENV);
+    assert.deepEqual(result.keys, ["LANGFUSE_PUBLIC_KEY", "POSTHOG_KEY"]);
+  });
+
+  it("preserves an explicit telemetry environment from .env.local", async () => {
+    const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "od-local-env-"));
+    await writeFile(path.join(workspaceRoot, ".env.local"), `${TELEMETRY_ENV_KEY}=dev_smoke\n`);
+    const env: NodeJS.ProcessEnv = {};
+
+    loadWorkspaceLocalEnv({ workspaceRoot, env });
+
+    assert.equal(env[TELEMETRY_ENV_KEY], "dev_smoke");
+  });
+});


### PR DESCRIPTION
## Why

Running `pnpm tools-dev` locally should use the repository's `.env.local` without requiring a manual `source .env.local` step. This came up while starting the project with local PostHog and Langfuse credentials: telemetry could be configured correctly in the file, but the default lifecycle command did not pick it up.

The pain addressed is twofold: local development startup was easier to misconfigure, and telemetry arriving from local smoke runs did not have a consistent environment marker shared across PostHog and Langfuse.

## What users will see

When a root `.env.local` file exists, `pnpm tools-dev` automatically loads it before launching daemon, web, and desktop. Local telemetry runs are tagged as `local_development` by default through `OD_TELEMETRY_ENV`, unless the file already sets an explicit telemetry environment.

PostHog and Langfuse events now include an `env` field so local development traffic can be filtered from production-like data.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface changed.

## Bug fix verification

N/A — this is a local development workflow improvement and telemetry labeling change, not a bug-fix PR tied to an issue.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/tools-dev test`
- `pnpm exec vitest run -c vitest.config.ts tests/analytics-env.test.ts tests/langfuse-env.test.ts` from `apps/daemon`
- `pnpm exec vitest run -c vitest.config.ts tests/analytics-session-replay.test.ts` from `apps/web`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm tools-dev restart`
- Verified `/api/analytics/config` returns `env: local_development` with local analytics credentials loaded from `.env.local`.