### PR TITLE
Fix runtime todo rendering and artifact echoes

### DIFF
--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -223,12 +223,10 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
       const candidateLength = artifactOpenCandidateLength(current, openTag);
       if (suppressNextArtifactText && candidateLength > 0) {
         artifactOpenCandidate = current.slice(-candidateLength);
-        pendingArtifactText += current.slice(0, -candidateLength);
-        return '';
+        return current.slice(0, -candidateLength);
       }
       if (suppressNextArtifactText) {
-        pendingArtifactText += current;
-        return '';
+        return current;
       }
       return current;
     }

--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -528,8 +528,8 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
   }
 
   function flushPendingArtifactText() {
-    if (!pendingArtifactText) return;
-    const text = pendingArtifactText;
+    const text = `${pendingArtifactText}${artifactOpenCandidate}`;
+    if (!text) return;
     pendingArtifactText = '';
     artifactOpenCandidate = '';
     suppressNextArtifactText = false;

--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -30,6 +30,12 @@ type BlockState = {
   input: string;
   inputValue?: unknown;
 };
+type RuntimeTask = {
+  id: string;
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'stopped';
+  activeForm?: string;
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -60,6 +66,91 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
   let currentMessageStreamedThinking = false;
   // Per-message role-marker guards for cross-chunk detection (#3247).
   const roleGuards = new Map<string, RoleMarkerGuard>();
+  const runtimeTasks = new Map<string, RuntimeTask>();
+  const canonicalTaskToolUseIds = new Set<string>();
+  let nextRuntimeTaskId = 1;
+  let fileWriteSeen = false;
+  let suppressDuplicateArtifactText = false;
+  let artifactOpenCandidate = '';
+
+  function normalizeTaskStatus(value: unknown): RuntimeTask['status'] {
+    if (value === 'completed' || value === 'in_progress' || value === 'stopped') {
+      return value;
+    }
+    if (value === 'complete' || value === 'done') return 'completed';
+    if (value === 'doing' || value === 'active') return 'in_progress';
+    if (value === 'failed' || value === 'canceled' || value === 'cancelled') return 'stopped';
+    return 'pending';
+  }
+
+  function emitCanonicalTaskSnapshot(toolUseId: unknown, name: unknown, input: unknown): void {
+    if (typeof toolUseId !== 'string' || typeof name !== 'string' || !isRecord(input)) return;
+    if (canonicalTaskToolUseIds.has(toolUseId)) return;
+    let changed = false;
+    if (name === 'TaskCreate') {
+      const content = typeof input.subject === 'string'
+        ? input.subject
+        : typeof input.description === 'string'
+          ? input.description
+          : '';
+      if (!content) return;
+      const id = typeof input.taskId === 'string' && input.taskId
+        ? input.taskId
+        : String(nextRuntimeTaskId++);
+      const activeForm = typeof input.activeForm === 'string' ? input.activeForm : undefined;
+      runtimeTasks.set(id, {
+        id,
+        content,
+        status: normalizeTaskStatus(input.status),
+        ...(activeForm ? { activeForm } : {}),
+      });
+      changed = true;
+    } else if (name === 'TaskUpdate') {
+      if (typeof input.taskId !== 'string') return;
+      const existing = runtimeTasks.get(input.taskId);
+      if (!existing) return;
+      const content = typeof input.subject === 'string'
+        ? input.subject
+        : typeof input.description === 'string'
+          ? input.description
+          : existing.content;
+      const activeForm = typeof input.activeForm === 'string' ? input.activeForm : existing.activeForm;
+      runtimeTasks.set(input.taskId, {
+        ...existing,
+        content,
+        status: normalizeTaskStatus(input.status),
+        ...(activeForm ? { activeForm } : {}),
+      });
+      changed = true;
+    }
+    canonicalTaskToolUseIds.add(toolUseId);
+    if (!changed || runtimeTasks.size === 0) return;
+    onEvent({
+      type: 'tool_use',
+      id: `${toolUseId}:todo-task`,
+      name: 'TodoWrite',
+      input: {
+        todos: Array.from(runtimeTasks.values()).map(({ content, status, activeForm }) => ({
+          content,
+          status,
+          ...(activeForm ? { activeForm } : {}),
+        })),
+      },
+    });
+  }
+
+  function emitToolUse(id: unknown, name: unknown, input: unknown): void {
+    emitCanonicalTaskSnapshot(id, name, input);
+    if (isFileWriteToolUse(name, input)) {
+      fileWriteSeen = true;
+    }
+    onEvent({
+      type: 'tool_use',
+      id,
+      name,
+      input,
+    });
+  }
 
   function blockKey(index: unknown): string {
     return `${currentMessageId ?? 'anon'}:${index}`;
@@ -80,6 +171,10 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
   // r3324xxxxxx. Thinking is passed through unguarded; only the
   // user-visible text channel is policed.
   function emitSafeText(msgId: string | null, text: string, eventType: string = 'text_delta') {
+    if (eventType === 'text_delta') {
+      text = stripDuplicateArtifactText(text);
+      if (!text) return;
+    }
     if (eventType !== 'text_delta' || !msgId) {
       onEvent({ type: eventType, delta: text });
       return;
@@ -99,6 +194,54 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
       const warn = guard.warningEvent();
       if (warn) onEvent(warn);
     }
+  }
+
+  function stripDuplicateArtifactText(text: string): string {
+    if (!fileWriteSeen) return text;
+    const openTag = '<artifact';
+    const current = `${artifactOpenCandidate}${text}`;
+    artifactOpenCandidate = '';
+    if (suppressDuplicateArtifactText) {
+      const closeIndex = current.indexOf('</artifact>');
+      if (closeIndex === -1) return '';
+      suppressDuplicateArtifactText = false;
+      return stripDuplicateArtifactText(current.slice(closeIndex + '</artifact>'.length));
+    }
+    const openIndex = current.indexOf(openTag);
+    if (openIndex === -1) {
+      const candidateLength = artifactOpenCandidateLength(current, openTag);
+      if (candidateLength > 0) {
+        artifactOpenCandidate = current.slice(-candidateLength);
+        return current.slice(0, -candidateLength);
+      }
+      return current;
+    }
+    suppressDuplicateArtifactText = true;
+    return `${current.slice(0, openIndex)}${stripDuplicateArtifactText(current.slice(openIndex))}`;
+  }
+
+  function artifactOpenCandidateLength(text: string, openTag: string): number {
+    const max = Math.min(openTag.length - 1, text.length);
+    for (let len = max; len > 0; len -= 1) {
+      if (openTag.startsWith(text.slice(-len))) return len;
+    }
+    return 0;
+  }
+
+  function isFileWriteToolUse(name: unknown, input: unknown): boolean {
+    if (typeof name !== 'string' || !isRecord(input)) return false;
+    const path = typeof input.file_path === 'string'
+      ? input.file_path
+      : typeof input.path === 'string'
+        ? input.path
+        : '';
+    const writesFile = name === 'Write' ||
+      name === 'Edit' ||
+      name === 'write_file' ||
+      name === 'replace';
+    if (!writesFile) return false;
+    if (/\.(html|htm|css|js|jsx|ts|tsx|md)$/iu.test(path)) return true;
+    return typeof input.content === 'string' || typeof input.new_string === 'string';
   }
 
   function feed(chunk: string) {
@@ -184,12 +327,7 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
             streamedToolUseIds.delete(block.id);
             continue;
           }
-          onEvent({
-            type: 'tool_use',
-            id: block.id,
-            name: block.name,
-            input: block.input ?? null,
-          });
+          emitToolUse(block.id, block.name, block.input ?? null);
         } else if (
           !textAlreadyStreamed &&
           block.type === 'text' &&
@@ -330,12 +468,7 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
       const state = blocks.get(key);
       if (state && state.type === 'tool_use' && typeof state.id === 'string' && state.input.trim()) {
         try {
-          onEvent({
-            type: 'tool_use',
-            id: state.id,
-            name: state.name,
-            input: JSON.parse(state.input),
-          });
+          emitToolUse(state.id, state.name, JSON.parse(state.input));
           streamedToolUseIds.add(state.id);
         } catch {
           // Fall through to the final assistant wrapper's input if the
@@ -347,12 +480,7 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
         typeof state.id === 'string' &&
         state.inputValue !== undefined
       ) {
-        onEvent({
-          type: 'tool_use',
-          id: state.id,
-          name: state.name,
-          input: state.inputValue,
-        });
+        emitToolUse(state.id, state.name, state.inputValue);
         streamedToolUseIds.add(state.id);
       }
       blocks.delete(key);

--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -84,6 +84,26 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
     return 'pending';
   }
 
+  function nextGeneratedRuntimeTaskId(): string {
+    while (runtimeTasks.has(String(nextRuntimeTaskId))) {
+      nextRuntimeTaskId += 1;
+    }
+    const id = String(nextRuntimeTaskId);
+    nextRuntimeTaskId += 1;
+    return id;
+  }
+
+  function runtimeTaskIdFromCreate(input: Record<string, unknown>): string {
+    if (typeof input.taskId === 'string' && input.taskId) {
+      const numericId = Number(input.taskId);
+      if (Number.isSafeInteger(numericId) && numericId >= nextRuntimeTaskId) {
+        nextRuntimeTaskId = numericId + 1;
+      }
+      return input.taskId;
+    }
+    return nextGeneratedRuntimeTaskId();
+  }
+
   function emitCanonicalTaskSnapshot(toolUseId: unknown, name: unknown, input: unknown): boolean {
     if (typeof toolUseId !== 'string' || typeof name !== 'string' || !isRecord(input)) return false;
     if (canonicalTaskToolUseIds.has(toolUseId)) return true;
@@ -95,9 +115,7 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
           ? input.description
           : '';
       if (!content) return false;
-      const id = typeof input.taskId === 'string' && input.taskId
-        ? input.taskId
-        : String(nextRuntimeTaskId++);
+      const id = runtimeTaskIdFromCreate(input);
       const activeForm = typeof input.activeForm === 'string' ? input.activeForm : undefined;
       runtimeTasks.set(id, {
         id,

--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -69,7 +69,7 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
   const runtimeTasks = new Map<string, RuntimeTask>();
   const canonicalTaskToolUseIds = new Set<string>();
   let nextRuntimeTaskId = 1;
-  let fileWriteSeen = false;
+  let suppressNextArtifactText = false;
   let suppressDuplicateArtifactText = false;
   let artifactOpenCandidate = '';
 
@@ -83,9 +83,9 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
     return 'pending';
   }
 
-  function emitCanonicalTaskSnapshot(toolUseId: unknown, name: unknown, input: unknown): void {
-    if (typeof toolUseId !== 'string' || typeof name !== 'string' || !isRecord(input)) return;
-    if (canonicalTaskToolUseIds.has(toolUseId)) return;
+  function emitCanonicalTaskSnapshot(toolUseId: unknown, name: unknown, input: unknown): boolean {
+    if (typeof toolUseId !== 'string' || typeof name !== 'string' || !isRecord(input)) return false;
+    if (canonicalTaskToolUseIds.has(toolUseId)) return true;
     let changed = false;
     if (name === 'TaskCreate') {
       const content = typeof input.subject === 'string'
@@ -93,7 +93,7 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
         : typeof input.description === 'string'
           ? input.description
           : '';
-      if (!content) return;
+      if (!content) return false;
       const id = typeof input.taskId === 'string' && input.taskId
         ? input.taskId
         : String(nextRuntimeTaskId++);
@@ -106,9 +106,9 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
       });
       changed = true;
     } else if (name === 'TaskUpdate') {
-      if (typeof input.taskId !== 'string') return;
+      if (typeof input.taskId !== 'string') return false;
       const existing = runtimeTasks.get(input.taskId);
-      if (!existing) return;
+      if (!existing) return false;
       const content = typeof input.subject === 'string'
         ? input.subject
         : typeof input.description === 'string'
@@ -122,9 +122,11 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
         ...(activeForm ? { activeForm } : {}),
       });
       changed = true;
+    } else {
+      return false;
     }
     canonicalTaskToolUseIds.add(toolUseId);
-    if (!changed || runtimeTasks.size === 0) return;
+    if (!changed || runtimeTasks.size === 0) return false;
     onEvent({
       type: 'tool_use',
       id: `${toolUseId}:todo-task`,
@@ -137,12 +139,13 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
         })),
       },
     });
