### PR TITLE
fix(plugins): pin the Motion React UMD loader in motionsites plugins (follow-up to #3973)

### DIFF
--- a/apps/daemon/src/artifact-runtime-compat.ts
+++ b/apps/daemon/src/artifact-runtime-compat.ts
@@ -3,11 +3,26 @@ import { Buffer } from 'node:buffer';
 const HTML_EXTENSION = /\.html?$/iu;
 const MOTION_REACT_HOOK_USAGE =
   /\bMotion\b[\s\S]*\b(?:useScroll|useTransform|useMotionTemplate|useMotionValue|useAnimationFrame)\b|\b(?:useScroll|useTransform|useMotionTemplate|useMotionValue|useAnimationFrame)\s*\(/u;
-const VANILLA_MOTION_UMD_SCRIPT =
-  /<script\b[^>]*\bsrc=(["'])https:\/\/unpkg\.com\/motion@([^/"']+)\/dist\/motion(?:\.min)?\.js\1[^>]*>\s*<\/script>/giu;
-const MOTION_UMD_SRC = /https:\/\/unpkg\.com\/motion@([^/"']+)\/dist\/motion(?:\.min)?\.js/iu;
-const FRAMER_MOTION_UMD_SCRIPT =
-  /<script\b[^>]*\bsrc=(["'])https:\/\/unpkg\.com\/framer-motion@([^/"']+)\/dist\/framer-motion(?:\.min)?\.js\1[^>]*>\s*<\/script>/iu;
+// Boundary: this normalizer only repairs the `<script src=...>` UMD shape served by unpkg/jsdelivr —
+// the vanilla `dist/motion.js` DOM bundle (`Motion.animate`), which has none of the React hooks. It does
+// NOT touch ESM `import`s, importmaps, esm.sh module URLs, or other CDNs; those paths are steered by the
+// official system prompt and the per-plugin "Motion loading (locked)" notes, not rewritten here. The
+// MOTION_REACT_HOOK_USAGE gate keeps legitimate vanilla DOM artifacts (animate-only, no hooks) untouched.
+const CDN_HOST = String.raw`https:\/\/(?:unpkg\.com|cdn\.jsdelivr\.net\/npm)`;
+// Wrong bundle = any package path (`motion@` or even `framer-motion@`) ending in the vanilla `dist/motion.js`
+// file. The correct `dist/framer-motion.js` file is never matched (it does not end in `/dist/motion.js`).
+const VANILLA_MOTION_UMD_SCRIPT = new RegExp(
+  String.raw`<script\b[^>]*\bsrc=(["'])${CDN_HOST}\/(?:framer-)?motion@[^/"']+\/dist\/motion(?:\.min)?\.js\1[^>]*>\s*<\/script>`,
+  'giu',
+);
+const MOTION_UMD_SRC = new RegExp(
+  String.raw`(${CDN_HOST}\/)(?:framer-)?motion@([^/"']+)\/dist\/motion(?:\.min)?\.js`,
+  'iu',
+);
+const FRAMER_MOTION_UMD_SCRIPT = new RegExp(
+  String.raw`<script\b[^>]*\bsrc=(["'])${CDN_HOST}\/framer-motion@[^/"']+\/dist\/framer-motion(?:\.min)?\.js\1[^>]*>\s*<\/script>`,
+  'iu',
+);
 const FRAMER_MOTION_GLOBAL_USAGE = /\bFramerMotion\b/u;
 const FRAMER_MOTION_ALIAS = '<script>window.FramerMotion = window.FramerMotion || window.Motion;</script>';
 const INTEGRITY_ATTR = /\s+integrity=(["'])[^"']*\1/iu;
@@ -18,9 +33,9 @@ export function normalizeArtifactRuntimeImports(name: string, body: unknown): un
   if (text === null) return body;
   if (!MOTION_REACT_HOOK_USAGE.test(text) && !FRAMER_MOTION_GLOBAL_USAGE.test(text)) return body;
 
-  let normalized = text.replace(VANILLA_MOTION_UMD_SCRIPT, (tag, _quote, version) => {
+  let normalized = text.replace(VANILLA_MOTION_UMD_SCRIPT, (tag) => {
     return tag
-      .replace(MOTION_UMD_SRC, `https://unpkg.com/framer-motion@${version}/dist/framer-motion.js`)
+      .replace(MOTION_UMD_SRC, (_src, host: string, version: string) => `${host}framer-motion@${version}/dist/framer-motion.js`)
       .replace(INTEGRITY_ATTR, '');
   });
   if (FRAMER_MOTION_GLOBAL_USAGE.test(normalized) && !normalized.includes(FRAMER_MOTION_ALIAS)) {

--- a/apps/daemon/src/prompts/official-system.ts
+++ b/apps/daemon/src/prompts/official-system.ts
@@ -79,12 +79,10 @@ When writing React prototypes with inline JSX, use these exact pinned versions a
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 \`\`\`
 
-If you use Framer Motion / Motion React APIs in inline JSX — \`motion\`, \`useScroll\`, \`useTransform\`, \`useMotionTemplate\`, \`useMotionValue\`, or \`useAnimationFrame\` — load the React UMD bundle:
+**Framer Motion / Motion React hooks.** The \`motion\` package ships two UMD builds: \`dist/motion.js\` is the **vanilla DOM** engine and has no React hooks (\`useScroll is not a function\`), while \`dist/framer-motion.js\` is the **React** build that exposes the hooks on \`window.Motion\`. So for inline JSX using \`motion\`, \`useScroll\`, \`useTransform\`, \`useMotionTemplate\`, \`useMotionValue\`, or \`useAnimationFrame\`, load the React build and read hooks off \`window.Motion\` (the global is \`Motion\`, not \`FramerMotion\`):
 \`\`\`html
 <script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>
 \`\`\`
-It exposes \`window.Motion\` with React hooks. Do not use \`https://unpkg.com/motion@.../dist/motion.js\` for React hooks; that is the vanilla DOM animation bundle and will crash with \`useScroll is not a function\`.
-When destructuring from this UMD bundle, use \`Motion\` as the global name, not \`FramerMotion\`.
 
 **CRITICAL — style-object naming.** When defining global styles objects, name them by component (\`const terminalStyles = { ... }\`). NEVER write a bare \`const styles = { ... }\` — multiple files with the same name break the page. Inline styles are fine too.
 

--- a/apps/daemon/tests/artifact-runtime-compat.test.ts
+++ b/apps/daemon/tests/artifact-runtime-compat.test.ts
@@ -127,4 +127,38 @@ describe('artifact runtime compatibility normalizer', () => {
     expect(normalized).not.toContain('/dist/motion.js');
     expect(normalized).toContain('window.FramerMotion = window.FramerMotion || window.Motion;');
   });
+
+  it('repairs the right package name but wrong file (framer-motion@.../dist/motion.js)', () => {
+    const html = brokenReactMotionHtml.replace(
+      'https://unpkg.com/motion@11.11.13/dist/motion.js',
+      'https://unpkg.com/framer-motion@11.11.13/dist/motion.js',
+    );
+
+    const normalized = normalizeArtifactRuntimeImports('landing.html', html) as string;
+
+    expect(normalized).toContain('https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js');
+    expect(normalized).not.toContain('/dist/motion.js');
+  });
+
+  it('repairs the vanilla bundle served from jsdelivr and preserves the host', () => {
+    const html = brokenReactMotionHtml.replace(
+      'https://unpkg.com/motion@11.11.13/dist/motion.js',
+      'https://cdn.jsdelivr.net/npm/motion@11.11.13/dist/motion.js',
+    );
+
+    const normalized = normalizeArtifactRuntimeImports('landing.html', html) as string;
+
+    expect(normalized).toContain('https://cdn.jsdelivr.net/npm/framer-motion@11.11.13/dist/framer-motion.js');
+    expect(normalized).not.toContain('/dist/motion.js');
+  });
+
+  it('leaves the correct framer-motion.js bundle untouched (no false rewrite)', () => {
+    const html = brokenReactMotionHtml.replace(
+      'https://unpkg.com/motion@11.11.13/dist/motion.js',
+      'https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js',
+    );
+
+    // Already correct → returned verbatim (idempotent), the vanilla-file matcher must not touch it.
+    expect(normalizeArtifactRuntimeImports('landing.html', html)).toBe(html);
+  });
 });

--- a/apps/daemon/tests/artifact-runtime-compat.test.ts
+++ b/apps/daemon/tests/artifact-runtime-compat.test.ts
@@ -74,4 +74,57 @@ describe('artifact runtime compatibility normalizer', () => {
       await rm(projectsRoot, { recursive: true, force: true });
     }
   });
+
+  // Port-path regression coverage for the reported luxury-botanical plugin. Its React port leans on
+  // the full Motion hook set (useScroll/useTransform/useAnimationFrame/useMotionValue), which only the
+  // framer-motion React UMD build exposes. A single-file prototype that reaches for the vanilla
+  // motion.js DOM bundle throws `useScroll is not a function` and renders blank — this is the artifact
+  // the normalizer must repair at the write boundary.
+  const luxuryBotanicalOrbitHtml = `<!doctype html>
+<html>
+  <head>
+    <script src="https://unpkg.com/motion@11.11.13/dist/motion.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      const { motion, useScroll, useTransform, useAnimationFrame, useMotionValue } = Motion;
+      function OrbitImages() {
+        const { scrollYProgress } = useScroll({ offset: ['start start', 'end end'] });
+        const progress = useMotionValue(0);
+        const radius = useTransform(scrollYProgress, [0.15, 0.25], [330, 650]);
+        useAnimationFrame(() => progress.set(progress.get() + 0.4));
+        return <motion.div style={{ '--r': radius }} />;
+      }
+    </script>
+  </body>
+</html>`;
+
+  it('repairs the luxury-botanical orbit prototype that uses the full Motion hook set', () => {
+    const normalized = normalizeArtifactRuntimeImports('beyond-the-collection.html', luxuryBotanicalOrbitHtml) as string;
+
+    expect(normalized).toContain('https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js');
+    expect(normalized).not.toContain('/dist/motion.js');
+    // The destructured `Motion` global now resolves to the React build that actually carries the hooks.
+    expect(normalized).toContain('useAnimationFrame');
+  });
+
+  it('rewrites the minified vanilla Motion bundle as well', () => {
+    const html = brokenReactMotionHtml.replace('dist/motion.js', 'dist/motion.min.js');
+
+    const normalized = normalizeArtifactRuntimeImports('landing.html', html) as string;
+
+    expect(normalized).toContain('https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js');
+    expect(normalized).not.toContain('/dist/motion.min.js');
+  });
+
+  it('repairs a prototype that loads the wrong bundle and reads the FramerMotion global', () => {
+    const html = brokenReactMotionHtml.replace('const { motion, useScroll, useTransform } = Motion;', 'const { motion, useScroll, useTransform } = FramerMotion;');
+
+    const normalized = normalizeArtifactRuntimeImports('landing.html', html) as string;
+
+    expect(normalized).toContain('https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js');
+    expect(normalized).not.toContain('/dist/motion.js');
+    expect(normalized).toContain('window.FramerMotion = window.FramerMotion || window.Motion;');
+  });
 });

--- a/packages/contracts/src/prompts/official-system.ts
+++ b/packages/contracts/src/prompts/official-system.ts
@@ -75,12 +75,10 @@ When writing React prototypes with inline JSX, use these exact pinned versions a
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 \`\`\`
 
-If you use Framer Motion / Motion React APIs in inline JSX — \`motion\`, \`useScroll\`, \`useTransform\`, \`useMotionTemplate\`, \`useMotionValue\`, or \`useAnimationFrame\` — load the React UMD bundle:
+**Framer Motion / Motion React hooks.** The \`motion\` package ships two UMD builds: \`dist/motion.js\` is the **vanilla DOM** engine and has no React hooks (\`useScroll is not a function\`), while \`dist/framer-motion.js\` is the **React** build that exposes the hooks on \`window.Motion\`. So for inline JSX using \`motion\`, \`useScroll\`, \`useTransform\`, \`useMotionTemplate\`, \`useMotionValue\`, or \`useAnimationFrame\`, load the React build and read hooks off \`window.Motion\` (the global is \`Motion\`, not \`FramerMotion\`):
 \`\`\`html
 <script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>
 \`\`\`
-It exposes \`window.Motion\` with React hooks. Do not use \`https://unpkg.com/motion@.../dist/motion.js\` for React hooks; that is the vanilla DOM animation bundle and will crash with \`useScroll is not a function\`.
-When destructuring from this UMD bundle, use \`Motion\` as the global name, not \`FramerMotion\`.
 
 **CRITICAL — style-object naming.** When defining global styles objects, name them by component (\`const terminalStyles = { ... }\`). NEVER write a bare \`const styles = { ... }\` — multiple files with the same name break the page. Inline styles are fine too.
 

--- a/plugins/_official/examples/3d-creator-portfolio/SKILL.md
+++ b/plugins/_official/examples/3d-creator-portfolio/SKILL.md
@@ -25,6 +25,7 @@ This is the authoritative build brief. Follow it exactly — the named colors, g
 
 - Default output: a single self-contained HTML file (the `example.html` seed) using vanilla CSS + JS. It already includes everything inline.
 - If the user explicitly asks for the React project: port the seed faithfully to **React 18 + TypeScript + Vite + Tailwind CSS + Framer Motion + lucide-react**. Same tokens, same markup structure, same animations. Section order: `HeroSection → MarqueeSection → AboutSection → ServicesSection → ProjectsSection → ContactSection (footer)`. Do not change the design while porting.
+- **Motion loading (locked).** If you emit a single self-contained inline-JSX file instead of the Vite project, Motion's React hooks (`useScroll`, `useTransform`, `useAnimationFrame`, …) exist only in the **React** UMD build: load `<script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>` and read them off `window.Motion` — never the vanilla `https://unpkg.com/motion@.../dist/motion.js` DOM bundle, which lacks `useScroll` and renders a blank page. (The Vite project imports from npm and is unaffected.)
 
 ## Global styles — locked
 

--- a/plugins/_official/examples/acreage-farming/SKILL.md
+++ b/plugins/_official/examples/acreage-farming/SKILL.md
@@ -23,6 +23,7 @@ This is the authoritative build brief. Follow it exactly — the named colors, r
 
 - Default output: a single self-contained HTML file (the `example.html` seed). It already includes everything inline.
 - If the user explicitly asks for a **React + TypeScript + Vite + Tailwind** project, port the seed faithfully: same tokens, same section order, same markup structure. Map vanilla features back up: the `IntersectionObserver` reveal → Framer-Motion `whileInView`; the passive scroll listener that toggles `.scrolled` on the nav → `useScroll`; the CSS marquee → a Framer-Motion loop or duplicated-track CSS keyframe. Do not change the design while porting.
+- **Motion loading (locked).** If you emit a single self-contained inline-JSX file instead of the Vite project, Motion's React hooks (`useScroll`, `useTransform`, `useAnimationFrame`, …) exist only in the **React** UMD build: load `<script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>` and read them off `window.Motion` — never the vanilla `https://unpkg.com/motion@.../dist/motion.js` DOM bundle, which lacks `useScroll` and renders a blank page. (The Vite project imports from npm and is unaffected.)
 
 ## Fonts
 

--- a/plugins/_official/examples/evergreen-finance/SKILL.md
+++ b/plugins/_official/examples/evergreen-finance/SKILL.md
@@ -23,6 +23,7 @@ This is the authoritative build brief. Follow it exactly — the named colors, f
 
 - Default output: the single self-contained `example.html` seed (vanilla HTML/CSS/JS). It already includes everything inline.
 - If the user explicitly asks for a **React + TypeScript + Vite + Tailwind + Framer Motion** project, port the seed faithfully: same tokens, same markup structure, same section order. Use `lucide-react` for icons and `framer-motion` for the FadeUp reveals. Do not change the design while porting.
+- **Motion loading (locked).** If you emit a single self-contained inline-JSX file instead of the Vite project, Motion's React hooks (`useScroll`, `useTransform`, `useAnimationFrame`, …) exist only in the **React** UMD build: load `<script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>` and read them off `window.Motion` — never the vanilla `https://unpkg.com/motion@.../dist/motion.js` DOM bundle, which lacks `useScroll` and renders a blank page. (The Vite project imports from npm and is unaffected.)
 - Dependencies for the React port: `framer-motion ^12.38.0`, `lucide-react ^0.344.0`, `react ^18.3.1`, `react-dom ^18.3.1`; dev: Vite, Tailwind CSS 3, TypeScript, PostCSS, Autoprefixer.
 
 ## Fonts (locked)

--- a/plugins/_official/examples/liquid-glass-agency/SKILL.md
+++ b/plugins/_official/examples/liquid-glass-agency/SKILL.md
@@ -25,6 +25,7 @@ This is the authoritative build brief. Follow it exactly — the named CSS varia
 
 - Default output: the single self-contained `example.html` seed (vanilla HTML/CSS/JS). It already includes everything inline.
 - If the user explicitly asks for a React + Vite + Tailwind + shadcn/ui + Framer Motion (`motion/react`) project, port the seed faithfully: same tokens, same section structure, `lucide-react` for icons, Instrument Serif + Barlow from Google Fonts. Do not change the design while porting. Key deps for the React port: `motion ^12.35.0`, `hls.js ^1.6.15` (for the Mux HLS section videos), `lucide-react ^0.462.0`, `react-router-dom ^6.30.1`.
+- **Motion loading (locked).** If you emit a single self-contained inline-JSX file instead of the Vite project, Motion's React hooks (`useScroll`, `useTransform`, `useAnimationFrame`, …) exist only in the **React** UMD build: load `<script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>` and read them off `window.Motion` — never the vanilla `https://unpkg.com/motion@.../dist/motion.js` DOM bundle, which lacks `useScroll` and renders a blank page. (The Vite project imports from npm and is unaffected.)
 
 ## Fonts
 

--- a/plugins/_official/examples/luxury-botanical/SKILL.md
+++ b/plugins/_official/examples/luxury-botanical/SKILL.md
@@ -23,6 +23,7 @@ This is the authoritative build brief. The named fonts, colors, scroll stops, ra
 
 - Default output: a single self-contained HTML file (the `example.html` seed). It uses **vanilla HTML/CSS/JS** — the scroll engine is one passive `requestAnimationFrame` loop reading `getBoundingClientRect()`, and `whileInView` reveals use an `IntersectionObserver`. Everything is inline.
 - If the user explicitly asks for a **React + TypeScript + Vite + Tailwind** project, port the seed faithfully into **Framer Motion**: the hero stage is a `useScroll({ offset: ["start start","end end"] })` over a `600vh` container with a `sticky top-0 h-screen` child; every animated value maps to a `useTransform`; the orbit carousel is the `OrbitImages` component driven by a `useAnimationFrame` progress value. Same fonts, same colors, same keyframe stops. Do not change the design while porting.
+- **Motion loading (locked).** If you emit a single self-contained inline-JSX file instead of the Vite project, Motion's React hooks (`useScroll`, `useTransform`, `useAnimationFrame`, …) exist only in the **React** UMD build: load `<script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>` and read them off `window.Motion` — never the vanilla `https://unpkg.com/motion@.../dist/motion.js` DOM bundle, which lacks `useScroll` and renders a blank page. (The Vite project imports from npm and is unaffected.)
 
 ## Fonts (Google Fonts, locked)
 

--- a/plugins/_official/examples/mindloop-landing/SKILL.md
+++ b/plugins/_official/examples/mindloop-landing/SKILL.md
@@ -27,6 +27,7 @@ This is the authoritative build brief. Follow it exactly — the HSL variables, 
 
 - Default output: a single self-contained HTML file (the `example.html` seed). It already includes everything inline.
 - If the user explicitly asks for the full project, port the seed faithfully to **React + Vite + TypeScript + Tailwind CSS + shadcn/ui + Framer Motion**. Same tokens, same markup structure. Install `hls.js` and `framer-motion`. Fonts via `@fontsource/inter` (400, 500, 600, 700) and `@fontsource/instrument-serif` (400, 400-italic). `lucide-react` for icons. `tailwindcss-animate` plugin. Do not change the design while porting.
+- **Motion loading (locked).** If you emit a single self-contained inline-JSX file instead of the Vite project, Motion's React hooks (`useScroll`, `useTransform`, `useAnimationFrame`, …) exist only in the **React** UMD build: load `<script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>` and read them off `window.Motion` — never the vanilla `https://unpkg.com/motion@.../dist/motion.js` DOM bundle, which lacks `useScroll` and renders a blank page. (The Vite project imports from npm and is unaffected.)
 
 ## Fonts
 

--- a/plugins/_official/examples/portfolio-cosmic/SKILL.md
+++ b/plugins/_official/examples/portfolio-cosmic/SKILL.md
@@ -25,6 +25,7 @@ This is the authoritative build brief. The named colors, fonts, gradient, animat
 
 - Default output: a single self-contained HTML file (the `example.html` seed). It already inlines everything.
 - If the user explicitly asks for a **React + Vite + Tailwind + TypeScript** project, port the seed faithfully: same tokens, same section structure, **GSAP** for entrance/marquee/ScrollTrigger pin, **Framer Motion** for `whileInView` reveals and role `AnimatePresence`, **hls.js** for the background video. Use `react-router-dom` + `tailwindcss-animate` and add smooth-scroll nav + page transitions. Do not change the design while porting.
+- **Motion loading (locked).** If you emit a single self-contained inline-JSX file instead of the Vite project, Motion's React hooks (`useScroll`, `useTransform`, `useAnimationFrame`, …) exist only in the **React** UMD build: load `<script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>` and read them off `window.Motion` — never the vanilla `https://unpkg.com/motion@.../dist/motion.js` DOM bundle, which lacks `useScroll` and renders a blank page. (The Vite project imports from npm and is unaffected.)
 
 ## Fonts
 

--- a/plugins/_official/examples/shamoni/SKILL.md
+++ b/plugins/_official/examples/shamoni/SKILL.md
@@ -23,6 +23,7 @@ This is the authoritative build brief. The named fonts, colors, video/image URLs
 
 - Default output: a single self-contained HTML file (the `example.html` seed). It already includes everything inline — vanilla HTML/CSS/JS, no build step.
 - If the user explicitly asks for the React project, port the seed faithfully: **React + Vite + Tailwind CSS v4 + `motion/react` (Framer Motion)**, `lucide-react` for icons. Same tokens, same markup structure, same numbers. The vanilla seed maps 1:1 to the React spec below — do not change the design while porting.
+- **Motion loading (locked).** If you emit a single self-contained inline-JSX file instead of the Vite project, Motion's React hooks (`useScroll`, `useTransform`, `useAnimationFrame`, …) exist only in the **React** UMD build: load `<script src="https://unpkg.com/framer-motion@11.11.13/dist/framer-motion.js"></script>` and read them off `window.Motion` — never the vanilla `https://unpkg.com/motion@.../dist/motion.js` DOM bundle, which lacks `useScroll` and renders a blank page. (The Vite project imports from npm and is unaffected.)
 
 ### Framework → vanilla mapping (already done in the seed)
 - `useScroll({ offset: ["start start","end end"] })` → a `getProgress()` reading `scrollRoot.getBoundingClientRect().top` over `(scrollHeight - innerHeight)`, clamped 0..1.


### PR DESCRIPTION
<!-- No issue to close; this is a direct follow-up to #3973. -->

## Why

- **Use case.** Reviewing #3973 (the "Luxury Botanical — Beyond The Collection" blank-screen report) for a teammate. The PR was the right direction but stopped short of the root cause, so I'm closing the remaining gaps so the next motionsites prototype doesn't trip the same wire.
- **The pain.** #3973 patched the symptom (Motion React hooks loaded from the vanilla `motion.js` DOM bundle → `useScroll is not a function` → blank page) at the runtime/write boundary and added a Framer Motion note to the official system prompt. But the actual source of the bug is the plugins: the 25-plugin motionsites batch (#3873) *prescribes* Framer Motion hooks in its React port while locking fonts, colors, and asset URLs — yet never locks how to load the one crash-prone dependency. It left the agent to guess, and it guessed the wrong bundle. The runtime normalizer was also narrow enough that a couple of realistic agent outputs still slipped through.

## What users will see

No visible UI change. Going forward, generated prototypes from the affected example plugins (and any freeform prototype using Framer Motion hooks) are far less likely to render a blank/black screen, because the correct Motion **React** UMD build is now pinned in the plugin briefs, the system-prompt rule reads as a reusable principle, and the runtime repair covers more of the wrong-bundle shapes agents actually emit.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **API / contract**
- [x] **Extension point** — `Motion loading (locked)` note added to 8 `plugins/_official/examples/*` SKILL.md briefs
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

> Note: `packages/contracts/src/prompts/official-system.ts` is edited, but it's the prompt-text twin of the daemon copy (not a DTO/SSE/error shape change), so this isn't an API/contract surface in the review-lane sense.

### What's in here

1. **Plugins (root cause).** Added a `Motion loading (locked)` note to the 8 example plugins that genuinely prescribe Framer Motion — `3d-creator-portfolio`, `acreage-farming`, `evergreen-finance`, `liquid-glass-agency`, `luxury-botanical`, `mindloop-landing`, `portfolio-cosmic`, `shamoni`. The note pins the React UMD build (`window.Motion`, never the vanilla `motion.js`) for the single-file inline-JSX path and notes the Vite path is unaffected. Plugins that only map `useScroll` *down* to a passive listener, or use GSAP exclusively (`cinematic-landing-page` — explicitly "No Framer Motion"), are intentionally left untouched.
2. **System prompt (both copies).** Generalized the note to lead with the principle — the `motion` package ships two UMD builds, vanilla DOM vs React, and the hooks live only on the React build's `window.Motion` — while keeping one pinned example version. Reads as a reusable rule rather than a Framer-specific patch.
3. **Runtime normalizer.** Widened `normalizeArtifactRuntimeImports` beyond the exact unpkg shape to also catch the vanilla bundle served from **jsdelivr** and the **right-package/wrong-file** spelling (`framer-motion@VER/dist/motion.js`), preserving the original CDN host on rewrite. Documented the `<script src>`-only boundary: ESM imports, importmaps, and esm.sh module URLs are steered by the prompt + plugin notes, not rewritten. The React-hook usage gate still keeps animate-only vanilla DOM artifacts untouched.

## Bug fix verification

This is a follow-up hardening rather than a fresh red-spec bug (the original repro shipped in #3973's tests). Coverage added in `apps/daemon/tests/artifact-runtime-compat.test.ts`:

- the luxury-botanical port path with its full hook set (`useScroll` / `useTransform` / `useAnimationFrame` / `useMotionValue`) — uncovered by #3973's test;
- the minified vanilla bundle, the wrong-bundle + `FramerMotion`-global combo;
- the new jsdelivr host and right-package/wrong-file shapes;
- an idempotence guard asserting the **correct** `framer-motion.js` bundle is never falsely rewritten.

All new assertions were written against the widened normalizer and pass; the idempotence guard fails against an over-broad matcher, which is the regression it pins.

## Validation

- `pnpm guard` — 40/40
- `pnpm --filter @open-design/contracts typecheck` + `pnpm --filter @open-design/daemon typecheck` — clean
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/artifact-runtime-compat.test.ts` — 11/11
