### PR TITLE
feat(plugins-home): content-hashed preview filenames + immutable CDN caching

### DIFF
--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -92,9 +92,12 @@ jobs:
         run: |
           endpoint="${R2_ENDPOINT%/}"
           # cp (not sync --delete) so untouched clips already on R2 stay put.
+          # Filenames are content-hashed, so the clips are immutable — let the
+          # CDN cache them forever (a content change ships a new filename).
           aws s3 cp .tmp/plugin-previews "s3://$R2_BUCKET/plugin-previews/" \
             --recursive --no-progress \
             --endpoint-url "$endpoint" \
+            --cache-control "public, max-age=31536000, immutable" \
             --exclude manifest.json
 
       - name: Open manifest PR for review

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -100,7 +100,7 @@ async function discoverIds() {
 }
 
 // ---- render + encode one plugin -------------------------------------------
-async function bakeOne(browser, id) {
+async function bakeOne(browser, id, hash) {
   const page = await browser.newPage();
   await page.setViewport({ width: RENDER_W, height: VIEW_H, deviceScaleFactor: 1 });
   try {
@@ -213,8 +213,13 @@ async function bakeOne(browser, id) {
   const listPath = path.join(frameDir, 'list.txt');
   writeFileSync(listPath, lines.join('\n'));
 
-  const video = path.join(OUT, `${id}.mp4`);
-  const poster = path.join(OUT, `${id}.poster.jpg`);
+  // Content-hashed filenames so a re-bake publishes a NEW URL the daemon points
+  // at via the manifest, instead of overwriting the same key — which the CDN
+  // edge would keep serving stale until its TTL expired. New name => new cache
+  // entry => safe to cache immutably forever.
+  const slug = hash ? `${id}.${hash}` : id;
+  const video = path.join(OUT, `${slug}.mp4`);
+  const poster = path.join(OUT, `${slug}.poster.jpg`);
   const ff = (a) => execFileSync('ffmpeg', ['-y', ...a], { stdio: 'ignore' });
   // H.264 MP4, constant frame rate (the fps filter resamples the concat's
   // real-time timeline to a constant FPS). H.264 decodes reliably in both
@@ -228,7 +233,7 @@ async function bakeOne(browser, id) {
     '-q:v', '5', '-frames:v', '1', poster]);
   rmSync(frameDir, { recursive: true, force: true });
 
-  return { id, durationMs: durMs, holdMs: HOLD_MS, video: `${id}.mp4`, poster: `${id}.poster.jpg`,
+  return { id, durationMs: durMs, holdMs: HOLD_MS, video: `${slug}.mp4`, poster: `${slug}.poster.jpg`,
     bytes: statSync(video).size, posterBytes: statSync(poster).size };
 }
 
@@ -269,7 +274,7 @@ for (const id of ids) {
     continue;
   }
   let r;
-  try { r = await bakeOne(browser, id); } catch (e) { r = { id, skipped: `error ${e.message}` }; }
+  try { r = await bakeOne(browser, id, hash); } catch (e) { r = { id, skipped: `error ${e.message}` }; }
   if (r.skipped) { skip += 1; console.log(`  ~ ${id}: skip (${r.skipped})`); continue; }
   previews[id] = { video: r.video, poster: r.poster, durationMs: r.durationMs, holdMs: r.holdMs, hash };
   ok += 1;


### PR DESCRIPTION
Follow-up to #3994.

## Why

The baked plugin-preview clips are served from R2 behind Cloudflare's CDN
(`cf-cache-status: HIT`). #3994 named each clip `example-<id>.mp4`, so a re-bake
**overwrites the same key** — and the CDN edge keeps serving the *stale* clip
until its TTL expires. So a fixed/updated preview wouldn't actually reach users
for a while. Spotted while confirming the clips were CDN-cached.

## What users will see

Nothing changes visibly — same clips, same gallery. Under the hood, when a
plugin's preview is re-baked the new clip is published immediately (no stale-edge
window), and previews load from a forever-cached, immutable CDN URL.

## How

- Filenames are now content-hashed: `example-<id>.<contentHash>.mp4` /
  `.poster.jpg` (reusing the hash already computed for the skip logic). A content
  change ships a **new URL** the committed manifest points at; the old edge entry
  is simply no longer referenced, and the unchanged-skip still reuses the same
  hashed name.
- The R2 upload sets `Cache-Control: public, max-age=31536000, immutable` so the
  CDN can cache each clip forever — safe now that names are content-addressed.

The daemon needs no change: it already builds URLs from the manifest's filenames.

## Surface area

- [x] **None** — CI/build-tool change (bake script + workflow) plus the manifest
  filename format. No UI, CLI, contract, or dependency change.

Note: old non-hashed clips already on R2 become unreferenced orphans; they're
harmless (cheap storage) and a periodic prune can be a later cleanup.