+    return true;
   }
 
   function emitToolUse(id: unknown, name: unknown, input: unknown): void {
-    emitCanonicalTaskSnapshot(id, name, input);
+    if (emitCanonicalTaskSnapshot(id, name, input)) return;
     if (isFileWriteToolUse(name, input)) {
-      fileWriteSeen = true;
+      suppressNextArtifactText = true;
     }
     onEvent({
       type: 'tool_use',
@@ -197,7 +200,13 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
   }
 
   function stripDuplicateArtifactText(text: string): string {
-    if (!fileWriteSeen) return text;
+    if (
+      !suppressNextArtifactText &&
+      !suppressDuplicateArtifactText &&
+      artifactOpenCandidate.length === 0
+    ) {
+      return text;
+    }
     const openTag = '<artifact';
     const current = `${artifactOpenCandidate}${text}`;
     artifactOpenCandidate = '';
@@ -205,18 +214,21 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
       const closeIndex = current.indexOf('</artifact>');
       if (closeIndex === -1) return '';
       suppressDuplicateArtifactText = false;
+      suppressNextArtifactText = false;
       return stripDuplicateArtifactText(current.slice(closeIndex + '</artifact>'.length));
     }
     const openIndex = current.indexOf(openTag);
     if (openIndex === -1) {
       const candidateLength = artifactOpenCandidateLength(current, openTag);
-      if (candidateLength > 0) {
+      if (suppressNextArtifactText && candidateLength > 0) {
         artifactOpenCandidate = current.slice(-candidateLength);
         return current.slice(0, -candidateLength);
       }
+      suppressNextArtifactText = false;
       return current;
     }
     suppressDuplicateArtifactText = true;
+    suppressNextArtifactText = false;
     return `${current.slice(0, openIndex)}${stripDuplicateArtifactText(current.slice(openIndex))}`;
   }
 

--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -72,6 +72,7 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
   let suppressNextArtifactText = false;
   let suppressDuplicateArtifactText = false;
   let artifactOpenCandidate = '';
+  let pendingArtifactText = '';
 
   function normalizeTaskStatus(value: unknown): RuntimeTask['status'] {
     if (value === 'completed' || value === 'in_progress' || value === 'stopped') {
@@ -222,14 +223,20 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
       const candidateLength = artifactOpenCandidateLength(current, openTag);
       if (suppressNextArtifactText && candidateLength > 0) {
         artifactOpenCandidate = current.slice(-candidateLength);
-        return current.slice(0, -candidateLength);
+        pendingArtifactText += current.slice(0, -candidateLength);
+        return '';
       }
-      suppressNextArtifactText = false;
+      if (suppressNextArtifactText) {
+        pendingArtifactText += current;
+        return '';
+      }
       return current;
     }
     suppressDuplicateArtifactText = true;
     suppressNextArtifactText = false;
-    return `${current.slice(0, openIndex)}${stripDuplicateArtifactText(current.slice(openIndex))}`;
+    const prefix = `${pendingArtifactText}${current.slice(0, openIndex)}`;
+    pendingArtifactText = '';
+    return `${prefix}${stripDuplicateArtifactText(current.slice(openIndex))}`;
   }
 
   function artifactOpenCandidateLength(text: string, openTag: string): number {
@@ -277,12 +284,14 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
   function flush() {
     const rem = buffer.trim();
     buffer = '';
-    if (!rem) return;
-    try {
-      handleObject(JSON.parse(rem));
-    } catch {
-      onEvent({ type: 'raw', line: rem });
+    if (rem) {
+      try {
+        handleObject(JSON.parse(rem));
+      } catch {
+        onEvent({ type: 'raw', line: rem });
+      }
     }
+    flushPendingArtifactText();
   }
 
   function handleObject(obj: unknown) {
@@ -416,6 +425,7 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
 
   function handleStreamEvent(ev: Record<string, unknown>) {
     if (ev.type === 'message_start') {
+      flushPendingArtifactText();
       // Clean up per-message role-marker guard from the previous message.
       if (currentMessageId) roleGuards.delete(currentMessageId);
       currentMessageId = isRecord(ev.message) && typeof ev.message.id === 'string' ? ev.message.id : null;
@@ -498,6 +508,15 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
       blocks.delete(key);
       return;
     }
+  }
+
+  function flushPendingArtifactText() {
+    if (!pendingArtifactText) return;
+    const text = pendingArtifactText;
+    pendingArtifactText = '';
+    artifactOpenCandidate = '';
+    suppressNextArtifactText = false;
+    emitSafeText(currentMessageId, text);
   }
 
   return { feed, flush };

--- a/apps/daemon/src/claude-stream.ts
+++ b/apps/daemon/src/claude-stream.ts
@@ -226,6 +226,7 @@ export function createClaudeStreamHandler(onEvent: EventSink) {
         return current.slice(0, -candidateLength);
       }
       if (suppressNextArtifactText) {
+        suppressNextArtifactText = false;
         return current;
       }
       return current;

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -455,8 +455,8 @@ function artifactOpenCandidateLength(text: string, openTag: string): number {
 }
 
 function flushPendingArtifactText(state: ParserState, onEvent: StreamEventHandler): void {
-  if (!state.pendingArtifactText) return;
-  const delta = state.pendingArtifactText;
+  const delta = `${state.pendingArtifactText}${state.artifactOpenCandidate}`;
+  if (!delta) return;
   state.pendingArtifactText = '';
   state.artifactOpenCandidate = '';
   state.suppressNextArtifactText = false;

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -10,6 +10,9 @@ type ParserState = {
   codexErrorEmitted: boolean;
   codexPreviousEventWasAgentMessage: boolean;
   codexLastAgentMessageEndedWithNewline: boolean;
+  fileWriteSeen: boolean;
+  suppressDuplicateArtifactText: boolean;
+  artifactOpenCandidate: string;
 };
 
 type Usage = {
@@ -214,7 +217,7 @@ function handleOpenCodeEvent(obj: unknown, onEvent: StreamEventHandler, state: P
   return false;
 }
 
-function handleGeminiEvent(obj: unknown, onEvent: StreamEventHandler): boolean {
+function handleGeminiEvent(obj: unknown, onEvent: StreamEventHandler, state: ParserState): boolean {
   if (!isRecord(obj)) return false;
 
   if (obj.type === 'init') {
@@ -236,7 +239,8 @@ function handleGeminiEvent(obj: unknown, onEvent: StreamEventHandler): boolean {
     typeof obj.content === 'string' &&
     obj.content.length > 0
   ) {
-    onEvent({ type: 'text_delta', delta: obj.content });
+    const delta = stripDuplicateArtifactText(obj.content, state);
+    if (delta) onEvent({ type: 'text_delta', delta });
     return true;
   }
 
@@ -245,11 +249,26 @@ function handleGeminiEvent(obj: unknown, onEvent: StreamEventHandler): boolean {
     typeof obj.tool_id === 'string' &&
     typeof obj.tool_name === 'string'
   ) {
+    const input = safeParseJson(obj.parameters) ?? obj.parameters ?? null;
+    if (obj.tool_name === 'write_todos') {
+      const todoInput = todoWriteInputFromParsedValue(input);
+      if (todoInput) {
+        onEvent({
+          type: 'tool_use',
+          id: `${obj.tool_id}:todo-native`,
+          name: 'TodoWrite',
+          input: todoInput,
+        });
+      }
+    }
+    if (isFileWriteToolUse(obj.tool_name, input)) {
+      state.fileWriteSeen = true;
+    }
     onEvent({
       type: 'tool_use',
       id: obj.tool_id,
       name: obj.tool_name,
-      input: safeParseJson(obj.parameters) ?? obj.parameters ?? null,
+      input,
     });
     return true;
   }
@@ -315,6 +334,133 @@ function extractCursorText(message: unknown): string {
     .filter((block): block is { type: 'text'; text: string } => isRecord(block) && block.type === 'text' && typeof block.text === 'string')
     .map((block) => block.text)
     .join('');
+}
+
+function normalizeTodoStatus(value: unknown): string {
+  const status = typeof value === 'string'
+    ? value.trim().toLowerCase().replace(/[-\s]+/g, '_')
+    : '';
+  if (status === 'completed' || status === 'complete' || status === 'done' || status.startsWith('completed')) {
+    return 'completed';
+  }
+  if (status === 'in_progress' || status === 'doing' || status === 'active' || status.startsWith('in_progress')) {
+    return 'in_progress';
+  }
+  if (
+    status === 'stopped' ||
+    status === 'failed' ||
+    status === 'blocked' ||
+    status === 'canceled' ||
+    status === 'cancelled' ||
+    status.startsWith('stopped') ||
+    status.startsWith('failed') ||
+    status.startsWith('blocked') ||
+    status.startsWith('canceled') ||
+    status.startsWith('cancelled')
+  ) {
+    return 'stopped';
+  }
+  return 'pending';
+}
+
+function todoWriteInputFromItems(items: unknown): JsonObject | null {
+  if (!Array.isArray(items)) return null;
+  const todos = items
+    .map((raw): JsonObject | null => {
+      if (!isRecord(raw)) return null;
+      const content = typeof raw.content === 'string'
+        ? raw.content
+        : typeof raw.label === 'string'
+          ? raw.label
+          : typeof raw.description === 'string'
+            ? raw.description
+            : typeof raw.text === 'string'
+              ? raw.text
+              : '';
+      if (!content) return null;
+      return {
+        content,
+        status: raw.completed === true
+          ? 'completed'
+          : normalizeTodoStatus(raw.status),
+      };
+    })
+    .filter((todo): todo is JsonObject => todo !== null);
+  return todos.length > 0 ? { todos } : null;
+}
+
+function todoWriteInputFromParsedValue(value: unknown): JsonObject | null {
+  if (Array.isArray(value)) return todoWriteInputFromItems(value);
+  if (!isRecord(value)) return null;
+  if (Array.isArray(value.todos)) return todoWriteInputFromItems(value.todos);
+  if (Array.isArray(value.todo)) return todoWriteInputFromItems(value.todo);
+  return null;
+}
+
+function stripDuplicateArtifactText(text: string, state: ParserState): string {
+  if (!state.fileWriteSeen) return text;
+  const openTag = '<artifact';
+  const current = `${state.artifactOpenCandidate}${text}`;
+  state.artifactOpenCandidate = '';
+  if (state.suppressDuplicateArtifactText) {
+    const closeIndex = current.indexOf('</artifact>');
+    if (closeIndex === -1) return '';
+    state.suppressDuplicateArtifactText = false;
+    return stripDuplicateArtifactText(current.slice(closeIndex + '</artifact>'.length), state);
+  }
+  const openIndex = current.indexOf(openTag);
+  if (openIndex === -1) {
+    const candidateLength = artifactOpenCandidateLength(current, openTag);
+    if (candidateLength > 0) {
+      state.artifactOpenCandidate = current.slice(-candidateLength);
+      return current.slice(0, -candidateLength);
+    }
+    return current;
+  }
+  state.suppressDuplicateArtifactText = true;
+  return `${current.slice(0, openIndex)}${stripDuplicateArtifactText(current.slice(openIndex), state)}`;
+}
+
+function artifactOpenCandidateLength(text: string, openTag: string): number {
+  const max = Math.min(openTag.length - 1, text.length);
+  for (let len = max; len > 0; len -= 1) {
+    if (openTag.startsWith(text.slice(-len))) return len;
+  }
+  return 0;
+}
+
+function isFileWriteToolUse(toolName: string, input: unknown): boolean {
+  if (!isRecord(input)) return false;
+  const path = typeof input.file_path === 'string'
+    ? input.file_path
+    : typeof input.path === 'string'
+      ? input.path
+      : '';
+  const writesFile = toolName === 'write_file' ||
+    toolName === 'write' ||
+    toolName === 'replace' ||
+    toolName === 'edit';
+  if (!writesFile) return false;
+  if (/\.(html|htm|css|js|jsx|ts|tsx|md)$/iu.test(path)) return true;
+  return typeof input.content === 'string' || typeof input.new_string === 'string';
+}
+
+function codexTodoListInput(item: JsonObject): JsonObject | null {
+  if (item.type !== 'todo_list' || !Array.isArray(item.items)) return null;
+  return todoWriteInputFromItems(item.items);
+}
+
+function emitCodexTodoList(item: JsonObject, onEvent: StreamEventHandler): boolean {
+  if (typeof item.id !== 'string') return false;
+  const input = codexTodoListInput(item);
+  if (!input) return false;
+  onEvent({
+    type: 'tool_use',
+    id: item.id,
+    name: 'TodoWrite',
+    input,
+  });
+  return true;
 }
 
 function emitCursorTextDelta(text: string, onEvent: StreamEventHandler, state: ParserState): void {
@@ -383,19 +529,19 @@ function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
 function handleCodexEvent(obj: unknown, onEvent: StreamEventHandler, state: ParserState): boolean {
   if (!isRecord(obj)) return false;
 
-if (obj.type === 'error') {
-  const message = extractErrorMessage(obj.message ?? obj.error, 'Codex error');
-  // Reconnecting events are recoverable — treat as status warning, not fatal
-  if (isRecoverableCodexReconnect(message)) {
-    onEvent({ type: 'status', label: message });
+  if (obj.type === 'error') {
+    const message = extractErrorMessage(obj.message ?? obj.error, 'Codex error');
+    // Reconnecting events are recoverable — treat as status warning, not fatal
+    if (isRecoverableCodexReconnect(message)) {
+      onEvent({ type: 'status', label: message });
+      return true;
+    }
+    if (!state.codexErrorEmitted) {
+      state.codexErrorEmitted = true;
+      onEvent({ type: 'error', message });
+    }
     return true;
   }
-  if (!state.codexErrorEmitted) {
-    state.codexErrorEmitted = true;
-    onEvent({ type: 'error', message });
-  }
-  return true;
-}
 
   if (obj.type === 'turn.failed') {
     if (!state.codexErrorEmitted) {
@@ -422,6 +568,11 @@ if (obj.type === 'error') {
 
   if (obj.type === 'item.started' && isRecord(obj.item)) {
     const item = obj.item;
+    if (emitCodexTodoList(item, onEvent)) {
+      state.codexPreviousEventWasAgentMessage = false;
+      state.codexLastAgentMessageEndedWithNewline = false;
+      return true;
+    }
     if (item.type === 'command_execution' && typeof item.id === 'string') {
       state.codexPreviousEventWasAgentMessage = false;
       state.codexLastAgentMessageEndedWithNewline = false;
@@ -440,8 +591,22 @@ if (obj.type === 'error') {
     }
   }
 
+  if (obj.type === 'item.updated' && isRecord(obj.item)) {
+    const item = obj.item;
+    if (emitCodexTodoList(item, onEvent)) {
+      state.codexPreviousEventWasAgentMessage = false;
+      state.codexLastAgentMessageEndedWithNewline = false;
+      return true;
+    }
+  }
+
   if (obj.type === 'item.completed' && isRecord(obj.item)) {
     const item = obj.item;
+    if (emitCodexTodoList(item, onEvent)) {
+      state.codexPreviousEventWasAgentMessage = false;
+      state.codexLastAgentMessageEndedWithNewline = false;
+      return true;
+    }
     if (item.type === 'command_execution' && typeof item.id === 'string') {
       state.codexPreviousEventWasAgentMessage = false;
       state.codexLastAgentMessageEndedWithNewline = false;
@@ -514,6 +679,9 @@ export function createJsonEventStreamHandler(kind: ParserKind, onEvent: StreamEv
     codexErrorEmitted: false,
     codexPreviousEventWasAgentMessage: false,
     codexLastAgentMessageEndedWithNewline: false,
+    fileWriteSeen: false,
+    suppressDuplicateArtifactText: false,
+    artifactOpenCandidate: '',
   };
 
   function handleLine(line: string): void {
@@ -526,7 +694,7 @@ export function createJsonEventStreamHandler(kind: ParserKind, onEvent: StreamEv
     }
 
     if (kind === 'opencode' && handleOpenCodeEvent(obj, onEvent, state)) return;
-    if (kind === 'gemini' && handleGeminiEvent(obj, onEvent)) return;
+    if (kind === 'gemini' && handleGeminiEvent(obj, onEvent, state)) return;
     if (kind === 'cursor-agent' && handleCursorEvent(obj, onEvent, state)) return;
     if (kind === 'codex' && handleCodexEvent(obj, onEvent, state)) return;
 

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -431,12 +431,10 @@ function stripDuplicateArtifactText(text: string, state: ParserState): string {
     const candidateLength = artifactOpenCandidateLength(current, openTag);
     if (state.suppressNextArtifactText && candidateLength > 0) {
       state.artifactOpenCandidate = current.slice(-candidateLength);
-      state.pendingArtifactText += current.slice(0, -candidateLength);
-      return '';
+      return current.slice(0, -candidateLength);
     }
     if (state.suppressNextArtifactText) {
-      state.pendingArtifactText += current;
-      return '';
+      return current;
     }
     return current;
   }

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -13,6 +13,7 @@ type ParserState = {
   suppressNextArtifactText: boolean;
   suppressDuplicateArtifactText: boolean;
   artifactOpenCandidate: string;
+  pendingArtifactText: string;
 };
 
 type Usage = {
@@ -220,6 +221,15 @@ function handleOpenCodeEvent(obj: unknown, onEvent: StreamEventHandler, state: P
 function handleGeminiEvent(obj: unknown, onEvent: StreamEventHandler, state: ParserState): boolean {
   if (!isRecord(obj)) return false;
 
+  const isAssistantTextMessage =
+    obj.type === 'message' &&
+    obj.role === 'assistant' &&
+    typeof obj.content === 'string' &&
+    obj.content.length > 0;
+  if (!isAssistantTextMessage) {
+    flushPendingArtifactText(state, onEvent);
+  }
+
   if (obj.type === 'init') {
     onEvent({
       type: 'status',
@@ -421,14 +431,20 @@ function stripDuplicateArtifactText(text: string, state: ParserState): string {
     const candidateLength = artifactOpenCandidateLength(current, openTag);
     if (state.suppressNextArtifactText && candidateLength > 0) {
       state.artifactOpenCandidate = current.slice(-candidateLength);
-      return current.slice(0, -candidateLength);
+      state.pendingArtifactText += current.slice(0, -candidateLength);
+      return '';
     }
-    state.suppressNextArtifactText = false;
+    if (state.suppressNextArtifactText) {
+      state.pendingArtifactText += current;
+      return '';
+    }
     return current;
   }
   state.suppressDuplicateArtifactText = true;
   state.suppressNextArtifactText = false;
-  return `${current.slice(0, openIndex)}${stripDuplicateArtifactText(current.slice(openIndex), state)}`;
+  const prefix = `${state.pendingArtifactText}${current.slice(0, openIndex)}`;
+  state.pendingArtifactText = '';
+  return `${prefix}${stripDuplicateArtifactText(current.slice(openIndex), state)}`;
 }
 
 function artifactOpenCandidateLength(text: string, openTag: string): number {
@@ -437,6 +453,15 @@ function artifactOpenCandidateLength(text: string, openTag: string): number {
     if (openTag.startsWith(text.slice(-len))) return len;
   }
   return 0;
+}
+
+function flushPendingArtifactText(state: ParserState, onEvent: StreamEventHandler): void {
+  if (!state.pendingArtifactText) return;
+  const delta = state.pendingArtifactText;
+  state.pendingArtifactText = '';
+  state.artifactOpenCandidate = '';
+  state.suppressNextArtifactText = false;
+  onEvent({ type: 'text_delta', delta });
 }
 
 function isFileWriteToolUse(toolName: string, input: unknown): boolean {
@@ -692,6 +717,7 @@ export function createJsonEventStreamHandler(kind: ParserKind, onEvent: StreamEv
     suppressNextArtifactText: false,
     suppressDuplicateArtifactText: false,
     artifactOpenCandidate: '',
+    pendingArtifactText: '',
   };
 
   function handleLine(line: string): void {
@@ -725,8 +751,8 @@ export function createJsonEventStreamHandler(kind: ParserKind, onEvent: StreamEv
   function flush(): void {
     const rem = buffer.trim();
     buffer = '';
-    if (!rem) return;
-    handleLine(rem);
+    if (rem) handleLine(rem);
+    flushPendingArtifactText(state, onEvent);
   }
 
   return { feed, flush };

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -434,6 +434,7 @@ function stripDuplicateArtifactText(text: string, state: ParserState): string {
       return current.slice(0, -candidateLength);
     }
     if (state.suppressNextArtifactText) {
+      state.suppressNextArtifactText = false;
       return current;
     }
     return current;

--- a/apps/daemon/src/json-event-stream.ts
+++ b/apps/daemon/src/json-event-stream.ts
@@ -10,7 +10,7 @@ type ParserState = {
   codexErrorEmitted: boolean;
   codexPreviousEventWasAgentMessage: boolean;
   codexLastAgentMessageEndedWithNewline: boolean;
-  fileWriteSeen: boolean;
+  suppressNextArtifactText: boolean;
   suppressDuplicateArtifactText: boolean;
   artifactOpenCandidate: string;
 };
@@ -259,10 +259,11 @@ function handleGeminiEvent(obj: unknown, onEvent: StreamEventHandler, state: Par
           name: 'TodoWrite',
           input: todoInput,
         });
+        return true;
       }
     }
     if (isFileWriteToolUse(obj.tool_name, input)) {
-      state.fileWriteSeen = true;
+      state.suppressNextArtifactText = true;
     }
     onEvent({
       type: 'tool_use',
@@ -398,7 +399,13 @@ function todoWriteInputFromParsedValue(value: unknown): JsonObject | null {
 }
 
 function stripDuplicateArtifactText(text: string, state: ParserState): string {
-  if (!state.fileWriteSeen) return text;
+  if (
+    !state.suppressNextArtifactText &&
+    !state.suppressDuplicateArtifactText &&
+    state.artifactOpenCandidate.length === 0
+  ) {
+    return text;
+  }
   const openTag = '<artifact';
   const current = `${state.artifactOpenCandidate}${text}`;
   state.artifactOpenCandidate = '';
@@ -406,18 +413,21 @@ function stripDuplicateArtifactText(text: string, state: ParserState): string {
     const closeIndex = current.indexOf('</artifact>');
     if (closeIndex === -1) return '';
     state.suppressDuplicateArtifactText = false;
+    state.suppressNextArtifactText = false;
     return stripDuplicateArtifactText(current.slice(closeIndex + '</artifact>'.length), state);
   }
   const openIndex = current.indexOf(openTag);
   if (openIndex === -1) {
     const candidateLength = artifactOpenCandidateLength(current, openTag);
-    if (candidateLength > 0) {
+    if (state.suppressNextArtifactText && candidateLength > 0) {
       state.artifactOpenCandidate = current.slice(-candidateLength);
       return current.slice(0, -candidateLength);
     }
+    state.suppressNextArtifactText = false;
     return current;
   }
   state.suppressDuplicateArtifactText = true;
+  state.suppressNextArtifactText = false;
   return `${current.slice(0, openIndex)}${stripDuplicateArtifactText(current.slice(openIndex), state)}`;
 }
 
@@ -679,7 +689,7 @@ export function createJsonEventStreamHandler(kind: ParserKind, onEvent: StreamEv
     codexErrorEmitted: false,
     codexPreviousEventWasAgentMessage: false,
     codexLastAgentMessageEndedWithNewline: false,
-    fileWriteSeen: false,
+    suppressNextArtifactText: false,
     suppressDuplicateArtifactText: false,
     artifactOpenCandidate: '',
   };

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -793,6 +793,12 @@ export function composeSystemPrompt({
   const mcpDirective = renderConnectedExternalMcpDirective(connectedExternalMcp);
   if (mcpDirective) parts.push(mcpDirective);
 
+  if (agentId === 'gemini') {
+    parts.push(
+      "\n\n---\n\n## Gemini todo tool mapping\n\nWhen an Open Design instruction says to call `TodoWrite`, use Gemini CLI's native `write_todos` tool only if it is present in the current tool list. Pass the full task list as `todos`, with each item using `description` for the task text and `status` set to `pending`, `in_progress`, `completed`, `cancelled`, or `blocked`.\n\nIf `write_todos` is not present, do not simulate it with markdown, plan-mode files, JSON files, TODO files, or shell commands. Continue the work normally without a todo tool.",
+    );
+  }
+
   // Claude only: nudge the model toward the `AskUserQuestion` tool for
   // mid-conversation clarifications. Without this hint Claude tends to fall
   // back to a markdown bulleted list of options, which the chat UI cannot

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -388,7 +388,11 @@ test('gemini stream suppresses duplicate artifact text split across chunks', () 
     },
     {
       type: 'text_delta',
-      delta: 'Done.\\n\\nTail',
+      delta: 'Done.\\n\\n',
+    },
+    {
+      type: 'text_delta',
+      delta: 'Tail',
     },
   ]);
 });
@@ -433,7 +437,50 @@ test('gemini stream suppresses duplicate artifact text when plain prose arrives 
     },
     {
       type: 'text_delta',
-      delta: 'Done.\\n\\nTail',
+      delta: 'Done.\\n\\n',
+    },
+    {
+      type: 'text_delta',
+      delta: 'Tail',
+    },
+  ]);
+});
+
+test('gemini stream emits prose immediately after file write when no artifact follows', () => {
+  const { events, handler } = collectEvents('gemini');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'tool_use',
+      tool_name: 'write_file',
+      tool_id: 'write_file__1',
+      parameters: {
+        file_path: 'index.html',
+        content: '<!doctype html><html></html>',
+      },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'message',
+      role: 'assistant',
+      content: 'Done, preview ready.',
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'write_file__1',
+      name: 'write_file',
+      input: {
+        file_path: 'index.html',
+        content: '<!doctype html><html></html>',
+      },
+    },
+    {
+      type: 'text_delta',
+      delta: 'Done, preview ready.',
     },
   ]);
 });

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -485,6 +485,50 @@ test('gemini stream emits prose immediately after file write when no artifact fo
   ]);
 });
 
+test('gemini stream flushes trailing partial artifact opener as prose', () => {
+  const { events, handler } = collectEvents('gemini');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'tool_use',
+      tool_name: 'write_file',
+      tool_id: 'write_file__1',
+      parameters: {
+        file_path: 'index.html',
+        content: '<!doctype html><html></html>',
+      },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'message',
+      role: 'assistant',
+      content: 'Done <art',
+    }) +
+    '\n',
+  );
+  handler.flush();
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'write_file__1',
+      name: 'write_file',
+      input: {
+        file_path: 'index.html',
+        content: '<!doctype html><html></html>',
+      },
+    },
+    {
+      type: 'text_delta',
+      delta: 'Done ',
+    },
+    {
+      type: 'text_delta',
+      delta: '<art',
+    },
+  ]);
+});
+
 test('gemini stream preserves later artifact text after suppressing immediate file-write echo', () => {
   const { events, handler } = collectEvents('gemini');
 

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -241,6 +241,174 @@ test('gemini stream handles real stream-json user, tool, and error frames', () =
   ]);
 });
 
+test('gemini stream emits TodoWrite from native write_todos tool', () => {
+  const { events, handler } = collectEvents('gemini');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'tool_use',
+      tool_name: 'write_todos',
+      tool_id: 'write_todos__1',
+      parameters: {
+        todos: [
+          { description: 'Inspect context', status: 'in_progress' },
+          { description: 'Answer user', status: 'pending' },
+          { description: 'Wait for input', status: 'blocked' },
+        ],
+      },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'write_todos__1:todo-native',
+      name: 'TodoWrite',
+      input: {
+        todos: [
+          { content: 'Inspect context', status: 'in_progress' },
+          { content: 'Answer user', status: 'pending' },
+          { content: 'Wait for input', status: 'stopped' },
+        ],
+      },
+    },
+    {
+      type: 'tool_use',
+      id: 'write_todos__1',
+      name: 'write_todos',
+      input: {
+        todos: [
+          { description: 'Inspect context', status: 'in_progress' },
+          { description: 'Answer user', status: 'pending' },
+          { description: 'Wait for input', status: 'blocked' },
+        ],
+      },
+    },
+  ]);
+});
+
+test('gemini stream normalizes suffixed native todo statuses', () => {
+  const { events, handler } = collectEvents('gemini');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'tool_use',
+      tool_name: 'write_todos',
+      tool_id: 'write_todos__extra',
+      parameters: {
+        todos: [
+          { description: 'Bind tokens', status: 'in_progressExtra' },
+          { description: 'Write page', status: 'pendingExtra' },
+          { description: 'Ship page', status: 'completedExtra' },
+        ],
+      },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events[0], {
+    type: 'tool_use',
+    id: 'write_todos__extra:todo-native',
+    name: 'TodoWrite',
+    input: {
+      todos: [
+        { content: 'Bind tokens', status: 'in_progress' },
+        { content: 'Write page', status: 'pending' },
+        { content: 'Ship page', status: 'completed' },
+      ],
+    },
+  });
+});
+
+test('gemini stream suppresses duplicate artifact text after file writes', () => {
+  const { events, handler } = collectEvents('gemini');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'tool_use',
+      tool_name: 'write_file',
+      tool_id: 'write_file__1',
+      parameters: {
+        file_path: 'index.html',
+        content: '<!doctype html><html></html>',
+      },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'message',
+      role: 'assistant',
+      content: 'Done.\\n\\n<artifact identifier="page" type="text/html">\\n<!doctype html><html></html>\\n</artifact>',
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'write_file__1',
+      name: 'write_file',
+      input: {
+        file_path: 'index.html',
+        content: '<!doctype html><html></html>',
+      },
+    },
+    {
+      type: 'text_delta',
+      delta: 'Done.\\n\\n',
+    },
+  ]);
+});
+
+test('gemini stream suppresses duplicate artifact text split across chunks', () => {
+  const { events, handler } = collectEvents('gemini');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'tool_use',
+      tool_name: 'write_file',
+      tool_id: 'write_file__1',
+      parameters: {
+        file_path: 'index.html',
+        content: '<!doctype html><html></html>',
+      },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'message',
+      role: 'assistant',
+      content: 'Done.\\n\\n<',
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'message',
+      role: 'assistant',
+      content: 'artifact identifier="page" type="text/html">\\n<!doctype html><html></html>\\n</artifact>Tail',
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'write_file__1',
+      name: 'write_file',
+      input: {
+        file_path: 'index.html',
+        content: '<!doctype html><html></html>',
+      },
+    },
+    {
+      type: 'text_delta',
+      delta: 'Done.\\n\\n',
+    },
+    {
+      type: 'text_delta',
+      delta: 'Tail',
+    },
+  ]);
+});
+
 test('gemini stream treats terminal error frames as fatal error events', () => {
   const { events, handler } = collectEvents('gemini');
 
@@ -522,6 +690,62 @@ test('codex json stream emits command execution tool events', () => {
       toolUseId: 'item-1',
       content: 'hello-from-codex\n',
       isError: false,
+    },
+  ]);
+});
+
+test('codex json stream emits TodoWrite events from todo_list items', () => {
+  const { events, handler } = collectEvents('codex');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'item.started',
+      item: {
+        id: 'item-0',
+        type: 'todo_list',
+        items: [
+          { text: 'Inspect workspace', completed: false },
+          { text: 'Write prototype', completed: false },
+        ],
+      },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'item.updated',
+      item: {
+        id: 'item-0',
+        type: 'todo_list',
+        items: [
+          { text: 'Inspect workspace', completed: true },
+          { text: 'Write prototype', completed: false },
+        ],
+      },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'item-0',
+      name: 'TodoWrite',
+      input: {
+        todos: [
+          { content: 'Inspect workspace', status: 'pending' },
+          { content: 'Write prototype', status: 'pending' },
+        ],
+      },
+    },
+    {
+      type: 'tool_use',
+      id: 'item-0',
+      name: 'TodoWrite',
+      input: {
+        todos: [
+          { content: 'Inspect workspace', status: 'completed' },
+          { content: 'Write prototype', status: 'pending' },
+        ],
+      },
     },
   ]);
 });

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -397,7 +397,7 @@ test('gemini stream suppresses duplicate artifact text split across chunks', () 
   ]);
 });
 
