### PR TITLE
[codex] Fix image export menu capture

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState, type CSSProperties, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
-import { createPortal } from 'react-dom';
+import { createPortal, flushSync } from 'react-dom';
 import { Button, Input, Select } from '@open-design/components';
 import { APP_CHROME_FILE_ACTIONS_ID, APP_CHROME_FILE_ACTIONS_SELECTOR } from './AppChromeHeader';
 import {
@@ -7339,11 +7339,15 @@ function HtmlViewer({
     }
   }, [captureExportImageSnapshot, t]);
 
-  const openImageExportModal = () => {
-    setDownloadMenuOpen(false);
+  const openImageExportModal = async () => {
+    flushSync(() => {
+      setDownloadMenuOpen(false);
+    });
     setImageExportError(null);
     setImageExportPreparedBlob(null);
     imageExportSnapshotDataUrlRef.current = null;
+    await waitForAnimationFrame();
+    await waitForAnimationFrame();
     setImageExportModalOpen(true);
     void prepareImageExportBlob(imageExportFormat);
   };

--- a/apps/web/tests/components/file-viewer-image-export.test.tsx
+++ b/apps/web/tests/components/file-viewer-image-export.test.tsx
@@ -5,12 +5,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ProjectFile } from '../../src/types';
 
 const {
+  captureHostIframeSnapshotMock,
   downloadImageDataUrlMock,
   imageDataUrlToBlobMock,
   prepareImageExportTargetMock,
   requestPreviewSnapshotMock,
   saveImageBlobMock,
 } = vi.hoisted(() => ({
+  captureHostIframeSnapshotMock: vi.fn(),
   downloadImageDataUrlMock: vi.fn(),
   imageDataUrlToBlobMock: vi.fn(),
   prepareImageExportTargetMock: vi.fn(),
@@ -24,6 +26,7 @@ vi.mock('../../src/runtime/exports', async () => {
   );
   return {
     ...actual,
+    captureHostIframeSnapshot: captureHostIframeSnapshotMock,
     downloadImageDataUrl: downloadImageDataUrlMock,
     imageDataUrlToBlob: imageDataUrlToBlobMock,
     prepareImageExportTarget: prepareImageExportTargetMock,
@@ -71,10 +74,10 @@ function renderHtmlPreview() {
   return { ...view, activeFrame, srcDocFrame: srcDocFrame as HTMLIFrameElement };
 }
 
-function openImageExportDialog() {
+async function openImageExportDialog() {
   fireEvent.click(screen.getByRole('button', { name: /download/i }));
   fireEvent.click(screen.getByRole('menuitem', { name: /export as image/i }));
-  expect(screen.getByRole('dialog', { name: /export as image/i })).toBeTruthy();
+  expect(await screen.findByRole('dialog', { name: /export as image/i })).toBeTruthy();
 }
 
 async function waitForSaveButton() {
@@ -100,7 +103,7 @@ describe('FileViewer image export', () => {
     imageDataUrlToBlobMock.mockResolvedValueOnce(new Blob(['png'], { type: 'image/png' }));
 
     const { container } = renderHtmlPreview();
-    openImageExportDialog();
+    await openImageExportDialog();
 
     const backdrop = document.body.querySelector('.viewer-modal-backdrop');
     expect(backdrop).toBeTruthy();
@@ -109,6 +112,33 @@ describe('FileViewer image export', () => {
     expect(container.querySelector('.viewer-modal-backdrop')).toBeNull();
     await waitFor(() => {
       expect(imageDataUrlToBlobMock).toHaveBeenCalledWith('data:image/png;base64,ok', 'png');
+    });
+  });
+
+  it('waits for the download menu to close before capturing host pixels', async () => {
+    captureHostIframeSnapshotMock.mockImplementationOnce(async () => {
+      expect(screen.queryByRole('menu')).toBeNull();
+      return {
+        dataUrl: 'data:image/png;base64,host',
+        w: 800,
+        h: 600,
+      };
+    });
+    imageDataUrlToBlobMock.mockResolvedValueOnce(new Blob(['png'], { type: 'image/png' }));
+
+    renderHtmlPreview();
+    fireEvent.click(screen.getByRole('button', { name: /download/i }));
+    expect(screen.getByRole('menu')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /export as image/i }));
+
+    expect(screen.queryByRole('menu')).toBeNull();
+    expect(captureHostIframeSnapshotMock).not.toHaveBeenCalled();
+
+    expect(await screen.findByRole('dialog', { name: /export as image/i })).toBeTruthy();
+    await waitFor(() => {
+      expect(captureHostIframeSnapshotMock).toHaveBeenCalledTimes(1);
+      expect(imageDataUrlToBlobMock).toHaveBeenCalledWith('data:image/png;base64,host', 'png');
     });
   });
 
@@ -131,7 +161,7 @@ describe('FileViewer image export', () => {
     });
 
     const { activeFrame } = renderHtmlPreview();
-    openImageExportDialog();
+    await openImageExportDialog();
     expect(screen.getByRole('radio', { name: 'PNG' })).toBeTruthy();
 
     await waitFor(() => {
@@ -171,7 +201,7 @@ describe('FileViewer image export', () => {
       }));
 
     renderHtmlPreview();
-    openImageExportDialog();
+    await openImageExportDialog();
 
     await waitForSaveButton();
 
@@ -204,7 +234,7 @@ describe('FileViewer image export', () => {
     imageDataUrlToBlobMock.mockResolvedValueOnce(pngBlob);
 
     const { srcDocFrame } = renderHtmlPreview();
-    openImageExportDialog();
+    await openImageExportDialog();
 
     await waitFor(() => {
       expect(requestPreviewSnapshotMock).toHaveBeenCalledWith(srcDocFrame, 1500);
@@ -228,7 +258,7 @@ describe('FileViewer image export', () => {
     imageDataUrlToBlobMock.mockResolvedValueOnce(pngBlob);
 
     const { activeFrame, srcDocFrame } = renderHtmlPreview();
-    openImageExportDialog();
+    await openImageExportDialog();
 
     await waitFor(() => {
       expect(requestPreviewSnapshotMock).toHaveBeenCalledWith(activeFrame, 1500);
@@ -253,7 +283,7 @@ describe('FileViewer image export', () => {
     });
 
     renderHtmlPreview();
-    openImageExportDialog();
+    await openImageExportDialog();
     fireEvent.click(await waitForSaveButton());
 
     await waitFor(() => {
@@ -273,7 +303,7 @@ describe('FileViewer image export', () => {
     });
 
     renderHtmlPreview();
-    openImageExportDialog();
+    await openImageExportDialog();
 
     await waitFor(() => {
       expect(screen.getByRole('alert').textContent).toBe(
@@ -300,7 +330,7 @@ describe('FileViewer image export', () => {
     });
 
     renderHtmlPreview();
-    openImageExportDialog();
+    await openImageExportDialog();
 
     await waitFor(() => {
       expect(screen.getByRole('alert').textContent).toBe(


### PR DESCRIPTION
## Why

Image export from the file viewer currently starts the desktop host pixel capture immediately after the user clicks Download -> Export as image. In the desktop runtime that capture reads the real compositor pixels for the preview iframe region, so React can still have the download popover on screen when the capture starts. Users then get an exported image with the dropdown menu embedded in the artwork.

This PR fixes that user-facing export artifact without changing the image export dialog or the capture backend.

## What users will see

When exporting a design file as an image, the download menu closes before the image snapshot is prepared. The exported image contains only the preview content, not the Open Design download dropdown.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The visible UI entry point is unchanged; the bug is in the exported file contents and is covered by the regression test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/file-viewer-image-export.test.tsx`
- Did the test go red on `main` and green on this branch? no; I added the regression directly on this branch after identifying the menu-close/capture race.
- The new test asserts that clicking Export as image closes the download menu and does not call the host pixel capture until after the dialog appears.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/web test -- file-viewer-image-export.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
