### PR TITLE
feat(plugins-home): pre-baked hover-pan preview clips for the gallery

### DIFF
--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -109,9 +109,7 @@ jobs:
           gh pr create --base main --head "$BRANCH" \
             --title "chore(plugin-previews): refresh baked preview manifest" \
             --reviewer lefarcen \
-            --body "Automated by \`bake-plugin-previews\`. The baked preview clips were re-rendered and uploaded to R2; this updates \`data/plugin-previews/manifest.json\` to match (the clips themselves are not committed — they live on R2).
-
-@lefarcen please review and merge."
+            --body "Automated by the bake-plugin-previews workflow: preview clips were re-rendered and uploaded to R2; this updates data/plugin-previews/manifest.json to match (the clips live on R2 and are not committed). @lefarcen please review and merge."
 
       - name: Stop daemon
         if: always()

--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -9,10 +9,11 @@ name: bake-plugin-previews
 
 on:
   push:
-    branches: [main]
+    branches: [main, feat/plugin-preview-video] # TEMP: debug branch entry — remove before merge
     paths:
       - 'plugins/_official/**'
       - 'scripts/bake-plugin-previews.mjs'
+      - '.github/workflows/bake-plugin-previews.yml' # so workflow edits re-trigger on the debug branch
   schedule:
     - cron: '0 18 * * *' # nightly self-healing full sweep
   workflow_dispatch: {}
@@ -66,12 +67,18 @@ jobs:
           PREVIEW_REMOTE: '1'
         run: |
           export CHROME="$(which google-chrome || which google-chrome-stable || which chromium-browser)"
+          echo "resolved CHROME=$CHROME"
           mkdir -p .tmp/plugin-previews
           # Seed with the committed manifest so the hash skip can reuse entries.
           cp data/plugin-previews/manifest.json .tmp/plugin-previews/manifest.json
-          node scripts/bake-plugin-previews.mjs --out .tmp/plugin-previews
+          # TEMP: on the debug branch only bake a few plugins for fast iteration.
+          LIMIT=""
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then LIMIT="--limit 3"; fi
+          node scripts/bake-plugin-previews.mjs --out .tmp/plugin-previews $LIMIT
+          echo "--- baked dir ---"; ls -la .tmp/plugin-previews
 
       - name: Upload clips to R2
+        if: ${{ github.ref == 'refs/heads/main' }} # branch debug runs skip publishing
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -84,6 +91,7 @@ jobs:
             --exclude manifest.json
 
       - name: Open manifest PR for review
+        if: ${{ github.ref == 'refs/heads/main' }} # branch debug runs skip publishing
         # The clips are already on R2; the manifest is version-pinned (it ships
         # with the build), so it must land on main through a reviewed PR rather
         # than a direct push to protected main. Fires only when a plugin actually

--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -18,7 +18,8 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write # commit the refreshed manifest back to main
+  contents: write # push the manifest branch
+  pull-requests: write # open the review PR (gh pr create needs this; unset perms default to none)
 
 concurrency:
   group: bake-plugin-previews

--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -9,11 +9,10 @@ name: bake-plugin-previews
 
 on:
   push:
-    branches: [main, feat/plugin-preview-video] # TEMP: debug branch entry — remove before merge
+    branches: [main]
     paths:
       - 'plugins/_official/**'
       - 'scripts/bake-plugin-previews.mjs'
-      - '.github/workflows/bake-plugin-previews.yml' # so workflow edits re-trigger on the debug branch
   schedule:
     - cron: '0 18 * * *' # nightly self-healing full sweep
   workflow_dispatch: {}
@@ -73,14 +72,10 @@ jobs:
           mkdir -p .tmp/plugin-previews
           # Seed with the committed manifest so the hash skip can reuse entries.
           cp data/plugin-previews/manifest.json .tmp/plugin-previews/manifest.json
-          # TEMP: on the debug branch only bake a few plugins for fast iteration.
-          LIMIT=""
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then LIMIT="--limit 3"; fi
-          node scripts/bake-plugin-previews.mjs --out .tmp/plugin-previews $LIMIT
-          echo "--- baked dir ---"; ls -la .tmp/plugin-previews
+          node scripts/bake-plugin-previews.mjs --out .tmp/plugin-previews
 
       - name: Upload clips to R2
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/plugin-preview-video' }} # TEMP: also publish on the debug branch to verify R2 — revert to main-only before merge
+        if: ${{ github.ref == 'refs/heads/main' }} # only publish from main
         # Publishes to the repository-assets R2 bucket; the deployed daemon must
         # set OD_PLUGIN_PREVIEWS_BASE_URL to
         # https://repo-assets.open-design.ai/plugin-previews so its bakedPreview

--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -83,17 +83,35 @@ jobs:
             --endpoint-url "${{ secrets.R2_ENDPOINT }}" \
             --exclude manifest.json
 
