### PR TITLE
Add Projects refresh control

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2139,6 +2139,7 @@ function AppInner() {
         onOpenLiveArtifact={handleOpenLiveArtifact}
         onDeleteProject={handleDeleteProject}
         onRenameProject={handleRenameProject}
+        onProjectsRefresh={refreshProjects}
         onChangeDefaultDesignSystem={handleChangeDefaultDesignSystem}
         onCreateDesignSystem={() => navigate({ kind: 'design-system-create' })}
         onOpenDesignSystem={(id: string) => navigate({ kind: 'design-system-detail', designSystemId: id })}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1042,6 +1042,12 @@ function AppInner() {
     reconcileFetchedProjects(list, request);
   }, [beginProjectListRequest, reconcileFetchedProjects]);
 
+  const refreshProjectsStrict = useCallback(async () => {
+    const request = beginProjectListRequest();
+    const list = await listProjects({ throwOnError: true });
+    reconcileFetchedProjects(list, request);
+  }, [beginProjectListRequest, reconcileFetchedProjects]);
+
   const refreshDesignSystems = useCallback(async () => {
     const list = await fetchDesignSystems();
     setDesignSystems(list);
@@ -2139,7 +2145,7 @@ function AppInner() {
         onOpenLiveArtifact={handleOpenLiveArtifact}
         onDeleteProject={handleDeleteProject}
         onRenameProject={handleRenameProject}
-        onProjectsRefresh={refreshProjects}
+        onProjectsRefresh={refreshProjectsStrict}
         onChangeDefaultDesignSystem={handleChangeDefaultDesignSystem}
         onCreateDesignSystem={() => navigate({ kind: 'design-system-create' })}
         onOpenDesignSystem={(id: string) => navigate({ kind: 'design-system-detail', designSystemId: id })}

--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { Dialog, DialogDescription, DialogFooter, DialogTitle } from "@open-design/components";
 import { projectKindToTracking } from "@open-design/contracts/analytics";
 import { useAnalytics } from "../analytics/provider";
@@ -39,6 +39,7 @@ type DesignListItem =
 	  };
 
 const DESIGNS_VIEW_STORAGE_KEY = "od:designs:view";
+const PROJECTS_AUTO_REFRESH_MS = 15000;
 
 export const STATUS_ORDER = [
 	"not_started",
@@ -71,6 +72,8 @@ interface Props {
 	onDelete: (id: string) => Promise<boolean | void> | boolean | void;
 	onRename?: (id: string, name: string) => void;
 	onNewProject?: () => void;
+	onRefresh?: () => Promise<void> | void;
+	isActive?: boolean;
 }
 
 export function DesignsTab({
@@ -82,6 +85,8 @@ export function DesignsTab({
 	onDelete,
 	onRename,
 	onNewProject,
+	onRefresh,
+	isActive = true,
 }: Props) {
 	const renameTitleId = useId();
 	const confirmTitleId = useId();
@@ -110,7 +115,9 @@ export function DesignsTab({
 	const [selected, setSelected] = useState<Set<string>>(new Set());
 	const deleteToastIdRef = useRef(0);
 	const [deleteToast, setDeleteToast] = useState<{ id: number; message: string } | null>(null);
+	const [projectsRefreshing, setProjectsRefreshing] = useState(false);
 	const menuContainerRef = useRef<HTMLDivElement | null>(null);
+	const projectsRefreshInFlightRef = useRef(false);
 	const [renameTarget, setRenameTarget] = useState<{ id: string; original: string } | null>(null);
 	const [renameInput, setRenameInput] = useState("");
 	const [confirmTarget, setConfirmTarget] = useState<{
@@ -261,6 +268,47 @@ export function DesignsTab({
 	useEffect(() => {
 		if (view === "kanban" && selectMode) exitSelectMode();
 	}, [selectMode, view]);
+
+	const refreshProjectsList = useCallback(
+		async (source: "manual" | "auto") => {
+			if (!onRefresh || projectsRefreshInFlightRef.current) return;
+			projectsRefreshInFlightRef.current = true;
+			setProjectsRefreshing(true);
+			if (source === "manual") {
+				trackProjectsListControlsClick(analytics.track, {
+					page_name: "projects",
+					area: "list_controls",
+					element: "refresh",
+				});
+			}
+			try {
+				await onRefresh();
+			} finally {
+				projectsRefreshInFlightRef.current = false;
+				setProjectsRefreshing(false);
+			}
+		},
+		[analytics.track, onRefresh],
+	);
+
+	useEffect(() => {
+		if (!isActive || !onRefresh) return;
+
+		const refreshIfVisible = () => {
+			if (document.visibilityState !== "visible") return;
+			void refreshProjectsList("auto");
+		};
+
+		refreshIfVisible();
+		const interval = window.setInterval(refreshIfVisible, PROJECTS_AUTO_REFRESH_MS);
+		window.addEventListener("focus", refreshIfVisible);
+		document.addEventListener("visibilitychange", refreshIfVisible);
+		return () => {
+			window.clearInterval(interval);
+			window.removeEventListener("focus", refreshIfVisible);
+			document.removeEventListener("visibilitychange", refreshIfVisible);
+		};
+	}, [isActive, onRefresh, refreshProjectsList]);
 
 	const filtered = useMemo(() => {
 		const q = filter.trim().toLowerCase();
@@ -474,6 +522,35 @@ export function DesignsTab({
 							}}
 						/>
 					</div>
+					{onRefresh ? (
+						<button
+							type="button"
+							className="designs-refresh-button"
+							onClick={() => void refreshProjectsList("manual")}
+							disabled={projectsRefreshing}
+							title={
+								projectsRefreshing
+									? t("designs.statusRefreshing")
+									: t("designFiles.refresh")
+							}
+							aria-label={
+								projectsRefreshing
+									? t("designs.statusRefreshing")
+									: t("designFiles.refresh")
+							}
+						>
+							<Icon
+								name={projectsRefreshing ? "spinner" : "refresh"}
+								size={13}
+								className={projectsRefreshing ? "icon-spin" : undefined}
+							/>
+							<span>
+								{projectsRefreshing
+									? t("designs.statusRefreshing")
+									: t("designFiles.refresh")}
+							</span>
+						</button>
+					) : null}
 					{view === "grid" && selectMode ? (
 						<div className="designs-select-bar" role="group">
 							<span className="designs-select-count">

--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -305,12 +305,18 @@ export function DesignsTab({
 		[analytics.track, onRefresh, t],
 	);
 
+	const refreshProjectsListRef = useRef(refreshProjectsList);
 	useEffect(() => {
-		if (!isActive || !onRefresh) return;
+		refreshProjectsListRef.current = refreshProjectsList;
+	}, [refreshProjectsList]);
+
+	const hasProjectsRefresh = Boolean(onRefresh);
+	useEffect(() => {
+		if (!isActive || !hasProjectsRefresh) return;
 
 		const refreshIfVisible = () => {
 			if (document.visibilityState !== "visible") return;
-			void refreshProjectsList("auto");
+			void refreshProjectsListRef.current("auto");
 		};
 
 		refreshIfVisible();
@@ -322,7 +328,7 @@ export function DesignsTab({
 			window.removeEventListener("focus", refreshIfVisible);
 			document.removeEventListener("visibilitychange", refreshIfVisible);
 		};
-	}, [isActive, onRefresh, refreshProjectsList]);
+	}, [hasProjectsRefresh, isActive]);
 
 	const filtered = useMemo(() => {
 		const q = filter.trim().toLowerCase();

--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -113,8 +113,13 @@ export function DesignsTab({
 	const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 	const [selectMode, setSelectMode] = useState(false);
 	const [selected, setSelected] = useState<Set<string>>(new Set());
-	const deleteToastIdRef = useRef(0);
-	const [deleteToast, setDeleteToast] = useState<{ id: number; message: string } | null>(null);
+	const toastIdRef = useRef(0);
+	const [designsToast, setDesignsToast] = useState<{
+		id: number;
+		message: string;
+		role?: "status" | "alert";
+		tone?: "default" | "success" | "error";
+	} | null>(null);
 	const [projectsRefreshing, setProjectsRefreshing] = useState(false);
 	const menuContainerRef = useRef<HTMLDivElement | null>(null);
 	const projectsRefreshInFlightRef = useRef(false);
@@ -283,12 +288,21 @@ export function DesignsTab({
 			}
 			try {
 				await onRefresh();
+			} catch {
+				if (source === "manual") {
+					setDesignsToast({
+						id: (toastIdRef.current += 1),
+						message: t("liveArtifact.refresh.networkFailure"),
+						role: "alert",
+						tone: "error",
+					});
+				}
 			} finally {
 				projectsRefreshInFlightRef.current = false;
 				setProjectsRefreshing(false);
 			}
 		},
-		[analytics.track, onRefresh],
+		[analytics.track, onRefresh, t],
 	);
 
 	useEffect(() => {
@@ -432,9 +446,10 @@ export function DesignsTab({
 					failed > 0
 						? t("designs.deleteSelectedPartial", { deleted, failed })
 						: t("designs.deleteSelectedSuccess", { n: deleted });
-				setDeleteToast({
-					id: (deleteToastIdRef.current += 1),
+				setDesignsToast({
+					id: (toastIdRef.current += 1),
 					message,
+					tone: "success",
 				});
 			},
 		});
@@ -1074,11 +1089,13 @@ export function DesignsTab({
 				</Dialog>
 			) : null}
 			<AnimatePresence>
-				{deleteToast ? (
+				{designsToast ? (
 					<Toast
-						key={deleteToast.id}
-						message={deleteToast.message}
-						onDismiss={() => setDeleteToast(null)}
+						key={designsToast.id}
+						message={designsToast.message}
+						role={designsToast.role}
+						tone={designsToast.tone}
+						onDismiss={() => setDesignsToast(null)}
 					/>
 				) : null}
 			</AnimatePresence>

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -351,6 +351,7 @@ interface Props {
   onOpenLiveArtifact: (projectId: string, artifactId: string) => void;
   onDeleteProject: (id: string) => Promise<boolean | void> | boolean | void;
   onRenameProject: (id: string, name: string) => void;
+  onProjectsRefresh?: () => Promise<void> | void;
   onChangeDefaultDesignSystem: (id: string) => void;
   onCreateDesignSystem?: () => void;
   // NOTE: first-run onboarding intentionally no longer hosts guided
@@ -449,6 +450,7 @@ export function EntryShell({
   onOpenLiveArtifact,
   onDeleteProject,
   onRenameProject,
+  onProjectsRefresh,
   onChangeDefaultDesignSystem,
   onCreateDesignSystem,
   onOpenDesignSystem,
@@ -832,6 +834,8 @@ export function EntryShell({
                     onDelete={onDeleteProject}
                     onRename={onRenameProject}
                     onNewProject={() => openNewProject()}
+                    onRefresh={onProjectsRefresh}
+                    isActive={view === 'projects'}
                   />
                 </div>
               )}

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -113,6 +113,7 @@ interface Props {
   onOpenLiveArtifact: (projectId: string, artifactId: string) => void;
   onDeleteProject: (id: string) => void;
   onRenameProject: (id: string, name: string) => void;
+  onProjectsRefresh?: () => Promise<void> | void;
   onChangeDefaultDesignSystem: (id: string) => void;
   onCreateDesignSystem?: () => void;
   onOpenDesignSystem?: (id: string) => void;
@@ -253,6 +254,7 @@ export function EntryView({
   onOpenLiveArtifact,
   onDeleteProject,
   onRenameProject,
+  onProjectsRefresh,
   onChangeDefaultDesignSystem,
   onCreateDesignSystem,
   onOpenDesignSystem,
@@ -366,6 +368,7 @@ export function EntryView({
       onOpenLiveArtifact={onOpenLiveArtifact}
       onDeleteProject={onDeleteProject}
       onRenameProject={onRenameProject}
+      onProjectsRefresh={onProjectsRefresh}
       onChangeDefaultDesignSystem={onChangeDefaultDesignSystem}
       onCreateDesignSystem={onCreateDesignSystem}
       onOpenDesignSystem={onOpenDesignSystem}

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -33,13 +33,17 @@ import type {
 export type { PluginInstallOutcome } from '@open-design/contracts';
 export type { PluginShareAction } from '@open-design/contracts';
 
-export async function listProjects(): Promise<Project[]> {
+export async function listProjects(options?: { throwOnError?: boolean }): Promise<Project[]> {
   try {
     const resp = await fetch('/api/projects');
-    if (!resp.ok) return [];
+    if (!resp.ok) {
+      if (options?.throwOnError) throw new Error(`projects ${resp.status}`);
+      return [];
+    }
     const json = (await resp.json()) as { projects: Project[] };
     return json.projects ?? [];
-  } catch {
+  } catch (err) {
+    if (options?.throwOnError) throw err;
     return [];
   }
 }

--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -685,6 +685,27 @@
   cursor: pointer;
 }
 .designs-select-toggle:hover { border-color: var(--border-strong); }
+.designs-refresh-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  min-height: 31px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--bg-panel);
+  color: var(--text-strong);
+  font-size: 12.5px;
+  cursor: pointer;
+  transition: border-color 120ms var(--ease-out), opacity 120ms var(--ease-out);
+}
+.designs-refresh-button:hover:not(:disabled) {
+  border-color: var(--border-strong);
+}
+.designs-refresh-button:disabled {
+  cursor: progress;
+  opacity: 0.72;
+}
 .designs-select-bar {
   display: inline-flex;
   align-items: center;

--- a/apps/web/tests/components/DesignsTab.select-mode.test.tsx
+++ b/apps/web/tests/components/DesignsTab.select-mode.test.tsx
@@ -136,6 +136,13 @@ describe('DesignsTab select mode', () => {
       expect(onRefresh).toHaveBeenCalledTimes(1);
     });
     expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 15000);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
     onRefresh.mockClear();
 
     await act(async () => {

--- a/apps/web/tests/components/DesignsTab.select-mode.test.tsx
+++ b/apps/web/tests/components/DesignsTab.select-mode.test.tsx
@@ -46,7 +46,99 @@ describe('DesignsTab select mode', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     cleanup();
+  });
+
+  it('refreshes the projects list from the toolbar button', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(
+      <DesignsTab
+        projects={[project]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        onRefresh={onRefresh}
+        isActive={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('auto-refreshes while the projects tab is active', async () => {
+    let intervalCallback: TimerHandler | undefined;
+    const originalSetInterval = window.setInterval.bind(window);
+    const featureIntervalHandle = originalSetInterval(
+      () => {},
+      2147483647,
+    ) as unknown as ReturnType<typeof setInterval>;
+    const setIntervalSpy = vi.spyOn(window, 'setInterval').mockImplementation((handler, timeout) => {
+      if (timeout !== 15000) {
+        return originalSetInterval(handler, timeout) as unknown as ReturnType<typeof setInterval>;
+      }
+      intervalCallback = handler;
+      return featureIntervalHandle;
+    });
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(
+      <DesignsTab
+        projects={[project]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        onRefresh={onRefresh}
+        isActive
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 15000);
+    onRefresh.mockClear();
+
+    await act(async () => {
+      if (typeof intervalCallback === 'function') intervalCallback();
+      await Promise.resolve();
+    });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not auto-refresh while the projects tab is inactive', () => {
+    vi.useFakeTimers();
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(
+      <DesignsTab
+        projects={[project]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        onRefresh={onRefresh}
+        isActive={false}
+      />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(15000);
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
   });
 
   it('only exposes select mode in grid view', () => {

--- a/apps/web/tests/components/DesignsTab.select-mode.test.tsx
+++ b/apps/web/tests/components/DesignsTab.select-mode.test.tsx
@@ -74,6 +74,35 @@ describe('DesignsTab select mode', () => {
     });
   });
 
+  it('contains refresh failures and returns the toolbar button to idle', async () => {
+    const onRefresh = vi.fn().mockRejectedValue(new Error('daemon unavailable'));
+    render(
+      <DesignsTab
+        projects={[project]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        onRefresh={onRefresh}
+        isActive={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain(
+        'Refresh request failed. Check your connection and try again.',
+      );
+    });
+    expect(
+      (screen.getByRole('button', { name: 'Refresh' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
+
   it('auto-refreshes while the projects tab is active', async () => {
     let intervalCallback: TimerHandler | undefined;
     const originalSetInterval = window.setInterval.bind(window);

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -7,6 +7,7 @@ import {
   importClaudeDesignZip,
   importFolderProject,
   installGeneratedPluginFolder,
+  listProjects,
   listPlugins,
   pickLocalFolderPath,
   publishGeneratedPluginToGitHub,
@@ -59,6 +60,24 @@ describe('applyPlugin', () => {
       grantCaps: [],
       locale: 'zh-CN',
     });
+  });
+});
+
+describe('listProjects', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the default fail-soft behavior for background app startup', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(null, { status: 503 })));
+
+    await expect(listProjects()).resolves.toEqual([]);
+  });
+
+  it('can reject transport failures for refresh paths that must preserve current state', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(null, { status: 503 })));
+
+    await expect(listProjects({ throwOnError: true })).rejects.toThrow('projects 503');
   });
 });
 

--- a/packages/contracts/src/analytics/events.ts
+++ b/packages/contracts/src/analytics/events.ts
@@ -1272,6 +1272,7 @@ export interface ProjectsListControlsClickProps {
     | 'your_designs'
     | 'search_input'
     | 'select'
+    | 'refresh'
     | 'create_project'
     | 'grid_view'
     | 'list_view';


### PR DESCRIPTION
## Why

While using Open Design as a local-first workspace, the Projects grid can stay stale after project data changes outside the current web view. The current workaround is to restart or manually reload the app, which is too heavy for a desktop design workflow.

This adds a bounded in-app refresh path for the Projects view so users can resync the list without leaving the app.

## What users will see

Projects now has a Refresh button next to search.

When the Projects tab is active and the document is visible, the list also refreshes:

- immediately when the Projects view becomes active
- when the window regains focus
- when the document becomes visible again
- every 15 seconds while active and visible

The refresh button shows the existing spinner state while a refresh is in flight, and repeated refreshes are guarded so the view does not stack concurrent requests.

## Surface area

- [x] **UI** - adds a Projects toolbar refresh button in `apps/web`
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** - extends the existing projects list controls analytics element union with `refresh`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys
- [ ] **New top-level dependency** - adding any new entry to the root `package.json`
- [x] **Default behavior change** - Projects now refreshes automatically while the tab is active and visible
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

Not captured in this environment.

## Bug fix verification

- Test path that covers the behavior: `apps/web/tests/components/DesignsTab.select-mode.test.tsx`
- Red on `main` and green on this branch: no. The bug was observed as stale project cards in the desktop app; this PR adds the missing refresh entry point and covers the new behavior with focused component tests.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/DesignsTab.select-mode.test.tsx` from `apps/web`: passed, 9 tests
- `pnpm --filter @open-design/web typecheck`: passed
- `pnpm --filter @open-design/contracts typecheck`: passed
- `pnpm --filter @open-design/web... build`: passed
- `pnpm guard`: passed

Notes:

- The local machine is running Node `v26.0.0`; the workspace emits the existing engine warning because it wants Node `~24`.
- `pnpm guard` and the web build had to run outside the Codex sandbox because `tsx` opens a temporary IPC pipe that the sandbox blocks with `listen EPERM`.