-test('gemini stream suppresses duplicate artifact text when plain prose arrives before the artifact chunk', () => {
+test('gemini stream preserves later artifact text after plain prose clears file-write suppression', () => {
   const { events, handler } = collectEvents('gemini');
 
   handler.feed(
@@ -441,7 +441,7 @@ test('gemini stream suppresses duplicate artifact text when plain prose arrives 
     },
     {
       type: 'text_delta',
-      delta: 'Tail',
+      delta: '<artifact identifier="page" type="text/html">\\n<!doctype html><html></html>\\n</artifact>Tail',
     },
   ]);
 });

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -388,11 +388,52 @@ test('gemini stream suppresses duplicate artifact text split across chunks', () 
     },
     {
       type: 'text_delta',
-      delta: 'Done.\\n\\n',
+      delta: 'Done.\\n\\nTail',
+    },
+  ]);
+});
+
+test('gemini stream suppresses duplicate artifact text when plain prose arrives before the artifact chunk', () => {
+  const { events, handler } = collectEvents('gemini');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'tool_use',
+      tool_name: 'write_file',
+      tool_id: 'write_file__1',
+      parameters: {
+        file_path: 'index.html',
+        content: '<!doctype html><html></html>',
+      },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'message',
+      role: 'assistant',
+      content: 'Done.\\n\\n',
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'message',
+      role: 'assistant',
+      content: '<artifact identifier="page" type="text/html">\\n<!doctype html><html></html>\\n</artifact>Tail',
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'write_file__1',
+      name: 'write_file',
+      input: {
+        file_path: 'index.html',
+        content: '<!doctype html><html></html>',
+      },
     },
     {
       type: 'text_delta',
-      delta: 'Tail',
+      delta: 'Done.\\n\\nTail',
     },
   ]);
 });