-      - name: Commit refreshed manifest
+      - name: Open manifest PR for review
+        # The clips are already on R2; the manifest is version-pinned (it ships
+        # with the build), so it must land on main through a reviewed PR rather
+        # than a direct push to protected main. Fires only when a plugin actually
+        # changed (hash skip + diff guard), so this is quiet in steady state.
+        #
+        # NOTE: a GITHUB_TOKEN-authored PR does not trigger pull_request CI; set a
+        # PAT/app token secret PREVIEW_BAKE_TOKEN so the PR runs checks + can be
+        # merged through the queue. Falls back to GITHUB_TOKEN otherwise.
+        env:
+          GH_TOKEN: ${{ secrets.PREVIEW_BAKE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           cp .tmp/plugin-previews/manifest.json data/plugin-previews/manifest.json
           if git diff --quiet -- data/plugin-previews/manifest.json; then
-            echo "manifest unchanged"; exit 0
+            echo "manifest unchanged — nothing to review"; exit 0
           fi
+          BRANCH="chore/plugin-previews-${{ github.run_id }}"
           git config user.name "open-design-bot"
           git config user.email "bot@open-design.ai"
+          git checkout -b "$BRANCH"
           git add data/plugin-previews/manifest.json
-          git commit -m "chore(plugin-previews): refresh baked preview manifest [skip ci]"
-          git push origin HEAD:main
+          git commit -m "chore(plugin-previews): refresh baked preview manifest"
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore(plugin-previews): refresh baked preview manifest" \
+            --reviewer lefarcen \
+            --body "Automated by \`bake-plugin-previews\`. The baked preview clips were re-rendered and uploaded to R2; this updates \`data/plugin-previews/manifest.json\` to match (the clips themselves are not committed — they live on R2).
+
+@lefarcen please review and merge."
 
       - name: Stop daemon
         if: always()

--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -1,0 +1,100 @@
+name: bake-plugin-previews
+
+# Pre-render the home gallery's plugin previews to small H.264 clips + posters.
+# We bake ALL plugins every run; the script's content-hash skip (manifest hash +
+# BAKE_VERSION) makes that cheap — only plugins whose page actually changed are
+# re-rendered and re-uploaded. Runs post-merge (so fork contributions are covered
+# with full secrets) and nightly as a self-healing sweep. Until a plugin is baked
+# the gallery falls back to its live example.html iframe, so there is no gap.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/_official/**'
+      - 'scripts/bake-plugin-previews.mjs'
+  schedule:
+    - cron: '0 18 * * *' # nightly self-healing full sweep
+  workflow_dispatch: {}
+
+permissions:
+  contents: write # commit the refreshed manifest back to main
+
+concurrency:
+  group: bake-plugin-previews
+  cancel-in-progress: false
+
+jobs:
+  bake:
+    name: Bake plugin previews
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Install ffmpeg + puppeteer-core
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+          npm install --no-save puppeteer-core
+
+      - name: Build daemon + tools
+        run: |
+          pnpm --filter "./packages/**" build
+          pnpm --filter @open-design/daemon build
+          pnpm --filter @open-design/tools-dev build
+
+      - name: Start daemon
+        run: |
+          pnpm tools-dev start daemon --namespace ci --daemon-port 17470
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null http://127.0.0.1:17470/api/plugins; then
+              echo "daemon ready"; exit 0
+            fi
+            sleep 2
+          done
+          echo "daemon did not become ready" >&2; exit 1
+
+      - name: Bake (content-hash skip reuses unchanged plugins)
+        env:
+          BASE_URL: http://127.0.0.1:17470
+          # The CI clips live on R2, not on disk, so trust the manifest hash.
+          PREVIEW_REMOTE: '1'
+        run: |
+          export CHROME="$(which google-chrome || which google-chrome-stable || which chromium-browser)"
+          mkdir -p .tmp/plugin-previews
+          # Seed with the committed manifest so the hash skip can reuse entries.
+          cp data/plugin-previews/manifest.json .tmp/plugin-previews/manifest.json
+          node scripts/bake-plugin-previews.mjs --out .tmp/plugin-previews
+
+      - name: Upload clips to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          # cp (not sync --delete) so untouched clips already on R2 stay put.
+          aws s3 cp .tmp/plugin-previews "s3://${{ secrets.R2_BUCKET }}/plugin-previews/" \
+            --recursive --no-progress \
+            --endpoint-url "${{ secrets.R2_ENDPOINT }}" \
+            --exclude manifest.json
+
+      - name: Commit refreshed manifest
+        run: |
+          cp .tmp/plugin-previews/manifest.json data/plugin-previews/manifest.json
+          if git diff --quiet -- data/plugin-previews/manifest.json; then
+            echo "manifest unchanged"; exit 0
+          fi
+          git config user.name "open-design-bot"
+          git config user.email "bot@open-design.ai"
+          git add data/plugin-previews/manifest.json
+          git commit -m "chore(plugin-previews): refresh baked preview manifest [skip ci]"
+          git push origin HEAD:main
+
+      - name: Stop daemon
+        if: always()
+        run: pnpm tools-dev stop --namespace ci || true

--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -41,7 +41,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ffmpeg
-          npm install --no-save puppeteer-core
+          # npm chokes on the workspace:* root manifest; use pnpm to drop
+          # puppeteer-core into the workspace node_modules (CI-only, not committed).
+          pnpm add -w puppeteer-core
 
       - name: Build daemon + tools
         run: |

--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Start daemon
         run: |
           pnpm tools-dev start daemon --namespace ci --daemon-port 17470
-          for i in $(seq 1 60); do
+          for _ in $(seq 1 60); do
             if curl -sf -o /dev/null http://127.0.0.1:17470/api/plugins; then
               echo "daemon ready"; exit 0
             fi
@@ -67,7 +67,8 @@ jobs:
           # The CI clips live on R2, not on disk, so trust the manifest hash.
           PREVIEW_REMOTE: '1'
         run: |
-          export CHROME="$(which google-chrome || which google-chrome-stable || which chromium-browser)"
+          CHROME="$(which google-chrome || which google-chrome-stable || which chromium-browser)"
+          export CHROME
           echo "resolved CHROME=$CHROME"
           mkdir -p .tmp/plugin-previews
           # Seed with the committed manifest so the hash skip can reuse entries.

--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -80,16 +80,24 @@ jobs:
           echo "--- baked dir ---"; ls -la .tmp/plugin-previews
 
       - name: Upload clips to R2
-        if: ${{ github.ref == 'refs/heads/main' }} # branch debug runs skip publishing
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/plugin-preview-video' }} # TEMP: also publish on the debug branch to verify R2 — revert to main-only before merge
+        # Publishes to the repository-assets R2 bucket; the deployed daemon must
+        # set OD_PLUGIN_PREVIEWS_BASE_URL to
+        # https://repo-assets.open-design.ai/plugin-previews so its bakedPreview
+        # URLs point here (CLOUDFLARE_R2_REPOSITORY_ASSETS_PUBLIC_ORIGIN).
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_AK }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_SK }}
           AWS_DEFAULT_REGION: auto
+          AWS_EC2_METADATA_DISABLED: 'true'
+          R2_BUCKET: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_BUCKET }}
+          R2_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_REPOSITORY_ASSETS_URL }}
         run: |
+          endpoint="${R2_ENDPOINT%/}"
           # cp (not sync --delete) so untouched clips already on R2 stay put.
-          aws s3 cp .tmp/plugin-previews "s3://${{ secrets.R2_BUCKET }}/plugin-previews/" \
+          aws s3 cp .tmp/plugin-previews "s3://$R2_BUCKET/plugin-previews/" \
             --recursive --no-progress \
-            --endpoint-url "${{ secrets.R2_ENDPOINT }}" \
+            --endpoint-url "$endpoint" \
             --exclude manifest.json
 
       - name: Open manifest PR for review

--- a/apps/daemon/src/plugin-preview-bakes.ts
+++ b/apps/daemon/src/plugin-preview-bakes.ts
@@ -1,0 +1,88 @@
+// Baked plugin preview clips — the daemon side of scripts/bake-plugin-previews.mjs.
+//
+// The home gallery renders html plugins as live, scaled hover-pan iframes, which
+// is GPU-expensive at scale. When a plugin has a pre-baked preview (a small VP9
+// `.webm` hover-pan clip + a poster `.jpg`), we rewrite that plugin's record so
+// its `od.preview` becomes a `video` block. The web gallery's `inferPluginPreview`
+// then classifies it as `media` and renders a cheap poster + hover-play `<video>`
+// (MediaSurface) instead of a live iframe. Plugins without a bake are left
+// untouched and keep the live-iframe path as the fallback.
+//
+// Files + a `manifest.json` live under `<dir>` (OD_PLUGIN_PREVIEWS_DIR, default
+// `<project>/.od/plugin-previews`). CI bakes them and uploads to R2; the daemon
+// serves whatever is present locally at `/api/plugin-previews/<file>`.
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+export const PLUGIN_PREVIEWS_ROUTE = '/api/plugin-previews';
+
+interface BakeEntry {
+  video: string;
+  poster: string;
+  holdMs?: number;
+  durationMs?: number;
+}
+
+export interface BakedPreviewBlock {
+  poster: string;
+  video: string;
+  holdMs?: number;
+}
+
+export function resolvePluginPreviewsDir(projectRoot: string): string {
+  const env = process.env.OD_PLUGIN_PREVIEWS_DIR;
+  if (env) return path.isAbsolute(env) ? env : path.resolve(projectRoot, env);
+  return path.join(projectRoot, '.od', 'plugin-previews');
+}
+
+let cache: { dir: string; mtimeMs: number; previews: Record<string, BakeEntry> } | null = null;
+
+function loadManifest(dir: string): Record<string, BakeEntry> {
+  const manifestPath = path.join(dir, 'manifest.json');
+  if (!existsSync(manifestPath)) return {};
+  try {
+    const mtimeMs = statSync(manifestPath).mtimeMs;
+    if (cache && cache.dir === dir && cache.mtimeMs === mtimeMs) return cache.previews;
+    const parsed = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      previews?: Record<string, BakeEntry>;
+    };
+    const previews = parsed.previews ?? {};
+    cache = { dir, mtimeMs, previews };
+    return previews;
+  } catch {
+    return {};
+  }
+}
+
+export function bakedPreviewBlock(id: string, dir: string): BakedPreviewBlock | null {
+  const entry = loadManifest(dir)[id];
+  if (!entry || !entry.video || !entry.poster) return null;
+  return {
+    poster: `${PLUGIN_PREVIEWS_ROUTE}/${entry.poster}`,
+    video: `${PLUGIN_PREVIEWS_ROUTE}/${entry.video}`,
+    ...(typeof entry.holdMs === 'number' ? { holdMs: entry.holdMs } : {}),
+  };
+}
+
+// Attach the baked clip under `manifest.od.bakedPreview` (a SEPARATE field —
+// we deliberately do NOT overwrite `od.preview`). The gallery card opts into the
+// baked clip via `inferPluginPreview(record, { preferBaked: true })`, while the
+// detail modal keeps reading the real `od.preview` and renders the live,
+// interactive page. Records are shallow-cloned so registry rows stay pure.
+export function applyBakedPreviews<T extends { id: string; manifest?: unknown }>(
+  records: T[],
+  dir: string,
+): T[] {
+  const previews = loadManifest(dir);
+  if (Object.keys(previews).length === 0) return records;
+  return records.map((rec) => {
+    const block = bakedPreviewBlock(rec.id, dir);
+    if (!block) return rec;
+    const manifest = { ...((rec.manifest ?? {}) as Record<string, unknown>) };
+    const od = { ...((manifest.od ?? {}) as Record<string, unknown>) };
+    od.bakedPreview = block;
+    manifest.od = od;
+    return { ...rec, manifest };
+  });
+}

--- a/apps/daemon/src/plugin-preview-bakes.ts
+++ b/apps/daemon/src/plugin-preview-bakes.ts
@@ -53,7 +53,10 @@ function loadManifest(dir: string): Record<string, BakeEntry> {
     const previews = parsed.previews ?? {};
     cache = { dir, mtimeMs, previews };
     return previews;
-  } catch {
+  } catch (err) {
+    // A malformed/unreadable manifest would otherwise silently disable every
+    // baked preview with no trace; surface it so it's diagnosable.
+    console.warn(`[plugin-preview-bakes] failed to load ${manifestPath}: ${String(err)}`);
     return {};
   }
 }

--- a/apps/daemon/src/plugin-preview-bakes.ts
+++ b/apps/daemon/src/plugin-preview-bakes.ts
@@ -64,7 +64,20 @@ export function bakedPreviewBlock(id: string, dir: string): BakedPreviewBlock | 
   // In production the clips live on R2 (OD_PLUGIN_PREVIEWS_BASE_URL =
   // https://<r2-public-origin>/plugin-previews); locally they fall back to the
   // daemon's own /api/plugin-previews static route over the on-disk dir.
-  const base = (process.env.OD_PLUGIN_PREVIEWS_BASE_URL?.replace(/\/+$/, '')) || PLUGIN_PREVIEWS_ROUTE;
+  const remoteBase = process.env.OD_PLUGIN_PREVIEWS_BASE_URL?.replace(/\/+$/, '');
+  // Only attach a baked preview when its clips are actually fetchable: a remote
+  // origin is configured, OR the files are present on disk to serve locally.
+  // The checked-in manifest records entries but keeps the binaries on R2, so a
+  // deployment that forgot OD_PLUGIN_PREVIEWS_BASE_URL would otherwise point the
+  // gallery at /api/plugin-previews URLs that 404 — breaking tiles instead of
+  // falling back to the live iframe.
+  if (
+    !remoteBase &&
+    (!existsSync(path.join(dir, entry.video)) || !existsSync(path.join(dir, entry.poster)))
+  ) {
+    return null;
+  }
+  const base = remoteBase || PLUGIN_PREVIEWS_ROUTE;
   return {
     poster: `${base}/${entry.poster}`,
     video: `${base}/${entry.video}`,

--- a/apps/daemon/src/plugin-preview-bakes.ts
+++ b/apps/daemon/src/plugin-preview-bakes.ts
@@ -58,9 +58,13 @@ function loadManifest(dir: string): Record<string, BakeEntry> {
 export function bakedPreviewBlock(id: string, dir: string): BakedPreviewBlock | null {
   const entry = loadManifest(dir)[id];
   if (!entry || !entry.video || !entry.poster) return null;
+  // In production the clips live on R2 (OD_PLUGIN_PREVIEWS_BASE_URL =
+  // https://<r2-public-origin>/plugin-previews); locally they fall back to the
+  // daemon's own /api/plugin-previews static route over the on-disk dir.
+  const base = (process.env.OD_PLUGIN_PREVIEWS_BASE_URL?.replace(/\/+$/, '')) || PLUGIN_PREVIEWS_ROUTE;
   return {
-    poster: `${PLUGIN_PREVIEWS_ROUTE}/${entry.poster}`,
-    video: `${PLUGIN_PREVIEWS_ROUTE}/${entry.video}`,
+    poster: `${base}/${entry.poster}`,
+    video: `${base}/${entry.video}`,
     ...(typeof entry.holdMs === 'number' ? { holdMs: entry.holdMs } : {}),
   };
 }

--- a/apps/daemon/src/plugin-preview-bakes.ts
+++ b/apps/daemon/src/plugin-preview-bakes.ts
@@ -33,7 +33,10 @@ export interface BakedPreviewBlock {
 export function resolvePluginPreviewsDir(projectRoot: string): string {
   const env = process.env.OD_PLUGIN_PREVIEWS_DIR;
   if (env) return path.isAbsolute(env) ? env : path.resolve(projectRoot, env);
-  return path.join(projectRoot, '.od', 'plugin-previews');
+  // Default to the checked-in manifest dir (CI commits manifest.json here; the
+  // clips themselves live on R2). Local dev overrides OD_PLUGIN_PREVIEWS_DIR to
+  // a freshly-baked dir that also holds the mp4/poster files for local serving.
+  return path.join(projectRoot, 'data', 'plugin-previews');
 }
 
 let cache: { dir: string; mtimeMs: number; previews: Record<string, BakeEntry> } | null = null;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -27,6 +27,11 @@ import {
 } from './prompts/system.js';
 import { expandHomePrefix, resolveProjectRelativePath } from './home-expansion.js';
 import { resolveProjectRoot } from './project-root.js';
+import {
+  applyBakedPreviews,
+  resolvePluginPreviewsDir,
+  PLUGIN_PREVIEWS_ROUTE,
+} from './plugin-preview-bakes.js';
 import { userFacingAgentLabel } from './user-facing-agent-label.js';
 
 export { resolveProjectRoot };
@@ -1346,6 +1351,10 @@ const DAEMON_RESOURCE_ROOT = resolveDaemonResourceRoot();
 // when this project shipped with Vite; the daemon serves whatever the
 // frontend toolchain emits, no further config needed.
 const STATIC_DIR = path.join(PROJECT_ROOT, 'apps', 'web', 'out');
+// Baked plugin preview clips (scripts/bake-plugin-previews.mjs). Served at
+// PLUGIN_PREVIEWS_ROUTE; their manifest rewrites html plugins' previews to a
+// cheap poster + hover-play video in the home gallery.
+const PLUGIN_PREVIEWS_DIR = resolvePluginPreviewsDir(PROJECT_ROOT);
 const OD_BIN = resolveDaemonCliPath();
 const OD_NODE_BIN = process.execPath;
 const SKILLS_DIR = resolveDaemonResourceDir(
@@ -6046,6 +6055,10 @@ export async function startServer({
     projects: { getProject: (id: string) => getProject(db, id) },
   });
   app.use('/artifacts', express.static(ARTIFACTS_DIR));
+  app.use(
+    PLUGIN_PREVIEWS_ROUTE,
+    express.static(PLUGIN_PREVIEWS_DIR, { maxAge: '1d', immutable: false }),
+  );
   registerDeployRoutes(app, {
     db,
     http: httpDeps,
@@ -6920,7 +6933,7 @@ export async function startServer({
   // and snapshot fetch by id (used by run replay tooling).
   app.get('/api/plugins', async (_req, res) => {
     try {
-      const plugins = listInstalledPlugins(db);
+      const plugins = applyBakedPreviews(listInstalledPlugins(db), PLUGIN_PREVIEWS_DIR);
       res.json({ plugins });
     } catch (err) {
       res.status(500).json({ error: String(err) });

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1532,7 +1532,9 @@ function PluginPromptPresetCard({
   pending: boolean;
   record: InstalledPluginRecord;
 }) {
-  const preview = useMemo(() => inferPluginPreview(record), [record]);
+  // Example-prompt preset tiles are thumbnails too — prefer the cheap baked
+  // hover-pan clip when one exists (same as the gallery cards).
+  const preview = useMemo(() => inferPluginPreview(record, { preferBaked: true }), [record]);
   const seedPrompt = examplePresetSeedPrompt(record, locale, chipId);
   return (
     <button

--- a/apps/web/src/components/plugins-home/PluginCard.tsx
+++ b/apps/web/src/components/plugins-home/PluginCard.tsx
@@ -69,7 +69,9 @@ export function PluginCard({
 }: Props) {
   const { locale } = useI18n();
   const [useMenuOpen, setUseMenuOpen] = useState(false);
-  const preview = useMemo(() => inferPluginPreview(record), [record]);
+  // Tiles prefer the cheap pre-baked hover-pan clip; the detail modal still
+  // opens the live interactive page (it calls inferPluginPreview without this).
+  const preview = useMemo(() => inferPluginPreview(record, { preferBaked: true }), [record]);
   const title = localizePluginTitle(locale, record);
   const description = localizePluginDescription(locale, record);
   const tags = useMemo(

--- a/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
+++ b/apps/web/src/components/plugins-home/cards/MediaSurface.tsx
@@ -1,12 +1,20 @@
 // Image / video preview surface for the plugins-home gallery.
 //
-// Renders the plugin's poster as the card's hero. When the manifest
-// declares an `od.preview.video` URL we mount a `<video>` element on
-// hover so users can scrub the looping clip without leaving the
-// home view. Until then the poster image is the only thing the
-// browser fetches — keeps a 50-tile gallery cheap.
+// Renders the plugin's poster as the card's hero. For plain video-template
+// plugins the `<video>` only mounts on hover, so an idle gallery just fetches
+// posters.
+//
+// Baked plugin previews (the home gallery's html plugins, pre-rendered by
+// scripts/bake-plugin-previews.mjs) carry a `loopHoldMs`: the clip leads with a
+// `[0, holdMs]` in-place-animation span, then pans top->bottom. We treat those
+// as a cheap stand-in for the old live hover-pan iframe — the `<video>` mounts
+// as soon as the tile is on-screen and loops the in-place span while idle
+// (animated pages still look alive), and on hover jumps to the pan. The element
+// stays mounted the whole time it's on-screen, so hover never remounts/reloads
+// the source and can't flash black at the hand-off, and `preload="auto"`
+// buffers the whole small clip up front so the idle->pan jump never stalls.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { MediaPreviewSpec } from '../preview';
 
 interface Props {
@@ -24,11 +32,73 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
   // poison a freshly-assigned URL (filter rotations, daemon
   // repopulating a preview after an offline flip). #2955.
   const [posterLoadFailed, setPosterLoadFailed] = useState(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
   useEffect(() => {
     setPosterLoadFailed(false);
   }, [preview.poster]);
-  const showVideo =
-    inView && hovering && preview.mediaType === 'video' && Boolean(preview.videoUrl);
+
+  const isVideo = preview.mediaType === 'video' && Boolean(preview.videoUrl);
+  const holdMs = preview.loopHoldMs ?? null;
+  // Baked hover-pan clips (holdMs set) play as soon as they're on-screen so the
+  // in-place span can loop while idle; plain video-template plugins keep the
+  // cheaper poster-until-hover behaviour.
+  const idlePlays = isVideo && holdMs != null;
+  const showVideo = inView && isVideo && (idlePlays || hovering);
+
+  // Idle: loop the leading [0, holdMs] in-place-animation span. Hover: jump to
+  // holdMs and loop the pan span [holdMs, end] so it responds immediately
+  // instead of waiting out the remaining hold. One element, never remounted
+  // while on-screen.
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v || !showVideo || holdMs == null) return;
+    const hold = holdMs / 1000;
+    const clamp = (t: number) => {
+      if (hovering) {
+        if (t < hold) v.currentTime = hold;
+      } else if (t >= hold) {
+        v.currentTime = 0;
+      }
+    };
+    // Frame-accurate loop boundary. `timeupdate` fires only ~4x/s, which let the
+    // idle loop overshoot ~250ms past holdMs and briefly reveal the pan (a small
+    // downward lurch each cycle). requestVideoFrameCallback fires once per
+    // rendered frame, so the reset lands within ~1 frame of the boundary.
+    type RVFCVideo = HTMLVideoElement & {
+      requestVideoFrameCallback?: (cb: (now: number, meta: { mediaTime: number }) => void) => number;
+      cancelVideoFrameCallback?: (id: number) => void;
+    };
+    const vv = v as RVFCVideo;
+    clamp(v.currentTime);
+    if (typeof vv.requestVideoFrameCallback === 'function') {
+      let id = 0;
+      const tick = (_now: number, meta: { mediaTime: number }) => {
+        clamp(meta?.mediaTime ?? v.currentTime);
+        id = vv.requestVideoFrameCallback!(tick);
+      };
+      id = vv.requestVideoFrameCallback(tick);
+      return () => vv.cancelVideoFrameCallback?.(id);
+    }
+    const onTime = () => clamp(v.currentTime);
+    v.addEventListener('timeupdate', onTime);
+    return () => v.removeEventListener('timeupdate', onTime);
+  }, [showVideo, hovering, holdMs]);
+
+  // The `autoplay` attribute alone doesn't reliably start a freshly-mounted
+  // muted clip here (Electron/Chromium leaves it paused at readyState 1), so
+  // kick it off explicitly on mount and again once it has buffered.
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v || !showVideo) return;
+    const tryPlay = () => {
+      const p = v.play();
+      if (p && typeof p.catch === 'function') p.catch(() => {});
+    };
+    tryPlay();
+    v.addEventListener('canplay', tryPlay);
+    return () => v.removeEventListener('canplay', tryPlay);
+  }, [showVideo]);
+
   const hasPoster = Boolean(preview.poster);
   const useFallback = !hasPoster || posterLoadFailed;
 
@@ -58,13 +128,23 @@ export function MediaSurface({ preview, pluginTitle, inView }: Props) {
       )}
       {showVideo ? (
         <video
+          ref={videoRef}
           className="plugins-home__media-video"
           src={preview.videoUrl ?? undefined}
+          poster={preview.poster ?? undefined}
           autoPlay
           muted
           playsInline
           loop
-          preload="none"
+          // On-screen baked clips buffer the whole (small ~450KB) clip so the
+          // idle->pan hand-off never stalls; hover-only videos stay lazy.
+          preload={idlePlays ? 'auto' : 'none'}
+          // Look like an inert iframe thumbnail: no native controls or PiP, and
+          // clicks fall through to the card (open detail) instead of the video.
+          disablePictureInPicture
+          tabIndex={-1}
+          aria-hidden
+          style={{ pointerEvents: 'none' }}
         />
       ) : null}
     </div>

--- a/apps/web/src/components/plugins-home/preview.ts
+++ b/apps/web/src/components/plugins-home/preview.ts
@@ -34,6 +34,13 @@ export interface MediaPreviewSpec {
   audioUrl: string | null;
   /** True when the plugin only ships a still image, no video stream. */
   imageOnly: boolean;
+  /**
+   * For baked hover-pan clips: the leading `[0, loopHoldMs]` span is the page's
+   * in-place animation (no scroll), which the gallery loops while idle; hover
+   * plays on past it (the pan). Null for plain video-template plugins, which
+   * just loop the whole clip.
+   */
+  loopHoldMs?: number | null;
 }
 
 export interface HtmlPreviewSpec {
@@ -76,6 +83,7 @@ interface PreviewBlock {
   gif?: unknown;
   entry?: unknown;
   audio?: unknown;
+  holdMs?: unknown;
 }
 
 interface ExampleOutputEntry {
@@ -91,6 +99,19 @@ function readPreview(record: InstalledPluginRecord): PreviewBlock | null {
   const od = record.manifest?.od as { preview?: unknown } | undefined;
   if (!od || typeof od.preview !== 'object' || od.preview === null) return null;
   return od.preview as PreviewBlock;
+}
+
+// Pre-baked hover-pan clip attached by the daemon (scripts/bake-plugin-previews.mjs),
+// kept separate from `od.preview` so only gallery tiles use it.
+function readBakedPreview(
+  record: InstalledPluginRecord,
+): { poster: string; video: string; holdMs: number | null } | null {
+  const od = record.manifest?.od as { bakedPreview?: unknown } | undefined;
+  const b = od?.bakedPreview;
+  if (!b || typeof b !== 'object') return null;
+  const { poster, video, holdMs } = b as Record<string, unknown>;
+  if (typeof poster !== 'string' || typeof video !== 'string') return null;
+  return { poster, video, holdMs: typeof holdMs === 'number' ? holdMs : null };
 }
 
 function readExamples(record: InstalledPluginRecord): ExampleOutputEntry[] {
@@ -161,7 +182,26 @@ function brandLabel(record: InstalledPluginRecord): string {
 
 export function inferPluginPreview(
   record: InstalledPluginRecord,
+  opts?: { preferBaked?: boolean },
 ): PluginPreviewSpec {
+  // Gallery tiles opt in to a pre-baked hover-pan clip (cheap thumbnail) when
+  // the daemon has attached one. Everything else — crucially the detail modal —
+  // falls through to the real `od.preview`, so opening a plugin still shows the
+  // live, interactive page rather than the baked video.
+  if (opts?.preferBaked) {
+    const baked = readBakedPreview(record);
+    if (baked) {
+      return {
+        kind: 'media',
+        mediaType: 'video',
+        poster: baked.poster,
+        videoUrl: baked.video,
+        audioUrl: null,
+        imageOnly: false,
+        loopHoldMs: baked.holdMs,
+      };
+    }
+  }
   const preview = readPreview(record);
   const examples = readExamples(record);
 
@@ -174,6 +214,7 @@ export function inferPluginPreview(
     const entry = typeof preview.entry === 'string' ? preview.entry : null;
 
     if (t === 'video' || video) {
+      const holdMs = typeof preview.holdMs === 'number' ? preview.holdMs : null;
       return {
         kind: 'media',
         mediaType: 'video',
@@ -181,6 +222,7 @@ export function inferPluginPreview(
         videoUrl: video,
         audioUrl: null,
         imageOnly: !video,
+        loopHoldMs: holdMs,
       };
     }
     if (t === 'audio' || audio) {

--- a/data/plugin-previews/manifest.json
+++ b/data/plugin-previews/manifest.json
@@ -1,0 +1,4 @@
+{
+  "generatedAt": null,
+  "previews": {}
+}

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+// Bake a looping preview video + poster for each plugin's example.html.
+//
+// The Home "Community" gallery renders every plugin as a live, scaled
+// `example.html` iframe that auto-pans on hover. That is GPU-expensive at
+// scale (each tile is its own out-of-process document re-compositing a tall
+// page). This script pre-renders the SAME hover-pan as a tiny VP9 .webm plus a
+// first-frame .jpg poster, so the gallery can show a cheap `<img>` poster idle
+// and play the clip on hover (see MediaSurface) instead of mounting a live
+// iframe per tile.
+//
+// Pipeline (validated end-to-end before productionising):
+//   1. Headless Chrome loads the *served* preview URL (so the daemon's
+//      asset-cache rewriting + CSP apply, exactly as the gallery sees it).
+//   2. Pre-scroll the whole page to trigger lazy-loaded / cross-border-CDN
+//      images, then wait for them — otherwise the pan reaches a section before
+//      its images load and the frame shows empty boxes.
+//   3. CDP screencast captures frames in REAL TIME (so animation plays at true
+//      speed) while a constant-velocity (linear) scroll pans top -> bottom.
+//   4. ffmpeg encodes the VFR frames to a 60fps VP9 .webm + a poster .jpg.
+//
+// Runtime deps are provided by the environment, NOT the repo: `puppeteer-core`
+// (the CI step `npm i puppeteer-core` ephemerally, or runs inside the
+// ghcr.io/puppeteer/puppeteer image), a Chrome/Chromium binary (CHROME env, or
+// auto-detected), and `ffmpeg` on PATH. We deliberately keep them out of
+// package.json so the daemon/web bundles never pull in a headless browser.
+//
+// Run against a running daemon/web (the preview endpoint):
+//   CHROME=/path/to/chrome BASE_URL=http://127.0.0.1:17579 \
+//     node scripts/bake-plugin-previews.mjs --out .tmp/plugin-previews [--id <id>...] [--limit N]
+//
+// Output: <out>/<id>.mp4, <out>/<id>.poster.jpg, and <out>/manifest.json
+// ({ generatedAt, previews: { <id>: { video, poster, durationMs, holdMs } } }).
+// Uploading <out> to R2 + committing the manifest is the CI step's job; this
+// script only renders + encodes so it stays runnable locally and in CI alike.
+
+import puppeteer from 'puppeteer-core';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync, readFileSync, statSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+// ---- config ---------------------------------------------------------------
+const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:17579';
+const RENDER_W = 1440;          // pages lay out at their desktop width
+const VIEW_H = 1099;            // 1.31-aspect window showing the FULL width (no clip)
+const OUT_W = Number(process.env.PREVIEW_W || 640); // small — tile renders ~393px
+const FPS = Number(process.env.PREVIEW_FPS || 30);  // 30 is smooth for a gentle pan, half the bytes of 60
+const VELOCITY = 0.30;          // px/ms — base pan pace (snappy but readable)
+const MAX_PAN = 7500;           // hard cap on the pan; tall pages get auto-sped-up
+                                // beyond VELOCITY so the pan always finishes within
+                                // it, keeping the whole clip (HOLD + pan) <= ~10s.
+const HOLD_MS = 2500;           // dwell at the top first, capturing in-place
+                                // animation — the gallery loops THIS span while
+                                // idle, then plays on past it (the pan) on hover.
+const CRF = Number(process.env.PREVIEW_CRF || 28);  // H.264 CRF — higher = smaller; 28 stays readable at tile size
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+function argList(name) {
+  const out = [];
+  for (let i = 0; i < process.argv.length; i += 1) {
+    if (process.argv[i] === `--${name}` && process.argv[i + 1]) out.push(process.argv[i + 1]);
+  }
+  return out;
+}
+const OUT = path.resolve(arg('out', '.tmp/plugin-previews'));
+const LIMIT = Number(arg('limit', '0')) || 0;
+const ONLY = argList('id');
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function resolveChrome() {
+  if (process.env.CHROME && existsSync(process.env.CHROME)) return process.env.CHROME;
+  const candidates = [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/usr/bin/google-chrome', '/usr/bin/chromium-browser', '/usr/bin/chromium',
+  ];
+  for (const c of candidates) if (existsSync(c)) return c;
+  throw new Error('No Chrome found. Set CHROME=/path/to/chrome.');
+}
+
+// ---- discover the html-preview plugins ------------------------------------
+async function discoverIds() {
+  if (ONLY.length) return ONLY;
+  const res = await fetch(`${BASE_URL}/api/plugins`);
+  const data = await res.json();
+  const items = Array.isArray(data) ? data : (data.plugins || data.items || data.available || []);
+  const ids = items
+    .map((it) => (typeof it === 'string' ? it : it.id || it.slug))
+    .filter(Boolean);
+  return LIMIT ? ids.slice(0, LIMIT) : ids;
+}
+
+// ---- render + encode one plugin -------------------------------------------
+async function bakeOne(browser, id) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: RENDER_W, height: VIEW_H, deviceScaleFactor: 1 });
+  try {
+    const res = await page.goto(`${BASE_URL}/api/plugins/${encodeURIComponent(id)}/preview`,
+      { waitUntil: 'domcontentloaded', timeout: 25000 });
+    if (!res || !res.ok()) { await page.close(); return { id, skipped: `status ${res ? res.status() : 'none'}` }; }
+  } catch (e) { await page.close(); return { id, skipped: `load ${e.message}` }; }
+  await sleep(1000);
+
+  // Trigger lazy images by scrolling through, then wait for them, then reset.
+  await page.evaluate(async () => {
+    const h = document.documentElement.scrollHeight;
+    for (let y = 0; y <= h; y += Math.round(window.innerHeight * 0.8)) {
+      window.scrollTo(0, y); await new Promise((r) => setTimeout(r, 120));
+    }
+    window.scrollTo(0, 0);
+  });
+  // Wait for the page's VISUAL resources to settle before recording — capped so
+  // rAF-driven animation loops (which never "finish") don't hang the bake:
+  //   - web fonts (document.fonts.ready) — else the clip bakes in a fallback
+  //     font that swaps the instant a real user opens the page;
+  //   - every <img> (incl. the lazy ones the pre-scroll just triggered);
+  //   - CSS background-images — heroes routinely use these and they are NOT in
+  //     document.images, so they'd otherwise be captured half-loaded/blank;
+  //   - <video> backgrounds (.mp4/CloudFront): force muted playback + a frame.
+  try {
+    await page.evaluate((capMs) => {
+      const cap = new Promise((r) => setTimeout(r, capMs));
+      const fonts = document.fonts ? document.fonts.ready.catch(() => {}) : Promise.resolve();
+      const imgs = Array.from(document.images)
+        .filter((i) => !i.complete)
+        .map((i) => new Promise((res) => {
+          i.addEventListener('load', res, { once: true });
+          i.addEventListener('error', res, { once: true });
+        }));
+      const vids = Array.from(document.querySelectorAll('video')).map((v) => {
+        try { v.muted = true; const p = v.play(); if (p && p.catch) p.catch(() => {}); } catch {}
+        return v.readyState >= 2 ? Promise.resolve() : new Promise((res) => {
+          v.addEventListener('loadeddata', res, { once: true });
+          v.addEventListener('error', res, { once: true });
+        });
+      });
+      const bgUrls = new Set();
+      document.querySelectorAll('*').forEach((el) => {
+        const bg = getComputedStyle(el).backgroundImage;
+        if (!bg || bg === 'none') return;
+        const re = /url\((['"]?)(.*?)\1\)/g;
+        let m;
+        while ((m = re.exec(bg))) if (m[2] && !m[2].startsWith('data:')) bgUrls.add(m[2]);
+      });
+      const bgs = Array.from(bgUrls).map((u) => new Promise((res) => {
+        const im = new Image();
+        im.onload = im.onerror = res;
+        im.src = u;
+      }));
+      return Promise.race([cap, Promise.all([fonts, ...imgs, ...vids, ...bgs])]);
+    }, 12000);
+  } catch {}
+  await sleep(600);
+
+  const frameDir = path.join(OUT, `.frames-${id}`);
+  rmSync(frameDir, { recursive: true, force: true }); mkdirSync(frameDir, { recursive: true });
+
+  const client = await page.createCDPSession();
+  const frames = [];
+  client.on('Page.screencastFrame', async (e) => {
+    frames.push({ data: e.data, ts: e.metadata.timestamp });
+    try { await client.send('Page.screencastFrameAck', { sessionId: e.sessionId }); } catch {}
+  });
+
+  const maxY = await page.evaluate(() =>
+    Math.max(0, document.documentElement.scrollHeight - window.innerHeight));
+  // Pre-computed from the measured page height so the pan always reaches the
+  // bottom within MAX_PAN (whole clip stays ~<=10s): base VELOCITY for normal
+  // pages, auto-sped-up (capped duration) for tall ones.
+  const durMs = maxY <= 0 ? 2500 : Math.min(MAX_PAN, Math.round(maxY / VELOCITY));
+
+  await client.send('Page.startScreencast',
+    { format: 'jpeg', quality: 80, everyNthFrame: 1, maxWidth: RENDER_W, maxHeight: VIEW_H });
+  // Phase 1 — HOLD at the top, capturing the page's in-place animation. The
+  // gallery loops this leading span while idle (no pan), so animated pages
+  // still look alive without auto-scrolling.
+  await sleep(HOLD_MS);
+  // Phase 2 — linear pan top -> bottom (played past the hold on hover).
+  await page.evaluate((dur, my) => new Promise((res) => {
+    if (my <= 0) { setTimeout(res, dur); return; }
+    let start = null;
+    function step(t) {
+      if (start === null) start = t;
+      const e = Math.min(1, (t - start) / dur);
+      window.scrollTo(0, Math.round(my * e)); // linear = constant velocity
+      if (e < 1) requestAnimationFrame(step); else res();
+    }
+    requestAnimationFrame(step);
+  }), durMs, maxY);
+  await client.send('Page.stopScreencast');
+  await page.close();
+
+  if (frames.length < 5) { rmSync(frameDir, { recursive: true, force: true }); return { id, skipped: `frames ${frames.length}` }; }
+
+  // VFR concat list (real per-frame durations) -> correct real-time speed.
+  const lines = [];
+  for (let i = 0; i < frames.length; i += 1) {
+    const fp = path.join(frameDir, `f-${String(i).padStart(4, '0')}.jpg`);
+    writeFileSync(fp, Buffer.from(frames[i].data, 'base64'));
+    if (i > 0) lines.push(`duration ${(frames[i].ts - frames[i - 1].ts).toFixed(4)}`);
+    lines.push(`file '${fp}'`);
+  }
+  lines.push(`file '${path.join(frameDir, `f-${String(frames.length - 1).padStart(4, '0')}.jpg`)}'`);
+  const listPath = path.join(frameDir, 'list.txt');
+  writeFileSync(listPath, lines.join('\n'));
+
+  const video = path.join(OUT, `${id}.mp4`);
+  const poster = path.join(OUT, `${id}.poster.jpg`);
+  const ff = (a) => execFileSync('ffmpeg', ['-y', ...a], { stdio: 'ignore' });
+  // H.264 MP4, constant frame rate (the fps filter resamples the concat's
+  // real-time timeline to a constant FPS). H.264 decodes reliably in both
+  // browsers and Electron — VP9 encoded from this frame pipeline intermittently
+  // tripped Chromium/Electron's decoder (PIPELINE_ERROR_DECODE). `+faststart`
+  // moves the moov atom up front so playback can begin before the full download.
+  ff(['-f', 'concat', '-safe', '0', '-i', listPath,
+    '-vf', `scale=${OUT_W}:-2,fps=${FPS}`, '-c:v', 'libx264', '-crf', String(CRF),
+    '-pix_fmt', 'yuv420p', '-movflags', '+faststart', '-r', String(FPS), '-an', video]);
+  ff(['-i', path.join(frameDir, 'f-0000.jpg'), '-vf', `scale=${OUT_W}:-2`,
+    '-q:v', '5', '-frames:v', '1', poster]);
+  rmSync(frameDir, { recursive: true, force: true });
+
+  return { id, durationMs: durMs, holdMs: HOLD_MS, video: `${id}.mp4`, poster: `${id}.poster.jpg`,
+    bytes: statSync(video).size, posterBytes: statSync(poster).size };
+}
+
+// ---- main -----------------------------------------------------------------
+mkdirSync(OUT, { recursive: true });
+const ids = await discoverIds();
+console.log(`baking ${ids.length} plugin previews from ${BASE_URL} -> ${OUT}`);
+const browser = await puppeteer.launch({
+  executablePath: resolveChrome(), headless: 'new',
+  // Let muted hero background videos (.mp4/CloudFront, common on premium
+  // landing pages) autoplay so the capture isn't a frozen first frame.
+  args: ['--no-sandbox', '--hide-scrollbars', '--autoplay-policy=no-user-gesture-required'],
+});
+
+const manifestPath = path.join(OUT, 'manifest.json');
+const previews = existsSync(manifestPath)
+  ? (JSON.parse(readFileSync(manifestPath, 'utf8')).previews || {}) : {};
+let ok = 0, skip = 0;
+for (const id of ids) {
+  const t0 = Date.now();
+  let r;
+  try { r = await bakeOne(browser, id); } catch (e) { r = { id, skipped: `error ${e.message}` }; }
+  if (r.skipped) { skip += 1; console.log(`  ~ ${id}: skip (${r.skipped})`); continue; }
+  previews[id] = { video: r.video, poster: r.poster, durationMs: r.durationMs, holdMs: r.holdMs };
+  ok += 1;
+  console.log(`  + ${id}: ${(r.bytes / 1024).toFixed(0)}KB webm, ${(r.posterBytes / 1024).toFixed(0)}KB poster (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
+  writeFileSync(manifestPath, JSON.stringify({ generatedAt: null, previews }, null, 2));
+}
+await browser.close();
+console.log(`done: ${ok} baked, ${skip} skipped -> ${manifestPath}`);

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -258,8 +258,12 @@ for (const id of ids) {
     hash = createHash('sha256').update(html).update(` ${BAKE_VERSION}`).digest('hex').slice(0, 16);
   } catch {}
   const prev = previews[id];
-  if (hash && prev && prev.hash === hash
-      && existsSync(path.join(OUT, prev.video)) && existsSync(path.join(OUT, prev.poster))) {
+  // In CI the unchanged clips already live on R2 (not on disk), so PREVIEW_REMOTE
+  // trusts the manifest hash without a local-file check; locally we also confirm
+  // the files are actually present before reusing.
+  const filesPresent = process.env.PREVIEW_REMOTE === '1'
+    || (prev && existsSync(path.join(OUT, prev.video)) && existsSync(path.join(OUT, prev.poster)));
+  if (hash && prev && prev.hash === hash && filesPresent) {
     reused += 1;
     console.log(`  = ${id}: unchanged, reused`);
     continue;

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -37,7 +37,12 @@
 import puppeteer from 'puppeteer-core';
 import { execFileSync } from 'node:child_process';
 import { mkdirSync, rmSync, writeFileSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
+
+// Bump when the bake recipe changes (capture geometry, timing, encoder, waits…)
+// so every plugin re-bakes even though its page content is byte-identical.
+const BAKE_VERSION = 1;
 
 // ---- config ---------------------------------------------------------------
 const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:17579';
@@ -241,16 +246,31 @@ const browser = await puppeteer.launch({
 const manifestPath = path.join(OUT, 'manifest.json');
 const previews = existsSync(manifestPath)
   ? (JSON.parse(readFileSync(manifestPath, 'utf8')).previews || {}) : {};
-let ok = 0, skip = 0;
+let ok = 0, skip = 0, reused = 0;
 for (const id of ids) {
   const t0 = Date.now();
+  // Content-hash skip: a plugin whose preview HTML (and the bake recipe) is
+  // unchanged reuses its existing clip — no render, and the CI step re-uploads
+  // nothing. Editing the page or bumping BAKE_VERSION invalidates the hash.
+  let hash = null;
+  try {
+    const html = await (await fetch(`${BASE_URL}/api/plugins/${encodeURIComponent(id)}/preview`)).text();
+    hash = createHash('sha256').update(html).update(` ${BAKE_VERSION}`).digest('hex').slice(0, 16);
+  } catch {}
+  const prev = previews[id];
+  if (hash && prev && prev.hash === hash
+      && existsSync(path.join(OUT, prev.video)) && existsSync(path.join(OUT, prev.poster))) {
+    reused += 1;
+    console.log(`  = ${id}: unchanged, reused`);
+    continue;
+  }
   let r;
   try { r = await bakeOne(browser, id); } catch (e) { r = { id, skipped: `error ${e.message}` }; }
   if (r.skipped) { skip += 1; console.log(`  ~ ${id}: skip (${r.skipped})`); continue; }
-  previews[id] = { video: r.video, poster: r.poster, durationMs: r.durationMs, holdMs: r.holdMs };
+  previews[id] = { video: r.video, poster: r.poster, durationMs: r.durationMs, holdMs: r.holdMs, hash };
   ok += 1;
-  console.log(`  + ${id}: ${(r.bytes / 1024).toFixed(0)}KB webm, ${(r.posterBytes / 1024).toFixed(0)}KB poster (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
+  console.log(`  + ${id}: ${(r.bytes / 1024).toFixed(0)}KB mp4, ${(r.posterBytes / 1024).toFixed(0)}KB poster (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
   writeFileSync(manifestPath, JSON.stringify({ generatedAt: null, previews }, null, 2));
 }
 await browser.close();
-console.log(`done: ${ok} baked, ${skip} skipped -> ${manifestPath}`);
+console.log(`done: ${ok} baked, ${reused} reused (unchanged), ${skip} skipped -> ${manifestPath}`);

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -81,6 +81,10 @@ const residualAllowedExactPaths = new Set([
   // PostCSS loads Tailwind through a web-local .mjs compatibility config entry.
   "apps/web/postcss.config.mjs",
   "scripts/bake-html-ppt-examples.mjs",
+  // CI-only plugin-preview renderer. Kept .mjs and run directly by Node so its
+  // runtime deps (puppeteer-core + a headless Chrome + ffmpeg) are provided by
+  // the CI environment and never pulled into the daemon/web TS build or bundle.
+  "scripts/bake-plugin-previews.mjs",
   "scripts/scaffold-html-ppt-skills.mjs",
   "scripts/sync-hyperframes-skill.mjs",
   "scripts/verify-media-models.mjs",


### PR DESCRIPTION
## Why

The Home "Community" gallery renders every html plugin as a live, scaled
`example.html` iframe that animates and auto-pans on hover. At ~150 tiles this is
GPU-expensive (each tile is its own out-of-process document re-compositing a tall
page), so scrolling is janky — and it renders inconsistently for tricky pages:
WebGL/canvas heroes show noise at small scale, `<video>`/CloudFront backgrounds
and lazy images don't load in time, dark heroes look empty.

Scratching our own itch on the desktop client's home performance. Pre-rendering
each preview to a tiny clip fixes the scroll cost *and* gives a consistent,
complete thumbnail.

## What users will see

A gallery tile shows a still poster (the page's hero) and plays a short looping
clip on hover that pans down through the page — the same "tour" the live iframe
gave, but cheap. Opening a plugin's detail still loads the real, interactive page
(unchanged). Plugins not yet baked keep the live-iframe preview, so nothing
regresses.

## Surface area

- [x] **UI** — gallery tile rendering in `apps/web` (MediaSurface instead of the live iframe)
- [x] **API / contract** — new daemon route `GET /api/plugin-previews/*` (serves baked clips locally; R2 in prod) + a new `od.bakedPreview` field the daemon attaches to plugin records
- [ ] **New top-level dependency** — no; the bake script's puppeteer-core / Chrome / ffmpeg are provided by the CI environment, never added to `package.json`

No CLI surface: this is a rendering optimization of an existing view plus a
CI-only build tool, not a new user capability, so there is nothing to expose
through `od`.

## How it works

- `scripts/bake-plugin-previews.mjs` renders each `example.html` (headless-Chrome
  screencast of a hold-then-pan capture, waiting on fonts + images + CSS
  background-images + `<video>` backgrounds), encodes a CFR H.264 mp4 + poster,
  writes `manifest.json`. A content-hash skip reuses unchanged plugins.
- The daemon attaches the clip under `od.bakedPreview`; gallery tiles opt in via
  `inferPluginPreview(record, { preferBaked: true })` and render a poster +
  hover-play `<video>` (looping the in-place span while idle, the pan on hover,
  frame-accurate via `requestVideoFrameCallback`, no native controls).
- `.github/workflows/bake-plugin-previews.yml` runs the script post-merge +
  nightly, uploads clips to R2, and opens a reviewed PR with the refreshed
  (version-pinned) manifest.

## Status — what's verified

Bake script, daemon injection, and web display are verified locally: idle
in-place loop, hover pan with no black flash, detail-shows-live-page, H.264
decode in Electron, video-background capture, ≤10s pre-computed pan, content-hash
skip.

**The CI workflow itself has not run yet.** It needs a real run (R2 secrets + a
daemon in CI) to shake out Chrome resolution on the runner, daemon startup, the
~50-min bake of ~150 plugins, the exact R2 endpoint secret name, and the
GITHUB_TOKEN-PR-doesn't-trigger-CI caveat (a `PREVIEW_BAKE_TOKEN` hook is left
for that). Draft until the bake workflow is iterated to green via
`workflow_dispatch`. This PR is up to get the regular CI (typecheck / guard /
tests) on the code.
