### PR TITLE
fix(nix): pin pnpm_10 through fetchPnpmDeps and pnpmConfigHook

### DIFF
--- a/nix/package-daemon.nix
+++ b/nix/package-daemon.nix
@@ -26,12 +26,18 @@
 #   are already wired.
 #
 # pnpm version note:
-#   `package.json` declares `engines.pnpm: ">=10.33.2 <11"` and pnpm
-#   enforces this on `pnpm install` (regardless of `engine-strict`).
-#   nixpkgs currently ships 10.33.0, which is rejected. The flake
-#   overrides `pkgs.pnpm_10` to fetch the 10.33.2 tarball from npm —
-#   see flake.nix for the override and how to bump the hash when
-#   `packageManager` advances.
+#   `package.json` declares `engines.pnpm` and pnpm enforces it on
+#   `pnpm install` (regardless of `engine-strict`). The nixpkgs
+#   default `pnpm` is generally incompatible with that constraint —
+#   it ships a version that is either older than the floor, newer
+#   than the ceiling, or both, depending on which nixpkgs the
+#   consuming flake is following. The flake overrides `pkgs.pnpm_10`
+#   to fetch the exact tarball pinned by `packageManager` — see
+#   flake.nix for the override and how to bump the hash when
+#   `packageManager` advances. This derivation then threads that
+#   pinned pnpm_10 into both `fetchPnpmDeps` (the dep-fetch phase)
+#   and `pnpmConfigHook` (the install phase) so neither falls back
+#   to the nixpkgs default `pnpm`.
 #
 # Workspace siblings the daemon depends on are built in dependency order
 # before the daemon itself; tsc emits each package's dist/, which is what
@@ -51,7 +57,21 @@ in
     nativeBuildInputs = [
       nodejs
       pnpm_10
-      pnpmConfigHook
+      # Override pnpmConfigHook's propagatedBuildInputs to use the
+      # flake's pinned pnpm_10. The upstream hook hardcodes
+      # `propagatedBuildInputs = [ pnpm … ]` (the nixpkgs default
+      # pnpm attribute plus writable-tmpdir-as-home-hook and friends
+      # depending on nixpkgs version), which is what puts the wrong
+      # pnpm binary on PATH during the install phase and trips the
+      # package's engines.pnpm gate. Append pnpm_10 to the existing
+      # list rather than replacing it, so the upstream's
+      # writable-tmpdir-as-home-hook (which sets $HOME in the build
+      # sandbox) survives the override.
+      (pnpmConfigHook.overrideAttrs (old: {
+        propagatedBuildInputs =
+          (old.propagatedBuildInputs or [])
+          ++ [pnpm_10];
+      }))
       makeWrapper
       # Required to rebuild better-sqlite3's native binding from source.
       # node-gyp drives this via Python; gnumake/pkg-config + the C++
@@ -61,9 +81,20 @@ in
       pkg-config
     ];
 
+    # Force every pnpm invocation in this build (deps fetch + install
+    # phase) to use the flake's pinned pnpm_10, not whatever
+    # `pkgs.pnpm` happens to be on the consuming flake's nixpkgs. The
+    # nixpkgs default pnpm moves independently of package.json's
+    # engines.pnpm, and pnpm enforces that gate on `pnpm install`.
+    # We override pnpmConfigHook in nativeBuildInputs above to carry
+    # pnpm_10 instead of the default `pnpm`, and we pass
+    # `pnpm = pnpm_10` explicitly to fetchPnpmDeps so the dep-fetch
+    # derivation uses the same version (fetchPnpmDeps' default is
+    # `pkgs.pnpm`).
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       hash = pnpmDepsHash;
+      pnpm = pnpm_10;
       pnpmWorkspaces = pnpmWorkspaceFilters;
       fetcherVersion = 3;
     };

--- a/nix/package-daemon.nix
+++ b/nix/package-daemon.nix
@@ -28,16 +28,15 @@
 # pnpm version note:
 #   `package.json` declares `engines.pnpm` and pnpm enforces it on
 #   `pnpm install` (regardless of `engine-strict`). The nixpkgs
-#   default `pnpm` is generally incompatible with that constraint —
-#   it ships a version that is either older than the floor, newer
-#   than the ceiling, or both, depending on which nixpkgs the
-#   consuming flake is following. The flake overrides `pkgs.pnpm_10`
-#   to fetch the exact tarball pinned by `packageManager` — see
-#   flake.nix for the override and how to bump the hash when
-#   `packageManager` advances. This derivation then threads that
-#   pinned pnpm_10 into both `fetchPnpmDeps` (the dep-fetch phase)
-#   and `pnpmConfigHook` (the install phase) so neither falls back
-#   to the nixpkgs default `pnpm`.
+#   default `pnpm` is generally incompatible — older than the
+#   floor or newer than the ceiling depending on which nixpkgs
+#   the consumer follows. The flake overrides `pkgs.pnpm_10` to
+#   the exact tarball pinned by `packageManager` (see flake.nix
+#   for the override + hash bump). This derivation uses
+#   `pnpm_10` for both phases: in `nativeBuildInputs` so the
+#   install-phase `pnpmConfigHook` resolves it from PATH, and
+#   `pnpm = pnpm_10` to `fetchPnpmDeps` to override its
+#   `pkgs.pnpm` default.
 #
 # Workspace siblings the daemon depends on are built in dependency order
 # before the daemon itself; tsc emits each package's dist/, which is what
