### PR TITLE
fix(daemon): keep OpenCode from clobbering the daemon's pnpm workspace

### DIFF
--- a/apps/daemon/src/memory-llm.ts
+++ b/apps/daemon/src/memory-llm.ts
@@ -62,6 +62,7 @@ import {
 import { resolveProviderConfig } from './media-config.js';
 import { AIHUBMIX_APP_CODE } from './aihubmix.js';
 import { spawn } from 'node:child_process';
+import os from 'node:os';
 import { createCommandInvocation } from '@open-design/platform';
 import {
   applyAgentLaunchEnv,
@@ -836,10 +837,15 @@ async function callLocalCli(provider, system, user, options) {
     throw new Error(`${def.name} CLI is not installed or not on PATH`);
   }
 
+  // The memory extractor is a tool-less, JSON-only background call that never
+  // reads project files, so it has no reason to run in the daemon's own cwd.
+  // Falling back to process.cwd() there meant a bun-based agent (OpenCode) ran
+  // its startup `bun install` in whatever directory the daemon was launched from
+  // — clobbering a pnpm workspace (dev checkout). Use a neutral temp cwd.
   const cwd =
     typeof options?.projectRoot === 'string' && options.projectRoot.trim()
       ? options.projectRoot
-      : process.cwd();
+      : os.tmpdir();
   const prompt = [
     system,
     '',

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -125,6 +125,20 @@ export function spawnEnvForAgent(
     ]);
     return reapplySandboxRuntimeEnv(env, sandboxRuntime);
   }
+  if (agentId === 'opencode') {
+    // OpenCode is bun-based and, left to its defaults, walks up from its cwd to
+    // the nearest project root and runs `bun install` there at startup to set up
+    // local plugins. When that root is a pnpm workspace (the daemon's own repo,
+    // or a project nested inside it), the install replaces the pnpm `.pnpm` store
+    // with a bun `node_modules/.bun` + `bun.lock` and breaks the workspace.
+    // Disable project-config discovery (and its install) so OpenCode only honors
+    // the config the daemon injects via OPENCODE_CONFIG_CONTENT — this is exactly
+    // what the AMR path already does for its private OpenCode server.
+    if (!env.OPENCODE_DISABLE_PROJECT_CONFIG?.trim()) {
+      env.OPENCODE_DISABLE_PROJECT_CONFIG = 'true';
+    }
+    return reapplySandboxRuntimeEnv(env, sandboxRuntime);
+  }
   return reapplySandboxRuntimeEnv(env, sandboxRuntime);
 }
 

--- a/apps/daemon/src/runtimes/invocation.ts
+++ b/apps/daemon/src/runtimes/invocation.ts
@@ -1,10 +1,22 @@
 import { execFile } from 'node:child_process';
+import os from 'node:os';
 import { promisify } from 'node:util';
 import { createCommandInvocation } from '@open-design/platform';
 import type { RuntimeExecOptions } from './types.js';
 
 const execFileP = promisify(execFile);
 
+// Agent probes (model-list / version / help / auth-status) are short read-only
+// metadata calls that never need the caller's project files. Default them to a
+// neutral working directory instead of inheriting the daemon process cwd.
+//
+// This matters because some agent CLIs are bun-based (OpenCode) and run a
+// `bun install` on startup in their cwd to set up local plugins. When the daemon
+// is launched from a pnpm workspace (e.g. a dev checkout), inheriting that cwd
+// let an `opencode models` probe drop a workspace `bun.lock` + `node_modules/.bun`
+// over the repo, wiping its pnpm store and breaking `next dev`. A probe writing a
+// stray lockfile under the OS temp dir is harmless. Actual agent runs spawn
+// elsewhere with an explicit project cwd and are unaffected.
 export function execAgentFile(
   command: string,
   args: string[],
@@ -24,6 +36,7 @@ export function execAgentFile(
   );
   return execFileP(invocation.command, invocation.args, {
     ...options,
+    cwd: options.cwd ?? os.tmpdir(),
     windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   });
 }