--- a/apps/daemon/tests/json-event-stream.test.ts
+++ b/apps/daemon/tests/json-event-stream.test.ts
@@ -273,18 +273,6 @@ test('gemini stream emits TodoWrite from native write_todos tool', () => {
         ],
       },
     },
-    {
-      type: 'tool_use',
-      id: 'write_todos__1',
-      name: 'write_todos',
-      input: {
-        todos: [
-          { description: 'Inspect context', status: 'in_progress' },
-          { description: 'Answer user', status: 'pending' },
-          { description: 'Wait for input', status: 'blocked' },
-        ],
-      },
-    },
   ]);
 });
 
@@ -405,6 +393,55 @@ test('gemini stream suppresses duplicate artifact text split across chunks', () 
     {
       type: 'text_delta',
       delta: 'Tail',
+    },
+  ]);
+});
+
+test('gemini stream preserves later artifact text after suppressing immediate file-write echo', () => {
+  const { events, handler } = collectEvents('gemini');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'tool_use',
+      tool_name: 'write_file',
+      tool_id: 'write_file__1',
+      parameters: {
+        file_path: 'helper.html',
+        content: '<!doctype html><html>helper</html>',
+      },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'message',
+      role: 'assistant',
+      content: 'Helper written.\\n\\n<artifact identifier="helper" type="text/html">\\n<!doctype html><html>helper</html>\\n</artifact>',
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'message',
+      role: 'assistant',
+      content: 'Final artifact:\\n\\n<artifact identifier="final" type="text/html">\\n<!doctype html><html>final</html>\\n</artifact>',
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    {
+      type: 'tool_use',
+      id: 'write_file__1',
+      name: 'write_file',
+      input: {
+        file_path: 'helper.html',
+        content: '<!doctype html><html>helper</html>',
+      },
+    },
+    {
+      type: 'text_delta',
+      delta: 'Helper written.\\n\\n',
+    },
+    {
+      type: 'text_delta',
+      delta: 'Final artifact:\\n\\n<artifact identifier="final" type="text/html">\\n<!doctype html><html>final</html>\\n</artifact>',
     },
   ]);
 });

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -354,6 +354,51 @@ describe('structured agent stream fixtures', () => {
     });
   });
 
+  it('flushes trailing partial Claude artifact opener as prose', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+    handler.feed(`${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'message_start', message: { id: 'msg-1' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'toolu-write-1', name: 'Write' },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: '{"file_path":"index.html","content":"<!doctype html><html></html>"}',
+        },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_stop', index: 0 },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_start', index: 1, content_block: { type: 'text', text: '' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'Done <art' } },
+    })}\n`);
+    handler.flush();
+
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: 'Done ',
+    });
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: '<art',
+    });
+  });
+
   it('preserves later Claude artifact text after suppressing immediate file-write echo', () => {
     const events: unknown[] = [];
     const handler = createClaudeStreamHandler((event: unknown) => events.push(event));

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -191,7 +191,11 @@ describe('structured agent stream fixtures', () => {
 
     expect(events).toContainEqual({
       type: 'text_delta',
-      delta: '全部完成。\\n\\nDone',
+      delta: '全部完成。\\n\\n',
+    });
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: 'Done',
     });
     expect(events.some((event) => {
       if (typeof event !== 'object' || event === null) return false;
@@ -250,13 +254,57 @@ describe('structured agent stream fixtures', () => {
 
     expect(events).toContainEqual({
       type: 'text_delta',
-      delta: '全部完成。\\n\\nDone',
+      delta: '全部完成。\\n\\n',
+    });
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: 'Done',
     });
     expect(events.some((event) => {
       if (typeof event !== 'object' || event === null) return false;
       const record = event as { type?: string; delta?: string };
       return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<!doctype html>');
     })).toBe(false);
+  });
+
+  it('emits Claude prose immediately after a file write when no artifact follows', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+    handler.feed(`${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'message_start', message: { id: 'msg-1' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'toolu-write-1', name: 'Write' },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: '{"file_path":"index.html","content":"<!doctype html><html></html>"}',
+        },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_stop', index: 0 },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_start', index: 1, content_block: { type: 'text', text: '' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'Done, preview ready.' } },
+    })}\n`);
+
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: 'Done, preview ready.',
+    });
   });
 
   it('preserves later Claude artifact text after suppressing immediate file-write echo', () => {

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -103,6 +103,58 @@ describe('structured agent stream fixtures', () => {
     }));
   });
 
+  it('keeps implicit Claude TaskCreate IDs distinct from explicit task IDs', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+    handler.feed(`${JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg-1',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu-create-1',
+            name: 'TaskCreate',
+            input: {
+              taskId: '1',
+              subject: 'Bind editorial tokens',
+            },
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu-create-2',
+            name: 'TaskCreate',
+            input: {
+              subject: 'Write index.html',
+            },
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu-update-2',
+            name: 'TaskUpdate',
+            input: {
+              taskId: '2',
+              status: 'completed',
+            },
+          },
+        ],
+      },
+    })}\n`);
+    handler.flush();
+
+    expect(events).toContainEqual({
+      type: 'tool_use',
+      id: 'toolu-update-2:todo-task',
+      name: 'TodoWrite',
+      input: {
+        todos: [
+          { content: 'Bind editorial tokens', status: 'pending' },
+          { content: 'Write index.html', status: 'completed' },
+        ],
+      },
+    });
+  });
+
   it('suppresses duplicate Claude artifact text after writing a file', () => {
     const events: unknown[] = [];
     const handler = createClaudeStreamHandler((event: unknown) => events.push(event));

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -35,6 +35,160 @@ describe('structured agent stream fixtures', () => {
     });
   });
 