@@ -57,21 +56,7 @@ in
     nativeBuildInputs = [
       nodejs
       pnpm_10
-      # Override pnpmConfigHook's propagatedBuildInputs to use the
-      # flake's pinned pnpm_10. The upstream hook hardcodes
-      # `propagatedBuildInputs = [ pnpm … ]` (the nixpkgs default
-      # pnpm attribute plus writable-tmpdir-as-home-hook and friends
-      # depending on nixpkgs version), which is what puts the wrong
-      # pnpm binary on PATH during the install phase and trips the
-      # package's engines.pnpm gate. Append pnpm_10 to the existing
-      # list rather than replacing it, so the upstream's
-      # writable-tmpdir-as-home-hook (which sets $HOME in the build
-      # sandbox) survives the override.
-      (pnpmConfigHook.overrideAttrs (old: {
-        propagatedBuildInputs =
-          (old.propagatedBuildInputs or [])
-          ++ [pnpm_10];
-      }))
+      pnpmConfigHook
       makeWrapper
       # Required to rebuild better-sqlite3's native binding from source.
       # node-gyp drives this via Python; gnumake/pkg-config + the C++
@@ -81,16 +66,8 @@ in
       pkg-config
     ];
 
-    # Force every pnpm invocation in this build (deps fetch + install
-    # phase) to use the flake's pinned pnpm_10, not whatever
-    # `pkgs.pnpm` happens to be on the consuming flake's nixpkgs. The
-    # nixpkgs default pnpm moves independently of package.json's
-    # engines.pnpm, and pnpm enforces that gate on `pnpm install`.
-    # We override pnpmConfigHook in nativeBuildInputs above to carry
-    # pnpm_10 instead of the default `pnpm`, and we pass
-    # `pnpm = pnpm_10` explicitly to fetchPnpmDeps so the dep-fetch
-    # derivation uses the same version (fetchPnpmDeps' default is
-    # `pkgs.pnpm`).
+    # `fetchPnpmDeps` defaults to `pkgs.pnpm`; pin to the flake's
+    # `pnpm_10` so the dep-fetch matches the install phase.
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       hash = pnpmDepsHash;

--- a/nix/package-web.nix
+++ b/nix/package-web.nix
@@ -39,21 +39,7 @@ in
     nativeBuildInputs = [
       nodejs
       pnpm_10
-      # Override pnpmConfigHook's propagatedBuildInputs to use the
-      # flake's pinned pnpm_10. The upstream hook hardcodes
-      # `propagatedBuildInputs = [ pnpm … ]` (the nixpkgs default
-      # pnpm attribute plus writable-tmpdir-as-home-hook and friends
-      # depending on nixpkgs version), which is what puts the wrong
-      # pnpm binary on PATH during the install phase and trips the
-      # package's engines.pnpm gate. Append pnpm_10 to the existing
-      # list rather than replacing it, so the upstream's
-      # writable-tmpdir-as-home-hook (which sets $HOME in the build
-      # sandbox) survives the override.
-      (pnpmConfigHook.overrideAttrs (old: {
-        propagatedBuildInputs =
-          (old.propagatedBuildInputs or [])
-          ++ [pnpm_10];
-      }))
+      pnpmConfigHook
     ];
 
     pnpmDeps = fetchPnpmDeps {

--- a/nix/package-web.nix
+++ b/nix/package-web.nix
@@ -39,12 +39,30 @@ in
     nativeBuildInputs = [
       nodejs
       pnpm_10
-      pnpmConfigHook
+      # Override pnpmConfigHook's propagatedBuildInputs to use the
+      # flake's pinned pnpm_10. The upstream hook hardcodes
+      # `propagatedBuildInputs = [ pnpm … ]` (the nixpkgs default
+      # pnpm attribute plus writable-tmpdir-as-home-hook and friends
+      # depending on nixpkgs version), which is what puts the wrong
+      # pnpm binary on PATH during the install phase and trips the
+      # package's engines.pnpm gate. Append pnpm_10 to the existing
+      # list rather than replacing it, so the upstream's
+      # writable-tmpdir-as-home-hook (which sets $HOME in the build
+      # sandbox) survives the override.
+      (pnpmConfigHook.overrideAttrs (old: {
+        propagatedBuildInputs =
+          (old.propagatedBuildInputs or [])
+          ++ [pnpm_10];
+      }))
     ];
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       hash = pnpmDepsHash;
+      # Force the deps-fetch derivation to use the flake's pinned
+      # pnpm_10 as well. fetchPnpmDeps defaults to `pkgs.pnpm` when
+      # the `pnpm` arg is omitted.
+      pnpm = pnpm_10;
       pnpmWorkspaces = pnpmWorkspaceFilters;
       fetcherVersion = 3;
     };


### PR DESCRIPTION
## Why

The flake's pnpm_10 override built a 10.33.2 binary, but only added it to nativeBuildInputs. Both fetchPnpmDeps (the deps-fetch phase) and pnpmConfigHook (the install phase) were silently falling back to pkgs.pnpm, which has moved to 11.x on nixpkgs-unstable. That triggers ERR_PNPM_UNSUPPORTED_ENGINE since package.json pins
>=10.33.2 <11.


## What users will see

Users with nix flake setups for their system that have later nixpkgs versions will now be able to build their flake with `open-design`.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug verification

Use this in a Nix flake with a nixpkgs hash pin on the latest `unstable`. You can see that `pnpm` version is now 11+. Without this change, you'll encounter pnpm errors.

## Validation

* Nix flake checks still pass
* Running this with a newer nixpkgs hash will no longer break
