### PR TITLE
feat: enforce 220px minimum width for workspace hover previews

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -1040,7 +1040,7 @@ export function WorkspaceTabsBar({ route, projects }: Props) {
               const previewDisplay = displayTabById.get(previewTab.id)
                 ?? displayTabFor(previewTab, projectById, t);
               const previewDetail = describePreviewDetail(previewTab, projectById);
-              const previewWidth = Math.max(1, Math.round(hoverPreview.anchorWidth));
+              const previewWidth = Math.max(220, Math.round(hoverPreview.anchorWidth));
               const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1024;
               const left = Math.max(
                 0,

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -490,6 +490,7 @@
   position: fixed;
   z-index: 140;
   box-sizing: border-box;
+  min-width: 220px;
   display: flex;
   align-items: flex-start;
   gap: 9px;

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -1,3 +1,4 @@
+
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -550,7 +551,7 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     });
   });
 
-  it('sizes the hover preview to the hovered tab width', async () => {
+  it('clamps the hover preview to 220px for narrow tabs', async () => {
     window.localStorage.setItem(
       'open-design:workspace-tabs:v1',
       JSON.stringify({
@@ -591,8 +592,53 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     await new Promise((resolve) => window.setTimeout(resolve, 430));
 
     const tooltip = await screen.findByRole('tooltip');
-    expect(tooltip.style.width).toBe('148px');
+    expect(tooltip.style.width).toBe('220px');
     expect(tooltip.style.left).toBe('32px');
+  });
+
+  it('matches anchor width for tabs wider than the 220px floor', async () => {
+    window.localStorage.setItem(
+      'open-design:workspace-tabs:v1',
+      JSON.stringify({
+        activeTabId: 'entry:home:seed',
+        tabs: [
+          {
+            id: 'entry:home:seed',
+            kind: 'entry',
+            view: 'home',
+            createdAt: 1,
+            lastActiveAt: 2,
+          },
+          {
+            id: 'project:project-alpha',
+            kind: 'project',
+            projectId: 'project-alpha',
+            conversationId: null,
+            fileName: null,
+            createdAt: 2,
+            lastActiveAt: 1,
+          },
+        ],
+      }),
+    );
+
+    render(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('tab')).toHaveLength(2);
+    });
+
+    const projectTab = screen.getAllByRole('tab').find((tab) =>
+      (tab.textContent ?? '').includes('Project Alpha'),
+    ) as HTMLElement;
+    mockTabRect(projectTab, 50, 300);
+    fireEvent.mouseEnter(projectTab);
+
+    await new Promise((resolve) => window.setTimeout(resolve, 430));
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip.style.width).toBe('300px');
+    expect(tooltip.style.left).toBe('50px');
   });
 
   it('keeps the Home tab pinned leftmost when a tab is dropped onto its left edge', async () => {


### PR DESCRIPTION
Fixes #3957 

## Why

- **Use case:** Encountered UI bug where the workspace tab hover preview popup shrinks to a narrow vertical column when multiple tabs are open and compressed.
- **Pain addressed:** When workspace tabs shrink (e.g., compressed desktop tabs or on mobile breakpoints), the hover preview width is dynamically calculated to match the tab's on-screen width. This leaves insufficient horizontal space for text inside the preview, causing it to collapse into a narrow, vertical layout where letters overflow and are unreadable. Enforcing a minimum width of `220px` ensures that the preview container has a stable, readable layout even for heavily compressed tabs.

## Proposed Changes

### apps/web

#### [MODIFY] [WorkspaceTabsBar.tsx](file:///home/kushaal/projects/OSS/open-design/apps/web/src/components/WorkspaceTabsBar.tsx)
- Updated calculated `previewWidth` of the hover preview portal to enforce a minimum width of 220px:
  ```typescript
  const previewWidth = Math.max(220, Math.round(hoverPreview.anchorWidth));
  ```

#### [MODIFY] [shell.css](file:///home/kushaal/projects/OSS/open-design/apps/web/src/styles/shell.css)
- Added `min-width: 220px;` to `.workspace-tab-preview` to provide a matching CSS-level safety boundary for the tooltip's container.

## What users will see

- Hovering compressed workspace tabs displays the preview tooltip with a readable width (at least 220px) instead of shrinking to the narrow visual width of the tab. Titles and metadata wrap or truncate cleanly within the constrained layout.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

- N/A (UI layout fixes for tab hover preview widths)

## Bug fix verification

- **Test path that reproduces the bug:** Hover over a compressed tab when many tabs are open (tab width under 220px). The hover preview collapses horizontally to match the narrow tab width.
- **Verification performed:** Verified layout updates dynamically respect the 220px floor in development.

## Validation

- Ran repository-wide typecheck (`pnpm typecheck`).