### PR TITLE
fix(web): suppress PDF export toast on cancel

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4507,10 +4507,21 @@ function HtmlViewer({
       const out = fn();
       if (out && typeof (out as Promise<unknown>).then === 'function') {
         (out as Promise<unknown>).then(
-          () => { finish('success'); if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportStarted'), tone: 'default' }); },
+          (result) => {
+            if (result === 'cancelled') {
+              finish('cancelled');
+              return;
+            }
+            finish('success');
+            if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportStarted'), tone: 'default' });
+          },
           (err) => finish('failed', err instanceof Error ? err.name : 'UNKNOWN'),
         );
       } else {
+        if (out === 'cancelled') {
+          finish('cancelled');
+          return;
+        }
         finish('success');
         if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportStarted'), tone: 'default' });
       }

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -727,7 +727,7 @@ export function exportAsImage(dataUrl: string, title: string): void {
   }
 }
 
-export type ProjectPdfExportResult = 'desktop' | 'fallback';
+export type ProjectPdfExportResult = 'desktop' | 'fallback' | 'cancelled';
 
 export async function exportProjectAsPdf(opts: {
   deck: boolean;
@@ -748,6 +748,7 @@ export async function exportProjectAsPdf(opts: {
     });
     if (!resp.ok) throw new Error(`desktop PDF export unavailable (${resp.status})`);
     const body = await resp.json().catch(() => ({}));
+    if (body?.canceled === true) return 'cancelled';
     if (body && body.ok === false) throw new Error(body.error || 'desktop PDF export failed');
     return 'desktop';
   } catch (err) {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -2288,6 +2288,58 @@ describe('FileViewer SVG artifacts', () => {
     expect(downloadItems).not.toContain('Export as Markdown');
   });
 
+  it('does not show an export-started toast when desktop PDF export is canceled', async () => {
+    const file = baseFile({
+      name: 'index.html',
+      path: 'index.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+    const fetchMock = vi.fn(async (input: unknown) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.pathname
+          : typeof (input as { url?: unknown })?.url === 'string'
+            ? (input as { url: string }).url
+            : '';
+      if (url === '/api/projects/project-1/export/pdf') {
+        return new Response(JSON.stringify({ ok: true, canceled: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ deployments: [] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={file}
+        liveHtml="<html><body><h1>Hello</h1></body></html>"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /download/i }));
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Export as PDF/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/projects/project-1/export/pdf',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText('Export started')).toBeNull();
+  });
+
   it('disables share link actions while the artifact is still streaming', async () => {
     const file = baseFile({
       name: 'index.html',

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -220,6 +220,22 @@ describe('exportProjectAsPdf', () => {
     });
   });
 
+  it('treats a canceled desktop PDF save dialog as a silent no-op', async () => {
+    const fallback = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ ok: true, canceled: true }), { status: 200 })));
+
+    const result = await exportProjectAsPdf({
+      deck: true,
+      fallbackPdf: fallback,
+      filePath: 'deck/index.html',
+      projectId: 'proj-1',
+      title: 'Seed Deck',
+    });
+
+    expect(result).toBe('cancelled');
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
   it('falls back to browser print when the desktop PDF export API is unavailable', async () => {
     const fallback = vi.fn();
     vi.spyOn(console, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
Fixes #3895

## Why

Canceling the native PDF Save dialog currently still looks like a started export in the artifact UI.

The desktop PDF exporter already distinguishes this case by returning `{ ok: true, canceled: true }`, and the daemon route forwards that result. The cancellation signal was lost in the web runtime: `exportProjectAsPdf()` treated every successful response as `desktop`, and `FileViewer` showed `fileViewer.exportStarted` for every resolved export promise.

I coordinated with @yinjialu, who had previously claimed #3895, and we agreed that I would take over this fix.

This PR keeps the existing desktop/daemon behavior and carries the cancellation result up to the toast/analytics layer, so canceling PDF export is a silent no-op instead of mixed feedback.

## What users will see

When a user starts PDF export and cancels the Save dialog, the app no longer shows “Export started”.

Successful PDF exports, fallback browser print behavior, and failed export handling are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — canceled PDF export now stays silent instead of showing an export-started toast
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A. This fixes the absence of an incorrect toast rather than adding a new UI surface. The behavior is covered by a component regression test.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/web/tests/runtime/exports.test.ts`
  - `apps/web/tests/components/FileViewer.test.tsx`
- Did the test go red on `main` and green on this branch? yes
  - Red check: old `origin/main` source with the new tests failed because `exportProjectAsPdf()` returned `desktop` instead of `cancelled`, and `FileViewer` rendered `Export started`.
  - Green check: current branch passes the same targeted tests.
- Why this is well covered:
  - The runtime test pins the contract boundary where `{ ok: true, canceled: true }` comes back from the daemon.
  - The component test exercises the user path through Download → Export as PDF and asserts that the canceled desktop result does not show `Export started`.

## Validation

- `git diff --check`
- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/runtime/exports.test.ts tests/components/FileViewer.test.tsx`
  - 2 files passed, 205 tests passed
- `corepack pnpm --filter @open-design/web test -- apps/web/tests/runtime/exports.test.ts`
  - ran the full web suite: 316 files passed, 3154 tests passed, 1 skipped
- `corepack pnpm --filter @open-design/web typecheck`

Local note: pnpm printed engine warnings because this machine is on Node `v23.10.0`; the repo expects Node `~24`.
