### PR TITLE
[codex] Align home mode popover left

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -360,6 +360,11 @@
 .home-hero__input-card .session-mode-toggle__popover-card {
   max-height: min(300px, calc(100vh - 120px));
 }
+.home-hero__input-card .session-mode-toggle__popover {
+  right: 0;
+  left: auto;
+  flex-direction: row-reverse;
+}
 .home-hero__input-card--compact-authoring {
   max-width: 640px;
   padding-block: 12px 10px;


### PR DESCRIPTION
## Why

The home page session mode popover expanded to the right from the mode button. On narrower or crowded home layouts, the description card could run into the right edge and become width constrained.

This PR keeps the existing home mode picker behavior but changes the home hero popover alignment so the menu stays anchored to the button while the description card opens to the left.

## What users will see

On the home page prompt composer, opening the Design/Ask mode picker now keeps the compact menu next to the button and expands the explanatory card leftward instead of rightward.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. I verified the home page popover in the local browser at `http://127.0.0.1:17573/`: the popover right edge aligns with the mode button right edge, the menu remains adjacent to the button, and the description card renders to the left.

## Bug fix verification

- Test path that reproduces the bug: not added; this is a small CSS positioning fix for a visible layout issue.
- Did the test go red on `main` and green on this branch? no.
- Verification: local browser DOM geometry confirmed `.home-hero__input-card .session-mode-toggle__popover` uses `right: 0`, `left: auto`, `flex-direction: row-reverse`, with the description card left of the menu.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
