### PR TITLE
[codex] Return project back button to home

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1586,7 +1586,7 @@ function AppInner() {
   }, []);
 
   const handleBack = useCallback(() => {
-    navigate({ kind: 'home', view: 'projects' });
+    navigate({ kind: 'home', view: 'home' });
   }, []);
 
   const handleClearPendingPrompt = useCallback(() => {

--- a/apps/web/tests/components/App.project-create-race.test.tsx
+++ b/apps/web/tests/components/App.project-create-race.test.tsx
@@ -58,6 +58,9 @@ vi.mock('../../src/components/EntryView', () => ({
     projects: Project[];
   }) => (
     <main>
+      {window.location.pathname === '/' ? (
+        <div data-testid="entry-home-surface" />
+      ) : null}
       <button
         type="button"
         onClick={() =>
@@ -667,11 +670,12 @@ describe('App project creation routing', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Back to projects' }));
 
     await waitFor(() => {
+      expect(screen.getByTestId('entry-home-surface')).toBeTruthy();
       expect(screen.getByTestId('entry-project-project-new').textContent).toContain(
         'Fresh project',
       );
     });
-    expect(window.location.pathname).toBe('/projects');
+    expect(window.location.pathname).toBe('/');
     expect(screen.queryByTestId('entry-project-project-existing')).toBeNull();
   });
 


### PR DESCRIPTION
## Why

Project detail currently sends the top-left back button to the Projects entry tab. This change restores the expected behavior: pressing back from a project returns to the Home entry view, matching the user expectation that this button exits the project workspace back to the main home page.

## What users will see

From a project detail page, clicking the top-left back arrow now opens the Home page instead of the Projects list tab.

## Surface area

- [x] **UI** — changed the project header back-button navigation behavior in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: this is a route target change for an existing button, with no visual UI changes.

## Bug fix verification

- Test path that reproduces the bug: not added. The fix is a one-line route target correction on the existing `handleBack` callback.
- Did the test go red on `main` and green on this branch? no; verified with typecheck and guard instead.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`