--- a/apps/daemon/tests/runtimes/exec-agent-cwd.test.ts
+++ b/apps/daemon/tests/runtimes/exec-agent-cwd.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Agent probes (model-list / version / help / auth) must NOT inherit the daemon
+ * process cwd. Some agent CLIs are bun-based (OpenCode) and run `bun install` on
+ * startup in their working directory; when the daemon is launched from a pnpm
+ * workspace (a dev checkout), an `opencode models` probe inheriting that cwd
+ * dropped a workspace `bun.lock` + `node_modules/.bun` over the repo and wiped
+ * its pnpm store. `execAgentFile` defaults probes to a neutral temp cwd; this
+ * pins that behaviour (red on the pre-fix `inherit daemon cwd` path).
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+import { execAgentFile } from '../../src/runtimes/invocation.js';
+
+const PRINT_CWD = 'process.stdout.write(process.cwd())';
+// `process.cwd()` reports the realpath, while os.tmpdir() / mkdtemp can sit
+// behind symlinks (e.g. macOS `/tmp` → `/private/tmp`). Compare realpaths.
+const real = (p: string) => fs.realpathSync(p);
+
+describe('execAgentFile cwd isolation', () => {
+  it('defaults to a neutral cwd (OS temp dir), not the daemon process cwd', async () => {
+    const { stdout } = await execAgentFile(process.execPath, ['-e', PRINT_CWD]);
+    const childCwd = real(String(stdout).trim());
+
+    expect(childCwd).toBe(real(os.tmpdir()));
+    // The daemon test runs from the package dir; the probe must not inherit it.
+    expect(childCwd).not.toBe(real(process.cwd()));
+  });
+
+  it('still honors an explicit cwd when the caller provides one', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-agent-cwd-'));
+    try {
+      const { stdout } = await execAgentFile(process.execPath, ['-e', PRINT_CWD], { cwd: dir });
+      expect(real(String(stdout).trim())).toBe(real(dir));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Why

Hit this repeatedly while running the dev stack from a worktree: selecting the
OpenCode runtime (or letting the background memory extractor run) silently
replaced the repo's pnpm `node_modules/.pnpm` with a bun `node_modules/.bun` +
`bun.lock`, which breaks `next dev` ("cannot find package next/zod/..."). Root
cause: OpenCode is bun-based and runs `bun install` at its resolved project root
on startup; the daemon was launching it with a cwd at/under the pnpm workspace.

## What users will see

Nothing changes for normal (packaged) installs — there `.od/projects` is never
inside a pnpm workspace. For contributors running `tools-dev` from the repo,
OpenCode (and AMR, and the memory extractor) no longer corrupts the checkout's
`node_modules`.

## Surface area

- [x] **None** — internal daemon fix (agent-spawn cwd / env), no UI/CLI/contract change

## Bug fix verification

- Test: `apps/daemon/tests/runtimes/exec-agent-cwd.test.ts` — asserts
  `execAgentFile` runs probes in a neutral cwd, not the daemon's cwd.
- Caught live: an `opencode models` probe / memory-extractor run inheriting the
  daemon cwd dropped a workspace `bun.lock` + `node_modules/.bun` over the repo,
  reproducibly wiping `.pnpm`. With the fix, probes/memory run in `os.tmpdir()`
  and the `opencode` runtime gets `OPENCODE_DISABLE_PROJECT_CONFIG=true`.

## Notes for reviewers

- `OPENCODE_DISABLE_PROJECT_CONFIG=true` is OAuth-safe: OpenCode stores model
  credentials in its **global** data dir (`~/.local/share/opencode/auth.json`),
  which the flag does not touch — it only skips project-local `.opencode/`
  discovery. od injects its own config via `OPENCODE_CONFIG_CONTENT`, which is
  also unaffected. This mirrors what the AMR/vela path already does for its
  private OpenCode server.
