### PR TITLE
[codex] Bump Vela CLI to 0.0.14

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-cFElX3G4K+c581UW4F1/JvVI8GcZ4/ZKG6r50RYxKUU=";
-  webHash = "sha256-Rx/9yiacA2vOfYfWdMnstfdtURKLrWLkGua/64VPKQc=";
+  daemonHash = "sha256-5x8DxYkjJ8FfIwMCw1+2kto75Bz+38RvtJe6Q0Z6Szk=";
+  webHash = "sha256-PmcdBBRRZO283U6ByUnnSyENFq1JwgEo1dXpdh2XZ5c=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,8 +706,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.13
-        version: 0.0.13
+        specifier: 0.0.14
+        version: 0.0.14
 
   tools/serve:
     dependencies:
@@ -1845,33 +1845,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.13':
-    resolution: {integrity: sha512-/RfnxaW9aRsCMZ7GwpDK6uSRRvfbLu89qlv+BFBqJV13n+3Pu4d0H7pEaK/6vtAQdHBsQqU5MB/z3N51SWavWw==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.14':
+    resolution: {integrity: sha512-nMLFRl47feNWQ+nTt1sTP78VZ/t9C2akohzbRtgaJWGg3Nyc+VAptXRrTa8LCdY511PqEYK8ka8j3xFQYz+J9Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.13':
-    resolution: {integrity: sha512-dKgelyjmTK5BvatQAjn5mC5puRX0jMBVjYV63tGrmZHjCUSE8B4AduZkk0rkRmcrFrz2QJ0IGfTrCzybFA1MsA==}
+  '@powerformer/vela-cli-darwin-x64@0.0.14':
+    resolution: {integrity: sha512-wT8e5n8o2Jbidh2d2grQWaqcNwHdBKzratJIj1VkFgBfrPVsziUH0uA7gv6xOA7gE+Z2AdrAN8X7CVeIHqvs8Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.13':
-    resolution: {integrity: sha512-HLByJGZedRYCFf5fUu1iStZP8BrNaLuBWj2NHQG1GM9pYTWIrDIn8XYBwupePT/p6gKQmsA7Rv4tWS2k0aGDXA==}
+  '@powerformer/vela-cli-linux-arm64@0.0.14':
+    resolution: {integrity: sha512-j2TbDkQFEp6Rdz46Ns7zroDaYm4wKxRyXHkS103JsukfkqA97jf6ufAE/4B6Rcd2uJ9pFoX+ob2CnzBaM9XCOA==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.13':
-    resolution: {integrity: sha512-YTgLFKlr0onbFKwsJT4DwzMfi7/Af5S/4iNAmq+hBEtmBxsgNnVEQZ1wD6JaiLtqsbwRhZYFpBNlxP2KRtnT2g==}
+  '@powerformer/vela-cli-linux-x64@0.0.14':
+    resolution: {integrity: sha512-jTIQkRdWnX1K0qhyna+HGjz4l8jjeA+Ys8ry/ZibBdfL8ruBsJkb1eg6WClII1XTFxSZCStA/a9RlsEB4uR1tQ==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.13':
-    resolution: {integrity: sha512-vfnDc58qY5918SXBcdNdt8wIkdIDFOUXnGmTgLYQsU77QK6sR71rspuA1TRpjIOTZD/OkMADQfLePqvimI37hQ==}
+  '@powerformer/vela-cli-win32-x64@0.0.14':
+    resolution: {integrity: sha512-GhqNEKmaGkc3YykXTDMsrnFXmo9F5u/6pJqOK9GKUcOm3psQkewLldUdsRaPSZxNayzfXY2yYE/FB24Q3tk01Q==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.13':
-    resolution: {integrity: sha512-Z8+DrsaWo9rUhjOvvCnSXzxW6832b/yQG27HwA60oW09evK3kaA41Eg1Ca1meujktoEaxAfn5u5M1toJVHV6Ig==}
+  '@powerformer/vela-cli@0.0.14':
+    resolution: {integrity: sha512-sdvhw84H57hoRHxVXt9+NMW6TRilQ9ytLbqfysoY+tC7npUWUt1rvc3sB6E4sVrhDZoH3Jolih6TjlM+KK6SJw==}
     hasBin: true
 
   '@preact/signals-core@1.14.2':
@@ -6560,28 +6560,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.13':
+  '@powerformer/vela-cli-darwin-arm64@0.0.14':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.13':
+  '@powerformer/vela-cli-darwin-x64@0.0.14':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.13':
+  '@powerformer/vela-cli-linux-arm64@0.0.14':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.13':
+  '@powerformer/vela-cli-linux-x64@0.0.14':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.13':
+  '@powerformer/vela-cli-win32-x64@0.0.14':
     optional: true
 
-  '@powerformer/vela-cli@0.0.13':
+  '@powerformer/vela-cli@0.0.14':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.13
-      '@powerformer/vela-cli-darwin-x64': 0.0.13
-      '@powerformer/vela-cli-linux-arm64': 0.0.13
-      '@powerformer/vela-cli-linux-x64': 0.0.13
-      '@powerformer/vela-cli-win32-x64': 0.0.13
+      '@powerformer/vela-cli-darwin-arm64': 0.0.14
+      '@powerformer/vela-cli-darwin-x64': 0.0.14
+      '@powerformer/vela-cli-linux-arm64': 0.0.14
+      '@powerformer/vela-cli-linux-x64': 0.0.14
+      '@powerformer/vela-cli-win32-x64': 0.0.14
     optional: true
 
   '@preact/signals-core@1.14.2': {}

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -24,7 +24,7 @@
     "resedit": "1.7.2"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.13"
+    "@powerformer/vela-cli": "0.0.14"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

Vela CLI has been released at 0.0.14, and Open Design's packaging surface should consume the latest bundled CLI version.

This keeps packaged Open Design builds aligned with the current Vela CLI release without changing any Open Design code paths.

## What users will see

Packaged builds that bundle Vela CLI will now include `@powerformer/vela-cli@0.0.14` instead of `0.0.13`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

Not applicable; this is a dependency version bump, not a bug fix.

## Validation

- `corepack pnpm install --lockfile-only --ignore-scripts`
- `corepack pnpm guard`
- `corepack pnpm --filter @open-design/tools-pack typecheck`
- `corepack pnpm --filter @open-design/tools-pack test`
- `PATH="/tmp/od-corepack-pnpm-shim:$PATH" corepack pnpm typecheck`