### PR TITLE
Fix AMR install URL metadata

### DIFF
--- a/apps/daemon/src/runtimes/metadata.ts
+++ b/apps/daemon/src/runtimes/metadata.ts
@@ -4,7 +4,7 @@ const AGENT_INSTALL_LINKS: Record<
   { installUrl?: string; docsUrl?: string }
 > = {
   amr: {
-    installUrl: 'https://github.com/nexu-io/vela',
+    installUrl: 'https://open-design.ai/amr',
     docsUrl: 'https://github.com/nexu-io/open-design/blob/main/docs/new-agent-runtime-acp.md',
   },
   claude: {

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -458,9 +458,13 @@ test('detectAgents includes sanitized install and docs metadata from split runti
       process.env.OD_AGENT_HOME = dir;
 
       const agents = await detectAgents();
+      const amr = agents.find((agent) => agent.id === 'amr');
       const qoder = agents.find((agent) => agent.id === 'qoder');
       const deepseek = agents.find((agent) => agent.id === 'deepseek');
 
+      assert.ok(amr);
+      assert.equal(amr.available, false);
+      assert.equal(amr.installUrl, 'https://open-design.ai/amr');
       assert.ok(qoder);
       assert.equal(qoder.available, false);
       assert.equal(qoder.installUrl, 'https://qoder.com/download');


### PR DESCRIPTION
Fixes #3989

## Why

I am opening this as TheAngryPit agent after #3989 confirmed that the Open Design AMR install link points to the dead https://github.com/nexu-io/vela URL.

This is a user-facing broken install/help path. The repo already treats https://open-design.ai/amr as the canonical AMR page in README, landing header, and analytics metadata, and that page currently returns HTTP 200.

## What users will see

When AMR is unavailable, the install action now points to https://open-design.ai/amr instead of a GitHub 404.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop, including Electron menu bar
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new od subcommand or flag, new tools-dev / tools-pack / tools-pr flag, or new OD_* env var
- [ ] **API / contract** — new /api/* endpoint, new SSE event, or changed shape in packages/contracts
- [ ] **Extension point** — new entry under skills, design-systems, design-templates, or craft, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root package.json
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A. This changes the existing AMR install link target, not visible layout.

## Bug fix verification

- Test path that reproduces the bug: apps/daemon/tests/runtimes/env-and-detection.test.ts
- Did the test go red on main and green on this branch? No. The added assertion directly covers the pre-fix metadata value from main, but the first local test attempt failed in setup because workspace links were stale after updating main. After refreshing workspace links with pnpm install, this branch is green.
- Additional verification: https://open-design.ai/amr returns HTTP 200.

## Validation

- pnpm exec vitest run -c vitest.config.ts tests/runtimes/env-and-detection.test.ts from apps/daemon, 53 passed
- pnpm --filter @open-design/daemon typecheck
- pnpm guard, outside sandbox because tsx IPC cannot bind inside the sandbox here
- curl -sSI https://open-design.ai/amr, HTTP 200

## Agent involvement

Prepared by Aegis, working as TheAngryPit agent.