### PR TITLE
[codex] Hide chat plugin preview use action

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -2375,6 +2375,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               await pluginsSectionRef.current?.applyById(record.id, record);
               setDetailsRecord(null);
             }}
+            hideUseAction
           />
         ) : null}
       </div>

--- a/apps/web/src/components/PluginDetailsModal.tsx
+++ b/apps/web/src/components/PluginDetailsModal.tsx
@@ -31,6 +31,7 @@ interface Props {
   onClose: () => void;
   onUse: (record: InstalledPluginRecord) => void;
   isApplying?: boolean;
+  hideUseAction?: boolean;
 }
 
 export function PluginDetailsModal({
@@ -38,6 +39,7 @@ export function PluginDetailsModal({
   onClose,
   onUse,
   isApplying,
+  hideUseAction,
 }: Props) {
   const preview = inferPluginPreview(record);
   let detail: JSX.Element;
@@ -49,6 +51,7 @@ export function PluginDetailsModal({
         onClose={onClose}
         onUse={onUse}
         isApplying={isApplying}
+        hideUseAction={hideUseAction}
       />
     );
   } else if (preview.kind === 'html') {
@@ -61,6 +64,7 @@ export function PluginDetailsModal({
         onClose={onClose}
         onUse={onUse}
         isApplying={isApplying}
+        hideUseAction={hideUseAction}
       />
     );
   } else if (preview.kind === 'design') {
@@ -70,6 +74,7 @@ export function PluginDetailsModal({
         onClose={onClose}
         onUse={onUse}
         isApplying={isApplying}
+        hideUseAction={hideUseAction}
       />
     );
   } else {
@@ -79,6 +84,7 @@ export function PluginDetailsModal({
         onClose={onClose}
         onUse={onUse}
         isApplying={isApplying}
+        hideUseAction={hideUseAction}
       />
     );
   }

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5654,6 +5654,7 @@ export function ProjectView({
           onClose={() => setContextPluginDetails(null)}
           onUse={() => setContextPluginDetails(null)}
           isApplying={false}
+          hideUseAction
         />
       ) : null}
       {contextDesignSystemDetails ? (

--- a/apps/web/src/components/plugin-details/PluginDesignSystemDetail.tsx
+++ b/apps/web/src/components/plugin-details/PluginDesignSystemDetail.tsx
@@ -32,6 +32,7 @@ interface Props {
   onClose: () => void;
   onUse: (record: InstalledPluginRecord) => void;
   isApplying?: boolean;
+  hideUseAction?: boolean;
 }
 
 interface ContextRef {
@@ -64,6 +65,7 @@ export function PluginDesignSystemDetail({
   onClose,
   onUse,
   isApplying,
+  hideUseAction,
 }: Props) {
   const { t, locale } = useI18n();
   const localizedTitle = localizePluginTitle(locale, record);
@@ -171,13 +173,15 @@ export function PluginDesignSystemDetail({
           </div>
         ),
       }}
-      primaryAction={{
-        label: 'Use plugin',
-        onClick: () => onUse(record),
-        busy: !!isApplying,
-        busyLabel: 'Applying…',
-        testId: `plugin-details-use-${record.id}`,
-      }}
+      primaryAction={hideUseAction
+        ? undefined
+        : {
+            label: 'Use plugin',
+            onClick: () => onUse(record),
+            busy: !!isApplying,
+            busyLabel: 'Applying…',
+            testId: `plugin-details-use-${record.id}`,
+          }}
       headerExtras={<PluginShareMenu record={record} variant="inline" />}
     />
   );

--- a/apps/web/src/components/plugin-details/PluginExampleDetail.tsx
+++ b/apps/web/src/components/plugin-details/PluginExampleDetail.tsx
@@ -25,6 +25,7 @@ interface Props {
   onClose: () => void;
   onUse: (record: InstalledPluginRecord) => void;
   isApplying?: boolean;
+  hideUseAction?: boolean;
 }
 
 export function PluginExampleDetail({
@@ -33,6 +34,7 @@ export function PluginExampleDetail({
   onClose,
   onUse,
   isApplying,
+  hideUseAction,
 }: Props) {
   const { t, locale } = useI18n();
   const localizedTitle = localizePluginTitle(locale, record);
@@ -139,13 +141,15 @@ export function PluginExampleDetail({
           </div>
         ),
       }}
-      primaryAction={{
-        label: 'Use plugin',
-        onClick: () => onUse(record),
-        busy: !!isApplying,
-        busyLabel: 'Applying…',
-        testId: `plugin-details-use-${record.id}`,
-      }}
+      primaryAction={hideUseAction
+        ? undefined
+        : {
+            label: 'Use plugin',
+            onClick: () => onUse(record),
+            busy: !!isApplying,
+            busyLabel: 'Applying…',
+            testId: `plugin-details-use-${record.id}`,
+          }}
       hideSidebarToggle
     />
   );

--- a/apps/web/src/components/plugin-details/PluginMediaDetail.tsx
+++ b/apps/web/src/components/plugin-details/PluginMediaDetail.tsx
@@ -26,6 +26,7 @@ interface Props {
   onClose: () => void;
   onUse: (record: InstalledPluginRecord) => void;
   isApplying?: boolean;
+  hideUseAction?: boolean;
 }
 
 interface MediaPreview {
@@ -76,6 +77,7 @@ export function PluginMediaDetail({
   onClose,
   onUse,
   isApplying,
+  hideUseAction,
 }: Props) {
   const t = useT();
   const [copied, setCopied] = useState(false);
@@ -222,13 +224,15 @@ export function PluginMediaDetail({
         contentKey: record.id,
         content: sidebar,
       }}
-      primaryAction={{
-        label: 'Use plugin',
-        onClick: () => onUse(record),
-        busy: !!isApplying,
-        busyLabel: 'Applying…',
-        testId: `plugin-details-use-${record.id}`,
-      }}
+      primaryAction={hideUseAction
+        ? undefined
+        : {
+            label: 'Use plugin',
+            onClick: () => onUse(record),
+            busy: !!isApplying,
+            busyLabel: 'Applying…',
+            testId: `plugin-details-use-${record.id}`,
+          }}
       headerExtras={<PluginShareMenu record={record} variant="inline" />}
     />
   );

--- a/apps/web/src/components/plugin-details/PluginScenarioDetail.tsx
+++ b/apps/web/src/components/plugin-details/PluginScenarioDetail.tsx
@@ -23,6 +23,7 @@ interface Props {
   onClose: () => void;
   onUse: (record: InstalledPluginRecord) => void;
   isApplying?: boolean;
+  hideUseAction?: boolean;
 }
 
 export function PluginScenarioDetail({
@@ -30,6 +31,7 @@ export function PluginScenarioDetail({
   onClose,
   onUse,
   isApplying,
+  hideUseAction,
 }: Props) {
   const closeRef = useRef<HTMLButtonElement | null>(null);
 
@@ -135,20 +137,22 @@ export function PluginScenarioDetail({
           >
             Close
           </button>
-          <button
-            type="button"
-            className="plugin-details-modal__primary"
-            onClick={() => onUse(record)}
-            disabled={isApplying}
-            aria-busy={isApplying ? 'true' : undefined}
-            data-testid={`plugin-details-use-${record.id}`}
-          >
-            {isApplying
-              ? 'Applying…'
-              : query
-                ? 'Use example query'
-                : 'Use plugin'}
-          </button>
+          {hideUseAction ? null : (
+            <button
+              type="button"
+              className="plugin-details-modal__primary"
+              onClick={() => onUse(record)}
+              disabled={isApplying}
+              aria-busy={isApplying ? 'true' : undefined}
+              data-testid={`plugin-details-use-${record.id}`}
+            >
+              {isApplying
+                ? 'Applying…'
+                : query
+                  ? 'Use example query'
+                  : 'Use plugin'}
+            </button>
+          )}
         </footer>
       </div>
     </div>

--- a/apps/web/tests/components/PluginDetailsModal.dispatch.test.tsx
+++ b/apps/web/tests/components/PluginDetailsModal.dispatch.test.tsx
@@ -74,10 +74,18 @@ function make(args: MakeArgs): InstalledPluginRecord {
   };
 }
 
-function render(record: InstalledPluginRecord): string {
+function render(
+  record: InstalledPluginRecord,
+  options: { hideUseAction?: boolean } = {},
+): string {
   return renderToStaticMarkup(
     <I18nProvider>
-      <PluginDetailsModal record={record} onClose={() => {}} onUse={() => {}} />
+      <PluginDetailsModal
+        record={record}
+        onClose={() => {}}
+        onUse={() => {}}
+        hideUseAction={options.hideUseAction}
+      />
     </I18nProvider>,
   );
 }
@@ -161,6 +169,20 @@ describe('PluginDetailsModal dispatch', () => {
     expect(html).not.toContain('plugin-share-live-dashboard');
   });
 
+  it('can hide the use action for conversation-context plugin previews', () => {
+    const record = make({
+      id: 'chat-context-preview',
+      title: 'Chat Context Preview',
+      preview: { type: 'html', entry: './example.html' },
+    });
+
+    const html = render(record, { hideUseAction: true });
+
+    expect(html).toContain('ds-modal');
+    expect(html).not.toContain('plugin-details-use-chat-context-preview');
+    expect(html).not.toContain('Use plugin');
+  });
+
   it('routes design-system plugins to the showcase + DESIGN.md surface (with share menu)', () => {
     const html = render(
       make({
@@ -189,6 +211,19 @@ describe('PluginDetailsModal dispatch', () => {
     expect(html).toContain('data-detail-variant="scenario"');
     expect(html).toContain('plugin-details-modal__title');
     expect(html).toContain('plugin-share-plain-scenario');
+  });
+
+  it('keeps the use action by default outside conversation context', () => {
+    const html = render(
+      make({
+        id: 'outside-chat',
+        title: 'Outside Chat',
+        preview: { type: 'html', entry: './example.html' },
+      }),
+    );
+
+    expect(html).toContain('plugin-details-use-outside-chat');
+    expect(html).toContain('Use plugin');
   });
 });
 


### PR DESCRIPTION
## Why

While checking a design conversation, the referenced plugin preview modal still exposed `Use plugin`. In that context the plugin is already part of the current conversation, so the CTA is confusing and can look broken or redundant.

## What users will see

When users open a plugin preview from the chat/session context, the modal now behaves as a read-only preview with share and close actions only. Plugin detail modals opened outside chat, such as Home or Plugins, still show `Use plugin`.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Verified locally in the desktop app: the chat-context plugin preview no longer renders `Use plugin`, while share and close remain available.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/PluginDetailsModal.dispatch.test.tsx`
- Did the test go red on `main` and green on this branch? no; the regression was covered at the shared modal contract level after identifying the chat-context entry points.
- Manual verification: confirmed in the local desktop app that chat-context plugin previews hide `Use plugin`.

## Validation

- `pnpm install`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/PluginDetailsModal.dispatch.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