+  it('emits TodoWrite snapshots from Claude TaskCreate and TaskUpdate tools', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+    handler.feed(`${JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg-1',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu-create-1',
+            name: 'TaskCreate',
+            input: {
+              subject: 'Bind editorial tokens',
+              activeForm: 'Bind tokens',
+            },
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu-create-2',
+            name: 'TaskCreate',
+            input: {
+              subject: 'Write index.html',
+              activeForm: 'Write page',
+            },
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu-update-1',
+            name: 'TaskUpdate',
+            input: {
+              taskId: '1',
+              status: 'completed',
+            },
+          },
+        ],
+      },
+    })}\n`);
+    handler.flush();
+
+    expect(events).toContainEqual({
+      type: 'tool_use',
+      id: 'toolu-update-1:todo-task',
+      name: 'TodoWrite',
+      input: {
+        todos: [
+          { content: 'Bind editorial tokens', status: 'completed', activeForm: 'Bind tokens' },
+          { content: 'Write index.html', status: 'pending', activeForm: 'Write page' },
+        ],
+      },
+    });
+  });
+
+  it('suppresses duplicate Claude artifact text after writing a file', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+    handler.feed(`${JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg-1',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu-write-1',
+            name: 'Write',
+            input: {
+              file_path: 'index.html',
+              content: '<!doctype html><html></html>',
+            },
+          },
+          {
+            type: 'text',
+            text: '全部完成。\\n\\n<artifact identifier="page" type="text/html">\\n<!doctype html><html></html>\\n</artifact>',
+          },
+        ],
+      },
+    })}\n`);
+    handler.flush();
+
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: '全部完成。\\n\\n',
+    });
+    expect(events.some((event) => JSON.stringify(event).includes('<!doctype html>'))).toBe(true);
+    expect(events.some((event) => {
+      if (typeof event !== 'object' || event === null) return false;
+      const record = event as { type?: string; delta?: string };
+      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<!doctype html>');
+    })).toBe(false);
+  });
+
+  it('suppresses duplicate Claude artifact text split across chunks', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+    handler.feed(`${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'message_start', message: { id: 'msg-1' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'toolu-write-1', name: 'Write' },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: '{"file_path":"index.html","content":"<!doctype html><html></html>"}',
+        },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_stop',
+        index: 0,
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_start', index: 1, content_block: { type: 'text', text: '' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: '全部完成。\\n\\n<' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 1,
+        delta: {
+          type: 'text_delta',
+          text: 'artifact identifier="page" type="text/html">\\n<!doctype html><html></html>\\n</artifact>Done',
+        },
+      },
+    })}\n`);
+    handler.flush();
+
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: '全部完成。\\n\\n',
+    });
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: 'Done',
+    });
+    expect(events.some((event) => {
+      if (typeof event !== 'object' || event === null) return false;
+      const record = event as { type?: string; delta?: string };
+      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<!doctype html>');
+    })).toBe(false);
+  });
+
   it('preserves streamed Claude Code tool input_json_delta payloads', () => {
     const events: unknown[] = [];
     const handler = createClaudeStreamHandler((event: unknown) => events.push(event));

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -86,6 +86,21 @@ describe('structured agent stream fixtures', () => {
         ],
       },
     });
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'tool_use',
+      id: 'toolu-create-1',
+      name: 'TaskCreate',
+    }));
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'tool_use',
+      id: 'toolu-create-2',
+      name: 'TaskCreate',
+    }));
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'tool_use',
+      id: 'toolu-update-1',
+      name: 'TaskUpdate',
+    }));
   });
 
   it('suppresses duplicate Claude artifact text after writing a file', () => {
@@ -186,6 +201,51 @@ describe('structured agent stream fixtures', () => {
       if (typeof event !== 'object' || event === null) return false;
       const record = event as { type?: string; delta?: string };
       return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<!doctype html>');
+    })).toBe(false);
+  });
+
+  it('preserves later Claude artifact text after suppressing immediate file-write echo', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+    handler.feed(`${JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg-1',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu-write-1',
+            name: 'Write',
+            input: {
+              file_path: 'helper.html',
+              content: '<!doctype html><html>helper</html>',
+            },
+          },
+          {
+            type: 'text',
+            text: 'Helper written.\\n\\n<artifact identifier="helper" type="text/html">\\n<!doctype html><html>helper</html>\\n</artifact>',
+          },
+          {
+            type: 'text',
+            text: 'Final artifact:\\n\\n<artifact identifier="final" type="text/html">\\n<!doctype html><html>final</html>\\n</artifact>',
+          },
+        ],
+      },
+    })}\n`);
+    handler.flush();
+
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: 'Helper written.\\n\\n',
+    });
+    expect(events).toContainEqual({
+      type: 'text_delta',
+      delta: 'Final artifact:\\n\\n<artifact identifier="final" type="text/html">\\n<!doctype html><html>final</html>\\n</artifact>',
+    });
+    expect(events.some((event) => {
+      if (typeof event !== 'object' || event === null) return false;
+      const record = event as { type?: string; delta?: string };
+      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<html>helper</html>');
     })).toBe(false);
   });
 

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -191,11 +191,66 @@ describe('structured agent stream fixtures', () => {
 
     expect(events).toContainEqual({
       type: 'text_delta',
-      delta: '全部完成。\\n\\n',
+      delta: '全部完成。\\n\\nDone',
     });
+    expect(events.some((event) => {
+      if (typeof event !== 'object' || event === null) return false;
+      const record = event as { type?: string; delta?: string };
+      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<!doctype html>');
+    })).toBe(false);
+  });
+
+  it('suppresses duplicate Claude artifact text when plain prose arrives before the artifact chunk', () => {
+    const events: unknown[] = [];
+    const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
+    handler.feed(`${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'message_start', message: { id: 'msg-1' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'toolu-write-1', name: 'Write' },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: '{"file_path":"index.html","content":"<!doctype html><html></html>"}',
+        },
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_stop',
+        index: 0,
+      },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_start', index: 1, content_block: { type: 'text', text: '' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: '全部完成。\\n\\n' } },
+    })}\n${JSON.stringify({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        index: 1,
+        delta: {
+          type: 'text_delta',
+          text: '<artifact identifier="page" type="text/html">\\n<!doctype html><html></html>\\n</artifact>Done',
+        },
+      },
+    })}\n`);
+    handler.flush();
+
     expect(events).toContainEqual({
       type: 'text_delta',
-      delta: 'Done',
+      delta: '全部完成。\\n\\nDone',
     });
     expect(events.some((event) => {
       if (typeof event !== 'object' || event === null) return false;

--- a/apps/daemon/tests/structured-streams.test.ts
+++ b/apps/daemon/tests/structured-streams.test.ts
@@ -204,7 +204,7 @@ describe('structured agent stream fixtures', () => {
     })).toBe(false);
   });
 
-  it('suppresses duplicate Claude artifact text when plain prose arrives before the artifact chunk', () => {
+  it('preserves later Claude artifact text after plain prose clears file-write suppression', () => {
     const events: unknown[] = [];
     const handler = createClaudeStreamHandler((event: unknown) => events.push(event));
     handler.feed(`${JSON.stringify({
@@ -258,13 +258,8 @@ describe('structured agent stream fixtures', () => {
     });
     expect(events).toContainEqual({
       type: 'text_delta',
-      delta: 'Done',
+      delta: '<artifact identifier="page" type="text/html">\\n<!doctype html><html></html>\\n</artifact>Done',
     });
-    expect(events.some((event) => {
-      if (typeof event !== 'object' || event === null) return false;
-      const record = event as { type?: string; delta?: string };
-      return record.type === 'text_delta' && typeof record.delta === 'string' && record.delta.includes('<!doctype html>');
-    })).toBe(false);
   });
 
   it('emits Claude prose immediately after a file write when no artifact follows', () => {

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -255,6 +255,11 @@ interface Props {
   // in-flight Write/Edit's code in real time before the full `tool_use`
   // arrives. Never persisted.
   liveToolInput?: Record<string, { name: string; text: string; seq?: number }>;
+  // ChatPane keeps one conversation-level TodoWrite card at the original
+  // message position where TodoWrite first appeared, while the card contents
+  // update from the latest TodoWrite snapshot in the conversation.
+  showConversationTodoCard?: boolean;
+  conversationTodoInput?: unknown | null;
   projectId: string | null;
   // Analytics context for the assistant_feedback_* events. Defaults
   // applied at the call site keep AssistantMessage usable in tests
@@ -319,6 +324,8 @@ interface Props {
 const ASSISTANT_MESSAGE_COMPARED_PROPS: Array<keyof Props> = [
   'message',
   'streaming',
+  'showConversationTodoCard',
+  'conversationTodoInput',
   'projectId',
   'projectKind',
   'conversationId',
@@ -369,6 +376,8 @@ function AssistantMessageImpl({
   message,
   streaming,
   liveToolInput,
+  showConversationTodoCard = false,
+  conversationTodoInput = null,
   projectId,
   projectKind = null,
   conversationId = null,
@@ -448,12 +457,16 @@ function AssistantMessageImpl({
           ];
         })()
       : [...buildBlocks(events), ...liveCodeBlocks];
-    return stripTodoToolGroups(
+    return placeConversationTodoCard(
       stripEmptyThinkingBlocks(
         suppressDuplicateQuestionForms(suppressAskUserQuestionFallbackText(rawBlocks)),
       ),
+      {
+        show: showConversationTodoCard,
+        input: conversationTodoInput,
+      },
     );
-  }, [events, liveAuq, liveCodeBlocks]);
+  }, [events, liveAuq, liveCodeBlocks, showConversationTodoCard, conversationTodoInput]);
   const fileOps = useMemo(() => deriveFileOps(events), [events]);
   const produced = message.producedFiles ?? [];
   const displayedProduced = useMemo(
@@ -2636,14 +2649,28 @@ type Block =
  * single tool-group block so the chat surface stays compact during chains
  * of edits / reads.
  */
-// Drop any tool-group composed entirely of TodoWrite calls. ChatPane
-// renders one canonical TodoCard above the composer using
-// `latestTodosFromConversation`, so leaving the same task list inline in
-// each assistant message just duplicates the view.
-function stripTodoToolGroups(blocks: Block[]): Block[] {
-  return blocks.filter((block) => {
-    if (block.kind !== "tool-group") return true;
-    return !block.items.every((it) => isTodoWriteToolName(it.use.name));
+function placeConversationTodoCard(
+  blocks: Block[],
+  options: { show: boolean; input: unknown | null },
+): Block[] {
+  let placed = false;
+  return blocks.flatMap((block): Block[] => {
+    if (block.kind !== "tool-group") return [block];
+    if (!block.items.every((it) => isTodoWriteToolName(it.use.name))) return [block];
+    if (!options.show || placed) return [];
+    placed = true;
+    const item = block.items[0];
+    if (!item || options.input == null) return [block];
+    return [{
+      ...block,
+      items: [{
+        ...item,
+        use: {
+          ...item.use,
+          input: options.input,
+        },
+      }],
+    }];
   });
 }
 

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -255,9 +255,9 @@ interface Props {
   // in-flight Write/Edit's code in real time before the full `tool_use`
   // arrives. Never persisted.
   liveToolInput?: Record<string, { name: string; text: string; seq?: number }>;
-  // ChatPane keeps one conversation-level TodoWrite card at the original
-  // message position where TodoWrite first appeared, while the card contents
-  // update from the latest TodoWrite snapshot in the conversation.
+  // ChatPane renders the canonical conversation-level TodoWrite card as its
+  // own row, while this message strips TodoWrite tool groups to avoid a
+  // duplicate per-message card.
   showConversationTodoCard?: boolean;
   conversationTodoInput?: unknown | null;
   projectId: string | null;
@@ -410,9 +410,9 @@ function AssistantMessageImpl({
   // shows the questions + options, so suppressing the trailing prose
   // avoids rendering the same content twice. The system prompt asks the
   // model not to do this; this is the belt-and-suspenders.
-  // The chat-pane-level PinnedTodoBar renders the canonical TodoWrite card
-  // above the composer, so we strip any TodoWrite tool-groups out of the
-  // per-message flow to avoid the same task list rendering twice.
+  // ChatPane renders the canonical TodoWrite card as a standalone chat row, so
+  // we strip TodoWrite tool-groups out of the per-message flow to avoid the
+  // same task list rendering twice.
   const settledUseIds = useMemo(
     () => new Set(events.filter((e) => e.kind === "tool_use").map((e) => e.id)),
     [events],

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -29,7 +29,7 @@ import {
   DESIGN_SYSTEM_WORKSPACE_DISPLAY_TITLE,
   isDesignSystemWorkspacePrompt,
 } from '../design-system-auto-prompt';
-import { latestTodoWriteInputForPinnedCard } from '../runtime/todos';
+import { isTodoWriteToolName, latestTodoWriteInputForPinnedCard } from '../runtime/todos';
 import type { AppConfig, ChatAttachment, ChatCommentAttachment, ChatMessage, ChatMessageFeedbackChange, Conversation, DesignSystemSummary, PreviewComment, Project, ProjectFile, ProjectMetadata, SkillSummary } from '../types';
 import { exactDateTime, messageTime, shortTime } from '../utils/chatTime';
 import { commentTargetDisplayName, commentsToAttachments, simplePositionLabel } from '../comments';
@@ -2222,6 +2222,7 @@ function ChatRows({
     overscanPx: CHAT_MESSAGE_OVERSCAN_PX,
     resetKey: activeConversationKey,
     initialTailRows: CHAT_VIRTUAL_INITIAL_TAIL_ROWS,
+    alwaysIncludeKey: conversationTodoInput != null ? 'conversation-todo' : undefined,
   });
 
   const renderItem = (item: ChatRenderItem) => {
@@ -2401,6 +2402,7 @@ function VirtualChatRow({
 
 function buildChatRenderItems(messages: ChatMessage[], conversationTodoInput: unknown | null): ChatRenderItem[] {
   const items: ChatRenderItem[] = [];
+  let insertedConversationTodo = false;
   for (let i = 0; i < messages.length; i += 1) {
     const message = messages[i]!;
     items.push({
@@ -2408,8 +2410,21 @@ function buildChatRenderItems(messages: ChatMessage[], conversationTodoInput: un
       key: `message:${message.id}`,
       message,
     });
+    if (
+      conversationTodoInput != null &&
+      !insertedConversationTodo &&
+      message.role === 'assistant' &&
+      message.events?.some((event) => event.kind === 'tool_use' && isTodoWriteToolName(event.name))
+    ) {
+      items.push({
+        kind: 'conversation-todo',
+        key: 'conversation-todo',
+        input: conversationTodoInput,
+      });
+      insertedConversationTodo = true;
+    }
   }
-  if (conversationTodoInput != null) {
+  if (conversationTodoInput != null && !insertedConversationTodo) {
     items.push({
       kind: 'conversation-todo',
       key: 'conversation-todo',
@@ -2447,6 +2462,7 @@ function useMeasuredVirtualWindow<T extends { key: string }>(
     overscanPx,
     resetKey,
     initialTailRows,
+    alwaysIncludeKey,
   }: {
     enabled: boolean;
     containerRef: MutableRefObject<HTMLDivElement | null>;
@@ -2454,6 +2470,7 @@ function useMeasuredVirtualWindow<T extends { key: string }>(
     overscanPx: number;
     resetKey: string;
     initialTailRows: number;
+    alwaysIncludeKey?: string;
   },
 ) {
   const measuredHeightsRef = useRef<Map<string, number>>(new Map());
@@ -2523,10 +2540,11 @@ function useMeasuredVirtualWindow<T extends { key: string }>(
     const height = viewport.height || CHAT_VIRTUAL_DEFAULT_VIEWPORT_PX;
     if (viewport.scrollTop === 0 && viewport.height === 0) {
       const start = Math.max(0, items.length - initialTailRows);
-      return items.slice(start).map((item, offset) => {
+      const rows = items.slice(start).map((item, offset) => {
         const index = start + offset;
         return { item, index, top: layout.offsets[index] ?? 0 };
       });
+      return includeVirtualRowByKey(rows, items, layout.offsets, alwaysIncludeKey);
     }
     const startTarget = Math.max(0, viewport.scrollTop - overscanPx);
     const endTarget = viewport.scrollTop + height + overscanPx;
@@ -2541,11 +2559,13 @@ function useMeasuredVirtualWindow<T extends { key: string }>(
     while (end < items.length && (layout.offsets[end] ?? 0) <= endTarget) {
       end += 1;
     }
-    return items.slice(start, end).map((item, offset) => {
+    const rows = items.slice(start, end).map((item, offset) => {
       const index = start + offset;
       return { item, index, top: layout.offsets[index] ?? 0 };
     });
+    return includeVirtualRowByKey(rows, items, layout.offsets, alwaysIncludeKey);
   }, [
+    alwaysIncludeKey,
     enabled,
     initialTailRows,
     items,
@@ -2570,6 +2590,25 @@ function useMeasuredVirtualWindow<T extends { key: string }>(
     totalHeight: layout.totalHeight,
     onMeasure,
   };
+}
+
+function includeVirtualRowByKey<T extends { key: string }>(
+  rows: Array<{ item: T; index: number; top: number }>,
+  items: T[],
+  offsets: number[],
+  key: string | undefined,
+): Array<{ item: T; index: number; top: number }> {
+  if (!key || rows.some((row) => row.item.key === key)) return rows;
+  const index = items.findIndex((item) => item.key === key);
+  if (index === -1) return rows;
+  return [
+    ...rows,
+    {
+      item: items[index]!,
+      index,
+      top: offsets[index] ?? 0,
+    },
+  ].sort((a, b) => a.index - b.index);
 }
 
 function QueuedSendStrip({

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -29,8 +29,7 @@ import {
   DESIGN_SYSTEM_WORKSPACE_DISPLAY_TITLE,
   isDesignSystemWorkspacePrompt,
 } from '../design-system-auto-prompt';
-import { latestTodoWriteInputForPinnedCard } from '../runtime/todos';
-import { TodoCard } from './ToolCard';
+import { isTodoWriteToolName, latestTodoWriteInputForPinnedCard } from '../runtime/todos';
 import type { AppConfig, ChatAttachment, ChatCommentAttachment, ChatMessage, ChatMessageFeedbackChange, Conversation, DesignSystemSummary, PreviewComment, Project, ProjectFile, ProjectMetadata, SkillSummary } from '../types';
 import { exactDateTime, messageTime, shortTime } from '../utils/chatTime';
 import { commentTargetDisplayName, commentsToAttachments, simplePositionLabel } from '../comments';
@@ -745,7 +744,6 @@ export function ChatPane({
   const composerRef = useRef<ChatComposerHandle | null>(null);
   const composerSlotRef = useRef<HTMLDivElement | null>(null);
   const composerLayerRef = useRef<HTMLDivElement | null>(null);
-  const pinnedTodoRef = useRef<HTMLDivElement | null>(null);
   const queuedSendStripRef = useRef<HTMLDivElement | null>(null);
   const didInitialScrollRef = useRef(false);
   const runFailedToastSurfaceKeysRef = useRef<Set<string>>(new Set());
@@ -807,34 +805,6 @@ export function ChatPane({
     bottom: number;
   } | null>(null);
   const [composerSlotHeight, setComposerSlotHeight] = useState(0);
-  // The user can dismiss the pinned task list once everything is complete.
-  // We key the dismissal on the snapshot (serialized TodoWrite input) so
-  // the next time the agent emits a different snapshot the card returns,
-  // but the same snapshot stays hidden across renders / streaming ticks.
-  // Persisted to sessionStorage so the dismissal survives tab switches and
-  // component remounts (the ChatPane key includes conversationId, so switching
-  // conversations unmounts and remounts the component). The stored value is the
-  // snapshot key, so a fresh TodoWrite snapshot still re-shows the card.
-  const dismissedStorageKey = `dismissedTodo:${activeConversationId ?? 'none'}`;
-  const [dismissedPinnedTodoKey, setDismissedPinnedTodoKey] = useState<string | null>(() => {
-    try {
-      return sessionStorage.getItem(dismissedStorageKey);
-    } catch {
-      return null;
-    }
-  });
-  // Sync dismissed state when conversationId changes (e.g., tab switching).
-  // The parent key includes conversationId so unmount/remount resets this,
-  // but if conversationId changes without unmounting or the storage key
-  // changes, re-read to keep the dismissed state in sync.
-  useEffect(() => {
-    try {
-      const stored = sessionStorage.getItem(dismissedStorageKey);
-      setDismissedPinnedTodoKey(stored);
-    } catch {
-      // sessionStorage access can fail in private browsing
-    }
-  }, [dismissedStorageKey]);
   const [editingQueuedSendId, setEditingQueuedSendId] = useState<string | null>(null);
   // Reverse scan (no array copy) + memo so this and the maps below don't
   // recompute on every non-`messages` render (scroll, hover, toggles).
@@ -1357,24 +1327,7 @@ export function ChatPane({
       }
     };
 
-    // The PinnedTodoSlot renders outside the scroll container. When the todo
-    // card grows, the chat-log's clientHeight shrinks (flex layout) and the
-    // user drifts away from the bottom. Observe the pinned-todo div so
-    // followLatestIfPinned fires whenever the card changes height.
-    let observedPinnedTodo: Element | null = null;
     let observedQueuedSendStrip: Element | null = null;
-    const syncPinnedTodo = () => {
-      if (!resizeObserver) return;
-      const pinnedEl = pinnedTodoRef.current;
-      if (pinnedEl && observedPinnedTodo !== pinnedEl) {
-        if (observedPinnedTodo) resizeObserver.unobserve(observedPinnedTodo);
-        resizeObserver.observe(pinnedEl);
-        observedPinnedTodo = pinnedEl;
-      } else if (!pinnedEl && observedPinnedTodo) {
-        resizeObserver.unobserve(observedPinnedTodo);
-        observedPinnedTodo = null;
-      }
-    };
     const syncQueuedSendStrip = () => {
       if (!resizeObserver) return;
       const queuedEl = queuedSendStripRef.current;
@@ -1391,14 +1344,12 @@ export function ChatPane({
     };
 
     syncObservedChildren();
-    syncPinnedTodo();
     syncQueuedSendStrip();
 
     const mutationObserver =
       typeof MutationObserver !== 'undefined'
         ? new MutationObserver(() => {
             syncObservedChildren();
-            syncPinnedTodo();
             syncQueuedSendStrip();
             followLatestIfPinned();
           })
@@ -1411,11 +1362,11 @@ export function ChatPane({
       childList: true,
       subtree: true,
     });
-    // PinnedTodoSlot and QueuedSendStrip live outside the chat-log subtree
-    // (they are siblings of .chat-log-wrap inside .pane). The
-    // MutationObserver above only fires for changes inside el, so it cannot
-    // detect those surfaces mounting or unmounting. Watch the nearest common
-    // ancestor (.pane) with childList-only to keep their observers current.
+    // QueuedSendStrip lives outside the chat-log subtree (it is a sibling of
+    // .chat-log-wrap inside .pane). The MutationObserver above only fires for
+    // changes inside el, so it cannot detect that surface mounting or
+    // unmounting. Watch the nearest common ancestor (.pane) with childList-only
+    // to keep its observer current.
     const paneEl = el.parentElement?.parentElement ?? null;
     if (paneEl && mutationObserver) {
       mutationObserver.observe(paneEl, { childList: true });
@@ -2096,24 +2047,6 @@ export function ChatPane({
               <span>{t('chat.jumpToLatest')}</span>
             </button>
           </div>
-          <PinnedTodoSlot
-            messages={messages}
-            streaming={streaming}
-            dismissedKey={dismissedPinnedTodoKey}
-            onDismiss={(key) => {
-              setDismissedPinnedTodoKey(key);
-              try {
-                if (key) {
-                  sessionStorage.setItem(dismissedStorageKey, key);
-                } else {
-                  sessionStorage.removeItem(dismissedStorageKey);
-                }
-              } catch {
-                // sessionStorage access can fail in private browsing / sandboxed contexts
-              }
-            }}
-            containerRef={pinnedTodoRef}
-          />
           <QueuedSendStrip
             containerRef={queuedSendStripRef}
             items={queuedItems}
@@ -2267,6 +2200,14 @@ function ChatRows({
   scrollContainerRef: MutableRefObject<HTMLDivElement | null>;
 }) {
   const items = useMemo(() => buildChatRenderItems(messages), [messages]);
+  const conversationTodoInput = useMemo(
+    () => latestTodoWriteInputForPinnedCard(messages),
+    [messages],
+  );
+  const conversationTodoAnchorMessageId = useMemo(
+    () => firstTodoWriteMessageId(messages),
+    [messages],
+  );
   const virtualized = items.length > CHAT_MESSAGE_VIRTUALIZE_THRESHOLD;
   const virtualWindow = useMeasuredVirtualWindow(items, {
     enabled: virtualized,
@@ -2316,6 +2257,8 @@ function ChatRows({
         // get a stable `undefined`, so adding `liveToolInput` to the memo
         // comparator re-renders just this row per `tool_input_delta`, not all N.
         liveToolInput={messageStreaming ? liveToolInput : undefined}
+        showConversationTodoCard={m.id === conversationTodoAnchorMessageId}
+        conversationTodoInput={conversationTodoInput}
         projectId={projectId}
         projectKind={projectKindForTracking}
         conversationId={activeConversationId}
@@ -2452,6 +2395,17 @@ function buildChatRenderItems(messages: ChatMessage[]): ChatRenderItem[] {
     });
   }
   return items;
+}
+
+function firstTodoWriteMessageId(messages: ChatMessage[]): string | null {
+  for (const message of messages) {
+    if (message.role !== 'assistant') continue;
+    const events = message.events ?? [];
+    if (events.some((event) => event.kind === 'tool_use' && isTodoWriteToolName(event.name))) {
+      return message.id;
+    }
+  }
+  return null;
 }
 
 function estimateChatRenderItemHeight(item: ChatRenderItem): number {
@@ -2604,57 +2558,6 @@ function useMeasuredVirtualWindow<T extends { key: string }>(
     totalHeight: layout.totalHeight,
     onMeasure,
   };
-}
-
-// Pinned task list above the chat composer. The latest TodoWrite snapshot
-// across the entire conversation is the canonical state; AssistantMessage
-// no longer renders these inline so there is exactly one TodoCard on
-// screen. When every task is complete the user can dismiss the card; the
-// dismissal sticks to the current snapshot only, so a fresh TodoWrite
-// from the agent re-shows it.
-function PinnedTodoSlot({
-  messages,
-  streaming,
-  dismissedKey,
-  onDismiss,
-  containerRef,
-}: {
-  messages: ChatMessage[];
-  streaming: boolean;
-  dismissedKey: string | null;
-  onDismiss: (key: string | null) => void;
-  containerRef?: MutableRefObject<HTMLDivElement | null>;
-}) {
-  // `exiting` lets the dismiss click play a slide-down transition before
-  // the slot tears down. Without it React would unmount immediately and
-  // the card would pop out without animation.
-  const [exiting, setExiting] = useState(false);
-  const input = latestTodoWriteInputForPinnedCard(messages);
-  if (input == null) return null;
-  let snapshotKey: string;
-  try {
-    snapshotKey = JSON.stringify(input);
-  } catch {
-    snapshotKey = String(input);
-  }
-  if (snapshotKey === dismissedKey) return null;
-  return (
-    <div className={`chat-pinned-todo${exiting ? ' chat-pinned-todo-exit' : ''}`} ref={containerRef}>
-      <TodoCard
-        input={input}
-        runStreaming={streaming}
-        runSucceeded={!streaming}
-        onDismiss={() => {
-          if (exiting) return;
-          setExiting(true);
-          // Match the slide-out duration in CSS (220ms) — once the
-          // transition completes the snapshot key is recorded as
-          // dismissed and the slot is unmounted by the early return.
-          window.setTimeout(() => onDismiss(snapshotKey), 220);
-        }}
-      />
-    </div>
-  );
 }
 
 function QueuedSendStrip({

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -34,7 +34,6 @@ import type { AppConfig, ChatAttachment, ChatCommentAttachment, ChatMessage, Cha
 import { exactDateTime, messageTime, shortTime } from '../utils/chatTime';
 import { commentTargetDisplayName, commentsToAttachments, simplePositionLabel } from '../comments';
 import { AssistantMessage, type QuestionFormOpenRequest } from './AssistantMessage';
-import { TodoCard } from './ToolCard';
 import { AmrGuidance } from './AmrGuidance';
 import { amrRechargeUrlForProfile, resolveRunFailureUi } from '../runtime/amr-guidance';
 import {
@@ -2101,17 +2100,11 @@ interface AssistantCallbacks {
   onShareToOpenDesign: ((assistantMessageId: string) => void) | undefined;
 }
 
-type ChatRenderItem =
-  | {
-      kind: 'message';
-      key: string;
-      message: ChatMessage;
-    }
-  | {
-      kind: 'conversation-todo';
-      key: string;
-      input: unknown;
-    };
+type ChatRenderItem = {
+  kind: 'message';
+  key: string;
+  message: ChatMessage;
+};
 
 function ChatConversationLoading({ t }: { t: TranslateFn }) {
   return (
@@ -2210,9 +2203,13 @@ function ChatRows({
     () => latestTodoWriteInputForPinnedCard(messages),
     [messages],
   );
+  const conversationTodoAnchorMessageId = useMemo(
+    () => firstTodoWriteAssistantMessageId(messages),
+    [messages],
+  );
   const items = useMemo(
-    () => buildChatRenderItems(messages, conversationTodoInput),
-    [messages, conversationTodoInput],
+    () => buildChatRenderItems(messages),
+    [messages],
   );
   const virtualized = items.length > CHAT_MESSAGE_VIRTUALIZE_THRESHOLD;
   const virtualWindow = useMeasuredVirtualWindow(items, {
@@ -2222,21 +2219,13 @@ function ChatRows({
     overscanPx: CHAT_MESSAGE_OVERSCAN_PX,
     resetKey: activeConversationKey,
     initialTailRows: CHAT_VIRTUAL_INITIAL_TAIL_ROWS,
-    alwaysIncludeKey: conversationTodoInput != null ? 'conversation-todo' : undefined,
+    alwaysIncludeKey:
+      conversationTodoInput != null && conversationTodoAnchorMessageId
+        ? `message:${conversationTodoAnchorMessageId}`
+        : undefined,
   });
 
   const renderItem = (item: ChatRenderItem) => {
-    if (item.kind === 'conversation-todo') {
-      return (
-        <div className="chat-conversation-todo-row">
-          <TodoCard
-            input={item.input}
-            runStreaming={streaming}
-            runSucceeded={!streaming}
-          />
-        </div>
-      );
-    }
     const m = item.message;
     const messageStreaming = isAssistantMessageStreaming(
       m,
@@ -2275,6 +2264,8 @@ function ChatRows({
         // get a stable `undefined`, so adding `liveToolInput` to the memo
         // comparator re-renders just this row per `tool_input_delta`, not all N.
         liveToolInput={messageStreaming ? liveToolInput : undefined}
+        showConversationTodoCard={m.id === conversationTodoAnchorMessageId}
+        conversationTodoInput={conversationTodoInput}
         projectId={projectId}
         projectKind={projectKindForTracking}
         conversationId={activeConversationId}
@@ -2400,9 +2391,8 @@ function VirtualChatRow({
   );
 }
 
-function buildChatRenderItems(messages: ChatMessage[], conversationTodoInput: unknown | null): ChatRenderItem[] {
+function buildChatRenderItems(messages: ChatMessage[]): ChatRenderItem[] {
   const items: ChatRenderItem[] = [];
-  let insertedConversationTodo = false;
   for (let i = 0; i < messages.length; i += 1) {
     const message = messages[i]!;
     items.push({
@@ -2410,32 +2400,22 @@ function buildChatRenderItems(messages: ChatMessage[], conversationTodoInput: un
       key: `message:${message.id}`,
       message,
     });
-    if (
-      conversationTodoInput != null &&
-      !insertedConversationTodo &&
-      message.role === 'assistant' &&
-      message.events?.some((event) => event.kind === 'tool_use' && isTodoWriteToolName(event.name))
-    ) {
-      items.push({
-        kind: 'conversation-todo',
-        key: 'conversation-todo',
-        input: conversationTodoInput,
-      });
-      insertedConversationTodo = true;
-    }
-  }
-  if (conversationTodoInput != null && !insertedConversationTodo) {
-    items.push({
-      kind: 'conversation-todo',
-      key: 'conversation-todo',
-      input: conversationTodoInput,
-    });
   }
   return items;
 }
 
+function firstTodoWriteAssistantMessageId(messages: ChatMessage[]): string | null {
+  const message = messages.find(
+    (candidate) =>
+      candidate.role === 'assistant' &&
+      candidate.events?.some(
+        (event) => event.kind === 'tool_use' && isTodoWriteToolName(event.name),
+      ),
+  );
+  return message?.id ?? null;
+}
+
 function estimateChatRenderItemHeight(item: ChatRenderItem): number {
-  if (item.kind === 'conversation-todo') return 180 + CHAT_VIRTUAL_ROW_GAP_PX;
   const message = item.message;
   const contentLength = message.content?.length ?? 0;
   const attachmentCount = (message.attachments?.length ?? 0) + (message.commentAttachments?.length ?? 0);

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -29,11 +29,12 @@ import {
   DESIGN_SYSTEM_WORKSPACE_DISPLAY_TITLE,
   isDesignSystemWorkspacePrompt,
 } from '../design-system-auto-prompt';
-import { isTodoWriteToolName, latestTodoWriteInputForPinnedCard } from '../runtime/todos';
+import { latestTodoWriteInputForPinnedCard } from '../runtime/todos';
 import type { AppConfig, ChatAttachment, ChatCommentAttachment, ChatMessage, ChatMessageFeedbackChange, Conversation, DesignSystemSummary, PreviewComment, Project, ProjectFile, ProjectMetadata, SkillSummary } from '../types';
 import { exactDateTime, messageTime, shortTime } from '../utils/chatTime';
 import { commentTargetDisplayName, commentsToAttachments, simplePositionLabel } from '../comments';
 import { AssistantMessage, type QuestionFormOpenRequest } from './AssistantMessage';
+import { TodoCard } from './ToolCard';
 import { AmrGuidance } from './AmrGuidance';
 import { amrRechargeUrlForProfile, resolveRunFailureUi } from '../runtime/amr-guidance';
 import {
@@ -2100,11 +2101,17 @@ interface AssistantCallbacks {
   onShareToOpenDesign: ((assistantMessageId: string) => void) | undefined;
 }
 
-type ChatRenderItem = {
-  kind: 'message';
-  key: string;
-  message: ChatMessage;
-};
+type ChatRenderItem =
+  | {
+      kind: 'message';
+      key: string;
+      message: ChatMessage;
+    }
+  | {
+      kind: 'conversation-todo';
+      key: string;
+      input: unknown;
+    };
 
 function ChatConversationLoading({ t }: { t: TranslateFn }) {
   return (
@@ -2199,14 +2206,13 @@ function ChatRows({
   onOpenQuestions?: (request?: QuestionFormOpenRequest) => void;
   scrollContainerRef: MutableRefObject<HTMLDivElement | null>;
 }) {
-  const items = useMemo(() => buildChatRenderItems(messages), [messages]);
   const conversationTodoInput = useMemo(
     () => latestTodoWriteInputForPinnedCard(messages),
     [messages],
   );
-  const conversationTodoAnchorMessageId = useMemo(
-    () => firstTodoWriteMessageId(messages),
-    [messages],
+  const items = useMemo(
+    () => buildChatRenderItems(messages, conversationTodoInput),
+    [messages, conversationTodoInput],
   );
   const virtualized = items.length > CHAT_MESSAGE_VIRTUALIZE_THRESHOLD;
   const virtualWindow = useMeasuredVirtualWindow(items, {
@@ -2219,6 +2225,17 @@ function ChatRows({
   });
 
   const renderItem = (item: ChatRenderItem) => {
+    if (item.kind === 'conversation-todo') {
+      return (
+        <div className="chat-conversation-todo-row">
+          <TodoCard
+            input={item.input}
+            runStreaming={streaming}
+            runSucceeded={!streaming}
+          />
+        </div>
+      );
+    }
     const m = item.message;
     const messageStreaming = isAssistantMessageStreaming(
       m,
@@ -2257,8 +2274,6 @@ function ChatRows({
         // get a stable `undefined`, so adding `liveToolInput` to the memo
         // comparator re-renders just this row per `tool_input_delta`, not all N.
         liveToolInput={messageStreaming ? liveToolInput : undefined}
-        showConversationTodoCard={m.id === conversationTodoAnchorMessageId}
-        conversationTodoInput={conversationTodoInput}
         projectId={projectId}
         projectKind={projectKindForTracking}
         conversationId={activeConversationId}
@@ -2384,7 +2399,7 @@ function VirtualChatRow({
   );
 }
 
-function buildChatRenderItems(messages: ChatMessage[]): ChatRenderItem[] {
+function buildChatRenderItems(messages: ChatMessage[], conversationTodoInput: unknown | null): ChatRenderItem[] {
   const items: ChatRenderItem[] = [];
   for (let i = 0; i < messages.length; i += 1) {
     const message = messages[i]!;
@@ -2394,21 +2409,18 @@ function buildChatRenderItems(messages: ChatMessage[]): ChatRenderItem[] {
       message,
     });
   }
+  if (conversationTodoInput != null) {
+    items.push({
+      kind: 'conversation-todo',
+      key: 'conversation-todo',
+      input: conversationTodoInput,
+    });
+  }
   return items;
 }
 
-function firstTodoWriteMessageId(messages: ChatMessage[]): string | null {
-  for (const message of messages) {
-    if (message.role !== 'assistant') continue;
-    const events = message.events ?? [];
-    if (events.some((event) => event.kind === 'tool_use' && isTodoWriteToolName(event.name))) {
-      return message.id;
-    }
-  }
-  return null;
-}
-
 function estimateChatRenderItemHeight(item: ChatRenderItem): number {
+  if (item.kind === 'conversation-todo') return 180 + CHAT_VIRTUAL_ROW_GAP_PX;
   const message = item.message;
   const contentLength = message.content?.length ?? 0;
   const attachmentCount = (message.attachments?.length ?? 0) + (message.commentAttachments?.length ?? 0);

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -903,22 +903,6 @@
 .chat-composer-fixed-layer .composer {
   pointer-events: auto;
 }
-/* Elevation kicks in only when a pinned todo card is sitting directly
- * above the composer. Without the card the chat scroll already provides
- * its own visual edge; the shadow would just darken empty whitespace. */
-.chat-pinned-todo + .composer {
-  box-shadow: 0 -10px 22px -10px rgba(0, 0, 0, 0.22);
-}
-/* Dark mode: the same alpha disappears against the dark panel, so push
- * it harder and let it spread a bit further. */
-[data-theme="dark"] .chat-pinned-todo + .composer {
-  box-shadow: 0 -14px 28px -12px rgba(0, 0, 0, 0.65);
-}
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .chat-pinned-todo + .composer {
-    box-shadow: 0 -14px 28px -12px rgba(0, 0, 0, 0.65);
-  }
-}
 .composer-shell {
   container-type: inline-size;
   border: 1px solid var(--bg-fill-secondary);

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -666,52 +666,6 @@
 }
 
 /*
- * Pinned task list above the chat composer. The card sits just above the
- * prompt input, persistent for the whole conversation rather than buried
- * in a single assistant message. It mirrors the Cursor / Codex / Claude
- * Code TTY pattern where the todo list is always one click away while you
- * are typing the next prompt. The card is collapsible via its own
- * header — see `.op-todo-toggle` below.
- */
-.chat-pinned-todo {
-  position: relative;
-  padding: 0 16px;
-  transition:
-    transform 220ms cubic-bezier(0.23, 1, 0.32, 1),
-    opacity 200ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-/* Slide-down dismiss: matches the global animation philosophy
- * (strong ease-out, ~200ms). The wrapper animates away while the
- * Done click still resolves the snapshot key. */
-.chat-pinned-todo-exit {
-  transform: translateY(24px);
-  opacity: 0;
-  pointer-events: none;
-}
-/* Soft fade above the pinned card so chat text scrolling beneath it
- * dissolves into the panel background instead of getting hard-clipped
- * at the card's top edge. Sits in the gutter directly above the card,
- * pulled up by negative bottom so it overlaps the chat scroll area. */
-.chat-pinned-todo::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 100%;
-  height: 28px;
-  background: linear-gradient(to top, var(--bg-panel), transparent);
-  pointer-events: none;
-}
-.chat-pinned-todo .op-card.op-todo {
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
-  /* Square the bottom corners so the card reads as tucked under the
-   * composer below it, rather than as a floating pill with a gap. */
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  border-bottom: 0;
-}
-
-/*
  * Shared accordion expand/collapse motion. `grid-template-rows: 0fr -> 1fr`
  * is the modern way to animate auto-height content; pair it with a
  * fade so the body doesn't pop in flat. Strong ease-out curve, with

--- a/apps/web/tests/components/ChatPane.streaming.test.tsx
+++ b/apps/web/tests/components/ChatPane.streaming.test.tsx
@@ -50,18 +50,27 @@ vi.mock('../../src/components/AssistantMessage', () => ({
     streaming,
     message,
     isLast,
+    showConversationTodoCard,
+    conversationTodoInput,
     onShareToOpenDesign,
     shareToOpenDesignBusy,
   }: {
     streaming: boolean;
     message: ChatMessage;
     isLast?: boolean;
+    showConversationTodoCard?: boolean;
+    conversationTodoInput?: unknown;
     onShareToOpenDesign?: () => void;
     shareToOpenDesignBusy?: boolean;
   }) => (
     <>
       <output data-testid={`assistant-streaming-${message.id}`}>{streaming ? 'streaming' : 'idle'}</output>
       <output data-testid={`assistant-last-${message.id}`}>{isLast ? 'last' : 'not-last'}</output>
+      {showConversationTodoCard ? (
+        <output data-testid={`assistant-todo-input-${message.id}`}>
+          {JSON.stringify(conversationTodoInput)}
+        </output>
+      ) : null}
       {onShareToOpenDesign ? (
         <button
           type="button"
@@ -716,7 +725,7 @@ Expected output:
     expect(spacer!.style.height).toBe('0px');
   });
 
-  it('renders a stopped pinned todo after a terminal run without a final TodoWrite', () => {
+  it('passes a stopped inline todo after a terminal run without a final TodoWrite', () => {
     const messages: ChatMessage[] = [
       {
         id: 'assistant-1',
@@ -764,10 +773,18 @@ Expected output:
       />,
     );
 
-    expect(screen.getByText('0/2')).toBeTruthy();
-    expect(container.querySelector('.todo-stopped')?.textContent).toContain('Build prototype');
-    expect(container.querySelector('.todo-in_progress')).toBeNull();
-    expect(container.querySelector('.op-todo-current')).toBeNull();
+    const todoInput = JSON.parse(screen.getByTestId('assistant-todo-input-assistant-1').textContent ?? '{}');
+    expect(todoInput).toEqual({
+      todos: [
+        {
+          content: 'Build prototype',
+          status: 'stopped',
+          activeForm: 'Building prototype',
+        },
+        { content: 'Run QA', status: 'pending' },
+      ],
+    });
+    expect(container.querySelector('.chat-pinned-todo')).toBeNull();
   });
   it('shows several queued prompts above the composer with compact controls', () => {
     const onRemoveQueuedSend = vi.fn();

--- a/apps/web/tests/components/ChatPane.streaming.test.tsx
+++ b/apps/web/tests/components/ChatPane.streaming.test.tsx
@@ -52,16 +52,35 @@ vi.mock('../../src/components/AssistantMessage', () => ({
     isLast,
     onShareToOpenDesign,
     shareToOpenDesignBusy,
+    showConversationTodoCard,
+    conversationTodoInput,
   }: {
     streaming: boolean;
     message: ChatMessage;
     isLast?: boolean;
     onShareToOpenDesign?: () => void;
     shareToOpenDesignBusy?: boolean;
+    showConversationTodoCard?: boolean;
+    conversationTodoInput?: {
+      todos?: Array<{ content: string; status?: string }>;
+      plan?: Array<{ content?: string; step?: string; status?: string }>;
+    } | null;
   }) => (
     <>
       <output data-testid={`assistant-streaming-${message.id}`}>{streaming ? 'streaming' : 'idle'}</output>
       <output data-testid={`assistant-last-${message.id}`}>{isLast ? 'last' : 'not-last'}</output>
+      {showConversationTodoCard && conversationTodoInput ? (
+        <div className="op-card op-todo">
+          {(conversationTodoInput.todos ?? conversationTodoInput.plan ?? []).map((todo, index) => {
+            const content = 'content' in todo ? todo.content : todo.step;
+            return (
+              <div key={`${content}-${index}`} className={`todo-${todo.status ?? 'pending'}`}>
+                <span className="todo-text">{content}</span>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
       {onShareToOpenDesign ? (
         <button
           type="button"

--- a/apps/web/tests/components/ChatPane.streaming.test.tsx
+++ b/apps/web/tests/components/ChatPane.streaming.test.tsx
@@ -50,27 +50,18 @@ vi.mock('../../src/components/AssistantMessage', () => ({
     streaming,
     message,
     isLast,
-    showConversationTodoCard,
-    conversationTodoInput,
     onShareToOpenDesign,
     shareToOpenDesignBusy,
   }: {
     streaming: boolean;
     message: ChatMessage;
     isLast?: boolean;
-    showConversationTodoCard?: boolean;
-    conversationTodoInput?: unknown;
     onShareToOpenDesign?: () => void;
     shareToOpenDesignBusy?: boolean;
   }) => (
     <>
       <output data-testid={`assistant-streaming-${message.id}`}>{streaming ? 'streaming' : 'idle'}</output>
       <output data-testid={`assistant-last-${message.id}`}>{isLast ? 'last' : 'not-last'}</output>
-      {showConversationTodoCard ? (
-        <output data-testid={`assistant-todo-input-${message.id}`}>
-          {JSON.stringify(conversationTodoInput)}
-        </output>
-      ) : null}
       {onShareToOpenDesign ? (
         <button
           type="button"
@@ -773,17 +764,9 @@ Expected output:
       />,
     );
 
-    const todoInput = JSON.parse(screen.getByTestId('assistant-todo-input-assistant-1').textContent ?? '{}');
-    expect(todoInput).toEqual({
-      todos: [
-        {
-          content: 'Build prototype',
-          status: 'stopped',
-          activeForm: 'Building prototype',
-        },
-        { content: 'Run QA', status: 'pending' },
-      ],
-    });
+    expect(container.querySelectorAll('.chat-log .op-card.op-todo')).toHaveLength(1);
+    expect(container.querySelector('.todo-stopped .todo-text')?.textContent).toBe('Build prototype');
+    expect(container.querySelector('.todo-pending .todo-text')?.textContent).toBe('Run QA');
     expect(container.querySelector('.chat-pinned-todo')).toBeNull();
   });
   it('shows several queued prompts above the composer with compact controls', () => {

--- a/apps/web/tests/components/chat-todo-autoscroll.test.tsx
+++ b/apps/web/tests/components/chat-todo-autoscroll.test.tsx
@@ -189,6 +189,36 @@ function messagesWithTwoTodoSnapshots(): ChatMessage[] {
   ];
 }
 
+function messagesWithTodoThenDone(): ChatMessage[] {
+  return [
+    { id: 'u1', role: 'user' as const, content: 'build something', createdAt: Date.now() },
+    {
+      id: 'a1',
+      role: 'assistant' as const,
+      content: 'planning',
+      createdAt: Date.now(),
+      events: [
+        {
+          kind: 'tool_use' as const,
+          id: 'tw-1',
+          name: 'TodoWrite',
+          input: {
+            todos: [
+              { content: 'Task 1 updated', status: 'in_progress' },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      id: 'a2',
+      role: 'assistant' as const,
+      content: 'done',
+      createdAt: Date.now(),
+    },
+  ];
+}
+
 function longConversationWithEarlyTodo(): ChatMessage[] {
   const messages = messagesWithTodo(2);
   for (let i = 0; i < 90; i += 1) {
@@ -237,6 +267,19 @@ describe('chat-log autoscroll when inline todo card grows', () => {
 
     expect(document.querySelectorAll('.chat-log .op-card.op-todo')).toHaveLength(1);
     expect(screen.queryAllByText('Task 2 updated').length).toBeGreaterThan(0);
+  });
+
+  it('renders the standalone todo card at the first TodoWrite position', async () => {
+    render(chatPaneEl(messagesWithTodoThenDone()));
+    await flushFrames();
+
+    const todoCard = document.querySelector('.chat-log .op-card.op-todo');
+    expect(todoCard).not.toBeNull();
+    const assistantMessages = document.querySelectorAll('.chat-log .msg.assistant');
+    expect(assistantMessages).toHaveLength(2);
+
+    expect(assistantMessages[0]!.compareDocumentPosition(todoCard!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(todoCard!.compareDocumentPosition(assistantMessages[1]!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   it('keeps the standalone todo card rendered when virtualization omits the original TodoWrite row', async () => {

--- a/apps/web/tests/components/chat-todo-autoscroll.test.tsx
+++ b/apps/web/tests/components/chat-todo-autoscroll.test.tsx
@@ -13,7 +13,7 @@ if (typeof HTMLElement.prototype.scrollTo !== 'function') {
   };
 }
 
-import { act, cleanup, render } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatPane } from '../../src/components/ChatPane';
 import type { ChatMessage } from '../../src/types';
@@ -25,9 +25,6 @@ type Geom = { scrollHeight: number; clientHeight: number; scrollTop: number };
 let geom: Geom;
 let rafCallbacks: FrameRequestCallback[];
 let resizeCallbacks: ResizeObserverCallback[];
-// All elements passed to any ResizeObserver.observe() call — used to
-// assert that the pinned-todo div is observed so real-browser resizes fire.
-let observedElements: Element[];
 let savedDescriptors: Record<
   'scrollTop' | 'scrollHeight' | 'clientHeight',
   PropertyDescriptor | undefined
@@ -42,7 +39,6 @@ beforeEach(() => {
   geom = { scrollHeight: 1000, clientHeight: 400, scrollTop: 1000 };
   rafCallbacks = [];
   resizeCallbacks = [];
-  observedElements = [];
 
   vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
     rafCallbacks.push(callback);
@@ -54,9 +50,7 @@ beforeEach(() => {
     constructor(callback: ResizeObserverCallback) {
       resizeCallbacks.push(callback);
     }
-    observe = vi.fn((el: Element) => {
-      observedElements.push(el);
-    });
+    observe = vi.fn();
     unobserve = vi.fn();
     disconnect = vi.fn();
   }
@@ -99,7 +93,6 @@ afterEach(() => {
   vi.restoreAllMocks();
   rafCallbacks = [];
   resizeCallbacks = [];
-  observedElements = [];
   if (originalResizeObserver) {
     Object.defineProperty(globalThis, 'ResizeObserver', {
       configurable: true,
@@ -127,7 +120,7 @@ async function flushFrames() {
   });
 }
 
-// Build a message set that includes a TodoWrite event so PinnedTodoSlot renders.
+// Build a message set that includes a TodoWrite event so the inline TodoCard renders.
 function messagesWithTodo(taskCount: number): ChatMessage[] {
   const todos = Array.from({ length: taskCount }, (_, i) => ({
     content: `Task ${i + 1}`,
@@ -146,6 +139,50 @@ function messagesWithTodo(taskCount: number): ChatMessage[] {
           id: 'tw-1',
           name: 'TodoWrite',
           input: { todos },
+        },
+      ],
+    },
+  ];
+}
+
+function messagesWithTwoTodoSnapshots(): ChatMessage[] {
+  return [
+    { id: 'u1', role: 'user' as const, content: 'build something', createdAt: Date.now() },
+    {
+      id: 'a1',
+      role: 'assistant' as const,
+      content: 'planning',
+      createdAt: Date.now(),
+      events: [
+        {
+          kind: 'tool_use' as const,
+          id: 'tw-1',
+          name: 'TodoWrite',
+          input: {
+            todos: [
+              { content: 'Task 1', status: 'pending' },
+              { content: 'Task 2', status: 'pending' },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      id: 'a2',
+      role: 'assistant' as const,
+      content: 'working',
+      createdAt: Date.now(),
+      events: [
+        {
+          kind: 'tool_use' as const,
+          id: 'tw-2',
+          name: 'TodoWrite',
+          input: {
+            todos: [
+              { content: 'Task 1', status: 'completed' },
+              { content: 'Task 2 updated', status: 'in_progress' },
+            ],
+          },
         },
       ],
     },
@@ -171,56 +208,34 @@ function chatPaneEl(messages: ChatMessage[]) {
   );
 }
 
-describe('chat-log autoscroll when pinned todo card grows', () => {
-  it('observes the pinned-todo element so its resize triggers the bottom-pin follow', async () => {
-    // The PinnedTodoSlot lives outside the chat-log scroll container.
-    // When the todo card grows, the chat-log viewport (clientHeight)
-    // shrinks. The ResizeObserver must observe the pinned-todo div so
-    // `followLatestIfPinned` fires and corrects the scroll position.
+describe('chat-log autoscroll when inline todo card grows', () => {
+  it('renders the todo card inline instead of in the composer-pinned slot', async () => {
     render(chatPaneEl(messagesWithTodo(3)));
     await flushFrames();
 
-    const pinnedTodoEl = document.querySelector('.chat-pinned-todo');
-    expect(pinnedTodoEl, 'PinnedTodoSlot should render with a TodoWrite message').not.toBeNull();
-
-    // The pinned-todo element must be registered with the ResizeObserver
-    // so that real-browser growth of the todo card triggers followLatestIfPinned.
-    expect(observedElements).toContain(pinnedTodoEl);
-  });
-
-  it('re-observes the pinned-todo element when a TodoWrite snapshot first mounts', async () => {
-    // Start with no TodoWrite — PinnedTodoSlot should be absent.
-    const { rerender } = render(chatPaneEl([]));
-    await flushFrames();
     expect(document.querySelector('.chat-pinned-todo')).toBeNull();
-
-    // Add messages with a TodoWrite — PinnedTodoSlot mounts for the first time.
-    await act(async () => {
-      rerender(chatPaneEl(messagesWithTodo(2)));
-      await Promise.resolve();
-    });
-    await flushFrames();
-
-    const pinnedTodoEl = document.querySelector('.chat-pinned-todo');
-    expect(pinnedTodoEl, 'PinnedTodoSlot should render when messages include a TodoWrite').not.toBeNull();
-
-    // The pane-level MutationObserver re-syncs the ResizeObserver when
-    // PinnedTodoSlot mounts. The new element must be registered so real-browser
-    // growth of the card triggers followLatestIfPinned.
-    expect(observedElements).toContain(pinnedTodoEl);
+    expect(document.querySelector('.chat-log .op-card.op-todo')).not.toBeNull();
+    expect(screen.queryAllByText('Task 1').length).toBeGreaterThan(0);
   });
 
-  it('scrolls to the bottom when pinned and the todo card grows', async () => {
+  it('keeps one inline todo card at the first TodoWrite position and updates it from the latest snapshot', async () => {
+    render(chatPaneEl(messagesWithTwoTodoSnapshots()));
+    await flushFrames();
+
+    expect(document.querySelectorAll('.chat-log .op-card.op-todo')).toHaveLength(1);
+    expect(screen.queryAllByText('Task 2 updated').length).toBeGreaterThan(0);
+  });
+
+  it('scrolls to the bottom when pinned and the inline todo card grows', async () => {
     // Start pinned: scrollTop == scrollHeight (user is at the very bottom).
     geom = { scrollHeight: 1000, clientHeight: 400, scrollTop: 1000 };
     render(chatPaneEl(messagesWithTodo(2)));
     await flushFrames();
 
     // The initial-bottom-scroll effect fires and confirms pinnedToBottomRef = true.
-    // Now simulate the todo card growing: the viewport (clientHeight) shrinks,
-    // which means the user can no longer see the latest content even though
-    // scrollTop is still at its old value. The ResizeObserver callback should
-    // fire followLatestIfPinned, which snaps scrollTop back to scrollHeight.
+    // Now simulate a rendered message growing as the inline todo card changes.
+    // The ResizeObserver callback should fire followLatestIfPinned, which snaps
+    // scrollTop back to scrollHeight.
     geom = { ...geom, clientHeight: 300, scrollHeight: 1000, scrollTop: 600 };
 
     await act(async () => {
@@ -231,9 +246,7 @@ describe('chat-log autoscroll when pinned todo card grows', () => {
     await flushFrames();
 
     // followLatestIfPinned fires from the shared callback and snaps scrollTop
-    // to scrollHeight (1000). The structural guarantee that the pinned-todo
-    // element is observed (tested separately above) ensures this path runs in
-    // the real browser when the card grows.
+    // to scrollHeight (1000).
     expect(geom.scrollTop).toBe(1000);
   });
 });

--- a/apps/web/tests/components/chat-todo-autoscroll.test.tsx
+++ b/apps/web/tests/components/chat-todo-autoscroll.test.tsx
@@ -219,6 +219,38 @@ function messagesWithTodoThenDone(): ChatMessage[] {
   ];
 }
 
+function messageWithTodoBetweenProse(): ChatMessage[] {
+  return [
+    { id: 'u1', role: 'user' as const, content: 'build something', createdAt: Date.now() },
+    {
+      id: 'a1',
+      role: 'assistant' as const,
+      content: 'Before todo.\n\nAfter todo.',
+      createdAt: Date.now(),
+      events: [
+        {
+          kind: 'text' as const,
+          text: 'Before todo.',
+        },
+        {
+          kind: 'tool_use' as const,
+          id: 'tw-1',
+          name: 'TodoWrite',
+          input: {
+            todos: [
+              { content: 'Task 1', status: 'pending' },
+            ],
+          },
+        },
+        {
+          kind: 'text' as const,
+          text: 'After todo.',
+        },
+      ],
+    },
+  ];
+}
+
 function longConversationWithEarlyTodo(): ChatMessage[] {
   const messages = messagesWithTodo(2);
   for (let i = 0; i < 90; i += 1) {
@@ -261,7 +293,7 @@ describe('chat-log autoscroll when inline todo card grows', () => {
     expect(screen.queryAllByText('Task 1').length).toBeGreaterThan(0);
   });
 
-  it('keeps one standalone todo card in the chat log and updates it from the latest snapshot', async () => {
+  it('keeps one todo card in the chat log and updates it from the latest snapshot', async () => {
     render(chatPaneEl(messagesWithTwoTodoSnapshots()));
     await flushFrames();
 
@@ -269,7 +301,7 @@ describe('chat-log autoscroll when inline todo card grows', () => {
     expect(screen.queryAllByText('Task 2 updated').length).toBeGreaterThan(0);
   });
 
-  it('renders the standalone todo card at the first TodoWrite position', async () => {
+  it('renders the todo card at the first TodoWrite message position', async () => {
     render(chatPaneEl(messagesWithTodoThenDone()));
     await flushFrames();
 
@@ -278,11 +310,25 @@ describe('chat-log autoscroll when inline todo card grows', () => {
     const assistantMessages = document.querySelectorAll('.chat-log .msg.assistant');
     expect(assistantMessages).toHaveLength(2);
 
-    expect(assistantMessages[0]!.compareDocumentPosition(todoCard!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    const firstAssistantPosition = assistantMessages[0]!.compareDocumentPosition(todoCard!);
+    expect(firstAssistantPosition & Node.DOCUMENT_POSITION_CONTAINED_BY).toBeTruthy();
     expect(todoCard!.compareDocumentPosition(assistantMessages[1]!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
-  it('keeps the standalone todo card rendered when virtualization omits the original TodoWrite row', async () => {
+  it('renders the todo card between prose around the first TodoWrite event', async () => {
+    render(chatPaneEl(messageWithTodoBetweenProse()));
+    await flushFrames();
+
+    const before = screen.getByText('Before todo.');
+    const after = screen.getByText('After todo.');
+    const todoCard = document.querySelector('.chat-log .op-card.op-todo');
+    expect(todoCard).not.toBeNull();
+
+    expect(before.compareDocumentPosition(todoCard!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(todoCard!.compareDocumentPosition(after)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('keeps the todo card rendered when virtualization omits the original TodoWrite row from the tail window', async () => {
     geom = { scrollHeight: 20000, clientHeight: 400, scrollTop: 20000 };
     render(chatPaneEl(longConversationWithEarlyTodo()));
     await flushFrames();

--- a/apps/web/tests/components/chat-todo-autoscroll.test.tsx
+++ b/apps/web/tests/components/chat-todo-autoscroll.test.tsx
@@ -189,6 +189,19 @@ function messagesWithTwoTodoSnapshots(): ChatMessage[] {
   ];
 }
 
+function longConversationWithEarlyTodo(): ChatMessage[] {
+  const messages = messagesWithTodo(2);
+  for (let i = 0; i < 90; i += 1) {
+    messages.push({
+      id: `tail-${i}`,
+      role: i % 2 === 0 ? 'user' : 'assistant',
+      content: `tail message ${i}`,
+      createdAt: Date.now() + i + 1,
+    });
+  }
+  return messages;
+}
+
 function chatPaneEl(messages: ChatMessage[]) {
   return (
     <ChatPane
@@ -218,12 +231,22 @@ describe('chat-log autoscroll when inline todo card grows', () => {
     expect(screen.queryAllByText('Task 1').length).toBeGreaterThan(0);
   });
 
-  it('keeps one inline todo card at the first TodoWrite position and updates it from the latest snapshot', async () => {
+  it('keeps one standalone todo card in the chat log and updates it from the latest snapshot', async () => {
     render(chatPaneEl(messagesWithTwoTodoSnapshots()));
     await flushFrames();
 
     expect(document.querySelectorAll('.chat-log .op-card.op-todo')).toHaveLength(1);
     expect(screen.queryAllByText('Task 2 updated').length).toBeGreaterThan(0);
+  });
+
+  it('keeps the standalone todo card rendered when virtualization omits the original TodoWrite row', async () => {
+    geom = { scrollHeight: 20000, clientHeight: 400, scrollTop: 20000 };
+    render(chatPaneEl(longConversationWithEarlyTodo()));
+    await flushFrames();
+
+    expect(document.querySelector('[data-testid="chat-virtual-spacer"]')).not.toBeNull();
+    expect(document.querySelectorAll('.chat-log .op-card.op-todo')).toHaveLength(1);
+    expect(screen.queryAllByText('Task 1').length).toBeGreaterThan(0);
   });
 
   it('scrolls to the bottom when pinned and the inline todo card grows', async () => {


### PR DESCRIPTION
## Why

This fixes regressions found while validating TodoWrite behavior across agent runtimes. The user-facing pain was twofold: Gemini / Claude-style runs could dump a full code artifact into chat after the file was already written, and the TodoWrite UI had drifted from its original in-message position into a composer-pinned card.

The runtime conclusion is that Gemini 3 / preview does not reliably expose native `write_todos`, so Open Design should not synthesize TodoWrite state from markdown, TODO files, temporary JSON files, or shell heredocs. We only map standard structured runtime events.

## What users will see

- Todo lists render once at the first TodoWrite position in the assistant message stream.
- Later TodoWrite updates refresh that original card instead of pinning a global card above the composer or creating duplicate cards.
- Gemini and Claude Code runs no longer show a final duplicated `<artifact>` / full-code block after the actual file-write tool has already produced the file.
- Gemini only shows TodoWrite when the CLI emits native `write_todos`; it no longer simulates todos from markdown/files/shell output.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached from this environment. The changed UI behavior is covered by `apps/web/tests/components/chat-todo-autoscroll.test.tsx`: no `.chat-pinned-todo`, one inline Todo card, latest snapshot updates the original card.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/daemon/tests/json-event-stream.test.ts`
  - `apps/daemon/tests/structured-streams.test.ts`
  - `apps/web/tests/components/chat-todo-autoscroll.test.tsx`
- Did the test go red on `main` and green on this branch? No. The local repro was interactive/manual; this PR adds focused regression coverage for the corrected behavior.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/json-event-stream.test.ts -t "gemini stream|codex json stream emits TodoWrite"`
- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/structured-streams.test.ts -t "Claude"`
- `corepack pnpm --filter @open-design/daemon typecheck`
- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/chat-todo-autoscroll.test.tsx tests/components/assistant-message-unfinished-todos.test.tsx`
- `corepack pnpm --filter @open-design/web typecheck`
