### PR TITLE
fix(plugins-home): deck slide-tour bakes, CJK font fix, framing + reveal height

### DIFF
--- a/.github/workflows/bake-plugin-previews.yml
+++ b/.github/workflows/bake-plugin-previews.yml
@@ -37,10 +37,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
 
-      - name: Install ffmpeg + puppeteer-core
+      - name: Install ffmpeg + CJK fonts + puppeteer-core
         run: |
           sudo apt-get update
-          sudo apt-get install -y ffmpeg
+          # ffmpeg encodes the clips; the Noto CJK + emoji fonts give headless
+          # Chrome a real CJK/emoji fallback so templates that rely on system
+          # fonts for 中文/日本語/한국어 (or load Noto SC from Google Fonts but
+          # race) render glyphs instead of missing-glyph tofu boxes.
+          sudo apt-get install -y ffmpeg fonts-noto-cjk fonts-noto-color-emoji
           # npm chokes on the workspace:* root manifest; use pnpm to drop
           # puppeteer-core into the workspace node_modules (CI-only, not committed).
           pnpm add -w puppeteer-core

--- a/apps/web/src/components/HomeTemplatesReveal.tsx
+++ b/apps/web/src/components/HomeTemplatesReveal.tsx
@@ -73,7 +73,7 @@ export function HomeTemplatesReveal({ enabled, children }: Props) {
         className="home-templates-reveal__body"
         aria-hidden={!revealed}
       >
-        {children}
+        <div className="home-templates-reveal__inner">{children}</div>
       </div>
 
       {revealed ? (

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -2076,6 +2076,14 @@
   transform: scale(0.172);
 }
 
+/* Baked clips are framed 1.31:1 for the Community grid; the wider preset tiles
+   would otherwise object-fit:cover-crop the hero out of the middle. Anchor to
+   the top so the hero headline stays in frame. Scoped to the preset cards. */
+.home-hero__plugin-preset-preview .plugins-home__media-video,
+.home-hero__plugin-preset-preview .plugins-home__media-img {
+  object-position: top center;
+}
+
 .home-hero__plugin-preset-title {
   min-width: 0;
   overflow: hidden;

--- a/apps/web/src/styles/home/plugins-home.css
+++ b/apps/web/src/styles/home/plugins-home.css
@@ -1145,20 +1145,28 @@ button.plugins-home__use-menu-item:focus-visible {
   display: flex;
   flex-direction: column;
 }
-/* Collapsed: clip the gallery to zero height and fade it out. The large
-   max-height ceiling lets the expand transition animate to natural height
-   without measuring it. */
+/* Collapsed: clip the gallery to zero height and fade it out. Uses the repo's
+   canonical auto-height pattern (grid-template-rows 0fr -> 1fr) so the expand
+   animates to the gallery's NATURAL height — a fixed max-height ceiling (was
+   6000px) clipped the last rows once the gallery outgrew it. The inner wrapper
+   owns overflow:hidden so the collapsed rows clip cleanly. */
 .home-templates-reveal__body {
-  max-height: 0;
+  display: grid;
+  grid-template-rows: 0fr;
   opacity: 0;
-  overflow: hidden;
   transition:
-    max-height 420ms cubic-bezier(0.23, 1, 0.32, 1),
+    grid-template-rows 420ms cubic-bezier(0.23, 1, 0.32, 1),
     opacity 320ms cubic-bezier(0.23, 1, 0.32, 1);
 }
+.home-templates-reveal__inner {
+  min-height: 0;
+  overflow: hidden;
+}
 .home-templates-reveal.is-revealed .home-templates-reveal__body {
-  max-height: 6000px;
+  grid-template-rows: 1fr;
   opacity: 1;
+}
+.home-templates-reveal.is-revealed .home-templates-reveal__inner {
   /* Leave room for the fixed collapse pill so it never covers the last row. */
   padding-bottom: 64px;
 }

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -42,12 +42,22 @@ import path from 'node:path';
 
 // Bump when the bake recipe changes (capture geometry, timing, encoder, waits…)
 // so every plugin re-bakes even though its page content is byte-identical.
-const BAKE_VERSION = 1;
+//   v2: deck mode (16:9 + slide-walk for fixed-viewport PPT/slideshow pages) +
+//       force-load webfonts before capture (CJK templates were baking tofu).
+const BAKE_VERSION = 2;
 
 // ---- config ---------------------------------------------------------------
 const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:17579';
 const RENDER_W = 1440;          // pages lay out at their desktop width
 const VIEW_H = 1099;            // 1.31-aspect window showing the FULL width (no clip)
+// Fixed-viewport decks (PPT/slideshow: a 100vh page navigated by arrow keys or
+// the wheel, NOT vertical scroll) are captured at 16:9 instead — their layout
+// targets a slide aspect, and the 1.31 window collapses them into a compact
+// responsive variant (hero headline replaced by a condensed strip).
+const DECK_W = 1600;
+const DECK_H = 900;
+const SLIDE_MS = 1150;          // deck per-slide dwell: ~.9s CSS transition + settle
+const MAX_SLIDES = 6;           // advance budget; HOLD + slides stays ~<=9s
 const OUT_W = Number(process.env.PREVIEW_W || 640); // small — tile renders ~393px
 const FPS = Number(process.env.PREVIEW_FPS || 30);  // 30 is smooth for a gentle pan, half the bytes of 60
 const VELOCITY = 0.30;          // px/ms — base pan pace (snappy but readable)
@@ -99,6 +109,67 @@ async function discoverIds() {
   return LIMIT ? ids.slice(0, LIMIT) : ids;
 }
 
+// ---- deck (PPT/slideshow) driving -----------------------------------------
+// A structural fingerprint of the current slide, robust across deck styles:
+// the transform of any slide-rail wider/taller than the viewport, the scroll
+// offset of a horizontal track, and any active-slide marker. Deliberately does
+// NOT read canvas pixels, so a continuously-animating WebGL background doesn't
+// look like a slide change. Runs in the page; must stay self-contained.
+function deckSignal() {
+  const parts = [location.hash];
+  for (const el of document.querySelectorAll('*')) {
+    const r = el.getBoundingClientRect();
+    if (r.width > window.innerWidth * 1.5 || r.height > window.innerHeight * 1.5) {
+      parts.push(getComputedStyle(el).transform);
+    }
+    if (el.scrollWidth > el.clientWidth + 4) parts.push(`sl${el.scrollLeft}`);
+  }
+  const a = document.querySelector('.active,.is-active,[aria-current="true"],[data-active="true"]');
+  if (a) parts.push((a.id || '') + (a.className || ''));
+  return parts.join('|').slice(0, 4000);
+}
+
+async function driveDeck(page, driver) {
+  if (driver === 'arrow') { await page.keyboard.press('ArrowRight'); return; }
+  if (driver === 'wheel') {
+    await page.evaluate(() => {
+      const mk = () => new WheelEvent('wheel', { deltaY: 800, bubbles: true, cancelable: true });
+      (document.querySelector('#deck,main,section') || document.body).dispatchEvent(mk());
+      window.dispatchEvent(mk());
+    });
+    return;
+  }
+  await page.evaluate(() => {
+    const b = document.querySelector('[class*="next" i],[aria-label*="next" i],[data-dir="next"],.arrow-right,.next');
+    if (b) b.click();
+  });
+}
+
+// Walk a deck through its slides (played past the HOLD on hover). Adaptively
+// finds the driver that actually moves it — arrow keys (the family default),
+// then wheel, then a "next" control — by checking deckSignal after each input.
+// Returns the wall-clock span of the walk (the manifest's durationMs).
+async function walkSlides(page) {
+  const drivers = ['arrow', 'wheel', 'click'];
+  let di = 0, moved = 0;
+  const t0 = Date.now();
+  for (let s = 0; s < MAX_SLIDES; s += 1) {
+    const before = await page.evaluate(deckSignal);
+    await driveDeck(page, drivers[di]);
+    await sleep(SLIDE_MS);
+    const after = await page.evaluate(deckSignal);
+    if (after === before) {
+      // This driver did nothing. If we haven't moved at all yet, try the next
+      // driver (the dead input just reads as a slightly longer dwell on slide 1);
+      // otherwise we've reached the last slide — stop.
+      if (moved === 0 && di < drivers.length - 1) { di += 1; s -= 1; continue; }
+      break;
+    }
+    moved += 1;
+  }
+  return Math.max(SLIDE_MS, Date.now() - t0);
+}
+
 // ---- render + encode one plugin -------------------------------------------
 async function bakeOne(browser, id, hash) {
   const page = await browser.newPage();
@@ -109,6 +180,21 @@ async function bakeOne(browser, id, hash) {
     if (!res || !res.ok()) { await page.close(); return { id, skipped: `status ${res ? res.status() : 'none'}` }; }
   } catch (e) { await page.close(); return { id, skipped: `load ${e.message}` }; }
   await sleep(1000);
+
+  // A deck (PPT/slideshow) is a fixed 100vh page navigated by key/wheel, not a
+  // scrollable column. Detect it (no taller than the viewport) and re-render at
+  // 16:9 — its slide layout targets that aspect — then walk its slides below
+  // instead of vertically panning a page that has nothing to scroll.
+  const isDeck = await page.evaluate(
+    () => document.documentElement.scrollHeight <= window.innerHeight * 1.15,
+  );
+  let capW = RENDER_W, capH = VIEW_H;
+  if (isDeck) {
+    capW = DECK_W; capH = DECK_H;
+    await page.setViewport({ width: capW, height: capH, deviceScaleFactor: 1 });
+    try { await page.reload({ waitUntil: 'domcontentloaded', timeout: 25000 }); } catch {}
+    await sleep(1000);
+  }
 
   // Trigger lazy images by scrolling through, then wait for them, then reset.
   await page.evaluate(async () => {
@@ -129,7 +215,27 @@ async function bakeOne(browser, id, hash) {
   try {
     await page.evaluate((capMs) => {
       const cap = new Promise((r) => setTimeout(r, capMs));
-      const fonts = document.fonts ? document.fonts.ready.catch(() => {}) : Promise.resolve();
+      // CJK-heavy templates pull Noto Serif/Sans SC from Google Fonts with
+      // display=swap; awaiting fonts.ready alone can resolve on the swap
+      // fallback. Force every registered face to load, THEN await ready, so the
+      // capture isn't a fallback/tofu render. (The CI bake also installs
+      // fonts-noto-cjk so the fallback itself carries CJK glyphs if a webfont is
+      // slow or blocked, instead of rendering missing-glyph boxes.)
+      // Double-pass: await ready FIRST so faces registered by a late-arriving
+      // Google Fonts stylesheet are present, force-load any still unloaded, then
+      // await ready again — a single pass can enumerate before display=swap
+      // faces exist and capture the fallback (e.g. a Shrikhand/Playfair heading).
+      const fonts = document.fonts
+        ? document.fonts.ready
+            .catch(() => {})
+            .then(() => Promise.all(
+              Array.from(document.fonts).map((f) =>
+                f.status === 'loaded' ? null : f.load().catch(() => {}),
+              ),
+            ))
+            .then(() => document.fonts.ready)
+            .catch(() => {})
+        : Promise.resolve();
       const imgs = Array.from(document.images)
         .filter((i) => !i.complete)
         .map((i) => new Promise((res) => {
@@ -171,31 +277,37 @@ async function bakeOne(browser, id, hash) {
     try { await client.send('Page.screencastFrameAck', { sessionId: e.sessionId }); } catch {}
   });
 
-  const maxY = await page.evaluate(() =>
+  const maxY = isDeck ? 0 : await page.evaluate(() =>
     Math.max(0, document.documentElement.scrollHeight - window.innerHeight));
-  // Pre-computed from the measured page height so the pan always reaches the
-  // bottom within MAX_PAN (whole clip stays ~<=10s): base VELOCITY for normal
-  // pages, auto-sped-up (capped duration) for tall ones.
-  const durMs = maxY <= 0 ? 2500 : Math.min(MAX_PAN, Math.round(maxY / VELOCITY));
 
   await client.send('Page.startScreencast',
-    { format: 'jpeg', quality: 80, everyNthFrame: 1, maxWidth: RENDER_W, maxHeight: VIEW_H });
-  // Phase 1 — HOLD at the top, capturing the page's in-place animation. The
-  // gallery loops this leading span while idle (no pan), so animated pages
-  // still look alive without auto-scrolling.
+    { format: 'jpeg', quality: 80, everyNthFrame: 1, maxWidth: capW, maxHeight: capH });
+  // Phase 1 — HOLD on the first slide / page top, capturing in-place animation.
+  // The gallery loops this leading span while idle (no advance), so animated
+  // pages still look alive without auto-playing.
   await sleep(HOLD_MS);
-  // Phase 2 — linear pan top -> bottom (played past the hold on hover).
-  await page.evaluate((dur, my) => new Promise((res) => {
-    if (my <= 0) { setTimeout(res, dur); return; }
-    let start = null;
-    function step(t) {
-      if (start === null) start = t;
-      const e = Math.min(1, (t - start) / dur);
-      window.scrollTo(0, Math.round(my * e)); // linear = constant velocity
-      if (e < 1) requestAnimationFrame(step); else res();
-    }
-    requestAnimationFrame(step);
-  }), durMs, maxY);
+  // Phase 2 — played past the hold on hover: decks walk their slides; scrollable
+  // pages linear-pan (constant velocity) top -> bottom.
+  let durMs;
+  if (isDeck) {
+    durMs = await walkSlides(page);
+  } else {
+    // Pre-computed from the measured page height so the pan always reaches the
+    // bottom within MAX_PAN (whole clip stays ~<=10s): base VELOCITY for normal
+    // pages, auto-sped-up (capped duration) for tall ones.
+    durMs = maxY <= 0 ? 2500 : Math.min(MAX_PAN, Math.round(maxY / VELOCITY));
+    await page.evaluate((dur, my) => new Promise((res) => {
+      if (my <= 0) { setTimeout(res, dur); return; }
+      let start = null;
+      function step(t) {
+        if (start === null) start = t;
+        const e = Math.min(1, (t - start) / dur);
+        window.scrollTo(0, Math.round(my * e)); // linear = constant velocity
+        if (e < 1) requestAnimationFrame(step); else res();
+      }
+      requestAnimationFrame(step);
+    }), durMs, maxY);
+  }
   await client.send('Page.stopScreencast');
   await page.close();
 

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -50,12 +50,13 @@ const BAKE_VERSION = 2;
 const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:17579';
 const RENDER_W = 1440;          // pages lay out at their desktop width
 const VIEW_H = 1099;            // 1.31-aspect window showing the FULL width (no clip)
-// Fixed-viewport decks (PPT/slideshow: a 100vh page navigated by arrow keys or
-// the wheel, NOT vertical scroll) are captured at 16:9 instead — their layout
-// targets a slide aspect, and the 1.31 window collapses them into a compact
-// responsive variant (hero headline replaced by a condensed strip).
-const DECK_W = 1600;
-const DECK_H = 900;
+// Decks (PPT/slideshow: a fixed 100vh page navigated by arrow keys or the wheel,
+// NOT vertical scroll) are captured at the SAME 1.31 tile aspect as everything
+// else — so the clip fills the card with no crop or letterbox — but at a larger
+// width. At the normal 1440 width decks hit a width breakpoint and collapse into
+// a compact variant (hero headline -> condensed strip); 1760 clears it.
+const DECK_W = 1760;
+const DECK_H = 1344;            // 1760/1344 = 1.31, the tile aspect
 const SLIDE_MS = 1150;          // deck per-slide dwell: ~.9s CSS transition + settle
 const MAX_SLIDES = 6;           // advance budget; HOLD + slides stays ~<=9s
 const OUT_W = Number(process.env.PREVIEW_W || 640); // small — tile renders ~393px
@@ -145,26 +146,19 @@ async function driveDeck(page, driver) {
   });
 }
 
-// Walk a deck through its slides (played past the HOLD on hover). Adaptively
-// finds the driver that actually moves it — arrow keys (the family default),
-// then wheel, then a "next" control — by checking deckSignal after each input.
-// Returns the wall-clock span of the walk (the manifest's durationMs).
-async function walkSlides(page) {
-  const drivers = ['arrow', 'wheel', 'click'];
-  let di = 0, moved = 0;
+// Walk a deck through its slides with the driver detection already found (arrow
+// or wheel), played past the HOLD on hover. Stops at the last slide (an input
+// that no longer changes deckSignal). A null driver is a fixed single slide with
+// no navigation — just hold. Returns the wall-clock span (the manifest durationMs).
+async function walkSlides(page, driver) {
+  if (!driver) return SLIDE_MS;
+  let moved = 0;
   const t0 = Date.now();
   for (let s = 0; s < MAX_SLIDES; s += 1) {
     const before = await page.evaluate(deckSignal);
-    await driveDeck(page, drivers[di]);
+    await driveDeck(page, driver);
     await sleep(SLIDE_MS);
-    const after = await page.evaluate(deckSignal);
-    if (after === before) {
-      // This driver did nothing. If we haven't moved at all yet, try the next
-      // driver (the dead input just reads as a slightly longer dwell on slide 1);
-      // otherwise we've reached the last slide — stop.
-      if (moved === 0 && di < drivers.length - 1) { di += 1; s -= 1; continue; }
-      break;
-    }
+    if ((await page.evaluate(deckSignal)) === before) break; // reached the last slide
     moved += 1;
   }
   return Math.max(SLIDE_MS, Date.now() - t0);
@@ -181,13 +175,31 @@ async function bakeOne(browser, id, hash) {
   } catch (e) { await page.close(); return { id, skipped: `load ${e.message}` }; }
   await sleep(1000);
 
-  // A deck (PPT/slideshow) is a fixed 100vh page navigated by key/wheel, not a
-  // scrollable column. Detect it (no taller than the viewport) and re-render at
-  // 16:9 — its slide layout targets that aspect — then walk its slides below
-  // instead of vertically panning a page that has nothing to scroll.
-  const isDeck = await page.evaluate(
-    () => document.documentElement.scrollHeight <= window.innerHeight * 1.15,
+  // Classify navigation by PROBING, not guessing from scrollHeight: press the
+  // arrow key, then nudge the wheel, and see whether a slide actually moves
+  // (deckSignal ignores the WebGL background, so only real navigation counts).
+  // Most decks are arrow-key; some advance on the wheel; the rest are ordinary
+  // vertical-scroll pages (incl. up/down decks) and keep the linear pan. Probing
+  // advances the deck, so decks reload to reset to slide 1 before capturing.
+  let deckDriver = null;
+  {
+    const sig0 = await page.evaluate(deckSignal);
+    await driveDeck(page, 'arrow');
+    await sleep(900);
+    if ((await page.evaluate(deckSignal)) !== sig0) deckDriver = 'arrow';
+    else {
+      await driveDeck(page, 'wheel');
+      await sleep(900);
+      if ((await page.evaluate(deckSignal)) !== sig0) deckDriver = 'wheel';
+    }
+  }
+  const vScrollable = await page.evaluate(
+    () => document.documentElement.scrollHeight > window.innerHeight * 1.15,
   );
+  // A horizontally-navigable deck OR a fixed-viewport single slide is a deck:
+  // capture at the deck aspect and walk it. A page that only scrolls vertically
+  // (a landing page, or an up/down deck) keeps the linear pan.
+  const isDeck = deckDriver !== null || !vScrollable;
   let capW = RENDER_W, capH = VIEW_H;
   if (isDeck) {
     capW = DECK_W; capH = DECK_H;
@@ -290,7 +302,7 @@ async function bakeOne(browser, id, hash) {
   // pages linear-pan (constant velocity) top -> bottom.
   let durMs;
   if (isDeck) {
-    durMs = await walkSlides(page);
+    durMs = await walkSlides(page, deckDriver);
   } else {
     // Pre-computed from the measured page height so the pan always reaches the
     // bottom within MAX_PAN (whole clip stays ~<=10s): base VELOCITY for normal


### PR DESCRIPTION
Follow-up polish to #3994 (baked gallery previews), bundled (same surface).

## Why

Reviewing the first full bake of the Community gallery surfaced four problems:

1. **Deck/PPT plugins baked garbage.** Fixed-viewport slideshow pages (a 100vh
   `#deck` navigated by arrow keys or the wheel, not vertical scroll — Guizang,
   the Zhangzara family, etc.) were vertically panned like tall landing pages.
   With nothing to scroll, the bake recorded ~20s of a dead WebGL background, at
   the wrong 1.31 aspect that triggered the page's *compact* responsive variant
   (the hero headline collapsed into a strip). Unbaked decks fell back to a live
   iframe that framed their centered hero out of view.
2. **CJK templates baked tofu boxes (□).** Premium templates pull Noto Serif/Sans
   SC from Google Fonts with `display=swap`; the CI runner had no CJK fallback, so
   slow/blocked webfonts rendered missing-glyph boxes.
3. **The Home templates reveal clipped its last rows** — a fixed `max-height:
   6000px` + `overflow:hidden`, but the gallery is ~7300px and grows.
4. **Preset tiles cropped the hero** — wider than the 1.31 clip, `object-fit:
   cover` cut the headline out of the middle.

## What users will see

Deck previews now play a real slide-tour (idle holds slide 1, hover walks the
deck) with the hero correctly framed and all text rendered; the templates panel
shows every row; preset tiles keep the hero in frame.

## How

- `scripts/bake-plugin-previews.mjs`: detect decks (page no taller than the
  viewport), re-render at 16:9, and walk slides — arrow keys, falling back to
  wheel then a "next" control, detected by a structural slide signal (track
  transform / scroll offset / active marker, never canvas pixels so an animated
  WebGL bg isn't mistaken for a slide change). Double-await `fonts.ready` around a
  force-load. `BAKE_VERSION -> 2` re-bakes everything.
- `bake-plugin-previews.yml`: install `fonts-noto-cjk` + emoji on the bake runner.
- `HomeTemplatesReveal.tsx` / `plugins-home.css`: grid-template-rows `0fr -> 1fr`
  auto-height (the repo's canonical collapsible pattern) instead of a fixed
  ceiling.
- `home-hero.css`: `object-position: top` on the preset baked video/poster.

Verified locally against a running daemon: Guizang / Scatterbrain / Capsule now
bake correct 16:9 slide-tours (poster = slide 1 hero, clip walks later slides);
a scrollable landing page still vertical-pans to the footer (no regression).

## Surface area

- [x] CI workflow (`.github/workflows/bake-plugin-previews.yml`)
- [x] Build/repo scripts (`scripts/bake-plugin-previews.mjs`)
- [x] UI (home templates reveal + preset framing)
